### PR TITLE
fix(orchestrator): align atomic verifier with Codex runtime evidence

### DIFF
--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -1233,8 +1233,8 @@ class CodexCliRuntime:
                 return candidate
         return {}
 
-    def _extract_path(self, item: dict[str, Any]) -> str:
-        """Extract a file path from a file change event."""
+    def _extract_paths(self, item: dict[str, Any]) -> tuple[str, ...]:
+        """Extract all file paths from a file change event."""
         candidates: list[object] = [
             item.get("path"),
             item.get("file_path"),
@@ -1248,13 +1248,40 @@ class CodexCliRuntime:
                         [
                             change.get("path"),
                             change.get("file_path"),
+                            change.get("target_file"),
                         ]
                     )
 
+        paths: list[str] = []
+        seen: set[str] = set()
         for candidate in candidates:
             if isinstance(candidate, str) and candidate.strip():
-                return candidate.strip()
-        return ""
+                path = candidate.strip()
+                if path not in seen:
+                    seen.add(path)
+                    paths.append(path)
+        return tuple(paths)
+
+    def _extract_path(self, item: dict[str, Any]) -> str:
+        """Extract the first file path from a file change event."""
+        paths = self._extract_paths(item)
+        return paths[0] if paths else ""
+
+    def _extract_command_metadata(self, item: dict[str, Any]) -> dict[str, Any]:
+        """Extract command result fields that can support verifier evidence."""
+        data: dict[str, Any] = {}
+        for key in ("output", "stdout", "stderr", "result_preview", "status"):
+            value = item.get(key)
+            if isinstance(value, str) and value.strip():
+                data[key] = value.strip()
+        for key in ("exit_code", "exitCode"):
+            value = item.get(key)
+            if isinstance(value, int):
+                data["exit_code"] = value
+                break
+        if item.get("success") is True:
+            data.setdefault("subtype", "success")
+        return data
 
     def _build_tool_message(
         self,
@@ -1338,6 +1365,7 @@ class CodexCliRuntime:
                         tool_input={"command": command},
                         content=f"Calling tool: Bash: {command}",
                         handle=current_handle,
+                        extra_data=self._extract_command_metadata(item),
                     )
                 ]
 
@@ -1354,8 +1382,8 @@ class CodexCliRuntime:
                 ]
 
             if item_type == "file_change":
