### PR TITLE
fix(runtime): preserve nested Codex command metadata

### DIFF
--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -1279,18 +1279,37 @@ class CodexCliRuntime:
     def _extract_command_metadata(self, item: dict[str, Any]) -> dict[str, Any]:
         """Extract command result fields that can support verifier evidence."""
         data: dict[str, Any] = {}
-        for key in ("output", "stdout", "stderr", "result_preview", "status"):
-            value = item.get(key)
-            if isinstance(value, str) and value.strip():
-                data[key] = value.strip()
-        for key in ("exit_code", "exitCode"):
-            value = item.get(key)
-            if isinstance(value, int):
-                data["exit_code"] = value
-                break
-        if item.get("success") is True:
-            data.setdefault("subtype", "success")
+        self._merge_command_metadata(data, item)
+        for container_key in ("output", "result", "metadata", "data"):
+            nested = item.get(container_key)
+            if isinstance(nested, dict):
+                self._merge_command_metadata(data, nested)
         return data
+
+    def _merge_command_metadata(self, data: dict[str, Any], source: dict[str, Any]) -> None:
+        """Merge known command-result fields from one Codex event object."""
+        text_key_map = {
+            "output": "output",
+            "stdout": "stdout",
+            "stderr": "stderr",
+            "result_preview": "result_preview",
+            "resultPreview": "result_preview",
+            "text": "output",
+            "status": "status",
+        }
+        for key, target_key in text_key_map.items():
+            value = source.get(key)
+            if isinstance(value, str) and value.strip():
+                data.setdefault(target_key, value.strip())
+        for key in ("exit_code", "exitCode", "returncode", "return_code"):
+            value = source.get(key)
+            if isinstance(value, int):
+                data.setdefault("exit_code", value)
+                break
+        if source.get("success") is True:
+            data.setdefault("subtype", "success")
+        if source.get("ok") is True:
+            data.setdefault("subtype", "success")
 
     def _build_tool_message(
         self,

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -685,6 +685,37 @@ class TestCodexCliRuntime:
         assert message.data["output"] == "1 passed in 0.01s"
         assert message.data["exit_code"] == 0
 
+    def test_convert_command_execution_preserves_nested_output_metadata(self) -> None:
+        """Codex command result fields may arrive under nested output/result objects."""
+        runtime = CodexCliRuntime(cli_path="codex")
+
+        messages = runtime._convert_event(
+            {
+                "type": "item.completed",
+                "item": {
+                    "type": "command_execution",
+                    "command": "/bin/zsh -lc 'python -m pytest test_hello.py'",
+                    "output": {
+                        "stdout": "1 passed in 0.01s",
+                        "exit_code": 0,
+                    },
+                    "result": {"status": "completed", "success": True},
+                },
+            },
+            current_handle=None,
+        )
+
+        assert len(messages) == 1
+        message = messages[0]
+        assert message.tool_name == "Bash"
+        assert message.data["tool_input"]["command"] == (
+            "/bin/zsh -lc 'python -m pytest test_hello.py'"
+        )
+        assert message.data["stdout"] == "1 passed in 0.01s"
+        assert message.data["exit_code"] == 0
+        assert message.data["status"] == "completed"
+        assert message.data["subtype"] == "success"
+
     def test_convert_file_change_event_emits_each_changed_file(self) -> None:
         """Multi-file Codex changes should create one proof message per path."""
         runtime = CodexCliRuntime(cli_path="codex")


### PR DESCRIPTION
## Summary
- Extends Codex `command_execution` conversion to preserve allowlisted nested command result metadata from `output`, `result`, `metadata`, and `data` objects.
- Captures stdout/stderr/output previews, status, success/ok, and exit-code aliases without persisting arbitrary raw payloads.
- Adds a regression for shell-wrapped pytest output under nested Codex result objects.

## Observation context
The #978 observation failed at verifier PASS because the typed `tests_passed` claim was unsupported by runtime command evidence. This PR addresses the runtime evidence-preservation side, so the verifier has non-final command metadata to evaluate.

## Validation
- `uv run ruff check src/ouroboros/orchestrator/codex_cli_runtime.py tests/unit/orchestrator/test_codex_cli_runtime.py`
- `uv run mypy src/ouroboros/orchestrator/codex_cli_runtime.py tests/unit/orchestrator/test_codex_cli_runtime.py`
- `uv run pytest tests/unit/orchestrator/test_codex_cli_runtime.py -q -k command_execution`

Refs #978
Refs #961