### PR TITLE
feat(orchestrator): add Workflow IR lifecycle contract

### DIFF
--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -394,6 +394,21 @@ def next_runnable_node_ids(
     dispatch work.
     """
     event_list = tuple(event for event in events if event.workflow_id == spec.spec_id)
+    latest_run_event = next(
+        (
+            event
+            for event in sorted(event_list, key=lambda item: item.timestamp, reverse=True)
+            if event.event_type in _RUN_EVENT_TYPES
+        ),
+        None,
+    )
+    if latest_run_event is not None and latest_run_event.event_type in {
+        WorkflowLifecycleEventType.RUN_COMPLETED,
+        WorkflowLifecycleEventType.RUN_FAILED,
+        WorkflowLifecycleEventType.RUN_CANCELLED,
+    }:
+        return ()
+
     states = effective_node_states(event_list)
     completed = {
         node_id

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -1,0 +1,428 @@
+"""Workflow IR lifecycle event contract.
+
+This module is the narrow #956 lifecycle slice over the existing
+``WorkflowSpec`` schema. It defines bounded, replay-safe lifecycle records
+that can be persisted as events and later projected without making the IR
+the live ``parallel_executor`` dispatch source.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
+from enum import StrEnum
+import json
+from types import MappingProxyType
+from typing import Any, Final, cast
+
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.orchestrator.workflow_ir import WorkflowNode, WorkflowSpec
+
+WORKFLOW_LIFECYCLE_SCHEMA_VERSION: Final[int] = 1
+MAX_WORKFLOW_LIFECYCLE_DATA_BYTES: Final[int] = 8192
+
+_REPLAY_UNSAFE_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "api_key",
+        "apikey",
+        "auth_token",
+        "bearer_token",
+        "client_secret",
+        "credential",
+        "credentials",
+        "password",
+        "private_key",
+        "prompt",
+        "raw_prompt",
+        "raw_stderr",
+        "raw_stdout",
+        "raw_output",
+        "refresh_token",
+        "secret",
+        "stderr",
+        "stdout",
+        "token",
+    }
+)
+_REPLAY_UNSAFE_SUFFIXES: Final[tuple[str, ...]] = (
+    "_api_key",
+    "_credential",
+    "_credentials",
+    "_password",
+    "_prompt",
+    "_secret",
+    "_stderr",
+    "_stdout",
+    "_token",
+)
+
+JsonScalar = str | int | float | bool | None
+JsonValue = JsonScalar | dict[str, "JsonValue"] | list["JsonValue"]
+FrozenJsonValue = JsonScalar | Mapping[str, "FrozenJsonValue"] | tuple["FrozenJsonValue", ...]
+
+
+class WorkflowLifecycleEventType(StrEnum):
+    """Bounded lifecycle event vocabulary for #956 Workflow IR."""
+
+    RUN_CREATED = "workflow.run.created"
+    NODE_SCHEDULED = "workflow.node.scheduled"
+    NODE_STARTED = "workflow.node.started"
+    NODE_COMPLETED = "workflow.node.completed"
+    NODE_FAILED = "workflow.node.failed"
+    NODE_RETRIED = "workflow.node.retried"
+    EDGE_TRAVERSED = "workflow.edge.traversed"
+    CHECKPOINT_SAVED = "workflow.checkpoint.saved"
+    RUN_COMPLETED = "workflow.run.completed"
+    RUN_FAILED = "workflow.run.failed"
+    RUN_CANCELLED = "workflow.run.cancelled"
+
+
+class WorkflowNodeLifecycleState(StrEnum):
+    """Effective node state derived from lifecycle history."""
+
+    PENDING = "pending"
+    SCHEDULED = "scheduled"
+    STARTED = "started"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    RETRIED = "retried"
+
+
+class WorkflowRunLifecycleState(StrEnum):
+    """Run-level lifecycle state represented by terminal run events."""
+
+    CREATED = "created"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+_NODE_EVENT_TYPES: Final[frozenset[WorkflowLifecycleEventType]] = frozenset(
+    {
+        WorkflowLifecycleEventType.NODE_SCHEDULED,
+        WorkflowLifecycleEventType.NODE_STARTED,
+        WorkflowLifecycleEventType.NODE_COMPLETED,
+        WorkflowLifecycleEventType.NODE_FAILED,
+        WorkflowLifecycleEventType.NODE_RETRIED,
+    }
+)
+_RUN_EVENT_TYPES: Final[frozenset[WorkflowLifecycleEventType]] = frozenset(
+    {
+        WorkflowLifecycleEventType.RUN_CREATED,
+        WorkflowLifecycleEventType.RUN_COMPLETED,
+        WorkflowLifecycleEventType.RUN_FAILED,
+        WorkflowLifecycleEventType.RUN_CANCELLED,
+    }
+)
+_NODE_STATE_BY_EVENT: Final[dict[WorkflowLifecycleEventType, WorkflowNodeLifecycleState]] = {
+    WorkflowLifecycleEventType.NODE_SCHEDULED: WorkflowNodeLifecycleState.SCHEDULED,
+    WorkflowLifecycleEventType.NODE_STARTED: WorkflowNodeLifecycleState.STARTED,
+    WorkflowLifecycleEventType.NODE_COMPLETED: WorkflowNodeLifecycleState.COMPLETED,
+    WorkflowLifecycleEventType.NODE_FAILED: WorkflowNodeLifecycleState.FAILED,
+    WorkflowLifecycleEventType.NODE_RETRIED: WorkflowNodeLifecycleState.RETRIED,
+}
+
+
+def _normalize_non_blank(name: str, value: str) -> str:
+    if not isinstance(value, str):
+        msg = f"Workflow lifecycle {name} must be a string"
+        raise TypeError(msg)
+    normalized = value.strip()
+    if not normalized:
+        msg = f"Workflow lifecycle {name} must be non-blank"
+        raise ValueError(msg)
+    return normalized
+
+
+def _normalize_optional_non_blank(name: str, value: str | None) -> str | None:
+    if value is None:
+        return None
+    return _normalize_non_blank(name, value)
+
+
+def _normalize_utc(value: datetime) -> datetime:
+    if not isinstance(value, datetime):
+        msg = "Workflow lifecycle timestamp must be a datetime"
+        raise TypeError(msg)
+    if value.tzinfo is None or value.utcoffset() is None:
+        msg = "Workflow lifecycle timestamp must be timezone-aware"
+        raise ValueError(msg)
+    return value.astimezone(UTC)
+
+
+def _is_replay_unsafe_key(key: str) -> bool:
+    normalized = key.strip().lower().replace("-", "_").replace(" ", "_")
+    return normalized in _REPLAY_UNSAFE_KEYS or normalized.endswith(_REPLAY_UNSAFE_SUFFIXES)
+
+
+def _normalize_json_value(name: str, value: Any, path: str) -> JsonValue:
+    if value is None or isinstance(value, str | int | bool):
+        return value
+    if isinstance(value, float):
+        if not json.dumps(value, allow_nan=False):  # pragma: no cover - json handles finite floats
+            raise ValueError(f"Workflow lifecycle {name} value at {path} is not finite")
+        return value
+    if isinstance(value, Mapping):
+        normalized: dict[str, JsonValue] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                msg = f"Workflow lifecycle {name} key at {path} must be a string"
+                raise TypeError(msg)
+            if _is_replay_unsafe_key(key):
+                msg = f"Workflow lifecycle {name} must not persist replay-unsafe key {key!r}"
+                raise ValueError(msg)
+            normalized[key] = _normalize_json_value(name, item, f"{path}.{key}")
+        return normalized
+    if isinstance(value, list | tuple):
+        return [
+            _normalize_json_value(name, item, f"{path}[{index}]")
+            for index, item in enumerate(value)
+        ]
+    msg = f"Workflow lifecycle {name} value at {path} must be JSON serializable"
+    raise TypeError(msg)
+
+
+def _freeze_json_value(value: JsonValue) -> FrozenJsonValue:
+    if isinstance(value, dict):
+        return MappingProxyType({key: _freeze_json_value(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze_json_value(item) for item in value)
+    return value
+
+
+def _thaw_json_value(value: FrozenJsonValue) -> JsonValue:
+    if isinstance(value, Mapping):
+        return {key: _thaw_json_value(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json_value(item) for item in value]
+    return value
+
+
+def _normalize_data(value: Mapping[str, Any]) -> Mapping[str, FrozenJsonValue]:
+    if not isinstance(value, Mapping):
+        msg = "Workflow lifecycle data must be a mapping"
+        raise TypeError(msg)
+    normalized = _normalize_json_value("data", value, "data")
+    encoded = json.dumps(normalized, allow_nan=False, separators=(",", ":")).encode("utf-8")
+    if len(encoded) > MAX_WORKFLOW_LIFECYCLE_DATA_BYTES:
+        msg = f"Workflow lifecycle data exceeds {MAX_WORKFLOW_LIFECYCLE_DATA_BYTES} bytes"
+        raise ValueError(msg)
+    return cast(Mapping[str, FrozenJsonValue], _freeze_json_value(normalized))
+
+
+def _thaw_data(value: Mapping[str, Any]) -> dict[str, JsonValue]:
+    return cast(dict[str, JsonValue], _thaw_json_value(value))
+
+
+def _normalize_refs(values: Iterable[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    for index, value in enumerate(values):
+        ref = _normalize_non_blank(f"refs[{index}]", value)
+        if ref in seen:
+            msg = f"Workflow lifecycle refs must be unique: {ref!r}"
+            raise ValueError(msg)
+        seen.add(ref)
+        normalized.append(ref)
+    return tuple(normalized)
+
+
+class WorkflowLifecycleEvent(BaseModel, frozen=True):
+    """Replay-safe lifecycle event for a ``WorkflowSpec`` run.
+
+    ``workflow_id`` is the stable ``WorkflowSpec.spec_id`` anchor. Node and
+    edge events use ``WorkflowNode.node_id`` / ``WorkflowEdge.edge_id`` so a
+    future #946 projector can correlate lifecycle rows without inventing a
+    second identity vocabulary.
+    """
+
+    schema_version: int = Field(default=WORKFLOW_LIFECYCLE_SCHEMA_VERSION, ge=1)
+    event_type: WorkflowLifecycleEventType
+    workflow_id: str
+    node_id: str | None = None
+    edge_id: str | None = None
+    attempt: int | None = Field(default=None, ge=1)
+    reason_code: str | None = None
+    refs: tuple[str, ...] = Field(default_factory=tuple)
+    data: Mapping[str, Any] = Field(default_factory=dict)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @field_validator("workflow_id")
+    @classmethod
+    def _workflow_id_non_blank(cls, value: str) -> str:
+        return _normalize_non_blank("workflow_id", value)
+
+    @field_validator("node_id", "edge_id", "reason_code")
+    @classmethod
+    def _optional_fields_non_blank(cls, value: str | None, info: Any) -> str | None:
+        return _normalize_optional_non_blank(str(info.field_name), value)
+
+    @field_validator("refs", mode="before")
+    @classmethod
+    def _coerce_refs(cls, value: Any) -> tuple[str, ...]:
+        if value is None:
+            return ()
+        if isinstance(value, str) or not isinstance(value, Iterable):
+            msg = "Workflow lifecycle refs must be an iterable of strings"
+            raise TypeError(msg)
+        return _normalize_refs(value)
+
+    @field_validator("data", mode="before")
+    @classmethod
+    def _coerce_data(cls, value: Any) -> Mapping[str, Any]:
+        if value is None:
+            return MappingProxyType({})
+        return _normalize_data(value)
+
+    @field_validator("timestamp")
+    @classmethod
+    def _timestamp_utc(cls, value: datetime) -> datetime:
+        return _normalize_utc(value)
+
+    @model_validator(mode="after")
+    def _validate_shape(self) -> WorkflowLifecycleEvent:
+        if self.event_type in _NODE_EVENT_TYPES and self.node_id is None:
+            msg = f"{self.event_type.value} requires node_id"
+            raise ValueError(msg)
+        if self.event_type not in _NODE_EVENT_TYPES and self.node_id is not None:
+            msg = f"{self.event_type.value} must not carry node_id"
+            raise ValueError(msg)
+        if self.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED and self.edge_id is None:
+            msg = "workflow.edge.traversed requires edge_id"
+            raise ValueError(msg)
+        if (
+            self.event_type is not WorkflowLifecycleEventType.EDGE_TRAVERSED
+            and self.edge_id is not None
+        ):
+            msg = f"{self.event_type.value} must not carry edge_id"
+            raise ValueError(msg)
+        if (
+            self.event_type
+            in {
+                WorkflowLifecycleEventType.NODE_FAILED,
+                WorkflowLifecycleEventType.NODE_RETRIED,
+                WorkflowLifecycleEventType.RUN_FAILED,
+                WorkflowLifecycleEventType.RUN_CANCELLED,
+            }
+            and self.reason_code is None
+        ):
+            msg = f"{self.event_type.value} requires reason_code"
+            raise ValueError(msg)
+        if self.event_type is WorkflowLifecycleEventType.CHECKPOINT_SAVED and not self.refs:
+            msg = "workflow.checkpoint.saved requires at least one checkpoint ref"
+            raise ValueError(msg)
+        if self.event_type in _RUN_EVENT_TYPES and self.attempt is not None:
+            msg = f"{self.event_type.value} must not carry a node attempt"
+            raise ValueError(msg)
+        return self
+
+    @property
+    def aggregate_id(self) -> str:
+        return self.workflow_id
+
+    def to_event_data(self) -> dict[str, JsonValue]:
+        data: dict[str, JsonValue] = {
+            "schema_version": self.schema_version,
+            "workflow_id": self.workflow_id,
+            "timestamp": self.timestamp.isoformat(),
+        }
+        if self.node_id is not None:
+            data["node_id"] = self.node_id
+        if self.edge_id is not None:
+            data["edge_id"] = self.edge_id
+        if self.attempt is not None:
+            data["attempt"] = self.attempt
+        if self.reason_code is not None:
+            data["reason_code"] = self.reason_code
+        if self.refs:
+            data["refs"] = list(self.refs)
+        if self.data:
+            data["data"] = _thaw_data(self.data)
+        return data
+
+    def to_base_event(self) -> BaseEvent:
+        return BaseEvent(
+            type=self.event_type.value,
+            aggregate_type="workflow_ir",
+            aggregate_id=self.aggregate_id,
+            data=self.to_event_data(),
+            event_version=self.schema_version,
+        )
+
+
+def lifecycle_event_for_spec(
+    spec: WorkflowSpec,
+    event_type: WorkflowLifecycleEventType,
+    **kwargs: Any,
+) -> WorkflowLifecycleEvent:
+    """Create a lifecycle event anchored to ``WorkflowSpec.spec_id``."""
+    return WorkflowLifecycleEvent(event_type=event_type, workflow_id=spec.spec_id, **kwargs)
+
+
+def completed_node_ids(events: Iterable[WorkflowLifecycleEvent]) -> frozenset[str]:
+    """Return nodes whose effective state is completed."""
+    return frozenset(
+        node_id
+        for node_id, state in effective_node_states(events).items()
+        if state is WorkflowNodeLifecycleState.COMPLETED
+    )
+
+
+def effective_node_states(
+    events: Iterable[WorkflowLifecycleEvent],
+) -> Mapping[str, WorkflowNodeLifecycleState]:
+    """Project latest effective node state while preserving failed history in events."""
+    states: dict[str, WorkflowNodeLifecycleState] = {}
+    for event in sorted(events, key=lambda item: item.timestamp):
+        if event.event_type not in _NODE_EVENT_TYPES or event.node_id is None:
+            continue
+        states[event.node_id] = _NODE_STATE_BY_EVENT[event.event_type]
+    return MappingProxyType(states)
+
+
+def next_runnable_node_ids(
+    spec: WorkflowSpec,
+    events: Iterable[WorkflowLifecycleEvent],
+) -> tuple[str, ...]:
+    """Return pending nodes whose incoming dependencies have completed.
+
+    This is intentionally a pure projection helper: it reads the Workflow IR
+    graph and lifecycle records only, performs no side effects, and does not
+    dispatch work.
+    """
+    states = effective_node_states(events)
+    completed = {
+        node_id
+        for node_id, state in states.items()
+        if state is WorkflowNodeLifecycleState.COMPLETED
+    }
+    nodes_by_id: dict[str, WorkflowNode] = {node.node_id: node for node in spec.nodes}
+    incoming: dict[str, set[str]] = {node_id: set() for node_id in nodes_by_id}
+    for edge in spec.edges:
+        if edge.target in incoming:
+            incoming[edge.target].add(edge.source)
+
+    runnable: list[str] = []
+    for node in spec.nodes:
+        if node.node_id in states:
+            continue
+        predecessors = incoming.get(node.node_id, set())
+        if predecessors <= completed:
+            runnable.append(node.node_id)
+    return tuple(runnable)
+
+
+__all__ = [
+    "MAX_WORKFLOW_LIFECYCLE_DATA_BYTES",
+    "WORKFLOW_LIFECYCLE_SCHEMA_VERSION",
+    "WorkflowLifecycleEvent",
+    "WorkflowLifecycleEventType",
+    "WorkflowNodeLifecycleState",
+    "WorkflowRunLifecycleState",
+    "completed_node_ids",
+    "effective_node_states",
+    "lifecycle_event_for_spec",
+    "next_runnable_node_ids",
+]

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -346,6 +346,7 @@ class WorkflowLifecycleEvent(BaseModel, frozen=True):
         return BaseEvent(
             type=self.event_type.value,
             aggregate_type="workflow_ir",
+            timestamp=self.timestamp,
             aggregate_id=self.aggregate_id,
             data=self.to_event_data(),
             event_version=self.schema_version,
@@ -392,7 +393,7 @@ def next_runnable_node_ids(
     graph and lifecycle records only, performs no side effects, and does not
     dispatch work.
     """
-    event_list = tuple(events)
+    event_list = tuple(event for event in events if event.workflow_id == spec.spec_id)
     states = effective_node_states(event_list)
     completed = {
         node_id

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -18,7 +18,7 @@ from typing import Any, Final, cast
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from ouroboros.events.base import BaseEvent
-from ouroboros.orchestrator.workflow_ir import WorkflowNode, WorkflowSpec
+from ouroboros.orchestrator.workflow_ir import EdgeKind, WorkflowEdge, WorkflowNode, WorkflowSpec
 
 WORKFLOW_LIFECYCLE_SCHEMA_VERSION: Final[int] = 1
 MAX_WORKFLOW_LIFECYCLE_DATA_BYTES: Final[int] = 8192
@@ -392,25 +392,37 @@ def next_runnable_node_ids(
     graph and lifecycle records only, performs no side effects, and does not
     dispatch work.
     """
-    states = effective_node_states(events)
+    event_list = tuple(events)
+    states = effective_node_states(event_list)
     completed = {
         node_id
         for node_id, state in states.items()
         if state is WorkflowNodeLifecycleState.COMPLETED
     }
+    traversed_edges = {
+        event.edge_id
+        for event in event_list
+        if event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED
+        and event.edge_id is not None
+    }
     nodes_by_id: dict[str, WorkflowNode] = {node.node_id: node for node in spec.nodes}
-    incoming: dict[str, set[str]] = {node_id: set() for node_id in nodes_by_id}
+    incoming: dict[str, list[WorkflowEdge]] = {node_id: [] for node_id in nodes_by_id}
     for edge in spec.edges:
         if edge.target in incoming:
-            incoming[edge.target].add(edge.source)
+            incoming[edge.target].append(edge)
+
+    def dependency_is_satisfied(edge: WorkflowEdge) -> bool:
+        if edge.kind is EdgeKind.CONDITIONAL:
+            return edge.edge_id in traversed_edges
+        return edge.source in completed
 
     runnable: list[str] = []
     for node in spec.nodes:
         state = states.get(node.node_id)
         if state is not None and state is not WorkflowNodeLifecycleState.RETRIED:
             continue
-        predecessors = incoming.get(node.node_id, set())
-        if predecessors <= completed:
+        predecessors = incoming.get(node.node_id, ())
+        if all(dependency_is_satisfied(edge) for edge in predecessors):
             runnable.append(node.node_id)
     return tuple(runnable)
 

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -400,12 +400,13 @@ def next_runnable_node_ids(
         for node_id, state in states.items()
         if state is WorkflowNodeLifecycleState.COMPLETED
     }
-    traversed_edges = {
-        event.edge_id
-        for event in event_list
-        if event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED
-        and event.edge_id is not None
-    }
+    latest_node_attempts: dict[str, int | None] = {}
+    traversed_edge_attempts: dict[str, set[int | None]] = {}
+    for event in sorted(event_list, key=lambda item: item.timestamp):
+        if event.event_type in _NODE_EVENT_TYPES and event.node_id is not None:
+            latest_node_attempts[event.node_id] = event.attempt
+        if event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED and event.edge_id:
+            traversed_edge_attempts.setdefault(event.edge_id, set()).add(event.attempt)
     nodes_by_id: dict[str, WorkflowNode] = {node.node_id: node for node in spec.nodes}
     incoming: dict[str, list[WorkflowEdge]] = {node_id: [] for node_id in nodes_by_id}
     for edge in spec.edges:
@@ -414,7 +415,15 @@ def next_runnable_node_ids(
 
     def dependency_is_satisfied(edge: WorkflowEdge) -> bool:
         if edge.kind is EdgeKind.CONDITIONAL:
-            return edge.edge_id in traversed_edges
+            if edge.source not in completed:
+                return False
+            edge_attempts = traversed_edge_attempts.get(edge.edge_id)
+            if not edge_attempts:
+                return False
+            source_attempt = latest_node_attempts.get(edge.source)
+            if source_attempt is None:
+                return True
+            return source_attempt in edge_attempts
         return edge.source in completed
 
     runnable: list[str] = []

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -401,12 +401,15 @@ def next_runnable_node_ids(
         if state is WorkflowNodeLifecycleState.COMPLETED
     }
     latest_node_attempts: dict[str, int | None] = {}
-    traversed_edge_attempts: dict[str, set[int | None]] = {}
+    latest_node_completed_at: dict[str, datetime] = {}
+    traversed_edge_events: dict[str, list[WorkflowLifecycleEvent]] = {}
     for event in sorted(event_list, key=lambda item: item.timestamp):
         if event.event_type in _NODE_EVENT_TYPES and event.node_id is not None:
             latest_node_attempts[event.node_id] = event.attempt
+            if event.event_type is WorkflowLifecycleEventType.NODE_COMPLETED:
+                latest_node_completed_at[event.node_id] = event.timestamp
         if event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED and event.edge_id:
-            traversed_edge_attempts.setdefault(event.edge_id, set()).add(event.attempt)
+            traversed_edge_events.setdefault(event.edge_id, []).append(event)
     nodes_by_id: dict[str, WorkflowNode] = {node.node_id: node for node in spec.nodes}
     incoming: dict[str, list[WorkflowEdge]] = {node_id: [] for node_id in nodes_by_id}
     for edge in spec.edges:
@@ -417,13 +420,17 @@ def next_runnable_node_ids(
         if edge.kind is EdgeKind.CONDITIONAL:
             if edge.source not in completed:
                 return False
-            edge_attempts = traversed_edge_attempts.get(edge.edge_id)
-            if not edge_attempts:
+            source_completed_at = latest_node_completed_at.get(edge.source)
+            if source_completed_at is None:
                 return False
             source_attempt = latest_node_attempts.get(edge.source)
-            if source_attempt is None:
+            for traversal in traversed_edge_events.get(edge.edge_id, ()):
+                if traversal.timestamp < source_completed_at:
+                    continue
+                if source_attempt is not None and traversal.attempt != source_attempt:
+                    continue
                 return True
-            return source_attempt in edge_attempts
+            return False
         return edge.source in completed
 
     runnable: list[str] = []

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -406,7 +406,8 @@ def next_runnable_node_ids(
 
     runnable: list[str] = []
     for node in spec.nodes:
-        if node.node_id in states:
+        state = states.get(node.node_id)
+        if state is not None and state is not WorkflowNodeLifecycleState.RETRIED:
             continue
         predecessors = incoming.get(node.node_id, set())
         if predecessors <= completed:

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -124,6 +124,24 @@ _NODE_STATE_BY_EVENT: Final[dict[WorkflowLifecycleEventType, WorkflowNodeLifecyc
     WorkflowLifecycleEventType.NODE_RETRIED: WorkflowNodeLifecycleState.RETRIED,
 }
 
+_EVENT_SORT_ORDER: Final[dict[WorkflowLifecycleEventType, int]] = {
+    WorkflowLifecycleEventType.RUN_CREATED: 0,
+    WorkflowLifecycleEventType.NODE_SCHEDULED: 10,
+    WorkflowLifecycleEventType.NODE_STARTED: 20,
+    WorkflowLifecycleEventType.NODE_FAILED: 30,
+    WorkflowLifecycleEventType.NODE_RETRIED: 40,
+    WorkflowLifecycleEventType.NODE_COMPLETED: 50,
+    WorkflowLifecycleEventType.EDGE_TRAVERSED: 60,
+    WorkflowLifecycleEventType.CHECKPOINT_SAVED: 70,
+    WorkflowLifecycleEventType.RUN_COMPLETED: 80,
+    WorkflowLifecycleEventType.RUN_FAILED: 80,
+    WorkflowLifecycleEventType.RUN_CANCELLED: 80,
+}
+
+
+def _event_sort_key(event: WorkflowLifecycleEvent) -> tuple[datetime, int, str]:
+    return (event.timestamp, _EVENT_SORT_ORDER[event.event_type], event.event_type.value)
+
 
 def _normalize_non_blank(name: str, value: str) -> str:
     if not isinstance(value, str):
@@ -376,7 +394,7 @@ def effective_node_states(
 ) -> Mapping[str, WorkflowNodeLifecycleState]:
     """Project latest effective node state while preserving failed history in events."""
     states: dict[str, WorkflowNodeLifecycleState] = {}
-    for event in sorted(events, key=lambda item: item.timestamp):
+    for event in sorted(events, key=_event_sort_key):
         if event.event_type not in _NODE_EVENT_TYPES or event.node_id is None:
             continue
         states[event.node_id] = _NODE_STATE_BY_EVENT[event.event_type]
@@ -397,7 +415,7 @@ def next_runnable_node_ids(
     latest_run_event = next(
         (
             event
-            for event in sorted(event_list, key=lambda item: item.timestamp, reverse=True)
+            for event in sorted(event_list, key=_event_sort_key, reverse=True)
             if event.event_type in _RUN_EVENT_TYPES
         ),
         None,
@@ -418,7 +436,7 @@ def next_runnable_node_ids(
     latest_node_attempts: dict[str, int | None] = {}
     latest_node_completed_at: dict[str, datetime] = {}
     traversed_edge_events: dict[str, list[WorkflowLifecycleEvent]] = {}
-    for event in sorted(event_list, key=lambda item: item.timestamp):
+    for event in sorted(event_list, key=_event_sort_key):
         if event.event_type in _NODE_EVENT_TYPES and event.node_id is not None:
             latest_node_attempts[event.node_id] = event.attempt
             if event.event_type is WorkflowLifecycleEventType.NODE_COMPLETED:

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -440,6 +440,50 @@ def test_next_runnable_nodes_stop_after_terminal_run_events() -> None:
         assert next_runnable_node_ids(spec, events) == ()
 
 
+def test_lifecycle_projection_uses_deterministic_tie_breakers() -> None:
+    spec = _spec()
+    timestamp = datetime(2026, 5, 15, tzinfo=UTC)
+    tied_node_events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=timestamp,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_RETRIED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=2,
+            reason_code="retry",
+            timestamp=timestamp,
+        ),
+    )
+
+    assert effective_node_states(tied_node_events)["node_a"] is WorkflowNodeLifecycleState.COMPLETED
+    assert (
+        effective_node_states(tuple(reversed(tied_node_events)))["node_a"]
+        is WorkflowNodeLifecycleState.COMPLETED
+    )
+
+    tied_run_events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CANCELLED,
+            workflow_id=spec.spec_id,
+            reason_code="cancelled",
+            timestamp=timestamp,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=timestamp,
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, tied_run_events) == ()
+    assert next_runnable_node_ids(spec, tuple(reversed(tied_run_events))) == ()
+
+
 def test_lifecycle_module_does_not_import_runtime_dispatcher() -> None:
     import ouroboros.orchestrator.workflow_lifecycle as lifecycle
 

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -88,16 +88,19 @@ def _conditional_spec() -> WorkflowSpec:
 
 
 def test_run_created_event_anchors_to_workflow_spec_id() -> None:
+    timestamp = datetime(2026, 5, 15, tzinfo=UTC)
     event = lifecycle_event_for_spec(
         _spec(),
         WorkflowLifecycleEventType.RUN_CREATED,
         refs=("seed://example",),
         data={"source_ref": "seed_001"},
+        timestamp=timestamp,
     )
 
     base = event.to_base_event()
 
     assert base.type == "workflow.run.created"
+    assert base.timestamp == timestamp
     assert base.aggregate_type == "workflow_ir"
     assert base.aggregate_id == "wfspec_lifecycle"
     assert base.event_version == WORKFLOW_LIFECYCLE_SCHEMA_VERSION
@@ -326,6 +329,37 @@ def test_next_runnable_nodes_follow_traversed_conditional_edges_only() -> None:
     )
 
     assert next_runnable_node_ids(spec, yes_selected) == ("branch_yes",)
+
+
+def test_next_runnable_nodes_ignore_foreign_workflow_events() -> None:
+    spec = _spec()
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id="other_workflow",
+            node_id="node_a",
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ("node_a",)
+
+
+def test_next_runnable_conditional_edges_ignore_foreign_traversal() -> None:
+    spec = _conditional_spec()
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="decide",
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id="other_workflow",
+            edge_id="edge_yes",
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ()
 
 
 def test_lifecycle_module_does_not_import_runtime_dispatcher() -> None:

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -244,7 +244,6 @@ def test_next_runnable_nodes_are_pure_projection_from_completed_predecessors() -
     assert next_runnable_node_ids(spec, all_done) == ("end",)
 
 
-
 def test_retried_node_becomes_runnable_again_after_failure_history() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)
@@ -276,6 +275,7 @@ def test_retried_node_becomes_runnable_again_after_failure_history() -> None:
 
     assert effective_node_states(events)["node_a"] is WorkflowNodeLifecycleState.RETRIED
     assert next_runnable_node_ids(spec, events) == ("node_a",)
+
 
 def test_lifecycle_module_does_not_import_runtime_dispatcher() -> None:
     import ouroboros.orchestrator.workflow_lifecycle as lifecycle

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -412,6 +412,34 @@ def test_next_runnable_conditional_edges_ignore_prior_attempt_traversal() -> Non
     assert next_runnable_node_ids(spec, retried_branch_selected) == ("branch_no",)
 
 
+def test_next_runnable_nodes_stop_after_terminal_run_events() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+
+    for terminal_event_type in (
+        WorkflowLifecycleEventType.RUN_COMPLETED,
+        WorkflowLifecycleEventType.RUN_FAILED,
+        WorkflowLifecycleEventType.RUN_CANCELLED,
+    ):
+        events = (
+            WorkflowLifecycleEvent(
+                event_type=WorkflowLifecycleEventType.RUN_CREATED,
+                workflow_id=spec.spec_id,
+                timestamp=start,
+            ),
+            WorkflowLifecycleEvent(
+                event_type=terminal_event_type,
+                workflow_id=spec.spec_id,
+                reason_code="terminal"
+                if terminal_event_type is not WorkflowLifecycleEventType.RUN_COMPLETED
+                else None,
+                timestamp=start + timedelta(seconds=1),
+            ),
+        )
+
+        assert next_runnable_node_ids(spec, events) == ()
+
+
 def test_lifecycle_module_does_not_import_runtime_dispatcher() -> None:
     import ouroboros.orchestrator.workflow_lifecycle as lifecycle
 

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -59,6 +59,34 @@ def _spec() -> WorkflowSpec:
     )
 
 
+def _conditional_spec() -> WorkflowSpec:
+    return WorkflowSpec(
+        spec_id="wfspec_conditional",
+        source=SourceKind.SYNTHETIC,
+        nodes=(
+            WorkflowNode(node_id="decide", kind=NodeKind.DECISION, owner=NodeOwner.HARNESS),
+            _task("branch_yes"),
+            _task("branch_no"),
+        ),
+        edges=(
+            WorkflowEdge(
+                edge_id="edge_yes",
+                source="decide",
+                target="branch_yes",
+                kind=EdgeKind.CONDITIONAL,
+                condition={"result": "yes"},
+            ),
+            WorkflowEdge(
+                edge_id="edge_no",
+                source="decide",
+                target="branch_no",
+                kind=EdgeKind.CONDITIONAL,
+                condition={"result": "no"},
+            ),
+        ),
+    )
+
+
 def test_run_created_event_anchors_to_workflow_spec_id() -> None:
     event = lifecycle_event_for_spec(
         _spec(),
@@ -275,6 +303,31 @@ def test_retried_node_becomes_runnable_again_after_failure_history() -> None:
 
     assert effective_node_states(events)["node_a"] is WorkflowNodeLifecycleState.RETRIED
     assert next_runnable_node_ids(spec, events) == ("node_a",)
+
+
+
+
+def test_next_runnable_nodes_follow_traversed_conditional_edges_only() -> None:
+    spec = _conditional_spec()
+    completed_decision = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="decide",
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, completed_decision) == ()
+
+    yes_selected = completed_decision + (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id=spec.spec_id,
+            edge_id="edge_yes",
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, yes_selected) == ("branch_yes",)
 
 
 def test_lifecycle_module_does_not_import_runtime_dispatcher() -> None:

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -244,6 +244,39 @@ def test_next_runnable_nodes_are_pure_projection_from_completed_predecessors() -
     assert next_runnable_node_ids(spec, all_done) == ("end",)
 
 
+
+def test_retried_node_becomes_runnable_again_after_failure_history() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=1,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_FAILED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=1,
+            reason_code="tool_timeout",
+            timestamp=start + timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_RETRIED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=2,
+            reason_code="bounded_retry",
+            timestamp=start + timedelta(seconds=2),
+        ),
+    )
+
+    assert effective_node_states(events)["node_a"] is WorkflowNodeLifecycleState.RETRIED
+    assert next_runnable_node_ids(spec, events) == ("node_a",)
+
 def test_lifecycle_module_does_not_import_runtime_dispatcher() -> None:
     import ouroboros.orchestrator.workflow_lifecycle as lifecycle
 

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -362,6 +362,56 @@ def test_next_runnable_conditional_edges_ignore_foreign_traversal() -> None:
     assert next_runnable_node_ids(spec, events) == ()
 
 
+def test_next_runnable_conditional_edges_ignore_prior_attempt_traversal() -> None:
+    spec = _conditional_spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="decide",
+            attempt=1,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id=spec.spec_id,
+            edge_id="edge_yes",
+            attempt=1,
+            timestamp=start + timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_RETRIED,
+            workflow_id=spec.spec_id,
+            node_id="decide",
+            attempt=2,
+            reason_code="retry_decision",
+            timestamp=start + timedelta(seconds=2),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="decide",
+            attempt=2,
+            timestamp=start + timedelta(seconds=3),
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ()
+
+    retried_branch_selected = events + (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id=spec.spec_id,
+            edge_id="edge_no",
+            attempt=2,
+            timestamp=start + timedelta(seconds=4),
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, retried_branch_selected) == ("branch_no",)
+
+
 def test_lifecycle_module_does_not_import_runtime_dispatcher() -> None:
     import ouroboros.orchestrator.workflow_lifecycle as lifecycle
 

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -1,0 +1,251 @@
+"""Tests for the #956 Workflow IR lifecycle event contract."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from pydantic import ValidationError
+import pytest
+
+from ouroboros.orchestrator.workflow_ir import (
+    EdgeKind,
+    NodeKind,
+    NodeOwner,
+    SourceKind,
+    WorkflowEdge,
+    WorkflowNode,
+    WorkflowSpec,
+)
+from ouroboros.orchestrator.workflow_lifecycle import (
+    WORKFLOW_LIFECYCLE_SCHEMA_VERSION,
+    WorkflowLifecycleEvent,
+    WorkflowLifecycleEventType,
+    WorkflowNodeLifecycleState,
+    completed_node_ids,
+    effective_node_states,
+    lifecycle_event_for_spec,
+    next_runnable_node_ids,
+)
+
+
+def _task(node_id: str) -> WorkflowNode:
+    return WorkflowNode(
+        node_id=node_id,
+        kind=NodeKind.TASK,
+        owner=NodeOwner.AGENT,
+        input_schema_ref="schema://input.agent.v1",
+        evidence_schema_ref="schema://evidence.agent.v1",
+    )
+
+
+def _terminal(node_id: str = "end") -> WorkflowNode:
+    return WorkflowNode(node_id=node_id, kind=NodeKind.TERMINAL, owner=NodeOwner.HARNESS)
+
+
+def _spec() -> WorkflowSpec:
+    return WorkflowSpec(
+        spec_id="wfspec_lifecycle",
+        source=SourceKind.SYNTHETIC,
+        nodes=(_task("node_a"), _task("node_b"), _terminal()),
+        edges=(
+            WorkflowEdge(edge_id="edge_a_b", source="node_a", target="node_b"),
+            WorkflowEdge(
+                edge_id="edge_b_end",
+                source="node_b",
+                target="end",
+                kind=EdgeKind.TERMINAL,
+            ),
+        ),
+    )
+
+
+def test_run_created_event_anchors_to_workflow_spec_id() -> None:
+    event = lifecycle_event_for_spec(
+        _spec(),
+        WorkflowLifecycleEventType.RUN_CREATED,
+        refs=("seed://example",),
+        data={"source_ref": "seed_001"},
+    )
+
+    base = event.to_base_event()
+
+    assert base.type == "workflow.run.created"
+    assert base.aggregate_type == "workflow_ir"
+    assert base.aggregate_id == "wfspec_lifecycle"
+    assert base.event_version == WORKFLOW_LIFECYCLE_SCHEMA_VERSION
+    assert base.data["workflow_id"] == "wfspec_lifecycle"
+    assert base.data["refs"] == ["seed://example"]
+    assert base.to_db_dict()["payload"]["event_version"] == WORKFLOW_LIFECYCLE_SCHEMA_VERSION
+
+
+def test_node_lifecycle_requires_node_id_and_preserves_attempt() -> None:
+    event = WorkflowLifecycleEvent(
+        event_type=WorkflowLifecycleEventType.NODE_STARTED,
+        workflow_id="wfspec_lifecycle",
+        node_id="node_a",
+        attempt=2,
+    )
+
+    assert event.to_event_data()["node_id"] == "node_a"
+    assert event.to_event_data()["attempt"] == 2
+
+    with pytest.raises(ValidationError, match="requires node_id"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id="wfspec_lifecycle",
+        )
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        WorkflowLifecycleEventType.NODE_FAILED,
+        WorkflowLifecycleEventType.NODE_RETRIED,
+        WorkflowLifecycleEventType.RUN_FAILED,
+        WorkflowLifecycleEventType.RUN_CANCELLED,
+    ],
+)
+def test_failure_and_retry_events_require_reason_code(
+    event_type: WorkflowLifecycleEventType,
+) -> None:
+    kwargs = {"node_id": "node_a"} if event_type.value.startswith("workflow.node") else {}
+    with pytest.raises(ValidationError, match="requires reason_code"):
+        WorkflowLifecycleEvent(
+            event_type=event_type,
+            workflow_id="wfspec_lifecycle",
+            **kwargs,
+        )
+
+
+def test_edge_traversed_requires_edge_id_and_excludes_node_id() -> None:
+    event = WorkflowLifecycleEvent(
+        event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+        workflow_id="wfspec_lifecycle",
+        edge_id="edge_a_b",
+    )
+    assert event.to_event_data()["edge_id"] == "edge_a_b"
+
+    with pytest.raises(ValidationError, match="requires edge_id"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id="wfspec_lifecycle",
+        )
+
+    with pytest.raises(ValidationError, match="must not carry node_id"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id="wfspec_lifecycle",
+            edge_id="edge_a_b",
+            node_id="node_a",
+        )
+
+
+def test_checkpoint_saved_requires_checkpoint_ref() -> None:
+    event = WorkflowLifecycleEvent(
+        event_type=WorkflowLifecycleEventType.CHECKPOINT_SAVED,
+        workflow_id="wfspec_lifecycle",
+        refs=("checkpoint://run/1",),
+    )
+    assert event.refs == ("checkpoint://run/1",)
+
+    with pytest.raises(ValidationError, match="requires at least one checkpoint ref"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.CHECKPOINT_SAVED,
+            workflow_id="wfspec_lifecycle",
+        )
+
+
+def test_replay_safe_payload_rejects_raw_output_and_secrets() -> None:
+    with pytest.raises(ValidationError, match="replay-unsafe key"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id="wfspec_lifecycle",
+            node_id="node_a",
+            data={"stdout": "large raw output"},
+        )
+
+    with pytest.raises(ValidationError, match="replay-unsafe key"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id="wfspec_lifecycle",
+            node_id="node_a",
+            data={"nested": {"api_key": "secret"}},
+        )
+
+
+def test_effective_state_keeps_failed_history_but_allows_retry_success() -> None:
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id="wfspec_lifecycle",
+            node_id="node_a",
+            attempt=1,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_FAILED,
+            workflow_id="wfspec_lifecycle",
+            node_id="node_a",
+            attempt=1,
+            reason_code="tool_timeout",
+            timestamp=start + timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_RETRIED,
+            workflow_id="wfspec_lifecycle",
+            node_id="node_a",
+            attempt=2,
+            reason_code="bounded_retry",
+            timestamp=start + timedelta(seconds=2),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id="wfspec_lifecycle",
+            node_id="node_a",
+            attempt=2,
+            timestamp=start + timedelta(seconds=3),
+        ),
+    )
+
+    states = effective_node_states(events)
+
+    assert [event.event_type for event in events] == [
+        WorkflowLifecycleEventType.NODE_STARTED,
+        WorkflowLifecycleEventType.NODE_FAILED,
+        WorkflowLifecycleEventType.NODE_RETRIED,
+        WorkflowLifecycleEventType.NODE_COMPLETED,
+    ]
+    assert states["node_a"] is WorkflowNodeLifecycleState.COMPLETED
+    assert completed_node_ids(events) == frozenset({"node_a"})
+
+
+def test_next_runnable_nodes_are_pure_projection_from_completed_predecessors() -> None:
+    spec = _spec()
+    assert next_runnable_node_ids(spec, ()) == ("node_a",)
+
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ("node_b",)
+
+    all_done = events + (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_b",
+        ),
+    )
+    assert next_runnable_node_ids(spec, all_done) == ("end",)
+
+
+def test_lifecycle_module_does_not_import_runtime_dispatcher() -> None:
+    import ouroboros.orchestrator.workflow_lifecycle as lifecycle
+
+    assert "ParallelACExecutor" not in lifecycle.__dict__
+    assert "OrchestratorRunner" not in lifecycle.__dict__

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -305,8 +305,6 @@ def test_retried_node_becomes_runnable_again_after_failure_history() -> None:
     assert next_runnable_node_ids(spec, events) == ("node_a",)
 
 
-
-
 def test_next_runnable_nodes_follow_traversed_conditional_edges_only() -> None:
     spec = _conditional_spec()
     completed_decision = (


### PR DESCRIPTION
## Summary

- Add a bounded `workflow_lifecycle` contract for #956 PR-3 lifecycle events.
- Preserve `WorkflowSpec.spec_id`, `WorkflowNode.node_id`, and `WorkflowEdge.edge_id` as the identifier anchors for future projection/event-store consumers.
- Add pure projection helpers for effective node state, completed nodes, and next-runnable nodes without dispatching work.
- Reject replay-unsafe lifecycle payload keys such as raw prompts/stdout/stderr and credentials.

## Issue / SSOT alignment

Closes a narrow #956 follow-up slice under #961 Tier 2 post-milestone sequencing.

This PR intentionally does **not**:

- make Workflow IR the live `parallel_executor` dispatch source;
- migrate `Seed.acceptance_criteria` to a new schema;
- create a second #946 Run/Step/Artifact projection vocabulary;
- change #978 TraceGuard/default-flip behavior;
- add external workflow SDKs or cloud dependencies.

## Verification

- `uv run pytest tests/unit/orchestrator/test_workflow_lifecycle.py tests/unit/orchestrator/test_workflow_ir.py tests/unit/orchestrator/test_workflow_ir_adapter.py -q` → 73 passed
- `uv run ruff check src/ouroboros/orchestrator/workflow_lifecycle.py tests/unit/orchestrator/test_workflow_lifecycle.py` → passed
- `uv run mypy src/ouroboros/orchestrator/workflow_lifecycle.py tests/unit/orchestrator/test_workflow_lifecycle.py` → success
