### PR TITLE
feat(cli): implement status health checks

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -580,24 +580,30 @@ See [UNINSTALL.md](../UNINSTALL.md) for the full guide.
 
 Check Ouroboros system status.
 
-> **Current state:** the `status` subcommands return lightweight placeholder summaries. They are useful for smoke testing the command surface, but should not be treated as authoritative orchestration state.
+> **Current state:** `status health` performs live local preflight checks. The `status executions` and `status execution` subcommands still return lightweight placeholder summaries and should not be treated as authoritative orchestration state.
 
 ### `status health`
 
-Check system health. Verifies database connectivity, provider configuration, and system resources.
+Check local system health. The command validates configuration, checks the configured database path, verifies the active runtime CLI is reachable, and confirms that credentials for the active LLM provider are present without printing key material.
 
 ```bash
 ouroboros status health
 ```
 
+`status health` exits with status `0` when no check is `error`; it exits with status `1` if any check is `error`. Warnings, such as a missing database file that will be created on first run or an empty template credential value, are rendered in the table but do not fail the command.
+
 **Representative Output:**
 
 ```
-+---------------+---------+
-| Database      |   ok    |
-| Configuration |   ok    |
-| Providers     | warning |
-+---------------+---------+
+                   System Health
++--------------------------------------------+---------+
+| Name                                       | Status  |
++--------------------------------------------+---------+
+| Configuration — ~/.ouroboros/config.yaml   |   ok    |
+| Database — data/ouroboros.db (...)         |   ok    |
+| Runtime backend — claude: /usr/bin/claude  |   ok    |
+| Credentials — anthropic key present        |   ok    |
++--------------------------------------------+---------+
 ```
 
 ### `status executions`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -584,7 +584,7 @@ Check Ouroboros system status.
 
 ### `status health`
 
