### PR TITLE
feat(codex): add live MCP doctor check

### DIFF
--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -189,7 +189,8 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
             else {}
         )
         command_entry = _CodexMCPCommandEntry(command=command, args=args, env=env)
-        _check_mcp_runtime_dependency_surface(command, list(args), failures)
+        if not live_mcp:
+            _check_mcp_runtime_dependency_surface(command, list(args), failures)
 
     if live_mcp and command_entry is not None and not failures:
         _check_live_mcp_tool_exposure(command_entry, failures)

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Mapping
+from dataclasses import dataclass
 import importlib.util
+import json
+import os
 from pathlib import Path
 import tomllib
-from typing import Annotated
+from typing import Annotated, Any
 
 import typer
 
@@ -17,6 +22,23 @@ app = typer.Typer(
     help="Manage Ouroboros Codex CLI integration artifacts.",
     no_args_is_help=True,
 )
+
+_REQUIRED_CODEX_AUTO_TOOLS = frozenset(
+    {
+        "ouroboros_auto",
+        "ouroboros_start_auto",
+        "ouroboros_interview",
+        "ouroboros_generate_seed",
+    }
+)
+_MCP_PROTOCOL_VERSION = "2024-11-05"
+
+
+@dataclass(frozen=True, slots=True)
+class _CodexMCPCommandEntry:
+    command: str
+    args: tuple[str, ...]
+    env: dict[str, str]
 
 
 @app.callback()
@@ -47,10 +69,20 @@ def doctor(
             help="Codex configuration directory to inspect. Defaults to ~/.codex.",
         ),
     ] = None,
