### PR TITLE
fix(jobs): fail stalled progress-accounting executions

### DIFF
--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -523,9 +523,18 @@ class JobManager:
         return "Execution complete"
 
     async def _derive_progress_accounting_blocker(self, snapshot: JobSnapshot) -> str | None:
-        """Return a terminal blocker when AC evidence exists but progress is stuck at zero."""
+        """Return a terminal blocker for failed executions with inconsistent AC progress."""
         if not snapshot.links.session_id or not snapshot.links.execution_id:
             return None
+
+        terminal_events = await self._event_store.query_events(
+            aggregate_id=snapshot.links.execution_id,
+            event_type="execution.terminal",
+            limit=1,
+        )
+        if not terminal_events or terminal_events[0].data.get("status") != "failed":
+            return None
+
         workflow_events = await self._event_store.query_events(
             aggregate_id=snapshot.links.execution_id,
             event_type="workflow.progress.updated",
@@ -550,44 +559,12 @@ class JobManager:
         if not any(event.data.get("success") is True for event in completed_events):
             return None
 
-        if await self._has_active_execution_session(snapshot.links.execution_id):
-            return None
-
         return (
-            "workflow progress accounting stalled: at least one AC execution session "
-            f"reported success, but workflow progress remains 0/{total} in Deliver after all "
-            "known AC runtime sessions reached a terminal state. Local output may exist, "
-            "but orchestration did not record AC completion."
+            "workflow progress accounting stalled: execution reached terminal failed state "
+            "after at least one AC execution session reported success, but workflow "
+            f"progress remained 0/{total} in Deliver. Local output may exist, but "
+            "orchestration did not record AC completion."
         )
-
-    async def _has_active_execution_session(self, execution_id: str) -> bool:
-        """Return True while any known AC runtime lifecycle stream is still active."""
-        lifecycle_events = await self._event_store.query_execution_related_events(
-            execution_id,
-            limit=None,
-        )
-        lifecycle_types = {
-            "execution.session.started",
-            "execution.session.resumed",
-            "execution.session.recovered",
-            "execution.session.completed",
-            "execution.session.failed",
-        }
-        latest_by_scope: dict[str, str] = {}
-        for event in lifecycle_events:
-            if event.type not in lifecycle_types:
-                continue
-            scope = event.data.get("session_scope_id") or event.data.get("session_attempt_id")
-            if not isinstance(scope, str) or not scope:
-                scope = event.aggregate_id
-            latest_by_scope.setdefault(scope, event.type)
-
-        active_types = {
-            "execution.session.started",
-            "execution.session.resumed",
-            "execution.session.recovered",
-        }
-        return any(event_type in active_types for event_type in latest_by_scope.values())
 
     async def _derive_status_message(self, snapshot: JobSnapshot) -> str | None:
         """Summarize linked execution or lineage progress."""

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -304,7 +304,7 @@ class JobManager:
             raise
         except Exception as exc:
             snapshot = await self.get_snapshot(job_id)
-            if snapshot.is_terminal:
+            if snapshot.is_terminal or job_id in self._monitor_terminalized_jobs:
                 return
             completed_result = await self._derive_completed_execution_result(snapshot)
             if completed_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
@@ -321,7 +321,7 @@ class JobManager:
             )
         else:
             snapshot = await self.get_snapshot(job_id)
-            if snapshot.is_terminal:
+            if snapshot.is_terminal or job_id in self._monitor_terminalized_jobs:
                 return
             completed_result = await self._derive_completed_execution_result(snapshot)
             if completed_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
@@ -418,6 +418,20 @@ class JobManager:
                 progress_blocker = await self._derive_progress_accounting_blocker(snapshot)
                 if progress_blocker is not None:
                     self._monitor_terminalized_jobs.add(job_id)
+                    await asyncio.shield(
+                        self._append_event(
+                            "mcp.job.failed",
+                            job_id,
+                            {
+                                "status": JobStatus.FAILED.value,
+                                "message": "Job failed: workflow progress accounting stalled",
+                                "error": progress_blocker,
+                                "result_text": progress_blocker,
+                                "result_meta": {"failed_from_progress_accounting_stall": True},
+                                "is_error": True,
+                            },
+                        )
+                    )
                     runner = self._runner_tasks.pop(job_id, None)
                     if runner is not None and not runner.done():
                         runner.cancel()
@@ -426,18 +440,6 @@ class JobManager:
                     if job_task is not None and not job_task.done():
                         job_task.cancel()
                         job_task.add_done_callback(_consume_task_result)
-                    await self._append_event(
-                        "mcp.job.failed",
-                        job_id,
-                        {
-                            "status": JobStatus.FAILED.value,
-                            "message": "Job failed: workflow progress accounting stalled",
-                            "error": progress_blocker,
-                            "result_text": progress_blocker,
-                            "result_meta": {"failed_from_progress_accounting_stall": True},
-                            "is_error": True,
-                        },
-                    )
                     return
 
             message = await self._derive_status_message(snapshot)

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -417,20 +417,28 @@ class JobManager:
 
                 progress_blocker = await self._derive_progress_accounting_blocker(snapshot)
                 if progress_blocker is not None:
-                    await asyncio.shield(
-                        self._append_event(
-                            "mcp.job.failed",
-                            job_id,
-                            {
-                                "status": JobStatus.FAILED.value,
-                                "message": "Job failed: workflow progress accounting stalled",
-                                "error": progress_blocker,
-                                "result_text": progress_blocker,
-                                "result_meta": {"failed_from_progress_accounting_stall": True},
-                                "is_error": True,
-                            },
+                    try:
+                        await asyncio.shield(
+                            self._append_event(
+                                "mcp.job.failed",
+                                job_id,
+                                {
+                                    "status": JobStatus.FAILED.value,
+                                    "message": "Job failed: workflow progress accounting stalled",
+                                    "error": progress_blocker,
+                                    "result_text": progress_blocker,
+                                    "result_meta": {"failed_from_progress_accounting_stall": True},
+                                    "is_error": True,
+                                },
+                            )
                         )
-                    )
+                    except Exception:
+                        logger.warning(
+                            "mcp.job.progress_accounting_failure_append_failed",
+                            extra={"job_id": job_id},
+                            exc_info=True,
+                        )
+                        continue
                     self._monitor_terminalized_jobs.add(job_id)
                     runner = self._runner_tasks.pop(job_id, None)
                     if runner is not None and not runner.done():

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -177,6 +177,7 @@ class JobManager:
         self._tasks: dict[str, asyncio.Task[Any]] = {}
         self._runner_tasks: dict[str, asyncio.Task[Any]] = {}
         self._monitors: dict[str, asyncio.Task[None]] = {}
+        self._monitor_terminalized_jobs: set[str] = set()
         self._recovery_locks: dict[str, asyncio.Lock] = {}
         self._initialized = False
         self._known_job_ids: set[str] = set()
@@ -280,7 +281,7 @@ class JobManager:
             result = await runner
         except asyncio.CancelledError:
             snapshot = await self.get_snapshot(job_id)
-            if snapshot.is_terminal:
+            if snapshot.is_terminal or job_id in self._monitor_terminalized_jobs:
                 return
             completed_result = await self._derive_completed_execution_result(snapshot)
             if completed_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
@@ -363,6 +364,7 @@ class JobManager:
         finally:
             self._tasks.pop(job_id, None)
             self._runner_tasks.pop(job_id, None)
+            self._monitor_terminalized_jobs.discard(job_id)
             monitor = self._monitors.pop(job_id, None)
             if monitor is not None:
                 monitor.cancel()
@@ -411,6 +413,31 @@ class JobManager:
                         return
                     except Exception:
                         return
+                    return
+
+                progress_blocker = await self._derive_progress_accounting_blocker(snapshot)
+                if progress_blocker is not None:
+                    self._monitor_terminalized_jobs.add(job_id)
+                    runner = self._runner_tasks.pop(job_id, None)
+                    if runner is not None and not runner.done():
+                        runner.cancel()
+                        runner.add_done_callback(_consume_task_result)
+                    job_task = self._tasks.pop(job_id, None)
+                    if job_task is not None and not job_task.done():
+                        job_task.cancel()
+                        job_task.add_done_callback(_consume_task_result)
+                    await self._append_event(
+                        "mcp.job.failed",
+                        job_id,
+                        {
+                            "status": JobStatus.FAILED.value,
+                            "message": "Job failed: workflow progress accounting stalled",
+                            "error": progress_blocker,
+                            "result_text": progress_blocker,
+                            "result_meta": {"failed_from_progress_accounting_stall": True},
+                            "is_error": True,
+                        },
+                    )
                     return
 
             message = await self._derive_status_message(snapshot)
@@ -492,6 +519,41 @@ class JobManager:
             ):
                 return f"Execution complete: {completed}/{total} ACs completed"
         return "Execution complete"
+
+    async def _derive_progress_accounting_blocker(self, snapshot: JobSnapshot) -> str | None:
+        """Return a terminal blocker when AC evidence exists but progress is stuck at zero."""
+        if not snapshot.links.session_id or not snapshot.links.execution_id:
+            return None
+        workflow_events = await self._event_store.query_events(
+            aggregate_id=snapshot.links.execution_id,
+            event_type="workflow.progress.updated",
+            limit=1,
+        )
+        if not workflow_events:
+            return None
+        data = workflow_events[0].data
+        completed = data.get("completed_count")
+        total = data.get("total_count")
+        phase = str(data.get("current_phase") or "")
+        if completed != 0 or not isinstance(total, int) or total <= 0:
+            return None
+        if phase.casefold() != "deliver":
+            return None
+
+        completed_events = await self._event_store.query_session_related_events(
+            snapshot.links.session_id,
+            execution_id=snapshot.links.execution_id,
+            event_type="execution.session.completed",
+            limit=1,
+        )
+        if not any(event.data.get("success") is True for event in completed_events):
+            return None
+
+        return (
+            "workflow progress accounting stalled: at least one AC execution session "
+            f"reported success, but workflow progress remains 0/{total} in Deliver. "
+            "Local output may exist, but orchestration did not record AC completion."
+        )
 
     async def _derive_status_message(self, snapshot: JobSnapshot) -> str | None:
         """Summarize linked execution or lineage progress."""

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -540,20 +540,52 @@ class JobManager:
         if phase.casefold() != "deliver":
             return None
 
