### PR TITLE
fix(harness): keep fat-harness leaves scoped to the current AC

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -3737,18 +3737,25 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                     and context_governance_audit.get("context_governed") is True
                 )
                 if context_is_governed:
-                    other_list = (
-                        "Sibling tasks in progress are summarized in the governed "
-                        "sibling-status section above."
-                    )
+                    if self._fat_harness_mode and self._execution_profile is not None:
+                        other_list = (
+                            "Sibling/future ACs are summarized in the governed "
+                            "sibling-status section above as out-of-scope boundary "
+                            "context."
+                        )
+                    else:
+                        other_list = (
+                            "Sibling tasks in progress are summarized in the governed "
+                            "sibling-status section above."
+                        )
                 else:
                     sibling_heading = (
                         "Sibling/future ACs that are OUT OF SCOPE for this dispatch:"
                         if self._fat_harness_mode and self._execution_profile is not None
                         else "Sibling tasks in progress:"
                     )
-                    other_list = sibling_heading + "\n" + "\n".join(
-                        f"- {ac[:80]}" for ac in other_acs
+                    other_list = (
+                        sibling_heading + "\n" + "\n".join(f"- {ac[:80]}" for ac in other_acs)
                     )
                 if self._fat_harness_mode and self._execution_profile is not None:
                     parallel_section = (

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -3742,16 +3742,32 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                         "sibling-status section above."
                     )
                 else:
-                    other_list = "Sibling tasks in progress:\n" + "\n".join(
+                    sibling_heading = (
+                        "Sibling/future ACs that are OUT OF SCOPE for this dispatch:"
+                        if self._fat_harness_mode and self._execution_profile is not None
+                        else "Sibling tasks in progress:"
+                    )
+                    other_list = sibling_heading + "\n" + "\n".join(
                         f"- {ac[:80]}" for ac in other_acs
                     )
-                parallel_section = (
-                    "\n## Parallel Execution Notice\n"
-                    "Other agents are working on sibling tasks concurrently. "
-                    "Avoid modifying files that other agents are likely editing. "
-                    "Focus on files directly related to YOUR task.\n\n"
-                    f"{other_list}\n"
-                )
+                if self._fat_harness_mode and self._execution_profile is not None:
+                    parallel_section = (
+                        "\n## Current AC Scope Boundary\n"
+                        "Sibling/future ACs are listed only to define work that is "
+                        "outside the current dispatch. Do not satisfy those criteria "
+                        "now, and do not pre-create their files, tests, docs, or "
+                        "evidence. Avoid modifying files that sibling/future ACs are "
+                        "likely to own unless the current AC explicitly requires it.\n\n"
+                        f"{other_list}\n"
+                    )
+                else:
+                    parallel_section = (
+                        "\n## Parallel Execution Notice\n"
+                        "Other agents are working on sibling tasks concurrently. "
+                        "Avoid modifying files that other agents are likely editing. "
+                        "Focus on files directly related to YOUR task.\n\n"
+                        f"{other_list}\n"
+                    )
 
         # Scan the requested runtime workspace so prompts stay aligned with the actual task cwd.
         import os
@@ -3768,6 +3784,14 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         if self._fat_harness_mode and self._execution_profile is not None:
             required_fields = ", ".join(self._execution_profile.evidence_schema.required)
             completion_instruction = (
+                "## Current AC Scope Contract\n"
+                "You are responsible only for the current acceptance criterion in "
+                "this dispatch. Do not implement, test, document, or pre-create work "
+                "that belongs only to sibling or future ACs. If another AC mentions "
+                "related files, future functions, tests, or docs, treat that work as "
+                "out of scope unless the current AC explicitly requires it.\n"
+                "Your final evidence JSON must cite only files, commands, and tests "
+                "directly changed or run for this current AC in this runtime session.\n\n"
                 "Use the available tools to accomplish this task. Report progress through "
                 "tool-visible work, not a prose-only completion claim.\n"
                 "When complete, emit exactly ONE fenced JSON evidence record as the "

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1366,7 +1366,84 @@ class TestParallelACExecutor:
         assert "files_touched, commands_run, tests_passed" in runtime.last_prompt
         assert "do not emit a generic command_result wrapper" in runtime.last_prompt
         assert "Do not prefix it with [TASK_COMPLETE]" in runtime.last_prompt
+        assert "You are responsible only for the current acceptance criterion" in (
+            runtime.last_prompt
+        )
+        assert "Do not implement, test, document, or pre-create work" in runtime.last_prompt
+        assert "sibling or future ACs" in runtime.last_prompt
+        assert "current AC in this runtime session" in runtime.last_prompt
         assert "explicitly state: [TASK_COMPLETE]" not in runtime.last_prompt
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_sibling_context_marks_siblings_out_of_scope(self) -> None:
+        """Fat-harness sibling context must be a boundary, not an invitation."""
+        event_store, _ = _make_replaying_event_store()
+        runtime = _FinalMessageRuntime(
+            "```json\n"
+            '{"files_touched":["string_utils.py","test_slugify.py"],'
+            '"commands_run":["python -m pytest test_slugify.py"],'
+            '"tests_passed":["python -m pytest test_slugify.py"]}'
+            "\n```",
+            native_session_id="opencode-session-scope-boundary",
+            support_messages=(
+                AgentMessage(
+                    type="tool",
+                    content="Write string_utils.py",
+                    tool_name="Write",
+                    data={"tool_input": {"file_path": "string_utils.py"}},
+                ),
+                AgentMessage(
+                    type="tool",
+                    content="Write test_slugify.py",
+                    tool_name="Write",
+                    data={"tool_input": {"file_path": "test_slugify.py"}},
+                ),
+                AgentMessage(
+                    type="tool",
+                    content="Bash: python -m pytest test_slugify.py",
+                    tool_name="Bash",
+                    data={"tool_input": {"command": "python -m pytest test_slugify.py"}},
+                ),
+                AgentMessage(
+                    type="result",
+                    content="test_slugify.py passed",
+                    data={"subtype": "success"},
+                ),
+            ),
+        )
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Create string_utils.py with slugify(text) and test_slugify.py.",
+            session_id="orch_123",
+            tools=["Read", "Write", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+            sibling_acs=[
+                (0, "Create string_utils.py with slugify(text) and test_slugify.py."),
+                (1, "Add truncate(text, max_length) and test_truncate.py."),
+                (2, "Document slugify and truncate usage in README.md."),
+            ],
+        )
+
+        assert result.success is True
+        assert runtime.last_prompt is not None
+        assert "## Current AC Scope Boundary" in runtime.last_prompt
+        assert "outside the current dispatch" in runtime.last_prompt
+        assert "Do not satisfy those criteria now" in runtime.last_prompt
+        assert "do not pre-create their files, tests, docs, or evidence" in runtime.last_prompt
+        assert "Sibling tasks in progress:" not in runtime.last_prompt
 
     @pytest.mark.asyncio
     async def test_fat_harness_accepts_validation_evidence_after_code_fence(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1443,7 +1443,11 @@ class TestParallelACExecutor:
         assert "outside the current dispatch" in runtime.last_prompt
         assert "Do not satisfy those criteria now" in runtime.last_prompt
         assert "do not pre-create their files, tests, docs, or evidence" in runtime.last_prompt
-        assert "Sibling tasks in progress:" not in runtime.last_prompt
+        assert "Sibling/future ACs are summarized in the governed sibling-status" in (
+            runtime.last_prompt
+        )
+        assert "as out-of-scope boundary context" in runtime.last_prompt
+        assert "Sibling tasks in progress" not in runtime.last_prompt
 
     @pytest.mark.asyncio
     async def test_fat_harness_accepts_validation_evidence_after_code_fence(self) -> None:


### PR DESCRIPTION
## Why

The expanded controlled #978 observations passed, but the normal-usage clean-main observation on `424eee9c` exposed an AC evidence ownership/isolation seam.

In the 3-AC string-utils seed, AC1 over-executed downstream AC2/AC3 work. AC2 then claimed `files_touched` / `tests_passed` evidence that the verifier did not consider current to AC2, so the fat-harness verifier correctly rejected it as `FABRICATION_SUSPECTED`.

This PR tightens the leaf dispatch contract so fat-harness leaves stay scoped to the current AC.

## What changed

- Adds a fat-harness current-AC scope contract to atomic leaf prompts.
- Reframes sibling/future AC context as out-of-scope boundary information.
- Requires final typed evidence to cite only files/commands/tests directly performed for the current AC runtime session.
- Adds prompt regression coverage for both the base fat-harness prompt and sibling/future AC context.

## What this does not do

- Does not remove legacy self-report fallback.
- Does not relax verifier enforcement.
- Does not auto-promote prior-AC evidence to later AC success.
- Does not add a new evidence schema, Workflow IR surface, or projection layer.

## Validation

- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py -k "fat_harness_atomic_prompt or sibling_context" -q` → 2 passed
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py -q` → 95 passed
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py` → passed
- `uv run mypy src/ouroboros/orchestrator/parallel_executor.py` → success

## Follow-up

After merge, rerun the normal-usage #978/#961 observation. P5 fallback-removal should still wait until that observation passes without visible fallback acceptance.
