### PR TITLE
Accept structured wrapped test command evidence

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -395,6 +395,38 @@ def _runtime_messages_support_claim(value: str, messages: tuple[AgentMessage, ..
     )
 
 
+def _runtime_message_supports_command_claim(value: str, message: AgentMessage) -> bool:
+    """Return True when one runtime message backs a command claim.
+
+    Codex commonly records the executed Bash command as a shell wrapper such as
+    ``/bin/zsh -lc 'cd /workspace && python -m unittest "test_hello.py"'``
+    while typed evidence may claim the inner test command.  Treat those as
+    equivalent only through the structured Bash command field; arbitrary output
+    text or assistant narration must not create command aliases.
+    """
+    if _runtime_messages_support_claim(value, (message,)):
+        return True
+    if message.tool_name != "Bash":
+        return False
+    tool_input = message.data.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return False
+    runtime_command = tool_input.get("command")
+    if not isinstance(runtime_command, str):
+        return False
+    claim_aliases = set(_normalized_command_claim_aliases(value))
+    runtime_aliases = set(_normalized_command_claim_aliases(runtime_command))
+    return bool(claim_aliases and runtime_aliases and claim_aliases.intersection(runtime_aliases))
+
+
+def _runtime_messages_support_command_claim(
+    value: str,
+    messages: tuple[AgentMessage, ...],
+) -> bool:
+    """Return True when runtime messages back a command claim."""
+    return any(_runtime_message_supports_command_claim(value, message) for message in messages)
+
+
 def _runtime_messages_support_file_claim(
     value: str,
     messages: tuple[AgentMessage, ...],
@@ -610,59 +642,128 @@ def _runtime_message_file_proof_text(message: AgentMessage) -> str:
 
 def _looks_like_test_command(command: str) -> bool:
     """Return True for common whole-suite or targeted test invocations."""
+    return _test_command_invocation(command) is not None
+
+
+def _test_command_invocation(command: str) -> str | None:
+    """Return the backed inner test invocation for a direct or wrapped command."""
     normalized = command.strip().lower()
     if not normalized:
-        return False
-    if _unittest_command_invocation(normalized) is not None:
-        return True
-    return bool(
-        re.search(
-            r"(^|[\s;&|])("
-            r"pytest|py\.test|tox|nox|npm\s+test|pnpm\s+test|yarn\s+test|"
-            r"uv\s+run\s+pytest|python\s+-m\s+pytest"
-            r")($|[\s;&|])",
-            normalized,
-        )
+        return None
+
+    direct = _test_invocation_from_prefix(normalized)
+    if direct is not None:
+        return direct
+
+    body = _shell_command_body(normalized)
+    if body is None:
+        return None
+    return _test_invocation_from_shell_body(body)
+
+
+def _shell_command_body(command: str) -> str | None:
+    """Return the ``-c`` body when the command starts with a shell wrapper."""
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return None
+    if len(parts) < 3:
+        return None
+    shell_name = Path(parts[0]).name
+    if shell_name not in {"bash", "zsh", "sh"}:
+        return None
+    option_index = next(
+        (index for index, part in enumerate(parts[1:], start=1) if part in {"-c", "-lc", "-cl"}),
+        None,
     )
+    if option_index is None or option_index + 1 >= len(parts):
+        return None
+    return parts[option_index + 1].strip()
+
+
+def _test_invocation_from_shell_body(body: str) -> str | None:
+    """Return a test invocation after conservative shell setup preambles."""
+    for segment in re.split(r"\s*&&\s*", body.strip()):
+        normalized_segment = segment.strip()
+        if not normalized_segment:
+            continue
+        invocation = _test_invocation_from_prefix(normalized_segment)
+        if invocation is not None:
+            return invocation
+        if _is_safe_test_command_preamble(normalized_segment):
+            continue
+        return None
+    return None
+
+
+def _is_safe_test_command_preamble(segment: str) -> bool:
+    """Return True for shell setup segments that do not execute tests themselves."""
+    try:
+        parts = shlex.split(segment)
+    except ValueError:
+        return False
+    if not parts:
+        return True
+    if parts[0] == "cd" and len(parts) == 2:
+        return True
+    if parts[0] == "export" and len(parts) > 1:
+        return all(_is_env_assignment(part) for part in parts[1:])
+    return all(_is_env_assignment(part) for part in parts)
+
+
+def _is_env_assignment(value: str) -> bool:
+    """Return True for a simple shell environment assignment token."""
+    return bool(re.match(r"^[A-Za-z_][A-Za-z0-9_]*=.*$", value))
+
+
+def _strip_env_prefix(parts: list[str]) -> list[str]:
+    """Remove leading env assignment tokens before command recognition."""
+    index = 0
+    if parts and parts[0] == "env":
+        index = 1
+    while index < len(parts) and _is_env_assignment(parts[index]):
+        index += 1
+    return parts[index:]
+
+
+def _test_invocation_from_prefix(command: str) -> str | None:
+    """Return a normalized test invocation only when it starts the command text."""
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        parts = command.replace('"', "").replace("'", "").split()
+    parts = _strip_env_prefix(parts)
+    if not parts:
+        return None
+
+    if parts[0] in {"pytest", "py.test", "tox", "nox"}:
+        return _normalized_evidence_text(" ".join(parts))
+    if len(parts) >= 2 and parts[0] in {"npm", "pnpm", "yarn"} and parts[1] == "test":
+        return _normalized_evidence_text(" ".join(parts))
+    if len(parts) >= 3 and parts[:3] == ["uv", "run", "pytest"]:
+        return _normalized_evidence_text(" ".join(parts))
+    if (
+        len(parts) >= 3
+        and parts[:2] == ["python", "-m"]
+        and parts[2]
+        in {
+            "pytest",
+            "unittest",
+        }
+    ):
+        return _normalized_evidence_text(" ".join(parts))
+    return None
 
 
 def _unittest_command_invocation(command: str) -> str | None:
     """Return the embedded ``python -m unittest`` invocation, if present."""
-    normalized = command.strip().lower()
-    if not normalized:
+    invocation = _test_command_invocation(command)
+    if invocation is None:
         return None
-
-    direct = _unittest_invocation_from_prefix(normalized)
-    if direct is not None:
-        return direct
-
-    shell_match = re.search(
-        r"^(?:[\w./-]+/)?(?:bash|zsh|sh)\s+-(?:l?c|c)\s+"
-        r"(?P<quote>['\"])(?P<body>.*?)(?P=quote)"
-        r"(?=$|[\s;&|])",
-        normalized,
-    )
-    if shell_match is None:
-        return None
-    return _unittest_invocation_from_prefix(shell_match.group("body").strip())
-
-
-def _unittest_invocation_from_prefix(command: str) -> str | None:
-    """Return a normalized unittest invocation only when it starts the command text."""
-    match = re.search(
-        r"^"
-        r"(python\s+-m\s+unittest"
-        r"(?:\s+(?:\"[^\"]+\"|'[^']+'|[^\s;&|'\"]+))*)"
-        r"(?=$|[\s;&|'\"])",
-        command,
-    )
-    if match is None:
-        return None
-    try:
-        parts = shlex.split(match.group(1))
-    except ValueError:
-        parts = match.group(1).replace('"', "").replace("'", "").split()
-    return _normalized_evidence_text(" ".join(parts))
+    parts = invocation.split()
+    if len(parts) >= 3 and parts[:3] == ["python", "-m", "unittest"]:
+        return invocation
+    return None
 
 
 def _looks_like_unittest_command(command: str) -> bool:
@@ -674,9 +775,9 @@ def _normalized_command_claim_aliases(command: str) -> tuple[str, ...]:
     """Return normalized command forms that a concise evidence claim may use."""
     normalized = _normalized_evidence_text(command)
     aliases = [normalized] if normalized else []
-    unittest_invocation = _unittest_command_invocation(command)
-    if unittest_invocation and unittest_invocation not in aliases:
-        aliases.append(unittest_invocation)
+    test_invocation = _test_command_invocation(command)
+    if test_invocation and test_invocation not in aliases:
+        aliases.append(test_invocation)
     return tuple(aliases)
 
 
@@ -842,7 +943,7 @@ def _test_command_targets_claim(
     # the claimed test file is also backed by current-run mutation evidence.
     # Existence alone is deliberately insufficient: otherwise a transcript with
     # unrelated ``pytest`` output could prove any stale test file in the tree.
-    command_parts = normalized_command.split()
+    command_parts = (_test_command_invocation(command) or normalized_command).split()
     broad_pytest = command_parts in (["pytest"], ["py.test"]) or command_parts[-3:] == [
         "python",
         "-m",
@@ -871,7 +972,7 @@ def _runtime_messages_support_test_claim(
             candidate
             for candidate in backed_commands
             if _looks_like_test_command(candidate)
-            and _runtime_messages_support_claim(candidate, (message,))
+            and _runtime_message_supports_command_claim(candidate, message)
         )
         if not matching_commands:
             continue
@@ -4703,7 +4804,7 @@ Files present:
         backed_commands = tuple(
             command
             for command in _flatten_evidence_values(typed_evidence.get("commands_run"))
-            if _runtime_messages_support_claim(
+            if _runtime_messages_support_command_claim(
                 command,
                 _runtime_support_messages_for_field("commands_run", support_messages),
             )
@@ -4725,6 +4826,11 @@ Files present:
                 continue
             field_messages = _runtime_support_messages_for_field(field_name, support_messages)
             for value in values:
+                if field_name == "commands_run":
+                    if _runtime_messages_support_command_claim(value, field_messages):
+                        continue
+                    unsupported.append(f"{field_name}: {value}")
+                    continue
                 if field_name == "files_touched":
                     if _runtime_messages_support_file_claim(
                         value,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -3634,6 +3634,98 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_passed"] is True
 
     @pytest.mark.asyncio
+    async def test_fat_harness_verifier_accepts_inner_unittest_claim_for_shell_wrapped_export_command(
+        self, tmp_path
+    ) -> None:
+        """Shell env setup preambles may precede the claimed inner unittest command."""
+        source_file = tmp_path / "string_utils.py"
+        test_file = tmp_path / "test_slugify.py"
+        source_file.write_text(
+            "def slugify(text):\n    return text.lower().replace(' ', '-')\n",
+            encoding="utf-8",
+        )
+        test_file.write_text(
+            "import unittest\n\n"
+            "from string_utils import slugify\n\n"
+            "class SlugifyTest(unittest.TestCase):\n"
+            "    def test_slugify_spaces(self):\n"
+            "        self.assertEqual(slugify('Hello World'), 'hello-world')\n\n"
+            "if __name__ == '__main__':\n"
+            "    unittest.main()\n",
+            encoding="utf-8",
+        )
+
+        inner_command = "python -m unittest test_slugify.py"
+        shell_command = (
+            f"/bin/zsh -lc 'export PYTHONPATH={tmp_path} && python -m unittest \"test_slugify.py\"'"
+        )
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["string_utils.py", "test_slugify.py"],\n'
+                f'  "commands_run": ["{inner_command}"],\n'
+                f'  "tests_passed": ["{inner_command}: OK"]\n'
+                "}\n"
+                "```",
+                native_session_id="codex-session-shell-wrapped-export-unittest-inner-claim",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {source_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(source_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {test_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(test_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Bash: {shell_command}",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {"command": shell_command},
+                            "output": "Ran 1 test in 0.000s\n\nOK",
+                            "exit_code": 0,
+                        },
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Create slugify and unittest coverage.",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
     async def test_fat_harness_verifier_rejects_shell_wrapped_unittest_summary_missing_from_runtime(
         self, tmp_path
     ) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -3544,6 +3544,96 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_passed"] is True
 
     @pytest.mark.asyncio
+    async def test_fat_harness_verifier_accepts_inner_unittest_claim_for_shell_wrapped_cd_command(
+        self, tmp_path
+    ) -> None:
+        """Codex shell wrappers may run setup before the claimed inner unittest command."""
+        source_file = tmp_path / "string_utils.py"
+        test_file = tmp_path / "test_slugify.py"
+        source_file.write_text(
+            "def slugify(text):\n    return text.lower().replace(' ', '-')\n",
+            encoding="utf-8",
+        )
+        test_file.write_text(
+            "import unittest\n\n"
+            "from string_utils import slugify\n\n"
+            "class SlugifyTest(unittest.TestCase):\n"
+            "    def test_slugify_spaces(self):\n"
+            "        self.assertEqual(slugify('Hello World'), 'hello-world')\n\n"
+            "if __name__ == '__main__':\n"
+            "    unittest.main()\n",
+            encoding="utf-8",
+        )
+
+        inner_command = "python -m unittest test_slugify.py"
+        shell_command = f"/bin/bash --noprofile --norc -lc 'cd {tmp_path} && python -m unittest \"test_slugify.py\"'"
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "```json\n"
+                "{\n"
+                '  "files_touched": ["string_utils.py", "test_slugify.py"],\n'
+                f'  "commands_run": ["{inner_command}"],\n'
+                f'  "tests_passed": ["{inner_command}: OK"]\n'
+                "}\n"
+                "```",
+                native_session_id="codex-session-shell-wrapped-cd-unittest-inner-claim",
+                support_messages=(
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {source_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(source_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Edit: {test_file}",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": str(test_file)}},
+                    ),
+                    AgentMessage(
+                        type="assistant",
+                        content=f"Calling tool: Bash: {shell_command}",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {"command": shell_command},
+                            "output": "Ran 1 test in 0.000s\n\nOK",
+                            "exit_code": 0,
+                        },
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Create slugify and unittest coverage.",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship string utilities",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
     async def test_fat_harness_verifier_rejects_shell_wrapped_unittest_summary_missing_from_runtime(
         self, tmp_path
     ) -> None:
@@ -3920,6 +4010,84 @@ class TestParallelACExecutor:
             if event.type == "execution.ac.typed_evidence.observed"
         )
         assert evidence_event.data["verifier_failure_class"] == "FABRICATION_SUSPECTED"
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_verifier_accepts_wrapped_broad_pytest_for_current_test_file(
+        self, tmp_path
+    ) -> None:
+        """Wrapped bare pytest should behave like unwrapped broad pytest for current files."""
+        source_file = tmp_path / "src" / "generated.py"
+        source_file.parent.mkdir()
+        source_file.write_text("VALUE = 1\n", encoding="utf-8")
+        test_file = tmp_path / "tests" / "test_generated.py"
+        test_file.parent.mkdir()
+        test_file.write_text("def test_generated():\n    assert True\n", encoding="utf-8")
+
+        shell_command = f"/bin/zsh -lc 'cd {tmp_path} && pytest'"
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["src/generated.py", "tests/test_generated.py"],'
+                f'"commands_run":["{shell_command}"],'
+                '"tests_passed":["tests/test_generated.py"]}\n'
+                "```",
+                native_session_id="codex-session-wrapped-broad-pytest",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Edit: src/generated.py",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": "src/generated.py"}},
+                    ),
+                    AgentMessage(
+                        type="tool",
+                        content="Edit: tests/test_generated.py",
+                        tool_name="Edit",
+                        data={"tool_input": {"file_path": "tests/test_generated.py"}},
+                    ),
+                    AgentMessage(
+                        type="tool",
+                        content=f"Bash: {shell_command}",
+                        tool_name="Bash",
+                        data={
+                            "tool_input": {"command": shell_command},
+                            "output": "tests/test_generated.py passed\n1 passed in 0.01s",
+                            "exit_code": 0,
+                        },
+                    ),
+                ),
+                cwd=str(tmp_path),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement AC 1",
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["verifier_passed"] is True
 
     @pytest.mark.asyncio
     async def test_fat_harness_verifier_rejects_test_not_covered_by_success_chunk(


### PR DESCRIPTION
## Summary
- Treat typed `commands_run` claims and runtime Bash wrapper commands as equivalent only when the alias comes from structured `tool_input.command`.
- Recognize conservative test invocations inside direct commands or shell wrappers with setup preambles such as `cd ... && python -m unittest ...`.
- Keep echoed commands, assistant narration, and runtime output text from creating command aliases.

## Why
Fresh #978 P5 controlled observation after #1026/#1044 reached `typed_evidence_present=true`, `typed_evidence_valid=true`, and `verifier_ran=true`, but still failed verifier PASS because Codex records Bash as shell-wrapped commands while typed evidence may claim the inner test command.

## Validation
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py -k 'unittest or message_contains' -q`
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_profile_strategy.py -q`
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py`
- `uv run ruff format --check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py && git diff --check`
- `uv run mypy src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py`

## Not tested
- Live #978 controlled observation rerun with external Codex runtime. That should be the next step after this PR merges.

## Boundaries
- No legacy self-report fallback removal.
- No default flip.
- No new AgentOS surface or dependency.
- Alias trust is limited to structured Bash `tool_input.command`.

Closes #1050
