### PR TITLE
feat(orchestrator): add workflow lifecycle conformance report

### DIFF
--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -193,7 +193,9 @@ def _has_terminal_restart_tie(events: Iterable[WorkflowLifecycleEvent]) -> bool:
 def _has_ambiguous_restart_tie(events: Iterable[WorkflowLifecycleEvent]) -> bool:
     event_tuple = tuple(events)
     return _has_terminal_restart_tie(event_tuple) and any(
-        event.event_type not in _RUN_EVENT_TYPES for event in event_tuple
+        event.event_type in _NODE_EVENT_TYPES
+        or event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED
+        for event in event_tuple
     )
 
 

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -160,8 +160,9 @@ def _run_boundary_group_order(
     event: WorkflowLifecycleEvent,
     *,
     has_terminal_restart_tie: bool,
+    active_run_at_timestamp: bool,
 ) -> tuple[int, str]:
-    if not has_terminal_restart_tie:
+    if not has_terminal_restart_tie or not active_run_at_timestamp:
         return (_EVENT_SORT_ORDER[event.event_type], event.event_type.value)
     if event.event_type in _TERMINAL_RUN_EVENT_TYPES:
         return (100, event.event_type.value)
@@ -190,31 +191,12 @@ def _has_terminal_restart_tie(events: Iterable[WorkflowLifecycleEvent]) -> bool:
     )
 
 
