### PR TITLE
fix(orchestrator): reconcile sibling ACs from execution evidence

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1531,7 +1531,6 @@ def _criterion_satisfied_by_evidence(
     passed_commands: set[str] | None = None,
 ) -> bool:
     """Conservatively decide whether evidence satisfies a sibling criterion."""
-    lowered = criterion.casefold()
     normalized_run_commands = {
         _normalize_command(command).casefold() for command in run_commands if command
     }
@@ -1543,27 +1542,12 @@ def _criterion_satisfied_by_evidence(
         if file_path and _criterion_is_exact_file_presence_ac(criterion, file_path):
             return True
 
-    command_success_markers = (
-        " pass",
-        " passes",
-        " passed",
-        " succeed",
-        " succeeds",
-        " exit code 0",
-    )
-    if any(marker in lowered for marker in command_success_markers):
-        for command in normalized_passed_commands:
-            if command and _criterion_is_exact_command_pass_ac(criterion, command):
-                return True
-        return False
+    for command in normalized_passed_commands:
+        if command and _criterion_is_exact_command_pass_ac(criterion, command):
+            return True
 
-    command_run_markers = (" run ", " runs ", " execute", " executes", " command ")
     for command in normalized_run_commands:
-        if (
-            command
-            and _criterion_is_exact_command_run_ac(criterion, command)
-            and any(marker in lowered for marker in command_run_markers)
-        ):
+        if command and _criterion_is_exact_command_run_ac(criterion, command):
             return True
 
     return False

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1532,7 +1532,6 @@ def _criterion_satisfied_by_evidence(
 ) -> bool:
     """Conservatively decide whether evidence satisfies a sibling criterion."""
     lowered = criterion.casefold()
-    normalized_criterion = _normalize_command(criterion).casefold()
     normalized_run_commands = {
         _normalize_command(command).casefold() for command in run_commands if command
     }
@@ -1554,7 +1553,7 @@ def _criterion_satisfied_by_evidence(
     )
     if any(marker in lowered for marker in command_success_markers):
         for command in normalized_passed_commands:
-            if command and command in normalized_criterion:
+            if command and _criterion_is_exact_command_pass_ac(criterion, command):
                 return True
         return False
 
@@ -1562,7 +1561,7 @@ def _criterion_satisfied_by_evidence(
     for command in normalized_run_commands:
         if (
             command
-            and command in normalized_criterion
+            and _criterion_is_exact_command_run_ac(criterion, command)
             and any(marker in lowered for marker in command_run_markers)
         ):
             return True
@@ -1595,6 +1594,56 @@ def _criterion_is_exact_file_presence_ac(criterion: str, file_path: str) -> bool
         "<path> is present",
         "the file <path> exists",
         "the file <path> is present",
+    }
+
+
+def _criterion_inline_code_values(criterion: str) -> list[str]:
+    """Return normalized inline-code fragments from a criterion."""
+    return [
+        _normalized_evidence_text(match.group(1).strip())
+        for match in re.finditer(r"`([^`]+)`", criterion)
+        if match.group(1).strip()
+    ]
+
+
+def _criterion_is_exact_command_pass_ac(criterion: str, command: str) -> bool:
+    """Return True when the criterion is only an exact command-pass AC."""
+    normalized_command = _normalized_evidence_text(command)
+    if not normalized_command or _criterion_inline_code_values(criterion) != [normalized_command]:
+        return False
+    normalized = _normalized_evidence_text(
+        re.sub(r"`[^`]+`", "<command>", criterion).strip().rstrip(".")
+    )
+    return normalized in {
+        "<command> passes",
+        "<command> passed",
+        "<command> succeeds",
+        "<command> succeeded",
+        "the exact command <command> passes",
+        "the exact command <command> passed",
+        "the exact command <command> succeeds",
+        "the exact command <command> succeeded",
+        "the exact command <command> exits with code 0",
+        "the command <command> passes",
+        "the command <command> succeeds",
+    }
+
+
+def _criterion_is_exact_command_run_ac(criterion: str, command: str) -> bool:
+    """Return True when the criterion is only an exact command-run AC."""
+    normalized_command = _normalized_evidence_text(command)
+    if not normalized_command or _criterion_inline_code_values(criterion) != [normalized_command]:
+        return False
+    normalized = _normalized_evidence_text(
+        re.sub(r"`[^`]+`", "<command>", criterion).strip().rstrip(".")
+    )
+    return normalized in {
+        "run <command>",
+        "run the exact command <command>",
+        "execute <command>",
+        "execute the exact command <command>",
+        "the exact command <command> runs",
+        "the command <command> runs",
     }
 
 

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1470,7 +1470,11 @@ def _successful_runtime_test_commands(messages: tuple[AgentMessage, ...]) -> set
             if following.tool_name == "Bash":
                 break
             chunk.append(following)
-        if any(_message_contains_test_success(item) for item in chunk):
+        if any(
+            not item.is_final
+            and _text_contains_test_success(_runtime_message_test_proof_text(item))
+            for item in chunk
+        ):
             commands.update(command for command in message_commands if command)
     return commands
 
@@ -1494,8 +1498,11 @@ def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], s
     passed_commands: set[str] = set()
 
     if result.typed_evidence is not None:
+        task_cwd = result.runtime_handle.cwd if result.runtime_handle is not None else None
         for value in _flatten_evidence_values(result.typed_evidence.get("files_touched")):
-            normalized = str(value).strip()
+            normalized = (
+                _workspace_relative_file_claim(str(value), task_cwd=task_cwd) or str(value).strip()
+            )
             if normalized:
                 files.add(normalized)
         for value in _flatten_evidence_values(result.typed_evidence.get("commands_run")):

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1543,18 +1543,11 @@ def _criterion_satisfied_by_evidence(
         _normalize_command(command).casefold() for command in (passed_commands or set()) if command
     }
 
-    existential_file_markers = (
-        " exists",
-        " create",
-        " creates",
-        " created",
-        " is present",
-        " are present",
-    )
+    existential_file_markers = (" exists", " is present", " are present")
     for file_path in files:
         if (
             file_path
-            and file_path.casefold() in lowered
+            and _criterion_mentions_exact_file_path(criterion, file_path)
             and any(marker in lowered for marker in existential_file_markers)
         ):
             return True
