### PR TITLE
feat(harness): add run snapshot projection

### DIFF
--- a/src/ouroboros/harness/__init__.py
+++ b/src/ouroboros/harness/__init__.py
@@ -33,6 +33,8 @@ from ouroboros.harness.journal import (
 from ouroboros.harness.projection import (
     ArtifactRecord,
     RunRecord,
+    RunSnapshotRecord,
+    RunSnapshotStatus,
     StageKind,
     StageRecord,
     StepKind,
@@ -40,6 +42,7 @@ from ouroboros.harness.projection import (
     VerdictOutcome,
     VerdictRecord,
 )
+from ouroboros.harness.run_snapshot import build_run_snapshot
 
 __all__ = [
     "ArtifactRecord",
@@ -52,6 +55,8 @@ __all__ = [
     "EventStoreEvidenceReader",
     "EvidenceManifest",
     "RunRecord",
+    "RunSnapshotRecord",
+    "RunSnapshotStatus",
     "ClaimTermGuard",
     "ClaimTermGuardFact",
     "ClaimTermGuardVerdict",
@@ -64,6 +69,7 @@ __all__ = [
     "TraceGuardValidator",
     "VerdictOutcome",
     "VerdictRecord",
+    "build_run_snapshot",
     "deterministic_claim_term_guard",
     "evaluate_deliver_claim",
     "filter_events_for_ac",

--- a/src/ouroboros/harness/projection.py
+++ b/src/ouroboros/harness/projection.py
@@ -218,6 +218,17 @@ class VerdictOutcome(StrEnum):
     UNKNOWN = "unknown"
 
 
+class RunSnapshotStatus(StrEnum):
+    """Effective run status for safe-resume inspection."""
+
+    RUNNING = "running"
+    WAITING = "waiting"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    UNKNOWN = "unknown"
+
+
 # ---------------------------------------------------------------------------
 # Record models
 # ---------------------------------------------------------------------------
@@ -485,6 +496,83 @@ class VerdictRecord(BaseModel, frozen=True):
         return self
 
 
+class RunSnapshotRecord(BaseModel, frozen=True):
+    model_config = ConfigDict(extra="forbid")
+
+    """Read-model snapshot of a run suitable for safe-resume decisions.
+
+    The snapshot summarizes the current projection bundle without becoming a
+    dispatcher. ``safe_resume`` is explicit and evidence-linked so callers can
+    distinguish a resumable interrupted run from a terminal or under-evidenced
+    one before attempting side effects.
+
+    Attributes:
+        snapshot_id: Stable identifier for the snapshot row.
+        run_id: Identifier of the owning :class:`RunRecord`.
+        status: Effective run status inferred by the snapshot builder.
+        safe_resume: Whether a caller may attempt resume from this read model.
+        resume_blockers: Human-readable blocker codes when resume is unsafe.
+        stage_ids: Stages present in the snapshot.
+        completed_step_ids: Steps that ended with ``ok=True``.
+        pending_step_ids: Steps that have no ``ended_at``.
+        failed_step_ids: Steps that ended with ``ok=False``.
+        unknown_step_ids: Ended steps whose ``ok`` value is unknown.
+        artifact_ids: Artifacts visible to the snapshot.
+        verdict_id: Optional linked verdict.
+        source_event_ids: Event evidence used to derive this snapshot.
+        recorded_at: Timestamp for when the snapshot was assembled.
+        metadata: Free-form read-only metadata.
+    """
+
+    schema_version: ProjectionSchemaVersion = PROJECTION_SCHEMA_VERSION
+    snapshot_id: Identifier = Field(default_factory=lambda: _new_id("snapshot"))
+    run_id: Identifier
+    status: RunSnapshotStatus
+    safe_resume: bool
+    resume_blockers: IdentifierTuple = Field(default_factory=tuple)
+    stage_ids: IdentifierTuple = Field(default_factory=tuple)
+    completed_step_ids: IdentifierTuple = Field(default_factory=tuple)
+    pending_step_ids: IdentifierTuple = Field(default_factory=tuple)
+    failed_step_ids: IdentifierTuple = Field(default_factory=tuple)
+    unknown_step_ids: IdentifierTuple = Field(default_factory=tuple)
+    artifact_ids: IdentifierTuple = Field(default_factory=tuple)
+    verdict_id: Identifier | None = Field(default=None)
+    source_event_ids: IdentifierTuple = Field(default_factory=tuple)
+    recorded_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    metadata: FrozenMetadata = Field(default_factory=_empty_frozen_metadata)
+
+    @field_validator("recorded_at")
+    @classmethod
+    def _recorded_at_must_be_aware(cls, value: datetime | None, info: Any) -> datetime | None:
+        checked = _require_aware_datetime(info.field_name, value)
+        assert checked is not None
+        return checked
+
+    @field_validator("verdict_id")
+    @classmethod
+    def _verdict_id_not_blank(cls, value: str | None) -> str | None:
+        if value is None:
+            return None
+        stripped = value.strip()
+        if not stripped:
+            msg = "RunSnapshotRecord.verdict_id must be None or a non-blank identifier"
+            raise ValueError(msg)
+        return stripped
+
+    @model_validator(mode="after")
+    def _validate_safe_resume_contract(self) -> RunSnapshotRecord:
+        if self.safe_resume and self.status not in {RunSnapshotStatus.RUNNING, RunSnapshotStatus.WAITING}:
+            msg = "RunSnapshotRecord.safe_resume is only valid for running or waiting runs"
+            raise ValueError(msg)
+        if self.safe_resume and self.resume_blockers:
+            msg = "RunSnapshotRecord.safe_resume cannot include resume_blockers"
+            raise ValueError(msg)
+        if not self.safe_resume and self.status in {RunSnapshotStatus.RUNNING, RunSnapshotStatus.WAITING} and not self.resume_blockers:
+            msg = "unsafe non-terminal RunSnapshotRecord must explain resume_blockers"
+            raise ValueError(msg)
+        return self
+
+
 class RunRecord(BaseModel, frozen=True):
     model_config = ConfigDict(extra="forbid")
 
@@ -550,6 +638,8 @@ __all__ = [
     "ProjectionSchemaVersion",
     "IdentifierTuple",
     "RunRecord",
+    "RunSnapshotRecord",
+    "RunSnapshotStatus",
     "StageKind",
     "StageRecord",
     "StepKind",

--- a/src/ouroboros/harness/projection.py
+++ b/src/ouroboros/harness/projection.py
@@ -561,13 +561,20 @@ class RunSnapshotRecord(BaseModel, frozen=True):
 
     @model_validator(mode="after")
     def _validate_safe_resume_contract(self) -> RunSnapshotRecord:
-        if self.safe_resume and self.status not in {RunSnapshotStatus.RUNNING, RunSnapshotStatus.WAITING}:
+        if self.safe_resume and self.status not in {
+            RunSnapshotStatus.RUNNING,
+            RunSnapshotStatus.WAITING,
+        }:
             msg = "RunSnapshotRecord.safe_resume is only valid for running or waiting runs"
             raise ValueError(msg)
         if self.safe_resume and self.resume_blockers:
             msg = "RunSnapshotRecord.safe_resume cannot include resume_blockers"
             raise ValueError(msg)
-        if not self.safe_resume and self.status in {RunSnapshotStatus.RUNNING, RunSnapshotStatus.WAITING} and not self.resume_blockers:
+        if (
+            not self.safe_resume
+            and self.status in {RunSnapshotStatus.RUNNING, RunSnapshotStatus.WAITING}
+            and not self.resume_blockers
+        ):
             msg = "unsafe non-terminal RunSnapshotRecord must explain resume_blockers"
             raise ValueError(msg)
         return self

--- a/src/ouroboros/harness/projection.py
+++ b/src/ouroboros/harness/projection.py
@@ -561,11 +561,8 @@ class RunSnapshotRecord(BaseModel, frozen=True):
 
     @model_validator(mode="after")
     def _validate_safe_resume_contract(self) -> RunSnapshotRecord:
-        if self.safe_resume and self.status not in {
-            RunSnapshotStatus.RUNNING,
-            RunSnapshotStatus.WAITING,
-        }:
-            msg = "RunSnapshotRecord.safe_resume is only valid for running or waiting runs"
+        if self.safe_resume and self.status is not RunSnapshotStatus.RUNNING:
+            msg = "RunSnapshotRecord.safe_resume is only valid for running runs"
             raise ValueError(msg)
         if self.safe_resume and self.resume_blockers:
             msg = "RunSnapshotRecord.safe_resume cannot include resume_blockers"

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -61,6 +61,9 @@ def build_run_snapshot(
     pending_failed_step_ids = tuple(
         step.step_id for step in step_tuple if step.ended_at is None and step.ok is False
     )
+    pending_success_step_ids = tuple(
+        step.step_id for step in step_tuple if step.ended_at is None and step.ok is True
+    )
     unknown_step_ids = tuple(
         step.step_id for step in step_tuple if step.ended_at is not None and step.ok is None
     )
@@ -81,6 +84,7 @@ def build_run_snapshot(
         unlinked_supplied_verdict=unlinked_supplied_verdict,
         pending_in_closed_stage_ids=pending_in_closed_stage_ids,
         pending_failed_step_ids=pending_failed_step_ids,
+        pending_success_step_ids=pending_success_step_ids,
         pending_step_ids=pending_step_ids,
         failed_step_ids=failed_step_ids,
         unknown_step_ids=unknown_step_ids,
@@ -94,6 +98,7 @@ def build_run_snapshot(
         unlinked_supplied_verdict=unlinked_supplied_verdict,
         pending_in_closed_stage_ids=pending_in_closed_stage_ids,
         pending_failed_step_ids=pending_failed_step_ids,
+        pending_success_step_ids=pending_success_step_ids,
         has_source_event_ids=bool(derived_source_event_ids),
     )
     safe_resume = status is RunSnapshotStatus.RUNNING and bool(pending_step_ids) and not blockers
@@ -250,6 +255,7 @@ def _derive_status(
     unlinked_supplied_verdict: bool,
     pending_in_closed_stage_ids: tuple[str, ...],
     pending_failed_step_ids: tuple[str, ...],
+    pending_success_step_ids: tuple[str, ...],
     pending_step_ids: tuple[str, ...],
     failed_step_ids: tuple[str, ...],
     unknown_step_ids: tuple[str, ...],
@@ -275,7 +281,7 @@ def _derive_status(
         return RunSnapshotStatus.UNKNOWN
     if missing_linked_verdict:
         return RunSnapshotStatus.UNKNOWN
-    if pending_in_closed_stage_ids or pending_failed_step_ids:
+    if pending_in_closed_stage_ids or pending_failed_step_ids or pending_success_step_ids:
         return RunSnapshotStatus.UNKNOWN
     if failed_step_ids:
         return RunSnapshotStatus.FAILED
@@ -314,6 +320,7 @@ def _resume_blockers(
     unlinked_supplied_verdict: bool,
     pending_in_closed_stage_ids: tuple[str, ...],
     pending_failed_step_ids: tuple[str, ...],
+    pending_success_step_ids: tuple[str, ...],
     has_source_event_ids: bool,
 ) -> tuple[str, ...]:
     blockers: list[str] = []
@@ -337,6 +344,8 @@ def _resume_blockers(
         blockers.append("pending_steps_after_stage_end")
     if pending_failed_step_ids:
         blockers.append("pending_failed_steps_present")
+    if pending_success_step_ids:
+        blockers.append("pending_success_steps_present")
     if status is RunSnapshotStatus.RUNNING and pending_step_ids and not has_source_event_ids:
         blockers.append("source_events_missing")
     if failed_step_ids:

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -45,7 +45,9 @@ def build_run_snapshot(
     step_tuple = tuple(steps)
     artifact_tuple = tuple(artifacts)
 
-    completed_step_ids = tuple(step.step_id for step in step_tuple if step.ended_at and step.ok is True)
+    completed_step_ids = tuple(
+        step.step_id for step in step_tuple if step.ended_at and step.ok is True
+    )
     pending_step_ids = tuple(step.step_id for step in step_tuple if step.ended_at is None)
     failed_step_ids = tuple(step.step_id for step in step_tuple if step.ok is False)
     unknown_step_ids = tuple(
@@ -121,7 +123,11 @@ def _resume_blockers(
     unknown_step_ids: tuple[str, ...],
 ) -> tuple[str, ...]:
     blockers: list[str] = []
-    if status in {RunSnapshotStatus.COMPLETED, RunSnapshotStatus.FAILED, RunSnapshotStatus.CANCELLED}:
+    if status in {
+        RunSnapshotStatus.COMPLETED,
+        RunSnapshotStatus.FAILED,
+        RunSnapshotStatus.CANCELLED,
+    }:
         blockers.append(f"terminal_status:{status.value}")
     if status is RunSnapshotStatus.WAITING:
         blockers.append("human_input_required")

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -112,13 +112,14 @@ def _validate_projection_bundle(
 ) -> None:
     stage_ids = {stage.stage_id for stage in stages}
     step_ids = {step.step_id for step in steps}
+    supplied_stage_ids = tuple(stage.stage_id for stage in stages)
     for stage in stages:
         if stage.run_id != run.run_id:
             msg = f"StageRecord {stage.stage_id!r} belongs to run {stage.run_id!r}, not {run.run_id!r}"
             raise ValueError(msg)
 
-    declared_stage_ids = set(run.stage_ids)
-    if declared_stage_ids != stage_ids:
+    if run.stage_ids != supplied_stage_ids:
+        declared_stage_ids = set(run.stage_ids)
         missing_stage_ids = sorted(declared_stage_ids - stage_ids)
         extra_stage_ids = sorted(stage_ids - declared_stage_ids)
         msg = _format_bundle_mismatch(
@@ -137,9 +138,10 @@ def _validate_projection_bundle(
             raise ValueError(msg)
 
     for stage in stages:
-        declared_step_ids = set(stage.step_ids)
-        stage_step_ids = {step.step_id for step in steps if step.stage_id == stage.stage_id}
-        if declared_step_ids != stage_step_ids:
+        supplied_step_ids = tuple(step.step_id for step in steps if step.stage_id == stage.stage_id)
+        if stage.step_ids != supplied_step_ids:
+            declared_step_ids = set(stage.step_ids)
+            stage_step_ids = set(supplied_step_ids)
             missing_step_ids = sorted(declared_step_ids - stage_step_ids)
             extra_step_ids = sorted(stage_step_ids - declared_step_ids)
             msg = _format_bundle_mismatch(
@@ -161,7 +163,7 @@ def _validate_projection_bundle(
         if verdict.scope != "run":
             msg = "build_run_snapshot requires a run-scoped VerdictRecord"
             raise ValueError(msg)
-        if run.verdict_id is not None and run.verdict_id != verdict.verdict_id:
+        if run.verdict_id != verdict.verdict_id:
             msg = "RunRecord.verdict_id must match the supplied VerdictRecord"
             raise ValueError(msg)
 

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -104,7 +104,7 @@ def build_run_snapshot(
         ),
         source_event_ids=_snapshot_source_event_ids(
             steps=step_tuple,
-            verdict=verdict if not unlinked_supplied_verdict else None,
+            verdict=verdict,
         ),
         recorded_at=recorded_at or datetime.now(UTC),
         metadata=MappingProxyType(metadata),

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -44,6 +44,13 @@ def build_run_snapshot(
     stage_tuple = tuple(stages)
     step_tuple = tuple(steps)
     artifact_tuple = tuple(artifacts)
+    _validate_projection_bundle(
+        run=run,
+        stages=stage_tuple,
+        steps=step_tuple,
+        artifacts=artifact_tuple,
+        verdict=verdict,
+    )
 
     completed_step_ids = tuple(
         step.step_id for step in step_tuple if step.ended_at and step.ok is True
@@ -85,6 +92,47 @@ def build_run_snapshot(
         recorded_at=recorded_at or datetime.now(UTC),
         metadata=MappingProxyType(metadata),
     )
+
+
+def _validate_projection_bundle(
+    *,
+    run: RunRecord,
+    stages: tuple[StageRecord, ...],
+    steps: tuple[StepRecord, ...],
+    artifacts: tuple[ArtifactRecord, ...],
+    verdict: VerdictRecord | None,
+) -> None:
+    stage_ids = {stage.stage_id for stage in stages}
+    step_ids = {step.step_id for step in steps}
+
+    for stage in stages:
+        if stage.run_id != run.run_id:
+            msg = f"StageRecord {stage.stage_id!r} belongs to run {stage.run_id!r}, not {run.run_id!r}"
+            raise ValueError(msg)
+
+    for step in steps:
+        if step.run_id != run.run_id:
+            msg = f"StepRecord {step.step_id!r} belongs to run {step.run_id!r}, not {run.run_id!r}"
+            raise ValueError(msg)
+        if stage_ids and step.stage_id not in stage_ids:
+            msg = f"StepRecord {step.step_id!r} references unknown stage {step.stage_id!r}"
+            raise ValueError(msg)
+
+    for artifact in artifacts:
+        if artifact.step_id not in step_ids:
+            msg = f"ArtifactRecord {artifact.artifact_id!r} references unknown step {artifact.step_id!r}"
+            raise ValueError(msg)
+
+    if verdict is not None:
+        if verdict.run_id != run.run_id:
+            msg = f"VerdictRecord {verdict.verdict_id!r} belongs to run {verdict.run_id!r}, not {run.run_id!r}"
+            raise ValueError(msg)
+        if verdict.scope != "run":
+            msg = "build_run_snapshot requires a run-scoped VerdictRecord"
+            raise ValueError(msg)
+        if run.verdict_id is not None and run.verdict_id != verdict.verdict_id:
+            msg = "RunRecord.verdict_id must match the supplied VerdictRecord"
+            raise ValueError(msg)
 
 
 def _derive_status(

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -61,14 +61,22 @@ def build_run_snapshot(
         step.step_id for step in step_tuple if step.ended_at is not None and step.ok is None
     )
 
+    missing_linked_verdict = run.verdict_id is not None and verdict is None
     status = _derive_status(
         run=run,
         verdict=verdict,
+        missing_linked_verdict=missing_linked_verdict,
         pending_step_ids=pending_step_ids,
         failed_step_ids=failed_step_ids,
         unknown_step_ids=unknown_step_ids,
     )
-    blockers = _resume_blockers(status, pending_step_ids, failed_step_ids, unknown_step_ids)
+    blockers = _resume_blockers(
+        status,
+        pending_step_ids,
+        failed_step_ids,
+        unknown_step_ids,
+        missing_linked_verdict=missing_linked_verdict,
+    )
     safe_resume = status is RunSnapshotStatus.RUNNING and bool(pending_step_ids) and not blockers
 
     metadata = {
@@ -139,6 +147,7 @@ def _derive_status(
     *,
     run: RunRecord,
     verdict: VerdictRecord | None,
+    missing_linked_verdict: bool,
     pending_step_ids: tuple[str, ...],
     failed_step_ids: tuple[str, ...],
     unknown_step_ids: tuple[str, ...],
@@ -153,14 +162,18 @@ def _derive_status(
         if verdict.outcome is VerdictOutcome.ESCALATE_HUMAN:
             return RunSnapshotStatus.WAITING
         return RunSnapshotStatus.UNKNOWN
+    if missing_linked_verdict:
+        return RunSnapshotStatus.UNKNOWN
     if failed_step_ids:
         return RunSnapshotStatus.FAILED
+    if run.ended_at is not None:
+        if unknown_step_ids:
+            return RunSnapshotStatus.UNKNOWN
+        return RunSnapshotStatus.COMPLETED
     if pending_step_ids:
         return RunSnapshotStatus.RUNNING
     if unknown_step_ids:
         return RunSnapshotStatus.UNKNOWN
-    if run.ended_at is not None:
-        return RunSnapshotStatus.COMPLETED
     return RunSnapshotStatus.RUNNING
 
 
@@ -169,6 +182,8 @@ def _resume_blockers(
     pending_step_ids: tuple[str, ...],
     failed_step_ids: tuple[str, ...],
     unknown_step_ids: tuple[str, ...],
+    *,
+    missing_linked_verdict: bool,
 ) -> tuple[str, ...]:
     blockers: list[str] = []
     if status in {
@@ -181,6 +196,8 @@ def _resume_blockers(
         blockers.append("human_input_required")
     if status is RunSnapshotStatus.UNKNOWN:
         blockers.append("status_unknown")
+    if missing_linked_verdict:
+        blockers.append("linked_verdict_missing")
     if failed_step_ids:
         blockers.append("failed_steps_present")
     if unknown_step_ids:

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -62,6 +62,7 @@ def build_run_snapshot(
 
     missing_linked_verdict = run.verdict_id is not None and verdict is None
     unlinked_supplied_verdict = verdict is not None and run.verdict_id is None
+    derived_source_event_ids = _snapshot_source_event_ids(steps=step_tuple, verdict=verdict)
     status = _derive_status(
         run=run,
         verdict=verdict,
@@ -78,6 +79,7 @@ def build_run_snapshot(
         unknown_step_ids,
         missing_linked_verdict=missing_linked_verdict,
         unlinked_supplied_verdict=unlinked_supplied_verdict,
+        has_source_event_ids=bool(derived_source_event_ids),
     )
     safe_resume = status is RunSnapshotStatus.RUNNING and bool(pending_step_ids) and not blockers
 
@@ -102,10 +104,7 @@ def build_run_snapshot(
             if verdict is not None and not unlinked_supplied_verdict
             else run.verdict_id
         ),
-        source_event_ids=_snapshot_source_event_ids(
-            steps=step_tuple,
-            verdict=verdict,
-        ),
+        source_event_ids=derived_source_event_ids,
         recorded_at=recorded_at or datetime.now(UTC),
         metadata=MappingProxyType(metadata),
     )
@@ -296,6 +295,7 @@ def _resume_blockers(
     *,
     missing_linked_verdict: bool,
     unlinked_supplied_verdict: bool,
+    has_source_event_ids: bool,
 ) -> tuple[str, ...]:
     blockers: list[str] = []
     if status in {
@@ -314,6 +314,8 @@ def _resume_blockers(
         blockers.append("linked_verdict_missing")
     if unlinked_supplied_verdict:
         blockers.append("unlinked_verdict_present")
+    if status is RunSnapshotStatus.RUNNING and pending_step_ids and not has_source_event_ids:
+        blockers.append("source_events_missing")
     if failed_step_ids:
         blockers.append("failed_steps_present")
     if unknown_step_ids:

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -112,18 +112,41 @@ def _validate_projection_bundle(
 ) -> None:
     stage_ids = {stage.stage_id for stage in stages}
     step_ids = {step.step_id for step in steps}
-
     for stage in stages:
         if stage.run_id != run.run_id:
             msg = f"StageRecord {stage.stage_id!r} belongs to run {stage.run_id!r}, not {run.run_id!r}"
             raise ValueError(msg)
 
+    declared_stage_ids = set(run.stage_ids)
+    if declared_stage_ids != stage_ids:
+        missing_stage_ids = sorted(declared_stage_ids - stage_ids)
+        extra_stage_ids = sorted(stage_ids - declared_stage_ids)
+        msg = _format_bundle_mismatch(
+            "RunRecord.stage_ids",
+            missing=missing_stage_ids,
+            extra=extra_stage_ids,
+        )
+        raise ValueError(msg)
+
     for step in steps:
         if step.run_id != run.run_id:
             msg = f"StepRecord {step.step_id!r} belongs to run {step.run_id!r}, not {run.run_id!r}"
             raise ValueError(msg)
-        if stage_ids and step.stage_id not in stage_ids:
+        if step.stage_id not in stage_ids:
             msg = f"StepRecord {step.step_id!r} references unknown stage {step.stage_id!r}"
+            raise ValueError(msg)
+
+    for stage in stages:
+        declared_step_ids = set(stage.step_ids)
+        stage_step_ids = {step.step_id for step in steps if step.stage_id == stage.stage_id}
+        if declared_step_ids != stage_step_ids:
+            missing_step_ids = sorted(declared_step_ids - stage_step_ids)
+            extra_step_ids = sorted(stage_step_ids - declared_step_ids)
+            msg = _format_bundle_mismatch(
+                f"StageRecord {stage.stage_id!r}.step_ids",
+                missing=missing_step_ids,
+                extra=extra_step_ids,
+            )
             raise ValueError(msg)
 
     for artifact in artifacts:
@@ -141,6 +164,16 @@ def _validate_projection_bundle(
         if run.verdict_id is not None and run.verdict_id != verdict.verdict_id:
             msg = "RunRecord.verdict_id must match the supplied VerdictRecord"
             raise ValueError(msg)
+
+
+def _format_bundle_mismatch(owner: str, *, missing: list[str], extra: list[str]) -> str:
+    details: list[str] = []
+    if missing:
+        details.append(f"missing {missing!r}")
+    if extra:
+        details.append(f"unexpected {extra!r}")
+    detail = "; ".join(details) or "mismatched projection records"
+    return f"{owner} does not match supplied projection bundle: {detail}"
 
 
 def _derive_status(
@@ -167,7 +200,7 @@ def _derive_status(
     if failed_step_ids:
         return RunSnapshotStatus.FAILED
     if run.ended_at is not None:
-        if unknown_step_ids:
+        if pending_step_ids or unknown_step_ids:
             return RunSnapshotStatus.UNKNOWN
         return RunSnapshotStatus.COMPLETED
     if pending_step_ids:
@@ -196,6 +229,8 @@ def _resume_blockers(
         blockers.append("human_input_required")
     if status is RunSnapshotStatus.UNKNOWN:
         blockers.append("status_unknown")
+    if status is RunSnapshotStatus.UNKNOWN and pending_step_ids:
+        blockers.append("pending_steps_present")
     if missing_linked_verdict:
         blockers.append("linked_verdict_missing")
     if failed_step_ids:

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -59,6 +59,12 @@ def build_run_snapshot(
     unknown_step_ids = tuple(
         step.step_id for step in step_tuple if step.ended_at is not None and step.ok is None
     )
+    closed_stage_ids = {stage.stage_id for stage in stage_tuple if stage.ended_at is not None}
+    pending_in_closed_stage_ids = tuple(
+        step.step_id
+        for step in step_tuple
+        if step.ended_at is None and step.stage_id in closed_stage_ids
+    )
 
     missing_linked_verdict = run.verdict_id is not None and verdict is None
     unlinked_supplied_verdict = verdict is not None and run.verdict_id is None
@@ -68,6 +74,7 @@ def build_run_snapshot(
         verdict=verdict,
         missing_linked_verdict=missing_linked_verdict,
         unlinked_supplied_verdict=unlinked_supplied_verdict,
+        pending_in_closed_stage_ids=pending_in_closed_stage_ids,
         pending_step_ids=pending_step_ids,
         failed_step_ids=failed_step_ids,
         unknown_step_ids=unknown_step_ids,
@@ -79,6 +86,7 @@ def build_run_snapshot(
         unknown_step_ids,
         missing_linked_verdict=missing_linked_verdict,
         unlinked_supplied_verdict=unlinked_supplied_verdict,
+        pending_in_closed_stage_ids=pending_in_closed_stage_ids,
         has_source_event_ids=bool(derived_source_event_ids),
     )
     safe_resume = status is RunSnapshotStatus.RUNNING and bool(pending_step_ids) and not blockers
@@ -233,6 +241,7 @@ def _derive_status(
     verdict: VerdictRecord | None,
     missing_linked_verdict: bool,
     unlinked_supplied_verdict: bool,
+    pending_in_closed_stage_ids: tuple[str, ...],
     pending_step_ids: tuple[str, ...],
     failed_step_ids: tuple[str, ...],
     unknown_step_ids: tuple[str, ...],
@@ -257,6 +266,8 @@ def _derive_status(
             return RunSnapshotStatus.WAITING
         return RunSnapshotStatus.UNKNOWN
     if missing_linked_verdict:
+        return RunSnapshotStatus.UNKNOWN
+    if pending_in_closed_stage_ids:
         return RunSnapshotStatus.UNKNOWN
     if failed_step_ids:
         return RunSnapshotStatus.FAILED
@@ -295,6 +306,7 @@ def _resume_blockers(
     *,
     missing_linked_verdict: bool,
     unlinked_supplied_verdict: bool,
+    pending_in_closed_stage_ids: tuple[str, ...],
     has_source_event_ids: bool,
 ) -> tuple[str, ...]:
     blockers: list[str] = []
@@ -314,6 +326,8 @@ def _resume_blockers(
         blockers.append("linked_verdict_missing")
     if unlinked_supplied_verdict:
         blockers.append("unlinked_verdict_present")
+    if pending_in_closed_stage_ids:
+        blockers.append("pending_steps_after_stage_end")
     if status is RunSnapshotStatus.RUNNING and pending_step_ids and not has_source_event_ids:
         blockers.append("source_events_missing")
     if failed_step_ids:

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -62,10 +62,12 @@ def build_run_snapshot(
     )
 
     missing_linked_verdict = run.verdict_id is not None and verdict is None
+    unlinked_supplied_verdict = verdict is not None and run.verdict_id is None
     status = _derive_status(
         run=run,
         verdict=verdict,
         missing_linked_verdict=missing_linked_verdict,
+        unlinked_supplied_verdict=unlinked_supplied_verdict,
         pending_step_ids=pending_step_ids,
         failed_step_ids=failed_step_ids,
         unknown_step_ids=unknown_step_ids,
@@ -76,6 +78,7 @@ def build_run_snapshot(
         failed_step_ids,
         unknown_step_ids,
         missing_linked_verdict=missing_linked_verdict,
+        unlinked_supplied_verdict=unlinked_supplied_verdict,
     )
     safe_resume = status is RunSnapshotStatus.RUNNING and bool(pending_step_ids) and not blockers
 
@@ -95,7 +98,11 @@ def build_run_snapshot(
         failed_step_ids=failed_step_ids,
         unknown_step_ids=unknown_step_ids,
         artifact_ids=tuple(artifact.artifact_id for artifact in artifact_tuple),
-        verdict_id=verdict.verdict_id if verdict is not None else run.verdict_id,
+        verdict_id=(
+            verdict.verdict_id
+            if verdict is not None and not unlinked_supplied_verdict
+            else run.verdict_id
+        ),
         source_event_ids=tuple(source_event_ids),
         recorded_at=recorded_at or datetime.now(UTC),
         metadata=MappingProxyType(metadata),
@@ -179,7 +186,7 @@ def _validate_projection_bundle(
         if verdict.scope != "run":
             msg = "build_run_snapshot requires a run-scoped VerdictRecord"
             raise ValueError(msg)
-        if run.verdict_id != verdict.verdict_id:
+        if run.verdict_id is not None and run.verdict_id != verdict.verdict_id:
             msg = "RunRecord.verdict_id must match the supplied VerdictRecord"
             raise ValueError(msg)
 
@@ -199,10 +206,13 @@ def _derive_status(
     run: RunRecord,
     verdict: VerdictRecord | None,
     missing_linked_verdict: bool,
+    unlinked_supplied_verdict: bool,
     pending_step_ids: tuple[str, ...],
     failed_step_ids: tuple[str, ...],
     unknown_step_ids: tuple[str, ...],
 ) -> RunSnapshotStatus:
+    if unlinked_supplied_verdict:
+        return RunSnapshotStatus.UNKNOWN
     if verdict is not None:
         if verdict.outcome is VerdictOutcome.PASS:
             return RunSnapshotStatus.COMPLETED
@@ -235,6 +245,7 @@ def _resume_blockers(
     unknown_step_ids: tuple[str, ...],
     *,
     missing_linked_verdict: bool,
+    unlinked_supplied_verdict: bool,
 ) -> tuple[str, ...]:
     blockers: list[str] = []
     if status in {
@@ -251,6 +262,8 @@ def _resume_blockers(
         blockers.append("pending_steps_present")
     if missing_linked_verdict:
         blockers.append("linked_verdict_missing")
+    if unlinked_supplied_verdict:
+        blockers.append("unlinked_verdict_present")
     if failed_step_ids:
         blockers.append("failed_steps_present")
     if unknown_step_ids:

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -214,6 +214,13 @@ def _derive_status(
     if unlinked_supplied_verdict:
         return RunSnapshotStatus.UNKNOWN
     if verdict is not None:
+        if _verdict_conflicts_with_steps(
+            verdict=verdict,
+            pending_step_ids=pending_step_ids,
+            failed_step_ids=failed_step_ids,
+            unknown_step_ids=unknown_step_ids,
+        ):
+            return RunSnapshotStatus.UNKNOWN
         if verdict.outcome is VerdictOutcome.PASS:
             return RunSnapshotStatus.COMPLETED
         if verdict.outcome is VerdictOutcome.FAIL:
@@ -236,6 +243,22 @@ def _derive_status(
     if unknown_step_ids:
         return RunSnapshotStatus.UNKNOWN
     return RunSnapshotStatus.RUNNING
+
+
+def _verdict_conflicts_with_steps(
+    *,
+    verdict: VerdictRecord,
+    pending_step_ids: tuple[str, ...],
+    failed_step_ids: tuple[str, ...],
+    unknown_step_ids: tuple[str, ...],
+) -> bool:
+    if verdict.outcome in {
+        VerdictOutcome.PASS,
+        VerdictOutcome.FAIL,
+        VerdictOutcome.CANCELLED,
+    } and (pending_step_ids or unknown_step_ids):
+        return True
+    return verdict.outcome is VerdictOutcome.PASS and bool(failed_step_ids)
 
 
 def _resume_blockers(

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -30,7 +30,6 @@ def build_run_snapshot(
     steps: Iterable[StepRecord] = (),
     artifacts: Iterable[ArtifactRecord] = (),
     verdict: VerdictRecord | None = None,
-    source_event_ids: Iterable[str] = (),
     recorded_at: datetime | None = None,
 ) -> RunSnapshotRecord:
     """Build a safe-resume snapshot from projection records.
@@ -103,7 +102,10 @@ def build_run_snapshot(
             if verdict is not None and not unlinked_supplied_verdict
             else run.verdict_id
         ),
-        source_event_ids=tuple(source_event_ids),
+        source_event_ids=_snapshot_source_event_ids(
+            steps=step_tuple,
+            verdict=verdict if not unlinked_supplied_verdict else None,
+        ),
         recorded_at=recorded_at or datetime.now(UTC),
         metadata=MappingProxyType(metadata),
     )
@@ -189,6 +191,31 @@ def _validate_projection_bundle(
         if run.verdict_id is not None and run.verdict_id != verdict.verdict_id:
             msg = "RunRecord.verdict_id must match the supplied VerdictRecord"
             raise ValueError(msg)
+        missing_evidence_artifact_ids = sorted(
+            set(verdict.evidence_artifact_ids) - {artifact.artifact_id for artifact in artifacts}
+        )
+        if missing_evidence_artifact_ids:
+            msg = _format_bundle_mismatch(
+                f"VerdictRecord {verdict.verdict_id!r}.evidence_artifact_ids",
+                missing=missing_evidence_artifact_ids,
+                extra=[],
+            )
+            raise ValueError(msg)
+
+
+def _snapshot_source_event_ids(
+    *, steps: tuple[StepRecord, ...], verdict: VerdictRecord | None
+) -> tuple[str, ...]:
+    ordered_ids: list[str] = []
+    seen: set[str] = set()
+    for event_id in (
+        *(event_id for step in steps for event_id in step.source_event_ids),
+        *((verdict.evidence_event_ids) if verdict is not None else ()),
+    ):
+        if event_id not in seen:
+            ordered_ids.append(event_id)
+            seen.add(event_id)
+    return tuple(ordered_ids)
 
 
 def _format_bundle_mismatch(owner: str, *, missing: list[str], extra: list[str]) -> str:

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -55,7 +55,12 @@ def build_run_snapshot(
         step.step_id for step in step_tuple if step.ended_at and step.ok is True
     )
     pending_step_ids = tuple(step.step_id for step in step_tuple if step.ended_at is None)
-    failed_step_ids = tuple(step.step_id for step in step_tuple if step.ok is False)
+    failed_step_ids = tuple(
+        step.step_id for step in step_tuple if step.ended_at is not None and step.ok is False
+    )
+    pending_failed_step_ids = tuple(
+        step.step_id for step in step_tuple if step.ended_at is None and step.ok is False
+    )
     unknown_step_ids = tuple(
         step.step_id for step in step_tuple if step.ended_at is not None and step.ok is None
     )
@@ -75,6 +80,7 @@ def build_run_snapshot(
         missing_linked_verdict=missing_linked_verdict,
         unlinked_supplied_verdict=unlinked_supplied_verdict,
         pending_in_closed_stage_ids=pending_in_closed_stage_ids,
+        pending_failed_step_ids=pending_failed_step_ids,
         pending_step_ids=pending_step_ids,
         failed_step_ids=failed_step_ids,
         unknown_step_ids=unknown_step_ids,
@@ -87,6 +93,7 @@ def build_run_snapshot(
         missing_linked_verdict=missing_linked_verdict,
         unlinked_supplied_verdict=unlinked_supplied_verdict,
         pending_in_closed_stage_ids=pending_in_closed_stage_ids,
+        pending_failed_step_ids=pending_failed_step_ids,
         has_source_event_ids=bool(derived_source_event_ids),
     )
     safe_resume = status is RunSnapshotStatus.RUNNING and bool(pending_step_ids) and not blockers
@@ -242,6 +249,7 @@ def _derive_status(
     missing_linked_verdict: bool,
     unlinked_supplied_verdict: bool,
     pending_in_closed_stage_ids: tuple[str, ...],
+    pending_failed_step_ids: tuple[str, ...],
     pending_step_ids: tuple[str, ...],
     failed_step_ids: tuple[str, ...],
     unknown_step_ids: tuple[str, ...],
@@ -267,14 +275,12 @@ def _derive_status(
         return RunSnapshotStatus.UNKNOWN
     if missing_linked_verdict:
         return RunSnapshotStatus.UNKNOWN
-    if pending_in_closed_stage_ids:
+    if pending_in_closed_stage_ids or pending_failed_step_ids:
         return RunSnapshotStatus.UNKNOWN
     if failed_step_ids:
         return RunSnapshotStatus.FAILED
     if run.ended_at is not None:
-        if pending_step_ids or unknown_step_ids:
-            return RunSnapshotStatus.UNKNOWN
-        return RunSnapshotStatus.COMPLETED
+        return RunSnapshotStatus.UNKNOWN
     if pending_step_ids:
         return RunSnapshotStatus.RUNNING
     if unknown_step_ids:
@@ -307,6 +313,7 @@ def _resume_blockers(
     missing_linked_verdict: bool,
     unlinked_supplied_verdict: bool,
     pending_in_closed_stage_ids: tuple[str, ...],
+    pending_failed_step_ids: tuple[str, ...],
     has_source_event_ids: bool,
 ) -> tuple[str, ...]:
     blockers: list[str] = []
@@ -328,6 +335,8 @@ def _resume_blockers(
         blockers.append("unlinked_verdict_present")
     if pending_in_closed_stage_ids:
         blockers.append("pending_steps_after_stage_end")
+    if pending_failed_step_ids:
+        blockers.append("pending_failed_steps_present")
     if status is RunSnapshotStatus.RUNNING and pending_step_ids and not has_source_event_ids:
         blockers.append("source_events_missing")
     if failed_step_ids:

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -64,6 +64,9 @@ def build_run_snapshot(
     pending_success_step_ids = tuple(
         step.step_id for step in step_tuple if step.ended_at is None and step.ok is True
     )
+    pending_without_source_event_ids = tuple(
+        step.step_id for step in step_tuple if step.ended_at is None and not step.source_event_ids
+    )
     unknown_step_ids = tuple(
         step.step_id for step in step_tuple if step.ended_at is not None and step.ok is None
     )
@@ -99,7 +102,7 @@ def build_run_snapshot(
         pending_in_closed_stage_ids=pending_in_closed_stage_ids,
         pending_failed_step_ids=pending_failed_step_ids,
         pending_success_step_ids=pending_success_step_ids,
-        has_source_event_ids=bool(derived_source_event_ids),
+        pending_without_source_event_ids=pending_without_source_event_ids,
     )
     safe_resume = status is RunSnapshotStatus.RUNNING and bool(pending_step_ids) and not blockers
 
@@ -321,7 +324,7 @@ def _resume_blockers(
     pending_in_closed_stage_ids: tuple[str, ...],
     pending_failed_step_ids: tuple[str, ...],
     pending_success_step_ids: tuple[str, ...],
-    has_source_event_ids: bool,
+    pending_without_source_event_ids: tuple[str, ...],
 ) -> tuple[str, ...]:
     blockers: list[str] = []
     if status in {
@@ -346,8 +349,8 @@ def _resume_blockers(
         blockers.append("pending_failed_steps_present")
     if pending_success_step_ids:
         blockers.append("pending_success_steps_present")
-    if status is RunSnapshotStatus.RUNNING and pending_step_ids and not has_source_event_ids:
-        blockers.append("source_events_missing")
+    if status is RunSnapshotStatus.RUNNING and pending_without_source_event_ids:
+        blockers.append("pending_step_source_events_missing")
     if failed_step_ids:
         blockers.append("failed_steps_present")
     if unknown_step_ids:

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -1,0 +1,139 @@
+"""RunSnapshot builder for safe-resume projection views.
+
+This is a narrow #946 follow-up over the public projection records. It derives a
+single immutable snapshot from already-projected Run/Stage/Step/Artifact/Verdict
+records and intentionally performs no EventStore writes or runtime dispatch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import UTC, datetime
+from types import MappingProxyType
+
+from ouroboros.harness.projection import (
+    ArtifactRecord,
+    RunRecord,
+    RunSnapshotRecord,
+    RunSnapshotStatus,
+    StageRecord,
+    StepRecord,
+    VerdictOutcome,
+    VerdictRecord,
+)
+
+
+def build_run_snapshot(
+    *,
+    run: RunRecord,
+    stages: Iterable[StageRecord] = (),
+    steps: Iterable[StepRecord] = (),
+    artifacts: Iterable[ArtifactRecord] = (),
+    verdict: VerdictRecord | None = None,
+    source_event_ids: Iterable[str] = (),
+    recorded_at: datetime | None = None,
+) -> RunSnapshotRecord:
+    """Build a safe-resume snapshot from projection records.
+
+    ``safe_resume`` is conservative: only non-terminal runs with at least one
+    pending step and no failed steps are marked resumable. Terminal verdicts,
+    failed steps, missing pending work, and explicit human-escalation verdicts
+    produce blocker codes instead of guessing a resume action.
+    """
+
+    stage_tuple = tuple(stages)
+    step_tuple = tuple(steps)
+    artifact_tuple = tuple(artifacts)
+
+    completed_step_ids = tuple(step.step_id for step in step_tuple if step.ended_at and step.ok is True)
+    pending_step_ids = tuple(step.step_id for step in step_tuple if step.ended_at is None)
+    failed_step_ids = tuple(step.step_id for step in step_tuple if step.ok is False)
+    unknown_step_ids = tuple(
+        step.step_id for step in step_tuple if step.ended_at is not None and step.ok is None
+    )
+
+    status = _derive_status(
+        run=run,
+        verdict=verdict,
+        pending_step_ids=pending_step_ids,
+        failed_step_ids=failed_step_ids,
+        unknown_step_ids=unknown_step_ids,
+    )
+    blockers = _resume_blockers(status, pending_step_ids, failed_step_ids, unknown_step_ids)
+    safe_resume = status is RunSnapshotStatus.RUNNING and bool(pending_step_ids) and not blockers
+
+    metadata = {
+        "stage_count": len(stage_tuple),
+        "step_count": len(step_tuple),
+        "artifact_count": len(artifact_tuple),
+    }
+    return RunSnapshotRecord(
+        run_id=run.run_id,
+        status=status,
+        safe_resume=safe_resume,
+        resume_blockers=blockers,
+        stage_ids=tuple(stage.stage_id for stage in stage_tuple),
+        completed_step_ids=completed_step_ids,
+        pending_step_ids=pending_step_ids,
+        failed_step_ids=failed_step_ids,
+        unknown_step_ids=unknown_step_ids,
+        artifact_ids=tuple(artifact.artifact_id for artifact in artifact_tuple),
+        verdict_id=verdict.verdict_id if verdict is not None else run.verdict_id,
+        source_event_ids=tuple(source_event_ids),
+        recorded_at=recorded_at or datetime.now(UTC),
+        metadata=MappingProxyType(metadata),
+    )
+
+
+def _derive_status(
+    *,
+    run: RunRecord,
+    verdict: VerdictRecord | None,
+    pending_step_ids: tuple[str, ...],
+    failed_step_ids: tuple[str, ...],
+    unknown_step_ids: tuple[str, ...],
+) -> RunSnapshotStatus:
+    if verdict is not None:
+        if verdict.outcome is VerdictOutcome.PASS:
+            return RunSnapshotStatus.COMPLETED
+        if verdict.outcome is VerdictOutcome.FAIL:
+            return RunSnapshotStatus.FAILED
+        if verdict.outcome is VerdictOutcome.CANCELLED:
+            return RunSnapshotStatus.CANCELLED
+        if verdict.outcome is VerdictOutcome.ESCALATE_HUMAN:
+            return RunSnapshotStatus.WAITING
+        return RunSnapshotStatus.UNKNOWN
+    if failed_step_ids:
+        return RunSnapshotStatus.FAILED
+    if pending_step_ids:
+        return RunSnapshotStatus.RUNNING
+    if unknown_step_ids:
+        return RunSnapshotStatus.UNKNOWN
+    if run.ended_at is not None:
+        return RunSnapshotStatus.COMPLETED
+    return RunSnapshotStatus.RUNNING
+
+
+def _resume_blockers(
+    status: RunSnapshotStatus,
+    pending_step_ids: tuple[str, ...],
+    failed_step_ids: tuple[str, ...],
+    unknown_step_ids: tuple[str, ...],
+) -> tuple[str, ...]:
+    blockers: list[str] = []
+    if status in {RunSnapshotStatus.COMPLETED, RunSnapshotStatus.FAILED, RunSnapshotStatus.CANCELLED}:
+        blockers.append(f"terminal_status:{status.value}")
+    if status is RunSnapshotStatus.WAITING:
+        blockers.append("human_input_required")
+    if status is RunSnapshotStatus.UNKNOWN:
+        blockers.append("status_unknown")
+    if failed_step_ids:
+        blockers.append("failed_steps_present")
+    if unknown_step_ids:
+        blockers.append("unknown_steps_present")
+    if status is RunSnapshotStatus.RUNNING and not pending_step_ids:
+        blockers.append("no_pending_steps")
+    return tuple(blockers)
+
+
+__all__ = ["build_run_snapshot"]

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -156,6 +156,22 @@ def _validate_projection_bundle(
             msg = f"ArtifactRecord {artifact.artifact_id!r} references unknown step {artifact.step_id!r}"
             raise ValueError(msg)
 
+    for step in steps:
+        supplied_artifact_ids = tuple(
+            artifact.artifact_id for artifact in artifacts if artifact.step_id == step.step_id
+        )
+        if step.artifact_ids != supplied_artifact_ids:
+            declared_artifact_ids = set(step.artifact_ids)
+            step_artifact_ids = set(supplied_artifact_ids)
+            missing_artifact_ids = sorted(declared_artifact_ids - step_artifact_ids)
+            extra_artifact_ids = sorted(step_artifact_ids - declared_artifact_ids)
+            msg = _format_bundle_mismatch(
+                f"StepRecord {step.step_id!r}.artifact_ids",
+                missing=missing_artifact_ids,
+                extra=extra_artifact_ids,
+            )
+            raise ValueError(msg)
+
     if verdict is not None:
         if verdict.run_id != run.run_id:
             msg = f"VerdictRecord {verdict.verdict_id!r} belongs to run {verdict.run_id!r}, not {run.run_id!r}"

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -294,7 +294,7 @@ def _derive_status(
         return RunSnapshotStatus.RUNNING
     if unknown_step_ids:
         return RunSnapshotStatus.UNKNOWN
-    return RunSnapshotStatus.RUNNING
+    return RunSnapshotStatus.UNKNOWN
 
 
 def _verdict_conflicts_with_steps(

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -472,3 +472,31 @@ def test_ended_run_without_verdict_is_unknown() -> None:
     assert snapshot.status is RunSnapshotStatus.UNKNOWN
     assert snapshot.safe_resume is False
     assert snapshot.resume_blockers == ("status_unknown",)
+
+
+def test_pending_success_step_is_unknown() -> None:
+    pending_success = StepRecord(
+        step_id="step_pending_success",
+        run_id="run_1",
+        stage_id="stage_1",
+        kind=StepKind.TOOL_CALL,
+        ended_at=None,
+        ok=True,
+        source_event_ids=("evt_pending_success",),
+    )
+
+    snapshot = build_run_snapshot(
+        run=_run(),
+        stages=[_stage("step_pending_success")],
+        steps=[pending_success],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.UNKNOWN
+    assert snapshot.safe_resume is False
+    assert snapshot.pending_step_ids == ("step_pending_success",)
+    assert snapshot.completed_step_ids == ()
+    assert snapshot.resume_blockers == (
+        "status_unknown",
+        "pending_steps_present",
+        "pending_success_steps_present",
+    )

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from pydantic import ValidationError
+import pytest
+
+from ouroboros.harness.projection import (
+    ArtifactRecord,
+    RunRecord,
+    RunSnapshotRecord,
+    RunSnapshotStatus,
+    StageKind,
+    StageRecord,
+    StepKind,
+    StepRecord,
+    VerdictOutcome,
+    VerdictRecord,
+)
+from ouroboros.harness.run_snapshot import build_run_snapshot
+
+
+def _run(*, ended: bool = False, verdict_id: str | None = None) -> RunRecord:
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    return RunRecord(
+        run_id="run_1",
+        seed_id="seed_1",
+        started_at=start,
+        ended_at=start + timedelta(seconds=10) if ended else None,
+        stage_ids=("stage_1",),
+        verdict_id=verdict_id,
+    )
+
+
+def _stage() -> StageRecord:
+    return StageRecord(stage_id="stage_1", run_id="run_1", kind=StageKind.EXECUTE)
+
+
+def _step(step_id: str, *, ended: bool, ok: bool | None) -> StepRecord:
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    return StepRecord(
+        step_id=step_id,
+        run_id="run_1",
+        stage_id="stage_1",
+        kind=StepKind.TOOL_CALL,
+        started_at=start,
+        ended_at=start + timedelta(seconds=1) if ended else None,
+        ok=ok,
+        source_event_ids=(f"evt_{step_id}",),
+    )
+
+
+def test_running_snapshot_with_pending_work_is_safe_to_resume() -> None:
+    completed = _step("step_done", ended=True, ok=True)
+    pending = _step("step_pending", ended=False, ok=None)
+    artifact = ArtifactRecord(artifact_id="artifact_1", step_id="step_done", kind="log")
+
+    snapshot = build_run_snapshot(
+        run=_run(),
+        stages=[_stage()],
+        steps=[completed, pending],
+        artifacts=[artifact],
+        source_event_ids=("evt_step_done", "evt_step_pending"),
+        recorded_at=datetime(2026, 5, 15, tzinfo=UTC),
+    )
+
+    assert snapshot.status is RunSnapshotStatus.RUNNING
+    assert snapshot.safe_resume is True
+    assert snapshot.resume_blockers == ()
+    assert snapshot.stage_ids == ("stage_1",)
+    assert snapshot.completed_step_ids == ("step_done",)
+    assert snapshot.pending_step_ids == ("step_pending",)
+    assert snapshot.artifact_ids == ("artifact_1",)
+    assert snapshot.source_event_ids == ("evt_step_done", "evt_step_pending")
+    assert snapshot.metadata == {"stage_count": 1, "step_count": 2, "artifact_count": 1}
+
+
+def test_failed_step_blocks_resume() -> None:
+    snapshot = build_run_snapshot(
+        run=_run(),
+        stages=[_stage()],
+        steps=[_step("step_failed", ended=True, ok=False)],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.FAILED
+    assert snapshot.safe_resume is False
+    assert snapshot.failed_step_ids == ("step_failed",)
+    assert "failed_steps_present" in snapshot.resume_blockers
+
+
+def test_human_escalation_verdict_is_waiting_but_not_safe_resume() -> None:
+    verdict = VerdictRecord(
+        verdict_id="verdict_1",
+        run_id="run_1",
+        scope="run",
+        outcome=VerdictOutcome.ESCALATE_HUMAN,
+        evidence_event_ids=("evt_verdict",),
+    )
+
+    snapshot = build_run_snapshot(run=_run(verdict_id="verdict_1"), verdict=verdict)
+
+    assert snapshot.status is RunSnapshotStatus.WAITING
+    assert snapshot.safe_resume is False
+    assert snapshot.verdict_id == "verdict_1"
+    assert snapshot.resume_blockers == ("human_input_required",)
+
+
+def test_terminal_verdicts_block_resume() -> None:
+    verdict = VerdictRecord(
+        verdict_id="verdict_pass",
+        run_id="run_1",
+        scope="run",
+        outcome=VerdictOutcome.PASS,
+    )
+
+    snapshot = build_run_snapshot(run=_run(ended=True, verdict_id="verdict_pass"), verdict=verdict)
+
+    assert snapshot.status is RunSnapshotStatus.COMPLETED
+    assert snapshot.safe_resume is False
+    assert snapshot.resume_blockers == ("terminal_status:completed",)
+
+
+def test_snapshot_record_enforces_safe_resume_invariant() -> None:
+    with pytest.raises(ValidationError, match="only valid"):
+        RunSnapshotRecord(run_id="run_1", status=RunSnapshotStatus.COMPLETED, safe_resume=True)
+
+    with pytest.raises(ValidationError, match="resume_blockers"):
+        RunSnapshotRecord(
+            run_id="run_1",
+            status=RunSnapshotStatus.RUNNING,
+            safe_resume=False,
+        )
+
+
+def test_snapshot_metadata_is_read_only() -> None:
+    snapshot = build_run_snapshot(run=_run(), steps=[_step("step_pending", ended=False, ok=None)])
+    with pytest.raises(TypeError):
+        snapshot.metadata["new"] = "value"  # type: ignore[index]

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -182,3 +182,29 @@ def test_rejects_foreign_or_ac_scoped_verdicts() -> None:
     )
     with pytest.raises(ValueError, match="run-scoped"):
         build_run_snapshot(run=_run(), verdict=ac_verdict)
+
+
+def test_ended_run_with_stale_pending_step_is_not_safe_resume() -> None:
+    snapshot = build_run_snapshot(
+        run=_run(ended=True),
+        stages=[_stage()],
+        steps=[_step("step_stale_pending", ended=False, ok=None)],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.COMPLETED
+    assert snapshot.safe_resume is False
+    assert snapshot.pending_step_ids == ("step_stale_pending",)
+    assert snapshot.resume_blockers == ("terminal_status:completed",)
+
+
+def test_missing_linked_run_verdict_blocks_resume_conservatively() -> None:
+    snapshot = build_run_snapshot(
+        run=_run(verdict_id="verdict_missing"),
+        stages=[_stage()],
+        steps=[_step("step_pending", ended=False, ok=None)],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.UNKNOWN
+    assert snapshot.safe_resume is False
+    assert snapshot.verdict_id == "verdict_missing"
+    assert snapshot.resume_blockers == ("status_unknown", "linked_verdict_missing")

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -406,3 +406,29 @@ def test_legacy_pending_step_without_source_events_blocks_resume() -> None:
     assert snapshot.safe_resume is False
     assert snapshot.source_event_ids == ()
     assert snapshot.resume_blockers == ("source_events_missing",)
+
+
+def test_pending_step_in_closed_stage_is_unknown() -> None:
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    closed_stage = StageRecord(
+        stage_id="stage_1",
+        run_id="run_1",
+        kind=StageKind.EXECUTE,
+        started_at=start,
+        ended_at=start + timedelta(seconds=5),
+        step_ids=("step_pending",),
+    )
+
+    snapshot = build_run_snapshot(
+        run=_run(),
+        stages=[closed_stage],
+        steps=[_step("step_pending", ended=False, ok=None)],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.UNKNOWN
+    assert snapshot.safe_resume is False
+    assert snapshot.resume_blockers == (
+        "status_unknown",
+        "pending_steps_present",
+        "pending_steps_after_stage_end",
+    )

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -432,3 +432,43 @@ def test_pending_step_in_closed_stage_is_unknown() -> None:
         "pending_steps_present",
         "pending_steps_after_stage_end",
     )
+
+
+def test_pending_failed_step_is_unknown() -> None:
+    pending_failed = StepRecord(
+        step_id="step_pending_failed",
+        run_id="run_1",
+        stage_id="stage_1",
+        kind=StepKind.TOOL_CALL,
+        ended_at=None,
+        ok=False,
+        source_event_ids=("evt_pending_failed",),
+    )
+
+    snapshot = build_run_snapshot(
+        run=_run(),
+        stages=[_stage("step_pending_failed")],
+        steps=[pending_failed],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.UNKNOWN
+    assert snapshot.safe_resume is False
+    assert snapshot.pending_step_ids == ("step_pending_failed",)
+    assert snapshot.failed_step_ids == ()
+    assert snapshot.resume_blockers == (
+        "status_unknown",
+        "pending_steps_present",
+        "pending_failed_steps_present",
+    )
+
+
+def test_ended_run_without_verdict_is_unknown() -> None:
+    snapshot = build_run_snapshot(
+        run=_run(ended=True),
+        stages=[_stage("step_done")],
+        steps=[_step("step_done", ended=True, ok=True)],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.UNKNOWN
+    assert snapshot.safe_resume is False
+    assert snapshot.resume_blockers == ("status_unknown",)

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -254,6 +254,7 @@ def test_unlinked_same_run_verdict_blocks_resume_conservatively() -> None:
         run_id="run_1",
         scope="run",
         outcome=VerdictOutcome.PASS,
+        evidence_event_ids=("evt_verdict_unlinked",),
     )
 
     snapshot = build_run_snapshot(run=_run(), stages=[_stage()], verdict=verdict)
@@ -261,6 +262,7 @@ def test_unlinked_same_run_verdict_blocks_resume_conservatively() -> None:
     assert snapshot.status is RunSnapshotStatus.UNKNOWN
     assert snapshot.safe_resume is False
     assert snapshot.verdict_id is None
+    assert snapshot.source_event_ids == ("evt_verdict_unlinked",)
     assert snapshot.resume_blockers == ("status_unknown", "unlinked_verdict_present")
 
 

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -405,7 +405,7 @@ def test_legacy_pending_step_without_source_events_blocks_resume() -> None:
     assert snapshot.status is RunSnapshotStatus.RUNNING
     assert snapshot.safe_resume is False
     assert snapshot.source_event_ids == ()
-    assert snapshot.resume_blockers == ("source_events_missing",)
+    assert snapshot.resume_blockers == ("pending_step_source_events_missing",)
 
 
 def test_pending_step_in_closed_stage_is_unknown() -> None:
@@ -500,3 +500,27 @@ def test_pending_success_step_is_unknown() -> None:
         "pending_steps_present",
         "pending_success_steps_present",
     )
+
+
+def test_mixed_legacy_pending_step_without_source_events_blocks_resume() -> None:
+    completed = _step("step_done", ended=True, ok=True)
+    legacy_pending = StepRecord(
+        step_id="step_legacy_pending",
+        run_id="run_1",
+        stage_id="stage_1",
+        kind=StepKind.TOOL_CALL,
+        ended_at=None,
+        ok=None,
+        legacy_inferred=True,
+    )
+
+    snapshot = build_run_snapshot(
+        run=_run(),
+        stages=[_stage("step_done", "step_legacy_pending")],
+        steps=[completed, legacy_pending],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.RUNNING
+    assert snapshot.safe_resume is False
+    assert snapshot.source_event_ids == ("evt_step_done",)
+    assert snapshot.resume_blockers == ("pending_step_source_events_missing",)

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -141,7 +141,7 @@ def test_snapshot_record_enforces_safe_resume_invariant() -> None:
     with pytest.raises(ValidationError, match="only valid"):
         RunSnapshotRecord(run_id="run_1", status=RunSnapshotStatus.WAITING, safe_resume=True)
 
-    with pytest.raises(ValidationError, match="resume_blockers"):
+    with pytest.raises(ValidationError, match="unsafe non-terminal"):
         RunSnapshotRecord(
             run_id="run_1",
             status=RunSnapshotStatus.RUNNING,
@@ -249,7 +249,7 @@ def test_rejects_incomplete_declared_step_bundle() -> None:
         )
 
 
-def test_rejects_unlinked_same_run_verdict() -> None:
+def test_unlinked_same_run_verdict_blocks_resume_conservatively() -> None:
     verdict = VerdictRecord(
         verdict_id="verdict_unlinked",
         run_id="run_1",
@@ -257,8 +257,12 @@ def test_rejects_unlinked_same_run_verdict() -> None:
         outcome=VerdictOutcome.PASS,
     )
 
-    with pytest.raises(ValueError, match="RunRecord.verdict_id"):
-        build_run_snapshot(run=_run(), stages=[_stage()], verdict=verdict)
+    snapshot = build_run_snapshot(run=_run(), stages=[_stage()], verdict=verdict)
+
+    assert snapshot.status is RunSnapshotStatus.UNKNOWN
+    assert snapshot.safe_resume is False
+    assert snapshot.verdict_id is None
+    assert snapshot.resume_blockers == ("status_unknown", "unlinked_verdict_present")
 
 
 def test_rejects_out_of_order_declared_stage_bundle() -> None:

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -32,8 +32,13 @@ def _run(*, ended: bool = False, verdict_id: str | None = None) -> RunRecord:
     )
 
 
-def _stage() -> StageRecord:
-    return StageRecord(stage_id="stage_1", run_id="run_1", kind=StageKind.EXECUTE)
+def _stage(*step_ids: str) -> StageRecord:
+    return StageRecord(
+        stage_id="stage_1",
+        run_id="run_1",
+        kind=StageKind.EXECUTE,
+        step_ids=step_ids,
+    )
 
 
 def _step(step_id: str, *, ended: bool, ok: bool | None) -> StepRecord:
@@ -57,7 +62,7 @@ def test_running_snapshot_with_pending_work_is_safe_to_resume() -> None:
 
     snapshot = build_run_snapshot(
         run=_run(),
-        stages=[_stage()],
+        stages=[_stage("step_done", "step_pending")],
         steps=[completed, pending],
         artifacts=[artifact],
         source_event_ids=("evt_step_done", "evt_step_pending"),
@@ -78,7 +83,7 @@ def test_running_snapshot_with_pending_work_is_safe_to_resume() -> None:
 def test_failed_step_blocks_resume() -> None:
     snapshot = build_run_snapshot(
         run=_run(),
-        stages=[_stage()],
+        stages=[_stage("step_failed")],
         steps=[_step("step_failed", ended=True, ok=False)],
     )
 
@@ -97,7 +102,9 @@ def test_human_escalation_verdict_is_waiting_but_not_safe_resume() -> None:
         evidence_event_ids=("evt_verdict",),
     )
 
-    snapshot = build_run_snapshot(run=_run(verdict_id="verdict_1"), verdict=verdict)
+    snapshot = build_run_snapshot(
+        run=_run(verdict_id="verdict_1"), stages=[_stage()], verdict=verdict
+    )
 
     assert snapshot.status is RunSnapshotStatus.WAITING
     assert snapshot.safe_resume is False
@@ -113,7 +120,11 @@ def test_terminal_verdicts_block_resume() -> None:
         outcome=VerdictOutcome.PASS,
     )
 
-    snapshot = build_run_snapshot(run=_run(ended=True, verdict_id="verdict_pass"), verdict=verdict)
+    snapshot = build_run_snapshot(
+        run=_run(ended=True, verdict_id="verdict_pass"),
+        stages=[_stage()],
+        verdict=verdict,
+    )
 
     assert snapshot.status is RunSnapshotStatus.COMPLETED
     assert snapshot.safe_resume is False
@@ -133,7 +144,11 @@ def test_snapshot_record_enforces_safe_resume_invariant() -> None:
 
 
 def test_snapshot_metadata_is_read_only() -> None:
-    snapshot = build_run_snapshot(run=_run(), steps=[_step("step_pending", ended=False, ok=None)])
+    snapshot = build_run_snapshot(
+        run=_run(),
+        stages=[_stage("step_pending")],
+        steps=[_step("step_pending", ended=False, ok=None)],
+    )
     with pytest.raises(TypeError):
         snapshot.metadata["new"] = "value"  # type: ignore[index]
 
@@ -153,14 +168,14 @@ def test_rejects_foreign_projection_records() -> None:
         legacy_inferred=True,
     )
     with pytest.raises(ValueError, match="belongs to run"):
-        build_run_snapshot(run=_run(), stages=[_stage()], steps=[foreign_step])
+        build_run_snapshot(run=_run(), stages=[_stage("step_foreign")], steps=[foreign_step])
 
 
 def test_rejects_artifacts_not_owned_by_snapshot_steps() -> None:
     artifact = ArtifactRecord(artifact_id="artifact_orphan", step_id="step_missing", kind="log")
 
     with pytest.raises(ValueError, match="unknown step"):
-        build_run_snapshot(run=_run(), artifacts=[artifact])
+        build_run_snapshot(run=_run(), stages=[_stage()], artifacts=[artifact])
 
 
 def test_rejects_foreign_or_ac_scoped_verdicts() -> None:
@@ -171,7 +186,7 @@ def test_rejects_foreign_or_ac_scoped_verdicts() -> None:
         outcome=VerdictOutcome.PASS,
     )
     with pytest.raises(ValueError, match="belongs to run"):
-        build_run_snapshot(run=_run(), verdict=foreign)
+        build_run_snapshot(run=_run(), stages=[_stage()], verdict=foreign)
 
     ac_verdict = VerdictRecord(
         verdict_id="verdict_ac",
@@ -181,30 +196,48 @@ def test_rejects_foreign_or_ac_scoped_verdicts() -> None:
         outcome=VerdictOutcome.PASS,
     )
     with pytest.raises(ValueError, match="run-scoped"):
-        build_run_snapshot(run=_run(), verdict=ac_verdict)
+        build_run_snapshot(run=_run(), stages=[_stage()], verdict=ac_verdict)
 
 
 def test_ended_run_with_stale_pending_step_is_not_safe_resume() -> None:
     snapshot = build_run_snapshot(
         run=_run(ended=True),
-        stages=[_stage()],
+        stages=[_stage("step_stale_pending")],
         steps=[_step("step_stale_pending", ended=False, ok=None)],
     )
 
-    assert snapshot.status is RunSnapshotStatus.COMPLETED
+    assert snapshot.status is RunSnapshotStatus.UNKNOWN
     assert snapshot.safe_resume is False
     assert snapshot.pending_step_ids == ("step_stale_pending",)
-    assert snapshot.resume_blockers == ("terminal_status:completed",)
+    assert snapshot.resume_blockers == ("status_unknown", "pending_steps_present")
 
 
 def test_missing_linked_run_verdict_blocks_resume_conservatively() -> None:
     snapshot = build_run_snapshot(
         run=_run(verdict_id="verdict_missing"),
-        stages=[_stage()],
+        stages=[_stage("step_pending")],
         steps=[_step("step_pending", ended=False, ok=None)],
     )
 
     assert snapshot.status is RunSnapshotStatus.UNKNOWN
     assert snapshot.safe_resume is False
     assert snapshot.verdict_id == "verdict_missing"
-    assert snapshot.resume_blockers == ("status_unknown", "linked_verdict_missing")
+    assert snapshot.resume_blockers == (
+        "status_unknown",
+        "pending_steps_present",
+        "linked_verdict_missing",
+    )
+
+
+def test_rejects_incomplete_declared_stage_bundle() -> None:
+    with pytest.raises(ValueError, match="RunRecord.stage_ids"):
+        build_run_snapshot(run=_run(), stages=[])
+
+
+def test_rejects_incomplete_declared_step_bundle() -> None:
+    with pytest.raises(ValueError, match="StageRecord 'stage_1'.step_ids"):
+        build_run_snapshot(
+            run=_run(),
+            stages=[_stage("step_missing")],
+            steps=[_step("step_present", ended=False, ok=None)],
+        )

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -41,7 +41,9 @@ def _stage(*step_ids: str) -> StageRecord:
     )
 
 
-def _step(step_id: str, *, ended: bool, ok: bool | None) -> StepRecord:
+def _step(
+    step_id: str, *, ended: bool, ok: bool | None, artifact_ids: tuple[str, ...] = ()
+) -> StepRecord:
     start = datetime(2026, 5, 15, tzinfo=UTC)
     return StepRecord(
         step_id=step_id,
@@ -52,11 +54,12 @@ def _step(step_id: str, *, ended: bool, ok: bool | None) -> StepRecord:
         ended_at=start + timedelta(seconds=1) if ended else None,
         ok=ok,
         source_event_ids=(f"evt_{step_id}",),
+        artifact_ids=artifact_ids,
     )
 
 
 def test_running_snapshot_with_pending_work_is_safe_to_resume() -> None:
-    completed = _step("step_done", ended=True, ok=True)
+    completed = _step("step_done", ended=True, ok=True, artifact_ids=("artifact_1",))
     pending = _step("step_pending", ended=False, ok=None)
     artifact = ArtifactRecord(artifact_id="artifact_1", step_id="step_done", kind="log")
 
@@ -134,6 +137,9 @@ def test_terminal_verdicts_block_resume() -> None:
 def test_snapshot_record_enforces_safe_resume_invariant() -> None:
     with pytest.raises(ValidationError, match="only valid"):
         RunSnapshotRecord(run_id="run_1", status=RunSnapshotStatus.COMPLETED, safe_resume=True)
+
+    with pytest.raises(ValidationError, match="only valid"):
+        RunSnapshotRecord(run_id="run_1", status=RunSnapshotStatus.WAITING, safe_resume=True)
 
     with pytest.raises(ValidationError, match="resume_blockers"):
         RunSnapshotRecord(
@@ -277,4 +283,26 @@ def test_rejects_out_of_order_declared_step_bundle() -> None:
             run=_run(),
             stages=[_stage("step_first", "step_second")],
             steps=[step_second, step_first],
+        )
+
+
+def test_rejects_missing_declared_step_artifact() -> None:
+    with pytest.raises(ValueError, match="StepRecord 'step_done'.artifact_ids"):
+        build_run_snapshot(
+            run=_run(),
+            stages=[_stage("step_done")],
+            steps=[_step("step_done", ended=True, ok=True, artifact_ids=("artifact_missing",))],
+            artifacts=[],
+        )
+
+
+def test_rejects_unexpected_step_artifact() -> None:
+    artifact = ArtifactRecord(artifact_id="artifact_extra", step_id="step_done", kind="log")
+
+    with pytest.raises(ValueError, match="StepRecord 'step_done'.artifact_ids"):
+        build_run_snapshot(
+            run=_run(),
+            stages=[_stage("step_done")],
+            steps=[_step("step_done", ended=True, ok=True)],
+            artifacts=[artifact],
         )

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -68,7 +68,6 @@ def test_running_snapshot_with_pending_work_is_safe_to_resume() -> None:
         stages=[_stage("step_done", "step_pending")],
         steps=[completed, pending],
         artifacts=[artifact],
-        source_event_ids=("evt_step_done", "evt_step_pending"),
         recorded_at=datetime(2026, 5, 15, tzinfo=UTC),
     )
 
@@ -350,3 +349,35 @@ def test_pass_verdict_with_failed_step_is_unknown() -> None:
     assert snapshot.status is RunSnapshotStatus.UNKNOWN
     assert snapshot.safe_resume is False
     assert snapshot.resume_blockers == ("status_unknown", "failed_steps_present")
+
+
+def test_snapshot_source_event_ids_are_derived_from_records() -> None:
+    verdict = VerdictRecord(
+        verdict_id="verdict_1",
+        run_id="run_1",
+        scope="run",
+        outcome=VerdictOutcome.FAIL,
+        evidence_event_ids=("evt_verdict", "evt_step_failed"),
+    )
+
+    snapshot = build_run_snapshot(
+        run=_run(verdict_id="verdict_1"),
+        stages=[_stage("step_failed")],
+        steps=[_step("step_failed", ended=True, ok=False)],
+        verdict=verdict,
+    )
+
+    assert snapshot.source_event_ids == ("evt_step_failed", "evt_verdict")
+
+
+def test_rejects_missing_verdict_evidence_artifact() -> None:
+    verdict = VerdictRecord(
+        verdict_id="verdict_1",
+        run_id="run_1",
+        scope="run",
+        outcome=VerdictOutcome.PASS,
+        evidence_artifact_ids=("artifact_missing",),
+    )
+
+    with pytest.raises(ValueError, match="VerdictRecord 'verdict_1'.evidence_artifact_ids"):
+        build_run_snapshot(run=_run(verdict_id="verdict_1"), stages=[_stage()], verdict=verdict)

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -310,3 +310,43 @@ def test_rejects_unexpected_step_artifact() -> None:
             steps=[_step("step_done", ended=True, ok=True)],
             artifacts=[artifact],
         )
+
+
+def test_terminal_verdict_with_pending_step_is_unknown() -> None:
+    verdict = VerdictRecord(
+        verdict_id="verdict_pass",
+        run_id="run_1",
+        scope="run",
+        outcome=VerdictOutcome.PASS,
+    )
+
+    snapshot = build_run_snapshot(
+        run=_run(verdict_id="verdict_pass"),
+        stages=[_stage("step_pending")],
+        steps=[_step("step_pending", ended=False, ok=None)],
+        verdict=verdict,
+    )
+
+    assert snapshot.status is RunSnapshotStatus.UNKNOWN
+    assert snapshot.safe_resume is False
+    assert snapshot.resume_blockers == ("status_unknown", "pending_steps_present")
+
+
+def test_pass_verdict_with_failed_step_is_unknown() -> None:
+    verdict = VerdictRecord(
+        verdict_id="verdict_pass",
+        run_id="run_1",
+        scope="run",
+        outcome=VerdictOutcome.PASS,
+    )
+
+    snapshot = build_run_snapshot(
+        run=_run(verdict_id="verdict_pass"),
+        stages=[_stage("step_failed")],
+        steps=[_step("step_failed", ended=True, ok=False)],
+        verdict=verdict,
+    )
+
+    assert snapshot.status is RunSnapshotStatus.UNKNOWN
+    assert snapshot.safe_resume is False
+    assert snapshot.resume_blockers == ("status_unknown", "failed_steps_present")

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -524,3 +524,15 @@ def test_mixed_legacy_pending_step_without_source_events_blocks_resume() -> None
     assert snapshot.safe_resume is False
     assert snapshot.source_event_ids == ("evt_step_done",)
     assert snapshot.resume_blockers == ("pending_step_source_events_missing",)
+
+
+def test_open_run_without_pending_or_verdict_is_unknown() -> None:
+    snapshot = build_run_snapshot(
+        run=_run(),
+        stages=[_stage("step_done")],
+        steps=[_step("step_done", ended=True, ok=True)],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.UNKNOWN
+    assert snapshot.safe_resume is False
+    assert snapshot.resume_blockers == ("status_unknown",)

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -136,3 +136,49 @@ def test_snapshot_metadata_is_read_only() -> None:
     snapshot = build_run_snapshot(run=_run(), steps=[_step("step_pending", ended=False, ok=None)])
     with pytest.raises(TypeError):
         snapshot.metadata["new"] = "value"  # type: ignore[index]
+
+
+def test_rejects_foreign_projection_records() -> None:
+    foreign_stage = StageRecord(
+        stage_id="stage_foreign", run_id="run_other", kind=StageKind.EXECUTE
+    )
+    with pytest.raises(ValueError, match="belongs to run"):
+        build_run_snapshot(run=_run(), stages=[foreign_stage])
+
+    foreign_step = StepRecord(
+        step_id="step_foreign",
+        run_id="run_other",
+        stage_id="stage_1",
+        kind=StepKind.TOOL_CALL,
+        legacy_inferred=True,
+    )
+    with pytest.raises(ValueError, match="belongs to run"):
+        build_run_snapshot(run=_run(), stages=[_stage()], steps=[foreign_step])
+
+
+def test_rejects_artifacts_not_owned_by_snapshot_steps() -> None:
+    artifact = ArtifactRecord(artifact_id="artifact_orphan", step_id="step_missing", kind="log")
+
+    with pytest.raises(ValueError, match="unknown step"):
+        build_run_snapshot(run=_run(), artifacts=[artifact])
+
+
+def test_rejects_foreign_or_ac_scoped_verdicts() -> None:
+    foreign = VerdictRecord(
+        verdict_id="verdict_foreign",
+        run_id="run_other",
+        scope="run",
+        outcome=VerdictOutcome.PASS,
+    )
+    with pytest.raises(ValueError, match="belongs to run"):
+        build_run_snapshot(run=_run(), verdict=foreign)
+
+    ac_verdict = VerdictRecord(
+        verdict_id="verdict_ac",
+        run_id="run_1",
+        scope="ac",
+        ac_id="ac_1",
+        outcome=VerdictOutcome.PASS,
+    )
+    with pytest.raises(ValueError, match="run-scoped"):
+        build_run_snapshot(run=_run(), verdict=ac_verdict)

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -383,3 +383,26 @@ def test_rejects_missing_verdict_evidence_artifact() -> None:
 
     with pytest.raises(ValueError, match="VerdictRecord 'verdict_1'.evidence_artifact_ids"):
         build_run_snapshot(run=_run(verdict_id="verdict_1"), stages=[_stage()], verdict=verdict)
+
+
+def test_legacy_pending_step_without_source_events_blocks_resume() -> None:
+    legacy_pending = StepRecord(
+        step_id="step_legacy_pending",
+        run_id="run_1",
+        stage_id="stage_1",
+        kind=StepKind.TOOL_CALL,
+        ended_at=None,
+        ok=None,
+        legacy_inferred=True,
+    )
+
+    snapshot = build_run_snapshot(
+        run=_run(),
+        stages=[_stage("step_legacy_pending")],
+        steps=[legacy_pending],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.RUNNING
+    assert snapshot.safe_resume is False
+    assert snapshot.source_event_ids == ()
+    assert snapshot.resume_blockers == ("source_events_missing",)

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -241,3 +241,40 @@ def test_rejects_incomplete_declared_step_bundle() -> None:
             stages=[_stage("step_missing")],
             steps=[_step("step_present", ended=False, ok=None)],
         )
+
+
+def test_rejects_unlinked_same_run_verdict() -> None:
+    verdict = VerdictRecord(
+        verdict_id="verdict_unlinked",
+        run_id="run_1",
+        scope="run",
+        outcome=VerdictOutcome.PASS,
+    )
+
+    with pytest.raises(ValueError, match="RunRecord.verdict_id"):
+        build_run_snapshot(run=_run(), stages=[_stage()], verdict=verdict)
+
+
+def test_rejects_out_of_order_declared_stage_bundle() -> None:
+    run = RunRecord(
+        run_id="run_1",
+        seed_id="seed_1",
+        stage_ids=("stage_1", "stage_2"),
+    )
+    stage_1 = StageRecord(stage_id="stage_1", run_id="run_1", kind=StageKind.EXECUTE)
+    stage_2 = StageRecord(stage_id="stage_2", run_id="run_1", kind=StageKind.EVALUATE)
+
+    with pytest.raises(ValueError, match="RunRecord.stage_ids"):
+        build_run_snapshot(run=run, stages=[stage_2, stage_1])
+
+
+def test_rejects_out_of_order_declared_step_bundle() -> None:
+    step_first = _step("step_first", ended=True, ok=True)
+    step_second = _step("step_second", ended=False, ok=None)
+
+    with pytest.raises(ValueError, match="StageRecord 'stage_1'.step_ids"):
+        build_run_snapshot(
+            run=_run(),
+            stages=[_stage("step_first", "step_second")],
+            steps=[step_second, step_first],
+        )


### PR DESCRIPTION
## Summary
- Adds `RunSnapshotRecord` and `RunSnapshotStatus` to the projection vocabulary.
- Adds a pure `build_run_snapshot` helper that summarizes completed/pending/failed/unknown steps, artifacts, verdicts, and conservative `safe_resume` blockers.
- Leaves EventStore query and runtime dispatch wiring for later slices.

## #961 / AgentOS fit
- Advances #946 by making safe-resume readiness inspectable from projection records, with EventStore-derived evidence remaining the SSOT.
- Avoids over-engineering: no new orchestration framework, no persistence migration, and no side effects.

## Validation
- `uv run ruff check src/ouroboros/harness/projection.py src/ouroboros/harness/run_snapshot.py src/ouroboros/harness/__init__.py tests/unit/harness/test_run_snapshot.py`
- `uv run mypy src/ouroboros/harness/projection.py src/ouroboros/harness/run_snapshot.py tests/unit/harness/test_run_snapshot.py`
- `uv run pytest tests/unit/harness/test_projection_records.py tests/unit/harness/test_projection_builder.py tests/unit/harness/test_run_snapshot.py -q`

Refs #946
Refs #961