### PR TITLE
fix(orchestrator): terminalize jobs from completed workflow progress

### DIFF
--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -81,8 +81,19 @@ def _safe_meta(value: Any) -> Any:
 
 
 _JOB_TTL = timedelta(hours=1)
+_COMPLETED_EXECUTION_CANCEL_GRACE_SECONDS = 5.0
 _RECOVERED_COMPLETION_EVENT_ID_PREFIX = "mcp-job-recovered-completed-"
 logger = logging.getLogger(__name__)
+
+
+def _consume_task_result(task: asyncio.Task[Any]) -> None:
+    """Drain a detached task result so forced cleanup does not log noise."""
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        logger.debug("Detached job task finished with error", exc_info=True)
 
 
 def _latest_job_terminal_event(events: list[BaseEvent]) -> BaseEvent | None:
@@ -372,8 +383,30 @@ class JobManager:
                 completed_result = await self._derive_completed_execution_result(snapshot)
                 if completed_result is not None:
                     runner = self._runner_tasks.get(job_id)
-                    if runner is not None and not runner.done():
-                        runner.cancel()
+                    if runner is None or runner.done():
+                        return
+                    runner.cancel()
+                    try:
+                        await asyncio.wait_for(
+                            asyncio.shield(runner),
+                            timeout=_COMPLETED_EXECUTION_CANCEL_GRACE_SECONDS,
+                        )
+                    except TimeoutError:
+                        current = await self.get_snapshot(job_id)
+                        if current.is_terminal or current.status == JobStatus.CANCEL_REQUESTED:
+                            return
+                        if await self._append_execution_completed_event(job_id, completed_result):
+                            self._runner_tasks.pop(job_id, None)
+                            runner.add_done_callback(_consume_task_result)
+                            job_task = self._tasks.pop(job_id, None)
+                            if job_task is not None and not job_task.done():
+                                job_task.cancel()
+                                job_task.add_done_callback(_consume_task_result)
+                        return
+                    except asyncio.CancelledError:
+                        return
+                    except Exception:
+                        return
                     return
 
             message = await self._derive_status_message(snapshot)

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -198,6 +198,10 @@ class JobManager:
             snapshot = await self.get_snapshot(job_id)
             if snapshot.is_terminal:
                 return
+            completed_result = await self._derive_completed_execution_result(snapshot)
+            if completed_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
+                await self._append_execution_completed_event(job_id, completed_result)
+                return
             if not runner.done():
                 runner.cancel()
                 try:
@@ -290,12 +294,6 @@ class JobManager:
             if snapshot.status != JobStatus.CANCEL_REQUESTED:
                 completed_result = await self._derive_completed_execution_result(snapshot)
                 if completed_result is not None:
-                    completed = await self._append_execution_completed_event(
-                        job_id,
-                        completed_result,
-                    )
-                    if not completed:
-                        return
                     runner = self._runner_tasks.get(job_id)
                     if runner is not None and not runner.done():
                         runner.cancel()
@@ -313,11 +311,18 @@ class JobManager:
             else:
                 interval = min(interval * 1.5, 5.0)  # Backoff up to 5s
 
-    async def _append_execution_completed_event(self, job_id: str, result_text: str) -> bool:
+    async def _append_execution_completed_event(
+        self,
+        job_id: str,
+        result_text: str,
+        *,
+        check_current: bool = True,
+    ) -> bool:
         """Persist durable job completion derived from terminal execution evidence."""
