### PR TITLE
Harden docs-only evidence prompts

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -4283,8 +4283,10 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                     "This is a documentation-only current AC: verify the requested docs "
                     "with current-session README/docs evidence such as Edit plus a direct "
                     "read/grep/diff command when that command is the validation for the docs change. "
-                    "Do not include tests_passed unless this current AC explicitly required "
-                    "code tests and you ran those tests in this runtime session.\n"
+                    "Do not include tests_passed at all for documentation-only ACs. "
+                    "If you ran tests as a sanity check, cite only the validation command "
+                    "in commands_run when it directly validates the current docs change; "
+                    "do not list individual test names or prior test IDs.\n"
                 )
             completion_instruction = (
                 "## Current AC Scope Contract\n"

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1536,6 +1536,10 @@ class TestParallelACExecutor:
         assert runtime.last_prompt is not None
         assert "documentation-only current AC" in runtime.last_prompt
         assert "read/grep/diff command when that command is the validation" in runtime.last_prompt
+        assert "Do not include tests_passed at all for documentation-only ACs" in (
+            runtime.last_prompt
+        )
+        assert "do not list individual test names or prior test IDs" in runtime.last_prompt
         assert "files_touched, commands_run" in runtime.last_prompt
         assert "files_touched, commands_run, tests_passed" not in runtime.last_prompt
         assert result.typed_evidence is not None
@@ -1622,6 +1626,10 @@ class TestParallelACExecutor:
         assert runtime.last_prompt is not None
         assert "documentation-only current AC" in runtime.last_prompt
         assert "read/grep/diff command when that command is the validation" in runtime.last_prompt
+        assert "Do not include tests_passed at all for documentation-only ACs" in (
+            runtime.last_prompt
+        )
+        assert "do not list individual test names or prior test IDs" in runtime.last_prompt
         assert "files_touched, commands_run" in runtime.last_prompt
         assert "files_touched, commands_run, tests_passed" not in runtime.last_prompt
         evidence_event = next(


### PR DESCRIPTION
## Summary
- Strengthen the docs-only AC prompt to say `tests_passed` must not be emitted at all.
- Clarify that sanity-check tests should not become individual test-name claims for docs-only ACs.
- Keep docs-only evidence focused on current-session docs evidence and validation commands.

## Why
The broader post-#1069 observation showed that schema omission alone was not enough: a docs-only README AC still over-reported individual unittest names in `tests_passed`. This prompt change reduces recurrence while the verifier policy remains the enforcement boundary.

## Scope boundaries
- Prompt-only preventative change.
- Does not change verifier acceptance semantics.
- Does not relax code AC `tests_passed` verification.
- Does not reintroduce legacy/self-report fallback.

## Validation
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py -k 'docs_only_ac_uses_effective_schema or docs_only_ac_allows_code_subject_documentation or markdown_code_ac_keeps_test_evidence_required' -q`
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py`
- `uv run ruff format --check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py && git diff --check`
- `uv run mypy src/ouroboros/orchestrator/parallel_executor.py`

## Not tested
- Live broader #978 observation rerun after this patch.

Refs #978, #961, #1069.
