### PR TITLE
Clarify auto complete-product completion status

### DIFF
--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -48,6 +48,10 @@ from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExec
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.orchestrator import resolve_agent_runtime_backend
 
+_STALE_COMPLETED_RALPH_HANDOFF_STATUSES = frozenset(
+    {RUN_HANDOFF_STARTED_STATUS, "ralph_retry_after_blocker"}
+)
+
 
 def _build_configured_ralph_handler(
     *, runtime: str | None, opencode_mode: str | None
@@ -726,7 +730,8 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
         console.print(f"  Execution ID: {result.execution_id}")
         console.print(f"  Session ID: {result.run_session_id}")
     if result.run_handoff_status and not (
-        completed_ralph_product and result.run_handoff_status == RUN_HANDOFF_STARTED_STATUS
+        completed_ralph_product
+        and result.run_handoff_status in _STALE_COMPLETED_RALPH_HANDOFF_STATUSES
     ):
         console.print(f"Run handoff status: [bold]{result.run_handoff_status}[/]")
     if result.run_handoff_guidance:

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -668,8 +668,16 @@ def _is_run_handoff_only_completion(result: AutoPipelineResult) -> bool:
     )
 
 
+def _is_completed_ralph_product(result: AutoPipelineResult) -> bool:
+    """True when ``--complete-product`` reached a terminal Ralph completion."""
+    return result.status == "complete" and bool(
+        result.ralph_job_id or result.ralph_lineage_id or result.ralph_dispatch_mode
+    )
+
+
 def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
     handoff_only = _is_run_handoff_only_completion(result)
+    completed_ralph_product = _is_completed_ralph_product(result)
     if handoff_only:
         print_info("Auto run handoff started")
     elif result.status == "complete":
@@ -685,6 +693,8 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
         console.print(
             "Product status: [yellow]not verified complete; execution is still external/pending[/]"
         )
+    elif completed_ralph_product:
+        console.print("Product status: [green]completed by Ralph loop[/]")
     authoring, run_label = _format_runtime_labels(result.runtime_backend, result.opencode_mode)
     console.print(f"Authoring backend: [bold]{authoring}[/]")
     console.print(f"Run backend: [bold]{run_label}[/]")
@@ -703,7 +713,9 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
         console.print(f"  Job ID: {result.job_id}")
         console.print(f"  Execution ID: {result.execution_id}")
         console.print(f"  Session ID: {result.run_session_id}")
-    if result.run_handoff_status:
+    if result.run_handoff_status and not (
+        completed_ralph_product and result.run_handoff_status == RUN_HANDOFF_STARTED_STATUS
+    ):
         console.print(f"Run handoff status: [bold]{result.run_handoff_status}[/]")
     if result.run_handoff_guidance:
         console.print(f"Run handoff guidance: [yellow]{result.run_handoff_guidance}[/]")

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -670,14 +670,22 @@ def _is_run_handoff_only_completion(result: AutoPipelineResult) -> bool:
 
 def _is_completed_ralph_product(result: AutoPipelineResult) -> bool:
     """True when ``--complete-product`` reached a terminal Ralph completion."""
-    return result.status == "complete" and bool(
-        result.ralph_job_id or result.ralph_lineage_id or result.ralph_dispatch_mode
+    return (
+        result.status == "complete"
+        and result.ralph_dispatch_mode != "plugin"
+        and bool(result.ralph_job_id or result.ralph_lineage_id)
     )
+
+
+def _is_external_ralph_plugin_completion(result: AutoPipelineResult) -> bool:
+    """True when auto is complete but product work lives in an OpenCode child."""
+    return result.status == "complete" and result.ralph_dispatch_mode == "plugin"
 
 
 def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
     handoff_only = _is_run_handoff_only_completion(result)
     completed_ralph_product = _is_completed_ralph_product(result)
+    external_ralph_plugin = _is_external_ralph_plugin_completion(result)
     if handoff_only:
         print_info("Auto run handoff started")
     elif result.status == "complete":
@@ -695,6 +703,10 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
         )
     elif completed_ralph_product:
         console.print("Product status: [green]completed by Ralph loop[/]")
+    elif external_ralph_plugin:
+        console.print(
+            "Product status: [yellow]not verified complete; Ralph loop is external/pending[/]"
+        )
     authoring, run_label = _format_runtime_labels(result.runtime_backend, result.opencode_mode)
     console.print(f"Authoring backend: [bold]{authoring}[/]")
     console.print(f"Run backend: [bold]{run_label}[/]")

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -681,6 +681,31 @@ def test_print_result_handoff_completion_is_not_labeled_product_complete() -> No
     assert "Auto pipeline completed" not in output
 
 
