### PR TITLE
fix(auto): wire configured Ralph loop for complete-product

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -216,8 +216,9 @@ class HandlerRalphStarter:
     job tools.
     """
 
-    def __init__(self, handler: RalphHandler) -> None:
+    def __init__(self, handler: RalphHandler, *, project_dir: str | None = None) -> None:
         self.handler = handler
+        self.project_dir = project_dir
 
     @property
     def job_event_store(self) -> Any:
@@ -292,6 +293,8 @@ class HandlerRalphStarter:
             "lineage_id": lineage_id,
             "seed_content": seed_yaml,
         }
+        if self.project_dir is not None:
+            arguments["project_dir"] = self.project_dir
         if max_total_seconds is not None:
             arguments["max_total_seconds"] = max_total_seconds
         if per_iteration_timeout_seconds is not None:

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -49,6 +49,29 @@ from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.orchestrator import resolve_agent_runtime_backend
 
 
+def _build_configured_ralph_handler(
+    *, runtime: str | None, opencode_mode: str | None
+) -> RalphHandler:
+    """Build the same fully wired Ralph handler used by the MCP composition root.
+
+    The plain ``RalphHandler(...)`` constructor intentionally supports tests and
+    plugin-only dispatch, but for in-process/job dispatch it creates a handler
+    whose ``EvolveStepHandler`` has no ``EvolutionaryLoop``. That leaks through
+    the direct CLI ``ooo auto --complete-product`` path as a background Ralph
+    failure: ``EvolutionaryLoop not configured``. Reuse the production MCP
+    composition root so CLI and MCP auto handoffs get the same executor,
+    evaluator, validator, event store, and job manager wiring.
+    """
+    from ouroboros.mcp.server.adapter import create_ouroboros_server
+
+    server = create_ouroboros_server(runtime_backend=runtime, opencode_mode=opencode_mode)
+    handler = server._tool_handlers["ouroboros_ralph"]  # noqa: SLF001
+    if not isinstance(handler, RalphHandler):
+        msg = "MCP composition root returned non-Ralph handler for ouroboros_ralph"
+        raise TypeError(msg)
+    return handler
+
+
 class AgentRuntimeBackend(str, Enum):  # noqa: UP042
     """Supported runtime backends for auto execution handoff."""
 
@@ -452,11 +475,17 @@ async def _run_auto(
         # ``ralph_opencode_mode`` so an OpenCode plugin session can take the
         # plugin ``_subagent`` dispatch path. ``opencode_mode`` (demoted) is
         # still correct for the authoring/run-handoff handlers above.
-        RalphHandler(agent_runtime_backend=runtime, opencode_mode=ralph_opencode_mode)
+        # Q00/ouroboros#1090: use the full MCP composition root rather than a
+        # bare RalphHandler so job-mode Ralph has an EvolutionaryLoop.
+        _build_configured_ralph_handler(runtime=runtime, opencode_mode=ralph_opencode_mode)
         if complete_product
         else None
     )
-    ralph_starter = HandlerRalphStarter(ralph_handler) if ralph_handler is not None else None
+    ralph_starter = (
+        HandlerRalphStarter(ralph_handler, project_dir=state.cwd)
+        if ralph_handler is not None
+        else None
+    )
     # Q00/ouroboros#773 (review-5 finding 1): wire a poller backed by the same
     # ``RalphHandler`` so a session interrupted in ``RALPH_HANDOFF`` (e.g.
     # client disconnects while the background Ralph job keeps running) can

--- a/tests/unit/auto/test_pipeline_evaluate.py
+++ b/tests/unit/auto/test_pipeline_evaluate.py
@@ -699,10 +699,13 @@ async def test_handler_ralph_starter_returns_result_text() -> None:
         async def get_snapshot(self, _job_id: str) -> _StubSnapshot:
             return _StubSnapshot()
 
+    captured_arguments: dict[str, Any] = {}
+
     class _StubRalphHandler:
         _job_manager = _StubJobManager()
 
-        async def handle(self, _arguments: dict[str, Any]):  # noqa: ANN201
+        async def handle(self, arguments: dict[str, Any]):  # noqa: ANN201
+            captured_arguments.update(arguments)
             from ouroboros.core.types import Result
             from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 
@@ -719,10 +722,13 @@ async def test_handler_ralph_starter_returns_result_text() -> None:
                 )
             )
 
-    starter = HandlerRalphStarter(_StubRalphHandler())  # type: ignore[arg-type]
+    starter = HandlerRalphStarter(  # type: ignore[arg-type]
+        _StubRalphHandler(), project_dir="/tmp/auto-project"
+    )
     result = await starter(_build_seed(), lineage_id="lineage_X")
     assert result["result_text"] == "ralph artifact text"
     assert result["terminal_status"] == "completed"
+    assert captured_arguments["project_dir"] == "/tmp/auto-project"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -379,6 +379,53 @@ def test_auto_result_pipeline_carries_runtime_labels(tmp_path) -> None:
     assert result.opencode_mode is None
 
 
+def test_run_auto_complete_product_configures_ralph_evolutionary_loop(
+    tmp_path, monkeypatch
+) -> None:
+    """Regression for #1090: CLI complete-product must not create a bare Ralph handler.
+
+    A bare ``RalphHandler(agent_runtime_backend=...)`` constructs an
+    ``EvolveStepHandler`` without an ``EvolutionaryLoop``. The background Ralph
+    job then fails at handoff time with ``EvolutionaryLoop not configured``.
+    """
+    import asyncio
+
+    from ouroboros.cli.commands.auto import _run_auto
+
+    captured = {}
+    monkeypatch.chdir(tmp_path)
+
+    async def fake_pipeline_run(self, run_state):  # noqa: ARG001
+        ralph_starter = self.ralph_starter
+        captured["evolve_handler"] = ralph_starter.handler._evolve_handler  # noqa: SLF001
+        captured["project_dir"] = ralph_starter.project_dir
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=run_state.auto_session_id,
+            phase="complete",
+            grade="A",
+        )
+
+    with patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=fake_pipeline_run):
+        result = asyncio.run(
+            _run_auto(
+                goal="safe goal",
+                resume=None,
+                runtime="hermes",
+                max_interview_rounds=2,
+                max_repair_rounds=1,
+                skip_run=False,
+                complete_product=True,
+            )
+        )
+
+    assert result.status == "complete"
+    evolve_handler = captured.get("evolve_handler")
+    assert evolve_handler is not None
+    assert getattr(evolve_handler, "evolutionary_loop", None) is not None
+    assert captured["project_dir"] == str(tmp_path)
+
+
 def test_run_auto_demotes_plugin_to_subprocess_in_state(tmp_path) -> None:
     """`_run_auto` must overwrite persisted plugin opencode_mode to subprocess."""
     import asyncio


### PR DESCRIPTION
## Summary
- Fixes #1090.
- Changes direct CLI `ouroboros auto --complete-product` to build Ralph through the production MCP composition root instead of constructing a bare `RalphHandler`.
- Adds a regression test proving CLI complete-product gets an `EvolveStepHandler` with a configured `EvolutionaryLoop`.

## Root cause
The direct CLI path created `RalphHandler(agent_runtime_backend=..., opencode_mode=...)` directly. That bare handler defaulted to an `EvolveStepHandler` without an `EvolutionaryLoop`, causing background Ralph handoff to fail immediately with:

```text
EvolutionaryLoop not configured
```

## Verification
- `uv run ruff check src/ouroboros/cli/commands/auto.py tests/unit/cli/test_auto_command.py`
- `uv run pytest tests/unit/cli/test_auto_command.py tests/unit/mcp/tools/test_auto_handler_ralph_runtime.py -q`

## Notes
This deliberately reuses the existing MCP composition root so CLI and MCP Ralph paths stay aligned for executor/evaluator/validator/event-store/job-manager wiring.
