### PR TITLE
fix(auto): keep observation report section out of execution ACs

### DIFF
--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1607,6 +1607,13 @@ def _extract_goal_sections(goal: str) -> dict[str, list[str]]:
 
 
 def _section_header(line: str) -> str | None:
+    stripped = line.strip()
+    # Observation prompts commonly use this report-only section after the
+    # executable success criteria. Treat it as a new section so report metadata
+    # (session IDs, fallback status, blocker recurrence) does not bleed into the
+    # execution-facing acceptance criteria ledger entry.
+    if stripped.casefold() == "after auto finishes, report:":
+        return "auto report"
     match = re.match(r"^\s*([A-Za-z][A-Za-z0-9 _/-]{1,60}):\s*$", line)
     if match is None:
         return None

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -370,7 +370,6 @@ If `ouroboros_auto` is unavailable or interpreted as normal text, stop and repor
     assert "Recursive auto invocation occurred: no." in preferences["failure_modes"]
 
 
-
 def test_structured_auto_goal_keeps_after_auto_report_section_out_of_acceptance() -> None:
     goal = """
 Goal:
@@ -404,6 +403,7 @@ After auto finishes, report:
     assert "auto session id" not in preferences["acceptance_criteria"].casefold()
     assert "execution job" not in preferences["acceptance_criteria"].casefold()
     assert "test result" not in preferences["acceptance_criteria"].casefold()
+
 
 def test_structured_auto_goal_preserves_non_allowlisted_execution_criteria() -> None:
     goal = """

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -370,6 +370,41 @@ If `ouroboros_auto` is unavailable or interpreted as normal text, stop and repor
     assert "Recursive auto invocation occurred: no." in preferences["failure_modes"]
 
 
+
+def test_structured_auto_goal_keeps_after_auto_report_section_out_of_acceptance() -> None:
+    goal = """
+Goal:
+Verify current ooo auto can create hello_auto.py and tests/test_hello_auto.py.
+
+Success criteria:
+- `hello_auto.py` exists.
+- `tests/test_hello_auto.py` exists.
+- The targeted test command `uv run pytest tests/test_hello_auto.py` passes.
+
+After auto finishes, report:
+- Whether MCP dispatch succeeded.
+- Whether manual fallback was used.
+- Auto session id.
+- Seed id and Seed path.
+- Execution job id.
+- Final execution job terminal status.
+- Whether previous blockers recurred.
+- Files changed.
+- Exact test command.
+- Test result.
+"""
+
+    preferences = _derive_goal_user_preferences(goal)
+
+    assert preferences["acceptance_criteria"] == (
+        "`hello_auto.py` exists.\n"
+        "`tests/test_hello_auto.py` exists.\n"
+        "The targeted test command `uv run pytest tests/test_hello_auto.py` passes."
+    )
+    assert "auto session id" not in preferences["acceptance_criteria"].casefold()
+    assert "execution job" not in preferences["acceptance_criteria"].casefold()
+    assert "test result" not in preferences["acceptance_criteria"].casefold()
+
 def test_structured_auto_goal_preserves_non_allowlisted_execution_criteria() -> None:
     goal = """
 Goal:


### PR DESCRIPTION
## Summary
- recognize `After auto finishes, report:` as a report-only section in structured auto prompts
- prevent session/job/test-result metadata bullets from bleeding into execution acceptance criteria
- add regression coverage for the latest observation prompt shape

## Tests
- uv run pytest tests/unit/mcp/tools/test_auto_interview_construction.py -q
- uv run ruff check src/ouroboros/mcp/tools/auto_handler.py tests/unit/mcp/tools/test_auto_interview_construction.py
- uv run ruff format --check src/ouroboros/mcp/tools/auto_handler.py tests/unit/mcp/tools/test_auto_interview_construction.py