### PR TITLE
Accept unittest evidence summaries

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -665,9 +665,9 @@ def _runtime_message_test_proof_text(message: AgentMessage) -> str:
     is not runtime output for that command. Keep summary matching tied to the
     Bash output/result payloads and tool-result messages that runtimes emit.
     """
-    resultish = message.type in {"result", "tool_result"} or message.data.get(
-        "subtype"
-    ) == "tool_result"
+    resultish = (
+        message.type in {"result", "tool_result"} or message.data.get("subtype") == "tool_result"
+    )
     parts: list[str] = []
     if resultish:
         parts.append(message.content)
@@ -812,9 +812,7 @@ def _runtime_messages_support_test_claim(
         if not any(_message_contains_test_success(item) for item in chunk):
             continue
         chunk_text = "\n".join(_runtime_message_search_text(item) for item in chunk)
-        chunk_test_proof_text = "\n".join(
-            _runtime_message_test_proof_text(item) for item in chunk
-        )
+        chunk_test_proof_text = "\n".join(_runtime_message_test_proof_text(item) for item in chunk)
         if any(
             _test_command_targets_claim(
                 command=command,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -616,24 +616,16 @@ def _looks_like_test_command(command: str) -> bool:
         re.search(
             r"(^|[\s;&|])("
             r"pytest|py\.test|tox|nox|npm\s+test|pnpm\s+test|yarn\s+test|"
-            r"uv\s+run\s+pytest|python\s+-m\s+pytest"
+            r"uv\s+run\s+pytest|python\s+-m\s+pytest|python\s+-m\s+unittest"
             r")($|[\s;&|])",
             normalized,
         )
     )
 
 
-def _message_contains_test_success(message: AgentMessage) -> bool:
-    """Return True when one message says a test command passed."""
-    parts = [message.content]
-    for key in ("result_preview", "output", "stdout", "status", "subtype"):
-        value = message.data.get(key)
-        if isinstance(value, str):
-            parts.append(value)
-    exit_code = message.data.get("exit_code")
-    if type(exit_code) is int:
-        parts.append(f"exit code {exit_code}")
-    text = "\n".join(parts).lower()
+def _text_contains_test_success(text: str) -> bool:
+    """Return True when text contains a conservative test-success signal."""
+    text = text.lower()
     zero_failure_pattern = (
         r"\b(0\s+(failed|failures?|errors?)|no\s+(tests?\s+)?(failed|failures?|errors?))\b"
     )
@@ -649,7 +641,21 @@ def _message_contains_test_success(message: AgentMessage) -> bool:
         return False
     return bool(
         re.search(r"\b([1-9]\d*\s+passed|passed|pass|success|succeeded)\b|exit\s*code\s*0", text)
+        or re.search(r"\bran\s+[1-9]\d*\s+tests?\b[\s\S]*\bok\b", text)
     )
+
+
+def _message_contains_test_success(message: AgentMessage) -> bool:
+    """Return True when one message says a test command passed."""
+    parts = [message.content]
+    for key in ("result_preview", "output", "stdout", "status", "subtype"):
+        value = message.data.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+    exit_code = message.data.get("exit_code")
+    if type(exit_code) is int:
+        parts.append(f"exit code {exit_code}")
+    return _text_contains_test_success("\n".join(parts))
 
 
 def _test_claim_file_part(value: str) -> str | None:
@@ -659,6 +665,34 @@ def _test_claim_file_part(value: str) -> str | None:
         return None
     file_part = stripped.split("::", 1)[0].strip()
     return file_part or None
+
+
+def _normalized_evidence_text(text: str) -> str:
+    """Normalize transcript/claim text for conservative containment checks."""
+    return " ".join(text.lower().split())
+
+
+def _claim_summary_matches_runtime_chunk(
+    *,
+    command: str,
+    claim: str,
+    chunk_text: str,
+) -> bool:
+    """Return True when a command+summary claim is present in runtime output.
+
+    This keeps the verifier transcript-driven: the claim may combine the backed
+    command and a unittest-style success summary, but the summary itself must
+    also appear in the runtime chunk. The claim text alone is never proof.
+    """
+    normalized_command = _normalized_evidence_text(command)
+    normalized_claim = _normalized_evidence_text(claim)
+    normalized_chunk = _normalized_evidence_text(chunk_text)
+    if not normalized_command or normalized_command not in normalized_claim:
+        return False
+    summary = normalized_claim.split(normalized_command, 1)[1].strip(" :-")
+    if not summary or summary not in normalized_chunk:
+        return False
+    return _text_contains_test_success(summary)
 
 
 def _test_command_targets_claim(
@@ -680,6 +714,8 @@ def _test_command_targets_claim(
     normalized_file = file_part.lower()
     normalized_command = command.lower()
     if normalized_file in chunk_text or normalized_file in normalized_command:
+        return True
+    if _claim_summary_matches_runtime_chunk(command=command, claim=claim, chunk_text=chunk_text):
         return True
 
     # A broad suite command such as ``pytest`` can cover a node-id claim when

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -623,6 +623,21 @@ def _looks_like_test_command(command: str) -> bool:
     )
 
 
+def _looks_like_unittest_command(command: str) -> bool:
+    """Return True when a shell command invokes stdlib unittest."""
+    normalized = command.strip().lower()
+    if not normalized:
+        return False
+    return bool(re.search(r"(^|[\s;&|])python\s+-m\s+unittest($|[\s;&|])", normalized))
+
+
+def _text_contains_unittest_success(text: str) -> bool:
+    """Return True for real unittest success output."""
+    return _text_contains_test_success(text) and bool(
+        re.search(r"\bran\s+[1-9]\d*\s+tests?\b[\s\S]*\bok\b", text.lower())
+    )
+
+
 def _text_contains_test_success(text: str) -> bool:
     """Return True when text contains a conservative test-success signal."""
     text = text.lower()
@@ -720,6 +735,12 @@ def _claim_summary_matches_runtime_chunk(
     summary = normalized_claim.split(normalized_command, 1)[1].strip(" :-")
     if not summary or summary not in normalized_chunk:
         return False
+    if (
+        summary == "ok"
+        and _looks_like_unittest_command(command)
+        and _text_contains_unittest_success(chunk_text)
+    ):
+        return True
     return _text_contains_test_success(summary)
 
 

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -35,6 +35,7 @@ import os
 from pathlib import Path
 import platform
 import re
+import shlex
 import subprocess
 import time
 from typing import TYPE_CHECKING, Any
@@ -612,23 +613,71 @@ def _looks_like_test_command(command: str) -> bool:
     normalized = command.strip().lower()
     if not normalized:
         return False
+    if _unittest_command_invocation(normalized) is not None:
+        return True
     return bool(
         re.search(
             r"(^|[\s;&|])("
             r"pytest|py\.test|tox|nox|npm\s+test|pnpm\s+test|yarn\s+test|"
-            r"uv\s+run\s+pytest|python\s+-m\s+pytest|python\s+-m\s+unittest"
+            r"uv\s+run\s+pytest|python\s+-m\s+pytest"
             r")($|[\s;&|])",
             normalized,
         )
     )
 
 
-def _looks_like_unittest_command(command: str) -> bool:
-    """Return True when a shell command invokes stdlib unittest."""
+def _unittest_command_invocation(command: str) -> str | None:
+    """Return the embedded ``python -m unittest`` invocation, if present."""
     normalized = command.strip().lower()
     if not normalized:
-        return False
-    return bool(re.search(r"(^|[\s;&|])python\s+-m\s+unittest($|[\s;&|])", normalized))
+        return None
+
+    direct = _unittest_invocation_from_prefix(normalized)
+    if direct is not None:
+        return direct
+
+    shell_match = re.search(
+        r"^(?:[\w./-]+/)?(?:bash|zsh|sh)\s+-(?:l?c|c)\s+"
+        r"(?P<quote>['\"])(?P<body>.*?)(?P=quote)"
+        r"(?=$|[\s;&|])",
+        normalized,
+    )
+    if shell_match is None:
+        return None
+    return _unittest_invocation_from_prefix(shell_match.group("body").strip())
+
+
+def _unittest_invocation_from_prefix(command: str) -> str | None:
+    """Return a normalized unittest invocation only when it starts the command text."""
+    match = re.search(
+        r"^"
+        r"(python\s+-m\s+unittest"
+        r"(?:\s+(?:\"[^\"]+\"|'[^']+'|[^\s;&|'\"]+))*)"
+        r"(?=$|[\s;&|'\"])",
+        command,
+    )
+    if match is None:
+        return None
+    try:
+        parts = shlex.split(match.group(1))
+    except ValueError:
+        parts = match.group(1).replace('"', "").replace("'", "").split()
+    return _normalized_evidence_text(" ".join(parts))
+
+
+def _looks_like_unittest_command(command: str) -> bool:
+    """Return True when a shell command invokes stdlib unittest."""
+    return _unittest_command_invocation(command) is not None
+
+
+def _normalized_command_claim_aliases(command: str) -> tuple[str, ...]:
+    """Return normalized command forms that a concise evidence claim may use."""
+    normalized = _normalized_evidence_text(command)
+    aliases = [normalized] if normalized else []
+    unittest_invocation = _unittest_command_invocation(command)
+    if unittest_invocation and unittest_invocation not in aliases:
+        aliases.append(unittest_invocation)
+    return tuple(aliases)
 
 
 def _text_contains_unittest_success(text: str) -> bool:
@@ -727,12 +776,13 @@ def _claim_summary_matches_runtime_chunk(
     command and a unittest-style success summary, but the summary itself must
     also appear in the runtime chunk. The claim text alone is never proof.
     """
