### PR TITLE
fix(artifacts): refuse symlinked managed install roots

### DIFF
--- a/src/ouroboros/codex/artifacts.py
+++ b/src/ouroboros/codex/artifacts.py
@@ -301,6 +301,22 @@ def _remove_installed_artifact(path: Path) -> None:
     path.unlink()
 
 
+def _prepare_managed_install_root(path: Path) -> None:
+    """Create an artifact root without following attacker-controlled symlinks."""
+    if path.is_symlink():
+        msg = f"Refusing to install Codex artifacts into symlinked directory: {path}"
+        raise OSError(msg)
+    path.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        msg = f"Refusing to install Codex artifacts into symlinked directory: {path}"
+        raise OSError(msg)
+
+
+def _installed_artifact_exists(path: Path) -> bool:
+    """Return whether an installed artifact path occupies the leaf, including symlinks."""
+    return path.exists() or path.is_symlink()
+
+
 def _is_namespaced_rule_artifact(path: Path) -> bool:
     """Return whether a rules entry is managed by Ouroboros."""
     if path.name == CODEX_RULE_FILENAME:
@@ -321,7 +337,7 @@ def install_codex_rules(
         Path(codex_dir).expanduser() if codex_dir is not None else Path.home() / ".codex"
     )
     target_root = resolved_codex_dir / "rules"
-    target_root.mkdir(parents=True, exist_ok=True)
+    _prepare_managed_install_root(target_root)
 
     installed_names: set[str] = set()
     primary_target_path: Path | None = None