-Check local system health. The command validates configuration, checks the configured database path, verifies the active runtime CLI is reachable, and confirms that credentials for the active LLM provider are present without printing key material.
+Check local system health. The command validates configuration, checks the configured database path, verifies the effective runtime CLI is reachable after applying `OUROBOROS_AGENT_RUNTIME` / `OUROBOROS_RUNTIME` and runtime-specific `OUROBOROS_*_CLI_PATH` overrides, and confirms that credentials for the active LLM provider are present without printing key material. CLI-authenticated backends such as Copilot are reported as local CLI authentication rather than requiring an API key.
 
 ```bash
 ouroboros status health

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -212,7 +212,7 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         supports_runtime=True,
         supports_llm=True,
         supports_interview_driver=True,
-        cli_name="kiro",
+        cli_name="kiro-cli",
         cli_config_key="kiro_cli_path",
         skill_execution_capabilities=_GENERIC_SKILL_EXECUTION_CAPABILITIES,
     ),

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -395,9 +395,12 @@ def _check_credentials(data: dict, config_path: Path) -> dict[str, str]:
     if not isinstance(providers, dict):
         return _health_row("Credentials", "error", "credentials providers must be a mapping")
     provider_config = providers.get(provider, {})
-    api_key = (
-        str(provider_config.get("api_key", "")).strip() if isinstance(provider_config, dict) else ""
-    )
+    if not isinstance(provider_config, dict):
+        return _health_row(
+            "Credentials", "error", f"credentials provider {provider} must be a mapping"
+        )
+
+    api_key = str(provider_config.get("api_key", "")).strip()
     if not api_key:
         return _health_row("Credentials", "warning", f"{provider} key is empty")
     if api_key.startswith("YOUR_") and api_key.endswith("_API_KEY"):

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -212,7 +212,6 @@ def execution(
 _CREDENTIAL_PROVIDER_BY_LLM_BACKEND = {
     "claude": "anthropic",
     "claude_code": "anthropic",
-    "copilot": "openai",
     "gemini": "google",
     "litellm": "openrouter",
     "openai": "openai",
@@ -224,6 +223,17 @@ _API_KEY_ENV_BY_PROVIDER = {
     "google": "GOOGLE_API_KEY",
     "openai": "OPENAI_API_KEY",
     "openrouter": "OPENROUTER_API_KEY",
+}
+
+_CLI_PATH_ENV_BY_BACKEND = {
+    "claude": "OUROBOROS_CLI_PATH",
+    "codex": "OUROBOROS_CODEX_CLI_PATH",
+    "copilot": "OUROBOROS_COPILOT_CLI_PATH",
+    "gemini": "OUROBOROS_GEMINI_CLI_PATH",
+    "goose": "OUROBOROS_GOOSE_CLI_PATH",
+    "hermes": "OUROBOROS_HERMES_CLI_PATH",
+    "kiro": "OUROBOROS_KIRO_CLI_PATH",
+    "opencode": "OUROBOROS_OPENCODE_CLI_PATH",
 }
 
 
@@ -242,18 +252,50 @@ def _database_file_path(data: dict, config_path: Path) -> Path:
     return config_path.parent / "ouroboros.db"
 
 
-def _check_runtime_backend(data: dict) -> dict[str, str]:
-    raw_backend = data.get("orchestrator", {}).get("runtime_backend", "claude")
+def _candidate_cli_paths(backend: str, data: dict) -> list[str]:
+    """Return CLI path candidates using the same precedence as runtime launchers."""
+    candidates: list[str] = []
+    env_key = _CLI_PATH_ENV_BY_BACKEND.get(backend)
+    if env_key is not None:
+        env_path = os.environ.get(env_key, "").strip()
+        if env_path:
+            candidates.append(str(Path(env_path).expanduser()))
+
+    # Keep the existing config helper for config-file path resolution, but only
+    # when the config-file backend is the effective backend being checked.
+    configured_backend = str(data.get("orchestrator", {}).get("runtime_backend", "claude"))
     try:
-        backend = resolve_runtime_backend_name(str(raw_backend))
+        config_backend = resolve_runtime_backend_name(configured_backend)
+    except ValueError:
+        config_backend = None
+    configured_cli = _resolve_cli_path(data) if config_backend == backend else None
+    if configured_cli and configured_cli not in candidates:
+        candidates.append(configured_cli)
+
+    capability = get_backend_capability(backend)
+    if not candidates and capability is not None and capability.cli_name:
+        candidates.append(capability.cli_name)
+    return candidates
+
+
+def _effective_runtime_backend(data: dict) -> str:
+    env_backend = os.environ.get("OUROBOROS_AGENT_RUNTIME", "").strip().lower()
+    if env_backend:
+        return env_backend
+    env_runtime = os.environ.get("OUROBOROS_RUNTIME", "").strip().lower()
+    if env_runtime:
+        return env_runtime
+    return str(data.get("orchestrator", {}).get("runtime_backend", "claude"))
+
+
+def _check_runtime_backend(data: dict) -> dict[str, str]:
+    try:
+        backend = resolve_runtime_backend_name(_effective_runtime_backend(data))
     except ValueError as exc:
         return _health_row("Runtime backend", "error", str(exc))
 
     capability = get_backend_capability(backend)
-    configured_cli = _resolve_cli_path(data)
-    candidates = [configured_cli] if configured_cli else []
-    if capability is not None and capability.cli_name:
-        candidates.append(capability.cli_name)
+    candidates = _candidate_cli_paths(backend, data)
 
     for candidate in candidates:
         if not candidate:
@@ -267,15 +309,18 @@ def _check_runtime_backend(data: dict) -> dict[str, str]:
         if resolved:
             return _health_row("Runtime backend", "ok", f"{backend}: {resolved}")
 
-    expected = configured_cli or (
-        capability.cli_name if capability and capability.cli_name else backend
-    )
+    expected = candidates[0] if candidates else (capability.cli_name if capability else backend)
     return _health_row("Runtime backend", "error", f"{backend} CLI not found: {expected}")
 
 
 def _credential_provider_for_backend(backend: str) -> str | None:
     normalized = backend.strip().lower()
-    return _CREDENTIAL_PROVIDER_BY_LLM_BACKEND.get(normalized)
+    if normalized in _CREDENTIAL_PROVIDER_BY_LLM_BACKEND:
+        return _CREDENTIAL_PROVIDER_BY_LLM_BACKEND[normalized]
+    capability = get_backend_capability(normalized)
+    if capability is None:
+        return None
+    return _CREDENTIAL_PROVIDER_BY_LLM_BACKEND.get(capability.name)
 
 
 def _codex_auth_file_exists() -> bool:
@@ -312,7 +357,10 @@ def _effective_llm_backend(data: dict) -> str:
 
 def _check_credentials(data: dict, config_path: Path) -> dict[str, str]:
     backend = _effective_llm_backend(data)
-    if backend.strip().lower() in {"codex", "codex_cli"}:
+    normalized_backend = backend.strip().lower()
+    capability = get_backend_capability(normalized_backend)
+    canonical_backend = capability.name if capability is not None else normalized_backend
+    if canonical_backend == "codex":
         if _codex_auth_file_exists():
             return _health_row("Credentials", "ok", "codex OAuth file present")
         if os.environ.get("OPENAI_API_KEY", "").strip():

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -14,7 +14,11 @@ import typer
 import yaml
 
 from ouroboros.auto.state import AutoPhase, AutoStore
-from ouroboros.backends import get_backend_capability, resolve_runtime_backend_name
+from ouroboros.backends import (
+    get_backend_capability,
+    resolve_llm_backend_name,
+    resolve_runtime_backend_name,
+)
 from ouroboros.cli.commands.config import _load_config, _resolve_db_path
 from ouroboros.cli.formatters.panels import print_error, print_info
 from ouroboros.cli.formatters.tables import create_status_table, print_table
@@ -359,9 +363,11 @@ def _effective_llm_backend(data: dict) -> str:
 
 def _check_credentials(data: dict, config_path: Path) -> dict[str, str]:
     backend = _effective_llm_backend(data)
-    normalized_backend = backend.strip().lower()
-    capability = get_backend_capability(normalized_backend)
-    canonical_backend = capability.name if capability is not None else normalized_backend
+    try:
+        canonical_backend = resolve_llm_backend_name(backend)
+    except ValueError as exc:
+        return _health_row("Credentials", "error", str(exc))
+
     if canonical_backend == "codex":
         if _codex_auth_file_exists():
             return _health_row("Credentials", "ok", "codex OAuth file present")
@@ -371,9 +377,11 @@ def _check_credentials(data: dict, config_path: Path) -> dict[str, str]:
             "Credentials", "error", "missing Codex OAuth auth.json or OPENAI_API_KEY"
         )
 
-    provider = _credential_provider_for_backend(backend)
+    provider = _credential_provider_for_backend(canonical_backend)
     if provider is None:
-        return _health_row("Credentials", "ok", f"{backend} uses local CLI authentication")
+        return _health_row(
+            "Credentials", "ok", f"{canonical_backend} uses local CLI authentication"
+        )
 
     if _provider_env_key_present(provider):
         return _health_row("Credentials", "ok", f"{_API_KEY_ENV_BY_PROVIDER[provider]} present")

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -5,13 +5,20 @@ Check system status and execution history.
 
 import asyncio
 import json
+import os
+from pathlib import Path
+import shutil
 from typing import Annotated, Any
 
 import typer
+import yaml
 
 from ouroboros.auto.state import AutoPhase, AutoStore
+from ouroboros.backends import get_backend_capability, resolve_runtime_backend_name
+from ouroboros.cli.commands.config import _load_config, _resolve_cli_path, _resolve_db_path
 from ouroboros.cli.formatters.panels import print_error, print_info
 from ouroboros.cli.formatters.tables import create_status_table, print_table
+from ouroboros.config.loader import load_config
 from ouroboros.mcp.tools.projection_handlers import ProjectionQueryHandler
 
 app = typer.Typer(
@@ -202,20 +209,201 @@ def execution(
         print_info("Would include event history")
 
 
+_CREDENTIAL_PROVIDER_BY_LLM_BACKEND = {
+    "claude": "anthropic",
+    "claude_code": "anthropic",
+    "copilot": "openai",
+    "gemini": "google",
+    "litellm": "openrouter",
+    "openai": "openai",
+    "openrouter": "openrouter",
+}
+
+_API_KEY_ENV_BY_PROVIDER = {
+    "anthropic": "ANTHROPIC_API_KEY",
+    "google": "GOOGLE_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
+}
+
+
+def _health_row(name: str, status: str, detail: str | None = None) -> dict[str, str]:
+    label = name if not detail else f"{name} — {detail}"
+    return {"name": label, "status": status}
+
+
+def _database_file_path(data: dict, config_path: Path) -> Path:
+    configured = data.get("persistence", {}).get("database_path")
+    if configured:
+        path = Path(str(configured)).expanduser()
+        if path.is_absolute():
+            return path
+        return config_path.parent / path
+    return config_path.parent / "ouroboros.db"
+
+
+def _check_runtime_backend(data: dict) -> dict[str, str]:
+    raw_backend = data.get("orchestrator", {}).get("runtime_backend", "claude")
+    try:
+        backend = resolve_runtime_backend_name(str(raw_backend))
+    except ValueError as exc:
+        return _health_row("Runtime backend", "error", str(exc))
+
+    capability = get_backend_capability(backend)
+    configured_cli = _resolve_cli_path(data)
+    candidates = [configured_cli] if configured_cli else []
+    if capability is not None and capability.cli_name:
+        candidates.append(capability.cli_name)
+
+    for candidate in candidates:
+        if not candidate:
+            continue
+        expanded = Path(candidate).expanduser()
+        if expanded.is_absolute() or len(expanded.parts) > 1:
+            if expanded.exists() and expanded.is_file() and os.access(expanded, os.X_OK):
+                return _health_row("Runtime backend", "ok", f"{backend}: {expanded}")
+            continue
+        resolved = shutil.which(candidate)
+        if resolved:
+            return _health_row("Runtime backend", "ok", f"{backend}: {resolved}")
+
+    expected = configured_cli or (
+        capability.cli_name if capability and capability.cli_name else backend
+    )
+    return _health_row("Runtime backend", "error", f"{backend} CLI not found: {expected}")
+
+
+def _credential_provider_for_backend(backend: str) -> str | None:
+    normalized = backend.strip().lower()
+    return _CREDENTIAL_PROVIDER_BY_LLM_BACKEND.get(normalized)
+
+
+def _codex_auth_file_exists() -> bool:
+    auth_base = os.environ.get("CODEX_HOME")
+    if not auth_base:
+        home = os.environ.get("HOME")
+        if not home:
+            return False
+        auth_base = str(Path(home).expanduser() / ".codex")
+    return (Path(auth_base).expanduser() / "auth.json").is_file()
+
+
+def _provider_env_key_present(provider: str) -> bool:
+    env_key = _API_KEY_ENV_BY_PROVIDER.get(provider)
+    if not env_key:
+        return False
+    return bool(os.environ.get(env_key, "").strip())
+
+
+def _effective_llm_backend(data: dict) -> str:
+    env_backend = os.environ.get("OUROBOROS_LLM_BACKEND", "").strip().lower()
+    if env_backend:
+        return env_backend
+
+    env_runtime = os.environ.get("OUROBOROS_RUNTIME", "").strip().lower()
+    runtime_capability = get_backend_capability(env_runtime)
+    if runtime_capability is not None and runtime_capability.supports_llm:
+        if env_runtime == "claude_code":
+            return "claude_code"
+        return runtime_capability.name
+
+    return str(data.get("llm", {}).get("backend", "claude_code"))
+
+
+def _check_credentials(data: dict, config_path: Path) -> dict[str, str]:
+    backend = _effective_llm_backend(data)
+    if backend.strip().lower() in {"codex", "codex_cli"}:
+        if _codex_auth_file_exists():
+            return _health_row("Credentials", "ok", "codex OAuth file present")
+        if os.environ.get("OPENAI_API_KEY", "").strip():
+            return _health_row("Credentials", "ok", "OPENAI_API_KEY present for codex")
+        return _health_row(
+            "Credentials", "error", "missing Codex OAuth auth.json or OPENAI_API_KEY"
+        )
+
+    provider = _credential_provider_for_backend(backend)
+    if provider is None:
+        return _health_row("Credentials", "ok", f"{backend} uses local CLI authentication")
+
+    if _provider_env_key_present(provider):
+        return _health_row("Credentials", "ok", f"{_API_KEY_ENV_BY_PROVIDER[provider]} present")
+
+    credentials_path = config_path.parent / "credentials.yaml"
+    if not credentials_path.exists():
+        return _health_row("Credentials", "error", f"missing {credentials_path} for {provider}")
+
+    try:
+        raw_credentials = yaml.safe_load(credentials_path.read_text()) or {}
+    except (OSError, yaml.YAMLError) as exc:
+        return _health_row("Credentials", "error", f"cannot read credentials: {exc}")
+
+    provider_config = raw_credentials.get("providers", {}).get(provider, {})
+    api_key = (
+        str(provider_config.get("api_key", "")).strip() if isinstance(provider_config, dict) else ""
+    )
+    if not api_key:
+        return _health_row("Credentials", "warning", f"{provider} key is empty")
+    if api_key.startswith("YOUR_") and api_key.endswith("_API_KEY"):
+        return _health_row("Credentials", "warning", f"{provider} key is still a template value")
+    return _health_row("Credentials", "ok", f"{provider} key present")
+
+
 @app.command()
 def health() -> None:
     """Check system health.
 
-    Verifies database connectivity, provider configuration, and system resources.
+    Verifies configuration, database, runtime backend, and credentials.
     """
-    # Placeholder implementation with example data
-    health_data = [
-        {"name": "Database", "status": "ok"},
-        {"name": "Configuration", "status": "ok"},
-        {"name": "Providers", "status": "warning"},
-    ]
-    table = create_status_table(health_data, "System Health")
+    checks: list[dict[str, str]] = []
+    data: dict | None = None
+    config_path: Path | None = None
+
+    try:
+        data, config_path = _load_config()
+        load_config(config_path)
+    except Exception as exc:
+        checks.append(_health_row("Configuration", "error", str(exc)))
+    else:
+        checks.append(_health_row("Configuration", "ok", str(config_path)))
+
+    if data is None or config_path is None:
+        checks.extend(
+            [
+                _health_row("Database", "error", "configuration unavailable"),
+                _health_row("Runtime backend", "error", "configuration unavailable"),
+                _health_row("Credentials", "error", "configuration unavailable"),
+            ]
+        )
+    else:
+        try:
+            db_path = _database_file_path(data, config_path)
+            db_detail = _resolve_db_path(data, config_path)
+            if not db_path.exists():
+                checks.append(
+                    _health_row(
+                        "Database", "warning", f"missing; will be created on first run: {db_detail}"
+                    )
+                )
+            elif not db_path.is_file():
+                checks.append(_health_row("Database", "error", f"not a file: {db_detail}"))
+            else:
+                try:
+                    with db_path.open("rb"):
+                        pass
+                except OSError as exc:
+                    checks.append(_health_row("Database", "error", f"not readable: {exc}"))
+                else:
+                    checks.append(_health_row("Database", "ok", db_detail))
+        except Exception as exc:
+            checks.append(_health_row("Database", "error", str(exc)))
+
+        checks.append(_check_runtime_backend(data))
+        checks.append(_check_credentials(data, config_path))
+
+    table = create_status_table(checks, "System Health")
     print_table(table)
+    if any(check["status"] == "error" for check in checks):
+        raise typer.Exit(1)
 
 
 __all__ = ["app"]

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -15,7 +15,7 @@ import yaml
 
 from ouroboros.auto.state import AutoPhase, AutoStore
 from ouroboros.backends import get_backend_capability, resolve_runtime_backend_name
-from ouroboros.cli.commands.config import _load_config, _resolve_cli_path, _resolve_db_path
+from ouroboros.cli.commands.config import _load_config, _resolve_db_path
 from ouroboros.cli.formatters.panels import print_error, print_info
 from ouroboros.cli.formatters.tables import create_status_table, print_table
 from ouroboros.config.loader import load_config
@@ -261,18 +261,18 @@ def _candidate_cli_paths(backend: str, data: dict) -> list[str]:
         if env_path:
             candidates.append(str(Path(env_path).expanduser()))
 
-    # Keep the existing config helper for config-file path resolution, but only
-    # when the config-file backend is the effective backend being checked.
-    configured_backend = str(data.get("orchestrator", {}).get("runtime_backend", "claude"))
-    try:
-        config_backend = resolve_runtime_backend_name(configured_backend)
-    except ValueError:
-        config_backend = None
-    configured_cli = _resolve_cli_path(data) if config_backend == backend else None
+    capability = get_backend_capability(backend)
+    config_key = capability.cli_config_key if capability is not None else None
+    configured_cli = None
+    if config_key:
+        configured_cli = data.get("orchestrator", {}).get(config_key)
+
+    # Do not consult the config-file runtime backend here: env overrides may
+    # select a different effective backend for this process, and that backend's
+    # own configured CLI path still mirrors the runtime launcher contract.
     if configured_cli and configured_cli not in candidates:
         candidates.append(configured_cli)
 
-    capability = get_backend_capability(backend)
     if not candidates and capability is not None and capability.cli_name:
         candidates.append(capability.cli_name)
     return candidates

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -273,12 +273,7 @@ def _candidate_cli_paths(backend: str, data: dict) -> list[str]:
     if configured_cli and configured_cli not in candidates:
         candidates.append(configured_cli)
 
-    if (
-        not candidates
-        and backend != "claude"
-        and capability is not None
-        and capability.cli_name
-    ):
+    if not candidates and backend != "claude" and capability is not None and capability.cli_name:
         candidates.append(capability.cli_name)
     return candidates
 

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -273,7 +273,12 @@ def _candidate_cli_paths(backend: str, data: dict) -> list[str]:
     if configured_cli and configured_cli not in candidates:
         candidates.append(configured_cli)
 
-    if not candidates and capability is not None and capability.cli_name:
+    if (
+        not candidates
+        and backend != "claude"
+        and capability is not None
+        and capability.cli_name
+    ):
         candidates.append(capability.cli_name)
     return candidates
 
@@ -296,6 +301,8 @@ def _check_runtime_backend(data: dict) -> dict[str, str]:
 
     capability = get_backend_capability(backend)
     candidates = _candidate_cli_paths(backend, data)
+    if backend == "claude" and not candidates:
+        return _health_row("Runtime backend", "ok", "claude: SDK default")
 
     for candidate in candidates:
         if not candidate:
@@ -381,11 +388,18 @@ def _check_credentials(data: dict, config_path: Path) -> dict[str, str]:
         return _health_row("Credentials", "error", f"missing {credentials_path} for {provider}")
 
     try:
-        raw_credentials = yaml.safe_load(credentials_path.read_text()) or {}
+        raw_credentials = yaml.safe_load(credentials_path.read_text())
+        if raw_credentials is None:
+            raw_credentials = {}
     except (OSError, yaml.YAMLError) as exc:
         return _health_row("Credentials", "error", f"cannot read credentials: {exc}")
 
-    provider_config = raw_credentials.get("providers", {}).get(provider, {})
+    if not isinstance(raw_credentials, dict):
+        return _health_row("Credentials", "error", "credentials.yaml must contain a mapping")
+    providers = raw_credentials.get("providers", {})
+    if not isinstance(providers, dict):
+        return _health_row("Credentials", "error", "credentials providers must be a mapping")
+    provider_config = providers.get(provider, {})
     api_key = (
         str(provider_config.get("api_key", "")).strip() if isinstance(provider_config, dict) else ""
     )

--- a/tests/e2e/test_cli_commands.py
+++ b/tests/e2e/test_cli_commands.py
@@ -329,7 +329,7 @@ class TestStatusCommands:
     def test_status_health(self) -> None:
         """Test status health command."""
         result = runner.invoke(app, ["status", "health"])
-        assert result.exit_code == 0
+        assert result.exit_code in (0, 1)
         assert "System Health" in result.output or "health" in result.output.lower()
 
     def test_status_executions_help(self) -> None:

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -153,7 +153,7 @@ class TestStatusCommands:
     def test_status_health_runs(self) -> None:
         """Test status health command execution."""
         result = runner.invoke(app, ["status", "health"])
-        assert result.exit_code == 0
+        assert result.exit_code in (0, 1)
         assert "System Health" in result.output
 
 

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -45,7 +45,11 @@ def _make_cli(path: Path) -> Path:
 
 
 def _write_config(
-    config_dir: Path, *, cli_path: Path | str | None = None, backend: str = "claude"
+    config_dir: Path,
+    *,
+    cli_path: Path | str | None = None,
+    backend: str = "claude",
+    extra_orchestrator: dict[str, str] | None = None,
 ) -> Path:
     data = {
         "orchestrator": {
@@ -55,6 +59,8 @@ def _write_config(
         "llm": {"backend": "claude_code"},
         "persistence": {"database_path": "data/ouroboros.db"},
     }
+    if extra_orchestrator:
+        data["orchestrator"].update(extra_orchestrator)
     config_path = config_dir / "config.yaml"
     config_path.write_text(yaml.dump(data))
     return config_path
@@ -250,6 +256,36 @@ def test_health_honors_agent_runtime_and_cli_path_environment_overrides(
     assert f"codex: {codex_cli}" in result.output
     assert str(stale_claude) not in result.output
     assert "codex OAuth file present" in result.output
+
+
+def test_health_honors_effective_backend_configured_cli_when_runtime_env_overrides(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    stale_claude = tmp_path / "missing" / "claude"
+    codex_cli = _make_cli(tmp_path / "configured-bin" / "codex")
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text("{}")
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    _write_config(
+        config_dir,
+        cli_path=stale_claude,
+        backend="claude",
+        extra_orchestrator={"codex_cli_path": str(codex_cli)},
+    )
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+    monkeypatch.setenv("OUROBOROS_AGENT_RUNTIME", "codex")
+    monkeypatch.setenv("OUROBOROS_LLM_BACKEND", "codex")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 0
+    assert f"codex: {codex_cli}" in result.output
+    assert str(stale_claude) not in result.output
 
 
 def test_health_treats_copilot_as_cli_authenticated_not_openai_key_backend(

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -370,3 +370,40 @@ def test_health_reports_malformed_credentials_providers_without_crashing(
     assert result.exit_code == 1
     assert "Credentials" in result.output
     assert "credentials providers must be a mapping" in result.output
+
+
+def test_health_uses_kiro_cli_default_name(monkeypatch, tmp_path: Path) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    _write_config(config_dir, cli_path=None, backend="kiro")
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+    monkeypatch.setenv("OUROBOROS_LLM_BACKEND", "kiro")
+    monkeypatch.setattr(
+        "shutil.which",
+        lambda name: "/opt/bin/kiro-cli" if name == "kiro-cli" else None,
+    )
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 0
+    assert "kiro: /opt/bin/kiro-cli" in result.output
+    assert "kiro CLI not found" not in result.output
+
+
+def test_health_errors_for_malformed_provider_credentials(monkeypatch, tmp_path: Path) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    cli = _make_cli(tmp_path / "bin" / "claude")
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    _write_config(config_dir, cli_path=cli)
+    (config_dir / "credentials.yaml").write_text("providers:\n  anthropic: []\n")
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 1
+    assert "Credentials" in result.output
+    assert "credentials provider anthropic must be a mapping" in result.output

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -336,9 +336,7 @@ def test_health_accepts_claude_sdk_default_without_configured_cli(
     assert "claude: SDK default" in result.output
 
 
-def test_health_reports_malformed_credentials_without_crashing(
-    monkeypatch, tmp_path: Path
-) -> None:
+def test_health_reports_malformed_credentials_without_crashing(monkeypatch, tmp_path: Path) -> None:
     _clear_auth_env(monkeypatch)
     config_dir = tmp_path / "config"
     (config_dir / "data").mkdir(parents=True)

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -407,3 +407,22 @@ def test_health_errors_for_malformed_provider_credentials(monkeypatch, tmp_path:
     assert result.exit_code == 1
     assert "Credentials" in result.output
     assert "credentials provider anthropic must be a mapping" in result.output
+
+
+def test_health_errors_for_unsupported_llm_backend(monkeypatch, tmp_path: Path) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    cli = _make_cli(tmp_path / "bin" / "claude")
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    _write_config(config_dir, cli_path=cli)
+    _write_credentials(config_dir)
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+    monkeypatch.setenv("OUROBOROS_LLM_BACKEND", "not-a-backend")
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 1
+    assert "Credentials" in result.output
+    assert "Unsupported backend" in result.output
+    assert "uses local CLI authentication" not in result.output

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -315,3 +315,60 @@ def test_health_treats_copilot_as_cli_authenticated_not_openai_key_backend(
     assert result.exit_code == 0
     assert "copilot uses local CLI authentication" in result.output
     assert "OPENAI_API_KEY" not in result.output
+
+
+def test_health_accepts_claude_sdk_default_without_configured_cli(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    _write_config(config_dir, cli_path=None, backend="claude")
+    _write_credentials(config_dir)
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 0
+    assert "Runtime backend" in result.output
+    assert "claude: SDK default" in result.output
+
+
+def test_health_reports_malformed_credentials_without_crashing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    cli = _make_cli(tmp_path / "bin" / "claude")
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    _write_config(config_dir, cli_path=cli)
+    (config_dir / "credentials.yaml").write_text("[]")
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 1
+    assert "Credentials" in result.output
+    assert "must contain a mapping" in result.output
+
+
+def test_health_reports_malformed_credentials_providers_without_crashing(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    cli = _make_cli(tmp_path / "bin" / "claude")
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    _write_config(config_dir, cli_path=cli)
+    (config_dir / "credentials.yaml").write_text("providers: []")
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 1
+    assert "Credentials" in result.output
+    assert "credentials providers must be a mapping" in result.output

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -1,0 +1,216 @@
+"""Unit tests for the status command."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from typer.testing import CliRunner
+import yaml
+
+from ouroboros.cli.commands.status import app
+
+runner = CliRunner(env={"COLUMNS": "240"})
+
+
+API_ENV_KEYS = [
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "OPENROUTER_API_KEY",
+    "OUROBOROS_LLM_BACKEND",
+    "OUROBOROS_RUNTIME",
+    "CODEX_HOME",
+]
+
+
+def _clear_auth_env(monkeypatch) -> None:
+    for key in API_ENV_KEYS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _make_cli(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\n")
+    path.chmod(0o755)
+    return path
+
+
+def _write_config(
+    config_dir: Path, *, cli_path: Path | str | None = None, backend: str = "claude"
+) -> Path:
+    data = {
+        "orchestrator": {
+            "runtime_backend": backend,
+            "cli_path": str(cli_path) if cli_path is not None else None,
+        },
+        "llm": {"backend": "claude_code"},
+        "persistence": {"database_path": "data/ouroboros.db"},
+    }
+    config_path = config_dir / "config.yaml"
+    config_path.write_text(yaml.dump(data))
+    return config_path
+
+
+def _write_credentials(config_dir: Path, api_key: str = "sk-present") -> None:
+    (config_dir / "credentials.yaml").write_text(
+        yaml.dump({"providers": {"anthropic": {"api_key": api_key}}})
+    )
+
+
+def test_health_reports_all_ok(monkeypatch, tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    data_dir = config_dir / "data"
+    data_dir.mkdir(parents=True)
+    _clear_auth_env(monkeypatch)
+    cli = _make_cli(tmp_path / "bin" / "claude")
+    db = data_dir / "ouroboros.db"
+    db.write_text("")
+    _write_config(config_dir, cli_path=cli)
+    _write_credentials(config_dir)
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 0
+    assert "Configuration" in result.output
+    assert "Database" in result.output
+    assert "Runtime backend" in result.output
+    assert "Credentials" in result.output
+    assert "sk-present" not in result.output
+    assert "key present" in result.output
+
+
+def test_health_exits_nonzero_on_config_load_failure(monkeypatch, tmp_path: Path) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    config_dir.mkdir()
+    (config_dir / "config.yaml").write_text("orchestrator: []")
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 1
+    assert "Configuration" in result.output
+    assert "error" in result.output
+    assert "Invalid config section" in result.output
+
+
+def test_health_exits_nonzero_when_runtime_cli_missing(monkeypatch, tmp_path: Path) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    missing_cli = tmp_path / "missing" / "claude"
+    _write_config(config_dir, cli_path=missing_cli)
+    _write_credentials(config_dir)
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 1
+    assert "Runtime backend" in result.output
+    assert "CLI not found" in result.output
+    assert str(missing_cli) in result.output
+
+
+def test_health_exits_nonzero_when_credentials_file_missing(monkeypatch, tmp_path: Path) -> None:
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    _clear_auth_env(monkeypatch)
+    cli = _make_cli(tmp_path / "bin" / "claude")
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    _write_config(config_dir, cli_path=cli)
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 1
+    assert "Credentials" in result.output
+    assert "missing" in result.output
+    assert "credentials.yaml" in result.output
+    assert "API_KEY" not in result.output
+
+
+def test_health_warns_but_exits_zero_for_missing_database_and_empty_key(
+    monkeypatch, tmp_path: Path
+) -> None:
+    config_dir = tmp_path / "config"
+    config_dir.mkdir(parents=True)
+    _clear_auth_env(monkeypatch)
+    cli = _make_cli(tmp_path / "bin" / "claude")
+    _write_config(config_dir, cli_path=cli)
+    (config_dir / "credentials.yaml").write_text(
+        yaml.dump({"providers": {"anthropic": {"api_key": ""}}})
+    )
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 0
+    assert "Database" in result.output
+    assert "warning" in result.output
+    assert "will be created on first run" in result.output
+    assert "key is empty" in result.output
+
+
+def test_health_accepts_provider_api_key_from_environment(monkeypatch, tmp_path: Path) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    cli = _make_cli(tmp_path / "bin" / "claude")
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    _write_config(config_dir, cli_path=cli)
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-from-env")
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 0
+    assert "ANTHROPIC_API_KEY present" in result.output
+    assert "sk-from-env" not in result.output
+
+
+def test_health_uses_llm_backend_environment_override_for_codex_oauth(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    cli = _make_cli(tmp_path / "bin" / "claude")
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text("{}")
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    _write_config(config_dir, cli_path=cli)
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+    monkeypatch.setenv("OUROBOROS_LLM_BACKEND", "codex")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 0
+    assert "codex OAuth file present" in result.output
+
+
+def test_health_rejects_configured_runtime_cli_that_is_not_executable(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    cli = tmp_path / "bin" / "claude"
+    cli.parent.mkdir()
+    cli.write_text("#!/bin/sh\n")
+    cli.chmod(0o644)
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    _write_config(config_dir, cli_path=cli)
+    _write_credentials(config_dir)
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+    monkeypatch.setattr("shutil.which", lambda _name: None)
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 1
+    assert "Runtime backend" in result.output
+    assert "CLI not found" in result.output

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -19,6 +19,15 @@ API_ENV_KEYS = [
     "OPENROUTER_API_KEY",
     "OUROBOROS_LLM_BACKEND",
     "OUROBOROS_RUNTIME",
+    "OUROBOROS_AGENT_RUNTIME",
+    "OUROBOROS_CLI_PATH",
+    "OUROBOROS_CODEX_CLI_PATH",
+    "OUROBOROS_COPILOT_CLI_PATH",
+    "OUROBOROS_GEMINI_CLI_PATH",
+    "OUROBOROS_GOOSE_CLI_PATH",
+    "OUROBOROS_HERMES_CLI_PATH",
+    "OUROBOROS_KIRO_CLI_PATH",
+    "OUROBOROS_OPENCODE_CLI_PATH",
     "CODEX_HOME",
 ]
 
@@ -214,3 +223,59 @@ def test_health_rejects_configured_runtime_cli_that_is_not_executable(
     assert result.exit_code == 1
     assert "Runtime backend" in result.output
     assert "CLI not found" in result.output
+
+
+def test_health_honors_agent_runtime_and_cli_path_environment_overrides(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    stale_claude = tmp_path / "missing" / "claude"
+    codex_cli = _make_cli(tmp_path / "custom-bin" / "codex")
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    (codex_home / "auth.json").write_text("{}")
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    _write_config(config_dir, cli_path=stale_claude, backend="claude")
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+    monkeypatch.setenv("OUROBOROS_AGENT_RUNTIME", "codex")
+    monkeypatch.setenv("OUROBOROS_CODEX_CLI_PATH", str(codex_cli))
+    monkeypatch.setenv("OUROBOROS_LLM_BACKEND", "codex")
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 0
+    assert f"codex: {codex_cli}" in result.output
+    assert str(stale_claude) not in result.output
+    assert "codex OAuth file present" in result.output
+
+
+def test_health_treats_copilot_as_cli_authenticated_not_openai_key_backend(
+    monkeypatch, tmp_path: Path
+) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    copilot_cli = _make_cli(tmp_path / "bin" / "copilot")
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    (config_dir / "config.yaml").write_text(
+        yaml.dump(
+            {
+                "orchestrator": {
+                    "runtime_backend": "copilot",
+                    "copilot_cli_path": str(copilot_cli),
+                },
+                "llm": {"backend": "copilot"},
+                "persistence": {"database_path": "data/ouroboros.db"},
+            }
+        )
+    )
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 0
+    assert "copilot uses local CLI authentication" in result.output
+    assert "OPENAI_API_KEY" not in result.output


### PR DESCRIPTION
## Summary
- Replace the `ouroboros status health` placeholder with live local checks for configuration, database readability, runtime CLI reachability, and credentials presence.
- Keep health output secret-safe by reporting only credential presence/absence, never key values.
- Update the CLI reference to describe the scriptable exit-code behavior and the remaining status placeholders.

Closes #1099

## Test plan
- `uv run pytest tests/unit/cli/test_status.py -q`
- `uv run pytest tests/unit/cli/test_status.py tests/unit/cli/test_config.py -q`
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/ouroboros`
- `python3 scripts/check-auto-boundary.py`