+def test_print_result_complete_product_completion_suppresses_stale_handoff_status() -> None:
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_complete_product",
+        phase="complete",
+        run_handoff_status="started",
+        job_id="job_123",
+        execution_id="exec_123",
+        run_session_id="orch_123",
+        ralph_job_id="job_ralph",
+        ralph_lineage_id="lineage_123",
+        ralph_dispatch_mode="sync",
+        resume_capability=AutoResumeCapability.NONE,
+    )
+
+    output = _capture_result(result)
+
+    assert "Auto pipeline completed" in output
+    assert "Status: complete" in output
+    assert "Product status: completed by Ralph loop" in output
+    assert "Status: run_handoff_started" not in output
+    assert "Run handoff status: started" not in output
+    assert "Product status: not verified complete" not in output
+
+
 def test_print_result_attached_completion_remains_product_complete() -> None:
     result = AutoPipelineResult(
         status="complete",

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -706,6 +706,34 @@ def test_print_result_complete_product_completion_suppresses_stale_handoff_statu
     assert "Product status: not verified complete" not in output
 
 
+def test_print_result_plugin_ralph_completion_remains_external_pending() -> None:
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_plugin_complete_product",
+        phase="complete",
+        run_handoff_status="started",
+        run_handoff_guidance=(
+            "Ralph loop delegated to the OpenCode plugin child session. "
+            "Track progress through the OpenCode Task widget."
+        ),
+        job_id="job_123",
+        execution_id="exec_123",
+        run_session_id="orch_123",
+        ralph_lineage_id="lineage_123",
+        ralph_dispatch_mode="plugin",
+        resume_capability=AutoResumeCapability.NONE,
+    )
+
+    output = _capture_result(result)
+
+    assert "Auto pipeline completed" in output
+    assert "Status: complete" in output
+    assert "Product status: not verified complete; Ralph loop is external/pending" in output
+    assert "Product status: completed by Ralph loop" not in output
+    assert "Run handoff status: started" in output
+    assert "Run handoff guidance: Ralph loop delegated to the OpenCode plugin" in output
+
+
 def test_print_result_attached_completion_remains_product_complete() -> None:
     result = AutoPipelineResult(
         status="complete",

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -706,6 +706,28 @@ def test_print_result_complete_product_completion_suppresses_stale_handoff_statu
     assert "Product status: not verified complete" not in output
 
 
+def test_print_result_complete_product_completion_suppresses_retry_handoff_status() -> None:
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_complete_product_retry",
+        phase="complete",
+        run_handoff_status="ralph_retry_after_blocker",
+        job_id="job_123",
+        execution_id="exec_123",
+        run_session_id="orch_123",
+        ralph_job_id="job_ralph",
+        ralph_lineage_id="lineage_123",
+        ralph_dispatch_mode="job",
+        resume_capability=AutoResumeCapability.NONE,
+    )
+
+    output = _capture_result(result)
+
+    assert "Auto pipeline completed" in output
+    assert "Product status: completed by Ralph loop" in output
+    assert "Run handoff status: ralph_retry_after_blocker" not in output
+
+
 def test_print_result_plugin_ralph_completion_remains_external_pending() -> None:
     result = AutoPipelineResult(
         status="complete",


### PR DESCRIPTION
## Summary
- show an explicit product-completed status when auto --complete-product reaches Ralph completion
- suppress the stale initial run handoff status in completed Ralph product output
- add CLI regression coverage for this exact confusing status surface

## Verification
- uv run pytest tests/unit/cli/test_auto_command.py::test_print_result_complete_product_completion_suppresses_stale_handoff_status tests/unit/cli/test_auto_command.py::test_print_result_handoff_completion_is_not_labeled_product_complete tests/unit/cli/test_auto_command.py::test_print_result_attached_completion_remains_product_complete -q
- uv run pytest tests/unit/auto/test_pipeline_evaluate.py tests/unit/cli/test_auto_command.py tests/unit/mcp/tools/test_auto_handler_ralph_runtime.py tests/unit/mcp/test_job_manager.py -q
- live smoke: /tmp/ouroboros-0390-complete-product-smoke-12 produced hello.py and python3 hello.py printed exactly Hello, Ouroboros!