### PR TITLE
fix(jobs): wait for runner cleanup after progress-stall failure

### DIFF
--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -452,10 +452,25 @@ class JobManager:
                         )
                         continue
                     self._monitor_terminalized_jobs.add(job_id)
-                    runner = self._runner_tasks.pop(job_id, None)
+                    runner = self._runner_tasks.get(job_id)
                     if runner is not None and not runner.done():
                         runner.cancel()
-                        runner.add_done_callback(_consume_task_result)
+                        try:
+                            await asyncio.wait_for(
+                                asyncio.shield(runner),
+                                timeout=_COMPLETED_EXECUTION_CANCEL_GRACE_SECONDS,
+                            )
+                        except TimeoutError:
+                            self._runner_tasks.pop(job_id, None)
+                            runner.add_done_callback(_consume_task_result)
+                        except asyncio.CancelledError:
+                            return
+                        except Exception:
+                            self._runner_tasks.pop(job_id, None)
+                        else:
+                            self._runner_tasks.pop(job_id, None)
+                    elif runner is not None:
+                        self._runner_tasks.pop(job_id, None)
                     job_task = self._tasks.pop(job_id, None)
                     if job_task is not None and not job_task.done():
                         job_task.cancel()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -365,6 +365,81 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
+    async def test_progress_accounting_failure_keeps_runner_tracked_during_cancel_cleanup(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+            cleanup_started = asyncio.Event()
+            cleanup_release = asyncio.Event()
+
+            async def _runner() -> MCPToolResult:
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    cleanup_started.set()
+                    await cleanup_release.wait()
+                    raise
+                raise AssertionError("runner should only exit through cancellation")
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id="orch_cleanup", execution_id="exec_cleanup"),
+            )
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_cleanup",
+                    data={
+                        "session_id": "orch_cleanup",
+                        "completed_count": 0,
+                        "total_count": 1,
+                        "current_phase": "Deliver",
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.session.completed",
+                    aggregate_type="execution",
+                    aggregate_id="exec_cleanup_ac_1",
+                    data={
+                        "execution_id": "exec_cleanup",
+                        "session_id": "child_1",
+                        "session_scope_id": "exec_cleanup_ac_1",
+                        "success": True,
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_cleanup",
+                    data={"session_id": "orch_cleanup", "status": "failed"},
+                )
+            )
+
+            await asyncio.wait_for(cleanup_started.wait(), timeout=2.0)
+
+            assert started.job_id in manager._runner_tasks
+
+            cleanup_release.set()
+            snapshot = await _wait_for_job_status(
+                manager, started.job_id, JobStatus.FAILED, timeout=2.0
+            )
+
+            assert snapshot.result_meta["failed_from_progress_accounting_stall"] is True
+        finally:
+            cleanup_release.set()
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_snapshot_recovers_progress_accounting_failed_terminal_after_restart(
         self, tmp_path
     ) -> None:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -440,6 +440,87 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
+    async def test_progress_accounting_failure_detaches_runner_after_cancel_grace_timeout(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+            cleanup_started = asyncio.Event()
+            cleanup_release = asyncio.Event()
+
+            async def _runner() -> MCPToolResult:
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    cleanup_started.set()
+                    await cleanup_release.wait()
+                    raise
+                raise AssertionError("runner should only exit through cancellation")
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(
+                    session_id="orch_cleanup_timeout", execution_id="exec_cleanup_timeout"
+                ),
+            )
+            await store.append(
+                BaseEvent(
+                    type="workflow.progress.updated",
+                    aggregate_type="execution",
+                    aggregate_id="exec_cleanup_timeout",
+                    data={
+                        "session_id": "orch_cleanup_timeout",
+                        "completed_count": 0,
+                        "total_count": 1,
+                        "current_phase": "Deliver",
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.session.completed",
+                    aggregate_type="execution",
+                    aggregate_id="exec_cleanup_timeout_ac_1",
+                    data={
+                        "execution_id": "exec_cleanup_timeout",
+                        "session_id": "child_1",
+                        "session_scope_id": "exec_cleanup_timeout_ac_1",
+                        "success": True,
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_cleanup_timeout",
+                    data={"session_id": "orch_cleanup_timeout", "status": "failed"},
+                )
+            )
+
+            with patch.object(
+                job_manager_module,
+                "_COMPLETED_EXECUTION_CANCEL_GRACE_SECONDS",
+                0.05,
+            ):
+                await asyncio.wait_for(cleanup_started.wait(), timeout=2.0)
+                await _wait_for_job_status(manager, started.job_id, JobStatus.FAILED, timeout=2.0)
+                deadline = asyncio.get_running_loop().time() + 1.0
+                while started.job_id in manager._runner_tasks:
+                    if asyncio.get_running_loop().time() >= deadline:
+                        raise AssertionError("runner task was not detached after grace timeout")
+                    await asyncio.sleep(0.01)
+
+            assert started.job_id not in manager._runner_tasks
+        finally:
+            cleanup_release.set()
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_snapshot_recovers_progress_accounting_failed_terminal_after_restart(
         self, tmp_path
     ) -> None:


### PR DESCRIPTION
## Summary\n- follow up PR #1085 after ouroboros-agent flagged that the live progress-stall failure path detached runners immediately after cancellation\n- keep runner ownership tracked during cancellation cleanup by waiting with the existing completion-recovery grace period before detaching\n- add a regression test covering a runner that performs async CancelledError cleanup\n\n## AgentOS / #961 alignment\n- stays inside the existing MCP job recovery seam introduced by #1085\n- preserves execution.terminal as the authoritative lifecycle source and does not add a new AgentOS surface\n- tightens live-runner ownership to match the already accepted completed-execution recovery discipline\n\n## Tests\n- uv run pytest tests/unit/mcp/test_job_manager.py -q\n- uv run ruff check src/ouroboros/mcp/job_manager.py tests/unit/mcp/test_job_manager.py\n- uv run mypy src/ouroboros/mcp/job_manager.py tests/unit/mcp/test_job_manager.py