### PR TITLE
fix(auto): pass last_question when reopening seed-ready interviews

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -110,9 +110,14 @@ class HandlerInterviewBackend(InterviewBackend):
         result = _unwrap(outcome, tool_name="ouroboros_interview")
         return _turn_from_result(result)
 
-    async def answer(self, session_id: str, answer: str) -> InterviewTurn:
+    async def answer(
+        self, session_id: str, answer: str, *, last_question: str | None = None
+    ) -> InterviewTurn:
+        arguments = {"session_id": session_id, "answer": answer}
+        if last_question:
+            arguments["last_question"] = last_question
         result = _unwrap(
-            await self.handler.handle({"session_id": session_id, "answer": answer}),
+            await self.handler.handle(arguments),
             tool_name="ouroboros_interview",
         )
         return _turn_from_result(result, fallback_session_id=session_id)

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -56,8 +56,17 @@ class InterviewBackend(Protocol):
         an id that disagrees with the on-disk interview file.
         """
 
-    async def answer(self, session_id: str, answer: str) -> InterviewTurn:
-        """Record an answer and return the next question or completion metadata."""
+    async def answer(
+        self, session_id: str, answer: str, *, last_question: str | None = None
+    ) -> InterviewTurn:
+        """Record an answer and return the next question or completion metadata.
+
+        ``last_question`` is supplied when the driver is answering a
+        driver-originated probe rather than an unanswered backend turn. The
+        MCP interview handler requires it when reopening an already-answered
+        seed-ready interview so the transcript is not bound to stale question
+        text.
+        """
 
     async def resume(self, session_id: str) -> InterviewTurn:
         """Return the outstanding question for a persisted interview session."""
@@ -293,7 +302,11 @@ class AutoInterviewDriver:
             try:
                 turn = _validate_turn(
                     await self._with_timeout(
-                        self.backend.answer(turn.session_id, answer.prefixed_text),
+                        self.backend.answer(
+                            turn.session_id,
+                            answer.prefixed_text,
+                            last_question=question_for_record,
+                        ),
                         state,
                         tool_name="interview.answer",
                     )
@@ -533,7 +546,7 @@ class FunctionInterviewBackend:
     def __init__(
         self,
         start: Callable[[str, str], Awaitable[InterviewTurn]],
-        answer: Callable[[str, str], Awaitable[InterviewTurn]],
+        answer: Callable[..., Awaitable[InterviewTurn]],
         resume: Callable[[str], Awaitable[InterviewTurn]] | None = None,
         is_session_persisted: Callable[[str], bool] | None = None,
     ) -> None:
@@ -549,7 +562,14 @@ class FunctionInterviewBackend:
             return await self._start(goal, cwd, interview_id=interview_id)  # type: ignore[call-arg]
         return await self._start(goal, cwd)
 
-    async def answer(self, session_id: str, answer: str) -> InterviewTurn:
+    async def answer(
+        self, session_id: str, answer: str, *, last_question: str | None = None
+    ) -> InterviewTurn:
+        # Forward ``last_question`` only to callables that opt into the
+        # reopened-interview contract; legacy ``(session_id, answer)`` test
+        # callables remain compatible.
+        if "last_question" in inspect.signature(self._answer).parameters:
+            return await self._answer(session_id, answer, last_question=last_question)
         return await self._answer(session_id, answer)
 
     async def resume(self, session_id: str) -> InterviewTurn:

--- a/tests/unit/auto/test_adapters_client_gates.py
+++ b/tests/unit/auto/test_adapters_client_gates.py
@@ -47,6 +47,46 @@ async def test_auto_interview_backend_ignores_seed_ready_client_gate_metadata(tm
 
 
 @pytest.mark.asyncio
+async def test_auto_interview_backend_forwards_last_question_for_reopened_answers(
+    tmp_path,
+) -> None:
+    """The handler adapter must preserve the driver's seed-ready reopen probe."""
+    handler = AsyncMock()
+    handler.handle = AsyncMock(
+        return_value=Result.ok(
+            MCPToolResult(
+                content=(
+                    MCPContentItem(
+                        type=ContentType.TEXT,
+                        text="Session interview_auto\n\nSeed-ready.",
+                    ),
+                ),
+                is_error=False,
+                meta={"session_id": "interview_auto", "seed_ready": True},
+            )
+        )
+    )
+    handler.resolved_state_dir.return_value = tmp_path
+    backend = HandlerInterviewBackend(handler, cwd=str(tmp_path))
+
+    await backend.answer(
+        "interview_auto",
+        "[from-auto] No cloud sync",
+        last_question="[driver gap-reopen 'non_goals': backend_completed=True ledger_done=False]",
+    )
+
+    handler.handle.assert_awaited_once_with(
+        {
+            "session_id": "interview_auto",
+            "answer": "[from-auto] No cloud sync",
+            "last_question": (
+                "[driver gap-reopen 'non_goals': backend_completed=True ledger_done=False]"
+            ),
+        }
+    )
+
+
+@pytest.mark.asyncio
 async def test_auto_seed_generator_passes_client_gate_acknowledgements() -> None:
     """The opt-in hard gate must not break maintained auto seed generation."""
     handler = AsyncMock()

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2651,6 +2651,51 @@ async def test_interview_driver_accepts_initial_completed_turn_without_answering
 
 
 @pytest.mark.asyncio
