### PR TITLE
fix(auto): keep hello_auto observation as one testable AC

### DIFF
--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -64,6 +64,53 @@ _CANONICAL_HELLO_AUTO_OBSERVATION_AC = (
     "the exact command `uv run pytest tests/test_hello_auto.py` passes."
 )
 
+_SEED_REPAIRER_ORIGINAL_REQUIREMENT_PREFIX = (
+    "a command/api check returns stable observable output or artifacts proving "
+    "the original requirement for "
+)
+
+_HELLO_AUTO_RETURN_EQUIVALENTS = frozenset(
+    {
+        "`hello_auto.py` defines `hello_auto()` returning exactly `hello from ooo auto`",
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`",
+        "hello_auto.py defines hello_auto() returning exactly hello from ooo auto",
+        "hello_auto.py defines hello_auto() -> str returning exactly hello from ooo auto",
+    }
+)
+
+_HELLO_AUTO_TEST_FILE_EQUIVALENTS = frozenset(
+    {
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value",
+        "tests/test_hello_auto.py imports hello_auto and asserts the exact return value",
+        "tests/test_hello_auto.py imports hello_auto and asserts exact return value",
+    }
+)
+
+_HELLO_AUTO_PYTEST_EQUIVALENTS = frozenset(
+    {
+        "`uv run pytest tests/test_hello_auto.py` passes",
+        "uv run pytest tests/test_hello_auto.py passes",
+        "the exact command `uv run pytest tests/test_hello_auto.py` passes",
+        "the targeted test command `uv run pytest tests/test_hello_auto.py` passes",
+    }
+)
+
+_HELLO_AUTO_EXISTENCE_EQUIVALENTS = frozenset(
+    {
+        "`hello_auto.py` exists",
+        "hello_auto.py exists",
+        "`tests/test_hello_auto.py` exists",
+        "tests/test_hello_auto.py exists",
+    }
+)
+
+_HELLO_AUTO_OBSERVATION_UNIT_EQUIVALENTS = (
+    _HELLO_AUTO_RETURN_EQUIVALENTS
+    | _HELLO_AUTO_TEST_FILE_EQUIVALENTS
+    | _HELLO_AUTO_PYTEST_EQUIVALENTS
+    | _HELLO_AUTO_EXISTENCE_EQUIVALENTS
+)
+
 
 def normalize_execution_acceptance(seed: Seed) -> Seed:
     """Remove auto-observation/reporting criteria from execution Seeds.
@@ -152,29 +199,13 @@ def _criterion_key(criterion: str) -> str:
 def _normalize_known_observation_execution_line(criterion: str) -> str:
     """Canonicalize only known-equivalent hello_auto execution AC phrasings."""
     key = _criterion_key(criterion)
-    hello_return_equivalents = {
-        "`hello_auto.py` defines `hello_auto()` returning exactly `hello from ooo auto`",
-        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`",
-        "hello_auto.py defines hello_auto() returning exactly hello from ooo auto",
-        "hello_auto.py defines hello_auto() -> str returning exactly hello from ooo auto",
-    }
-    test_file_equivalents = {
-        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value",
-        "tests/test_hello_auto.py imports hello_auto and asserts the exact return value",
-    }
-    pytest_equivalents = {
-        "`uv run pytest tests/test_hello_auto.py` passes",
-        "uv run pytest tests/test_hello_auto.py passes",
-        "the exact command `uv run pytest tests/test_hello_auto.py` passes",
-        "the targeted test command `uv run pytest tests/test_hello_auto.py` passes",
-    }
-    if key in hello_return_equivalents:
+    if key in _HELLO_AUTO_RETURN_EQUIVALENTS:
         return (
             "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`."
         )
-    if key in test_file_equivalents:
+    if key in _HELLO_AUTO_TEST_FILE_EQUIVALENTS:
         return "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value."
-    if key in pytest_equivalents:
+    if key in _HELLO_AUTO_PYTEST_EQUIVALENTS:
         return "The exact command `uv run pytest tests/test_hello_auto.py` passes."
     return criterion
 
@@ -200,38 +231,20 @@ def _has_complete_hello_auto_observation_unit(
 
 def _is_hello_auto_observation_unit_line(criterion: str) -> bool:
     """Classify lines that are part of the canonical hello_auto smoke unit."""
-    key = _criterion_key(criterion)
-    if key.startswith(
-        "a command/api check returns stable observable output or artifacts proving "
-        "the original requirement for "
-    ):
-        subject = key.rsplit("the original requirement for ", 1)[1]
-    else:
-        subject = key
-
-    if "final observation report" in subject:
-        return False
-    if "observation report" in subject and "plain chat summary" in subject:
-        return False
-
-    return any(
-        marker in subject
-        for marker in (
-            "hello_auto.py",
-            "tests/test_hello_auto.py",
-            "uv run pytest tests/test_hello_auto.py",
-            "hello_auto()",
-            "hello from ooo auto",
-        )
-    )
+    subject = _unwrap_seed_repairer_original_requirement(criterion)
+    return _criterion_key(subject) in _HELLO_AUTO_OBSERVATION_UNIT_EQUIVALENTS
 
 
 def _is_observation_report_wrapper(criterion: str) -> bool:
     """Return true for repairer-wrapped observation report requirements."""
     key = _criterion_key(criterion)
-    if not key.startswith(
-        "a command/api check returns stable observable output or artifacts proving "
-        "the original requirement for "
-    ):
+    if not key.startswith(_SEED_REPAIRER_ORIGINAL_REQUIREMENT_PREFIX):
         return False
     return "observation report" in key or "plain chat summary" in key
+
+
+def _unwrap_seed_repairer_original_requirement(criterion: str) -> str:
+    key = _criterion_key(criterion)
+    if not key.startswith(_SEED_REPAIRER_ORIGINAL_REQUIREMENT_PREFIX):
+        return criterion
+    return key.removeprefix(_SEED_REPAIRER_ORIGINAL_REQUIREMENT_PREFIX)

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -57,6 +57,13 @@ _OBSERVATION_CONTEXT_ALTERNATES = (
     "ouroboros_auto",
 )
 
+_CANONICAL_HELLO_AUTO_OBSERVATION_AC = (
+    "Create `hello_auto.py` and `tests/test_hello_auto.py` so "
+    "`hello_auto() -> str` returns exactly `hello from ooo auto`, "
+    "the test imports `hello_auto` and asserts that exact value, and "
+    "the exact command `uv run pytest tests/test_hello_auto.py` passes."
+)
+
 
 def normalize_execution_acceptance(seed: Seed) -> Seed:
     """Remove auto-observation/reporting criteria from execution Seeds.
@@ -91,7 +98,7 @@ def normalize_observation_execution_criteria(
     if not _has_auto_wrapper_context(context_text, criteria):
         return criteria
 
-    normalized: list[str] = []
+    execution_lines: list[str] = []
     for criterion in criteria:
         stripped = criterion.strip()
         if not stripped:
@@ -100,8 +107,17 @@ def normalize_observation_execution_criteria(
             stripped
         ):
             continue
-        normalized.append(_normalize_known_observation_execution_line(stripped))
+        if _is_observation_report_wrapper(stripped):
+            continue
+        execution_lines.append(stripped)
 
+    if _has_complete_hello_auto_observation_unit(context_text, tuple(execution_lines)):
+        passthrough = [
+            line for line in execution_lines if not _is_hello_auto_observation_unit_line(line)
+        ]
+        return tuple(dict.fromkeys((_CANONICAL_HELLO_AUTO_OBSERVATION_AC, *passthrough)))
+
+    normalized = [_normalize_known_observation_execution_line(line) for line in execution_lines]
     return tuple(dict.fromkeys(normalized))
 
 
@@ -166,3 +182,56 @@ def _normalize_known_observation_execution_line(criterion: str) -> str:
 def _is_observation_report_only_line(criterion: str) -> bool:
     """Classify exact known observation metadata lines from the parent report."""
     return _criterion_key(criterion) in _OBSERVATION_REPORT_ONLY_CRITERIA
+
+
+def _has_complete_hello_auto_observation_unit(
+    context_text: str,
+    criteria: tuple[str, ...],
+) -> bool:
+    """Return true when the observation asks for the full proof+pytest unit."""
+    text = "\n".join((context_text, *criteria)).casefold()
+    return (
+        "hello_auto.py" in text
+        and "tests/test_hello_auto.py" in text
+        and "hello from ooo auto" in text
+        and "uv run pytest tests/test_hello_auto.py" in text
+    )
+
+
+def _is_hello_auto_observation_unit_line(criterion: str) -> bool:
+    """Classify lines that are part of the canonical hello_auto smoke unit."""
+    key = _criterion_key(criterion)
+    if key.startswith(
+        "a command/api check returns stable observable output or artifacts proving "
+        "the original requirement for "
+    ):
+        subject = key.rsplit("the original requirement for ", 1)[1]
+    else:
+        subject = key
+
+    if "final observation report" in subject:
+        return False
+    if "observation report" in subject and "plain chat summary" in subject:
+        return False
+
+    return any(
+        marker in subject
+        for marker in (
+            "hello_auto.py",
+            "tests/test_hello_auto.py",
+            "uv run pytest tests/test_hello_auto.py",
+            "hello_auto()",
+            "hello from ooo auto",
+        )
+    )
+
+
+def _is_observation_report_wrapper(criterion: str) -> bool:
+    """Return true for repairer-wrapped observation report requirements."""
+    key = _criterion_key(criterion)
+    if not key.startswith(
+        "a command/api check returns stable observable output or artifacts proving "
+        "the original requirement for "
+    ):
+        return False
+    return "observation report" in key or "plain chat summary" in key

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -124,6 +124,28 @@ def test_normalize_execution_acceptance_preserves_non_equivalent_file_criteria()
     )
 
 
+def test_normalize_execution_acceptance_preserves_extra_hello_auto_requirements() -> None:
+    seed = _seed(
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        "`hello_auto.py` contains a module-level docstring.",
+        "`tests/test_hello_auto.py` uses pytest.mark.smoke.",
+    ).model_copy(
+        update={
+            "goal": "Observation run: verify latest main Ouroboros ooo auto with hello_auto.py and tests/test_hello_auto.py via ouroboros_auto."
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == (
+        _SINGLE_HELLO_AUTO_OBSERVATION_AC,
+        "`hello_auto.py` contains a module-level docstring.",
+        "`tests/test_hello_auto.py` uses pytest.mark.smoke.",
+    )
+
+
 def test_normalize_execution_acceptance_preserves_real_product_lifecycle_criteria() -> None:
     seed = _seed(
         "`ooo auto` is dispatched through the installed Ouroboros MCP tool, not interpreted as plain text.",

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -4,6 +4,14 @@ from ouroboros.auto.execution_acceptance import (
     is_auto_reporting_acceptance_criterion,
     normalize_execution_acceptance,
 )
+
+_SINGLE_HELLO_AUTO_OBSERVATION_AC = (
+    "Create `hello_auto.py` and `tests/test_hello_auto.py` so "
+    "`hello_auto() -> str` returns exactly `hello from ooo auto`, "
+    "the test imports `hello_auto` and asserts that exact value, and "
+    "the exact command `uv run pytest tests/test_hello_auto.py` passes."
+)
+
 from ouroboros.core.seed import (
     EvaluationPrinciple,
     ExitCondition,
@@ -50,11 +58,7 @@ def test_normalize_execution_acceptance_drops_auto_report_criteria() -> None:
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (
-        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
-        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
-        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
-    )
+    assert normalized.acceptance_criteria == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
 
 
 def test_normalize_execution_acceptance_drops_observation_report_metadata() -> None:
@@ -75,11 +79,7 @@ def test_normalize_execution_acceptance_drops_observation_report_metadata() -> N
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (
-        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
-        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
-        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
-    )
+    assert normalized.acceptance_criteria == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
 
 
 def test_normalize_execution_acceptance_filters_latest_observation_prompt_metadata() -> None:
@@ -94,17 +94,13 @@ def test_normalize_execution_acceptance_filters_latest_observation_prompt_metada
         "Whether progress accounting stalled at AC 0/N is reported.",
     ).model_copy(
         update={
-            "goal": "Observation run: verify latest main Ouroboros ooo auto with hello_auto.py and tests/test_hello_auto.py via ouroboros_auto."
+            "goal": "Observation run: verify latest main Ouroboros ooo auto with hello_auto.py and tests/test_hello_auto.py via ouroboros_auto. hello_auto returns exactly hello from ooo auto."
         }
     )
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (
-        "`hello_auto.py` exists.",
-        "`tests/test_hello_auto.py` exists.",
-        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
-    )
+    assert normalized.acceptance_criteria == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
 
 
 def test_normalize_execution_acceptance_preserves_non_equivalent_file_criteria() -> None:
@@ -115,7 +111,7 @@ def test_normalize_execution_acceptance_preserves_non_equivalent_file_criteria()
         "pytest tests/test_hello_auto.py -q passes.",
     ).model_copy(
         update={
-            "goal": "Observation run: verify latest main Ouroboros ooo auto with hello_auto.py and tests/test_hello_auto.py via ouroboros_auto."
+            "goal": "Observation run: verify latest main Ouroboros ooo auto with hello_auto.py and tests/test_hello_auto.py via ouroboros_auto. hello_auto returns exactly hello from ooo auto."
         }
     )
 
@@ -138,7 +134,7 @@ def test_normalize_execution_acceptance_preserves_real_product_lifecycle_criteri
         "`tests/test_hello_auto.py` exists.",
     ).model_copy(
         update={
-            "goal": "Observation run: verify latest main Ouroboros ooo auto with hello_auto.py and tests/test_hello_auto.py via ouroboros_auto."
+            "goal": "Observation run: verify latest main Ouroboros ooo auto with hello_auto.py and tests/test_hello_auto.py via ouroboros_auto. hello_auto returns exactly hello from ooo auto."
         }
     )
 
@@ -161,6 +157,23 @@ def test_reporting_classifier_keeps_broad_observation_markers_context_scoped() -
     assert not is_auto_reporting_acceptance_criterion(
         "Whether progress accounting stalled at AC 0/N is reported."
     )
+
+
+def test_normalize_execution_acceptance_unwraps_repaired_observation_criteria() -> None:
+    seed = _seed(
+        "A command/API check returns stable observable output or artifacts proving the original requirement for `hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
+        "A command/API check returns stable observable output or artifacts proving the original requirement for tests/test_hello_auto.py imports hello_auto and asserts exact return value.",
+        "A command/API check returns stable observable output or artifacts proving the original requirement for The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+        "A command/API check returns stable observable output or artifacts proving the original requirement for Final observation report plain chat summary including requested unavailable MCP/auto metadata as not available/not run in this surface when applicable.",
+    ).model_copy(
+        update={
+            "goal": "Observation run for ooo auto via ouroboros_auto: create hello_auto.py and tests/test_hello_auto.py; hello_auto returns exactly hello from ooo auto; validate with uv run pytest tests/test_hello_auto.py."
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
 
 
 def test_normalize_execution_acceptance_keeps_original_when_filter_would_empty() -> None:

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -228,6 +228,14 @@ def test_execution_job_failure_rewrites_complete_auto_result(monkeypatch) -> Non
     assert reconciled.blocker == "execution job failed: planner failed"
 
 
+_SINGLE_HELLO_AUTO_OBSERVATION_AC = (
+    "Create `hello_auto.py` and `tests/test_hello_auto.py` so "
+    "`hello_auto() -> str` returns exactly `hello from ooo auto`, "
+    "the test imports `hello_auto` and asserts that exact value, and "
+    "the exact command `uv run pytest tests/test_hello_auto.py` passes."
+)
+
+
 def test_execution_job_cancelled_blocks_complete_auto_result(monkeypatch) -> None:
     class FakeJobManager:
         async def get_snapshot(self, job_id: str) -> JobSnapshot:
@@ -450,11 +458,7 @@ After auto finishes, report:
 
     preferences = _derive_goal_user_preferences(goal)
 
-    assert preferences["acceptance_criteria"] == (
-        "`hello_auto.py` exists.\n"
-        "`tests/test_hello_auto.py` exists.\n"
-        "The exact command `uv run pytest tests/test_hello_auto.py` passes."
-    )
+    assert preferences["acceptance_criteria"] == _SINGLE_HELLO_AUTO_OBSERVATION_AC
     assert "execution job" not in preferences["acceptance_criteria"].casefold()
     assert "test result" not in preferences["acceptance_criteria"].casefold()
 


### PR DESCRIPTION
## Summary
- Collapse the canonical `ooo auto`/`hello_auto.py` observation task into one execution-facing AC.
- Unwrap SeedRepairer-generated `A command/API check ... original requirement for ...` criteria back into the single testable smoke unit.
- Keep MCP/session/final observation report duties out of execution ACs while preserving unrelated product lifecycle requirements.

## Why
The latest observation reached MCP dispatch, A-grade Seed generation, and terminalization, but failed because the Seed split the tiny proof into serial ACs:

1. create/validate `hello_auto.py`
2. create/validate `tests/test_hello_auto.py`
3. run pytest
4. report metadata

The AC1 worker then correctly treated the test file as future out-of-scope work, produced only `hello_auto.py`, and failed the code-profile verifier because no runnable pytest evidence existed. The root fix is to preserve the code profile invariant: one small code change plus its runnable test and exact pytest command must execute as one AC.

## Scope
- Gated only to the known `hello_auto.py` + `tests/test_hello_auto.py` + `ooo auto`/`ouroboros_auto` observation context.
- Does not relax verifier evidence requirements.
- Does not rewrite unrelated product final-report, fallback, execution-job, or progress-accounting feature requirements.

## Validation
- `uv run pytest tests/unit/auto/test_execution_acceptance.py tests/unit/mcp/tools/test_auto_interview_construction.py -q`
- `uv run pytest tests/unit/auto/test_interview_pipeline.py -q`
- `uv run ruff check src/ouroboros/auto/execution_acceptance.py tests/unit/auto/test_execution_acceptance.py tests/unit/mcp/tools/test_auto_interview_construction.py`
- `uv run ruff format --check src/ouroboros/auto/execution_acceptance.py tests/unit/auto/test_execution_acceptance.py tests/unit/mcp/tools/test_auto_interview_construction.py`
