### PR TITLE
fix(orchestrator): prevent execution workers from recursively invoking auto

### DIFF
--- a/src/ouroboros/core/seed_contract_prompt.py
+++ b/src/ouroboros/core/seed_contract_prompt.py
@@ -4,6 +4,18 @@ from __future__ import annotations
 
 from ouroboros.core.seed_contract import OntologyLens, SeedContract
 
+AUTO_RECURSION_GUARD = """## Auto Recursion Guard
+Do not invoke `ooo auto`, `ouroboros_auto`, `ouroboros_start_auto`, or any MCP auto
+tool while executing this Seed. This execution is already downstream of any auto
+authoring step. Implement the concrete Seed requirements directly; if evidence
+about a prior auto run is needed, inspect existing artifacts/logs only and never
+start a nested auto session."""
+
+
+def render_auto_recursion_guard() -> str:
+    """Render the execution-session guard that prevents nested auto dispatch."""
+    return AUTO_RECURSION_GUARD
+
 
 def render_constraints_section(contract: SeedContract) -> str:
     """Render hard boundaries from the Seed contract."""
@@ -160,6 +172,8 @@ def render_seed_contract_for_execution(contract: SeedContract) -> str:
 
 
 __all__ = [
+    "AUTO_RECURSION_GUARD",
+    "render_auto_recursion_guard",
     "render_brownfield_section",
     "render_acceptance_criteria_section",
     "render_constraints_section",

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -819,6 +819,12 @@ in the seed, respecting constraints and acceptance criteria.
 {seed_content}
 ```
 
+## Auto Recursion Guard
+Do not invoke `ooo auto`, `ouroboros_auto`, `ouroboros_start_auto`, or any MCP auto
+tool from this execution session. This task is already executing a Seed; implement
+the concrete Seed requirements directly. If evidence about a prior auto run is
+needed, inspect existing artifacts/logs only and never start a nested auto session.
+
 Implement the seed requirements. Work iteratively, testing as you go.
 Stop when all acceptance criteria are met or max iterations reached."""
 

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -39,6 +39,7 @@ from typing import Any
 
 import structlog
 
+from ouroboros.core.seed_contract_prompt import render_auto_recursion_guard
 from ouroboros.core.types import Result
 from ouroboros.mcp.types import (
     ContentType,
@@ -819,11 +820,7 @@ in the seed, respecting constraints and acceptance criteria.
 {seed_content}
 ```
 
-## Auto Recursion Guard
-Do not invoke `ooo auto`, `ouroboros_auto`, `ouroboros_start_auto`, or any MCP auto
-tool from this execution session. This task is already executing a Seed; implement
-the concrete Seed requirements directly. If evidence about a prior auto run is
-needed, inspect existing artifacts/logs only and never start a nested auto session.
+{render_auto_recursion_guard()}
 
 Implement the seed requirements. Work iteratively, testing as you go.
 Stop when all acceptance criteria are met or max iterations reached."""

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -43,6 +43,7 @@ from typing import TYPE_CHECKING, Any
 import anyio
 from rich.console import Console
 
+from ouroboros.core.seed_contract_prompt import render_auto_recursion_guard
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.adapter import (
     AgentMessage,
@@ -4330,12 +4331,7 @@ Files present:
 ## Goal Context
 {seed_goal}
 
-## Auto Recursion Guard
-Do not invoke `ooo auto`, `ouroboros_auto`, `ouroboros_start_auto`, or any MCP auto
-tool while executing this Seed. This execution is already downstream of any auto
-authoring step. Implement the concrete Seed requirements directly; if evidence
-about a prior auto run is needed, inspect existing artifacts/logs only and never
-start a nested auto session.
+{render_auto_recursion_guard()}
 
 {task_section}
 {legacy_context_section}{retry_section}{parallel_section}

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -4330,6 +4330,13 @@ Files present:
 ## Goal Context
 {seed_goal}
 
+## Auto Recursion Guard
+Do not invoke `ooo auto`, `ouroboros_auto`, `ouroboros_start_auto`, or any MCP auto
+tool while executing this Seed. This execution is already downstream of any auto
+authoring step. Implement the concrete Seed requirements directly; if evidence
+about a prior auto run is needed, inspect existing artifacts/logs only and never
+start a nested auto session.
+
 {task_section}
 {legacy_context_section}{retry_section}{parallel_section}
 {completion_instruction}

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -36,7 +36,10 @@ from rich.text import Text
 from ouroboros.backends import backend_supports_tool_envelope
 from ouroboros.core.errors import OuroborosError
 from ouroboros.core.seed_contract import SeedContract
-from ouroboros.core.seed_contract_prompt import render_seed_contract_for_execution
+from ouroboros.core.seed_contract_prompt import (
+    render_auto_recursion_guard,
+    render_seed_contract_for_execution,
+)
 from ouroboros.core.types import Result
 from ouroboros.core.worktree import TaskWorkspace, heartbeat_lock, release_lock
 from ouroboros.observability.drift import DriftMeasurement
@@ -338,12 +341,7 @@ def build_task_prompt(
 ## Acceptance Criteria
 {ac_list}
 
-## Auto Recursion Guard
-Do not invoke `ooo auto`, `ouroboros_auto`, `ouroboros_start_auto`, or any MCP auto
-tool while executing this Seed. This execution is already downstream of any auto
-authoring step. Implement the concrete Seed requirements directly; if evidence
-about a prior auto run is needed, inspect existing artifacts/logs only and never
-start a nested auto session.
+{render_auto_recursion_guard()}
 
 {suffix}
 """

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -338,6 +338,13 @@ def build_task_prompt(
 ## Acceptance Criteria
 {ac_list}
 
+## Auto Recursion Guard
+Do not invoke `ooo auto`, `ouroboros_auto`, `ouroboros_start_auto`, or any MCP auto
+tool while executing this Seed. This execution is already downstream of any auto
+authoring step. Implement the concrete Seed requirements directly; if evidence
+about a prior auto run is needed, inspect existing artifacts/logs only and never
+start a nested auto session.
+
 {suffix}
 """
 

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -788,6 +788,15 @@ class TestBuildExecuteSubagent:
         )
         assert "build a CLI tool" in p.prompt
 
+    def test_prompt_includes_auto_recursion_guard(self) -> None:
+        p = build_execute_subagent(
+            seed_content="goal: build a CLI tool",
+            session_id="sess-123",
+        )
+        assert "Auto Recursion Guard" in p.prompt
+        assert "ouroboros_auto" in p.prompt
+        assert "nested auto session" in p.prompt
+
     def test_context_preserves_execution_args(self) -> None:
         p = build_execute_subagent(
             seed_content="goal: test",

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1467,6 +1467,9 @@ class TestParallelACExecutor:
         assert "never absolute paths" in runtime.last_prompt
         assert "omit exploratory" in runtime.last_prompt
         assert "rg, grep, sed, cat, ls, find, or pwd" in runtime.last_prompt
+        assert "Auto Recursion Guard" in runtime.last_prompt
+        assert "ouroboros_auto" in runtime.last_prompt
+        assert "nested auto session" in runtime.last_prompt
         assert "explicitly state: [TASK_COMPLETE]" not in runtime.last_prompt
 
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -238,6 +238,13 @@ class TestBuildTaskPrompt:
         assert "## Ontology / Conceptual Lens" not in prompt
         assert "conceptual lens for execution decisions" not in prompt
 
+    def test_includes_auto_recursion_guard(self, sample_seed: Seed) -> None:
+        prompt = build_task_prompt(sample_seed)
+
+        assert "Auto Recursion Guard" in prompt
+        assert "ouroboros_auto" in prompt
+        assert "nested auto session" in prompt
+
 
 class TestOrchestratorResult:
     """Tests for OrchestratorResult dataclass."""


### PR DESCRIPTION
## Summary
- Add an Auto Recursion Guard to seed execution prompts.
- Apply the guard to top-level runner prompts, parallel AC worker prompts, and execute-subagent prompts.
- Cover the prompt contract in runner/subagent tests.

## Why
The latest observation showed execution workers calling back into auto-style MCP verification instead of creating the requested files. Execution sessions are already downstream of auto authoring; they should implement concrete Seed requirements directly and only inspect existing auto artifacts when evidence is needed.

## Tests
- `uv run pytest tests/unit/orchestrator/test_runner.py tests/unit/mcp/tools/test_subagent.py -q`
- `uv run ruff check src/ouroboros/orchestrator/runner.py src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/mcp/tools/subagent.py tests/unit/orchestrator/test_runner.py tests/unit/mcp/tools/test_subagent.py`
- `uv run ruff format --check src/ouroboros/orchestrator/runner.py src/ouroboros/orchestrator/parallel_executor.py src/ouroboros/mcp/tools/subagent.py tests/unit/orchestrator/test_runner.py tests/unit/mcp/tools/test_subagent.py`