+async def test_interview_driver_supplies_last_question_for_seed_ready_gap_reopen(tmp_path) -> None:
+    """A backend-completed interview can be reopened by a driver gap probe.
+
+    The MCP interview handler rejects answers against an already-answered
+    seed-ready transcript unless the caller supplies the fresh probe text as
+    ``last_question``. Pin the auto-driver contract so `ooo auto` can fill a
+    remaining ledger gap after backend completion instead of blocking before
+    Seed generation.
+    """
+
+    observed_last_questions: list[str | None] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("already complete", "interview_done", seed_ready=True, completed=True)
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        observed_last_questions.append(last_question)
+        if not last_question:
+            raise RuntimeError("missing last_question for reopened seed-ready interview")
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    ledger.sections["non_goals"].entries.clear()
+    assert ledger.open_gaps() == ["non_goals"]
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=2,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert observed_last_questions == [
+        "[driver gap-reopen 'non_goals': backend_completed=True ledger_done=False]"
+    ]
+    assert ledger.is_seed_ready()
+
+
+@pytest.mark.asyncio
 async def test_interview_driver_does_not_replace_specific_verification_answer_with_gap_prompt(
     tmp_path,
 ) -> None:


### PR DESCRIPTION
## Summary
- extend the auto interview backend contract with optional `last_question`
- pass the driver-originated gap-reopen probe through `AutoInterviewDriver` when answering a backend-completed but ledger-incomplete interview
- forward `last_question` from `HandlerInterviewBackend` to `ouroboros_interview`
- keep legacy test/function backends compatible by forwarding `last_question` only when their callable accepts it

## Why
A live `ooo auto` Codex observation reached `ouroboros_auto`, then blocked before Seed generation with:

```
Cannot record answer - the previous round is already answered and no follow-up question was provided. When reopening a completed interview (Seed-ready challenge), pass the new probe question as last_question alongside answer.
```

That means dispatch worked, but auto answered a driver-created closure/gap probe without passing the probe text to the MCP interview handler.

## Test plan
- `uv run pytest tests/unit/auto/test_interview_pipeline.py tests/unit/auto/test_adapters_client_gates.py -q`
- `uv run ruff check src/ouroboros/auto/interview_driver.py src/ouroboros/auto/adapters.py tests/unit/auto/test_interview_pipeline.py tests/unit/auto/test_adapters_client_gates.py`
- `uv run ruff format --check src/ouroboros/auto/interview_driver.py src/ouroboros/auto/adapters.py tests/unit/auto/test_interview_pipeline.py tests/unit/auto/test_adapters_client_gates.py`

Refs #1045