@@ -1585,6 +1578,23 @@ def _criterion_satisfied_by_evidence(
     return False
 
 
+def _criterion_mentions_exact_file_path(criterion: str, file_path: str) -> bool:
+    """Return True when a criterion cites the exact evidence path."""
+    normalized_path = Path(file_path.strip()).as_posix().casefold()
+    if (
+        not normalized_path
+        or Path(normalized_path).is_absolute()
+        or ".." in Path(normalized_path).parts
+    ):
+        return False
+    inline_code_paths = {
+        Path(match.group(1).strip()).as_posix().casefold()
+        for match in re.finditer(r"`([^`]+)`", criterion)
+        if match.group(1).strip()
+    }
+    return normalized_path in inline_code_paths
+
+
 def _complete_sibling_acs_from_evidence(
     *,
     level_results: list[ACExecutionResult],
@@ -1611,7 +1621,7 @@ def _complete_sibling_acs_from_evidence(
         return completed_count, level_success, level_failed, level_results
 
     for result in level_results:
-        if result.success:
+        if result.success or result.outcome != ACExecutionOutcome.FAILED:
             continue
         for source_idx, files, run_commands, passed_commands in successful_evidence:
             if source_idx == result.ac_index:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1451,6 +1451,156 @@ def _extract_leaf_evidence_lines(result: ACExecutionResult) -> list[str]:
     return lines
 
 
+def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], set[str]]:
+    """Return normalized file paths and commands observed for an AC result.
+
+    This intentionally uses only structured/runtime evidence, not broad natural
+    language success claims, so sibling AC completion remains conservative.
+    """
+    files: set[str] = set()
+    commands: set[str] = set()
+
+    if result.typed_evidence is not None:
+        for value in _flatten_evidence_values(result.typed_evidence.get("files_touched")):
+            normalized = str(value).strip()
+            if normalized:
+                files.add(normalized)
+        for field in ("commands_run", "tests_passed"):
+            for value in _flatten_evidence_values(result.typed_evidence.get(field)):
+                normalized = _normalize_command(str(value))
+                if normalized:
+                    commands.add(normalized)
+
+    for message in result.messages:
+        if not message.tool_name:
+            continue
+        tool_input = message.data.get("tool_input", {})
+        if not isinstance(tool_input, dict):
+            continue
+
+        if message.tool_name == "Bash":
+            command = tool_input.get("command")
+            if isinstance(command, str):
+                normalized = _normalize_command(command)
+                if normalized:
+                    commands.add(normalized)
+            continue
+
+        if message.tool_name in ("Write", "Edit", "NotebookEdit"):
+            path_key = "notebook_path" if message.tool_name == "NotebookEdit" else "file_path"
+            file_path = tool_input.get(path_key)
+            if isinstance(file_path, str) and file_path.strip():
+                files.add(file_path.strip())
+
+    return files, commands
+
+
+def _criterion_satisfied_by_evidence(criterion: str, files: set[str], commands: set[str]) -> bool:
+    """Conservatively decide whether evidence satisfies a sibling criterion."""
+    lowered = criterion.casefold()
+    normalized_commands = {_normalize_command(command).casefold() for command in commands}
+
+    positive_file_markers = (
+        " exists",
+        " define",
+        " defines",
+        " import",
+        " imports",
+        " assert",
+        " asserts",
+        " create",
+        " creates",
+        " created",
+        " contain",
+        " contains",
+    )
+    for file_path in files:
+        if (
+            file_path
+            and file_path.casefold() in lowered
+            and any(marker in lowered for marker in positive_file_markers)
+        ):
+            return True
+
+    for command in normalized_commands:
+        if command and command in _normalize_command(criterion).casefold():
+            return True
+
+    # Common test AC phrasing names only the pytest target while the transcript
+    # stores the whole command. Require both pytest and the exact target path.
+    if "uv run pytest" in lowered and "tests/test_hello_auto.py" in lowered:
+        return any(
+            "uv run pytest" in command and "tests/test_hello_auto.py" in command
+            for command in normalized_commands
+        )
+
+    return False
+
+
+def _complete_sibling_acs_from_evidence(
+    *,
+    level_results: list[ACExecutionResult],
+    ac_statuses: dict[int, str],
+    failed_indices: set[int],
+    completed_count: int,
+    level_success: int,
+    level_failed: int,
+) -> tuple[int, int, int, list[ACExecutionResult]]:
+    """Mark sibling ACs satisfied when a successful sibling has exact evidence.
+
+    Observation jobs often ask for separate ACs such as "file exists", "test
+    file exists", and "pytest passes". A single worker can legitimately create
+    both files and run the test. This function reconciles those concrete sibling
+    ACs from runtime/typed evidence instead of leaving them failed or pending.
+    """
+    replacements: dict[int, ACExecutionResult] = {}
+    successful_evidence = [
+        (result.ac_index, *_evidence_values_from_result(result))
+        for result in level_results
+        if result.success
+    ]
+    if not successful_evidence:
+        return completed_count, level_success, level_failed, level_results
+
+    for result in level_results:
+        if result.success:
+            continue
+        for source_idx, files, commands in successful_evidence:
+            if source_idx == result.ac_index:
+                continue
+            if not _criterion_satisfied_by_evidence(result.ac_content, files, commands):
+                continue
+            replacements[result.ac_index] = ACExecutionResult(
+                ac_index=result.ac_index,
+                ac_content=result.ac_content,
+                success=True,
+                final_message=(f"Satisfied by runtime evidence from sibling AC {source_idx + 1}."),
+                retry_attempt=result.retry_attempt,
+                outcome=ACExecutionOutcome.SATISFIED_EXTERNALLY,
+            )
+            break
+
+    if not replacements:
+        return completed_count, level_success, level_failed, level_results
+
+    reconciled: list[ACExecutionResult] = []
+    for result in level_results:
+        replacement = replacements.get(result.ac_index)
+        if replacement is None:
+            reconciled.append(result)
+            continue
+        if result.outcome == ACExecutionOutcome.FAILED:
+            failed_indices.discard(result.ac_index)
+            if level_failed > 0:
+                level_failed -= 1
+        ac_statuses[result.ac_index] = "completed"
+        completed_count += 1
+        level_success += 1
+        reconciled.append(replacement)
+
+    return completed_count, level_success, level_failed, reconciled
+
+
 def _render_ac_section(
     result: ACExecutionResult,
     *,
@@ -3223,6 +3373,25 @@ class ParallelACExecutor:
 
                         all_results.append(ac_result)
                         stage_ac_results.append(ac_result)
+
+                (
+                    completed_count,
+                    level_success,
+                    level_failed,
+                    stage_ac_results,
+                ) = _complete_sibling_acs_from_evidence(
+                    level_results=stage_ac_results,
+                    ac_statuses=ac_statuses,
+                    failed_indices=failed_indices,
+                    completed_count=completed_count,
+                    level_success=level_success,
+                    level_failed=level_failed,
+                )
+
+                reconciled_by_index = {result.ac_index: result for result in stage_ac_results}
+                all_results = [
+                    reconciled_by_index.get(result.ac_index, result) for result in all_results
+                ]
 
                 stage_result = ParallelExecutionStageResult(
                     stage_index=level_idx,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1181,7 +1181,7 @@ def _runtime_messages_support_test_claim(
             continue
         chunk = [message]
         for following in messages[index + 1 :]:
-            if following.tool_name == "Bash":
+            if following.tool_name:
                 break
             chunk.append(following)
         if not any(_message_contains_test_success(item) for item in chunk):
@@ -1401,6 +1401,11 @@ def _normalize_command(command: str) -> str:
     return " ".join(command.split())
 
 
+def _normalize_exact_command(command: str) -> str:
+    """Normalize command whitespace while preserving case-sensitive exactness."""
+    return " ".join(command.split())
+
+
 def _truncate_text(text: str, limit: int = _MAX_LEAF_RESULT_CHARS) -> str:
     """Truncate long evidence blocks while preserving their beginning."""
     stripped = text.strip()
@@ -1467,7 +1472,7 @@ def _successful_runtime_test_commands(messages: tuple[AgentMessage, ...]) -> set
             continue
         chunk = [message]
         for following in messages[index + 1 :]:
-            if following.tool_name == "Bash":
+            if following.tool_name:
                 break
             chunk.append(following)
         if any(
@@ -1486,7 +1491,7 @@ def _add_runtime_command_evidence(commands: set[str], command: str) -> None:
 
 def _runtime_command_evidence_aliases(command: str) -> tuple[str, ...]:
     """Return exact runtime command aliases for sibling reconciliation."""
-    aliases = [_normalize_command(command)]
+    aliases = [_normalize_exact_command(command)]
     single_inner_command = _single_exact_command_after_safe_shell_preamble(command)
     if single_inner_command and single_inner_command not in aliases:
         aliases.append(single_inner_command)
@@ -1501,7 +1506,7 @@ def _single_exact_command_after_safe_shell_preamble(command: str) -> str | None:
     segments = tuple(_segments_after_safe_shell_preamble(body))
     if len(segments) != 1:
         return None
-    return _normalize_command(segments[0])
+    return _normalize_exact_command(segments[0])
 
 
 def _typed_evidence_is_usable_for_sibling_reconciliation(result: ACExecutionResult) -> bool:
@@ -1560,9 +1565,11 @@ def _criterion_satisfied_by_evidence(
     passed_commands: set[str] | None = None,
 ) -> bool:
     """Conservatively decide whether evidence satisfies a sibling criterion."""
-    normalized_run_commands = {_normalize_command(command) for command in run_commands if command}
+    normalized_run_commands = {
+        _normalize_exact_command(command) for command in run_commands if command
+    }
     normalized_passed_commands = {
-        _normalize_command(command) for command in (passed_commands or set()) if command
+        _normalize_exact_command(command) for command in (passed_commands or set()) if command
     }
 
     for file_path in files:
@@ -1611,7 +1618,7 @@ def _criterion_is_exact_file_presence_ac(criterion: str, file_path: str) -> bool
 def _criterion_inline_code_values(criterion: str) -> list[str]:
     """Return normalized inline-code fragments from a criterion."""
     return [
-        _normalize_command(match.group(1).strip())
+        _normalize_exact_command(match.group(1).strip())
         for match in re.finditer(r"`([^`]+)`", criterion)
         if match.group(1).strip()
     ]
@@ -1619,7 +1626,7 @@ def _criterion_inline_code_values(criterion: str) -> list[str]:
 
 def _criterion_is_exact_command_pass_ac(criterion: str, command: str) -> bool:
     """Return True when the criterion is only an exact command-pass AC."""
-    normalized_command = _normalize_command(command)
+    normalized_command = _normalize_exact_command(command)
     if not normalized_command or _criterion_inline_code_values(criterion) != [normalized_command]:
         return False
     normalized = _normalized_evidence_text(
@@ -1642,7 +1649,7 @@ def _criterion_is_exact_command_pass_ac(criterion: str, command: str) -> bool:
 
 def _criterion_is_exact_command_run_ac(criterion: str, command: str) -> bool:
     """Return True when the criterion is only an exact command-run AC."""
-    normalized_command = _normalize_command(command)
+    normalized_command = _normalize_exact_command(command)
     if not normalized_command or _criterion_inline_code_values(criterion) != [normalized_command]:
         return False
     normalized = _normalized_evidence_text(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1054,6 +1054,11 @@ def _runtime_message_test_proof_text(message: AgentMessage) -> str:
     return "\n".join(parts)
 
 
+def _is_tool_result_message(message: AgentMessage) -> bool:
+    """Return True for runtime tool-result messages, including named-tool variants."""
+    return message.type in {"result", "tool_result"} or message.data.get("subtype") == "tool_result"
+
+
 def _test_claim_file_part(value: str) -> str | None:
     """Return the file path portion of a pytest node-id style claim."""
     stripped = value.strip()
@@ -1181,7 +1186,7 @@ def _runtime_messages_support_test_claim(
             continue
         chunk = [message]
         for following in messages[index + 1 :]:
-            if following.tool_name:
+            if following.tool_name and not _is_tool_result_message(following):
                 break
             chunk.append(following)
         if not any(_message_contains_test_success(item) for item in chunk):
@@ -1472,7 +1477,7 @@ def _successful_runtime_test_commands(messages: tuple[AgentMessage, ...]) -> set
             continue
         chunk = [message]
         for following in messages[index + 1 :]:
-            if following.tool_name:
+            if following.tool_name and not _is_tool_result_message(following):
                 break
             chunk.append(following)
         if any(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1451,25 +1451,58 @@ def _extract_leaf_evidence_lines(result: ACExecutionResult) -> list[str]:
     return lines
 
 
-def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], set[str]]:
-    """Return normalized file paths and commands observed for an AC result.
+def _successful_runtime_test_commands(messages: tuple[AgentMessage, ...]) -> set[str]:
+    """Return Bash test commands backed by adjacent runtime success output."""
+    commands: set[str] = set()
+    for index, message in enumerate(messages):
+        if message.tool_name != "Bash":
+            continue
+        message_commands = {
+            alias
+            for command in _runtime_message_command_values(message)
+            if _looks_like_test_command(command)
+            for alias in _normalized_command_claim_aliases(command)
+        }
+        if not message_commands:
+            continue
+        chunk = [message]
+        for following in messages[index + 1 :]:
+            if following.tool_name == "Bash":
+                break
+            chunk.append(following)
+        if any(_message_contains_test_success(item) for item in chunk):
+            commands.update(command for command in message_commands if command)
+    return commands
+
+
+def _add_command_evidence(commands: set[str], command: str) -> None:
+    """Add exact command evidence plus existing wrapper/test aliases."""
+    normalized = _normalize_command(command)
+    if normalized:
+        commands.add(normalized)
+    commands.update(alias for alias in _normalized_command_claim_aliases(command) if alias)
+
+
+def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], set[str], set[str]]:
+    """Return normalized file paths, run commands, and passed commands.
 
     This intentionally uses only structured/runtime evidence, not broad natural
     language success claims, so sibling AC completion remains conservative.
     """
     files: set[str] = set()
-    commands: set[str] = set()
+    run_commands: set[str] = set()
+    passed_commands: set[str] = set()
 
     if result.typed_evidence is not None:
         for value in _flatten_evidence_values(result.typed_evidence.get("files_touched")):
             normalized = str(value).strip()
             if normalized:
                 files.add(normalized)
-        for field in ("commands_run", "tests_passed"):
-            for value in _flatten_evidence_values(result.typed_evidence.get(field)):
-                normalized = _normalize_command(str(value))
-                if normalized:
-                    commands.add(normalized)
+        for value in _flatten_evidence_values(result.typed_evidence.get("commands_run")):
+            _add_command_evidence(run_commands, str(value))
+        for value in _flatten_evidence_values(result.typed_evidence.get("tests_passed")):
+            _add_command_evidence(passed_commands, str(value))
+            _add_command_evidence(run_commands, str(value))
 
     for message in result.messages:
         if not message.tool_name:
@@ -1481,9 +1514,7 @@ def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], s
         if message.tool_name == "Bash":
             command = tool_input.get("command")
             if isinstance(command, str):
-                normalized = _normalize_command(command)
-                if normalized:
-                    commands.add(normalized)
+                _add_command_evidence(run_commands, command)
             continue
 
         if message.tool_name in ("Write", "Edit", "NotebookEdit"):
@@ -1492,13 +1523,25 @@ def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], s
             if isinstance(file_path, str) and file_path.strip():
                 files.add(file_path.strip())
 
-    return files, commands
+    passed_commands.update(_successful_runtime_test_commands(result.messages))
+    return files, run_commands, passed_commands
 
 
-def _criterion_satisfied_by_evidence(criterion: str, files: set[str], commands: set[str]) -> bool:
+def _criterion_satisfied_by_evidence(
+    criterion: str,
+    files: set[str],
+    run_commands: set[str],
+    passed_commands: set[str] | None = None,
+) -> bool:
     """Conservatively decide whether evidence satisfies a sibling criterion."""
     lowered = criterion.casefold()
-    normalized_commands = {_normalize_command(command).casefold() for command in commands}
+    normalized_criterion = _normalize_command(criterion).casefold()
+    normalized_run_commands = {
+        _normalize_command(command).casefold() for command in run_commands if command
+    }
+    normalized_passed_commands = {
+        _normalize_command(command).casefold() for command in (passed_commands or set()) if command
+    }
 
     positive_file_markers = (
         " exists",
@@ -1522,17 +1565,19 @@ def _criterion_satisfied_by_evidence(criterion: str, files: set[str], commands: 
         ):
             return True
 
-    for command in normalized_commands:
-        if command and command in _normalize_command(criterion).casefold():
-            return True
+    command_success_markers = (" pass", " passes", " passed", " succeed", " succeeds", " exit code 0")
+    if any(marker in lowered for marker in command_success_markers):
+        for command in normalized_passed_commands:
+            if command and command in normalized_criterion:
+                return True
+        return False
 
-    # Common test AC phrasing names only the pytest target while the transcript
-    # stores the whole command. Require both pytest and the exact target path.
-    if "uv run pytest" in lowered and "tests/test_hello_auto.py" in lowered:
-        return any(
-            "uv run pytest" in command and "tests/test_hello_auto.py" in command
-            for command in normalized_commands
-        )
+    command_run_markers = (" run ", " runs ", " execute", " executes", " command ")
+    for command in normalized_run_commands:
+        if command and command in normalized_criterion and any(
+            marker in lowered for marker in command_run_markers
+        ):
+            return True
 
     return False
 
@@ -1565,10 +1610,15 @@ def _complete_sibling_acs_from_evidence(
     for result in level_results:
         if result.success:
             continue
-        for source_idx, files, commands in successful_evidence:
+        for source_idx, files, run_commands, passed_commands in successful_evidence:
             if source_idx == result.ac_index:
                 continue
-            if not _criterion_satisfied_by_evidence(result.ac_content, files, commands):
+            if not _criterion_satisfied_by_evidence(
+                result.ac_content,
+                files,
+                run_commands,
+                passed_commands,
+            ):
                 continue
             replacements[result.ac_index] = ACExecutionResult(
                 ac_index=result.ac_index,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1479,14 +1479,6 @@ def _successful_runtime_test_commands(messages: tuple[AgentMessage, ...]) -> set
     return commands
 
 
-def _add_command_evidence(commands: set[str], command: str) -> None:
-    """Add exact command evidence plus existing wrapper/test aliases."""
-    normalized = _normalize_command(command)
-    if normalized:
-        commands.add(normalized)
-    commands.update(alias for alias in _normalized_command_claim_aliases(command) if alias)
-
-
 def _add_runtime_command_evidence(commands: set[str], command: str) -> None:
     """Add runtime command evidence without accepting compound shell aliases."""
     commands.update(_runtime_command_evidence_aliases(command))
@@ -1520,10 +1512,10 @@ def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], s
             if normalized:
                 files.add(normalized)
         for value in _flatten_evidence_values(result.typed_evidence.get("commands_run")):
-            _add_command_evidence(run_commands, str(value))
+            _add_runtime_command_evidence(run_commands, str(value))
         for value in _flatten_evidence_values(result.typed_evidence.get("tests_passed")):
-            _add_command_evidence(passed_commands, str(value))
-            _add_command_evidence(run_commands, str(value))
+            _add_runtime_command_evidence(passed_commands, str(value))
+            _add_runtime_command_evidence(run_commands, str(value))
 
     for message in result.messages:
         if not message.tool_name:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1486,11 +1486,33 @@ def _add_runtime_command_evidence(commands: set[str], command: str) -> None:
 
 def _runtime_command_evidence_aliases(command: str) -> tuple[str, ...]:
     """Return exact runtime command aliases for sibling reconciliation."""
-    aliases = [_normalized_evidence_text(command)]
-    single_inner_command = _single_command_after_safe_shell_preamble(command)
+    aliases = [_normalize_command(command)]
+    single_inner_command = _single_exact_command_after_safe_shell_preamble(command)
     if single_inner_command and single_inner_command not in aliases:
         aliases.append(single_inner_command)
     return tuple(alias for alias in aliases if alias)
+
+
+def _single_exact_command_after_safe_shell_preamble(command: str) -> str | None:
+    """Return one wrapped inner command without lowercasing exact evidence."""
+    body = _shell_command_body(command)
+    if body is None:
+        return None
+    segments = tuple(_segments_after_safe_shell_preamble(body))
+    if len(segments) != 1:
+        return None
+    return _normalize_command(segments[0])
+
+
+def _typed_evidence_is_usable_for_sibling_reconciliation(result: ACExecutionResult) -> bool:
+    """Return True when typed evidence was not rejected by validation/verifier."""
+    if result.typed_evidence is None:
+        return False
+    if result.typed_evidence_error:
+        return False
+    if result.typed_evidence_validation is not None and not result.typed_evidence_validation.ok:
+        return False
+    return result.atomic_verifier_verdict is None or result.atomic_verifier_verdict.passed
 
 
 def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], set[str], set[str]]:
@@ -1503,7 +1525,8 @@ def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], s
     run_commands: set[str] = set()
     passed_commands: set[str] = set()
 
-    if result.typed_evidence is not None:
+    if _typed_evidence_is_usable_for_sibling_reconciliation(result):
+        assert result.typed_evidence is not None
         task_cwd = result.runtime_handle.cwd if result.runtime_handle is not None else None
         for value in _flatten_evidence_values(result.typed_evidence.get("files_touched")):
             normalized = (
@@ -1537,11 +1560,9 @@ def _criterion_satisfied_by_evidence(
     passed_commands: set[str] | None = None,
 ) -> bool:
     """Conservatively decide whether evidence satisfies a sibling criterion."""
-    normalized_run_commands = {
-        _normalize_command(command).casefold() for command in run_commands if command
-    }
+    normalized_run_commands = {_normalize_command(command) for command in run_commands if command}
     normalized_passed_commands = {
-        _normalize_command(command).casefold() for command in (passed_commands or set()) if command
+        _normalize_command(command) for command in (passed_commands or set()) if command
     }
 
     for file_path in files:
@@ -1561,7 +1582,7 @@ def _criterion_satisfied_by_evidence(
 
 def _criterion_is_exact_file_presence_ac(criterion: str, file_path: str) -> bool:
     """Return True when the criterion is only an exact file-presence AC."""
-    normalized_path = Path(file_path.strip()).as_posix().casefold()
+    normalized_path = Path(file_path.strip()).as_posix()
     if (
         not normalized_path
         or Path(normalized_path).is_absolute()
@@ -1569,7 +1590,7 @@ def _criterion_is_exact_file_presence_ac(criterion: str, file_path: str) -> bool
     ):
         return False
     inline_code_paths = [
-        Path(match.group(1).strip()).as_posix().casefold()
+        Path(match.group(1).strip()).as_posix()
         for match in re.finditer(r"`([^`]+)`", criterion)
         if match.group(1).strip()
     ]
@@ -1590,7 +1611,7 @@ def _criterion_is_exact_file_presence_ac(criterion: str, file_path: str) -> bool
 def _criterion_inline_code_values(criterion: str) -> list[str]:
     """Return normalized inline-code fragments from a criterion."""
     return [
-        _normalized_evidence_text(match.group(1).strip())
+        _normalize_command(match.group(1).strip())
         for match in re.finditer(r"`([^`]+)`", criterion)
         if match.group(1).strip()
     ]
@@ -1598,7 +1619,7 @@ def _criterion_inline_code_values(criterion: str) -> list[str]:
 
 def _criterion_is_exact_command_pass_ac(criterion: str, command: str) -> bool:
     """Return True when the criterion is only an exact command-pass AC."""
-    normalized_command = _normalized_evidence_text(command)
+    normalized_command = _normalize_command(command)
     if not normalized_command or _criterion_inline_code_values(criterion) != [normalized_command]:
         return False
     normalized = _normalized_evidence_text(
@@ -1621,7 +1642,7 @@ def _criterion_is_exact_command_pass_ac(criterion: str, command: str) -> bool:
 
 def _criterion_is_exact_command_run_ac(criterion: str, command: str) -> bool:
     """Return True when the criterion is only an exact command-run AC."""
-    normalized_command = _normalized_evidence_text(command)
+    normalized_command = _normalize_command(command)
     if not normalized_command or _criterion_inline_code_values(criterion) != [normalized_command]:
         return False
     normalized = _normalized_evidence_text(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1543,29 +1543,30 @@ def _criterion_satisfied_by_evidence(
         _normalize_command(command).casefold() for command in (passed_commands or set()) if command
     }
 
-    positive_file_markers = (
+    existential_file_markers = (
         " exists",
-        " define",
-        " defines",
-        " import",
-        " imports",
-        " assert",
-        " asserts",
         " create",
         " creates",
         " created",
-        " contain",
-        " contains",
+        " is present",
+        " are present",
     )
     for file_path in files:
         if (
             file_path
             and file_path.casefold() in lowered
-            and any(marker in lowered for marker in positive_file_markers)
+            and any(marker in lowered for marker in existential_file_markers)
         ):
             return True
 
-    command_success_markers = (" pass", " passes", " passed", " succeed", " succeeds", " exit code 0")
+    command_success_markers = (
+        " pass",
+        " passes",
+        " passed",
+        " succeed",
+        " succeeds",
+        " exit code 0",
+    )
     if any(marker in lowered for marker in command_success_markers):
         for command in normalized_passed_commands:
             if command and command in normalized_criterion:
@@ -1574,8 +1575,10 @@ def _criterion_satisfied_by_evidence(
 
     command_run_markers = (" run ", " runs ", " execute", " executes", " command ")
     for command in normalized_run_commands:
-        if command and command in normalized_criterion and any(
-            marker in lowered for marker in command_run_markers
+        if (
+            command
+            and command in normalized_criterion
+            and any(marker in lowered for marker in command_run_markers)
         ):
             return True
 

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1517,12 +1517,6 @@ def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], s
                 _add_command_evidence(run_commands, command)
             continue
 
-        if message.tool_name in ("Write", "Edit", "NotebookEdit"):
-            path_key = "notebook_path" if message.tool_name == "NotebookEdit" else "file_path"
-            file_path = tool_input.get(path_key)
-            if isinstance(file_path, str) and file_path.strip():
-                files.add(file_path.strip())
-
     passed_commands.update(_successful_runtime_test_commands(result.messages))
     return files, run_commands, passed_commands
 
@@ -1543,13 +1537,8 @@ def _criterion_satisfied_by_evidence(
         _normalize_command(command).casefold() for command in (passed_commands or set()) if command
     }
 
-    existential_file_markers = (" exists", " is present", " are present")
     for file_path in files:
-        if (
-            file_path
-            and _criterion_mentions_exact_file_path(criterion, file_path)
-            and any(marker in lowered for marker in existential_file_markers)
-        ):
+        if file_path and _criterion_is_exact_file_presence_ac(criterion, file_path):
             return True
 
     command_success_markers = (
@@ -1578,8 +1567,8 @@ def _criterion_satisfied_by_evidence(
     return False
 
 
-def _criterion_mentions_exact_file_path(criterion: str, file_path: str) -> bool:
-    """Return True when a criterion cites the exact evidence path."""
+def _criterion_is_exact_file_presence_ac(criterion: str, file_path: str) -> bool:
+    """Return True when the criterion is only an exact file-presence AC."""
     normalized_path = Path(file_path.strip()).as_posix().casefold()
     if (
         not normalized_path
@@ -1587,12 +1576,23 @@ def _criterion_mentions_exact_file_path(criterion: str, file_path: str) -> bool:
         or ".." in Path(normalized_path).parts
     ):
         return False
-    inline_code_paths = {
+    inline_code_paths = [
         Path(match.group(1).strip()).as_posix().casefold()
         for match in re.finditer(r"`([^`]+)`", criterion)
         if match.group(1).strip()
+    ]
+    if inline_code_paths != [normalized_path]:
+        return False
+
+    normalized = _normalized_evidence_text(
+        re.sub(r"`[^`]+`", "<path>", criterion).strip().rstrip(".")
+    )
+    return normalized in {
+        "<path> exists",
+        "<path> is present",
+        "the file <path> exists",
+        "the file <path> is present",
     }
-    return normalized_path in inline_code_paths
 
 
 def _complete_sibling_acs_from_evidence(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1520,6 +1520,21 @@ def _typed_evidence_is_usable_for_sibling_reconciliation(result: ACExecutionResu
     return result.atomic_verifier_verdict is None or result.atomic_verifier_verdict.passed
 
 
+def _typed_file_evidence_proves_current_existence(
+    result: ACExecutionResult,
+    relative_path: str,
+) -> bool:
+    """Return True when typed file evidence is backed by current end-state existence."""
+    if result.runtime_handle is None or result.runtime_handle.cwd is None:
+        return False
+    candidate = (Path(result.runtime_handle.cwd).resolve() / relative_path).resolve()
+    try:
+        candidate.relative_to(Path(result.runtime_handle.cwd).resolve())
+    except ValueError:
+        return False
+    return candidate.is_file()
+
+
 def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], set[str], set[str]]:
     """Return normalized file paths, run commands, and passed commands.
 
@@ -1537,7 +1552,7 @@ def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], s
             normalized = (
                 _workspace_relative_file_claim(str(value), task_cwd=task_cwd) or str(value).strip()
             )
-            if normalized:
+            if normalized and _typed_file_evidence_proves_current_existence(result, normalized):
                 files.add(normalized)
         for value in _flatten_evidence_values(result.typed_evidence.get("commands_run")):
             _add_runtime_command_evidence(run_commands, str(value))

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1461,7 +1461,7 @@ def _successful_runtime_test_commands(messages: tuple[AgentMessage, ...]) -> set
             alias
             for command in _runtime_message_command_values(message)
             if _looks_like_test_command(command)
-            for alias in _normalized_command_claim_aliases(command)
+            for alias in _runtime_command_evidence_aliases(command)
         }
         if not message_commands:
             continue
@@ -1485,6 +1485,20 @@ def _add_command_evidence(commands: set[str], command: str) -> None:
     if normalized:
         commands.add(normalized)
     commands.update(alias for alias in _normalized_command_claim_aliases(command) if alias)
+
+
+def _add_runtime_command_evidence(commands: set[str], command: str) -> None:
+    """Add runtime command evidence without accepting compound shell aliases."""
+    commands.update(_runtime_command_evidence_aliases(command))
+
+
+def _runtime_command_evidence_aliases(command: str) -> tuple[str, ...]:
+    """Return exact runtime command aliases for sibling reconciliation."""
+    aliases = [_normalized_evidence_text(command)]
+    single_inner_command = _single_command_after_safe_shell_preamble(command)
+    if single_inner_command and single_inner_command not in aliases:
+        aliases.append(single_inner_command)
+    return tuple(alias for alias in aliases if alias)
 
 
 def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], set[str], set[str]]:
@@ -1517,7 +1531,7 @@ def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], s
 
         if message.tool_name == "Bash":
             for command in _runtime_message_command_values(message):
-                _add_command_evidence(run_commands, command)
+                _add_runtime_command_evidence(run_commands, command)
             continue
 
     passed_commands.update(_successful_runtime_test_commands(result.messages))

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1507,13 +1507,9 @@ def _evidence_values_from_result(result: ACExecutionResult) -> tuple[set[str], s
     for message in result.messages:
         if not message.tool_name:
             continue
-        tool_input = message.data.get("tool_input", {})
-        if not isinstance(tool_input, dict):
-            continue
 
         if message.tool_name == "Bash":
-            command = tool_input.get("command")
-            if isinstance(command, str):
+            for command in _runtime_message_command_values(message):
                 _add_command_evidence(run_commands, command)
             continue
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -200,6 +200,11 @@ def test_complete_sibling_acs_requires_runtime_test_success_for_pass_claim() -> 
                     }
                 },
             ),
