### PR TITLE
fix(auto): distinguish handoff from terminal execution

### DIFF
--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1242,7 +1242,7 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
 
 
 async def _reconcile_execution_job_snapshot(result: AutoPipelineResult) -> AutoPipelineResult:
-    """Surface terminal execution job failures/cancellations on auto resume."""
+    """Project the linked execution job lifecycle onto the auto resume result."""
     if not result.job_id:
         return result
     try:

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1251,7 +1251,16 @@ async def _reconcile_execution_job_snapshot(result: AutoPipelineResult) -> AutoP
         return result
     blocker = result.blocker
     status = result.status
-    if snapshot.status in {JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.INTERRUPTED}:
+    resume_capability = result.resume_capability
+    if snapshot.status in {JobStatus.QUEUED, JobStatus.RUNNING, JobStatus.CANCEL_REQUESTED}:
+        # A started execution handoff is not the same as product completion.
+        # AutoPipeline persists COMPLETE after returning a durable run handle so
+        # it does not start duplicate work on resume; the MCP surface should
+        # still report the linked job as non-terminal and keep resume polling
+        # discoverable until the background job reaches a terminal state.
+        status = snapshot.status.value
+        resume_capability = AutoResumeCapability.RESUME
+    elif snapshot.status in {JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.INTERRUPTED}:
         detail = snapshot.error or snapshot.result_text or snapshot.message
         blocker = (
             f"execution job {snapshot.status.value}: {detail}"
@@ -1259,10 +1268,15 @@ async def _reconcile_execution_job_snapshot(result: AutoPipelineResult) -> AutoP
             else f"execution job {snapshot.status.value}"
         )
         status = "failed" if snapshot.status is JobStatus.FAILED else "blocked"
+        resume_capability = AutoResumeCapability.NONE
+    elif snapshot.status is JobStatus.COMPLETED:
+        status = "complete"
+        resume_capability = AutoResumeCapability.NONE
     return replace(
         result,
         status=status,
         blocker=blocker,
+        resume_capability=resume_capability,
         execution_job_status=snapshot.status.value,
         execution_job_error=snapshot.error,
         execution_job_message=snapshot.message,

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -132,33 +132,39 @@ def _job_snapshot(status: JobStatus, *, error: str | None = None) -> JobSnapshot
     )
 
 
+def test_non_terminal_execution_job_keeps_auto_result_pollable(monkeypatch) -> None:
+    snapshots = {
+        "job_queued": JobStatus.QUEUED,
+        "job_running": JobStatus.RUNNING,
+        "job_cancel_requested": JobStatus.CANCEL_REQUESTED,
+    }
 
-def test_execution_job_running_keeps_auto_result_pollable(monkeypatch) -> None:
     class FakeJobManager:
         async def get_snapshot(self, job_id: str) -> JobSnapshot:
-            assert job_id == "job_running"
-            return _job_snapshot(JobStatus.RUNNING)
+            return _job_snapshot(snapshots[job_id])
 
     monkeypatch.setattr(
         "ouroboros.mcp.tools.auto_handler.JobManager",
         lambda: FakeJobManager(),
     )
-    result = AutoPipelineResult(
-        status="complete",
-        auto_session_id="auto_1",
-        phase="complete",
-        job_id="job_running",
-        run_handoff_status="started",
-        resume_capability=AutoResumeCapability.NONE,
-    )
 
-    reconciled = asyncio.run(_reconcile_execution_job_snapshot(result))
+    for job_id, expected_status in snapshots.items():
+        result = AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_1",
+            phase="complete",
+            job_id=job_id,
+            run_handoff_status="started",
+            resume_capability=AutoResumeCapability.NONE,
+        )
 
-    assert reconciled.status == "running"
-    assert reconciled.phase == "complete"
-    assert reconciled.execution_job_status == "running"
-    assert reconciled.blocker is None
-    assert reconciled.resume_capability is AutoResumeCapability.RESUME
+        reconciled = asyncio.run(_reconcile_execution_job_snapshot(result))
+
+        assert reconciled.status == expected_status.value
+        assert reconciled.phase == "complete"
+        assert reconciled.execution_job_status == expected_status.value
+        assert reconciled.blocker is None
+        assert reconciled.resume_capability is AutoResumeCapability.RESUME
 
 
 def test_execution_job_completed_keeps_auto_complete(monkeypatch) -> None:
@@ -184,6 +190,7 @@ def test_execution_job_completed_keeps_auto_complete(monkeypatch) -> None:
     assert reconciled.status == "complete"
     assert reconciled.execution_job_status == "completed"
     assert reconciled.resume_capability is AutoResumeCapability.NONE
+
 
 def test_execution_job_failure_rewrites_complete_auto_result(monkeypatch) -> None:
     class FakeJobManager:

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -21,7 +21,7 @@ from ouroboros.auto.adapters import HandlerInterviewBackend
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipelineResult
-from ouroboros.auto.state import AutoPipelineState, AutoStore
+from ouroboros.auto.state import AutoPipelineState, AutoResumeCapability, AutoStore
 from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError
@@ -131,6 +131,59 @@ def _job_snapshot(status: JobStatus, *, error: str | None = None) -> JobSnapshot
         error=error,
     )
 
+
+
+def test_execution_job_running_keeps_auto_result_pollable(monkeypatch) -> None:
+    class FakeJobManager:
+        async def get_snapshot(self, job_id: str) -> JobSnapshot:
+            assert job_id == "job_running"
+            return _job_snapshot(JobStatus.RUNNING)
+
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.auto_handler.JobManager",
+        lambda: FakeJobManager(),
+    )
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_1",
+        phase="complete",
+        job_id="job_running",
+        run_handoff_status="started",
+        resume_capability=AutoResumeCapability.NONE,
+    )
+
+    reconciled = asyncio.run(_reconcile_execution_job_snapshot(result))
+
+    assert reconciled.status == "running"
+    assert reconciled.phase == "complete"
+    assert reconciled.execution_job_status == "running"
+    assert reconciled.blocker is None
+    assert reconciled.resume_capability is AutoResumeCapability.RESUME
+
+
+def test_execution_job_completed_keeps_auto_complete(monkeypatch) -> None:
+    class FakeJobManager:
+        async def get_snapshot(self, job_id: str) -> JobSnapshot:
+            assert job_id == "job_done"
+            return _job_snapshot(JobStatus.COMPLETED)
+
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.auto_handler.JobManager",
+        lambda: FakeJobManager(),
+    )
+    result = AutoPipelineResult(
+        status="running",
+        auto_session_id="auto_1",
+        phase="complete",
+        job_id="job_done",
+        resume_capability=AutoResumeCapability.RESUME,
+    )
+
+    reconciled = asyncio.run(_reconcile_execution_job_snapshot(result))
+
+    assert reconciled.status == "complete"
+    assert reconciled.execution_job_status == "completed"
+    assert reconciled.resume_capability is AutoResumeCapability.NONE
 
 def test_execution_job_failure_rewrites_complete_auto_result(monkeypatch) -> None:
     class FakeJobManager:


### PR DESCRIPTION
## Summary\n- surface non-terminal execution jobs from ooo auto as running/queued/cancel-requested instead of complete\n- keep resume polling discoverable while the linked background job is still non-terminal\n- preserve complete only for terminal completed execution jobs and keep failure/cancelled blockers intact\n\n## Tests\n- uv run pytest tests/unit/mcp/tools/test_auto_interview_construction.py -q\n- uv run ruff check src/ouroboros/mcp/tools/auto_handler.py tests/unit/mcp/tools/test_auto_interview_construction.py