-        completed_events = await self._event_store.query_session_related_events(
-            snapshot.links.session_id,
-            execution_id=snapshot.links.execution_id,
+        completed_events = await self._event_store.query_execution_related_events(
+            snapshot.links.execution_id,
             event_type="execution.session.completed",
-            limit=1,
+            limit=None,
         )
         if not any(event.data.get("success") is True for event in completed_events):
             return None
 
+        if await self._has_active_execution_session(snapshot.links.execution_id):
+            return None
+
         return (
             "workflow progress accounting stalled: at least one AC execution session "
-            f"reported success, but workflow progress remains 0/{total} in Deliver. "
-            "Local output may exist, but orchestration did not record AC completion."
+            f"reported success, but workflow progress remains 0/{total} in Deliver after all "
+            "known AC runtime sessions reached a terminal state. Local output may exist, "
+            "but orchestration did not record AC completion."
         )
+
+    async def _has_active_execution_session(self, execution_id: str) -> bool:
+        """Return True while any known AC runtime lifecycle stream is still active."""
+        lifecycle_events = await self._event_store.query_execution_related_events(
+            execution_id,
+            limit=None,
+        )
+        lifecycle_types = {
+            "execution.session.started",
+            "execution.session.resumed",
+            "execution.session.recovered",
+            "execution.session.completed",
+            "execution.session.failed",
+        }
+        latest_by_scope: dict[str, str] = {}
+        for event in lifecycle_events:
+            if event.type not in lifecycle_types:
+                continue
+            scope = event.data.get("session_scope_id") or event.data.get("session_attempt_id")
+            if not isinstance(scope, str) or not scope:
+                scope = event.aggregate_id
+            latest_by_scope.setdefault(scope, event.type)
+
+        active_types = {
+            "execution.session.started",
+            "execution.session.resumed",
+            "execution.session.recovered",
+        }
+        return any(event_type in active_types for event_type in latest_by_scope.values())
 
     async def _derive_status_message(self, snapshot: JobSnapshot) -> str | None:
         """Summarize linked execution or lineage progress."""

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -417,7 +417,6 @@ class JobManager:
 
                 progress_blocker = await self._derive_progress_accounting_blocker(snapshot)
                 if progress_blocker is not None:
-                    self._monitor_terminalized_jobs.add(job_id)
                     await asyncio.shield(
                         self._append_event(
                             "mcp.job.failed",
@@ -432,6 +431,7 @@ class JobManager:
                             },
                         )
                     )
+                    self._monitor_terminalized_jobs.add(job_id)
                     runner = self._runner_tasks.pop(job_id, None)
                     if runner is not None and not runner.done():
                         runner.cancel()

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -83,6 +83,7 @@ def _safe_meta(value: Any) -> Any:
 _JOB_TTL = timedelta(hours=1)
 _COMPLETED_EXECUTION_CANCEL_GRACE_SECONDS = 5.0
 _RECOVERED_COMPLETION_EVENT_ID_PREFIX = "mcp-job-recovered-completed-"
+_RECOVERED_FAILURE_EVENT_ID_PREFIX = "mcp-job-recovered-failed-"
 logger = logging.getLogger(__name__)
 
 
@@ -141,6 +142,25 @@ def _execution_completed_job_event(job_id: str, result_text: str) -> BaseEvent:
             "result_text": result_text,
             "result_meta": {"completed_from_execution_terminal": True},
             "is_error": False,
+            "timestamp": datetime.now(UTC).isoformat(),
+        },
+    )
+
+
+def _progress_accounting_failed_job_event(job_id: str, blocker: str) -> BaseEvent:
+    """Build the synthetic/persisted job-failure event for execution recovery."""
+    return BaseEvent(
+        id=f"{_RECOVERED_FAILURE_EVENT_ID_PREFIX}{job_id}",
+        type="mcp.job.failed",
+        aggregate_type="job",
+        aggregate_id=job_id,
+        data={
+            "status": JobStatus.FAILED.value,
+            "message": "Job failed: workflow progress accounting stalled",
+            "error": blocker,
+            "result_text": blocker,
+            "result_meta": {"failed_from_progress_accounting_stall": True},
+            "is_error": True,
             "timestamp": datetime.now(UTC).isoformat(),
         },
     )
