### PR TITLE
fix(auto): seed interview ledger from structured prompts

### DIFF
--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -1833,10 +1833,6 @@ def _maybe_apply_user_preference(
         return answer
     if not context.user_preferences:
         return answer
-    # Compute the lowered form lazily — most call sites pass it; ``answer_gap``
-    # and any future caller can rely on the inline normalisation here.
-    lowered_q = lowered or (_normalize_question(question) if question else "")
-    lowered_goal = _normalize_question(goal_text) if goal_text else ""
     for section in section_hints:
         raw_value = context.user_preferences.get(section)
         if not isinstance(raw_value, str):
@@ -1849,11 +1845,11 @@ def _maybe_apply_user_preference(
         # converged goal text so synthetic gap-fill prompts (which erase the
         # original risky context) cannot smuggle a confirmed USER_PREFERENCE
         # past the gate.
-        risky_blocker: AutoBlocker | None = None
-        if lowered_q and question:
-            risky_blocker = _risky_fallback_blocker_for(question, lowered_q)
-        if risky_blocker is None and lowered_goal and goal_text:
-            risky_blocker = _risky_fallback_blocker_for(goal_text, lowered_goal)
+        risky_blocker = risky_user_preference_blocker_for(
+            question=question,
+            lowered=lowered,
+            goal_text=goal_text,
+        )
         if risky_blocker is not None:
             return AutoAnswer(
                 text=(
@@ -1891,6 +1887,29 @@ def _maybe_apply_user_preference(
             generic_default=False,
         )
     return answer
+
+
+def risky_user_preference_blocker_for(
+    *,
+    question: str = "",
+    lowered: str = "",
+    goal_text: str = "",
+) -> AutoBlocker | None:
+    """Apply the risky-fallback gate for caller-supplied preferences.
+
+    ``user_preferences`` can enter the ledger through the answerer during an
+    interview or through MCP preallocation of a structured prompt. Both paths
+    must use the same gate so unsafe preference text cannot be persisted as
+    confirmed evidence before the interview has a chance to block it.
+    """
+    lowered_q = lowered or (_normalize_question(question) if question else "")
+    lowered_goal = _normalize_question(goal_text) if goal_text else ""
+    risky_blocker: AutoBlocker | None = None
+    if lowered_q and question:
+        risky_blocker = _risky_fallback_blocker_for(question, lowered_q)
+    if risky_blocker is None and lowered_goal and goal_text:
+        risky_blocker = _risky_fallback_blocker_for(goal_text, lowered_goal)
+    return risky_blocker
 
 
 _DESTRUCTIVE_BULK_VERBS = (

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -190,7 +190,9 @@ class AutoHandler:
                         "(e.g. runtime_context, constraints, non_goals). The Driver "
                         "tags matching answers with [from-auto][user_preference] in the "
                         "ledger. Keys must be valid ledger section names; values must "
-                        "be non-empty strings or non-empty lists of strings/numbers."
+                        "be non-empty strings or non-empty lists of strings/numbers. "
+                        "On resume, null/empty values clear the persisted preference "
+                        "for that section."
                     ),
                     required=False,
                 ),
@@ -293,11 +295,7 @@ class AutoHandler:
         user_preferences_supplied = (
             "user_preferences" in arguments and arguments.get("user_preferences") is not None
         )
-        supplied_user_preferences = (
-            _parse_user_preferences(arguments.get("user_preferences"))
-            if user_preferences_supplied
-            else {}
-        )
+        supplied_user_preferences: dict[str, str | None] = {}
         if isinstance(resume, str) and resume:
             state = store.load(resume)
             cwd = state.cwd
@@ -315,6 +313,10 @@ class AutoHandler:
             # ones; otherwise the original session's preferences are reused so
             # the same input converges to the same Seed.
             if user_preferences_supplied:
+                supplied_user_preferences = _parse_user_preferences(
+                    arguments.get("user_preferences"),
+                    allow_deletions=True,
+                )
                 state.user_preferences = _merge_resume_user_preferences(
                     state.goal,
                     state.user_preferences,
@@ -335,6 +337,11 @@ class AutoHandler:
             elif complete_product and not state.complete_product:
                 state.complete_product = True
         else:
+            supplied_user_preferences = (
+                _parse_user_preferences(arguments.get("user_preferences"))
+                if user_preferences_supplied
+                else {}
+            )
             goal = arguments.get("goal")
             if not isinstance(goal, str) or not goal.strip():
                 raise ValueError("goal is required when not resuming")
@@ -755,7 +762,7 @@ class StartAutoHandler:
         state.max_repair_rounds = _positive_int_arg(arguments, "max_repair_rounds", 5)
         state.skip_run = bool(arguments.get("skip_run", False))
         state.complete_product = bool(arguments.get("complete_product", False))
-        supplied_user_preferences: dict[str, str] = {}
+        supplied_user_preferences: dict[str, str | None] = {}
         if "user_preferences" in arguments and arguments.get("user_preferences") is not None:
             supplied_user_preferences = _parse_user_preferences(arguments.get("user_preferences"))
         state.user_preferences = _merge_goal_user_preferences(goal, supplied_user_preferences)
@@ -1261,7 +1268,11 @@ def _optional_pipeline_timeout(arguments: dict[str, Any]) -> float | None:
     return timeout
 
 
-def _parse_user_preferences(value: object) -> dict[str, str]:
+def _parse_user_preferences(
+    value: object,
+    *,
+    allow_deletions: bool = False,
+) -> dict[str, str | None]:
     """Validate and normalise the optional ``user_preferences`` MCP arg.
 
     Returns a dict keyed by ledger section names. Empty input yields an empty
@@ -1271,9 +1282,11 @@ def _parse_user_preferences(value: object) -> dict[str, str]:
 
     Accepted value shapes per key:
 
-    * ``str``  — stripped; must be non-empty.
+    * ``str``  — stripped; must be non-empty unless resume deletion is allowed.
     * ``list[str | int | float]`` — each item stringified+stripped, empties
       dropped, joined with ``"\\n"``; final result must be non-empty.
+    * ``None`` / empty string / empty list — only when ``allow_deletions`` is
+      true, clears a persisted preference for that key.
 
     The downstream ``answerer.py`` still consumes the value as a single
     string (via ``raw_value.strip()``); only the input contract widens.
@@ -1285,7 +1298,7 @@ def _parse_user_preferences(value: object) -> dict[str, str]:
     if not value:
         return {}
     valid_sections = frozenset(REQUIRED_SECTIONS)
-    cleaned: dict[str, str] = {}
+    cleaned: dict[str, str | None] = {}
     for raw_key, raw_val in value.items():
         if not isinstance(raw_key, str):
             raise ValueError("user_preferences keys must be strings")
@@ -1296,9 +1309,15 @@ def _parse_user_preferences(value: object) -> dict[str, str]:
                 f"user_preferences key '{raw_key}' is not a valid ledger section "
                 f"(allowed: {', '.join(sorted(valid_sections))}){hint}"
             )
+        if raw_val is None and allow_deletions:
+            cleaned[raw_key] = None
+            continue
         if isinstance(raw_val, str):
             normalised = raw_val.strip()
             if not normalised:
+                if allow_deletions:
+                    cleaned[raw_key] = None
+                    continue
                 raise ValueError(
                     f"user_preferences['{raw_key}'] must be a non-empty string or "
                     "list of strings/numbers"
@@ -1317,6 +1336,9 @@ def _parse_user_preferences(value: object) -> dict[str, str]:
                 if text:
                     parts.append(text)
             if not parts:
+                if allow_deletions:
+                    cleaned[raw_key] = None
+                    continue
                 raise ValueError(
                     f"user_preferences['{raw_key}'] must be a non-empty string or "
                     "list of strings/numbers"
@@ -1329,22 +1351,30 @@ def _parse_user_preferences(value: object) -> dict[str, str]:
     return cleaned
 
 
-def _merge_goal_user_preferences(goal: str, supplied: dict[str, str]) -> dict[str, str]:
+def _merge_goal_user_preferences(goal: str, supplied: dict[str, str | None]) -> dict[str, str]:
     """Merge explicit MCP preferences over preferences derived from the goal text."""
     merged = _derive_goal_user_preferences(goal)
-    merged.update(supplied)
+    for key, value in supplied.items():
+        if value is None:
+            merged.pop(key, None)
+        else:
+            merged[key] = value
     return merged
 
 
 def _merge_resume_user_preferences(
     goal: str,
     persisted: dict[str, str],
-    supplied: dict[str, str],
+    supplied: dict[str, str | None],
 ) -> dict[str, str]:
     """Merge resume preferences without dropping previously persisted facts."""
     merged = _derive_goal_user_preferences(goal)
     merged.update(persisted)
-    merged.update(supplied)
+    for key, value in supplied.items():
+        if value is None:
+            merged.pop(key, None)
+        else:
+            merged[key] = value
     return merged
 
 
@@ -1455,9 +1485,9 @@ def _derive_goal_user_preferences(goal: str) -> dict[str, str]:
     if success:
         preferences["acceptance_criteria"] = success
 
-    implementation = _section_text(sections, "implementation", "task")
-    if implementation:
-        preferences["outputs"] = implementation
+    outputs = _section_text(sections, "outputs", "deliverables")
+    if outputs:
+        preferences["outputs"] = outputs
 
     constraint_lines = _matching_lines(
         goal,

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -9,6 +9,7 @@ import inspect
 import json
 import os
 from pathlib import Path
+import re
 from typing import Any
 from uuid import uuid4
 
@@ -25,7 +26,13 @@ from ouroboros.auto.adapters import (
 )
 from ouroboros.auto.answerer import AutoAnswerContext
 from ouroboros.auto.interview_driver import AutoInterviewDriver
-from ouroboros.auto.ledger import REQUIRED_SECTIONS
+from ouroboros.auto.ledger import (
+    REQUIRED_SECTIONS,
+    LedgerEntry,
+    LedgerSource,
+    LedgerStatus,
+    SeedDraftLedger,
+)
 from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
 from ouroboros.auto.repo_context import repo_auto_answer_context
 from ouroboros.auto.resume_render import render_resume_lines
@@ -325,8 +332,14 @@ class AutoHandler:
             max_interview_rounds = _positive_int_arg(arguments, "max_interview_rounds", 12)
             max_repair_rounds = _positive_int_arg(arguments, "max_repair_rounds", 5)
             skip_run = requested_skip_run
-            state = AutoPipelineState(goal=goal.strip(), cwd=cwd)
-            state.user_preferences = dict(supplied_user_preferences)
+            goal_text = goal.strip()
+            state = AutoPipelineState(goal=goal_text, cwd=cwd)
+            state.user_preferences = _merge_goal_user_preferences(
+                goal_text, supplied_user_preferences
+            )
+            state.ledger = _seed_initial_ledger_from_user_preferences(
+                goal_text, state.user_preferences
+            ).to_dict()
             state.max_interview_rounds = max_interview_rounds
             state.max_repair_rounds = max_repair_rounds
             state.complete_product = complete_product
@@ -722,8 +735,13 @@ class StartAutoHandler:
         state.max_repair_rounds = _positive_int_arg(arguments, "max_repair_rounds", 5)
         state.skip_run = bool(arguments.get("skip_run", False))
         state.complete_product = bool(arguments.get("complete_product", False))
+        supplied_user_preferences: dict[str, str] = {}
         if "user_preferences" in arguments and arguments.get("user_preferences") is not None:
-            state.user_preferences = _parse_user_preferences(arguments.get("user_preferences"))
+            supplied_user_preferences = _parse_user_preferences(arguments.get("user_preferences"))
+        state.user_preferences = _merge_goal_user_preferences(goal, supplied_user_preferences)
+        state.ledger = _seed_initial_ledger_from_user_preferences(
+            goal, state.user_preferences
+        ).to_dict()
         if pipeline_timeout_seconds is not None:
             state.pipeline_timeout_seconds = pipeline_timeout_seconds
         runtime_backend = resolve_agent_runtime_backend(self.agent_runtime_backend)
@@ -1289,6 +1307,173 @@ def _parse_user_preferences(value: object) -> dict[str, str]:
             f"user_preferences['{raw_key}'] must be a non-empty string or list of strings/numbers"
         )
     return cleaned
+
+
+def _merge_goal_user_preferences(goal: str, supplied: dict[str, str]) -> dict[str, str]:
+    """Merge explicit MCP preferences over preferences derived from the goal text."""
+    merged = _derive_goal_user_preferences(goal)
+    merged.update(supplied)
+    return merged
+
+
+def _seed_initial_ledger_from_user_preferences(
+    goal: str, user_preferences: dict[str, str]
+) -> SeedDraftLedger:
+    """Create an initial ledger seeded with explicit goal-prompt preferences."""
+    ledger = SeedDraftLedger.from_goal(goal)
+    for section in REQUIRED_SECTIONS:
+        if section == "goal":
+            continue
+        value = user_preferences.get(section)
+        if not value:
+            continue
+        ledger.add_entry(
+            section,
+            LedgerEntry(
+                key=f"{section}.goal_prompt",
+                value=value,
+                source=LedgerSource.USER_PREFERENCE,
+                confidence=0.86,
+                status=LedgerStatus.CONFIRMED,
+                rationale=(
+                    "Derived from explicit structured text in the initial ooo auto goal prompt."
+                ),
+            ),
+        )
+    return ledger
+
+
+def _derive_goal_user_preferences(goal: str) -> dict[str, str]:
+    """Extract explicit ledger preferences from a structured multiline auto goal.
+
+    This is intentionally conservative: it recognizes operator-authored section
+    labels and concrete command/file constraints, then lets the normal
+    interview/repair pipeline validate and refine the resulting ledger. It does
+    not invent product behavior beyond common local-repository observation
+    framing that is explicitly present in the prompt.
+    """
+    sections = _extract_goal_sections(goal)
+    preferences: dict[str, str] = {}
+
+    runtime = _section_text(sections, "runtime context", "runtime_context")
+    if runtime:
+        preferences["runtime_context"] = runtime
+
+    non_goals = _section_text(sections, "non-goals", "non goals", "non_goals")
+    if non_goals:
+        preferences["non_goals"] = non_goals
+
+    success = _section_text(sections, "success criteria", "acceptance criteria")
+    if success:
+        preferences["acceptance_criteria"] = success
+
+    implementation = _section_text(sections, "implementation", "task")
+    if implementation:
+        preferences["outputs"] = implementation
+        preferences["inputs"] = (
+            "Inputs are the local repository state, the requested implementation contract, "
+            "and the verification commands described in the goal prompt."
+        )
+
+    constraint_lines = _matching_lines(
+        goal,
+        (
+            "do not",
+            "keep ",
+            "local file edits are allowed",
+            "running targeted tests is allowed",
+            "network access is not required",
+            "no credentials are required",
+        ),
+    )
+    if constraint_lines:
+        preferences["constraints"] = "\n".join(constraint_lines)
+
+    verification_lines = _matching_lines(
+        goal,
+        (
+            "uv run pytest",
+            "targeted test",
+            "test command",
+            "test result",
+            "pytest test",
+        ),
+    )
+    if verification_lines:
+        preferences["verification_plan"] = "\n".join(verification_lines)
+
+    failure_lines = _matching_lines(
+        goal,
+        (
+            "if ",
+            "blocked",
+            "unavailable",
+            "interpreted as normal text",
+            "previous ",
+            "manual fallback",
+        ),
+    )
+    if failure_lines:
+        preferences["failure_modes"] = "\n".join(failure_lines)
+
+    if _looks_like_local_operator_goal(goal):
+        preferences["actors"] = (
+            "A single local developer/operator using Codex and Ouroboros in the local repository."
+        )
+
+    return preferences
+
+
+def _extract_goal_sections(goal: str) -> dict[str, list[str]]:
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for raw_line in goal.splitlines():
+        line = raw_line.rstrip()
+        header = _section_header(line)
+        if header is not None:
+            current = header
+            sections.setdefault(current, [])
+            continue
+        if current is not None and line.strip():
+            sections[current].append(_clean_prompt_line(line))
+    return sections
+
+
+def _section_header(line: str) -> str | None:
+    match = re.match(r"^\s*([A-Za-z][A-Za-z0-9 _/-]{1,60}):\s*$", line)
+    if match is None:
+        return None
+    return " ".join(match.group(1).replace("_", " ").casefold().split())
+
+
+def _section_text(sections: dict[str, list[str]], *names: str) -> str:
+    values: list[str] = []
+    for name in names:
+        values.extend(sections.get(" ".join(name.replace("_", " ").casefold().split()), ()))
+    return "\n".join(dict.fromkeys(value for value in values if value.strip()))
+
+
+def _matching_lines(text: str, needles: tuple[str, ...]) -> list[str]:
+    matches: list[str] = []
+    for line in text.splitlines():
+        cleaned = _clean_prompt_line(line)
+        lowered = cleaned.casefold()
+        if cleaned and any(needle in lowered for needle in needles):
+            matches.append(cleaned)
+    return list(dict.fromkeys(matches))
+
+
+def _clean_prompt_line(line: str) -> str:
+    return re.sub(r"^\s*(?:[-*]|\d+[.)])\s*", "", line).strip()
+
+
+def _looks_like_local_operator_goal(goal: str) -> bool:
+    lowered = goal.casefold()
+    return (
+        "local development repository" in lowered
+        or "local repository" in lowered
+        or "local file edits are allowed" in lowered
+    )
 
 
 def _build_context_provider(user_preferences: dict[str, str]):

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1363,13 +1363,15 @@ def _merge_goal_user_preferences(goal: str, supplied: dict[str, str | None]) -> 
 
 
 def _merge_resume_user_preferences(
-    goal: str,
+    _goal: str,
     persisted: dict[str, str],
     supplied: dict[str, str | None],
 ) -> dict[str, str]:
     """Merge resume preferences without dropping previously persisted facts."""
-    merged = _derive_goal_user_preferences(goal)
-    merged.update(persisted)
+    # Fresh sessions already persist goal-derived preferences. On resume the
+    # persisted map is the durable source of truth; re-deriving from the goal
+    # would resurrect sections the operator explicitly cleared earlier.
+    merged = dict(persisted)
     for key, value in supplied.items():
         if value is None:
             merged.pop(key, None)

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -315,7 +315,14 @@ class AutoHandler:
             # ones; otherwise the original session's preferences are reused so
             # the same input converges to the same Seed.
             if user_preferences_supplied:
-                state.user_preferences = dict(supplied_user_preferences)
+                state.user_preferences = _merge_goal_user_preferences(
+                    state.goal, supplied_user_preferences
+                )
+                state.ledger = _reseed_preference_ledger(
+                    state.goal,
+                    state.ledger,
+                    state.user_preferences,
+                ).to_dict()
             # Q00/ouroboros#773 (review-3): ``complete_product`` is durable
             # session intent, not a per-invocation flag. Honor the persisted
             # value so MCP callers that omit ``complete_product`` on resume
@@ -1354,6 +1361,38 @@ def _seed_initial_ledger_from_user_preferences(
             ),
         )
     return ledger
+
+
+def _reseed_preference_ledger(
+    goal: str,
+    existing_ledger: dict[str, Any] | None,
+    user_preferences: dict[str, str],
+) -> SeedDraftLedger:
+    """Refresh preference-derived ledger entries after a resume override.
+
+    The auto pipeline treats a persisted ledger as the Seed source of truth.
+    Therefore a resume call that overrides ``state.user_preferences`` must also
+    refresh the preconfirmed preference entries; otherwise stale values from a
+    preallocated start_auto request can survive even though the preference map
+    was corrected. Non-preference interview facts are preserved.
+    """
+    refreshed = _seed_initial_ledger_from_user_preferences(goal, user_preferences)
+    if not existing_ledger:
+        return refreshed
+    existing = SeedDraftLedger.from_dict(existing_ledger)
+    refreshed.question_history = list(existing.question_history)
+    for section_name, section in existing.sections.items():
+        for entry in section.entries:
+            if (
+                entry.source == LedgerSource.USER_PREFERENCE
+                or entry.key.endswith(".goal_prompt")
+                or entry.key.endswith(".user_preference")
+            ):
+                continue
+            if section_name == "goal" and entry.key == "goal.primary":
+                continue
+            refreshed.add_entry(section_name, entry)
+    return refreshed
 
 
 def _user_preference_would_bypass_risky_gate(goal: str, value: str) -> bool:

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -315,8 +315,10 @@ class AutoHandler:
             # ones; otherwise the original session's preferences are reused so
             # the same input converges to the same Seed.
             if user_preferences_supplied:
-                state.user_preferences = _merge_goal_user_preferences(
-                    state.goal, supplied_user_preferences
+                state.user_preferences = _merge_resume_user_preferences(
+                    state.goal,
+                    state.user_preferences,
+                    supplied_user_preferences,
                 )
                 state.ledger = _reseed_preference_ledger(
                     state.goal,
@@ -1334,6 +1336,18 @@ def _merge_goal_user_preferences(goal: str, supplied: dict[str, str]) -> dict[st
     return merged
 
 
+def _merge_resume_user_preferences(
+    goal: str,
+    persisted: dict[str, str],
+    supplied: dict[str, str],
+) -> dict[str, str]:
+    """Merge resume preferences without dropping previously persisted facts."""
+    merged = _derive_goal_user_preferences(goal)
+    merged.update(persisted)
+    merged.update(supplied)
+    return merged
+
+
 def _seed_initial_ledger_from_user_preferences(
     goal: str, user_preferences: dict[str, str]
 ) -> SeedDraftLedger:
@@ -1429,6 +1443,14 @@ def _derive_goal_user_preferences(goal: str) -> dict[str, str]:
     if non_goals:
         preferences["non_goals"] = non_goals
 
+    actors = _section_text(sections, "actors", "actor")
+    if actors:
+        preferences["actors"] = actors
+
+    inputs = _section_text(sections, "inputs", "input")
+    if inputs:
+        preferences["inputs"] = inputs
+
     success = _section_text(sections, "success criteria", "acceptance criteria")
     if success:
         preferences["acceptance_criteria"] = success
@@ -1436,10 +1458,6 @@ def _derive_goal_user_preferences(goal: str) -> dict[str, str]:
     implementation = _section_text(sections, "implementation", "task")
     if implementation:
         preferences["outputs"] = implementation
-        preferences["inputs"] = (
-            "Inputs are the local repository state, the requested implementation contract, "
-            "and the verification commands described in the goal prompt."
-        )
 
     constraint_lines = _matching_lines(
         goal,
@@ -1481,11 +1499,6 @@ def _derive_goal_user_preferences(goal: str) -> dict[str, str]:
     )
     if failure_lines:
         preferences["failure_modes"] = "\n".join(failure_lines)
-
-    if _looks_like_local_operator_goal(goal):
-        preferences["actors"] = (
-            "A single local developer/operator using Codex and Ouroboros in the local repository."
-        )
 
     return preferences
 
@@ -1531,15 +1544,6 @@ def _matching_lines(text: str, needles: tuple[str, ...]) -> list[str]:
 
 def _clean_prompt_line(line: str) -> str:
     return re.sub(r"^\s*(?:[-*]|\d+[.)])\s*", "", line).strip()
-
-
-def _looks_like_local_operator_goal(goal: str) -> bool:
-    lowered = goal.casefold()
-    return (
-        "local development repository" in lowered
-        or "local repository" in lowered
-        or "local file edits are allowed" in lowered
-    )
 
 
 def _build_context_provider(user_preferences: dict[str, str]):

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -24,7 +24,10 @@ from ouroboros.auto.adapters import (
     load_seed,
     save_seed,
 )
-from ouroboros.auto.answerer import AutoAnswerContext
+from ouroboros.auto.answerer import (
+    AutoAnswerContext,
+    risky_user_preference_blocker_for,
+)
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import (
     REQUIRED_SECTIONS,
@@ -599,6 +602,14 @@ class StartAutoHandler:
             auto_session_id = state.auto_session_id
             runner_arguments["resume"] = auto_session_id
             runner_arguments.pop("pipeline_timeout_seconds", None)
+            # The freshly preallocated state already contains the canonical
+            # merged preference map derived from the structured goal plus any
+            # explicit caller preferences.  Do not pass the original fresh-call
+            # preference payload back through the resume runner: AutoHandler's
+            # resume contract treats a supplied preference map as an override,
+            # which would drop goal-derived sections and make start_auto
+            # diverge from the synchronous auto path.
+            runner_arguments.pop("user_preferences", None)
 
         already_running = await self._active_session_error(auto_session_id)
         if already_running is not None:
@@ -1327,6 +1338,8 @@ def _seed_initial_ledger_from_user_preferences(
         value = user_preferences.get(section)
         if not value:
             continue
+        if _user_preference_would_bypass_risky_gate(goal, value):
+            continue
         ledger.add_entry(
             section,
             LedgerEntry(
@@ -1341,6 +1354,20 @@ def _seed_initial_ledger_from_user_preferences(
             ),
         )
     return ledger
+
+
+def _user_preference_would_bypass_risky_gate(goal: str, value: str) -> bool:
+    """Return True when pre-confirming a preference would skip answerer safety.
+
+    Normal user_preferences only become confirmed ledger entries through
+    ``AutoAnswerer._maybe_apply_user_preference()``, which runs the risky
+    fallback gate against both the current question and the converged goal.
+    Preallocating a ledger for structured MCP prompts must honor that same
+    policy: unsafe preference text may remain in ``state.user_preferences`` so
+    the interview answerer can surface the blocker at the right question, but
+    it must not be persisted as already-confirmed ledger evidence.
+    """
+    return risky_user_preference_blocker_for(question=value, goal_text=goal) is not None
 
 
 def _derive_goal_user_preferences(goal: str) -> dict[str, str]:

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -20,7 +20,7 @@ from ouroboros.auto.adapters import HandlerInterviewBackend
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipelineResult
-from ouroboros.auto.state import AutoStore
+from ouroboros.auto.state import AutoPipelineState, AutoStore
 from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError
@@ -28,6 +28,7 @@ from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
 from ouroboros.mcp.tools.auto_handler import (
     AutoHandler,
     _derive_goal_user_preferences,
+    _reseed_preference_ledger,
     _seed_initial_ledger_from_user_preferences,
 )
 from ouroboros.mcp.types import ContentType
@@ -148,6 +149,27 @@ Success criteria:
     assert "acceptance_criteria" not in ledger.summary()["evidence_backed_sections"]
 
 
+def test_resume_preference_override_reseeds_stale_preconfirmed_ledger() -> None:
+    """Resume preference overrides must update persisted ledger source of truth."""
+    original_preferences = _derive_goal_user_preferences(_OBSERVATION_GOAL)
+    original_ledger = _seed_initial_ledger_from_user_preferences(
+        _OBSERVATION_GOAL, original_preferences
+    )
+
+    refreshed = _reseed_preference_ledger(
+        _OBSERVATION_GOAL,
+        original_ledger.to_dict(),
+        {
+            **original_preferences,
+            "constraints": "Keep only the corrected local reversible constraint.",
+        },
+    )
+
+    constraints = refreshed.sections["constraints"].entries
+    active_constraints = [entry.value for entry in constraints if entry.status == "confirmed"]
+    assert active_constraints == ["Keep only the corrected local reversible constraint."]
+
+
 def test_auto_handler_fresh_session_persists_goal_derived_ledger_preferences(
     tmp_path: Path,
 ) -> None:
@@ -177,6 +199,57 @@ def test_auto_handler_fresh_session_persists_goal_derived_ledger_preferences(
     assert "non_goals" in state.user_preferences
     ledger = SeedDraftLedger.from_dict(state.ledger)
     assert ledger.open_gaps() == []
+
+
+def test_auto_handler_resume_preference_override_updates_persisted_ledger(
+    tmp_path: Path,
+) -> None:
+    store = AutoStore(tmp_path)
+    original_preferences = _derive_goal_user_preferences(_OBSERVATION_GOAL)
+    state = AutoPipelineState(goal=_OBSERVATION_GOAL, cwd=str(tmp_path))
+    state.user_preferences = dict(original_preferences)
+    state.ledger = _seed_initial_ledger_from_user_preferences(
+        _OBSERVATION_GOAL, original_preferences
+    ).to_dict()
+    store.save(state)
+    captured: dict[str, Any] = {}
+
+    async def _capture_state(self, state):  # type: ignore[no-untyped-def]
+        captured["state"] = state
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+        )
+
+    with patch(
+        "ouroboros.mcp.tools.auto_handler.AutoPipeline.run",
+        new=_capture_state,
+    ):
+        result = asyncio.run(
+            AutoHandler(store=store).handle(
+                {
+                    "resume": state.auto_session_id,
+                    "user_preferences": {
+                        "constraints": "Keep only the corrected local reversible constraint."
+                    },
+                }
+            )
+        )
+
+    assert result.is_ok, result.error
+    resumed = captured["state"]
+    assert "runtime_context" in resumed.user_preferences
+    assert resumed.user_preferences["constraints"] == (
+        "Keep only the corrected local reversible constraint."
+    )
+    ledger = SeedDraftLedger.from_dict(resumed.ledger)
+    active_constraints = [
+        entry.value
+        for entry in ledger.sections["constraints"].entries
+        if entry.status == "confirmed"
+    ]
+    assert active_constraints == ["Keep only the corrected local reversible constraint."]
 
 
 def _call_names(node: ast.AST) -> set[str]:

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -222,6 +222,27 @@ def test_resume_preference_override_can_clear_persisted_section() -> None:
     assert "constraints" not in refreshed.summary()["evidence_backed_sections"]
 
 
+def test_resume_preference_clear_is_durable_across_later_overrides() -> None:
+    """Cleared goal-derived sections must not reappear on later resumes."""
+    original_preferences = {
+        **_derive_goal_user_preferences(_OBSERVATION_GOAL),
+        "constraints": "Stale constraint that should be removed.",
+    }
+    after_clear = _merge_resume_user_preferences(
+        _OBSERVATION_GOAL,
+        original_preferences,
+        {"constraints": None},
+    )
+    after_later_override = _merge_resume_user_preferences(
+        _OBSERVATION_GOAL,
+        after_clear,
+        {"non_goals": "Keep the later non-goal override."},
+    )
+
+    assert "constraints" not in after_later_override
+    assert after_later_override["non_goals"] == "Keep the later non-goal override."
+
+
 def test_auto_handler_fresh_session_persists_goal_derived_ledger_preferences(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -28,6 +28,7 @@ from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
 from ouroboros.mcp.tools.auto_handler import (
     AutoHandler,
     _derive_goal_user_preferences,
+    _merge_resume_user_preferences,
     _reseed_preference_ledger,
     _seed_initial_ledger_from_user_preferences,
 )
@@ -67,6 +68,10 @@ Verify current ooo auto can create hello_auto.py and tests/test_hello_auto.py.
 Implementation:
 - Create `hello_auto.py` at the repository root.
 - Add a minimal pytest test at `tests/test_hello_auto.py`.
+
+Outputs:
+- `hello_auto.py` exists.
+- `tests/test_hello_auto.py` exists.
 
 Runtime context:
 - This is a local development repository.
@@ -142,6 +147,9 @@ Build a data cleanup tool.
 Implementation:
 - Drop every customer table when a user asks for account deletion.
 
+Outputs:
+- A migration that truncates all customer PII tables.
+
 Success criteria:
 - The migration truncates all PII rows.
 """
@@ -155,8 +163,8 @@ Success criteria:
     assert "acceptance_criteria" not in ledger.summary()["evidence_backed_sections"]
 
 
-def test_implementation_section_does_not_fabricate_inputs_preference() -> None:
-    """Only explicitly authored Inputs sections may seed required inputs."""
+def test_implementation_section_does_not_fabricate_io_preferences() -> None:
+    """Only explicitly authored Inputs/Outputs sections may seed required IO."""
     goal = """
 Goal:
 Create a hello world file.
@@ -167,7 +175,7 @@ Implementation:
 
     preferences = _derive_goal_user_preferences(goal)
 
-    assert preferences["outputs"] == "Create `hello.py`."
+    assert "outputs" not in preferences
     assert "inputs" not in preferences
 
 
@@ -190,6 +198,28 @@ def test_resume_preference_override_reseeds_stale_preconfirmed_ledger() -> None:
     constraints = refreshed.sections["constraints"].entries
     active_constraints = [entry.value for entry in constraints if entry.status == "confirmed"]
     assert active_constraints == ["Keep only the corrected local reversible constraint."]
+
+
+def test_resume_preference_override_can_clear_persisted_section() -> None:
+    """Resume callers need an escape hatch for bad preallocated preferences."""
+    original_preferences = {
+        **_derive_goal_user_preferences(_OBSERVATION_GOAL),
+        "constraints": "Stale constraint that should be removed.",
+    }
+
+    refreshed = _reseed_preference_ledger(
+        _OBSERVATION_GOAL,
+        _seed_initial_ledger_from_user_preferences(
+            _OBSERVATION_GOAL, original_preferences
+        ).to_dict(),
+        _merge_resume_user_preferences(
+            _OBSERVATION_GOAL,
+            original_preferences,
+            {"constraints": None},
+        ),
+    )
+
+    assert "constraints" not in refreshed.summary()["evidence_backed_sections"]
 
 
 def test_auto_handler_fresh_session_persists_goal_derived_ledger_preferences(

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -75,6 +75,12 @@ Runtime context:
 - Network access is not required.
 - No credentials are required.
 
+Actors:
+- A single local developer/operator using Codex and Ouroboros in the local repository.
+
+Inputs:
+- The local repository state, the requested implementation contract, and the verification commands described in this goal prompt.
+
 Non-goals:
 - Do not refactor existing code.
 - Do not add dependencies.
@@ -149,6 +155,22 @@ Success criteria:
     assert "acceptance_criteria" not in ledger.summary()["evidence_backed_sections"]
 
 
+def test_implementation_section_does_not_fabricate_inputs_preference() -> None:
+    """Only explicitly authored Inputs sections may seed required inputs."""
+    goal = """
+Goal:
+Create a hello world file.
+
+Implementation:
+- Create `hello.py`.
+"""
+
+    preferences = _derive_goal_user_preferences(goal)
+
+    assert preferences["outputs"] == "Create `hello.py`."
+    assert "inputs" not in preferences
+
+
 def test_resume_preference_override_reseeds_stale_preconfirmed_ledger() -> None:
     """Resume preference overrides must update persisted ledger source of truth."""
     original_preferences = _derive_goal_user_preferences(_OBSERVATION_GOAL)
@@ -208,8 +230,9 @@ def test_auto_handler_resume_preference_override_updates_persisted_ledger(
     original_preferences = _derive_goal_user_preferences(_OBSERVATION_GOAL)
     state = AutoPipelineState(goal=_OBSERVATION_GOAL, cwd=str(tmp_path))
     state.user_preferences = dict(original_preferences)
+    state.user_preferences["runtime_context"] = "Persisted explicit runtime context."
     state.ledger = _seed_initial_ledger_from_user_preferences(
-        _OBSERVATION_GOAL, original_preferences
+        _OBSERVATION_GOAL, state.user_preferences
     ).to_dict()
     store.save(state)
     captured: dict[str, Any] = {}
@@ -239,7 +262,7 @@ def test_auto_handler_resume_preference_override_updates_persisted_ledger(
 
     assert result.is_ok, result.error
     resumed = captured["state"]
-    assert "runtime_context" in resumed.user_preferences
+    assert resumed.user_preferences["runtime_context"] == "Persisted explicit runtime context."
     assert resumed.user_preferences["constraints"] == (
         "Keep only the corrected local reversible constraint."
     )

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -18,13 +18,18 @@ from unittest.mock import MagicMock, patch
 
 from ouroboros.auto.adapters import HandlerInterviewBackend
 from ouroboros.auto.interview_driver import AutoInterviewDriver
+from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipelineResult
 from ouroboros.auto.state import AutoStore
 from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError
 from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
-from ouroboros.mcp.tools.auto_handler import AutoHandler
+from ouroboros.mcp.tools.auto_handler import (
+    AutoHandler,
+    _derive_goal_user_preferences,
+    _seed_initial_ledger_from_user_preferences,
+)
 from ouroboros.mcp.types import ContentType
 from ouroboros.providers.base import CompletionResponse, Message, UsageInfo
 from ouroboros.providers.claude_code_adapter import ClaudeCodeAdapter
@@ -54,6 +59,37 @@ _TOOL_CALL_CAPABLE_LEAKAGE_PATHS = frozenset(
     }
 )
 
+_OBSERVATION_GOAL = """
+Goal:
+Verify current ooo auto can create hello_auto.py and tests/test_hello_auto.py.
+
+Implementation:
+- Create `hello_auto.py` at the repository root.
+- Add a minimal pytest test at `tests/test_hello_auto.py`.
+
+Runtime context:
+- This is a local development repository.
+- Local file edits are allowed.
+- Running targeted tests is allowed.
+- Network access is not required.
+- No credentials are required.
+
+Non-goals:
+- Do not refactor existing code.
+- Do not add dependencies.
+- Do not edit unrelated files.
+
+Success criteria:
+- `ooo auto` is handled by Ouroboros auto/MCP, not plain text.
+- `hello_auto.py` exists.
+- `tests/test_hello_auto.py` exists.
+- The targeted test command `uv run pytest tests/test_hello_auto.py` passes.
+- Final report includes auto session id, seed id, files changed, exact test command, and test result.
+
+Important dispatch rule:
+If `ouroboros_auto` is unavailable or interpreted as normal text, stop and report failure.
+"""
+
 
 def _assert_isolated_allowed_tools(factory_kwargs: dict[str, Any]) -> None:
     """Assert the auto sub-interviewer cannot opt into tool-call surfaces."""
@@ -65,6 +101,60 @@ def _assert_isolated_allowed_tools(factory_kwargs: dict[str, Any]) -> None:
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[4]
+
+
+def test_structured_auto_goal_seeds_required_ledger_sections() -> None:
+    """Observation-style prompts should seed known ledger sections before interview."""
+    preferences = _derive_goal_user_preferences(_OBSERVATION_GOAL)
+    ledger = _seed_initial_ledger_from_user_preferences(_OBSERVATION_GOAL, preferences)
+
+    assert {
+        "actors",
+        "inputs",
+        "outputs",
+        "constraints",
+        "non_goals",
+        "acceptance_criteria",
+        "verification_plan",
+        "failure_modes",
+        "runtime_context",
+    } <= set(preferences)
+    assert ledger.open_gaps() == []
+    summary = ledger.summary()
+    assert "runtime_context" in summary["evidence_backed_sections"]
+    assert "constraints" in summary["evidence_backed_sections"]
+    assert "non_goals" in summary["evidence_backed_sections"]
+
+
+def test_auto_handler_fresh_session_persists_goal_derived_ledger_preferences(
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def _capture_state(self, state):  # type: ignore[no-untyped-def]
+        captured["state"] = state
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+        )
+
+    with patch(
+        "ouroboros.mcp.tools.auto_handler.AutoPipeline.run",
+        new=_capture_state,
+    ):
+        result = asyncio.run(
+            AutoHandler(store=AutoStore(tmp_path)).handle(
+                {"goal": _OBSERVATION_GOAL, "cwd": str(tmp_path)}
+            )
+        )
+
+    assert result.is_ok, result.error
+    state = captured["state"]
+    assert "runtime_context" in state.user_preferences
+    assert "non_goals" in state.user_preferences
+    ledger = SeedDraftLedger.from_dict(state.ledger)
+    assert ledger.open_gaps() == []
 
 
 def _call_names(node: ast.AST) -> set[str]:

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -126,6 +126,28 @@ def test_structured_auto_goal_seeds_required_ledger_sections() -> None:
     assert "non_goals" in summary["evidence_backed_sections"]
 
 
+def test_structured_auto_goal_does_not_preconfirm_risky_preference() -> None:
+    """Pre-seeding must not bypass the answerer's risky USER_PREFERENCE gate."""
+    risky_goal = """
+Goal:
+Build a data cleanup tool.
+
+Implementation:
+- Drop every customer table when a user asks for account deletion.
+
+Success criteria:
+- The migration truncates all PII rows.
+"""
+    preferences = _derive_goal_user_preferences(risky_goal)
+
+    assert "outputs" in preferences
+    assert "acceptance_criteria" in preferences
+    ledger = _seed_initial_ledger_from_user_preferences(risky_goal, preferences)
+
+    assert "outputs" not in ledger.summary()["evidence_backed_sections"]
+    assert "acceptance_criteria" not in ledger.summary()["evidence_backed_sections"]
+
+
 def test_auto_handler_fresh_session_persists_goal_derived_ledger_preferences(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -41,6 +41,12 @@ Runtime context:
 - Network access is not required.
 - No credentials are required.
 
+Actors:
+- A single local developer/operator using Codex and Ouroboros in the local repository.
+
+Inputs:
+- The local repository state, the requested implementation contract, and the verification commands described in this goal prompt.
+
 Non-goals:
 - Do not refactor existing code.
 - Do not add dependencies.

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -34,6 +34,10 @@ Implementation:
 - Create `hello_auto.py` at the repository root.
 - Add a minimal pytest test at `tests/test_hello_auto.py`.
 
+Outputs:
+- `hello_auto.py` exists.
+- `tests/test_hello_auto.py` exists.
+
 Runtime context:
 - This is a local development repository.
 - Local file edits are allowed.

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -18,12 +18,44 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipelineResult
 from ouroboros.auto.state import AutoPipelineState, AutoStore
 from ouroboros.core.types import Result
 from ouroboros.mcp.tools.auto_handler import AutoHandler, StartAutoHandler
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.persistence.event_store import EventStore
+
+_STRUCTURED_OBSERVATION_GOAL = """
+Goal:
+Verify current ooo auto can create hello_auto.py and tests/test_hello_auto.py.
+
+Implementation:
+- Create `hello_auto.py` at the repository root.
+- Add a minimal pytest test at `tests/test_hello_auto.py`.
+
+Runtime context:
+- This is a local development repository.
+- Local file edits are allowed.
+- Running targeted tests is allowed.
+- Network access is not required.
+- No credentials are required.
+
+Non-goals:
+- Do not refactor existing code.
+- Do not add dependencies.
+- Do not edit unrelated files.
+
+Success criteria:
+- `ooo auto` is handled by Ouroboros auto/MCP, not plain text.
+- `hello_auto.py` exists.
+- `tests/test_hello_auto.py` exists.
+- The targeted test command `uv run pytest tests/test_hello_auto.py` passes.
+- Final report includes auto session id, seed id, files changed, exact test command, and test result.
+
+Important dispatch rule:
+If `ouroboros_auto` is unavailable or interpreted as normal text, stop and report failure.
+"""
 
 
 @pytest.fixture
@@ -183,6 +215,34 @@ class TestBackgroundJobPath:
         assert store.path_for(auto_session_id).exists()
         # The inner AutoHandler must NOT have run synchronously — the runner is
         # enqueued on the JobManager only.
+        fake_inner_auto.handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_new_structured_goal_preallocates_seed_ready_ledger(
+        self, event_store, tmp_path, fake_inner_auto
+    ) -> None:
+        job_manager = MagicMock()
+        snapshot = MagicMock()
+        snapshot.job_id = "job_auto_structured"
+
+        async def _start_job(*, runner, **_):
+            if inspect.iscoroutine(runner):
+                runner.close()
+            return snapshot
+
+        job_manager.start_job = AsyncMock(side_effect=_start_job)
+        store = AutoStore(tmp_path)
+        h = StartAutoHandler(event_store=event_store, job_manager=job_manager, store=store)
+        h._inner_auto = fake_inner_auto
+
+        result = await h.handle({"goal": _STRUCTURED_OBSERVATION_GOAL, "cwd": str(tmp_path)})
+
+        assert result.is_ok
+        state = store.load(result.value.meta["auto_session_id"])
+        assert "runtime_context" in state.user_preferences
+        assert "non_goals" in state.user_preferences
+        assert "failure_modes" in state.user_preferences
+        assert SeedDraftLedger.from_dict(state.ledger).open_gaps() == []
         fake_inner_auto.handle.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -246,6 +246,54 @@ class TestBackgroundJobPath:
         fake_inner_auto.handle.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_fresh_structured_goal_runner_resumes_without_preference_override(
+        self, event_store, tmp_path
+    ) -> None:
+        store = AutoStore(tmp_path)
+        job_manager = MagicMock()
+        snapshot = MagicMock()
+        snapshot.job_id = "job_auto_structured_runner"
+        captured: dict[str, object] = {}
+
+        async def _start_job(*, runner, **_):
+            captured["runner"] = runner
+            return snapshot
+
+        job_manager.start_job = AsyncMock(side_effect=_start_job)
+        h = StartAutoHandler(event_store=event_store, job_manager=job_manager, store=store)
+        inner = MagicMock(spec=AutoHandler)
+        inner.handle = AsyncMock(
+            return_value=Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="ran"),),
+                    is_error=False,
+                    meta={"auto_session_id": "auto_structured"},
+                )
+            )
+        )
+        h._inner_auto = inner
+
+        result = await h.handle(
+            {
+                "goal": _STRUCTURED_OBSERVATION_GOAL,
+                "cwd": str(tmp_path),
+                "user_preferences": {"constraints": "Keep changes local and reversible."},
+            }
+        )
+
+        assert result.is_ok
+        auto_session_id = result.value.meta["auto_session_id"]
+        state = store.load(auto_session_id)
+        assert "runtime_context" in state.user_preferences
+        assert state.user_preferences["constraints"] == "Keep changes local and reversible."
+
+        await captured["runner"]
+        inner.handle.assert_awaited_once()
+        runner_args = inner.handle.await_args.args[0]
+        assert runner_args["resume"] == auto_session_id
+        assert "user_preferences" not in runner_args
+
+    @pytest.mark.asyncio
     async def test_plugin_mode_returns_subagent_without_enqueue(
         self, event_store, tmp_path, fake_inner_auto
     ) -> None:


### PR DESCRIPTION
## Summary
- Derive auto user preferences from explicit sectioned goal prompts (runtime context, non-goals, success criteria, implementation, constraints, verification, failure handling).
- Initialize the fresh auto session ledger from those derived preferences before the first interview round.
- Apply the same preallocation behavior to both synchronous `ouroboros_auto` and background `ouroboros_start_auto` sessions.

## Why
The latest observation run proved MCP dispatch works and the previous last_question / Seed grade blockers did not recur, but `ooo auto` still blocked before Seed generation because the interview ledger stayed open after 8 rounds for already-stated sections (`actors`, `inputs`, `outputs`, `constraints`, `non_goals`, `failure_modes`, `runtime_context`). This PR makes structured observation prompts count as initial ledger evidence instead of forcing the interviewer to rediscover all of it.

## Tests
- `uv run pytest tests/unit/mcp/tools/test_auto_interview_construction.py tests/unit/mcp/tools/test_start_auto.py tests/unit/auto/test_user_preference_and_floor.py -q`
- `uv run ruff check src/ouroboros/mcp/tools/auto_handler.py tests/unit/mcp/tools/test_auto_interview_construction.py tests/unit/mcp/tools/test_start_auto.py tests/unit/auto/test_user_preference_and_floor.py`
- `uv run ruff format --check src/ouroboros/mcp/tools/auto_handler.py tests/unit/mcp/tools/test_auto_interview_construction.py tests/unit/mcp/tools/test_start_auto.py tests/unit/auto/test_user_preference_and_floor.py`

## Not tested
- Live Codex observation run after merge.