@@ -332,7 +348,7 @@ def install_codex_rules(
         primary_source_path = _select_primary_packaged_codex_rule(packaged_rules)
         for source_path in packaged_rules:
             target_path = target_root / source_path.name
-            if target_path.exists():
+            if _installed_artifact_exists(target_path):
                 _remove_installed_artifact(target_path)
 
             if source_path == primary_source_path:
@@ -370,7 +386,7 @@ def install_codex_skills(
         Path(codex_dir).expanduser() if codex_dir is not None else Path.home() / ".codex"
     )
     target_root = resolved_codex_dir / "skills"
-    target_root.mkdir(parents=True, exist_ok=True)
+    _prepare_managed_install_root(target_root)
 
     installed_paths: list[Path] = []
     with _packaged_codex_skills_dir(skills_dir=skills_dir) as source_root:
@@ -379,7 +395,7 @@ def install_codex_skills(
 
         for packaged_skill in packaged_skills:
             target_path = target_root / packaged_skill.install_dir_name
-            if target_path.exists():
+            if _installed_artifact_exists(target_path):
                 _remove_installed_artifact(target_path)
 
             shutil.copytree(packaged_skill.source_dir, target_path)

--- a/src/ouroboros/codex/artifacts.py
+++ b/src/ouroboros/codex/artifacts.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 import importlib.resources
+import os
 from pathlib import Path
 import shutil
 from typing import Literal
@@ -310,6 +311,36 @@ def _prepare_managed_install_root(path: Path) -> None:
 
 def _refuse_symlinked_path_component(path: Path) -> None:
     """Fail closed when any existing component in an install root is a symlink."""
+    for candidate_path in _install_root_candidates(path):
+        _refuse_symlinked_candidate_path_component(candidate_path)
+
+
+def _install_root_candidates(path: Path) -> tuple[Path, ...]:
+    """Return filesystem paths that may be followed for an install root."""
+    if path.is_absolute():
+        return (path,)
+
+    candidates = [Path.cwd() / path]
+    pwd = os.environ.get("PWD")
+    if not pwd:
+        return tuple(candidates)
+
+    pwd_path = Path(pwd).expanduser()
+    if not pwd_path.is_absolute():
+        return tuple(candidates)
+
+    try:
+        pwd_matches_cwd = pwd_path.resolve(strict=True) == Path.cwd().resolve(strict=True)
+    except OSError:
+        pwd_matches_cwd = False
+    if pwd_matches_cwd:
+        candidates.append(pwd_path / path)
+
+    return tuple(dict.fromkeys(candidates))
+
+
+def _refuse_symlinked_candidate_path_component(path: Path) -> None:
+    """Fail closed when any existing component in one install-root candidate is a symlink."""
     for component in (*reversed(path.parents), path):
         if not component.is_symlink():
             continue

--- a/src/ouroboros/codex/artifacts.py
+++ b/src/ouroboros/codex/artifacts.py
@@ -303,12 +303,20 @@ def _remove_installed_artifact(path: Path) -> None:
 
 def _prepare_managed_install_root(path: Path) -> None:
     """Create an artifact root without following attacker-controlled symlinks."""
-    if path.is_symlink():
-        msg = f"Refusing to install Codex artifacts into symlinked directory: {path}"
-        raise OSError(msg)
+    _refuse_symlinked_path_component(path)
     path.mkdir(parents=True, exist_ok=True)
-    if path.is_symlink():
-        msg = f"Refusing to install Codex artifacts into symlinked directory: {path}"
+    _refuse_symlinked_path_component(path)
+
+
+def _refuse_symlinked_path_component(path: Path) -> None:
+    """Fail closed when any existing component in an install root is a symlink."""
+    for component in (*reversed(path.parents), path):
+        if not component.is_symlink():
+            continue
+        msg = (
+            "Refusing to install Codex artifacts into a path with a symlinked "
+            f"directory component: {component}"
+        )
         raise OSError(msg)
 
 

--- a/src/ouroboros/hermes/artifacts.py
+++ b/src/ouroboros/hermes/artifacts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+import os
 from pathlib import Path
 import shutil
 
@@ -63,6 +64,36 @@ def _prepare_hermes_install_root(path: Path) -> None:
 
 def _refuse_symlinked_path_component(path: Path) -> None:
     """Fail closed when any existing component in the install root is a symlink."""
+    for candidate_path in _install_root_candidates(path):
+        _refuse_symlinked_candidate_path_component(candidate_path)
+
+
+def _install_root_candidates(path: Path) -> tuple[Path, ...]:
+    """Return filesystem paths that may be followed for an install root."""
+    if path.is_absolute():
+        return (path,)
+
+    candidates = [Path.cwd() / path]
+    pwd = os.environ.get("PWD")
+    if not pwd:
+        return tuple(candidates)
+
+    pwd_path = Path(pwd).expanduser()
+    if not pwd_path.is_absolute():
+        return tuple(candidates)
+
+    try:
+        pwd_matches_cwd = pwd_path.resolve(strict=True) == Path.cwd().resolve(strict=True)
+    except OSError:
+        pwd_matches_cwd = False
+    if pwd_matches_cwd:
+        candidates.append(pwd_path / path)
+
+    return tuple(dict.fromkeys(candidates))
+
+
+def _refuse_symlinked_candidate_path_component(path: Path) -> None:
+    """Fail closed when any existing component in one install-root candidate is a symlink."""
     for component in (*reversed(path.parents), path):
         if not component.is_symlink():
             continue

--- a/src/ouroboros/hermes/artifacts.py
+++ b/src/ouroboros/hermes/artifacts.py
@@ -56,12 +56,20 @@ def _remove_target_path(path: Path) -> None:
 
 def _prepare_hermes_install_root(path: Path) -> None:
     """Create the Hermes skill root without following symlinked managed dirs."""
-    if path.is_symlink():
-        msg = f"Refusing to install Hermes skills into symlinked directory: {path}"
-        raise OSError(msg)
+    _refuse_symlinked_path_component(path)
     path.mkdir(parents=True, exist_ok=True)
-    if path.is_symlink():
-        msg = f"Refusing to install Hermes skills into symlinked directory: {path}"
+    _refuse_symlinked_path_component(path)
+
+
+def _refuse_symlinked_path_component(path: Path) -> None:
+    """Fail closed when any existing component in the install root is a symlink."""
+    for component in (*reversed(path.parents), path):
+        if not component.is_symlink():
+            continue
+        msg = (
+            "Refusing to install Hermes skills into a path with a symlinked "
+            f"directory component: {component}"
+        )
         raise OSError(msg)
 
 

--- a/src/ouroboros/hermes/artifacts.py
+++ b/src/ouroboros/hermes/artifacts.py
@@ -54,6 +54,17 @@ def _remove_target_path(path: Path) -> None:
     shutil.rmtree(path)
 
 
+def _prepare_hermes_install_root(path: Path) -> None:
+    """Create the Hermes skill root without following symlinked managed dirs."""
+    if path.is_symlink():
+        msg = f"Refusing to install Hermes skills into symlinked directory: {path}"
+        raise OSError(msg)
+    path.mkdir(parents=True, exist_ok=True)
+    if path.is_symlink():
+        msg = f"Refusing to install Hermes skills into symlinked directory: {path}"
+        raise OSError(msg)
+
+
 def install_hermes_skills(
     *,
     hermes_dir: str | Path | None = None,
@@ -66,15 +77,20 @@ def install_hermes_skills(
 
     target_dir = resolved_hermes_dir / "skills" / HERMES_SKILL_CATEGORY / HERMES_SKILL_NAME
 
+    if target_dir.is_symlink():
+        msg = f"Refusing to install Hermes skills into symlinked directory: {target_dir}"
+        raise OSError(msg)
     if target_dir.exists() and not target_dir.is_dir():
         _remove_target_path(target_dir)
 
     with _packaged_skills_dir() as source_root:
-        target_dir.mkdir(parents=True, exist_ok=True)
+        _prepare_hermes_install_root(target_dir)
         source_skill_dirs = collect_skill_bundle_dirs(source_root)
         desired_skill_names = {skill_dir.name for skill_dir in source_skill_dirs}
 
-        (target_dir / HERMES_SKILL_CAPABILITY_GUIDE_FILENAME).write_text(
+        capability_guide_path = target_dir / HERMES_SKILL_CAPABILITY_GUIDE_FILENAME
+        _remove_target_path(capability_guide_path)
+        capability_guide_path.write_text(
             render_backend_skill_capability_guide("hermes"),
             encoding="utf-8",
         )

--- a/tests/unit/hermes/test_artifacts.py
+++ b/tests/unit/hermes/test_artifacts.py
@@ -208,3 +208,27 @@ class TestInstallHermesSkills:
 
         assert not outside_dir.joinpath(HERMES_SKILL_CAPABILITY_GUIDE_FILENAME).exists()
         assert not outside_dir.joinpath("run").exists()
+
+    def test_refuses_symlinked_hermes_dir_ancestor(self, tmp_path: Path, monkeypatch) -> None:
+        """Hermes install must not write or prune through a symlinked Hermes root."""
+        source_skills_dir = tmp_path / "source-skills"
+        self._write_skill(source_skills_dir, "run", body="fresh skill\n")
+        monkeypatch.setattr(
+            "ouroboros.hermes.artifacts._repo_root_skills_dir",
+            lambda: source_skills_dir,
+        )
+
+        hermes_dir = tmp_path / ".hermes"
+        outside_hermes_dir = tmp_path / "outside-hermes"
+        outside_skill_root = outside_hermes_dir / "skills" / "autonomous-ai-agents" / "ouroboros"
+        outside_skill_root.mkdir(parents=True)
+        stale_skill = outside_skill_root / "status"
+        stale_skill.mkdir()
+        stale_skill.joinpath("SKILL.md").write_text("outside stale", encoding="utf-8")
+        hermes_dir.symlink_to(outside_hermes_dir, target_is_directory=True)
+
+        with pytest.raises(OSError, match="symlinked"):
+            install_hermes_skills(hermes_dir=hermes_dir, prune=True)
+
+        assert stale_skill.joinpath("SKILL.md").read_text(encoding="utf-8") == "outside stale"
+        assert not outside_skill_root.joinpath("run").exists()

--- a/tests/unit/hermes/test_artifacts.py
+++ b/tests/unit/hermes/test_artifacts.py
@@ -232,3 +232,27 @@ class TestInstallHermesSkills:
 
         assert stale_skill.joinpath("SKILL.md").read_text(encoding="utf-8") == "outside stale"
         assert not outside_skill_root.joinpath("run").exists()
+
+    def test_refuses_relative_hermes_root_from_symlinked_cwd(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Relative Hermes installs must not resolve through a symlinked cwd."""
+        source_skills_dir = tmp_path / "source-skills"
+        self._write_skill(source_skills_dir, "run", body="fresh skill\n")
+        monkeypatch.setattr(
+            "ouroboros.hermes.artifacts._repo_root_skills_dir",
+            lambda: source_skills_dir,
+        )
+        real_workspace = tmp_path / "real-workspace"
+        symlink_workspace = tmp_path / "linked-workspace"
+        real_workspace.mkdir()
+        symlink_workspace.symlink_to(real_workspace, target_is_directory=True)
+        monkeypatch.chdir(symlink_workspace)
+        monkeypatch.setenv("PWD", str(symlink_workspace))
+
+        with pytest.raises(OSError, match="symlinked"):
+            install_hermes_skills(hermes_dir=".hermes")
+
+        assert not real_workspace.joinpath(
+            ".hermes", "skills", "autonomous-ai-agents", "ouroboros", "run"
+        ).exists()

--- a/tests/unit/hermes/test_artifacts.py
+++ b/tests/unit/hermes/test_artifacts.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from ouroboros.hermes.artifacts import (
     HERMES_SKILL_CAPABILITY_GUIDE_FILENAME,
     install_hermes_skills,
@@ -159,3 +161,50 @@ class TestInstallHermesSkills:
         assert not stale_skill_dir.exists()
         assert target_dir.joinpath("run", "SKILL.md").is_file()
         assert target_dir.joinpath("notes.txt").read_text(encoding="utf-8") == "keep me"
+
+    def test_replaces_symlinked_capability_guide_without_following_it(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Hermes install should replace a guide symlink without writing through it."""
+        source_skills_dir = tmp_path / "source-skills"
+        self._write_skill(source_skills_dir, "run", body="fresh skill\n")
+        monkeypatch.setattr(
+            "ouroboros.hermes.artifacts._repo_root_skills_dir",
+            lambda: source_skills_dir,
+        )
+
+        target_dir = tmp_path / ".hermes" / "skills" / "autonomous-ai-agents" / "ouroboros"
+        outside_file = tmp_path / "outside-guide.md"
+        outside_file.write_text("outside content", encoding="utf-8")
+        target_dir.mkdir(parents=True)
+        target_dir.joinpath(HERMES_SKILL_CAPABILITY_GUIDE_FILENAME).symlink_to(outside_file)
+
+        install_hermes_skills(hermes_dir=tmp_path / ".hermes")
+
+        guide_path = target_dir / HERMES_SKILL_CAPABILITY_GUIDE_FILENAME
+        assert not guide_path.is_symlink()
+        assert guide_path.read_text(encoding="utf-8").startswith(
+            "## Ouroboros Skill Capability Guide: Hermes\n"
+        )
+        assert outside_file.read_text(encoding="utf-8") == "outside content"
+
+    def test_refuses_symlinked_hermes_skill_root(self, tmp_path: Path, monkeypatch) -> None:
+        """Hermes install must not write or prune through a symlinked managed root."""
+        source_skills_dir = tmp_path / "source-skills"
+        self._write_skill(source_skills_dir, "run", body="fresh skill\n")
+        monkeypatch.setattr(
+            "ouroboros.hermes.artifacts._repo_root_skills_dir",
+            lambda: source_skills_dir,
+        )
+
+        target_dir = tmp_path / ".hermes" / "skills" / "autonomous-ai-agents" / "ouroboros"
+        outside_dir = tmp_path / "outside-hermes"
+        outside_dir.mkdir()
+        target_dir.parent.mkdir(parents=True)
+        target_dir.symlink_to(outside_dir, target_is_directory=True)
+
+        with pytest.raises(OSError, match="symlinked directory"):
+            install_hermes_skills(hermes_dir=tmp_path / ".hermes", prune=True)
+
+        assert not outside_dir.joinpath(HERMES_SKILL_CAPABILITY_GUIDE_FILENAME).exists()
+        assert not outside_dir.joinpath("run").exists()

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -115,6 +115,21 @@ class TestInstallCodexRules:
         assert not stale_namespaced_rule.exists()
         assert unrelated_rule.read_text(encoding="utf-8") == "keep me"
 
+    def test_refuses_symlinked_rules_root(self, tmp_path: Path) -> None:
+        """Rule install must not follow a symlinked managed rules directory."""
+        codex_dir = tmp_path / ".codex"
+        outside_dir = tmp_path / "outside-rules"
+        packaged_rules_dir = tmp_path / "packaged-rules"
+        outside_dir.mkdir()
+        (codex_dir).mkdir()
+        (codex_dir / "rules").symlink_to(outside_dir, target_is_directory=True)
+        self._write_rule(packaged_rules_dir, CODEX_RULE_FILENAME, "# fresh rules\n")
+
+        with pytest.raises(OSError, match="symlinked directory"):
+            install_codex_rules(codex_dir=codex_dir, rules_dir=packaged_rules_dir)
+
+        assert not (outside_dir / CODEX_RULE_FILENAME).exists()
+
     def test_packaged_rules_fail_closed_for_ooo_auto(self) -> None:
         """Codex rules must route ``ooo auto`` to the real MCP tool, not manual work."""
         rules = load_packaged_codex_rules()
@@ -424,6 +439,26 @@ class TestInstallCodexSkills:
         assert installed_skill_dir.joinpath("SKILL.md").read_text(encoding="utf-8") == (
             "installed status"
         )
+
+    def test_refuses_symlinked_skills_root(self, tmp_path: Path) -> None:
+        """Skill install must not copy or prune through a symlinked managed root."""
+        source_skills_dir = tmp_path / "packaged-skills"
+        self._write_skill(source_skills_dir, "status", body="fresh status skill")
+
+        codex_dir = tmp_path / ".codex"
+        outside_dir = tmp_path / "outside-skills"
+        outside_dir.mkdir()
+        codex_dir.mkdir()
+        (codex_dir / "skills").symlink_to(outside_dir, target_is_directory=True)
+        legacy_skill = outside_dir / f"{CODEX_SKILL_NAMESPACE}legacy"
+        legacy_skill.mkdir()
+        legacy_skill.joinpath("SKILL.md").write_text("outside stale", encoding="utf-8")
+
+        with pytest.raises(OSError, match="symlinked directory"):
+            install_codex_skills(codex_dir=codex_dir, skills_dir=source_skills_dir, prune=True)
+
+        assert legacy_skill.joinpath("SKILL.md").read_text(encoding="utf-8") == "outside stale"
+        assert not outside_dir.joinpath(f"{CODEX_SKILL_NAMESPACE}status").exists()
 
 
 class TestResolvePackagedCodexAssets:

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -130,6 +130,20 @@ class TestInstallCodexRules:
 
         assert not (outside_dir / CODEX_RULE_FILENAME).exists()
 
+    def test_refuses_symlinked_codex_dir_for_rules(self, tmp_path: Path) -> None:
+        """Rule install must not follow a symlinked Codex root ancestor."""
+        codex_dir = tmp_path / ".codex"
+        outside_codex_dir = tmp_path / "outside-codex"
+        packaged_rules_dir = tmp_path / "packaged-rules"
+        outside_codex_dir.mkdir()
+        codex_dir.symlink_to(outside_codex_dir, target_is_directory=True)
+        self._write_rule(packaged_rules_dir, CODEX_RULE_FILENAME, "# fresh rules\n")
+
+        with pytest.raises(OSError, match="symlinked"):
+            install_codex_rules(codex_dir=codex_dir, rules_dir=packaged_rules_dir)
+
+        assert not outside_codex_dir.joinpath("rules", CODEX_RULE_FILENAME).exists()
+
     def test_packaged_rules_fail_closed_for_ooo_auto(self) -> None:
         """Codex rules must route ``ooo auto`` to the real MCP tool, not manual work."""
         rules = load_packaged_codex_rules()
@@ -459,6 +473,26 @@ class TestInstallCodexSkills:
 
         assert legacy_skill.joinpath("SKILL.md").read_text(encoding="utf-8") == "outside stale"
         assert not outside_dir.joinpath(f"{CODEX_SKILL_NAMESPACE}status").exists()
+
+    def test_refuses_symlinked_codex_dir_for_skills(self, tmp_path: Path) -> None:
+        """Skill install must not copy or prune through a symlinked Codex root ancestor."""
+        source_skills_dir = tmp_path / "packaged-skills"
+        self._write_skill(source_skills_dir, "status", body="fresh status skill")
+
+        codex_dir = tmp_path / ".codex"
+        outside_codex_dir = tmp_path / "outside-codex"
+        outside_skills_dir = outside_codex_dir / "skills"
+        outside_skills_dir.mkdir(parents=True)
+        legacy_skill = outside_skills_dir / f"{CODEX_SKILL_NAMESPACE}legacy"
+        legacy_skill.mkdir()
+        legacy_skill.joinpath("SKILL.md").write_text("outside stale", encoding="utf-8")
+        codex_dir.symlink_to(outside_codex_dir, target_is_directory=True)
+
+        with pytest.raises(OSError, match="symlinked"):
+            install_codex_skills(codex_dir=codex_dir, skills_dir=source_skills_dir, prune=True)
+
+        assert legacy_skill.joinpath("SKILL.md").read_text(encoding="utf-8") == "outside stale"
+        assert not outside_skills_dir.joinpath(f"{CODEX_SKILL_NAMESPACE}status").exists()
 
 
 class TestResolvePackagedCodexAssets:

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -144,6 +144,24 @@ class TestInstallCodexRules:
 
         assert not outside_codex_dir.joinpath("rules", CODEX_RULE_FILENAME).exists()
 
+    def test_replaces_dangling_symlinked_rule_leaf(self, tmp_path: Path) -> None:
+        """Rule refresh should replace a dangling managed rule symlink leaf."""
+        codex_dir = tmp_path / ".codex"
+        rules_dir = codex_dir / "rules"
+        packaged_rules_dir = tmp_path / "packaged-rules"
+        missing_target = tmp_path / "missing-outside-rule.md"
+        target_path = rules_dir / CODEX_RULE_FILENAME
+        rules_dir.mkdir(parents=True)
+        target_path.symlink_to(missing_target)
+        self._write_rule(packaged_rules_dir, CODEX_RULE_FILENAME, "# fresh rules\n")
+
+        installed_path = install_codex_rules(codex_dir=codex_dir, rules_dir=packaged_rules_dir)
+
+        assert installed_path == target_path
+        assert not installed_path.is_symlink()
+        assert installed_path.read_text(encoding="utf-8").startswith("# fresh rules\n")
+        assert not missing_target.exists()
+
     def test_packaged_rules_fail_closed_for_ooo_auto(self) -> None:
         """Codex rules must route ``ooo auto`` to the real MCP tool, not manual work."""
         rules = load_packaged_codex_rules()
@@ -493,6 +511,27 @@ class TestInstallCodexSkills:
 
         assert legacy_skill.joinpath("SKILL.md").read_text(encoding="utf-8") == "outside stale"
         assert not outside_skills_dir.joinpath(f"{CODEX_SKILL_NAMESPACE}status").exists()
+
+    def test_replaces_dangling_symlinked_skill_leaf(self, tmp_path: Path) -> None:
+        """Skill refresh should replace a dangling managed skill symlink leaf."""
+        source_skills_dir = tmp_path / "packaged-skills"
+        self._write_skill(source_skills_dir, "status", body="fresh status skill")
+
+        codex_dir = tmp_path / ".codex"
+        skills_dir = codex_dir / "skills"
+        missing_target = tmp_path / "missing-outside-skill"
+        target_path = skills_dir / f"{CODEX_SKILL_NAMESPACE}status"
+        skills_dir.mkdir(parents=True)
+        target_path.symlink_to(missing_target, target_is_directory=True)
+
+        installed_paths = install_codex_skills(codex_dir=codex_dir, skills_dir=source_skills_dir)
+
+        assert installed_paths == (target_path,)
+        assert not target_path.is_symlink()
+        assert target_path.joinpath("SKILL.md").read_text(encoding="utf-8") == (
+            "fresh status skill"
+        )
+        assert not missing_target.exists()
 
 
 class TestResolvePackagedCodexAssets:

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -162,6 +162,24 @@ class TestInstallCodexRules:
         assert installed_path.read_text(encoding="utf-8").startswith("# fresh rules\n")
         assert not missing_target.exists()
 
+    def test_refuses_relative_rules_root_from_symlinked_cwd(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Relative rule installs must not resolve through a symlinked cwd."""
+        real_workspace = tmp_path / "real-workspace"
+        symlink_workspace = tmp_path / "linked-workspace"
+        packaged_rules_dir = tmp_path / "packaged-rules"
+        real_workspace.mkdir()
+        symlink_workspace.symlink_to(real_workspace, target_is_directory=True)
+        self._write_rule(packaged_rules_dir, CODEX_RULE_FILENAME, "# fresh rules\n")
+        monkeypatch.chdir(symlink_workspace)
+        monkeypatch.setenv("PWD", str(symlink_workspace))
+
+        with pytest.raises(OSError, match="symlinked"):
+            install_codex_rules(codex_dir=".codex", rules_dir=packaged_rules_dir)
+
+        assert not real_workspace.joinpath(".codex", "rules", CODEX_RULE_FILENAME).exists()
+
     def test_packaged_rules_fail_closed_for_ooo_auto(self) -> None:
         """Codex rules must route ``ooo auto`` to the real MCP tool, not manual work."""
         rules = load_packaged_codex_rules()
@@ -532,6 +550,26 @@ class TestInstallCodexSkills:
             "fresh status skill"
         )
         assert not missing_target.exists()
+
+    def test_refuses_relative_skills_root_from_symlinked_cwd(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        """Relative skill installs must not resolve through a symlinked cwd."""
+        source_skills_dir = tmp_path / "packaged-skills"
+        self._write_skill(source_skills_dir, "status", body="fresh status skill")
+        real_workspace = tmp_path / "real-workspace"
+        symlink_workspace = tmp_path / "linked-workspace"
+        real_workspace.mkdir()
+        symlink_workspace.symlink_to(real_workspace, target_is_directory=True)
+        monkeypatch.chdir(symlink_workspace)
+        monkeypatch.setenv("PWD", str(symlink_workspace))
+
+        with pytest.raises(OSError, match="symlinked"):
+            install_codex_skills(codex_dir=".codex", skills_dir=source_skills_dir)
+
+        assert not real_workspace.joinpath(
+            ".codex", "skills", f"{CODEX_SKILL_NAMESPACE}status"
+        ).exists()
 
 
 class TestResolvePackagedCodexAssets:


### PR DESCRIPTION
## Summary
- refuse Codex rules/skills installs when managed roots are symlinks
- refuse Hermes skill installs when the managed skill root is a symlink
- keep existing leaf symlink replacement behavior for managed artifacts, but fail closed on root redirection

## Security impact
Prevents setup/update flows from following attacker-controlled managed install root symlinks and writing or pruning outside the intended Codex/Hermes artifact directories.

## Tests
- uv run ruff format src/ouroboros/codex/artifacts.py src/ouroboros/hermes/artifacts.py tests/unit/test_codex_artifacts.py tests/unit/hermes/test_artifacts.py
- uv run ruff check src/ouroboros/codex/artifacts.py src/ouroboros/hermes/artifacts.py tests/unit/test_codex_artifacts.py tests/unit/hermes/test_artifacts.py
- uv run pytest -q tests/unit/test_codex_artifacts.py tests/unit/hermes/test_artifacts.py