+            AgentMessage(
+                type="result",
+                content="success",
+                data={"subtype": "success"},
+            ),
         ),
     )
     failed_pytest = ACExecutionResult(
@@ -225,6 +230,41 @@ def test_complete_sibling_acs_requires_runtime_test_success_for_pass_claim() -> 
     assert [result.outcome for result in results] == [
         ACExecutionOutcome.SUCCEEDED,
         ACExecutionOutcome.FAILED,
+    ]
+
+
+def test_complete_sibling_acs_normalizes_absolute_typed_file_evidence(tmp_path: Any) -> None:
+    test_file = tmp_path / "tests" / "test_hello_auto.py"
+    success = ACExecutionResult(
+        ac_index=0,
+        ac_content="`tests/test_hello_auto.py` exists.",
+        success=True,
+        typed_evidence=EvidenceRecord(data={"files_touched": [str(test_file)]}),
+        runtime_handle=RuntimeHandle(backend="codex_cli", cwd=str(tmp_path)),
+    )
+    failed_file_presence = ACExecutionResult(
+        ac_index=1,
+        ac_content="`tests/test_hello_auto.py` exists.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success, failed_file_presence],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+    )
+
+    assert completed_count == 2
+    assert level_success == 2
+    assert level_failed == 0
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
+        ACExecutionOutcome.SATISFIED_EXTERNALLY,
     ]
 
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -396,6 +396,48 @@ def test_complete_sibling_acs_rejects_compound_runtime_command_alias() -> None:
     ]
 
 
