### PR TITLE
fix(auto): surface execution terminal failures instead of reporting complete

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -175,6 +175,9 @@ class AutoPipelineResult:
     execution_id: str | None = None
     job_id: str | None = None
     run_session_id: str | None = None
+    execution_job_status: str | None = None
+    execution_job_error: str | None = None
+    execution_job_message: str | None = None
     run_subagent: dict[str, Any] | None = None
     current_round: int = 0
     pending_question: str | None = None

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 import difflib
 import inspect
@@ -54,7 +54,7 @@ from ouroboros.config import get_opencode_mode
 from ouroboros.core.file_lock import file_lock
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
-from ouroboros.mcp.job_manager import JobLinks, JobManager
+from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler
@@ -250,6 +250,7 @@ class AutoHandler:
             return Result.err(
                 MCPToolError(f"Auto pipeline failed: {exc}", tool_name="ouroboros_auto")
             )
+        result = await _reconcile_execution_job_snapshot(result)
         release_session_id = result.auto_session_id or auto_session_id
         if release_session_id and release_start_lease:
             _release_start_lease(store, release_session_id, token=start_lease_token)
@@ -1163,6 +1164,9 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         "execution_id": result.execution_id,
         "job_id": result.job_id,
         "run_session_id": result.run_session_id,
+        "execution_job_status": result.execution_job_status,
+        "execution_job_error": result.execution_job_error,
+        "execution_job_message": result.execution_job_message,
     }
     # Only advertise a runnable resume_command when --resume actually has
     # something to do. NONE-capability sessions (COMPLETE, or unrecoverable
@@ -1228,6 +1232,34 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
     meta["evidence_backed_sections"] = list(result.evidence_backed_sections)
     meta["assumption_only_sections"] = list(result.assumption_only_sections)
     return meta
+
+
+async def _reconcile_execution_job_snapshot(result: AutoPipelineResult) -> AutoPipelineResult:
+    """Surface terminal execution job failures/cancellations on auto resume."""
+    if not result.job_id:
+        return result
+    try:
+        snapshot = await JobManager().get_snapshot(result.job_id)
+    except Exception:
+        return result
+    blocker = result.blocker
+    status = result.status
+    if snapshot.status in {JobStatus.FAILED, JobStatus.CANCELLED}:
+        detail = snapshot.error or snapshot.result_text or snapshot.message
+        blocker = (
+            f"execution job {snapshot.status.value}: {detail}"
+            if detail
+            else f"execution job {snapshot.status.value}"
+        )
+        status = "failed" if snapshot.status is JobStatus.FAILED else "blocked"
+    return replace(
+        result,
+        status=status,
+        blocker=blocker,
+        execution_job_status=snapshot.status.value,
+        execution_job_error=snapshot.error,
+        execution_job_message=snapshot.message,
+    )
 
 
 def _resolved_opencode_mode(runtime_backend: str | None, opencode_mode: str | None) -> str | None:
@@ -1782,6 +1814,12 @@ def _format_result(result: AutoPipelineResult) -> str:
         )
     if result.run_handoff_status:
         lines.append(f"Run handoff status: {result.run_handoff_status}")
+    if result.execution_job_status:
+        lines.append(f"Execution job status: {result.execution_job_status}")
+    if result.execution_job_error:
+        lines.append(f"Execution job error: {result.execution_job_error}")
+    elif result.execution_job_message and result.execution_job_status in {"failed", "cancelled"}:
+        lines.append(f"Execution job message: {result.execution_job_message}")
     if result.run_handoff_guidance:
         lines.append(f"Run handoff guidance: {result.run_handoff_guidance}")
     if result.attached_run_handle:

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1164,10 +1164,13 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         "execution_id": result.execution_id,
         "job_id": result.job_id,
         "run_session_id": result.run_session_id,
-        "execution_job_status": result.execution_job_status,
-        "execution_job_error": result.execution_job_error,
-        "execution_job_message": result.execution_job_message,
     }
+    if result.execution_job_status:
+        meta["execution_job_status"] = result.execution_job_status
+    if result.execution_job_error:
+        meta["execution_job_error"] = result.execution_job_error
+    if result.execution_job_message:
+        meta["execution_job_message"] = result.execution_job_message
     # Only advertise a runnable resume_command when --resume actually has
     # something to do. NONE-capability sessions (COMPLETE, or unrecoverable
     # BLOCKED/FAILED) must not surface a resume action via metadata —
@@ -1244,7 +1247,7 @@ async def _reconcile_execution_job_snapshot(result: AutoPipelineResult) -> AutoP
         return result
     blocker = result.blocker
     status = result.status
