### PR TITLE
Use validation-only evidence scope for test runs

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -178,8 +178,19 @@ _TEST_WORK_RE = re.compile(
     re.IGNORECASE,
 )
 _TEST_MUTATION_WORK_RE = re.compile(
+    r"("
     r"\b(?:add|write|create|implement|fix|update|extend|expand)\b.{0,60}\b"
-    r"(?:tests?|unit\s+tests?|integration\s+tests?|coverage|test_[\w.-]+\.py)\b",
+    r"(?:tests?|unit\s+tests?|integration\s+tests?|coverage|test_[\w.-]+\.py)\b"
+    r"|"
+    r"\b(?:tests?|unit\s+tests?|integration\s+tests?|test_[\w.-]+\.py)\b.{0,60}\b"
+    r"(?:cover|coverage)\b"
+    r"|"
+    r"\bcheck(?:ed)?\s+(?:tests?|unit\s+tests?|integration\s+tests?|test_[\w.-]+\.py)"
+    r"\s+into\b"
+    r"|"
+    r"\bcheck\s+in\b.{0,60}\b"
+    r"(?:tests?|unit\s+tests?|integration\s+tests?|test_[\w.-]+\.py)\b"
+    r")",
     re.IGNORECASE,
 )
 _VALIDATION_ONLY_ACTION_RE = re.compile(
@@ -265,6 +276,8 @@ def _is_validation_only_ac(ac_content: str) -> bool:
         return False
     if _TEST_MUTATION_WORK_RE.search(normalized):
         return False
+    if _CODE_MUTATION_ACTION_RE.search(normalized) and _CODE_WORK_SIGNAL_RE.search(normalized):
+        return False
     if _CODE_IMPLEMENTATION_ACTION_RE.search(normalized):
         return False
     if _has_mixed_code_and_documentation_work(normalized):
@@ -310,6 +323,18 @@ def _out_of_scope_evidence_fields_for_ac(
         for field in profile.evidence_schema.required
         if field not in required_fields and _flatten_evidence_values(record.get(field))
     )
+
+
+def _out_of_scope_evidence_values_for_ac(
+    profile: ExecutionProfile,
+    ac_content: str,
+    record: EvidenceRecord | None,
+) -> dict[str, Any]:
+    """Return out-of-scope evidence values retained for audit metadata only."""
+    if record is None:
+        return {}
+    fields = _out_of_scope_evidence_fields_for_ac(profile, ac_content, record)
+    return {field: record.data[field] for field in fields if field in record.data}
 
 
 def _scoped_evidence_record_for_ac(
@@ -5118,6 +5143,11 @@ Files present:
                     ac_content,
                     typed_evidence,
                 )
+            )
+            data["ignored_out_of_scope_evidence"] = _out_of_scope_evidence_values_for_ac(
+                self._execution_profile,
+                ac_content,
+                typed_evidence,
             )
         if typed_validation is not None:
             data["missing_fields"] = list(typed_validation.missing_fields)

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -177,6 +177,20 @@ _TEST_WORK_RE = re.compile(
     r")",
     re.IGNORECASE,
 )
+_TEST_MUTATION_WORK_RE = re.compile(
+    r"\b(?:add|write|create|implement|fix|update|extend|expand)\b.{0,60}\b"
+    r"(?:tests?|unit\s+tests?|integration\s+tests?|coverage|test_[\w.-]+\.py)\b",
+    re.IGNORECASE,
+)
+_VALIDATION_ONLY_ACTION_RE = re.compile(
+    r"\b(?:run|execute|pass|validate|verify|ensure|confirm|check)\b",
+    re.IGNORECASE,
+)
+_VALIDATION_ONLY_TEST_SIGNAL_RE = re.compile(
+    r"\b(?:pytest|unit\s+tests?|integration\s+tests?|tests?|test suite|"
+    r"test_[\w.-]+\.py|python\s+-m\s+unittest)\b",
+    re.IGNORECASE,
+)
 
 
 def _has_mixed_code_and_documentation_work(ac_content: str) -> bool:
@@ -236,12 +250,42 @@ def _is_documentation_only_ac(ac_content: str) -> bool:
     )
 
 