-    normalized_command = _normalized_evidence_text(command)
     normalized_claim = _normalized_evidence_text(claim)
     normalized_chunk = _normalized_evidence_text(chunk_text)
-    if not normalized_command or normalized_command not in normalized_claim:
-        return False
-    summary = normalized_claim.split(normalized_command, 1)[1].strip(" :-")
+    summary = ""
+    for normalized_command in _normalized_command_claim_aliases(command):
+        if normalized_command in normalized_claim:
+            summary = normalized_claim.split(normalized_command, 1)[1].strip(" :-")
+            break
     if not summary or summary not in normalized_chunk:
         return False
     if (
@@ -746,12 +796,12 @@ def _claim_summary_matches_runtime_chunk(
 
 def _claim_contains_command_success_summary(*, command: str, claim: str) -> bool:
     """Return True when a test claim appends a success summary to a command."""
-    normalized_command = _normalized_evidence_text(command)
     normalized_claim = _normalized_evidence_text(claim)
-    if not normalized_command or normalized_command not in normalized_claim:
-        return False
-    summary = normalized_claim.split(normalized_command, 1)[1].strip(" :-")
-    return bool(summary) and _text_contains_test_success(summary)
+    for normalized_command in _normalized_command_claim_aliases(command):
+        if normalized_command in normalized_claim:
+            summary = normalized_claim.split(normalized_command, 1)[1].strip(" :-")
+            return bool(summary) and _text_contains_test_success(summary)
+    return False
 
 
 def _test_command_targets_claim(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -658,6 +658,34 @@ def _message_contains_test_success(message: AgentMessage) -> bool:
     return _text_contains_test_success("\n".join(parts))
 
 
+def _runtime_message_test_proof_text(message: AgentMessage) -> str:
+    """Return runtime-produced text that can prove test output for a Bash chunk.
+
+    Assistant narration after a Bash call is useful transcript context, but it
+    is not runtime output for that command. Keep summary matching tied to the
+    Bash output/result payloads and tool-result messages that runtimes emit.
+    """
+    resultish = message.type in {"result", "tool_result"} or message.data.get(
+        "subtype"
+    ) == "tool_result"
+    parts: list[str] = []
+    if resultish:
+        parts.append(message.content)
+    for key in ("result_preview", "output", "stdout", "stderr", "tool_result_text"):
+        value = message.data.get(key)
+        if isinstance(value, str):
+            parts.append(value)
+    tool_result = message.data.get("tool_result")
+    if isinstance(tool_result, dict):
+        for key in ("text_content", "content", "output", "stdout", "stderr"):
+            value = tool_result.get(key)
+            if isinstance(value, str):
+                parts.append(value)
+    elif isinstance(tool_result, str):
+        parts.append(tool_result)
+    return "\n".join(parts)
+
+
 def _test_claim_file_part(value: str) -> str | None:
     """Return the file path portion of a pytest node-id style claim."""
     stripped = value.strip()
@@ -695,16 +723,33 @@ def _claim_summary_matches_runtime_chunk(
     return _text_contains_test_success(summary)
 
 
+def _claim_contains_command_success_summary(*, command: str, claim: str) -> bool:
+    """Return True when a test claim appends a success summary to a command."""
+    normalized_command = _normalized_evidence_text(command)
+    normalized_claim = _normalized_evidence_text(claim)
+    if not normalized_command or normalized_command not in normalized_claim:
+        return False
+    summary = normalized_claim.split(normalized_command, 1)[1].strip(" :-")
+    return bool(summary) and _text_contains_test_success(summary)
+
+
 def _test_command_targets_claim(
     *,
     command: str,
     claim: str,
     chunk_text: str,
+    chunk_test_proof_text: str,
     messages: tuple[AgentMessage, ...],
     task_cwd: str | None,
 ) -> bool:
     """Return True when a successful test command can cover a test claim."""
     needle = claim.strip().lower()
+    if _claim_contains_command_success_summary(command=command, claim=claim):
+        return _claim_summary_matches_runtime_chunk(
+            command=command,
+            claim=claim,
+            chunk_text=chunk_test_proof_text,
+        )
     if needle and needle in chunk_text:
         return True
 
@@ -715,7 +760,11 @@ def _test_command_targets_claim(
     normalized_command = command.lower()
     if normalized_file in chunk_text or normalized_file in normalized_command:
         return True
-    if _claim_summary_matches_runtime_chunk(command=command, claim=claim, chunk_text=chunk_text):
+    if _claim_summary_matches_runtime_chunk(
+        command=command,
+        claim=claim,
+        chunk_text=chunk_test_proof_text,
+    ):
         return True
 
     # A broad suite command such as ``pytest`` can cover a node-id claim when
@@ -763,11 +812,15 @@ def _runtime_messages_support_test_claim(
         if not any(_message_contains_test_success(item) for item in chunk):
             continue
         chunk_text = "\n".join(_runtime_message_search_text(item) for item in chunk)
+        chunk_test_proof_text = "\n".join(
+            _runtime_message_test_proof_text(item) for item in chunk
+        )
         if any(
             _test_command_targets_claim(
                 command=command,
                 claim=value,
                 chunk_text=chunk_text,
+                chunk_test_proof_text=chunk_test_proof_text,
                 messages=messages,
                 task_cwd=task_cwd,
             )

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -3356,6 +3356,99 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_passed"] is True
 
     @pytest.mark.asyncio
+    async def test_fat_harness_verifier_accepts_unittest_command_bare_ok_claim(
+        self, tmp_path
+    ) -> None:
+        """A backed unittest command plus bare OK can rely on real Bash unittest output."""
+        source_file = tmp_path / "string_utils.py"
+        test_file = tmp_path / "test_slugify.py"
+        source_file.write_text(
+            "def slugify(text):\n    return text.lower().replace(' ', '-')\n",
+            encoding="utf-8",
+        )
+        test_file.write_text(
+            "import unittest\n\n"
+            "from string_utils import slugify\n\n"
+            "class SlugifyTest(unittest.TestCase):\n"
+            "    def test_slugify_spaces(self):\n"
+            "        self.assertEqual(slugify('Hello World'), 'hello-world')\n"
+            "    def test_slugify_lowercase(self):\n"
+            "        self.assertEqual(slugify('Already Lower'), 'already-lower')\n"
+            "    def test_slugify_empty(self):\n"
+            "        self.assertEqual(slugify(''), '')\n"
+            "    def test_slugify_one_word(self):\n"
+            "        self.assertEqual(slugify('Hello'), 'hello')\n\n"
+            "if __name__ == '__main__':\n"
+            "    unittest.main()\n",
+            encoding="utf-8",
+        )
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["string_utils.py", "test_slugify.py"],\n'
+                '  "commands_run": ["python -m unittest test_slugify.py"],\n'
+                '  "tests_passed": ["python -m unittest test_slugify.py: OK"]\n'
+                "}\n"
+                "```",
+                native_session_id="codex-session-unittest-bare-ok-claim",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {source_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(source_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {test_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(test_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content="Calling tool: Bash: python -m unittest test_slugify.py",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {"command": "python -m unittest test_slugify.py"},
+                            "output": "Ran 4 tests in 0.000s\n\nOK",
+                        },
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Create slugify and unittest coverage.",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
     async def test_fat_harness_verifier_rejects_unittest_summary_missing_from_runtime(
         self, tmp_path
     ) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -3449,6 +3449,184 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_passed"] is True
 
     @pytest.mark.asyncio
+    async def test_fat_harness_verifier_accepts_shell_wrapped_unittest_bare_ok_claim(
+        self, tmp_path
+    ) -> None:
+        """Shell-wrapped unittest commands can back concise unittest claims."""
+        source_file = tmp_path / "string_utils.py"
+        test_file = tmp_path / "test_slugify.py"
+        source_file.write_text(
+            "def slugify(text):\n    return text.lower().replace(' ', '-')\n",
+            encoding="utf-8",
+        )
+        test_file.write_text(
+            "import unittest\n\n"
+            "from string_utils import slugify\n\n"
+            "class SlugifyTest(unittest.TestCase):\n"
+            "    def test_slugify_spaces(self):\n"
+            "        self.assertEqual(slugify('Hello World'), 'hello-world')\n"
+            "    def test_slugify_lowercase(self):\n"
+            "        self.assertEqual(slugify('Already Lower'), 'already-lower')\n"
+            "    def test_slugify_empty(self):\n"
+            "        self.assertEqual(slugify(''), '')\n"
+            "    def test_slugify_one_word(self):\n"
+            "        self.assertEqual(slugify('Hello'), 'hello')\n\n"
+            "if __name__ == '__main__':\n"
+            "    unittest.main()\n",
+            encoding="utf-8",
+        )
+
+        shell_command = "/bin/zsh -lc 'python -m unittest \"test_slugify.py\"'"
+        escaped_shell_command = shell_command.replace('"', '\\"')
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["string_utils.py", "test_slugify.py"],\n'
+                f'  "commands_run": ["{escaped_shell_command}"],\n'
+                '  "tests_passed": ["python -m unittest test_slugify.py: OK"]\n'
+                "}\n"
+                "```",
+                native_session_id="codex-session-shell-wrapped-unittest-bare-ok",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {source_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(source_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {test_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(test_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Bash: {shell_command}",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {"command": shell_command},
+                            "output": "Ran 4 tests in 0.000s\n\nOK",
+                        },
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Create slugify and unittest coverage.",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_shell_wrapped_unittest_summary_missing_from_runtime(
+        self, tmp_path
+    ) -> None:
+        """Shell wrappers must not let assistant prose prove a unittest summary."""
+        source_file = tmp_path / "string_utils.py"
+        test_file = tmp_path / "test_slugify.py"
+        source_file.write_text("def slugify(text):\n    return text\n", encoding="utf-8")
+        test_file.write_text("import unittest\n", encoding="utf-8")
+
+        shell_command = "/bin/zsh -lc 'python -m unittest \"test_slugify.py\"'"
+        escaped_shell_command = shell_command.replace('"', '\\"')
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["string_utils.py", "test_slugify.py"],\n'
+                f'  "commands_run": ["{escaped_shell_command}"],\n'
+                '  "tests_passed": ["python -m unittest test_slugify.py: Ran 4 tests in 0.000s OK"]\n'
+                "}\n"
+                "```",
+                native_session_id="codex-session-shell-wrapped-unittest-invented-summary",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {source_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(source_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {test_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(test_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Bash: {shell_command}",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": shell_command}, "exit_code": 0},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content=(
+                            "Tests passed: python -m unittest test_slugify.py: "
+                            "Ran 4 tests in 0.000s OK"
+                        ),
+                        data={},
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Create slugify and unittest coverage.",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "tests_passed:" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_failure_class"] == "FABRICATION_SUSPECTED"
+
+    @pytest.mark.asyncio
     async def test_fat_harness_verifier_rejects_unittest_summary_missing_from_runtime(
         self, tmp_path
     ) -> None:
@@ -3596,6 +3774,146 @@ class TestParallelACExecutor:
         assert result.success is False
         assert result.error is not None
         assert "tests_passed: unittest docs" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_failure_class"] == "FABRICATION_SUSPECTED"
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_echoed_unittest_command_as_test_command(
+        self, tmp_path
+    ) -> None:
+        """Echoing a unittest command string must not count as running unittest."""
+        source_file = tmp_path / "string_utils.py"
+        source_file.write_text("def slugify(text):\n    return text\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["string_utils.py"],\n'
+                '  "commands_run": ["echo python -m unittest test_slugify.py"],\n'
+                '  "tests_passed": ["python -m unittest test_slugify.py: OK"]\n'
+                "}\n"
+                "```",
+                native_session_id="codex-session-echoed-unittest-command",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {source_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(source_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content="Calling tool: Bash: echo python -m unittest test_slugify.py",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {"command": "echo python -m unittest test_slugify.py"},
+                            "output": "python -m unittest test_slugify.py\nsuccess\nRan 4 tests in 0.000s\n\nOK",
+                            "exit_code": 0,
+                        },
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Create slugify and unittest coverage.",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "tests_passed:" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_failure_class"] == "FABRICATION_SUSPECTED"
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_echoed_shell_wrapped_unittest_command(
+        self, tmp_path
+    ) -> None:
+        """Echoing a shell-wrapped unittest command must not count as running it."""
+        source_file = tmp_path / "string_utils.py"
+        source_file.write_text("def slugify(text):\n    return text\n", encoding="utf-8")
+
+        shell_command = "echo /bin/zsh -lc 'python -m unittest \"test_slugify.py\"'"
+        escaped_shell_command = shell_command.replace('"', '\\"')
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["string_utils.py"],\n'
+                f'  "commands_run": ["{escaped_shell_command}"],\n'
+                '  "tests_passed": ["python -m unittest test_slugify.py: OK"]\n'
+                "}\n"
+                "```",
+                native_session_id="codex-session-echoed-shell-wrapped-unittest-command",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {source_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(source_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Bash: {shell_command}",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {"command": shell_command},
+                            "output": "/bin/zsh -lc 'python -m unittest \"test_slugify.py\"'\nsuccess\nRan 4 tests in 0.000s\n\nOK",
+                            "exit_code": 0,
+                        },
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Create slugify and unittest coverage.",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "tests_passed:" in result.error
         evidence_event = next(
             event
             for event in appended_events

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -3400,6 +3400,14 @@ class TestParallelACExecutor:
                             "exit_code": 0,
                         },
                     ),
+                    AgentMessage(
+                        type="assistant",
+                        content=(
+                            "Tests passed: python -m unittest test_slugify.py: "
+                            "Ran 4 tests in 0.000s OK"
+                        ),
+                        data={},
+                    ),
                 ),
                 cwd=str(tmp_path),
             ),

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -95,7 +95,10 @@ def _make_replaying_event_store() -> tuple[AsyncMock, list[BaseEvent]]:
         ("no errors, 3 passed", True),
         ("no tests failed, 3 passed", True),
         ("exit code 0", True),
+        ("Ran 4 tests in 0.000s\nOK", True),
+        ("python -m unittest test_slugify.py: Ran 4 tests in 0.000s OK", True),
         ("success", True),
+        ("FAILED (failures=1)\nRan 4 tests in 0.000s", False),
         ("1 failed, 3 passed", False),
         ("2 errors, 1 passed", False),
         ("FAILED tests/test_app.py::test_auth", False),
@@ -3262,6 +3265,242 @@ class TestParallelACExecutor:
             if event.type == "execution.ac.typed_evidence.observed"
         )
         assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_accepts_unittest_command_summary_claim(
+        self, tmp_path
+    ) -> None:
+        """Regression for #961: Codex may put unittest command + OK summary in tests_passed."""
+        source_file = tmp_path / "string_utils.py"
+        test_file = tmp_path / "test_slugify.py"
+        source_file.write_text(
+            "def slugify(text):\n    return text.lower().replace(' ', '-')\n",
+            encoding="utf-8",
+        )
+        test_file.write_text(
+            "import unittest\n\n"
+            "from string_utils import slugify\n\n"
+            "class SlugifyTest(unittest.TestCase):\n"
+            "    def test_slugify(self):\n"
+            "        self.assertEqual(slugify('Hello World'), 'hello-world')\n\n"
+            "if __name__ == '__main__':\n"
+            "    unittest.main()\n",
+            encoding="utf-8",
+        )
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["string_utils.py", "test_slugify.py"],\n'
+                '  "commands_run": ["python -m unittest test_slugify.py"],\n'
+                '  "tests_passed": ['
+                '"python -m unittest test_slugify.py: Ran 4 tests in 0.000s OK"'
+                "]\n"
+                "}\n"
+                "```",
+                native_session_id="codex-session-unittest-summary-claim",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {source_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(source_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {test_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(test_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content="Calling tool: Bash: python -m unittest test_slugify.py",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {"command": "python -m unittest test_slugify.py"},
+                            "output": "Ran 4 tests in 0.000s\n\nOK",
+                        },
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Create slugify and unittest coverage.",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_unittest_summary_missing_from_runtime(
+        self, tmp_path
+    ) -> None:
+        """A tests_passed summary must be backed by runtime output, not claim text."""
+        source_file = tmp_path / "string_utils.py"
+        test_file = tmp_path / "test_slugify.py"
+        source_file.write_text("def slugify(text):\n    return text\n", encoding="utf-8")
+        test_file.write_text("import unittest\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["string_utils.py", "test_slugify.py"],\n'
+                '  "commands_run": ["python -m unittest test_slugify.py"],\n'
+                '  "tests_passed": ['
+                '"python -m unittest test_slugify.py: Ran 4 tests in 0.000s OK"'
+                "]\n"
+                "}\n"
+                "```",
+                native_session_id="codex-session-unittest-invented-summary",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {source_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(source_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {test_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(test_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content="Calling tool: Bash: python -m unittest test_slugify.py",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {"command": "python -m unittest test_slugify.py"},
+                            "exit_code": 0,
+                        },
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Create slugify and unittest coverage.",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "tests_passed:" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_failure_class"] == "FABRICATION_SUSPECTED"
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_rejects_bare_unittest_word_as_test_command(
+        self, tmp_path
+    ) -> None:
+        """Commands merely mentioning unittest must not back tests_passed."""
+        source_file = tmp_path / "string_utils.py"
+        source_file.write_text("def slugify(text):\n    return text\n", encoding="utf-8")
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["string_utils.py"],\n'
+                '  "commands_run": ["echo unittest docs"],\n'
+                '  "tests_passed": ["unittest docs"]\n'
+                "}\n"
+                "```",
+                native_session_id="codex-session-bare-unittest-word",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {source_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(source_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content="Calling tool: Bash: echo unittest docs",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {"command": "echo unittest docs"},
+                            "output": "unittest docs\nsuccess",
+                            "exit_code": 0,
+                        },
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Create slugify and unittest coverage.",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "tests_passed: unittest docs" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_failure_class"] == "FABRICATION_SUSPECTED"
 
     @pytest.mark.asyncio
     async def test_fat_harness_verifier_rejects_test_not_covered_by_success_chunk(


### PR DESCRIPTION
## Summary
- Recognize `python -m unittest` / `unittest` as backed test commands in fat-harness evidence verification.
- Recognize conservative unittest success output (`Ran N tests ... OK`) as test success while still rejecting failure summaries.
- Accept the observed Codex evidence shape where `tests_passed` combines the unittest command and OK summary, but only when the command is backed by current-session Bash evidence.

## Why
Fresh latest-main observation after #1043 merge reached SHA `a13a5661` but failed at AC1 before AC3 could be tested. AC1 stayed scoped and manual `python -m unittest test_slugify.py` passed, but the fat-harness verifier rejected:

`tests_passed: python -m unittest test_slugify.py: Ran 4 tests in 0.000s OK`

as `FABRICATION_SUSPECTED`.

## Validation
- `uv run ruff check tracked Python files`
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py -k "unittest or message_contains" -q`
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_profile_strategy.py -q`

## Not tested
- Full live `ouroboros run normal-usage-string-utils-seed-978.yaml` re-observation with external Codex/OpenCode runtime. That should be rerun after merge on fresh latest-main for #961 closure.
