### PR TITLE
feat(mcp): expose seed generation client gates

### DIFF
--- a/docs/runtime-guides/skill-capability-guides.md
+++ b/docs/runtime-guides/skill-capability-guides.md
@@ -16,6 +16,16 @@ consume the rendered guide through the instruction surface they actually own.
 | Kiro | Not yet a setup-owned prompt/rule artifact | Fallback: use the generic guide from `backends.capabilities`; setup currently registers MCP and backend config only. |
 | Copilot | Not yet a setup-owned prompt/rule artifact | Fallback: use the generic guide from `backends.capabilities`; setup currently registers MCP and model/runtime config only. |
 
+## Seed generation client-gate enforcement
+
+`ouroboros_generate_seed` always reports `required_client_gates`,
+`accepted_client_gates`, and `missing_client_gates` metadata so runtimes can
+confirm that the Seed-ready Acceptance Guard and Restate gate ran before seed
+generation. By default, missing gates remain warnings for compatibility with
+existing clients. Set `OUROBOROS_REQUIRE_CLIENT_GATES=1` to promote missing
+gates to a hard MCP precondition while migrating maintained clients to pass the
+`client_gates` acknowledgements.
+
 ## Fallback behavior for runtimes without generated artifacts
 
 Until a runtime has a durable instruction surface owned by `ouroboros setup`,

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -15,7 +15,11 @@ from ouroboros.auto.interview_driver import InterviewBackend, InterviewTurn
 from ouroboros.core.seed import Seed
 from ouroboros.mcp.errors import MCPServerError
 from ouroboros.mcp.job_manager import JobManager, JobStatus
-from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
+from ouroboros.mcp.tools.authoring_handlers import (
+    REQUIRED_CLIENT_GATES,
+    GenerateSeedHandler,
+    InterviewHandler,
+)
 from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
 from ouroboros.mcp.tools.execution_handlers import StartExecuteSeedHandler
 from ouroboros.mcp.tools.qa import QAHandler
@@ -144,8 +148,17 @@ class HandlerSeedGenerator:
         self.handler = handler
 
     async def __call__(self, session_id: str) -> Seed:
+        # AutoPipeline reaches this adapter only after its own interview driver
+        # closure gate records a seed-ready interview. Pass the maintained
+        # first-party acknowledgement set so the opt-in MCP hard gate can be
+        # enabled without breaking `ooo auto` seed generation.
         result = _unwrap(
-            await self.handler.handle({"session_id": session_id}),
+            await self.handler.handle(
+                {
+                    "session_id": session_id,
+                    "client_gates": REQUIRED_CLIENT_GATES,
+                }
+            ),
             tool_name="ouroboros_generate_seed",
         )
         text = result.content[0].text if result.content else ""

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -78,7 +78,7 @@ _SUGGESTED_INTERVIEW_ID_RE = re.compile(r"^interview_[a-f0-9]{16}$")
 
 _LIVE_AMBIGUITY_MAX_RETRIES = 3
 
-_REQUIRED_CLIENT_GATES: tuple[str, ...] = (
+REQUIRED_CLIENT_GATES: tuple[str, ...] = (
     # TODO(#1008): derive required gate names from the interview skill /
     # backend capability registry once non-skippable gates have a structured
     # source of truth instead of a Markdown-only checklist.
@@ -100,9 +100,9 @@ def _normalize_client_gates(value: Any) -> frozenset[str]:
 def get_client_gate_status(arguments: dict[str, Any]) -> dict[str, Any]:
     """Return required/accepted/missing client gate metadata for seed generation."""
     accepted = _normalize_client_gates(arguments.get("client_gates"))
-    missing = tuple(gate for gate in _REQUIRED_CLIENT_GATES if gate not in accepted)
+    missing = tuple(gate for gate in REQUIRED_CLIENT_GATES if gate not in accepted)
     status: dict[str, Any] = {
-        "required_client_gates": _REQUIRED_CLIENT_GATES,
+        "required_client_gates": REQUIRED_CLIENT_GATES,
         "accepted_client_gates": tuple(sorted(accepted)),
         "missing_client_gates": missing,
     }
@@ -1200,7 +1200,7 @@ class InterviewHandler:
                     "ambiguity_score": score.overall_score if score is not None else None,
                     "milestone": _milestone_for_score(score),
                     "seed_ready": score.is_ready_for_seed if score is not None else None,
-                    "required_client_gates": _REQUIRED_CLIENT_GATES,
+                    "required_client_gates": REQUIRED_CLIENT_GATES,
                 },
             )
         )

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -78,6 +78,48 @@ _SUGGESTED_INTERVIEW_ID_RE = re.compile(r"^interview_[a-f0-9]{16}$")
 
 _LIVE_AMBIGUITY_MAX_RETRIES = 3
 
