### PR TITLE
Clarify auto handoff-only completion status

### DIFF
--- a/src/ouroboros/auto/handoff_contract.py
+++ b/src/ouroboros/auto/handoff_contract.py
@@ -35,6 +35,11 @@ from __future__ import annotations
 
 from typing import Final
 
+# Known run-handoff lifecycle status values. Kept named so presentation
+# surfaces key off the pipeline state machine rather than any non-empty
+# run_handoff_status.
+RUN_HANDOFF_STARTED_STATUS: Final[str] = "started"
+
 # Unknown handoff status values. Kept named so pipeline code does not need to
 # restate the retryable status alphabet outside this contract module.
 UNKNOWN_NO_HANDLE_STATUS: Final[str] = "unknown_no_handle"
@@ -93,6 +98,7 @@ def unknown_handoff_guidance(status: str) -> str:
 __all__ = [
     "IDEMPOTENCY_KEY_FIELD",
     "IDEMPOTENCY_KWARG_NAME",
+    "RUN_HANDOFF_STARTED_STATUS",
     "MAX_RUN_HANDOFF_RETRIES",
     "UNKNOWN_NO_HANDLE_GUIDANCE",
     "UNKNOWN_NO_HANDLE_STATUS",

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -21,6 +21,7 @@ from ouroboros.auto.handoff_contract import (
     IDEMPOTENCY_KEY_FIELD,
     IDEMPOTENCY_KWARG_NAME,
     RETRY_GUIDANCE_PHRASE,
+    RUN_HANDOFF_STARTED_STATUS,
     UNKNOWN_HANDOFF_STATUSES,
     UNKNOWN_NO_HANDLE_STATUS,
     UNKNOWN_TIMEOUT_STATUS,
@@ -813,7 +814,7 @@ class AutoPipeline:
                 blocker = transient_blocker or state.last_error
                 return self._result(state, ledger, review=review, blocker=blocker)
             if any((state.job_id, state.execution_id, state.run_session_id)):
-                state.run_handoff_status = "started"
+                state.run_handoff_status = RUN_HANDOFF_STARTED_STATUS
                 state.run_handoff_guidance = None
                 # Q00/ouroboros#773 (review-5 finding 2): honor the durable
                 # ``complete_product`` intent on RUN resume. Without this
@@ -1022,7 +1023,7 @@ class AutoPipeline:
                 )
                 state.run_subagent = run_subagent or {}
                 if any((state.job_id, state.execution_id, state.run_session_id)):
-                    state.run_handoff_status = "started"
+                    state.run_handoff_status = RUN_HANDOFF_STARTED_STATUS
                     state.run_handoff_guidance = None
                     # Q00/ouroboros#773: when ``--complete-product`` is set
                     # and a ralph starter is configured, chain RUN →

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -623,15 +623,35 @@ def _print_status(state: AutoPipelineState) -> None:
         console.print(line)
 
 
+def _is_run_handoff_only_completion(result: AutoPipelineResult) -> bool:
+    """True when auto completed only by handing off execution work.
+
+    The persisted pipeline marks this state COMPLETE to avoid duplicate run
+    starts on resume, but it is not verified product completion yet.
+    """
+    return (
+        result.status == "complete"
+        and bool(result.run_handoff_status)
+        and not result.ralph_job_id
+        and not result.ralph_lineage_id
+    )
+
+
 def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
-    if result.status == "complete":
+    handoff_only = _is_run_handoff_only_completion(result)
+    if handoff_only:
+        print_info("Auto run handoff started")
+    elif result.status == "complete":
         print_success("Auto pipeline completed")
     elif result.status in {"blocked", "failed"}:
         print_error("Auto pipeline did not complete")
     else:
         print_info("Auto pipeline status")
     console.print(f"Auto session: [cyan]{result.auto_session_id}[/]")
-    console.print(f"Status: [bold]{result.status}[/]")
+    displayed_status = "run_handoff_started" if handoff_only else result.status
+    console.print(f"Status: [bold]{displayed_status}[/]")
+    if handoff_only:
+        console.print("Product status: [yellow]not verified complete; execution is still external/pending[/]")
     authoring, run_label = _format_runtime_labels(result.runtime_backend, result.opencode_mode)
     console.print(f"Authoring backend: [bold]{authoring}[/]")
     console.print(f"Run backend: [bold]{run_label}[/]")

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -21,6 +21,7 @@ from ouroboros.auto.adapters import (
     save_seed,
 )
 from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
+from ouroboros.auto.handoff_contract import RUN_HANDOFF_STARTED_STATUS
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
 
@@ -631,7 +632,8 @@ def _is_run_handoff_only_completion(result: AutoPipelineResult) -> bool:
     """
     return (
         result.status == "complete"
-        and bool(result.run_handoff_status)
+        and result.run_handoff_status == RUN_HANDOFF_STARTED_STATUS
+        and result.execution_job_status != "completed"
         and not result.ralph_job_id
         and not result.ralph_lineage_id
     )
@@ -651,7 +653,9 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
     displayed_status = "run_handoff_started" if handoff_only else result.status
     console.print(f"Status: [bold]{displayed_status}[/]")
     if handoff_only:
-        console.print("Product status: [yellow]not verified complete; execution is still external/pending[/]")
+        console.print(
+            "Product status: [yellow]not verified complete; execution is still external/pending[/]"
+        )
     authoring, run_label = _format_runtime_labels(result.runtime_backend, result.opencode_mode)
     console.print(f"Authoring backend: [bold]{authoring}[/]")
     console.print(f"Run backend: [bold]{run_label}[/]")

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1159,8 +1159,23 @@ def _utc_iso(*, ttl_seconds: float | None = None) -> str:
     return value.isoformat()
 
 
+def _is_run_handoff_only_completion(result: AutoPipelineResult) -> bool:
+    """True when auto completed only by handing off execution work."""
+    return (
+        result.status == "complete"
+        and bool(result.run_handoff_status)
+        and not result.ralph_job_id
+        and not result.ralph_lineage_id
+    )
+
+
+def _presentation_status(result: AutoPipelineResult) -> str:
+    return "run_handoff_started" if _is_run_handoff_only_completion(result) else result.status
+
+
 def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
     """Build MCP metadata for clients that render auto progress outside CLI text."""
+    handoff_only = _is_run_handoff_only_completion(result)
     meta: dict[str, Any] = {
         "status": result.status,
         "auto_session_id": result.auto_session_id,
@@ -1179,6 +1194,9 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         "job_id": result.job_id,
         "run_session_id": result.run_session_id,
     }
+    if handoff_only:
+        meta["presentation_status"] = _presentation_status(result)
+        meta["product_status"] = "not_verified_complete"
     if result.execution_job_status:
         meta["execution_job_status"] = result.execution_job_status
     if result.execution_job_error:
@@ -1842,11 +1860,14 @@ def _execution_start_handler(
 
 
 def _format_result(result: AutoPipelineResult) -> str:
+    handoff_only = _is_run_handoff_only_completion(result)
     lines = [
         f"Auto session: {result.auto_session_id}",
-        f"Status: {result.status}",
+        f"Status: {_presentation_status(result)}",
         f"Phase: {result.phase}",
     ]
+    if handoff_only:
+        lines.append("Product status: not verified complete; execution is still external/pending")
     if result.grade:
         lines.append(f"Seed grade: {result.grade}")
     if result.interview_session_id:

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -33,6 +33,7 @@ from ouroboros.auto.execution_acceptance import (
     has_auto_wrapper_context,
     is_auto_reporting_acceptance_criterion,
 )
+from ouroboros.auto.handoff_contract import RUN_HANDOFF_STARTED_STATUS
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import (
     REQUIRED_SECTIONS,
@@ -1163,7 +1164,8 @@ def _is_run_handoff_only_completion(result: AutoPipelineResult) -> bool:
     """True when auto completed only by handing off execution work."""
     return (
         result.status == "complete"
-        and bool(result.run_handoff_status)
+        and result.run_handoff_status == RUN_HANDOFF_STARTED_STATUS
+        and result.execution_job_status != "completed"
         and not result.ralph_job_id
         and not result.ralph_lineage_id
     )

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -2211,3 +2211,26 @@ async def test_auto_handler_complete_product_uses_configured_ralph_factory(
     assert captured["factory_opencode_mode"] == "plugin"
     assert captured["ralph_starter_handler"] is configured_ralph
     assert captured["ralph_resumer_handler"] is configured_ralph
+
+
+def test_auto_handler_meta_and_text_distinguish_handoff_from_product_completion() -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.mcp.tools.auto_handler import _format_result, _result_meta
+
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_handoff",
+        phase="complete",
+        run_handoff_status="started",
+        job_id="job_123",
+        execution_id="exec_123",
+    )
+
+    meta = _result_meta(result)
+    text = _format_result(result)
+
+    assert meta["status"] == "complete"
+    assert meta["presentation_status"] == "run_handoff_started"
+    assert meta["product_status"] == "not_verified_complete"
+    assert "Status: run_handoff_started" in text
+    assert "Product status: not verified complete" in text

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -2213,6 +2213,31 @@ async def test_auto_handler_complete_product_uses_configured_ralph_factory(
     assert captured["ralph_resumer_handler"] is configured_ralph
 
 
+def test_auto_handler_attached_completion_is_not_handoff_started() -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.mcp.tools.auto_handler import _format_result, _result_meta
+
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_attached",
+        phase="complete",
+        run_handoff_status="attached",
+        attached_run_handle="exec_existing",
+        attached_run_source="operator",
+        attached_at="2026-05-07T00:00:00+00:00",
+    )
+
+    meta = _result_meta(result)
+    text = _format_result(result)
+
+    assert meta["status"] == "complete"
+    assert "presentation_status" not in meta
+    assert "product_status" not in meta
+    assert "Status: complete" in text
+    assert "Status: run_handoff_started" not in text
+    assert "Product status: not verified complete" not in text
+
+
 def test_auto_handler_meta_and_text_distinguish_handoff_from_product_completion() -> None:
     from ouroboros.auto.pipeline import AutoPipelineResult
     from ouroboros.mcp.tools.auto_handler import _format_result, _result_meta

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -633,3 +633,22 @@ def test_print_result_handoff_completion_is_not_labeled_product_complete() -> No
     assert "Product status: not verified complete" in output
     assert "Auto pipeline completed" not in output
 
+
+def test_print_result_attached_completion_remains_product_complete() -> None:
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_attached",
+        phase="complete",
+        run_handoff_status="attached",
+        attached_run_handle="exec_existing",
+        attached_run_source="operator",
+        attached_at="2026-05-07T00:00:00+00:00",
+        resume_capability=AutoResumeCapability.NONE,
+    )
+
+    output = _capture_result(result)
+
+    assert "Auto pipeline completed" in output
+    assert "Status: complete" in output
+    assert "Status: run_handoff_started" not in output
+    assert "Product status: not verified complete" not in output

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -613,3 +613,23 @@ def test_print_result_resume_capability_none_emits_no_resume_line() -> None:
     assert "Resume:" not in output
     assert "Retry:" not in output
     assert "Start fresh" not in output
+
+
+def test_print_result_handoff_completion_is_not_labeled_product_complete() -> None:
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_handoff",
+        phase="complete",
+        run_handoff_status="started",
+        job_id="job_123",
+        execution_id="exec_123",
+        resume_capability=AutoResumeCapability.NONE,
+    )
+
+    output = _capture_result(result)
+
+    assert "Auto run handoff started" in output
+    assert "Status: run_handoff_started" in output
+    assert "Product status: not verified complete" in output
+    assert "Auto pipeline completed" not in output
+

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -30,9 +30,11 @@ from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
 from ouroboros.mcp.tools.auto_handler import (
     AutoHandler,
     _derive_goal_user_preferences,
+    _format_result,
     _merge_resume_user_preferences,
     _reconcile_execution_job_snapshot,
     _reseed_preference_ledger,
+    _result_meta,
     _seed_initial_ledger_from_user_preferences,
 )
 from ouroboros.mcp.types import ContentType
@@ -182,6 +184,7 @@ def test_execution_job_completed_keeps_auto_complete(monkeypatch) -> None:
         auto_session_id="auto_1",
         phase="complete",
         job_id="job_done",
+        run_handoff_status="started",
         resume_capability=AutoResumeCapability.RESUME,
     )
 
@@ -190,6 +193,14 @@ def test_execution_job_completed_keeps_auto_complete(monkeypatch) -> None:
     assert reconciled.status == "complete"
     assert reconciled.execution_job_status == "completed"
     assert reconciled.resume_capability is AutoResumeCapability.NONE
+    meta = _result_meta(reconciled)
+    text = _format_result(reconciled)
+
+    assert "presentation_status" not in meta
+    assert "product_status" not in meta
+    assert "Status: complete" in text
+    assert "Status: run_handoff_started" not in text
+    assert "Product status: not verified complete" not in text
 
 
 def test_execution_job_failure_rewrites_complete_auto_result(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- distinguish handoff-only auto completion from verified product completion in CLI output
- add MCP presentation/product status metadata for handoff-only completions without changing legacy status
- render MCP text as run_handoff_started when execution was only handed off

## Tests
- uv run pytest tests/unit/cli/test_auto_command.py tests/unit/auto/test_surface.py -q

## Context
This addresses the release-gate confusion where `ooo auto` displayed `Status: complete` after an execution handoff even though the product artifact was not verified yet.