### PR TITLE
feat(core): add HITL state projection

### DIFF
--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -98,11 +98,18 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
             if current is not None and current.is_terminal:
                 continue
             snapshot = _snapshot_from_requested(event, request_id)
+            if current is not None:
+                snapshot = replace(
+                    snapshot,
+                    request_event_id=current.request_event_id,
+                    created_at=current.created_at,
+                )
             if request_id not in snapshots:
                 order.append(request_id)
             # A pre-terminal duplicate request refreshes the request payload
-            # while preserving insertion order. Once terminal, first terminal
-            # state wins so replay cannot reopen an already-resolved wait.
+            # while preserving insertion order and original request provenance.
+            # Once terminal, first terminal state wins so replay cannot reopen
+            # an already-resolved wait.
             snapshots[request_id] = snapshot
             continue
 
@@ -123,7 +130,9 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
             continue
 
         if event.type == HumanInputRequest.TIMED_OUT_EVENT_TYPE:
-            if not _request_has_timeout(current):
+            if not _request_has_timeout(current) or not _event_context_matches_request(
+                event, current
+            ):
                 continue
             snapshots[request_id] = _snapshot_from_terminal(
                 current,
@@ -134,6 +143,8 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
             continue
 
         if event.type == HumanInputRequest.CANCELLED_EVENT_TYPE:
+            if not _event_context_matches_request(event, current):
+                continue
             snapshots[request_id] = _snapshot_from_terminal(
                 current,
                 event,
@@ -199,7 +210,7 @@ def _state_from_answered_event(
 ) -> HumanInputState | None:
     if _optional_str(event.data.get("actor")) is None:
         return None
-    if not _answer_context_matches_request(event, current):
+    if not _event_context_matches_request(event, current):
         return None
 
     response_kind = event.data.get("response_kind")
@@ -262,7 +273,7 @@ def _state_from_answered_event(
     return None
 
 
-def _answer_context_matches_request(event: BaseEvent, current: HumanInputSnapshot) -> bool:
+def _event_context_matches_request(event: BaseEvent, current: HumanInputSnapshot) -> bool:
     for key in ("session_id", "run_id", "invocation_id"):
         event_value = _optional_str(event.data.get(key))
         if event_value is not None and event_value != getattr(current, key):

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -16,7 +16,11 @@ from enum import StrEnum
 from types import MappingProxyType
 from typing import Any
 
-from ouroboros.core.hitl_contract import HumanInputRequest, HumanInputResponse
+from ouroboros.core.hitl_contract import (
+    HumanInputRequest,
+    HumanInputResponse,
+    HumanInputResponseKind,
+)
 from ouroboros.events.base import BaseEvent
 
 
@@ -109,7 +113,7 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
             snapshots[request_id] = _snapshot_from_terminal(
                 current,
                 event,
-                state=HumanInputState.ANSWERED,
+                state=_state_from_answered_event(event),
                 response=_frozen_payload(event.data),
             )
             continue
@@ -182,6 +186,15 @@ def _snapshot_from_terminal(
         reason=reason,
         response=response,
     )
+
+
+def _state_from_answered_event(event: BaseEvent) -> HumanInputState:
+    response_kind = event.data.get("response_kind")
+    if response_kind == HumanInputResponseKind.CANCEL.value:
+        return HumanInputState.CANCELLED
+    if response_kind == HumanInputResponseKind.TIMEOUT.value:
+        return HumanInputState.TIMED_OUT
+    return HumanInputState.ANSWERED
 
 
 def _event_request_id(event: BaseEvent) -> str | None:

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -103,6 +103,8 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
             except ValueError:
                 continue
             if current is not None:
+                if not _duplicate_request_context_matches(snapshot, current):
+                    continue
                 snapshot = replace(
                     snapshot,
                     request_event_id=current.request_event_id,
@@ -210,6 +212,17 @@ def _snapshot_from_terminal(
         actor=actor if actor is not None else _optional_str(event.data.get("actor")),
         reason=reason,
         response=response,
+    )
+
+
+def _duplicate_request_context_matches(
+    snapshot: HumanInputSnapshot, current: HumanInputSnapshot
+) -> bool:
+    return (
+        snapshot.session_id == current.session_id
+        and snapshot.run_id == current.run_id
+        and snapshot.invocation_id == current.invocation_id
+        and snapshot.resume_target == current.resume_target
     )
 
 

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -248,6 +248,8 @@ def _state_from_answered_event(
         ):
             return None
         normalized_values = tuple(str(value).strip() for value in selected_values)
+        if len(set(normalized_values)) != len(normalized_values):
+            return None
         options = _request_options(current)
         if any(value not in options for value in normalized_values):
             return None

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -137,7 +137,7 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
             if (
                 _optional_str(event.data.get("reason")) is None
                 or not _request_timeout_is_terminal(current)
-                or not _event_context_matches_request(event, current)
+                or not _terminal_event_context_matches_request(event, current)
             ):
                 continue
             snapshots[request_id] = _snapshot_from_terminal(
@@ -151,7 +151,7 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
         if event.type == HumanInputRequest.CANCELLED_EVENT_TYPE:
             if _optional_str(
                 event.data.get("reason")
-            ) is None or not _event_context_matches_request(event, current):
+            ) is None or not _terminal_event_context_matches_request(event, current):
                 continue
             snapshots[request_id] = _snapshot_from_terminal(
                 current,
@@ -287,6 +287,16 @@ def _event_context_matches_request(event: BaseEvent, current: HumanInputSnapshot
     for key in ("session_id", "run_id", "invocation_id"):
         event_value = _optional_str(event.data.get(key))
         if event_value is not None and event_value != getattr(current, key):
+            return False
+    return True
+
+
+def _terminal_event_context_matches_request(event: BaseEvent, current: HumanInputSnapshot) -> bool:
+    if _optional_str(event.data.get("session_id")) != current.session_id:
+        return False
+    for key in ("run_id", "invocation_id"):
+        current_value = getattr(current, key)
+        if current_value is not None and _optional_str(event.data.get(key)) != current_value:
             return False
     return True
 

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -313,10 +313,15 @@ def _event_request_id(event: BaseEvent) -> str | None:
         HumanInputRequest.CANCELLED_EVENT_TYPE,
     }:
         return None
-    value = event.data.get("request_id") or event.aggregate_id
-    if isinstance(value, str) and value.strip():
-        return value.strip()
-    return None
+    data_request_id = _optional_str(event.data.get("request_id"))
+    aggregate_request_id = _optional_str(event.aggregate_id)
+    if (
+        data_request_id is not None
+        and aggregate_request_id is not None
+        and data_request_id != aggregate_request_id
+    ):
+        return None
+    return data_request_id or aggregate_request_id
 
 
 def _required_str(data: Mapping[str, Any], key: str, event_id: str) -> str:

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -110,10 +110,13 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
             continue
 
         if event.type == HumanInputResponse.ANSWERED_EVENT_TYPE:
+            answered_state = _state_from_answered_event(event)
+            if answered_state is None:
+                continue
             snapshots[request_id] = _snapshot_from_terminal(
                 current,
                 event,
-                state=_state_from_answered_event(event),
+                state=answered_state,
                 response=_frozen_payload(event.data),
             )
             continue
@@ -188,13 +191,33 @@ def _snapshot_from_terminal(
     )
 
 
-def _state_from_answered_event(event: BaseEvent) -> HumanInputState:
+def _state_from_answered_event(event: BaseEvent) -> HumanInputState | None:
+    if _optional_str(event.data.get("actor")) is None:
+        return None
+
     response_kind = event.data.get("response_kind")
     if response_kind == HumanInputResponseKind.CANCEL.value:
         return HumanInputState.CANCELLED
     if response_kind == HumanInputResponseKind.TIMEOUT.value:
         return HumanInputState.TIMED_OUT
-    return HumanInputState.ANSWERED
+    if response_kind == HumanInputResponseKind.TEXT.value:
+        return (
+            HumanInputState.ANSWERED if _optional_str(event.data.get("text")) is not None else None
+        )
+    if response_kind == HumanInputResponseKind.SELECTION.value:
+        selected_values = event.data.get("selected_values")
+        if isinstance(selected_values, list | tuple) and any(
+            _optional_str(value) is not None for value in selected_values
+        ):
+            return HumanInputState.ANSWERED
+        return None
+    if response_kind == HumanInputResponseKind.APPROVAL.value:
+        return (
+            HumanInputState.ANSWERED
+            if isinstance(event.data.get("approval_decision"), bool)
+            else None
+        )
+    return None
 
 
 def _event_request_id(event: BaseEvent) -> str | None:

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -1,0 +1,229 @@
+"""Replay projection for durable human-in-the-loop WAIT/RESUME state.
+
+This module is a narrow #960 read-model slice over the existing HITL event
+contract. It intentionally stays pure: callers provide an ordered event stream
+from the EventStore and receive immutable request snapshots that can be used by
+CLI/MCP/runtime surfaces to list pending waits, detect terminal answers, and
+resume without reparsing raw event payloads.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field, replace
+from datetime import datetime
+from enum import StrEnum
+from types import MappingProxyType
+from typing import Any
+
+from ouroboros.core.hitl_contract import HumanInputRequest, HumanInputResponse
+from ouroboros.events.base import BaseEvent
+
+
+class HumanInputState(StrEnum):
+    """Effective replay state for one HITL request."""
+
+    PENDING = "pending"
+    ANSWERED = "answered"
+    TIMED_OUT = "timed_out"
+    CANCELLED = "cancelled"
+
+
+_TERMINAL_STATES = frozenset(
+    {
+        HumanInputState.ANSWERED,
+        HumanInputState.TIMED_OUT,
+        HumanInputState.CANCELLED,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class HumanInputSnapshot:
+    """Immutable read-model row for a single HITL request.
+
+    ``request`` and ``response`` are normalized event payloads, not live
+    dataclass instances. Keeping the raw JSON-safe contract data avoids adding a
+    second parser while preserving enough information for durable WAIT/RESUME
+    query surfaces.
+    """
+
+    request_id: str
+    state: HumanInputState
+    request_event_id: str
+    updated_event_id: str
+    created_at: datetime
+    updated_at: datetime
+    session_id: str
+    resume_target: str
+    run_id: str | None = None
+    invocation_id: str | None = None
+    terminal_event_id: str | None = None
+    actor: str | None = None
+    reason: str | None = None
+    request: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+    response: Mapping[str, Any] | None = None
+
+    @property
+    def is_terminal(self) -> bool:
+        """Return whether this request can no longer be resumed as pending."""
+
+        return self.state in _TERMINAL_STATES
+
+
+def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSnapshot, ...]:
+    """Project HITL request snapshots from an ordered event stream.
+
+    Orphan terminal events are ignored because they cannot be resumed safely
+    without a prior ``hitl.requested`` payload. If an already terminal request
+    receives later HITL events, the first terminal state is retained so replay is
+    deterministic and double-terminal histories remain visible in raw events.
+    """
+
+    snapshots: dict[str, HumanInputSnapshot] = {}
+    order: list[str] = []
+
+    for event in events:
+        request_id = _event_request_id(event)
+        if request_id is None:
+            continue
+
+        if event.type == HumanInputRequest.REQUESTED_EVENT_TYPE:
+            snapshot = _snapshot_from_requested(event, request_id)
+            if request_id not in snapshots:
+                order.append(request_id)
+            # A request event is the authoritative initial row. Replayed
+            # duplicate request ids keep the latest request payload only while
+            # preserving the original insertion order.
+            snapshots[request_id] = snapshot
+            continue
+
+        current = snapshots.get(request_id)
+        if current is None or current.is_terminal:
+            continue
+
+        if event.type == HumanInputResponse.ANSWERED_EVENT_TYPE:
+            snapshots[request_id] = _snapshot_from_terminal(
+                current,
+                event,
+                state=HumanInputState.ANSWERED,
+                response=_frozen_payload(event.data),
+            )
+            continue
+
+        if event.type == HumanInputRequest.TIMED_OUT_EVENT_TYPE:
+            snapshots[request_id] = _snapshot_from_terminal(
+                current,
+                event,
+                state=HumanInputState.TIMED_OUT,
+                reason=_optional_str(event.data.get("reason")),
+            )
+            continue
+
+        if event.type == HumanInputRequest.CANCELLED_EVENT_TYPE:
+            snapshots[request_id] = _snapshot_from_terminal(
+                current,
+                event,
+                state=HumanInputState.CANCELLED,
+                actor=_optional_str(event.data.get("actor")),
+                reason=_optional_str(event.data.get("reason")),
+            )
+
+    return tuple(snapshots[request_id] for request_id in order if request_id in snapshots)
+
+
+def pending_human_input_requests(events: Iterable[BaseEvent]) -> tuple[HumanInputSnapshot, ...]:
+    """Return only pending HITL requests from an ordered event stream."""
+
+    return tuple(
+        snapshot
+        for snapshot in project_human_input_state(events)
+        if snapshot.state is HumanInputState.PENDING
+    )
+
+
+def _snapshot_from_requested(event: BaseEvent, request_id: str) -> HumanInputSnapshot:
+    session_id = _required_str(event.data, "session_id", event.id)
+    resume_target = _required_str(event.data, "resume_target", event.id)
+    return HumanInputSnapshot(
+        request_id=request_id,
+        state=HumanInputState.PENDING,
+        request_event_id=event.id,
+        updated_event_id=event.id,
+        created_at=event.timestamp,
+        updated_at=event.timestamp,
+        session_id=session_id,
+        resume_target=resume_target,
+        run_id=_optional_str(event.data.get("run_id")),
+        invocation_id=_optional_str(event.data.get("invocation_id")),
+        request=_frozen_payload(event.data),
+    )
+
+
+def _snapshot_from_terminal(
+    current: HumanInputSnapshot,
+    event: BaseEvent,
+    *,
+    state: HumanInputState,
+    actor: str | None = None,
+    reason: str | None = None,
+    response: Mapping[str, Any] | None = None,
+) -> HumanInputSnapshot:
+    return replace(
+        current,
+        state=state,
+        updated_event_id=event.id,
+        updated_at=event.timestamp,
+        terminal_event_id=event.id,
+        actor=actor if actor is not None else _optional_str(event.data.get("actor")),
+        reason=reason,
+        response=response,
+    )
+
+
+def _event_request_id(event: BaseEvent) -> str | None:
+    if event.type not in {
+        HumanInputRequest.REQUESTED_EVENT_TYPE,
+        HumanInputResponse.ANSWERED_EVENT_TYPE,
+        HumanInputRequest.TIMED_OUT_EVENT_TYPE,
+        HumanInputRequest.CANCELLED_EVENT_TYPE,
+    }:
+        return None
+    value = event.data.get("request_id") or event.aggregate_id
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _required_str(data: Mapping[str, Any], key: str, event_id: str) -> str:
+    value = data.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    msg = f"HITL requested event {event_id} missing non-empty {key!r}"
+    raise ValueError(msg)
+
+
+def _optional_str(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _frozen_payload(data: Mapping[str, Any]) -> Mapping[str, Any]:
+    return MappingProxyType({key: _freeze_value(value) for key, value in data.items()})
+
+
+def _freeze_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _freeze_value(item) for key, item in value.items()})
+    if isinstance(value, list | tuple):
+        return tuple(_freeze_value(item) for item in value)
+    return value
+
+
+__all__ = [
+    "HumanInputSnapshot",
+    "HumanInputState",
+    "pending_human_input_requests",
+    "project_human_input_state",
+]

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -134,8 +134,10 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
             continue
 
         if event.type == HumanInputRequest.TIMED_OUT_EVENT_TYPE:
-            if not _request_timeout_is_terminal(current) or not _event_context_matches_request(
-                event, current
+            if (
+                _optional_str(event.data.get("reason")) is None
+                or not _request_timeout_is_terminal(current)
+                or not _event_context_matches_request(event, current)
             ):
                 continue
             snapshots[request_id] = _snapshot_from_terminal(
@@ -147,7 +149,9 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
             continue
 
         if event.type == HumanInputRequest.CANCELLED_EVENT_TYPE:
-            if not _event_context_matches_request(event, current):
+            if _optional_str(
+                event.data.get("reason")
+            ) is None or not _event_context_matches_request(event, current):
                 continue
             snapshots[request_id] = _snapshot_from_terminal(
                 current,

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -17,6 +17,7 @@ from types import MappingProxyType
 from typing import Any
 
 from ouroboros.core.hitl_contract import (
+    HumanInputKind,
     HumanInputRequest,
     HumanInputResponse,
     HumanInputResponseKind,
@@ -110,7 +111,7 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
             continue
 
         if event.type == HumanInputResponse.ANSWERED_EVENT_TYPE:
-            answered_state = _state_from_answered_event(event)
+            answered_state = _state_from_answered_event(event, current)
             if answered_state is None:
                 continue
             snapshots[request_id] = _snapshot_from_terminal(
@@ -122,6 +123,8 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
             continue
 
         if event.type == HumanInputRequest.TIMED_OUT_EVENT_TYPE:
+            if not _request_has_timeout(current):
+                continue
             snapshots[request_id] = _snapshot_from_terminal(
                 current,
                 event,
@@ -191,8 +194,12 @@ def _snapshot_from_terminal(
     )
 
 
-def _state_from_answered_event(event: BaseEvent) -> HumanInputState | None:
+def _state_from_answered_event(
+    event: BaseEvent, current: HumanInputSnapshot
+) -> HumanInputState | None:
     if _optional_str(event.data.get("actor")) is None:
+        return None
+    if not _answer_context_matches_request(event, current):
         return None
 
     response_kind = event.data.get("response_kind")
@@ -203,25 +210,48 @@ def _state_from_answered_event(event: BaseEvent) -> HumanInputState | None:
     if response_kind == HumanInputResponseKind.CANCEL.value:
         return None if has_text or has_selection or has_approval else HumanInputState.CANCELLED
     if response_kind == HumanInputResponseKind.TIMEOUT.value:
-        return None if has_text or has_selection or has_approval else HumanInputState.TIMED_OUT
+        if has_text or has_selection or has_approval or not _request_has_timeout(current):
+            return None
+        return HumanInputState.TIMED_OUT
     if response_kind == HumanInputResponseKind.TEXT.value:
+        if current.request.get("kind") != HumanInputKind.FREE_TEXT.value:
+            return None
         if has_selection or has_approval:
             return None
         return (
             HumanInputState.ANSWERED if _optional_str(event.data.get("text")) is not None else None
         )
     if response_kind == HumanInputResponseKind.SELECTION.value:
+        if current.request.get("kind") not in {
+            HumanInputKind.SINGLE_SELECT.value,
+            HumanInputKind.MULTI_SELECT.value,
+        }:
+            return None
         if has_text or has_approval:
             return None
         selected_values = event.data.get("selected_values")
-        if (
+        if not (
             isinstance(selected_values, list | tuple)
             and bool(selected_values)
             and all(_optional_str(value) is not None for value in selected_values)
         ):
-            return HumanInputState.ANSWERED
-        return None
+            return None
+        normalized_values = tuple(str(value).strip() for value in selected_values)
+        options = _request_options(current)
+        if any(value not in options for value in normalized_values):
+            return None
+        if (
+            current.request.get("kind") == HumanInputKind.SINGLE_SELECT.value
+            and len(normalized_values) != 1
+        ):
+            return None
+        return HumanInputState.ANSWERED
     if response_kind == HumanInputResponseKind.APPROVAL.value:
+        if current.request.get("kind") not in {
+            HumanInputKind.APPROVAL.value,
+            HumanInputKind.DESTRUCTIVE_CONFIRMATION.value,
+        }:
+            return None
         if has_text or has_selection:
             return None
         return (
@@ -230,6 +260,25 @@ def _state_from_answered_event(event: BaseEvent) -> HumanInputState | None:
             else None
         )
     return None
+
+
+def _answer_context_matches_request(event: BaseEvent, current: HumanInputSnapshot) -> bool:
+    for key in ("session_id", "run_id", "invocation_id"):
+        event_value = _optional_str(event.data.get(key))
+        if event_value is not None and event_value != getattr(current, key):
+            return False
+    return True
+
+
+def _request_has_timeout(current: HumanInputSnapshot) -> bool:
+    return type(current.request.get("timeout_seconds")) is int
+
+
+def _request_options(current: HumanInputSnapshot) -> frozenset[str]:
+    options = current.request.get("options", ())
+    if not isinstance(options, list | tuple):
+        return frozenset()
+    return frozenset(value.strip() for value in options if isinstance(value, str) and value.strip())
 
 
 def _event_request_id(event: BaseEvent) -> str | None:

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -196,22 +196,34 @@ def _state_from_answered_event(event: BaseEvent) -> HumanInputState | None:
         return None
 
     response_kind = event.data.get("response_kind")
+    has_text = "text" in event.data
+    has_selection = "selected_values" in event.data
+    has_approval = "approval_decision" in event.data
+
     if response_kind == HumanInputResponseKind.CANCEL.value:
-        return HumanInputState.CANCELLED
+        return None if has_text or has_selection or has_approval else HumanInputState.CANCELLED
     if response_kind == HumanInputResponseKind.TIMEOUT.value:
-        return HumanInputState.TIMED_OUT
+        return None if has_text or has_selection or has_approval else HumanInputState.TIMED_OUT
     if response_kind == HumanInputResponseKind.TEXT.value:
+        if has_selection or has_approval:
+            return None
         return (
             HumanInputState.ANSWERED if _optional_str(event.data.get("text")) is not None else None
         )
     if response_kind == HumanInputResponseKind.SELECTION.value:
+        if has_text or has_approval:
+            return None
         selected_values = event.data.get("selected_values")
-        if isinstance(selected_values, list | tuple) and any(
-            _optional_str(value) is not None for value in selected_values
+        if (
+            isinstance(selected_values, list | tuple)
+            and bool(selected_values)
+            and all(_optional_str(value) is not None for value in selected_values)
         ):
             return HumanInputState.ANSWERED
         return None
     if response_kind == HumanInputResponseKind.APPROVAL.value:
+        if has_text or has_selection:
+            return None
         return (
             HumanInputState.ANSWERED
             if isinstance(event.data.get("approval_decision"), bool)

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -89,12 +89,15 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
             continue
 
         if event.type == HumanInputRequest.REQUESTED_EVENT_TYPE:
+            current = snapshots.get(request_id)
+            if current is not None and current.is_terminal:
+                continue
             snapshot = _snapshot_from_requested(event, request_id)
             if request_id not in snapshots:
                 order.append(request_id)
-            # A request event is the authoritative initial row. Replayed
-            # duplicate request ids keep the latest request payload only while
-            # preserving the original insertion order.
+            # A pre-terminal duplicate request refreshes the request payload
+            # while preserving insertion order. Once terminal, first terminal
+            # state wins so replay cannot reopen an already-resolved wait.
             snapshots[request_id] = snapshot
             continue
 

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -21,6 +21,8 @@ from ouroboros.core.hitl_contract import (
     HumanInputRequest,
     HumanInputResponse,
     HumanInputResponseKind,
+    HumanInputRiskClass,
+    HumanInputSource,
     HumanInputTimeoutAction,
 )
 from ouroboros.events.base import BaseEvent
@@ -177,6 +179,9 @@ def pending_human_input_requests(events: Iterable[BaseEvent]) -> tuple[HumanInpu
 
 
 def _snapshot_from_requested(event: BaseEvent, request_id: str) -> HumanInputSnapshot:
+    if not _requested_event_matches_contract(event, request_id):
+        msg = f"HITL requested event {event.id} has malformed contract payload"
+        raise ValueError(msg)
     session_id = _required_str(event.data, "session_id", event.id)
     resume_target = _required_str(event.data, "resume_target", event.id)
     return HumanInputSnapshot(
@@ -192,6 +197,42 @@ def _snapshot_from_requested(event: BaseEvent, request_id: str) -> HumanInputSna
         invocation_id=_optional_str(event.data.get("invocation_id")),
         request=_frozen_payload(event.data),
     )
+
+
+def _requested_event_matches_contract(event: BaseEvent, request_id: str) -> bool:
+    try:
+        options = event.data.get("options", ())
+        if not isinstance(options, list | tuple):
+            return False
+        payload = event.data.get("payload", {})
+        if not isinstance(payload, Mapping):
+            return False
+        timeout_seconds = event.data.get("timeout_seconds")
+        HumanInputRequest(
+            request_id=request_id,
+            session_id=_required_str(event.data, "session_id", event.id),
+            run_id=_optional_str(event.data.get("run_id")),
+            invocation_id=_optional_str(event.data.get("invocation_id")),
+            created_by=_required_str(event.data, "created_by", event.id),
+            kind=HumanInputKind(event.data.get("kind")),
+            source=HumanInputSource(event.data.get("source")),
+            risk_class=HumanInputRiskClass(event.data.get("risk_class")),
+            question=_required_str(event.data, "question", event.id),
+            resume_target=_required_str(event.data, "resume_target", event.id),
+            title=_optional_str(event.data.get("title")),
+            body=_optional_str(event.data.get("body")),
+            options=tuple(options),
+            required_permission=_optional_str(event.data.get("required_permission")),
+            timeout_seconds=timeout_seconds if timeout_seconds is not None else None,
+            timeout_action=HumanInputTimeoutAction(
+                event.data.get("timeout_action", HumanInputTimeoutAction.STAY_WAITING.value)
+            ),
+            surface=_optional_str(event.data.get("surface")),
+            payload=payload,
+        )
+    except (TypeError, ValueError):
+        return False
+    return True
 
 
 def _snapshot_from_terminal(

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -21,6 +21,7 @@ from ouroboros.core.hitl_contract import (
     HumanInputRequest,
     HumanInputResponse,
     HumanInputResponseKind,
+    HumanInputTimeoutAction,
 )
 from ouroboros.events.base import BaseEvent
 
@@ -97,7 +98,10 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
             current = snapshots.get(request_id)
             if current is not None and current.is_terminal:
                 continue
-            snapshot = _snapshot_from_requested(event, request_id)
+            try:
+                snapshot = _snapshot_from_requested(event, request_id)
+            except ValueError:
+                continue
             if current is not None:
                 snapshot = replace(
                     snapshot,
@@ -130,7 +134,7 @@ def project_human_input_state(events: Iterable[BaseEvent]) -> tuple[HumanInputSn
             continue
 
         if event.type == HumanInputRequest.TIMED_OUT_EVENT_TYPE:
-            if not _request_has_timeout(current) or not _event_context_matches_request(
+            if not _request_timeout_is_terminal(current) or not _event_context_matches_request(
                 event, current
             ):
                 continue
@@ -221,7 +225,7 @@ def _state_from_answered_event(
     if response_kind == HumanInputResponseKind.CANCEL.value:
         return None if has_text or has_selection or has_approval else HumanInputState.CANCELLED
     if response_kind == HumanInputResponseKind.TIMEOUT.value:
-        if has_text or has_selection or has_approval or not _request_has_timeout(current):
+        if has_text or has_selection or has_approval or not _request_timeout_is_terminal(current):
             return None
         return HumanInputState.TIMED_OUT
     if response_kind == HumanInputResponseKind.TEXT.value:
@@ -283,8 +287,11 @@ def _event_context_matches_request(event: BaseEvent, current: HumanInputSnapshot
     return True
 
 
-def _request_has_timeout(current: HumanInputSnapshot) -> bool:
-    return type(current.request.get("timeout_seconds")) is int
+def _request_timeout_is_terminal(current: HumanInputSnapshot) -> bool:
+    return (
+        type(current.request.get("timeout_seconds")) is int
+        and current.request.get("timeout_action") != HumanInputTimeoutAction.STAY_WAITING.value
+    )
 
 
 def _request_options(current: HumanInputSnapshot) -> frozenset[str]:

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -101,6 +101,60 @@ def test_answered_event_closes_request_with_response_payload() -> None:
     assert pending_human_input_requests(events) == ()
 
 
+def test_answered_cancel_and_timeout_responses_project_terminal_state() -> None:
+    cancel_request = _request("hitl-cancel-answer")
+    timeout_request = _request("hitl-timeout-answer")
+    events = [
+        _with_time(create_hitl_requested_event(cancel_request), 0, "evt_cancel_req"),
+        _with_time(create_hitl_requested_event(timeout_request), 1, "evt_timeout_req"),
+        _with_time(
+            create_hitl_answered_event(
+                cancel_request,
+                HumanInputResponse(
+                    request_id="hitl-cancel-answer",
+                    session_id="session-1",
+                    run_id="run-1",
+                    actor="local-user",
+                    response_kind=HumanInputResponseKind.CANCEL,
+                    payload={"reason_code": "user_abort"},
+                ),
+            ),
+            2,
+            "evt_cancel_answer",
+        ),
+        _with_time(
+            create_hitl_answered_event(
+                timeout_request,
+                HumanInputResponse(
+                    request_id="hitl-timeout-answer",
+                    session_id="session-1",
+                    run_id="run-1",
+                    actor="runtime",
+                    response_kind=HumanInputResponseKind.TIMEOUT,
+                    payload={"deadline_ms": 30000},
+                ),
+            ),
+            3,
+            "evt_timeout_answer",
+        ),
+    ]
+
+    cancelled, timed_out = project_human_input_state(events)
+
+    assert cancelled.state is HumanInputState.CANCELLED
+    assert cancelled.terminal_event_id == "evt_cancel_answer"
+    assert cancelled.actor == "local-user"
+    assert cancelled.response is not None
+    assert cancelled.response["response_kind"] == "cancel"
+    assert cancelled.response["payload"] == {"reason_code": "user_abort"}
+    assert timed_out.state is HumanInputState.TIMED_OUT
+    assert timed_out.terminal_event_id == "evt_timeout_answer"
+    assert timed_out.actor == "runtime"
+    assert timed_out.response is not None
+    assert timed_out.response["response_kind"] == "timeout"
+    assert pending_human_input_requests(events) == ()
+
+
 def test_timeout_and_cancel_events_project_terminal_reason() -> None:
     timeout_request = _request("hitl-timeout")
     cancel_request = _request("hitl-cancel")

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -101,6 +101,63 @@ def test_answered_event_closes_request_with_response_payload() -> None:
     assert pending_human_input_requests(events) == ()
 
 
+def test_malformed_answered_events_do_not_close_pending_request() -> None:
+    request = _request()
+    requested = _with_time(create_hitl_requested_event(request), 0, "evt_requested")
+    missing_kind = _with_time(
+        BaseEvent(
+            type="hitl.answered",
+            aggregate_type="hitl",
+            aggregate_id="hitl-1",
+            data={"request_id": "hitl-1", "actor": "local-user"},
+        ),
+        1,
+        "evt_missing_kind",
+    )
+    unknown_kind = _with_time(
+        BaseEvent(
+            type="hitl.answered",
+            aggregate_type="hitl",
+            aggregate_id="hitl-1",
+            data={
+                "request_id": "hitl-1",
+                "actor": "local-user",
+                "response_kind": "unknown",
+            },
+        ),
+        2,
+        "evt_unknown_kind",
+    )
+    missing_answer_content = _with_time(
+        BaseEvent(
+            type="hitl.answered",
+            aggregate_type="hitl",
+            aggregate_id="hitl-1",
+            data={
+                "request_id": "hitl-1",
+                "actor": "local-user",
+                "response_kind": "approval",
+            },
+        ),
+        3,
+        "evt_missing_answer_content",
+    )
+
+    snapshots = project_human_input_state(
+        [requested, missing_kind, unknown_kind, missing_answer_content]
+    )
+
+    assert len(snapshots) == 1
+    assert snapshots[0].state is HumanInputState.PENDING
+    assert snapshots[0].updated_event_id == "evt_requested"
+    assert (
+        pending_human_input_requests(
+            [requested, missing_kind, unknown_kind, missing_answer_content]
+        )
+        == snapshots
+    )
+
+
 def test_answered_cancel_and_timeout_responses_project_terminal_state() -> None:
     cancel_request = _request("hitl-cancel-answer")
     timeout_request = _request("hitl-timeout-answer")

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -187,12 +187,57 @@ def test_malformed_answered_events_do_not_close_pending_request() -> None:
     assert len(snapshots) == 1
     assert snapshots[0].state is HumanInputState.PENDING
     assert snapshots[0].updated_event_id == "evt_requested"
-    assert (
-        pending_human_input_requests(
-            [requested, missing_kind, unknown_kind, missing_answer_content]
-        )
-        == snapshots
+    assert pending_human_input_requests(malformed_events) == snapshots
+
+
+def test_mismatched_timeout_and_cancel_events_do_not_close_pending_request() -> None:
+    timeout_request = _request("hitl-timeout-mismatch")
+    cancel_request = _request("hitl-cancel-mismatch")
+    events = [
+        _with_time(create_hitl_requested_event(timeout_request), 0, "evt_timeout_req"),
+        _with_time(create_hitl_requested_event(cancel_request), 1, "evt_cancel_req"),
+        _with_time(
+            BaseEvent(
+                type="hitl.timed_out",
+                aggregate_type="hitl",
+                aggregate_id="hitl-timeout-mismatch",
+                data={
+                    "request_id": "hitl-timeout-mismatch",
+                    "session_id": "other-session",
+                    "run_id": "run-1",
+                    "invocation_id": "invoke-1",
+                    "reason": "deadline elapsed",
+                },
+            ),
+            2,
+            "evt_timeout_mismatch",
+        ),
+        _with_time(
+            BaseEvent(
+                type="hitl.cancelled",
+                aggregate_type="hitl",
+                aggregate_id="hitl-cancel-mismatch",
+                data={
+                    "request_id": "hitl-cancel-mismatch",
+                    "session_id": "session-1",
+                    "run_id": "other-run",
+                    "invocation_id": "invoke-1",
+                    "reason": "user aborted",
+                    "actor": "local-user",
+                },
+            ),
+            3,
+            "evt_cancel_mismatch",
+        ),
+    ]
+
+    snapshots = project_human_input_state(events)
+
+    assert tuple(snapshot.state for snapshot in snapshots) == (
+        HumanInputState.PENDING,
+        HumanInputState.PENDING,
     )
+    assert pending_human_input_requests(events) == snapshots
 
 
 def test_incompatible_answered_events_do_not_close_pending_request() -> None:
@@ -398,6 +443,38 @@ def test_timeout_and_cancel_events_project_terminal_reason() -> None:
     assert cancelled.state is HumanInputState.CANCELLED
     assert cancelled.reason == "user aborted"
     assert cancelled.actor == "local-user"
+
+
+def test_duplicate_pending_request_preserves_original_request_provenance() -> None:
+    request = _request()
+    duplicate_request = HumanInputRequest(
+        request_id=request.request_id,
+        session_id=request.session_id,
+        run_id=request.run_id,
+        invocation_id=request.invocation_id,
+        created_by=request.created_by,
+        kind=request.kind,
+        source=request.source,
+        risk_class=request.risk_class,
+        question="Approve the refreshed plan?",
+        resume_target=request.resume_target,
+        timeout_seconds=request.timeout_seconds,
+        payload={"nested": {"count": 2}},
+    )
+    requested = _with_time(create_hitl_requested_event(request), 0, "evt_requested")
+    duplicate_requested = _with_time(
+        create_hitl_requested_event(duplicate_request), 1, "evt_requested_again"
+    )
+
+    snapshot = project_human_input_state([requested, duplicate_requested])[0]
+
+    assert snapshot.state is HumanInputState.PENDING
+    assert snapshot.request_event_id == "evt_requested"
+    assert snapshot.created_at == requested.timestamp
+    assert snapshot.updated_event_id == "evt_requested_again"
+    assert snapshot.updated_at == duplicate_requested.timestamp
+    assert snapshot.request["question"] == "Approve the refreshed plan?"
+    assert snapshot.request["payload"] == {"nested": {"count": 2}}
 
 
 def test_duplicate_request_after_terminal_does_not_reopen_wait() -> None:

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -1,0 +1,169 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from ouroboros.core.hitl_contract import (
+    HumanInputKind,
+    HumanInputRequest,
+    HumanInputResponse,
+    HumanInputResponseKind,
+    HumanInputRiskClass,
+    HumanInputSource,
+)
+from ouroboros.core.hitl_state import (
+    HumanInputState,
+    pending_human_input_requests,
+    project_human_input_state,
+)
+from ouroboros.events.base import BaseEvent
+from ouroboros.events.hitl import (
+    create_hitl_answered_event,
+    create_hitl_cancelled_event,
+    create_hitl_requested_event,
+    create_hitl_timed_out_event,
+)
+
+
+def _request(request_id: str = "hitl-1") -> HumanInputRequest:
+    return HumanInputRequest(
+        request_id=request_id,
+        session_id="session-1",
+        run_id="run-1",
+        invocation_id="invoke-1",
+        created_by="plan",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Approve?",
+        resume_target="plan:resume",
+        timeout_seconds=30,
+        payload={"nested": {"count": 1}},
+    )
+
+
+def _with_time(event: BaseEvent, seconds: int, event_id: str) -> BaseEvent:
+    return event.model_copy(
+        update={
+            "id": event_id,
+            "timestamp": datetime(2026, 5, 15, tzinfo=UTC) + timedelta(seconds=seconds),
+        }
+    )
+
+
+def test_projects_pending_request_snapshot() -> None:
+    event = _with_time(create_hitl_requested_event(_request()), 0, "evt_requested")
+
+    snapshots = project_human_input_state([event])
+
+    assert len(snapshots) == 1
+    snapshot = snapshots[0]
+    assert snapshot.request_id == "hitl-1"
+    assert snapshot.state is HumanInputState.PENDING
+    assert snapshot.request_event_id == "evt_requested"
+    assert snapshot.updated_event_id == "evt_requested"
+    assert snapshot.session_id == "session-1"
+    assert snapshot.run_id == "run-1"
+    assert snapshot.invocation_id == "invoke-1"
+    assert snapshot.resume_target == "plan:resume"
+    assert snapshot.is_terminal is False
+    assert snapshot.request["payload"] == {"nested": {"count": 1}}
+
+
+def test_answered_event_closes_request_with_response_payload() -> None:
+    request = _request()
+    events = [
+        _with_time(create_hitl_requested_event(request), 0, "evt_requested"),
+        _with_time(
+            create_hitl_answered_event(
+                request,
+                HumanInputResponse(
+                    request_id="hitl-1",
+                    session_id="session-1",
+                    run_id="run-1",
+                    actor="local-user",
+                    response_kind=HumanInputResponseKind.APPROVAL,
+                    approval_decision=True,
+                ),
+            ),
+            1,
+            "evt_answered",
+        ),
+    ]
+
+    snapshot = project_human_input_state(events)[0]
+
+    assert snapshot.state is HumanInputState.ANSWERED
+    assert snapshot.is_terminal is True
+    assert snapshot.terminal_event_id == "evt_answered"
+    assert snapshot.actor == "local-user"
+    assert snapshot.response is not None
+    assert snapshot.response["approval_decision"] is True
+    assert pending_human_input_requests(events) == ()
+
+
+def test_timeout_and_cancel_events_project_terminal_reason() -> None:
+    timeout_request = _request("hitl-timeout")
+    cancel_request = _request("hitl-cancel")
+    events = [
+        _with_time(create_hitl_requested_event(timeout_request), 0, "evt_timeout_req"),
+        _with_time(create_hitl_requested_event(cancel_request), 1, "evt_cancel_req"),
+        _with_time(
+            create_hitl_timed_out_event(timeout_request, reason="deadline elapsed"),
+            2,
+            "evt_timeout",
+        ),
+        _with_time(
+            create_hitl_cancelled_event(
+                cancel_request,
+                reason="user aborted",
+                actor="local-user",
+            ),
+            3,
+            "evt_cancel",
+        ),
+    ]
+
+    timeout, cancelled = project_human_input_state(events)
+
+    assert timeout.state is HumanInputState.TIMED_OUT
+    assert timeout.reason == "deadline elapsed"
+    assert cancelled.state is HumanInputState.CANCELLED
+    assert cancelled.reason == "user aborted"
+    assert cancelled.actor == "local-user"
+
+
+def test_ignores_orphan_and_late_terminal_events() -> None:
+    request = _request()
+    requested = _with_time(create_hitl_requested_event(request), 0, "evt_requested")
+    answered = _with_time(
+        create_hitl_answered_event(
+            request,
+            HumanInputResponse(
+                request_id="hitl-1",
+                actor="local-user",
+                response_kind=HumanInputResponseKind.APPROVAL,
+                approval_decision=True,
+            ),
+        ),
+        1,
+        "evt_answered",
+    )
+    late_cancel = _with_time(
+        create_hitl_cancelled_event(request, reason="late cancellation"),
+        2,
+        "evt_late_cancel",
+    )
+    orphan = BaseEvent(
+        id="evt_orphan",
+        type="hitl.answered",
+        timestamp=datetime(2026, 5, 15, tzinfo=UTC),
+        aggregate_type="hitl",
+        aggregate_id="orphan",
+        data={"request_id": "orphan", "actor": "local-user"},
+    )
+
+    snapshots = project_human_input_state([orphan, requested, answered, late_cancel])
+
+    assert len(snapshots) == 1
+    assert snapshots[0].state is HumanInputState.ANSWERED
+    assert snapshots[0].terminal_event_id == "evt_answered"

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -142,10 +142,47 @@ def test_malformed_answered_events_do_not_close_pending_request() -> None:
         3,
         "evt_missing_answer_content",
     )
-
-    snapshots = project_human_input_state(
-        [requested, missing_kind, unknown_kind, missing_answer_content]
+    invalid_selection = _with_time(
+        BaseEvent(
+            type="hitl.answered",
+            aggregate_type="hitl",
+            aggregate_id="hitl-1",
+            data={
+                "request_id": "hitl-1",
+                "actor": "local-user",
+                "response_kind": "selection",
+                "selected_values": ["Approve", 7],
+            },
+        ),
+        4,
+        "evt_invalid_selection",
     )
+    cancel_with_answer_content = _with_time(
+        BaseEvent(
+            type="hitl.answered",
+            aggregate_type="hitl",
+            aggregate_id="hitl-1",
+            data={
+                "request_id": "hitl-1",
+                "actor": "local-user",
+                "response_kind": "cancel",
+                "text": "never mind",
+            },
+        ),
+        5,
+        "evt_cancel_with_answer_content",
+    )
+
+    malformed_events = [
+        requested,
+        missing_kind,
+        unknown_kind,
+        missing_answer_content,
+        invalid_selection,
+        cancel_with_answer_content,
+    ]
+
+    snapshots = project_human_input_state(malformed_events)
 
     assert len(snapshots) == 1
     assert snapshots[0].state is HumanInputState.PENDING

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -344,6 +344,53 @@ def test_malformed_timeout_and_cancel_events_do_not_close_pending_request() -> N
     assert pending_human_input_requests(events) == snapshots
 
 
+def test_terminal_events_missing_request_context_do_not_close_pending_request() -> None:
+    timeout_request = _request(
+        "hitl-timeout-missing-context", timeout_action=HumanInputTimeoutAction.CANCEL
+    )
+    cancel_request = _request("hitl-cancel-missing-context")
+    events = [
+        _with_time(create_hitl_requested_event(timeout_request), 0, "evt_timeout_req"),
+        _with_time(create_hitl_requested_event(cancel_request), 1, "evt_cancel_req"),
+        _with_time(
+            BaseEvent(
+                type="hitl.timed_out",
+                aggregate_type="hitl",
+                aggregate_id="hitl-timeout-missing-context",
+                data={
+                    "request_id": "hitl-timeout-missing-context",
+                    "session_id": "session-1",
+                    "reason": "deadline elapsed",
+                },
+            ),
+            2,
+            "evt_timeout_missing_run_context",
+        ),
+        _with_time(
+            BaseEvent(
+                type="hitl.cancelled",
+                aggregate_type="hitl",
+                aggregate_id="hitl-cancel-missing-context",
+                data={
+                    "request_id": "hitl-cancel-missing-context",
+                    "reason": "user aborted",
+                    "actor": "local-user",
+                },
+            ),
+            3,
+            "evt_cancel_missing_session_context",
+        ),
+    ]
+
+    snapshots = project_human_input_state(events)
+
+    assert tuple(snapshot.state for snapshot in snapshots) == (
+        HumanInputState.PENDING,
+        HumanInputState.PENDING,
+    )
+    assert pending_human_input_requests(events) == snapshots
+
+
 def test_mismatched_timeout_and_cancel_events_do_not_close_pending_request() -> None:
     timeout_request = _request(
         "hitl-timeout-mismatch", timeout_action=HumanInputTimeoutAction.CANCEL

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -195,6 +195,126 @@ def test_malformed_answered_events_do_not_close_pending_request() -> None:
     )
 
 
+def test_incompatible_answered_events_do_not_close_pending_request() -> None:
+    text_request = HumanInputRequest(
+        request_id="hitl-text",
+        session_id="session-1",
+        run_id="run-1",
+        created_by="plan",
+        kind=HumanInputKind.FREE_TEXT,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Explain?",
+        resume_target="plan:resume",
+    )
+    single_select_request = HumanInputRequest(
+        request_id="hitl-select",
+        session_id="session-1",
+        run_id="run-1",
+        created_by="plan",
+        kind=HumanInputKind.SINGLE_SELECT,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Choose?",
+        resume_target="plan:resume",
+        options=("Approve", "Reject"),
+    )
+    approval_without_timeout = HumanInputRequest(
+        request_id="hitl-no-timeout",
+        session_id="session-1",
+        run_id="run-1",
+        created_by="plan",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Approve?",
+        resume_target="plan:resume",
+    )
+    events = [
+        _with_time(create_hitl_requested_event(text_request), 0, "evt_text_req"),
+        _with_time(create_hitl_requested_event(single_select_request), 1, "evt_select_req"),
+        _with_time(create_hitl_requested_event(approval_without_timeout), 2, "evt_timeout_req"),
+        _with_time(
+            BaseEvent(
+                type="hitl.answered",
+                aggregate_type="hitl",
+                aggregate_id="hitl-text",
+                data={
+                    "request_id": "hitl-text",
+                    "actor": "local-user",
+                    "response_kind": "approval",
+                    "approval_decision": True,
+                },
+            ),
+            3,
+            "evt_wrong_kind",
+        ),
+        _with_time(
+            BaseEvent(
+                type="hitl.answered",
+                aggregate_type="hitl",
+                aggregate_id="hitl-select",
+                data={
+                    "request_id": "hitl-select",
+                    "actor": "local-user",
+                    "response_kind": "selection",
+                    "selected_values": ["Approve", "Reject"],
+                },
+            ),
+            4,
+            "evt_multi_single_select",
+        ),
+        _with_time(
+            BaseEvent(
+                type="hitl.answered",
+                aggregate_type="hitl",
+                aggregate_id="hitl-select",
+                data={
+                    "request_id": "hitl-select",
+                    "actor": "local-user",
+                    "response_kind": "selection",
+                    "selected_values": ["Other"],
+                },
+            ),
+            5,
+            "evt_selection_outside_options",
+        ),
+        _with_time(
+            BaseEvent(
+                type="hitl.answered",
+                aggregate_type="hitl",
+                aggregate_id="hitl-no-timeout",
+                data={
+                    "request_id": "hitl-no-timeout",
+                    "actor": "runtime",
+                    "response_kind": "timeout",
+                },
+            ),
+            6,
+            "evt_timeout_answer_without_timeout",
+        ),
+        _with_time(
+            BaseEvent(
+                type="hitl.timed_out",
+                aggregate_type="hitl",
+                aggregate_id="hitl-no-timeout",
+                data={"request_id": "hitl-no-timeout", "reason": "deadline elapsed"},
+            ),
+            7,
+            "evt_timeout_event_without_timeout",
+        ),
+    ]
+
+    snapshots = project_human_input_state(events)
+
+    assert tuple(snapshot.state for snapshot in snapshots) == (
+        HumanInputState.PENDING,
+        HumanInputState.PENDING,
+        HumanInputState.PENDING,
+    )
+    assert pending_human_input_requests(events) == snapshots
+
+
 def test_answered_cancel_and_timeout_responses_project_terminal_state() -> None:
     cancel_request = _request("hitl-cancel-answer")
     timeout_request = _request("hitl-timeout-answer")

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -196,6 +196,51 @@ def test_malformed_answered_events_do_not_close_pending_request() -> None:
     assert pending_human_input_requests(malformed_events) == snapshots
 
 
+def test_mismatched_event_request_identifiers_are_ignored() -> None:
+    request = _request("hitl-identity")
+    events = [
+        _with_time(create_hitl_requested_event(request), 0, "evt_requested"),
+        _with_time(
+            BaseEvent(
+                type="hitl.cancelled",
+                aggregate_type="hitl",
+                aggregate_id="other-hitl",
+                data={
+                    "request_id": "hitl-identity",
+                    "session_id": "session-1",
+                    "run_id": "run-1",
+                    "invocation_id": "invoke-1",
+                    "reason": "user aborted",
+                    "actor": "local-user",
+                },
+            ),
+            1,
+            "evt_mismatched_cancel",
+        ),
+        _with_time(
+            BaseEvent(
+                type="hitl.requested",
+                aggregate_type="hitl",
+                aggregate_id="other-request",
+                data={
+                    "request_id": "hitl-spoofed",
+                    "session_id": "session-1",
+                    "resume_target": "plan:resume",
+                },
+            ),
+            2,
+            "evt_mismatched_request",
+        ),
+    ]
+
+    snapshots = project_human_input_state(events)
+
+    assert len(snapshots) == 1
+    assert snapshots[0].request_id == "hitl-identity"
+    assert snapshots[0].state is HumanInputState.PENDING
+    assert pending_human_input_requests(events) == snapshots
+
+
 def test_malformed_requested_event_does_not_abort_projection() -> None:
     valid_request = _request("hitl-valid")
     malformed_request = BaseEvent(

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -328,6 +328,21 @@ def test_incompatible_answered_events_do_not_close_pending_request() -> None:
             BaseEvent(
                 type="hitl.answered",
                 aggregate_type="hitl",
+                aggregate_id="hitl-select",
+                data={
+                    "request_id": "hitl-select",
+                    "actor": "local-user",
+                    "response_kind": "selection",
+                    "selected_values": ["Approve", " Approve "],
+                },
+            ),
+            6,
+            "evt_duplicate_selection",
+        ),
+        _with_time(
+            BaseEvent(
+                type="hitl.answered",
+                aggregate_type="hitl",
                 aggregate_id="hitl-no-timeout",
                 data={
                     "request_id": "hitl-no-timeout",
@@ -335,7 +350,7 @@ def test_incompatible_answered_events_do_not_close_pending_request() -> None:
                     "response_kind": "timeout",
                 },
             ),
-            6,
+            7,
             "evt_timeout_answer_without_timeout",
         ),
         _with_time(
@@ -345,7 +360,7 @@ def test_incompatible_answered_events_do_not_close_pending_request() -> None:
                 aggregate_id="hitl-no-timeout",
                 data={"request_id": "hitl-no-timeout", "reason": "deadline elapsed"},
             ),
-            7,
+            8,
             "evt_timeout_event_without_timeout",
         ),
     ]

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -107,6 +107,80 @@ def test_answered_event_closes_request_with_response_payload() -> None:
     assert pending_human_input_requests(events) == ()
 
 
+def test_text_and_selection_answers_close_compatible_requests() -> None:
+    text_request = HumanInputRequest(
+        request_id="hitl-text-answer",
+        session_id="session-1",
+        run_id="run-1",
+        invocation_id="invoke-1",
+        created_by="plan",
+        kind=HumanInputKind.FREE_TEXT,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Explain?",
+        resume_target="plan:resume",
+    )
+    selection_request = HumanInputRequest(
+        request_id="hitl-selection-answer",
+        session_id="session-1",
+        run_id="run-1",
+        invocation_id="invoke-1",
+        created_by="plan",
+        kind=HumanInputKind.MULTI_SELECT,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Pick options",
+        resume_target="plan:resume",
+        options=("A", "B", "C"),
+    )
+    events = [
+        _with_time(create_hitl_requested_event(text_request), 0, "evt_text_req"),
+        _with_time(create_hitl_requested_event(selection_request), 1, "evt_selection_req"),
+        _with_time(
+            create_hitl_answered_event(
+                text_request,
+                HumanInputResponse(
+                    request_id="hitl-text-answer",
+                    session_id="session-1",
+                    run_id="run-1",
+                    invocation_id="invoke-1",
+                    actor="local-user",
+                    response_kind=HumanInputResponseKind.TEXT,
+                    text="Looks good",
+                ),
+            ),
+            2,
+            "evt_text_answer",
+        ),
+        _with_time(
+            create_hitl_answered_event(
+                selection_request,
+                HumanInputResponse(
+                    request_id="hitl-selection-answer",
+                    session_id="session-1",
+                    run_id="run-1",
+                    invocation_id="invoke-1",
+                    actor="local-user",
+                    response_kind=HumanInputResponseKind.SELECTION,
+                    selected_values=("A", "C"),
+                ),
+            ),
+            3,
+            "evt_selection_answer",
+        ),
+    ]
+
+    text_snapshot, selection_snapshot = project_human_input_state(events)
+
+    assert text_snapshot.state is HumanInputState.ANSWERED
+    assert text_snapshot.response is not None
+    assert text_snapshot.response["text"] == "Looks good"
+    assert selection_snapshot.state is HumanInputState.ANSWERED
+    assert selection_snapshot.response is not None
+    assert selection_snapshot.response["selected_values"] == ("A", "C")
+    assert pending_human_input_requests(events) == ()
+
+
 def test_malformed_answered_events_do_not_close_pending_request() -> None:
     request = _request()
     requested = _with_time(create_hitl_requested_event(request), 0, "evt_requested")
@@ -243,17 +317,32 @@ def test_mismatched_event_request_identifiers_are_ignored() -> None:
 
 def test_malformed_requested_event_does_not_abort_projection() -> None:
     valid_request = _request("hitl-valid")
-    malformed_request = BaseEvent(
+    missing_resume_target = BaseEvent(
         type="hitl.requested",
         aggregate_type="hitl",
         aggregate_id="hitl-bad",
         data={"request_id": "hitl-bad", "session_id": "session-1"},
     )
+    missing_kind = BaseEvent(
+        type="hitl.requested",
+        aggregate_type="hitl",
+        aggregate_id="hitl-bad-kind",
+        data={
+            "request_id": "hitl-bad-kind",
+            "session_id": "session-1",
+            "created_by": "plan",
+            "source": "plan_approval",
+            "risk_class": "material_branch",
+            "question": "Approve?",
+            "resume_target": "plan:resume",
+        },
+    )
 
     snapshots = project_human_input_state(
         [
-            _with_time(malformed_request, 0, "evt_bad_request"),
-            _with_time(create_hitl_requested_event(valid_request), 1, "evt_valid_request"),
+            _with_time(missing_resume_target, 0, "evt_bad_request"),
+            _with_time(missing_kind, 1, "evt_bad_kind_request"),
+            _with_time(create_hitl_requested_event(valid_request), 2, "evt_valid_request"),
         ]
     )
 

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -663,6 +663,39 @@ def test_timeout_and_cancel_events_project_terminal_reason() -> None:
     assert cancelled.actor == "local-user"
 
 
+def test_conflicting_duplicate_pending_request_is_ignored() -> None:
+    request = _request()
+    conflicting_duplicate = HumanInputRequest(
+        request_id=request.request_id,
+        session_id="other-session",
+        run_id=request.run_id,
+        invocation_id=request.invocation_id,
+        created_by=request.created_by,
+        kind=request.kind,
+        source=request.source,
+        risk_class=request.risk_class,
+        question="Approve the conflicting plan?",
+        resume_target="other:resume",
+        timeout_seconds=request.timeout_seconds,
+        timeout_action=request.timeout_action,
+        payload={"nested": {"count": 99}},
+    )
+    requested = _with_time(create_hitl_requested_event(request), 0, "evt_requested")
+    duplicate_requested = _with_time(
+        create_hitl_requested_event(conflicting_duplicate), 1, "evt_conflicting_request"
+    )
+
+    snapshot = project_human_input_state([requested, duplicate_requested])[0]
+
+    assert snapshot.state is HumanInputState.PENDING
+    assert snapshot.session_id == "session-1"
+    assert snapshot.resume_target == "plan:resume"
+    assert snapshot.request_event_id == "evt_requested"
+    assert snapshot.updated_event_id == "evt_requested"
+    assert snapshot.request["question"] == "Approve?"
+    assert snapshot.request["payload"] == {"nested": {"count": 1}}
+
+
 def test_duplicate_pending_request_preserves_original_request_provenance() -> None:
     request = _request()
     duplicate_request = HumanInputRequest(

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -9,6 +9,7 @@ from ouroboros.core.hitl_contract import (
     HumanInputResponseKind,
     HumanInputRiskClass,
     HumanInputSource,
+    HumanInputTimeoutAction,
 )
 from ouroboros.core.hitl_state import (
     HumanInputState,
@@ -24,7 +25,11 @@ from ouroboros.events.hitl import (
 )
 
 
-def _request(request_id: str = "hitl-1") -> HumanInputRequest:
+def _request(
+    request_id: str = "hitl-1",
+    *,
+    timeout_action: HumanInputTimeoutAction = HumanInputTimeoutAction.STAY_WAITING,
+) -> HumanInputRequest:
     return HumanInputRequest(
         request_id=request_id,
         session_id="session-1",
@@ -37,6 +42,7 @@ def _request(request_id: str = "hitl-1") -> HumanInputRequest:
         question="Approve?",
         resume_target="plan:resume",
         timeout_seconds=30,
+        timeout_action=timeout_action,
         payload={"nested": {"count": 1}},
     )
 
@@ -190,8 +196,62 @@ def test_malformed_answered_events_do_not_close_pending_request() -> None:
     assert pending_human_input_requests(malformed_events) == snapshots
 
 
+def test_malformed_requested_event_does_not_abort_projection() -> None:
+    valid_request = _request("hitl-valid")
+    malformed_request = BaseEvent(
+        type="hitl.requested",
+        aggregate_type="hitl",
+        aggregate_id="hitl-bad",
+        data={"request_id": "hitl-bad", "session_id": "session-1"},
+    )
+
+    snapshots = project_human_input_state(
+        [
+            _with_time(malformed_request, 0, "evt_bad_request"),
+            _with_time(create_hitl_requested_event(valid_request), 1, "evt_valid_request"),
+        ]
+    )
+
+    assert len(snapshots) == 1
+    assert snapshots[0].request_id == "hitl-valid"
+    assert snapshots[0].state is HumanInputState.PENDING
+
+
+def test_stay_waiting_timeout_events_do_not_close_pending_request() -> None:
+    request = _request("hitl-stay-waiting")
+    events = [
+        _with_time(create_hitl_requested_event(request), 0, "evt_requested"),
+        _with_time(
+            create_hitl_timed_out_event(request, reason="deadline elapsed"), 1, "evt_timeout"
+        ),
+        _with_time(
+            create_hitl_answered_event(
+                request,
+                HumanInputResponse(
+                    request_id="hitl-stay-waiting",
+                    session_id="session-1",
+                    run_id="run-1",
+                    actor="runtime",
+                    response_kind=HumanInputResponseKind.TIMEOUT,
+                    payload={"deadline_ms": 30000},
+                ),
+            ),
+            2,
+            "evt_timeout_answer",
+        ),
+    ]
+
+    snapshot = project_human_input_state(events)[0]
+
+    assert snapshot.state is HumanInputState.PENDING
+    assert snapshot.updated_event_id == "evt_requested"
+    assert pending_human_input_requests(events) == (snapshot,)
+
+
 def test_mismatched_timeout_and_cancel_events_do_not_close_pending_request() -> None:
-    timeout_request = _request("hitl-timeout-mismatch")
+    timeout_request = _request(
+        "hitl-timeout-mismatch", timeout_action=HumanInputTimeoutAction.CANCEL
+    )
     cancel_request = _request("hitl-cancel-mismatch")
     events = [
         _with_time(create_hitl_requested_event(timeout_request), 0, "evt_timeout_req"),
@@ -377,7 +437,7 @@ def test_incompatible_answered_events_do_not_close_pending_request() -> None:
 
 def test_answered_cancel_and_timeout_responses_project_terminal_state() -> None:
     cancel_request = _request("hitl-cancel-answer")
-    timeout_request = _request("hitl-timeout-answer")
+    timeout_request = _request("hitl-timeout-answer", timeout_action=HumanInputTimeoutAction.CANCEL)
     events = [
         _with_time(create_hitl_requested_event(cancel_request), 0, "evt_cancel_req"),
         _with_time(create_hitl_requested_event(timeout_request), 1, "evt_timeout_req"),
@@ -430,7 +490,7 @@ def test_answered_cancel_and_timeout_responses_project_terminal_state() -> None:
 
 
 def test_timeout_and_cancel_events_project_terminal_reason() -> None:
-    timeout_request = _request("hitl-timeout")
+    timeout_request = _request("hitl-timeout", timeout_action=HumanInputTimeoutAction.CANCEL)
     cancel_request = _request("hitl-cancel")
     events = [
         _with_time(create_hitl_requested_event(timeout_request), 0, "evt_timeout_req"),

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -132,6 +132,31 @@ def test_timeout_and_cancel_events_project_terminal_reason() -> None:
     assert cancelled.actor == "local-user"
 
 
+def test_duplicate_request_after_terminal_does_not_reopen_wait() -> None:
+    request = _request()
+    requested = _with_time(create_hitl_requested_event(request), 0, "evt_requested")
+    answered = _with_time(
+        create_hitl_answered_event(
+            request,
+            HumanInputResponse(
+                request_id="hitl-1",
+                actor="local-user",
+                response_kind=HumanInputResponseKind.APPROVAL,
+                approval_decision=True,
+            ),
+        ),
+        1,
+        "evt_answered",
+    )
+    duplicate_requested = _with_time(create_hitl_requested_event(request), 2, "evt_requested_again")
+
+    snapshot = project_human_input_state([requested, answered, duplicate_requested])[0]
+
+    assert snapshot.state is HumanInputState.ANSWERED
+    assert snapshot.terminal_event_id == "evt_answered"
+    assert pending_human_input_requests([requested, answered, duplicate_requested]) == ()
+
+
 def test_ignores_orphan_and_late_terminal_events() -> None:
     request = _request()
     requested = _with_time(create_hitl_requested_event(request), 0, "evt_requested")

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -248,6 +248,57 @@ def test_stay_waiting_timeout_events_do_not_close_pending_request() -> None:
     assert pending_human_input_requests(events) == (snapshot,)
 
 
+def test_malformed_timeout_and_cancel_events_do_not_close_pending_request() -> None:
+    timeout_request = _request(
+        "hitl-timeout-malformed", timeout_action=HumanInputTimeoutAction.CANCEL
+    )
+    cancel_request = _request("hitl-cancel-malformed")
+    events = [
+        _with_time(create_hitl_requested_event(timeout_request), 0, "evt_timeout_req"),
+        _with_time(create_hitl_requested_event(cancel_request), 1, "evt_cancel_req"),
+        _with_time(
+            BaseEvent(
+                type="hitl.timed_out",
+                aggregate_type="hitl",
+                aggregate_id="hitl-timeout-malformed",
+                data={
+                    "request_id": "hitl-timeout-malformed",
+                    "session_id": "session-1",
+                    "run_id": "run-1",
+                    "invocation_id": "invoke-1",
+                },
+            ),
+            2,
+            "evt_timeout_missing_reason",
+        ),
+        _with_time(
+            BaseEvent(
+                type="hitl.cancelled",
+                aggregate_type="hitl",
+                aggregate_id="hitl-cancel-malformed",
+                data={
+                    "request_id": "hitl-cancel-malformed",
+                    "session_id": "session-1",
+                    "run_id": "run-1",
+                    "invocation_id": "invoke-1",
+                    "reason": "   ",
+                    "actor": "local-user",
+                },
+            ),
+            3,
+            "evt_cancel_blank_reason",
+        ),
+    ]
+
+    snapshots = project_human_input_state(events)
+
+    assert tuple(snapshot.state for snapshot in snapshots) == (
+        HumanInputState.PENDING,
+        HumanInputState.PENDING,
+    )
+    assert pending_human_input_requests(events) == snapshots
+
+
 def test_mismatched_timeout_and_cancel_events_do_not_close_pending_request() -> None:
     timeout_request = _request(
         "hitl-timeout-mismatch", timeout_action=HumanInputTimeoutAction.CANCEL


### PR DESCRIPTION
## Summary
- Adds a pure replay read model over existing `hitl.*` events.
- Exposes immutable `HumanInputSnapshot` rows plus pending-request filtering for durable WAIT/RESUME query surfaces.
- Keeps runtime dispatch/UI/persistence wiring out of this slice so #960 can review the contract independently.

## #961 / AgentOS fit
- Advances #960 durable HITL WAIT/RESUME without introducing a new orchestration layer.
- Uses existing EventStore-shaped events as SSOT and avoids over-engineering by staying read-only and side-effect-free.

## Validation
- `uv run ruff check src/ouroboros/core/hitl_state.py tests/unit/core/test_hitl_state.py`
- `uv run mypy src/ouroboros/core/hitl_state.py tests/unit/core/test_hitl_state.py`
- `uv run pytest tests/unit/core/test_hitl_contract.py tests/unit/events/test_hitl_events.py tests/unit/core/test_hitl_state.py -q`

Refs #960
Refs #961