### PR TITLE
feat(harness): expose pending HITL waits in run snapshots

### DIFF
--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -11,7 +11,7 @@ from collections.abc import Iterable
 from datetime import UTC, datetime
 from types import MappingProxyType
 
-from ouroboros.core.hitl_state import HumanInputSnapshot
+from ouroboros.core.hitl_state import HumanInputSnapshot, HumanInputState
 from ouroboros.harness.projection import (
     ArtifactRecord,
     RunRecord,
@@ -45,8 +45,9 @@ def build_run_snapshot(
     stage_tuple = tuple(stages)
     step_tuple = tuple(steps)
     artifact_tuple = tuple(artifacts)
-    pending_human_input_tuple = tuple(
-        request for request in pending_human_inputs if request.run_id in {None, run.run_id}
+    pending_human_input_tuple = _pending_human_inputs_for_run(
+        pending_human_inputs,
+        run_id=run.run_id,
     )
     _validate_projection_bundle(
         run=run,
@@ -149,6 +150,16 @@ def build_run_snapshot(
         source_event_ids=derived_source_event_ids,
         recorded_at=recorded_at or datetime.now(UTC),
         metadata=MappingProxyType(metadata),
+    )
+
+
+def _pending_human_inputs_for_run(
+    pending_human_inputs: Iterable[HumanInputSnapshot], *, run_id: str
+) -> tuple[HumanInputSnapshot, ...]:
+    return tuple(
+        request
+        for request in pending_human_inputs
+        if request.state is HumanInputState.PENDING and request.run_id == run_id
     )
 
 

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -11,6 +11,7 @@ from collections.abc import Iterable
 from datetime import UTC, datetime
 from types import MappingProxyType
 
+from ouroboros.core.hitl_state import HumanInputSnapshot
 from ouroboros.harness.projection import (
     ArtifactRecord,
     RunRecord,
@@ -30,6 +31,7 @@ def build_run_snapshot(
     steps: Iterable[StepRecord] = (),
     artifacts: Iterable[ArtifactRecord] = (),
     verdict: VerdictRecord | None = None,
+    pending_human_inputs: Iterable[HumanInputSnapshot] = (),
     recorded_at: datetime | None = None,
 ) -> RunSnapshotRecord:
     """Build a safe-resume snapshot from projection records.
@@ -43,6 +45,9 @@ def build_run_snapshot(
     stage_tuple = tuple(stages)
     step_tuple = tuple(steps)
     artifact_tuple = tuple(artifacts)
+    pending_human_input_tuple = tuple(
+        request for request in pending_human_inputs if request.run_id in {None, run.run_id}
+    )
     _validate_projection_bundle(
         run=run,
         stages=stage_tuple,
@@ -79,7 +84,11 @@ def build_run_snapshot(
 
     missing_linked_verdict = run.verdict_id is not None and verdict is None
     unlinked_supplied_verdict = verdict is not None and run.verdict_id is None
-    derived_source_event_ids = _snapshot_source_event_ids(steps=step_tuple, verdict=verdict)
+    derived_source_event_ids = _snapshot_source_event_ids(
+        steps=step_tuple,
+        verdict=verdict,
+        pending_human_inputs=pending_human_input_tuple,
+    )
     status = _derive_status(
         run=run,
         verdict=verdict,
@@ -89,6 +98,9 @@ def build_run_snapshot(
         pending_failed_step_ids=pending_failed_step_ids,
         pending_success_step_ids=pending_success_step_ids,
         pending_step_ids=pending_step_ids,
+        pending_human_input_request_ids=tuple(
+            request.request_id for request in pending_human_input_tuple
+        ),
         failed_step_ids=failed_step_ids,
         unknown_step_ids=unknown_step_ids,
     )
@@ -111,6 +123,13 @@ def build_run_snapshot(
         "step_count": len(step_tuple),
         "artifact_count": len(artifact_tuple),
     }
+    if pending_human_input_tuple:
+        metadata["pending_human_input_request_ids"] = tuple(
+            request.request_id for request in pending_human_input_tuple
+        )
+        metadata["pending_human_input_resume_targets"] = tuple(
+            request.resume_target for request in pending_human_input_tuple
+        )
     return RunSnapshotRecord(
         run_id=run.run_id,
         status=status,
@@ -226,13 +245,17 @@ def _validate_projection_bundle(
 
 
 def _snapshot_source_event_ids(
-    *, steps: tuple[StepRecord, ...], verdict: VerdictRecord | None
+    *,
+    steps: tuple[StepRecord, ...],
+    verdict: VerdictRecord | None,
+    pending_human_inputs: tuple[HumanInputSnapshot, ...] = (),
 ) -> tuple[str, ...]:
     ordered_ids: list[str] = []
     seen: set[str] = set()
     for event_id in (
         *(event_id for step in steps for event_id in step.source_event_ids),
         *((verdict.evidence_event_ids) if verdict is not None else ()),
+        *(request.request_event_id for request in pending_human_inputs),
     ):
         if event_id not in seen:
             ordered_ids.append(event_id)
@@ -260,6 +283,7 @@ def _derive_status(
     pending_failed_step_ids: tuple[str, ...],
     pending_success_step_ids: tuple[str, ...],
     pending_step_ids: tuple[str, ...],
+    pending_human_input_request_ids: tuple[str, ...],
     failed_step_ids: tuple[str, ...],
     unknown_step_ids: tuple[str, ...],
 ) -> RunSnapshotStatus:
@@ -284,6 +308,8 @@ def _derive_status(
         return RunSnapshotStatus.UNKNOWN
     if missing_linked_verdict:
         return RunSnapshotStatus.UNKNOWN
+    if pending_human_input_request_ids:
+        return RunSnapshotStatus.WAITING
     if pending_in_closed_stage_ids or pending_failed_step_ids or pending_success_step_ids:
         return RunSnapshotStatus.UNKNOWN
     if failed_step_ids:

--- a/src/ouroboros/harness/run_snapshot.py
+++ b/src/ouroboros/harness/run_snapshot.py
@@ -319,18 +319,18 @@ def _derive_status(
         return RunSnapshotStatus.UNKNOWN
     if missing_linked_verdict:
         return RunSnapshotStatus.UNKNOWN
-    if pending_human_input_request_ids:
-        return RunSnapshotStatus.WAITING
     if pending_in_closed_stage_ids or pending_failed_step_ids or pending_success_step_ids:
         return RunSnapshotStatus.UNKNOWN
     if failed_step_ids:
         return RunSnapshotStatus.FAILED
     if run.ended_at is not None:
         return RunSnapshotStatus.UNKNOWN
-    if pending_step_ids:
-        return RunSnapshotStatus.RUNNING
     if unknown_step_ids:
         return RunSnapshotStatus.UNKNOWN
+    if pending_human_input_request_ids:
+        return RunSnapshotStatus.WAITING
+    if pending_step_ids:
+        return RunSnapshotStatus.RUNNING
     return RunSnapshotStatus.UNKNOWN
 
 

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime, timedelta
 from pydantic import ValidationError
 import pytest
 
+from ouroboros.core.hitl_state import HumanInputSnapshot, HumanInputState
 from ouroboros.harness.projection import (
     ArtifactRecord,
     RunRecord,
@@ -112,6 +113,57 @@ def test_human_escalation_verdict_is_waiting_but_not_safe_resume() -> None:
     assert snapshot.safe_resume is False
     assert snapshot.verdict_id == "verdict_1"
     assert snapshot.resume_blockers == ("human_input_required",)
+
+
+def test_pending_hitl_request_is_exposed_in_run_snapshot_metadata() -> None:
+    pending = HumanInputSnapshot(
+        request_id="hitl_approve",
+        state=HumanInputState.PENDING,
+        request_event_id="evt_hitl_requested",
+        updated_event_id="evt_hitl_requested",
+        created_at=datetime(2026, 5, 15, tzinfo=UTC),
+        updated_at=datetime(2026, 5, 15, tzinfo=UTC),
+        session_id="session_1",
+        run_id="run_1",
+        resume_target="plan:resume",
+    )
+
+    snapshot = build_run_snapshot(
+        run=_run(),
+        stages=[_stage()],
+        pending_human_inputs=[pending],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.WAITING
+    assert snapshot.safe_resume is False
+    assert snapshot.resume_blockers == ("human_input_required",)
+    assert snapshot.source_event_ids == ("evt_hitl_requested",)
+    assert snapshot.metadata["pending_human_input_request_ids"] == ("hitl_approve",)
+    assert snapshot.metadata["pending_human_input_resume_targets"] == ("plan:resume",)
+
+
+def test_foreign_pending_hitl_request_is_ignored_for_run_snapshot() -> None:
+    pending = HumanInputSnapshot(
+        request_id="hitl_other",
+        state=HumanInputState.PENDING,
+        request_event_id="evt_other_hitl",
+        updated_event_id="evt_other_hitl",
+        created_at=datetime(2026, 5, 15, tzinfo=UTC),
+        updated_at=datetime(2026, 5, 15, tzinfo=UTC),
+        session_id="session_other",
+        run_id="run_other",
+        resume_target="plan:resume",
+    )
+
+    snapshot = build_run_snapshot(
+        run=_run(),
+        stages=[_stage()],
+        pending_human_inputs=[pending],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.UNKNOWN
+    assert "pending_human_input_request_ids" not in snapshot.metadata
+    assert snapshot.source_event_ids == ()
 
 
 def test_terminal_verdicts_block_resume() -> None:

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -59,6 +59,28 @@ def _step(
     )
 
 
+def _human_input_snapshot(
+    request_id: str = "hitl_approve",
+    *,
+    state: HumanInputState = HumanInputState.PENDING,
+    request_event_id: str = "evt_hitl_requested",
+    session_id: str = "session_1",
+    run_id: str | None = "run_1",
+    resume_target: str = "plan:resume",
+) -> HumanInputSnapshot:
+    return HumanInputSnapshot(
+        request_id=request_id,
+        state=state,
+        request_event_id=request_event_id,
+        updated_event_id=request_event_id,
+        created_at=datetime(2026, 5, 15, tzinfo=UTC),
+        updated_at=datetime(2026, 5, 15, tzinfo=UTC),
+        session_id=session_id,
+        run_id=run_id,
+        resume_target=resume_target,
+    )
+
+
 def test_running_snapshot_with_pending_work_is_safe_to_resume() -> None:
     completed = _step("step_done", ended=True, ok=True, artifact_ids=("artifact_1",))
     pending = _step("step_pending", ended=False, ok=None)
@@ -116,17 +138,7 @@ def test_human_escalation_verdict_is_waiting_but_not_safe_resume() -> None:
 
 
 def test_pending_hitl_request_is_exposed_in_run_snapshot_metadata() -> None:
-    pending = HumanInputSnapshot(
-        request_id="hitl_approve",
-        state=HumanInputState.PENDING,
-        request_event_id="evt_hitl_requested",
-        updated_event_id="evt_hitl_requested",
-        created_at=datetime(2026, 5, 15, tzinfo=UTC),
-        updated_at=datetime(2026, 5, 15, tzinfo=UTC),
-        session_id="session_1",
-        run_id="run_1",
-        resume_target="plan:resume",
-    )
+    pending = _human_input_snapshot()
 
     snapshot = build_run_snapshot(
         run=_run(),
@@ -143,22 +155,45 @@ def test_pending_hitl_request_is_exposed_in_run_snapshot_metadata() -> None:
 
 
 def test_foreign_pending_hitl_request_is_ignored_for_run_snapshot() -> None:
-    pending = HumanInputSnapshot(
-        request_id="hitl_other",
-        state=HumanInputState.PENDING,
+    pending = _human_input_snapshot(
+        "hitl_other",
         request_event_id="evt_other_hitl",
-        updated_event_id="evt_other_hitl",
-        created_at=datetime(2026, 5, 15, tzinfo=UTC),
-        updated_at=datetime(2026, 5, 15, tzinfo=UTC),
         session_id="session_other",
         run_id="run_other",
-        resume_target="plan:resume",
     )
 
     snapshot = build_run_snapshot(
         run=_run(),
         stages=[_stage()],
         pending_human_inputs=[pending],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.UNKNOWN
+    assert "pending_human_input_request_ids" not in snapshot.metadata
+    assert snapshot.source_event_ids == ()
+
+
+def test_terminal_hitl_request_is_ignored_for_run_snapshot() -> None:
+    answered = _human_input_snapshot(state=HumanInputState.ANSWERED)
+
+    snapshot = build_run_snapshot(
+        run=_run(),
+        stages=[_stage()],
+        pending_human_inputs=[answered],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.UNKNOWN
+    assert "pending_human_input_request_ids" not in snapshot.metadata
+    assert snapshot.source_event_ids == ()
+
+
+def test_session_scoped_hitl_request_is_not_attached_to_run_snapshot() -> None:
+    session_scoped = _human_input_snapshot(run_id=None)
+
+    snapshot = build_run_snapshot(
+        run=_run(),
+        stages=[_stage()],
+        pending_human_inputs=[session_scoped],
     )
 
     assert snapshot.status is RunSnapshotStatus.UNKNOWN

--- a/tests/unit/harness/test_run_snapshot.py
+++ b/tests/unit/harness/test_run_snapshot.py
@@ -173,6 +173,31 @@ def test_foreign_pending_hitl_request_is_ignored_for_run_snapshot() -> None:
     assert snapshot.source_event_ids == ()
 
 
+def test_pending_hitl_request_does_not_override_failed_step_status() -> None:
+    snapshot = build_run_snapshot(
+        run=_run(),
+        stages=[_stage("step_failed")],
+        steps=[_step("step_failed", ended=True, ok=False)],
+        pending_human_inputs=[_human_input_snapshot()],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.FAILED
+    assert "failed_steps_present" in snapshot.resume_blockers
+    assert snapshot.metadata["pending_human_input_request_ids"] == ("hitl_approve",)
+
+
+def test_pending_hitl_request_does_not_override_ended_run_status() -> None:
+    snapshot = build_run_snapshot(
+        run=_run(ended=True),
+        stages=[_stage()],
+        pending_human_inputs=[_human_input_snapshot()],
+    )
+
+    assert snapshot.status is RunSnapshotStatus.UNKNOWN
+    assert "status_unknown" in snapshot.resume_blockers
+    assert snapshot.metadata["pending_human_input_request_ids"] == ("hitl_approve",)
+
+
 def test_terminal_hitl_request_is_ignored_for_run_snapshot() -> None:
     answered = _human_input_snapshot(state=HumanInputState.ANSWERED)
 


### PR DESCRIPTION
## Summary
- let `build_run_snapshot` accept pending HITL request snapshots as read-model input
- derive `RunSnapshotStatus.WAITING` and `human_input_required` blockers when a pending request belongs to the run
- expose pending HITL request ids and resume targets in snapshot metadata, with the HITL request event included as source evidence

## Scope
Narrow #960 RunSnapshot/read-model slice only. This does not emit HITL events, adapt deep-interview/plan approval, replace renderers, or change runtime dispatch/resume behavior.

## Why
#960 requires pending HITL to be visible in status/snapshot surfaces before broader WAIT/RESUME adapters land. This keeps the projection pure while giving callers a typed place to surface pending human input.

## Validation
- `uv run pytest tests/unit/harness/test_run_snapshot.py -q`
- `uv run ruff check src/ouroboros/harness/run_snapshot.py tests/unit/harness/test_run_snapshot.py`
- `uv run ruff format --check src/ouroboros/harness/run_snapshot.py tests/unit/harness/test_run_snapshot.py`
- `uv run mypy src/ouroboros/harness/run_snapshot.py tests/unit/harness/test_run_snapshot.py`

Refs #960
Refs #961