+def _is_validation_only_ac(ac_content: str) -> bool:
+    """Return True when an AC asks only to run or verify tests.
+
+    Test-writing ACs still require ``files_touched``; validation-only ACs are
+    allowed to prove completion with command/test evidence and no file mutation.
+    """
+    normalized = " ".join(ac_content.split())
+    if not normalized:
+        return False
+    if _is_documentation_only_ac(normalized):
+        return False
+    if _DOC_ONLY_TARGET_RE.search(normalized) and _DOC_ONLY_ACTION_RE.search(normalized):
+        return False
+    if _TEST_MUTATION_WORK_RE.search(normalized):
+        return False
+    if _CODE_IMPLEMENTATION_ACTION_RE.search(normalized):
+        return False
+    if _has_mixed_code_and_documentation_work(normalized):
+        return False
+    return bool(_VALIDATION_ONLY_ACTION_RE.search(normalized)) and bool(
+        _VALIDATION_ONLY_TEST_SIGNAL_RE.search(normalized)
+    )
+
+
 def _effective_evidence_schema_for_ac(
     profile: ExecutionProfile,
     ac_content: str,
 ) -> EvidenceSchema:
     """Return the active evidence schema for one atomic AC dispatch."""
     schema = profile.evidence_schema
+    if _is_validation_only_ac(ac_content) and "files_touched" in schema.required:
+        required = tuple(field for field in schema.required if field != "files_touched")
+        rejected_if = tuple(
+            expr for expr in schema.rejected_if if not expr.strip().startswith("files_touched")
+        )
+        return EvidenceSchema(required=required, rejected_if=rejected_if)
     if not _is_documentation_only_ac(ac_content) or "tests_passed" not in schema.required:
         return schema
     required = tuple(field for field in schema.required if field != "tests_passed")
@@ -4320,6 +4364,15 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                     "in commands_run when it directly validates the current docs change; "
                     "do not list individual test names or prior test IDs.\n"
                 )