+    live_mcp: Annotated[
+        bool,
+        typer.Option(
+            "--live-mcp",
+            help=(
+                "Launch the configured stdio MCP server, run initialize/list_tools, "
+                "and verify the official auto tools are exposed."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Verify installed Codex artifacts can route ``ooo auto`` to Ouroboros."""
     resolved_codex_dir = codex_dir or Path.home() / ".codex"
-    failures = _check_auto_dispatch_surface(resolved_codex_dir)
+    failures = _check_auto_dispatch_surface(resolved_codex_dir, live_mcp=live_mcp)
 
     if failures:
         print_error(
@@ -65,12 +97,13 @@ def doctor(
         "Codex ooo auto dispatch: OK\n"
         "- rule maps `ooo auto` to `ouroboros_auto`\n"
         "- auto skill declares MCP dispatch through `ouroboros_auto`\n"
-        "- Codex config contains an `ouroboros` MCP server entry",
+        "- Codex config contains an `ouroboros` MCP server entry"
+        + ("\n- live stdio initialize/list_tools exposes required auto tools" if live_mcp else ""),
         title="Codex Doctor",
     )
 
 
-def _check_auto_dispatch_surface(codex_dir: Path) -> list[str]:
+def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> list[str]:
     """Return configuration failures that can silently bypass ``ooo auto`` dispatch."""
     failures: list[str] = []
 
@@ -129,14 +162,30 @@ def _check_auto_dispatch_surface(codex_dir: Path) -> list[str]:
     if isinstance(url, str) and url.strip():
         return failures
 
+    command_entry: _CodexMCPCommandEntry | None = None
     command = ouroboros_entry.get("command")
     if not isinstance(command, str) or not command.strip():
         failures.append("[mcp_servers.ouroboros] is missing `command` or `url`")
     else:
-        args = ouroboros_entry.get("args")
-        if not isinstance(args, list):
-            args = []
-        _check_mcp_runtime_dependency_surface(command, args, failures)
+        args_obj = ouroboros_entry.get("args")
+        if not isinstance(args_obj, list):
+            args_obj = []
+        args = tuple(arg for arg in args_obj if isinstance(arg, str))
+        env_obj = ouroboros_entry.get("env")
+        env = (
+            {
+                key: value
+                for key, value in env_obj.items()
+                if isinstance(key, str) and isinstance(value, str)
+            }
+            if isinstance(env_obj, dict)
+            else {}
+        )
+        command_entry = _CodexMCPCommandEntry(command=command, args=args, env=env)
+        _check_mcp_runtime_dependency_surface(command, list(args), failures)
+
+    if live_mcp and command_entry is not None and not failures:
+        _check_live_mcp_tool_exposure(command_entry, failures)
 
     if failures:
         print_warning(
@@ -177,6 +226,174 @@ def _check_mcp_runtime_dependency_surface(
             "current `ouroboros` environment cannot import `mcp`; reinstall for Codex MCP "
             "usage with `uv tool install --force 'ouroboros-ai[mcp]'`"
         )
+
+
+def _check_live_mcp_tool_exposure(
+    command_entry: _CodexMCPCommandEntry, failures: list[str]
+) -> None:
+    """Verify Codex's configured stdio command can initialize and list tools."""
+    try:
+        tool_names = asyncio.run(
+            _list_stdio_mcp_tool_names(
+                command_entry.command,
+                command_entry.args,
+                command_entry.env,
+            )
+        )
+    except Exception as exc:
+        failures.append(f"Codex MCP stdio initialize/list_tools failed: {exc}")
+        return
+
+    missing_tools = sorted(_REQUIRED_CODEX_AUTO_TOOLS - tool_names)
+    if missing_tools:
+        failures.append(
+            "Codex MCP stdio list_tools is missing required auto tools: " + ", ".join(missing_tools)
+        )
+
+
+async def _list_stdio_mcp_tool_names(
+    command: str, args: tuple[str, ...], env: dict[str, str]
+) -> frozenset[str]:
+    """Launch a stdio MCP server and return the names exposed by list_tools().
+
+    This doctor probe intentionally speaks the small MCP initialize/list_tools
+    JSON-RPC sequence directly instead of using :class:`MCPClientAdapter`.
+    Codex can point at a self-contained command such as
+    ``uvx --from ouroboros-ai[mcp] ouroboros mcp serve``; validating that
+    setup must not first require the current ``ouroboros codex doctor``
+    interpreter to have installed the optional local ``mcp`` extra.
+    """
+    process_env = os.environ.copy()
+    process_env.update(env)
+    proc = await asyncio.create_subprocess_exec(
+        command,
+        *args,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=process_env,
+    )
+    try:
+        await _send_stdio_mcp_message(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": _MCP_PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": {
+                        "name": "ouroboros-codex-doctor",
+                        "version": "0.0.0",
+                    },
+                },
+            },
+        )
+        await _read_stdio_mcp_response(proc, request_id=1, timeout=30.0)
+        await _send_stdio_mcp_message(
+            proc,
+            {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+        )
+        await _send_stdio_mcp_message(
+            proc,
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+        )
+        response = await _read_stdio_mcp_response(proc, request_id=2, timeout=30.0)
+        result = response.get("result")
+        if not isinstance(result, Mapping):
+            raise RuntimeError("tools/list response did not contain an object result")
+        tools = result.get("tools")
+        if not isinstance(tools, list):
+            raise RuntimeError("tools/list response did not contain a tools list")
+        return frozenset(
+            tool["name"]
+            for tool in tools
+            if isinstance(tool, Mapping) and isinstance(tool.get("name"), str)
+        )
+    finally:
+        await _terminate_stdio_mcp_process(proc)
+
+
+async def _send_stdio_mcp_message(
+    proc: asyncio.subprocess.Process, message: Mapping[str, Any]
+) -> None:
+    if proc.stdin is None:
+        raise RuntimeError("MCP stdio process has no stdin")
+    body = json.dumps(message, separators=(",", ":")).encode("utf-8")
+    proc.stdin.write(f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body)
+    await proc.stdin.drain()
+
+
+async def _read_stdio_mcp_response(
+    proc: asyncio.subprocess.Process, *, request_id: int, timeout: float
+) -> Mapping[str, Any]:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise TimeoutError(f"timed out waiting for MCP stdio response id {request_id}")
+        message = await asyncio.wait_for(_read_stdio_mcp_message(proc), timeout=remaining)
+        if message.get("id") != request_id:
+            continue
+        error = message.get("error")
+        if isinstance(error, Mapping):
+            raise RuntimeError(str(error.get("message") or error))
+        return message
+
+
+async def _read_stdio_mcp_message(proc: asyncio.subprocess.Process) -> Mapping[str, Any]:
+    if proc.stdout is None:
+        raise RuntimeError("MCP stdio process has no stdout")
+
+    content_length: int | None = None
+    while True:
+        line = await proc.stdout.readline()
+        if line == b"":
+            stderr = await _read_stdio_mcp_stderr(proc)
+            detail = f": {stderr}" if stderr else ""
+            raise RuntimeError(f"MCP stdio process exited before response{detail}")
+        stripped = line.strip()
+        if not stripped:
+            break
+        if stripped.startswith(b"{"):
+            decoded = json.loads(stripped.decode("utf-8"))
+            if not isinstance(decoded, Mapping):
+                raise RuntimeError("MCP stdio response was not a JSON object")
+            return decoded
+        key, separator, value = stripped.partition(b":")
+        if separator and key.lower() == b"content-length":
+            content_length = int(value.strip())
+
+    if content_length is None:
+        raise RuntimeError("MCP stdio response missing Content-Length header")
+    body = await proc.stdout.readexactly(content_length)
+    decoded = json.loads(body.decode("utf-8"))
+    if not isinstance(decoded, Mapping):
+        raise RuntimeError("MCP stdio response was not a JSON object")
+    return decoded
+
+
+async def _read_stdio_mcp_stderr(proc: asyncio.subprocess.Process) -> str:
+    if proc.stderr is None:
+        return ""
+    try:
+        data = await asyncio.wait_for(proc.stderr.read(), timeout=0.2)
+    except TimeoutError:
+        return ""
+    return data.decode("utf-8", errors="replace").strip()
+
+
+async def _terminate_stdio_mcp_process(proc: asyncio.subprocess.Process) -> None:
+    if proc.returncode is not None:
+        return
+    proc.terminate()
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=2.0)
+    except TimeoutError:
+        proc.kill()
+        await proc.wait()
 
 
 def _read_codex_text(path: Path, label: str, failures: list[str]) -> str | None:

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -32,6 +32,7 @@ _REQUIRED_CODEX_AUTO_TOOLS = frozenset(
     }
 )
 _MCP_PROTOCOL_VERSION = "2024-11-05"
