### PR TITLE
fix(auto): repair Seed goal drift from the ledger

### DIFF
--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -72,7 +72,14 @@ class SeedRepairer:
         ledger: SeedDraftLedger | None = None,
     ) -> RepairResult:
         """Apply one deterministic repair pass."""
-        if review.grade_result.blockers:
+        repairable_blocker_codes = set()
+        unrepaired_blockers = []
+        for blocker in review.grade_result.blockers:
+            if blocker.code == "seed_goal_mismatch" and ledger is not None:
+                repairable_blocker_codes.add(blocker.code)
+            else:
+                unrepaired_blockers.append(blocker)
+        if unrepaired_blockers:
             return RepairResult(
                 changed=False,
                 seed=seed,
@@ -82,11 +89,20 @@ class SeedRepairer:
 
         constraints = list(seed.constraints)
         acceptance = list(seed.acceptance_criteria)
+        goal = seed.goal
         applied: list[str] = []
         unresolved: list[ReviewFinding] = []
         repaired_acceptance_indices: set[int] = set()
 
+        for blocker_code in repairable_blocker_codes:
+            ledger_goal = _latest_resolved_goal(ledger)
+            if ledger_goal:
+                goal = ledger_goal
+                applied.append(_finding_fingerprint(review, blocker_code))
+
         for finding in review.findings:
+            if finding.code in repairable_blocker_codes:
+                continue
             if finding.code in {"vague_acceptance_criteria", "untestable_acceptance_criteria"}:
                 index = _target_index(finding.target)
                 if index is not None and index < len(acceptance):
@@ -131,6 +147,7 @@ class SeedRepairer:
         if changed:
             updated_seed = seed.model_copy(
                 update={
+                    "goal": goal,
                     "constraints": tuple(dict.fromkeys(constraints)),
                     "acceptance_criteria": tuple(dict.fromkeys(acceptance)),
                     "metadata": seed.metadata.model_copy(
@@ -245,6 +262,13 @@ def _target_index(target: str) -> int | None:
         return int(target.split("[", 1)[1].split("]", 1)[0])
     except ValueError:
         return None
+
+
+def _finding_fingerprint(review: SeedReview, code: str) -> str:
+    for finding in review.findings:
+        if finding.code == code:
+            return finding.fingerprint
+    return code
 
 
 def _safe_auto_mvp_non_goal(ledger: SeedDraftLedger) -> str:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -967,6 +967,49 @@ def test_seed_repairer_assigns_new_seed_identity_after_mutation() -> None:
     assert result.seed.metadata.parent_seed_id == seed.metadata.seed_id
 
 
+def test_seed_repairer_repairs_goal_mismatch_from_ledger() -> None:
+    ledger_goal = (
+        "Create hello_auto.py at the repository root and verify hello_auto() returns "
+        "the expected string with pytest"
+    )
+    ledger = SeedDraftLedger.from_goal(ledger_goal)
+    _fill_ready(ledger)
+    seed = _seed(
+        ac=("The targeted pytest test asserts hello_auto() returns the expected string and passes",)
+    ).model_copy(update={"goal": "Create a minimal proof file"})
+    review = SeedReviewer().review(seed, ledger=ledger)
+
+    result = SeedRepairer().repair_once(seed, review, ledger=ledger)
+
+    assert result.changed
+    assert result.blocker is None
+    assert result.seed.goal == ledger_goal
+    assert result.seed.metadata.seed_id != seed.metadata.seed_id
+    assert result.seed.metadata.parent_seed_id == seed.metadata.seed_id
+
+
+def test_seed_repairer_converges_after_repairable_goal_mismatch() -> None:
+    ledger_goal = (
+        "Create hello_auto.py at the repository root and verify hello_auto() returns "
+        "the expected string with pytest"
+    )
+    ledger = SeedDraftLedger.from_goal(ledger_goal)
+    _fill_ready(ledger)
+    seed = _seed(
+        ac=("The targeted pytest test asserts hello_auto() returns the expected string and passes",)
+    ).model_copy(update={"goal": "Create a minimal proof file"})
+
+    repaired, final_review, history = SeedRepairer(max_iterations=2).converge(
+        seed,
+        ledger=ledger,
+    )
+
+    assert len(history) == 1
+    assert repaired.goal == ledger_goal
+    assert final_review.grade_result.grade == SeedGrade.A
+    assert final_review.may_run
+
+
 def test_seed_repairer_non_goals_do_not_contradict_goal_scope() -> None:
     seed = _seed()
     ledger = SeedDraftLedger.from_goal("Add authentication and deploy this service to production")


### PR DESCRIPTION
## Summary
- allow the deterministic repair loop to repair `seed_goal_mismatch` by restoring the latest resolved ledger goal onto the Seed
- keep non-repairable hard blockers as blockers
- preserve strict grade-gate semantics: the repaired Seed is re-reviewed before it may run

## Why
The latest `ooo auto` observation reached Seed generation but blocked at grade C because the generated Seed goal compressed the full interview goal enough to trigger `seed_goal_mismatch`. That is deterministic Seed drift and should be repaired, not bypassed.

## Direction check
This matches the intended `ooo auto` direction: auto should converge to an A-grade Seed through bounded repair while keeping execution gated. This PR does not loosen grading or allow manual fallback.

## Test plan
- `uv run pytest tests/unit/auto/test_interview_pipeline.py tests/unit/auto/test_ledger_grading_answerer.py -q`
- `uv run ruff check src/ouroboros/auto/seed_repairer.py tests/unit/auto/test_interview_pipeline.py`
- `uv run ruff format --check src/ouroboros/auto/seed_repairer.py tests/unit/auto/test_interview_pipeline.py`

Refs #1045