@@ -419,17 +439,9 @@ class JobManager:
                 if progress_blocker is not None:
                     try:
                         await asyncio.shield(
-                            self._append_event(
-                                "mcp.job.failed",
+                            self._append_progress_accounting_failed_event(
                                 job_id,
-                                {
-                                    "status": JobStatus.FAILED.value,
-                                    "message": "Job failed: workflow progress accounting stalled",
-                                    "error": progress_blocker,
-                                    "result_text": progress_blocker,
-                                    "result_meta": {"failed_from_progress_accounting_stall": True},
-                                    "is_error": True,
-                                },
+                                progress_blocker,
                             )
                         )
                     except Exception:
@@ -484,6 +496,34 @@ class JobManager:
                 "result_text": result_text,
                 "result_meta": {"completed_from_execution_terminal": True},
                 "is_error": False,
+            },
+            event_id=event_id,
+        )
+        return True
+
+    async def _append_progress_accounting_failed_event(
+        self,
+        job_id: str,
+        blocker: str,
+        *,
+        check_current: bool = True,
+        event_id: str | None = None,
+    ) -> bool:
+        """Persist durable job failure derived from terminal execution evidence."""
+        if check_current:
+            snapshot = await self.get_snapshot(job_id)
+            if snapshot.is_terminal or snapshot.status == JobStatus.CANCEL_REQUESTED:
+                return False
+        await self._append_event(
+            "mcp.job.failed",
+            job_id,
+            {
+                "status": JobStatus.FAILED.value,
+                "message": "Job failed: workflow progress accounting stalled",
+                "error": blocker,
+                "result_text": blocker,
+                "result_meta": {"failed_from_progress_accounting_stall": True},
+                "is_error": True,
             },
             event_id=event_id,
         )
@@ -773,17 +813,19 @@ class JobManager:
             result_meta=result_meta,
             error=error,
         )
-        return await self._recover_completed_execution_snapshot(snapshot)
+        return await self._recover_linked_execution_terminal_snapshot(snapshot)
 
-    async def _recover_completed_execution_snapshot(self, snapshot: JobSnapshot) -> JobSnapshot:
-        """Recover completed linked execution jobs when no live runner remains.
+    async def _recover_linked_execution_terminal_snapshot(
+        self, snapshot: JobSnapshot
+    ) -> JobSnapshot:
+        """Recover linked execution terminal jobs when no live runner remains.
 
         Live jobs keep the existing JobManager invariant: terminal job state is
         emitted by the runner-owned path after the runner exits or cooperates
         with cancellation. After process restart, however, there is no live
         runner left to write that event; if the linked execution already has