+_REQUIRED_CLIENT_GATES: tuple[str, ...] = (
+    "seed_ready_acceptance_guard",
+    "restate_goal_approved",
+)
+
+
+def _normalize_client_gates(value: Any) -> frozenset[str]:
+    """Normalize caller-reported client-side gate acknowledgements."""
+    if isinstance(value, str):
+        return frozenset(part.strip() for part in value.split(",") if part.strip())
+    if isinstance(value, (list, tuple, set, frozenset)):
+        return frozenset(item.strip() for item in value if isinstance(item, str) and item.strip())
+    return frozenset()
+
+
+def _client_gate_status(arguments: dict[str, Any]) -> dict[str, Any]:
+    """Return required/accepted/missing client gate metadata for seed generation."""
+    accepted = _normalize_client_gates(arguments.get("client_gates"))
+    missing = tuple(gate for gate in _REQUIRED_CLIENT_GATES if gate not in accepted)
+    status: dict[str, Any] = {
+        "required_client_gates": _REQUIRED_CLIENT_GATES,
+        "accepted_client_gates": tuple(sorted(accepted)),
+        "missing_client_gates": missing,
+    }
+    if missing:
+        status["client_gate_warning"] = (
+            "Seed generation was requested without all client-side interview gates "
+            "being acknowledged. The client should run the Seed-ready Acceptance Guard "
+            "and Restate gate, then pass client_gates with the acknowledged gate names."
+        )
+    return status
+
+
+def _client_gate_warning_text(gate_status: dict[str, Any]) -> str:
+    warning = gate_status.get("client_gate_warning")
+    missing = gate_status.get("missing_client_gates")
+    if not isinstance(warning, str) or not missing:
+        return ""
+    missing_display = ", ".join(str(item) for item in missing)
+    return f"Client Gate Warning: {warning} Missing: {missing_display}.\n\n"
+
+
 _INTERVIEW_COMPLETION_SIGNALS = {
     "done",
     "complete",
@@ -628,6 +670,16 @@ class GenerateSeedHandler:
                     ),
                     required=False,
                 ),
+                MCPToolParameter(
+                    name="client_gates",
+                    type=ToolInputType.ARRAY,
+                    description=(
+                        "Client-side interview gates acknowledged before seed generation. "
+                        "Expected values include seed_ready_acceptance_guard and "
+                        "restate_goal_approved."
+                    ),
+                    required=False,
+                ),
             ),
         )
 
@@ -653,6 +705,7 @@ class GenerateSeedHandler:
             )
 
         ambiguity_score_value = arguments.get("ambiguity_score")
+        client_gate_status = _client_gate_status(arguments)
 
         log.info(
             "mcp.tool.generate_seed",
@@ -729,6 +782,7 @@ class GenerateSeedHandler:
                     "session_id": session_id,
                     "status": "delegated_to_subagent",
                     "dispatch_mode": "plugin",
+                    **client_gate_status,
                 },
             )
 
@@ -841,7 +895,7 @@ class GenerateSeedHandler:
             )
 
             result_text = (
-                f"Seed Generated Successfully\n"
+                _client_gate_warning_text(client_gate_status) + f"Seed Generated Successfully\n"
                 f"=========================\n"
                 f"Seed ID: {seed.metadata.seed_id}\n"
                 f"Interview ID: {seed.metadata.interview_id}\n"
@@ -859,6 +913,7 @@ class GenerateSeedHandler:
                         "seed_id": seed.metadata.seed_id,
                         "interview_id": seed.metadata.interview_id,
                         "ambiguity_score": seed.metadata.ambiguity_score,
+                        **client_gate_status,
                     },
                 )
             )
