### PR TITLE
feat(runtime): ship skill capability guides for Hermes and Claude

### DIFF
--- a/.claude-plugin/SKILL_CAPABILITY_GUIDE.md
+++ b/.claude-plugin/SKILL_CAPABILITY_GUIDE.md
@@ -9,8 +9,17 @@ Use the runtime's local file search/read tools and prefer exact repository evide
 ### When a skill requires `call_mcp`
 Call available Ouroboros MCP tools through the runtime's MCP/tool surface instead of emulating MCP workflows manually.
 
+### When a skill requires `web_research`
+Use the runtime's web/search capability only when current external facts are required, and cite the sources used.
+
+### When a skill requires `run_shell`
+Use the runtime's bounded local shell capability for safe repository/version checks; avoid destructive commands unless explicitly authorized.
+
 ### When a skill requires `refine_answer`
 Confirm structured interpretations of free-text decisions before forwarding them to workflow state.
+
+### When a skill requires `maintain_ledger`
+Keep ambiguity, gates, and unresolved decisions visible in the main session rather than hiding them only in tool state.
 
 ### When a skill requires `run_closure_gate`
 Audit required client-side gates even when an MCP response says the workflow is ready to proceed.

--- a/.claude-plugin/SKILL_CAPABILITY_GUIDE.md
+++ b/.claude-plugin/SKILL_CAPABILITY_GUIDE.md
@@ -1,0 +1,19 @@
+## Ouroboros Skill Capability Guide: Claude
+
+### When a skill requires `ask_user`
+Use the runtime's native structured question surface when available; otherwise ask one concise question and wait.
+
+### When a skill requires `inspect_code`
+Use the runtime's local file search/read tools and prefer exact repository evidence over inference.
+
+### When a skill requires `call_mcp`
+Call available Ouroboros MCP tools through the runtime's MCP/tool surface instead of emulating MCP workflows manually.
+
+### When a skill requires `refine_answer`
+Confirm structured interpretations of free-text decisions before forwarding them to workflow state.
+
+### When a skill requires `run_closure_gate`
+Audit required client-side gates even when an MCP response says the workflow is ready to proceed.
+
+### When a skill requires `restate_goal`
+Restate the goal and require explicit approval before irreversible workflow transitions such as seed generation.

--- a/src/ouroboros/hermes/artifacts.py
+++ b/src/ouroboros/hermes/artifacts.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from pathlib import Path
 import shutil
 
