### PR TITLE
feat(codex): install runtime skill capability guide

### DIFF
--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -55,8 +55,8 @@ Before starting the interview, check if a newer version is available:
 curl -s --max-time 3 https://api.github.com/repos/Q00/ouroboros/releases/latest | grep -o '"tag_name": "[^"]*"' | head -1
 ```
 
-Compare the result with the current version in `.claude-plugin/plugin.json`.
-- If a newer version exists, ask the user via `AskUserQuestion`:
+Compare the result with the current version in the active runtime's local plugin metadata (for Claude installs this is `.claude-plugin/plugin.json`).
+- If a newer version exists, ask the user through the active runtime's `ask_user` capability:
   ```json
   {
     "questions": [{
@@ -71,8 +71,10 @@ Compare the result with the current version in `.claude-plugin/plugin.json`.
   }
   ```
   - If "Update now":
-    1. Run `claude plugin marketplace update ouroboros` via Bash (refresh marketplace index). If this fails, tell the user "⚠️ Marketplace refresh failed, continuing…" and proceed.
-    2. Run `claude plugin update ouroboros@ouroboros` via Bash (update plugin/skills). If this fails, inform the user and stop — do NOT proceed to step 3.
+    - On Claude-plugin installs only:
+      1. Run `claude plugin marketplace update ouroboros` via the active runtime's `run_shell` capability (refresh marketplace index). If this fails, tell the user "⚠️ Marketplace refresh failed, continuing…" and proceed.
+      2. Run `claude plugin update ouroboros@ouroboros` via the active runtime's `run_shell` capability (update plugin/skills). If this fails, inform the user and stop — do NOT proceed to the package-manager step.
+    - On non-Claude runtimes, skip Claude plugin commands and proceed directly to the package-manager step for `ouroboros-ai`; do not require Claude-only commands or tools.
     3. Detect the user's Python package manager and upgrade the MCP server:
        - Check which tool installed `ouroboros-ai` by running these in order:
          - `uv tool list 2>/dev/null | grep "^ouroboros-ai "` → if found, use `uv tool upgrade ouroboros-ai`
@@ -88,22 +90,22 @@ Then choose the execution path:
 
 The Ouroboros MCP tools are often registered as **deferred tools** that must be explicitly loaded before use. **You MUST perform this step before deciding between Path A and Path B.**
 
-1. Use the `ToolSearch` tool to find and load the interview MCP tool:
+1. Use the active runtime's tool-discovery capability to find and load the interview MCP tool:
    ```
-   ToolSearch query: "+ouroboros interview"
+   tool discovery query: "+ouroboros interview"
    ```
    This searches for tools with "ouroboros" in the name related to "interview".
 
-2. The tool will typically be named `mcp__plugin_ouroboros_ouroboros__ouroboros_interview` (with a plugin prefix). After ToolSearch returns, the tool becomes callable.
+2. The tool will typically be named `mcp__plugin_ouroboros_ouroboros__ouroboros_interview` (with a plugin prefix). After runtime tool discovery returns, the tool becomes callable.
 
-3. If ToolSearch finds the tool → proceed to **Path A**.
-   If ToolSearch returns no matching tools → proceed to **Path B**.
+3. If runtime tool discovery finds the tool → proceed to **Path A**.
+   If runtime tool discovery returns no matching tools → proceed to **Path B**.
 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
 ### Path A: MCP Mode (Preferred)
 
-If the `ouroboros_interview` MCP tool is available (loaded via ToolSearch above), use it for persistent, structured interviews.
+If the `ouroboros_interview` MCP tool is available (loaded via runtime tool discovery above), use it for persistent, structured interviews.
 
 **Architecture**: MCP is a pure question generator. You (the main session) are the answerer and router.
 
@@ -113,7 +115,7 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
 
 **Role split**:
 - **MCP**: Generates Socratic questions, manages interview state, scores ambiguity. Does NOT read code.
-- **You (main session)**: Receives MCP questions, answers them by reading code (Read/Glob/Grep), or routes to the user when human judgment is needed.
+- **You (main session)**: Receives MCP questions, answers them by reading code through the active runtime's `inspect_code` capability, or routes to the user when human judgment is needed.
 - **User**: Only answers questions that require human decisions (goals, acceptance criteria, business logic, preferences).
 
 #### Interview Flow
@@ -132,7 +134,7 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    **PATH 1 — Code Answer** (describe current state from codebase):
    When the question asks about existing tech stack, frameworks, dependencies,
    current patterns, architecture, or file structure:
-   - Use Read/Glob/Grep to find the factual answer
+   - Use the active runtime's `inspect_code` capability to find the factual answer
    - **Description, not prescription**: "The project uses JWT" is fact.
      "The new feature should also use JWT" is a DECISION — route to PATH 2.
    - Evaluate confidence and choose sub-path:
@@ -162,7 +164,7 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    **PATH 1b — Code Confirmation** (medium/low confidence, user confirms):
    When the codebase has relevant information but confidence is not high enough
    for auto-confirm (inferred from patterns, multiple candidates, or no manifest match):
-   - Present findings to user as a **confirmation question** via AskUserQuestion:
+   - Present findings to user as a **confirmation question** through the active runtime's `ask_user` capability:
      ```json
      {
        "questions": [{
@@ -180,8 +182,7 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    - If the user picks "Yes, correct", send the concise factual answer with
      `[from-code]` and do not apply the Refine gate. Increment the
      auto-confirm counter (see Dialectic Rhythm Guard below).
-   - If the user picks "No, let me correct", immediately ask a second
-     AskUserQuestion to collect the corrected answer as free text:
+   - If the user picks "No, let me correct", immediately use the `ask_user` capability to collect the corrected answer as free text:
      ```json
      {
        "questions": [{
@@ -203,13 +204,13 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    **PATH 2 — Human Judgment** (decisions only humans can make):
    When the question asks about goals, vision, acceptance criteria, business logic,
    preferences, tradeoffs, scope, or desired behavior for NEW features:
-   - Present question directly to user via AskUserQuestion with suggested options
+   - Present question directly to user through the active runtime's `ask_user` capability with suggested options
    - Prefix answer with `[from-user]` when sending to MCP
 
    **PATH 3 — Code + Judgment** (facts exist but interpretation needed):
    When code contains relevant facts BUT the question also requires judgment
    (e.g., "I see a saga pattern in orders/. Should payments use the same?"):
-   - Read relevant code first
+   - Use the active runtime's `inspect_code` capability to read relevant code first
    - Present BOTH the code findings AND the question to user
    - If any part of the question requires judgment, route the ENTIRE question to user
    - Prefix answer with `[from-user]` (human made the decision)
@@ -218,8 +219,8 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    When the question asks about third-party APIs, pricing models, library
    capabilities, version compatibility, security advisories, or industry
    standards that are NOT answerable from the local codebase:
-   - Use WebFetch/WebSearch to gather external information
-   - Present findings to user as a **confirmation question** via AskUserQuestion
+   - Use the active runtime's `web_research` capability to gather external information
+   - Present findings to user as a **confirmation question** through the active runtime's `ask_user` capability
      (same pattern as PATH 1, but with web sources instead of code):
      ```json
      {
@@ -238,8 +239,7 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    - If the user picks "Yes, correct", send the concise factual answer with
      `[from-research]` and do not apply the Refine gate. Increment the
      auto-confirm counter (see Dialectic Rhythm Guard below).
-   - If the user picks "No, let me correct", immediately ask a second
-     AskUserQuestion to collect the corrected answer as free text:
+   - If the user picks "No, let me correct", immediately use the `ask_user` capability to collect the corrected answer as free text:
      ```json
      {
        "questions": [{
@@ -320,7 +320,7 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    When the user gives a free-text answer that carries reasoning, constraints,
    or scope decisions, do NOT forward it to MCP unmodified and do NOT compress
    it to a label. Structure it into the multi-section payload above, then ask
-   the user a single AskUserQuestion to confirm nothing is lost:
+   the user a single `ask_user` capability to confirm nothing is lost:
 
    ```json
    {
@@ -364,7 +364,7 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
 
    If the user picks "Add to Constraints", "Add to Out of scope", "Add context",
    or "Rewrite", do not infer the missing text from the option label. Immediately
-   ask one follow-up AskUserQuestion to collect the exact text:
+   use the `ask_user` capability for one follow-up to collect the exact text:
    ```json
    {
      "questions": [{
@@ -435,7 +435,7 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    ```
 
    Only after the user accepts the restated line do you suggest `ooo seed`.
-   If the user picks "Adjust wording", immediately ask a second AskUserQuestion
+   If the user picks "Adjust wording", immediately use the `ask_user` capability
    to collect the replacement wording:
    ```json
    {
@@ -446,7 +446,7 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    }
    ```
 
-   If the user picks "Missing scope", immediately ask a second AskUserQuestion
+   If the user picks "Missing scope", immediately use the `ask_user` capability
    to collect the missing condition or boundary:
    ```json
    {
@@ -533,7 +533,7 @@ response carries this `meta.reason` (with `meta.recoverable=true` and
 `is_error=false` — the wire success/failure axis is intentionally **not**
 flipped, to keep existing callers like the auto driver working), the text
 body is a meta-directive asking *you* to re-send a shorter context — it is
-**NOT** an interview question. Do not route it via AskUserQuestion.
+**NOT** an interview question. Do not route it through the active runtime's `ask_user` capability.
 Instead, produce a concise summary of the original `initial_context`
 (≤ `meta.max_chars` characters; covers goal, constraints, success criteria)
 and re-call `ouroboros_interview` with `session_id=<from meta>` and the
@@ -546,10 +546,10 @@ summary as `answer`. The next response will contain the real first question.
 If the MCP tool is NOT available, fall back to agent-based interview:
 
 1. Read `src/ouroboros/agents/socratic-interviewer.md` and adopt that role
-2. **Pre-scan the codebase**: Use Glob to check for config files (`pyproject.toml`, `package.json`, `go.mod`, etc.). If found, use Read/Grep to scan key files and incorporate findings into your questions as confirmation-style ("I see X. Should I assume Y?") rather than open-ended discovery ("Do you have X?")
+2. **Pre-scan the codebase**: Use the active runtime's `inspect_code` capability to check for config files (`pyproject.toml`, `package.json`, `go.mod`, etc.). If found, inspect key files and incorporate findings into your questions as confirmation-style ("I see X. Should I assume Y?") rather than open-ended discovery ("Do you have X?")
 3. Ask clarifying questions based on the user's topic and codebase context
-4. **Present each question using AskUserQuestion** with contextually relevant suggested answers (same format as Path A step 2)
-5. Use Read, Glob, Grep, WebFetch to explore further context if needed
+4. **Present each question using the active runtime's `ask_user` capability** with contextually relevant suggested answers (same format as Path A step 2)
+5. Use the active runtime's `inspect_code` and `web_research` capabilities to explore further context if needed
 6. Maintain the same ambiguity ledger and breadth-check behavior as in Path A:
    - Track multiple independent ambiguity threads
    - Revisit unresolved threads every few rounds
@@ -581,7 +581,7 @@ If the MCP tool is NOT available, fall back to agent-based interview:
 
 **You (main session)** are a Socratic facilitator:
 - Read `src/ouroboros/agents/socratic-interviewer.md` to understand the interview methodology
-- You CAN use Read/Glob/Grep to scan the codebase for answering MCP questions
+- You CAN use the active runtime's `inspect_code` capability to scan the codebase for answering MCP questions
 - For high-confidence factual questions (PATH 1a), auto-confirm and notify the user
 - For all other questions, present to user as confirmation or direct question
 - You NEVER make decisions on behalf of the user — auto-confirm is for FACTS only

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -11,6 +11,28 @@ mcp_args:
 
 Socratic interview to crystallize vague requirements into clear specifications.
 
+
+## Required Skill Capabilities
+
+- `ask_user` — ask human-judgment questions through the active runtime's user-question surface.
+- `inspect_code` — answer repo-local factual questions from exact local files before asking the user.
+- `call_mcp` — use Ouroboros MCP tools for persistent interview state and seed generation.
+- `web_research` — fetch current external facts only when the interview genuinely depends on them.
+- `run_shell` — run bounded local commands for version checks and repository inspection.
+- `refine_answer` — confirm structured interpretations of free-text answers before forwarding them.
+- `maintain_ledger` — keep ambiguity, gates, and unresolved decisions visible in the main session.
+- `run_closure_gate` — audit readiness locally even when MCP reports `seed-ready`.
+- `restate_goal` — restate the goal and require explicit approval before seed generation.
+
+## Non-Skippable Gates
+
+- Refine free-text answers that carry scope, constraints, or decisions.
+- Maintain a visible ambiguity ledger in the main session.
+- Treat MCP `seed-ready` as permission to audit closure, not as completion.
+- Apply Seed Closer criteria before suggesting or running seed generation.
+- Run the Restate gate before seed generation.
+- Require explicit user approval before suggesting or running seed generation.
+
 ## Usage
 
 ```

--- a/src/ouroboros/backends/__init__.py
+++ b/src/ouroboros/backends/__init__.py
@@ -2,10 +2,12 @@
 
 from ouroboros.backends.capabilities import (
     BackendCapability,
+    SkillExecutionCapability,
     backend_supports_tool_envelope,
     get_backend_capability,
     interview_driver_backend_choices,
     llm_backend_choices,
+    render_backend_skill_capability_guide,
     resolve_backend_alias,
     resolve_interview_driver_backend,
     resolve_llm_backend_name,
@@ -16,11 +18,13 @@ from ouroboros.backends.capabilities import (
 
 __all__ = [
     "BackendCapability",
+    "SkillExecutionCapability",
     "backend_supports_tool_envelope",
     "get_backend_capability",
     "interview_driver_backend_choices",
     "llm_backend_choices",
     "resolve_backend_alias",
+    "render_backend_skill_capability_guide",
     "resolve_interview_driver_backend",
     "resolve_llm_backend_name",
     "resolve_runtime_backend_name",

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -124,8 +124,20 @@ _GENERIC_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
         guidance="Call available Ouroboros MCP tools through the runtime's MCP/tool surface instead of emulating MCP workflows manually.",
     ),
     SkillExecutionCapability(
+        name="web_research",
+        guidance="Use the runtime's web/search capability only when current external facts are required, and cite the sources used.",
+    ),
+    SkillExecutionCapability(
+        name="run_shell",
+        guidance="Use the runtime's bounded local shell capability for safe repository/version checks; avoid destructive commands unless explicitly authorized.",
+    ),
+    SkillExecutionCapability(
         name="refine_answer",
         guidance="Confirm structured interpretations of free-text decisions before forwarding them to workflow state.",
+    ),
+    SkillExecutionCapability(
+        name="maintain_ledger",
+        guidance="Keep ambiguity, gates, and unresolved decisions visible in the main session rather than hiding them only in tool state.",
     ),
     SkillExecutionCapability(
         name="run_closure_gate",

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -12,6 +12,14 @@ from dataclasses import dataclass
 
 
 @dataclass(frozen=True, slots=True)
+class SkillExecutionCapability:
+    """Runtime-specific guidance for one abstract skill capability."""
+
+    name: str
+    guidance: str
+
+
+@dataclass(frozen=True, slots=True)
 class BackendCapability:
     """Capabilities and aliases for one canonical backend."""
 
@@ -25,12 +33,109 @@ class BackendCapability:
     cli_config_key: str | None = None
     soft_tool_enforcement: bool = False
     supports_tool_envelope: bool = True
+    skill_execution_capabilities: tuple[SkillExecutionCapability, ...] = ()
 
     @property
     def names(self) -> tuple[str, ...]:
         """Canonical name plus accepted aliases."""
         return (self.name, *self.aliases)
 
+
+_CODEX_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
+    SkillExecutionCapability(
+        name="ask_user",
+        guidance=(
+            "Ask directly in the main Codex conversation. Use `request_user_input` "
+            "only when that structured input tool is available; otherwise ask one "
+            "concise question and wait for the answer."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="inspect_code",
+        guidance=(
+            "Use local repository inspection with `rg`, `find`, `sed`, `cat`, and "
+            "`exec_command`; prefer reading exact files over guessing from memory."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="call_mcp",
+        guidance=(
+            "Use available Ouroboros MCP tools directly when exposed, and use "
+            "Codex tool discovery only when a deferred MCP surface must be loaded. "
+            "Do not rely on Claude-specific `ToolSearch` names."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="web_research",
+        guidance=(
+            "Use Codex web/search tooling only when current external evidence is "
+            "required; cite sources and keep repo-local facts grounded in local files."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="run_shell",
+        guidance=(
+            "Use `exec_command` for safe local shell commands, keep commands scoped, "
+            "and avoid destructive or external-production actions unless explicitly authorized."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="refine_answer",
+        guidance=(
+            "When a free-text answer carries scope, constraints, or decisions, restate "
+            "the structured interpretation and get confirmation before treating it as settled."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="maintain_ledger",
+        guidance=(
+            "Keep the ambiguity or acceptance ledger visible in concise updates; do not "
+            "hide unresolved gates inside MCP state alone."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="run_closure_gate",
+        guidance=(
+            "Treat MCP `seed-ready` as permission to audit closure in the main session, "
+            "not as completion by itself. Verify non-goals, constraints, acceptance criteria, "
+            "and unresolved decisions before moving on."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="restate_goal",
+        guidance=(
+            "Before suggesting or running seed generation, restate the goal, non-goals, "
+            "constraints, and acceptance criteria, then require explicit user approval."
+        ),
+    ),
+)
+
+_GENERIC_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
+    SkillExecutionCapability(
+        name="ask_user",
+        guidance="Use the runtime's native structured question surface when available; otherwise ask one concise question and wait.",
+    ),
+    SkillExecutionCapability(
+        name="inspect_code",
+        guidance="Use the runtime's local file search/read tools and prefer exact repository evidence over inference.",
+    ),
+    SkillExecutionCapability(
+        name="call_mcp",
+        guidance="Call available Ouroboros MCP tools through the runtime's MCP/tool surface instead of emulating MCP workflows manually.",
+    ),
+    SkillExecutionCapability(
+        name="refine_answer",
+        guidance="Confirm structured interpretations of free-text decisions before forwarding them to workflow state.",
+    ),
+    SkillExecutionCapability(
+        name="run_closure_gate",
+        guidance="Audit required client-side gates even when an MCP response says the workflow is ready to proceed.",
+    ),
+    SkillExecutionCapability(
+        name="restate_goal",
+        guidance="Restate the goal and require explicit approval before irreversible workflow transitions such as seed generation.",
+    ),
+)
 
 _CAPABILITIES: tuple[BackendCapability, ...] = (
     BackendCapability(
@@ -42,6 +147,7 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         switchable_runtime=True,
         cli_name="claude",
         cli_config_key="cli_path",
+        skill_execution_capabilities=_GENERIC_SKILL_EXECUTION_CAPABILITIES,
     ),
     BackendCapability(
         name="codex",
@@ -52,6 +158,7 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         switchable_runtime=True,
         cli_name="codex",
         cli_config_key="codex_cli_path",
+        skill_execution_capabilities=_CODEX_SKILL_EXECUTION_CAPABILITIES,
     ),
     BackendCapability(
         name="copilot",
@@ -61,6 +168,7 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         supports_interview_driver=True,
         cli_name="copilot",
         cli_config_key="copilot_cli_path",
+        skill_execution_capabilities=_GENERIC_SKILL_EXECUTION_CAPABILITIES,
     ),
     BackendCapability(
         name="gemini",
@@ -71,6 +179,7 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         switchable_runtime=True,
         cli_name="gemini",
         cli_config_key="gemini_cli_path",
+        skill_execution_capabilities=_GENERIC_SKILL_EXECUTION_CAPABILITIES,
         soft_tool_enforcement=True,
     ),
     BackendCapability(
@@ -82,6 +191,7 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         switchable_runtime=True,
         cli_name="hermes",
         cli_config_key="hermes_cli_path",
+        skill_execution_capabilities=_GENERIC_SKILL_EXECUTION_CAPABILITIES,
         supports_tool_envelope=False,
     ),
     BackendCapability(
@@ -92,6 +202,7 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         supports_interview_driver=True,
         cli_name="kiro",
         cli_config_key="kiro_cli_path",
+        skill_execution_capabilities=_GENERIC_SKILL_EXECUTION_CAPABILITIES,
     ),
     BackendCapability(
         name="opencode",
@@ -101,6 +212,7 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         supports_interview_driver=True,
         cli_name="opencode",
         cli_config_key="opencode_cli_path",
+        skill_execution_capabilities=_GENERIC_SKILL_EXECUTION_CAPABILITIES,
         soft_tool_enforcement=True,
     ),
     BackendCapability(
@@ -114,6 +226,29 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
 _BY_NAME: dict[str, BackendCapability] = {
     name: capability for capability in _CAPABILITIES for name in capability.names
 }
+
+
+def render_backend_skill_capability_guide(name: str) -> str:
+    """Render runtime-specific guidance for abstract skill capabilities as Markdown."""
+    capability = get_backend_capability(name)
+    if capability is None:
+        msg = f"Unsupported backend: {name.strip().lower()}"
+        raise ValueError(msg)
+
+    lines = [f"## Ouroboros Skill Capability Guide: {capability.name.title()}", ""]
+    if not capability.skill_execution_capabilities:
+        lines.append("No backend-specific skill execution capability guidance is registered yet.")
+        return "\n".join(lines).rstrip() + "\n"
+
+    for skill_capability in capability.skill_execution_capabilities:
+        lines.extend(
+            (
+                f"### When a skill requires `{skill_capability.name}`",
+                skill_capability.guidance,
+                "",
+            )
+        )
+    return "\n".join(lines).rstrip() + "\n"
 
 
 def get_backend_capability(name: str) -> BackendCapability | None:
@@ -195,11 +330,13 @@ def backend_supports_tool_envelope(name: str | None) -> bool:
 
 __all__ = [
     "BackendCapability",
+    "SkillExecutionCapability",
     "backend_supports_tool_envelope",
     "get_backend_capability",
     "interview_driver_backend_choices",
     "llm_backend_choices",
     "resolve_backend_alias",
+    "render_backend_skill_capability_guide",
     "resolve_interview_driver_backend",
     "resolve_llm_backend_name",
     "resolve_runtime_backend_name",

--- a/src/ouroboros/codex/artifacts.py
+++ b/src/ouroboros/codex/artifacts.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import shutil
 from typing import Literal
 
+from ouroboros.backends.capabilities import render_backend_skill_capability_guide
 from ouroboros.skills.artifacts import (
     SKILL_ENTRYPOINT,
     collect_skill_bundle_dirs,
@@ -18,8 +19,16 @@ from ouroboros.skills.artifacts import (
 
 CODEX_RULE_FILENAME = "ouroboros.md"
 CODEX_SKILL_NAMESPACE = "ouroboros-"
+_SKILL_CAPABILITY_GUIDE_MARKER = "<!-- ouroboros:skill-capability-guide -->"
 _RULE_NAMESPACE = Path(CODEX_RULE_FILENAME).stem
 _RULE_SUFFIX = Path(CODEX_RULE_FILENAME).suffix
+
+
+def _render_codex_rules(source: str) -> str:
+    """Return Codex rules with the generated skill capability guide appended."""
+    base = source.rstrip()
+    guide = render_backend_skill_capability_guide("codex").rstrip()
+    return f"{base}\n\n{_SKILL_CAPABILITY_GUIDE_MARKER}\n{guide}\n"
 
 
 @dataclass(frozen=True, slots=True)
@@ -267,7 +276,7 @@ def resolve_packaged_codex_assets(
 def load_packaged_codex_rules() -> str:
     """Load the packaged Codex rules markdown."""
     with _packaged_codex_rules_path() as resolved_rules_path:
-        return resolved_rules_path.read_text(encoding="utf-8")
+        return _render_codex_rules(resolved_rules_path.read_text(encoding="utf-8"))
 
 
 def load_packaged_codex_skill(
@@ -326,10 +335,15 @@ def install_codex_rules(
             if target_path.exists():
                 _remove_installed_artifact(target_path)
 
-            shutil.copy2(source_path, target_path)
-            installed_names.add(target_path.name)
             if source_path == primary_source_path:
+                target_path.write_text(
+                    _render_codex_rules(source_path.read_text(encoding="utf-8")),
+                    encoding="utf-8",
+                )
                 primary_target_path = target_path
+            else:
+                shutil.copy2(source_path, target_path)
+            installed_names.add(target_path.name)
 
     if prune:
         for installed_path in tuple(target_root.iterdir()):

--- a/src/ouroboros/codex/artifacts.py
+++ b/src/ouroboros/codex/artifacts.py
@@ -26,7 +26,7 @@ _RULE_SUFFIX = Path(CODEX_RULE_FILENAME).suffix
 
 def _render_codex_rules(source: str) -> str:
     """Return Codex rules with the generated skill capability guide appended."""
-    base = source.rstrip()
+    base = source.split(_SKILL_CAPABILITY_GUIDE_MARKER, 1)[0].rstrip()
     guide = render_backend_skill_capability_guide("codex").rstrip()
     return f"{base}\n\n{_SKILL_CAPABILITY_GUIDE_MARKER}\n{guide}\n"
 

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -7,6 +7,7 @@ from ouroboros.backends import (
     get_backend_capability,
     interview_driver_backend_choices,
     llm_backend_choices,
+    render_backend_skill_capability_guide,
     resolve_backend_alias,
     resolve_llm_backend_name,
     resolve_runtime_backend_name,
@@ -60,3 +61,34 @@ def test_switchable_runtime_metadata_is_registry_owned() -> None:
     assert capability.name == "gemini"
     assert capability.switchable_runtime is True
     assert capability.cli_config_key == "gemini_cli_path"
+
+
+def test_codex_skill_execution_guidance_is_registry_owned() -> None:
+    capability = get_backend_capability("codex_cli")
+
+    assert capability is not None
+    names = {item.name for item in capability.skill_execution_capabilities}
+    assert {
+        "ask_user",
+        "inspect_code",
+        "call_mcp",
+        "refine_answer",
+        "run_closure_gate",
+        "restate_goal",
+    }.issubset(names)
+
+
+def test_renders_codex_skill_capability_guide_as_stable_markdown() -> None:
+    guide = render_backend_skill_capability_guide("codex")
+
+    assert guide.startswith("## Ouroboros Skill Capability Guide: Codex\n")
+    assert "### When a skill requires `ask_user`" in guide
+    assert "request_user_input" in guide
+    assert "### When a skill requires `inspect_code`" in guide
+    assert "`rg`" in guide
+    assert "### When a skill requires `call_mcp`" in guide
+    assert "Do not rely on Claude-specific `ToolSearch` names." in guide
+    assert "### When a skill requires `run_closure_gate`" in guide
+    assert "MCP `seed-ready`" in guide
+    assert "### When a skill requires `restate_goal`" in guide
+    assert "require explicit user approval" in guide

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -72,7 +72,28 @@ def test_codex_skill_execution_guidance_is_registry_owned() -> None:
         "ask_user",
         "inspect_code",
         "call_mcp",
+        "web_research",
+        "run_shell",
         "refine_answer",
+        "maintain_ledger",
+        "run_closure_gate",
+        "restate_goal",
+    }.issubset(names)
+
+
+def test_generic_skill_execution_guidance_covers_interview_requirements() -> None:
+    capability = get_backend_capability("claude")
+
+    assert capability is not None
+    names = {item.name for item in capability.skill_execution_capabilities}
+    assert {
+        "ask_user",
+        "inspect_code",
+        "call_mcp",
+        "web_research",
+        "run_shell",
+        "refine_answer",
+        "maintain_ledger",
         "run_closure_gate",
         "restate_goal",
     }.issubset(names)

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -189,6 +189,17 @@ class TestLoadPackagedCodexSkills:
         assert "must be executed by invoking MCP tool `ouroboros_auto`" in skill
         assert "manual fallback is not an `ooo auto` run" in skill
 
+    def test_packaged_interview_skill_uses_runtime_capability_terms(self) -> None:
+        """Runtime skill instructions should not hardcode Claude-only tool surfaces."""
+        skill = load_packaged_codex_skill("interview")
+
+        assert "AskUserQuestion" not in skill
+        assert "ToolSearch" not in skill
+        assert "Read/Glob/Grep" not in skill
+        assert "WebFetch/WebSearch" not in skill
+        assert "active runtime's `ask_user` capability" in skill
+        assert "active runtime's tool-discovery capability" in skill
+
     def test_raises_when_explicit_packaged_skill_is_missing(self, tmp_path: Path) -> None:
         """Missing skill entrypoints should fail fast."""
         packaged_skills_dir = tmp_path / "packaged-skills"

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -133,6 +133,24 @@ class TestInstallCodexRules:
         assert "### When a skill requires `run_closure_gate`" in rules
         assert "MCP `seed-ready`" in rules
 
+    def test_rendered_skill_capability_guide_is_idempotent(self, tmp_path: Path) -> None:
+        """Refreshing from an already rendered rule source should not duplicate the guide."""
+        packaged_rules_dir = tmp_path / "packaged-rules"
+        rendered_once = (
+            f"# custom rules\n\n{_SKILL_CAPABILITY_GUIDE_MARKER}\n## stale generated guide\n"
+        )
+        self._write_rule(packaged_rules_dir, CODEX_RULE_FILENAME, rendered_once)
+
+        installed_path = install_codex_rules(
+            codex_dir=tmp_path / ".codex",
+            rules_dir=packaged_rules_dir,
+        )
+        installed_content = installed_path.read_text(encoding="utf-8")
+
+        assert installed_content.count(_SKILL_CAPABILITY_GUIDE_MARKER) == 1
+        assert "## stale generated guide" not in installed_content
+        assert "## Ouroboros Skill Capability Guide: Codex" in installed_content
+
 
 class TestLoadPackagedCodexSkills:
     """Test packaged Codex skill entrypoint resolution helpers."""

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from ouroboros.codex.artifacts import (
+    _SKILL_CAPABILITY_GUIDE_MARKER,
     CODEX_RULE_FILENAME,
     CODEX_SKILL_NAMESPACE,
     CodexManagedArtifact,
@@ -58,7 +59,9 @@ class TestInstallCodexRules:
         installed_path = install_codex_rules(codex_dir=codex_dir, rules_dir=packaged_rules_dir)
 
         assert installed_path == target_path
-        assert installed_path.read_text(encoding="utf-8") == "# fresh rules\n"
+        installed_content = installed_path.read_text(encoding="utf-8")
+        assert installed_content.startswith("# fresh rules\n")
+        assert _SKILL_CAPABILITY_GUIDE_MARKER in installed_content
         assert secondary_target_path.read_text(encoding="utf-8") == "# status rules\n"
         assert not rules_dir.joinpath("team.md").exists()
 
@@ -77,7 +80,9 @@ class TestInstallCodexRules:
         installed_path = install_codex_rules(codex_dir=codex_dir, rules_dir=packaged_rules_dir)
 
         assert installed_path == rules_dir / CODEX_RULE_FILENAME
-        assert installed_path.read_text(encoding="utf-8") == "# fresh rules\n"
+        installed_content = installed_path.read_text(encoding="utf-8")
+        assert installed_content.startswith("# fresh rules\n")
+        assert _SKILL_CAPABILITY_GUIDE_MARKER in installed_content
         assert stale_namespaced_rule.read_text(encoding="utf-8") == "keep for refresh-only"
         assert unrelated_rule.read_text(encoding="utf-8") == "keep me"
 
@@ -101,7 +106,9 @@ class TestInstallCodexRules:
         )
 
         assert installed_path == rules_dir / CODEX_RULE_FILENAME
-        assert installed_path.read_text(encoding="utf-8") == "# upgraded rules\n"
+        installed_content = installed_path.read_text(encoding="utf-8")
+        assert installed_content.startswith("# upgraded rules\n")
+        assert _SKILL_CAPABILITY_GUIDE_MARKER in installed_content
         assert rules_dir.joinpath("ouroboros-status.md").read_text(encoding="utf-8") == (
             "# upgraded status\n"
         )
@@ -115,6 +122,16 @@ class TestInstallCodexRules:
         assert "| `ooo auto ...` | `ouroboros_auto`" in rules
         assert "Do not emulate it with manual" in rules
         assert "If that MCP tool\nis unavailable" in rules
+
+    def test_packaged_rules_include_rendered_skill_capability_guide(self) -> None:
+        """Codex rules should include the generated runtime skill capability guide."""
+        rules = load_packaged_codex_rules()
+
+        assert _SKILL_CAPABILITY_GUIDE_MARKER in rules
+        assert "## Ouroboros Skill Capability Guide: Codex" in rules
+        assert "### When a skill requires `ask_user`" in rules
+        assert "### When a skill requires `run_closure_gate`" in rules
+        assert "MCP `seed-ready`" in rules
 
 
 class TestLoadPackagedCodexSkills:
@@ -597,7 +614,9 @@ class TestCodexAssetSyncSmoke:
         )
 
         assert installed_rule == codex_dir / "rules" / CODEX_RULE_FILENAME
-        assert installed_rule.read_text(encoding="utf-8") == "# codex rules v1\n"
+        installed_content = installed_rule.read_text(encoding="utf-8")
+        assert installed_content.startswith("# codex rules v1\n")
+        assert _SKILL_CAPABILITY_GUIDE_MARKER in installed_content
         assert installed_skills == (
             codex_dir / "skills" / f"{CODEX_SKILL_NAMESPACE}run",
             codex_dir / "skills" / f"{CODEX_SKILL_NAMESPACE}setup",
@@ -680,7 +699,9 @@ class TestCodexAssetSyncSmoke:
         )
 
         assert installed_rule == codex_dir / "rules" / CODEX_RULE_FILENAME
-        assert installed_rule.read_text(encoding="utf-8") == "# codex rules v2\n"
+        installed_content = installed_rule.read_text(encoding="utf-8")
+        assert installed_content.startswith("# codex rules v2\n")
+        assert _SKILL_CAPABILITY_GUIDE_MARKER in installed_content
         assert installed_skills == (
             codex_dir / "skills" / f"{CODEX_SKILL_NAMESPACE}interview",
             codex_dir / "skills" / f"{CODEX_SKILL_NAMESPACE}run",


### PR DESCRIPTION
## Summary

Implements the Phase 1 Codex path from #1008:

- extends the canonical backend capability registry with `SkillExecutionCapability` metadata;
- adds `render_backend_skill_capability_guide(name)` for stable Markdown rendering;
- registers Codex-specific guidance for `ask_user`, `inspect_code`, `call_mcp`, `web_research`, `run_shell`, `refine_answer`, `maintain_ledger`, `run_closure_gate`, and `restate_goal`;
- installs the rendered Codex guide into the managed Codex rules artifact;
- front-loads `skills/interview/SKILL.md` with concise Required Skill Capabilities and Non-Skippable Gates.

## Issue #1008 validity check

#1008 is directionally valid. The repo already has a backend-owned capability registry in `src/ouroboros/backends/capabilities.py`, while `skills/interview/SKILL.md` currently mixes runtime-neutral interview gates with Claude/OpenCode-shaped tool instructions. Putting execution guidance in backend metadata avoids adding a parallel tool graph and avoids copying adapter guidance into every skill.

## Scope boundaries

This PR intentionally covers the Codex end-to-end path only. Follow-up PRs should wire the same renderer into Hermes/Claude and then the remaining supported runtime artifact surfaces, plus MCP hard gates.

## Validation

```bash
uv run pytest tests/unit/backends/test_capabilities.py tests/unit/test_codex_artifacts.py tests/unit/cli/test_setup.py -q
# 161 passed

uv run mypy src/ouroboros/backends/capabilities.py src/ouroboros/codex/artifacts.py tests/unit/backends/test_capabilities.py tests/unit/test_codex_artifacts.py
# Success: no issues found in 4 source files

uv run ruff check src/ouroboros/backends/capabilities.py src/ouroboros/backends/__init__.py src/ouroboros/codex/artifacts.py tests/unit/backends/test_capabilities.py tests/unit/test_codex_artifacts.py
# All checks passed!

uv run ruff format --check src/ouroboros/backends/capabilities.py src/ouroboros/backends/__init__.py src/ouroboros/codex/artifacts.py tests/unit/backends/test_capabilities.py tests/unit/test_codex_artifacts.py
# 5 files already formatted
```

Refs #1008.
