### PR TITLE
fix(codex): detect missing MCP extra in doctor

### DIFF
--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 import tomllib
 from typing import Annotated
@@ -131,6 +132,11 @@ def _check_auto_dispatch_surface(codex_dir: Path) -> list[str]:
     command = ouroboros_entry.get("command")
     if not isinstance(command, str) or not command.strip():
         failures.append("[mcp_servers.ouroboros] is missing `command` or `url`")
+    else:
+        args = ouroboros_entry.get("args")
+        if not isinstance(args, list):
+            args = []
+        _check_mcp_runtime_dependency_surface(command, args, failures)
 
     if failures:
         print_warning(
@@ -139,6 +145,38 @@ def _check_auto_dispatch_surface(codex_dir: Path) -> list[str]:
         )
 
     return failures
+
+
+def _check_mcp_runtime_dependency_surface(
+    command: str, args: list[object], failures: list[str]
+) -> None:
+    """Detect Codex MCP server entries that cannot import the MCP runtime.
+
+    ``ouroboros codex doctor`` used to validate only rules, skill metadata, and
+    config presence. A direct ``ouroboros mcp serve`` entry can pass those checks
+    while the installed ``ouroboros-ai`` environment lacks the optional ``mcp``
+    extra, causing Codex's real stdio handshake to close before tools are listed.
+    """
+    command_name = Path(command).name
+    string_args = [arg for arg in args if isinstance(arg, str)]
+
+    if command_name in {"uvx", "uv"}:
+        joined_args = " ".join(string_args)
+        if "ouroboros-ai" in joined_args and "ouroboros-ai[mcp]" not in joined_args:
+            failures.append(
+                "Codex MCP command installs `ouroboros-ai` without the `mcp` extra; "
+                "use `ouroboros-ai[mcp]` so stdio initialize/list_tools can start"
+            )
+        return
+
+    if command_name != "ouroboros":
+        return
+
+    if importlib.util.find_spec("mcp") is None:
+        failures.append(
+            "current `ouroboros` environment cannot import `mcp`; reinstall for Codex MCP "
+            "usage with `uv tool install --force 'ouroboros-ai[mcp]'`"
+        )
 
 
 def _read_codex_text(path: Path, label: str, failures: list[str]) -> str | None:

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -106,6 +106,57 @@ class TestCodexDoctor:
 
         assert _check_auto_dispatch_surface(codex_dir) == []
 
+    def test_check_auto_dispatch_surface_reports_uvx_without_mcp_extra(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            'command = "uvx"\n'
+            'args = ["--from", "ouroboros-ai", "ouroboros", "mcp", "serve"]\n',
+            encoding="utf-8",
+        )
+
+        failures = _check_auto_dispatch_surface(codex_dir)
+
+        assert any("without the `mcp` extra" in failure for failure in failures)
+
+    def test_check_auto_dispatch_surface_reports_direct_ouroboros_without_mcp_import(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            'command = "/home/user/.local/bin/ouroboros"\n'
+            'args = ["mcp", "serve", "--runtime", "codex"]\n',
+            encoding="utf-8",
+        )
+
+        with patch("ouroboros.cli.commands.codex.importlib.util.find_spec", return_value=None):
+            failures = _check_auto_dispatch_surface(codex_dir)
+
+        assert any("cannot import `mcp`" in failure for failure in failures)
+
+    def test_check_auto_dispatch_surface_accepts_direct_ouroboros_with_mcp_import(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            'command = "ouroboros"\n'
+            'args = ["mcp", "serve", "--runtime", "codex"]\n',
+            encoding="utf-8",
+        )
+
+        with patch("ouroboros.cli.commands.codex.importlib.util.find_spec", return_value=object()):
+            assert _check_auto_dispatch_surface(codex_dir) == []
+
     def test_packaged_codex_artifacts_satisfy_doctor_contract(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary
- extend `ouroboros codex doctor` to flag `uvx --from ouroboros-ai` MCP server entries that omit the `mcp` extra
- flag direct `ouroboros mcp serve` entries when the current environment cannot import `mcp`
- add regression coverage for the reported Codex MCP handshake failure class

## Test plan
- `uv run pytest tests/unit/cli/test_codex_command.py`
- `uv run ruff check src/ouroboros/cli/commands/codex.py tests/unit/cli/test_codex_command.py`
- `uv run ruff format --check src/ouroboros/cli/commands/codex.py tests/unit/cli/test_codex_command.py`

Refs #1045
Refs #961