+def test_complete_sibling_acs_rejects_compound_typed_command_alias() -> None:
+    success_with_compound_typed_command = ACExecutionResult(
+        ac_index=0,
+        ac_content="Run the requested test command.",
+        success=True,
+        typed_evidence=EvidenceRecord(
+            data={
+                "tests_passed": [
+                    (
+                        "/bin/zsh -lc 'uv run pytest tests/test_hello_auto.py "
+                        "&& python scripts/postprocess.py'"
+                    )
+                ]
+            }
+        ),
+    )
+    failed_pytest = ACExecutionResult(
+        ac_index=1,
+        ac_content="The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success_with_compound_typed_command, failed_pytest],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+    )
+
+    assert completed_count == 1
+    assert level_success == 1
+    assert level_failed == 1
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
+        ACExecutionOutcome.FAILED,
+    ]
+
+
 def test_complete_sibling_acs_reuses_structured_command_aliases() -> None:
     success_with_goose_command_shape = ACExecutionResult(
         ac_index=0,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -105,6 +105,17 @@ def test_criterion_satisfied_by_exact_runtime_evidence() -> None:
         commands,
     )
     assert not _criterion_satisfied_by_evidence(
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes and covers edge cases.",
+        files,
+        commands,
+        commands,
+    )
+    assert not _criterion_satisfied_by_evidence(
+        "Run the exact command `uv run pytest tests/test_hello_auto.py` and inspect output.",
+        files,
+        commands,
+    )
+    assert not _criterion_satisfied_by_evidence(
         "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
         files,
         commands,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -79,6 +79,11 @@ def test_criterion_satisfied_by_exact_runtime_evidence() -> None:
     assert _criterion_satisfied_by_evidence("`tests/test_hello_auto.py` exists.", files, commands)
     assert not _criterion_satisfied_by_evidence("`src/hello_auto.py` exists.", files, commands)
     assert not _criterion_satisfied_by_evidence(
+        "`tests/test_hello_auto.py` exists and imports `hello_auto`.",
+        files,
+        commands,
+    )
+    assert not _criterion_satisfied_by_evidence(
         "`hello_auto.py` is created with exact content.",
         files,
         commands,
@@ -302,6 +307,46 @@ def test_complete_sibling_acs_does_not_rewrite_blocked_results() -> None:
     assert [result.outcome for result in results] == [
         ACExecutionOutcome.SUCCEEDED,
         ACExecutionOutcome.BLOCKED,
+    ]
+
+
+def test_complete_sibling_acs_does_not_use_bare_write_call_as_file_proof() -> None:
+    success_with_write_call_only = ACExecutionResult(
+        ac_index=0,
+        ac_content="Attempt a file write.",
+        success=True,
+        messages=(
+            AgentMessage(
+                type="tool_use",
+                content="write file",
+                tool_name="Write",
+                data={"tool_input": {"file_path": "hello_auto.py"}},
+            ),
+        ),
+    )
+    failed_file_presence = ACExecutionResult(
+        ac_index=1,
+        ac_content="`hello_auto.py` exists.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success_with_write_call_only, failed_file_presence],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+    )
+
+    assert completed_count == 1
+    assert level_success == 1
+    assert level_failed == 1
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
+        ACExecutionOutcome.FAILED,
     ]
 
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -77,6 +77,12 @@ def test_criterion_satisfied_by_exact_runtime_evidence() -> None:
 
     assert _criterion_satisfied_by_evidence("`hello_auto.py` exists.", files, commands)
     assert _criterion_satisfied_by_evidence("`tests/test_hello_auto.py` exists.", files, commands)
+    assert not _criterion_satisfied_by_evidence("`src/hello_auto.py` exists.", files, commands)
+    assert not _criterion_satisfied_by_evidence(
+        "`hello_auto.py` is created with exact content.",
+        files,
+        commands,
+    )
     assert not _criterion_satisfied_by_evidence(
         "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
         files,
@@ -263,6 +269,39 @@ def test_complete_sibling_acs_accepts_shell_wrapped_successful_test_command() ->
     assert [result.outcome for result in results] == [
         ACExecutionOutcome.SUCCEEDED,
         ACExecutionOutcome.SATISFIED_EXTERNALLY,
+    ]
+
+
+def test_complete_sibling_acs_does_not_rewrite_blocked_results() -> None:
+    success = ACExecutionResult(
+        ac_index=0,
+        ac_content="`hello_auto.py` exists.",
+        success=True,
+        typed_evidence=EvidenceRecord(data={"files_touched": ["tests/test_hello_auto.py"]}),
+    )
+    blocked = ACExecutionResult(
+        ac_index=1,
+        ac_content="`tests/test_hello_auto.py` exists.",
+        success=False,
+        error="Skipped: dependency failed",
+        outcome=ACExecutionOutcome.BLOCKED,
+    )
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success, blocked],
+        ac_statuses={0: "completed", 1: "blocked"},
+        failed_indices=set(),
+        completed_count=1,
+        level_success=1,
+        level_failed=0,
+    )
+
+    assert completed_count == 1
+    assert level_success == 1
+    assert level_failed == 0
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
+        ACExecutionOutcome.BLOCKED,
     ]
 
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -147,7 +147,9 @@ def test_criterion_satisfied_by_exact_runtime_evidence() -> None:
     assert not _criterion_satisfied_by_evidence("`other.py` exists.", files, commands)
 
 
