### PR TITLE
Route cancel confirmation through typed HITL events

### DIFF
--- a/src/ouroboros/cli/commands/cancel.py
+++ b/src/ouroboros/cli/commands/cancel.py
@@ -26,7 +26,11 @@ from ouroboros.core.hitl_contract import (
     HumanInputRiskClass,
     HumanInputSource,
 )
-from ouroboros.events.hitl import create_hitl_answered_event, create_hitl_requested_event
+from ouroboros.events.hitl import (
+    create_hitl_answered_event,
+    create_hitl_cancelled_event,
+    create_hitl_requested_event,
+)
 
 app = typer.Typer(
     name="cancel",
@@ -60,9 +64,22 @@ async def _confirm_cancel_session_with_hitl(
         payload={"session_status": status},
         created_at=requested_at,
     )
-    await event_store.append(create_hitl_requested_event(request))
+    requested_event = create_hitl_requested_event(request)
+    try:
+        approved = typer.confirm(request.question)
+    except (KeyboardInterrupt, EOFError, typer.Abort):
+        await event_store.append_batch(
+            [
+                requested_event,
+                create_hitl_cancelled_event(
+                    request,
+                    reason="Local CLI confirmation prompt aborted",
+                    actor="local-user",
+                ),
+            ]
+        )
+        return False
 
-    approved = typer.confirm(request.question)
     response = HumanInputResponse(
         request_id=request.request_id,
         session_id=session_id,
@@ -73,7 +90,12 @@ async def _confirm_cancel_session_with_hitl(
         surface="cli.cancel.execution",
         received_at=datetime.now(UTC),
     )
-    await event_store.append(create_hitl_answered_event(request, response))
+    await event_store.append_batch(
+        [
+            requested_event,
+            create_hitl_answered_event(request, response),
+        ]
+    )
     return approved
 
 
@@ -299,11 +321,15 @@ async def _interactive_cancel(reason: str) -> None:
         selected = active_sessions[index]
         session_id = selected.session_id
 
-        confirmed = await _confirm_cancel_session_with_hitl(
-            event_store,
-            session_id=session_id,
-            status=selected.status.value,
-        )
+        try:
+            confirmed = await _confirm_cancel_session_with_hitl(
+                event_store,
+                session_id=session_id,
+                status=selected.status.value,
+            )
+        except Exception as exc:
+            print_error(f"Failed to record cancellation confirmation: {exc}")
+            raise typer.Exit(1) from exc
 
         if not confirmed:
             print_info("Cancelled. No executions were modified.")

--- a/src/ouroboros/cli/commands/cancel.py
+++ b/src/ouroboros/cli/commands/cancel.py
@@ -8,20 +8,73 @@ Interacts directly with the EventStore (not via MCP tool).
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 import os
 from typing import Annotated
+from uuid import uuid4
 
 import typer
 
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success, print_warning
 from ouroboros.cli.formatters.tables import create_table, print_table
+from ouroboros.core.hitl_contract import (
+    HumanInputKind,
+    HumanInputRequest,
+    HumanInputResponse,
+    HumanInputResponseKind,
+    HumanInputRiskClass,
+    HumanInputSource,
+)
+from ouroboros.events.hitl import create_hitl_answered_event, create_hitl_requested_event
 
 app = typer.Typer(
     name="cancel",
     help="Cancel stuck or orphaned executions.",
     invoke_without_command=True,
 )
+
+
+async def _confirm_cancel_session_with_hitl(
+    event_store,
+    *,
+    session_id: str,
+    status: str,
+) -> bool:
+    """Ask for cancellation confirmation through the typed HITL contract."""
+
+    requested_at = datetime.now(UTC)
+    request = HumanInputRequest(
+        request_id=f"hitl_cancel_{uuid4().hex[:12]}",
+        session_id=session_id,
+        run_id=session_id,
+        created_by="ouroboros.cancel",
+        kind=HumanInputKind.DESTRUCTIVE_CONFIRMATION,
+        source=HumanInputSource.CONTROL_PLANE,
+        risk_class=HumanInputRiskClass.DESTRUCTIVE,
+        question=f"Cancel session {session_id} ({status})?",
+        resume_target=f"cancel:execution:{session_id}",
+        title="Cancel execution",
+        body="Confirm before cancelling a running or paused execution.",
+        surface="cli.cancel.execution",
+        payload={"session_status": status},
+        created_at=requested_at,
+    )
+    await event_store.append(create_hitl_requested_event(request))
+
+    approved = typer.confirm(request.question)
+    response = HumanInputResponse(
+        request_id=request.request_id,
+        session_id=session_id,
+        run_id=session_id,
+        actor="local-user",
+        response_kind=HumanInputResponseKind.APPROVAL,
+        approval_decision=approved,
+        surface="cli.cancel.execution",
+        received_at=datetime.now(UTC),
+    )
+    await event_store.append(create_hitl_answered_event(request, response))
+    return approved
 
 
 async def _get_event_store():
@@ -246,12 +299,13 @@ async def _interactive_cancel(reason: str) -> None:
         selected = active_sessions[index]
         session_id = selected.session_id
 
-        # Confirm before cancelling
-        confirm = typer.confirm(
-            f"Cancel session {session_id} ({selected.status.value})?",
+        confirmed = await _confirm_cancel_session_with_hitl(
+            event_store,
+            session_id=session_id,
+            status=selected.status.value,
         )
 
-        if not confirm:
+        if not confirmed:
             print_info("Cancelled. No executions were modified.")
             return
 

--- a/tests/unit/cli/test_cancel.py
+++ b/tests/unit/cli/test_cancel.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 import pytest
+import typer
 from typer.testing import CliRunner
 
 from ouroboros.cli.main import app
@@ -136,9 +137,11 @@ class TestBareMode:
 
         assert result.exit_code == 0
         assert "Cancelled" in result.output
-        assert mock_es.append.await_count == 2
-        requested_event = mock_es.append.await_args_list[0].args[0]
-        answered_event = mock_es.append.await_args_list[1].args[0]
+        mock_es.append.assert_not_awaited()
+        mock_es.append_batch.assert_awaited_once()
+        batch = mock_es.append_batch.await_args.args[0]
+        assert len(batch) == 2
+        requested_event, answered_event = batch
         assert requested_event.type == "hitl.requested"
         assert requested_event.data["kind"] == "destructive_confirmation"
         assert requested_event.data["source"] == "control_plane"
@@ -178,11 +181,94 @@ class TestBareMode:
 
         assert result.exit_code == 0
         assert "No executions were modified" in result.output
-        assert mock_es.append.await_count == 2
-        assert mock_es.append.await_args_list[0].args[0].type == "hitl.requested"
-        answered_event = mock_es.append.await_args_list[1].args[0]
+        mock_es.append.assert_not_awaited()
+        mock_es.append_batch.assert_awaited_once()
+        batch = mock_es.append_batch.await_args.args[0]
+        assert len(batch) == 2
+        assert batch[0].type == "hitl.requested"
+        answered_event = batch[1]
         assert answered_event.type == "hitl.answered"
         assert answered_event.data["approval_decision"] is False
+        mock_repo.mark_cancelled.assert_not_called()
+
+    @patch("ouroboros.cli.commands.cancel._get_event_store")
+    def test_bare_mode_prompt_abort_records_hitl_cancelled(self, mock_get_es: AsyncMock) -> None:
+        """Test bare mode: aborted confirmation records a terminal HITL event."""
+        from ouroboros.events.base import BaseEvent
+
+        mock_es = AsyncMock()
+        mock_get_es.return_value = mock_es
+
+        mock_es.get_all_sessions = AsyncMock(
+            return_value=[
+                BaseEvent(
+                    type="orchestrator.session.started",
+                    aggregate_type="session",
+                    aggregate_id="orch_001",
+                    data={},
+                ),
+            ]
+        )
+
+        tracker = _make_tracker(session_id="orch_001", status=SessionStatus.RUNNING)
+
+        with (
+            patch("ouroboros.orchestrator.session.SessionRepository") as MockRepo,
+            patch("ouroboros.cli.commands.cancel.typer.confirm", side_effect=typer.Abort),
+        ):
+            mock_repo = MockRepo.return_value
+            mock_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+
+            result = runner.invoke(app, ["cancel", "execution"], input="1\n")
+
+        assert result.exit_code == 0
+        assert "No executions were modified" in result.output
+        mock_es.append.assert_not_awaited()
+        mock_es.append_batch.assert_awaited_once()
+        batch = mock_es.append_batch.await_args.args[0]
+        assert len(batch) == 2
+        assert batch[0].type == "hitl.requested"
+        assert batch[1].type == "hitl.cancelled"
+        assert batch[1].aggregate_id == batch[0].aggregate_id
+        assert batch[1].data["reason"] == "Local CLI confirmation prompt aborted"
+        mock_repo.mark_cancelled.assert_not_called()
+
+    @patch("ouroboros.cli.commands.cancel._get_event_store")
+    def test_bare_mode_append_batch_failure_does_not_cancel_session(
+        self, mock_get_es: AsyncMock
+    ) -> None:
+        """Test failed HITL persistence cannot leave a partial request or cancel."""
+        from ouroboros.events.base import BaseEvent
+
+        mock_es = AsyncMock()
+        mock_es.append_batch = AsyncMock(side_effect=PersistenceError("batch failed"))
+        mock_get_es.return_value = mock_es
+
+        mock_es.get_all_sessions = AsyncMock(
+            return_value=[
+                BaseEvent(
+                    type="orchestrator.session.started",
+                    aggregate_type="session",
+                    aggregate_id="orch_001",
+                    data={},
+                ),
+            ]
+        )
+
+        tracker = _make_tracker(session_id="orch_001", status=SessionStatus.RUNNING)
+
+        with patch("ouroboros.orchestrator.session.SessionRepository") as MockRepo:
+            mock_repo = MockRepo.return_value
+            mock_repo.reconstruct_session = AsyncMock(return_value=Result.ok(tracker))
+
+            result = runner.invoke(app, ["cancel", "execution"], input="1\ny\n")
+
+        assert result.exit_code == 1
+        assert "Failed to record cancellation confirmation" in result.output
+        mock_es.append.assert_not_awaited()
+        mock_es.append_batch.assert_awaited_once()
+        batch = mock_es.append_batch.await_args.args[0]
+        assert [event.type for event in batch] == ["hitl.requested", "hitl.answered"]
         mock_repo.mark_cancelled.assert_not_called()
 
     @patch("ouroboros.cli.commands.cancel._get_event_store")

--- a/tests/unit/cli/test_cancel.py
+++ b/tests/unit/cli/test_cancel.py
@@ -136,6 +136,17 @@ class TestBareMode:
 
         assert result.exit_code == 0
         assert "Cancelled" in result.output
+        assert mock_es.append.await_count == 2
+        requested_event = mock_es.append.await_args_list[0].args[0]
+        answered_event = mock_es.append.await_args_list[1].args[0]
+        assert requested_event.type == "hitl.requested"
+        assert requested_event.data["kind"] == "destructive_confirmation"
+        assert requested_event.data["source"] == "control_plane"
+        assert requested_event.data["risk_class"] == "destructive"
+        assert requested_event.data["resume_target"] == "cancel:execution:orch_001"
+        assert answered_event.type == "hitl.answered"
+        assert answered_event.aggregate_id == requested_event.aggregate_id
+        assert answered_event.data["approval_decision"] is True
 
     @patch("ouroboros.cli.commands.cancel._get_event_store")
     def test_bare_mode_select_and_decline(self, mock_get_es: AsyncMock) -> None:
@@ -167,6 +178,12 @@ class TestBareMode:
 
         assert result.exit_code == 0
         assert "No executions were modified" in result.output
+        assert mock_es.append.await_count == 2
+        assert mock_es.append.await_args_list[0].args[0].type == "hitl.requested"
+        answered_event = mock_es.append.await_args_list[1].args[0]
+        assert answered_event.type == "hitl.answered"
+        assert answered_event.data["approval_decision"] is False
+        mock_repo.mark_cancelled.assert_not_called()
 
     @patch("ouroboros.cli.commands.cancel._get_event_store")
     def test_bare_mode_invalid_selection(self, mock_get_es: AsyncMock) -> None:


### PR DESCRIPTION
## Summary

- Route the interactive `ouroboros cancel execution` confirmation through typed HITL request/response events.
- Persist `hitl.requested` before prompting and `hitl.answered` after the user approves or declines cancellation.
- Add regression coverage for approved and declined cancellation confirmations.

## Scope

This is PR 4 of the #960 typed HITL WAIT/RESUME breakdown:

1. typed model — already merged in #971
2. EventStore/RunSnapshot pending state — already merged in #1036/#1060
3. resume response validation — #1104
4. one call-site integration — this PR

The chosen call site is intentionally narrow: interactive cancellation already has an initialized EventStore and an explicit user approval prompt.

## Boundaries

- Does not migrate all CLI prompts.
- Does not change direct `cancel execution <id>` headless behavior.
- Does not add plugin permission flow or UI renderer changes.
- Does not change session cancellation semantics after approval.

## Validation

- `uv run pytest tests/unit/cli/test_cancel.py -q`
- `uv run ruff check src/ouroboros/cli/commands/cancel.py tests/unit/cli/test_cancel.py`
- `uv run ruff format --check src/ouroboros/cli/commands/cancel.py tests/unit/cli/test_cancel.py`
- `git diff --check`
- `uv run mypy src/ouroboros/cli/commands/cancel.py tests/unit/cli/test_cancel.py`

## Not tested

- Live CLI cancellation against a real EventStore.

Refs #960
Refs #961
