### PR TITLE
fix(goose): preserve approval for default permission modes

### DIFF
--- a/src/ouroboros/orchestrator/goose_runtime.py
+++ b/src/ouroboros/orchestrator/goose_runtime.py
@@ -110,11 +110,11 @@ class GooseCliRuntime(CodexCliRuntime):
         historically uses Claude/Codex-style names, so map the common values to
         Goose's documented modes while preserving explicit Goose-native values.
         """
-        candidate = (permission_mode or "auto").strip()
+        candidate = (permission_mode or "approve").strip()
         aliases = {
-            "default": "auto",
-            "acceptedits": "auto",
-            "accept_edits": "auto",
+            "default": "approve",
+            "acceptedits": "approve",
+            "accept_edits": "approve",
             "bypasspermissions": "auto",
             "bypass_permissions": "auto",
             "auto": "auto",

--- a/src/ouroboros/providers/goose_cli_adapter.py
+++ b/src/ouroboros/providers/goose_cli_adapter.py
@@ -90,11 +90,11 @@ class GooseCliLLMAdapter(CodexCliLLMAdapter):
 
     def _resolve_permission_mode(self, permission_mode: str | None) -> str:
         """Normalize Goose permission mode values for ``GOOSE_MODE``."""
-        candidate = (permission_mode or "auto").strip()
+        candidate = (permission_mode or "approve").strip()
         aliases = {
-            "default": "auto",
-            "acceptedits": "auto",
-            "accept_edits": "auto",
+            "default": "approve",
+            "acceptedits": "approve",
+            "accept_edits": "approve",
             "bypasspermissions": "auto",
             "bypass_permissions": "auto",
             "auto": "auto",

--- a/tests/unit/orchestrator/test_goose_runtime.py
+++ b/tests/unit/orchestrator/test_goose_runtime.py
@@ -56,6 +56,29 @@ class _FakeProcess:
         return self._returncode
 
 
+def test_goose_default_permission_mode_preserves_approval_gate() -> None:
+    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project")
+
+    assert runtime.permission_mode == "approve"
+    assert runtime._build_child_env()["GOOSE_MODE"] == "approve"
+
+
+@pytest.mark.parametrize("mode", ["default", "acceptEdits", "accept_edits", "acceptedits"])
+def test_goose_safe_permission_aliases_preserve_approval_gate(mode: str) -> None:
+    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode=mode)
+
+    assert runtime.permission_mode == "approve"
+    assert runtime._build_child_env()["GOOSE_MODE"] == "approve"
+
+
+@pytest.mark.parametrize("mode", ["auto", "bypassPermissions", "bypass_permissions"])
+def test_goose_explicit_bypass_permission_aliases_map_to_auto(mode: str) -> None:
+    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode=mode)
+
+    assert runtime.permission_mode == "auto"
+    assert runtime._build_child_env()["GOOSE_MODE"] == "auto"
+
+
 def test_goose_command_uses_run_stream_json_and_stdin() -> None:
     runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project", permission_mode="auto")
 

--- a/tests/unit/providers/test_goose_cli_adapter.py
+++ b/tests/unit/providers/test_goose_cli_adapter.py
@@ -113,6 +113,30 @@ class TestGooseCliLLMAdapter:
         assert "OUROBOROS_LLM_BACKEND" not in env
         assert "OUROBOROS_RUNTIME" not in env
 
+    def test_default_permission_mode_preserves_approval_gate(self) -> None:
+        adapter = GooseCliLLMAdapter(cli_path="/tmp/goose", cwd="/tmp/project")
+
+        assert adapter._permission_mode == "approve"
+        assert adapter._build_env_for_instance()["GOOSE_MODE"] == "approve"
+
+    @pytest.mark.parametrize("mode", ["default", "acceptEdits", "accept_edits", "acceptedits"])
+    def test_safe_permission_aliases_preserve_approval_gate(self, mode: str) -> None:
+        adapter = GooseCliLLMAdapter(
+            cli_path="/tmp/goose", cwd="/tmp/project", permission_mode=mode
+        )
+
+        assert adapter._permission_mode == "approve"
+        assert adapter._build_env_for_instance()["GOOSE_MODE"] == "approve"
+
+    @pytest.mark.parametrize("mode", ["auto", "bypassPermissions", "bypass_permissions"])
+    def test_explicit_bypass_permission_aliases_map_to_auto(self, mode: str) -> None:
+        adapter = GooseCliLLMAdapter(
+            cli_path="/tmp/goose", cwd="/tmp/project", permission_mode=mode
+        )
+
+        assert adapter._permission_mode == "auto"
+        assert adapter._build_env_for_instance()["GOOSE_MODE"] == "auto"
+
     @pytest.mark.asyncio
     async def test_complete_success_from_goose_stream_json(self) -> None:
         adapter = GooseCliLLMAdapter(cli_path="/tmp/goose", cwd="/tmp/project")


### PR DESCRIPTION
## Summary
- Map Goose `default` / `acceptEdits` compatibility modes to `GOOSE_MODE=approve` instead of `auto`.
- Keep explicit `auto` / `bypassPermissions` mappings on `GOOSE_MODE=auto`.
- Add runtime and LLM adapter regressions for default, safe aliases, and explicit bypass aliases.

## Test Plan
- [x] `uv run ruff format src/ouroboros/orchestrator/goose_runtime.py src/ouroboros/providers/goose_cli_adapter.py tests/unit/orchestrator/test_goose_runtime.py tests/unit/providers/test_goose_cli_adapter.py`
- [x] `uv run ruff check src/ouroboros/orchestrator/goose_runtime.py src/ouroboros/providers/goose_cli_adapter.py tests/unit/orchestrator/test_goose_runtime.py tests/unit/providers/test_goose_cli_adapter.py`
- [x] `uv run pytest -q tests/unit/orchestrator/test_goose_runtime.py tests/unit/providers/test_goose_cli_adapter.py`

## Security note
This avoids silently escalating Goose's safe/default Ouroboros permission modes into fully automatic execution. Operators must now opt into Goose `auto` via explicit `auto` or `bypassPermissions`.
