### PR TITLE
Validate HITL resume responses against pending waits

### DIFF
--- a/src/ouroboros/core/hitl_resume.py
+++ b/src/ouroboros/core/hitl_resume.py
@@ -1,0 +1,185 @@
+"""Validation helpers for durable HITL RESUME responses.
+
+This module bridges persisted ``hitl.*`` event history to a new user response.
+Callers that only have the EventStore stream should validate against the current
+pending request before appending ``hitl.answered``.  The helper is pure: it does
+not append events or perform runtime dispatch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from datetime import datetime
+from typing import Any
+
+from ouroboros.core.hitl_contract import (
+    HumanInputKind,
+    HumanInputRequest,
+    HumanInputResponse,
+    HumanInputRiskClass,
+    HumanInputSource,
+    HumanInputTimeoutAction,
+)
+from ouroboros.core.hitl_state import HumanInputSnapshot, HumanInputState, project_human_input_state
+from ouroboros.events.base import BaseEvent
+from ouroboros.events.hitl import create_hitl_answered_event
+
+
+class HumanInputResumeValidationError(ValueError):
+    """Raised when a HITL response cannot resolve a pending request."""
+
+
+def create_validated_hitl_resume_event(
+    events: Iterable[BaseEvent],
+    response: HumanInputResponse,
+) -> BaseEvent:
+    """Return a ``hitl.answered`` event after validating pending WAIT state.
+
+    ``events`` must contain the ordered HITL history for at least the target
+    request.  Validation fails when the request is missing, already terminal, or
+    the response does not satisfy the originating request contract.  This keeps
+    resume surfaces from accepting stale, duplicate, wrong-session, or
+    wrong-shape responses.
+    """
+
+    snapshot = pending_human_input_snapshot_for_response(events, response)
+    request = human_input_request_from_snapshot(snapshot)
+    return create_hitl_answered_event(request, response)
+
+
+def pending_human_input_snapshot_for_response(
+    events: Iterable[BaseEvent],
+    response: HumanInputResponse,
+) -> HumanInputSnapshot:
+    """Resolve the pending request snapshot targeted by ``response``.
+
+    Raises :class:`HumanInputResumeValidationError` when no pending request can
+    be resumed.  Terminal requests are reported distinctly from unknown request
+    IDs so CLI/MCP surfaces can present actionable errors.
+    """
+
+    snapshots = project_human_input_state(events)
+    matching = tuple(
+        snapshot for snapshot in snapshots if snapshot.request_id == response.request_id
+    )
+    if not matching:
+        raise HumanInputResumeValidationError(
+            f"HITL request {response.request_id!r} was not found in replayed state"
+        )
+
+    snapshot = matching[-1]
+    if snapshot.state is not HumanInputState.PENDING:
+        raise HumanInputResumeValidationError(
+            f"HITL request {response.request_id!r} is not pending; current state is {snapshot.state.value}"
+        )
+
+    _validate_response_context(response, snapshot)
+    return snapshot
+
+
+def human_input_request_from_snapshot(snapshot: HumanInputSnapshot) -> HumanInputRequest:
+    """Reconstruct the immutable request contract from a pending snapshot."""
+
+    data = snapshot.request
+    try:
+        return HumanInputRequest(
+            request_id=_required_str(data, "request_id"),
+            session_id=_required_str(data, "session_id"),
+            run_id=_optional_str(data.get("run_id")),
+            invocation_id=_optional_str(data.get("invocation_id")),
+            created_by=_required_str(data, "created_by"),
+            kind=HumanInputKind(_required_str(data, "kind")),
+            source=HumanInputSource(_required_str(data, "source")),
+            risk_class=HumanInputRiskClass(_required_str(data, "risk_class")),
+            question=_required_str(data, "question"),
+            resume_target=_required_str(data, "resume_target"),
+            title=_optional_str(data.get("title")),
+            body=_optional_str(data.get("body")),
+            options=_string_tuple(data.get("options", ())),
+            required_permission=_optional_str(data.get("required_permission")),
+            timeout_seconds=_optional_int(data.get("timeout_seconds")),
+            timeout_action=HumanInputTimeoutAction(
+                _optional_str(data.get("timeout_action"))
+                or HumanInputTimeoutAction.STAY_WAITING.value
+            ),
+            surface=_optional_str(data.get("surface")),
+            payload=_plain_mapping(data.get("payload", {})),
+            created_at=_datetime_from_payload(data.get("created_at"), fallback=snapshot.created_at),
+        )
+    except (TypeError, ValueError) as exc:
+        raise HumanInputResumeValidationError(
+            f"HITL request {snapshot.request_id!r} cannot be reconstructed from persisted state"
+        ) from exc
+
+
+def _validate_response_context(response: HumanInputResponse, snapshot: HumanInputSnapshot) -> None:
+    for field_name in ("session_id", "run_id", "invocation_id"):
+        response_value = getattr(response, field_name)
+        if response_value is None:
+            continue
+        snapshot_value = getattr(snapshot, field_name)
+        if snapshot_value is not None and response_value != snapshot_value:
+            raise HumanInputResumeValidationError(
+                f"HITL response {field_name} must match pending request state"
+            )
+
+
+def _required_str(data: Mapping[str, Any], key: str) -> str:
+    value = data.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    raise ValueError(f"missing non-empty {key}")
+
+
+def _optional_str(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _optional_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    if type(value) is int:
+        return value
+    raise TypeError("expected int or None")
+
+
+def _string_tuple(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        raise TypeError("expected sequence of strings")
+    if not isinstance(value, list | tuple):
+        raise TypeError("expected sequence of strings")
+    return tuple(str(item) for item in value)
+
+
+def _plain_mapping(value: Any) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise TypeError("expected mapping")
+    return {str(key): _plain_json_value(item) for key, item in value.items()}
+
+
+def _plain_json_value(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {str(key): _plain_json_value(item) for key, item in value.items()}
+    if isinstance(value, tuple | list):
+        return [_plain_json_value(item) for item in value]
+    return value
+
+
+def _datetime_from_payload(value: Any, *, fallback: datetime) -> datetime:
+    if isinstance(value, str) and value.strip():
+        return datetime.fromisoformat(value)
+    return fallback
+
+
+__all__ = [
+    "HumanInputResumeValidationError",
+    "create_validated_hitl_resume_event",
+    "human_input_request_from_snapshot",
+    "pending_human_input_snapshot_for_response",
+]

--- a/src/ouroboros/core/hitl_resume.py
+++ b/src/ouroboros/core/hitl_resume.py
@@ -174,9 +174,12 @@ def _plain_json_value(value: Any) -> Any:
 def _datetime_from_payload(value: Any, *, fallback: datetime) -> datetime:
     if isinstance(value, str) and value.strip():
         try:
-            return datetime.fromisoformat(value)
+            parsed = datetime.fromisoformat(value)
         except ValueError:
             return fallback
+        if parsed.tzinfo is None or parsed.utcoffset() is None:
+            return fallback
+        return parsed
     return fallback
 
 

--- a/src/ouroboros/core/hitl_resume.py
+++ b/src/ouroboros/core/hitl_resume.py
@@ -173,7 +173,10 @@ def _plain_json_value(value: Any) -> Any:
 
 def _datetime_from_payload(value: Any, *, fallback: datetime) -> datetime:
     if isinstance(value, str) and value.strip():
-        return datetime.fromisoformat(value)
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            return fallback
     return fallback
 
 

--- a/tests/unit/core/test_hitl_resume.py
+++ b/tests/unit/core/test_hitl_resume.py
@@ -140,3 +140,27 @@ def test_create_validated_hitl_resume_event_answers_wait_with_malformed_created_
     assert reconstructed.to_event_data()["created_at"] == "2026-05-19T12:30:00+00:00"
     assert event.type == "hitl.answered"
     assert event.aggregate_id == "hitl-1"
+
+
+def test_create_validated_hitl_resume_event_answers_wait_with_naive_created_at() -> None:
+    base_requested = create_hitl_requested_event(_request())
+    requested = base_requested.model_copy(
+        update={
+            "timestamp": datetime(2026, 5, 19, 12, 30, tzinfo=UTC),
+            "data": {
+                **base_requested.data,
+                "created_at": "2026-05-19T12:30:00",
+            },
+        }
+    )
+    snapshot = project_human_input_state([requested])[0]
+
+    assert snapshot.state is HumanInputState.PENDING
+
+    reconstructed = human_input_request_from_snapshot(snapshot)
+    event = create_validated_hitl_resume_event([requested], _approval_response())
+
+    assert reconstructed.created_at == requested.timestamp
+    assert reconstructed.to_event_data()["created_at"] == "2026-05-19T12:30:00+00:00"
+    assert event.type == "hitl.answered"
+    assert event.aggregate_id == "hitl-1"

--- a/tests/unit/core/test_hitl_resume.py
+++ b/tests/unit/core/test_hitl_resume.py
@@ -18,7 +18,7 @@ from ouroboros.core.hitl_resume import (
     human_input_request_from_snapshot,
     pending_human_input_snapshot_for_response,
 )
-from ouroboros.core.hitl_state import project_human_input_state
+from ouroboros.core.hitl_state import HumanInputState, project_human_input_state
 from ouroboros.events.hitl import create_hitl_answered_event, create_hitl_requested_event
 
 
@@ -116,3 +116,27 @@ def test_human_input_request_from_snapshot_reconstructs_persisted_contract() -> 
     assert reconstructed.risk_class is HumanInputRiskClass.MATERIAL_BRANCH
     assert reconstructed.payload["plan_id"] == "plan-1"
     assert reconstructed.to_event_data()["created_at"] == "2026-05-18T00:00:00+00:00"
+
+
+def test_create_validated_hitl_resume_event_answers_wait_with_malformed_created_at() -> None:
+    base_requested = create_hitl_requested_event(_request())
+    requested = base_requested.model_copy(
+        update={
+            "timestamp": datetime(2026, 5, 19, 12, 30, tzinfo=UTC),
+            "data": {
+                **base_requested.data,
+                "created_at": "not-a-timestamp",
+            },
+        }
+    )
+    snapshot = project_human_input_state([requested])[0]
+
+    assert snapshot.state is HumanInputState.PENDING
+
+    reconstructed = human_input_request_from_snapshot(snapshot)
+    event = create_validated_hitl_resume_event([requested], _approval_response())
+
+    assert reconstructed.created_at == requested.timestamp
+    assert reconstructed.to_event_data()["created_at"] == "2026-05-19T12:30:00+00:00"
+    assert event.type == "hitl.answered"
+    assert event.aggregate_id == "hitl-1"

--- a/tests/unit/core/test_hitl_resume.py
+++ b/tests/unit/core/test_hitl_resume.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ouroboros.core.hitl_contract import (
+    HumanInputKind,
+    HumanInputRequest,
+    HumanInputResponse,
+    HumanInputResponseKind,
+    HumanInputRiskClass,
+    HumanInputSource,
+)
+from ouroboros.core.hitl_resume import (
+    HumanInputResumeValidationError,
+    create_validated_hitl_resume_event,
+    human_input_request_from_snapshot,
+    pending_human_input_snapshot_for_response,
+)
+from ouroboros.core.hitl_state import project_human_input_state
+from ouroboros.events.hitl import create_hitl_answered_event, create_hitl_requested_event
+
+
+def _request() -> HumanInputRequest:
+    return HumanInputRequest(
+        request_id="hitl-1",
+        session_id="session-1",
+        run_id="run-1",
+        invocation_id="invoke-1",
+        created_by="plan",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLAN_APPROVAL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Approve the plan?",
+        resume_target="plan:approval",
+        timeout_seconds=60,
+        payload={"plan_id": "plan-1"},
+        created_at=datetime(2026, 5, 18, tzinfo=UTC),
+    )
+
+
+def _approval_response(**overrides: object) -> HumanInputResponse:
+    kwargs = {
+        "request_id": "hitl-1",
+        "session_id": "session-1",
+        "run_id": "run-1",
+        "invocation_id": "invoke-1",
+        "actor": "local-user",
+        "response_kind": HumanInputResponseKind.APPROVAL,
+        "approval_decision": True,
+    }
+    kwargs.update(overrides)
+    return HumanInputResponse(**kwargs)  # type: ignore[arg-type]
+
+
+def test_create_validated_hitl_resume_event_accepts_pending_matching_response() -> None:
+    requested = create_hitl_requested_event(_request())
+    response = _approval_response()
+
+    event = create_validated_hitl_resume_event([requested], response)
+
+    assert event.type == "hitl.answered"
+    assert event.aggregate_id == "hitl-1"
+    assert event.data["approval_decision"] is True
+
+
+def test_pending_human_input_snapshot_for_response_requires_existing_request() -> None:
+    with pytest.raises(HumanInputResumeValidationError, match="not found"):
+        pending_human_input_snapshot_for_response([], _approval_response())
+
+
+def test_create_validated_hitl_resume_event_rejects_duplicate_answer() -> None:
+    request = _request()
+    requested = create_hitl_requested_event(request)
+    answered = create_hitl_answered_event(request, _approval_response())
+
+    with pytest.raises(HumanInputResumeValidationError, match="not pending"):
+        create_validated_hitl_resume_event([requested, answered], _approval_response())
+
+
+def test_create_validated_hitl_resume_event_rejects_context_mismatch() -> None:
+    requested = create_hitl_requested_event(_request())
+    response = _approval_response(session_id="other-session")
+
+    with pytest.raises(HumanInputResumeValidationError, match="session_id"):
+        create_validated_hitl_resume_event([requested], response)
+
+
+def test_create_validated_hitl_resume_event_rejects_wrong_response_kind() -> None:
+    requested = create_hitl_requested_event(_request())
+    response = HumanInputResponse(
+        request_id="hitl-1",
+        session_id="session-1",
+        actor="local-user",
+        response_kind=HumanInputResponseKind.TEXT,
+        text="approved",
+    )
+
+    with pytest.raises(ValueError, match="approval"):
+        create_validated_hitl_resume_event([requested], response)
+
+
+def test_human_input_request_from_snapshot_reconstructs_persisted_contract() -> None:
+    requested = create_hitl_requested_event(_request())
+    snapshot = project_human_input_state([requested])[0]
+
+    reconstructed = human_input_request_from_snapshot(snapshot)
+
+    assert reconstructed.request_id == "hitl-1"
+    assert reconstructed.session_id == "session-1"
+    assert reconstructed.run_id == "run-1"
+    assert reconstructed.invocation_id == "invoke-1"
+    assert reconstructed.kind is HumanInputKind.APPROVAL
+    assert reconstructed.source is HumanInputSource.PLAN_APPROVAL
+    assert reconstructed.risk_class is HumanInputRiskClass.MATERIAL_BRANCH
+    assert reconstructed.payload["plan_id"] == "plan-1"
+    assert reconstructed.to_event_data()["created_at"] == "2026-05-18T00:00:00+00:00"


### PR DESCRIPTION
## Summary

- Add a pure HITL resume validation helper over replayed `hitl.*` events.
- Reconstruct the originating `HumanInputRequest` from pending HITL state before creating `hitl.answered`.
- Reject missing, terminal/duplicate, wrong-context, and wrong-shape responses before any caller appends a resume event.

## Scope

This is PR 3 of the #960 typed HITL WAIT/RESUME breakdown:

1. typed model — already merged in #971
2. EventStore/RunSnapshot pending state — already merged in #1036/#1060
3. resume response validation — this PR
4. one call-site integration — next PR

## Boundaries

- No EventStore append in this helper.
- No CLI/MCP/UI renderer changes.
- No plugin permission flow changes.
- No runtime dispatch or resume orchestration changes.

## Validation

- `uv run pytest tests/unit/core/test_hitl_resume.py tests/unit/core/test_hitl_state.py tests/unit/events/test_hitl_events.py -q`
- `uv run ruff check src/ouroboros/core/hitl_resume.py tests/unit/core/test_hitl_resume.py`
- `uv run ruff format --check src/ouroboros/core/hitl_resume.py tests/unit/core/test_hitl_resume.py`
- `git diff --check`
- `uv run mypy src/ouroboros/core/hitl_resume.py tests/unit/core/test_hitl_resume.py`

## Not tested

- Live interactive HITL resume flow.

Refs #960
Refs #961
