### PR TITLE
fix(codex): use JSONL stdio for live MCP doctor

### DIFF
--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -345,7 +345,7 @@ async def _send_stdio_mcp_message(
     if proc.stdin is None:
         raise RuntimeError("MCP stdio process has no stdin")
     body = json.dumps(message, separators=(",", ":")).encode("utf-8")
-    proc.stdin.write(f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body)
+    proc.stdin.write(body + b"\n")
     await proc.stdin.drain()
 
 
@@ -379,7 +379,6 @@ async def _read_stdio_mcp_message(
     if proc.stdout is None:
         raise RuntimeError("MCP stdio process has no stdout")
 
-    content_length: int | None = None
     while True:
         line = await proc.stdout.readline()
         if line == b"":
@@ -388,23 +387,11 @@ async def _read_stdio_mcp_message(
             raise RuntimeError(f"MCP stdio process exited before response{detail}")
         stripped = line.strip()
         if not stripped:
-            break
-        if stripped.startswith(b"{"):
-            decoded = json.loads(stripped.decode("utf-8"))
-            if not isinstance(decoded, Mapping):
-                raise RuntimeError("MCP stdio response was not a JSON object")
-            return decoded
-        key, separator, value = stripped.partition(b":")
-        if separator and key.lower() == b"content-length":
-            content_length = int(value.strip())
-
-    if content_length is None:
-        raise RuntimeError("MCP stdio response missing Content-Length header")
-    body = await proc.stdout.readexactly(content_length)
-    decoded = json.loads(body.decode("utf-8"))
-    if not isinstance(decoded, Mapping):
-        raise RuntimeError("MCP stdio response was not a JSON object")
-    return decoded
+            continue
+        decoded = json.loads(stripped.decode("utf-8"))
+        if not isinstance(decoded, Mapping):
+            raise RuntimeError("MCP stdio response was not a JSON object")
+        return decoded
 
 
 async def _drain_stdio_mcp_stderr(stderr: asyncio.StreamReader, stderr_buffer: bytearray) -> None:

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -281,6 +281,12 @@ async def _list_stdio_mcp_tool_names(
         return await _list_stdio_mcp_tool_names_with_framing(
             command, args, env, framing="content-length"
         )
+    except (RuntimeError, TimeoutError) as exc:
+        if not _should_retry_stdio_mcp_framing(exc):
+            raise
+        return await _list_stdio_mcp_tool_names_with_framing(
+            command, args, env, framing="content-length"
+        )
 
 
 async def _list_stdio_mcp_tool_names_with_framing(
@@ -368,6 +374,13 @@ async def _list_stdio_mcp_tool_names_with_framing(
             except TimeoutError:
                 stderr_task.cancel()
                 await asyncio.gather(stderr_task, return_exceptions=True)
+
+
+def _should_retry_stdio_mcp_framing(exc: BaseException) -> bool:
+    """Return True when JSONL failed before a valid initialize response existed."""
+    if isinstance(exc, TimeoutError):
+        return True
+    return isinstance(exc, RuntimeError) and "exited before response" in str(exc)
 
 
 async def _send_stdio_mcp_message(

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -39,6 +39,10 @@ class _StdioMcpFramingMismatch(RuntimeError):
     """Raised when a stdio MCP response clearly uses another wire framing."""
 
 
+class _StdioMcpFramingProbeFailed(RuntimeError):
+    """Raised when the initialize response failed before framing was established."""
+
+
 @dataclass(frozen=True, slots=True)
 class _CodexMCPCommandEntry:
     command: str
@@ -277,13 +281,7 @@ async def _list_stdio_mcp_tool_names(
     """
     try:
         return await _list_stdio_mcp_tool_names_with_framing(command, args, env, framing="jsonl")
-    except (json.JSONDecodeError, _StdioMcpFramingMismatch):
-        return await _list_stdio_mcp_tool_names_with_framing(
-            command, args, env, framing="content-length"
-        )
-    except (RuntimeError, TimeoutError) as exc:
-        if not _should_retry_stdio_mcp_framing(exc):
-            raise
+    except _StdioMcpFramingProbeFailed:
         return await _list_stdio_mcp_tool_names_with_framing(
             command, args, env, framing="content-length"
         )
@@ -331,13 +329,23 @@ async def _list_stdio_mcp_tool_names_with_framing(
             },
             framing=framing,
         )
-        await _read_stdio_mcp_response(
-            proc,
-            request_id=1,
-            timeout=30.0,
-            stderr_buffer=stderr_buffer,
-            framing=framing,
-        )
+        try:
+            await _read_stdio_mcp_response(
+                proc,
+                request_id=1,
+                timeout=30.0,
+                stderr_buffer=stderr_buffer,
+                framing=framing,
+            )
+        except (
+            json.JSONDecodeError,
+            _StdioMcpFramingMismatch,
+            RuntimeError,
+            TimeoutError,
+        ) as exc:
+            if framing == "jsonl" and _should_retry_stdio_mcp_framing(exc):
+                raise _StdioMcpFramingProbeFailed(str(exc)) from exc
+            raise
         await _send_stdio_mcp_message(
             proc,
             {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
@@ -379,6 +387,8 @@ async def _list_stdio_mcp_tool_names_with_framing(
 def _should_retry_stdio_mcp_framing(exc: BaseException) -> bool:
     """Return True when JSONL failed before a valid initialize response existed."""
     if isinstance(exc, TimeoutError):
+        return True
+    if isinstance(exc, (json.JSONDecodeError, _StdioMcpFramingMismatch)):
         return True
     return isinstance(exc, RuntimeError) and "exited before response" in str(exc)
 

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -271,6 +271,22 @@ async def _list_stdio_mcp_tool_names(
     setup must not first require the current ``ouroboros codex doctor``
     interpreter to have installed the optional local ``mcp`` extra.
     """
+    try:
+        return await _list_stdio_mcp_tool_names_with_framing(command, args, env, framing="jsonl")
+    except (json.JSONDecodeError, RuntimeError, TimeoutError):
+        return await _list_stdio_mcp_tool_names_with_framing(
+            command, args, env, framing="content-length"
+        )
+
+
+async def _list_stdio_mcp_tool_names_with_framing(
+    command: str,
+    args: tuple[str, ...],
+    env: dict[str, str],
+    *,
+    framing: str,
+) -> frozenset[str]:
+    """Launch a stdio MCP server with one wire framing and return tool names."""
     process_env = os.environ.copy()
     process_env.update(env)
     proc = await asyncio.create_subprocess_exec(
@@ -303,20 +319,31 @@ async def _list_stdio_mcp_tool_names(
                     },
                 },
             },
+            framing=framing,
         )
         await _read_stdio_mcp_response(
-            proc, request_id=1, timeout=30.0, stderr_buffer=stderr_buffer
+            proc,
+            request_id=1,
+            timeout=30.0,
+            stderr_buffer=stderr_buffer,
+            framing=framing,
         )
         await _send_stdio_mcp_message(
             proc,
             {"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}},
+            framing=framing,
         )
         await _send_stdio_mcp_message(
             proc,
             {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+            framing=framing,
         )
         response = await _read_stdio_mcp_response(
-            proc, request_id=2, timeout=30.0, stderr_buffer=stderr_buffer
+            proc,
+            request_id=2,
+            timeout=30.0,
+            stderr_buffer=stderr_buffer,
+            framing=framing,
         )
         result = response.get("result")
         if not isinstance(result, Mapping):
@@ -340,12 +367,18 @@ async def _list_stdio_mcp_tool_names(
 
 
 async def _send_stdio_mcp_message(
-    proc: asyncio.subprocess.Process, message: Mapping[str, Any]
+    proc: asyncio.subprocess.Process, message: Mapping[str, Any], *, framing: str
 ) -> None:
     if proc.stdin is None:
         raise RuntimeError("MCP stdio process has no stdin")
     body = json.dumps(message, separators=(",", ":")).encode("utf-8")
-    proc.stdin.write(body + b"\n")
+    if framing == "jsonl":
+        proc.stdin.write(body + b"\n")
+    elif framing == "content-length":
+        header = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii")
+        proc.stdin.write(header + body)
+    else:  # pragma: no cover - internal defensive guard
+        raise RuntimeError(f"unsupported MCP stdio framing: {framing}")
     await proc.stdin.drain()
 
 
@@ -355,6 +388,7 @@ async def _read_stdio_mcp_response(
     request_id: int,
     timeout: float,
     stderr_buffer: bytearray,
+    framing: str,
 ) -> Mapping[str, Any]:
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
@@ -363,7 +397,8 @@ async def _read_stdio_mcp_response(
         if remaining <= 0:
             raise TimeoutError(f"timed out waiting for MCP stdio response id {request_id}")
         message = await asyncio.wait_for(
-            _read_stdio_mcp_message(proc, stderr_buffer=stderr_buffer), timeout=remaining
+            _read_stdio_mcp_message(proc, stderr_buffer=stderr_buffer, framing=framing),
+            timeout=remaining,
         )
         if message.get("id") != request_id:
             continue
@@ -374,10 +409,15 @@ async def _read_stdio_mcp_response(
 
 
 async def _read_stdio_mcp_message(
-    proc: asyncio.subprocess.Process, *, stderr_buffer: bytearray
+    proc: asyncio.subprocess.Process, *, stderr_buffer: bytearray, framing: str
 ) -> Mapping[str, Any]:
     if proc.stdout is None:
         raise RuntimeError("MCP stdio process has no stdout")
+
+    if framing == "content-length":
+        return await _read_content_length_stdio_mcp_message(proc, stderr_buffer=stderr_buffer)
+    if framing != "jsonl":  # pragma: no cover - internal defensive guard
+        raise RuntimeError(f"unsupported MCP stdio framing: {framing}")
 
     while True:
         line = await proc.stdout.readline()
@@ -389,6 +429,38 @@ async def _read_stdio_mcp_message(
         if not stripped:
             continue
         decoded = json.loads(stripped.decode("utf-8"))
+        if not isinstance(decoded, Mapping):
+            raise RuntimeError("MCP stdio response was not a JSON object")
+        return decoded
+
+
+async def _read_content_length_stdio_mcp_message(
+    proc: asyncio.subprocess.Process, *, stderr_buffer: bytearray
+) -> Mapping[str, Any]:
+    if proc.stdout is None:
+        raise RuntimeError("MCP stdio process has no stdout")
+
+    while True:
+        headers: dict[str, str] = {}
+        while True:
+            line = await proc.stdout.readline()
+            if line == b"":
+                stderr = _format_stdio_mcp_stderr(stderr_buffer)
+                detail = f": {stderr}" if stderr else ""
+                raise RuntimeError(f"MCP stdio process exited before response{detail}")
+            stripped = line.strip()
+            if not stripped:
+                break
+            name, separator, value = stripped.decode("ascii", errors="replace").partition(":")
+            if not separator:
+                raise RuntimeError("MCP stdio response header was malformed")
+            headers[name.lower()] = value.strip()
+
+        content_length = headers.get("content-length")
+        if content_length is None:
+            continue
+        body = await proc.stdout.readexactly(int(content_length))
+        decoded = json.loads(body.decode("utf-8"))
         if not isinstance(decoded, Mapping):
             raise RuntimeError("MCP stdio response was not a JSON object")
         return decoded

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -35,6 +35,10 @@ _MCP_PROTOCOL_VERSION = "2024-11-05"
 _MCP_STDERR_TAIL_BYTES = 8192
 
 
+class _StdioMcpFramingMismatch(RuntimeError):
+    """Raised when a stdio MCP response clearly uses another wire framing."""
+
+
 @dataclass(frozen=True, slots=True)
 class _CodexMCPCommandEntry:
     command: str
@@ -273,7 +277,7 @@ async def _list_stdio_mcp_tool_names(
     """
     try:
         return await _list_stdio_mcp_tool_names_with_framing(command, args, env, framing="jsonl")
-    except (json.JSONDecodeError, RuntimeError, TimeoutError):
+    except (json.JSONDecodeError, _StdioMcpFramingMismatch):
         return await _list_stdio_mcp_tool_names_with_framing(
             command, args, env, framing="content-length"
         )
@@ -428,6 +432,8 @@ async def _read_stdio_mcp_message(
         stripped = line.strip()
         if not stripped:
             continue
+        if stripped.lower().startswith(b"content-length:"):
+            raise _StdioMcpFramingMismatch("MCP stdio response used Content-Length framing")
         decoded = json.loads(stripped.decode("utf-8"))
         if not isinstance(decoded, Mapping):
             raise RuntimeError("MCP stdio response was not a JSON object")

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -312,24 +312,24 @@ async def _list_stdio_mcp_tool_names_with_framing(
         else None
     )
     try:
-        await _send_stdio_mcp_message(
-            proc,
-            {
-                "jsonrpc": "2.0",
-                "id": 1,
-                "method": "initialize",
-                "params": {
-                    "protocolVersion": _MCP_PROTOCOL_VERSION,
-                    "capabilities": {},
-                    "clientInfo": {
-                        "name": "ouroboros-codex-doctor",
-                        "version": "0.0.0",
+        try:
+            await _send_stdio_mcp_message(
+                proc,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "initialize",
+                    "params": {
+                        "protocolVersion": _MCP_PROTOCOL_VERSION,
+                        "capabilities": {},
+                        "clientInfo": {
+                            "name": "ouroboros-codex-doctor",
+                            "version": "0.0.0",
+                        },
                     },
                 },
-            },
-            framing=framing,
-        )
-        try:
+                framing=framing,
+            )
             await _read_stdio_mcp_response(
                 proc,
                 request_id=1,
@@ -338,6 +338,7 @@ async def _list_stdio_mcp_tool_names_with_framing(
                 framing=framing,
             )
         except (
+            OSError,
             json.JSONDecodeError,
             _StdioMcpFramingMismatch,
             RuntimeError,
@@ -388,7 +389,7 @@ def _should_retry_stdio_mcp_framing(exc: BaseException) -> bool:
     """Return True when JSONL failed before a valid initialize response existed."""
     if isinstance(exc, TimeoutError):
         return True
-    if isinstance(exc, (json.JSONDecodeError, _StdioMcpFramingMismatch)):
+    if isinstance(exc, (OSError, json.JSONDecodeError, _StdioMcpFramingMismatch)):
         return True
     return isinstance(exc, RuntimeError) and "exited before response" in str(exc)
 

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -8,6 +8,7 @@ import sys
 import textwrap
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from ouroboros.cli.commands.codex import (
@@ -333,7 +334,9 @@ class TestCodexDoctor:
 
                 first_line = sys.stdin.buffer.readline()
                 if first_line and first_line.lstrip().startswith(b"{"):
-                    raise SystemExit(2)
+                    sys.stdout.buffer.write(b"Content-Length: 2\r\n\r\n{}")
+                    sys.stdout.buffer.flush()
+                    raise SystemExit(0)
 
                 def read_message():
                     headers = {}
@@ -390,6 +393,32 @@ class TestCodexDoctor:
         )
 
         assert tool_names >= _REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST
+
+    def test_list_stdio_mcp_tool_names_surfaces_json_rpc_errors_without_framing_retry(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        server_path = tmp_path / "fake_error_mcp_server.py"
+        server_path.write_text(
+            textwrap.dedent(
+                r"""
+                import json
+                import sys
+
+                initialize = json.loads(sys.stdin.buffer.readline())
+                sys.stdout.buffer.write(json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": initialize["id"],
+                    "error": {"code": -32000, "message": "initialize rejected"},
+                }).encode("utf-8") + b"\n")
+                sys.stdout.buffer.flush()
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(RuntimeError, match="initialize rejected"):
+            asyncio.run(_list_stdio_mcp_tool_names(sys.executable, (str(server_path),), {}))
 
     def test_check_auto_dispatch_surface_live_mcp_accepts_uvx_mcp_extra_without_local_mcp(
         self,

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -250,7 +250,7 @@ class TestCodexDoctor:
             {"OUROBOROS_AGENT_RUNTIME": "codex"},
         )
 
-    def test_list_stdio_mcp_tool_names_uses_protocol_without_local_mcp_import(
+    def test_list_stdio_mcp_tool_names_uses_jsonl_protocol_without_local_mcp_import(
         self,
         tmp_path: Path,
     ) -> None:
@@ -266,22 +266,14 @@ class TestCodexDoctor:
                 sys.stderr.buffer.flush()
 
                 def read_message():
-                    content_length = None
-                    while True:
-                        line = sys.stdin.buffer.readline()
-                        if not line:
-                            raise SystemExit(0)
-                        line = line.strip()
-                        if not line:
-                            break
-                        key, _, value = line.partition(b":")
-                        if key.lower() == b"content-length":
-                            content_length = int(value.strip())
-                    return json.loads(sys.stdin.buffer.read(content_length))
+                    line = sys.stdin.buffer.readline()
+                    if not line:
+                        raise SystemExit(0)
+                    return json.loads(line)
 
                 def write_message(message):
                     body = json.dumps(message).encode("utf-8")
-                    sys.stdout.buffer.write(b"Content-Length: " + str(len(body)).encode("ascii") + b"\r\n\r\n" + body)
+                    sys.stdout.buffer.write(body + b"\n")
                     sys.stdout.buffer.flush()
 
                 initialize = read_message()
@@ -299,6 +291,11 @@ class TestCodexDoctor:
                     },
                 })
                 read_message()  # notifications/initialized
+                write_message({
+                    "jsonrpc": "2.0",
+                    "method": "notifications/message",
+                    "params": {"level": "info", "data": "skip non-response messages"},
+                })
                 tools_list = read_message()
                 write_message({
                     "jsonrpc": "2.0",

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -320,6 +320,77 @@ class TestCodexDoctor:
 
         assert tool_names >= _REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST
 
+    def test_list_stdio_mcp_tool_names_preserves_content_length_fallback(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        server_path = tmp_path / "fake_header_mcp_server.py"
+        server_path.write_text(
+            textwrap.dedent(
+                r"""
+                import json
+                import sys
+
+                first_line = sys.stdin.buffer.readline()
+                if first_line and first_line.lstrip().startswith(b"{"):
+                    raise SystemExit(2)
+
+                def read_message():
+                    headers = {}
+                    line = first_line
+                    while True:
+                        if not line:
+                            raise SystemExit(0)
+                        stripped = line.strip()
+                        if not stripped:
+                            break
+                        name, value = stripped.decode("ascii").split(":", 1)
+                        headers[name.lower()] = value.strip()
+                        line = sys.stdin.buffer.readline()
+                    return json.loads(sys.stdin.buffer.read(int(headers["content-length"])))
+
+                def write_message(message):
+                    body = json.dumps(message).encode("utf-8")
+                    sys.stdout.buffer.write(
+                        f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body
+                    )
+                    sys.stdout.buffer.flush()
+
+                initialize = read_message()
+                write_message({
+                    "jsonrpc": "2.0",
+                    "id": initialize["id"],
+                    "result": {
+                        "protocolVersion": initialize["params"]["protocolVersion"],
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "fake", "version": "1.0.0"},
+                    },
+                })
+                read_message()
+                tools_list = read_message()
+                write_message({
+                    "jsonrpc": "2.0",
+                    "id": tools_list["id"],
+                    "result": {
+                        "tools": [
+                            {"name": "ouroboros_auto", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_start_auto", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_interview", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_generate_seed", "inputSchema": {"type": "object"}},
+                        ]
+                    },
+                })
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        tool_names = asyncio.run(
+            _list_stdio_mcp_tool_names(sys.executable, (str(server_path),), {})
+        )
+
+        assert tool_names >= _REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST
+
     def test_check_auto_dispatch_surface_live_mcp_accepts_uvx_mcp_extra_without_local_mcp(
         self,
         tmp_path: Path,

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -426,6 +426,39 @@ class TestCodexDoctor:
         )
         assert not _should_retry_stdio_mcp_framing(RuntimeError("initialize rejected"))
 
+    def test_list_stdio_mcp_tool_names_does_not_retry_after_initialize_response(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        server_path = tmp_path / "fake_post_initialize_exit_mcp_server.py"
+        server_path.write_text(
+            textwrap.dedent(
+                r"""
+                import json
+                import sys
+
+                initialize = json.loads(sys.stdin.buffer.readline())
+                sys.stdout.buffer.write(json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": initialize["id"],
+                    "result": {
+                        "protocolVersion": initialize["params"]["protocolVersion"],
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "fake", "version": "1.0.0"},
+                    },
+                }).encode("utf-8") + b"\n")
+                sys.stdout.buffer.flush()
+                sys.stdin.buffer.readline()  # notifications/initialized
+                sys.stdin.buffer.readline()  # tools/list
+                raise SystemExit(3)
+                """
+            ),
+            encoding="utf-8",
+        )
+
+        with pytest.raises(RuntimeError, match="exited before response"):
+            asyncio.run(_list_stdio_mcp_tool_names(sys.executable, (str(server_path),), {}))
+
     def test_check_auto_dispatch_surface_live_mcp_accepts_uvx_mcp_extra_without_local_mcp(
         self,
         tmp_path: Path,

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -15,6 +15,7 @@ from ouroboros.cli.commands.codex import (
     _MCP_PROTOCOL_VERSION,
     _check_auto_dispatch_surface,
     _list_stdio_mcp_tool_names,
+    _should_retry_stdio_mcp_framing,
     app,
 )
 from ouroboros.codex import CodexArtifactInstallResult, install_codex_artifacts
@@ -334,9 +335,7 @@ class TestCodexDoctor:
 
                 first_line = sys.stdin.buffer.readline()
                 if first_line and first_line.lstrip().startswith(b"{"):
-                    sys.stdout.buffer.write(b"Content-Length: 2\r\n\r\n{}")
-                    sys.stdout.buffer.flush()
-                    raise SystemExit(0)
+                    raise SystemExit(2)
 
                 def read_message():
                     headers = {}
@@ -419,6 +418,13 @@ class TestCodexDoctor:
 
         with pytest.raises(RuntimeError, match="initialize rejected"):
             asyncio.run(_list_stdio_mcp_tool_names(sys.executable, (str(server_path),), {}))
+
+    def test_stdio_mcp_framing_retry_policy_distinguishes_probe_failures(self) -> None:
+        assert _should_retry_stdio_mcp_framing(TimeoutError("timed out waiting"))
+        assert _should_retry_stdio_mcp_framing(
+            RuntimeError("MCP stdio process exited before response")
+        )
+        assert not _should_retry_stdio_mcp_framing(RuntimeError("initialize rejected"))
 
     def test_check_auto_dispatch_surface_live_mcp_accepts_uvx_mcp_extra_without_local_mcp(
         self,

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from typer.testing import CliRunner
 
+from ouroboros.cli.commands import codex as codex_command
 from ouroboros.cli.commands.codex import (
     _MCP_PROTOCOL_VERSION,
     _check_auto_dispatch_surface,
@@ -393,6 +394,82 @@ class TestCodexDoctor:
 
         assert tool_names >= _REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST
 
+    def test_list_stdio_mcp_tool_names_retries_when_jsonl_initialize_send_fails(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        server_path = tmp_path / "fake_header_mcp_server.py"
+        server_path.write_text(
+            textwrap.dedent(
+                r"""
+                import json
+                import sys
+
+                def read_message():
+                    headers = {}
+                    while True:
+                        line = sys.stdin.buffer.readline()
+                        if not line:
+                            raise SystemExit(0)
+                        stripped = line.strip()
+                        if not stripped:
+                            break
+                        name, value = stripped.decode("ascii").split(":", 1)
+                        headers[name.lower()] = value.strip()
+                    return json.loads(sys.stdin.buffer.read(int(headers["content-length"])))
+
+                def write_message(message):
+                    body = json.dumps(message).encode("utf-8")
+                    sys.stdout.buffer.write(
+                        f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body
+                    )
+                    sys.stdout.buffer.flush()
+
+                initialize = read_message()
+                write_message({
+                    "jsonrpc": "2.0",
+                    "id": initialize["id"],
+                    "result": {
+                        "protocolVersion": initialize["params"]["protocolVersion"],
+                        "capabilities": {"tools": {}},
+                        "serverInfo": {"name": "fake", "version": "1.0.0"},
+                    },
+                })
+                read_message()
+                tools_list = read_message()
+                write_message({
+                    "jsonrpc": "2.0",
+                    "id": tools_list["id"],
+                    "result": {
+                        "tools": [
+                            {"name": "ouroboros_auto", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_start_auto", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_interview", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_generate_seed", "inputSchema": {"type": "object"}},
+                        ]
+                    },
+                })
+                """
+            ),
+            encoding="utf-8",
+        )
+        original_send = codex_command._send_stdio_mcp_message
+
+        async def fail_jsonl_initialize_send(proc, message, *, framing):
+            if framing == "jsonl" and message.get("method") == "initialize":
+                raise BrokenPipeError("pipe closed during JSONL initialize write")
+            await original_send(proc, message, framing=framing)
+
+        with patch(
+            "ouroboros.cli.commands.codex._send_stdio_mcp_message",
+            side_effect=fail_jsonl_initialize_send,
+        ):
+            tool_names = asyncio.run(
+                _list_stdio_mcp_tool_names(sys.executable, (str(server_path),), {})
+            )
+
+        assert tool_names >= _REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST
+
     def test_list_stdio_mcp_tool_names_surfaces_json_rpc_errors_without_framing_retry(
         self,
         tmp_path: Path,
@@ -421,6 +498,7 @@ class TestCodexDoctor:
 
     def test_stdio_mcp_framing_retry_policy_distinguishes_probe_failures(self) -> None:
         assert _should_retry_stdio_mcp_framing(TimeoutError("timed out waiting"))
+        assert _should_retry_stdio_mcp_framing(BrokenPipeError("pipe closed"))
         assert _should_retry_stdio_mcp_framing(
             RuntimeError("MCP stdio process exited before response")
         )


### PR DESCRIPTION
## Summary
- change `ouroboros codex doctor --live-mcp` to speak the Python MCP stdio JSON-lines transport instead of LSP-style `Content-Length` frames
- keep the live probe dependency-light by preserving the direct JSON-RPC initialize/tools-list flow
- update the fake MCP server regression test to require JSONL and verify notifications are skipped while waiting for the matching response id

## Why
`mcp.client.stdio.stdio_client` writes newline-delimited JSON messages. The live doctor introduced in #1047 used `Content-Length` framing, so it could report `ooo auto` dispatch as broken even when a real MCP SDK client lists `ouroboros_auto` correctly.

## Test plan
- `uv run pytest tests/unit/cli/test_codex_command.py -q`
- `uv run ruff check src/ouroboros/cli/commands/codex.py tests/unit/cli/test_codex_command.py`
- `uv run ruff format --check src/ouroboros/cli/commands/codex.py tests/unit/cli/test_codex_command.py`
- `uv run ouroboros codex doctor --live-mcp`

Refs #1045
Refs #1047