+from ouroboros.backends.capabilities import render_backend_skill_capability_guide
 from ouroboros.skills.artifacts import (
     collect_skill_bundle_dirs,
     contains_skill_bundles,
@@ -16,6 +17,7 @@ from ouroboros.skills.artifacts import (
 
 HERMES_SKILL_CATEGORY = "autonomous-ai-agents"
 HERMES_SKILL_NAME = "ouroboros"
+HERMES_SKILL_CAPABILITY_GUIDE_FILENAME = "SKILL_CAPABILITY_GUIDE.md"
 _SKILL_ENTRYPOINT = "SKILL.md"
 _LEGACY_PACKAGE_ARTIFACTS = ("__init__.py", "artifacts.py", "__pycache__")
 
@@ -71,6 +73,11 @@ def install_hermes_skills(
         target_dir.mkdir(parents=True, exist_ok=True)
         source_skill_dirs = collect_skill_bundle_dirs(source_root)
         desired_skill_names = {skill_dir.name for skill_dir in source_skill_dirs}
+
+        (target_dir / HERMES_SKILL_CAPABILITY_GUIDE_FILENAME).write_text(
+            render_backend_skill_capability_guide("hermes"),
+            encoding="utf-8",
+        )
 
         for artifact_name in _LEGACY_PACKAGE_ARTIFACTS:
             _remove_target_path(target_dir / artifact_name)

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -15,6 +15,18 @@ from ouroboros.backends import (
     soft_tool_enforcement_backends,
 )
 
+REQUIRED_SKILL_CAPABILITY_NAMES = {
+    "ask_user",
+    "inspect_code",
+    "call_mcp",
+    "web_research",
+    "run_shell",
+    "refine_answer",
+    "maintain_ledger",
+    "run_closure_gate",
+    "restate_goal",
+}
+
 
 def test_resolves_aliases_to_canonical_names() -> None:
     assert resolve_backend_alias("codex_cli") == "codex"
@@ -68,17 +80,7 @@ def test_codex_skill_execution_guidance_is_registry_owned() -> None:
 
     assert capability is not None
     names = {item.name for item in capability.skill_execution_capabilities}
-    assert {
-        "ask_user",
-        "inspect_code",
-        "call_mcp",
-        "web_research",
-        "run_shell",
-        "refine_answer",
-        "maintain_ledger",
-        "run_closure_gate",
-        "restate_goal",
-    }.issubset(names)
+    assert names == REQUIRED_SKILL_CAPABILITY_NAMES
 
 
 def test_generic_skill_execution_guidance_covers_interview_requirements() -> None:
@@ -86,17 +88,7 @@ def test_generic_skill_execution_guidance_covers_interview_requirements() -> Non
 
     assert capability is not None
     names = {item.name for item in capability.skill_execution_capabilities}
-    assert {
-        "ask_user",
-        "inspect_code",
-        "call_mcp",
-        "web_research",
-        "run_shell",
-        "refine_answer",
-        "maintain_ledger",
-        "run_closure_gate",
-        "restate_goal",
-    }.issubset(names)
+    assert names == REQUIRED_SKILL_CAPABILITY_NAMES
 
 
 def test_renders_codex_skill_capability_guide_as_stable_markdown() -> None:
@@ -120,5 +112,5 @@ def test_renders_generic_skill_capability_guides_for_phase_two_runtimes() -> Non
         guide = render_backend_skill_capability_guide(backend_name)
 
         assert guide.startswith(f"## Ouroboros Skill Capability Guide: {backend_name.title()}\n")
-        assert "### When a skill requires `ask_user`" in guide
-        assert "### When a skill requires `run_closure_gate`" in guide
+        for capability_name in REQUIRED_SKILL_CAPABILITY_NAMES:
+            assert f"### When a skill requires `{capability_name}`" in guide

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -113,3 +113,12 @@ def test_renders_codex_skill_capability_guide_as_stable_markdown() -> None:
     assert "MCP `seed-ready`" in guide
     assert "### When a skill requires `restate_goal`" in guide
     assert "require explicit user approval" in guide
+
+
+def test_renders_generic_skill_capability_guides_for_phase_two_runtimes() -> None:
+    for backend_name in ("hermes", "claude"):
+        guide = render_backend_skill_capability_guide(backend_name)
+
+        assert guide.startswith(f"## Ouroboros Skill Capability Guide: {backend_name.title()}\n")
+        assert "### When a skill requires `ask_user`" in guide
+        assert "### When a skill requires `run_closure_gate`" in guide

--- a/tests/unit/hermes/test_artifacts.py
+++ b/tests/unit/hermes/test_artifacts.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from ouroboros.hermes.artifacts import install_hermes_skills
+from ouroboros.hermes.artifacts import (
+    HERMES_SKILL_CAPABILITY_GUIDE_FILENAME,
+    install_hermes_skills,
+)
 
 
 class TestInstallHermesSkills:
@@ -56,6 +59,24 @@ class TestInstallHermesSkills:
         )
         assert installed_path.joinpath("run", "notes.txt").read_text(encoding="utf-8") == "copied"
         assert installed_path.joinpath("interview", "SKILL.md").is_file()
+
+    def test_installs_runtime_skill_capability_guide(self, tmp_path: Path, monkeypatch) -> None:
+        """Hermes installs should include backend-specific skill execution guidance."""
+        source_skills_dir = tmp_path / "source-skills"
+        self._write_skill(source_skills_dir, "interview", body="fresh skill\n")
+        monkeypatch.setattr(
+            "ouroboros.hermes.artifacts._repo_root_skills_dir",
+            lambda: source_skills_dir,
+        )
+
+        installed_path = install_hermes_skills(hermes_dir=tmp_path / ".hermes")
+        guide = installed_path.joinpath(HERMES_SKILL_CAPABILITY_GUIDE_FILENAME).read_text(
+            encoding="utf-8"
+        )
+
+        assert guide.startswith("## Ouroboros Skill Capability Guide: Hermes\n")
+        assert "### When a skill requires `ask_user`" in guide
+        assert "### When a skill requires `run_closure_gate`" in guide
 
     def test_replaces_existing_hermes_bundle(self, tmp_path: Path, monkeypatch) -> None:
         """Refreshing the Hermes install should replace managed skill directories."""

--- a/tests/unit/hermes/test_artifacts.py
+++ b/tests/unit/hermes/test_artifacts.py
@@ -75,8 +75,18 @@ class TestInstallHermesSkills:
         )
 
         assert guide.startswith("## Ouroboros Skill Capability Guide: Hermes\n")
-        assert "### When a skill requires `ask_user`" in guide
-        assert "### When a skill requires `run_closure_gate`" in guide
+        for capability_name in (
+            "ask_user",
+            "inspect_code",
+            "call_mcp",
+            "web_research",
+            "run_shell",
+            "refine_answer",
+            "maintain_ledger",
+            "run_closure_gate",
+            "restate_goal",
+        ):
+            assert f"### When a skill requires `{capability_name}`" in guide
 
     def test_replaces_existing_hermes_bundle(self, tmp_path: Path, monkeypatch) -> None:
         """Refreshing the Hermes install should replace managed skill directories."""

--- a/tests/unit/test_claude_plugin_skill_guide.py
+++ b/tests/unit/test_claude_plugin_skill_guide.py
@@ -8,4 +8,6 @@ from ouroboros.backends.capabilities import render_backend_skill_capability_guid
 def test_claude_plugin_ships_rendered_skill_capability_guide() -> None:
     guide_path = Path(".claude-plugin") / "SKILL_CAPABILITY_GUIDE.md"
 
+    # The Claude plugin artifact is generated from the backend capability registry;
+    # update it by rendering this helper rather than hand-editing the snapshot.
     assert guide_path.read_text(encoding="utf-8") == render_backend_skill_capability_guide("claude")

--- a/tests/unit/test_claude_plugin_skill_guide.py
+++ b/tests/unit/test_claude_plugin_skill_guide.py
@@ -1,0 +1,11 @@
+"""Tests for Claude plugin skill execution guide artifact."""
+
+from pathlib import Path
+
+from ouroboros.backends.capabilities import render_backend_skill_capability_guide
+
+
+def test_claude_plugin_ships_rendered_skill_capability_guide() -> None:
+    guide_path = Path(".claude-plugin") / "SKILL_CAPABILITY_GUIDE.md"
+
+    assert guide_path.read_text(encoding="utf-8") == render_backend_skill_capability_guide("claude")


### PR DESCRIPTION
## Summary

Stacked on #1028. Implements #1008 Phase 2 parity for Hermes and Claude by consuming the backend-owned skill capability renderer introduced in the Codex PR.

- Hermes setup now writes `SKILL_CAPABILITY_GUIDE.md` into the installed Hermes skill bundle using `render_backend_skill_capability_guide("hermes")`.
- The Claude plugin package now ships `SKILL_CAPABILITY_GUIDE.md` generated from `render_backend_skill_capability_guide("claude")`.
- Tests cover the Hermes install artifact, the Claude plugin artifact staying in sync with the renderer, and generic guide rendering for both backends.

## Stacking

Base branch is `issue1008-skill-runtime-guides-codex` / PR #1028. This PR should be reviewed after #1028 or retargeted to `main` after #1028 merges.

## Validation

```bash
uv run pytest tests/unit/hermes/test_artifacts.py tests/unit/backends/test_capabilities.py tests/unit/test_claude_plugin_skill_guide.py tests/unit/cli/test_setup.py -q
# 145 passed

uv run mypy src/ouroboros/hermes/artifacts.py tests/unit/hermes/test_artifacts.py tests/unit/test_claude_plugin_skill_guide.py
# Success: no issues found in 3 source files

uv run ruff check src/ouroboros/hermes/artifacts.py tests/unit/hermes/test_artifacts.py tests/unit/backends/test_capabilities.py tests/unit/test_claude_plugin_skill_guide.py
# All checks passed!

uv run ruff format --check src/ouroboros/hermes/artifacts.py tests/unit/hermes/test_artifacts.py tests/unit/backends/test_capabilities.py tests/unit/test_claude_plugin_skill_guide.py
# 4 files already formatted
```

Refs #1008.