+            validation_only_note = ""
+            if _is_validation_only_ac(ac_content):
+                validation_only_note = (
+                    "This is a validation-only current AC: prove it with commands_run "
+                    "and tests_passed from this runtime session. Do not include "
+                    "files_touched unless you actually edited, wrote, or generated files "
+                    "for this current AC. Read-only inspection or running tests does not "
+                    "count as files_touched.\n"
+                )
             completion_instruction = (
                 "## Current AC Scope Contract\n"
                 "You are responsible only for the current acceptance criterion in "
@@ -4336,7 +4389,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 "as test, build, lint, generation, or docs verification commands; omit "
                 "exploratory discovery commands such as rg, grep, sed, cat, ls, find, "
                 "or pwd unless the current AC explicitly requires that command as validation.\n"
-                f"{doc_only_note}\n"
+                f"{doc_only_note}{validation_only_note}\n"
                 "Use the available tools to accomplish this task. Report progress through "
                 "tool-visible work, not a prose-only completion claim.\n"
                 "When complete, emit exactly ONE fenced JSON evidence record as the "

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -28,6 +28,7 @@ from ouroboros.orchestrator.parallel_executor import (
     ParallelExecutionResult,
     StageExecutionOutcome,
     _build_governed_parent_summary,
+    _effective_evidence_schema_for_ac,
     _message_contains_test_success,
     _runtime_messages_support_command_claim,
     render_parallel_completion_message,
@@ -113,6 +114,38 @@ def test_message_contains_test_success_handles_zero_failure_summaries(
     """Verifier accepts explicit zero-failure summaries without allowing failures."""
     message = AgentMessage(type="result", content=content, data={})
     assert _message_contains_test_success(message) is expected
+
+
+@pytest.mark.parametrize(
+    "ac_content",
+    (
+        "Run python -m unittest test_todo.py successfully.",
+        "Verify the unit tests pass.",
+        "Ensure test_todo.py passes.",
+        "Validate the test suite.",
+    ),
+)
+def test_validation_only_ac_drops_files_touched_requirement(ac_content: str) -> None:
+    """Validation-only ACs prove command/test evidence without requiring file mutation."""
+    schema = _effective_evidence_schema_for_ac(load_profile("code"), ac_content)
+    assert schema.required == ("commands_run", "tests_passed")
+
+
+@pytest.mark.parametrize(
+    "ac_content",
+    (
+        "Create test_todo.py with unittest coverage.",
+        "Add tests for invalid index handling.",
+        "Update test_todo.py to cover the done command.",
+        "Implement TodoList.add and run tests.",
+    ),
+)
+def test_test_writing_and_implementation_acs_keep_files_touched_required(
+    ac_content: str,
+) -> None:
+    """ACs that mutate code/tests must still prove files_touched."""
+    schema = _effective_evidence_schema_for_ac(load_profile("code"), ac_content)
+    assert schema.required == ("files_touched", "commands_run", "tests_passed")
 
 
 def test_build_governed_parent_summary_preserves_embedded_wrapper_headings() -> None:
@@ -2605,6 +2638,209 @@ class TestParallelACExecutor:
         assert evidence_event.data["typed_evidence_valid"] is True
         assert evidence_event.data["verifier_ran"] is True
         assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_validation_only_ac_accepts_no_files_touched(
+        self,
+    ) -> None:
+        """Validation-only ACs can pass with command and test evidence only."""
+        event_store, appended_events = _make_replaying_event_store()
+        runtime = _FinalMessageRuntime(
+            "Done.\n"
+            "```json\n"
+            '{"commands_run":["python -m unittest test_todo.py"],'
+            '"tests_passed":["python -m unittest test_todo.py"]}\n'
+            "```",
+            native_session_id="opencode-session-validation-only",
+            support_messages=(
+                AgentMessage(
+                    type="tool",
+                    content="Bash: python -m unittest test_todo.py",
+                    tool_name="Bash",
+                    data={"tool_input": {"command": "python -m unittest test_todo.py"}},
+                ),
+                AgentMessage(
+                    type="result",
+                    content="Ran 6 tests in 0.002s\n\nOK",
+                    data={"subtype": "success", "exit_code": 0},
+                ),
+            ),
+        )
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Run python -m unittest test_todo.py successfully.",
+            session_id="orch_123",
+            tools=["Read", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        assert runtime.last_prompt is not None
+        assert "validation-only current AC" in runtime.last_prompt
+        assert "Do not include files_touched unless you actually edited" in runtime.last_prompt
+        assert "Read-only inspection or running tests does not count as files_touched" in (
+            runtime.last_prompt
+        )
+        assert "commands_run, tests_passed" in runtime.last_prompt
+        assert "files_touched, commands_run, tests_passed" not in runtime.last_prompt
+        assert result.typed_evidence is not None
+        assert result.typed_evidence.data == {
+            "commands_run": ["python -m unittest test_todo.py"],
+            "tests_passed": ["python -m unittest test_todo.py"],
+        }
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["required_fields"] == ["commands_run", "tests_passed"]
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_validation_only_ac_ignores_files_touched_overclaim(
+        self,
+    ) -> None:
+        """Validation-only ACs record but ignore extra files_touched overclaims."""
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"files_touched":["test_todo.py"],'
+                '"commands_run":["python -m unittest test_todo.py"],'
+                '"tests_passed":["python -m unittest test_todo.py"]}\n'
+                "```",
+                native_session_id="opencode-session-validation-only-overclaim",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: sed -n '1,240p' test_todo.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "sed -n '1,240p' test_todo.py"}},
+                    ),
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: python -m unittest test_todo.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "python -m unittest test_todo.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="Ran 6 tests in 0.002s\n\nOK",
+                        data={"subtype": "success", "exit_code": 0},
+                    ),
+                ),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Run python -m unittest test_todo.py successfully.",
+            session_id="orch_123",
+            tools=["Read", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        assert result.typed_evidence is not None
+        assert result.typed_evidence.data == {
+            "commands_run": ["python -m unittest test_todo.py"],
+            "tests_passed": ["python -m unittest test_todo.py"],
+        }
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["required_fields"] == ["commands_run", "tests_passed"]
+        assert evidence_event.data["ignored_out_of_scope_evidence_fields"] == ["files_touched"]
+        assert evidence_event.data["verifier_passed"] is True
+
+    @pytest.mark.asyncio
+    async def test_fat_harness_test_writing_ac_still_requires_files_touched(
+        self,
+    ) -> None:
+        """Test-writing ACs must still prove file mutation."""
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_FinalMessageRuntime(
+                "Done.\n"
+                "```json\n"
+                '{"commands_run":["python -m unittest test_todo.py"],'
+                '"tests_passed":["python -m unittest test_todo.py"]}\n'
+                "```",
+                native_session_id="opencode-session-test-writing-missing-file",
+                support_messages=(
+                    AgentMessage(
+                        type="tool",
+                        content="Bash: python -m unittest test_todo.py",
+                        tool_name="Bash",
+                        data={"tool_input": {"command": "python -m unittest test_todo.py"}},
+                    ),
+                    AgentMessage(
+                        type="result",
+                        content="Ran 6 tests in 0.002s\n\nOK",
+                        data={"subtype": "success", "exit_code": 0},
+                    ),
+                ),
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Create test_todo.py with unittest coverage.",
+            session_id="orch_123",
+            tools=["Read", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        assert "missing fields: files_touched" in result.error
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["required_fields"] == [
+            "files_touched",
+            "commands_run",
+            "tests_passed",
+        ]
+        assert "files_touched" in evidence_event.data["missing_fields"]
 
     @pytest.mark.asyncio
     async def test_fat_harness_mode_rejects_unbacked_typed_evidence(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -138,6 +138,12 @@ def test_validation_only_ac_drops_files_touched_requirement(ac_content: str) -> 
         "Add tests for invalid index handling.",
         "Update test_todo.py to cover the done command.",
         "Implement TodoList.add and run tests.",
+        "Modify parser.py and ensure tests pass.",
+        "Refactor the validator and verify unit tests pass.",
+        "Change the runtime workflow and run pytest.",
+        "Ensure tests cover invalid inputs.",
+        "Check tests into the repo for the new parser.",
+        "Check in tests for the new parser.",
     ),
 )
 def test_test_writing_and_implementation_acs_keep_files_touched_required(
@@ -2778,6 +2784,9 @@ class TestParallelACExecutor:
         )
         assert evidence_event.data["required_fields"] == ["commands_run", "tests_passed"]
         assert evidence_event.data["ignored_out_of_scope_evidence_fields"] == ["files_touched"]
+        assert evidence_event.data["ignored_out_of_scope_evidence"] == {
+            "files_touched": ["test_todo.py"]
+        }
         assert evidence_event.data["verifier_passed"] is True
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add validation-only AC detection for test-run/verification acceptance criteria.
- Drop `files_touched` from the effective evidence schema for validation-only ACs.
- Keep extra `files_touched` overclaims out of verifier success/failure while recording them via existing `ignored_out_of_scope_evidence_fields`.
- Add prompt guidance that read-only inspection or running tests does not count as `files_touched`.

## Why
The latest broader #978/#961 observation failed at AC3 even though `python -m unittest test_todo.py` exited 0 and printed `OK`. Transcript analysis showed AC3 performed no file mutation and explicitly said no edits were needed, but the code profile still required `files_touched`, causing the agent to overclaim `test_todo.py`.

This keeps `files_touched` strict for real code/test-writing ACs while allowing validation-only ACs to prove completion with `commands_run` + `tests_passed`.

## Scope boundaries
- Does not loosen file-touch verification.
- Does not treat read-only `sed`/`cat`/`grep` or passing tests as file mutation evidence.
- Does not reuse previous AC edits as current-AC `files_touched` proof.
- Does not broaden individual unittest-name acceptance from aggregate unittest output.
- Test-writing and implementation ACs still require `files_touched`.

## Validation
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py -k 'validation_only or mixed_code_and_docs_ac_keeps_test_evidence_required or test_writing_ac_still_requires_files_touched' -q`
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_profile_strategy.py tests/unit/orchestrator/test_phase_wrappers.py -q`
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py`
- `uv run ruff format --check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py && git diff --check`
- `uv run mypy src/ouroboros/orchestrator/parallel_executor.py`

## Not tested
- Live #978 broader observation rerun after this patch.

Refs #978, #961, #1073.
