### PR TITLE
fix(orchestrator): recover from invalid dependency stages

### DIFF
--- a/src/ouroboros/orchestrator/dependency_analyzer.py
+++ b/src/ouroboros/orchestrator/dependency_analyzer.py
@@ -273,68 +273,97 @@ class HybridExecutionPlanner:
             msg = "Dependency graph contains duplicate AC node indices"
             raise ExecutionPlanningError(msg)
 
-        execution_levels = dependency_graph.execution_levels
-        if not execution_levels and dependency_graph.nodes:
-            execution_levels = _apply_serial_only_constraints(
+        if dependency_graph.execution_levels:
+            normalized_levels = tuple(
+                tuple(sorted(level)) for level in dependency_graph.execution_levels if level
+            )
+            try:
+                return _create_staged_execution_plan(
+                    nodes=dependency_graph.nodes,
+                    node_map=node_map,
+                    normalized_levels=normalized_levels,
+                )
+            except ExecutionPlanningError as exc:
+                log.warning(
+                    "dependency_analyzer.invalid_execution_levels_recomputed",
+                    error=str(exc),
+                    execution_levels=normalized_levels,
+                )
+
+        recomputed_levels: tuple[tuple[int, ...], ...] = ()
+        if dependency_graph.nodes:
+            recomputed_levels = _apply_serial_only_constraints(
                 _compute_execution_levels(dependency_graph.nodes),
                 dependency_graph.nodes,
             )
+        return _create_staged_execution_plan(
+            nodes=dependency_graph.nodes,
+            node_map=node_map,
+            normalized_levels=recomputed_levels,
+        )
 
-        normalized_levels = tuple(tuple(sorted(level)) for level in execution_levels if level)
-        ac_to_stage: dict[int, int] = {}
-        for stage_index, level in enumerate(normalized_levels):
-            for ac_index in level:
-                if ac_index in ac_to_stage:
-                    msg = f"AC {ac_index} appears in multiple execution stages"
-                    raise ExecutionPlanningError(msg)
-                ac_to_stage[ac_index] = stage_index
 
-        if node_map:
-            expected = set(node_map)
-            planned = set(ac_to_stage)
-            if expected != planned:
-                missing = sorted(expected - planned)
-                extra = sorted(planned - expected)
-                details: list[str] = []
-                if missing:
-                    details.append(f"missing={missing}")
-                if extra:
-                    details.append(f"extra={extra}")
-                msg = "Execution stages do not match dependency graph nodes: " + ", ".join(details)
+def _create_staged_execution_plan(
+    *,
+    nodes: tuple[ACNode, ...],
+    node_map: dict[int, ACNode],
+    normalized_levels: tuple[tuple[int, ...], ...],
+) -> StagedExecutionPlan:
+    """Build a staged plan from pre-normalized levels after validation."""
+    ac_to_stage: dict[int, int] = {}
+    for stage_index, level in enumerate(normalized_levels):
+        for ac_index in level:
+            if ac_index in ac_to_stage:
+                msg = f"AC {ac_index} appears in multiple execution stages"
                 raise ExecutionPlanningError(msg)
+            ac_to_stage[ac_index] = stage_index
 
-        stages: list[ExecutionStage] = []
-        for stage_index, level in enumerate(normalized_levels):
-            depends_on_stages: set[int] = set()
-            for ac_index in level:
-                node = node_map.get(ac_index)
-                if node is None:
-                    continue
-                if node.requires_serial_stage and len(level) > 1:
-                    msg = f"Serialized AC {ac_index} cannot share stage {stage_index + 1}"
+    if node_map:
+        expected = set(node_map)
+        planned = set(ac_to_stage)
+        if expected != planned:
+            missing = sorted(expected - planned)
+            extra = sorted(planned - expected)
+            details: list[str] = []
+            if missing:
+                details.append(f"missing={missing}")
+            if extra:
+                details.append(f"extra={extra}")
+            msg = "Execution stages do not match dependency graph nodes: " + ", ".join(details)
+            raise ExecutionPlanningError(msg)
+
+    stages: list[ExecutionStage] = []
+    for stage_index, level in enumerate(normalized_levels):
+        depends_on_stages: set[int] = set()
+        for ac_index in level:
+            node = node_map.get(ac_index)
+            if node is None:
+                continue
+            if node.requires_serial_stage and len(level) > 1:
+                msg = f"Serialized AC {ac_index} cannot share stage {stage_index + 1}"
+                raise ExecutionPlanningError(msg)
+            for dependency in node.depends_on:
+                dependency_stage = ac_to_stage.get(dependency)
+                if dependency_stage is None:
+                    msg = f"AC {ac_index} depends on missing AC {dependency}"
                     raise ExecutionPlanningError(msg)
-                for dependency in node.depends_on:
-                    dependency_stage = ac_to_stage.get(dependency)
-                    if dependency_stage is None:
-                        msg = f"AC {ac_index} depends on missing AC {dependency}"
-                        raise ExecutionPlanningError(msg)
-                    if dependency_stage >= stage_index:
-                        msg = (
-                            f"AC {ac_index} depends on AC {dependency}, but both are assigned "
-                            f"to stage {stage_index + 1}"
-                        )
-                        raise ExecutionPlanningError(msg)
-                    depends_on_stages.add(dependency_stage)
+                if dependency_stage >= stage_index:
+                    msg = (
+                        f"AC {ac_index} depends on AC {dependency}, but both are assigned "
+                        f"to stage {stage_index + 1}"
+                    )
+                    raise ExecutionPlanningError(msg)
+                depends_on_stages.add(dependency_stage)
 
-            stages.append(
-                ExecutionStage(
-                    index=stage_index,
-                    ac_indices=level,
-                    depends_on_stages=tuple(sorted(depends_on_stages)),
-                )
+        stages.append(
+            ExecutionStage(
+                index=stage_index,
+                ac_indices=level,
+                depends_on_stages=tuple(sorted(depends_on_stages)),
             )
+        )
 
-        return StagedExecutionPlan(nodes=dependency_graph.nodes, stages=tuple(stages))
+    return StagedExecutionPlan(nodes=nodes, stages=tuple(stages))
 
 
 class DependencyAnalyzer:

--- a/tests/unit/orchestrator/test_dependency_analyzer.py
+++ b/tests/unit/orchestrator/test_dependency_analyzer.py
@@ -432,7 +432,7 @@ class TestHybridExecutionPlanner:
         )
         assert plan.get_stage_for_ac(3) == plan.stages[2]
 
-    def test_create_plan_rejects_same_stage_dependency_conflicts(self) -> None:
+    def test_create_plan_repairs_same_stage_dependency_conflicts(self) -> None:
         planner = HybridExecutionPlanner()
         graph = DependencyGraph(
             nodes=(
@@ -442,8 +442,48 @@ class TestHybridExecutionPlanner:
             execution_levels=((0, 1),),
         )
 
-        with pytest.raises(ExecutionPlanningError, match="assigned to stage 1"):
-            planner.create_plan(graph)
+        plan = planner.create_plan(graph)
+
+        assert plan.execution_levels == ((0,), (1,))
+        assert plan.stages == (
+            ExecutionStage(index=0, ac_indices=(0,), depends_on_stages=()),
+            ExecutionStage(index=1, ac_indices=(1,), depends_on_stages=(0,)),
+        )
+
+    def test_create_plan_repairs_invalid_supplied_levels_from_observation_failure(
+        self,
+    ) -> None:
+        planner = HybridExecutionPlanner()
+        graph = DependencyGraph(
+            nodes=(
+                ACNode(index=0, content="Dispatch ooo auto through MCP"),
+                ACNode(index=1, content="Generate a Seed", depends_on=(0,)),
+                ACNode(index=2, content="Reach grade A", depends_on=(1,)),
+                ACNode(index=3, content="Execute the generated Seed", depends_on=(5,)),
+                ACNode(index=4, content="Run targeted pytest", depends_on=(3,)),
+                ACNode(index=5, content="Create hello_auto files", depends_on=(2,)),
+            ),
+            execution_levels=((0,), (1,), (2,), (3, 5), (4,)),
+        )
+
+        plan = planner.create_plan(graph)
+
+        assert plan.get_stage_for_ac(5).index < plan.get_stage_for_ac(3).index
+        assert plan.execution_levels == ((0,), (1,), (2,), (5,), (3,), (4,))
+
+    def test_create_plan_repairs_missing_and_extra_supplied_levels(self) -> None:
+        planner = HybridExecutionPlanner()
+        graph = DependencyGraph(
+            nodes=(
+                ACNode(index=0, content="Create runtime"),
+                ACNode(index=1, content="Add resume flow", depends_on=(0,)),
+            ),
+            execution_levels=((0, 99),),
+        )
+
+        plan = planner.create_plan(graph)
+
+        assert plan.execution_levels == ((0,), (1,))
 
     def test_build_runtime_plan_groups_sparse_ac_ids_into_staged_batches(self) -> None:
         planner = HybridExecutionPlanner()


### PR DESCRIPTION
## Summary
- Recompute runtime execution stages from graph edges when supplied `execution_levels` are invalid.
- Preserve hard failures for invalid dependency edges such as references to missing ACs.
- Add regression coverage for the latest observation failure shape: a dependent AC assigned to the same stage as its prerequisite.

## Why
The latest `ooo auto` observation reached MCP dispatch, interview closure, A-grade Seed generation, and execution handoff, but the background execution failed before creating files with:

```text
AC 3 depends on AC 5, but both are assigned to stage 3
```

The dependency graph contained enough ordering information to recover, but the planner trusted the invalid supplied stage layout and failed before work began. This PR treats inconsistent level layouts as repairable derived data, while keeping invalid graph edges as hard errors.

## Tests
- `uv run pytest tests/unit/orchestrator/test_dependency_analyzer.py -q`
- `uv run ruff check src/ouroboros/orchestrator/dependency_analyzer.py tests/unit/orchestrator/test_dependency_analyzer.py`
- `uv run ruff format --check src/ouroboros/orchestrator/dependency_analyzer.py tests/unit/orchestrator/test_dependency_analyzer.py`

## Not tested
- Live `ooo auto` observation run after merge.
