### PR TITLE
Keep docs-only AC evidence scoped

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -137,7 +137,7 @@ _IMPLEMENTATION_SESSION_KIND = "implementation_session"
 
 
 _DOC_ONLY_TARGET_RE = re.compile(
-    r"\b(readme(?:\.md)?|docs?/|docs?|documentation|guide|manual|changelog)\b",
+    r"\b(readme(?:\.md)?|docs?/|docs?\.[a-z0-9_-]+|documentation|guide|manual|changelog)\b",
     re.IGNORECASE,
 )
 _DOC_ONLY_ACTION_RE = re.compile(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -194,7 +194,13 @@ def _profile_with_evidence_schema(
     schema: EvidenceSchema,
 ) -> ExecutionProfile:
     """Return a shallow profile copy using an AC-specific evidence schema."""
-    return profile.model_copy(update={"evidence_schema": schema})
+    required_fields = set(schema.required)
+    must_produce = tuple(
+        field for field in profile.must_produce if field in required_fields
+    )
+    return profile.model_copy(
+        update={"evidence_schema": schema, "must_produce": must_produce}
+    )
 
 
 def _subtask_event_label(content: str, *, max_length: int = 50) -> str:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -195,12 +195,8 @@ def _profile_with_evidence_schema(
 ) -> ExecutionProfile:
     """Return a shallow profile copy using an AC-specific evidence schema."""
     required_fields = set(schema.required)
-    must_produce = tuple(
-        field for field in profile.must_produce if field in required_fields
-    )
-    return profile.model_copy(
-        update={"evidence_schema": schema, "must_produce": must_produce}
-    )
+    must_produce = tuple(field for field in profile.must_produce if field in required_fields)
+    return profile.model_copy(update={"evidence_schema": schema, "must_produce": must_produce})
 
 
 def _subtask_event_label(content: str, *, max_length: int = 50) -> str:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -148,7 +148,10 @@ _CODE_IMPLEMENTATION_ACTION_RE = re.compile(
     r"\b(implement|build|develop|ship)\b",
     re.IGNORECASE,
 )
-_CODE_MUTATION_ACTION_RE = re.compile(r"\b(add|fix|create|update)\b", re.IGNORECASE)
+_CODE_MUTATION_ACTION_RE = re.compile(
+    r"\b(add|fix|create|update|change|modify|refactor|repair)\b",
+    re.IGNORECASE,
+)
 _CODE_WORK_SIGNAL_RE = re.compile(
     r"("
     r"\b[a-zA-Z_][a-zA-Z0-9_]*\s*\("
@@ -171,11 +174,17 @@ def _has_mixed_code_and_documentation_work(ac_content: str) -> bool:
     for connector in re.finditer(r"\b(?:and|then)\b|,", ac_content, re.IGNORECASE):
         before = ac_content[: connector.start()]
         after = ac_content[connector.end() :]
-        if not _DOC_ONLY_TARGET_RE.search(after):
-            continue
-        if _DOC_ONLY_TARGET_RE.search(before):
-            continue
-        if _CODE_MUTATION_ACTION_RE.search(before) and _CODE_WORK_SIGNAL_RE.search(before):
+        before_has_docs = bool(_DOC_ONLY_TARGET_RE.search(before))
+        after_has_docs = bool(_DOC_ONLY_TARGET_RE.search(after))
+        before_has_code_work = bool(
+            _CODE_MUTATION_ACTION_RE.search(before) and _CODE_WORK_SIGNAL_RE.search(before)
+        )
+        after_has_code_work = bool(
+            _CODE_MUTATION_ACTION_RE.search(after) and _CODE_WORK_SIGNAL_RE.search(after)
+        )
+        if after_has_docs and not before_has_docs and before_has_code_work:
+            return True
+        if before_has_docs and not after_has_docs and after_has_code_work:
             return True
     return False
 

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -163,8 +163,16 @@ _CODE_WORK_SIGNAL_RE = re.compile(
     r")",
     re.IGNORECASE,
 )
-_TEST_EVIDENCE_RE = re.compile(
-    r"\b(test|tests?|pytest|unit\s+test|integration\s+test)\b",
+_TEST_WORK_RE = re.compile(
+    r"("
+    r"\b(?:run|execute|pass|validate|verify)\b.{0,40}\b(?:pytest|tests?|unit\s+tests?|integration\s+tests?)\b"
+    r"|"
+    r"\b(?:add|write|create|implement|fix|update)\b.{0,40}\b"
+    r"(?:tests?|unit\s+tests?|integration\s+tests?)\b"
+    r"(?!\s+(?:guide|docs?|documentation|setup))"
+    r"|"
+    r"\b(?:pytest|tests_passed|test\s+command)\b"
+    r")",
     re.IGNORECASE,
 )
 
@@ -200,7 +208,7 @@ def _is_documentation_only_ac(ac_content: str) -> bool:
     normalized = " ".join(ac_content.split())
     if not normalized:
         return False
-    if _TEST_EVIDENCE_RE.search(normalized):
+    if _TEST_WORK_RE.search(normalized):
         return False
     if _CODE_IMPLEMENTATION_ACTION_RE.search(normalized):
         return False

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -149,7 +149,7 @@ _CODE_IMPLEMENTATION_ACTION_RE = re.compile(
     re.IGNORECASE,
 )
 _CODE_MUTATION_ACTION_RE = re.compile(
-    r"\b(add|fix|create|update|change|modify|refactor|repair)\b",
+    r"\b(add(?:ing)?|fix(?:ing)?|create|creating|update|updating|change|changing|modify|modifying|refactor(?:ing)?|repair(?:ing)?)\b",
     re.IGNORECASE,
 )
 _CODE_WORK_SIGNAL_RE = re.compile(
@@ -179,7 +179,11 @@ _TEST_WORK_RE = re.compile(
 
 def _has_mixed_code_and_documentation_work(ac_content: str) -> bool:
     """Return True when one AC appears to combine code mutation and docs work."""
-    for connector in re.finditer(r"\b(?:and|then)\b|,", ac_content, re.IGNORECASE):
+    for connector in re.finditer(
+        r"\b(?:and|then|while|plus)\b|,",
+        ac_content,
+        re.IGNORECASE,
+    ):
         before = ac_content[: connector.start()]
         after = ac_content[connector.end() :]
         before_has_docs = bool(_DOC_ONLY_TARGET_RE.search(before))
@@ -213,6 +217,17 @@ def _is_documentation_only_ac(ac_content: str) -> bool:
     if _CODE_IMPLEMENTATION_ACTION_RE.search(normalized):
         return False
     if _has_mixed_code_and_documentation_work(normalized):
+        return False
+    if (
+        re.search(r"\bdocumentation\b", normalized, re.IGNORECASE)
+        and _CODE_MUTATION_ACTION_RE.search(normalized)
+        and _CODE_WORK_SIGNAL_RE.search(normalized)
+        and not re.search(
+            r"\b(readme(?:\.md)?|docs?/|docs?\.[a-z0-9_-]+|guide|manual|changelog)\b",
+            normalized,
+            re.IGNORECASE,
+        )
+    ):
         return False
     return bool(_DOC_ONLY_TARGET_RE.search(normalized)) and bool(
         _DOC_ONLY_ACTION_RE.search(normalized)

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -103,7 +103,7 @@ from ouroboros.orchestrator.policy import (
     PolicySessionRole,
     evaluate_capability_policy,
 )
-from ouroboros.orchestrator.profile_loader import ExecutionProfile
+from ouroboros.orchestrator.profile_loader import EvidenceSchema, ExecutionProfile
 from ouroboros.orchestrator.runtime_message_projection import (
     project_runtime_message,
 )
@@ -134,6 +134,67 @@ MIN_SUB_ACS = 2
 MAX_SUB_ACS = 5
 DECOMPOSITION_TIMEOUT_SECONDS = 60.0
 _IMPLEMENTATION_SESSION_KIND = "implementation_session"
+
+
+_DOC_ONLY_TARGET_RE = re.compile(
+    r"\b(readme(?:\.md)?|docs?/|docs?|documentation|guide|manual|changelog)\b",
+    re.IGNORECASE,
+)
+_DOC_ONLY_ACTION_RE = re.compile(
+    r"\b(document|describe|explain|add|update|create|fix|write|improve)\b",
+    re.IGNORECASE,
+)
+_CODE_IMPLEMENTATION_ACTION_RE = re.compile(
+    r"\b(implement|build|develop|ship)\b",
+    re.IGNORECASE,
+)
+_TEST_EVIDENCE_RE = re.compile(
+    r"\b(test|tests?|pytest|unit\s+test|integration\s+test)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_documentation_only_ac(ac_content: str) -> bool:
+    """Return True when an AC asks only for documentation/README work.
+
+    The code profile normally requires runnable test evidence. Normal usage can
+    still include a final docs-only AC (for example README usage examples after
+    code ACs already passed). Such an AC should be verified by docs evidence
+    from the current runtime session, not by re-claiming prior code test IDs.
+    """
+    normalized = " ".join(ac_content.split())
+    if not normalized:
+        return False
+    if _TEST_EVIDENCE_RE.search(normalized):
+        return False
+    if _CODE_IMPLEMENTATION_ACTION_RE.search(normalized):
+        return False
+    return bool(_DOC_ONLY_TARGET_RE.search(normalized)) and bool(
+        _DOC_ONLY_ACTION_RE.search(normalized)
+    )
+
+
+def _effective_evidence_schema_for_ac(
+    profile: ExecutionProfile,
+    ac_content: str,
+) -> EvidenceSchema:
+    """Return the active evidence schema for one atomic AC dispatch."""
+    schema = profile.evidence_schema
+    if not _is_documentation_only_ac(ac_content) or "tests_passed" not in schema.required:
+        return schema
+    required = tuple(field for field in schema.required if field != "tests_passed")
+    rejected_if = tuple(
+        expr for expr in schema.rejected_if if not expr.strip().startswith("tests_passed")
+    )
+    return EvidenceSchema(required=required, rejected_if=rejected_if)
+
+
+def _profile_with_evidence_schema(
+    profile: ExecutionProfile,
+    schema: EvidenceSchema,
+) -> ExecutionProfile:
+    """Return a shallow profile copy using an AC-specific evidence schema."""
+    return profile.model_copy(update={"evidence_schema": schema})
 
 
 def _subtask_event_label(content: str, *, max_length: int = 50) -> str:
@@ -3789,7 +3850,18 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
             file_listing = "(unable to list)"
 
         if self._fat_harness_mode and self._execution_profile is not None:
-            required_fields = ", ".join(self._execution_profile.evidence_schema.required)
+            effective_schema = _effective_evidence_schema_for_ac(
+                self._execution_profile, ac_content
+            )
+            required_fields = ", ".join(effective_schema.required)
+            doc_only_note = ""
+            if _is_documentation_only_ac(ac_content):
+                doc_only_note = (
+                    "This is a documentation-only current AC: verify the requested docs "
+                    "with current-session README/docs evidence such as Edit plus grep/read/diff. "
+                    "Do not include tests_passed unless this current AC explicitly required "
+                    "code tests and you ran those tests in this runtime session.\n"
+                )
             completion_instruction = (
                 "## Current AC Scope Contract\n"
                 "You are responsible only for the current acceptance criterion in "
@@ -3798,7 +3870,8 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 "related files, future functions, tests, or docs, treat that work as "
                 "out of scope unless the current AC explicitly requires it.\n"
                 "Your final evidence JSON must cite only files, commands, and tests "
-                "directly changed or run for this current AC in this runtime session.\n\n"
+                "directly changed or run for this current AC in this runtime session.\n"
+                f"{doc_only_note}\n"
                 "Use the available tools to accomplish this task. Report progress through "
                 "tool-visible work, not a prose-only completion claim.\n"
                 "When complete, emit exactly ONE fenced JSON evidence record as the "
@@ -4121,6 +4194,7 @@ Files present:
             duration = (datetime.now(UTC) - start_time).total_seconds()
 
             typed_evidence, typed_validation, typed_error = self._observe_atomic_typed_evidence(
+                ac_content=ac_content,
                 final_message=final_message,
                 success=success,
             )
@@ -4267,6 +4341,7 @@ Files present:
     def _observe_atomic_typed_evidence(
         self,
         *,
+        ac_content: str,
         final_message: str,
         success: bool,
     ) -> tuple[EvidenceRecord | None, ValidationResult | None, str | None]:
@@ -4282,7 +4357,14 @@ Files present:
 
         try:
             record = extract_evidence(final_message)
-            validation = validate_evidence(self._execution_profile, record)
+            effective_schema = _effective_evidence_schema_for_ac(
+                self._execution_profile,
+                ac_content,
+            )
+            validation = validate_evidence(
+                _profile_with_evidence_schema(self._execution_profile, effective_schema),
+                record,
+            )
         except ProfileEvidenceConfigError:
             raise
         except EvidenceError as exc:
@@ -4348,9 +4430,15 @@ Files present:
 
         verifier = self._atomic_verifier
         try:
+            effective_schema = _effective_evidence_schema_for_ac(
+                self._execution_profile, ac_content
+            )
+            effective_profile = _profile_with_evidence_schema(
+                self._execution_profile, effective_schema
+            )
             verdict = (
                 verifier(
-                    profile=self._execution_profile,
+                    profile=effective_profile,
                     ac=ac_content,
                     leaf_output=final_message,
                     record=typed_evidence,
@@ -4359,6 +4447,7 @@ Files present:
                 else self._verify_atomic_evidence_against_runtime_messages(
                     messages=messages,
                     typed_evidence=typed_evidence,
+                    ac_content=ac_content,
                 )
             )
         except VerifierContractError:
@@ -4375,6 +4464,7 @@ Files present:
         *,
         messages: tuple[AgentMessage, ...],
         typed_evidence: EvidenceRecord,
+        ac_content: str,
     ) -> VerifierVerdict:
         """Verify leaf evidence is backed by runtime transcript events.
 
@@ -4398,10 +4488,20 @@ Files present:
                 _runtime_support_messages_for_field("commands_run", support_messages),
             )
         )
+        effective_schema = _effective_evidence_schema_for_ac(self._execution_profile, ac_content)
+        required_fields = set(effective_schema.required)
+        fields_to_verify = list(effective_schema.required)
         for field_name in self._execution_profile.evidence_schema.required:
+            if field_name not in required_fields and _flatten_evidence_values(
+                typed_evidence.get(field_name)
+            ):
+                fields_to_verify.append(field_name)
+
+        for field_name in fields_to_verify:
             values = tuple(_flatten_evidence_values(typed_evidence.get(field_name)))
             if not values:
-                unsupported.append(f"{field_name}: no concrete claim values")
+                if field_name in required_fields:
+                    unsupported.append(f"{field_name}: no concrete claim values")
                 continue
             field_messages = _runtime_support_messages_for_field(field_name, support_messages)
             for value in values:
@@ -4462,7 +4562,9 @@ Files present:
             "session_id": session_id,
             "acceptance_criterion": ac_content,
             "profile": self._execution_profile.profile,
-            "required_fields": list(self._execution_profile.evidence_schema.required),
+            "required_fields": list(
+                _effective_evidence_schema_for_ac(self._execution_profile, ac_content).required
+            ),
             "observe_only": not self._fat_harness_mode,
             "enforced": self._fat_harness_mode,
             "fat_harness_mode": self._fat_harness_mode,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -148,6 +148,7 @@ _CODE_IMPLEMENTATION_ACTION_RE = re.compile(
     r"\b(implement|build|develop|ship)\b",
     re.IGNORECASE,
 )
+_CODE_MUTATION_ACTION_RE = re.compile(r"\b(add|fix|create|update)\b", re.IGNORECASE)
 _CODE_WORK_SIGNAL_RE = re.compile(
     r"("
     r"\b[a-zA-Z_][a-zA-Z0-9_]*\s*\("
@@ -165,6 +166,20 @@ _TEST_EVIDENCE_RE = re.compile(
 )
 
 
+def _has_mixed_code_and_documentation_work(ac_content: str) -> bool:
+    """Return True when one AC appears to combine code mutation and docs work."""
+    for connector in re.finditer(r"\b(?:and|then)\b|,", ac_content, re.IGNORECASE):
+        before = ac_content[: connector.start()]
+        after = ac_content[connector.end() :]
+        if not _DOC_ONLY_TARGET_RE.search(after):
+            continue
+        if _DOC_ONLY_TARGET_RE.search(before):
+            continue
+        if _CODE_MUTATION_ACTION_RE.search(before) and _CODE_WORK_SIGNAL_RE.search(before):
+            return True
+    return False
+
+
 def _is_documentation_only_ac(ac_content: str) -> bool:
     """Return True when an AC asks only for documentation/README work.
 
@@ -180,9 +195,7 @@ def _is_documentation_only_ac(ac_content: str) -> bool:
         return False
     if _CODE_IMPLEMENTATION_ACTION_RE.search(normalized):
         return False
-    if _CODE_WORK_SIGNAL_RE.search(normalized):
-        return False
-    if len(_DOC_ONLY_ACTION_RE.findall(normalized)) > 1:
+    if _has_mixed_code_and_documentation_work(normalized):
         return False
     return bool(_DOC_ONLY_TARGET_RE.search(normalized)) and bool(
         _DOC_ONLY_ACTION_RE.search(normalized)

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -148,6 +148,17 @@ _CODE_IMPLEMENTATION_ACTION_RE = re.compile(
     r"\b(implement|build|develop|ship)\b",
     re.IGNORECASE,
 )
+_CODE_WORK_SIGNAL_RE = re.compile(
+    r"("
+    r"\b[a-zA-Z_][a-zA-Z0-9_]*\s*\("
+    r"|"
+    r"\.(?:py|pyi|js|jsx|ts|tsx|go|rs|java|kt|c|cc|cpp|h|hpp|swift|rb|php|sh|zsh|fish)\b"
+    r"|"
+    r"\b(parser|function|module|api|endpoint|class|method|cli\s+flag|flag|command|"
+    r"bug|runtime|workflow|validator|validation|implementation)\b"
+    r")",
+    re.IGNORECASE,
+)
 _TEST_EVIDENCE_RE = re.compile(
     r"\b(test|tests?|pytest|unit\s+test|integration\s+test)\b",
     re.IGNORECASE,
@@ -168,6 +179,10 @@ def _is_documentation_only_ac(ac_content: str) -> bool:
     if _TEST_EVIDENCE_RE.search(normalized):
         return False
     if _CODE_IMPLEMENTATION_ACTION_RE.search(normalized):
+        return False
+    if _CODE_WORK_SIGNAL_RE.search(normalized):
+        return False
+    if len(_DOC_ONLY_ACTION_RE.findall(normalized)) > 1:
         return False
     return bool(_DOC_ONLY_TARGET_RE.search(normalized)) and bool(
         _DOC_ONLY_ACTION_RE.search(normalized)

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1630,6 +1630,9 @@ class TestParallelACExecutor:
             "Write docs/api.md and add endpoint validation.",
             "Document README.md, then create parser.py.",
             "Run pytest and update README.md.",
+            "Add docs command to CLI.",
+            "Create docs endpoint.",
+            "Fix docs parser bug.",
         ],
     )
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1624,6 +1624,9 @@ class TestParallelACExecutor:
         [
             "Add slugify() and update README.md.",
             "Fix parser bug and document it in docs/.",
+            "Update README.md and fix parser bug.",
+            "Write docs/api.md and add endpoint validation.",
+            "Document README.md, then create parser.py.",
         ],
     )
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1458,6 +1458,8 @@ class TestParallelACExecutor:
             ("Document the API in docs/api.md.", "docs/api.md"),
             ("Write a CLI flag guide in README.md.", "README.md"),
             ("Update the changelog for the parser bug.", "CHANGELOG.md"),
+            ("Document test setup in README.md.", "README.md"),
+            ("Write a unit test guide in docs/testing.md.", "docs/testing.md"),
         ],
     )
     @pytest.mark.asyncio
@@ -1627,6 +1629,7 @@ class TestParallelACExecutor:
             "Update README.md and fix parser bug.",
             "Write docs/api.md and add endpoint validation.",
             "Document README.md, then create parser.py.",
+            "Run pytest and update README.md.",
         ],
     )
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1375,6 +1375,238 @@ class TestParallelACExecutor:
         assert "explicitly state: [TASK_COMPLETE]" not in runtime.last_prompt
 
     @pytest.mark.asyncio
+    async def test_fat_harness_docs_only_ac_uses_docs_evidence_contract(self, tmp_path) -> None:
+        """Regression for #961: README-only ACs must not require prior test IDs."""
+        readme = tmp_path / "README.md"
+        readme.write_text("# String utils\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        runtime = _FinalMessageRuntime(
+            "```json\n"
+            "{\n"
+            '  "files_touched": ["README.md"],\n'
+            '  "commands_run": ["grep -n slugify README.md"]\n'
+            "}\n"
+            "```",
+            native_session_id="codex-session-docs-only-current-ac",
+            support_messages=(
+                AgentMessage(
+                    type="assistant",
+                    content=f"Calling tool: Edit: {readme}",
+                    tool_name="Edit",
+                    data={"tool_input": {"file_path": str(readme)}},
+                ),
+                AgentMessage(
+                    type="assistant",
+                    content="Calling tool: Bash: grep -n slugify README.md",
+                    tool_name="Bash",
+                    data={
+                        "tool_input": {"command": "grep -n slugify README.md"},
+                        "output": "12:slugify('Hello World') -> hello-world",
+                        "exit_code": 0,
+                    },
+                ),
+            ),
+            cwd=str(tmp_path),
+        )
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=2,
+            ac_content="Document slugify and truncate usage in README.md.",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+            sibling_acs=[
+                (0, "Create string_utils.py with slugify(text) and test_slugify.py."),
+                (1, "Add truncate(text, max_length) and test_truncate.py."),
+                (2, "Document slugify and truncate usage in README.md."),
+            ],
+        )
+
+        assert result.success is True
+        assert result.error is None
+        assert runtime.last_prompt is not None
+        assert "documentation-only current AC" in runtime.last_prompt
+        assert "files_touched, commands_run" in runtime.last_prompt
+        assert "files_touched, commands_run, tests_passed" not in runtime.last_prompt
+        assert result.typed_evidence is not None
+        assert "tests_passed" not in result.typed_evidence.data
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["required_fields"] == ["files_touched", "commands_run"]
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_markdown_code_ac_keeps_test_evidence_required(
+        self, tmp_path
+    ) -> None:
+        """A markdown-related implementation AC must not be misclassified as docs-only."""
+        parser_file = tmp_path / "src" / "markdown_parser.py"
+        parser_file.parent.mkdir()
+        parser_file.write_text("def parse(text):\n    return text\n", encoding="utf-8")
+        test_file = tmp_path / "tests" / "test_markdown_parser.py"
+        test_file.parent.mkdir()
+        test_file.write_text("def test_parse():\n    assert True\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        runtime = _FinalMessageRuntime(
+            "```json\n"
+            "{\n"
+            '  "files_touched": ["src/markdown_parser.py", "tests/test_markdown_parser.py"],\n'
+            '  "commands_run": ["python -m pytest tests/test_markdown_parser.py"],\n'
+            '  "tests_passed": ["tests/test_markdown_parser.py::test_parse"]\n'
+            "}\n"
+            "```",
+            native_session_id="codex-session-markdown-code-ac",
+            support_messages=(
+                AgentMessage(
+                    type="assistant",
+                    content=f"Calling tool: Edit: {parser_file}",
+                    tool_name="Edit",
+                    data={"tool_input": {"file_path": str(parser_file)}},
+                ),
+                AgentMessage(
+                    type="assistant",
+                    content=f"Calling tool: Edit: {test_file}",
+                    tool_name="Edit",
+                    data={"tool_input": {"file_path": str(test_file)}},
+                ),
+                AgentMessage(
+                    type="assistant",
+                    content="Calling tool: Bash: python -m pytest tests/test_markdown_parser.py",
+                    tool_name="Bash",
+                    data={
+                        "tool_input": {"command": "python -m pytest tests/test_markdown_parser.py"},
+                        "output": "tests/test_markdown_parser.py::test_parse passed; 1 passed",
+                        "exit_code": 0,
+                    },
+                ),
+            ),
+            cwd=str(tmp_path),
+        )
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement a markdown parser and usage examples.",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship markdown support",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert runtime.last_prompt is not None
+        assert "documentation-only current AC" not in runtime.last_prompt
+        assert "files_touched, commands_run, tests_passed" in runtime.last_prompt
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["required_fields"] == [
+            "files_touched",
+            "commands_run",
+            "tests_passed",
+        ]
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_docs_only_ac_rejects_prior_test_id_bleed(self, tmp_path) -> None:
+        """Docs-only ACs may omit tests, but non-empty stale tests_passed is still checked."""
+        readme = tmp_path / "README.md"
+        readme.write_text("# String utils\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["README.md"],\n'
+                '  "commands_run": ["grep -n slugify README.md"],\n'
+                '  "tests_passed": ["test_slugify.py::test_slugify"]\n'
+                "}\n"
+                "```",
+                native_session_id="codex-session-docs-only-prior-test-bleed",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {readme}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(readme)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content="Calling tool: Bash: grep -n slugify README.md",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {"command": "grep -n slugify README.md"},
+                            "output": "12:slugify('Hello World') -> hello-world",
+                            "exit_code": 0,
+                        },
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=2,
+            ac_content="Document slugify and truncate usage in README.md.",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "tests_passed: test_slugify.py::test_slugify" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["required_fields"] == ["files_touched", "commands_run"]
+        assert evidence_event.data["verifier_failure_class"] == "FABRICATION_SUSPECTED"
+
+    @pytest.mark.asyncio
     async def test_fat_harness_sibling_context_marks_siblings_out_of_scope(self) -> None:
         """Fat-harness sibling context must be a boundary, not an invitation."""
         event_store, _ = _make_replaying_event_store()

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1607,6 +1607,87 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_failure_class"] == "FABRICATION_SUSPECTED"
 
     @pytest.mark.asyncio
+    async def test_fat_harness_docs_only_ac_passes_consistent_profile_to_injected_verifier(
+        self, tmp_path
+    ) -> None:
+        """Docs-only AC profile overrides must keep must_produce within required evidence."""
+        readme = tmp_path / "README.md"
+        readme.write_text("# String utils\n", encoding="utf-8")
+        verifier_profiles: list[tuple[tuple[str, ...], tuple[str, ...]]] = []
+
+        def _recording_verifier(**kwargs: object) -> VerifierVerdict:
+            profile = kwargs["profile"]
+            verifier_profiles.append(
+                (
+                    tuple(profile.evidence_schema.required),  # type: ignore[attr-defined]
+                    tuple(profile.must_produce),  # type: ignore[attr-defined]
+                )
+            )
+            return VerifierVerdict(passed=True)
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["README.md"],\n'
+                '  "commands_run": ["grep -n slugify README.md"]\n'
+                "}\n"
+                "```",
+                native_session_id="codex-session-docs-only-injected-verifier",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {readme}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(readme)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content="Calling tool: Bash: grep -n slugify README.md",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {"command": "grep -n slugify README.md"},
+                            "output": "12:slugify('Hello World') -> hello-world",
+                            "exit_code": 0,
+                        },
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            atomic_verifier=_recording_verifier,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=2,
+            ac_content="Document slugify and truncate usage in README.md.",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert verifier_profiles == [(("files_touched", "commands_run"), ("files_touched",))]
+        assert set(verifier_profiles[0][1]).issubset(verifier_profiles[0][0])
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["required_fields"] == ["files_touched", "commands_run"]
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
     async def test_fat_harness_sibling_context_marks_siblings_out_of_scope(self) -> None:
         """Fat-harness sibling context must be a boundary, not an invitation."""
         event_store, _ = _make_replaying_event_store()

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1633,6 +1633,9 @@ class TestParallelACExecutor:
             "Add docs command to CLI.",
             "Create docs endpoint.",
             "Fix docs parser bug.",
+            "Update README.md while fixing parser bug.",
+            "Update README.md plus fix parser bug.",
+            "Fix documentation parser bug.",
         ],
     )
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1452,6 +1452,87 @@ class TestParallelACExecutor:
         assert evidence_event.data["required_fields"] == ["files_touched", "commands_run"]
         assert evidence_event.data["verifier_passed"] is True
 
