### PR TITLE
Wire configured Ralph handler into auto complete-product

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1665,6 +1665,13 @@ def create_ouroboros_server(
         agent_runtime_backend=resolved_runtime_backend,
         opencode_mode=opencode_mode,
     )
+    ralph_handler = RalphHandler(
+        evolve_handler=evolve_step,
+        event_store=event_store,
+        job_manager=job_manager,
+        agent_runtime_backend=resolved_runtime_backend,
+        opencode_mode=opencode_mode,
+    )
     interview = InterviewHandler(
         event_store=event_store,
         llm_adapter=llm_adapter,
@@ -1692,6 +1699,7 @@ def create_ouroboros_server(
             opencode_mode=opencode_mode,
             mcp_manager=auto_mcp_manager,
             mcp_tool_prefix=auto_mcp_prefix,
+            ralph_handler=ralph_handler,
         ),
         StartAutoHandler(
             interview_handler=interview,
@@ -1704,6 +1712,7 @@ def create_ouroboros_server(
             opencode_mode=opencode_mode,
             mcp_manager=auto_mcp_manager,
             mcp_tool_prefix=auto_mcp_prefix,
+            ralph_handler=ralph_handler,
         ),
         SessionStatusHandler(
             event_store=event_store,
@@ -1784,13 +1793,7 @@ def create_ouroboros_server(
             agent_runtime_backend=resolved_runtime_backend,
             opencode_mode=opencode_mode,
         ),
-        RalphHandler(
-            evolve_handler=evolve_step,
-            event_store=event_store,
-            job_manager=job_manager,
-            agent_runtime_backend=resolved_runtime_backend,
-            opencode_mode=opencode_mode,
-        ),
+        ralph_handler,
         LineageStatusHandler(
             event_store=event_store,
         ),

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1665,13 +1665,20 @@ def create_ouroboros_server(
         agent_runtime_backend=resolved_runtime_backend,
         opencode_mode=opencode_mode,
     )
-    ralph_handler = RalphHandler(
-        evolve_handler=evolve_step,
-        event_store=event_store,
-        job_manager=job_manager,
-        agent_runtime_backend=resolved_runtime_backend,
-        opencode_mode=opencode_mode,
-    )
+
+    def build_ralph_handler(
+        runtime_backend: str | None,
+        ralph_opencode_mode: str | None,
+    ) -> RalphHandler:
+        return RalphHandler(
+            evolve_handler=evolve_step,
+            event_store=event_store,
+            job_manager=job_manager,
+            agent_runtime_backend=runtime_backend,
+            opencode_mode=ralph_opencode_mode,
+        )
+
+    ralph_handler = build_ralph_handler(resolved_runtime_backend, opencode_mode)
     interview = InterviewHandler(
         event_store=event_store,
         llm_adapter=llm_adapter,
@@ -1699,7 +1706,7 @@ def create_ouroboros_server(
             opencode_mode=opencode_mode,
             mcp_manager=auto_mcp_manager,
             mcp_tool_prefix=auto_mcp_prefix,
-            ralph_handler=ralph_handler,
+            ralph_handler_factory=build_ralph_handler,
         ),
         StartAutoHandler(
             interview_handler=interview,
@@ -1712,7 +1719,7 @@ def create_ouroboros_server(
             opencode_mode=opencode_mode,
             mcp_manager=auto_mcp_manager,
             mcp_tool_prefix=auto_mcp_prefix,
-            ralph_handler=ralph_handler,
+            ralph_handler_factory=build_ralph_handler,
         ),
         SessionStatusHandler(
             event_store=event_store,

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -99,6 +99,7 @@ class AutoHandler:
     opencode_mode: str | None = field(default=None, repr=False)
     mcp_manager: object | None = field(default=None, repr=False)
     mcp_tool_prefix: str = ""
+    ralph_handler: RalphHandler | None = field(default=None, repr=False)
 
     @property
     def definition(self) -> MCPToolDefinition:
@@ -417,14 +418,12 @@ class AutoHandler:
         # ``_subagent`` dispatch path instead of silently downgrading Ralph to
         # in-process job mode. Mirrors the CLI fix in ``cli/commands/auto.py``.
         ralph_opencode_mode = state.ralph_opencode_mode or opencode_mode
-        ralph_handler = (
-            RalphHandler(
+        ralph_handler = None
+        if complete_product:
+            ralph_handler = self.ralph_handler or RalphHandler(
                 agent_runtime_backend=runtime_backend,
                 opencode_mode=ralph_opencode_mode,
             )
-            if complete_product
-            else None
-        )
         ralph_starter = HandlerRalphStarter(ralph_handler) if ralph_handler is not None else None
         # Q00/ouroboros#773 (review-5 finding 1): wire a poller backed by the
         # same ``RalphHandler`` so MCP-side resumes of an interrupted
@@ -522,6 +521,7 @@ class StartAutoHandler:
     mcp_tool_prefix: str = ""
     event_store: EventStore | None = field(default=None, repr=False)
     job_manager: JobManager | None = field(default=None, repr=False)
+    ralph_handler: RalphHandler | None = field(default=None, repr=False)
 
     def __post_init__(self) -> None:
         self._event_store = self.event_store or EventStore()
@@ -537,6 +537,7 @@ class StartAutoHandler:
             opencode_mode=self.opencode_mode,
             mcp_manager=self.mcp_manager,
             mcp_tool_prefix=self.mcp_tool_prefix,
+            ralph_handler=self.ralph_handler,
         )
 
     @property

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime, timedelta
 import difflib
@@ -99,7 +100,9 @@ class AutoHandler:
     opencode_mode: str | None = field(default=None, repr=False)
     mcp_manager: object | None = field(default=None, repr=False)
     mcp_tool_prefix: str = ""
-    ralph_handler: RalphHandler | None = field(default=None, repr=False)
+    ralph_handler_factory: Callable[[str | None, str | None], RalphHandler] | None = field(
+        default=None, repr=False
+    )
 
     @property
     def definition(self) -> MCPToolDefinition:
@@ -420,9 +423,13 @@ class AutoHandler:
         ralph_opencode_mode = state.ralph_opencode_mode or opencode_mode
         ralph_handler = None
         if complete_product:
-            ralph_handler = self.ralph_handler or RalphHandler(
-                agent_runtime_backend=runtime_backend,
-                opencode_mode=ralph_opencode_mode,
+            ralph_handler = (
+                self.ralph_handler_factory(runtime_backend, ralph_opencode_mode)
+                if self.ralph_handler_factory is not None
+                else RalphHandler(
+                    agent_runtime_backend=runtime_backend,
+                    opencode_mode=ralph_opencode_mode,
+                )
             )
         ralph_starter = HandlerRalphStarter(ralph_handler) if ralph_handler is not None else None
         # Q00/ouroboros#773 (review-5 finding 1): wire a poller backed by the
@@ -521,7 +528,9 @@ class StartAutoHandler:
     mcp_tool_prefix: str = ""
     event_store: EventStore | None = field(default=None, repr=False)
     job_manager: JobManager | None = field(default=None, repr=False)
-    ralph_handler: RalphHandler | None = field(default=None, repr=False)
+    ralph_handler_factory: Callable[[str | None, str | None], RalphHandler] | None = field(
+        default=None, repr=False
+    )
 
     def __post_init__(self) -> None:
         self._event_store = self.event_store or EventStore()
@@ -537,7 +546,7 @@ class StartAutoHandler:
             opencode_mode=self.opencode_mode,
             mcp_manager=self.mcp_manager,
             mcp_tool_prefix=self.mcp_tool_prefix,
-            ralph_handler=self.ralph_handler,
+            ralph_handler_factory=self.ralph_handler_factory,
         )
 
     @property

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -2167,7 +2167,9 @@ def test_auto_save_seed_accepts_default_seed_id_inside_seed_dir(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
-async def test_auto_handler_complete_product_uses_injected_configured_ralph_handler(monkeypatch, tmp_path) -> None:
+async def test_auto_handler_complete_product_uses_configured_ralph_factory(
+    monkeypatch, tmp_path
+) -> None:
     from ouroboros.auto.pipeline import AutoPipelineResult
     from ouroboros.auto.state import AutoStore
     from ouroboros.mcp.tools import auto_handler as auto_module
@@ -2175,8 +2177,13 @@ async def test_auto_handler_complete_product_uses_injected_configured_ralph_hand
     class FakeRalphHandler:
         pass
 
-    injected_ralph = FakeRalphHandler()
+    configured_ralph = FakeRalphHandler()
     captured: dict[str, object] = {}
+
+    def build_ralph(runtime_backend, opencode_mode):  # noqa: ANN001
+        captured["factory_runtime_backend"] = runtime_backend
+        captured["factory_opencode_mode"] = opencode_mode
+        return configured_ralph
 
     class FakePipeline:
         def __init__(self, driver, _seed_generator, **kwargs):  # noqa: ANN001, ANN003, ARG002
@@ -2193,11 +2200,14 @@ async def test_auto_handler_complete_product_uses_injected_configured_ralph_hand
     monkeypatch.setattr(auto_module, "AutoStore", lambda: AutoStore(tmp_path / "store"))
     monkeypatch.setattr(auto_module, "AutoPipeline", FakePipeline)
 
-    result = await AutoHandler(ralph_handler=injected_ralph).handle(
-        {"goal": "Build a CLI", "cwd": str(tmp_path), "complete_product": True}
-    )
+    result = await AutoHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+        ralph_handler_factory=build_ralph,
+    ).handle({"goal": "Build a CLI", "cwd": str(tmp_path), "complete_product": True})
 
     assert result.is_ok
-    assert captured["ralph_starter_handler"] is injected_ralph
-    assert captured["ralph_resumer_handler"] is injected_ralph
-
+    assert captured["factory_runtime_backend"] == "opencode"
+    assert captured["factory_opencode_mode"] == "plugin"
+    assert captured["ralph_starter_handler"] is configured_ralph
+    assert captured["ralph_resumer_handler"] is configured_ralph

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -2164,3 +2164,40 @@ def test_auto_save_seed_accepts_default_seed_id_inside_seed_dir(tmp_path: Path) 
     assert path == (seeds_dir / "seed_safe_123.yaml").resolve()
     assert path.exists()
     assert load_seed(path).metadata.seed_id == "seed_safe_123"
+
+
+@pytest.mark.asyncio
+async def test_auto_handler_complete_product_uses_injected_configured_ralph_handler(monkeypatch, tmp_path) -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.auto.state import AutoStore
+    from ouroboros.mcp.tools import auto_handler as auto_module
+
+    class FakeRalphHandler:
+        pass
+
+    injected_ralph = FakeRalphHandler()
+    captured: dict[str, object] = {}
+
+    class FakePipeline:
+        def __init__(self, driver, _seed_generator, **kwargs):  # noqa: ANN001, ANN003, ARG002
+            captured["ralph_starter_handler"] = kwargs["ralph_starter"].handler
+            captured["ralph_resumer_handler"] = kwargs["ralph_resumer"].handler
+
+        async def run(self, run_state):  # noqa: ANN001
+            return AutoPipelineResult(
+                status="complete",
+                auto_session_id=run_state.auto_session_id,
+                phase="complete",
+            )
+
+    monkeypatch.setattr(auto_module, "AutoStore", lambda: AutoStore(tmp_path / "store"))
+    monkeypatch.setattr(auto_module, "AutoPipeline", FakePipeline)
+
+    result = await AutoHandler(ralph_handler=injected_ralph).handle(
+        {"goal": "Build a CLI", "cwd": str(tmp_path), "complete_product": True}
+    )
+
+    assert result.is_ok
+    assert captured["ralph_starter_handler"] is injected_ralph
+    assert captured["ralph_resumer_handler"] is injected_ralph
+

--- a/tests/unit/mcp/tools/test_auto_handler_ralph_runtime.py
+++ b/tests/unit/mcp/tools/test_auto_handler_ralph_runtime.py
@@ -96,3 +96,57 @@ def test_mcp_resume_passes_undemoted_ralph_opencode_mode_to_ralph_handler(
     # The fix: Ralph must see the un-demoted plugin mode, NOT the demoted
     # ``state.opencode_mode == "subprocess"`` used for authoring/run handlers.
     assert captured["kwargs"]["opencode_mode"] == "plugin"
+
+
+def test_mcp_resume_configured_ralph_factory_preserves_session_runtime_and_mode(
+    tmp_path,
+) -> None:
+    """Configured MCP Ralph factories must keep resume-specific dispatch settings."""
+    state = AutoPipelineState(goal="ralph factory resume", cwd=str(tmp_path))
+    state.runtime_backend = "opencode"
+    state.opencode_mode = "subprocess"
+    state.ralph_opencode_mode = "plugin"
+    state.complete_product = True
+    state.skip_run = True
+    state.max_interview_rounds = 2
+    state.max_repair_rounds = 1
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    captured: dict[str, Any] = {}
+
+    class _ConfiguredRalphHandler:
+        def __init__(self, runtime_backend: str | None, opencode_mode: str | None) -> None:
+            captured["runtime_backend"] = runtime_backend
+            captured["opencode_mode"] = opencode_mode
+
+    def _build_ralph_handler(
+        runtime_backend: str | None,
+        opencode_mode: str | None,
+    ) -> _ConfiguredRalphHandler:
+        return _ConfiguredRalphHandler(runtime_backend, opencode_mode)
+
+    async def _noop_run(self, state):  # noqa: ARG001
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            grade="A",
+            runtime_backend=state.runtime_backend,
+            opencode_mode=state.opencode_mode,
+        )
+
+    handler = AutoHandler(
+        store=store,
+        agent_runtime_backend="subprocess",
+        ralph_handler_factory=_build_ralph_handler,
+    )
+
+    with patch(
+        "ouroboros.mcp.tools.auto_handler.AutoPipeline.run",
+        new=_noop_run,
+    ):
+        asyncio.run(handler.handle({"resume": state.auto_session_id}))
+
+    assert captured == {"runtime_backend": "opencode", "opencode_mode": "plugin"}


### PR DESCRIPTION
## Summary
- reuse the composition-root RalphHandler for MCP auto complete-product sessions
- pass that handler through AutoHandler/StartAutoHandler so complete-product has a configured EvolutionaryLoop instead of constructing an unwired RalphHandler
- add regression coverage that complete_product injects the configured Ralph handler into both start and resume adapters

## Test
- uv run pytest tests/unit/auto/test_surface.py tests/unit/test_ralph_loop_progress.py -q