-    if snapshot.status in {JobStatus.FAILED, JobStatus.CANCELLED}:
+    if snapshot.status in {JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.INTERRUPTED}:
         detail = snapshot.error or snapshot.result_text or snapshot.message
         blocker = (
             f"execution job {snapshot.status.value}: {detail}"
@@ -1818,7 +1821,11 @@ def _format_result(result: AutoPipelineResult) -> str:
         lines.append(f"Execution job status: {result.execution_job_status}")
     if result.execution_job_error:
         lines.append(f"Execution job error: {result.execution_job_error}")
-    elif result.execution_job_message and result.execution_job_status in {"failed", "cancelled"}:
+    elif result.execution_job_message and result.execution_job_status in {
+        "failed",
+        "cancelled",
+        "interrupted",
+    }:
         lines.append(f"Execution job message: {result.execution_job_message}")
     if result.run_handoff_guidance:
         lines.append(f"Run handoff guidance: {result.run_handoff_guidance}")

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import ast
 import asyncio
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
@@ -24,11 +25,13 @@ from ouroboros.auto.state import AutoPipelineState, AutoStore
 from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError
+from ouroboros.mcp.job_manager import JobLinks, JobSnapshot, JobStatus
 from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
 from ouroboros.mcp.tools.auto_handler import (
     AutoHandler,
     _derive_goal_user_preferences,
     _merge_resume_user_preferences,
+    _reconcile_execution_job_snapshot,
     _reseed_preference_ledger,
     _seed_initial_ledger_from_user_preferences,
 )
@@ -113,6 +116,69 @@ def _assert_isolated_allowed_tools(factory_kwargs: dict[str, Any]) -> None:
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[4]
+
+
+def _job_snapshot(status: JobStatus, *, error: str | None = None) -> JobSnapshot:
+    now = datetime.now(UTC)
+    return JobSnapshot(
+        job_id="job_failed",
+        job_type="execute_seed",
+        status=status,
+        message=f"Job {status.value}",
+        created_at=now,
+        updated_at=now,
+        links=JobLinks(session_id="orch_1", execution_id="exec_1"),
+        error=error,
+    )
+
+
+def test_execution_job_failure_rewrites_complete_auto_result(monkeypatch) -> None:
+    class FakeJobManager:
+        async def get_snapshot(self, job_id: str) -> JobSnapshot:
+            assert job_id == "job_failed"
+            return _job_snapshot(JobStatus.FAILED, error="planner failed")
+
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.auto_handler.JobManager",
+        lambda: FakeJobManager(),
+    )
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_1",
+        phase="complete",
+        job_id="job_failed",
+    )
+
+    reconciled = asyncio.run(_reconcile_execution_job_snapshot(result))
+
+    assert reconciled.status == "failed"
+    assert reconciled.execution_job_status == "failed"
+    assert reconciled.execution_job_error == "planner failed"
+    assert reconciled.blocker == "execution job failed: planner failed"
+
+
+def test_execution_job_cancelled_blocks_complete_auto_result(monkeypatch) -> None:
+    class FakeJobManager:
+        async def get_snapshot(self, job_id: str) -> JobSnapshot:
+            assert job_id == "job_failed"
+            return _job_snapshot(JobStatus.CANCELLED)
+
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.auto_handler.JobManager",
+        lambda: FakeJobManager(),
+    )
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_1",
+        phase="complete",
+        job_id="job_failed",
+    )
+
+    reconciled = asyncio.run(_reconcile_execution_job_snapshot(result))
+
+    assert reconciled.status == "blocked"
+    assert reconciled.execution_job_status == "cancelled"
+    assert reconciled.blocker == "execution job cancelled: Job cancelled"
 
 
 def test_structured_auto_goal_seeds_required_ledger_sections() -> None:

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -181,6 +181,30 @@ def test_execution_job_cancelled_blocks_complete_auto_result(monkeypatch) -> Non
     assert reconciled.blocker == "execution job cancelled: Job cancelled"
 
 
+def test_execution_job_interrupted_blocks_complete_auto_result(monkeypatch) -> None:
+    class FakeJobManager:
+        async def get_snapshot(self, job_id: str) -> JobSnapshot:
+            assert job_id == "job_failed"
+            return _job_snapshot(JobStatus.INTERRUPTED)
+
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.auto_handler.JobManager",
+        lambda: FakeJobManager(),
+    )
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_1",
+        phase="complete",
+        job_id="job_failed",
+    )
+
+    reconciled = asyncio.run(_reconcile_execution_job_snapshot(result))
+
+    assert reconciled.status == "blocked"
+    assert reconciled.execution_job_status == "interrupted"
+    assert reconciled.blocker == "execution job interrupted: Job interrupted"
+
+
 def test_structured_auto_goal_seeds_required_ledger_sections() -> None:
     """Observation-style prompts should seed known ledger sections before interview."""
     preferences = _derive_goal_user_preferences(_OBSERVATION_GOAL)


### PR DESCRIPTION
## Summary
- Add execution job terminal status fields to `AutoPipelineResult`.
- Reconcile linked execution job snapshots on `ouroboros_auto` responses.
- Surface failed/cancelled terminal jobs as auto blockers instead of a misleading complete result.

## Why
Observation runs reported `Auto-session result: complete` after run handoff while the linked background execution job later failed or was cancelled. Auto reporting should distinguish handoff-started from end-to-end completion.

## Tests
- `uv run pytest tests/unit/mcp/tools/test_auto_interview_construction.py -q`
- `uv run ruff check src/ouroboros/auto/pipeline.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/mcp/tools/test_auto_interview_construction.py`
- `uv run ruff format --check src/ouroboros/auto/pipeline.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/mcp/tools/test_auto_interview_construction.py`
