### PR TITLE
docs(runtime): record skill capability guide coverage

### DIFF
--- a/docs/runtime-guides/skill-capability-guides.md
+++ b/docs/runtime-guides/skill-capability-guides.md
@@ -1,0 +1,45 @@
+# Runtime Skill Capability Guides
+
+Issue #1008 moves runtime-specific skill execution guidance out of individual
+`SKILL.md` files and into the backend capability registry. Runtime adapters then
+consume the rendered guide through the instruction surface they actually own.
+
+## Current coverage
+
+| Runtime | Generated artifact surface | Status |
+| --- | --- | --- |
+| Codex | Managed rule under `~/.codex/rules/ouroboros.md` | Installed during Codex setup/update via the generated guide renderer. |
+| Hermes | `~/.hermes/skills/autonomous-ai-agents/ouroboros/SKILL_CAPABILITY_GUIDE.md` | Installed with the Hermes skill bundle. |
+| Claude | `.claude-plugin/SKILL_CAPABILITY_GUIDE.md` | Shipped with the Claude plugin package and checked against the renderer. |
+| OpenCode | Not yet a stable prompt/rule artifact in setup | Fallback: use the generic guide from `backends.capabilities` and keep bridge-plugin behavior unchanged until OpenCode exposes a durable instruction surface. |
+| Gemini | Not yet a setup-owned prompt/rule artifact | Fallback: use the generic guide from `backends.capabilities`; setup only switches Ouroboros runtime/backend config today. |
+| Kiro | Not yet a setup-owned prompt/rule artifact | Fallback: use the generic guide from `backends.capabilities`; setup currently registers MCP and backend config only. |
+| Copilot | Not yet a setup-owned prompt/rule artifact | Fallback: use the generic guide from `backends.capabilities`; setup currently registers MCP and model/runtime config only. |
+
+## Fallback behavior for runtimes without generated artifacts
+
+Until a runtime has a durable instruction surface owned by `ouroboros setup`,
+clients should render `render_backend_skill_capability_guide(<backend>)` when
+building prompts or user-facing setup guidance, but must not copy long adapter
+sections into individual `SKILL.md` files.
+
+The fallback is intentionally conservative:
+
+1. Keep `SKILL.md` files runtime-neutral.
+2. Keep backend-specific execution wording in `src/ouroboros/backends/capabilities.py`.
+3. Add an installer only when the runtime has a stable, documented artifact
+   surface that setup can refresh idempotently.
+4. If no such surface exists, document the gap here and rely on the generic
+   backend guide until the runtime integration grows one.
+
+## Adding a new runtime artifact
+
+When a runtime gains a stable rule/skill/plugin instruction surface:
+
+1. Add or refine its `SkillExecutionCapability` entries in
+   `backends.capabilities`.
+2. Consume `render_backend_skill_capability_guide("<backend>")` from the
+   runtime installer or package artifact.
+3. Add an artifact test that proves setup/package output contains the rendered
+   guide and does not duplicate generated sections on refresh.
+4. Update the coverage table above.

--- a/tests/unit/test_runtime_skill_capability_docs.py
+++ b/tests/unit/test_runtime_skill_capability_docs.py
@@ -1,0 +1,14 @@
+"""Tests for runtime skill capability guide coverage docs."""
+
+from pathlib import Path
+
+
+def test_runtime_skill_capability_guide_docs_cover_all_runtime_backends() -> None:
+    docs = Path("docs/runtime-guides/skill-capability-guides.md").read_text(encoding="utf-8")
+
+    for backend in ("Codex", "Hermes", "Claude", "OpenCode", "Gemini", "Kiro", "Copilot"):
+        assert f"| {backend} |" in docs
+
+    assert "render_backend_skill_capability_guide(<backend>)" in docs
+    compact = " ".join(docs.split())
+    assert "must not copy long adapter sections into individual `SKILL.md` files" in compact


### PR DESCRIPTION
## Summary

Stacked on #1030. Completes the #1008 Phase 3 runtime coverage pass by documenting generated-guide support and fallback behavior for every supported runtime.

- Adds `docs/runtime-guides/skill-capability-guides.md` with a coverage table for Codex, Hermes, Claude, OpenCode, Gemini, Kiro, and Copilot.
- Documents why OpenCode/Gemini/Kiro/Copilot should not get invented setup files until each runtime exposes a durable prompt/rule artifact surface.
- Adds a regression test so the coverage doc keeps naming every supported runtime and preserves the `render_backend_skill_capability_guide(<backend>)` fallback contract.

## Stacking

Base branch is `issue1008-skill-runtime-guides-hermes-claude` / PR #1030. This PR should be reviewed after #1030 or retargeted after the stack lands.

## Validation

```bash
uv run pytest tests/unit/test_runtime_skill_capability_docs.py -q
# 1 passed

uv run ruff check tests/unit/test_runtime_skill_capability_docs.py
# All checks passed!

uv run ruff format --check tests/unit/test_runtime_skill_capability_docs.py
# 1 file already formatted
```

Refs #1008.
