### PR TITLE
fix(config): block PATH from untrusted project env

### DIFF
--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -137,6 +137,8 @@ def _is_placeholder_api_key(value: str) -> bool:
 # split across downstream sinks.
 _UNTRUSTED_ENV_DENYLIST = frozenset(
     {
+        # Search PATH used by shutil.which()/bare executable spawning.
+        "PATH",
         # Explicit executable-path overrides.
         "OUROBOROS_CLI_PATH",
         "OUROBOROS_CODEX_CLI_PATH",

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -132,9 +132,11 @@ def _is_placeholder_api_key(value: str) -> bool:
 #      auto-approve arbitrary tool calls (effectively RCE).
 # These keys are only honored from trusted sources (the real process
 # environment, ~/.ouroboros/.env, ~/.ouroboros/config.yaml), never from
-# the project-directory .env that travels with a cloned repo. Enforcing
-# this here — at the .env load — keeps the policy in one place rather than
-# split across downstream sinks.
+# the project-directory .env that travels with a cloned repo. Trusted .env
+# files still follow the loader's normal "do not override an already-set
+# real process environment value" precedence. Enforcing this here — at the
+# .env load — keeps the policy in one place rather than split across
+# downstream sinks.
 _UNTRUSTED_ENV_DENYLIST = frozenset(
     {
         # Search PATH used by shutil.which()/bare executable spawning.

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -168,6 +168,11 @@ _UNTRUSTED_ENV_DENYLIST = frozenset(
 )
 
 
+def _is_untrusted_env_denied_key(key: str) -> bool:
+    """Return whether an untrusted .env key may alter execution routing."""
+    return key.upper() in _UNTRUSTED_ENV_DENYLIST
+
+
 def _load_env_file(path: Path, *, trusted: bool = False) -> None:
     if not path.is_file():
         return
@@ -186,7 +191,7 @@ def _load_env_file(path: Path, *, trusted: bool = False) -> None:
         if not key or any(ch.isspace() for ch in key):
             continue
 
-        if not trusted and key in _UNTRUSTED_ENV_DENYLIST:
+        if not trusted and _is_untrusted_env_denied_key(key):
             # Untrusted project-directory .env must not redirect which
             # binary Ouroboros executes (remote code execution guard).
             continue

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -1397,10 +1397,10 @@ class TestLLMHelperLookups:
 class TestEnvFileTrustBoundary:
     """Test trusted vs untrusted .env execution-routing boundaries."""
 
-    def test_untrusted_env_file_does_not_override_path(
+    def test_untrusted_env_file_does_not_set_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Project .env must not hijack PATH used by CLI resolution."""
+        """Project .env must not inject PATH used by CLI resolution."""
         original_path = "/usr/bin:/bin"
         malicious_bin = tmp_path / "repo" / "bin"
         env_file = tmp_path / "repo" / ".env"
@@ -1411,20 +1411,35 @@ class TestEnvFileTrustBoundary:
             "PROJECT_ONLY_VALUE=kept\n",
             encoding="utf-8",
         )
-        monkeypatch.setenv("PATH", original_path)
+        monkeypatch.delenv("PATH", raising=False)
         monkeypatch.delenv("PROJECT_ONLY_VALUE", raising=False)
         monkeypatch.delenv("OUROBOROS_GOOSE_CLI_PATH", raising=False)
 
         _load_env_file(env_file, trusted=False)
 
-        assert os.environ["PATH"] == original_path
+        assert "PATH" not in os.environ
         assert "OUROBOROS_GOOSE_CLI_PATH" not in os.environ
         assert os.environ["PROJECT_ONLY_VALUE"] == "kept"
 
-    def test_trusted_env_file_can_override_path(
+    def test_untrusted_env_file_does_not_override_process_path(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """User-owned ~/.ouroboros/.env remains able to configure PATH intentionally."""
+        """Project .env must not replace an existing process PATH."""
+        process_path = "/usr/bin:/bin"
+        malicious_bin = tmp_path / "repo" / "bin"
+        env_file = tmp_path / "repo" / ".env"
+        malicious_bin.mkdir(parents=True)
+        env_file.write_text(f"PATH={malicious_bin}:{process_path}\n", encoding="utf-8")
+        monkeypatch.setenv("PATH", process_path)
+
+        _load_env_file(env_file, trusted=False)
+
+        assert os.environ["PATH"] == process_path
+
+    def test_trusted_env_file_can_seed_missing_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """User-owned ~/.ouroboros/.env may supply PATH when the process lacks one."""
         original_path = "/usr/bin:/bin"
         trusted_bin = tmp_path / "trusted-bin"
         env_file = tmp_path / ".env"
@@ -1434,6 +1449,20 @@ class TestEnvFileTrustBoundary:
         _load_env_file(env_file, trusted=True)
 
         assert os.environ["PATH"] == f"{trusted_bin}:{original_path}"
+
+    def test_trusted_env_file_does_not_override_process_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Trusted .env keeps normal process-environment precedence for PATH."""
+        process_path = "/usr/bin:/bin"
+        trusted_bin = tmp_path / "trusted-bin"
+        env_file = tmp_path / ".env"
+        env_file.write_text(f"PATH={trusted_bin}:{process_path}\n", encoding="utf-8")
+        monkeypatch.setenv("PATH", process_path)
+
+        _load_env_file(env_file, trusted=True)
+
+        assert os.environ["PATH"] == process_path
 
 
 class TestCredentialsFileSecure:

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 
 from ouroboros.config.loader import (
+    _load_env_file,
     config_exists,
     create_default_config,
     credentials_file_secure,
@@ -1391,6 +1392,48 @@ class TestLLMHelperLookups:
         """Consensus roster can be overridden from a comma-separated env var."""
         monkeypatch.setenv("OUROBOROS_CONSENSUS_MODELS", "gpt-5-a, gpt-5-b ,gpt-5-c")
         assert get_consensus_models() == ("gpt-5-a", "gpt-5-b", "gpt-5-c")
+
+
+class TestEnvFileTrustBoundary:
+    """Test trusted vs untrusted .env execution-routing boundaries."""
+
+    def test_untrusted_env_file_does_not_override_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Project .env must not hijack PATH used by CLI resolution."""
+        original_path = "/usr/bin:/bin"
+        malicious_bin = tmp_path / "repo" / "bin"
+        env_file = tmp_path / "repo" / ".env"
+        malicious_bin.mkdir(parents=True)
+        env_file.write_text(
+            f"PATH={malicious_bin}:{original_path}\n"
+            "OUROBOROS_GOOSE_CLI_PATH=/tmp/evil-goose\n"
+            "PROJECT_ONLY_VALUE=kept\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("PATH", original_path)
+        monkeypatch.delenv("PROJECT_ONLY_VALUE", raising=False)
+        monkeypatch.delenv("OUROBOROS_GOOSE_CLI_PATH", raising=False)
+
+        _load_env_file(env_file, trusted=False)
+
+        assert os.environ["PATH"] == original_path
+        assert "OUROBOROS_GOOSE_CLI_PATH" not in os.environ
+        assert os.environ["PROJECT_ONLY_VALUE"] == "kept"
+
+    def test_trusted_env_file_can_override_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """User-owned ~/.ouroboros/.env remains able to configure PATH intentionally."""
+        original_path = "/usr/bin:/bin"
+        trusted_bin = tmp_path / "trusted-bin"
+        env_file = tmp_path / ".env"
+        env_file.write_text(f"PATH={trusted_bin}:{original_path}\n", encoding="utf-8")
+        monkeypatch.delenv("PATH", raising=False)
+
+        _load_env_file(env_file, trusted=True)
+
+        assert os.environ["PATH"] == f"{trusted_bin}:{original_path}"
 
 
 class TestCredentialsFileSecure:

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -9,7 +9,6 @@ import pytest
 import yaml
 
 from ouroboros.config.loader import (
-    _load_env_file,
     config_exists,
     create_default_config,
     credentials_file_secure,
@@ -1392,77 +1391,6 @@ class TestLLMHelperLookups:
         """Consensus roster can be overridden from a comma-separated env var."""
         monkeypatch.setenv("OUROBOROS_CONSENSUS_MODELS", "gpt-5-a, gpt-5-b ,gpt-5-c")
         assert get_consensus_models() == ("gpt-5-a", "gpt-5-b", "gpt-5-c")
-
-
-class TestEnvFileTrustBoundary:
-    """Test trusted vs untrusted .env execution-routing boundaries."""
-
-    def test_untrusted_env_file_does_not_set_path(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Project .env must not inject PATH used by CLI resolution."""
-        original_path = "/usr/bin:/bin"
-        malicious_bin = tmp_path / "repo" / "bin"
-        env_file = tmp_path / "repo" / ".env"
-        malicious_bin.mkdir(parents=True)
-        env_file.write_text(
-            f"PATH={malicious_bin}:{original_path}\n"
-            "OUROBOROS_GOOSE_CLI_PATH=/tmp/evil-goose\n"
-            "PROJECT_ONLY_VALUE=kept\n",
-            encoding="utf-8",
-        )
-        monkeypatch.delenv("PATH", raising=False)
-        monkeypatch.delenv("PROJECT_ONLY_VALUE", raising=False)
-        monkeypatch.delenv("OUROBOROS_GOOSE_CLI_PATH", raising=False)
-
-        _load_env_file(env_file, trusted=False)
-
-        assert "PATH" not in os.environ
-        assert "OUROBOROS_GOOSE_CLI_PATH" not in os.environ
-        assert os.environ["PROJECT_ONLY_VALUE"] == "kept"
-
-    def test_untrusted_env_file_does_not_override_process_path(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Project .env must not replace an existing process PATH."""
-        process_path = "/usr/bin:/bin"
-        malicious_bin = tmp_path / "repo" / "bin"
-        env_file = tmp_path / "repo" / ".env"
-        malicious_bin.mkdir(parents=True)
-        env_file.write_text(f"PATH={malicious_bin}:{process_path}\n", encoding="utf-8")
-        monkeypatch.setenv("PATH", process_path)
-
-        _load_env_file(env_file, trusted=False)
-
-        assert os.environ["PATH"] == process_path
-
-    def test_trusted_env_file_can_seed_missing_path(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """User-owned ~/.ouroboros/.env may supply PATH when the process lacks one."""
-        original_path = "/usr/bin:/bin"
-        trusted_bin = tmp_path / "trusted-bin"
-        env_file = tmp_path / ".env"
-        env_file.write_text(f"PATH={trusted_bin}:{original_path}\n", encoding="utf-8")
-        monkeypatch.delenv("PATH", raising=False)
-
-        _load_env_file(env_file, trusted=True)
-
-        assert os.environ["PATH"] == f"{trusted_bin}:{original_path}"
-
-    def test_trusted_env_file_does_not_override_process_path(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """Trusted .env keeps normal process-environment precedence for PATH."""
-        process_path = "/usr/bin:/bin"
-        trusted_bin = tmp_path / "trusted-bin"
-        env_file = tmp_path / ".env"
-        env_file.write_text(f"PATH={trusted_bin}:{process_path}\n", encoding="utf-8")
-        monkeypatch.setenv("PATH", process_path)
-
-        _load_env_file(env_file, trusted=True)
-
-        assert os.environ["PATH"] == process_path
 
 
 class TestCredentialsFileSecure:

--- a/tests/unit/config/test_loader_env.py
+++ b/tests/unit/config/test_loader_env.py
@@ -78,6 +78,8 @@ def test_load_env_file_skips_template_placeholders(tmp_path: Path, monkeypatch) 
 
 
 _DENYLISTED_KEYS = (
+    # Search PATH used by shutil.which()/bare executable spawning.
+    "PATH",
     "OUROBOROS_CLI_PATH",
     "OUROBOROS_CODEX_CLI_PATH",
     "OUROBOROS_COPILOT_CLI_PATH",
@@ -130,6 +132,22 @@ def test_untrusted_env_cannot_disable_approval_gate(
     assert "OUROBOROS_AGENT_PERMISSION_MODE" not in os.environ
 
 
+def test_untrusted_env_cannot_set_mixed_case_path(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Mixed-case PATH variants must not bypass the denylist on Windows."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("Path=./malicious-bin\n")
+    monkeypatch.delenv("PATH", raising=False)
+    monkeypatch.delenv("Path", raising=False)
+
+    _load_env_file(env_file, trusted=False)
+
+    assert "PATH" not in os.environ
+    assert "Path" not in os.environ
+
+
 @pytest.mark.parametrize("key", _DENYLISTED_KEYS)
 def test_untrusted_env_cannot_redirect_executable(
     tmp_path: Path,
@@ -160,6 +178,36 @@ def test_trusted_env_may_set_executable_path(
     _load_env_file(env_file, trusted=True)
 
     assert os.environ[key] == "/usr/local/bin/claude"
+
+
+def test_untrusted_env_does_not_override_process_path(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Project .env must not replace an existing process PATH."""
+    process_path = "/usr/bin:/bin"
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"PATH=./malicious-bin:{process_path}\n")
+    monkeypatch.setenv("PATH", process_path)
+
+    _load_env_file(env_file, trusted=False)
+
+    assert os.environ["PATH"] == process_path
+
+
+def test_trusted_env_does_not_override_process_path(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Trusted .env keeps normal process-environment precedence for PATH."""
+    process_path = "/usr/bin:/bin"
+    env_file = tmp_path / ".env"
+    env_file.write_text(f"PATH=/trusted/bin:{process_path}\n")
+    monkeypatch.setenv("PATH", process_path)
+
+    _load_env_file(env_file, trusted=True)
+
+    assert os.environ["PATH"] == process_path
 
 
 def test_untrusted_env_still_loads_non_sensitive_keys(


### PR DESCRIPTION
## Summary
- add PATH to the untrusted project .env denylist
- keep project-local non-sensitive values loadable while blocking execution-routing variables
- cover trusted vs untrusted .env behavior with regression tests

## Security impact
Prevents a cloned repository from using a project .env PATH override to hijack bare CLI resolution such as Goose/Codex-compatible runtimes that eventually call shutil.which or spawn bare executable names.

## Tests
- uv run ruff check src/ouroboros/config/loader.py tests/unit/config/test_loader.py
- uv run pytest -q tests/unit/config/test_loader.py -k 'EnvFileTrustBoundary or goose or cli_path'