### PR TITLE
fix(auto): canonicalize observation execution criteria

### DIFF
--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -69,10 +69,7 @@ def normalize_observation_execution_criteria(
     if not _has_auto_wrapper_context(context_text, criteria):
         return criteria
 
-    keep_return = False
-    keep_test_file = False
-    keep_pytest = False
-    passthrough: list[str] = []
+    normalized: list[str] = []
     for criterion in criteria:
         stripped = criterion.strip()
         if not stripped:
@@ -82,30 +79,9 @@ def normalize_observation_execution_criteria(
             lowered
         ):
             continue
-        if "uv run pytest" in lowered and "tests/test_hello_auto.py" in lowered:
-            keep_pytest = True
-            continue
-        if "tests/test_hello_auto.py" in lowered:
-            keep_test_file = True
-            continue
-        if "hello_auto.py" in lowered:
-            keep_return = True
-            continue
-        passthrough.append(stripped)
+        normalized.append(_normalize_known_observation_execution_line(stripped))
 
-    canonical: list[str] = []
-    if keep_return:
-        canonical.append(
-            "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`."
-        )
-    if keep_test_file:
-        canonical.append(
-            "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value."
-        )
-    if keep_pytest:
-        canonical.append("The exact command `uv run pytest tests/test_hello_auto.py` passes.")
-
-    return tuple(dict.fromkeys((*canonical, *passthrough)))
+    return tuple(dict.fromkeys(normalized))
 
 
 def is_auto_reporting_acceptance_criterion(criterion: str) -> bool:
@@ -134,6 +110,36 @@ def _has_auto_wrapper_context(goal: str, criteria: tuple[str, ...]) -> bool:
 
 def _criterion_key(criterion: str) -> str:
     return " ".join(criterion.casefold().strip().rstrip(".").split())
+
+
+def _normalize_known_observation_execution_line(criterion: str) -> str:
+    """Canonicalize only known-equivalent hello_auto execution AC phrasings."""
+    key = _criterion_key(criterion)
+    hello_return_equivalents = {
+        "`hello_auto.py` defines `hello_auto()` returning exactly `hello from ooo auto`",
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`",
+        "hello_auto.py defines hello_auto() returning exactly hello from ooo auto",
+        "hello_auto.py defines hello_auto() -> str returning exactly hello from ooo auto",
+    }
+    test_file_equivalents = {
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value",
+        "tests/test_hello_auto.py imports hello_auto and asserts the exact return value",
+    }
+    pytest_equivalents = {
+        "`uv run pytest tests/test_hello_auto.py` passes",
+        "uv run pytest tests/test_hello_auto.py passes",
+        "the exact command `uv run pytest tests/test_hello_auto.py` passes",
+        "the targeted test command `uv run pytest tests/test_hello_auto.py` passes",
+    }
+    if key in hello_return_equivalents:
+        return (
+            "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`."
+        )
+    if key in test_file_equivalents:
+        return "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value."
+    if key in pytest_equivalents:
+        return "The exact command `uv run pytest tests/test_hello_auto.py` passes."
+    return criterion
 
 
 def _is_observation_report_only_line(lowered: str) -> bool:

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -25,6 +25,28 @@ _AUTO_WRAPPER_CRITERIA = frozenset(
     }
 )
 
