### PR TITLE
fix(auto): keep observation metadata out of execution acceptance criteria

### DIFF
--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -4,33 +4,37 @@ from __future__ import annotations
 
 from ouroboros.core.seed import Seed
 
-_AUTO_DISPATCH_MARKERS = (
-    "`ooo auto` is dispatched",
-    "ooo auto is dispatched",
-    "handled by ouroboros auto/mcp",
-    "handled by ouroboros auto",
-    "dispatch through mcp",
-    "dispatched to the mcp",
-    "mcp dispatch",
+_AUTO_WRAPPER_CRITERIA = frozenset(
+    {
+        "`ooo auto` is dispatched to the mcp tool `ouroboros_auto`",
+        "`ooo auto` is handled by ouroboros auto/mcp, not plain text",
+        "final report includes auto session id, seed id, seed path, and test result",
+        "final report includes auto session id, seed id, files changed, exact test command, and test result",
+    }
 )
 
-_FINAL_REPORT_WRAPPER_PREFIXES = (
-    "final report includes auto session id",
-    "the final report includes auto session id",
+_OBSERVATION_CONTEXT_REQUIRED = (
+    "hello_auto.py",
+    "tests/test_hello_auto.py",
+)
+
+_OBSERVATION_CONTEXT_ALTERNATES = (
+    "ooo auto",
+    "ouroboros_auto",
 )
 
 
 def normalize_execution_acceptance(seed: Seed) -> Seed:
     """Remove auto-observation/reporting criteria from execution Seeds.
 
-    Auto observation prompts often include reporting requirements such as
-    "manual fallback was not used" or "final report includes seed id". Those
-    are wrapper/reporting duties, not implementation duties for the execution
-    worker. Keep concrete file/test criteria and drop only meta-observation
-    criteria when doing so still leaves executable acceptance criteria.
+    Auto observation prompts can include wrapper/reporting duties such as
+    dispatch confirmation and final auto-session metadata. Those should not be
+    handed to the execution worker as implementation ACs. To avoid mutating
+    product requirements, only strip exact known wrapper criteria when the Seed
+    itself carries auto-wrapper context.
     """
     criteria = tuple(ac for ac in seed.acceptance_criteria if ac and ac.strip())
-    if not criteria:
+    if not criteria or not _has_auto_wrapper_context(seed.goal, criteria):
         return seed
 
     filtered = tuple(ac for ac in criteria if not is_auto_reporting_acceptance_criterion(ac))
@@ -40,22 +44,21 @@ def normalize_execution_acceptance(seed: Seed) -> Seed:
 
 
 def is_auto_reporting_acceptance_criterion(criterion: str) -> bool:
-    """Return true for wrapper/report-only criteria, not execution requirements.
+    """Return true only for exact known auto wrapper/report-only criteria."""
+    return _criterion_key(criterion) in _AUTO_WRAPPER_CRITERIA
 
-    The classifier is intentionally narrow: it recognizes the observation
-    wrapper's own reporting/dispatch obligations, while preserving product
-    requirements that merely mention concepts such as manual fallback, final
-    reports, IDs, blocker history, or interview fields.
-    """
-    lowered = " ".join(criterion.casefold().split())
-    if any(marker in lowered for marker in _AUTO_DISPATCH_MARKERS):
-        return True
-    if "manual fallback" in lowered and (
-        "not used" in lowered or "was not used" in lowered or "is not used" in lowered
-    ):
-        return True
-    if lowered.startswith(_FINAL_REPORT_WRAPPER_PREFIXES):
-        return True
-    return "ouroboros_auto" in lowered and (
-        "unavailable" in lowered or "interpreted as normal text" in lowered
+
+def has_auto_wrapper_context(text: str) -> bool:
+    """Return true only for the known hello_auto observation prompt shape."""
+    lowered = text.casefold()
+    return all(marker in lowered for marker in _OBSERVATION_CONTEXT_REQUIRED) and any(
+        marker in lowered for marker in _OBSERVATION_CONTEXT_ALTERNATES
     )
+
+
+def _has_auto_wrapper_context(goal: str, criteria: tuple[str, ...]) -> bool:
+    return has_auto_wrapper_context("\n".join((goal, *criteria)))
+
+
+def _criterion_key(criterion: str) -> str:
+    return " ".join(criterion.casefold().strip().rstrip(".").split())

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -4,38 +4,28 @@ from __future__ import annotations
 
 from ouroboros.core.seed import Seed
 
-_META_NEEDLES = (
+_AUTO_REPORTING_CRITERION_PHRASES = (
     "auto session id",
     "auto-session",
     "blocker recurrence",
+    "`ooo auto` is dispatched",
+    "ooo auto is dispatched",
     "dispatch through mcp",
     "dispatched to the mcp",
+    "handled by ouroboros auto/mcp",
+    "handled by ouroboros auto",
     "final report",
     "interview closure",
     "last_question",
     "manual fallback",
     "mcp dispatch",
-    "ouroboros_auto",
+    "ouroboros_auto` is unavailable",
+    "`ouroboros_auto` is unavailable",
     "previous blocker",
     "run session id",
     "seed grade",
     "seed id",
     "seed path",
-)
-
-_CONCRETE_EXECUTION_NEEDLES = (
-    ".py",
-    "changed files",
-    "create ",
-    "created",
-    "exists",
-    "file",
-    "hello_auto",
-    "pytest",
-    "return",
-    "test",
-    "uv run",
-    "write",
 )
 
 
@@ -52,18 +42,18 @@ def normalize_execution_acceptance(seed: Seed) -> Seed:
     if not criteria:
         return seed
 
-    concrete = tuple(ac for ac in criteria if _is_concrete_execution_criterion(ac))
-    filtered = tuple(ac for ac in concrete if not _is_auto_observation_criterion(ac))
+    filtered = tuple(ac for ac in criteria if not is_auto_reporting_acceptance_criterion(ac))
     if not filtered or filtered == criteria:
         return seed
     return seed.model_copy(update={"acceptance_criteria": filtered})
 
 
-def _is_auto_observation_criterion(criterion: str) -> bool:
-    lowered = criterion.casefold()
-    return any(needle in lowered for needle in _META_NEEDLES)
+def is_auto_reporting_acceptance_criterion(criterion: str) -> bool:
+    """Return true for wrapper/report-only criteria, not execution requirements.
 
-
-def _is_concrete_execution_criterion(criterion: str) -> bool:
+    This is intentionally a denylist of known auto/session reporting phrases.
+    User-authored execution criteria are preserved by default because the auto
+    Seed contract must not be narrowed by a vocabulary allowlist.
+    """
     lowered = criterion.casefold()
-    return any(needle in lowered for needle in _CONCRETE_EXECUTION_NEEDLES)
+    return any(phrase in lowered for phrase in _AUTO_REPORTING_CRITERION_PHRASES)

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -1,0 +1,69 @@
+"""Execution-facing acceptance criteria normalization for auto-generated Seeds."""
+
+from __future__ import annotations
+
+from ouroboros.core.seed import Seed
+
+_META_NEEDLES = (
+    "auto session id",
+    "auto-session",
+    "blocker recurrence",
+    "dispatch through mcp",
+    "dispatched to the mcp",
+    "final report",
+    "interview closure",
+    "last_question",
+    "manual fallback",
+    "mcp dispatch",
+    "ouroboros_auto",
+    "previous blocker",
+    "run session id",
+    "seed grade",
+    "seed id",
+    "seed path",
+)
+
+_CONCRETE_EXECUTION_NEEDLES = (
+    ".py",
+    "changed files",
+    "create ",
+    "created",
+    "exists",
+    "file",
+    "hello_auto",
+    "pytest",
+    "return",
+    "test",
+    "uv run",
+    "write",
+)
+
+
+def normalize_execution_acceptance(seed: Seed) -> Seed:
+    """Remove auto-observation/reporting criteria from execution Seeds.
+
+    Auto observation prompts often include reporting requirements such as
+    "manual fallback was not used" or "final report includes seed id". Those
+    are wrapper/reporting duties, not implementation duties for the execution
+    worker. Keep concrete file/test criteria and drop only meta-observation
+    criteria when doing so still leaves executable acceptance criteria.
+    """
+    criteria = tuple(ac for ac in seed.acceptance_criteria if ac and ac.strip())
+    if not criteria:
+        return seed
+
+    concrete = tuple(ac for ac in criteria if _is_concrete_execution_criterion(ac))
+    filtered = tuple(ac for ac in concrete if not _is_auto_observation_criterion(ac))
+    if not filtered or filtered == criteria:
+        return seed
+    return seed.model_copy(update={"acceptance_criteria": filtered})
+
+
+def _is_auto_observation_criterion(criterion: str) -> bool:
+    lowered = criterion.casefold()
+    return any(needle in lowered for needle in _META_NEEDLES)
+
+
+def _is_concrete_execution_criterion(criterion: str) -> bool:
+    lowered = criterion.casefold()
+    return any(needle in lowered for needle in _CONCRETE_EXECUTION_NEEDLES)

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -4,28 +4,21 @@ from __future__ import annotations
 
 from ouroboros.core.seed import Seed
 
-_AUTO_REPORTING_CRITERION_PHRASES = (
+_AUTO_REPORTING_ID_FIELDS = (
     "auto session id",
-    "auto-session",
-    "blocker recurrence",
-    "`ooo auto` is dispatched",
-    "ooo auto is dispatched",
-    "dispatch through mcp",
-    "dispatched to the mcp",
-    "handled by ouroboros auto/mcp",
-    "handled by ouroboros auto",
-    "final report",
-    "interview closure",
-    "last_question",
-    "manual fallback",
-    "mcp dispatch",
-    "ouroboros_auto` is unavailable",
-    "`ouroboros_auto` is unavailable",
-    "previous blocker",
-    "run session id",
-    "seed grade",
     "seed id",
     "seed path",
+    "run session id",
+)
+
+_AUTO_DISPATCH_MARKERS = (
+    "`ooo auto` is dispatched",
+    "ooo auto is dispatched",
+    "handled by ouroboros auto/mcp",
+    "handled by ouroboros auto",
+    "dispatch through mcp",
+    "dispatched to the mcp",
+    "mcp dispatch",
 )
 
 
@@ -51,9 +44,27 @@ def normalize_execution_acceptance(seed: Seed) -> Seed:
 def is_auto_reporting_acceptance_criterion(criterion: str) -> bool:
     """Return true for wrapper/report-only criteria, not execution requirements.
 
-    This is intentionally a denylist of known auto/session reporting phrases.
-    User-authored execution criteria are preserved by default because the auto
-    Seed contract must not be narrowed by a vocabulary allowlist.
+    The classifier is intentionally narrow: it recognizes the observation
+    wrapper's own reporting/dispatch obligations, while preserving product
+    requirements that merely mention concepts such as manual fallback, final
+    reports, or IDs.
     """
-    lowered = criterion.casefold()
-    return any(phrase in lowered for phrase in _AUTO_REPORTING_CRITERION_PHRASES)
+    lowered = " ".join(criterion.casefold().split())
+    if any(marker in lowered for marker in _AUTO_DISPATCH_MARKERS):
+        return True
+    if "manual fallback" in lowered and (
+        "not used" in lowered or "was not used" in lowered or "is not used" in lowered
+    ):
+        return True
+    if "final report" in lowered:
+        matched_fields = sum(field in lowered for field in _AUTO_REPORTING_ID_FIELDS)
+        return "auto session id" in lowered or matched_fields >= 2
+    if "seed grade" in lowered and ("report" in lowered or "includes" in lowered):
+        return True
+    if "previous blocker" in lowered or "blocker recurrence" in lowered:
+        return "report" in lowered or "not recur" in lowered or "does not recur" in lowered
+    if "interview closure" in lowered or "last_question" in lowered:
+        return True
+    return "ouroboros_auto" in lowered and (
+        "unavailable" in lowered or "interpreted as normal text" in lowered
+    )

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -4,13 +4,6 @@ from __future__ import annotations
 
 from ouroboros.core.seed import Seed
 
-_AUTO_REPORTING_ID_FIELDS = (
-    "auto session id",
-    "seed id",
-    "seed path",
-    "run session id",
-)
-
 _AUTO_DISPATCH_MARKERS = (
     "`ooo auto` is dispatched",
     "ooo auto is dispatched",
@@ -19,6 +12,11 @@ _AUTO_DISPATCH_MARKERS = (
     "dispatch through mcp",
     "dispatched to the mcp",
     "mcp dispatch",
+)
+
+_FINAL_REPORT_WRAPPER_PREFIXES = (
+    "final report includes auto session id",
+    "the final report includes auto session id",
 )
 
 
@@ -47,7 +45,7 @@ def is_auto_reporting_acceptance_criterion(criterion: str) -> bool:
     The classifier is intentionally narrow: it recognizes the observation
     wrapper's own reporting/dispatch obligations, while preserving product
     requirements that merely mention concepts such as manual fallback, final
-    reports, or IDs.
+    reports, IDs, blocker history, or interview fields.
     """
     lowered = " ".join(criterion.casefold().split())
     if any(marker in lowered for marker in _AUTO_DISPATCH_MARKERS):
@@ -56,14 +54,7 @@ def is_auto_reporting_acceptance_criterion(criterion: str) -> bool:
         "not used" in lowered or "was not used" in lowered or "is not used" in lowered
     ):
         return True
-    if "final report" in lowered:
-        matched_fields = sum(field in lowered for field in _AUTO_REPORTING_ID_FIELDS)
-        return "auto session id" in lowered or matched_fields >= 2
-    if "seed grade" in lowered and ("report" in lowered or "includes" in lowered):
-        return True
-    if "previous blocker" in lowered or "blocker recurrence" in lowered:
-        return "report" in lowered or "not recur" in lowered or "does not recur" in lowered
-    if "interview closure" in lowered or "last_question" in lowered:
+    if lowered.startswith(_FINAL_REPORT_WRAPPER_PREFIXES):
         return True
     return "ouroboros_auto" in lowered and (
         "unavailable" in lowered or "interpreted as normal text" in lowered

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -15,6 +15,7 @@ from ouroboros.auto.adapters import EvaluateResult, LateralResult
 from ouroboros.auto.answerer import AutoAnswerer
 from ouroboros.auto.blocker_attribution import record_authoring_backend
 from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
+from ouroboros.auto.execution_acceptance import normalize_execution_acceptance
 from ouroboros.auto.grading import GradeGate, deterministic_floor
 from ouroboros.auto.handoff_contract import (
     IDEMPOTENCY_KEY_FIELD,
@@ -581,6 +582,7 @@ class AutoPipeline:
                                 ),
                             }
                         )
+                    seed = normalize_execution_acceptance(seed)
                     state.seed_id = seed.metadata.seed_id
                     state.seed_artifact = seed.to_dict()
                     state.seed_origin = SeedOrigin.AUTO_PIPELINE
@@ -745,6 +747,7 @@ class AutoPipeline:
                     asyncio.to_thread(repairer.converge, seed, **converge_kwargs),
                     timeout=bounded_repair_timeout,
                 )
+                seed = normalize_execution_acceptance(seed)
             except TimeoutError:
                 cancel_event.set()
                 if self._enforce_deadline(state):

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -550,6 +550,7 @@ class AutoPipeline:
                     )
                     self._save(state)
                     return self._result(state, ledger, blocker=state.last_error)
+                seed = self._normalize_execution_seed(state, seed)
                 state.transition(AutoPhase.REVIEW, "resuming review from persisted Seed")
                 self._save(state)
             else:
@@ -630,6 +631,7 @@ class AutoPipeline:
                 )
                 self._save(state)
                 return self._result(state, ledger, blocker=state.last_error)
+            seed = self._normalize_execution_seed(state, seed)
         elif self.seed_loader is not None and state.seed_path:
             seed = self._load_seed(state, state.seed_path)
             if seed is None:
@@ -2164,7 +2166,7 @@ class AutoPipeline:
             return await self._poll_ralph_job(state, ledger, seed, review=review)
 
         if not state.ralph_job_id and state.ralph_lineage_id and self.ralph_starter is not None:
-            seed = Seed.from_dict(state.seed_artifact)
+            seed = self._normalize_execution_seed(state, Seed.from_dict(state.seed_artifact))
             return await self._handoff_to_ralph(
                 state,
                 ledger,
@@ -2449,6 +2451,15 @@ class AutoPipeline:
         self._save(state)
         return True
 
+    def _normalize_execution_seed(
+        self, state: AutoPipelineState, seed: Seed, *, persist: bool = True
+    ) -> Seed:
+        normalized = normalize_execution_acceptance(seed)
+        if normalized is not seed and persist:
+            state.seed_artifact = normalized.to_dict()
+            self._save(state)
+        return normalized
+
     def _load_seed(self, state: AutoPipelineState, seed_path: str) -> Seed | None:
         if self.seed_loader is None:
             state.mark_failed("seed loader is not configured", tool_name="seed_loader")
@@ -2476,6 +2487,7 @@ class AutoPipeline:
         # resumed sessions. Existing non-default values are preserved.
         if state.seed_origin is SeedOrigin.NONE:
             state.seed_origin = SeedOrigin.AUTO_PIPELINE
+        seed = self._normalize_execution_seed(state, seed, persist=False)
         state.seed_id = seed.metadata.seed_id
         state.seed_artifact = seed.to_dict()
         return seed

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -28,7 +28,10 @@ from ouroboros.auto.answerer import (
     AutoAnswerContext,
     risky_user_preference_blocker_for,
 )
-from ouroboros.auto.execution_acceptance import is_auto_reporting_acceptance_criterion
+from ouroboros.auto.execution_acceptance import (
+    has_auto_wrapper_context,
+    is_auto_reporting_acceptance_criterion,
+)
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import (
     REQUIRED_SECTIONS,
@@ -1521,7 +1524,7 @@ def _derive_goal_user_preferences(goal: str) -> dict[str, str]:
 
     success = _section_text(sections, "success criteria", "acceptance criteria")
     if success:
-        execution_success = _execution_success_criteria(success)
+        execution_success = _execution_success_criteria(success, context_text=goal)
         if execution_success:
             preferences["acceptance_criteria"] = execution_success
 
@@ -1602,11 +1605,12 @@ def _section_text(sections: dict[str, list[str]], *names: str) -> str:
     return "\n".join(dict.fromkeys(value for value in values if value.strip()))
 
 
-def _execution_success_criteria(text: str) -> str:
+def _execution_success_criteria(text: str, *, context_text: str = "") -> str:
+    strip_auto_wrapper = has_auto_wrapper_context("\n".join((context_text, text)))
     lines = [
         line
         for line in (_clean_prompt_line(raw) for raw in text.splitlines())
-        if line and not is_auto_reporting_acceptance_criterion(line)
+        if line and not (strip_auto_wrapper and is_auto_reporting_acceptance_criterion(line))
     ]
     return "\n".join(dict.fromkeys(lines))
 

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1520,7 +1520,9 @@ def _derive_goal_user_preferences(goal: str) -> dict[str, str]:
 
     success = _section_text(sections, "success criteria", "acceptance criteria")
     if success:
-        preferences["acceptance_criteria"] = success
+        execution_success = _execution_success_criteria(success)
+        if execution_success:
+            preferences["acceptance_criteria"] = execution_success
 
     outputs = _section_text(sections, "outputs", "deliverables")
     if outputs:
@@ -1597,6 +1599,56 @@ def _section_text(sections: dict[str, list[str]], *names: str) -> str:
     for name in names:
         values.extend(sections.get(" ".join(name.replace("_", " ").casefold().split()), ()))
     return "\n".join(dict.fromkeys(value for value in values if value.strip()))
+
+
+def _execution_success_criteria(text: str) -> str:
+    lines = [
+        line
+        for line in (_clean_prompt_line(raw) for raw in text.splitlines())
+        if line
+        and _looks_like_execution_criterion(line)
+        and not _looks_like_auto_report_criterion(line)
+    ]
+    return "\n".join(dict.fromkeys(lines))
+
+
+def _looks_like_execution_criterion(line: str) -> bool:
+    lowered = line.casefold()
+    return any(
+        needle in lowered
+        for needle in (
+            ".py",
+            "changed files",
+            "create",
+            "exists",
+            "hello_auto",
+            "pytest",
+            "return",
+            "test",
+            "uv run",
+        )
+    )
+
+
+def _looks_like_auto_report_criterion(line: str) -> bool:
+    lowered = line.casefold()
+    return any(
+        needle in lowered
+        for needle in (
+            "auto session id",
+            "blocker",
+            "dispatch",
+            "final report",
+            "interview closure",
+            "last_question",
+            "manual fallback",
+            "ooo auto",
+            "ouroboros_auto",
+            "seed grade",
+            "seed id",
+            "seed path",
+        )
+    )
 
 
 def _matching_lines(text: str, needles: tuple[str, ...]) -> list[str]:

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -28,6 +28,7 @@ from ouroboros.auto.answerer import (
     AutoAnswerContext,
     risky_user_preference_blocker_for,
 )
+from ouroboros.auto.execution_acceptance import is_auto_reporting_acceptance_criterion
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import (
     REQUIRED_SECTIONS,
@@ -1605,50 +1606,9 @@ def _execution_success_criteria(text: str) -> str:
     lines = [
         line
         for line in (_clean_prompt_line(raw) for raw in text.splitlines())
-        if line
-        and _looks_like_execution_criterion(line)
-        and not _looks_like_auto_report_criterion(line)
+        if line and not is_auto_reporting_acceptance_criterion(line)
     ]
     return "\n".join(dict.fromkeys(lines))
-
-
-def _looks_like_execution_criterion(line: str) -> bool:
-    lowered = line.casefold()
-    return any(
-        needle in lowered
-        for needle in (
-            ".py",
-            "changed files",
-            "create",
-            "exists",
-            "hello_auto",
-            "pytest",
-            "return",
-            "test",
-            "uv run",
-        )
-    )
-
-
-def _looks_like_auto_report_criterion(line: str) -> bool:
-    lowered = line.casefold()
-    return any(
-        needle in lowered
-        for needle in (
-            "auto session id",
-            "blocker",
-            "dispatch",
-            "final report",
-            "interview closure",
-            "last_question",
-            "manual fallback",
-            "ooo auto",
-            "ouroboros_auto",
-            "seed grade",
-            "seed id",
-            "seed path",
-        )
-    )
 
 
 def _matching_lines(text: str, needles: tuple[str, ...]) -> list[str]:

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -58,3 +58,33 @@ def test_normalize_execution_acceptance_keeps_original_when_filter_would_empty()
     seed = _seed("Final report includes auto session id and seed id.")
 
     assert normalize_execution_acceptance(seed) is seed
+
+
+def test_normalize_execution_acceptance_preserves_mixed_non_keyword_requirements() -> None:
+    seed = _seed(
+        "`foo.py` exists.",
+        "CLI exits 2 on invalid flags.",
+        "HTTP 400 responses include a machine-readable error code.",
+        "JSON output matches the documented schema.",
+        "Final report includes auto session id and seed path.",
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == (
+        "`foo.py` exists.",
+        "CLI exits 2 on invalid flags.",
+        "HTTP 400 responses include a machine-readable error code.",
+        "JSON output matches the documented schema.",
+    )
+
+
+def test_normalize_execution_acceptance_preserves_expected_ooo_auto_output() -> None:
+    seed = _seed(
+        "The command prints exactly `hello from ooo auto`.",
+        "Manual fallback is not used.",
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == ("The command prints exactly `hello from ooo auto`.",)

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -94,7 +94,9 @@ def test_normalize_execution_acceptance_preserves_product_final_report_and_fallb
     seed = _seed(
         "Implement a manual fallback mode for offline users.",
         "The final report endpoint includes the session id field.",
+        "The final report endpoint includes seed id and seed path.",
         "Previous blocker history is visible in the admin UI.",
+        "Persist last_question for resumed interviews.",
         "Manual fallback is not used.",
     )
 
@@ -103,5 +105,7 @@ def test_normalize_execution_acceptance_preserves_product_final_report_and_fallb
     assert normalized.acceptance_criteria == (
         "Implement a manual fallback mode for offline users.",
         "The final report endpoint includes the session id field.",
+        "The final report endpoint includes seed id and seed path.",
         "Previous blocker history is visible in the admin UI.",
+        "Persist last_question for resumed interviews.",
     )

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -88,3 +88,20 @@ def test_normalize_execution_acceptance_preserves_expected_ooo_auto_output() -> 
     normalized = normalize_execution_acceptance(seed)
 
     assert normalized.acceptance_criteria == ("The command prints exactly `hello from ooo auto`.",)
+
+
+def test_normalize_execution_acceptance_preserves_product_final_report_and_fallback() -> None:
+    seed = _seed(
+        "Implement a manual fallback mode for offline users.",
+        "The final report endpoint includes the session id field.",
+        "Previous blocker history is visible in the admin UI.",
+        "Manual fallback is not used.",
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == (
+        "Implement a manual fallback mode for offline users.",
+        "The final report endpoint includes the session id field.",
+        "Previous blocker history is visible in the admin UI.",
+    )

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -48,6 +48,7 @@ def test_normalize_execution_acceptance_drops_auto_report_criteria() -> None:
     normalized = normalize_execution_acceptance(seed)
 
     assert normalized.acceptance_criteria == (
+        "Manual fallback is not used.",
         "`hello_auto.py` defines `hello_auto()` returning exactly `hello from ooo auto`.",
         "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
         "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
@@ -76,6 +77,7 @@ def test_normalize_execution_acceptance_preserves_mixed_non_keyword_requirements
         "CLI exits 2 on invalid flags.",
         "HTTP 400 responses include a machine-readable error code.",
         "JSON output matches the documented schema.",
+        "Final report includes auto session id and seed path.",
     )
 
 
@@ -87,7 +89,10 @@ def test_normalize_execution_acceptance_preserves_expected_ooo_auto_output() -> 
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == ("The command prints exactly `hello from ooo auto`.",)
+    assert normalized.acceptance_criteria == (
+        "The command prints exactly `hello from ooo auto`.",
+        "Manual fallback is not used.",
+    )
 
 
 def test_normalize_execution_acceptance_preserves_product_final_report_and_fallback() -> None:
@@ -98,7 +103,7 @@ def test_normalize_execution_acceptance_preserves_product_final_report_and_fallb
         "Previous blocker history is visible in the admin UI.",
         "Persist last_question for resumed interviews.",
         "Manual fallback is not used.",
-    )
+    ).model_copy(update={"goal": "Build a reporting API with fallback controls"})
 
     normalized = normalize_execution_acceptance(seed)
 
@@ -108,4 +113,13 @@ def test_normalize_execution_acceptance_preserves_product_final_report_and_fallb
         "The final report endpoint includes seed id and seed path.",
         "Previous blocker history is visible in the admin UI.",
         "Persist last_question for resumed interviews.",
+        "Manual fallback is not used.",
     )
+
+
+def test_normalize_execution_acceptance_preserves_exact_product_metadata_requirement() -> None:
+    seed = _seed(
+        "Final report includes auto session id, seed id, seed path, and test result.",
+    ).model_copy(update={"goal": "Build a product final-report endpoint"})
+
+    assert normalize_execution_acceptance(seed) is seed

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from ouroboros.auto.execution_acceptance import normalize_execution_acceptance
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+
+def _seed(*criteria: str) -> Seed:
+    return Seed(
+        goal="Verify ooo auto with a minimal coding task",
+        constraints=("Only edit hello_auto.py and tests/test_hello_auto.py",),
+        acceptance_criteria=criteria,
+        ontology_schema=OntologySchema(
+            name="HelloAuto",
+            description="Minimal coding task",
+            fields=(OntologyField(name="file", field_type="string", description="File"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Runnable tests pass"),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Targeted test passes",
+                evaluation_criteria="All execution criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(seed_id="seed_test", ambiguity_score=0.1),
+    )
+
+
+def test_normalize_execution_acceptance_drops_auto_report_criteria() -> None:
+    seed = _seed(
+        "`ooo auto` is dispatched to the MCP tool `ouroboros_auto`.",
+        "Manual fallback is not used.",
+        "`hello_auto.py` defines `hello_auto()` returning exactly `hello from ooo auto`.",
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        "Final report includes auto session id, seed id, seed path, and test result.",
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == (
+        "`hello_auto.py` defines `hello_auto()` returning exactly `hello from ooo auto`.",
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+    )
+
+
+def test_normalize_execution_acceptance_keeps_original_when_filter_would_empty() -> None:
+    seed = _seed("Final report includes auto session id and seed id.")
+
+    assert normalize_execution_acceptance(seed) is seed

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -3786,10 +3786,12 @@ async def test_pipeline_normalizes_persisted_seed_artifact_on_resume(tmp_path) -
 
     seed = _seed(
         ac=(
+            "`hello_auto.py` exists.",
+            "`tests/test_hello_auto.py` exists.",
             "Final report includes auto session id, seed id, seed path, and test result.",
             "CLI exits 2 on invalid flags.",
         )
-    )
+    ).model_copy(update={"goal": "Verify current ooo auto can create hello_auto.py."})
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
     state.transition(AutoPhase.INTERVIEW, "interview")
     state.transition(AutoPhase.SEED_GENERATION, "seed generated")

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -3771,3 +3771,41 @@ async def test_convergence_contract_stalled_generic_followups_report_actionable_
     open_gaps = ledger.open_gaps()
     assert open_gaps, "stalled generic loop must leave at least one open required gap"
     assert any(section in blocker for section in open_gaps)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_normalizes_persisted_seed_artifact_on_resume(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume with seed_artifact should not interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume with seed_artifact should not answer")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("resume with seed_artifact should not generate")
+
+    seed = _seed(
+        ac=(
+            "Final report includes auto session id, seed id, seed path, and test result.",
+            "CLI exits 2 on invalid flags.",
+        )
+    )
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed generated")
+    state.transition(AutoPhase.REVIEW, "resume review")
+    state.seed_artifact = seed.to_dict()
+    state.seed_id = seed.metadata.seed_id
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    resumed_seed = Seed.from_dict(state.seed_artifact)
+    criteria_text = "\n".join(resumed_seed.acceptance_criteria)
+    assert "Final report includes auto session id" not in criteria_text
+    assert "CLI exits 2 on invalid flags" in criteria_text

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -300,7 +300,45 @@ Success criteria:
         "CLI exits 2 on invalid flags.\n"
         "HTTP 400 responses include a machine-readable error code.\n"
         "JSON output matches the documented schema.\n"
-        "The command prints exactly `hello from ooo auto`."
+        "The command prints exactly `hello from ooo auto`.\n"
+        "Final report includes auto session id, seed id, seed path, and test result."
+    )
+
+
+def test_structured_auto_goal_filters_wrapper_criteria_using_full_prompt_context() -> None:
+    goal = """
+Goal:
+Verify current ooo auto can create hello_auto.py and tests/test_hello_auto.py.
+
+Success criteria:
+- `hello_auto.py` exists.
+- `tests/test_hello_auto.py` exists.
+- Final report includes auto session id, seed id, seed path, and test result.
+
+Important dispatch rule:
+If `ouroboros_auto` is unavailable or interpreted as normal text, stop and report failure.
+"""
+
+    preferences = _derive_goal_user_preferences(goal)
+
+    assert preferences["acceptance_criteria"] == (
+        "`hello_auto.py` exists.\n`tests/test_hello_auto.py` exists."
+    )
+
+
+def test_structured_product_goal_preserves_exact_final_report_metadata_requirement() -> None:
+    goal = """
+Goal:
+Build a product final-report endpoint.
+
+Success criteria:
+- Final report includes auto session id, seed id, seed path, and test result.
+"""
+
+    preferences = _derive_goal_user_preferences(goal)
+
+    assert preferences["acceptance_criteria"] == (
+        "Final report includes auto session id, seed id, seed path, and test result."
     )
 
 

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -226,6 +226,8 @@ def test_structured_auto_goal_seeds_required_ledger_sections() -> None:
     assert "runtime_context" in summary["evidence_backed_sections"]
     assert "constraints" in summary["evidence_backed_sections"]
     assert "non_goals" in summary["evidence_backed_sections"]
+    assert "Final report" not in preferences["acceptance_criteria"]
+    assert "`hello_auto.py` exists" in preferences["acceptance_criteria"]
 
 
 def test_structured_auto_goal_does_not_preconfirm_risky_preference() -> None:
@@ -246,7 +248,6 @@ Success criteria:
     preferences = _derive_goal_user_preferences(risky_goal)
 
     assert "outputs" in preferences
-    assert "acceptance_criteria" in preferences
     ledger = _seed_initial_ledger_from_user_preferences(risky_goal, preferences)
 
     assert "outputs" not in ledger.summary()["evidence_backed_sections"]
@@ -267,6 +268,15 @@ Implementation:
 
     assert "outputs" not in preferences
     assert "inputs" not in preferences
+
+
+def test_structured_auto_goal_filters_report_only_success_criteria() -> None:
+    preferences = _derive_goal_user_preferences(_OBSERVATION_GOAL)
+
+    assert "acceptance_criteria" in preferences
+    assert "manual fallback" not in preferences["acceptance_criteria"].casefold()
+    assert "seed id" not in preferences["acceptance_criteria"].casefold()
+    assert "uv run pytest tests/test_hello_auto.py" in preferences["acceptance_criteria"]
 
 
 def test_resume_preference_override_reseeds_stale_preconfirmed_ledger() -> None:

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -279,6 +279,31 @@ def test_structured_auto_goal_filters_report_only_success_criteria() -> None:
     assert "uv run pytest tests/test_hello_auto.py" in preferences["acceptance_criteria"]
 
 
+def test_structured_auto_goal_preserves_non_allowlisted_execution_criteria() -> None:
+    goal = """
+Goal:
+Build a CLI validation endpoint.
+
+Success criteria:
+- `validator.py` exists.
+- CLI exits 2 on invalid flags.
+- HTTP 400 responses include a machine-readable error code.
+- JSON output matches the documented schema.
+- The command prints exactly `hello from ooo auto`.
+- Final report includes auto session id, seed id, seed path, and test result.
+"""
+
+    preferences = _derive_goal_user_preferences(goal)
+
+    assert preferences["acceptance_criteria"] == (
+        "`validator.py` exists.\n"
+        "CLI exits 2 on invalid flags.\n"
+        "HTTP 400 responses include a machine-readable error code.\n"
+        "JSON output matches the documented schema.\n"
+        "The command prints exactly `hello from ooo auto`."
+    )
+
+
 def test_resume_preference_override_reseeds_stale_preconfirmed_ledger() -> None:
     """Resume preference overrides must update persisted ledger source of truth."""
     original_preferences = _derive_goal_user_preferences(_OBSERVATION_GOAL)


### PR DESCRIPTION
## Summary
- Filter auto wrapper/reporting obligations out of execution-facing acceptance criteria.
- Preserve concrete file/test criteria such as `hello_auto.py`, `tests/test_hello_auto.py`, and targeted pytest commands.
- Seed the structured prompt ledger with execution criteria only, not final-report/session metadata criteria.

## Why
The latest observation reached A-grade Seed and execution handoff, but the execution worker stalled while chasing auto result metadata and prior-blocker reporting instead of creating the requested files. Auto/session metadata belongs to the auto final report; execution workers should receive concrete deliverable/test criteria.

## Tests
- `uv run pytest tests/unit/auto/test_execution_acceptance.py tests/unit/mcp/tools/test_auto_interview_construction.py tests/unit/auto/test_interview_pipeline.py -q`
- `uv run ruff check src/ouroboros/auto/execution_acceptance.py src/ouroboros/auto/pipeline.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_execution_acceptance.py tests/unit/mcp/tools/test_auto_interview_construction.py`
- `uv run ruff format --check src/ouroboros/auto/execution_acceptance.py src/ouroboros/auto/pipeline.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_execution_acceptance.py tests/unit/mcp/tools/test_auto_interview_construction.py`
