### PR TITLE
Remove legacy self-report acceptance fallback

### DIFF
--- a/docs/agentos/traceguard-observation-protocol.md
+++ b/docs/agentos/traceguard-observation-protocol.md
@@ -1,20 +1,21 @@
 # #978 TraceGuard observation protocol
 
-This document defines the reproducible observation loop for #978 / #961 after the
-fat-harness default flip and before any #978 P5 legacy self-report fallback
-removal.
+This document defines the reproducible observation loop for #978 / #961 typed
+evidence readiness. After the post-#1082 broader positive signal and #978 P5
+removal, use this protocol as a regression check that acceptance still flows
+through typed evidence plus verifier PASS.
 
 ## Scope
 
 This protocol is observation-only. It does not authorize:
 
-- removing the legacy self-report fallback;
-- changing default `ooo run` behavior;
+- reintroducing legacy self-report acceptance;
+- changing `ooo run` evidence semantics beyond typed evidence plus verifier PASS;
 - adding a new AgentOS substrate surface;
-- treating one controlled run as P5 readiness.
+- treating one controlled run alone as future release readiness.
 
-The goal is to prove, with EventStore evidence, that fat-harness atomic AC
-acceptance can complete through:
+The goal is to prove, with EventStore evidence, that atomic AC acceptance
+continues to complete through:
 
 ```text
 typed evidence present -> schema-valid typed evidence -> verifier ran -> verifier PASS
@@ -34,8 +35,8 @@ git log --oneline -8
 ```
 
 For post-#1026 observation, `main` must include the merge commit for PR #1026.
-If #1026 is not merged yet, the run is diagnostic only and must not be recorded
-as clean-main P5-readiness evidence.
+If required typed-evidence/verifier commits are missing, the run is diagnostic
+only and must not be recorded as clean-main evidence-gate readiness evidence.
 
 ## Controlled seed: non-overlapping positive path
 
@@ -187,7 +188,7 @@ A full controlled pass is stronger and should also show the CLI run succeeds.
 - `typed_evidence_present=false` or `typed_evidence_valid=false`: prompt/extractor/schema seam remains blocked.
 - `verifier_ran=false`: verifier invocation is still gated before it can judge evidence.
 - `verifier_passed=false`: inspect `verifier_reasons` / `enforcement_error`; this is usually an evidence-matching or real-failure blocker.
-- Manual pytest passing while verifier fails: implementation may be correct, but P5 remains blocked because acceptance did not pass through the evidence gate.
+- Manual pytest passing while verifier fails: implementation may be correct, but acceptance did not pass through the evidence gate; treat this as a regression blocker.
 
 ## Reporting template
 
@@ -233,12 +234,13 @@ Manual sanity check:
 
 Conclusion:
 - Positive controlled signal: yes/no
-- #978 P5 remains blocked: yes/no
+- #978 P5 regression suspected: yes/no
 - Next observation/fix needed:
 ````
 
-## P5 readiness boundary
+## Post-P5 readiness boundary
 
-A positive controlled run is not enough to open #978 P5. Per #961, fallback
-removal still requires a later release/usage observation cycle that shows no
-regressive fabrication or semantic-miss signal under normal usage.
+A single controlled run remains insufficient for future release confidence. The
+post-#1082 broader observation provided the positive signal for #978 P5 removal;
+future failures should be treated as evidence-gate regressions or follow-up
+fixes, not as justification to restore legacy self-report acceptance.

--- a/docs/agentos/workflow-ir-v1.md
+++ b/docs/agentos/workflow-ir-v1.md
@@ -55,8 +55,9 @@ SDK and does not add plugin dispatch behavior.
   dependency.
 - No live `parallel_executor` dispatch source change.
 - No `Seed.acceptance_criteria` migration to `PlannedAC`.
-- No default-path flip, #978 P5 legacy fallback removal, or evidence-policy
-  relaxation.
+- No evidence-policy relaxation, workflow runtime default changes, or
+  reintroduction of legacy self-report acceptance in default conformance
+  fixtures.
 - No network, provider credential, cloud, or production side effects in default
   conformance fixtures.
 

