### PR TITLE
fix(plugin): require lifecycle read scope for v0.3 hooks

### DIFF
--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import Any
 
 from ouroboros.plugin.hooks import (
+    HOOK_LIFECYCLE_READ_SCOPE,
     is_deferred_hook_kind,
     is_excluded_hook_kind,
     is_v1_failure_policy,
@@ -386,6 +387,13 @@ def _build_hook(
                 got=scope,
             )
 
+    _validate_hook_lifecycle_permission(
+        raw,
+        hook_index=hook_index,
+        manifest_path=manifest_path,
+        schema_version=schema_version,
+    )
+
     entrypoint_raw = raw["entrypoint"]
     return HookSpec(
         name=hook_name,
@@ -397,6 +405,35 @@ def _build_hook(
         timeout_seconds=raw.get("timeout_seconds"),
         permissions=tuple(raw.get("permissions", ())),
         description=raw.get("description", ""),
+    )
+
+
+def _validate_hook_lifecycle_permission(
+    raw: dict[str, Any],
+    *,
+    hook_index: int,
+    manifest_path: str | Path,
+    schema_version: str,
+) -> None:
+    """Require v0.3 lifecycle hooks to declare the v1 read permission.
+
+    Earlier slices introduced ``plugin:lifecycle:read`` as the permission
+    boundary for v1 observability hooks. Enforce it only for the tightened
+    v0.3 hook contract so supported v0.2 manifests keep their compatibility
+    behavior until that schema version is retired deliberately.
+    """
+
+    if schema_version != "0.3" or not is_v1_hook_kind(raw["name"]):
+        return
+    permissions = raw.get("permissions", ())
+    if HOOK_LIFECYCLE_READ_SCOPE in permissions:
+        return
+    raise PluginManifestError(
+        "v0.3 lifecycle hook must declare plugin:lifecycle:read",
+        path=str(manifest_path),
+        json_pointer=f"/hooks/{hook_index}/permissions",
+        expected=f"{HOOK_LIFECYCLE_READ_SCOPE!r} in hooks[].permissions",
+        got=permissions,
     )
 
 

--- a/src/ouroboros/plugin/schemas/0.3/_source.json
+++ b/src/ouroboros/plugin/schemas/0.3/_source.json
@@ -1,11 +1,12 @@
 {
   "source": "Q00/ouroboros",
-  "purpose": "Local plugin manifest schema v0.3: tightens hook lifecycle vocabulary to v1 names only.",
-  "note": "Iterates on local 0.2 by narrowing hooks[].name to the v1 HookKind set ('before_invocation', 'after_invocation'). Deferred and excluded hook names are no longer accepted at the JSON Schema layer for v0.3; the still-supported v0.2 schema keeps its broader hook enum for backward compatibility. Hook execution/dispatch remains intentionally out of scope.",
+  "purpose": "Local plugin manifest schema v0.3: tightens hook lifecycle vocabulary and required lifecycle read permission to v1-only contract.",
+  "note": "Iterates on local 0.2 by narrowing hooks[].name to the v1 HookKind set ('before_invocation', 'after_invocation') and requiring each v0.3 hook permission list to contain plugin:lifecycle:read. Deferred and excluded hook names remain accepted only by the still-supported v0.2 schema for backward compatibility. Hook execution/dispatch remains intentionally out of scope.",
   "local_extensions": {
     "plugin.schema.json": [
       "Bumped $id/title/schema_version const from 0.2 to 0.3.",
       "Narrowed hooks[].name enum to the v1 HookKind set: 'before_invocation' and 'after_invocation'. Deferred candidates (before_tool_call, after_tool_call, before_artifact_write, after_artifact_write, on_error, on_cancel) and excluded candidates (before_runtime_start, after_runtime_start, before_state_commit, after_state_commit, on_event, on_rewind) are no longer accepted at the schema layer; refer to src/ouroboros/plugin/hooks.py for the routing helpers and follow-up RFC slices.",
+      "Requires hooks[].permissions and requires that array to contain plugin:lifecycle:read so archived v0.3 JSON Schema and Python loader enforce the same lifecycle permission boundary.",
       "Allows plugin.hook.blocked / plugin.hook.failed in explicit audit.events declarations while preserving the four-event default used by the Python manifest loader until runtime hook dispatch lands."
     ],
     "audit-event.schema.json": [

--- a/src/ouroboros/plugin/schemas/0.3/plugin.schema.json
+++ b/src/ouroboros/plugin/schemas/0.3/plugin.schema.json
@@ -240,7 +240,7 @@
       "default": [],
       "items": {
         "type": "object",
-        "required": ["name", "entrypoint", "failure_policy"],
+        "required": ["name", "entrypoint", "failure_policy", "permissions"],
         "additionalProperties": false,
         "properties": {
           "name": {
@@ -273,6 +273,9 @@
             "items": {
               "type": "string",
               "pattern": "^[a-z][a-z0-9_-]*(?::[a-z][a-z0-9_-]*){0,3}$"
+            },
+            "contains": {
+              "const": "plugin:lifecycle:read"
             },
             "uniqueItems": true,
             "default": []

--- a/tests/unit/plugin/test_hook_permission_scopes.py
+++ b/tests/unit/plugin/test_hook_permission_scopes.py
@@ -6,9 +6,8 @@ frozen membership set and ``is_hook_lifecycle_scope`` is the routing
 helper consumed by manifest validators / capability resolvers in a
 later slice.
 
-This PR adds only the constants and the routing helper — no manifest
-validation requirement that hooks declare a lifecycle scope (that
-lands alongside the `plugin.permission_used` emission rule update).
+The manifest validator consumes the constants so v0.3 hook declarations
+must opt into the lifecycle read boundary before runtime dispatch lands.
 """
 
 from __future__ import annotations

--- a/tests/unit/plugin/test_manifest_hook_validation.py
+++ b/tests/unit/plugin/test_manifest_hook_validation.py
@@ -150,8 +150,7 @@ class TestHookLifecyclePermission:
 
         err = exc_info.value
         assert err.json_pointer == "/hooks/0/permissions"
-        assert "plugin:lifecycle:read" in err.args[0]
-        assert "hooks[].permissions" in err.expected
+        assert HOOK_LIFECYCLE_READ_SCOPE in err.expected
 
     def test_lifecycle_permission_must_still_be_declared_top_level(self, tmp_path: Path) -> None:
         payload = _hook_manifest()

--- a/tests/unit/plugin/test_manifest_hook_validation.py
+++ b/tests/unit/plugin/test_manifest_hook_validation.py
@@ -19,6 +19,7 @@ from pathlib import Path
 
 import pytest
 
+from ouroboros.plugin.hooks import HOOK_LIFECYCLE_READ_SCOPE
 from ouroboros.plugin.manifest import PluginManifestError, load_manifest
 
 # Re-use the canonical reference manifest from the existing manifest
@@ -30,6 +31,14 @@ from tests.unit.plugin.test_manifest import REFERENCE_MANIFEST
 def _hook_manifest() -> dict:
     payload = deepcopy(REFERENCE_MANIFEST)
     payload["schema_version"] = "0.3"
+    payload["permissions"].append(
+        {
+            "scope": HOOK_LIFECYCLE_READ_SCOPE,
+            "risk": "read_only",
+            "required": True,
+            "reason": "Allow v1 lifecycle hook observation.",
+        }
+    )
     return payload
 
 
@@ -50,7 +59,7 @@ def _valid_hook(name: str = "before_invocation", failure_policy: str = "fail_clo
             "type": "command",
             "command": "python -m plugin_hooks before",
         },
-        "permissions": [],
+        "permissions": [HOOK_LIFECYCLE_READ_SCOPE],
         "failure_policy": failure_policy,
         "timeout_seconds": 5,
     }
@@ -126,3 +135,36 @@ class TestHookFailurePolicy:
             load_manifest(_write(tmp_path, payload))
         err = exc_info.value
         assert err.json_pointer == "/hooks/0/failure_policy"
+
+
+class TestHookLifecyclePermission:
+    """v0.3 hooks must opt into the v1 lifecycle permission boundary."""
+
+    def test_missing_lifecycle_permission_rejected(self, tmp_path: Path) -> None:
+        payload = _hook_manifest()
+        payload["hooks"] = [_valid_hook()]
+        payload["hooks"][0]["permissions"] = []
+
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+
+        err = exc_info.value
+        assert err.json_pointer == "/hooks/0/permissions"
+        assert "plugin:lifecycle:read" in err.args[0]
+        assert "hooks[].permissions" in err.expected
+
+    def test_lifecycle_permission_must_still_be_declared_top_level(self, tmp_path: Path) -> None:
+        payload = _hook_manifest()
+        payload["permissions"] = [
+            permission
+            for permission in payload["permissions"]
+            if permission["scope"] != HOOK_LIFECYCLE_READ_SCOPE
+        ]
+        payload["hooks"] = [_valid_hook()]
+
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+
+        err = exc_info.value
+        assert err.json_pointer == "/hooks/0/permissions/0"
+        assert "top-level permissions" in err.args[0]

--- a/tests/unit/plugin/test_manifest_schema_0_3.py
+++ b/tests/unit/plugin/test_manifest_schema_0_3.py
@@ -143,6 +143,33 @@ class TestV03HookEnum:
         assert exc_info.value.json_pointer == "/hooks/0/name"
 
 
+class TestV03HookLifecyclePermissionSchema:
+    """v0.3 schema must match the Python lifecycle permission contract."""
+
+    def test_permissions_field_required_at_schema_layer(self, tmp_path: Path) -> None:
+        payload = _v03_manifest()
+        hook = _valid_hook()
+        hook.pop("permissions")
+        payload["hooks"] = [hook]
+
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+
+        assert exc_info.value.json_pointer == "/hooks/0"
+        assert "permissions" in exc_info.value.args[0]
+
+    def test_lifecycle_permission_required_at_schema_layer(self, tmp_path: Path) -> None:
+        payload = _v03_manifest()
+        payload["hooks"] = [_valid_hook()]
+        payload["hooks"][0]["permissions"] = []
+
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+
+        assert exc_info.value.json_pointer == "/hooks/0/permissions"
+        assert HOOK_LIFECYCLE_READ_SCOPE in exc_info.value.expected
+
+
 class TestV02Compatibility:
     """The still-supported v0.2 schema keeps its broader hook enum.
 

--- a/tests/unit/plugin/test_manifest_schema_0_3.py
+++ b/tests/unit/plugin/test_manifest_schema_0_3.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 import pytest
 
+from ouroboros.plugin.hooks import HOOK_LIFECYCLE_READ_SCOPE
 from ouroboros.plugin.manifest import (
     SUPPORTED_SCHEMA_VERSIONS,
     PluginManifestError,
@@ -38,6 +39,14 @@ from tests.unit.plugin.test_manifest import REFERENCE_MANIFEST
 def _v03_manifest() -> dict:
     payload = deepcopy(REFERENCE_MANIFEST)
     payload["schema_version"] = "0.3"
+    payload["permissions"].append(
+        {
+            "scope": HOOK_LIFECYCLE_READ_SCOPE,
+            "risk": "read_only",
+            "required": True,
+            "reason": "Allow v1 lifecycle hook observation.",
+        }
+    )
     return payload
 
 
@@ -61,7 +70,7 @@ def _valid_hook(name: str = "before_invocation", failure_policy: str = "fail_clo
             "type": "command",
             "command": "python -m plugin_hooks before",
         },
-        "permissions": [],
+        "permissions": [HOOK_LIFECYCLE_READ_SCOPE],
         "failure_policy": failure_policy,
         "timeout_seconds": 5,
     }
@@ -146,6 +155,7 @@ class TestV02Compatibility:
     def test_v02_deferred_name_still_loads(self, tmp_path: Path) -> None:
         payload = _v02_manifest()
         payload["hooks"] = [_valid_hook(name="before_tool_call")]
+        payload["hooks"][0]["permissions"] = []
         manifest = load_manifest(_write(tmp_path, payload))
         assert manifest.schema_version == "0.2"
         assert manifest.hooks[0].name == "before_tool_call"


### PR DESCRIPTION
## Summary
- require v0.3 lifecycle hook declarations to include `plugin:lifecycle:read` in `hooks[].permissions`
- keep the existing top-level permission declaration check, so hook permissions must still be declared in `permissions[].scope`
- preserve v0.2 compatibility for older hook manifests

## Scope
Narrow #939 manifest-validator slice only. This does not add runtime hook dispatch, new audit event emission, plugin permission-used runtime wiring, or a schema-version support-window change.

## Why
The v1 hook rollout already defines `plugin:lifecycle:read` as the lifecycle observation boundary. Enforcing it in v0.3 manifests prevents permissionless hook declarations before runtime dispatch and later `plugin.permission_used` emission rules land.

## Validation
- `uv run pytest tests/unit/plugin/test_manifest_hook_validation.py tests/unit/plugin/test_manifest_schema_0_3.py tests/unit/plugin/test_hook_permission_scopes.py -q`
- `uv run ruff check src/ouroboros/plugin/manifest.py tests/unit/plugin/test_manifest_hook_validation.py tests/unit/plugin/test_manifest_schema_0_3.py tests/unit/plugin/test_hook_permission_scopes.py`
- `uv run ruff format --check src/ouroboros/plugin/manifest.py tests/unit/plugin/test_manifest_hook_validation.py tests/unit/plugin/test_manifest_schema_0_3.py tests/unit/plugin/test_hook_permission_scopes.py`
- `uv run mypy src/ouroboros/plugin/manifest.py tests/unit/plugin/test_manifest_hook_validation.py tests/unit/plugin/test_manifest_schema_0_3.py tests/unit/plugin/test_hook_permission_scopes.py`

Refs #939
Refs #961
