### PR TITLE
docs(codex): distinguish auto blocked from dispatch failure

### DIFF
--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -26,6 +26,11 @@ otherwise emulate the auto pipeline as a substitute.
 If `ouroboros_auto` is unavailable, stop and report that the required MCP tool
 is unavailable. A manual fallback is not an `ooo auto` run.
 
+If `ouroboros_auto` is invoked successfully but returns `blocked`, `failed`, or
+another terminal auto-session status, report that auto-session status and the
+tool's blocker. Do not label that outcome as MCP dispatch failure; dispatch
+failure means the MCP tool could not be invoked.
+
 ## Usage
 
 ```text

--- a/src/ouroboros/codex/ouroboros.md
+++ b/src/ouroboros/codex/ouroboros.md
@@ -42,6 +42,12 @@ If a user input starts with `ooo auto`, call `ouroboros_auto`. If that MCP tool
 is unavailable, stop and report that `ouroboros_auto` is unavailable instead of
 continuing as a normal Codex task.
 
+If `ouroboros_auto` is invoked and returns an auto-session outcome such as
+`blocked`, `failed`, or `complete`, report that outcome as the auto session
+result. Do not call a `blocked` or `failed` auto-session result a dispatch
+failure; dispatch failure is reserved for cases where the MCP tool could not be
+invoked.
+
 ## Setup & Update
 
 - `ooo setup` → write Ouroboros config (`~/.ouroboros/config.yaml`) and register the MCP server

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -122,6 +122,7 @@ class TestInstallCodexRules:
         assert "| `ooo auto ...` | `ouroboros_auto`" in rules
         assert "Do not emulate it with manual" in rules
         assert "If that MCP tool\nis unavailable" in rules
+        assert "Do not call a `blocked` or `failed` auto-session result a dispatch" in rules
 
     def test_packaged_rules_include_rendered_skill_capability_guide(self) -> None:
         """Codex rules should include the generated runtime skill capability guide."""
@@ -188,6 +189,7 @@ class TestLoadPackagedCodexSkills:
 
         assert "must be executed by invoking MCP tool `ouroboros_auto`" in skill
         assert "manual fallback is not an `ooo auto` run" in skill
+        assert "Do not label that outcome as MCP dispatch failure" in skill
 
     def test_packaged_interview_skill_uses_runtime_capability_terms(self) -> None:
         """Runtime skill instructions should not hardcode Claude-only tool surfaces."""


### PR DESCRIPTION
## Summary
- clarify in the packaged auto skill that a returned `blocked`/`failed` auto-session status is not MCP dispatch failure
- clarify in Codex rules that dispatch failure means `ouroboros_auto` could not be invoked
- pin the wording in packaged artifact tests

## Why
A live observation correctly dispatched `ooo auto` to `ouroboros_auto`, but the final report started with “Dispatch failed” even though the tool had been invoked and returned a blocked auto-session state. That wording makes environment/config regressions harder to distinguish from auto pipeline blockers.

## Test plan
- `uv run pytest tests/unit/test_codex_artifacts.py -q`
- `uv run ruff check tests/unit/test_codex_artifacts.py`
- `uv run ruff format --check tests/unit/test_codex_artifacts.py`

Refs #1045