### PR TITLE
feat(harness): project artifact and verdict records

### DIFF
--- a/src/ouroboros/harness/projection_builder.py
+++ b/src/ouroboros/harness/projection_builder.py
@@ -623,7 +623,7 @@ def _verdict_from_event(
         return None
     scope = _optional_str(event.data.get("scope")) or "run"
     if scope not in {"run", "ac"}:
-        scope = "run"
+        return None
     ac_id = _optional_str(event.data.get("ac_id")) if scope == "ac" else None
     if scope == "ac" and ac_id is None:
         return None

--- a/src/ouroboros/harness/projection_builder.py
+++ b/src/ouroboros/harness/projection_builder.py
@@ -16,7 +16,12 @@ Recognized event families in PR-1b:
   ``Bash`` tool calls are classified as :attr:`StepKind.SHELL_COMMAND`.
 * ``llm.call.requested`` / ``llm.call.returned`` — paired by ``call_id``
   into a :class:`StepRecord` of kind :attr:`StepKind.MODEL_CALL`.
-* Stage / verdict events are not mapped yet. The builder produces a
+* ``harness.artifact.recorded`` / ``evaluation.artifact.recorded`` —
+  attached to already-projected steps as :class:`ArtifactRecord` rows.
+* ``harness.verdict.recorded`` / ``evaluation.verdict.recorded`` —
+  projected as :class:`VerdictRecord` rows with snapshot-safe evidence
+  links.
+* Stage events are not mapped yet. The builder produces a
   single default :class:`StageRecord` of kind
   :attr:`StageKind.EXECUTE` that owns every step; richer stage
   detection is deferred to a future PR.

--- a/src/ouroboros/harness/projection_builder.py
+++ b/src/ouroboros/harness/projection_builder.py
@@ -224,6 +224,7 @@ class ProjectionBuilder:
             for slot_key, step in self._steps.items()
         )
 