-def _has_ambiguous_restart_tie(events: Iterable[WorkflowLifecycleEvent]) -> bool:
-    event_tuple = tuple(events)
-    return _has_terminal_restart_tie(event_tuple) and any(
+def _has_scheduling_event(events: Iterable[WorkflowLifecycleEvent]) -> bool:
+    return any(
         event.event_type in _NODE_EVENT_TYPES
         or event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED
-        for event in event_tuple
+        for event in events
     )
-
-
-def _sort_run_boundary_events(
-    events: Iterable[WorkflowLifecycleEvent],
-) -> tuple[WorkflowLifecycleEvent, ...]:
-    ordered_events: list[WorkflowLifecycleEvent] = []
-    for timestamp_events in _timestamp_groups(events):
-        has_terminal_restart_tie = _has_terminal_restart_tie(timestamp_events)
-        ordered_events.extend(
-            sorted(
-                timestamp_events,
-                key=lambda event: _run_boundary_group_order(
-                    event,
-                    has_terminal_restart_tie=has_terminal_restart_tie,
-                ),
-            )
-        )
-    return tuple(ordered_events)
 
 
 def _run_lifecycle_segment(
@@ -227,12 +209,18 @@ def _run_lifecycle_segment(
     latest_segment: list[WorkflowLifecycleEvent] = []
     latest_segment_ambiguous = False
     for timestamp_events in _timestamp_groups(events):
-        timestamp_ambiguous = _has_ambiguous_restart_tie(timestamp_events)
+        active_run_at_timestamp = active_run
+        timestamp_ambiguous = (
+            active_run_at_timestamp
+            and _has_terminal_restart_tie(timestamp_events)
+            and _has_scheduling_event(timestamp_events)
+        )
         for event in sorted(
             timestamp_events,
             key=lambda item: _run_boundary_group_order(
                 item,
                 has_terminal_restart_tie=_has_terminal_restart_tie(timestamp_events),
+                active_run_at_timestamp=active_run_at_timestamp,
             ),
         ):
             if terminal_state is not None:
@@ -673,8 +661,20 @@ def validate_workflow_lifecycle_conformance(
             )
         )
 
+    node_ids = {node.node_id for node in spec.nodes}
+    edge_ids = {edge.edge_id for edge in spec.edges}
+    seen_run_created = False
+    terminal_seen = False
+    terminal_seen_at: datetime | None = None
+    active_run = False
+    terminal_allows_restart = False
     for timestamp_events in _timestamp_groups(event_list):
-        if _has_ambiguous_restart_tie(timestamp_events):
+        active_run_at_timestamp = active_run
+        if (
+            active_run_at_timestamp
+            and _has_terminal_restart_tie(timestamp_events)
+            and _has_scheduling_event(timestamp_events)
+        ):
             issues.append(
                 WorkflowConformanceIssue(
                     severity="error",
@@ -687,110 +687,109 @@ def validate_workflow_lifecycle_conformance(
                 )
             )
 
-    node_ids = {node.node_id for node in spec.nodes}
-    edge_ids = {edge.edge_id for edge in spec.edges}
-    seen_run_created = False
-    terminal_seen = False
-    terminal_seen_at: datetime | None = None
-    active_run = False
-    terminal_allows_restart = False
-    sorted_events = _sort_run_boundary_events(event_list)
-    for event in sorted_events:
-        if terminal_seen:
-            can_restart_after_terminal = terminal_allows_restart or (
-                terminal_seen_at is not None and event.timestamp > terminal_seen_at
-            )
-            if (
-                event.event_type is WorkflowLifecycleEventType.RUN_CREATED
-                and can_restart_after_terminal
-            ):
-                terminal_seen = False
-                terminal_seen_at = None
-                terminal_allows_restart = False
-                active_run = True
-                seen_run_created = True
-                continue
-            issues.append(
-                WorkflowConformanceIssue(
-                    severity="error",
-                    code="event_after_terminal_run",
-                    message=(
-                        "Workflow lifecycle event appears after a terminal run event "
-                        "without a new workflow.run.created boundary."
-                    ),
-                    event_type=event.event_type,
-                    node_id=event.node_id,
-                    edge_id=event.edge_id,
+        for event in sorted(
+            timestamp_events,
+            key=lambda item: _run_boundary_group_order(
+                item,
+                has_terminal_restart_tie=_has_terminal_restart_tie(timestamp_events),
+                active_run_at_timestamp=active_run_at_timestamp,
+            ),
+        ):
+            if terminal_seen:
+                can_restart_after_terminal = terminal_allows_restart or (
+                    terminal_seen_at is not None and event.timestamp > terminal_seen_at
                 )
-            )
-            continue
-
-        if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
-            if active_run:
+                if (
+                    event.event_type is WorkflowLifecycleEventType.RUN_CREATED
+                    and can_restart_after_terminal
+                ):
+                    terminal_seen = False
+                    terminal_seen_at = None
+                    terminal_allows_restart = False
+                    active_run = True
+                    seen_run_created = True
+                    continue
                 issues.append(
                     WorkflowConformanceIssue(
                         severity="error",
-                        code="run_created_before_terminal",
+                        code="event_after_terminal_run",
                         message=(
-                            "workflow.run.created appears before the active run reached "
-                            "a terminal event."
+                            "Workflow lifecycle event appears after a terminal run event "
+                            "without a new workflow.run.created boundary."
                         ),
                         event_type=event.event_type,
+                        node_id=event.node_id,
+                        edge_id=event.edge_id,
                     )
                 )
                 continue
-            seen_run_created = True
-            active_run = True
 
-        if event.event_type in _NODE_EVENT_TYPES and event.node_id is not None:
-            if event.node_id not in node_ids:
-                issues.append(
-                    WorkflowConformanceIssue(
-                        severity="error",
-                        code="unknown_node_id",
-                        message=f"Lifecycle event references unknown node id {event.node_id!r}.",
-                        event_type=event.event_type,
-                        node_id=event.node_id,
+            if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
+                if active_run:
+                    issues.append(
+                        WorkflowConformanceIssue(
+                            severity="error",
+                            code="run_created_before_terminal",
+                            message=(
+                                "workflow.run.created appears before the active run reached "
+                                "a terminal event."
+                            ),
+                            event_type=event.event_type,
+                        )
                     )
-                )
-            if not seen_run_created:
-                issues.append(
-                    WorkflowConformanceIssue(
-                        severity="warning",
-                        code="lifecycle_before_run_created",
-                        message="Node lifecycle event appears before workflow.run.created.",
-                        event_type=event.event_type,
-                        node_id=event.node_id,
-                    )
-                )
+                    continue
+                seen_run_created = True
+                active_run = True
 
-        if event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED and event.edge_id:
-            if event.edge_id not in edge_ids:
-                issues.append(
-                    WorkflowConformanceIssue(
-                        severity="error",
-                        code="unknown_edge_id",
-                        message=f"Lifecycle event references unknown edge id {event.edge_id!r}.",
-                        event_type=event.event_type,
-                        edge_id=event.edge_id,
+            if event.event_type in _NODE_EVENT_TYPES and event.node_id is not None:
+                if event.node_id not in node_ids:
+                    issues.append(
+                        WorkflowConformanceIssue(
+                            severity="error",
+                            code="unknown_node_id",
+                            message=f"Lifecycle event references unknown node id {event.node_id!r}.",
+                            event_type=event.event_type,
+                            node_id=event.node_id,
+                        )
                     )
-                )
-            if not seen_run_created:
-                issues.append(
-                    WorkflowConformanceIssue(
-                        severity="warning",
-                        code="lifecycle_before_run_created",
-                        message="Edge traversal event appears before workflow.run.created.",
-                        event_type=event.event_type,
-                        edge_id=event.edge_id,
+                if not seen_run_created:
+                    issues.append(
+                        WorkflowConformanceIssue(
+                            severity="warning",
+                            code="lifecycle_before_run_created",
+                            message="Node lifecycle event appears before workflow.run.created.",
+                            event_type=event.event_type,
+                            node_id=event.node_id,
+                        )
                     )
-                )
 
-        if event.event_type in _TERMINAL_RUN_EVENT_TYPES:
-            terminal_seen = True
-            terminal_seen_at = event.timestamp
-            terminal_allows_restart = active_run
-            active_run = False
+            if event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED and event.edge_id:
+                if event.edge_id not in edge_ids:
+                    issues.append(
+                        WorkflowConformanceIssue(
+                            severity="error",
+                            code="unknown_edge_id",
+                            message=f"Lifecycle event references unknown edge id {event.edge_id!r}.",
+                            event_type=event.event_type,
+                            edge_id=event.edge_id,
+                        )
+                    )
+                if not seen_run_created:
+                    issues.append(
+                        WorkflowConformanceIssue(
+                            severity="warning",
+                            code="lifecycle_before_run_created",
+                            message="Edge traversal event appears before workflow.run.created.",
+                            event_type=event.event_type,
+                            edge_id=event.edge_id,
+                        )
+                    )
+
+            if event.event_type in _TERMINAL_RUN_EVENT_TYPES:
+                terminal_seen = True
+                terminal_seen_at = event.timestamp
+                terminal_allows_restart = active_run
+                active_run = False
 
     return WorkflowConformanceReport(
         workflow_id=spec.spec_id,

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -247,6 +247,10 @@ def _run_lifecycle_segment(
                 latest_segment_ambiguous = latest_segment_ambiguous or timestamp_ambiguous
                 continue
             if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
+                if active_run:
+                    latest_segment.append(event)
+                    latest_segment_ambiguous = latest_segment_ambiguous or timestamp_ambiguous
+                    continue
                 active_run = True
                 latest_segment = [event]
                 latest_segment_ambiguous = timestamp_ambiguous
@@ -383,6 +387,7 @@ class WorkflowConformanceIssue(BaseModel, frozen=True):
         "unknown_edge_id",
         "lifecycle_before_run_created",
         "event_after_terminal_run",
+        "run_created_before_terminal",
     ]
     message: str
     event_type: WorkflowLifecycleEventType | None = None
@@ -708,6 +713,19 @@ def validate_workflow_lifecycle_conformance(
             continue
 
         if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
+            if active_run:
+                issues.append(
+                    WorkflowConformanceIssue(
+                        severity="error",
+                        code="run_created_before_terminal",
+                        message=(
+                            "workflow.run.created appears before the active run reached "
+                            "a terminal event."
+                        ),
+                        event_type=event.event_type,
+                    )
+                )
+                continue
             seen_run_created = True
             active_run = True
 

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -195,6 +195,7 @@ def _has_scheduling_event(events: Iterable[WorkflowLifecycleEvent]) -> bool:
     return any(
         event.event_type in _NODE_EVENT_TYPES
         or event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED
+        or event.event_type is WorkflowLifecycleEventType.CHECKPOINT_SAVED
         for event in events
     )
 
@@ -704,8 +705,8 @@ def validate_workflow_lifecycle_conformance(
                     code="ambiguous_run_boundary_timestamp",
                     message=(
                         "Timestamp contains a terminal run event, workflow.run.created, "
-                        "and node/edge lifecycle rows; add a distinct timestamp or run id "
-                        "before validating restart conformance."
+                        "and node/edge/checkpoint lifecycle rows; add a distinct timestamp "
+                        "or run id before validating restart conformance."
                     ),
                 )
             )

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -530,9 +530,7 @@ def validate_workflow_lifecycle_conformance(
     so callers may pass a mixed EventStore replay safely.
     """
 
-    event_list = tuple(
-        event for event in events if event.workflow_id == spec.spec_id
-    )
+    event_list = tuple(event for event in events if event.workflow_id == spec.spec_id)
     issues: list[WorkflowConformanceIssue] = []
 
     validation = validate_workflow(spec)

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -726,6 +726,29 @@ def validate_workflow_lifecycle_conformance(
                     active_run = True
                     seen_run_created = True
                     continue
+                if event.event_type in _NODE_EVENT_TYPES and event.node_id not in node_ids:
+                    issues.append(
+                        WorkflowConformanceIssue(
+                            severity="error",
+                            code="unknown_node_id",
+                            message=f"Lifecycle event references unknown node id {event.node_id!r}.",
+                            event_type=event.event_type,
+                            node_id=event.node_id,
+                        )
+                    )
+                if (
+                    event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED
+                    and event.edge_id not in edge_ids
+                ):
+                    issues.append(
+                        WorkflowConformanceIssue(
+                            severity="error",
+                            code="unknown_edge_id",
+                            message=f"Lifecycle event references unknown edge id {event.edge_id!r}.",
+                            event_type=event.event_type,
+                            edge_id=event.edge_id,
+                        )
+                    )
                 issues.append(
                     WorkflowConformanceIssue(
                         severity="error",

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -201,13 +201,14 @@ def _has_scheduling_event(events: Iterable[WorkflowLifecycleEvent]) -> bool:
 
 def _run_lifecycle_segment(
     events: Iterable[WorkflowLifecycleEvent],
-) -> tuple[WorkflowRunLifecycleState | None, tuple[WorkflowLifecycleEvent, ...], bool]:
+) -> tuple[WorkflowRunLifecycleState | None, tuple[WorkflowLifecycleEvent, ...], bool, bool]:
     active_run = False
     terminal_state: WorkflowRunLifecycleState | None = None
     terminal_allows_restart = False
     terminal_timestamp: datetime | None = None
     latest_segment: list[WorkflowLifecycleEvent] = []
     latest_segment_ambiguous = False
+    post_terminal_violation = False
     for timestamp_events in _timestamp_groups(events):
         active_run_at_timestamp = active_run
         timestamp_ambiguous = (
@@ -240,6 +241,7 @@ def _run_lifecycle_segment(
                     continue
                 latest_segment.append(event)
                 latest_segment_ambiguous = latest_segment_ambiguous or timestamp_ambiguous
+                post_terminal_violation = True
                 continue
             if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
                 if active_run:
@@ -262,10 +264,20 @@ def _run_lifecycle_segment(
                 terminal_timestamp = event.timestamp
                 active_run = False
     if terminal_state is not None:
-        return terminal_state, tuple(latest_segment), latest_segment_ambiguous
+        return (
+            terminal_state,
+            tuple(latest_segment),
+            latest_segment_ambiguous,
+            post_terminal_violation,
+        )
     if active_run:
-        return WorkflowRunLifecycleState.CREATED, tuple(latest_segment), latest_segment_ambiguous
-    return None, tuple(latest_segment), latest_segment_ambiguous
+        return (
+            WorkflowRunLifecycleState.CREATED,
+            tuple(latest_segment),
+            latest_segment_ambiguous,
+            post_terminal_violation,
+        )
+    return None, tuple(latest_segment), latest_segment_ambiguous, post_terminal_violation
 
 
 def _normalize_non_blank(name: str, value: str) -> str:
@@ -573,8 +585,13 @@ def next_runnable_node_ids(
     dispatch work.
     """
     event_list = tuple(event for event in events if event.workflow_id == spec.spec_id)
-    latest_run_state, latest_run_events, latest_run_ambiguous = _run_lifecycle_segment(event_list)
-    if latest_run_ambiguous:
+    (
+        latest_run_state,
+        latest_run_events,
+        latest_run_ambiguous,
+        post_terminal_violation,
+    ) = _run_lifecycle_segment(event_list)
+    if latest_run_ambiguous or post_terminal_violation:
         return ()
     if latest_run_state in {
         WorkflowRunLifecycleState.COMPLETED,

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -13,12 +13,18 @@ from datetime import UTC, datetime
 from enum import StrEnum
 import json
 from types import MappingProxyType
-from typing import Any, Final, cast
+from typing import Any, Final, Literal, cast
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from ouroboros.events.base import BaseEvent
-from ouroboros.orchestrator.workflow_ir import EdgeKind, WorkflowEdge, WorkflowNode, WorkflowSpec
+from ouroboros.orchestrator.workflow_ir import (
+    EdgeKind,
+    WorkflowEdge,
+    WorkflowNode,
+    WorkflowSpec,
+    validate_workflow,
+)
 
 WORKFLOW_LIFECYCLE_SCHEMA_VERSION: Final[int] = 1
 MAX_WORKFLOW_LIFECYCLE_DATA_BYTES: Final[int] = 8192
@@ -245,6 +251,40 @@ def _normalize_refs(values: Iterable[str]) -> tuple[str, ...]:
         seen.add(ref)
         normalized.append(ref)
     return tuple(normalized)
+
+
+class WorkflowConformanceIssue(BaseModel, frozen=True):
+    """One lifecycle/spec conformance finding."""
+
+    severity: Literal["error", "warning"]
+    code: Literal[
+        "invalid_spec",
+        "unknown_node_id",
+        "unknown_edge_id",
+        "lifecycle_before_run_created",
+        "event_after_terminal_run",
+    ]
+    message: str
+    event_type: WorkflowLifecycleEventType | None = None
+    node_id: str | None = None
+    edge_id: str | None = None
+
+
+class WorkflowConformanceReport(BaseModel, frozen=True):
+    """Validation report connecting a WorkflowSpec with lifecycle history."""
+
+    workflow_id: str
+    ok: bool
+    issues: tuple[WorkflowConformanceIssue, ...] = Field(default_factory=tuple)
+    event_count: int = 0
+
+    @property
+    def errors(self) -> tuple[WorkflowConformanceIssue, ...]:
+        return tuple(issue for issue in self.issues if issue.severity == "error")
+
+    @property
+    def warnings(self) -> tuple[WorkflowConformanceIssue, ...]:
+        return tuple(issue for issue in self.issues if issue.severity == "warning")
 
 
 class WorkflowLifecycleEvent(BaseModel, frozen=True):
@@ -477,9 +517,122 @@ def next_runnable_node_ids(
     return tuple(runnable)
 
 
+def validate_workflow_lifecycle_conformance(
+    spec: WorkflowSpec,
+    events: Iterable[WorkflowLifecycleEvent],
+) -> WorkflowConformanceReport:
+    """Validate lifecycle events against the Workflow IR graph.
+
+    This is a pure conformance read: it does not dispatch nodes, mutate the
+    workflow, or persist state. It rejects lifecycle rows that point at unknown
+    node/edge ids, flags node events before ``workflow.run.created``, and flags
+    history appended after a terminal run event. Foreign workflow ids are ignored
+    so callers may pass a mixed EventStore replay safely.
+    """
+
+    event_list = tuple(
+        event for event in events if event.workflow_id == spec.spec_id
+    )
+    issues: list[WorkflowConformanceIssue] = []
+
+    validation = validate_workflow(spec)
+    for error in validation.errors:
+        issues.append(
+            WorkflowConformanceIssue(
+                severity="error",
+                code="invalid_spec",
+                message=error.message,
+                node_id=error.node_id,
+                edge_id=error.edge_id,
+            )
+        )
+
+    node_ids = {node.node_id for node in spec.nodes}
+    edge_ids = {edge.edge_id for edge in spec.edges}
+    seen_run_created = False
+    terminal_seen = False
+    sorted_events = sorted(event_list, key=_event_sort_key)
+    for event in sorted_events:
+        if terminal_seen:
+            issues.append(
+                WorkflowConformanceIssue(
+                    severity="error",
+                    code="event_after_terminal_run",
+                    message="Workflow lifecycle event appears after a terminal run event.",
+                    event_type=event.event_type,
+                    node_id=event.node_id,
+                    edge_id=event.edge_id,
+                )
+            )
+            continue
+
+        if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
+            seen_run_created = True
+
+        if event.event_type in _NODE_EVENT_TYPES and event.node_id is not None:
+            if event.node_id not in node_ids:
+                issues.append(
+                    WorkflowConformanceIssue(
+                        severity="error",
+                        code="unknown_node_id",
+                        message=f"Lifecycle event references unknown node id {event.node_id!r}.",
+                        event_type=event.event_type,
+                        node_id=event.node_id,
+                    )
+                )
+            if not seen_run_created:
+                issues.append(
+                    WorkflowConformanceIssue(
+                        severity="warning",
+                        code="lifecycle_before_run_created",
+                        message="Node lifecycle event appears before workflow.run.created.",
+                        event_type=event.event_type,
+                        node_id=event.node_id,
+                    )
+                )
+
+        if event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED and event.edge_id:
+            if event.edge_id not in edge_ids:
+                issues.append(
+                    WorkflowConformanceIssue(
+                        severity="error",
+                        code="unknown_edge_id",
+                        message=f"Lifecycle event references unknown edge id {event.edge_id!r}.",
+                        event_type=event.event_type,
+                        edge_id=event.edge_id,
+                    )
+                )
+            if not seen_run_created:
+                issues.append(
+                    WorkflowConformanceIssue(
+                        severity="warning",
+                        code="lifecycle_before_run_created",
+                        message="Edge traversal event appears before workflow.run.created.",
+                        event_type=event.event_type,
+                        edge_id=event.edge_id,
+                    )
+                )
+
+        if event.event_type in {
+            WorkflowLifecycleEventType.RUN_COMPLETED,
+            WorkflowLifecycleEventType.RUN_FAILED,
+            WorkflowLifecycleEventType.RUN_CANCELLED,
+        }:
+            terminal_seen = True
+
+    return WorkflowConformanceReport(
+        workflow_id=spec.spec_id,
+        ok=not any(issue.severity == "error" for issue in issues),
+        issues=tuple(issues),
+        event_count=len(event_list),
+    )
+
+
 __all__ = [
     "MAX_WORKFLOW_LIFECYCLE_DATA_BYTES",
     "WORKFLOW_LIFECYCLE_SCHEMA_VERSION",
+    "WorkflowConformanceIssue",
+    "WorkflowConformanceReport",
     "WorkflowLifecycleEvent",
     "WorkflowLifecycleEventType",
     "WorkflowNodeLifecycleState",
@@ -488,4 +641,5 @@ __all__ = [
     "effective_node_states",
     "lifecycle_event_for_spec",
     "next_runnable_node_ids",
+    "validate_workflow_lifecycle_conformance",
 ]

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -160,9 +160,9 @@ def _run_boundary_group_order(
     event: WorkflowLifecycleEvent,
     *,
     has_terminal_restart_tie: bool,
-    active_run_at_timestamp: bool,
+    prefer_restart_tie: bool,
 ) -> tuple[int, str]:
-    if not has_terminal_restart_tie or not active_run_at_timestamp:
+    if not has_terminal_restart_tie or not prefer_restart_tie:
         return (_EVENT_SORT_ORDER[event.event_type], event.event_type.value)
     if event.event_type in _TERMINAL_RUN_EVENT_TYPES:
         return (100, event.event_type.value)
@@ -209,10 +209,13 @@ def _run_lifecycle_segment(
     latest_segment: list[WorkflowLifecycleEvent] = []
     latest_segment_ambiguous = False
     post_terminal_violation = False
-    for timestamp_events in _timestamp_groups(events):
+    timestamp_group_list = _timestamp_groups(events)
+    for group_index, timestamp_events in enumerate(timestamp_group_list):
         active_run_at_timestamp = active_run
+        has_later_events = group_index < len(timestamp_group_list) - 1
+        prefer_restart_tie = active_run_at_timestamp or has_later_events
         timestamp_ambiguous = (
-            active_run_at_timestamp
+            prefer_restart_tie
             and _has_terminal_restart_tie(timestamp_events)
             and _has_scheduling_event(timestamp_events)
         )
@@ -221,12 +224,14 @@ def _run_lifecycle_segment(
             key=lambda item: _run_boundary_group_order(
                 item,
                 has_terminal_restart_tie=_has_terminal_restart_tie(timestamp_events),
-                active_run_at_timestamp=active_run_at_timestamp,
+                prefer_restart_tie=prefer_restart_tie,
             ),
         ):
             if terminal_state is not None:
-                can_restart_after_terminal = terminal_allows_restart or (
-                    terminal_timestamp is not None and event.timestamp > terminal_timestamp
+                can_restart_after_terminal = (
+                    terminal_allows_restart
+                    or (terminal_timestamp is not None and event.timestamp > terminal_timestamp)
+                    or (prefer_restart_tie and event.timestamp == terminal_timestamp)
                 )
                 if (
                     event.event_type is WorkflowLifecycleEventType.RUN_CREATED
@@ -685,10 +690,13 @@ def validate_workflow_lifecycle_conformance(
     terminal_seen_at: datetime | None = None
     active_run = False
     terminal_allows_restart = False
-    for timestamp_events in _timestamp_groups(event_list):
+    timestamp_group_list = _timestamp_groups(event_list)
+    for group_index, timestamp_events in enumerate(timestamp_group_list):
         active_run_at_timestamp = active_run
+        has_later_events = group_index < len(timestamp_group_list) - 1
+        prefer_restart_tie = active_run_at_timestamp or has_later_events
         if (
-            active_run_at_timestamp
+            prefer_restart_tie
             and _has_terminal_restart_tie(timestamp_events)
             and _has_scheduling_event(timestamp_events)
         ):
@@ -709,12 +717,14 @@ def validate_workflow_lifecycle_conformance(
             key=lambda item: _run_boundary_group_order(
                 item,
                 has_terminal_restart_tie=_has_terminal_restart_tie(timestamp_events),
-                active_run_at_timestamp=active_run_at_timestamp,
+                prefer_restart_tie=prefer_restart_tie,
             ),
         ):
             if terminal_seen:
-                can_restart_after_terminal = terminal_allows_restart or (
-                    terminal_seen_at is not None and event.timestamp > terminal_seen_at
+                can_restart_after_terminal = (
+                    terminal_allows_restart
+                    or (terminal_seen_at is not None and event.timestamp > terminal_seen_at)
+                    or (prefer_restart_tie and event.timestamp == terminal_seen_at)
                 )
                 if (
                     event.event_type is WorkflowLifecycleEventType.RUN_CREATED

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -217,42 +217,55 @@ def _sort_run_boundary_events(
 
 def _run_lifecycle_segment(
     events: Iterable[WorkflowLifecycleEvent],
-) -> tuple[WorkflowRunLifecycleState | None, tuple[WorkflowLifecycleEvent, ...]]:
+) -> tuple[WorkflowRunLifecycleState | None, tuple[WorkflowLifecycleEvent, ...], bool]:
     active_run = False
     terminal_state: WorkflowRunLifecycleState | None = None
     terminal_allows_restart = False
     latest_segment: list[WorkflowLifecycleEvent] = []
-    for event in _sort_run_boundary_events(events):
-        if terminal_state is not None:
-            if (
-                event.event_type is WorkflowLifecycleEventType.RUN_CREATED
-                and terminal_allows_restart
-            ):
+    latest_segment_ambiguous = False
+    for timestamp_events in _timestamp_groups(events):
+        timestamp_ambiguous = _has_ambiguous_restart_tie(timestamp_events)
+        for event in sorted(
+            timestamp_events,
+            key=lambda item: _run_boundary_group_order(
+                item,
+                has_terminal_restart_tie=_has_terminal_restart_tie(timestamp_events),
+            ),
+        ):
+            if terminal_state is not None:
+                if (
+                    event.event_type is WorkflowLifecycleEventType.RUN_CREATED
+                    and terminal_allows_restart
+                ):
+                    active_run = True
+                    terminal_state = None
+                    terminal_allows_restart = False
+                    latest_segment = [event]
+                    latest_segment_ambiguous = timestamp_ambiguous
+                    continue
+                latest_segment.append(event)
+                latest_segment_ambiguous = latest_segment_ambiguous or timestamp_ambiguous
+                continue
+            if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
                 active_run = True
-                terminal_state = None
-                terminal_allows_restart = False
                 latest_segment = [event]
+                latest_segment_ambiguous = timestamp_ambiguous
                 continue
             latest_segment.append(event)
-            continue
-        if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
-            active_run = True
-            latest_segment = [event]
-            continue
-        latest_segment.append(event)
-        if event.event_type in _TERMINAL_RUN_EVENT_TYPES:
-            terminal_state = {
-                WorkflowLifecycleEventType.RUN_COMPLETED: WorkflowRunLifecycleState.COMPLETED,
-                WorkflowLifecycleEventType.RUN_FAILED: WorkflowRunLifecycleState.FAILED,
-                WorkflowLifecycleEventType.RUN_CANCELLED: WorkflowRunLifecycleState.CANCELLED,
-            }[event.event_type]
-            terminal_allows_restart = active_run
-            active_run = False
+            latest_segment_ambiguous = latest_segment_ambiguous or timestamp_ambiguous
+            if event.event_type in _TERMINAL_RUN_EVENT_TYPES:
+                terminal_state = {
+                    WorkflowLifecycleEventType.RUN_COMPLETED: WorkflowRunLifecycleState.COMPLETED,
+                    WorkflowLifecycleEventType.RUN_FAILED: WorkflowRunLifecycleState.FAILED,
+                    WorkflowLifecycleEventType.RUN_CANCELLED: WorkflowRunLifecycleState.CANCELLED,
+                }[event.event_type]
+                terminal_allows_restart = active_run
+                active_run = False
     if terminal_state is not None:
-        return terminal_state, tuple(latest_segment)
+        return terminal_state, tuple(latest_segment), latest_segment_ambiguous
     if active_run:
-        return WorkflowRunLifecycleState.CREATED, tuple(latest_segment)
-    return None, tuple(latest_segment)
+        return WorkflowRunLifecycleState.CREATED, tuple(latest_segment), latest_segment_ambiguous
+    return None, tuple(latest_segment), latest_segment_ambiguous
 
 
 def _normalize_non_blank(name: str, value: str) -> str:
@@ -559,9 +572,9 @@ def next_runnable_node_ids(
     dispatch work.
     """
     event_list = tuple(event for event in events if event.workflow_id == spec.spec_id)
-    if any(_has_ambiguous_restart_tie(group) for group in _timestamp_groups(event_list)):
+    latest_run_state, latest_run_events, latest_run_ambiguous = _run_lifecycle_segment(event_list)
+    if latest_run_ambiguous:
         return ()
-    latest_run_state, latest_run_events = _run_lifecycle_segment(event_list)
     if latest_run_state in {
         WorkflowRunLifecycleState.COMPLETED,
         WorkflowRunLifecycleState.FAILED,

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -122,6 +122,13 @@ _RUN_EVENT_TYPES: Final[frozenset[WorkflowLifecycleEventType]] = frozenset(
         WorkflowLifecycleEventType.RUN_CANCELLED,
     }
 )
+_TERMINAL_RUN_EVENT_TYPES: Final[frozenset[WorkflowLifecycleEventType]] = frozenset(
+    {
+        WorkflowLifecycleEventType.RUN_COMPLETED,
+        WorkflowLifecycleEventType.RUN_FAILED,
+        WorkflowLifecycleEventType.RUN_CANCELLED,
+    }
+)
 _NODE_STATE_BY_EVENT: Final[dict[WorkflowLifecycleEventType, WorkflowNodeLifecycleState]] = {
     WorkflowLifecycleEventType.NODE_SCHEDULED: WorkflowNodeLifecycleState.SCHEDULED,
     WorkflowLifecycleEventType.NODE_STARTED: WorkflowNodeLifecycleState.STARTED,
@@ -550,80 +557,91 @@ def validate_workflow_lifecycle_conformance(
     seen_run_created = False
     terminal_seen = False
     sorted_events = sorted(event_list, key=_event_sort_key)
+    grouped_events: list[list[WorkflowLifecycleEvent]] = []
     for event in sorted_events:
-        if terminal_seen:
-            if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
-                terminal_seen = False
-                seen_run_created = True
-                continue
-            issues.append(
-                WorkflowConformanceIssue(
-                    severity="error",
-                    code="event_after_terminal_run",
-                    message=(
-                        "Workflow lifecycle event appears after a terminal run event "
-                        "without a new workflow.run.created boundary."
-                    ),
-                    event_type=event.event_type,
-                    node_id=event.node_id,
-                    edge_id=event.edge_id,
-                )
-            )
-            continue
+        if grouped_events and grouped_events[-1][0].timestamp == event.timestamp:
+            grouped_events[-1].append(event)
+        else:
+            grouped_events.append([event])
 
-        if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
+    for timestamp_events in grouped_events:
+        # ``workflow_id`` is spec-scoped, not run-scoped. If timestamp precision
+        # collapses a terminal event and the next run boundary, prefer the valid
+        # multi-run interpretation instead of letting tie-break order invent an
+        # event_after_terminal_run finding.
+        timestamp_has_run_created = any(
+            event.event_type is WorkflowLifecycleEventType.RUN_CREATED for event in timestamp_events
+        )
+        if terminal_seen and timestamp_has_run_created:
+            terminal_seen = False
             seen_run_created = True
 
-        if event.event_type in _NODE_EVENT_TYPES and event.node_id is not None:
-            if event.node_id not in node_ids:
+        for event in timestamp_events:
+            if terminal_seen:
                 issues.append(
                     WorkflowConformanceIssue(
                         severity="error",
-                        code="unknown_node_id",
-                        message=f"Lifecycle event references unknown node id {event.node_id!r}.",
+                        code="event_after_terminal_run",
+                        message=(
+                            "Workflow lifecycle event appears after a terminal run event "
+                            "without a new workflow.run.created boundary."
+                        ),
                         event_type=event.event_type,
                         node_id=event.node_id,
-                    )
-                )
-            if not seen_run_created:
-                issues.append(
-                    WorkflowConformanceIssue(
-                        severity="warning",
-                        code="lifecycle_before_run_created",
-                        message="Node lifecycle event appears before workflow.run.created.",
-                        event_type=event.event_type,
-                        node_id=event.node_id,
-                    )
-                )
-
-        if event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED and event.edge_id:
-            if event.edge_id not in edge_ids:
-                issues.append(
-                    WorkflowConformanceIssue(
-                        severity="error",
-                        code="unknown_edge_id",
-                        message=f"Lifecycle event references unknown edge id {event.edge_id!r}.",
-                        event_type=event.event_type,
                         edge_id=event.edge_id,
                     )
                 )
-            if not seen_run_created:
-                issues.append(
-                    WorkflowConformanceIssue(
-                        severity="warning",
-                        code="lifecycle_before_run_created",
-                        message="Edge traversal event appears before workflow.run.created.",
-                        event_type=event.event_type,
-                        edge_id=event.edge_id,
-                    )
-                )
+                continue
 
-        if event.event_type in {
-            WorkflowLifecycleEventType.RUN_COMPLETED,
-            WorkflowLifecycleEventType.RUN_FAILED,
-            WorkflowLifecycleEventType.RUN_CANCELLED,
-        }:
-            terminal_seen = True
+            if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
+                seen_run_created = True
+
+            if event.event_type in _NODE_EVENT_TYPES and event.node_id is not None:
+                if event.node_id not in node_ids:
+                    issues.append(
+                        WorkflowConformanceIssue(
+                            severity="error",
+                            code="unknown_node_id",
+                            message=f"Lifecycle event references unknown node id {event.node_id!r}.",
+                            event_type=event.event_type,
+                            node_id=event.node_id,
+                        )
+                    )
+                if not seen_run_created:
+                    issues.append(
+                        WorkflowConformanceIssue(
+                            severity="warning",
+                            code="lifecycle_before_run_created",
+                            message="Node lifecycle event appears before workflow.run.created.",
+                            event_type=event.event_type,
+                            node_id=event.node_id,
+                        )
+                    )
+
+            if event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED and event.edge_id:
+                if event.edge_id not in edge_ids:
+                    issues.append(
+                        WorkflowConformanceIssue(
+                            severity="error",
+                            code="unknown_edge_id",
+                            message=f"Lifecycle event references unknown edge id {event.edge_id!r}.",
+                            event_type=event.event_type,
+                            edge_id=event.edge_id,
+                        )
+                    )
+                if not seen_run_created:
+                    issues.append(
+                        WorkflowConformanceIssue(
+                            severity="warning",
+                            code="lifecycle_before_run_created",
+                            message="Edge traversal event appears before workflow.run.created.",
+                            event_type=event.event_type,
+                            edge_id=event.edge_id,
+                        )
+                    )
+
+        if any(event.event_type in _TERMINAL_RUN_EVENT_TYPES for event in timestamp_events):
+            terminal_seen = not timestamp_has_run_created
 
     return WorkflowConformanceReport(
         workflow_id=spec.spec_id,

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -170,9 +170,9 @@ def _run_boundary_group_order(
     return (_EVENT_SORT_ORDER[event.event_type], event.event_type.value)
 
 
-def _sort_run_boundary_events(
+def _timestamp_groups(
     events: Iterable[WorkflowLifecycleEvent],
-) -> tuple[WorkflowLifecycleEvent, ...]:
+) -> tuple[tuple[WorkflowLifecycleEvent, ...], ...]:
     sorted_events = sorted(events, key=lambda event: event.timestamp)
     grouped_events: list[list[WorkflowLifecycleEvent]] = []
     for event in sorted_events:
@@ -180,14 +180,29 @@ def _sort_run_boundary_events(
             grouped_events[-1].append(event)
         else:
             grouped_events.append([event])
+    return tuple(tuple(group) for group in grouped_events)
 
+
+def _has_terminal_restart_tie(events: Iterable[WorkflowLifecycleEvent]) -> bool:
+    event_tuple = tuple(events)
+    return any(event.event_type in _TERMINAL_RUN_EVENT_TYPES for event in event_tuple) and any(
+        event.event_type is WorkflowLifecycleEventType.RUN_CREATED for event in event_tuple
+    )
+
+
+def _has_ambiguous_restart_tie(events: Iterable[WorkflowLifecycleEvent]) -> bool:
+    event_tuple = tuple(events)
+    return _has_terminal_restart_tie(event_tuple) and any(
+        event.event_type not in _RUN_EVENT_TYPES for event in event_tuple
+    )
+
+
+def _sort_run_boundary_events(
+    events: Iterable[WorkflowLifecycleEvent],
+) -> tuple[WorkflowLifecycleEvent, ...]:
     ordered_events: list[WorkflowLifecycleEvent] = []
-    for timestamp_events in grouped_events:
-        has_terminal_restart_tie = any(
-            event.event_type in _TERMINAL_RUN_EVENT_TYPES for event in timestamp_events
-        ) and any(
-            event.event_type is WorkflowLifecycleEventType.RUN_CREATED for event in timestamp_events
-        )
+    for timestamp_events in _timestamp_groups(events):
+        has_terminal_restart_tie = _has_terminal_restart_tie(timestamp_events)
         ordered_events.extend(
             sorted(
                 timestamp_events,
@@ -349,6 +364,7 @@ class WorkflowConformanceIssue(BaseModel, frozen=True):
 
     severity: Literal["error", "warning"]
     code: Literal[
+        "ambiguous_run_boundary_timestamp",
         "invalid_spec",
         "unknown_node_id",
         "unknown_edge_id",
@@ -543,6 +559,8 @@ def next_runnable_node_ids(
     dispatch work.
     """
     event_list = tuple(event for event in events if event.workflow_id == spec.spec_id)
+    if any(_has_ambiguous_restart_tie(group) for group in _timestamp_groups(event_list)):
+        return ()
     latest_run_state, latest_run_events = _run_lifecycle_segment(event_list)
     if latest_run_state in {
         WorkflowRunLifecycleState.COMPLETED,
@@ -628,6 +646,20 @@ def validate_workflow_lifecycle_conformance(
                 edge_id=error.edge_id,
             )
         )
+
+    for timestamp_events in _timestamp_groups(event_list):
+        if _has_ambiguous_restart_tie(timestamp_events):
+            issues.append(
+                WorkflowConformanceIssue(
+                    severity="error",
+                    code="ambiguous_run_boundary_timestamp",
+                    message=(
+                        "Timestamp contains a terminal run event, workflow.run.created, "
+                        "and node/edge lifecycle rows; add a distinct timestamp or run id "
+                        "before validating restart conformance."
+                    ),
+                )
+            )
 
     node_ids = {node.node_id for node in spec.nodes}
     edge_ids = {edge.edge_id for edge in spec.edges}

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -156,14 +156,48 @@ def _event_sort_key(event: WorkflowLifecycleEvent) -> tuple[datetime, int, str]:
     return (event.timestamp, _EVENT_SORT_ORDER[event.event_type], event.event_type.value)
 
 
-def _run_boundary_sort_key(event: WorkflowLifecycleEvent) -> tuple[datetime, int, str]:
+def _run_boundary_group_order(
+    event: WorkflowLifecycleEvent,
+    *,
+    has_terminal_restart_tie: bool,
+) -> tuple[int, str]:
+    if not has_terminal_restart_tie:
+        return (_EVENT_SORT_ORDER[event.event_type], event.event_type.value)
     if event.event_type in _TERMINAL_RUN_EVENT_TYPES:
-        order = 0
-    elif event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
-        order = 1
-    else:
-        order = 10 + _EVENT_SORT_ORDER[event.event_type]
-    return (event.timestamp, order, event.event_type.value)
+        return (100, event.event_type.value)
+    if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
+        return (101, event.event_type.value)
+    return (_EVENT_SORT_ORDER[event.event_type], event.event_type.value)
+
+
+def _sort_run_boundary_events(
+    events: Iterable[WorkflowLifecycleEvent],
+) -> tuple[WorkflowLifecycleEvent, ...]:
+    sorted_events = sorted(events, key=lambda event: event.timestamp)
+    grouped_events: list[list[WorkflowLifecycleEvent]] = []
+    for event in sorted_events:
+        if grouped_events and grouped_events[-1][0].timestamp == event.timestamp:
+            grouped_events[-1].append(event)
+        else:
+            grouped_events.append([event])
+
+    ordered_events: list[WorkflowLifecycleEvent] = []
+    for timestamp_events in grouped_events:
+        has_terminal_restart_tie = any(
+            event.event_type in _TERMINAL_RUN_EVENT_TYPES for event in timestamp_events
+        ) and any(
+            event.event_type is WorkflowLifecycleEventType.RUN_CREATED for event in timestamp_events
+        )
+        ordered_events.extend(
+            sorted(
+                timestamp_events,
+                key=lambda event: _run_boundary_group_order(
+                    event,
+                    has_terminal_restart_tie=has_terminal_restart_tie,
+                ),
+            )
+        )
+    return tuple(ordered_events)
 
 
 def _run_lifecycle_segment(
@@ -173,7 +207,7 @@ def _run_lifecycle_segment(
     terminal_state: WorkflowRunLifecycleState | None = None
     terminal_allows_restart = False
     latest_segment: list[WorkflowLifecycleEvent] = []
-    for event in sorted(events, key=_run_boundary_sort_key):
+    for event in _sort_run_boundary_events(events):
         if terminal_state is not None:
             if (
                 event.event_type is WorkflowLifecycleEventType.RUN_CREATED
@@ -601,7 +635,7 @@ def validate_workflow_lifecycle_conformance(
     terminal_seen = False
     active_run = False
     terminal_allows_restart = False
-    sorted_events = sorted(event_list, key=_run_boundary_sort_key)
+    sorted_events = _sort_run_boundary_events(event_list)
     for event in sorted_events:
         if terminal_seen:
             if (

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -210,10 +210,9 @@ def _run_lifecycle_segment(
     latest_segment_ambiguous = False
     post_terminal_violation = False
     timestamp_group_list = _timestamp_groups(events)
-    for group_index, timestamp_events in enumerate(timestamp_group_list):
+    for timestamp_events in timestamp_group_list:
         active_run_at_timestamp = active_run
-        has_later_events = group_index < len(timestamp_group_list) - 1
-        prefer_restart_tie = active_run_at_timestamp or has_later_events
+        prefer_restart_tie = active_run_at_timestamp
         timestamp_ambiguous = (
             prefer_restart_tie
             and _has_terminal_restart_tie(timestamp_events)
@@ -691,10 +690,9 @@ def validate_workflow_lifecycle_conformance(
     active_run = False
     terminal_allows_restart = False
     timestamp_group_list = _timestamp_groups(event_list)
-    for group_index, timestamp_events in enumerate(timestamp_group_list):
+    for timestamp_events in timestamp_group_list:
         active_run_at_timestamp = active_run
-        has_later_events = group_index < len(timestamp_group_list) - 1
-        prefer_restart_tie = active_run_at_timestamp or has_later_events
+        prefer_restart_tie = active_run_at_timestamp
         if (
             prefer_restart_tie
             and _has_terminal_restart_tie(timestamp_events)

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -683,6 +683,16 @@ def validate_workflow_lifecycle_conformance(
                 edge_id=error.edge_id,
             )
         )
+    for warning in validation.warnings:
+        issues.append(
+            WorkflowConformanceIssue(
+                severity="warning",
+                code="invalid_spec",
+                message=warning.message,
+                node_id=warning.node_id,
+                edge_id=warning.edge_id,
+            )
+        )
 
     node_ids = {node.node_id for node in spec.nodes}
     edge_ids = {edge.edge_id for edge in spec.edges}

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -122,6 +122,13 @@ _RUN_EVENT_TYPES: Final[frozenset[WorkflowLifecycleEventType]] = frozenset(
         WorkflowLifecycleEventType.RUN_CANCELLED,
     }
 )
+_TERMINAL_RUN_EVENT_TYPES: Final[frozenset[WorkflowLifecycleEventType]] = frozenset(
+    {
+        WorkflowLifecycleEventType.RUN_COMPLETED,
+        WorkflowLifecycleEventType.RUN_FAILED,
+        WorkflowLifecycleEventType.RUN_CANCELLED,
+    }
+)
 _NODE_STATE_BY_EVENT: Final[dict[WorkflowLifecycleEventType, WorkflowNodeLifecycleState]] = {
     WorkflowLifecycleEventType.NODE_SCHEDULED: WorkflowNodeLifecycleState.SCHEDULED,
     WorkflowLifecycleEventType.NODE_STARTED: WorkflowNodeLifecycleState.STARTED,
@@ -147,6 +154,50 @@ _EVENT_SORT_ORDER: Final[dict[WorkflowLifecycleEventType, int]] = {
 
 def _event_sort_key(event: WorkflowLifecycleEvent) -> tuple[datetime, int, str]:
     return (event.timestamp, _EVENT_SORT_ORDER[event.event_type], event.event_type.value)
+
+
+def _run_boundary_sort_key(event: WorkflowLifecycleEvent) -> tuple[datetime, int, str]:
+    if event.event_type in _TERMINAL_RUN_EVENT_TYPES:
+        order = 0
+    elif event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
+        order = 1
+    else:
+        order = 10 + _EVENT_SORT_ORDER[event.event_type]
+    return (event.timestamp, order, event.event_type.value)
+
+
+def _run_lifecycle_state(
+    events: Iterable[WorkflowLifecycleEvent],
+) -> WorkflowRunLifecycleState | None:
+    active_run = False
+    terminal_state: WorkflowRunLifecycleState | None = None
+    terminal_allows_restart = False
+    for event in sorted(events, key=_run_boundary_sort_key):
+        if terminal_state is not None:
+            if (
+                event.event_type is WorkflowLifecycleEventType.RUN_CREATED
+                and terminal_allows_restart
+            ):
+                active_run = True
+                terminal_state = None
+                terminal_allows_restart = False
+            continue
+        if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
+            active_run = True
+            continue
+        if event.event_type in _TERMINAL_RUN_EVENT_TYPES:
+            terminal_state = {
+                WorkflowLifecycleEventType.RUN_COMPLETED: WorkflowRunLifecycleState.COMPLETED,
+                WorkflowLifecycleEventType.RUN_FAILED: WorkflowRunLifecycleState.FAILED,
+                WorkflowLifecycleEventType.RUN_CANCELLED: WorkflowRunLifecycleState.CANCELLED,
+            }[event.event_type]
+            terminal_allows_restart = active_run
+            active_run = False
+    if terminal_state is not None:
+        return terminal_state
+    if active_run:
+        return WorkflowRunLifecycleState.CREATED
+    return None
 
 
 def _normalize_non_blank(name: str, value: str) -> str:
@@ -452,18 +503,11 @@ def next_runnable_node_ids(
     dispatch work.
     """
     event_list = tuple(event for event in events if event.workflow_id == spec.spec_id)
-    latest_run_event = next(
-        (
-            event
-            for event in sorted(event_list, key=_event_sort_key, reverse=True)
-            if event.event_type in _RUN_EVENT_TYPES
-        ),
-        None,
-    )
-    if latest_run_event is not None and latest_run_event.event_type in {
-        WorkflowLifecycleEventType.RUN_COMPLETED,
-        WorkflowLifecycleEventType.RUN_FAILED,
-        WorkflowLifecycleEventType.RUN_CANCELLED,
+    latest_run_state = _run_lifecycle_state(event_list)
+    if latest_run_state in {
+        WorkflowRunLifecycleState.COMPLETED,
+        WorkflowRunLifecycleState.FAILED,
+        WorkflowRunLifecycleState.CANCELLED,
     }:
         return ()
 
@@ -549,19 +593,18 @@ def validate_workflow_lifecycle_conformance(
     edge_ids = {edge.edge_id for edge in spec.edges}
     seen_run_created = False
     terminal_seen = False
-    # Conformance reasons about run boundaries, so same-timestamp ties must
-    # preserve replay order instead of reusing ``_event_sort_key``'s event-type
-    # priority. ``workflow_id`` is spec-scoped, and a terminal event followed by
-    # RUN_CREATED at the same timestamp is the only available local signal that
-    # a new run began after the prior one ended.
-    sorted_events = tuple(
-        event
-        for _, event in sorted(enumerate(event_list), key=lambda item: (item[1].timestamp, item[0]))
-    )
+    active_run = False
+    terminal_allows_restart = False
+    sorted_events = sorted(event_list, key=_run_boundary_sort_key)
     for event in sorted_events:
         if terminal_seen:
-            if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
+            if (
+                event.event_type is WorkflowLifecycleEventType.RUN_CREATED
+                and terminal_allows_restart
+            ):
                 terminal_seen = False
+                terminal_allows_restart = False
+                active_run = True
                 seen_run_created = True
                 continue
             issues.append(
@@ -581,6 +624,7 @@ def validate_workflow_lifecycle_conformance(
 
         if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
             seen_run_created = True
+            active_run = True
 
         if event.event_type in _NODE_EVENT_TYPES and event.node_id is not None:
             if event.node_id not in node_ids:
@@ -626,12 +670,10 @@ def validate_workflow_lifecycle_conformance(
                     )
                 )
 
-        if event.event_type in {
-            WorkflowLifecycleEventType.RUN_COMPLETED,
-            WorkflowLifecycleEventType.RUN_FAILED,
-            WorkflowLifecycleEventType.RUN_CANCELLED,
-        }:
+        if event.event_type in _TERMINAL_RUN_EVENT_TYPES:
             terminal_seen = True
+            terminal_allows_restart = active_run
+            active_run = False
 
     return WorkflowConformanceReport(
         workflow_id=spec.spec_id,

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -252,6 +252,7 @@ def _run_lifecycle_segment(
                 if active_run:
                     latest_segment.append(event)
                     latest_segment_ambiguous = latest_segment_ambiguous or timestamp_ambiguous
+                    post_terminal_violation = True
                     continue
                 active_run = True
                 latest_segment = [event]

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -223,6 +223,7 @@ def _run_lifecycle_segment(
     active_run = False
     terminal_state: WorkflowRunLifecycleState | None = None
     terminal_allows_restart = False
+    terminal_timestamp: datetime | None = None
     latest_segment: list[WorkflowLifecycleEvent] = []
     latest_segment_ambiguous = False
     for timestamp_events in _timestamp_groups(events):
@@ -235,13 +236,17 @@ def _run_lifecycle_segment(
             ),
         ):
             if terminal_state is not None:
+                can_restart_after_terminal = terminal_allows_restart or (
+                    terminal_timestamp is not None and event.timestamp > terminal_timestamp
+                )
                 if (
                     event.event_type is WorkflowLifecycleEventType.RUN_CREATED
-                    and terminal_allows_restart
+                    and can_restart_after_terminal
                 ):
                     active_run = True
                     terminal_state = None
                     terminal_allows_restart = False
+                    terminal_timestamp = None
                     latest_segment = [event]
                     latest_segment_ambiguous = timestamp_ambiguous
                     continue
@@ -266,6 +271,7 @@ def _run_lifecycle_segment(
                     WorkflowLifecycleEventType.RUN_CANCELLED: WorkflowRunLifecycleState.CANCELLED,
                 }[event.event_type]
                 terminal_allows_restart = active_run
+                terminal_timestamp = event.timestamp
                 active_run = False
     if terminal_state is not None:
         return terminal_state, tuple(latest_segment), latest_segment_ambiguous
@@ -685,16 +691,21 @@ def validate_workflow_lifecycle_conformance(
     edge_ids = {edge.edge_id for edge in spec.edges}
     seen_run_created = False
     terminal_seen = False
+    terminal_seen_at: datetime | None = None
     active_run = False
     terminal_allows_restart = False
     sorted_events = _sort_run_boundary_events(event_list)
     for event in sorted_events:
         if terminal_seen:
+            can_restart_after_terminal = terminal_allows_restart or (
+                terminal_seen_at is not None and event.timestamp > terminal_seen_at
+            )
             if (
                 event.event_type is WorkflowLifecycleEventType.RUN_CREATED
-                and terminal_allows_restart
+                and can_restart_after_terminal
             ):
                 terminal_seen = False
+                terminal_seen_at = None
                 terminal_allows_restart = False
                 active_run = True
                 seen_run_created = True
@@ -777,6 +788,7 @@ def validate_workflow_lifecycle_conformance(
 
         if event.event_type in _TERMINAL_RUN_EVENT_TYPES:
             terminal_seen = True
+            terminal_seen_at = event.timestamp
             terminal_allows_restart = active_run
             active_run = False
 

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -122,13 +122,6 @@ _RUN_EVENT_TYPES: Final[frozenset[WorkflowLifecycleEventType]] = frozenset(
         WorkflowLifecycleEventType.RUN_CANCELLED,
     }
 )
-_TERMINAL_RUN_EVENT_TYPES: Final[frozenset[WorkflowLifecycleEventType]] = frozenset(
-    {
-        WorkflowLifecycleEventType.RUN_COMPLETED,
-        WorkflowLifecycleEventType.RUN_FAILED,
-        WorkflowLifecycleEventType.RUN_CANCELLED,
-    }
-)
 _NODE_STATE_BY_EVENT: Final[dict[WorkflowLifecycleEventType, WorkflowNodeLifecycleState]] = {
     WorkflowLifecycleEventType.NODE_SCHEDULED: WorkflowNodeLifecycleState.SCHEDULED,
     WorkflowLifecycleEventType.NODE_STARTED: WorkflowNodeLifecycleState.STARTED,
@@ -556,92 +549,89 @@ def validate_workflow_lifecycle_conformance(
     edge_ids = {edge.edge_id for edge in spec.edges}
     seen_run_created = False
     terminal_seen = False
-    sorted_events = sorted(event_list, key=_event_sort_key)
-    grouped_events: list[list[WorkflowLifecycleEvent]] = []
+    # Conformance reasons about run boundaries, so same-timestamp ties must
+    # preserve replay order instead of reusing ``_event_sort_key``'s event-type
+    # priority. ``workflow_id`` is spec-scoped, and a terminal event followed by
+    # RUN_CREATED at the same timestamp is the only available local signal that
+    # a new run began after the prior one ended.
+    sorted_events = tuple(
+        event
+        for _, event in sorted(enumerate(event_list), key=lambda item: (item[1].timestamp, item[0]))
+    )
     for event in sorted_events:
-        if grouped_events and grouped_events[-1][0].timestamp == event.timestamp:
-            grouped_events[-1].append(event)
-        else:
-            grouped_events.append([event])
+        if terminal_seen:
+            if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
+                terminal_seen = False
+                seen_run_created = True
+                continue
+            issues.append(
+                WorkflowConformanceIssue(
+                    severity="error",
+                    code="event_after_terminal_run",
+                    message=(
+                        "Workflow lifecycle event appears after a terminal run event "
+                        "without a new workflow.run.created boundary."
+                    ),
+                    event_type=event.event_type,
+                    node_id=event.node_id,
+                    edge_id=event.edge_id,
+                )
+            )
+            continue
 
-    for timestamp_events in grouped_events:
-        # ``workflow_id`` is spec-scoped, not run-scoped. If timestamp precision
-        # collapses a terminal event and the next run boundary, prefer the valid
-        # multi-run interpretation instead of letting tie-break order invent an
-        # event_after_terminal_run finding.
-        timestamp_has_run_created = any(
-            event.event_type is WorkflowLifecycleEventType.RUN_CREATED for event in timestamp_events
-        )
-        if terminal_seen and timestamp_has_run_created:
-            terminal_seen = False
+        if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
             seen_run_created = True
 
-        for event in timestamp_events:
-            if terminal_seen:
+        if event.event_type in _NODE_EVENT_TYPES and event.node_id is not None:
+            if event.node_id not in node_ids:
                 issues.append(
                     WorkflowConformanceIssue(
                         severity="error",
-                        code="event_after_terminal_run",
-                        message=(
-                            "Workflow lifecycle event appears after a terminal run event "
-                            "without a new workflow.run.created boundary."
-                        ),
+                        code="unknown_node_id",
+                        message=f"Lifecycle event references unknown node id {event.node_id!r}.",
                         event_type=event.event_type,
                         node_id=event.node_id,
+                    )
+                )
+            if not seen_run_created:
+                issues.append(
+                    WorkflowConformanceIssue(
+                        severity="warning",
+                        code="lifecycle_before_run_created",
+                        message="Node lifecycle event appears before workflow.run.created.",
+                        event_type=event.event_type,
+                        node_id=event.node_id,
+                    )
+                )
+
+        if event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED and event.edge_id:
+            if event.edge_id not in edge_ids:
+                issues.append(
+                    WorkflowConformanceIssue(
+                        severity="error",
+                        code="unknown_edge_id",
+                        message=f"Lifecycle event references unknown edge id {event.edge_id!r}.",
+                        event_type=event.event_type,
                         edge_id=event.edge_id,
                     )
                 )
-                continue
-
-            if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
-                seen_run_created = True
-
-            if event.event_type in _NODE_EVENT_TYPES and event.node_id is not None:
-                if event.node_id not in node_ids:
-                    issues.append(
-                        WorkflowConformanceIssue(
-                            severity="error",
-                            code="unknown_node_id",
-                            message=f"Lifecycle event references unknown node id {event.node_id!r}.",
-                            event_type=event.event_type,
-                            node_id=event.node_id,
-                        )
+            if not seen_run_created:
+                issues.append(
+                    WorkflowConformanceIssue(
+                        severity="warning",
+                        code="lifecycle_before_run_created",
+                        message="Edge traversal event appears before workflow.run.created.",
+                        event_type=event.event_type,
+                        edge_id=event.edge_id,
                     )
-                if not seen_run_created:
-                    issues.append(
-                        WorkflowConformanceIssue(
-                            severity="warning",
-                            code="lifecycle_before_run_created",
-                            message="Node lifecycle event appears before workflow.run.created.",
-                            event_type=event.event_type,
-                            node_id=event.node_id,
-                        )
-                    )
+                )
 
-            if event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED and event.edge_id:
-                if event.edge_id not in edge_ids:
-                    issues.append(
-                        WorkflowConformanceIssue(
-                            severity="error",
-                            code="unknown_edge_id",
-                            message=f"Lifecycle event references unknown edge id {event.edge_id!r}.",
-                            event_type=event.event_type,
-                            edge_id=event.edge_id,
-                        )
-                    )
-                if not seen_run_created:
-                    issues.append(
-                        WorkflowConformanceIssue(
-                            severity="warning",
-                            code="lifecycle_before_run_created",
-                            message="Edge traversal event appears before workflow.run.created.",
-                            event_type=event.event_type,
-                            edge_id=event.edge_id,
-                        )
-                    )
-
-        if any(event.event_type in _TERMINAL_RUN_EVENT_TYPES for event in timestamp_events):
-            terminal_seen = not timestamp_has_run_created
+        if event.event_type in {
+            WorkflowLifecycleEventType.RUN_COMPLETED,
+            WorkflowLifecycleEventType.RUN_FAILED,
+            WorkflowLifecycleEventType.RUN_CANCELLED,
+        }:
+            terminal_seen = True
 
     return WorkflowConformanceReport(
         workflow_id=spec.spec_id,

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -552,11 +552,18 @@ def validate_workflow_lifecycle_conformance(
     sorted_events = sorted(event_list, key=_event_sort_key)
     for event in sorted_events:
         if terminal_seen:
+            if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
+                terminal_seen = False
+                seen_run_created = True
+                continue
             issues.append(
                 WorkflowConformanceIssue(
                     severity="error",
                     code="event_after_terminal_run",
-                    message="Workflow lifecycle event appears after a terminal run event.",
+                    message=(
+                        "Workflow lifecycle event appears after a terminal run event "
+                        "without a new workflow.run.created boundary."
+                    ),
                     event_type=event.event_type,
                     node_id=event.node_id,
                     edge_id=event.edge_id,

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -166,12 +166,13 @@ def _run_boundary_sort_key(event: WorkflowLifecycleEvent) -> tuple[datetime, int
     return (event.timestamp, order, event.event_type.value)
 
 
-def _run_lifecycle_state(
+def _run_lifecycle_segment(
     events: Iterable[WorkflowLifecycleEvent],
-) -> WorkflowRunLifecycleState | None:
+) -> tuple[WorkflowRunLifecycleState | None, tuple[WorkflowLifecycleEvent, ...]]:
     active_run = False
     terminal_state: WorkflowRunLifecycleState | None = None
     terminal_allows_restart = False
+    latest_segment: list[WorkflowLifecycleEvent] = []
     for event in sorted(events, key=_run_boundary_sort_key):
         if terminal_state is not None:
             if (
@@ -181,10 +182,15 @@ def _run_lifecycle_state(
                 active_run = True
                 terminal_state = None
                 terminal_allows_restart = False
+                latest_segment = [event]
+                continue
+            latest_segment.append(event)
             continue
         if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
             active_run = True
+            latest_segment = [event]
             continue
+        latest_segment.append(event)
         if event.event_type in _TERMINAL_RUN_EVENT_TYPES:
             terminal_state = {
                 WorkflowLifecycleEventType.RUN_COMPLETED: WorkflowRunLifecycleState.COMPLETED,
@@ -194,10 +200,10 @@ def _run_lifecycle_state(
             terminal_allows_restart = active_run
             active_run = False
     if terminal_state is not None:
-        return terminal_state
+        return terminal_state, tuple(latest_segment)
     if active_run:
-        return WorkflowRunLifecycleState.CREATED
-    return None
+        return WorkflowRunLifecycleState.CREATED, tuple(latest_segment)
+    return None, tuple(latest_segment)
 
 
 def _normalize_non_blank(name: str, value: str) -> str:
@@ -503,7 +509,7 @@ def next_runnable_node_ids(
     dispatch work.
     """
     event_list = tuple(event for event in events if event.workflow_id == spec.spec_id)
-    latest_run_state = _run_lifecycle_state(event_list)
+    latest_run_state, latest_run_events = _run_lifecycle_segment(event_list)
     if latest_run_state in {
         WorkflowRunLifecycleState.COMPLETED,
         WorkflowRunLifecycleState.FAILED,
@@ -511,7 +517,7 @@ def next_runnable_node_ids(
     }:
         return ()
 
-    states = effective_node_states(event_list)
+    states = effective_node_states(latest_run_events)
     completed = {
         node_id
         for node_id, state in states.items()
@@ -520,7 +526,7 @@ def next_runnable_node_ids(
     latest_node_attempts: dict[str, int | None] = {}
     latest_node_completed_at: dict[str, datetime] = {}
     traversed_edge_events: dict[str, list[WorkflowLifecycleEvent]] = {}
-    for event in sorted(event_list, key=_event_sort_key):
+    for event in sorted(latest_run_events, key=_event_sort_key):
         if event.event_type in _NODE_EVENT_TYPES and event.node_id is not None:
             latest_node_attempts[event.node_id] = event.attempt
             if event.event_type is WorkflowLifecycleEventType.NODE_COMPLETED:

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -214,10 +214,8 @@ def _run_lifecycle_segment(
     for timestamp_events in timestamp_group_list:
         active_run_at_timestamp = active_run
         prefer_restart_tie = active_run_at_timestamp
-        timestamp_ambiguous = (
-            prefer_restart_tie
-            and _has_terminal_restart_tie(timestamp_events)
-            and _has_scheduling_event(timestamp_events)
+        timestamp_ambiguous = _has_terminal_restart_tie(timestamp_events) and _has_scheduling_event(
+            timestamp_events
         )
         for event in sorted(
             timestamp_events,
@@ -705,11 +703,7 @@ def validate_workflow_lifecycle_conformance(
     for timestamp_events in timestamp_group_list:
         active_run_at_timestamp = active_run
         prefer_restart_tie = active_run_at_timestamp
-        if (
-            prefer_restart_tie
-            and _has_terminal_restart_tie(timestamp_events)
-            and _has_scheduling_event(timestamp_events)
-        ):
+        if _has_terminal_restart_tie(timestamp_events) and _has_scheduling_event(timestamp_events):
             issues.append(
                 WorkflowConformanceIssue(
                     severity="error",

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -509,6 +509,36 @@ def test_next_runnable_allows_new_run_at_terminal_timestamp_after_active_run() -
     assert next_runnable_node_ids(spec, tuple(reversed(events))) == ("node_a",)
 
 
+def test_next_runnable_scopes_node_state_to_latest_run_after_restart() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=start + timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=2),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=3),
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ("node_a",)
+
+
 def test_lifecycle_module_does_not_import_runtime_dispatcher() -> None:
     import ouroboros.orchestrator.workflow_lifecycle as lifecycle
 

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -553,7 +553,7 @@ def test_next_runnable_allows_clean_restart_after_truncated_terminal_slice() -> 
     assert next_runnable_node_ids(spec, events) == ("node_a",)
 
 
-def test_next_runnable_allows_checkpoint_at_restart_timestamp() -> None:
+def test_next_runnable_refuses_checkpoint_at_restart_timestamp() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)
     boundary = start + timedelta(seconds=1)
@@ -581,7 +581,7 @@ def test_next_runnable_allows_checkpoint_at_restart_timestamp() -> None:
         ),
     )
 
-    assert next_runnable_node_ids(spec, events) == ("node_a",)
+    assert next_runnable_node_ids(spec, events) == ()
 
 
 def test_next_runnable_refuses_ambiguous_same_timestamp_restart_completion() -> None:

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -509,6 +509,37 @@ def test_next_runnable_allows_new_run_at_terminal_timestamp_after_active_run() -
     assert next_runnable_node_ids(spec, tuple(reversed(events))) == ("node_a",)
 
 
+def test_next_runnable_allows_checkpoint_at_restart_timestamp() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    boundary = start + timedelta(seconds=1)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.CHECKPOINT_SAVED,
+            workflow_id=spec.spec_id,
+            refs=("checkpoint://run-1",),
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ("node_a",)
+
+
 def test_next_runnable_refuses_ambiguous_same_timestamp_restart_completion() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -509,7 +509,7 @@ def test_next_runnable_allows_new_run_at_terminal_timestamp_after_active_run() -
     assert next_runnable_node_ids(spec, tuple(reversed(events))) == ("node_a",)
 
 
-def test_next_runnable_allows_same_timestamp_restart_from_truncated_terminal_slice() -> None:
+def test_next_runnable_refuses_same_timestamp_restart_from_truncated_terminal_slice() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)
     events = (

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -509,6 +509,31 @@ def test_next_runnable_allows_new_run_at_terminal_timestamp_after_active_run() -
     assert next_runnable_node_ids(spec, tuple(reversed(events))) == ("node_a",)
 
 
+def test_next_runnable_allows_same_timestamp_restart_from_truncated_terminal_slice() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=start + timedelta(seconds=1),
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ()
+
+
 def test_next_runnable_allows_clean_restart_after_truncated_terminal_slice() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -571,6 +571,31 @@ def test_next_runnable_refuses_ambiguous_same_timestamp_restart_node_state() -> 
     assert next_runnable_node_ids(spec, events) == ()
 
 
+def test_next_runnable_ignores_stray_run_created_inside_active_run() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=start + timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=2),
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ("node_b",)
+
+
 def test_next_runnable_ignores_historical_ambiguity_after_clean_restart() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -509,6 +509,25 @@ def test_next_runnable_allows_new_run_at_terminal_timestamp_after_active_run() -
     assert next_runnable_node_ids(spec, tuple(reversed(events))) == ("node_a",)
 
 
+def test_next_runnable_allows_clean_restart_after_truncated_terminal_slice() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=1),
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ("node_a",)
+
+
 def test_next_runnable_allows_checkpoint_at_restart_timestamp() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -534,6 +534,31 @@ def test_next_runnable_refuses_same_timestamp_restart_from_truncated_terminal_sl
     assert next_runnable_node_ids(spec, events) == ()
 
 
+def test_next_runnable_refuses_truncated_restart_with_same_timestamp_activity() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=start,
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ()
+
+
 def test_next_runnable_allows_clean_restart_after_truncated_terminal_slice() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -484,6 +484,31 @@ def test_lifecycle_projection_uses_deterministic_tie_breakers() -> None:
     assert next_runnable_node_ids(spec, tuple(reversed(tied_run_events))) == ()
 
 
+def test_next_runnable_allows_new_run_at_terminal_timestamp_after_active_run() -> None:
+    spec = _spec()
+    timestamp = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=timestamp - timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=timestamp,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=timestamp,
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ("node_a",)
+    assert next_runnable_node_ids(spec, tuple(reversed(events))) == ("node_a",)
+
+
 def test_lifecycle_module_does_not_import_runtime_dispatcher() -> None:
     import ouroboros.orchestrator.workflow_lifecycle as lifecycle
 

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -509,6 +509,37 @@ def test_next_runnable_allows_new_run_at_terminal_timestamp_after_active_run() -
     assert next_runnable_node_ids(spec, tuple(reversed(events))) == ("node_a",)
 
 
+def test_next_runnable_keeps_same_timestamp_completion_in_closing_run() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    boundary = start + timedelta(seconds=1)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ("node_a",)
+
+
 def test_next_runnable_scopes_node_state_to_latest_run_after_restart() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -646,6 +646,43 @@ def test_next_runnable_refuses_ambiguous_same_timestamp_restart_node_state() -> 
     assert next_runnable_node_ids(spec, events) == ()
 
 
+def test_next_runnable_refuses_ambiguous_same_timestamp_restart_edge_traversal() -> None:
+    spec = _conditional_spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    boundary = start + timedelta(seconds=1)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="decide",
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id=spec.spec_id,
+            edge_id="edge_yes",
+            timestamp=boundary,
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ()
+
+
 def test_next_runnable_refuses_post_terminal_events_before_later_restart() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)
@@ -772,6 +809,42 @@ def test_next_runnable_scopes_node_state_to_latest_run_after_restart() -> None:
     )
 
     assert next_runnable_node_ids(spec, events) == ("node_a",)
+
+
+def test_next_runnable_scopes_edge_traversals_to_latest_run_after_restart() -> None:
+    spec = _conditional_spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="decide",
+            timestamp=start + timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id=spec.spec_id,
+            edge_id="edge_yes",
+            timestamp=start + timedelta(seconds=2),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=3),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=4),
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ("decide",)
 
 
 def test_lifecycle_module_does_not_import_runtime_dispatcher() -> None:

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -713,7 +713,7 @@ def test_next_runnable_refuses_post_terminal_events_before_later_restart() -> No
     assert next_runnable_node_ids(spec, events) == ()
 
 
-def test_next_runnable_ignores_stray_run_created_inside_active_run() -> None:
+def test_next_runnable_refuses_stray_run_created_inside_active_run() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)
     events = (
@@ -735,7 +735,7 @@ def test_next_runnable_ignores_stray_run_created_inside_active_run() -> None:
         ),
     )
 
-    assert next_runnable_node_ids(spec, events) == ("node_b",)
+    assert next_runnable_node_ids(spec, events) == ()
 
 
 def test_next_runnable_ignores_historical_ambiguity_after_clean_restart() -> None:

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -509,7 +509,7 @@ def test_next_runnable_allows_new_run_at_terminal_timestamp_after_active_run() -
     assert next_runnable_node_ids(spec, tuple(reversed(events))) == ("node_a",)
 
 
-def test_next_runnable_keeps_same_timestamp_completion_in_closing_run() -> None:
+def test_next_runnable_refuses_ambiguous_same_timestamp_restart_completion() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)
     boundary = start + timedelta(seconds=1)
@@ -537,7 +537,38 @@ def test_next_runnable_keeps_same_timestamp_completion_in_closing_run() -> None:
         ),
     )
 
-    assert next_runnable_node_ids(spec, events) == ("node_a",)
+    assert next_runnable_node_ids(spec, events) == ()
+
+
+def test_next_runnable_refuses_ambiguous_same_timestamp_restart_node_state() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    boundary = start + timedelta(seconds=1)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=boundary,
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ()
 
 
 def test_next_runnable_scopes_node_state_to_latest_run_after_restart() -> None:

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -621,6 +621,36 @@ def test_next_runnable_refuses_ambiguous_same_timestamp_restart_node_state() -> 
     assert next_runnable_node_ids(spec, events) == ()
 
 
+def test_next_runnable_refuses_post_terminal_events_before_later_restart() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=start + timedelta(seconds=2),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=3),
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ()
+
+
 def test_next_runnable_ignores_stray_run_created_inside_active_run() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle.py
@@ -571,6 +571,49 @@ def test_next_runnable_refuses_ambiguous_same_timestamp_restart_node_state() -> 
     assert next_runnable_node_ids(spec, events) == ()
 
 
+def test_next_runnable_ignores_historical_ambiguity_after_clean_restart() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    ambiguous_boundary = start + timedelta(seconds=1)
+    clean_restart = start + timedelta(seconds=3)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=ambiguous_boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=ambiguous_boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=ambiguous_boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_FAILED,
+            workflow_id=spec.spec_id,
+            reason_code="bad_boundary",
+            timestamp=start + timedelta(seconds=2),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=clean_restart,
+        ),
+    )
+
+    assert next_runnable_node_ids(spec, events) == ("node_a",)
+
+
 def test_next_runnable_scopes_node_state_to_latest_run_after_restart() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -176,6 +176,34 @@ def test_conformance_accepts_new_run_created_at_terminal_timestamp() -> None:
     assert report.errors == ()
 
 
+def test_conformance_allows_same_timestamp_restart_from_truncated_terminal_slice() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=start + timedelta(seconds=1),
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is True
+    assert report.errors == ()
+
+
 def test_conformance_allows_clean_restart_after_truncated_terminal_slice() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)
@@ -314,34 +342,6 @@ def test_conformance_accepts_zero_duration_run_without_later_events() -> None:
 
     assert report.ok is True
     assert report.errors == ()
-
-
-def test_conformance_flags_events_after_zero_duration_terminal_run() -> None:
-    spec = _spec()
-    timestamp = datetime(2026, 5, 15, tzinfo=UTC)
-    events = (
-        WorkflowLifecycleEvent(
-            event_type=WorkflowLifecycleEventType.RUN_CREATED,
-            workflow_id=spec.spec_id,
-            timestamp=timestamp,
-        ),
-        WorkflowLifecycleEvent(
-            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
-            workflow_id=spec.spec_id,
-            timestamp=timestamp,
-        ),
-        WorkflowLifecycleEvent(
-            event_type=WorkflowLifecycleEventType.NODE_STARTED,
-            workflow_id=spec.spec_id,
-            node_id="node_a",
-            timestamp=timestamp + timedelta(seconds=1),
-        ),
-    )
-
-    report = validate_workflow_lifecycle_conformance(spec, events)
-
-    assert report.ok is False
-    assert "event_after_terminal_run" in {issue.code for issue in report.errors}
 
 
 def test_conformance_still_flags_later_event_after_same_timestamp_terminal_group() -> None:

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -322,6 +322,46 @@ def test_conformance_rejects_ambiguous_same_timestamp_restart_node_state() -> No
     assert "ambiguous_run_boundary_timestamp" in {issue.code for issue in report.errors}
 
 
+def test_conformance_rejects_ambiguous_same_timestamp_restart_edge_traversal() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    boundary = start + timedelta(seconds=1)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id=spec.spec_id,
+            edge_id="edge_a_end",
+            timestamp=boundary,
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is False
+    assert "ambiguous_run_boundary_timestamp" in {issue.code for issue in report.errors}
+
+
 def test_conformance_accepts_zero_duration_run_without_later_events() -> None:
     spec = _spec()
     timestamp = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -294,6 +294,28 @@ def test_conformance_rejects_ambiguous_same_timestamp_restart_node_state() -> No
     assert "ambiguous_run_boundary_timestamp" in {issue.code for issue in report.errors}
 
 
+def test_conformance_accepts_zero_duration_run_without_later_events() -> None:
+    spec = _spec()
+    timestamp = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=timestamp,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=timestamp,
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is True
+    assert report.errors == ()
+
+
 def test_conformance_flags_events_after_zero_duration_terminal_run() -> None:
     spec = _spec()
     timestamp = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -230,6 +230,34 @@ def test_conformance_rejects_same_timestamp_restart_from_truncated_terminal_slic
     assert "event_after_terminal_run" in {issue.code for issue in report.errors}
 
 
+def test_conformance_rejects_truncated_restart_with_same_timestamp_activity() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=start,
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is False
+    assert "ambiguous_run_boundary_timestamp" in {issue.code for issue in report.errors}
+
+
 def test_conformance_allows_clean_restart_after_truncated_terminal_slice() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -130,10 +130,6 @@ def test_conformance_preserves_spec_validation_warnings() -> None:
 
     report = validate_workflow_lifecycle_conformance(spec, ())
 
-    assert report.ok is False
-    assert [(issue.code, issue.node_id) for issue in report.errors] == [
-        ("invalid_spec", "isolated")
-    ]
     assert [(issue.code, issue.node_id) for issue in report.warnings] == [
         ("invalid_spec", "isolated")
     ]

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -176,6 +176,40 @@ def test_conformance_accepts_new_run_created_at_terminal_timestamp() -> None:
     assert report.errors == ()
 
 
+def test_conformance_allows_checkpoint_at_restart_timestamp() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    boundary = start + timedelta(seconds=1)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.CHECKPOINT_SAVED,
+            workflow_id=spec.spec_id,
+            refs=("checkpoint://run-1",),
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is True
+    assert report.errors == ()
+
+
 def test_conformance_rejects_run_created_before_terminal() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -142,6 +142,75 @@ def test_conformance_allows_new_run_created_after_terminal_boundary() -> None:
     assert report.errors == ()
 
 
+def test_conformance_accepts_new_run_created_at_terminal_timestamp() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    boundary = start + timedelta(seconds=1)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=boundary + timedelta(seconds=1),
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is True
+    assert report.errors == ()
+
+
+def test_conformance_still_flags_later_event_after_same_timestamp_terminal_group() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    boundary = start + timedelta(seconds=1)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id=spec.spec_id,
+            edge_id="edge_a_end",
+            timestamp=boundary + timedelta(seconds=1),
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is False
+    assert [issue.code for issue in report.errors] == ["event_after_terminal_run"]
+
+
 def test_conformance_flags_events_after_terminal_run() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -176,6 +176,28 @@ def test_conformance_accepts_new_run_created_at_terminal_timestamp() -> None:
     assert report.errors == ()
 
 
+def test_conformance_rejects_run_created_before_terminal() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=1),
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is False
+    assert "run_created_before_terminal" in {issue.code for issue in report.errors}
+
+
 def test_conformance_rejects_ambiguous_same_timestamp_restart_node_state() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -109,6 +109,36 @@ def test_conformance_rejects_unknown_node_and_edge_ids() -> None:
     assert [issue.code for issue in report.errors] == ["unknown_node_id", "unknown_edge_id"]
 
 
+def test_conformance_preserves_spec_validation_warnings() -> None:
+    spec = WorkflowSpec(
+        spec_id="wfspec_conformance_with_warning",
+        source=SourceKind.SYNTHETIC,
+        nodes=(
+            _task("node_a"),
+            _task("isolated"),
+            WorkflowNode(node_id="end", kind=NodeKind.TERMINAL, owner=NodeOwner.HARNESS),
+        ),
+        edges=(
+            WorkflowEdge(
+                edge_id="edge_a_end",
+                source="node_a",
+                target="end",
+                kind=EdgeKind.TERMINAL,
+            ),
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, ())
+
+    assert report.ok is False
+    assert [(issue.code, issue.node_id) for issue in report.errors] == [
+        ("invalid_spec", "isolated")
+    ]
+    assert [(issue.code, issue.node_id) for issue in report.warnings] == [
+        ("invalid_spec", "isolated")
+    ]
+
+
 def test_conformance_allows_new_run_created_after_terminal_boundary() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -379,6 +379,37 @@ def test_conformance_still_flags_later_event_after_same_timestamp_terminal_group
     assert "event_after_terminal_run" in {issue.code for issue in report.errors}
 
 
+def test_conformance_reports_unknown_node_after_terminal_run() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="missing_node",
+            timestamp=start + timedelta(seconds=2),
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is False
+    assert {issue.code for issue in report.errors} == {
+        "event_after_terminal_run",
+        "unknown_node_id",
+    }
+
+
 def test_conformance_flags_events_after_terminal_run() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -109,6 +109,39 @@ def test_conformance_rejects_unknown_node_and_edge_ids() -> None:
     assert [issue.code for issue in report.errors] == ["unknown_node_id", "unknown_edge_id"]
 
 
+def test_conformance_allows_new_run_created_after_terminal_boundary() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=2),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=start + timedelta(seconds=3),
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is True
+    assert report.errors == ()
+
+
 def test_conformance_flags_events_after_terminal_run() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -232,7 +232,7 @@ def test_conformance_allows_clean_restart_after_truncated_terminal_slice() -> No
     assert report.errors == ()
 
 
-def test_conformance_allows_checkpoint_at_restart_timestamp() -> None:
+def test_conformance_rejects_checkpoint_at_restart_timestamp() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)
     boundary = start + timedelta(seconds=1)
@@ -262,8 +262,8 @@ def test_conformance_allows_checkpoint_at_restart_timestamp() -> None:
 
     report = validate_workflow_lifecycle_conformance(spec, events)
 
-    assert report.ok is True
-    assert report.errors == ()
+    assert report.ok is False
+    assert "ambiguous_run_boundary_timestamp" in {issue.code for issue in report.errors}
 
 
 def test_conformance_rejects_run_created_before_terminal() -> None:

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -176,6 +176,34 @@ def test_conformance_accepts_new_run_created_at_terminal_timestamp() -> None:
     assert report.errors == ()
 
 
+def test_conformance_allows_clean_restart_after_truncated_terminal_slice() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=start + timedelta(seconds=2),
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is True
+    assert report.errors == ()
+
+
 def test_conformance_allows_checkpoint_at_restart_timestamp() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -176,7 +176,7 @@ def test_conformance_accepts_new_run_created_at_terminal_timestamp() -> None:
     assert report.errors == ()
 
 
-def test_conformance_allows_same_timestamp_restart_from_truncated_terminal_slice() -> None:
+def test_conformance_rejects_same_timestamp_restart_from_truncated_terminal_slice() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)
     events = (
@@ -200,8 +200,8 @@ def test_conformance_allows_same_timestamp_restart_from_truncated_terminal_slice
 
     report = validate_workflow_lifecycle_conformance(spec, events)
 
-    assert report.ok is True
-    assert report.errors == ()
+    assert report.ok is False
+    assert "event_after_terminal_run" in {issue.code for issue in report.errors}
 
 
 def test_conformance_allows_clean_restart_after_truncated_terminal_slice() -> None:

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -176,6 +176,34 @@ def test_conformance_accepts_new_run_created_at_terminal_timestamp() -> None:
     assert report.errors == ()
 
 
+def test_conformance_flags_events_after_zero_duration_terminal_run() -> None:
+    spec = _spec()
+    timestamp = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=timestamp,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=timestamp,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=timestamp + timedelta(seconds=1),
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is False
+    assert [issue.code for issue in report.errors] == ["event_after_terminal_run"]
+
+
 def test_conformance_still_flags_later_event_after_same_timestamp_terminal_group() -> None:
     spec = _spec()
     start = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -176,6 +176,40 @@ def test_conformance_accepts_new_run_created_at_terminal_timestamp() -> None:
     assert report.errors == ()
 
 
+def test_conformance_rejects_ambiguous_same_timestamp_restart_node_state() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    boundary = start + timedelta(seconds=1)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=boundary,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=boundary,
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is False
+    assert "ambiguous_run_boundary_timestamp" in {issue.code for issue in report.errors}
+
+
 def test_conformance_flags_events_after_zero_duration_terminal_run() -> None:
     spec = _spec()
     timestamp = datetime(2026, 5, 15, tzinfo=UTC)

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+from ouroboros.orchestrator.workflow_ir import (
+    EdgeKind,
+    NodeKind,
+    NodeOwner,
+    SourceKind,
+    WorkflowEdge,
+    WorkflowNode,
+    WorkflowSpec,
+)
+from ouroboros.orchestrator.workflow_lifecycle import (
+    WorkflowLifecycleEvent,
+    WorkflowLifecycleEventType,
+    validate_workflow_lifecycle_conformance,
+)
+
+
+def _task(node_id: str) -> WorkflowNode:
+    return WorkflowNode(
+        node_id=node_id,
+        kind=NodeKind.TASK,
+        owner=NodeOwner.AGENT,
+        input_schema_ref="schema://input.agent.v1",
+        evidence_schema_ref="schema://evidence.agent.v1",
+    )
+
+
+def _spec() -> WorkflowSpec:
+    return WorkflowSpec(
+        spec_id="wfspec_conformance",
+        source=SourceKind.SYNTHETIC,
+        nodes=(
+            _task("node_a"),
+            WorkflowNode(node_id="end", kind=NodeKind.TERMINAL, owner=NodeOwner.HARNESS),
+        ),
+        edges=(
+            WorkflowEdge(
+                edge_id="edge_a_end",
+                source="node_a",
+                target="end",
+                kind=EdgeKind.TERMINAL,
+            ),
+        ),
+    )
+
+
+def test_conformance_accepts_known_lifecycle_history() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=start + timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id=spec.spec_id,
+            edge_id="edge_a_end",
+            timestamp=start + timedelta(seconds=2),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=3),
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.workflow_id == spec.spec_id
+    assert report.ok is True
+    assert report.event_count == 4
+    assert report.errors == ()
+    assert report.warnings == ()
+
+
+def test_conformance_rejects_unknown_node_and_edge_ids() -> None:
+    spec = _spec()
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="missing_node",
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id=spec.spec_id,
+            edge_id="missing_edge",
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is False
+    assert [issue.code for issue in report.errors] == ["unknown_node_id", "unknown_edge_id"]
+
+
+def test_conformance_flags_events_after_terminal_run() -> None:
+    spec = _spec()
+    start = datetime(2026, 5, 15, tzinfo=UTC)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=start,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=start + timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            timestamp=start + timedelta(seconds=2),
+        ),
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, events)
+
+    assert report.ok is False
+    assert [issue.code for issue in report.errors] == ["event_after_terminal_run"]
+
+
+def test_conformance_warns_when_node_events_precede_run_created() -> None:
+    spec = _spec()
+    event = WorkflowLifecycleEvent(
+        event_type=WorkflowLifecycleEventType.NODE_STARTED,
+        workflow_id=spec.spec_id,
+        node_id="node_a",
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, (event,))
+
+    assert report.ok is True
+    assert [issue.code for issue in report.warnings] == ["lifecycle_before_run_created"]
+
+
+def test_conformance_ignores_foreign_workflow_events() -> None:
+    spec = _spec()
+    event = WorkflowLifecycleEvent(
+        event_type=WorkflowLifecycleEventType.NODE_STARTED,
+        workflow_id="other_workflow",
+        node_id="missing_node",
+    )
+
+    report = validate_workflow_lifecycle_conformance(spec, (event,))
+
+    assert report.ok is True
+    assert report.event_count == 0
+    assert report.issues == ()

--- a/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_conformance.py
@@ -201,7 +201,7 @@ def test_conformance_flags_events_after_zero_duration_terminal_run() -> None:
     report = validate_workflow_lifecycle_conformance(spec, events)
 
     assert report.ok is False
-    assert [issue.code for issue in report.errors] == ["event_after_terminal_run"]
+    assert "event_after_terminal_run" in {issue.code for issue in report.errors}
 
 
 def test_conformance_still_flags_later_event_after_same_timestamp_terminal_group() -> None:
@@ -236,7 +236,7 @@ def test_conformance_still_flags_later_event_after_same_timestamp_terminal_group
     report = validate_workflow_lifecycle_conformance(spec, events)
 
     assert report.ok is False
-    assert [issue.code for issue in report.errors] == ["event_after_terminal_run"]
+    assert "event_after_terminal_run" in {issue.code for issue in report.errors}
 
 
 def test_conformance_flags_events_after_terminal_run() -> None:


### PR DESCRIPTION
## Summary
- Adds a pure conformance report connecting `WorkflowSpec` with `WorkflowLifecycleEvent` history.
- Detects invalid specs, unknown node/edge lifecycle references, lifecycle rows before `workflow.run.created`, and history after terminal run events.
- Keeps dispatch and persistence wiring out of this slice.

## #961 / AgentOS fit
- Advances #956 by making Workflow IR lifecycle replay self-checking before runtime adoption.
- Matches the #961 SSOT direction: typed in-repo AgentOS contracts plus replay validation, not an external workflow engine.

## Validation
- `uv run ruff check src/ouroboros/orchestrator/workflow_lifecycle.py tests/unit/orchestrator/test_workflow_lifecycle_conformance.py`
- `uv run mypy src/ouroboros/orchestrator/workflow_lifecycle.py tests/unit/orchestrator/test_workflow_lifecycle_conformance.py`
- `uv run pytest tests/unit/orchestrator/test_workflow_lifecycle.py tests/unit/orchestrator/test_workflow_lifecycle_conformance.py -q`

Refs #956
Refs #961