-                file_path = self._extract_path(item)
-                if not file_path:
+                file_paths = self._extract_paths(item)
+                if not file_paths:
                     return []
                 return [
                     self._build_tool_message(
@@ -1364,6 +1392,7 @@ class CodexCliRuntime:
                         content=f"Calling tool: Edit: {file_path}",
                         handle=current_handle,
                     )
+                    for file_path in file_paths
                 ]
 
             if item_type == "web_search":

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -186,7 +186,16 @@ def _runtime_message_file_path_values(message: AgentMessage) -> tuple[str, ...]:
     structured path extraction separate from broad text search so read-only text
     mentions still cannot prove ``files_touched``.
     """
-    path_keys = {"file_path", "filepath", "filePath", "path", "target_file", "targetFile"}
+    path_keys = {
+        "file_path",
+        "filepath",
+        "filePath",
+        "notebook_path",
+        "notebookPath",
+        "path",
+        "target_file",
+        "targetFile",
+    }
     values: list[str] = []
 
     def visit(value: object) -> None:
@@ -531,6 +540,7 @@ def _test_command_targets_claim(
     command: str,
     claim: str,
     chunk_text: str,
+    messages: tuple[AgentMessage, ...],
     task_cwd: str | None,
 ) -> bool:
     """Return True when a successful test command can cover a test claim."""
@@ -546,11 +556,10 @@ def _test_command_targets_claim(
     if normalized_file in chunk_text or normalized_file in normalized_command:
         return True
 
-    # A broad suite command such as ``pytest`` covers an existing claimed test
-    # file when its own output reports success. This keeps unrelated targeted
-    # commands (for example ``pytest tests/test_a.py`` while claiming
-    # ``tests/test_b.py``) rejected, but lets real Codex CLI transcripts that
-    # only report ``pytest`` + ``1 passed`` support node-id evidence.
+    # A broad suite command such as ``pytest`` can cover a node-id claim when
+    # the claimed test file is also backed by current-run mutation evidence.
+    # Existence alone is deliberately insufficient: otherwise a transcript with
+    # unrelated ``pytest`` output could prove any stale test file in the tree.
     command_parts = normalized_command.split()
     broad_pytest = command_parts in (["pytest"], ["py.test"]) or command_parts[-3:] == [
         "python",
@@ -559,16 +568,7 @@ def _test_command_targets_claim(
     ]
     if not broad_pytest or task_cwd is None:
         return False
-    candidate = Path(file_part)
-    if candidate.is_absolute() or ".." in candidate.parts:
-        return False
-    base = Path(task_cwd).resolve()
-    resolved = (base / candidate).resolve()
-    try:
-        resolved.relative_to(base)
-    except ValueError:
-        return False
-    return resolved.exists()
+    return _runtime_messages_support_file_claim(file_part, messages, task_cwd=task_cwd)
 
 
 def _runtime_messages_support_test_claim(
@@ -606,6 +606,7 @@ def _runtime_messages_support_test_claim(
                 command=command,
                 claim=value,
                 chunk_text=chunk_text,
+                messages=messages,
                 task_cwd=task_cwd,
             )
             for command in matching_commands

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -178,6 +178,69 @@ def _runtime_message_search_text(message: AgentMessage) -> str:
     return "\n".join(parts).lower()
 
 
+def _runtime_message_file_path_values(message: AgentMessage) -> tuple[str, ...]:
+    """Return explicit file path values carried by a runtime message.
+
+    Codex/OpenCode file-change events may report absolute workspace paths while
+    typed evidence should normally claim workspace-relative paths. Keep this
+    structured path extraction separate from broad text search so read-only text
+    mentions still cannot prove ``files_touched``.
+    """
+    path_keys = {"file_path", "filepath", "filePath", "path", "target_file", "targetFile"}
+    values: list[str] = []
+
+    def visit(value: object) -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                if key in path_keys and isinstance(child, str) and child.strip():
+                    values.append(child.strip())
+                else:
+                    visit(child)
+        elif isinstance(value, (list, tuple)):
+            for child in value:
+                visit(child)
+
+    for container_key in ("tool_input", "input", "arguments", "args"):
+        visit(message.data.get(container_key))
+    return tuple(values)
+
+
+def _file_claim_matches_runtime_path(
+    claim: str,
+    runtime_path: str,
+    *,
+    task_cwd: str | None,
+) -> bool:
+    """Return True when a claimed workspace path matches a runtime path value."""
+    claim_path = Path(claim.strip())
+    if not claim_path or claim_path.is_absolute() or ".." in claim_path.parts:
+        return False
+
+    runtime_path = runtime_path.strip()
+    if not runtime_path:
+        return False
+
+    runtime_candidate = Path(runtime_path)
+    if task_cwd is not None:
+        base = Path(task_cwd).resolve()
+        claimed_absolute = (base / claim_path).resolve()
+        runtime_absolute = (
+            runtime_candidate if runtime_candidate.is_absolute() else base / runtime_candidate
+        ).resolve()
+        try:
+            claimed_absolute.relative_to(base)
+            runtime_absolute.relative_to(base)
+        except ValueError:
+            return False
+        return runtime_absolute == claimed_absolute
+
+    normalized_claim = claim_path.as_posix().lower()
+    normalized_runtime = runtime_candidate.as_posix().lower()
+    return normalized_runtime == normalized_claim or normalized_runtime.endswith(
+        "/" + normalized_claim
+    )
+
+
 def _runtime_support_messages_for_field(
     field_name: str,
     messages: tuple[AgentMessage, ...],
@@ -225,7 +288,13 @@ def _runtime_messages_support_file_claim(
     except ValueError:
         return False
     if any(
-        _runtime_message_supports_file_reference(value, message, messages=messages, index=index)
+        _runtime_message_supports_file_reference(
+            value,
+            message,
+            messages=messages,
+            index=index,
+            task_cwd=task_cwd,
+        )
         for index, message in enumerate(messages)
     ):
         return True
@@ -238,6 +307,7 @@ def _runtime_messages_support_file_claim(
             message,
             messages=messages,
             index=index,
+            task_cwd=task_cwd,
             allow_bash_command_text=False,
         )
         for index, message in enumerate(messages)
@@ -250,6 +320,7 @@ def _runtime_message_supports_file_reference(
     *,
     messages: tuple[AgentMessage, ...],
     index: int,
+    task_cwd: str | None,
     allow_bash_command_text: bool = True,
 ) -> bool:
     """Return True when one message plausibly reports touching a file reference."""
@@ -261,10 +332,13 @@ def _runtime_message_supports_file_reference(
         return _text_supports_file_mutation_reference(text, normalized_reference) or (
             allow_bash_command_text
             and _bash_command_mutates_file_reference(message, normalized_reference)
-            and _runtime_message_has_following_success(messages, index)
+            and _runtime_message_has_success_evidence(message, messages=messages, index=index)
         )
     if message.tool_name in {"Edit", "Write", "NotebookEdit"}:
-        return bool(text and _file_reference_pattern(normalized_reference).search(text))
+        return any(
+            _file_claim_matches_runtime_path(reference, path, task_cwd=task_cwd)
+            for path in _runtime_message_file_path_values(message)
+        )
     return _text_supports_file_mutation_reference(text, normalized_reference)
 
 
@@ -328,6 +402,48 @@ def _bash_command_mutates_file_reference(message: AgentMessage, normalized_refer
     )
 
 
+def _runtime_message_has_success_signal(message: AgentMessage) -> bool:
+    """Return True when one runtime message carries successful completion evidence."""
+    if message.is_error:
+        return False
+    exit_code = message.data.get("exit_code")
+    if isinstance(exit_code, int):
+        return exit_code == 0
+    if message.data.get("subtype") == "success":
+        return True
+    status = message.data.get("status")
+    if isinstance(status, str) and status.strip().lower() in {
+        "completed",
+        "success",
+        "succeeded",
+    }:
+        return True
+    text = "\n".join(
+        str(part)
+        for part in (
+            message.content,
+            message.data.get("result_preview"),
+            message.data.get("output"),
+            message.data.get("stdout"),
+            message.data.get("stderr"),
+        )
+        if isinstance(part, str)
+    ).lower()
+    return bool(re.search(r"\b(exit\s*code\s*0|completed|succeeded|success)\b", text))
+
+
+def _runtime_message_has_success_evidence(
+    message: AgentMessage,
+    *,
+    messages: tuple[AgentMessage, ...],
+    index: int,
+) -> bool:
+    """Return True when a tool-call message itself or its result proves success."""
+    if _runtime_message_has_success_signal(message):
+        return True
+    return _runtime_message_has_following_success(messages, index)
+
+
 def _runtime_message_has_following_success(messages: tuple[AgentMessage, ...], index: int) -> bool:
     """Return True when a tool-call message is followed by a successful result."""
     for candidate in messages[index + 1 :]:
@@ -335,22 +451,7 @@ def _runtime_message_has_following_success(messages: tuple[AgentMessage, ...], i
             return False
         if candidate.is_error:
             return False
-        exit_code = candidate.data.get("exit_code")
-        if isinstance(exit_code, int):
-            return exit_code == 0
-        if candidate.data.get("subtype") == "success":
-            return True
-        text = "\n".join(
-            str(part)
-            for part in (
-                candidate.content,
-                candidate.data.get("result_preview"),
-                candidate.data.get("output"),
-                candidate.data.get("stdout"),
-            )
-            if isinstance(part, str)
-        ).lower()
-        if re.search(r"\b(exit\s*code\s*0|completed|succeeded|success)\b", text):
+        if _runtime_message_has_success_signal(candidate):
             return True
     return False
 
@@ -416,11 +517,66 @@ def _message_contains_test_success(message: AgentMessage) -> bool:
     )
 
 
+def _test_claim_file_part(value: str) -> str | None:
+    """Return the file path portion of a pytest node-id style claim."""
+    stripped = value.strip()
+    if not stripped:
+        return None
+    file_part = stripped.split("::", 1)[0].strip()
+    return file_part or None
+
+
+def _test_command_targets_claim(
+    *,
+    command: str,
+    claim: str,
+    chunk_text: str,
+    task_cwd: str | None,
+) -> bool:
+    """Return True when a successful test command can cover a test claim."""
+    needle = claim.strip().lower()
+    if needle and needle in chunk_text:
+        return True
+
+    file_part = _test_claim_file_part(claim)
+    if file_part is None:
+        return False
+    normalized_file = file_part.lower()
+    normalized_command = command.lower()
+    if normalized_file in chunk_text or normalized_file in normalized_command:
+        return True
+
+    # A broad suite command such as ``pytest`` covers an existing claimed test
+    # file when its own output reports success. This keeps unrelated targeted
+    # commands (for example ``pytest tests/test_a.py`` while claiming
+    # ``tests/test_b.py``) rejected, but lets real Codex CLI transcripts that
+    # only report ``pytest`` + ``1 passed`` support node-id evidence.
+    command_parts = normalized_command.split()
+    broad_pytest = command_parts in (["pytest"], ["py.test"]) or command_parts[-3:] == [
+        "python",
+        "-m",
+        "pytest",
+    ]
+    if not broad_pytest or task_cwd is None:
+        return False
+    candidate = Path(file_part)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        return False
+    base = Path(task_cwd).resolve()
+    resolved = (base / candidate).resolve()
+    try:
+        resolved.relative_to(base)
+    except ValueError:
+        return False
+    return resolved.exists()
+
+
 def _runtime_messages_support_test_claim(
     *,
     value: str,
     backed_commands: tuple[str, ...],
     messages: tuple[AgentMessage, ...],
+    task_cwd: str | None,
 ) -> bool:
     """Return True when a backed test command chunk proves one test claim."""
     needle = value.strip().lower()
@@ -429,21 +585,31 @@ def _runtime_messages_support_test_claim(
     for index, message in enumerate(messages):
         if message.tool_name != "Bash":
             continue
-        if not any(
-            _looks_like_test_command(candidate)
-            and _runtime_messages_support_claim(candidate, (message,))
+        matching_commands = tuple(
+            candidate
             for candidate in backed_commands
-        ):
+            if _looks_like_test_command(candidate)
+            and _runtime_messages_support_claim(candidate, (message,))
+        )
+        if not matching_commands:
             continue
         chunk = [message]
         for following in messages[index + 1 :]:
             if following.tool_name == "Bash":
                 break
             chunk.append(following)
-        chunk_text = "\n".join(_runtime_message_search_text(item) for item in chunk)
-        if needle not in chunk_text:
+        if not any(_message_contains_test_success(item) for item in chunk):
             continue
-        if any(_message_contains_test_success(item) for item in chunk):
+        chunk_text = "\n".join(_runtime_message_search_text(item) for item in chunk)
+        if any(
+            _test_command_targets_claim(
+                command=command,
+                claim=value,
+                chunk_text=chunk_text,
+                task_cwd=task_cwd,
+            )
+            for command in matching_commands
+        ):
             return True
     return False
 
@@ -4205,6 +4371,7 @@ Files present:
                         value=value,
                         backed_commands=backed_commands,
                         messages=support_messages,
+                        task_cwd=self._task_cwd or self._adapter.working_directory,
                     ):
                         continue
                     unsupported.append(f"{field_name}: {value}")

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -661,6 +661,54 @@ class TestCodexCliRuntime:
         assert message.tool_name == "Bash"
         assert message.data["tool_input"]["command"] == "pytest -q"
 
+    def test_convert_command_execution_preserves_output_metadata(self) -> None:
+        """Command output must remain available for fat-harness verification."""
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "command_execution",
+                    "command": "pytest",
+                    "output": "1 passed in 0.01s",
+                    "exit_code": 0,
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 1
+        message = messages[0]
+        assert message.tool_name == "Bash"
+        assert message.data["tool_input"]["command"] == "pytest"
+        assert message.data["output"] == "1 passed in 0.01s"
+        assert message.data["exit_code"] == 0
+
+    def test_convert_file_change_event_emits_each_changed_file(self) -> None:
+        """Multi-file Codex changes should create one proof message per path."""
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "file_change",
+                    "changes": [
+                        {"path": "/tmp/project/hello.py"},
+                        {"path": "/tmp/project/test_hello.py"},
+                    ],
+                },
+            },
+            current_handle=None,
+        )
+
+        assert [message.tool_name for message in messages] == ["Edit", "Edit"]
+        assert [message.data["tool_input"]["file_path"] for message in messages] == [
+            "/tmp/project/hello.py",
+            "/tmp/project/test_hello.py",
+        ]
+
     def test_runtime_does_not_expose_local_dispatch_parser_helpers(self) -> None:
         """Dispatch parsing and metadata resolution live in the shared router."""
         obsolete_helpers = {

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1452,6 +1452,92 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_passed"] is True
 
     @pytest.mark.asyncio
+    async def test_fat_harness_verifier_accepts_codex_runtime_evidence_shape(
+        self, tmp_path
+    ) -> None:
+        """Regression for #978 post-#1025: Codex emits abs paths and same-message output."""
+        hello_file = tmp_path / "hello.py"
+        test_file = tmp_path / "test_hello.py"
+        hello_file.write_text('def hello():\n    return "hello"\n', encoding="utf-8")
+        test_file.write_text(
+            "from hello import hello\n\n"
+            "def test_hello_returns_hello():\n"
+            "    assert hello() == 'hello'\n",
+            encoding="utf-8",
+        )
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["hello.py", "test_hello.py"],\n'
+                '  "commands_run": ["pytest"],\n'
+                '  "tests_passed": ["test_hello.py::test_hello_returns_hello"]\n'
+                "}\n"
+                "```",
+                native_session_id="codex-session-post-1025-observation",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {hello_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(hello_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {test_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(test_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content="Calling tool: Bash: pytest",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {"command": "pytest"},
+                            "output": "1 passed in 0.01s",
+                            "exit_code": 0,
+                        },
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content='Create hello.py with hello() returning "hello".',
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        assert result.atomic_verifier_verdict is not None
+        assert result.atomic_verifier_verdict.passed is True
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["typed_evidence_present"] is True
+        assert evidence_event.data["typed_evidence_valid"] is True
+        assert evidence_event.data["verifier_ran"] is True
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
     async def test_fat_harness_rejects_command_result_wrapper_after_parsing_json_fence(
         self,
     ) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1538,6 +1538,149 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_passed"] is True
 
     @pytest.mark.asyncio
+    async def test_fat_harness_verifier_accepts_notebookedit_notebook_path(self, tmp_path) -> None:
+        """NotebookEdit reports its target as notebook_path, not file_path."""
+        notebook_file = tmp_path / "analysis.ipynb"
+        notebook_file.write_text("{}\n", encoding="utf-8")
+        test_file = tmp_path / "tests" / "test_analysis.py"
+        test_file.parent.mkdir()
+        test_file.write_text("def test_analysis():\n    assert True\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["analysis.ipynb"],\n'
+                '  "commands_run": ["pytest tests/test_analysis.py"],\n'
+                '  "tests_passed": ["tests/test_analysis.py"]\n'
+                "}\n"
+                "```",
+                native_session_id="codex-session-notebook-path",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content="Calling tool: NotebookEdit",
+                        tool_name="NotebookEdit",
+                        data={"tool_input": {"notebook_path": str(notebook_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content="Calling tool: Bash: pytest tests/test_analysis.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "pytest tests/test_analysis.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="tests/test_analysis.py passed; 1 passed",
+                        data={"subtype": "success"},
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Update notebook and tests.",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_bare_pytest_for_unmentioned_stale_test(
+        self, tmp_path
+    ) -> None:
+        """A bare pytest success must not prove arbitrary existing test files."""
+        generated_file = tmp_path / "src" / "generated.py"
+        generated_file.parent.mkdir()
+        generated_file.write_text("VALUE = 1\n", encoding="utf-8")
+        stale_test = tmp_path / "tests" / "test_other.py"
+        stale_test.parent.mkdir()
+        stale_test.write_text("def test_other():\n    assert True\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["src/generated.py"],\n'
+                '  "commands_run": ["pytest"],\n'
+                '  "tests_passed": ["tests/test_other.py::test_other"]\n'
+                "}\n"
+                "```",
+                native_session_id="codex-session-bare-pytest-unrelated-test",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {generated_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(generated_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content="Calling tool: Bash: pytest",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {"command": "pytest"},
+                            "output": "1 passed in 0.01s",
+                            "exit_code": 0,
+                        },
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement generated module.",
+            session_id="orch_123",
+            tools=["Read"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "tests_passed: tests/test_other.py::test_other" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is False
+
+    @pytest.mark.asyncio
     async def test_fat_harness_rejects_command_result_wrapper_after_parsing_json_fence(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

Fixes the post-#1025 #978 observation blocker where typed evidence is present, schema-valid, and verifier-invoked, but atomic verification rejects real Codex runtime-backed claims as unsupported.

The controlled post-#1025 run failed at:

- `files_touched: hello.py`
- `files_touched: test_hello.py`
- `tests_passed: test_hello.py::test_hello_returns_hello`

This PR aligns verifier support matching with the real Codex CLI transcript shape while preserving anti-fabrication guardrails.

Refs #978
Refs #961

## Changes

- Preserve Codex `command_execution` output metadata (`output` / `stdout` / `stderr` / `exit_code` / `status`) on Bash `AgentMessage`s so verifier success checks can inspect the command result.
- Convert multi-file Codex `file_change.changes[]` payloads into one file-proof message per changed path instead of only the first path.
- Let `files_touched` claims compare workspace-relative typed evidence paths against absolute runtime file-change paths.
- Let same-message successful Bash events support explicit shell mutation claims when the command/result are emitted together.
- Let successful broad pytest commands (`pytest`, `python -m pytest`) support an existing pytest node-id claim, while preserving targeted-test rejection.

## Scope guardrails

- No legacy self-report fallback removal.
- No #978 P5 readiness claim.
- No default behavior expansion.
- No new AgentOS substrate surface.
- Final self-report remains excluded from verifier support; evidence still must come from non-final runtime transcript messages.

## Validation

- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py -q` → 88 passed
- `uv run pytest tests/unit/orchestrator/test_codex_cli_runtime.py -q` → 53 passed
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/codex_cli_runtime.py tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_codex_cli_runtime.py` → passed
- `uv run ruff format --check src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/codex_cli_runtime.py tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_codex_cli_runtime.py` → passed
- `uv run mypy src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/orchestrator/codex_cli_runtime.py` → success
- Controlled #978 seed on this branch: AC1 produced `typed_evidence_present=true`, `typed_evidence_valid=true`, `verifier_ran=true`, `verifier_passed=true`. AC2 still failed because the two-AC seed is overlapping/redundant after AC1 creates the test file; post-merge #978 observation should use either the same seed for at-least-one positive signal or a non-overlapping controlled seed for full-run success.

## Follow-up

After merge, rerun #978 observation on clean `main` before proposing any fallback-removal PR. A controlled positive signal is still not enough to start #978 P5 by itself; #961 requires a later release/usage observation cycle.