+    @pytest.mark.parametrize(
+        ("ac_content", "doc_path"),
+        [
+            ("Document the API in docs/api.md.", "docs/api.md"),
+            ("Write a CLI flag guide in README.md.", "README.md"),
+            ("Update the changelog for the parser bug.", "CHANGELOG.md"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_fat_harness_docs_only_ac_allows_code_subject_documentation(
+        self, tmp_path, ac_content: str, doc_path: str
+    ) -> None:
+        """Docs about code subjects are still docs-only when they do not mutate code."""
+        doc_file = tmp_path / doc_path
+        doc_file.parent.mkdir(parents=True, exist_ok=True)
+        doc_file.write_text("Documentation\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        runtime = _FinalMessageRuntime(
+            "```json\n"
+            "{\n"
+            f'  "files_touched": ["{doc_path}"],\n'
+            f'  "commands_run": ["grep -n Documentation {doc_path}"]\n'
+            "}\n"
+            "```",
+            native_session_id="codex-session-docs-only-code-subject",
+            support_messages=(
+                AgentMessage(
+                    type="assistant",
+                    content=f"Calling tool: Edit: {doc_file}",
+                    tool_name="Edit",
+                    data={"tool_input": {"file_path": str(doc_file)}},
+                ),
+                AgentMessage(
+                    type="assistant",
+                    content=f"Calling tool: Bash: grep -n Documentation {doc_path}",
+                    tool_name="Bash",
+                    data={
+                        "tool_input": {"command": f"grep -n Documentation {doc_path}"},
+                        "output": "1:Documentation",
+                        "exit_code": 0,
+                    },
+                ),
+            ),
+            cwd=str(tmp_path),
+        )
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content=ac_content,
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship docs",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert runtime.last_prompt is not None
+        assert "documentation-only current AC" in runtime.last_prompt
+        assert "files_touched, commands_run" in runtime.last_prompt
+        assert "files_touched, commands_run, tests_passed" not in runtime.last_prompt
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["required_fields"] == ["files_touched", "commands_run"]
+        assert evidence_event.data["verifier_passed"] is True
+
     @pytest.mark.asyncio
     async def test_fat_harness_markdown_code_ac_keeps_test_evidence_required(
         self, tmp_path

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1538,6 +1538,107 @@ class TestParallelACExecutor:
         ]
         assert evidence_event.data["verifier_passed"] is True
 
+    @pytest.mark.parametrize(
+        "ac_content",
+        [
+            "Add slugify() and update README.md.",
+            "Fix parser bug and document it in docs/.",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_fat_harness_mixed_code_and_docs_ac_keeps_test_evidence_required(
+        self, tmp_path, ac_content: str
+    ) -> None:
+        """Mixed implementation/docs ACs must not drop tests_passed from code profile evidence."""
+        source_file = tmp_path / "src" / "string_utils.py"
+        source_file.parent.mkdir()
+        source_file.write_text("def slugify(text):\n    return text.lower()\n", encoding="utf-8")
+        test_file = tmp_path / "tests" / "test_string_utils.py"
+        test_file.parent.mkdir()
+        test_file.write_text("def test_slugify():\n    assert True\n", encoding="utf-8")
+        readme = tmp_path / "README.md"
+        readme.write_text("# String utils\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        runtime = _FinalMessageRuntime(
+            "```json\n"
+            "{\n"
+            '  "files_touched": ["src/string_utils.py", "tests/test_string_utils.py", "README.md"],\n'
+            '  "commands_run": ["python -m pytest tests/test_string_utils.py"],\n'
+            '  "tests_passed": ["tests/test_string_utils.py::test_slugify"]\n'
+            "}\n"
+            "```",
+            native_session_id="codex-session-mixed-code-docs-ac",
+            support_messages=(
+                AgentMessage(
+                    type="assistant",
+                    content=f"Calling tool: Edit: {source_file}",
+                    tool_name="Edit",
+                    data={"tool_input": {"file_path": str(source_file)}},
+                ),
+                AgentMessage(
+                    type="assistant",
+                    content=f"Calling tool: Edit: {test_file}",
+                    tool_name="Edit",
+                    data={"tool_input": {"file_path": str(test_file)}},
+                ),
+                AgentMessage(
+                    type="assistant",
+                    content=f"Calling tool: Edit: {readme}",
+                    tool_name="Edit",
+                    data={"tool_input": {"file_path": str(readme)}},
+                ),
+                AgentMessage(
+                    type="assistant",
+                    content="Calling tool: Bash: python -m pytest tests/test_string_utils.py",
+                    tool_name="Bash",
+                    data={
+                        "tool_input": {"command": "python -m pytest tests/test_string_utils.py"},
+                        "output": "tests/test_string_utils.py::test_slugify passed; 1 passed",
+                        "exit_code": 0,
+                    },
+                ),
+            ),
+            cwd=str(tmp_path),
+        )
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content=ac_content,
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert runtime.last_prompt is not None
+        assert "documentation-only current AC" not in runtime.last_prompt
+        assert "files_touched, commands_run, tests_passed" in runtime.last_prompt
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["required_fields"] == [
+            "files_touched",
+            "commands_run",
+            "tests_passed",
+        ]
+        assert evidence_event.data["verifier_passed"] is True
+
     @pytest.mark.asyncio
     async def test_fat_harness_docs_only_ac_rejects_prior_test_id_bleed(self, tmp_path) -> None:
         """Docs-only ACs may omit tests, but non-empty stale tests_passed is still checked."""


### PR DESCRIPTION
## Summary
- Treat documentation-only atomic ACs under the code profile as docs evidence leaves, requiring current-session `files_touched` + `commands_run` instead of `tests_passed`.
- Update the fat-harness prompt so README/docs ACs explicitly avoid prior/future AC test evidence.
- Keep fabrication protection: if a docs-only AC still emits a non-empty `tests_passed`, the verifier checks it and rejects unsupported prior-test bleed.

## Why
Latest #961/#978 observation on main `67e473327` showed AC1/AC2 scoped execution fixed, but AC3 README-only work failed because final evidence claimed AC1/AC2 test IDs and the verifier returned `FABRICATION_SUSPECTED`.

## Validation
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py`
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py -q`
- `uv run pytest tests/unit/orchestrator/test_profile_strategy.py tests/unit/orchestrator/test_parallel_executor.py -q`

## Not tested
- Full live `ouroboros run normal-usage-string-utils-seed-978.yaml` re-observation with external Codex/OpenCode runtime. That should be rerun after merge on fresh latest-main for #961 closure.