+_MCP_STDERR_TAIL_BYTES = 8192
 
 
 @dataclass(frozen=True, slots=True)
@@ -279,6 +280,12 @@ async def _list_stdio_mcp_tool_names(
         stderr=asyncio.subprocess.PIPE,
         env=process_env,
     )
+    stderr_buffer = bytearray()
+    stderr_task = (
+        asyncio.create_task(_drain_stdio_mcp_stderr(proc.stderr, stderr_buffer))
+        if proc.stderr is not None
+        else None
+    )
     try:
         await _send_stdio_mcp_message(
             proc,
@@ -296,7 +303,9 @@ async def _list_stdio_mcp_tool_names(
                 },
             },
         )
-        await _read_stdio_mcp_response(proc, request_id=1, timeout=30.0)
+        await _read_stdio_mcp_response(
+            proc, request_id=1, timeout=30.0, stderr_buffer=stderr_buffer
+        )
         await _send_stdio_mcp_message(
             proc,
             {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
@@ -305,7 +314,9 @@ async def _list_stdio_mcp_tool_names(
             proc,
             {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
         )
-        response = await _read_stdio_mcp_response(proc, request_id=2, timeout=30.0)
+        response = await _read_stdio_mcp_response(
+            proc, request_id=2, timeout=30.0, stderr_buffer=stderr_buffer
+        )
         result = response.get("result")
         if not isinstance(result, Mapping):
             raise RuntimeError("tools/list response did not contain an object result")
@@ -319,6 +330,12 @@ async def _list_stdio_mcp_tool_names(
         )
     finally:
         await _terminate_stdio_mcp_process(proc)
+        if stderr_task is not None:
+            try:
+                await asyncio.wait_for(stderr_task, timeout=0.2)
+            except TimeoutError:
+                stderr_task.cancel()
+                await asyncio.gather(stderr_task, return_exceptions=True)
 
 
 async def _send_stdio_mcp_message(
@@ -332,7 +349,11 @@ async def _send_stdio_mcp_message(
 
 
 async def _read_stdio_mcp_response(
-    proc: asyncio.subprocess.Process, *, request_id: int, timeout: float
+    proc: asyncio.subprocess.Process,
+    *,
+    request_id: int,
+    timeout: float,
+    stderr_buffer: bytearray,
 ) -> Mapping[str, Any]:
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
@@ -340,7 +361,9 @@ async def _read_stdio_mcp_response(
         remaining = deadline - loop.time()
         if remaining <= 0:
             raise TimeoutError(f"timed out waiting for MCP stdio response id {request_id}")
-        message = await asyncio.wait_for(_read_stdio_mcp_message(proc), timeout=remaining)
+        message = await asyncio.wait_for(
+            _read_stdio_mcp_message(proc, stderr_buffer=stderr_buffer), timeout=remaining
+        )
         if message.get("id") != request_id:
             continue
         error = message.get("error")
@@ -349,7 +372,9 @@ async def _read_stdio_mcp_response(
         return message
 
 
-async def _read_stdio_mcp_message(proc: asyncio.subprocess.Process) -> Mapping[str, Any]:
+async def _read_stdio_mcp_message(
+    proc: asyncio.subprocess.Process, *, stderr_buffer: bytearray
+) -> Mapping[str, Any]:
     if proc.stdout is None:
         raise RuntimeError("MCP stdio process has no stdout")
 
@@ -357,7 +382,7 @@ async def _read_stdio_mcp_message(proc: asyncio.subprocess.Process) -> Mapping[s
     while True:
         line = await proc.stdout.readline()
         if line == b"":
-            stderr = await _read_stdio_mcp_stderr(proc)
+            stderr = _format_stdio_mcp_stderr(stderr_buffer)
             detail = f": {stderr}" if stderr else ""
             raise RuntimeError(f"MCP stdio process exited before response{detail}")
         stripped = line.strip()
@@ -381,14 +406,18 @@ async def _read_stdio_mcp_message(proc: asyncio.subprocess.Process) -> Mapping[s
     return decoded
 
 
-async def _read_stdio_mcp_stderr(proc: asyncio.subprocess.Process) -> str:
-    if proc.stderr is None:
-        return ""
-    try:
-        data = await asyncio.wait_for(proc.stderr.read(), timeout=0.2)
-    except TimeoutError:
-        return ""
-    return data.decode("utf-8", errors="replace").strip()
+async def _drain_stdio_mcp_stderr(stderr: asyncio.StreamReader, stderr_buffer: bytearray) -> None:
+    while True:
+        chunk = await stderr.read(4096)
+        if not chunk:
+            return
+        stderr_buffer.extend(chunk)
+        if len(stderr_buffer) > _MCP_STDERR_TAIL_BYTES:
+            del stderr_buffer[: len(stderr_buffer) - _MCP_STDERR_TAIL_BYTES]
+
+
+def _format_stdio_mcp_stderr(stderr_buffer: bytearray) -> str:
+    return bytes(stderr_buffer).decode("utf-8", errors="replace").strip()
 
 
 async def _terminate_stdio_mcp_process(proc: asyncio.subprocess.Process) -> None:

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -160,6 +160,12 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
 
     url = ouroboros_entry.get("url")
     if isinstance(url, str) and url.strip():
+        if live_mcp:
+            failures.append(
+                "Codex MCP server uses `url`, but `--live-mcp` currently verifies only "
+                "stdio `command` entries; use a stdio command config or run without "
+                "`--live-mcp`"
+            )
         return failures
 
     command_entry: _CodexMCPCommandEntry | None = None

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -107,6 +107,24 @@ class TestCodexDoctor:
 
         assert _check_auto_dispatch_surface(codex_dir) == []
 
+    def test_check_auto_dispatch_surface_live_mcp_rejects_url_mcp_server_entry(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n',
+            encoding="utf-8",
+        )
+
+        with patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names") as live_probe:
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=True)
+
+        live_probe.assert_not_called()
+        assert any("uses `url`" in failure for failure in failures)
+        assert any("verifies only stdio `command` entries" in failure for failure in failures)
+
     def test_check_auto_dispatch_surface_accepts_custom_command_mcp_entry(
         self,
         tmp_path: Path,
@@ -399,3 +417,23 @@ class TestCodexDoctor:
 
         assert cli_result.exit_code == 0
         assert "Codex ooo auto dispatch: OK" in cli_result.output
+
+    def test_doctor_live_mcp_url_config_fails_without_stdio_success_claim(
+        self, tmp_path: Path
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            '[mcp_servers.ouroboros]\nurl = "http://127.0.0.1:12000/mcp"\n',
+            encoding="utf-8",
+        )
+
+        cli_result = runner.invoke(app, ["doctor", "--codex-dir", str(codex_dir), "--live-mcp"])
+
+        assert cli_result.exit_code == 1
+        assert "Codex ooo auto dispatch: BROKEN" in cli_result.output
+        assert "currently verifies only" in cli_result.output
+        assert "stdio `command` entries" in cli_result.output
+        assert (
+            "live stdio initialize/list_tools exposes required auto tools" not in cli_result.output
+        )

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -236,6 +236,9 @@ class TestCodexDoctor:
                 import json
                 import sys
 
+                sys.stderr.buffer.write(b"startup noise\\n" * 20000)
+                sys.stderr.buffer.flush()
+
                 def read_message():
                     content_length = None
                     while True:

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -189,6 +189,32 @@ class TestCodexDoctor:
         with patch("ouroboros.cli.commands.codex.importlib.util.find_spec", return_value=object()):
             assert _check_auto_dispatch_surface(codex_dir) == []
 
+    def test_check_auto_dispatch_surface_live_mcp_uses_configured_direct_command_without_local_mcp(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            'command = "ouroboros"\n'
+            'args = ["mcp", "serve", "--runtime", "codex"]\n',
+            encoding="utf-8",
+        )
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with (
+            patch("ouroboros.cli.commands.codex.importlib.util.find_spec", return_value=None),
+            patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe),
+        ):
+            assert _check_auto_dispatch_surface(codex_dir, live_mcp=True) == []
+
+        live_probe.assert_awaited_once_with(
+            "ouroboros",
+            ("mcp", "serve", "--runtime", "codex"),
+            {},
+        )
+
     def test_check_auto_dispatch_surface_live_mcp_verifies_required_tools(
         self,
         tmp_path: Path,

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -2,15 +2,29 @@
 
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
-from unittest.mock import patch
+import sys
+import textwrap
+from unittest.mock import AsyncMock, patch
 
 from typer.testing import CliRunner
 
-from ouroboros.cli.commands.codex import _check_auto_dispatch_surface, app
+from ouroboros.cli.commands.codex import (
+    _MCP_PROTOCOL_VERSION,
+    _check_auto_dispatch_surface,
+    _list_stdio_mcp_tool_names,
+    app,
+)
 from ouroboros.codex import CodexArtifactInstallResult, install_codex_artifacts
 
 runner = CliRunner()
+_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST = {
+    "ouroboros_auto",
+    "ouroboros_start_auto",
+    "ouroboros_interview",
+    "ouroboros_generate_seed",
+}
 
 
 class TestCodexRefresh:
@@ -156,6 +170,163 @@ class TestCodexDoctor:
 
         with patch("ouroboros.cli.commands.codex.importlib.util.find_spec", return_value=object()):
             assert _check_auto_dispatch_surface(codex_dir) == []
+
+    def test_check_auto_dispatch_surface_live_mcp_verifies_required_tools(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        (codex_dir / "config.toml").write_text(
+            "[mcp_servers.ouroboros]\n"
+            'command = "ouroboros"\n'
+            'args = ["mcp", "serve", "--runtime", "codex"]\n'
+            "[mcp_servers.ouroboros.env]\n"
+            'OUROBOROS_AGENT_RUNTIME = "codex"\n',
+            encoding="utf-8",
+        )
+
+        live_probe = AsyncMock(
+            return_value={
+                "ouroboros_auto",
+                "ouroboros_start_auto",
+                "ouroboros_interview",
+                "ouroboros_generate_seed",
+            }
+        )
+        with (
+            patch("ouroboros.cli.commands.codex.importlib.util.find_spec", return_value=object()),
+            patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe),
+        ):
+            assert _check_auto_dispatch_surface(codex_dir, live_mcp=True) == []
+
+        live_probe.assert_awaited_once_with(
+            "ouroboros",
+            ("mcp", "serve", "--runtime", "codex"),
+            {"OUROBOROS_AGENT_RUNTIME": "codex"},
+        )
+
+    def test_list_stdio_mcp_tool_names_uses_protocol_without_local_mcp_import(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        assert _MCP_PROTOCOL_VERSION == "2024-11-05"
+        server_path = tmp_path / "fake_mcp_server.py"
+        server_path.write_text(
+            textwrap.dedent(
+                r"""
+                import json
+                import sys
+
+                def read_message():
+                    content_length = None
+                    while True:
+                        line = sys.stdin.buffer.readline()
+                        if not line:
+                            raise SystemExit(0)
+                        line = line.strip()
+                        if not line:
+                            break
+                        key, _, value = line.partition(b":")
+                        if key.lower() == b"content-length":
+                            content_length = int(value.strip())
+                    return json.loads(sys.stdin.buffer.read(content_length))
+
+                def write_message(message):
+                    body = json.dumps(message).encode("utf-8")
+                    sys.stdout.buffer.write(b"Content-Length: " + str(len(body)).encode("ascii") + b"\r\n\r\n" + body)
+                    sys.stdout.buffer.flush()
+
+                initialize = read_message()
+                if initialize["params"]["protocolVersion"] != "2024-11-05":
+                    raise SystemExit(
+                        f"unsupported protocol {initialize['params']['protocolVersion']}"
+                    )
+                write_message({
+                    "jsonrpc": "2.0",
+                    "id": initialize["id"],
+                    "result": {
+                        "protocolVersion": initialize["params"]["protocolVersion"],
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "fake", "version": "1.0.0"},
+                    },
+                })
+                read_message()  # notifications/initialized
+                tools_list = read_message()
+                write_message({
+                    "jsonrpc": "2.0",
+                    "id": tools_list["id"],
+                    "result": {
+                        "tools": [
+                            {"name": "ouroboros_auto", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_start_auto", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_interview", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_generate_seed", "inputSchema": {"type": "object"}},
+                        ]
+                    },
+                })
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        tool_names = asyncio.run(
+            _list_stdio_mcp_tool_names(sys.executable, (str(server_path),), {})
+        )
+
+        assert tool_names >= _REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST
+
+    def test_check_auto_dispatch_surface_live_mcp_accepts_uvx_mcp_extra_without_local_mcp(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        live_probe = AsyncMock(return_value=_REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST)
+
+        with (
+            patch("ouroboros.cli.commands.codex.importlib.util.find_spec", return_value=None),
+            patch("ouroboros.cli.commands.codex._list_stdio_mcp_tool_names", live_probe),
+        ):
+            assert _check_auto_dispatch_surface(codex_dir, live_mcp=True) == []
+
+        live_probe.assert_awaited_once_with(
+            "uvx",
+            ("--from", "ouroboros-ai[mcp]", "ouroboros", "mcp", "serve"),
+            {},
+        )
+
+    def test_check_auto_dispatch_surface_live_mcp_reports_missing_auto_tool(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+
+        with patch(
+            "ouroboros.cli.commands.codex._list_stdio_mcp_tool_names",
+            AsyncMock(return_value={"ouroboros_interview", "ouroboros_generate_seed"}),
+        ):
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=True)
+
+        assert any("missing required auto tools" in failure for failure in failures)
+        assert any("ouroboros_auto" in failure for failure in failures)
+
+    def test_check_auto_dispatch_surface_live_mcp_reports_handshake_failure(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+
+        with patch(
+            "ouroboros.cli.commands.codex._list_stdio_mcp_tool_names",
+            AsyncMock(side_effect=RuntimeError("connection closed during initialize")),
+        ):
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=True)
+
+        assert any("initialize/list_tools failed" in failure for failure in failures)
+        assert any("connection closed during initialize" in failure for failure in failures)
 
     def test_packaged_codex_artifacts_satisfy_doctor_contract(
         self,


### PR DESCRIPTION
## Summary\n- Adds an opt-in `ouroboros codex doctor --live-mcp` check that launches the configured stdio MCP server and runs initialize/list_tools.\n- Verifies the official Codex auto tool surface is actually exposed: `ouroboros_auto`, `ouroboros_start_auto`, `ouroboros_interview`, and `ouroboros_generate_seed`.\n- Reports handshake/list_tools failures and missing tool names with actionable doctor output.\n\n## Stack\n- Follow-up stacked on #1046 so the diff only contains the live exposure check. After #1046 lands, this PR can be retargeted to `main`.\n\n## Tests\n- `uv run ruff format src/ouroboros/cli/commands/codex.py tests/unit/cli/test_codex_command.py`\n- `uv run ruff check src/ouroboros/cli/commands/codex.py tests/unit/cli/test_codex_command.py`\n- `uv run pytest tests/unit/cli/test_codex_command.py`\n\nRefs #1045\nFollow-up to #1046