### PR TITLE
fix(jobs): preserve runner failure over terminal evidence

### DIFF
--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -326,11 +326,6 @@ class JobManager:
             snapshot = await self.get_snapshot(job_id)
             if snapshot.is_terminal:
                 return
-            if job_id in self._monitor_terminalized_jobs:
-                completed_result = await self._derive_completed_execution_result(snapshot)
-                if completed_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
-                    await self._append_execution_completed_event(job_id, completed_result)
-                return
             await self._append_event(
                 "mcp.job.failed",
                 job_id,
@@ -344,11 +339,6 @@ class JobManager:
         else:
             snapshot = await self.get_snapshot(job_id)
             if snapshot.is_terminal:
-                return
-            if job_id in self._monitor_terminalized_jobs:
-                completed_result = await self._derive_completed_execution_result(snapshot)
-                if completed_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
-                    await self._append_execution_completed_event(job_id, completed_result)
                 return
             terminal_type = "mcp.job.completed"
             terminal_status = JobStatus.COMPLETED
@@ -368,6 +358,11 @@ class JobManager:
             elif getattr(result, "is_error", False):
                 terminal_type = "mcp.job.failed"
                 terminal_status = JobStatus.FAILED
+            elif job_id in self._monitor_terminalized_jobs:
+                completed_result = await self._derive_completed_execution_result(snapshot)
+                if completed_result is not None:
+                    await self._append_execution_completed_event(job_id, completed_result)
+                    return
             else:
                 completed_result = await self._derive_completed_execution_result(snapshot)
                 if completed_result is not None:

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -301,7 +301,7 @@ class JobManager:
             result = await runner
         except asyncio.CancelledError:
             snapshot = await self.get_snapshot(job_id)
-            if snapshot.is_terminal or job_id in self._monitor_terminalized_jobs:
+            if snapshot.is_terminal:
                 return
             completed_result = await self._derive_completed_execution_result(snapshot)
             if completed_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
@@ -324,11 +324,12 @@ class JobManager:
             raise
         except Exception as exc:
             snapshot = await self.get_snapshot(job_id)
-            if snapshot.is_terminal or job_id in self._monitor_terminalized_jobs:
+            if snapshot.is_terminal:
                 return
-            completed_result = await self._derive_completed_execution_result(snapshot)
-            if completed_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
-                await self._append_execution_completed_event(job_id, completed_result)
+            if job_id in self._monitor_terminalized_jobs:
+                completed_result = await self._derive_completed_execution_result(snapshot)
+                if completed_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
+                    await self._append_execution_completed_event(job_id, completed_result)
                 return
             await self._append_event(
                 "mcp.job.failed",
@@ -337,15 +338,17 @@ class JobManager:
                     "status": JobStatus.FAILED.value,
                     "message": f"Job failed: {exc}",
                     "error": str(exc),
+                    "is_error": True,
                 },
             )
         else:
             snapshot = await self.get_snapshot(job_id)
-            if snapshot.is_terminal or job_id in self._monitor_terminalized_jobs:
+            if snapshot.is_terminal:
                 return
-            completed_result = await self._derive_completed_execution_result(snapshot)
-            if completed_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
-                await self._append_execution_completed_event(job_id, completed_result)
+            if job_id in self._monitor_terminalized_jobs:
+                completed_result = await self._derive_completed_execution_result(snapshot)
+                if completed_result is not None and snapshot.status != JobStatus.CANCEL_REQUESTED:
+                    await self._append_execution_completed_event(job_id, completed_result)
                 return
             terminal_type = "mcp.job.completed"
             terminal_status = JobStatus.COMPLETED
@@ -365,6 +368,11 @@ class JobManager:
             elif getattr(result, "is_error", False):
                 terminal_type = "mcp.job.failed"
                 terminal_status = JobStatus.FAILED
+            else:
+                completed_result = await self._derive_completed_execution_result(snapshot)
+                if completed_result is not None:
+                    await self._append_execution_completed_event(job_id, completed_result)
+                    return
             await self._append_event(
                 terminal_type,
                 job_id,
@@ -411,6 +419,7 @@ class JobManager:
                     runner = self._runner_tasks.get(job_id)
                     if runner is None or runner.done():
                         return
+                    self._monitor_terminalized_jobs.add(job_id)
                     runner.cancel()
                     try:
                         await asyncio.wait_for(

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -284,6 +284,57 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
+    async def test_monitor_completion_does_not_mask_cancel_cleanup_error_result(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+
+        try:
+
+            async def _runner() -> MCPToolResult:
+                try:
+                    await asyncio.Event().wait()
+                except asyncio.CancelledError:
+                    return MCPToolResult(
+                        content=(
+                            MCPContentItem(
+                                type=ContentType.TEXT,
+                                text="cancel cleanup returned failure",
+                            ),
+                        ),
+                        is_error=True,
+                    )
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(
+                    session_id="orch_monitor_error_result",
+                    execution_id="exec_monitor_error_result",
+                ),
+            )
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_monitor_error_result",
+                    data={"session_id": "orch_monitor_error_result", "status": "completed"},
+                )
+            )
+
+            snapshot = await _wait_for_job_status(
+                manager, started.job_id, JobStatus.FAILED, timeout=3.0
+            )
+
+            assert snapshot.result_text == "cancel cleanup returned failure"
+            assert snapshot.result_meta.get("completed_from_execution_terminal") is not True
+        finally:
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_monitor_fails_job_when_deliver_progress_stays_zero_after_ac_success(
         self, tmp_path
     ) -> None:
@@ -1064,7 +1115,7 @@ class TestJobManager:
         finally:
             await store.close()
 
-    async def test_execution_terminal_completion_overrides_runner_cancel_result(
+    async def test_execution_terminal_completion_preserves_runner_cancel_result(
         self, tmp_path
     ) -> None:
         store = _build_store(tmp_path)
@@ -1107,11 +1158,12 @@ class TestJobManager:
             snapshot = await _wait_for_job_status(
                 manager,
                 started.job_id,
-                JobStatus.COMPLETED,
+                JobStatus.CANCELLED,
                 timeout=2.0,
             )
 
-            assert snapshot.result_meta["completed_from_execution_terminal"] is True
+            assert snapshot.result_text == "cancelled"
+            assert snapshot.result_meta.get("completed_from_execution_terminal") is not True
             events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
             terminal_events = [
                 event.type
@@ -1124,12 +1176,12 @@ class TestJobManager:
                     "mcp.job.interrupted",
                 }
             ]
-            assert terminal_events == ["mcp.job.completed"]
+            assert terminal_events == ["mcp.job.cancelled"]
         finally:
             await _cancel_manager_tasks(manager)
             await store.close()
 
-    async def test_execution_terminal_completion_overrides_runner_cancel_exception(
+    async def test_execution_terminal_completion_preserves_runner_cancel_exception(
         self, tmp_path
     ) -> None:
         store = _build_store(tmp_path)
@@ -1168,12 +1220,12 @@ class TestJobManager:
             snapshot = await _wait_for_job_status(
                 manager,
                 started.job_id,
-                JobStatus.COMPLETED,
+                JobStatus.FAILED,
                 timeout=2.0,
             )
 
-            assert snapshot.result_meta["completed_from_execution_terminal"] is True
-            assert snapshot.error is None
+            assert snapshot.result_meta.get("completed_from_execution_terminal") is not True
+            assert snapshot.error == "cleanup failed after terminal execution"
             events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
             terminal_events = [
                 event.type
@@ -1186,7 +1238,7 @@ class TestJobManager:
                     "mcp.job.interrupted",
                 }
             ]
-            assert terminal_events == ["mcp.job.completed"]
+            assert terminal_events == ["mcp.job.failed"]
         finally:
             await _cancel_manager_tasks(manager)
             await store.close()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -200,6 +200,90 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
+    async def test_runner_exception_is_not_masked_by_execution_completion(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+
+        try:
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_runner_failed_after_terminal",
+                    data={"session_id": "orch_runner_failed", "status": "completed"},
+                )
+            )
+
+            async def _runner() -> MCPToolResult:
+                raise RuntimeError("post-processing failed")
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(
+                    session_id="orch_runner_failed",
+                    execution_id="exec_runner_failed_after_terminal",
+                ),
+            )
+
+            snapshot = await _wait_for_job_status(
+                manager, started.job_id, JobStatus.FAILED, timeout=2.0
+            )
+
+            assert "post-processing failed" in (snapshot.error or "")
+            assert snapshot.result_meta.get("completed_from_execution_terminal") is not True
+        finally:
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_error_result_is_not_masked_by_execution_completion(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+
+        try:
+            await store.append(
+                BaseEvent(
+                    type="execution.terminal",
+                    aggregate_type="execution",
+                    aggregate_id="exec_tool_error_after_terminal",
+                    data={"session_id": "orch_tool_error", "status": "completed"},
+                )
+            )
+
+            async def _runner() -> MCPToolResult:
+                return MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text="handler failed after execution terminal",
+                        ),
+                    ),
+                    is_error=True,
+                )
+
+            started = await manager.start_job(
+                job_type="execute_seed",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(
+                    session_id="orch_tool_error",
+                    execution_id="exec_tool_error_after_terminal",
+                ),
+            )
+
+            snapshot = await _wait_for_job_status(
+                manager, started.job_id, JobStatus.FAILED, timeout=2.0
+            )
+
+            assert snapshot.result_text == "handler failed after execution terminal"
+            assert snapshot.result_meta.get("completed_from_execution_terminal") is not True
+        finally:
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_monitor_fails_job_when_deliver_progress_stays_zero_after_ac_success(
         self, tmp_path
     ) -> None:


### PR DESCRIPTION
## Summary
- fail closed when a background job runner raises after linked execution terminal evidence exists
- preserve explicit MCP error/cancel/interrupted runner results instead of replacing them with synthetic completed jobs
- keep monitor-triggered terminal-evidence completion for the long-running runner handoff case

## Security impact
Prevents a false-success path where stale or early execution.terminal(status=completed) evidence could mask handler post-processing failures or MCP is_error results as mcp.job.completed/is_error=false.

## Tests
- uv run pytest -q tests/unit/mcp/test_job_manager.py
- uv run ruff check src/ouroboros/mcp/job_manager.py tests/unit/mcp/test_job_manager.py