-        authoritative completed terminal evidence, materialize the job terminal
-        event from that durable evidence.
+        authoritative terminal evidence, materialize the job terminal event
+        from that durable evidence.
         """
         if (
             snapshot.is_terminal
@@ -793,14 +835,20 @@ class JobManager:
         ):
             return snapshot
         completed_result = await self._derive_completed_execution_result(snapshot)
-        if completed_result is None:
+        progress_blocker = (
+            None
+            if completed_result is not None
+            else await self._derive_progress_accounting_blocker(snapshot)
+        )
+        if completed_result is None and progress_blocker is None:
             return snapshot
         if getattr(self._event_store, "_read_only", False):
-            return _snapshot_with_terminal_event(
-                snapshot,
-                _execution_completed_job_event(snapshot.job_id, completed_result),
-                snapshot.cursor,
+            event = (
+                _execution_completed_job_event(snapshot.job_id, completed_result)
+                if completed_result is not None
+                else _progress_accounting_failed_job_event(snapshot.job_id, progress_blocker or "")
             )
+            return _snapshot_with_terminal_event(snapshot, event, snapshot.cursor)
         lock = self._recovery_locks.setdefault(snapshot.job_id, asyncio.Lock())
         async with lock:
             events, cursor = await self._event_store.get_events_after(
@@ -816,12 +864,20 @@ class JobManager:
             ):
                 return _snapshot_with_status_event(snapshot, latest_status_event, cursor)
             try:
-                completed = await self._append_execution_completed_event(
-                    snapshot.job_id,
-                    completed_result,
-                    check_current=False,
-                    event_id=f"{_RECOVERED_COMPLETION_EVENT_ID_PREFIX}{snapshot.job_id}",
-                )
+                if completed_result is not None:
+                    recovered = await self._append_execution_completed_event(
+                        snapshot.job_id,
+                        completed_result,
+                        check_current=False,
+                        event_id=f"{_RECOVERED_COMPLETION_EVENT_ID_PREFIX}{snapshot.job_id}",
+                    )
+                else:
+                    recovered = await self._append_progress_accounting_failed_event(
+                        snapshot.job_id,
+                        progress_blocker or "",
+                        check_current=False,
+                        event_id=f"{_RECOVERED_FAILURE_EVENT_ID_PREFIX}{snapshot.job_id}",
+                    )
             except PersistenceError:
                 events, cursor = await self._event_store.get_events_after(
                     "job", snapshot.job_id, last_row_id=0
@@ -830,7 +886,7 @@ class JobManager:
                 if existing_terminal is not None:
                     return _snapshot_with_terminal_event(snapshot, existing_terminal, cursor)
                 raise
-            if not completed:
+            if not recovered:
                 return snapshot
             events, cursor = await self._event_store.get_events_after(
                 "job", snapshot.job_id, last_row_id=0

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -558,13 +558,45 @@ class JobManager:
         )
         if not any(event.data.get("success") is True for event in completed_events):
             return None
+        if await self._has_active_execution_session(snapshot.links.execution_id):
+            return None
 
         return (
             "workflow progress accounting stalled: execution reached terminal failed state "
-            "after at least one AC execution session reported success, but workflow "
-            f"progress remained 0/{total} in Deliver. Local output may exist, but "
-            "orchestration did not record AC completion."
+            "after at least one AC execution session reported success, all known AC "
+            f"runtime sessions were terminal, but workflow progress remained 0/{total} "
+            "in Deliver. Local output may exist, but orchestration did not record "
+            "AC completion."
         )
+
+    async def _has_active_execution_session(self, execution_id: str) -> bool:
+        """Return True while any known AC runtime lifecycle stream is still active."""
+        lifecycle_events = await self._event_store.query_execution_related_events(
+            execution_id,
+            limit=None,
+        )
+        lifecycle_types = {
+            "execution.session.started",
+            "execution.session.resumed",
+            "execution.session.recovered",
+            "execution.session.completed",
+            "execution.session.failed",
+        }
+        latest_by_scope: dict[str, str] = {}
+        for event in lifecycle_events:
+            if event.type not in lifecycle_types:
+                continue
+            scope = event.data.get("session_scope_id") or event.data.get("session_attempt_id")
+            if not isinstance(scope, str) or not scope:
+                scope = event.aggregate_id
+            latest_by_scope.setdefault(scope, event.type)
+
+        active_types = {
+            "execution.session.started",
+            "execution.session.resumed",
+            "execution.session.recovered",
+        }
+        return any(event_type in active_types for event_type in latest_by_scope.values())
 
     async def _derive_status_message(self, snapshot: JobSnapshot) -> str | None:
         """Summarize linked execution or lineage progress."""

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -222,6 +222,21 @@ class TestJobManager:
                 runner=_runner(),
                 links=JobLinks(session_id="orch_stalled", execution_id="exec_stalled"),
             )
+
+            original_append_event = manager._append_event
+
+            async def _assert_failure_persists_before_teardown(
+                event_type: str, job_id: str, data: dict, **kwargs
+            ) -> None:
+                if event_type == "mcp.job.failed":
+                    runner_task = manager._runner_tasks[job_id]
+                    job_task = manager._tasks[job_id]
+                    assert not runner_task.cancelled()
+                    assert not job_task.cancelled()
+                await original_append_event(event_type, job_id, data, **kwargs)
+
+            manager._append_event = _assert_failure_persists_before_teardown
+
             await store.append(
                 BaseEvent(
                     type="workflow.progress.updated",

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -282,7 +282,7 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
-    async def test_progress_accounting_append_failure_does_not_suppress_runner_terminalization(
+    async def test_progress_accounting_append_failure_retries_terminalization(
         self, tmp_path
     ) -> None:
         store = _build_store(tmp_path)
@@ -306,15 +306,18 @@ class TestJobManager:
             )
 
             original_append_event = manager._append_event
+            failed_attempts = 0
 
-            async def _fail_terminal_failure_append(
+            async def _fail_first_terminal_failure_append(
                 event_type: str, job_id: str, data: dict, **kwargs
             ) -> None:
-                if event_type == "mcp.job.failed":
+                nonlocal failed_attempts
+                if event_type == "mcp.job.failed" and failed_attempts == 0:
+                    failed_attempts += 1
                     raise PersistenceError("synthetic append failure", operation="insert")
                 await original_append_event(event_type, job_id, data, **kwargs)
 
-            manager._append_event = _fail_terminal_failure_append
+            manager._append_event = _fail_first_terminal_failure_append
 
             await store.append(
                 BaseEvent(
@@ -351,10 +354,12 @@ class TestJobManager:
                 )
             )
 
-            await asyncio.sleep(1.2)
+            snapshot = await _wait_for_job_status(
+                manager, started.job_id, JobStatus.FAILED, timeout=3.0
+            )
 
-            assert started.job_id not in manager._monitor_terminalized_jobs
-            assert (await manager.get_snapshot(started.job_id)).status is JobStatus.RUNNING
+            assert failed_attempts == 1
+            assert snapshot.result_meta["failed_from_progress_accounting_stall"] is True
         finally:
             stop.set()
             await _cancel_manager_tasks(manager)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -360,6 +360,95 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
+    async def test_progress_accounting_blocker_waits_for_active_ac_sessions_after_terminal(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+
+        try:
+            snapshot = JobSnapshot(
+                job_id="job_parallel",
+                job_type="execute_seed",
+                status=JobStatus.RUNNING,
+                message="Running execute_seed",
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+                links=JobLinks(
+                    session_id="orch_parallel_active", execution_id="exec_parallel_active"
+                ),
+            )
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_parallel_active",
+                    data={
+                        "session_id": "orch_parallel_active",
+                        "completed_count": 0,
+                        "total_count": 2,
+                        "current_phase": "Deliver",
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.session.completed",
+                    aggregate_type="execution",
+                    aggregate_id="exec_parallel_active_ac_1",
+                    data={
+                        "execution_id": "exec_parallel_active",
+                        "session_id": "child_1",
+                        "session_scope_id": "exec_parallel_active_ac_1",
+                        "success": True,
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.session.started",
+                    aggregate_type="execution",
+                    aggregate_id="exec_parallel_active_ac_2",
+                    data={
+                        "execution_id": "exec_parallel_active",
+                        "session_id": "child_2",
+                        "session_scope_id": "exec_parallel_active_ac_2",
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_parallel_active",
+                    data={"session_id": "orch_parallel_active", "status": "failed"},
+                )
+            )
+
+            assert await manager._derive_progress_accounting_blocker(snapshot) is None
+
+            await store.append(
+                BaseEvent(
+                    type="execution.session.failed",
+                    aggregate_type="execution",
+                    aggregate_id="exec_parallel_active_ac_2",
+                    data={
+                        "execution_id": "exec_parallel_active",
+                        "session_id": "child_2",
+                        "session_scope_id": "exec_parallel_active_ac_2",
+                        "success": False,
+                    },
+                )
+            )
+
+            blocker = await manager._derive_progress_accounting_blocker(snapshot)
+
+            assert blocker is not None
+            assert "all known AC runtime sessions were terminal" in blocker
+        finally:
+            await store.close()
+
     async def test_progress_accounting_blocker_requires_failed_execution_terminal(
         self, tmp_path
     ) -> None:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -282,6 +282,84 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
+    async def test_progress_accounting_append_failure_does_not_suppress_runner_terminalization(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+            stop = asyncio.Event()
+
+            async def _runner() -> MCPToolResult:
+                await stop.wait()
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late done"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id="orch_append_fail", execution_id="exec_append_fail"),
+            )
+
+            original_append_event = manager._append_event
+
+            async def _fail_terminal_failure_append(
+                event_type: str, job_id: str, data: dict, **kwargs
+            ) -> None:
+                if event_type == "mcp.job.failed":
+                    raise PersistenceError("synthetic append failure", operation="insert")
+                await original_append_event(event_type, job_id, data, **kwargs)
+
+            manager._append_event = _fail_terminal_failure_append
+
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_append_fail",
+                    data={
+                        "session_id": "orch_append_fail",
+                        "completed_count": 0,
+                        "total_count": 1,
+                        "current_phase": "Deliver",
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.session.completed",
+                    aggregate_type="execution",
+                    aggregate_id="exec_append_fail_ac_1",
+                    data={
+                        "execution_id": "exec_append_fail",
+                        "session_id": "child_1",
+                        "session_scope_id": "exec_append_fail_ac_1",
+                        "success": True,
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_append_fail",
+                    data={"session_id": "orch_append_fail", "status": "failed"},
+                )
+            )
+
+            await asyncio.sleep(1.2)
+
+            assert started.job_id not in manager._monitor_terminalized_jobs
+            assert (await manager.get_snapshot(started.job_id)).status is JobStatus.RUNNING
+        finally:
+            stop.set()
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_progress_accounting_blocker_requires_failed_execution_terminal(
         self, tmp_path
     ) -> None:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -200,7 +200,6 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
-
     async def test_monitor_fails_job_when_deliver_progress_stays_zero_after_ac_success(
         self, tmp_path
     ) -> None:
@@ -243,6 +242,7 @@ class TestJobManager:
                     data={
                         "execution_id": "exec_stalled",
                         "session_id": "child_1",
+                        "session_scope_id": "exec_stalled_ac_1",
                         "success": True,
                     },
                 )
@@ -257,6 +257,83 @@ class TestJobManager:
         finally:
             stop.set()
             await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_progress_accounting_blocker_waits_for_active_ac_sessions(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+
+        try:
+            snapshot = JobSnapshot(
+                job_id="job_parallel",
+                job_type="execute_seed",
+                status=JobStatus.RUNNING,
+                message="Running execute_seed",
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+                links=JobLinks(session_id="orch_parallel", execution_id="exec_parallel"),
+            )
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_parallel",
+                    data={
+                        "session_id": "orch_parallel",
+                        "completed_count": 0,
+                        "total_count": 2,
+                        "current_phase": "Deliver",
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.session.completed",
+                    aggregate_type="execution",
+                    aggregate_id="exec_parallel_ac_1",
+                    data={
+                        "execution_id": "exec_parallel",
+                        "session_id": "child_1",
+                        "session_scope_id": "exec_parallel_ac_1",
+                        "success": True,
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.session.started",
+                    aggregate_type="execution",
+                    aggregate_id="exec_parallel_ac_2",
+                    data={
+                        "execution_id": "exec_parallel",
+                        "session_id": "child_2",
+                        "session_scope_id": "exec_parallel_ac_2",
+                    },
+                )
+            )
+
+            assert await manager._derive_progress_accounting_blocker(snapshot) is None
+
+            await store.append(
+                BaseEvent(
+                    type="execution.session.failed",
+                    aggregate_type="execution",
+                    aggregate_id="exec_parallel_ac_2",
+                    data={
+                        "execution_id": "exec_parallel",
+                        "session_id": "child_2",
+                        "session_scope_id": "exec_parallel_ac_2",
+                        "success": False,
+                    },
+                )
+            )
+
+            blocker = await manager._derive_progress_accounting_blocker(snapshot)
+
+            assert blocker is not None
+            assert "all known AC runtime sessions reached a terminal state" in blocker
+        finally:
             await store.close()
 
     async def test_cancel_requested_wins_over_complete_execution_terminal(self, tmp_path) -> None:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -262,6 +262,14 @@ class TestJobManager:
                     },
                 )
             )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_stalled",
+                    data={"session_id": "orch_stalled", "status": "failed"},
+                )
+            )
 
             snapshot = await _wait_for_job_status(
                 manager, started.job_id, JobStatus.FAILED, timeout=2.0
@@ -274,7 +282,9 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
-    async def test_progress_accounting_blocker_waits_for_active_ac_sessions(self, tmp_path) -> None:
+    async def test_progress_accounting_blocker_requires_failed_execution_terminal(
+        self, tmp_path
+    ) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)
         await store.initialize()
@@ -315,39 +325,22 @@ class TestJobManager:
                     },
                 )
             )
-            await store.append(
-                BaseEvent(
-                    type="execution.session.started",
-                    aggregate_type="execution",
-                    aggregate_id="exec_parallel_ac_2",
-                    data={
-                        "execution_id": "exec_parallel",
-                        "session_id": "child_2",
-                        "session_scope_id": "exec_parallel_ac_2",
-                    },
-                )
-            )
 
             assert await manager._derive_progress_accounting_blocker(snapshot) is None
 
             await store.append(
                 BaseEvent(
-                    type="execution.session.failed",
+                    type="execution.terminal",
                     aggregate_type="execution",
-                    aggregate_id="exec_parallel_ac_2",
-                    data={
-                        "execution_id": "exec_parallel",
-                        "session_id": "child_2",
-                        "session_scope_id": "exec_parallel_ac_2",
-                        "success": False,
-                    },
+                    aggregate_id="exec_parallel",
+                    data={"session_id": "orch_parallel", "status": "failed"},
                 )
             )
 
             blocker = await manager._derive_progress_accounting_blocker(snapshot)
 
             assert blocker is not None
-            assert "all known AC runtime sessions reached a terminal state" in blocker
+            assert "execution reached terminal failed state" in blocker
         finally:
             await store.close()
 

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -200,6 +200,65 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
+
+    async def test_monitor_fails_job_when_deliver_progress_stays_zero_after_ac_success(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+            stop = asyncio.Event()
+
+            async def _runner() -> MCPToolResult:
+                await stop.wait()
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="late done"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id="orch_stalled", execution_id="exec_stalled"),
+            )
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_stalled",
+                    data={
+                        "completed_count": 0,
+                        "total_count": 23,
+                        "current_phase": "Deliver",
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.session.completed",
+                    aggregate_type="execution",
+                    aggregate_id="exec_stalled_ac_1",
+                    data={
+                        "execution_id": "exec_stalled",
+                        "session_id": "child_1",
+                        "success": True,
+                    },
+                )
+            )
+
+            snapshot = await _wait_for_job_status(
+                manager, started.job_id, JobStatus.FAILED, timeout=2.0
+            )
+
+            assert "workflow progress accounting stalled" in (snapshot.error or "")
+            assert snapshot.result_meta["failed_from_progress_accounting_stall"] is True
+        finally:
+            stop.set()
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_cancel_requested_wins_over_complete_execution_terminal(self, tmp_path) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -1134,6 +1134,97 @@ class TestJobManager:
         finally:
             await read_only_store.close()
 
+    async def test_progress_accounting_failure_recovery_is_non_mutating_for_read_only_store(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        database_url = store._database_url
+
+        try:
+            await store.initialize()
+            await store.append(
+                BaseEvent(
+                    type="mcp.job.created",
+                    aggregate_type="job",
+                    aggregate_id="job_recover_failed_read_only",
+                    data={
+                        "job_type": "execute_seed",
+                        "status": JobStatus.RUNNING.value,
+                        "message": "Running execute_seed",
+                        "links": {
+                            "session_id": "orch_recover_failed_read_only",
+                            "execution_id": "exec_recover_failed_read_only",
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_recover_failed_read_only",
+                    data={
+                        "session_id": "orch_recover_failed_read_only",
+                        "completed_count": 0,
+                        "total_count": 1,
+                        "current_phase": "Deliver",
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.session.completed",
+                    aggregate_type="execution",
+                    aggregate_id="exec_recover_failed_read_only_ac_1",
+                    data={
+                        "execution_id": "exec_recover_failed_read_only",
+                        "session_id": "child_1",
+                        "session_scope_id": "exec_recover_failed_read_only_ac_1",
+                        "success": True,
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_recover_failed_read_only",
+                    data={"session_id": "orch_recover_failed_read_only", "status": "failed"},
+                )
+            )
+        finally:
+            await store.close()
+
+        read_only_store = EventStore(database_url, read_only=True)
+        read_only_manager = JobManager(read_only_store)
+        try:
+            await read_only_store.initialize(create_schema=False)
+            snapshot = await read_only_manager.get_snapshot("job_recover_failed_read_only")
+
+            assert snapshot.status is JobStatus.FAILED
+            assert snapshot.result_meta["failed_from_progress_accounting_stall"] is True
+            assert "workflow progress accounting stalled" in (snapshot.error or "")
+            events, _ = await read_only_store.get_events_after(
+                "job",
+                "job_recover_failed_read_only",
+                last_row_id=0,
+            )
+            terminal_events = [
+                event.type
+                for event in events
+                if event.type
+                in {
+                    "mcp.job.completed",
+                    "mcp.job.failed",
+                    "mcp.job.cancelled",
+                    "mcp.job.interrupted",
+                }
+            ]
+            assert terminal_events == []
+        finally:
+            await read_only_store.close()
+
     async def test_completed_execution_recovery_does_not_beat_concurrent_cancel_request(
         self, tmp_path
     ) -> None:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -365,6 +365,74 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
+    async def test_snapshot_recovers_progress_accounting_failed_terminal_after_restart(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        writer = JobManager(store)
+
+        try:
+            await writer._append_event(
+                "mcp.job.created",
+                "job_recover_failed",
+                {
+                    "job_type": "execute_seed",
+                    "status": JobStatus.RUNNING.value,
+                    "message": "Running execute_seed",
+                    "links": {
+                        "session_id": "orch_recover_failed",
+                        "execution_id": "exec_recover_failed",
+                        "lineage_id": None,
+                    },
+                },
+            )
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_recover_failed",
+                    data={
+                        "session_id": "orch_recover_failed",
+                        "completed_count": 0,
+                        "total_count": 1,
+                        "current_phase": "Deliver",
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.session.completed",
+                    aggregate_type="execution",
+                    aggregate_id="exec_recover_failed_ac_1",
+                    data={
+                        "execution_id": "exec_recover_failed",
+                        "session_id": "child_1",
+                        "session_scope_id": "exec_recover_failed_ac_1",
+                        "success": True,
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_recover_failed",
+                    data={"session_id": "orch_recover_failed", "status": "failed"},
+                )
+            )
+
+            restarted = JobManager(store)
+
+            snapshot = await restarted.get_snapshot("job_recover_failed")
+
+            assert snapshot.status is JobStatus.FAILED
+            assert snapshot.result_meta["failed_from_progress_accounting_stall"] is True
+            assert "workflow progress accounting stalled" in (snapshot.error or "")
+            events, _ = await store.get_events_after("job", "job_recover_failed", last_row_id=0)
+            assert [event.type for event in events] == ["mcp.job.created", "mcp.job.failed"]
+        finally:
+            await store.close()
+
     async def test_progress_accounting_blocker_waits_for_active_ac_sessions_after_terminal(
         self, tmp_path
     ) -> None:


### PR DESCRIPTION
## Summary\n- detect the observed stuck state where Deliver progress remains 0/N after an AC session has reported success\n- terminalize that state as a failed job with an actionable progress-accounting blocker instead of leaving it running indefinitely\n- keep completed execution-terminal recovery and cancel-requested precedence intact\n\n## Tests\n- uv run pytest tests/unit/mcp/test_job_manager.py -q\n- uv run ruff check src/ouroboros/mcp/job_manager.py tests/unit/mcp/test_job_manager.py