@@ -1114,6 +1169,7 @@ class InterviewHandler:
                     "ambiguity_score": score.overall_score if score is not None else None,
                     "milestone": _milestone_for_score(score),
                     "seed_ready": score.is_ready_for_seed if score is not None else None,
+                    "required_client_gates": _REQUIRED_CLIENT_GATES,
                 },
             )
         )

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -79,9 +79,13 @@ _SUGGESTED_INTERVIEW_ID_RE = re.compile(r"^interview_[a-f0-9]{16}$")
 _LIVE_AMBIGUITY_MAX_RETRIES = 3
 
 _REQUIRED_CLIENT_GATES: tuple[str, ...] = (
+    # TODO(#1008): derive required gate names from the interview skill /
+    # backend capability registry once non-skippable gates have a structured
+    # source of truth instead of a Markdown-only checklist.
     "seed_ready_acceptance_guard",
     "restate_goal_approved",
 )
+_REQUIRE_CLIENT_GATES_ENV = "OUROBOROS_REQUIRE_CLIENT_GATES"
 
 
 def _normalize_client_gates(value: Any) -> frozenset[str]:
@@ -93,7 +97,7 @@ def _normalize_client_gates(value: Any) -> frozenset[str]:
     return frozenset()
 
 
-def _client_gate_status(arguments: dict[str, Any]) -> dict[str, Any]:
+def get_client_gate_status(arguments: dict[str, Any]) -> dict[str, Any]:
     """Return required/accepted/missing client gate metadata for seed generation."""
     accepted = _normalize_client_gates(arguments.get("client_gates"))
     missing = tuple(gate for gate in _REQUIRED_CLIENT_GATES if gate not in accepted)
@@ -109,6 +113,28 @@ def _client_gate_status(arguments: dict[str, Any]) -> dict[str, Any]:
             "and Restate gate, then pass client_gates with the acknowledged gate names."
         )
     return status
+
+
+def _require_client_gates_enabled() -> bool:
+    """Return True when missing client gates should hard-block generation."""
+    return os.environ.get(_REQUIRE_CLIENT_GATES_ENV, "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _client_gate_error(gate_status: dict[str, Any]) -> MCPToolError | None:
+    missing = gate_status.get("missing_client_gates")
+    if not missing or not _require_client_gates_enabled():
+        return None
+    missing_display = ", ".join(str(item) for item in missing)
+    return MCPToolError(
+        "Seed generation requires acknowledged client-side interview gates "
+        f"when {_REQUIRE_CLIENT_GATES_ENV}=1. Missing: {missing_display}.",
+        tool_name="ouroboros_generate_seed",
+    )
 
 
 def _client_gate_warning_text(gate_status: dict[str, Any]) -> str:
@@ -679,6 +705,7 @@ class GenerateSeedHandler:
                         "restate_goal_approved."
                     ),
                     required=False,
+                    items={"type": "string"},
                 ),
             ),
         )
@@ -705,7 +732,10 @@ class GenerateSeedHandler:
             )
 
         ambiguity_score_value = arguments.get("ambiguity_score")
