### PR TITLE
feat(cli): expose status run projection JSON

### DIFF
--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -3,13 +3,16 @@
 Check system status and execution history.
 """
 
-from typing import Annotated
+import asyncio
+import json
+from typing import Annotated, Any
 
 import typer
 
 from ouroboros.auto.state import AutoPhase, AutoStore
 from ouroboros.cli.formatters.panels import print_error, print_info
 from ouroboros.cli.formatters.tables import create_status_table, print_table
+from ouroboros.mcp.tools.projection_handlers import ProjectionQueryHandler
 
 app = typer.Typer(
     name="status",
@@ -101,6 +104,53 @@ def auto(
         print_error(f"Auto status failed: {exc}")
         raise typer.Exit(1) from exc
     typer.echo(_format_auto_status(state), nl=False)
+
+
+@app.command(name="run")
+def run_projection(
+    session_id: Annotated[
+        str | None,
+        typer.Option("--session-id", help="Optional orchestrator session ID to project."),
+    ] = None,
+    execution_id: Annotated[
+        str | None,
+        typer.Option("--execution-id", help="Optional execution aggregate ID to project."),
+    ] = None,
+    seed_id: Annotated[
+        str | None,
+        typer.Option("--seed-id", help="Optional seed ID override for projection labels."),
+    ] = None,
+    limit: Annotated[
+        int | None,
+        typer.Option("--limit", help="Optional event count safety cap."),
+    ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit machine-readable projection JSON."),
+    ] = False,
+) -> None:
+    """Build a read-only Run/Stage/Step projection from persisted events."""
+
+    arguments: dict[str, Any] = {}
+    if session_id is not None:
+        arguments["session_id"] = session_id
+    if execution_id is not None:
+        arguments["execution_id"] = execution_id
+    if seed_id is not None:
+        arguments["seed_id"] = seed_id
+    if limit is not None:
+        arguments["limit"] = limit
+
+    result = asyncio.run(ProjectionQueryHandler().handle(arguments))
+    if result.is_err:
+        print_error(f"Run projection failed: {result.error}")
+        raise typer.Exit(1)
+
+    tool_result = result.value
+    if json_output:
+        typer.echo(json.dumps(tool_result.meta, indent=2, sort_keys=True))
+        return
+    typer.echo(tool_result.text_content, nl=False)
 
 
 @app.command()

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -302,3 +302,48 @@ class TestShorthandCommands:
 
         # _run_orchestrator should be awaited by the default orchestrator path
         mock_run_orchestrator.assert_awaited_once()
+
+
+class TestStatusRunProjectionCommand:
+    def test_status_run_json_uses_projection_handler(self) -> None:
+        async def fake_handle(self, arguments):
+            from ouroboros.core.types import Result
+            from ouroboros.mcp.types import MCPToolResult
+
+            assert arguments == {"execution_id": "exec_123", "limit": 20}
+            return Result.ok(
+                MCPToolResult(
+                    content=(),
+                    meta={
+                        "execution_id": "exec_123",
+                        "run": {"run_id": "run_123"},
+                        "stages": [],
+                        "steps": [],
+                        "artifacts": [],
+                        "verdicts": [],
+                    },
+                )
+            )
+
+        with patch("ouroboros.cli.commands.status.ProjectionQueryHandler.handle", fake_handle):
+            result = runner.invoke(
+                app,
+                ["status", "run", "--execution-id", "exec_123", "--limit", "20", "--json"],
+            )
+
+        assert result.exit_code == 0
+        assert '"execution_id": "exec_123"' in result.output
+        assert '"run_id": "run_123"' in result.output
+
+    def test_status_run_reports_projection_errors(self) -> None:
+        async def fake_handle(self, arguments):
+            from ouroboros.core.types import Result
+            from ouroboros.mcp.errors import MCPToolError
+
+            return Result.err(MCPToolError("session_id or execution_id is required"))
+
+        with patch("ouroboros.cli.commands.status.ProjectionQueryHandler.handle", fake_handle):
+            result = runner.invoke(app, ["status", "run", "--json"])
+
+        assert result.exit_code == 1
+        assert "session_id or execution_id is required" in result.output

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -335,6 +335,30 @@ class TestStatusRunProjectionCommand:
         assert '"execution_id": "exec_123"' in result.output
         assert '"run_id": "run_123"' in result.output
 
+    def test_status_run_renders_projection_text_by_default(self) -> None:
+        async def fake_handle(self, arguments):
+            from ouroboros.core.types import Result
+            from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+
+            assert arguments == {"session_id": "session_123"}
+            return Result.ok(
+                MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text="Run Projection\nRun: run_123\nSteps: 1",
+                        ),
+                    ),
+                    meta={"run": {"run_id": "run_123"}},
+                )
+            )
+
+        with patch("ouroboros.cli.commands.status.ProjectionQueryHandler.handle", fake_handle):
+            result = runner.invoke(app, ["status", "run", "--session-id", "session_123"])
+
+        assert result.exit_code == 0
+        assert result.output == "Run Projection\nRun: run_123\nSteps: 1"
+
     def test_status_run_reports_projection_errors(self) -> None:
         async def fake_handle(self, arguments):
             from ouroboros.core.types import Result


### PR DESCRIPTION
## Summary
- Adds `ouroboros status run` as a thin read-only wrapper over `ProjectionQueryHandler`.
- Supports `--session-id`, `--execution-id`, `--seed-id`, `--limit`, and `--json`.
- Adds CLI tests for JSON output and projection errors while preserving MCP projection tests.

## Scope / #961 fit
- Track C Tier 2 follow-up for #946 machine-readable CLI projection access.
- Reuses existing MCP projection semantics; no EventStore writes, cache, or runtime resume behavior.

## Validation
- `uv run pytest tests/unit/cli/test_main.py::TestStatusRunProjectionCommand tests/unit/mcp/tools/test_definitions.py::TestProjectionQueryHandler -q`
- `uv run ruff check src/ouroboros/cli/commands/status.py tests/unit/cli/test_main.py`
- `uv run ruff format --check src/ouroboros/cli/commands/status.py tests/unit/cli/test_main.py`
- `uv run mypy src/ouroboros/cli/commands/status.py tests/unit/cli/test_main.py`

Refs #946
Refs #961
