### PR TITLE
fix(auto): keep repaired seed identifiers synchronized

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -753,6 +753,7 @@ class AutoPipeline:
                 self._save(state)
                 return self._result(state, ledger, blocker=state.last_error)
             state.seed_artifact = seed.to_dict()
+            state.seed_id = seed.metadata.seed_id
             state.repair_round = len(repairs)
             state.last_grade = review.grade_result.grade.value
             state.findings = [asdict(finding) for finding in review.findings]
@@ -2469,6 +2470,8 @@ class AutoPipeline:
         # resumed sessions. Existing non-default values are preserved.
         if state.seed_origin is SeedOrigin.NONE:
             state.seed_origin = SeedOrigin.AUTO_PIPELINE
+        state.seed_id = seed.metadata.seed_id
+        state.seed_artifact = seed.to_dict()
         return seed
 
     def _result(

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2657,6 +2657,7 @@ async def test_pipeline_grade_gate_resume_prefers_repaired_seed_path(tmp_path) -
     assert result.status == "complete"
     assert result.grade == "A"
     assert state.seed_artifact == repaired_seed.to_dict()
+    assert state.seed_id == repaired_seed.metadata.seed_id
 
 
 @pytest.mark.asyncio
@@ -2849,6 +2850,7 @@ async def test_pipeline_recovers_seed_loader_failure_from_review(tmp_path) -> No
     assert result.status == "complete"
     assert result.grade == "A"
     assert state.seed_artifact == repaired_seed.to_dict()
+    assert state.seed_id == repaired_seed.metadata.seed_id
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1161,6 +1161,50 @@ async def test_pipeline_uses_explicit_goal_facts_before_completed_interview(tmp_
 
 
 @pytest.mark.asyncio
+async def test_pipeline_syncs_state_seed_id_after_repair_changes_identity(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", "interview_repair", seed_ready=True, completed=True)
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("completed interview should not need another answer")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed(ac=("Make it nice",))
+
+    saved: list[str] = []
+
+    def save(seed: Seed) -> str:
+        path = str(tmp_path / f"{seed.metadata.seed_id}.yaml")
+        saved.append(path)
+        return path
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.skip_run = True
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        seed_saver=save,
+        skip_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    repaired = Seed.from_dict(state.seed_artifact)
+    assert result.status == "complete"
+    assert state.seed_id == repaired.metadata.seed_id
+    assert saved == [str(tmp_path / f"{repaired.metadata.seed_id}.yaml")]
+    assert state.seed_path == saved[0]
+    assert repaired.metadata.parent_seed_id is not None
+
+
+@pytest.mark.asyncio
 async def test_interview_resume_uses_persisted_pending_question(tmp_path) -> None:
     calls: list[str] = []
 


### PR DESCRIPTION
## Summary
- Synchronize `state.seed_id` after repair changes the active Seed identity.
- Backfill `state.seed_id` and `seed_artifact` when loading a Seed from `seed_path`.
- Add regression coverage for repaired Seed ids matching state and saved path.

## Why
Recent observation runs reported one Seed id from auto state while `seed_path` and Seed metadata pointed at a repaired child Seed. That makes final reports and execution handles ambiguous.

## Tests
- `uv run pytest tests/unit/auto/test_interview_pipeline.py -q`
- `uv run ruff check src/ouroboros/auto/pipeline.py tests/unit/auto/test_interview_pipeline.py`
- `uv run ruff format --check src/ouroboros/auto/pipeline.py tests/unit/auto/test_interview_pipeline.py`