-        client_gate_status = _client_gate_status(arguments)
+        client_gate_status = get_client_gate_status(arguments)
+        client_gate_error = _client_gate_error(client_gate_status)
+        if client_gate_error is not None:
+            return Result.err(client_gate_error)
 
         log.info(
             "mcp.tool.generate_seed",

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -770,6 +770,7 @@ class GenerateSeedHandler:
                 session_id=session_id,
                 ambiguity_score=effective_score,
                 transcript=transcript,
+                client_gates=client_gate_status["accepted_client_gates"],
             )
             await emit_subagent_dispatched_event(
                 self.event_store,

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -656,6 +656,7 @@ def build_generate_seed_subagent(
     session_id: str,
     ambiguity_score: float | None = None,
     transcript: str = "",
+    client_gates: tuple[str, ...] = (),
 ) -> SubagentPayload:
     """Build subagent payload for seed generation from interview."""
     from ouroboros.agents.loader import load_agent_prompt
@@ -690,6 +691,7 @@ autonomous execution."""
     context: dict[str, Any] = {
         "session_id": session_id,
         "ambiguity_score": ambiguity_score,
+        "client_gates": client_gates,
     }
 
     return build_subagent_payload(

--- a/tests/unit/auto/test_adapters_client_gates.py
+++ b/tests/unit/auto/test_adapters_client_gates.py
@@ -6,8 +6,9 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from ouroboros.auto.adapters import HandlerInterviewBackend
+from ouroboros.auto.adapters import HandlerError, HandlerInterviewBackend, HandlerSeedGenerator
 from ouroboros.core.types import Result
+from ouroboros.mcp.errors import MCPToolError
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 
 
@@ -43,3 +44,28 @@ async def test_auto_interview_backend_ignores_seed_ready_client_gate_metadata(tm
 
     assert turn.session_id == "interview_auto"
     assert turn.seed_ready is True
+
+
+@pytest.mark.asyncio
+async def test_auto_seed_generator_passes_client_gate_acknowledgements() -> None:
+    """The opt-in hard gate must not break maintained auto seed generation."""
+    handler = AsyncMock()
+    handler.handle = AsyncMock(
+        return_value=Result.err(
+            MCPToolError("stop after capturing arguments", tool_name="ouroboros_generate_seed")
+        )
+    )
+    generator = HandlerSeedGenerator(handler)
+
+    with pytest.raises(HandlerError):
+        await generator("interview_auto")
+
+    handler.handle.assert_awaited_once_with(
+        {
+            "session_id": "interview_auto",
+            "client_gates": (
+                "seed_ready_acceptance_guard",
+                "restate_goal_approved",
+            ),
+        }
+    )

--- a/tests/unit/auto/test_adapters_client_gates.py
+++ b/tests/unit/auto/test_adapters_client_gates.py
@@ -1,0 +1,45 @@
+"""Auto adapter compatibility with interview client-gate metadata."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ouroboros.auto.adapters import HandlerInterviewBackend
+from ouroboros.core.types import Result
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+
+
+@pytest.mark.asyncio
+async def test_auto_interview_backend_ignores_seed_ready_client_gate_metadata(tmp_path) -> None:
+    """New seed-ready metadata must not break the in-flight auto driver adapter."""
+    handler = AsyncMock()
+    handler.handle = AsyncMock(
+        return_value=Result.ok(
+            MCPToolResult(
+                content=(
+                    MCPContentItem(
+                        type=ContentType.TEXT,
+                        text="Session interview_auto\n\nSeed-ready.",
+                    ),
+                ),
+                is_error=False,
+                meta={
+                    "session_id": "interview_auto",
+                    "seed_ready": True,
+                    "required_client_gates": (
+                        "seed_ready_acceptance_guard",
+                        "restate_goal_approved",
+                    ),
+                },
+            )
+        )
+    )
+    handler.resolved_state_dir.return_value = tmp_path
+    backend = HandlerInterviewBackend(handler, cwd=str(tmp_path))
+
+    turn = await backend.resume("interview_auto")
+
+    assert turn.session_id == "interview_auto"
+    assert turn.seed_ready is True

--- a/tests/unit/mcp/tools/test_client_gates.py
+++ b/tests/unit/mcp/tools/test_client_gates.py
@@ -6,13 +6,14 @@ from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBre
 from ouroboros.bigbang.interview import InterviewState
 from ouroboros.core.types import Result
 from ouroboros.mcp.tools.authoring_handlers import (
+    GenerateSeedHandler,
     InterviewHandler,
-    _client_gate_status,
+    get_client_gate_status,
 )
 
 
 def test_client_gate_status_reports_missing_required_gates() -> None:
-    status = _client_gate_status({})
+    status = get_client_gate_status({})
 
     assert status["required_client_gates"] == (
         "seed_ready_acceptance_guard",
@@ -23,12 +24,53 @@ def test_client_gate_status_reports_missing_required_gates() -> None:
 
 
 def test_client_gate_status_accepts_all_required_gates() -> None:
-    status = _client_gate_status(
+    status = get_client_gate_status(
         {"client_gates": ["restate_goal_approved", "seed_ready_acceptance_guard"]}
     )
 
     assert status["missing_client_gates"] == ()
     assert "client_gate_warning" not in status
+
+
+def test_generate_seed_definition_types_client_gates_as_string_array() -> None:
+    param = next(p for p in GenerateSeedHandler().definition.parameters if p.name == "client_gates")
+
+    assert param.items == {"type": "string"}
+
+
+@pytest.mark.asyncio
+async def test_generate_seed_hard_blocks_missing_client_gates_when_required(monkeypatch) -> None:
+    monkeypatch.setenv("OUROBOROS_REQUIRE_CLIENT_GATES", "1")
+    handler = GenerateSeedHandler()
+
+    result = await handler.handle({"session_id": "session-gate"})
+
+    assert result.is_err
+    assert "requires acknowledged client-side interview gates" in result.error.message
+    assert "seed_ready_acceptance_guard" in result.error.message
+    assert "restate_goal_approved" in result.error.message
+
+
+@pytest.mark.asyncio
+async def test_generate_seed_hard_gate_allows_complete_client_gates(monkeypatch) -> None:
+    monkeypatch.setenv("OUROBOROS_REQUIRE_CLIENT_GATES", "1")
+
+    class Engine:
+        async def load_state(self, session_id: str):
+            return Result.err("stop after client-gate precondition")
+
+    handler = GenerateSeedHandler(interview_engine=Engine())
+
+    result = await handler.handle(
+        {
+            "session_id": "session-gate",
+            "client_gates": ["seed_ready_acceptance_guard", "restate_goal_approved"],
+        }
+    )
+
+    assert result.is_err
+    assert "requires acknowledged client-side interview gates" not in result.error.message
+    assert "Failed to load interview state" in result.error.message
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_client_gates.py
+++ b/tests/unit/mcp/tools/test_client_gates.py
@@ -1,0 +1,79 @@
+"""Tests for MCP client-side interview gate metadata."""
+
+import pytest
+
+from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBreakdown
+from ouroboros.bigbang.interview import InterviewState
+from ouroboros.core.types import Result
+from ouroboros.mcp.tools.authoring_handlers import (
+    InterviewHandler,
+    _client_gate_status,
+)
+
+
+def test_client_gate_status_reports_missing_required_gates() -> None:
+    status = _client_gate_status({})
+
+    assert status["required_client_gates"] == (
+        "seed_ready_acceptance_guard",
+        "restate_goal_approved",
+    )
+    assert status["missing_client_gates"] == status["required_client_gates"]
+    assert "client_gate_warning" in status
+
+
+def test_client_gate_status_accepts_all_required_gates() -> None:
+    status = _client_gate_status(
+        {"client_gates": ["restate_goal_approved", "seed_ready_acceptance_guard"]}
+    )
+
+    assert status["missing_client_gates"] == ()
+    assert "client_gate_warning" not in status
+
+
+@pytest.mark.asyncio
+async def test_seed_ready_response_exposes_required_client_gates() -> None:
+    class Engine:
+        async def complete_interview(self, state: InterviewState):
+            return Result.ok(state)
+
+        async def save_state(self, state: InterviewState):
+            return Result.ok(None)
+
+    handler = InterviewHandler()
+    score = AmbiguityScore(
+        overall_score=0.1,
+        breakdown=ScoreBreakdown(
+            goal_clarity=ComponentScore(
+                name="Goal Clarity",
+                clarity_score=0.9,
+                weight=0.4,
+                justification="clear",
+            ),
+            constraint_clarity=ComponentScore(
+                name="Constraint Clarity",
+                clarity_score=0.9,
+                weight=0.3,
+                justification="clear",
+            ),
+            success_criteria_clarity=ComponentScore(
+                name="Success Criteria Clarity",
+                clarity_score=0.9,
+                weight=0.3,
+                justification="clear",
+            ),
+        ),
+    )
+
+    result = await handler._complete_interview_response(
+        Engine(),
+        InterviewState(interview_id="session-gate"),
+        "session-gate",
+        score,
+    )
+
+    assert result.is_ok
+    assert result.value.meta["required_client_gates"] == (
+        "seed_ready_acceptance_guard",
+        "restate_goal_approved",
+    )

--- a/tests/unit/mcp/tools/test_handler_subagent_wiring.py
+++ b/tests/unit/mcp/tools/test_handler_subagent_wiring.py
@@ -161,6 +161,21 @@ class TestGenerateSeedHandlerSubagentDispatch:
         # Plugin path now prefers caller-supplied score over persisted
         assert ctx["ambiguity_score"] == 0.15
 
+    async def test_plugin_context_preserves_client_gate_acknowledgements(self, handler) -> None:
+        result = await handler.handle(
+            {
+                "session_id": "sess-456",
+                "client_gates": ["restate_goal_approved", "seed_ready_acceptance_guard"],
+            }
+        )
+
+        ctx = result.value.meta["_subagent"]["context"]
+        assert ctx["client_gates"] == (
+            "restate_goal_approved",
+            "seed_ready_acceptance_guard",
+        )
+        assert result.value.meta["missing_client_gates"] == ()
+
 
 # ---------------------------------------------------------------------------
 # InterviewHandler

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -718,6 +718,17 @@ class TestBuildGenerateSeedSubagent:
         assert p.context["session_id"] == "sess-123"
         assert p.context["ambiguity_score"] == 0.15
 
+    def test_context_preserves_client_gate_acknowledgements(self) -> None:
+        p = build_generate_seed_subagent(
+            session_id="sess-123",
+            client_gates=("restate_goal_approved", "seed_ready_acceptance_guard"),
+        )
+
+        assert p.context["client_gates"] == (
+            "restate_goal_approved",
+            "seed_ready_acceptance_guard",
+        )
+
 
 # ---------------------------------------------------------------------------
 # Tool-specific builders: Evaluate


### PR DESCRIPTION
## Summary

Stacked on #1033. Implements the first MCP-side client gate contract from #1008 Phase 4.

- Seed-ready interview responses now declare `required_client_gates`.
- `ouroboros_generate_seed` accepts optional `client_gates` acknowledgements.
- Generate-seed responses include `required_client_gates`, `accepted_client_gates`, `missing_client_gates`, and a warning when required gates are missing.
- Missing gates remain warning-only by default so existing clients keep working.
- `OUROBOROS_REQUIRE_CLIENT_GATES=1` promotes missing gates to a hard `Result.err(...)` precondition for rollout/CI enforcement.
- Plugin subagent delegation and first-party `ooo auto` seed generation now pass the acknowledged gates so maintained paths can run with the enforcement flag enabled.

## Rollout path

This PR establishes the server-visible contract and the opt-in enforcement path without breaking existing clients by default. Maintained clients can pass `client_gates` now; operators can enable `OUROBOROS_REQUIRE_CLIENT_GATES=1` once their client surface is updated.

## Stacking

Base branch is `issue1008-skill-runtime-guides-coverage` / PR #1033. This PR should be reviewed after #1033 or retargeted/rebased after the stack lands.

## Validation

```bash
uv run pytest -q tests/unit/auto/test_adapters_client_gates.py tests/unit/mcp/tools/test_client_gates.py tests/unit/mcp/tools/test_definitions.py tests/unit/mcp/tools/test_interview_reopen_seed_ready.py tests/unit/mcp/tools/test_subagent.py tests/unit/mcp/tools/test_handler_subagent_wiring.py tests/unit/test_runtime_skill_capability_docs.py
# 228 passed

uv run ruff check src/ouroboros/mcp/tools/authoring_handlers.py src/ouroboros/mcp/tools/subagent.py src/ouroboros/auto/adapters.py tests/unit/auto/test_adapters_client_gates.py tests/unit/mcp/tools/test_client_gates.py tests/unit/mcp/tools/test_definitions.py tests/unit/mcp/tools/test_subagent.py tests/unit/mcp/tools/test_handler_subagent_wiring.py tests/unit/test_runtime_skill_capability_docs.py
# All checks passed!

uv run mypy src/ouroboros/mcp/tools/authoring_handlers.py src/ouroboros/mcp/tools/subagent.py src/ouroboros/auto/adapters.py tests/unit/mcp/tools/test_client_gates.py tests/unit/auto/test_adapters_client_gates.py
# Success: no issues found in 5 source files

uv run ruff format --check src/ouroboros/mcp/tools/authoring_handlers.py src/ouroboros/mcp/tools/subagent.py src/ouroboros/auto/adapters.py tests/unit/auto/test_adapters_client_gates.py tests/unit/mcp/tools/test_client_gates.py tests/unit/mcp/tools/test_definitions.py tests/unit/mcp/tools/test_subagent.py tests/unit/mcp/tools/test_handler_subagent_wiring.py tests/unit/test_runtime_skill_capability_docs.py
# 9 files already formatted
```

Refs #1008.