-def test_complete_sibling_acs_from_successful_runtime_evidence() -> None:
+def test_complete_sibling_acs_from_successful_runtime_evidence(tmp_path: Any) -> None:
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_hello_auto.py").write_text("def test_hello(): pass\n")
     success = ACExecutionResult(
         ac_index=0,
         ac_content="`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
@@ -179,6 +181,7 @@ def test_complete_sibling_acs_from_successful_runtime_evidence() -> None:
                 "tests_passed": ["uv run pytest tests/test_hello_auto.py"],
             }
         ),
+        runtime_handle=RuntimeHandle(backend="codex_cli", cwd=str(tmp_path)),
     )
     failed_test_file = ACExecutionResult(
         ac_index=1,
@@ -355,6 +358,8 @@ def test_complete_sibling_acs_keeps_exact_command_case_sensitive() -> None:
 
 def test_complete_sibling_acs_normalizes_absolute_typed_file_evidence(tmp_path: Any) -> None:
     test_file = tmp_path / "tests" / "test_hello_auto.py"
+    test_file.parent.mkdir()
+    test_file.write_text("def test_hello(): pass\n")
     success = ACExecutionResult(
         ac_index=0,
         ac_content="`tests/test_hello_auto.py` exists.",
@@ -385,6 +390,40 @@ def test_complete_sibling_acs_normalizes_absolute_typed_file_evidence(tmp_path: 
     assert [result.outcome for result in results] == [
         ACExecutionOutcome.SUCCEEDED,
         ACExecutionOutcome.SATISFIED_EXTERNALLY,
+    ]
+
+
+def test_complete_sibling_acs_requires_file_end_state_existence(tmp_path: Any) -> None:
+    success_without_current_file = ACExecutionResult(
+        ac_index=0,
+        ac_content="`tests/test_hello_auto.py` exists.",
+        success=True,
+        typed_evidence=EvidenceRecord(data={"files_touched": ["tests/test_hello_auto.py"]}),
+        runtime_handle=RuntimeHandle(backend="codex_cli", cwd=str(tmp_path)),
+    )
+    failed_file_presence = ACExecutionResult(
+        ac_index=1,
+        ac_content="`tests/test_hello_auto.py` exists.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success_without_current_file, failed_file_presence],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+    )
+
+    assert completed_count == 1
+    assert level_success == 1
+    assert level_failed == 1
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
+        ACExecutionOutcome.FAILED,
     ]
 
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -17,6 +17,7 @@ from ouroboros.mcp.types import MCPToolDefinition
 from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
 from ouroboros.orchestrator.coordinator import CoordinatorReview, FileConflict
 from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
+from ouroboros.orchestrator.evidence_schema import EvidenceRecord
 from ouroboros.orchestrator.execution_runtime_scope import ExecutionNodeIdentity
 from ouroboros.orchestrator.level_context import ACContextSummary, LevelContext
 from ouroboros.orchestrator.parallel_executor import (
@@ -28,6 +29,8 @@ from ouroboros.orchestrator.parallel_executor import (
     ParallelExecutionResult,
     StageExecutionOutcome,
     _build_governed_parent_summary,
+    _complete_sibling_acs_from_evidence,
+    _criterion_satisfied_by_evidence,
     _effective_evidence_schema_for_ac,
     _message_contains_test_success,
     _runtime_messages_support_command_claim,
@@ -66,6 +69,91 @@ def _make_executor() -> ParallelACExecutor:
     executor._emit_level_completed = AsyncMock()
     executor._emit_subtask_event = AsyncMock()
     return executor
+
+
+def test_criterion_satisfied_by_exact_runtime_evidence() -> None:
+    files = {"hello_auto.py", "tests/test_hello_auto.py"}
+    commands = {"uv run pytest tests/test_hello_auto.py"}
+
+    assert _criterion_satisfied_by_evidence("`hello_auto.py` exists.", files, commands)
+    assert _criterion_satisfied_by_evidence("`tests/test_hello_auto.py` exists.", files, commands)
+    assert _criterion_satisfied_by_evidence(
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        files,
+        commands,
+    )
+    assert not _criterion_satisfied_by_evidence("`other.py` exists.", files, commands)
+
+
+def test_complete_sibling_acs_from_successful_runtime_evidence() -> None:
+    success = ACExecutionResult(
+        ac_index=0,
+        ac_content="`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
+        success=True,
+        messages=(
+            AgentMessage(
+                type="tool_use",
+                content="write hello_auto",
+                tool_name="Write",
+                data={"tool_input": {"file_path": "hello_auto.py"}},
+            ),
+            AgentMessage(
+                type="tool_use",
+                content="write test",
+                tool_name="Write",
+                data={"tool_input": {"file_path": "tests/test_hello_auto.py"}},
+            ),
+            AgentMessage(
+                type="tool_use",
+                content="run pytest",
+                tool_name="Bash",
+                data={"tool_input": {"command": "uv run pytest tests/test_hello_auto.py"}},
+            ),
+        ),
+        typed_evidence=EvidenceRecord(
+            data={
+                "files_touched": ["hello_auto.py", "tests/test_hello_auto.py"],
+                "commands_run": ["uv run pytest tests/test_hello_auto.py"],
+                "tests_passed": ["uv run pytest tests/test_hello_auto.py"],
+            }
+        ),
+    )
+    failed_test_file = ACExecutionResult(
+        ac_index=1,
+        ac_content="`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+    failed_pytest = ACExecutionResult(
+        ac_index=2,
+        ac_content="The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+    failed_indices = {1, 2}
+    ac_statuses = {0: "completed", 1: "failed", 2: "failed"}
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success, failed_test_file, failed_pytest],
+        ac_statuses=ac_statuses,
+        failed_indices=failed_indices,
+        completed_count=1,
+        level_success=1,
+        level_failed=2,
+    )
+
+    assert completed_count == 3
+    assert level_success == 3
+    assert level_failed == 0
+    assert failed_indices == set()
+    assert ac_statuses == {0: "completed", 1: "completed", 2: "completed"}
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
+        ACExecutionOutcome.SATISFIED_EXTERNALLY,
+        ACExecutionOutcome.SATISFIED_EXTERNALLY,
+    ]
 
 
 def _make_replaying_event_store() -> tuple[AsyncMock, list[BaseEvent]]:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -81,6 +81,18 @@ def test_criterion_satisfied_by_exact_runtime_evidence() -> None:
         "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
         files,
         commands,
+        commands,
+    )
+    assert _criterion_satisfied_by_evidence(
+        "Run the exact command `uv run pytest tests/test_hello_auto.py`.",
+        files,
+        commands,
+    )
+    assert not _criterion_satisfied_by_evidence(
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        files,
+        commands,
+        set(),
     )
     assert not _criterion_satisfied_by_evidence("`other.py` exists.", files, commands)
 
@@ -152,6 +164,99 @@ def test_complete_sibling_acs_from_successful_runtime_evidence() -> None:
     assert [result.outcome for result in results] == [
         ACExecutionOutcome.SUCCEEDED,
         ACExecutionOutcome.SATISFIED_EXTERNALLY,
+        ACExecutionOutcome.SATISFIED_EXTERNALLY,
+    ]
+
+
+def test_complete_sibling_acs_requires_runtime_test_success_for_pass_claim() -> None:
+    success_without_test_output = ACExecutionResult(
+        ac_index=0,
+        ac_content="`hello_auto.py` defines `hello_auto() -> str`.",
+        success=True,
+        messages=(
+            AgentMessage(
+                type="tool_use",
+                content="run pytest",
+                tool_name="Bash",
+                data={
+                    "tool_input": {
+                        "command": "/bin/zsh -lc 'uv run pytest tests/test_hello_auto.py'"
+                    }
+                },
+            ),
+        ),
+    )
+    failed_pytest = ACExecutionResult(
+        ac_index=1,
+        ac_content="The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success_without_test_output, failed_pytest],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+    )
+
+    assert completed_count == 1
+    assert level_success == 1
+    assert level_failed == 1
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
+        ACExecutionOutcome.FAILED,
+    ]
+
+
+def test_complete_sibling_acs_accepts_shell_wrapped_successful_test_command() -> None:
+    success_with_test_output = ACExecutionResult(
+        ac_index=0,
+        ac_content="`hello_auto.py` defines `hello_auto() -> str`.",
+        success=True,
+        messages=(
+            AgentMessage(
+                type="tool_use",
+                content="run pytest",
+                tool_name="Bash",
+                data={
+                    "tool_input": {
+                        "command": "/bin/zsh -lc 'uv run pytest tests/test_hello_auto.py'"
+                    }
+                },
+            ),
+            AgentMessage(
+                type="tool_result",
+                content="1 passed in 0.01s",
+                data={"stdout": "1 passed in 0.01s"},
+            ),
+        ),
+    )
+    failed_pytest = ACExecutionResult(
+        ac_index=1,
+        ac_content="The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success_with_test_output, failed_pytest],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+    )
+
+    assert completed_count == 2
+    assert level_success == 2
+    assert level_failed == 0
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
         ACExecutionOutcome.SATISFIED_EXTERNALLY,
     ]
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -17,7 +17,7 @@ from ouroboros.mcp.types import MCPToolDefinition
 from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
 from ouroboros.orchestrator.coordinator import CoordinatorReview, FileConflict
 from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
-from ouroboros.orchestrator.evidence_schema import EvidenceRecord
+from ouroboros.orchestrator.evidence_schema import EvidenceRecord, ValidationResult
 from ouroboros.orchestrator.execution_runtime_scope import ExecutionNodeIdentity
 from ouroboros.orchestrator.level_context import ACContextSummary, LevelContext
 from ouroboros.orchestrator.parallel_executor import (
@@ -78,6 +78,7 @@ def test_criterion_satisfied_by_exact_runtime_evidence() -> None:
     assert _criterion_satisfied_by_evidence("`hello_auto.py` exists.", files, commands)
     assert _criterion_satisfied_by_evidence("`tests/test_hello_auto.py` exists.", files, commands)
     assert not _criterion_satisfied_by_evidence("`src/hello_auto.py` exists.", files, commands)
+    assert not _criterion_satisfied_by_evidence("`Hello_Auto.py` exists.", files, commands)
     assert not _criterion_satisfied_by_evidence(
         "`tests/test_hello_auto.py` exists and imports `hello_auto`.",
         files,
@@ -122,6 +123,12 @@ def test_criterion_satisfied_by_exact_runtime_evidence() -> None:
     )
     assert not _criterion_satisfied_by_evidence(
         "The exact command `uv run pytest tests/test_hello_auto.py` passes and covers edge cases.",
+        files,
+        commands,
+        commands,
+    )
+    assert not _criterion_satisfied_by_evidence(
+        "The exact command `uv run pytest Tests/test_hello_auto.py` passes.",
         files,
         commands,
         commands,
@@ -292,6 +299,80 @@ def test_complete_sibling_acs_normalizes_absolute_typed_file_evidence(tmp_path: 
     assert [result.outcome for result in results] == [
         ACExecutionOutcome.SUCCEEDED,
         ACExecutionOutcome.SATISFIED_EXTERNALLY,
+    ]
+
+
+def test_complete_sibling_acs_rejects_invalid_typed_evidence() -> None:
+    success_with_invalid_typed_evidence = ACExecutionResult(
+        ac_index=0,
+        ac_content="`tests/test_hello_auto.py` exists.",
+        success=True,
+        typed_evidence=EvidenceRecord(data={"files_touched": ["tests/test_hello_auto.py"]}),
+        typed_evidence_validation=ValidationResult(ok=False, missing_fields=("tests_passed",)),
+    )
+    failed_file_presence = ACExecutionResult(
+        ac_index=1,
+        ac_content="`tests/test_hello_auto.py` exists.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success_with_invalid_typed_evidence, failed_file_presence],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+    )
+
+    assert completed_count == 1
+    assert level_success == 1
+    assert level_failed == 1
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
+        ACExecutionOutcome.FAILED,
+    ]
+
+
+def test_complete_sibling_acs_rejects_verifier_failed_typed_evidence() -> None:
+    success_with_rejected_typed_evidence = ACExecutionResult(
+        ac_index=0,
+        ac_content="The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        success=True,
+        typed_evidence=EvidenceRecord(
+            data={"tests_passed": ["uv run pytest tests/test_hello_auto.py"]}
+        ),
+        atomic_verifier_verdict=VerifierVerdict(
+            passed=False,
+            reasons=("fabricated test output",),
+            failure_class="FABRICATION_SUSPECTED",
+        ),
+    )
+    failed_pytest = ACExecutionResult(
+        ac_index=1,
+        ac_content="The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success_with_rejected_typed_evidence, failed_pytest],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+    )
+
+    assert completed_count == 1
+    assert level_success == 1
+    assert level_failed == 1
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
+        ACExecutionOutcome.FAILED,
     ]
 
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -104,6 +104,22 @@ def test_criterion_satisfied_by_exact_runtime_evidence() -> None:
         files,
         commands,
     )
+    assert _criterion_satisfied_by_evidence(
+        "Run `uv run pytest tests/test_hello_auto.py`.",
+        files,
+        commands,
+    )
+    assert _criterion_satisfied_by_evidence(
+        "Execute `uv run pytest tests/test_hello_auto.py`.",
+        files,
+        commands,
+    )
+    assert _criterion_satisfied_by_evidence(
+        "The exact command `uv run pytest tests/test_hello_auto.py` exits with code 0.",
+        files,
+        commands,
+        commands,
+    )
     assert not _criterion_satisfied_by_evidence(
         "The exact command `uv run pytest tests/test_hello_auto.py` passes and covers edge cases.",
         files,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -550,6 +550,52 @@ def test_complete_sibling_acs_accepts_shell_wrapped_successful_test_command() ->
     ]
 
 
+def test_complete_sibling_acs_accepts_named_tool_result_test_output() -> None:
+    success_with_named_tool_result = ACExecutionResult(
+        ac_index=0,
+        ac_content="Run the requested test command.",
+        success=True,
+        messages=(
+            AgentMessage(
+                type="tool_use",
+                content="run pytest",
+                tool_name="Bash",
+                data={"tool_input": {"command": "uv run pytest tests/test_hello_auto.py"}},
+            ),
+            AgentMessage(
+                type="tool",
+                content="1 passed in 0.01s",
+                tool_name="Bash",
+                data={"subtype": "tool_result", "stdout": "1 passed in 0.01s"},
+            ),
+        ),
+    )
+    failed_pytest = ACExecutionResult(
+        ac_index=1,
+        ac_content="The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success_with_named_tool_result, failed_pytest],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+    )
+
+    assert completed_count == 2
+    assert level_success == 2
+    assert level_failed == 0
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
+        ACExecutionOutcome.SATISFIED_EXTERNALLY,
+    ]
+
+
 def test_complete_sibling_acs_rejects_compound_runtime_command_alias() -> None:
     success_with_compound_runtime_command = ACExecutionResult(
         ac_index=0,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -77,6 +77,11 @@ def test_criterion_satisfied_by_exact_runtime_evidence() -> None:
 
     assert _criterion_satisfied_by_evidence("`hello_auto.py` exists.", files, commands)
     assert _criterion_satisfied_by_evidence("`tests/test_hello_auto.py` exists.", files, commands)
+    assert not _criterion_satisfied_by_evidence(
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
+        files,
+        commands,
+    )
     assert _criterion_satisfied_by_evidence(
         "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
         files,
@@ -132,7 +137,7 @@ def test_complete_sibling_acs_from_successful_runtime_evidence() -> None:
     )
     failed_test_file = ACExecutionResult(
         ac_index=1,
-        ac_content="`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
+        ac_content="`tests/test_hello_auto.py` exists.",
         success=False,
         error="worker did not update this AC separately",
         outcome=ACExecutionOutcome.FAILED,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -267,6 +267,92 @@ def test_complete_sibling_acs_requires_runtime_test_success_for_pass_claim() -> 
     ]
 
 
+def test_complete_sibling_acs_does_not_use_later_tool_success_as_test_proof() -> None:
+    success_with_unrelated_tool_success = ACExecutionResult(
+        ac_index=0,
+        ac_content="Run pytest and edit a file.",
+        success=True,
+        messages=(
+            AgentMessage(
+                type="tool_use",
+                content="run pytest",
+                tool_name="Bash",
+                data={"tool_input": {"command": "uv run pytest tests/test_hello_auto.py"}},
+            ),
+            AgentMessage(
+                type="tool_use",
+                content="write file",
+                tool_name="Write",
+                data={"tool_input": {"file_path": "hello_auto.py"}},
+            ),
+            AgentMessage(
+                type="tool_result",
+                content="success",
+                data={"subtype": "tool_result", "stdout": "success"},
+            ),
+        ),
+    )
+    failed_pytest = ACExecutionResult(
+        ac_index=1,
+        ac_content="The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success_with_unrelated_tool_success, failed_pytest],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+    )
+
+    assert completed_count == 1
+    assert level_success == 1
+    assert level_failed == 1
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
+        ACExecutionOutcome.FAILED,
+    ]
+
+
+def test_complete_sibling_acs_keeps_exact_command_case_sensitive() -> None:
+    success = ACExecutionResult(
+        ac_index=0,
+        ac_content="The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        success=True,
+        typed_evidence=EvidenceRecord(
+            data={"tests_passed": ["uv run pytest tests/test_hello_auto.py"]}
+        ),
+    )
+    failed_wrong_case_pytest = ACExecutionResult(
+        ac_index=1,
+        ac_content="The exact command `uv run pytest Tests/test_hello_auto.py` passes.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success, failed_wrong_case_pytest],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+    )
+
+    assert completed_count == 1
+    assert level_success == 1
+    assert level_failed == 1
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
+        ACExecutionOutcome.FAILED,
+    ]
+
+
 def test_complete_sibling_acs_normalizes_absolute_typed_file_evidence(tmp_path: Any) -> None:
     test_file = tmp_path / "tests" / "test_hello_auto.py"
     success = ACExecutionResult(

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -344,6 +344,58 @@ def test_complete_sibling_acs_accepts_shell_wrapped_successful_test_command() ->
     ]
 
 
+def test_complete_sibling_acs_rejects_compound_runtime_command_alias() -> None:
+    success_with_compound_runtime_command = ACExecutionResult(
+        ac_index=0,
+        ac_content="Run the requested test command.",
+        success=True,
+        messages=(
+            AgentMessage(
+                type="tool_use",
+                content="run pytest and postprocess",
+                tool_name="Bash",
+                data={
+                    "tool_input": {
+                        "command": (
+                            "/bin/zsh -lc 'uv run pytest tests/test_hello_auto.py "
+                            "&& python scripts/postprocess.py'"
+                        )
+                    }
+                },
+            ),
+            AgentMessage(
+                type="tool_result",
+                content="1 passed in 0.01s",
+                data={"stdout": "1 passed in 0.01s"},
+            ),
+        ),
+    )
+    failed_pytest = ACExecutionResult(
+        ac_index=1,
+        ac_content="The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success_with_compound_runtime_command, failed_pytest],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+    )
+
+    assert completed_count == 1
+    assert level_success == 1
+    assert level_failed == 1
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
+        ACExecutionOutcome.FAILED,
+    ]
+
+
 def test_complete_sibling_acs_reuses_structured_command_aliases() -> None:
     success_with_goose_command_shape = ACExecutionResult(
         ac_index=0,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -277,6 +277,46 @@ def test_complete_sibling_acs_accepts_shell_wrapped_successful_test_command() ->
     ]
 
 
+def test_complete_sibling_acs_reuses_structured_command_aliases() -> None:
+    success_with_goose_command_shape = ACExecutionResult(
+        ac_index=0,
+        ac_content="Run the requested test command.",
+        success=True,
+        messages=(
+            AgentMessage(
+                type="tool_use",
+                content="run pytest",
+                tool_name="Bash",
+                data={"tool_input": {"cmd": ["uv", "run", "pytest", "tests/test_hello_auto.py"]}},
+            ),
+        ),
+    )
+    failed_run_command = ACExecutionResult(
+        ac_index=1,
+        ac_content="Run the exact command `uv run pytest tests/test_hello_auto.py`.",
+        success=False,
+        error="worker did not update this AC separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+
+    completed_count, level_success, level_failed, results = _complete_sibling_acs_from_evidence(
+        level_results=[success_with_goose_command_shape, failed_run_command],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+    )
+
+    assert completed_count == 2
+    assert level_success == 2
+    assert level_failed == 0
+    assert [result.outcome for result in results] == [
+        ACExecutionOutcome.SUCCEEDED,
+        ACExecutionOutcome.SATISFIED_EXTERNALLY,
+    ]
+
+
 def test_complete_sibling_acs_does_not_rewrite_blocked_results() -> None:
     success = ACExecutionResult(
         ac_index=0,


### PR DESCRIPTION
## Summary
- Add conservative sibling-AC reconciliation from concrete runtime/typed evidence.
- If one successful worker result proves sibling file/command ACs with exact tool transcript or typed evidence, mark those siblings `SATISFIED_EXTERNALLY` instead of leaving them failed.
- Restrict file matching to positive file criteria and exact path/command evidence to avoid natural-language self-report completion.

## Why
The latest observation no longer got stuck running, and the requested files/tests passed, but the job still terminalized as failed with partial AC progress. The likely gap is AC accounting: one worker can create both proof files and run pytest, while sibling ACs remain unsatisfied even though the runtime evidence proves them.

## Validation
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py -q`
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py`
