### PR TITLE
fix(auto): keep observation status metadata out of ACs

### DIFF
--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -10,6 +10,18 @@ _AUTO_WRAPPER_CRITERIA = frozenset(
         "`ooo auto` is handled by ouroboros auto/mcp, not plain text",
         "final report includes auto session id, seed id, seed path, and test result",
         "final report includes auto session id, seed id, files changed, exact test command, and test result",
+        "manual fallback is not used",
+        "manual fallback was not used",
+        "manual fallback used: no",
+        "manual fallback used: false",
+        "previous blocker recurrence is reported",
+        "previous blocker recurrence: no",
+        "previous last_question blocker did not recur",
+        "previous seed grade c blocker did not recur",
+        "previous interview closure blocker did not recur",
+        "recursive auto invocation did not occur",
+        "recursive auto invocation occurred: no",
+        "report whether recursive auto invocation occurred",
     }
 )
 

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1568,6 +1568,7 @@ def _derive_goal_user_preferences(goal: str) -> dict[str, str]:
             "interpreted as normal text",
             "previous ",
             "manual fallback",
+            "recursive auto invocation",
         ),
     )
     if failure_lines:

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -54,7 +54,6 @@ def test_normalize_execution_acceptance_drops_auto_report_criteria() -> None:
     )
 
 
-
 def test_normalize_execution_acceptance_drops_observation_report_metadata() -> None:
     seed = _seed(
         "`hello_auto.py` exists.",
@@ -78,6 +77,7 @@ def test_normalize_execution_acceptance_drops_observation_report_metadata() -> N
         "`tests/test_hello_auto.py` exists.",
         "The targeted test command `uv run pytest tests/test_hello_auto.py` passes.",
     )
+
 
 def test_normalize_execution_acceptance_keeps_original_when_filter_would_empty() -> None:
     seed = _seed("Final report includes auto session id and seed id.")

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -48,12 +48,36 @@ def test_normalize_execution_acceptance_drops_auto_report_criteria() -> None:
     normalized = normalize_execution_acceptance(seed)
 
     assert normalized.acceptance_criteria == (
-        "Manual fallback is not used.",
         "`hello_auto.py` defines `hello_auto()` returning exactly `hello from ooo auto`.",
         "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
         "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
     )
 
+
+
+def test_normalize_execution_acceptance_drops_observation_report_metadata() -> None:
+    seed = _seed(
+        "`hello_auto.py` exists.",
+        "`tests/test_hello_auto.py` exists.",
+        "The targeted test command `uv run pytest tests/test_hello_auto.py` passes.",
+        "Manual fallback used: no.",
+        "Previous last_question blocker did not recur.",
+        "Previous Seed grade C blocker did not recur.",
+        "Previous interview closure blocker did not recur.",
+        "Recursive auto invocation occurred: no.",
+    ).model_copy(
+        update={
+            "goal": "Verify current ooo auto can create hello_auto.py and tests/test_hello_auto.py using ouroboros_auto."
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == (
+        "`hello_auto.py` exists.",
+        "`tests/test_hello_auto.py` exists.",
+        "The targeted test command `uv run pytest tests/test_hello_auto.py` passes.",
+    )
 
 def test_normalize_execution_acceptance_keeps_original_when_filter_would_empty() -> None:
     seed = _seed("Final report includes auto session id and seed id.")

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -276,8 +276,38 @@ def test_structured_auto_goal_filters_report_only_success_criteria() -> None:
     assert "acceptance_criteria" in preferences
     assert "manual fallback" not in preferences["acceptance_criteria"].casefold()
     assert "seed id" not in preferences["acceptance_criteria"].casefold()
+    assert "files changed" not in preferences["acceptance_criteria"].casefold()
     assert "uv run pytest tests/test_hello_auto.py" in preferences["acceptance_criteria"]
 
+
+
+def test_structured_auto_goal_filters_observation_status_reporting_criteria() -> None:
+    goal = """
+Goal:
+Verify current ooo auto can create hello_auto.py and tests/test_hello_auto.py.
+
+Success criteria:
+- `hello_auto.py` exists.
+- `tests/test_hello_auto.py` exists.
+- The targeted test command `uv run pytest tests/test_hello_auto.py` passes.
+- Manual fallback used: no.
+- Previous last_question blocker did not recur.
+- Previous Seed grade C blocker did not recur.
+- Recursive auto invocation occurred: no.
+
+Important dispatch rule:
+If `ouroboros_auto` is unavailable or interpreted as normal text, stop and report failure.
+"""
+
+    preferences = _derive_goal_user_preferences(goal)
+
+    assert preferences["acceptance_criteria"] == (
+        "`hello_auto.py` exists.\n"
+        "`tests/test_hello_auto.py` exists.\n"
+        "The targeted test command `uv run pytest tests/test_hello_auto.py` passes."
+    )
+    assert "Previous last_question" in preferences["failure_modes"]
+    assert "Manual fallback used: no." in preferences["failure_modes"]
 
 def test_structured_auto_goal_preserves_non_allowlisted_execution_criteria() -> None:
     goal = """

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -307,6 +307,7 @@ If `ouroboros_auto` is unavailable or interpreted as normal text, stop and repor
     )
     assert "Previous last_question" in preferences["failure_modes"]
     assert "Manual fallback used: no." in preferences["failure_modes"]
+    assert "Recursive auto invocation occurred: no." in preferences["failure_modes"]
 
 
 def test_structured_auto_goal_preserves_non_allowlisted_execution_criteria() -> None:

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -280,7 +280,6 @@ def test_structured_auto_goal_filters_report_only_success_criteria() -> None:
     assert "uv run pytest tests/test_hello_auto.py" in preferences["acceptance_criteria"]
 
 
-
 def test_structured_auto_goal_filters_observation_status_reporting_criteria() -> None:
     goal = """
 Goal:
@@ -308,6 +307,7 @@ If `ouroboros_auto` is unavailable or interpreted as normal text, stop and repor
     )
     assert "Previous last_question" in preferences["failure_modes"]
     assert "Manual fallback used: no." in preferences["failure_modes"]
+
 
 def test_structured_auto_goal_preserves_non_allowlisted_execution_criteria() -> None:
     goal = """


### PR DESCRIPTION
## Summary\n- filter auto-observation status/reporting lines such as manual fallback, previous blocker recurrence, and recursive-auto status from execution acceptance criteria\n- keep concrete implementation criteria for hello_auto observation prompts\n- preserve product requirements by keeping the filter gated to the known ooo auto hello_auto observation context\n\n## Tests\n- uv run pytest tests/unit/auto/test_execution_acceptance.py tests/unit/mcp/tools/test_auto_interview_construction.py -q\n- uv run ruff check src/ouroboros/auto/execution_acceptance.py tests/unit/auto/test_execution_acceptance.py tests/unit/mcp/tools/test_auto_interview_construction.py