### PR TITLE
fix(orchestrator): emit execution-scoped AC completion evidence

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2633,25 +2633,33 @@ class ParallelACExecutor:
             event.data["tool_catalog"] = tool_catalog
         await self._event_store.append(event)
         if success is True and execution_id:
-            await self._event_store.append(
-                BaseEvent(
-                    type="execution.ac.completed",
-                    aggregate_type="execution",
-                    aggregate_id=execution_id,
-                    data={
-                        **identity_metadata,
-                        "ac_id": runtime_identity.ac_id,
-                        "acceptance_criterion": ac_content,
-                        "execution_id": execution_id,
-                        "session_id": effective_session_id,
-                        "session_scope_id": runtime_identity.session_scope_id,
-                        "retry_attempt": runtime_identity.retry_attempt,
-                        "attempt_number": runtime_identity.attempt_number,
-                        "success": True,
-                        "result_summary": result_summary,
-                    },
+            try:
+                await self._event_store.append(
+                    BaseEvent(
+                        type="execution.ac.completed",
+                        aggregate_type="execution",
+                        aggregate_id=execution_id,
+                        data={
+                            **identity_metadata,
+                            "ac_id": runtime_identity.ac_id,
+                            "acceptance_criterion": ac_content,
+                            "execution_id": execution_id,
+                            "session_id": effective_session_id,
+                            "session_scope_id": runtime_identity.session_scope_id,
+                            "retry_attempt": runtime_identity.retry_attempt,
+                            "attempt_number": runtime_identity.attempt_number,
+                            "success": True,
+                            "result_summary": result_summary,
+                        },
+                    )
                 )
-            )
+            except Exception as exc:
+                log.warning(
+                    "parallel_executor.execution_ac_completed_append_failed",
+                    ac_id=runtime_identity.ac_id,
+                    execution_id=execution_id,
+                    error=str(exc),
+                )
 
     @staticmethod
     def _coerce_ac_indices(raw_indices: Any) -> tuple[int, ...]:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2632,6 +2632,26 @@ class ParallelACExecutor:
         if tool_catalog is not None:
             event.data["tool_catalog"] = tool_catalog
         await self._event_store.append(event)
+        if success is True and execution_id:
+            await self._event_store.append(
+                BaseEvent(
+                    type="execution.ac.completed",
+                    aggregate_type="execution",
+                    aggregate_id=execution_id,
+                    data={
+                        **identity_metadata,
+                        "ac_id": runtime_identity.ac_id,
+                        "acceptance_criterion": ac_content,
+                        "execution_id": execution_id,
+                        "session_id": effective_session_id,
+                        "session_scope_id": runtime_identity.session_scope_id,
+                        "retry_attempt": runtime_identity.retry_attempt,
+                        "attempt_number": runtime_identity.attempt_number,
+                        "success": True,
+                        "result_summary": result_summary,
+                    },
+                )
+            )
 
     @staticmethod
     def _coerce_ac_indices(raw_indices: Any) -> tuple[int, ...]:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -6320,6 +6320,7 @@ class TestParallelACExecutor:
             seed_goal="Ship the feature",
             depth=0,
             start_time=datetime.now(UTC),
+            execution_id="exec_ac_progress",
         )
 
         appended_events = [call.args[0] for call in event_store.append.await_args_list]
@@ -6328,6 +6329,9 @@ class TestParallelACExecutor:
         )
         completed_event = next(
             event for event in appended_events if event.type == "execution.session.completed"
+        )
+        execution_completed_event = next(
+            event for event in appended_events if event.type == "execution.ac.completed"
         )
 
         assert result.success is True
@@ -6347,6 +6351,11 @@ class TestParallelACExecutor:
         assert "transcript_path" not in started_event.data["runtime"]
         assert "updated_at" not in started_event.data["runtime"]
         assert completed_event.data["session_id"] == "server-42"
+        assert execution_completed_event.aggregate_id == "exec_ac_progress"
+        assert execution_completed_event.data["success"] is True
+        assert execution_completed_event.data["acceptance_criterion"] == (
+            "Persist reconnectable OpenCode implementation handles"
+        )
 
     @pytest.mark.asyncio
     async def test_restarted_executor_loads_persisted_runtime_handle_for_same_attempt(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -6358,6 +6358,46 @@ class TestParallelACExecutor:
         )
 
     @pytest.mark.asyncio
+    async def test_execution_scoped_ac_completion_append_is_best_effort(self) -> None:
+        """Root AC evidence must not corrupt an already persisted successful AC lifecycle."""
+
+        event_store = AsyncMock()
+        event_store.replay = AsyncMock(return_value=[])
+        appended_events: list[BaseEvent] = []
+
+        async def _append(event: BaseEvent) -> None:
+            if event.type == "execution.ac.completed":
+                raise RuntimeError("root aggregate temporarily unavailable")
+            appended_events.append(event)
+
+        event_store.append = AsyncMock(side_effect=_append)
+        executor = ParallelACExecutor(
+            adapter=MagicMock(),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity = executor._resolve_ac_runtime_identity(
+            0,
+            execution_context_id="exec_ac_progress",
+            retry_attempt=0,
+        )
+
+        await executor._emit_ac_runtime_event(
+            event_type="execution.session.completed",
+            runtime_identity=runtime_identity,
+            ac_content="Persist AC completion evidence",
+            runtime_handle=None,
+            execution_id="exec_ac_progress",
+            session_id="server-42",
+            result_summary="[TASK_COMPLETE]",
+            success=True,
+        )
+
+        assert [event.type for event in appended_events] == ["execution.session.completed"]
+        assert event_store.append.await_count == 2
+
+    @pytest.mark.asyncio
     async def test_restarted_executor_loads_persisted_runtime_handle_for_same_attempt(self) -> None:
         """A fresh executor should rehydrate the same-attempt runtime handle from events."""
 


### PR DESCRIPTION
## Summary\n- mirror successful atomic AC completion onto the root execution aggregate as \n- preserve existing child session lifecycle events while making AC completion evidence visible to execution/job monitors\n- add regression coverage for execution-scoped completion evidence\n\n## Tests\n- uv run pytest tests/unit/orchestrator/test_parallel_executor.py -q\n- uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py