### PR TITLE
fix(mcp): expose durable job links in status output

### DIFF
--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -359,6 +359,10 @@ async def _render_job_snapshot_inner(
         f"**Cursor**: {snapshot.cursor}",
     ]
 
+    link_lines = _render_job_link_lines(snapshot)
+    if link_lines:
+        lines.extend(["", "### Links", *link_lines])
+
     if snapshot.links.execution_id:
         workflow_event = await _query_latest_workflow_event(
             event_store, snapshot.links.execution_id
@@ -490,6 +494,26 @@ async def _render_job_snapshot_inner(
         lines.extend(["", f"**Error**: {snapshot.error}"])
 
     return "\n".join(lines), progress
+
+
+def _render_job_link_lines(snapshot: JobSnapshot) -> list[str]:
+    """Return stable job cross-reference lines for every linked job surface.
+
+    Some long-running flows, notably ``ouroboros_start_auto``, use
+    ``links.session_id`` as their durable resume handle without necessarily
+    having a matching orchestrator session row. Render the raw links before
+    optional rich session/execution/lineage sections so callers always see the
+    identifiers they need to poll, resume, or diagnose the job.
+    """
+
+    lines: list[str] = []
+    if snapshot.links.session_id:
+        lines.append(f"**Session ID**: {snapshot.links.session_id}")
+    if snapshot.links.execution_id:
+        lines.append(f"**Execution ID**: {snapshot.links.execution_id}")
+    if snapshot.links.lineage_id:
+        lines.append(f"**Lineage ID**: {snapshot.links.lineage_id}")
+    return lines
 
 
 @dataclass

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -1370,6 +1370,46 @@ class TestJobManager:
         assert "**Status**: running" in result.value.text_content
         assert "job_default_full | running" not in result.value.text_content
 
+    async def test_job_status_full_view_renders_raw_links_without_session_row(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        snapshot = JobSnapshot(
+            job_id="job_auto_links",
+            job_type="auto",
+            status=JobStatus.RUNNING,
+            message="Running auto",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=4,
+            links=JobLinks(
+                session_id="auto_session_links",
+                execution_id="exec_links",
+                lineage_id="lin_links",
+            ),
+        )
+
+        class StaticJobManager:
+            async def get_snapshot(self, job_id: str) -> JobSnapshot:
+                assert job_id == snapshot.job_id
+                return snapshot
+
+        handler = JobStatusHandler(event_store=store, job_manager=StaticJobManager())
+        await store.initialize()
+        try:
+            result = await handler.handle({"job_id": "job_auto_links"})
+        finally:
+            await store.close()
+
+        assert result.is_ok
+        assert "### Links" in result.value.text_content
+        assert "**Session ID**: auto_session_links" in result.value.text_content
+        assert "**Execution ID**: exec_links" in result.value.text_content
+        assert "**Lineage ID**: lin_links" in result.value.text_content
+        assert result.value.meta["session_id"] == "auto_session_links"
+        assert result.value.meta["execution_id"] == "exec_links"
+        assert result.value.meta["lineage_id"] == "lin_links"
+
     async def test_job_wait_omitted_view_preserves_full_unchanged_snapshot(self, tmp_path) -> None:
         store = _build_store(tmp_path)
         snapshot = JobSnapshot(


### PR DESCRIPTION
## Summary
- render raw job cross-reference links (`session_id`, `execution_id`, `lineage_id`) in full `ouroboros_job_status` output before optional rich session/execution lookup
- preserve existing structured meta fields for polling clients
- add regression coverage for an auto-shaped job whose `session_id` is a durable resume handle but has no orchestrator session row

## Scope
Narrow #925 read-model/status slice only. This does not change JobManager lifecycle, start handler behavior, cancellation, plugin delegation, or runtime transition semantics.

## Why
Long-running MCP start surfaces need consistent job/session identifiers. Some flows such as `ouroboros_start_auto` persist `links.session_id` as the resume handle even when there is no `SessionRepository` row to render, so the status text should still expose that ID.

## Validation
- `uv run pytest tests/unit/mcp/test_job_manager.py -q`
- `uv run ruff check src/ouroboros/mcp/tools/job_handlers.py tests/unit/mcp/test_job_manager.py`
- `uv run ruff format --check src/ouroboros/mcp/tools/job_handlers.py tests/unit/mcp/test_job_manager.py`
- `uv run mypy src/ouroboros/mcp/tools/job_handlers.py tests/unit/mcp/test_job_manager.py`

Refs #925
Refs #961