-        snapshot = await self.get_snapshot(job_id)
-        if snapshot.is_terminal or snapshot.status == JobStatus.CANCEL_REQUESTED:
-            return False
+        if check_current:
+            snapshot = await self.get_snapshot(job_id)
+            if snapshot.is_terminal or snapshot.status == JobStatus.CANCEL_REQUESTED:
+                return False
         await self._append_event(
             "mcp.job.completed",
             job_id,
@@ -526,7 +531,7 @@ class JobManager:
             if "error" in data:
                 error = data["error"]
 
-        return JobSnapshot(
+        snapshot = JobSnapshot(
             job_id=job_id,
             job_type=created.data.get("job_type", "unknown"),
             status=status,
@@ -538,6 +543,49 @@ class JobManager:
             result_text=result_text,
             result_meta=result_meta,
             error=error,
+        )
+        return await self._recover_completed_execution_snapshot(snapshot)
+
+    async def _recover_completed_execution_snapshot(self, snapshot: JobSnapshot) -> JobSnapshot:
+        """Recover completed linked execution jobs when no live runner remains.
+
+        Live jobs keep the existing JobManager invariant: terminal job state is
+        emitted by the runner-owned path after the runner exits or cooperates
+        with cancellation. After process restart, however, there is no live
+        runner left to write that event; if the linked execution already has
+        authoritative completed terminal evidence, materialize the job terminal
+        event from that durable evidence.
+        """
+        if (
+            snapshot.is_terminal
+            or snapshot.status == JobStatus.CANCEL_REQUESTED
+            or snapshot.job_id in self._tasks
+            or snapshot.job_id in self._runner_tasks
+        ):
+            return snapshot
+        completed_result = await self._derive_completed_execution_result(snapshot)
+        if completed_result is None:
+            return snapshot
+        completed = await self._append_execution_completed_event(
+            snapshot.job_id,
+            completed_result,
+            check_current=False,
+        )
+        if not completed:
+            return snapshot
+        events, cursor = await self._event_store.get_events_after(
+            "job", snapshot.job_id, last_row_id=0
+        )
+        latest = events[-1]
+        return replace(
+            snapshot,
+            status=JobStatus.COMPLETED,
+            message=latest.data.get("message", "Job complete"),
+            updated_at=latest.timestamp,
+            cursor=cursor,
+            result_text=latest.data.get("result_text"),
+            result_meta=latest.data.get("result_meta") or {},
+            error=None,
         )
 
     async def wait_for_change(

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -83,6 +83,37 @@ _JOB_TTL = timedelta(hours=1)
 logger = logging.getLogger(__name__)
 
 
+def _latest_job_terminal_event(events: list[BaseEvent]) -> BaseEvent | None:
+    """Return the latest persisted terminal job event from a job stream."""
+    terminal_types = {
+        "mcp.job.completed",
+        "mcp.job.failed",
+        "mcp.job.cancelled",
+        "mcp.job.interrupted",
+    }
+    return next((event for event in reversed(events) if event.type in terminal_types), None)
+
+
+def _snapshot_with_terminal_event(
+    snapshot: JobSnapshot,
+    event: BaseEvent,
+    cursor: int,
+) -> JobSnapshot:
+    """Project a terminal job event onto an existing reconstructed snapshot."""
+    data = event.data
+    status = JobStatus(data.get("status", snapshot.status.value))
+    return replace(
+        snapshot,
+        status=status,
+        message=data.get("message", snapshot.message),
+        updated_at=event.timestamp,
+        cursor=cursor,
+        result_text=data.get("result_text", snapshot.result_text),
+        result_meta=data.get("result_meta") if isinstance(data.get("result_meta"), dict) else {},
+        error=data.get("error"),
+    )
+
+
 class JobManager:
     """Owns background MCP jobs and persists their state as events."""
 
@@ -94,6 +125,7 @@ class JobManager:
         self._tasks: dict[str, asyncio.Task[Any]] = {}
         self._runner_tasks: dict[str, asyncio.Task[Any]] = {}
         self._monitors: dict[str, asyncio.Task[None]] = {}
+        self._recovery_locks: dict[str, asyncio.Lock] = {}
         self._initialized = False
         self._known_job_ids: set[str] = set()
         self._reserved_job_ids: set[str] = set()
@@ -566,27 +598,26 @@ class JobManager:
         completed_result = await self._derive_completed_execution_result(snapshot)
         if completed_result is None:
             return snapshot
-        completed = await self._append_execution_completed_event(
-            snapshot.job_id,
-            completed_result,
-            check_current=False,
-        )
-        if not completed:
-            return snapshot
-        events, cursor = await self._event_store.get_events_after(
-            "job", snapshot.job_id, last_row_id=0
-        )
-        latest = events[-1]
-        return replace(
-            snapshot,
-            status=JobStatus.COMPLETED,
-            message=latest.data.get("message", "Job complete"),
-            updated_at=latest.timestamp,
-            cursor=cursor,
-            result_text=latest.data.get("result_text"),
-            result_meta=latest.data.get("result_meta") or {},
-            error=None,
-        )
+        lock = self._recovery_locks.setdefault(snapshot.job_id, asyncio.Lock())
+        async with lock:
+            events, cursor = await self._event_store.get_events_after(
+                "job", snapshot.job_id, last_row_id=0
+            )
+            existing_terminal = _latest_job_terminal_event(events)
+            if existing_terminal is not None:
+                return _snapshot_with_terminal_event(snapshot, existing_terminal, cursor)
+            completed = await self._append_execution_completed_event(
+                snapshot.job_id,
+                completed_result,
+                check_current=False,
+            )
+            if not completed:
+                return snapshot
+            events, cursor = await self._event_store.get_events_after(
+                "job", snapshot.job_id, last_row_id=0
+            )
+            latest = events[-1]
+        return _snapshot_with_terminal_event(snapshot, latest, cursor)
 
     async def wait_for_change(
         self,

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -94,6 +94,7 @@ class JobManager:
         self._tasks: dict[str, asyncio.Task[Any]] = {}
         self._runner_tasks: dict[str, asyncio.Task[Any]] = {}
         self._monitors: dict[str, asyncio.Task[None]] = {}
+        self._monitor_terminalized_jobs: set[str] = set()
         self._initialized = False
         self._known_job_ids: set[str] = set()
         self._reserved_job_ids: set[str] = set()
@@ -201,6 +202,8 @@ class JobManager:
                     await runner
                 except asyncio.CancelledError:
                     pass
+            if job_id in self._monitor_terminalized_jobs:
+                return
             await self._append_event(
                 "mcp.job.cancelled",
                 job_id,
@@ -259,6 +262,7 @@ class JobManager:
         finally:
             self._tasks.pop(job_id, None)
             self._runner_tasks.pop(job_id, None)
+            self._monitor_terminalized_jobs.discard(job_id)
             monitor = self._monitors.pop(job_id, None)
             if monitor is not None:
                 monitor.cancel()
@@ -279,6 +283,25 @@ class JobManager:
             if snapshot.is_terminal:
                 return
 
+            completed_result = await self._derive_completed_workflow_result(snapshot)
+            if completed_result is not None:
+                self._monitor_terminalized_jobs.add(job_id)
+                await self._append_event(
+                    "mcp.job.completed",
+                    job_id,
+                    {
+                        "status": JobStatus.COMPLETED.value,
+                        "message": "Job complete",
+                        "result_text": completed_result,
+                        "result_meta": {"completed_from_workflow_progress": True},
+                        "is_error": False,
+                    },
+                )
+                runner = self._runner_tasks.get(job_id)
+                if runner is not None and not runner.done():
+                    runner.cancel()
+                return
+
             message = await self._derive_status_message(snapshot)
             now = asyncio.get_running_loop().time()
             changed = message and message != last_message
@@ -290,6 +313,32 @@ class JobManager:
                 interval = 1.0  # Reset on change
             else:
                 interval = min(interval * 1.5, 5.0)  # Backoff up to 5s
+
+    async def _derive_completed_workflow_result(self, snapshot: JobSnapshot) -> str | None:
+        """Return a terminal result when linked workflow progress proves completion.
+
+        Background execution runners normally append the terminal job event when
+        the runtime exits. Some runtimes can satisfy every acceptance criterion
+        yet keep the process open; in that case the execution stream's workflow
+        progress is the authoritative completion evidence for the job surface.
+        """
+        if not snapshot.links.execution_id:
+            return None
+        workflow_events = await self._event_store.query_events(
+            aggregate_id=snapshot.links.execution_id,
+            event_type="workflow.progress.updated",
+            limit=1,
+        )
+        if not workflow_events:
+            return None
+        data = workflow_events[0].data
+        completed = data.get("completed_count")
+        total = data.get("total_count")
+        if not (isinstance(completed, int) and isinstance(total, int)):
+            return None
+        if total <= 0 or completed < total:
+            return None
+        return f"Workflow complete: {completed}/{total} ACs completed"
 
     async def _derive_status_message(self, snapshot: JobSnapshot) -> str | None:
         """Summarize linked execution or lineage progress."""

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -117,6 +117,24 @@ def _snapshot_with_status_event(
     )
 
 
+def _execution_completed_job_event(job_id: str, result_text: str) -> BaseEvent:
+    """Build the synthetic/persisted job-completion event for execution recovery."""
+    return BaseEvent(
+        id=f"{_RECOVERED_COMPLETION_EVENT_ID_PREFIX}{job_id}",
+        type="mcp.job.completed",
+        aggregate_type="job",
+        aggregate_id=job_id,
+        data={
+            "status": JobStatus.COMPLETED.value,
+            "message": "Job complete",
+            "result_text": result_text,
+            "result_meta": {"completed_from_execution_terminal": True},
+            "is_error": False,
+            "timestamp": datetime.now(UTC).isoformat(),
+        },
+    )
+
+
 def _snapshot_with_terminal_event(
     snapshot: JobSnapshot,
     event: BaseEvent,
@@ -627,6 +645,12 @@ class JobManager:
         completed_result = await self._derive_completed_execution_result(snapshot)
         if completed_result is None:
             return snapshot
+        if getattr(self._event_store, "_read_only", False):
+            return _snapshot_with_terminal_event(
+                snapshot,
+                _execution_completed_job_event(snapshot.job_id, completed_result),
+                snapshot.cursor,
+            )
         lock = self._recovery_locks.setdefault(snapshot.job_id, asyncio.Lock())
         async with lock:
             events, cursor = await self._event_store.get_events_after(

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -266,6 +266,10 @@ class JobManager:
             snapshot = await self.get_snapshot(job_id)
             if snapshot.is_terminal:
                 return
+            completed_result = await self._derive_completed_execution_result(snapshot)
+            if completed_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
+                await self._append_execution_completed_event(job_id, completed_result)
+                return
             terminal_type = "mcp.job.completed"
             terminal_status = JobStatus.COMPLETED
             result_meta = getattr(result, "meta", {})

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -305,6 +305,10 @@ class JobManager:
             snapshot = await self.get_snapshot(job_id)
             if snapshot.is_terminal:
                 return
+            completed_result = await self._derive_completed_execution_result(snapshot)
+            if completed_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
+                await self._append_execution_completed_event(job_id, completed_result)
+                return
             await self._append_event(
                 "mcp.job.failed",
                 job_id,

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -94,7 +94,7 @@ class JobManager:
         self._tasks: dict[str, asyncio.Task[Any]] = {}
         self._runner_tasks: dict[str, asyncio.Task[Any]] = {}
         self._monitors: dict[str, asyncio.Task[None]] = {}
-        self._monitor_terminalized_jobs: set[str] = set()
+        self._workflow_completed_results: dict[str, str] = {}
         self._initialized = False
         self._known_job_ids: set[str] = set()
         self._reserved_job_ids: set[str] = set()
@@ -202,7 +202,10 @@ class JobManager:
                     await runner
                 except asyncio.CancelledError:
                     pass
-            if job_id in self._monitor_terminalized_jobs:
+            workflow_result = self._workflow_completed_results.get(job_id)
+            snapshot = await self.get_snapshot(job_id)
+            if workflow_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
+                await self._append_workflow_completed_event(job_id, workflow_result)
                 return
             await self._append_event(
                 "mcp.job.cancelled",
@@ -225,6 +228,10 @@ class JobManager:
             )
         else:
             snapshot = await self.get_snapshot(job_id)
+            workflow_result = self._workflow_completed_results.get(job_id)
+            if workflow_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
+                await self._append_workflow_completed_event(job_id, workflow_result)
+                return
             terminal_type = "mcp.job.completed"
             terminal_status = JobStatus.COMPLETED
             result_meta = getattr(result, "meta", {})
@@ -262,7 +269,7 @@ class JobManager:
         finally:
             self._tasks.pop(job_id, None)
             self._runner_tasks.pop(job_id, None)
-            self._monitor_terminalized_jobs.discard(job_id)
+            self._workflow_completed_results.pop(job_id, None)
             monitor = self._monitors.pop(job_id, None)
             if monitor is not None:
                 monitor.cancel()
@@ -283,24 +290,14 @@ class JobManager:
             if snapshot.is_terminal:
                 return
 
-            completed_result = await self._derive_completed_workflow_result(snapshot)
-            if completed_result is not None:
-                self._monitor_terminalized_jobs.add(job_id)
-                await self._append_event(
-                    "mcp.job.completed",
-                    job_id,
-                    {
-                        "status": JobStatus.COMPLETED.value,
-                        "message": "Job complete",
-                        "result_text": completed_result,
-                        "result_meta": {"completed_from_workflow_progress": True},
-                        "is_error": False,
-                    },
-                )
-                runner = self._runner_tasks.get(job_id)
-                if runner is not None and not runner.done():
-                    runner.cancel()
-                return
+            if snapshot.status != JobStatus.CANCEL_REQUESTED:
+                completed_result = await self._derive_completed_workflow_result(snapshot)
+                if completed_result is not None:
+                    self._workflow_completed_results[job_id] = completed_result
+                    runner = self._runner_tasks.get(job_id)
+                    if runner is not None and not runner.done():
+                        runner.cancel()
+                    return
 
             message = await self._derive_status_message(snapshot)
             now = asyncio.get_running_loop().time()
@@ -313,6 +310,20 @@ class JobManager:
                 interval = 1.0  # Reset on change
             else:
                 interval = min(interval * 1.5, 5.0)  # Backoff up to 5s
+
+    async def _append_workflow_completed_event(self, job_id: str, result_text: str) -> None:
+        """Persist runner-owned completion derived from workflow progress evidence."""
+        await self._append_event(
+            "mcp.job.completed",
+            job_id,
+            {
+                "status": JobStatus.COMPLETED.value,
+                "message": "Job complete",
+                "result_text": result_text,
+                "result_meta": {"completed_from_workflow_progress": True},
+                "is_error": False,
+            },
+        )
 
     async def _derive_completed_workflow_result(self, snapshot: JobSnapshot) -> str | None:
         """Return a terminal result when linked workflow progress proves completion.

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -94,6 +94,27 @@ def _latest_job_terminal_event(events: list[BaseEvent]) -> BaseEvent | None:
     return next((event for event in reversed(events) if event.type in terminal_types), None)
 
 
+def _latest_job_status_event(events: list[BaseEvent]) -> BaseEvent | None:
+    """Return the latest job event carrying a status field."""
+    return next((event for event in reversed(events) if "status" in event.data), None)
+
+
+def _snapshot_with_status_event(
+    snapshot: JobSnapshot,
+    event: BaseEvent,
+    cursor: int,
+) -> JobSnapshot:
+    """Project a non-terminal status event onto an existing reconstructed snapshot."""
+    data = event.data
+    return replace(
+        snapshot,
+        status=JobStatus(data.get("status", snapshot.status.value)),
+        message=data.get("message", snapshot.message),
+        updated_at=event.timestamp,
+        cursor=cursor,
+    )
+
+
 def _snapshot_with_terminal_event(
     snapshot: JobSnapshot,
     event: BaseEvent,
@@ -610,6 +631,12 @@ class JobManager:
             existing_terminal = _latest_job_terminal_event(events)
             if existing_terminal is not None:
                 return _snapshot_with_terminal_event(snapshot, existing_terminal, cursor)
+            latest_status_event = _latest_job_status_event(events)
+            if (
+                latest_status_event is not None
+                and latest_status_event.data.get("status") == JobStatus.CANCEL_REQUESTED.value
+            ):
+                return _snapshot_with_status_event(snapshot, latest_status_event, cursor)
             completed = await self._append_execution_completed_event(
                 snapshot.job_id,
                 completed_result,

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -11,6 +11,7 @@ import logging
 from typing import Any
 from uuid import uuid4
 
+from ouroboros.core.errors import PersistenceError
 from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.agent_process import AgentProcessHandle
 from ouroboros.orchestrator.events import create_execution_terminal_event
@@ -80,6 +81,7 @@ def _safe_meta(value: Any) -> Any:
 
 
 _JOB_TTL = timedelta(hours=1)
+_RECOVERED_COMPLETION_EVENT_ID_PREFIX = "mcp-job-recovered-completed-"
 logger = logging.getLogger(__name__)
 
 
@@ -374,6 +376,7 @@ class JobManager:
         result_text: str,
         *,
         check_current: bool = True,
+        event_id: str | None = None,
     ) -> bool:
         """Persist durable job completion derived from terminal execution evidence."""
         if check_current:
@@ -390,6 +393,7 @@ class JobManager:
                 "result_meta": {"completed_from_execution_terminal": True},
                 "is_error": False,
             },
+            event_id=event_id,
         )
         return True
 
@@ -637,11 +641,21 @@ class JobManager:
                 and latest_status_event.data.get("status") == JobStatus.CANCEL_REQUESTED.value
             ):
                 return _snapshot_with_status_event(snapshot, latest_status_event, cursor)
-            completed = await self._append_execution_completed_event(
-                snapshot.job_id,
-                completed_result,
-                check_current=False,
-            )
+            try:
+                completed = await self._append_execution_completed_event(
+                    snapshot.job_id,
+                    completed_result,
+                    check_current=False,
+                    event_id=f"{_RECOVERED_COMPLETION_EVENT_ID_PREFIX}{snapshot.job_id}",
+                )
+            except PersistenceError:
+                events, cursor = await self._event_store.get_events_after(
+                    "job", snapshot.job_id, last_row_id=0
+                )
+                existing_terminal = _latest_job_terminal_event(events)
+                if existing_terminal is not None:
+                    return _snapshot_with_terminal_event(snapshot, existing_terminal, cursor)
+                raise
             if not completed:
                 return snapshot
             events, cursor = await self._event_store.get_events_after(
@@ -955,11 +969,19 @@ class JobManager:
             self._monitors.pop(job_id, None)
         return len(expired)
 
-    async def _append_event(self, event_type: str, job_id: str, data: dict[str, Any]) -> None:
+    async def _append_event(
+        self,
+        event_type: str,
+        job_id: str,
+        data: dict[str, Any],
+        *,
+        event_id: str | None = None,
+    ) -> None:
         """Persist one job event."""
         await self._ensure_initialized()
         await self._event_store.append(
             BaseEvent(
+                id=event_id or str(uuid4()),
                 type=event_type,
                 aggregate_type="job",
                 aggregate_id=job_id,

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -94,7 +94,6 @@ class JobManager:
         self._tasks: dict[str, asyncio.Task[Any]] = {}
         self._runner_tasks: dict[str, asyncio.Task[Any]] = {}
         self._monitors: dict[str, asyncio.Task[None]] = {}
-        self._execution_completed_results: dict[str, str] = {}
         self._initialized = False
         self._known_job_ids: set[str] = set()
         self._reserved_job_ids: set[str] = set()
@@ -196,17 +195,15 @@ class JobManager:
         try:
             result = await runner
         except asyncio.CancelledError:
+            snapshot = await self.get_snapshot(job_id)
+            if snapshot.is_terminal:
+                return
             if not runner.done():
                 runner.cancel()
                 try:
                     await runner
                 except asyncio.CancelledError:
                     pass
-            workflow_result = self._execution_completed_results.get(job_id)
-            snapshot = await self.get_snapshot(job_id)
-            if workflow_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
-                await self._append_execution_completed_event(job_id, workflow_result)
-                return
             await self._append_event(
                 "mcp.job.cancelled",
                 job_id,
@@ -217,6 +214,9 @@ class JobManager:
             )
             raise
         except Exception as exc:
+            snapshot = await self.get_snapshot(job_id)
+            if snapshot.is_terminal:
+                return
             await self._append_event(
                 "mcp.job.failed",
                 job_id,
@@ -228,9 +228,7 @@ class JobManager:
             )
         else:
             snapshot = await self.get_snapshot(job_id)
-            workflow_result = self._execution_completed_results.get(job_id)
-            if workflow_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
-                await self._append_execution_completed_event(job_id, workflow_result)
+            if snapshot.is_terminal:
                 return
             terminal_type = "mcp.job.completed"
             terminal_status = JobStatus.COMPLETED
@@ -269,7 +267,6 @@ class JobManager:
         finally:
             self._tasks.pop(job_id, None)
             self._runner_tasks.pop(job_id, None)
-            self._execution_completed_results.pop(job_id, None)
             monitor = self._monitors.pop(job_id, None)
             if monitor is not None:
                 monitor.cancel()
@@ -293,7 +290,12 @@ class JobManager:
             if snapshot.status != JobStatus.CANCEL_REQUESTED:
                 completed_result = await self._derive_completed_execution_result(snapshot)
                 if completed_result is not None:
-                    self._execution_completed_results[job_id] = completed_result
+                    completed = await self._append_execution_completed_event(
+                        job_id,
+                        completed_result,
+                    )
+                    if not completed:
+                        return
                     runner = self._runner_tasks.get(job_id)
                     if runner is not None and not runner.done():
                         runner.cancel()
@@ -311,8 +313,11 @@ class JobManager:
             else:
                 interval = min(interval * 1.5, 5.0)  # Backoff up to 5s
 
-    async def _append_execution_completed_event(self, job_id: str, result_text: str) -> None:
-        """Persist runner-owned completion derived from terminal execution evidence."""
+    async def _append_execution_completed_event(self, job_id: str, result_text: str) -> bool:
+        """Persist durable job completion derived from terminal execution evidence."""
+        snapshot = await self.get_snapshot(job_id)
+        if snapshot.is_terminal or snapshot.status == JobStatus.CANCEL_REQUESTED:
+            return False
         await self._append_event(
             "mcp.job.completed",
             job_id,
@@ -324,6 +329,7 @@ class JobManager:
                 "is_error": False,
             },
         )
+        return True
 
     async def _derive_completed_execution_result(self, snapshot: JobSnapshot) -> str | None:
         """Return a terminal result when linked execution state proves completion.
@@ -357,7 +363,12 @@ class JobManager:
             data = workflow_events[0].data
             completed = data.get("completed_count")
             total = data.get("total_count")
-            if isinstance(completed, int) and isinstance(total, int) and total > 0:
+            if (
+                isinstance(completed, int)
+                and isinstance(total, int)
+                and total > 0
+                and completed >= total
+            ):
                 return f"Execution complete: {completed}/{total} ACs completed"
         return "Execution complete"
 

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -94,7 +94,7 @@ class JobManager:
         self._tasks: dict[str, asyncio.Task[Any]] = {}
         self._runner_tasks: dict[str, asyncio.Task[Any]] = {}
         self._monitors: dict[str, asyncio.Task[None]] = {}
-        self._workflow_completed_results: dict[str, str] = {}
+        self._execution_completed_results: dict[str, str] = {}
         self._initialized = False
         self._known_job_ids: set[str] = set()
         self._reserved_job_ids: set[str] = set()
@@ -202,10 +202,10 @@ class JobManager:
                     await runner
                 except asyncio.CancelledError:
                     pass
-            workflow_result = self._workflow_completed_results.get(job_id)
+            workflow_result = self._execution_completed_results.get(job_id)
             snapshot = await self.get_snapshot(job_id)
             if workflow_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
-                await self._append_workflow_completed_event(job_id, workflow_result)
+                await self._append_execution_completed_event(job_id, workflow_result)
                 return
             await self._append_event(
                 "mcp.job.cancelled",
@@ -228,9 +228,9 @@ class JobManager:
             )
         else:
             snapshot = await self.get_snapshot(job_id)
-            workflow_result = self._workflow_completed_results.get(job_id)
+            workflow_result = self._execution_completed_results.get(job_id)
             if workflow_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
-                await self._append_workflow_completed_event(job_id, workflow_result)
+                await self._append_execution_completed_event(job_id, workflow_result)
                 return
             terminal_type = "mcp.job.completed"
             terminal_status = JobStatus.COMPLETED
@@ -269,7 +269,7 @@ class JobManager:
         finally:
             self._tasks.pop(job_id, None)
             self._runner_tasks.pop(job_id, None)
-            self._workflow_completed_results.pop(job_id, None)
+            self._execution_completed_results.pop(job_id, None)
             monitor = self._monitors.pop(job_id, None)
             if monitor is not None:
                 monitor.cancel()
@@ -291,9 +291,9 @@ class JobManager:
                 return
 
             if snapshot.status != JobStatus.CANCEL_REQUESTED:
-                completed_result = await self._derive_completed_workflow_result(snapshot)
+                completed_result = await self._derive_completed_execution_result(snapshot)
                 if completed_result is not None:
-                    self._workflow_completed_results[job_id] = completed_result
+                    self._execution_completed_results[job_id] = completed_result
                     runner = self._runner_tasks.get(job_id)
                     if runner is not None and not runner.done():
                         runner.cancel()
@@ -311,8 +311,8 @@ class JobManager:
             else:
                 interval = min(interval * 1.5, 5.0)  # Backoff up to 5s
 
-    async def _append_workflow_completed_event(self, job_id: str, result_text: str) -> None:
-        """Persist runner-owned completion derived from workflow progress evidence."""
+    async def _append_execution_completed_event(self, job_id: str, result_text: str) -> None:
+        """Persist runner-owned completion derived from terminal execution evidence."""
         await self._append_event(
             "mcp.job.completed",
             job_id,
@@ -320,36 +320,46 @@ class JobManager:
                 "status": JobStatus.COMPLETED.value,
                 "message": "Job complete",
                 "result_text": result_text,
-                "result_meta": {"completed_from_workflow_progress": True},
+                "result_meta": {"completed_from_execution_terminal": True},
                 "is_error": False,
             },
         )
 
-    async def _derive_completed_workflow_result(self, snapshot: JobSnapshot) -> str | None:
-        """Return a terminal result when linked workflow progress proves completion.
+    async def _derive_completed_execution_result(self, snapshot: JobSnapshot) -> str | None:
+        """Return a terminal result when linked execution state proves completion.
 
         Background execution runners normally append the terminal job event when
-        the runtime exits. Some runtimes can satisfy every acceptance criterion
-        yet keep the process open; in that case the execution stream's workflow
-        progress is the authoritative completion evidence for the job surface.
+        the MCP handler returns. If the execution stream has already emitted its
+        source-of-truth ``execution.terminal`` completion but the handler remains
+        open, the job can finish from that terminal execution evidence.
+        ``workflow.progress.updated`` remains observational and is used only to
+        enrich the result text.
         """
         if not snapshot.links.execution_id:
             return None
+        terminal_events = await self._event_store.query_events(
+            aggregate_id=snapshot.links.execution_id,
+            event_type="execution.terminal",
+            limit=1,
+        )
+        if not terminal_events:
+            return None
+        terminal_data = terminal_events[0].data
+        if terminal_data.get("status") != "completed":
+            return None
+
         workflow_events = await self._event_store.query_events(
             aggregate_id=snapshot.links.execution_id,
             event_type="workflow.progress.updated",
             limit=1,
         )
-        if not workflow_events:
-            return None
-        data = workflow_events[0].data
-        completed = data.get("completed_count")
-        total = data.get("total_count")
-        if not (isinstance(completed, int) and isinstance(total, int)):
-            return None
-        if total <= 0 or completed < total:
-            return None
-        return f"Workflow complete: {completed}/{total} ACs completed"
+        if workflow_events:
+            data = workflow_events[0].data
+            completed = data.get("completed_count")
+            total = data.get("total_count")
+            if isinstance(completed, int) and isinstance(total, int) and total > 0:
+                return f"Execution complete: {completed}/{total} ACs completed"
+        return "Execution complete"
 
     async def _derive_status_message(self, snapshot: JobSnapshot) -> str | None:
         """Summarize linked execution or lineage progress."""

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -555,6 +555,70 @@ class TestJobManager:
         finally:
             await store.close()
 
+    async def test_completed_execution_recovery_is_non_mutating_for_read_only_store(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        database_url = store._database_url
+
+        try:
+            await store.initialize()
+            await store.append(
+                BaseEvent(
+                    type="mcp.job.created",
+                    aggregate_type="job",
+                    aggregate_id="job_recover_read_only",
+                    data={
+                        "job_type": "execute_seed",
+                        "status": JobStatus.RUNNING.value,
+                        "message": "Running execute_seed",
+                        "links": {
+                            "session_id": "orch_recover_read_only",
+                            "execution_id": "exec_recover_read_only",
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_recover_read_only",
+                    data={"session_id": "orch_recover_read_only", "status": "completed"},
+                )
+            )
+        finally:
+            await store.close()
+
+        read_only_store = EventStore(database_url, read_only=True)
+        read_only_manager = JobManager(read_only_store)
+        try:
+            await read_only_store.initialize(create_schema=False)
+            snapshot = await read_only_manager.get_snapshot("job_recover_read_only")
+
+            assert snapshot.status is JobStatus.COMPLETED
+            assert snapshot.result_meta["completed_from_execution_terminal"] is True
+            events, _ = await read_only_store.get_events_after(
+                "job",
+                "job_recover_read_only",
+                last_row_id=0,
+            )
+            terminal_events = [
+                event.type
+                for event in events
+                if event.type
+                in {
+                    "mcp.job.completed",
+                    "mcp.job.failed",
+                    "mcp.job.cancelled",
+                    "mcp.job.interrupted",
+                }
+            ]
+            assert terminal_events == []
+        finally:
+            await read_only_store.close()
+
     async def test_completed_execution_recovery_does_not_beat_concurrent_cancel_request(
         self, tmp_path
     ) -> None:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -132,7 +132,9 @@ class TestJobManager:
         finally:
             await store.close()
 
-    async def test_monitor_completes_job_when_workflow_progress_is_complete(self, tmp_path) -> None:
+    async def test_monitor_completes_job_when_execution_terminal_is_complete(
+        self, tmp_path
+    ) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)
 
@@ -164,13 +166,21 @@ class TestJobManager:
                     },
                 )
             )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_complete",
+                    data={"session_id": "orch_complete", "status": "completed"},
+                )
+            )
 
             snapshot = await _wait_for_job_status(
                 manager, started.job_id, JobStatus.COMPLETED, timeout=2.0
             )
 
-            assert snapshot.result_text == "Workflow complete: 2/2 ACs completed"
-            assert snapshot.result_meta["completed_from_workflow_progress"] is True
+            assert snapshot.result_text == "Execution complete: 2/2 ACs completed"
+            assert snapshot.result_meta["completed_from_execution_terminal"] is True
             events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
             terminal_events = [
                 event
@@ -189,7 +199,7 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
-    async def test_cancel_requested_wins_over_complete_workflow_progress(self, tmp_path) -> None:
+    async def test_cancel_requested_wins_over_complete_execution_terminal(self, tmp_path) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)
 
@@ -211,14 +221,10 @@ class TestJobManager:
             )
             await store.append(
                 BaseEvent(
-                    type="workflow.progress.updated",
+                    type="execution.terminal",
                     aggregate_type="execution",
                     aggregate_id="exec_cancel",
-                    data={
-                        "completed_count": 2,
-                        "total_count": 2,
-                        "current_phase": "Deliver",
-                    },
+                    data={"session_id": "orch_cancel", "status": "completed"},
                 )
             )
 
@@ -229,13 +235,13 @@ class TestJobManager:
             snapshot = await manager.get_snapshot(started.job_id)
 
             assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
-            assert snapshot.result_meta.get("completed_from_workflow_progress") is not True
+            assert snapshot.result_meta.get("completed_from_execution_terminal") is not True
         finally:
             stop.set()
             await _cancel_manager_tasks(manager)
             await store.close()
 
-    async def test_workflow_completion_waits_for_runner_cancellation_before_terminal_event(
+    async def test_execution_completion_waits_for_runner_cancellation_before_job_terminal_event(
         self, tmp_path
     ) -> None:
         store = _build_store(tmp_path)
@@ -268,6 +274,14 @@ class TestJobManager:
                     data={"completed_count": 1, "total_count": 1},
                 )
             )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_wait",
+                    data={"session_id": "orch_wait", "status": "completed"},
+                )
+            )
 
             await asyncio.wait_for(cancel_seen.wait(), timeout=2)
             snapshot = await manager.get_snapshot(started.job_id)
@@ -278,7 +292,7 @@ class TestJobManager:
                 manager, started.job_id, JobStatus.COMPLETED, timeout=2.0
             )
 
-            assert snapshot.result_text == "Workflow complete: 1/1 ACs completed"
+            assert snapshot.result_text == "Execution complete: 1/1 ACs completed"
             events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
             assert [
                 event.type
@@ -290,7 +304,7 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
-    async def test_cancel_requested_wins_after_workflow_completion_is_staged(
+    async def test_cancel_requested_wins_after_execution_completion_is_staged(
         self, tmp_path
     ) -> None:
         store = _build_store(tmp_path)
@@ -317,10 +331,10 @@ class TestJobManager:
             )
             await store.append(
                 BaseEvent(
-                    type="workflow.progress.updated",
+                    type="execution.terminal",
                     aggregate_type="execution",
                     aggregate_id="exec_staged_cancel",
-                    data={"completed_count": 1, "total_count": 1},
+                    data={"session_id": "orch_staged_cancel", "status": "completed"},
                 )
             )
 
@@ -334,7 +348,7 @@ class TestJobManager:
                 manager, started.job_id, JobStatus.CANCELLED, timeout=2.0
             )
 
-            assert snapshot.result_meta.get("completed_from_workflow_progress") is not True
+            assert snapshot.result_meta.get("completed_from_execution_terminal") is not True
             events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
             terminal_events = [
                 event.type
@@ -350,6 +364,44 @@ class TestJobManager:
             assert terminal_events == ["mcp.job.cancelled"]
         finally:
             release.set()
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_complete_workflow_progress_without_terminal_event_does_not_complete_job(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+            stop = asyncio.Event()
+
+            async def _runner() -> MCPToolResult:
+                await stop.wait()
+                return MCPToolResult()
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id="orch_progress_only", execution_id="exec_progress_only"),
+            )
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_progress_only",
+                    data={"completed_count": 1, "total_count": 1},
+                )
+            )
+
+            await asyncio.sleep(1.2)
+            snapshot = await manager.get_snapshot(started.job_id)
+
+            assert snapshot.is_terminal is False
+            assert snapshot.result_meta.get("completed_from_execution_terminal") is not True
+        finally:
+            stop.set()
             await _cancel_manager_tasks(manager)
             await store.close()
 

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -132,7 +132,6 @@ class TestJobManager:
         finally:
             await store.close()
 
-
     async def test_monitor_completes_job_when_workflow_progress_is_complete(self, tmp_path) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)
@@ -172,8 +171,185 @@ class TestJobManager:
 
             assert snapshot.result_text == "Workflow complete: 2/2 ACs completed"
             assert snapshot.result_meta["completed_from_workflow_progress"] is True
+            events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
+            terminal_events = [
+                event
+                for event in events
+                if event.type
+                in {
+                    "mcp.job.completed",
+                    "mcp.job.failed",
+                    "mcp.job.cancelled",
+                    "mcp.job.interrupted",
+                }
+            ]
+            assert [event.type for event in terminal_events] == ["mcp.job.completed"]
         finally:
             stop.set()
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_cancel_requested_wins_over_complete_workflow_progress(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+            stop = asyncio.Event()
+
+            async def _runner() -> MCPToolResult:
+                await stop.wait()
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late done"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id="orch_cancel", execution_id="exec_cancel"),
+            )
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_cancel",
+                    data={
+                        "completed_count": 2,
+                        "total_count": 2,
+                        "current_phase": "Deliver",
+                    },
+                )
+            )
+
+            snapshot = await manager.cancel_job(started.job_id)
+            assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
+
+            await asyncio.sleep(1.2)
+            snapshot = await manager.get_snapshot(started.job_id)
+
+            assert snapshot.status in {JobStatus.CANCEL_REQUESTED, JobStatus.CANCELLED}
+            assert snapshot.result_meta.get("completed_from_workflow_progress") is not True
+        finally:
+            stop.set()
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_workflow_completion_waits_for_runner_cancellation_before_terminal_event(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+            cancel_seen = asyncio.Event()
+            release = asyncio.Event()
+
+            async def _runner() -> MCPToolResult:
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    cancel_seen.set()
+                    await release.wait()
+                    raise
+                return MCPToolResult()
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id="orch_wait", execution_id="exec_wait"),
+            )
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_wait",
+                    data={"completed_count": 1, "total_count": 1},
+                )
+            )
+
+            await asyncio.wait_for(cancel_seen.wait(), timeout=2)
+            snapshot = await manager.get_snapshot(started.job_id)
+            assert snapshot.is_terminal is False
+
+            release.set()
+            snapshot = await _wait_for_job_status(
+                manager, started.job_id, JobStatus.COMPLETED, timeout=2.0
+            )
+
+            assert snapshot.result_text == "Workflow complete: 1/1 ACs completed"
+            events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
+            assert [
+                event.type
+                for event in events
+                if event.type.startswith("mcp.job.") and event.type != "mcp.job.updated"
+            ].count("mcp.job.completed") == 1
+        finally:
+            release.set()
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_cancel_requested_wins_after_workflow_completion_is_staged(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+            cancel_seen = asyncio.Event()
+            release = asyncio.Event()
+
+            async def _runner() -> MCPToolResult:
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    cancel_seen.set()
+                    await release.wait()
+                    raise
+                return MCPToolResult()
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id="orch_staged_cancel", execution_id="exec_staged_cancel"),
+            )
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_staged_cancel",
+                    data={"completed_count": 1, "total_count": 1},
+                )
+            )
+
+            await asyncio.wait_for(cancel_seen.wait(), timeout=2)
+            await manager.update_status(
+                started.job_id, JobStatus.CANCEL_REQUESTED, "Cancellation requested"
+            )
+
+            release.set()
+            snapshot = await _wait_for_job_status(
+                manager, started.job_id, JobStatus.CANCELLED, timeout=2.0
+            )
+
+            assert snapshot.result_meta.get("completed_from_workflow_progress") is not True
+            events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
+            terminal_events = [
+                event.type
+                for event in events
+                if event.type
+                in {
+                    "mcp.job.completed",
+                    "mcp.job.failed",
+                    "mcp.job.cancelled",
+                    "mcp.job.interrupted",
+                }
+            ]
+            assert terminal_events == ["mcp.job.cancelled"]
+        finally:
+            release.set()
             await _cancel_manager_tasks(manager)
             await store.close()
 

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -371,6 +371,63 @@ class TestJobManager:
         finally:
             await store.close()
 
+    async def test_completed_execution_recovery_writes_single_terminal_event_with_concurrent_readers(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+            await store.initialize()
+            await store.append(
+                BaseEvent(
+                    type="mcp.job.created",
+                    aggregate_type="job",
+                    aggregate_id="job_recover_race",
+                    data={
+                        "job_type": "execute_seed",
+                        "status": JobStatus.RUNNING.value,
+                        "message": "Running execute_seed",
+                        "links": {
+                            "session_id": "orch_recover_race",
+                            "execution_id": "exec_recover_race",
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_recover_race",
+                    data={"session_id": "orch_recover_race", "status": "completed"},
+                )
+            )
+
+            first, second = await asyncio.gather(
+                manager.get_snapshot("job_recover_race"),
+                manager.get_snapshot("job_recover_race"),
+            )
+
+            assert first.status is JobStatus.COMPLETED
+            assert second.status is JobStatus.COMPLETED
+            events, _ = await store.get_events_after("job", "job_recover_race", last_row_id=0)
+            terminal_events = [
+                event.type
+                for event in events
+                if event.type
+                in {
+                    "mcp.job.completed",
+                    "mcp.job.failed",
+                    "mcp.job.cancelled",
+                    "mcp.job.interrupted",
+                }
+            ]
+            assert terminal_events == ["mcp.job.completed"]
+        finally:
+            await store.close()
+
     async def test_complete_workflow_progress_without_terminal_event_does_not_complete_job(
         self, tmp_path
     ) -> None:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -505,6 +505,68 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
+    async def test_execution_terminal_completion_overrides_runner_cancel_exception(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+            cancel_seen = asyncio.Event()
+
+            async def _runner() -> MCPToolResult:
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError as exc:
+                    cancel_seen.set()
+                    raise RuntimeError("cleanup failed after terminal execution") from exc
+                return MCPToolResult()
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(
+                    session_id="orch_cancel_exception",
+                    execution_id="exec_cancel_exception",
+                ),
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_cancel_exception",
+                    data={"session_id": "orch_cancel_exception", "status": "completed"},
+                )
+            )
+
+            await asyncio.wait_for(cancel_seen.wait(), timeout=2)
+            snapshot = await _wait_for_job_status(
+                manager,
+                started.job_id,
+                JobStatus.COMPLETED,
+                timeout=2.0,
+            )
+
+            assert snapshot.result_meta["completed_from_execution_terminal"] is True
+            assert snapshot.error is None
+            events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
+            terminal_events = [
+                event.type
+                for event in events
+                if event.type
+                in {
+                    "mcp.job.completed",
+                    "mcp.job.failed",
+                    "mcp.job.cancelled",
+                    "mcp.job.interrupted",
+                }
+            ]
+            assert terminal_events == ["mcp.job.completed"]
+        finally:
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_completed_execution_recovery_writes_single_terminal_event_with_concurrent_readers(
         self, tmp_path
     ) -> None:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -493,6 +493,68 @@ class TestJobManager:
         finally:
             await store.close()
 
+    async def test_completed_execution_recovery_is_idempotent_across_managers(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        first_manager = JobManager(store)
+        second_manager = JobManager(store)
+
+        try:
+            await store.initialize()
+            await store.append(
+                BaseEvent(
+                    type="mcp.job.created",
+                    aggregate_type="job",
+                    aggregate_id="job_recover_multi_manager",
+                    data={
+                        "job_type": "execute_seed",
+                        "status": JobStatus.RUNNING.value,
+                        "message": "Running execute_seed",
+                        "links": {
+                            "session_id": "orch_recover_multi_manager",
+                            "execution_id": "exec_recover_multi_manager",
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_recover_multi_manager",
+                    data={"session_id": "orch_recover_multi_manager", "status": "completed"},
+                )
+            )
+
+            first, second = await asyncio.gather(
+                first_manager.get_snapshot("job_recover_multi_manager"),
+                second_manager.get_snapshot("job_recover_multi_manager"),
+            )
+
+            assert first.status is JobStatus.COMPLETED
+            assert second.status is JobStatus.COMPLETED
+            events, _ = await store.get_events_after(
+                "job",
+                "job_recover_multi_manager",
+                last_row_id=0,
+            )
+            terminal_events = [
+                event.type
+                for event in events
+                if event.type
+                in {
+                    "mcp.job.completed",
+                    "mcp.job.failed",
+                    "mcp.job.cancelled",
+                    "mcp.job.interrupted",
+                }
+            ]
+            assert terminal_events == ["mcp.job.completed"]
+        finally:
+            await store.close()
+
     async def test_completed_execution_recovery_does_not_beat_concurrent_cancel_request(
         self, tmp_path
     ) -> None:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -132,6 +132,51 @@ class TestJobManager:
         finally:
             await store.close()
 
+
+    async def test_monitor_completes_job_when_workflow_progress_is_complete(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+            stop = asyncio.Event()
+
+            async def _runner() -> MCPToolResult:
+                await stop.wait()
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late done"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id="orch_complete", execution_id="exec_complete"),
+            )
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_complete",
+                    data={
+                        "completed_count": 2,
+                        "total_count": 2,
+                        "current_phase": "Deliver",
+                    },
+                )
+            )
+
+            snapshot = await _wait_for_job_status(
+                manager, started.job_id, JobStatus.COMPLETED, timeout=2.0
+            )
+
+            assert snapshot.result_text == "Workflow complete: 2/2 ACs completed"
+            assert snapshot.result_meta["completed_from_workflow_progress"] is True
+        finally:
+            stop.set()
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_start_job_completes_and_persists_result(self, tmp_path) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -493,6 +493,82 @@ class TestJobManager:
         finally:
             await store.close()
 
+    async def test_completed_execution_recovery_does_not_beat_concurrent_cancel_request(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+            await store.initialize()
+            await store.append(
+                BaseEvent(
+                    type="mcp.job.created",
+                    aggregate_type="job",
+                    aggregate_id="job_recover_cancel_race",
+                    data={
+                        "job_type": "execute_seed",
+                        "status": JobStatus.RUNNING.value,
+                        "message": "Running execute_seed",
+                        "links": {
+                            "session_id": "orch_recover_cancel_race",
+                            "execution_id": "exec_recover_cancel_race",
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_recover_cancel_race",
+                    data={"session_id": "orch_recover_cancel_race", "status": "completed"},
+                )
+            )
+            recovery_lock = manager._recovery_locks.setdefault(
+                "job_recover_cancel_race",
+                asyncio.Lock(),
+            )
+            await recovery_lock.acquire()
+            snapshot_task = asyncio.create_task(manager.get_snapshot("job_recover_cancel_race"))
+            await asyncio.sleep(0)
+            await store.append(
+                BaseEvent(
+                    type="mcp.job.updated",
+                    aggregate_type="job",
+                    aggregate_id="job_recover_cancel_race",
+                    data={
+                        "status": JobStatus.CANCEL_REQUESTED.value,
+                        "message": "Cancellation requested",
+                    },
+                )
+            )
+
+            recovery_lock.release()
+            snapshot = await snapshot_task
+
+            assert snapshot.status is JobStatus.CANCEL_REQUESTED
+            events, _ = await store.get_events_after(
+                "job",
+                "job_recover_cancel_race",
+                last_row_id=0,
+            )
+            terminal_events = [
+                event.type
+                for event in events
+                if event.type
+                in {
+                    "mcp.job.completed",
+                    "mcp.job.failed",
+                    "mcp.job.cancelled",
+                    "mcp.job.interrupted",
+                }
+            ]
+            assert terminal_events == []
+        finally:
+            await store.close()
+
     async def test_complete_workflow_progress_without_terminal_event_does_not_complete_job(
         self, tmp_path
     ) -> None:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -371,6 +371,71 @@ class TestJobManager:
         finally:
             await store.close()
 
+    async def test_execution_terminal_completion_overrides_runner_cancel_result(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+            cancel_seen = asyncio.Event()
+
+            async def _runner() -> MCPToolResult:
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    cancel_seen.set()
+                    return MCPToolResult(
+                        content=(MCPContentItem(type=ContentType.TEXT, text="cancelled"),),
+                        is_error=False,
+                        meta={"action": "cancelled"},
+                    )
+                return MCPToolResult()
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(
+                    session_id="orch_cancel_return",
+                    execution_id="exec_cancel_return",
+                ),
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_cancel_return",
+                    data={"session_id": "orch_cancel_return", "status": "completed"},
+                )
+            )
+
+            await asyncio.wait_for(cancel_seen.wait(), timeout=2)
+            snapshot = await _wait_for_job_status(
+                manager,
+                started.job_id,
+                JobStatus.COMPLETED,
+                timeout=2.0,
+            )
+
+            assert snapshot.result_meta["completed_from_execution_terminal"] is True
+            events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
+            terminal_events = [
+                event.type
+                for event in events
+                if event.type
+                in {
+                    "mcp.job.completed",
+                    "mcp.job.failed",
+                    "mcp.job.cancelled",
+                    "mcp.job.interrupted",
+                }
+            ]
+            assert terminal_events == ["mcp.job.completed"]
+        finally:
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_completed_execution_recovery_writes_single_terminal_event_with_concurrent_readers(
         self, tmp_path
     ) -> None:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -241,7 +241,7 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
-    async def test_execution_completion_persists_before_runner_cancellation_finishes(
+    async def test_execution_completion_waits_for_runner_cancellation_before_job_terminal_event(
         self, tmp_path
     ) -> None:
         store = _build_store(tmp_path)
@@ -284,11 +284,13 @@ class TestJobManager:
             )
 
             await asyncio.wait_for(cancel_seen.wait(), timeout=2)
+            snapshot = await manager.get_snapshot(started.job_id)
+            assert snapshot.is_terminal is False
+
+            release.set()
             snapshot = await _wait_for_job_status(
                 manager, started.job_id, JobStatus.COMPLETED, timeout=2.0
             )
-
-            release.set()
 
             assert snapshot.result_text == "Execution complete: 1/1 ACs completed"
             recovered = JobManager(store)
@@ -304,50 +306,56 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
-    async def test_execution_completion_does_not_depend_on_runner_cooperative_cancel(
+    async def test_completed_execution_recovers_after_restart_without_live_runner(
         self, tmp_path
     ) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)
 
         try:
-            cancel_seen = asyncio.Event()
-            release = asyncio.Event()
-
-            async def _runner() -> MCPToolResult:
-                try:
-                    await asyncio.sleep(10)
-                except asyncio.CancelledError:
-                    cancel_seen.set()
-                    try:
-                        await release.wait()
-                    except asyncio.CancelledError:
-                        raise
-                    raise
-                return MCPToolResult()
-
-            started = await manager.start_job(
-                job_type="execute_seed",
-                initial_message="queued",
-                runner=_runner(),
-                links=JobLinks(session_id="orch_stubborn", execution_id="exec_stubborn"),
+            await store.initialize()
+            await store.append(
+                BaseEvent(
+                    type="mcp.job.created",
+                    aggregate_type="job",
+                    aggregate_id="job_recover_complete",
+                    data={
+                        "job_type": "execute_seed",
+                        "status": JobStatus.QUEUED.value,
+                        "message": "queued",
+                        "links": {
+                            "session_id": "orch_recover",
+                            "execution_id": "exec_recover",
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="mcp.job.updated",
+                    aggregate_type="job",
+                    aggregate_id="job_recover_complete",
+                    data={
+                        "status": JobStatus.RUNNING.value,
+                        "message": "Running execute_seed",
+                    },
+                )
             )
             await store.append(
                 BaseEvent(
                     type="execution.terminal",
                     aggregate_type="execution",
-                    aggregate_id="exec_stubborn",
-                    data={"session_id": "orch_stubborn", "status": "completed"},
+                    aggregate_id="exec_recover",
+                    data={"session_id": "orch_recover", "status": "completed"},
                 )
             )
 
-            await asyncio.wait_for(cancel_seen.wait(), timeout=2)
-            snapshot = await _wait_for_job_status(
-                manager, started.job_id, JobStatus.COMPLETED, timeout=2.0
-            )
+            snapshot = await manager.get_snapshot("job_recover_complete")
 
+            assert snapshot.status is JobStatus.COMPLETED
             assert snapshot.result_meta["completed_from_execution_terminal"] is True
-            events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
+            events, _ = await store.get_events_after("job", "job_recover_complete", last_row_id=0)
             terminal_events = [
                 event.type
                 for event in events
@@ -361,8 +369,6 @@ class TestJobManager:
             ]
             assert terminal_events == ["mcp.job.completed"]
         finally:
-            release.set()
-            await _cancel_manager_tasks(manager)
             await store.close()
 
     async def test_complete_workflow_progress_without_terminal_event_does_not_complete_job(

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -241,7 +241,7 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
-    async def test_execution_completion_waits_for_runner_cancellation_before_job_terminal_event(
+    async def test_execution_completion_persists_before_runner_cancellation_finishes(
         self, tmp_path
     ) -> None:
         store = _build_store(tmp_path)
@@ -284,15 +284,15 @@ class TestJobManager:
             )
 
             await asyncio.wait_for(cancel_seen.wait(), timeout=2)
-            snapshot = await manager.get_snapshot(started.job_id)
-            assert snapshot.is_terminal is False
-
-            release.set()
             snapshot = await _wait_for_job_status(
                 manager, started.job_id, JobStatus.COMPLETED, timeout=2.0
             )
 
+            release.set()
+
             assert snapshot.result_text == "Execution complete: 1/1 ACs completed"
+            recovered = JobManager(store)
+            assert (await recovered.get_snapshot(started.job_id)).status is JobStatus.COMPLETED
             events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
             assert [
                 event.type
@@ -304,7 +304,7 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
-    async def test_cancel_requested_wins_after_execution_completion_is_staged(
+    async def test_execution_completion_does_not_depend_on_runner_cooperative_cancel(
         self, tmp_path
     ) -> None:
         store = _build_store(tmp_path)
@@ -319,7 +319,10 @@ class TestJobManager:
                     await asyncio.sleep(10)
                 except asyncio.CancelledError:
                     cancel_seen.set()
-                    await release.wait()
+                    try:
+                        await release.wait()
+                    except asyncio.CancelledError:
+                        raise
                     raise
                 return MCPToolResult()
 
@@ -327,28 +330,23 @@ class TestJobManager:
                 job_type="execute_seed",
                 initial_message="queued",
                 runner=_runner(),
-                links=JobLinks(session_id="orch_staged_cancel", execution_id="exec_staged_cancel"),
+                links=JobLinks(session_id="orch_stubborn", execution_id="exec_stubborn"),
             )
             await store.append(
                 BaseEvent(
                     type="execution.terminal",
                     aggregate_type="execution",
-                    aggregate_id="exec_staged_cancel",
-                    data={"session_id": "orch_staged_cancel", "status": "completed"},
+                    aggregate_id="exec_stubborn",
+                    data={"session_id": "orch_stubborn", "status": "completed"},
                 )
             )
 
             await asyncio.wait_for(cancel_seen.wait(), timeout=2)
-            await manager.update_status(
-                started.job_id, JobStatus.CANCEL_REQUESTED, "Cancellation requested"
-            )
-
-            release.set()
             snapshot = await _wait_for_job_status(
-                manager, started.job_id, JobStatus.CANCELLED, timeout=2.0
+                manager, started.job_id, JobStatus.COMPLETED, timeout=2.0
             )
 
-            assert snapshot.result_meta.get("completed_from_execution_terminal") is not True
+            assert snapshot.result_meta["completed_from_execution_terminal"] is True
             events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
             terminal_events = [
                 event.type
@@ -361,7 +359,7 @@ class TestJobManager:
                     "mcp.job.interrupted",
                 }
             ]
-            assert terminal_events == ["mcp.job.cancelled"]
+            assert terminal_events == ["mcp.job.completed"]
         finally:
             release.set()
             await _cancel_manager_tasks(manager)
@@ -400,6 +398,53 @@ class TestJobManager:
 
             assert snapshot.is_terminal is False
             assert snapshot.result_meta.get("completed_from_execution_terminal") is not True
+        finally:
+            stop.set()
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_execution_terminal_ignores_incomplete_progress_for_result_text(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+            stop = asyncio.Event()
+
+            async def _runner() -> MCPToolResult:
+                await stop.wait()
+                return MCPToolResult()
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id="orch_partial_progress", execution_id="exec_partial"),
+            )
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_partial",
+                    data={"completed_count": 1, "total_count": 2},
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_partial",
+                    data={"session_id": "orch_partial_progress", "status": "completed"},
+                )
+            )
+
+            snapshot = await _wait_for_job_status(
+                manager, started.job_id, JobStatus.COMPLETED, timeout=2.0
+            )
+
+            assert snapshot.result_text == "Execution complete"
+            assert snapshot.result_meta["completed_from_execution_terminal"] is True
         finally:
             stop.set()
             await _cancel_manager_tasks(manager)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, patch
 from ouroboros.core.types import Result
 from ouroboros.events.base import BaseEvent
 from ouroboros.events.lineage import lineage_generation_watchdog_decision
+from ouroboros.mcp import job_manager as job_manager_module
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobSnapshot, JobStatus
 from ouroboros.mcp.tools.job_handlers import (
     JobStatusHandler,
@@ -303,6 +304,74 @@ class TestJobManager:
             ].count("mcp.job.completed") == 1
         finally:
             release.set()
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_completed_execution_force_completes_noncooperative_live_runner(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        stop = asyncio.Event()
+        cancel_seen = asyncio.Event()
+
+        async def _runner() -> MCPToolResult:
+            while not stop.is_set():
+                try:
+                    await asyncio.sleep(10)
+                except asyncio.CancelledError:
+                    cancel_seen.set()
+                    continue
+            return MCPToolResult(content=(MCPContentItem(type=ContentType.TEXT, text="late"),))
+
+        runner_task = asyncio.create_task(_runner())
+        try:
+            with patch.object(
+                job_manager_module,
+                "_COMPLETED_EXECUTION_CANCEL_GRACE_SECONDS",
+                0.05,
+            ):
+                started = await manager.start_job(
+                    job_type="execute_seed",
+                    initial_message="queued",
+                    runner=runner_task,
+                    links=JobLinks(session_id="orch_stubborn", execution_id="exec_stubborn"),
+                )
+                await store.append(
+                    BaseEvent(
+                        type="workflow.progress.updated",
+                        aggregate_type="execution",
+                        aggregate_id="exec_stubborn",
+                        data={"completed_count": 1, "total_count": 1},
+                    )
+                )
+                await store.append(
+                    BaseEvent(
+                        type="execution.terminal",
+                        aggregate_type="execution",
+                        aggregate_id="exec_stubborn",
+                        data={"session_id": "orch_stubborn", "status": "completed"},
+                    )
+                )
+
+                await asyncio.wait_for(cancel_seen.wait(), timeout=2)
+                snapshot = await _wait_for_job_status(
+                    manager, started.job_id, JobStatus.COMPLETED, timeout=2.0
+                )
+
+                assert snapshot.result_text == "Execution complete: 1/1 ACs completed"
+                assert snapshot.result_meta["completed_from_execution_terminal"] is True
+                assert manager.has_live_job_task(started.job_id) is False
+                events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
+                assert [
+                    event.type
+                    for event in events
+                    if event.type.startswith("mcp.job.") and event.type != "mcp.job.updated"
+                ].count("mcp.job.completed") == 1
+        finally:
+            stop.set()
+            runner_task.cancel()
+            await asyncio.gather(runner_task, return_exceptions=True)
             await _cancel_manager_tasks(manager)
             await store.close()
 


### PR DESCRIPTION
## Summary
- let JobManager complete a linked `execute_seed` job only after the execution stream emits authoritative `execution.terminal` `completed` evidence
- keep `workflow.progress.updated` as observational status/result detail instead of promoting it to terminal job state
- preserve runner-owned terminalization: the monitor stages the completed result and cancels the runner, while `_run_job` writes the single job terminal event after runner cancellation/termination
- add regressions for cancellation precedence, no early terminal state, single terminal event emission, and progress-only non-completion

## Tests
- `uv run pytest tests/unit/mcp/test_job_manager.py -q`
- `uv run pytest tests/unit/mcp -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/ouroboros/mcp/job_manager.py tests/unit/mcp/test_job_manager.py`
- `git diff --check`