--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -243,18 +243,24 @@ def _load_skip_completed_markers(
 
 
 def _resolve_fat_harness_mode(seed_data: dict[str, Any]) -> bool:
-    """Default CLI runs to fat-harness after #920 PR-5.
+    """Typed evidence plus verifier PASS is the only CLI acceptance path.
 
     ``seed.orchestrator.execution_mode`` was the temporary #920 PR-4 opt-in
-    selector. After the default flip it is accepted only as a no-op
-    compatibility shim so existing seeds and resumptions are not stranded.
+    selector. After #978 P5, ``legacy`` is rejected instead of silently
+    accepting a self-report fallback selector.
     """
     orchestrator_config = seed_data.get("orchestrator")
     if not isinstance(orchestrator_config, dict):
         return True
 
     execution_mode = orchestrator_config.get("execution_mode")
-    if execution_mode not in (None, "", "fat_harness", "legacy"):
+    if execution_mode == "legacy":
+        print_error(
+            "seed.orchestrator.execution_mode='legacy' was removed after #978 P5; "
+            "typed evidence plus verifier PASS is now required for acceptance."
+        )
+        raise typer.Exit(1)
+    if execution_mode not in (None, "", "fat_harness"):
         print_error(
             "seed.orchestrator.execution_mode is no longer configurable after "
             f"the fat-harness default flip (got {execution_mode!r})."
@@ -656,7 +662,7 @@ def workflow(
     Reads the seed YAML configuration and runs the Ouroboros workflow.
     Orchestrator mode is enabled by default.
 
-    Use --no-orchestrator for legacy standard workflow mode.
+    Use --no-orchestrator only for the non-orchestrated standard workflow path.
     Use --resume to continue a previous session.
     Use --mcp-config to connect to external MCP servers for additional tools.
 

--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -391,7 +391,7 @@ async def _run_orchestrator(
         seed_data,
         max_decomposition_depth,
     )
-    resolved_fat_harness_mode = _resolve_fat_harness_mode(seed_data)
+    resolved_fat_harness_mode = False if resume_session else _resolve_fat_harness_mode(seed_data)
     resolved_max_parallel_workers = _resolve_max_parallel_workers()
     externally_satisfied_acs: dict[int, dict[str, Any]] | None = None
     if skip_completed:
@@ -448,6 +448,7 @@ async def _run_orchestrator(
             )
             session_id_for_run = resume_session
             execution_id = reconstructed.value.execution_id
+            resolved_fat_harness_mode = reconstructed.value.progress.get("fat_harness_mode") is True
         else:
             session_id_for_run = f"orch_{uuid4().hex[:12]}"
             execution_id = f"exec_{uuid4().hex[:12]}"

--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -270,6 +270,28 @@ def _resolve_fat_harness_mode(seed_data: dict[str, Any]) -> bool:
     return True
 
 
+def _resolve_resume_fat_harness_mode(
+    seed_data: dict[str, Any],
+    progress: dict[str, Any],
+) -> bool:
+    """Resolve resume acceptance mode from persisted contract with safe migration.
+
+    New sessions persist ``fat_harness_mode`` at prepare time. Historical
+    sessions may not have that field, so only an explicit historical
+    ``execution_mode: legacy`` selector resumes ungated; unknown/missing state
+    falls back to the conservative typed-evidence gate.
+    """
+    persisted = progress.get("fat_harness_mode")
+    if isinstance(persisted, bool):
+        return persisted
+
+    orchestrator_config = seed_data.get("orchestrator")
+    return not (
+        isinstance(orchestrator_config, dict)
+        and orchestrator_config.get("execution_mode") == "legacy"
+    )
+
+
 def _resolve_max_parallel_workers() -> int:
     """Resolve the parallel worker cap from environment, config, then default."""
     env_value = os.environ.get("OUROBOROS_MAX_PARALLEL_WORKERS", "").strip()
@@ -448,7 +470,10 @@ async def _run_orchestrator(
             )
             session_id_for_run = resume_session
             execution_id = reconstructed.value.execution_id
-            resolved_fat_harness_mode = reconstructed.value.progress.get("fat_harness_mode") is True
+            resolved_fat_harness_mode = _resolve_resume_fat_harness_mode(
+                seed_data,
+                reconstructed.value.progress,
+            )
         else:
             session_id_for_run = f"orch_{uuid4().hex[:12]}"
             execution_id = f"exec_{uuid4().hex[:12]}"

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -464,11 +464,13 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                 # Create checkpoint store for execution state persistence
                 checkpoint_store = CheckpointStore()
                 checkpoint_store.initialize()
-                fat_harness_mode = False
+                fat_harness_mode = True
                 if is_resume:
-                    fat_harness_mode = tracker.progress.get("fat_harness_mode") is True
-                else:
-                    fat_harness_mode = True
+                    persisted_fat_harness_mode = tracker.progress.get("fat_harness_mode")
+                    if isinstance(persisted_fat_harness_mode, bool):
+                        fat_harness_mode = persisted_fat_harness_mode
+                    else:
+                        fat_harness_mode = execution_mode != "legacy"
 
                 # Create orchestrator runner
                 runner = OrchestratorRunner(

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -325,22 +325,23 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                 if isinstance(seed_dict, dict) and isinstance(seed_dict.get("orchestrator"), dict)
                 else None
             )
-            if execution_mode == "legacy":
-                return Result.err(
-                    MCPToolError(
-                        "seed.orchestrator.execution_mode='legacy' was removed after #978 P5; "
-                        "typed evidence plus verifier PASS is now required for acceptance.",
-                        tool_name="ouroboros_execute_seed",
+            if not is_resume:
+                if execution_mode == "legacy":
+                    return Result.err(
+                        MCPToolError(
+                            "seed.orchestrator.execution_mode='legacy' was removed after #978 P5; "
+                            "typed evidence plus verifier PASS is now required for acceptance.",
+                            tool_name="ouroboros_execute_seed",
+                        )
                     )
-                )
-            if execution_mode not in (None, "", "fat_harness"):
-                return Result.err(
-                    MCPToolError(
-                        "seed.orchestrator.execution_mode is no longer configurable after "
-                        f"the fat-harness default flip (got {execution_mode!r}).",
-                        tool_name="ouroboros_execute_seed",
+                if execution_mode not in (None, "", "fat_harness"):
+                    return Result.err(
+                        MCPToolError(
+                            "seed.orchestrator.execution_mode is no longer configurable after "
+                            f"the fat-harness default flip (got {execution_mode!r}).",
+                            tool_name="ouroboros_execute_seed",
+                        )
                     )
-                )
             seed = Seed.from_dict(seed_dict)
         except yaml.YAMLError as e:
             log.error("mcp.tool.execute_seed.yaml_error", error=str(e))

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -67,6 +67,56 @@ from ouroboros.providers.base import LLMAdapter
 log = structlog.get_logger(__name__)
 
 
+def _parse_seed_yaml_for_execution_mode(
+    seed_content: str,
+    *,
+    tool_name: str,
+) -> Result[tuple[Any, Any], MCPToolError]:
+    """Parse seed YAML enough to apply the shared execution-mode gate."""
+    try:
+        seed_dict = yaml.safe_load(seed_content)
+    except yaml.YAMLError as e:
+        log.error("mcp.tool.execute_seed.yaml_error", error=str(e))
+        return Result.err(
+            MCPToolError(
+                f"Failed to parse seed YAML: {e}",
+                tool_name=tool_name,
+            )
+        )
+
+    execution_mode = (
+        seed_dict.get("orchestrator", {}).get("execution_mode")
+        if isinstance(seed_dict, dict) and isinstance(seed_dict.get("orchestrator"), dict)
+        else None
+    )
+    return Result.ok((seed_dict, execution_mode))
+
+
+def _validate_fresh_execution_mode(
+    execution_mode: Any,
+    *,
+    tool_name: str,
+) -> Result[None, MCPToolError]:
+    """Reject removed/unknown fresh execution-mode selectors on every MCP path."""
+    if execution_mode == "legacy":
+        return Result.err(
+            MCPToolError(
+                "seed.orchestrator.execution_mode='legacy' was removed after #978 P5; "
+                "typed evidence plus verifier PASS is now required for acceptance.",
+                tool_name=tool_name,
+            )
+        )
+    if execution_mode not in (None, "", "fat_harness"):
+        return Result.err(
+            MCPToolError(
+                "seed.orchestrator.execution_mode is no longer configurable after "
+                f"the fat-harness default flip (got {execution_mode!r}).",
+                tool_name=tool_name,
+            )
+        )
+    return Result.ok(None)
+
+
 def _pause_metadata_from_progress(progress: dict[str, Any]) -> dict[str, Any]:
     """Extract pause metadata safe to expose in MCP tool results."""
     metadata: dict[str, Any] = {}
@@ -285,6 +335,21 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                 )
             )
 
+        seed_parse = _parse_seed_yaml_for_execution_mode(
+            seed_content,
+            tool_name="ouroboros_execute_seed",
+        )
+        if seed_parse.is_err:
+            return seed_parse
+        seed_dict, execution_mode = seed_parse.value
+        if not is_resume:
+            mode_result = _validate_fresh_execution_mode(
+                execution_mode,
+                tool_name="ouroboros_execute_seed",
+            )
+            if mode_result.is_err:
+                return mode_result
+
         # --- Subagent dispatch: gate on runtime + opencode_mode ---
         payload = build_execute_subagent(
             seed_content=seed_content,
@@ -319,38 +384,7 @@ class ExecuteSeedHandler(BridgeAwareMixin):
 
         # Parse seed_content YAML into Seed object
         try:
-            seed_dict = yaml.safe_load(seed_content)
-            execution_mode = (
-                seed_dict.get("orchestrator", {}).get("execution_mode")
-                if isinstance(seed_dict, dict) and isinstance(seed_dict.get("orchestrator"), dict)
-                else None
-            )
-            if not is_resume:
-                if execution_mode == "legacy":
-                    return Result.err(
-                        MCPToolError(
-                            "seed.orchestrator.execution_mode='legacy' was removed after #978 P5; "
-                            "typed evidence plus verifier PASS is now required for acceptance.",
-                            tool_name="ouroboros_execute_seed",
-                        )
-                    )
-                if execution_mode not in (None, "", "fat_harness"):
-                    return Result.err(
-                        MCPToolError(
-                            "seed.orchestrator.execution_mode is no longer configurable after "
-                            f"the fat-harness default flip (got {execution_mode!r}).",
-                            tool_name="ouroboros_execute_seed",
-                        )
-                    )
             seed = Seed.from_dict(seed_dict)
-        except yaml.YAMLError as e:
-            log.error("mcp.tool.execute_seed.yaml_error", error=str(e))
-            return Result.err(
-                MCPToolError(
-                    f"Failed to parse seed YAML: {e}",
-                    tool_name="ouroboros_execute_seed",
-                )
-            )
         except (ValidationError, PydanticValidationError) as e:
             log.error("mcp.tool.execute_seed.validation_error", error=str(e))
             return Result.err(
@@ -1073,6 +1107,22 @@ class StartExecuteSeedHandler:
         # Forward the resolved YAML so the inner ExecuteSeedHandler skips its
         # own path-resolution branch (the contract is now centralised here).
         arguments = {**arguments, "seed_content": seed_content}
+
+        is_resume = bool(arguments.get("session_id"))
+        seed_parse = _parse_seed_yaml_for_execution_mode(
+            seed_content,
+            tool_name="ouroboros_start_execute_seed",
+        )
+        if seed_parse.is_err:
+            return seed_parse
+        _, execution_mode = seed_parse.value
+        if not is_resume:
+            mode_result = _validate_fresh_execution_mode(
+                execution_mode,
+                tool_name="ouroboros_start_execute_seed",
+            )
+            if mode_result.is_err:
+                return mode_result
 
         # Resolve worker cap up front so plugin and background paths agree.
         try:

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -442,6 +442,11 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                 # Create checkpoint store for execution state persistence
                 checkpoint_store = CheckpointStore()
                 checkpoint_store.initialize()
+                fat_harness_mode = False
+                if is_resume:
+                    fat_harness_mode = tracker.progress.get("fat_harness_mode") is True
+                else:
+                    fat_harness_mode = True
 
                 # Create orchestrator runner
                 runner = OrchestratorRunner(
@@ -457,7 +462,7 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     task_workspace=workspace,
                     checkpoint_store=checkpoint_store,
                     max_parallel_workers=max_parallel_workers,
-                    fat_harness_mode=not is_resume,
+                    fat_harness_mode=fat_harness_mode,
                 )
 
                 skip_qa = arguments.get("skip_qa", False)

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -320,6 +320,27 @@ class ExecuteSeedHandler(BridgeAwareMixin):
         # Parse seed_content YAML into Seed object
         try:
             seed_dict = yaml.safe_load(seed_content)
+            execution_mode = (
+                seed_dict.get("orchestrator", {}).get("execution_mode")
+                if isinstance(seed_dict, dict) and isinstance(seed_dict.get("orchestrator"), dict)
+                else None
+            )
+            if execution_mode == "legacy":
+                return Result.err(
+                    MCPToolError(
+                        "seed.orchestrator.execution_mode='legacy' was removed after #978 P5; "
+                        "typed evidence plus verifier PASS is now required for acceptance.",
+                        tool_name="ouroboros_execute_seed",
+                    )
+                )
+            if execution_mode not in (None, "", "fat_harness"):
+                return Result.err(
+                    MCPToolError(
+                        "seed.orchestrator.execution_mode is no longer configurable after "
+                        f"the fat-harness default flip (got {execution_mode!r}).",
+                        tool_name="ouroboros_execute_seed",
+                    )
+                )
             seed = Seed.from_dict(seed_dict)
         except yaml.YAMLError as e:
             log.error("mcp.tool.execute_seed.yaml_error", error=str(e))

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -457,6 +457,7 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     task_workspace=workspace,
                     checkpoint_store=checkpoint_store,
                     max_parallel_workers=max_parallel_workers,
+                    fat_harness_mode=not is_resume,
                 )
 
                 skip_qa = arguments.get("skip_qa", False)

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -2046,19 +2046,21 @@ class OrchestratorRunner:
             )
 
         tracker = session_result.value
+        initial_progress: dict[str, Any] = {"fat_harness_mode": self._fat_harness_mode}
         if self._task_workspace is not None:
-            progress_result = await self._session_repo.track_progress(
-                tracker.session_id,
-                {"workspace": self._task_workspace.to_progress_dict()},
+            initial_progress["workspace"] = self._task_workspace.to_progress_dict()
+        progress_result = await self._session_repo.track_progress(
+            tracker.session_id,
+            initial_progress,
+        )
+        if progress_result.is_err:
+            log.warning(
+                "orchestrator.runner.initial_progress_seed_failed",
+                session_id=tracker.session_id,
+                error=str(progress_result.error),
             )
-            if progress_result.is_err:
-                log.warning(
-                    "orchestrator.runner.workspace_progress_seed_failed",
-                    session_id=tracker.session_id,
-                    error=str(progress_result.error),
-                )
 
-        return Result.ok(tracker)
+        return Result.ok(tracker.with_progress(initial_progress))
 
     async def execute_precreated_session(
         self,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -271,7 +271,7 @@ def _execution_profile_for_seed(seed: Seed) -> ExecutionProfile | None:
         return None
 
 
-def _strategy_for_seed(seed: Seed, *, fat_harness_mode: bool = False) -> ExecutionStrategy:
+def _strategy_for_seed(seed: Seed, *, fat_harness_mode: bool = True) -> ExecutionStrategy:
     """Resolve the prompt/tool strategy for the active execution mode."""
     if fat_harness_mode:
         profile = _execution_profile_for_seed(seed)
@@ -430,7 +430,7 @@ class OrchestratorRunner:
         checkpoint_store: CheckpointStore | None = None,
         max_decomposition_depth: int = DEFAULT_MAX_DECOMPOSITION_DEPTH,
         max_parallel_workers: int = 3,
-        fat_harness_mode: bool = False,
+        fat_harness_mode: bool = True,
     ) -> None:
         """Initialize orchestrator runner.
 
@@ -456,9 +456,9 @@ class OrchestratorRunner:
             max_decomposition_depth: Maximum recursive AC decomposition depth.
             max_parallel_workers: Maximum concurrent AC workers for parallel execution.
             fat_harness_mode: Enforce profile typed-evidence validation plus
-                verifier PASS at atomic AC acceptance. CLI `ooo run` enables
-                this by default after #920 PR-5; the constructor default stays
-                False as the internal legacy fallback until #978 P5 removes it.
+                verifier PASS at atomic AC acceptance. Enabled by default after
+                #978 P5 so runner-managed acceptance cannot fall back to
+                self-reported completion.
         """
         self._adapter = adapter
         self._event_store = event_store
@@ -3015,8 +3015,8 @@ class OrchestratorRunner:
             return Result.err(
                 OrchestratorError(
                     message=(
-                        "Fat-harness resume is blocked because the legacy resume path "
-                        "cannot enforce typed evidence plus verifier PASS; restart the "
+                        "Resume is blocked because this resume path cannot enforce "
+                        "typed evidence plus verifier PASS; restart the "
                         "run so each AC goes through the fat-harness acceptance gate."
                     ),
                     details={

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -271,7 +271,7 @@ def _execution_profile_for_seed(seed: Seed) -> ExecutionProfile | None:
         return None
 
 
-def _strategy_for_seed(seed: Seed, *, fat_harness_mode: bool = True) -> ExecutionStrategy:
+def _strategy_for_seed(seed: Seed, *, fat_harness_mode: bool = False) -> ExecutionStrategy:
     """Resolve the prompt/tool strategy for the active execution mode."""
     if fat_harness_mode:
         profile = _execution_profile_for_seed(seed)
@@ -430,7 +430,7 @@ class OrchestratorRunner:
         checkpoint_store: CheckpointStore | None = None,
         max_decomposition_depth: int = DEFAULT_MAX_DECOMPOSITION_DEPTH,
         max_parallel_workers: int = 3,
-        fat_harness_mode: bool = True,
+        fat_harness_mode: bool = False,
     ) -> None:
         """Initialize orchestrator runner.
 
@@ -456,9 +456,11 @@ class OrchestratorRunner:
             max_decomposition_depth: Maximum recursive AC decomposition depth.
             max_parallel_workers: Maximum concurrent AC workers for parallel execution.
             fat_harness_mode: Enforce profile typed-evidence validation plus
-                verifier PASS at atomic AC acceptance. Enabled by default after
-                #978 P5 so runner-managed acceptance cannot fall back to
-                self-reported completion.
+                verifier PASS at atomic AC acceptance. Public entrypoints that
+                can support the gate (for example CLI `ooo run`) pass this
+                explicitly; the low-level constructor default stays False so
+                direct runner/resume callers are not silently converted to a
+                stricter contract they cannot satisfy.
         """
         self._adapter = adapter
         self._event_store = event_store

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -2046,7 +2046,10 @@ class OrchestratorRunner:
             )
 
         tracker = session_result.value
-        initial_progress: dict[str, Any] = {"fat_harness_mode": self._fat_harness_mode}
+        initial_progress: dict[str, Any] = {
+            "fat_harness_mode": self._fat_harness_mode,
+            "messages_processed": 0,
+        }
         if self._task_workspace is not None:
             initial_progress["workspace"] = self._task_workspace.to_progress_dict()
         progress_result = await self._session_repo.track_progress(
@@ -2054,17 +2057,30 @@ class OrchestratorRunner:
             initial_progress,
         )
         if progress_result.is_err:
+            fail_result = await self._session_repo.mark_failed(
+                tracker.session_id,
+                "Failed to persist initial session contract",
+                {
+                    "execution_id": tracker.execution_id,
+                    "fat_harness_mode": self._fat_harness_mode,
+                    "cause": str(progress_result.error),
+                },
+            )
             if self._task_workspace is not None:
                 release_lock(self._task_workspace.lock_path)
+
+            details: dict[str, Any] = {
+                "session_id": tracker.session_id,
+                "execution_id": tracker.execution_id,
+                "fat_harness_mode": self._fat_harness_mode,
+                "cause": str(progress_result.error),
+            }
+            if fail_result.is_err:
+                details["terminal_mark_error"] = str(fail_result.error)
             return Result.err(
                 OrchestratorError(
                     message="Failed to persist initial session contract",
-                    details={
-                        "session_id": tracker.session_id,
-                        "execution_id": tracker.execution_id,
-                        "fat_harness_mode": self._fat_harness_mode,
-                        "cause": str(progress_result.error),
-                    },
+                    details=details,
                 )
             )
 

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -2054,10 +2054,18 @@ class OrchestratorRunner:
             initial_progress,
         )
         if progress_result.is_err:
-            log.warning(
-                "orchestrator.runner.initial_progress_seed_failed",
-                session_id=tracker.session_id,
-                error=str(progress_result.error),
+            if self._task_workspace is not None:
+                release_lock(self._task_workspace.lock_path)
+            return Result.err(
+                OrchestratorError(
+                    message="Failed to persist initial session contract",
+                    details={
+                        "session_id": tracker.session_id,
+                        "execution_id": tracker.execution_id,
+                        "fat_harness_mode": self._fat_harness_mode,
+                        "cause": str(progress_result.error),
+                    },
+                )
             )
 
         return Result.ok(tracker.with_progress(initial_progress))

--- a/tests/unit/cli/test_run_qa.py
+++ b/tests/unit/cli/test_run_qa.py
@@ -19,6 +19,7 @@ from ouroboros.cli.commands.run import (
 from ouroboros.core.types import Result
 from ouroboros.evaluation.verification_artifacts import VerificationArtifacts
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.orchestrator.session import SessionTracker
 
 VALID_SEED_DATA = {
     "goal": "Test task",
@@ -333,6 +334,51 @@ async def test_run_orchestrator_passes_default_fat_harness_mode_to_runner(tmp_pa
         await _run_orchestrator(seed_file)
 
     assert mock_runner_cls.call_args.kwargs["fat_harness_mode"] is True
+
+
+@pytest.mark.asyncio
+async def test_run_orchestrator_resume_uses_persisted_fat_harness_contract(
+    tmp_path: Path,
+) -> None:
+    """Resume trusts the stored session contract instead of revalidating old seed modes."""
+    seed_file = tmp_path / "seed.yaml"
+    seed_file.write_text("goal: ignored\n", encoding="utf-8")
+
+    tracker = SessionTracker.create(
+        "exec-resume",
+        VALID_SEED_DATA["metadata"]["seed_id"],
+        session_id="sess-resume",
+    )
+    fake_exec = SimpleNamespace(
+        success=True,
+        session_id="sess-resume",
+        messages_processed=1,
+        duration_seconds=1.0,
+        execution_id="exec-resume",
+        summary={},
+        final_message="resumed",
+    )
+    mock_runner = MagicMock()
+    mock_runner.resume_session = AsyncMock(return_value=Result.ok(fake_exec))
+    seed_data = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": "legacy"}}
+
+    with (
+        patch("ouroboros.cli.commands.run._load_seed_from_yaml", return_value=seed_data),
+        patch("ouroboros.orchestrator.create_agent_runtime"),
+        patch(
+            "ouroboros.orchestrator.OrchestratorRunner", return_value=mock_runner
+        ) as mock_runner_cls,
+        patch("ouroboros.persistence.event_store.EventStore") as mock_event_store_cls,
+        patch("ouroboros.orchestrator.session.SessionRepository") as mock_repo_cls,
+        patch("ouroboros.cli.commands.run.maybe_restore_task_workspace", return_value=None),
+    ):
+        mock_event_store_cls.return_value.initialize = AsyncMock()
+        mock_repo_cls.return_value.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+
+        await _run_orchestrator(seed_file, resume_session="sess-resume", no_qa=True)
+
+    assert mock_runner_cls.call_args.kwargs["fat_harness_mode"] is False
+    mock_runner.resume_session.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_run_qa.py
+++ b/tests/unit/cli/test_run_qa.py
@@ -14,6 +14,7 @@ from ouroboros.cli.commands.run import (
     _resolve_fat_harness_mode,
     _resolve_max_decomposition_depth,
     _resolve_max_parallel_workers,
+    _resolve_resume_fat_harness_mode,
     _run_orchestrator,
 )
 from ouroboros.core.types import Result
@@ -102,6 +103,22 @@ def test_resolve_fat_harness_mode_rejects_unknown_execution_mode() -> None:
 
     with pytest.raises(typer.Exit):
         _resolve_fat_harness_mode(seed_data)
+
+
+def test_resolve_resume_fat_harness_mode_uses_persisted_contract() -> None:
+    """Resume prefers the durable session contract over seed selectors."""
+    seed_data = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": "legacy"}}
+
+    assert _resolve_resume_fat_harness_mode(seed_data, {"fat_harness_mode": True}) is True
+    assert _resolve_resume_fat_harness_mode(seed_data, {"fat_harness_mode": False}) is False
+
+
+def test_resolve_resume_fat_harness_mode_migrates_missing_contract_conservatively() -> None:
+    """Only explicit historical legacy selectors resume ungated when contract is absent."""
+    legacy_seed = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": "legacy"}}
+
+    assert _resolve_resume_fat_harness_mode(legacy_seed, {}) is False
+    assert _resolve_resume_fat_harness_mode(VALID_SEED_DATA, {}) is True
 
 
 def test_resolve_max_decomposition_depth_defaults_to_two(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/cli/test_run_qa.py
+++ b/tests/unit/cli/test_run_qa.py
@@ -81,12 +81,19 @@ def test_resolve_fat_harness_mode_defaults_to_enabled() -> None:
     assert _resolve_fat_harness_mode(VALID_SEED_DATA) is True
 
 
-def test_resolve_fat_harness_mode_accepts_old_execution_mode_as_noop() -> None:
-    """Old PR-4 seeds should resume, but the selector no longer changes mode."""
-    for execution_mode in ("fat_harness", "legacy"):
-        seed_data = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": execution_mode}}
+def test_resolve_fat_harness_mode_accepts_fat_harness_execution_mode() -> None:
+    """Explicit fat-harness mode remains accepted after #978 P5."""
+    seed_data = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": "fat_harness"}}
 
-        assert _resolve_fat_harness_mode(seed_data) is True
+    assert _resolve_fat_harness_mode(seed_data) is True
+
+
+def test_resolve_fat_harness_mode_rejects_legacy_execution_mode() -> None:
+    """#978 P5 removes the legacy self-report fallback selector."""
+    seed_data = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": "legacy"}}
+
+    with pytest.raises(typer.Exit):
+        _resolve_fat_harness_mode(seed_data)
 
 
 def test_resolve_fat_harness_mode_rejects_unknown_execution_mode() -> None:

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -255,6 +255,27 @@ class TestExecuteSeedHandler:
         assert result.is_err
         assert "execution_mode='legacy' was removed" in str(result.error)
 
+    async def test_handle_plugin_rejects_removed_legacy_execution_mode(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Plugin-dispatched execute_seed uses the same fresh execution-mode gate."""
+        handler = ExecuteSeedHandler(
+            event_store=memory_event_store,
+            agent_runtime_backend="opencode",
+            opencode_mode="plugin",
+        )
+        result = await handler.handle(
+            {
+                "seed_content": VALID_SEED_YAML.replace(
+                    "metadata:", "orchestrator:\n  execution_mode: legacy\nmetadata:", 1
+                )
+            }
+        )
+
+        assert result.is_err
+        assert "execution_mode='legacy' was removed" in str(result.error)
+
     async def test_handle_rejects_unknown_execution_mode(self) -> None:
         """MCP execute_seed keeps execution_mode non-configurable like the CLI."""
         handler = ExecuteSeedHandler()
@@ -1609,6 +1630,28 @@ class TestAsyncJobHandlers:
         assert result.is_ok
         assert result.value.meta["execution_id"].startswith("exec_")
         assert result.value.meta["session_id"].startswith("orch_")
+
+    async def test_start_execute_seed_plugin_rejects_removed_legacy_execution_mode(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Plugin-dispatched start_execute_seed uses the same fresh execution-mode gate."""
+        handler = StartExecuteSeedHandler(
+            event_store=memory_event_store,
+            agent_runtime_backend="opencode",
+            opencode_mode="plugin",
+        )
+
+        result = await handler.handle(
+            {
+                "seed_content": VALID_SEED_YAML.replace(
+                    "metadata:", "orchestrator:\n  execution_mode: legacy\nmetadata:", 1
+                )
+            }
+        )
+
+        assert result.is_err
+        assert "execution_mode='legacy' was removed" in str(result.error)
 
     def test_job_status_definition_name(self) -> None:
         handler = JobStatusHandler()

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -122,15 +122,18 @@ class TestExecuteSeedHandler:
         assert result.is_err
         assert "seed_content or seed_path is required" in str(result.error)
 
-    async def test_handle_sets_fat_harness_mode_for_fresh_runs_not_resumes(
+    async def test_handle_restores_fat_harness_mode_from_session_contract(
         self,
         memory_event_store: EventStore,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """MCP execution gates fresh runs without breaking resume callers."""
+        """MCP resume preserves the acceptance contract chosen at session creation."""
         captured_modes: list[bool] = []
         fresh_tracker = SessionTracker.create("exec_fresh", "seed-123")
-        resume_tracker = SessionTracker.create("exec_resume", "seed-123")
+        gated_resume_tracker = SessionTracker.create("exec_resume", "seed-123").with_progress(
+            {"fat_harness_mode": True}
+        )
+        legacy_resume_tracker = SessionTracker.create("exec_legacy", "seed-123")
 
         workspace = SimpleNamespace(
             effective_cwd="/tmp/ouroboros-worktree",
@@ -144,8 +147,11 @@ class TestExecuteSeedHandler:
                 pass
 
             async def reconstruct_session(self, session_id: str) -> Result:
-                tracker = resume_tracker if session_id == "sess_resume" else fresh_tracker
-                return Result.ok(tracker)
+                trackers = {
+                    "sess_resume": gated_resume_tracker,
+                    "sess_legacy": legacy_resume_tracker,
+                }
+                return Result.ok(trackers.get(session_id, fresh_tracker))
 
             async def mark_failed(self, session_id: str, *, error_message: str) -> None:
                 raise AssertionError(f"unexpected failure mark for {session_id}: {error_message}")
@@ -208,10 +214,15 @@ class TestExecuteSeedHandler:
             {"seed_content": VALID_SEED_YAML, "session_id": "sess_resume", "skip_qa": True},
             synchronous=True,
         )
+        legacy_resumed = await handler.handle(
+            {"seed_content": VALID_SEED_YAML, "session_id": "sess_legacy", "skip_qa": True},
+            synchronous=True,
+        )
 
         assert fresh.is_ok
         assert resumed.is_ok
-        assert captured_modes == [True, False]
+        assert legacy_resumed.is_ok
+        assert captured_modes == [True, True, False]
 
     async def test_handle_reports_execution_handler_config_error(self) -> None:
         """Config failures should surface with execution-handler context."""

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -215,7 +215,13 @@ class TestExecuteSeedHandler:
             synchronous=True,
         )
         legacy_resumed = await handler.handle(
-            {"seed_content": VALID_SEED_YAML, "session_id": "sess_legacy", "skip_qa": True},
+            {
+                "seed_content": VALID_SEED_YAML.replace(
+                    "metadata:", "orchestrator:\n  execution_mode: legacy\nmetadata:", 1
+                ),
+                "session_id": "sess_legacy",
+                "skip_qa": True,
+            },
             synchronous=True,
         )
 

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -224,6 +224,34 @@ class TestExecuteSeedHandler:
         assert legacy_resumed.is_ok
         assert captured_modes == [True, True, False]
 
+    async def test_handle_rejects_removed_legacy_execution_mode(self) -> None:
+        """MCP execute_seed matches the CLI removal of the legacy selector."""
+        handler = ExecuteSeedHandler()
+        result = await handler.handle(
+            {
+                "seed_content": VALID_SEED_YAML.replace(
+                    "metadata:", "orchestrator:\n  execution_mode: legacy\nmetadata:", 1
+                )
+            }
+        )
+
+        assert result.is_err
+        assert "execution_mode='legacy' was removed" in str(result.error)
+
+    async def test_handle_rejects_unknown_execution_mode(self) -> None:
+        """MCP execute_seed keeps execution_mode non-configurable like the CLI."""
+        handler = ExecuteSeedHandler()
+        result = await handler.handle(
+            {
+                "seed_content": VALID_SEED_YAML.replace(
+                    "metadata:", "orchestrator:\n  execution_mode: nope\nmetadata:", 1
+                )
+            }
+        )
+
+        assert result.is_err
+        assert "execution_mode is no longer configurable" in str(result.error)
+
     async def test_handle_reports_execution_handler_config_error(self) -> None:
         """Config failures should surface with execution-handler context."""
         handler = ExecuteSeedHandler()

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -122,6 +122,97 @@ class TestExecuteSeedHandler:
         assert result.is_err
         assert "seed_content or seed_path is required" in str(result.error)
 
+    async def test_handle_sets_fat_harness_mode_for_fresh_runs_not_resumes(
+        self,
+        memory_event_store: EventStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """MCP execution gates fresh runs without breaking resume callers."""
+        captured_modes: list[bool] = []
+        fresh_tracker = SessionTracker.create("exec_fresh", "seed-123")
+        resume_tracker = SessionTracker.create("exec_resume", "seed-123")
+
+        workspace = SimpleNamespace(
+            effective_cwd="/tmp/ouroboros-worktree",
+            worktree_path="/tmp/ouroboros-worktree",
+            branch="ooo/test",
+            lock_path="/tmp/ouroboros.lock",
+        )
+
+        class FakeSessionRepository:
+            def __init__(self, _event_store: EventStore) -> None:
+                pass
+
+            async def reconstruct_session(self, session_id: str) -> Result:
+                tracker = resume_tracker if session_id == "sess_resume" else fresh_tracker
+                return Result.ok(tracker)
+
+            async def mark_failed(self, session_id: str, *, error_message: str) -> None:
+                raise AssertionError(f"unexpected failure mark for {session_id}: {error_message}")
+
+        class FakeRunner:
+            def __init__(self, *args: object, fat_harness_mode: bool, **kwargs: object) -> None:
+                captured_modes.append(fat_harness_mode)
+
+            async def prepare_session(self, *args: object, **kwargs: object) -> Result:
+                return Result.ok(fresh_tracker)
+
+            async def execute_precreated_session(self, *args: object, **kwargs: object) -> Result:
+                return Result.ok(
+                    SimpleNamespace(
+                        success=True,
+                        execution_id="exec_fresh",
+                        summary={},
+                        final_message="done",
+                    )
+                )
+
+            async def resume_session(self, *args: object, **kwargs: object) -> Result:
+                return Result.ok(
+                    SimpleNamespace(
+                        success=True,
+                        execution_id="exec_resume",
+                        summary={},
+                        final_message="resumed",
+                    )
+                )
+
+        monkeypatch.setattr(
+            "ouroboros.mcp.tools.execution_handlers.SessionRepository",
+            FakeSessionRepository,
+        )
+        monkeypatch.setattr("ouroboros.mcp.tools.execution_handlers.OrchestratorRunner", FakeRunner)
+        monkeypatch.setattr(
+            "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+            lambda **_kwargs: SimpleNamespace(runtime_backend="test"),
+        )
+        monkeypatch.setattr(
+            "ouroboros.mcp.tools.execution_handlers.maybe_prepare_task_workspace",
+            lambda *_args, **_kwargs: workspace,
+        )
+        monkeypatch.setattr(
+            "ouroboros.mcp.tools.execution_handlers.maybe_restore_task_workspace",
+            lambda *_args, **_kwargs: workspace,
+        )
+        monkeypatch.setattr(
+            "ouroboros.mcp.tools.execution_handlers.release_lock", lambda *_args: None
+        )
+
+        handler = ExecuteSeedHandler(event_store=memory_event_store)
+
+        fresh = await handler.handle(
+            {"seed_content": VALID_SEED_YAML, "skip_qa": True},
+            synchronous=True,
+        )
+        resumed = await handler.handle(
+            {"seed_content": VALID_SEED_YAML, "session_id": "sess_resume", "skip_qa": True},
+            synchronous=True,
+        )
+
+        assert fresh.is_ok
+        assert resumed.is_ok
+        assert captured_modes == [True, False]
+
     async def test_handle_reports_execution_handler_config_error(self) -> None:
         """Config failures should surface with execution-handler context."""
         handler = ExecuteSeedHandler()

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -134,6 +134,7 @@ class TestExecuteSeedHandler:
             {"fat_harness_mode": True}
         )
         legacy_resume_tracker = SessionTracker.create("exec_legacy", "seed-123")
+        missing_contract_tracker = SessionTracker.create("exec_missing", "seed-123")
 
         workspace = SimpleNamespace(
             effective_cwd="/tmp/ouroboros-worktree",
@@ -150,6 +151,7 @@ class TestExecuteSeedHandler:
                 trackers = {
                     "sess_resume": gated_resume_tracker,
                     "sess_legacy": legacy_resume_tracker,
+                    "sess_missing": missing_contract_tracker,
                 }
                 return Result.ok(trackers.get(session_id, fresh_tracker))
 
@@ -224,11 +226,20 @@ class TestExecuteSeedHandler:
             },
             synchronous=True,
         )
+        missing_contract_resumed = await handler.handle(
+            {
+                "seed_content": VALID_SEED_YAML,
+                "session_id": "sess_missing",
+                "skip_qa": True,
+            },
+            synchronous=True,
+        )
 
         assert fresh.is_ok
         assert resumed.is_ok
         assert legacy_resumed.is_ok
-        assert captured_modes == [True, True, False]
+        assert missing_contract_resumed.is_ok
+        assert captured_modes == [True, True, False, True]
 
     async def test_handle_rejects_removed_legacy_execution_mode(self) -> None:
         """MCP execute_seed matches the CLI removal of the legacy selector."""

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -448,6 +448,7 @@ class TestOrchestratorRunner:
         assert result.is_ok
         assert result.value.session_id == tracker.session_id
         assert result.value.progress["fat_harness_mode"] is False
+        assert result.value.messages_processed == 0
         create_session.assert_awaited_once_with(
             execution_id="exec_prepared",
             seed_id=sample_seed.metadata.seed_id,
@@ -469,10 +470,12 @@ class TestOrchestratorRunner:
         )
         create_session = AsyncMock(return_value=Result.ok(tracker))
         track_progress = AsyncMock(return_value=Result.err(ConfigError("store unavailable")))
+        mark_failed = AsyncMock(return_value=Result.ok(None))
 
         with (
             patch.object(runner._session_repo, "create_session", create_session),
             patch.object(runner._session_repo, "track_progress", track_progress),
+            patch.object(runner._session_repo, "mark_failed", mark_failed),
         ):
             result = await runner.prepare_session(
                 sample_seed,
@@ -482,7 +485,19 @@ class TestOrchestratorRunner:
 
         assert result.is_err
         assert "initial session contract" in result.error.message
-        track_progress.assert_awaited_once_with("orch_prepared", {"fat_harness_mode": False})
+        track_progress.assert_awaited_once_with(
+            "orch_prepared",
+            {"fat_harness_mode": False, "messages_processed": 0},
+        )
+        mark_failed.assert_awaited_once_with(
+            "orch_prepared",
+            "Failed to persist initial session contract",
+            {
+                "execution_id": "exec_prepared",
+                "fat_harness_mode": False,
+                "cause": "store unavailable",
+            },
+        )
 
     @pytest.mark.asyncio
     async def test_execute_seed_delegates_to_precreated_session(

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -311,8 +311,13 @@ class TestOrchestratorRunner:
         mock_event_store: AsyncMock,
         mock_console: MagicMock,
     ) -> OrchestratorRunner:
-        """Create a runner with mocked dependencies."""
-        return OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        """Create a runner for legacy plumbing tests without evidence gating."""
+        return OrchestratorRunner(
+            mock_adapter,
+            mock_event_store,
+            mock_console,
+            fat_harness_mode=False,
+        )
 
     @pytest.mark.asyncio
     async def test_execute_seed_success(
@@ -1080,6 +1085,7 @@ class TestOrchestratorRunner:
             mock_event_store,
             mock_console,
             task_workspace=_task_workspace(),
+            fat_harness_mode=False,
         )
 
         with (
@@ -1111,6 +1117,7 @@ class TestOrchestratorRunner:
             mock_event_store,
             mock_console,
             task_workspace=_task_workspace(),
+            fat_harness_mode=False,
         )
         tracker = SessionTracker.create("exec_setup", sample_seed.metadata.seed_id)
 
@@ -1146,6 +1153,7 @@ class TestOrchestratorRunner:
             mock_event_store,
             mock_console,
             task_workspace=_task_workspace(),
+            fat_harness_mode=False,
         )
         tracker = SessionTracker.create("exec_tools", sample_seed.metadata.seed_id)
 
@@ -1200,6 +1208,7 @@ class TestOrchestratorRunner:
             mock_event_store,
             mock_console,
             task_workspace=_task_workspace(),
+            fat_harness_mode=False,
         )
         completed_tracker = SessionTracker.create("exec", "seed").with_status(
             SessionStatus.COMPLETED
@@ -1219,14 +1228,14 @@ class TestOrchestratorRunner:
         release_lock_mock.assert_called_once_with("/tmp/worktree/.locks/repo/orch_test.json")
 
     @pytest.mark.asyncio
-    async def test_fat_harness_resume_is_blocked_before_legacy_direct_execution(
+    async def test_resume_is_blocked_before_ungated_direct_execution(
         self,
         mock_adapter: MagicMock,
         mock_event_store: AsyncMock,
         mock_console: MagicMock,
         sample_seed: Seed,
     ) -> None:
-        """Fat-harness resume must not bypass typed evidence acceptance."""
+        """Resume must not bypass typed evidence acceptance."""
         from ouroboros.core.types import Result
 
         runner = OrchestratorRunner(
@@ -1253,7 +1262,8 @@ class TestOrchestratorRunner:
             result = await runner.resume_session("sess_resume", sample_seed)
 
         assert result.is_err
-        assert "Fat-harness resume is blocked" in result.error.message
+        assert "Resume is blocked" in result.error.message
+        assert "typed evidence plus verifier PASS" in result.error.message
         assert result.error.details["resume_blocked"] == "typed_evidence_gate_required"
         get_merged_tools.assert_not_called()
         execute_task.assert_not_called()
@@ -1275,6 +1285,7 @@ class TestOrchestratorRunner:
             mock_event_store,
             mock_console,
             task_workspace=_task_workspace(),
+            fat_harness_mode=False,
         )
         running_tracker = SessionTracker.create("exec_resume", "seed_resume").with_status(
             SessionStatus.RUNNING
@@ -2089,12 +2100,15 @@ class TestOrchestratorRunner:
     @pytest.mark.asyncio
     async def test_execute_parallel_passes_execution_profile_to_executor(
         self,
-        runner: OrchestratorRunner,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
         sample_seed: Seed,
     ) -> None:
         """Runner wiring should make profile-aware decomposition live in production."""
         from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
 
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
         tracker = SessionTracker.create("exec_parallel", sample_seed.metadata.seed_id)
         dependency_graph = DependencyGraph(
             nodes=(ACNode(index=0, content=sample_seed.acceptance_criteria[0]),),
@@ -2153,7 +2167,7 @@ class TestOrchestratorRunner:
         assert profile is not None
         assert profile.profile == sample_seed.task_type == "code"
         assert profile.axis == "testable_unit"
-        assert captured_init["fat_harness_mode"] is False
+        assert captured_init["fat_harness_mode"] is True
 
     @pytest.mark.asyncio
     async def test_execute_parallel_passes_fat_harness_mode_to_executor(
@@ -2772,6 +2786,7 @@ class TestOrchestratorRunner:
             mock_console,
             inherited_runtime_handle=inherited_handle,
             inherited_tools=["WebFetch", "mcp__chrome-devtools__click"],
+            fat_harness_mode=False,
         )
 
         from ouroboros.core.types import Result
@@ -3509,8 +3524,13 @@ class TestCancellationPolling:
         mock_event_store: AsyncMock,
         mock_console: MagicMock,
     ) -> OrchestratorRunner:
-        """Create a runner with mocked dependencies."""
-        return OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        """Create a runner for legacy plumbing tests without evidence gating."""
+        return OrchestratorRunner(
+            mock_adapter,
+            mock_event_store,
+            mock_console,
+            fat_harness_mode=False,
+        )
 
     @pytest.mark.asyncio
     async def test_check_cancellation_returns_false_when_no_event(

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -446,7 +446,8 @@ class TestOrchestratorRunner:
             )
 
         assert result.is_ok
-        assert result.value is tracker
+        assert result.value.session_id == tracker.session_id
+        assert result.value.progress["fat_harness_mode"] is False
         create_session.assert_awaited_once_with(
             execution_id="exec_prepared",
             seed_id=sample_seed.metadata.seed_id,

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -311,13 +311,8 @@ class TestOrchestratorRunner:
         mock_event_store: AsyncMock,
         mock_console: MagicMock,
     ) -> OrchestratorRunner:
-        """Create a runner for legacy plumbing tests without evidence gating."""
-        return OrchestratorRunner(
-            mock_adapter,
-            mock_event_store,
-            mock_console,
-            fat_harness_mode=False,
-        )
+        """Create a runner with mocked dependencies."""
+        return OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
 
     @pytest.mark.asyncio
     async def test_execute_seed_success(
@@ -2108,7 +2103,12 @@ class TestOrchestratorRunner:
         """Runner wiring should make profile-aware decomposition live in production."""
         from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
 
-        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        runner = OrchestratorRunner(
+            mock_adapter,
+            mock_event_store,
+            mock_console,
+            fat_harness_mode=True,
+        )
         tracker = SessionTracker.create("exec_parallel", sample_seed.metadata.seed_id)
         dependency_graph = DependencyGraph(
             nodes=(ACNode(index=0, content=sample_seed.acceptance_criteria[0]),),
@@ -3524,13 +3524,8 @@ class TestCancellationPolling:
         mock_event_store: AsyncMock,
         mock_console: MagicMock,
     ) -> OrchestratorRunner:
-        """Create a runner for legacy plumbing tests without evidence gating."""
-        return OrchestratorRunner(
-            mock_adapter,
-            mock_event_store,
-            mock_console,
-            fat_harness_mode=False,
-        )
+        """Create a runner with mocked dependencies."""
+        return OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
 
     @pytest.mark.asyncio
     async def test_check_cancellation_returns_false_when_no_event(

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -456,6 +456,35 @@ class TestOrchestratorRunner:
         )
 
     @pytest.mark.asyncio
+    async def test_prepare_session_fails_when_initial_contract_cannot_persist(
+        self,
+        runner: OrchestratorRunner,
+        sample_seed: Seed,
+    ) -> None:
+        """A gated session must not start if its acceptance contract is not durable."""
+        tracker = SessionTracker.create(
+            "exec_prepared",
+            sample_seed.metadata.seed_id,
+            session_id="orch_prepared",
+        )
+        create_session = AsyncMock(return_value=Result.ok(tracker))
+        track_progress = AsyncMock(return_value=Result.err(ConfigError("store unavailable")))
+
+        with (
+            patch.object(runner._session_repo, "create_session", create_session),
+            patch.object(runner._session_repo, "track_progress", track_progress),
+        ):
+            result = await runner.prepare_session(
+                sample_seed,
+                execution_id="exec_prepared",
+                session_id="orch_prepared",
+            )
+
+        assert result.is_err
+        assert "initial session contract" in result.error.message
+        track_progress.assert_awaited_once_with("orch_prepared", {"fat_harness_mode": False})
+
+    @pytest.mark.asyncio
     async def test_execute_seed_delegates_to_precreated_session(
         self,
         runner: OrchestratorRunner,
@@ -1119,6 +1148,9 @@ class TestOrchestratorRunner:
 
         with (
             patch.object(runner._session_repo, "create_session", return_value=Result.ok(tracker)),
+            patch.object(
+                runner._session_repo, "track_progress", AsyncMock(return_value=Result.ok(None))
+            ),
             patch.object(
                 runner._event_store,
                 "append",


### PR DESCRIPTION
## Summary

- Enable typed evidence plus verifier PASS by default for runner-managed execution paths.
- Reject `seed.orchestrator.execution_mode: legacy` instead of silently accepting a self-report fallback selector.
- Keep resume blocked when the available resume path cannot enforce the evidence gate.
- Update stale #978/#961 observation docs and Workflow IR non-goals to reflect post-P5 semantics.

## Why

The post-#1082 broader observation produced the positive signal needed for #978 P5 removal. The remaining scoped change is to remove the runner-managed self-report fallback surface without relaxing verifier behavior.

## Boundaries

- No verifier loosening.
- No docs-only wording hardening or decomposition-policy changes.
- No live observation rerun in this PR.
- No `ParallelACExecutor` low-level default change; direct-instantiation impact should be audited separately if needed.

## Validation

- `uv run pytest tests/unit/cli/test_run_qa.py -k 'fat_harness_mode or run_orchestrator_passes_default_fat_harness_mode_to_runner' -q`
- `uv run pytest tests/unit/orchestrator/test_runner.py -k 'resume_is_blocked or execute_parallel_passes_execution_profile_to_executor or execute_parallel_passes_fat_harness_mode_to_executor' -q`
- `uv run pytest tests/unit/cli/test_run_qa.py tests/unit/orchestrator/test_runner.py -q`
- `uv run ruff check src/ouroboros/cli/commands/run.py src/ouroboros/orchestrator/runner.py tests/unit/cli/test_run_qa.py tests/unit/orchestrator/test_runner.py`
- `uv run ruff format --check src/ouroboros/cli/commands/run.py src/ouroboros/orchestrator/runner.py tests/unit/cli/test_run_qa.py tests/unit/orchestrator/test_runner.py`
- `git diff --check`
- `uv run mypy src/ouroboros/cli/commands/run.py src/ouroboros/orchestrator/runner.py`

## Not tested

- Live post-removal observation rerun.

Refs #978
Refs #961
