### PR TITLE
refactor(bigbang): add force flag to SeedGenerator.generate to replace FORCED_SCORE_VALUE hack

### DIFF
--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -93,6 +93,8 @@ class SeedGenerator:
         ambiguity_score: AmbiguityScore,
         parent_seed: Seed | None = None,
         reflect_output: Any | None = None,
+        *,
+        force: bool = False,
     ) -> Result[Seed, ValidationError | ProviderError]:
         """Generate an immutable Seed from interview state or reflect output.
 
@@ -101,11 +103,19 @@ class SeedGenerator:
         - Gen 2+ (reflect_output provided): Use refined ACs and ontology mutations
           from ReflectEngine. Skip ambiguity gating.
 
+        When ``force=True``, the ambiguity threshold gate is bypassed but every
+        other validation (initial-context summary, extraction, build) still runs.
+        The real ``ambiguity_score.overall_score`` is recorded in metadata so
+        forced seeds carry truthful provenance.
+
         Args:
             state: Completed interview state.
             ambiguity_score: The ambiguity score for the interview.
             parent_seed: Optional parent seed for evolutionary lineage.
             reflect_output: Optional ReflectOutput for Gen 2+ evolution.
+            force: When True, bypass the ambiguity threshold gate. The real
+                score is still stamped into ``SeedMetadata.ambiguity_score``.
+                Defaults to False (gate enforced).
 
         Returns:
             Result containing the generated Seed or error.
@@ -120,8 +130,15 @@ class SeedGenerator:
             ambiguity_score=ambiguity_score.overall_score,
         )
 
-        # Gate on ambiguity score
-        if not ambiguity_score.is_ready_for_seed:
+        # Gate on ambiguity score (skipped when force=True)
+        if force:
+            log.warning(
+                "seed.generation.ambiguity_gate_bypassed",
+                interview_id=state.interview_id,
+                ambiguity_score=ambiguity_score.overall_score,
+                threshold=AMBIGUITY_THRESHOLD,
+            )
+        elif not ambiguity_score.is_ready_for_seed:
             log.warning(
                 "seed.generation.ambiguity_too_high",
                 interview_id=state.interview_id,

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -430,20 +430,11 @@ async def _generate_seed_from_interview(
             llm_adapter=llm_adapter,
             model=get_clarification_model(llm_backend),
         )
-        # For forced generation, we need to bypass the threshold check
-        if ambiguity_score.is_ready_for_seed:
-            seed_result = await generator.generate(state, ambiguity_score)
-        else:
-            # TODO: Add force=True parameter to SeedGenerator.generate() instead of this hack
-            # Creating a modified score to bypass threshold check
-            from ouroboros.bigbang.ambiguity import AmbiguityScore as AmbScore
-
-            FORCED_SCORE_VALUE = 0.19  # Just under threshold (0.2)
-            forced_score = AmbScore(
-                overall_score=FORCED_SCORE_VALUE,
-                breakdown=ambiguity_score.breakdown,
-            )
-            seed_result = await generator.generate(state, forced_score)
+        seed_result = await generator.generate(
+            state,
+            ambiguity_score,
+            force=not ambiguity_score.is_ready_for_seed,
+        )
 
     if seed_result.is_err:
         error = seed_result.error

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -300,6 +300,124 @@ class TestSeedGeneratorAmbiguityGating:
         assert "summary required" in result.error.message
         mock_adapter.complete.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_generate_with_force_bypasses_gate_at_high_score(self) -> None:
+        """force=True bypasses the ambiguity gate even at scores far above threshold."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        high_ambiguity = create_high_ambiguity_score(0.5)
+
+        extraction_response = create_valid_extraction_response()
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(extraction_response))
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, high_ambiguity, force=True)
+
+            assert result.is_ok
+            assert isinstance(result.value, Seed)
+            # Provenance: forced seeds carry the real (high) score, not a fabricated one.
+            assert result.value.metadata.ambiguity_score == 0.5
+
+    @pytest.mark.asyncio
+    async def test_generate_with_force_bypasses_just_above_threshold(self) -> None:
+        """force=True succeeds at the boundary just above the gate (score=0.21)."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        boundary = create_high_ambiguity_score(AMBIGUITY_THRESHOLD + 0.01)
+
+        extraction_response = create_valid_extraction_response()
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(extraction_response))
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, boundary, force=True)
+
+            assert result.is_ok
+
+    @pytest.mark.asyncio
+    async def test_generate_without_force_still_fails_above_threshold(self) -> None:
+        """Default force=False preserves existing failure when score > threshold."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        above_threshold = create_high_ambiguity_score(AMBIGUITY_THRESHOLD + 0.01)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, above_threshold)
+
+            assert result.is_err
+            assert isinstance(result.error, ValidationError)
+            assert "exceeds threshold" in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_generate_with_force_logs_bypass_warning(self) -> None:
+        """force=True emits a structured warning so bypass is auditable."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        high_ambiguity = create_high_ambiguity_score(0.5)
+
+        extraction_response = create_valid_extraction_response()
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(extraction_response))
+        )
+
+        from unittest.mock import patch
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            with patch("ouroboros.bigbang.seed_generator.log.warning") as mock_warning:
+                result = await generator.generate(state, high_ambiguity, force=True)
+
+            assert result.is_ok
+            bypass_calls = [
+                call
+                for call in mock_warning.call_args_list
+                if call.args and call.args[0] == "seed.generation.ambiguity_gate_bypassed"
+            ]
+            assert len(bypass_calls) == 1
+            assert bypass_calls[0].kwargs["ambiguity_score"] == 0.5
+            assert bypass_calls[0].kwargs["threshold"] == AMBIGUITY_THRESHOLD
+
+    @pytest.mark.asyncio
+    async def test_generate_with_force_still_requires_initial_context_summary(
+        self,
+    ) -> None:
+        """force=True only bypasses the ambiguity gate, not the summary check."""
+        mock_adapter = AsyncMock()
+        state = InterviewState(
+            interview_id="test_force_with_long_context",
+            initial_context=("A" * 4_000) + "TAIL_MARKER",
+        )
+        high_ambiguity = create_high_ambiguity_score(0.5)
+        generator = SeedGenerator(llm_adapter=mock_adapter)
+
+        result = await generator.generate(state, high_ambiguity, force=True)
+
+        assert result.is_err
+        assert isinstance(result.error, ValidationError)
+        assert "summary required" in result.error.message
+
 
 class TestSeedGeneratorExtraction:
     """Test SeedGenerator requirement extraction."""

--- a/tests/unit/cli/test_init_runtime.py
+++ b/tests/unit/cli/test_init_runtime.py
@@ -205,3 +205,62 @@ class TestInitWorkflowRuntimeHandoff:
         error_text = mock_print_error.call_args.args[0]
         assert "configured_cli_path" in error_text
         assert "/Applications/cmux.app/Contents/Resources/bin/claude" in error_text
+
+    @pytest.mark.asyncio
+    async def test_seed_generation_forces_when_ambiguity_above_threshold(self) -> None:
+        """When the user picks 'generate anyway' on a high-ambiguity interview,
+        the CLI passes force=True to SeedGenerator.generate() instead of fabricating
+        a fake AmbiguityScore."""
+        state = InterviewState(
+            interview_id="interview_force_path",
+            initial_context="Build something",
+        )
+        llm_adapter = MagicMock()
+        high_ambiguity = AmbiguityScore(
+            overall_score=0.45,
+            breakdown=ScoreBreakdown(
+                goal_clarity=ComponentScore(
+                    name="Goal",
+                    clarity_score=0.5,
+                    weight=0.4,
+                    justification="unclear",
+                ),
+                constraint_clarity=ComponentScore(
+                    name="Constraints",
+                    clarity_score=0.5,
+                    weight=0.3,
+                    justification="unclear",
+                ),
+                success_criteria_clarity=ComponentScore(
+                    name="Success",
+                    clarity_score=0.5,
+                    weight=0.3,
+                    justification="unclear",
+                ),
+            ),
+        )
+
+        mock_scorer = MagicMock()
+        mock_scorer.score = AsyncMock(return_value=Result.ok(high_ambiguity))
+
+        mock_seed = MagicMock()
+        mock_seed.metadata.seed_id = "seed_force_path"
+        mock_generator = MagicMock()
+        mock_generator.generate = AsyncMock(return_value=Result.ok(mock_seed))
+        mock_generator.save_seed = AsyncMock(return_value=Result.ok(Path("/tmp/seed.yaml")))
+
+        with (
+            patch("ouroboros.cli.commands.init.AmbiguityScorer", return_value=mock_scorer),
+            patch("ouroboros.cli.commands.init.SeedGenerator", return_value=mock_generator),
+            patch("ouroboros.cli.commands.init.Prompt.ask", return_value="2"),
+        ):
+            seed_path, result = await _generate_seed_from_interview(state, llm_adapter)
+
+        assert result == SeedGenerationResult.SUCCESS
+        assert seed_path is not None
+        # The replacement for the FORCED_SCORE_VALUE hack: real score is preserved,
+        # force=True is passed as an explicit keyword argument.
+        call_kwargs = mock_generator.generate.call_args.kwargs
+        assert call_kwargs.get("force") is True
+        passed_score = mock_generator.generate.call_args.args[1]
+        assert passed_score.overall_score == 0.45


### PR DESCRIPTION
## Summary

- Add a keyword-only `force: bool = False` parameter to `SeedGenerator.generate()` that bypasses the ambiguity threshold gate when explicitly requested.
- Replace the `FORCED_SCORE_VALUE = 0.19` workaround in `src/ouroboros/cli/commands/init.py:433-446` with a single `await generator.generate(state, ambiguity_score, force=not ambiguity_score.is_ready_for_seed)` call.
- Resolves the inline `# TODO: Add force=True parameter to SeedGenerator.generate() instead of this hack` at `src/ouroboros/cli/commands/init.py:437`.

## Why

When the user picks "Generate Seed anyway (force)" on a high-ambiguity interview, `init.py` currently fabricates an `AmbiguityScore(overall_score=0.19, ...)` to slip under the 0.2 threshold check. That value is then persisted into `SeedMetadata.ambiguity_score`, so forced seeds carry an incorrect score in their permanent metadata. The inline TODO at `init.py:437` already prescribes this exact fix. With a proper `force` flag the original score (e.g., 0.45) is preserved in metadata while the gate is honestly bypassed.

## Behaviour preservation

- Default `force=False` keeps the contract identical for both non-forcing callers:
  - `src/ouroboros/mcp/tools/authoring_handlers.py:918` — unchanged, still gated.
  - The `init.py` happy path (score already below threshold) — unchanged, still gated.
- `force=True` only skips the ambiguity gate. The `initial_context_summary_missing` check still runs, the extraction step still runs, and the build/save path is unchanged.
- A `log.warning("seed.generation.ambiguity_gate_bypassed", ...)` is emitted on every forced run so the bypass is auditable.
- `SeedMetadata.ambiguity_score` now records the **real** score (e.g., 0.45) for forced seeds; previously it was always stamped with the fabricated 0.19.

## Test plan

Five new tests appended to `TestSeedGeneratorAmbiguityGating` in `tests/unit/bigbang/test_seed_generator.py`:

- `test_generate_with_force_bypasses_gate_at_high_score` — force=True succeeds at 0.5; metadata records 0.5.
- `test_generate_with_force_bypasses_just_above_threshold` — boundary case at threshold + 0.01.
- `test_generate_without_force_still_fails_above_threshold` — regression guard for the default path.
- `test_generate_with_force_logs_bypass_warning` — confirms structured warning is emitted.
- `test_generate_with_force_still_requires_initial_context_summary` — confirms force only bypasses ambiguity, not other validations.

One CLI integration test added to `tests/unit/cli/test_init_runtime.py`:

- `test_seed_generation_forces_when_ambiguity_above_threshold` — high-ambiguity interview, user picks "2", asserts `force=True` is passed and the real score (0.45) is preserved.

The existing six gating tests (lines 182/202/226/243/265/282) and all other `test_seed_generator.py` cases pass unmodified — they call `generate()` positionally and rely on the new `force=False` default.

## Out of scope

- Exposing the `force` flag through the MCP `ouroboros_generate_seed` tool (`authoring_handlers.py:918`) — natural follow-up, deliberately deferred.
- Adding a `force_generated: bool` field to `SeedMetadata` — would require a schema-version bump for `core/seed.py`. The structured `ambiguity_gate_bypassed` warning plus the truthful score in metadata already provide forensic signal.
- No `docs/` changes — the previous `FORCED_SCORE_VALUE` workaround was never documented (`grep -rn "FORCED_SCORE_VALUE\|force.*generate.*Seed" docs/` returns zero hits), so there is nothing to amend.

## Validation

```
$ uv run ruff check src/ tests/                                          # All checks passed!
$ uv run ruff format --check src/ tests/                                 # 826 files already formatted
$ uv run mypy src/ouroboros                                              # Success: no issues found in 365 source files
$ python3 scripts/check-auto-boundary.py                                 # ooo-auto-boundary: OK (27 files scanned, 0 findings)
$ uv run pytest tests/unit/bigbang/test_seed_generator.py \
                tests/unit/cli/test_init_runtime.py                      # 47 passed in 1.19s
$ uv run ouroboros --help && uv run ouroboros init --help                # both load cleanly
```

Diff: `+201 / -16` across 4 files (2 source, 2 test).