+        artifact_ids = frozenset(artifact.artifact_id for artifact in artifacts)
         verdicts = tuple(
             verdict
             for event in self._verdict_events
@@ -232,12 +233,14 @@ class ProjectionBuilder:
                     event,
                     source_key=source_key,
                     run_id=run_id,
+                    artifact_ids=artifact_ids,
                 )
             )
             is not None
         )
         run_verdict_id = next(
-            (verdict.verdict_id for verdict in verdicts if verdict.scope == "run"), None
+            (verdict.verdict_id for verdict in reversed(verdicts) if verdict.scope == "run"),
+            None,
         )
 
         stage = StageRecord(
@@ -606,6 +609,7 @@ def _verdict_from_event(
     *,
     source_key: str,
     run_id: str,
+    artifact_ids: frozenset[str],
 ) -> VerdictRecord | None:
     if not isinstance(event.data, dict):
         return None
@@ -618,7 +622,18 @@ def _verdict_from_event(
     ac_id = _optional_str(event.data.get("ac_id")) if scope == "ac" else None
     if scope == "ac" and ac_id is None:
         return None
-    artifact_ids = _string_tuple(event.data.get("evidence_artifact_ids"))
+    recorded_artifact_ids = _string_tuple(event.data.get("evidence_artifact_ids"))
+    linked_artifact_ids = tuple(
+        artifact_id for artifact_id in recorded_artifact_ids if artifact_id in artifact_ids
+    )
+    missing_artifact_ids = tuple(
+        artifact_id for artifact_id in recorded_artifact_ids if artifact_id not in artifact_ids
+    )
+    metadata: dict[str, Any] = {"source_event_id": event.id, "event_type": event.type}
+    if missing_artifact_ids:
+        metadata["missing_evidence_artifact_ids"] = missing_artifact_ids
+        metadata["recorded_evidence_artifact_ids"] = recorded_artifact_ids
+        outcome = VerdictOutcome.UNKNOWN
     return VerdictRecord(
         verdict_id=_optional_str(event.data.get("verdict_id"))
         or _stable_verdict_id(source_key, event.id),
@@ -628,9 +643,9 @@ def _verdict_from_event(
         outcome=outcome,
         rationale=_optional_str(event.data.get("rationale")) or "",
         evidence_event_ids=(event.id, *_string_tuple(event.data.get("evidence_event_ids"))),
-        evidence_artifact_ids=artifact_ids,
+        evidence_artifact_ids=linked_artifact_ids,
         recorded_at=event.timestamp,
-        metadata={"source_event_id": event.id, "event_type": event.type},
+        metadata=metadata,
     )
 
 

--- a/src/ouroboros/harness/projection_builder.py
+++ b/src/ouroboros/harness/projection_builder.py
@@ -37,17 +37,26 @@ from uuid import NAMESPACE_URL, uuid5
 from ouroboros.events.base import BaseEvent
 from ouroboros.harness.projection import (
     PROJECTION_SCHEMA_VERSION,
+    ArtifactRecord,
     RunRecord,
     StageKind,
     StageRecord,
     StepKind,
     StepRecord,
+    VerdictOutcome,
+    VerdictRecord,
 )
 
 _TOOL_STARTED = "tool.call.started"
 _TOOL_RETURNED = "tool.call.returned"
 _LLM_REQUESTED = "llm.call.requested"
 _LLM_RETURNED = "llm.call.returned"
+_ARTIFACT_RECORDED_TYPES = frozenset(
+    {"artifact.created", "harness.artifact.recorded", "evaluation.artifact.recorded"}
+)
+_VERDICT_RECORDED_TYPES = frozenset(
+    {"verdict.recorded", "harness.verdict.recorded", "evaluation.verdict.recorded"}
+)
 
 _SHELL_TOOL_NAMES = frozenset({"Bash"})
 
@@ -65,6 +74,8 @@ class ProjectionBuildResult:
     run: RunRecord
     stages: tuple[StageRecord, ...]
     steps: tuple[StepRecord, ...]
+    artifacts: tuple[ArtifactRecord, ...] = ()
+    verdicts: tuple[VerdictRecord, ...] = ()
 
 
 class ProjectionBuilder:
@@ -101,6 +112,8 @@ class ProjectionBuilder:
         self._llm_started: OrderedDict[str, BaseEvent] = OrderedDict()
         self._steps: OrderedDict[str, StepRecord] = OrderedDict()
         self._identity_events: list[BaseEvent] = []
+        self._artifact_events: list[BaseEvent] = []
+        self._verdict_events: list[BaseEvent] = []
         self._idle_started_at = datetime.now(UTC)
         self._first_event_at: datetime | None = None
         self._last_event_at: datetime | None = None
@@ -156,6 +169,14 @@ class ProjectionBuilder:
             self._handle_llm_returned(event)
             return self
 
+        if event.type in _ARTIFACT_RECORDED_TYPES:
+            self._artifact_events.append(event)
+            return self
+
+        if event.type in _VERDICT_RECORDED_TYPES:
+            self._verdict_events.append(event)
+            return self
+
         # Other event types are ignored in PR-1b; they will be mapped
         # in follow-up PRs alongside their dedicated kinds.
         return self
@@ -177,14 +198,45 @@ class ProjectionBuilder:
         started_at = self._first_event_at or self._idle_started_at
         ended_at = self._last_event_at
 
+        artifacts = tuple(
+            artifact
+            for event in self._artifact_events
+            if (artifact := _artifact_from_event(event, source_key=source_key)) is not None
+        )
+        artifact_ids_by_step_id: dict[str, list[str]] = {}
+        for artifact in artifacts:
+            artifact_ids_by_step_id.setdefault(artifact.step_id, []).append(artifact.artifact_id)
+
         steps_for_stage = tuple(
             _rewrite_step_identity(
                 step,
                 step_id=_stable_step_id(source_key, *_slot_parts(slot_key)),
                 run_id=run_id,
                 stage_id=stage_id,
+                artifact_ids=tuple(
+                    artifact_ids_by_step_id.get(
+                        _stable_step_id(source_key, *_slot_parts(slot_key)), ()
+                    )
+                ),
             )
             for slot_key, step in self._steps.items()
+        )
+
+        verdicts = tuple(
+            verdict
+            for event in self._verdict_events
+            if (
+                verdict := _verdict_from_event(
+                    event,
+                    source_key=source_key,
+                    run_id=run_id,
+                    artifacts=artifacts,
+                )
+            )
+            is not None
+        )
+        run_verdict_id = next(
+            (verdict.verdict_id for verdict in verdicts if verdict.scope == "run"), None
         )
 
         stage = StageRecord(
@@ -205,12 +257,15 @@ class ProjectionBuilder:
             started_at=started_at,
             ended_at=ended_at,
             stage_ids=(stage_id,),
+            verdict_id=run_verdict_id,
         )
 
         return ProjectionBuildResult(
             run=run,
             stages=(stage,),
             steps=steps_for_stage,
+            artifacts=artifacts,
+            verdicts=verdicts,
         )
 
     # -- internals ------------------------------------------------------
@@ -496,6 +551,7 @@ def _rewrite_step_identity(
     step_id: str,
     run_id: str,
     stage_id: str,
+    artifact_ids: tuple[str, ...] = (),
 ) -> StepRecord:
     return StepRecord(
         schema_version=step.schema_version,
@@ -510,9 +566,128 @@ def _rewrite_step_identity(
         ok=step.ok,
         source_event_ids=step.source_event_ids,
         legacy_inferred=step.legacy_inferred,
-        artifact_ids=step.artifact_ids,
+        artifact_ids=(*step.artifact_ids, *artifact_ids),
         metadata=step.metadata,
     )
+
+
+def _artifact_from_event(
+    event: BaseEvent,
+    *,
+    source_key: str,
+) -> ArtifactRecord | None:
+    if not isinstance(event.data, dict):
+        return None
+    call_id = _extract_call_id(event) or _optional_str(event.data.get("step_call_id"))
+    if call_id is None:
+        return None
+    family = _optional_str(event.data.get("step_family")) or "tool"
+    step_id = _stable_step_id(source_key, family, call_id)
+    artifact_id = _optional_str(event.data.get("artifact_id")) or _stable_artifact_id(
+        source_key, event.id
+    )
+    kind = _optional_str(event.data.get("kind")) or "evidence"
+    return ArtifactRecord(
+        artifact_id=artifact_id,
+        step_id=step_id,
+        kind=kind,
+        path=_optional_str(event.data.get("path")),
+        media_type=_optional_str(event.data.get("media_type")),
+        size_bytes=_optional_int(event.data.get("size_bytes")),
+        digest=_optional_str(event.data.get("digest")),
+        summary=_optional_str(event.data.get("summary")) or "",
+        metadata={"source_event_id": event.id, "event_type": event.type},
+    )
+
+
+def _verdict_from_event(
+    event: BaseEvent,
+    *,
+    source_key: str,
+    run_id: str,
+    artifacts: tuple[ArtifactRecord, ...],
+) -> VerdictRecord | None:
+    if not isinstance(event.data, dict):
+        return None
+    outcome = _verdict_outcome(event.data)
+    if outcome is None:
+        return None
+    scope = _optional_str(event.data.get("scope")) or "run"
+    if scope not in {"run", "ac"}:
+        scope = "run"
+    ac_id = _optional_str(event.data.get("ac_id")) if scope == "ac" else None
+    if scope == "ac" and ac_id is None:
+        return None
+    artifact_ids = tuple(
+        artifact.artifact_id
+        for artifact in artifacts
+        if artifact.artifact_id in _string_tuple(event.data.get("evidence_artifact_ids"))
+    )
+    return VerdictRecord(
+        verdict_id=_optional_str(event.data.get("verdict_id"))
+        or _stable_verdict_id(source_key, event.id),
+        run_id=run_id,
+        scope=scope,
+        ac_id=ac_id,
+        outcome=outcome,
+        rationale=_optional_str(event.data.get("rationale")) or "",
+        evidence_event_ids=(event.id, *_string_tuple(event.data.get("evidence_event_ids"))),
+        evidence_artifact_ids=artifact_ids,
+        recorded_at=event.timestamp,
+        metadata={"source_event_id": event.id, "event_type": event.type},
+    )
+
+
+def _verdict_outcome(data: dict[str, Any]) -> VerdictOutcome | None:
+    raw = data.get("outcome", data.get("verdict"))
+    if isinstance(raw, str):
+        normalized = raw.strip().lower()
+        aliases = {
+            "approved": VerdictOutcome.PASS,
+            "pass": VerdictOutcome.PASS,
+            "passed": VerdictOutcome.PASS,
+            "rejected": VerdictOutcome.FAIL,
+            "fail": VerdictOutcome.FAIL,
+            "failed": VerdictOutcome.FAIL,
+            "cancelled": VerdictOutcome.CANCELLED,
+            "canceled": VerdictOutcome.CANCELLED,
+            "escalate_human": VerdictOutcome.ESCALATE_HUMAN,
+            "human": VerdictOutcome.ESCALATE_HUMAN,
+            "unknown": VerdictOutcome.UNKNOWN,
+        }
+        return aliases.get(normalized)
+    approved = data.get("approved")
+    if isinstance(approved, bool):
+        return VerdictOutcome.PASS if approved else VerdictOutcome.FAIL
+    return None
+
+
+def _optional_str(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _optional_int(value: Any) -> int | None:
+    if isinstance(value, int) and value >= 0:
+        return value
+    return None
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list | tuple):
+        return ()
+    return tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
+
+
+def _stable_artifact_id(source_key: str, event_id: str) -> str:
+    digest = uuid5(NAMESPACE_URL, f"ouroboros:harness:artifact:{source_key}:{event_id}").hex[:12]
+    return f"artifact_{digest}"
+
+
+def _stable_verdict_id(source_key: str, event_id: str) -> str:
+    digest = uuid5(NAMESPACE_URL, f"ouroboros:harness:verdict:{source_key}:{event_id}").hex[:12]
+    return f"verdict_{digest}"
 
 
 def _step_from_start_only(

--- a/src/ouroboros/harness/projection_builder.py
+++ b/src/ouroboros/harness/projection_builder.py
@@ -198,10 +198,16 @@ class ProjectionBuilder:
         started_at = self._first_event_at or self._idle_started_at
         ended_at = self._last_event_at
 
+        step_ids_by_slot_key = {
+            slot_key: _stable_step_id(source_key, *_slot_parts(slot_key))
+            for slot_key in self._steps
+        }
+        valid_step_ids = frozenset(step_ids_by_slot_key.values())
         artifacts = tuple(
             artifact
             for event in self._artifact_events
             if (artifact := _artifact_from_event(event, source_key=source_key)) is not None
+            and artifact.step_id in valid_step_ids
         )
         artifact_ids_by_step_id: dict[str, list[str]] = {}
         for artifact in artifacts:
@@ -210,14 +216,10 @@ class ProjectionBuilder:
         steps_for_stage = tuple(
             _rewrite_step_identity(
                 step,
-                step_id=_stable_step_id(source_key, *_slot_parts(slot_key)),
+                step_id=step_ids_by_slot_key[slot_key],
                 run_id=run_id,
                 stage_id=stage_id,
-                artifact_ids=tuple(
-                    artifact_ids_by_step_id.get(
-                        _stable_step_id(source_key, *_slot_parts(slot_key)), ()
-                    )
-                ),
+                artifact_ids=tuple(artifact_ids_by_step_id.get(step_ids_by_slot_key[slot_key], ())),
             )
             for slot_key, step in self._steps.items()
         )
@@ -230,7 +232,6 @@ class ProjectionBuilder:
                     event,
                     source_key=source_key,
                     run_id=run_id,
-                    artifacts=artifacts,
                 )
             )
             is not None
@@ -605,7 +606,6 @@ def _verdict_from_event(
     *,
     source_key: str,
     run_id: str,
-    artifacts: tuple[ArtifactRecord, ...],
 ) -> VerdictRecord | None:
     if not isinstance(event.data, dict):
         return None
@@ -618,11 +618,7 @@ def _verdict_from_event(
     ac_id = _optional_str(event.data.get("ac_id")) if scope == "ac" else None
     if scope == "ac" and ac_id is None:
         return None
-    artifact_ids = tuple(
-        artifact.artifact_id
-        for artifact in artifacts
-        if artifact.artifact_id in _string_tuple(event.data.get("evidence_artifact_ids"))
-    )
+    artifact_ids = _string_tuple(event.data.get("evidence_artifact_ids"))
     return VerdictRecord(
         verdict_id=_optional_str(event.data.get("verdict_id"))
         or _stable_verdict_id(source_key, event.id),

--- a/src/ouroboros/mcp/tools/projection_handlers.py
+++ b/src/ouroboros/mcp/tools/projection_handlers.py
@@ -320,8 +320,8 @@ def _projection_meta(
         "run": projection.run.model_dump(mode="json"),
         "stages": [stage.model_dump(mode="json") for stage in projection.stages],
         "steps": [step.model_dump(mode="json") for step in projection.steps],
-        "artifacts": [],
-        "verdicts": [],
+        "artifacts": [artifact.model_dump(mode="json") for artifact in projection.artifacts],
+        "verdicts": [verdict.model_dump(mode="json") for verdict in projection.verdicts],
     }
 
 
@@ -334,6 +334,8 @@ def _format_projection_text(projection: ProjectionBuildResult, event_count: int)
         f"Events inspected: {event_count}",
         f"Stages: {len(projection.stages)}",
         f"Steps: {len(projection.steps)}",
+        f"Artifacts: {len(projection.artifacts)}",
+        f"Verdicts: {len(projection.verdicts)}",
     ]
     if projection.steps:
         lines.append("")

--- a/tests/unit/harness/test_projection_builder.py
+++ b/tests/unit/harness/test_projection_builder.py
@@ -600,3 +600,17 @@ class TestArtifactAndVerdictProjection:
         result = build_projection([event], seed_id="seed_abc")
 
         assert result.verdicts == ()
+
+    def test_verdict_rejects_unknown_scope(self) -> None:
+        event = BaseEvent(
+            id="evt_bad_scope_verdict",
+            type="harness.verdict.recorded",
+            aggregate_type="execution",
+            aggregate_id="exec_1",
+            data={"scope": "workflow", "outcome": "pass"},
+        )
+
+        result = build_projection([event], seed_id="seed_abc")
+
+        assert result.run.verdict_id is None
+        assert result.verdicts == ()

--- a/tests/unit/harness/test_projection_builder.py
+++ b/tests/unit/harness/test_projection_builder.py
@@ -430,3 +430,90 @@ class TestIncrementalIngestion:
             ("evt_slow_start", "evt_slow_ret"),
             ("evt_fast_start", "evt_fast_ret"),
         ]
+
+
+class TestArtifactAndVerdictProjection:
+    def test_artifact_event_attaches_to_projected_step(self) -> None:
+        t0 = datetime.now(UTC)
+        events = [
+            _tool_started(call_id="c_art", tool_name="Bash", when=t0),
+            _tool_returned(call_id="c_art", tool_name="Bash", when=t0 + timedelta(seconds=1)),
+            BaseEvent(
+                id="evt_artifact",
+                type="harness.artifact.recorded",
+                timestamp=t0 + timedelta(seconds=2),
+                aggregate_type="execution",
+                aggregate_id="exec_1",
+                data={
+                    "call_id": "c_art",
+                    "artifact_id": "artifact_tests",
+                    "kind": "evidence",
+                    "path": "artifacts/tests.json",
+                    "media_type": "application/json",
+                    "summary": "pytest evidence",
+                },
+            ),
+        ]
+
+        result = build_projection(events, seed_id="seed_abc")
+
+        assert len(result.artifacts) == 1
+        artifact = result.artifacts[0]
+        assert artifact.artifact_id == "artifact_tests"
+        assert artifact.step_id == result.steps[0].step_id
+        assert artifact.kind == "evidence"
+        assert artifact.path == "artifacts/tests.json"
+        assert result.steps[0].artifact_ids == ("artifact_tests",)
+
+    def test_run_verdict_links_event_and_artifact_evidence(self) -> None:
+        t0 = datetime.now(UTC)
+        events = [
+            _tool_started(call_id="c_verdict", tool_name="Bash", when=t0),
+            _tool_returned(call_id="c_verdict", tool_name="Bash", when=t0 + timedelta(seconds=1)),
+            BaseEvent(
+                id="evt_artifact",
+                type="harness.artifact.recorded",
+                timestamp=t0 + timedelta(seconds=2),
+                aggregate_type="execution",
+                aggregate_id="exec_1",
+                data={"call_id": "c_verdict", "artifact_id": "artifact_tests", "kind": "evidence"},
+            ),
+            BaseEvent(
+                id="evt_verdict",
+                type="harness.verdict.recorded",
+                timestamp=t0 + timedelta(seconds=3),
+                aggregate_type="execution",
+                aggregate_id="exec_1",
+                data={
+                    "verdict_id": "verdict_run",
+                    "scope": "run",
+                    "outcome": "pass",
+                    "rationale": "all checks passed",
+                    "evidence_event_ids": ["evt_artifact"],
+                    "evidence_artifact_ids": ["artifact_tests"],
+                },
+            ),
+        ]
+
+        result = build_projection(events, seed_id="seed_abc")
+
+        assert len(result.verdicts) == 1
+        verdict = result.verdicts[0]
+        assert verdict.verdict_id == "verdict_run"
+        assert result.run.verdict_id == "verdict_run"
+        assert verdict.evidence_event_ids == ("evt_verdict", "evt_artifact")
+        assert verdict.evidence_artifact_ids == ("artifact_tests",)
+        assert verdict.rationale == "all checks passed"
+
+    def test_ac_verdict_requires_ac_id(self) -> None:
+        event = BaseEvent(
+            id="evt_bad_ac_verdict",
+            type="harness.verdict.recorded",
+            aggregate_type="execution",
+            aggregate_id="exec_1",
+            data={"scope": "ac", "outcome": "pass"},
+        )
+
+        result = build_projection([event], seed_id="seed_abc")
+
+        assert result.verdicts == ()

--- a/tests/unit/harness/test_projection_builder.py
+++ b/tests/unit/harness/test_projection_builder.py
@@ -21,12 +21,13 @@ from datetime import UTC, datetime, timedelta
 import pytest
 
 from ouroboros.events.base import BaseEvent
-from ouroboros.harness.projection import StageKind, StepKind
+from ouroboros.harness.projection import StageKind, StepKind, VerdictOutcome
 from ouroboros.harness.projection_builder import (
     ProjectionBuilder,
     ProjectionBuildResult,
     build_projection,
 )
+from ouroboros.harness.run_snapshot import build_run_snapshot
 
 
 def _tool_started(
@@ -521,7 +522,7 @@ class TestArtifactAndVerdictProjection:
         assert result.steps == ()
         assert result.artifacts == ()
 
-    def test_verdict_preserves_missing_artifact_references(self) -> None:
+    def test_verdict_marks_missing_artifact_references_unknown(self) -> None:
         t0 = datetime.now(UTC)
         event = BaseEvent(
             id="evt_verdict",
@@ -541,7 +542,51 @@ class TestArtifactAndVerdictProjection:
 
         assert len(result.verdicts) == 1
         assert result.artifacts == ()
-        assert result.verdicts[0].evidence_artifact_ids == ("missing_artifact",)
+        verdict = result.verdicts[0]
+        assert verdict.outcome is VerdictOutcome.UNKNOWN
+        assert verdict.evidence_artifact_ids == ()
+        assert verdict.metadata["missing_evidence_artifact_ids"] == ("missing_artifact",)
+        assert verdict.metadata["recorded_evidence_artifact_ids"] == ("missing_artifact",)
+        build_run_snapshot(
+            run=result.run,
+            stages=result.stages,
+            steps=result.steps,
+            artifacts=result.artifacts,
+            verdict=verdict,
+        )
+
+    def test_latest_run_verdict_wins(self) -> None:
+        t0 = datetime.now(UTC)
+        events = [
+            BaseEvent(
+                id="evt_verdict_escalate",
+                type="harness.verdict.recorded",
+                timestamp=t0,
+                aggregate_type="execution",
+                aggregate_id="exec_1",
+                data={
+                    "verdict_id": "verdict_escalate",
+                    "scope": "run",
+                    "outcome": "escalate_human",
+                },
+            ),
+            BaseEvent(
+                id="evt_verdict_pass",
+                type="harness.verdict.recorded",
+                timestamp=t0 + timedelta(seconds=1),
+                aggregate_type="execution",
+                aggregate_id="exec_1",
+                data={"verdict_id": "verdict_pass", "scope": "run", "outcome": "pass"},
+            ),
+        ]
+
+        result = build_projection(events, seed_id="seed_abc")
+
+        assert [verdict.verdict_id for verdict in result.verdicts] == [
+            "verdict_escalate",
+            "verdict_pass",
+        ]
+        assert result.run.verdict_id == "verdict_pass"
 
     def test_ac_verdict_requires_ac_id(self) -> None:
         event = BaseEvent(

--- a/tests/unit/harness/test_projection_builder.py
+++ b/tests/unit/harness/test_projection_builder.py
@@ -505,6 +505,44 @@ class TestArtifactAndVerdictProjection:
         assert verdict.evidence_artifact_ids == ("artifact_tests",)
         assert verdict.rationale == "all checks passed"
 
+    def test_artifact_event_without_projected_step_is_dropped(self) -> None:
+        t0 = datetime.now(UTC)
+        event = BaseEvent(
+            id="evt_orphan_artifact",
+            type="harness.artifact.recorded",
+            timestamp=t0,
+            aggregate_type="execution",
+            aggregate_id="exec_1",
+            data={"call_id": "missing_call", "artifact_id": "artifact_orphan"},
+        )
+
+        result = build_projection([event], seed_id="seed_abc")
+
+        assert result.steps == ()
+        assert result.artifacts == ()
+
+    def test_verdict_preserves_missing_artifact_references(self) -> None:
+        t0 = datetime.now(UTC)
+        event = BaseEvent(
+            id="evt_verdict",
+            type="harness.verdict.recorded",
+            timestamp=t0,
+            aggregate_type="execution",
+            aggregate_id="exec_1",
+            data={
+                "verdict_id": "verdict_run",
+                "scope": "run",
+                "outcome": "pass",
+                "evidence_artifact_ids": ["missing_artifact"],
+            },
+        )
+
+        result = build_projection([event], seed_id="seed_abc")
+
+        assert len(result.verdicts) == 1
+        assert result.artifacts == ()
+        assert result.verdicts[0].evidence_artifact_ids == ("missing_artifact",)
+
     def test_ac_verdict_requires_ac_id(self) -> None:
         event = BaseEvent(
             id="evt_bad_ac_verdict",

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -620,6 +620,36 @@ class TestProjectionQueryHandler:
         )
         await memory_event_store.append(
             BaseEvent(
+                id="evt_proj_artifact",
+                type="harness.artifact.recorded",
+                timestamp=t0 + timedelta(milliseconds=15),
+                aggregate_type="execution",
+                aggregate_id="exec_projection_123",
+                data={
+                    "call_id": "call_1",
+                    "artifact_id": "artifact_projection_123",
+                    "kind": "evidence",
+                    "path": "artifacts/projection.json",
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
+                id="evt_proj_verdict",
+                type="harness.verdict.recorded",
+                timestamp=t0 + timedelta(milliseconds=18),
+                aggregate_type="execution",
+                aggregate_id="exec_projection_123",
+                data={
+                    "verdict_id": "verdict_projection_123",
+                    "scope": "run",
+                    "outcome": "pass",
+                    "evidence_artifact_ids": ["artifact_projection_123"],
+                },
+            )
+        )
+        await memory_event_store.append(
+            BaseEvent(
                 id="evt_proj_child",
                 type="tool.call.started",
                 timestamp=t0 + timedelta(milliseconds=20),
@@ -643,10 +673,34 @@ class TestProjectionQueryHandler:
         assert result.value.meta["execution_id"] == "exec_projection_123"
         assert result.value.meta["seed_id"] == "seed_projection_123"
         assert result.value.meta["seed_id_source"] == "event"
-        assert result.value.meta["event_count"] == 3
+        assert result.value.meta["event_count"] == 5
+        assert "Artifacts: 1" in result.value.text_content
+        assert "Verdicts: 1" in result.value.text_content
         assert result.value.meta["run"]["goal"] == "Inspect projection"
+        assert result.value.meta["run"]["verdict_id"] == "verdict_projection_123"
         assert len(result.value.meta["stages"]) == 1
         assert len(result.value.meta["steps"]) == 2
+        assert result.value.meta["artifacts"] == [
+            {
+                "schema_version": 1,
+                "artifact_id": "artifact_projection_123",
+                "step_id": result.value.meta["steps"][0]["step_id"],
+                "kind": "evidence",
+                "path": "artifacts/projection.json",
+                "media_type": None,
+                "size_bytes": None,
+                "digest": None,
+                "summary": "",
+                "metadata": {
+                    "source_event_id": "evt_proj_artifact",
+                    "event_type": "harness.artifact.recorded",
+                },
+            }
+        ]
+        assert result.value.meta["verdicts"][0]["verdict_id"] == "verdict_projection_123"
+        assert result.value.meta["verdicts"][0]["evidence_artifact_ids"] == [
+            "artifact_projection_123"
+        ]
         step = result.value.meta["steps"][0]
         assert step["kind"] == "shell_command"
         assert step["ok"] is True


### PR DESCRIPTION
## Summary
- Projects bounded artifact events into existing `ArtifactRecord` rows and links them back to producing steps.
- Projects bounded verdict events into existing `VerdictRecord` rows and exposes run-level verdict IDs.
- Returns projected artifacts/verdicts through `ouroboros_query_projection` metadata instead of permanent empty arrays.

## Scope / #961 fit
- Track C Tier 2 follow-up for #946 after #1037.
- Read-model only: no new evidence schema, no verifier policy, no writes/cache/runtime behavior.

## Validation
- `uv run pytest tests/unit/harness/test_projection_builder.py tests/unit/mcp/tools/test_definitions.py::TestProjectionQueryHandler -q`
- `uv run ruff check src/ouroboros/harness/projection_builder.py src/ouroboros/mcp/tools/projection_handlers.py tests/unit/harness/test_projection_builder.py`
- `uv run ruff format --check src/ouroboros/harness/projection_builder.py src/ouroboros/mcp/tools/projection_handlers.py tests/unit/harness/test_projection_builder.py`
- `uv run mypy src/ouroboros/harness/projection_builder.py src/ouroboros/mcp/tools/projection_handlers.py tests/unit/harness/test_projection_builder.py`

Refs #946
Refs #961