+_OBSERVATION_REPORT_ONLY_CRITERIA = frozenset(
+    {
+        "`ooo auto` is dispatched through the installed ouroboros mcp tool, not interpreted as plain text",
+        "`ooo auto` is dispatched to the mcp tool `ouroboros_auto`",
+        "`ooo auto` is handled by ouroboros auto/mcp, not plain text",
+        "whether mcp dispatch succeeded",
+        "seed reaches grade a",
+        "execution is handed off to the background execution job",
+        "the execution job reaches a terminal status without manual cancellation",
+        "whether progress accounting stalled at ac 0/n is reported",
+        "execution job id",
+        "final execution job terminal status",
+        "whether manual fallback was used",
+        "whether previous blockers recurred",
+        "auto session id",
+        "seed id and seed path",
+        "files changed",
+        "exact test command",
+        "test result",
+    }
+)
+
 _OBSERVATION_CONTEXT_REQUIRED = (
     "hello_auto.py",
     "tests/test_hello_auto.py",
@@ -74,9 +96,8 @@ def normalize_observation_execution_criteria(
         stripped = criterion.strip()
         if not stripped:
             continue
-        lowered = stripped.casefold()
         if is_auto_reporting_acceptance_criterion(stripped) or _is_observation_report_only_line(
-            lowered
+            stripped
         ):
             continue
         normalized.append(_normalize_known_observation_execution_line(stripped))
@@ -142,35 +163,6 @@ def _normalize_known_observation_execution_line(criterion: str) -> str:
     return criterion
 
 
-def _is_observation_report_only_line(lowered: str) -> bool:
-    """Classify observation metadata lines that belong to the parent report."""
-    report_markers = (
-        "mcp dispatch",
-        "dispatched through the installed ouroboros mcp tool",
-        "dispatched to the mcp tool",
-        "handled by ouroboros auto/mcp",
-        "manual fallback",
-        "auto session id",
-        "seed id",
-        "seed path",
-        "seed grade",
-        "seed reaches grade",
-        "execution is handed off",
-        "execution job",
-        "execution id",
-        "run session id",
-        "run projection id",
-        "terminal status",
-        "non-terminal",
-        "progress accounting",
-        "recursive auto",
-        "previous blocker",
-        "last_question blocker",
-        "interview open-gaps",
-        "files changed",
-        "exact test command",
-        "test result",
-        "final report",
-        "after auto finishes",
-    )
-    return any(marker in lowered for marker in report_markers)
+def _is_observation_report_only_line(criterion: str) -> bool:
+    """Classify exact known observation metadata lines from the parent report."""
+    return _criterion_key(criterion) in _OBSERVATION_REPORT_ONLY_CRITERIA

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -42,22 +42,74 @@ def normalize_execution_acceptance(seed: Seed) -> Seed:
     Auto observation prompts can include wrapper/reporting duties such as
     dispatch confirmation and final auto-session metadata. Those should not be
     handed to the execution worker as implementation ACs. To avoid mutating
-    product requirements, only strip exact known wrapper criteria when the Seed
-    itself carries auto-wrapper context.
+    product requirements, only normalize the known hello_auto observation
+    context.
     """
     criteria = tuple(ac for ac in seed.acceptance_criteria if ac and ac.strip())
     if not criteria or not _has_auto_wrapper_context(seed.goal, criteria):
         return seed
 
-    filtered = tuple(ac for ac in criteria if not is_auto_reporting_acceptance_criterion(ac))
+    filtered = normalize_observation_execution_criteria(criteria, context_text=seed.goal)
     if not filtered or filtered == criteria:
         return seed
     return seed.model_copy(update={"acceptance_criteria": filtered})
 
 
+def normalize_observation_execution_criteria(
+    criteria: tuple[str, ...],
+    *,
+    context_text: str = "",
+) -> tuple[str, ...]:
+    """Return concrete execution criteria for the hello_auto observation task.
+
+    In the observation context, parent/reporting duties must not become worker
+    ACs.  Keep only concrete local checks and canonicalize equivalent phrasings
+    so the worker sees a small stable AC set.
+    """
+    if not _has_auto_wrapper_context(context_text, criteria):
+        return criteria
+
+    keep_return = False
+    keep_test_file = False
+    keep_pytest = False
+    passthrough: list[str] = []
+    for criterion in criteria:
+        stripped = criterion.strip()
+        if not stripped or is_auto_reporting_acceptance_criterion(stripped):
+            continue
+        lowered = stripped.casefold()
+        if _is_observation_report_only_line(lowered):
+            continue
+        if "uv run pytest" in lowered and "tests/test_hello_auto.py" in lowered:
+            keep_pytest = True
+            continue
+        if "tests/test_hello_auto.py" in lowered:
+            keep_test_file = True
+            continue
+        if "hello_auto.py" in lowered:
+            keep_return = True
+            continue
+        passthrough.append(stripped)
+
+    canonical: list[str] = []
+    if keep_return:
+        canonical.append(
+            "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`."
+        )
+    if keep_test_file:
+        canonical.append(
+            "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value."
+        )
+    if keep_pytest:
+        canonical.append("The exact command `uv run pytest tests/test_hello_auto.py` passes.")
+
+    return tuple(dict.fromkeys((*canonical, *passthrough)))
+
+
 def is_auto_reporting_acceptance_criterion(criterion: str) -> bool:
-    """Return true only for exact known auto wrapper/report-only criteria."""
-    return _criterion_key(criterion) in _AUTO_WRAPPER_CRITERIA
+    """Return true for known auto wrapper/report-only criteria."""
+    key = _criterion_key(criterion)
+    return key in _AUTO_WRAPPER_CRITERIA or _is_observation_report_only_line(key)
 
 
 def has_auto_wrapper_context(text: str) -> bool:
@@ -74,3 +126,37 @@ def _has_auto_wrapper_context(goal: str, criteria: tuple[str, ...]) -> bool:
 
 def _criterion_key(criterion: str) -> str:
     return " ".join(criterion.casefold().strip().rstrip(".").split())
+
+
+def _is_observation_report_only_line(lowered: str) -> bool:
+    """Classify observation metadata lines that belong to the parent report."""
+    report_markers = (
+        "mcp dispatch",
+        "dispatched through the installed ouroboros mcp tool",
+        "dispatched to the mcp tool",
+        "handled by ouroboros auto/mcp",
+        "manual fallback",
+        "auto session id",
+        "seed id",
+        "seed path",
+        "seed grade",
+        "seed reaches grade",
+        "execution is handed off",
+        "execution job",
+        "execution id",
+        "run session id",
+        "run projection id",
+        "terminal status",
+        "non-terminal",
+        "progress accounting",
+        "recursive auto",
+        "previous blocker",
+        "last_question blocker",
+        "interview open-gaps",
+        "files changed",
+        "exact test command",
+        "test result",
+        "final report",
+        "after auto finishes",
+    )
+    return any(marker in lowered for marker in report_markers)

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -75,10 +75,12 @@ def normalize_observation_execution_criteria(
     passthrough: list[str] = []
     for criterion in criteria:
         stripped = criterion.strip()
-        if not stripped or is_auto_reporting_acceptance_criterion(stripped):
+        if not stripped:
             continue
         lowered = stripped.casefold()
-        if _is_observation_report_only_line(lowered):
+        if is_auto_reporting_acceptance_criterion(stripped) or _is_observation_report_only_line(
+            lowered
+        ):
             continue
         if "uv run pytest" in lowered and "tests/test_hello_auto.py" in lowered:
             keep_pytest = True
@@ -107,9 +109,15 @@ def normalize_observation_execution_criteria(
 
 
 def is_auto_reporting_acceptance_criterion(criterion: str) -> bool:
-    """Return true for known auto wrapper/report-only criteria."""
-    key = _criterion_key(criterion)
-    return key in _AUTO_WRAPPER_CRITERIA or _is_observation_report_only_line(key)
+    """Return true only for exact known auto wrapper/report-only criteria.
+
+    Broad observation-only report markers are intentionally handled behind the
+    hello_auto observation context gate in ``normalize_observation_execution_criteria``.
+    Keeping this standalone helper exact prevents unrelated product requirements
+    such as execution-job or progress-accounting features from being classified
+    as reporting metadata by a future caller that lacks the observation guard.
+    """
+    return _criterion_key(criterion) in _AUTO_WRAPPER_CRITERIA
 
 
 def has_auto_wrapper_context(text: str) -> bool:

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -32,6 +32,7 @@ from ouroboros.auto.answerer import (
 from ouroboros.auto.execution_acceptance import (
     has_auto_wrapper_context,
     is_auto_reporting_acceptance_criterion,
+    normalize_observation_execution_criteria,
 )
 from ouroboros.auto.handoff_contract import RUN_HANDOFF_STARTED_STATUS
 from ouroboros.auto.interview_driver import AutoInterviewDriver
@@ -1659,11 +1660,13 @@ def _section_text(sections: dict[str, list[str]], *names: str) -> str:
 
 def _execution_success_criteria(text: str, *, context_text: str = "") -> str:
     strip_auto_wrapper = has_auto_wrapper_context("\n".join((context_text, text)))
-    lines = [
+    lines = tuple(
         line
         for line in (_clean_prompt_line(raw) for raw in text.splitlines())
         if line and not (strip_auto_wrapper and is_auto_reporting_acceptance_criterion(line))
-    ]
+    )
+    if strip_auto_wrapper:
+        lines = normalize_observation_execution_criteria(lines, context_text=context_text)
     return "\n".join(dict.fromkeys(lines))
 
 

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from ouroboros.auto.execution_acceptance import normalize_execution_acceptance
+from ouroboros.auto.execution_acceptance import (
+    is_auto_reporting_acceptance_criterion,
+    normalize_execution_acceptance,
+)
 from ouroboros.core.seed import (
     EvaluationPrinciple,
     ExitCondition,
@@ -101,6 +104,16 @@ def test_normalize_execution_acceptance_canonicalizes_latest_observation_prompt(
         "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
         "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
         "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+    )
+
+
+def test_reporting_classifier_keeps_broad_observation_markers_context_scoped() -> None:
+    assert is_auto_reporting_acceptance_criterion("Manual fallback is not used.")
+    assert not is_auto_reporting_acceptance_criterion(
+        "The execution job reaches a terminal status without manual cancellation."
+    )
+    assert not is_auto_reporting_acceptance_criterion(
+        "Whether progress accounting stalled at AC 0/N is reported."
     )
 
 

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -128,6 +128,31 @@ def test_normalize_execution_acceptance_preserves_non_equivalent_file_criteria()
     )
 
 
+def test_normalize_execution_acceptance_preserves_real_product_lifecycle_criteria() -> None:
+    seed = _seed(
+        "`ooo auto` is dispatched through the installed Ouroboros MCP tool, not interpreted as plain text.",
+        "Implement a manual fallback mode for unavailable tools.",
+        "Persist execution job status for resumed runs.",
+        "Display progress accounting for every acceptance criterion.",
+        "`hello_auto.py` exists.",
+        "`tests/test_hello_auto.py` exists.",
+    ).model_copy(
+        update={
+            "goal": "Observation run: verify latest main Ouroboros ooo auto with hello_auto.py and tests/test_hello_auto.py via ouroboros_auto."
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == (
+        "Implement a manual fallback mode for unavailable tools.",
+        "Persist execution job status for resumed runs.",
+        "Display progress accounting for every acceptance criterion.",
+        "`hello_auto.py` exists.",
+        "`tests/test_hello_auto.py` exists.",
+    )
+
+
 def test_reporting_classifier_keeps_broad_observation_markers_context_scoped() -> None:
     assert is_auto_reporting_acceptance_criterion("Manual fallback is not used.")
     assert not is_auto_reporting_acceptance_criterion(

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -39,7 +39,7 @@ def test_normalize_execution_acceptance_drops_auto_report_criteria() -> None:
     seed = _seed(
         "`ooo auto` is dispatched to the MCP tool `ouroboros_auto`.",
         "Manual fallback is not used.",
-        "`hello_auto.py` defines `hello_auto()` returning exactly `hello from ooo auto`.",
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
         "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
         "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
         "Final report includes auto session id, seed id, seed path, and test result.",
@@ -48,7 +48,7 @@ def test_normalize_execution_acceptance_drops_auto_report_criteria() -> None:
     normalized = normalize_execution_acceptance(seed)
 
     assert normalized.acceptance_criteria == (
-        "`hello_auto.py` defines `hello_auto()` returning exactly `hello from ooo auto`.",
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
         "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
         "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
     )
@@ -56,9 +56,9 @@ def test_normalize_execution_acceptance_drops_auto_report_criteria() -> None:
 
 def test_normalize_execution_acceptance_drops_observation_report_metadata() -> None:
     seed = _seed(
-        "`hello_auto.py` exists.",
-        "`tests/test_hello_auto.py` exists.",
-        "The targeted test command `uv run pytest tests/test_hello_auto.py` passes.",
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
         "Manual fallback used: no.",
         "Previous last_question blocker did not recur.",
         "Previous Seed grade C blocker did not recur.",
@@ -73,9 +73,34 @@ def test_normalize_execution_acceptance_drops_observation_report_metadata() -> N
     normalized = normalize_execution_acceptance(seed)
 
     assert normalized.acceptance_criteria == (
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+    )
+
+
+def test_normalize_execution_acceptance_canonicalizes_latest_observation_prompt() -> None:
+    seed = _seed(
+        "`ooo auto` is dispatched through the installed Ouroboros MCP tool, not interpreted as plain text.",
+        "Seed reaches grade A.",
+        "Execution is handed off to the background execution job.",
         "`hello_auto.py` exists.",
         "`tests/test_hello_auto.py` exists.",
-        "The targeted test command `uv run pytest tests/test_hello_auto.py` passes.",
+        "`uv run pytest tests/test_hello_auto.py` passes.",
+        "The execution job reaches a terminal status without manual cancellation.",
+        "Whether progress accounting stalled at AC 0/N is reported.",
+    ).model_copy(
+        update={
+            "goal": "Observation run: verify latest main Ouroboros ooo auto with hello_auto.py and tests/test_hello_auto.py via ouroboros_auto."
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == (
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
     )
 
 

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -82,7 +82,7 @@ def test_normalize_execution_acceptance_drops_observation_report_metadata() -> N
     )
 
 
-def test_normalize_execution_acceptance_canonicalizes_latest_observation_prompt() -> None:
+def test_normalize_execution_acceptance_filters_latest_observation_prompt_metadata() -> None:
     seed = _seed(
         "`ooo auto` is dispatched through the installed Ouroboros MCP tool, not interpreted as plain text.",
         "Seed reaches grade A.",
@@ -101,9 +101,30 @@ def test_normalize_execution_acceptance_canonicalizes_latest_observation_prompt(
     normalized = normalize_execution_acceptance(seed)
 
     assert normalized.acceptance_criteria == (
-        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
-        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
+        "`hello_auto.py` exists.",
+        "`tests/test_hello_auto.py` exists.",
         "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+    )
+
+
+def test_normalize_execution_acceptance_preserves_non_equivalent_file_criteria() -> None:
+    seed = _seed(
+        "`ooo auto` is dispatched through the installed Ouroboros MCP tool, not interpreted as plain text.",
+        "`hello_auto.py` contains a module-level docstring.",
+        "`tests/test_hello_auto.py` uses pytest.mark.smoke.",
+        "pytest tests/test_hello_auto.py -q passes.",
+    ).model_copy(
+        update={
+            "goal": "Observation run: verify latest main Ouroboros ooo auto with hello_auto.py and tests/test_hello_auto.py via ouroboros_auto."
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == (
+        "`hello_auto.py` contains a module-level docstring.",
+        "`tests/test_hello_auto.py` uses pytest.mark.smoke.",
+        "pytest tests/test_hello_auto.py -q passes.",
     )
 
 

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -298,7 +298,7 @@ def test_structured_auto_goal_seeds_required_ledger_sections() -> None:
     assert "constraints" in summary["evidence_backed_sections"]
     assert "non_goals" in summary["evidence_backed_sections"]
     assert "Final report" not in preferences["acceptance_criteria"]
-    assert "`hello_auto.py` exists" in preferences["acceptance_criteria"]
+    assert "`hello_auto.py` defines `hello_auto() -> str`" in preferences["acceptance_criteria"]
 
 
 def test_structured_auto_goal_does_not_preconfirm_risky_preference() -> None:
@@ -372,9 +372,9 @@ If `ouroboros_auto` is unavailable or interpreted as normal text, stop and repor
     preferences = _derive_goal_user_preferences(goal)
 
     assert preferences["acceptance_criteria"] == (
-        "`hello_auto.py` exists.\n"
-        "`tests/test_hello_auto.py` exists.\n"
-        "The targeted test command `uv run pytest tests/test_hello_auto.py` passes."
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.\n"
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.\n"
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes."
     )
     assert "Previous last_question" in preferences["failure_modes"]
     assert "Manual fallback used: no." in preferences["failure_modes"]
@@ -407,11 +407,54 @@ After auto finishes, report:
     preferences = _derive_goal_user_preferences(goal)
 
     assert preferences["acceptance_criteria"] == (
-        "`hello_auto.py` exists.\n"
-        "`tests/test_hello_auto.py` exists.\n"
-        "The targeted test command `uv run pytest tests/test_hello_auto.py` passes."
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.\n"
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.\n"
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes."
     )
     assert "auto session id" not in preferences["acceptance_criteria"].casefold()
+    assert "execution job" not in preferences["acceptance_criteria"].casefold()
+    assert "test result" not in preferences["acceptance_criteria"].casefold()
+
+
+def test_structured_auto_goal_canonicalizes_latest_observation_success_criteria() -> None:
+    goal = """
+Observation run: verify latest main Ouroboros `ooo auto` execution lifecycle after the merged fixes.
+
+Goal:
+Create a minimal local proof file and test.
+
+Implementation:
+- Create `hello_auto.py` at the repository root.
+- Define `hello_auto() -> str`.
+- It must return exactly `hello from ooo auto`.
+- Create `tests/test_hello_auto.py`.
+- The test must import `hello_auto` and assert the exact return value.
+
+Success criteria:
+- `ooo auto` is dispatched through the installed Ouroboros MCP tool, not interpreted as plain text.
+- Seed reaches grade A.
+- Execution is handed off to the background execution job.
+- `hello_auto.py` exists.
+- `tests/test_hello_auto.py` exists.
+- `uv run pytest tests/test_hello_auto.py` passes.
+- The execution job reaches a terminal status without manual cancellation.
+
+After auto finishes, report:
+- Whether MCP dispatch succeeded.
+- Execution job id.
+- Whether progress accounting stalled at AC 0/N.
+- Files changed.
+- Exact test command.
+- Test result.
+"""
+
+    preferences = _derive_goal_user_preferences(goal)
+
+    assert preferences["acceptance_criteria"] == (
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.\n"
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.\n"
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes."
+    )
     assert "execution job" not in preferences["acceptance_criteria"].casefold()
     assert "test result" not in preferences["acceptance_criteria"].casefold()
 
@@ -459,7 +502,8 @@ If `ouroboros_auto` is unavailable or interpreted as normal text, stop and repor
     preferences = _derive_goal_user_preferences(goal)
 
     assert preferences["acceptance_criteria"] == (
-        "`hello_auto.py` exists.\n`tests/test_hello_auto.py` exists."
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.\n"
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value."
     )
 
 

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -298,7 +298,7 @@ def test_structured_auto_goal_seeds_required_ledger_sections() -> None:
     assert "constraints" in summary["evidence_backed_sections"]
     assert "non_goals" in summary["evidence_backed_sections"]
     assert "Final report" not in preferences["acceptance_criteria"]
-    assert "`hello_auto.py` defines `hello_auto() -> str`" in preferences["acceptance_criteria"]
+    assert "`hello_auto.py` exists" in preferences["acceptance_criteria"]
 
 
 def test_structured_auto_goal_does_not_preconfirm_risky_preference() -> None:
@@ -372,8 +372,8 @@ If `ouroboros_auto` is unavailable or interpreted as normal text, stop and repor
     preferences = _derive_goal_user_preferences(goal)
 
     assert preferences["acceptance_criteria"] == (
-        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.\n"
-        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.\n"
+        "`hello_auto.py` exists.\n"
+        "`tests/test_hello_auto.py` exists.\n"
         "The exact command `uv run pytest tests/test_hello_auto.py` passes."
     )
     assert "Previous last_question" in preferences["failure_modes"]
@@ -407,8 +407,8 @@ After auto finishes, report:
     preferences = _derive_goal_user_preferences(goal)
 
     assert preferences["acceptance_criteria"] == (
-        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.\n"
-        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.\n"
+        "`hello_auto.py` exists.\n"
+        "`tests/test_hello_auto.py` exists.\n"
         "The exact command `uv run pytest tests/test_hello_auto.py` passes."
     )
     assert "auto session id" not in preferences["acceptance_criteria"].casefold()
@@ -451,8 +451,8 @@ After auto finishes, report:
     preferences = _derive_goal_user_preferences(goal)
 
     assert preferences["acceptance_criteria"] == (
-        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.\n"
-        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.\n"
+        "`hello_auto.py` exists.\n"
+        "`tests/test_hello_auto.py` exists.\n"
         "The exact command `uv run pytest tests/test_hello_auto.py` passes."
     )
     assert "execution job" not in preferences["acceptance_criteria"].casefold()
@@ -502,8 +502,8 @@ If `ouroboros_auto` is unavailable or interpreted as normal text, stop and repor
     preferences = _derive_goal_user_preferences(goal)
 
     assert preferences["acceptance_criteria"] == (
-        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.\n"
-        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value."
+        "`hello_auto.py` exists.\n"
+        "`tests/test_hello_auto.py` exists."
     )
 
 

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -502,8 +502,7 @@ If `ouroboros_auto` is unavailable or interpreted as normal text, stop and repor
     preferences = _derive_goal_user_preferences(goal)
 
     assert preferences["acceptance_criteria"] == (
-        "`hello_auto.py` exists.\n"
-        "`tests/test_hello_auto.py` exists."
+        "`hello_auto.py` exists.\n`tests/test_hello_auto.py` exists."
     )
 
 


### PR DESCRIPTION
## Summary
- Normalize the known `hello_auto` `ooo auto` observation prompt into a small worker-facing AC set.
- Keep parent lifecycle/reporting duties such as MCP dispatch, seed metadata, execution job status, progress accounting, fallback reporting, and final report fields out of execution criteria.
- Preserve the safety gate so product final-report/fallback requirements outside the `hello_auto` auto-observation context remain untouched.

## Why
The latest observation proved dispatch and A-grade Seed generation work, but the execution Seed still contained broad lifecycle/reporting criteria. That made a locally successful proof run (`hello_auto.py`, test file, pytest pass) look like a failed execution job. This PR narrows the execution contract to concrete local proof only.

## Validation
- `uv run pytest tests/unit/auto/test_execution_acceptance.py tests/unit/mcp/tools/test_auto_interview_construction.py -q`
- `uv run ruff check src/ouroboros/auto/execution_acceptance.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_execution_acceptance.py tests/unit/mcp/tools/test_auto_interview_construction.py`
