### PR TITLE
Respect docs-only evidence scope

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -267,6 +267,22 @@ def _out_of_scope_evidence_fields_for_ac(
     )
 
 
+def _scoped_evidence_record_for_ac(
+    profile: ExecutionProfile,
+    ac_content: str,
+    record: EvidenceRecord | None,
+) -> EvidenceRecord | None:
+    """Return only evidence fields inside the AC-specific schema."""
+    if record is None:
+        return None
+    effective_schema = _effective_evidence_schema_for_ac(profile, ac_content)
+    allowed_fields = set(effective_schema.required)
+    return EvidenceRecord(
+        data={field: value for field, value in record.data.items() if field in allowed_fields},
+        source=record.source,
+    )
+
+
 def _profile_with_evidence_schema(
     profile: ExecutionProfile,
     schema: EvidenceSchema,
@@ -4698,6 +4714,13 @@ Files present:
                 ),
             )
             clear_cached_runtime_handle = True
+            result_typed_evidence = typed_evidence
+            if success and self._execution_profile is not None:
+                result_typed_evidence = _scoped_evidence_record_for_ac(
+                    self._execution_profile,
+                    ac_content,
+                    typed_evidence,
+                )
 
             log.info(
                 "parallel_executor.ac.completed",
@@ -4719,7 +4742,7 @@ Files present:
                 retry_attempt=retry_attempt,
                 depth=depth,
                 runtime_handle=runtime_handle,
-                typed_evidence=typed_evidence,
+                typed_evidence=result_typed_evidence,
                 typed_evidence_validation=typed_validation,
                 typed_evidence_error=typed_error,
                 atomic_verifier_verdict=verifier_verdict,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -270,11 +270,9 @@ def _out_of_scope_evidence_fields_for_ac(
 def _scoped_evidence_record_for_ac(
     profile: ExecutionProfile,
     ac_content: str,
-    record: EvidenceRecord | None,
-) -> EvidenceRecord | None:
+    record: EvidenceRecord,
+) -> EvidenceRecord:
     """Return only evidence fields inside the AC-specific schema."""
-    if record is None:
-        return None
     effective_schema = _effective_evidence_schema_for_ac(profile, ac_content)
     allowed_fields = set(effective_schema.required)
     return EvidenceRecord(
@@ -4715,7 +4713,7 @@ Files present:
             )
             clear_cached_runtime_handle = True
             result_typed_evidence = typed_evidence
-            if success and self._execution_profile is not None:
+            if success and self._execution_profile is not None and typed_evidence is not None:
                 result_typed_evidence = _scoped_evidence_record_for_ac(
                     self._execution_profile,
                     ac_content,
@@ -4907,17 +4905,22 @@ Files present:
             effective_profile = _profile_with_evidence_schema(
                 self._execution_profile, effective_schema
             )
+            scoped_evidence = _scoped_evidence_record_for_ac(
+                self._execution_profile,
+                ac_content,
+                typed_evidence,
+            )
             verdict = (
                 verifier(
                     profile=effective_profile,
                     ac=ac_content,
                     leaf_output=final_message,
-                    record=typed_evidence,
+                    record=scoped_evidence,
                 )
                 if verifier is not None
                 else self._verify_atomic_evidence_against_runtime_messages(
                     messages=messages,
-                    typed_evidence=typed_evidence,
+                    typed_evidence=scoped_evidence,
                     ac_content=ac_content,
                 )
             )

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -250,6 +250,23 @@ def _effective_evidence_schema_for_ac(
     return EvidenceSchema(required=required, rejected_if=rejected_if)
 
 
+def _out_of_scope_evidence_fields_for_ac(
+    profile: ExecutionProfile,
+    ac_content: str,
+    record: EvidenceRecord | None,
+) -> tuple[str, ...]:
+    """Return non-empty evidence fields excluded by the AC-specific schema."""
+    if record is None:
+        return ()
+    effective_schema = _effective_evidence_schema_for_ac(profile, ac_content)
+    required_fields = set(effective_schema.required)
+    return tuple(
+        field
+        for field in profile.evidence_schema.required
+        if field not in required_fields and _flatten_evidence_values(record.get(field))
+    )
+
+
 def _profile_with_evidence_schema(
     profile: ExecutionProfile,
     schema: EvidenceSchema,
@@ -4922,11 +4939,6 @@ Files present:
         effective_schema = _effective_evidence_schema_for_ac(self._execution_profile, ac_content)
         required_fields = set(effective_schema.required)
         fields_to_verify = list(effective_schema.required)
-        for field_name in self._execution_profile.evidence_schema.required:
-            if field_name not in required_fields and _flatten_evidence_values(
-                typed_evidence.get(field_name)
-            ):
-                fields_to_verify.append(field_name)
 
         for field_name in fields_to_verify:
             values = tuple(_flatten_evidence_values(typed_evidence.get(field_name)))
@@ -5016,6 +5028,13 @@ Files present:
             data["verifier_failure_class"] = verifier_verdict.failure_class
         if typed_evidence is not None:
             data["typed_evidence_fields"] = sorted(typed_evidence.data)
+            data["ignored_out_of_scope_evidence_fields"] = list(
+                _out_of_scope_evidence_fields_for_ac(
+                    self._execution_profile,
+                    ac_content,
+                    typed_evidence,
+                )
+            )
         if typed_validation is not None:
             data["missing_fields"] = list(typed_validation.missing_fields)
             data["rejected_by"] = list(typed_validation.rejected_by)

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1912,15 +1912,18 @@ class TestParallelACExecutor:
         readme = tmp_path / "README.md"
         readme.write_text("# String utils\n", encoding="utf-8")
         verifier_profiles: list[tuple[tuple[str, ...], tuple[str, ...]]] = []
+        verifier_records: list[dict[str, object]] = []
 
         def _recording_verifier(**kwargs: object) -> VerifierVerdict:
             profile = kwargs["profile"]
+            record = kwargs["record"]
             verifier_profiles.append(
                 (
                     tuple(profile.evidence_schema.required),  # type: ignore[attr-defined]
                     tuple(profile.must_produce),  # type: ignore[attr-defined]
                 )
             )
+            verifier_records.append(dict(record.data))  # type: ignore[attr-defined]
             return VerifierVerdict(passed=True)
 
         event_store, appended_events = _make_replaying_event_store()
@@ -1929,7 +1932,8 @@ class TestParallelACExecutor:
                 "```json\n"
                 "{\n"
                 '  "files_touched": ["README.md"],\n'
-                '  "commands_run": ["grep -n slugify README.md"]\n'
+                '  "commands_run": ["grep -n slugify README.md"],\n'
+                '  "tests_passed": ["test_slugify.py::test_slugify"]\n'
                 "}\n"
                 "```",
                 native_session_id="codex-session-docs-only-injected-verifier",
@@ -1977,12 +1981,19 @@ class TestParallelACExecutor:
         assert result.success is True
         assert verifier_profiles == [(("files_touched", "commands_run"), ("files_touched",))]
         assert set(verifier_profiles[0][1]).issubset(verifier_profiles[0][0])
+        assert verifier_records == [
+            {
+                "files_touched": ["README.md"],
+                "commands_run": ["grep -n slugify README.md"],
+            }
+        ]
         evidence_event = next(
             event
             for event in appended_events
             if event.type == "execution.ac.typed_evidence.observed"
         )
         assert evidence_event.data["required_fields"] == ["files_touched", "commands_run"]
+        assert evidence_event.data["ignored_out_of_scope_evidence_fields"] == ["tests_passed"]
         assert evidence_event.data["verifier_passed"] is True
 
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1890,6 +1890,11 @@ class TestParallelACExecutor:
 
         assert result.success is True
         assert result.error is None
+        assert result.typed_evidence is not None
+        assert result.typed_evidence.data == {
+            "files_touched": ["README.md"],
+            "commands_run": ["grep -n slugify README.md"],
+        }
         evidence_event = next(
             event
             for event in appended_events

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1830,8 +1830,10 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_passed"] is True
 
     @pytest.mark.asyncio
-    async def test_fat_harness_docs_only_ac_rejects_prior_test_id_bleed(self, tmp_path) -> None:
-        """Docs-only ACs may omit tests, but non-empty stale tests_passed is still checked."""
+    async def test_fat_harness_docs_only_ac_ignores_out_of_scope_test_id_bleed(
+        self, tmp_path
+    ) -> None:
+        """Docs-only ACs ignore extra tests_passed instead of failing required docs evidence."""
         readme = tmp_path / "README.md"
         readme.write_text("# String utils\n", encoding="utf-8")
 
@@ -1886,16 +1888,16 @@ class TestParallelACExecutor:
             start_time=datetime.now(UTC),
         )
 
-        assert result.success is False
-        assert result.error is not None
-        assert "tests_passed: test_slugify.py::test_slugify" in result.error
+        assert result.success is True
+        assert result.error is None
         evidence_event = next(
             event
             for event in appended_events
             if event.type == "execution.ac.typed_evidence.observed"
         )
         assert evidence_event.data["required_fields"] == ["files_touched", "commands_run"]
-        assert evidence_event.data["verifier_failure_class"] == "FABRICATION_SUSPECTED"
+        assert evidence_event.data["ignored_out_of_scope_evidence_fields"] == ["tests_passed"]
+        assert evidence_event.data["verifier_passed"] is True
 
     @pytest.mark.asyncio
     async def test_fat_harness_docs_only_ac_passes_consistent_profile_to_injected_verifier(


### PR DESCRIPTION
## Summary
- Make the AC-specific effective evidence schema authoritative for verifier success/failure.
- Ignore non-empty evidence fields that were removed by the effective schema for docs-only ACs, instead of failing the AC on out-of-scope `tests_passed` noise.
- Persist `ignored_out_of_scope_evidence_fields` in typed-evidence events so over-reported fields remain observable.

## Why
The broader post-#1069 #978/#961 observation completed the implementation and passed `python -m unittest test_todo.py`, but AC4 was documentation-only and still emitted individual `tests_passed` names. The docs-only effective schema required only `files_touched` and `commands_run`, yet the verifier re-added the excluded `tests_passed` field and failed with `FABRICATION_SUSPECTED`.

## Scope boundaries
- Code/implementation ACs still verify `tests_passed` strictly.
- This does not broadly accept individual unittest names from aggregate unittest output.
- This does not restore legacy/self-report fallback.
- This only ignores fields excluded by the AC-specific effective schema and records them for audit.

## Validation
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py -k 'docs_only_ac_ignores_out_of_scope_test_id_bleed or test_not_covered_by_success_chunk or docs_only_ac_uses_effective_schema' -q`
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_profile_strategy.py tests/unit/orchestrator/test_phase_wrappers.py -q`
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py`
- `uv run ruff format --check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py && git diff --check`
- `uv run mypy src/ouroboros/orchestrator/parallel_executor.py`

## Not tested
- Live broader #978 observation rerun after this patch.

Refs #978, #961, #1069.
