### PR TITLE
feat(plugin): add hook runtime audit schema names

### DIFF
--- a/src/ouroboros/plugin/hooks.py
+++ b/src/ouroboros/plugin/hooks.py
@@ -17,10 +17,10 @@ What this module owns:
 * :class:`HookFailurePolicy` — the v1 failure policies (``fail_open``
   / ``fail_closed``).
 * :data:`HOOK_OUTCOME_AUDIT_EVENTS` — the v1 hook outcome event names
-  currently vendored in the manifest/audit schemas
-  (``plugin.hook.blocked`` / ``plugin.hook.failed``). These are not the
-  full future hook telemetry set; successful hook start/completion
-  events remain deferred until their schema/runtime slice lands.
+  currently vendored in the manifest schemas
+  (``plugin.hook.blocked`` / ``plugin.hook.failed``). The v0.3 audit-event
+  schema also vendors the successful hook start/completion names for forward
+  compatibility, but runtime emission of those events remains deferred.
 * :func:`is_v1_hook_kind` / :func:`is_v1_failure_policy` — helpers
   consumed by manifest validators in follow-up PRs. They live here so
   the contract is the single source of truth.
@@ -130,16 +130,16 @@ class HookFailurePolicy(StrEnum):
 
 
 #: V1 hook outcome event names currently vendored in the
-#: manifest/audit schemas. These are exported as constants so manifest
+#: manifest schemas. These are exported as constants so manifest
 #: validators and audit consumers reference the same string set the
 #: wrapper will emit for hook block/failure outcomes when dispatch
 #: lands in a follow-up PR.
 #:
 #: This is deliberately narrower than the full future hook telemetry
-#: vocabulary in ``docs/rfc/userlevel-plugins.md``. Successful
-#: ``plugin.hook.invoked`` / ``plugin.hook.completed`` emission remains
-#: deferred until the upstream audit schema and core runtime wiring both
-#: support those events.
+#: vocabulary in ``docs/rfc/userlevel-plugins.md``. The v0.3 audit-event
+#: schema vendors ``plugin.hook.invoked`` / ``plugin.hook.completed`` for
+#: forward compatibility, but core runtime emission remains deferred until
+#: dispatch wiring lands.
 HOOK_INVOKED_EVENT: Final[str] = "plugin.hook.invoked"
 HOOK_COMPLETED_EVENT: Final[str] = "plugin.hook.completed"
 HOOK_BLOCKED_EVENT: Final[str] = "plugin.hook.blocked"

--- a/src/ouroboros/plugin/hooks.py
+++ b/src/ouroboros/plugin/hooks.py
@@ -140,11 +140,17 @@ class HookFailurePolicy(StrEnum):
 #: ``plugin.hook.invoked`` / ``plugin.hook.completed`` emission remains
 #: deferred until the upstream audit schema and core runtime wiring both
 #: support those events.
+HOOK_INVOKED_EVENT: Final[str] = "plugin.hook.invoked"
+HOOK_COMPLETED_EVENT: Final[str] = "plugin.hook.completed"
 HOOK_BLOCKED_EVENT: Final[str] = "plugin.hook.blocked"
 HOOK_FAILED_EVENT: Final[str] = "plugin.hook.failed"
+HOOK_RUNTIME_AUDIT_EVENTS: Final[frozenset[str]] = frozenset(
+    {HOOK_INVOKED_EVENT, HOOK_COMPLETED_EVENT}
+)
 HOOK_OUTCOME_AUDIT_EVENTS: Final[frozenset[str]] = frozenset(
     {HOOK_BLOCKED_EVENT, HOOK_FAILED_EVENT}
 )
+HOOK_EVENT_TYPES: Final[frozenset[str]] = HOOK_RUNTIME_AUDIT_EVENTS | HOOK_OUTCOME_AUDIT_EVENTS
 
 #: Backward-compatible alias for the original #984 export. Prefer
 #: :data:`HOOK_OUTCOME_AUDIT_EVENTS` in new call sites so the name does
@@ -208,10 +214,14 @@ def is_hook_lifecycle_scope(value: str) -> bool:
 __all__ = [
     "HOOK_AUDIT_EVENTS",
     "HOOK_BLOCKED_EVENT",
+    "HOOK_COMPLETED_EVENT",
+    "HOOK_EVENT_TYPES",
     "HOOK_FAILED_EVENT",
+    "HOOK_INVOKED_EVENT",
     "HOOK_LIFECYCLE_READ_SCOPE",
     "HOOK_LIFECYCLE_SCOPES",
     "HOOK_OUTCOME_AUDIT_EVENTS",
+    "HOOK_RUNTIME_AUDIT_EVENTS",
     "DeferredHookKind",
     "ExcludedHookKind",
     "HookFailurePolicy",

--- a/src/ouroboros/plugin/ledger_adapter.py
+++ b/src/ouroboros/plugin/ledger_adapter.py
@@ -1,10 +1,13 @@
 """Adapter from firewall audit events to the core event store.
 
-The firewall (`plugin/firewall.py`) emits events that conform to
-`schemas/0.1/audit-event.schema.json`. Those events have
-`additionalProperties: false`, so any wrapping fields the core ledger
-needs (`id`, `aggregate_type`, `aggregate_id`, `timestamp`) MUST live
-in a layer ABOVE the audit-event boundary, not inside it.
+The firewall (`plugin/firewall.py`) emits current-runtime plugin audit
+events that conform to `schemas/0.1/audit-event.schema.json`. Newer
+schema versions may vendor forward-compatible event names before the
+runtime emits them; this adapter still treats the audit event as an
+opaque payload whose schema boundary has `additionalProperties: false`.
+Any wrapping fields the core ledger needs (`id`, `aggregate_type`,
+`aggregate_id`, `timestamp`) MUST live in a layer ABOVE the audit-event
+boundary, not inside it.
 
 This adapter:
 
@@ -63,10 +66,10 @@ def wrap_plugin_event(
     """Wrap a plugin audit event in a core-ledger row envelope.
 
     Args:
-        audit_event: A dict matching schemas/0.1/audit-event.schema.json.
-            This becomes the `payload` field verbatim — the schema's
-            `additionalProperties: false` is preserved by NOT mutating
-            the event in place.
+        audit_event: A dict matching the plugin audit-event schema version
+            used by the caller. This becomes the `payload` field verbatim —
+            the schema's `additionalProperties: false` is preserved by NOT
+            mutating the event in place.
         correlation_id: Cross-event correlation id (from the firewall).
             Used as the default `aggregate_id`.
         aggregate_id: Override for the aggregate id. Defaults to

--- a/src/ouroboros/plugin/ledger_adapter.py
+++ b/src/ouroboros/plugin/ledger_adapter.py
@@ -36,14 +36,12 @@ from collections.abc import Callable
 import copy
 import uuid
 
-from ouroboros.plugin.hooks import HOOK_EVENT_TYPES
-
 PLUGIN_AGGREGATE_TYPE = "plugin"
 
-# Plugin audit event types accepted by the current core ledger adapter.
-# Runtime hook dispatch remains a separate #939 follow-up; these hook event
-# names are schema-vendored here so future dispatch does not invent audit
-# vocabulary at emission time.
+# Plugin audit event types accepted by the current core ledger adapter and
+# emitted by current runtime/plugin-manager paths. Future hook lifecycle event
+# names may be vendored in newer audit-event schemas before runtime dispatch
+# lands, but they are intentionally not part of this current-runtime vocabulary.
 AUDIT_EVENT_TYPES: tuple[str, ...] = (
     "plugin.discovered",
     "plugin.installed",
@@ -52,7 +50,6 @@ AUDIT_EVENT_TYPES: tuple[str, ...] = (
     "plugin.permission_used",
     "plugin.completed",
     "plugin.failed",
-    *tuple(sorted(HOOK_EVENT_TYPES)),
 )
 
 

--- a/src/ouroboros/plugin/ledger_adapter.py
+++ b/src/ouroboros/plugin/ledger_adapter.py
@@ -36,13 +36,14 @@ from collections.abc import Callable
 import copy
 import uuid
 
+from ouroboros.plugin.hooks import HOOK_EVENT_TYPES
+
 PLUGIN_AGGREGATE_TYPE = "plugin"
 
-# Plugin audit event types currently emitted by the v0.1 runtime.
-# Hook and permission-denial-specific event names are intentionally not
-# part of this manifest/audit vocabulary until the runtime emits them;
-# permission denials are represented as plugin.failed with
-# result.status == "blocked".
+# Plugin audit event types accepted by the current core ledger adapter.
+# Runtime hook dispatch remains a separate #939 follow-up; these hook event
+# names are schema-vendored here so future dispatch does not invent audit
+# vocabulary at emission time.
 AUDIT_EVENT_TYPES: tuple[str, ...] = (
     "plugin.discovered",
     "plugin.installed",
@@ -51,6 +52,7 @@ AUDIT_EVENT_TYPES: tuple[str, ...] = (
     "plugin.permission_used",
     "plugin.completed",
     "plugin.failed",
+    *tuple(sorted(HOOK_EVENT_TYPES)),
 )
 
 

--- a/src/ouroboros/plugin/schemas/0.3/_source.json
+++ b/src/ouroboros/plugin/schemas/0.3/_source.json
@@ -7,7 +7,7 @@
       "Bumped $id/title/schema_version const from 0.2 to 0.3.",
       "Narrowed hooks[].name enum to the v1 HookKind set: 'before_invocation' and 'after_invocation'. Deferred candidates (before_tool_call, after_tool_call, before_artifact_write, after_artifact_write, on_error, on_cancel) and excluded candidates (before_runtime_start, after_runtime_start, before_state_commit, after_state_commit, on_event, on_rewind) are no longer accepted at the schema layer; refer to src/ouroboros/plugin/hooks.py for the routing helpers and follow-up RFC slices.",
       "Requires hooks[].permissions and requires that array to contain plugin:lifecycle:read so archived v0.3 JSON Schema and Python loader enforce the same lifecycle permission boundary.",
-      "Allows plugin.hook.blocked / plugin.hook.failed in explicit audit.events declarations while preserving the four-event default used by the Python manifest loader until runtime hook dispatch lands."
+      "Allows the v0.3 hook audit-event vocabulary (plugin.hook.invoked, plugin.hook.completed, plugin.hook.blocked, plugin.hook.failed) in explicit audit.events declarations while preserving the four-event default used by the Python manifest loader until runtime hook dispatch lands."
     ],
     "audit-event.schema.json": [
       "Vendored audit-event.schema.json with local 0.3 $id/title/schema_version alignment and added plugin.hook.blocked / plugin.hook.failed to match the v1 hook wrapper event constants.",

--- a/src/ouroboros/plugin/schemas/0.3/_source.json
+++ b/src/ouroboros/plugin/schemas/0.3/_source.json
@@ -10,7 +10,8 @@
       "Allows plugin.hook.blocked / plugin.hook.failed in explicit audit.events declarations while preserving the four-event default used by the Python manifest loader until runtime hook dispatch lands."
     ],
     "audit-event.schema.json": [
-      "Vendored audit-event.schema.json with local 0.3 $id/title/schema_version alignment and added plugin.hook.blocked / plugin.hook.failed to match the v1 hook wrapper event constants."
+      "Vendored audit-event.schema.json with local 0.3 $id/title/schema_version alignment and added plugin.hook.blocked / plugin.hook.failed to match the v1 hook wrapper event constants.",
+      "Added plugin.hook.invoked / plugin.hook.completed as schema-vendored runtime event names for future v1 lifecycle dispatch without enabling runtime hook execution."
     ]
   }
 }

--- a/src/ouroboros/plugin/schemas/0.3/audit-event.schema.json
+++ b/src/ouroboros/plugin/schemas/0.3/audit-event.schema.json
@@ -30,6 +30,8 @@
         "plugin.permission_used",
         "plugin.completed",
         "plugin.failed",
+        "plugin.hook.invoked",
+        "plugin.hook.completed",
         "plugin.hook.blocked",
         "plugin.hook.failed"
       ]

--- a/src/ouroboros/plugin/schemas/0.3/plugin.schema.json
+++ b/src/ouroboros/plugin/schemas/0.3/plugin.schema.json
@@ -226,6 +226,8 @@
               "plugin.permission_used",
               "plugin.completed",
               "plugin.failed",
+              "plugin.hook.invoked",
+              "plugin.hook.completed",
               "plugin.hook.blocked",
               "plugin.hook.failed"
             ]

--- a/tests/unit/plugin/test_hooks_contract.py
+++ b/tests/unit/plugin/test_hooks_contract.py
@@ -19,8 +19,12 @@ from __future__ import annotations
 from ouroboros.plugin.hooks import (
     HOOK_AUDIT_EVENTS,
     HOOK_BLOCKED_EVENT,
+    HOOK_COMPLETED_EVENT,
+    HOOK_EVENT_TYPES,
     HOOK_FAILED_EVENT,
+    HOOK_INVOKED_EVENT,
     HOOK_OUTCOME_AUDIT_EVENTS,
+    HOOK_RUNTIME_AUDIT_EVENTS,
     DeferredHookKind,
     ExcludedHookKind,
     HookFailurePolicy,
@@ -124,3 +128,11 @@ class TestRoutingHelpers:
         assert not is_v1_hook_kind(unknown)
         assert not is_deferred_hook_kind(unknown)
         assert not is_excluded_hook_kind(unknown)
+
+
+def test_hook_runtime_audit_event_contract_includes_invoked_and_completed() -> None:
+    assert HOOK_INVOKED_EVENT == "plugin.hook.invoked"
+    assert HOOK_COMPLETED_EVENT == "plugin.hook.completed"
+    assert frozenset({"plugin.hook.invoked", "plugin.hook.completed"}) == HOOK_RUNTIME_AUDIT_EVENTS
+    assert HOOK_RUNTIME_AUDIT_EVENTS <= HOOK_EVENT_TYPES
+    assert HOOK_OUTCOME_AUDIT_EVENTS <= HOOK_EVENT_TYPES

--- a/tests/unit/plugin/test_ledger_adapter.py
+++ b/tests/unit/plugin/test_ledger_adapter.py
@@ -22,12 +22,17 @@ SCHEMA_PATH = Path(__file__).resolve().parents[3] / (
 )
 AUDIT_SCHEMA = json.loads(SCHEMA_PATH.read_text())
 AUDIT_VALIDATOR = Draft202012Validator(AUDIT_SCHEMA)
+SCHEMA_0_3_PATH = Path(__file__).resolve().parents[3] / (
+    "src/ouroboros/plugin/schemas/0.3/audit-event.schema.json"
+)
+AUDIT_SCHEMA_0_3 = json.loads(SCHEMA_0_3_PATH.read_text())
+AUDIT_VALIDATOR_0_3 = Draft202012Validator(AUDIT_SCHEMA_0_3)
 
 
-def _audit_event(event_type: str, **overrides) -> dict:
-    """Build an audit event matching schemas/0.1/audit-event.schema.json."""
+def _audit_event(event_type: str, *, schema_version: str = "0.1", **overrides) -> dict:
+    """Build an audit event matching the requested audit-event schema."""
     base = {
-        "schema_version": "0.1",
+        "schema_version": schema_version,
         "event_type": event_type,
         "occurred_at": "2026-05-07T12:00:00Z",
         "plugin": {
@@ -43,7 +48,8 @@ def _audit_event(event_type: str, **overrides) -> dict:
     }
     base.update(overrides)
     # Confirm the test fixture itself validates against the schema.
-    errs = list(AUDIT_VALIDATOR.iter_errors(base))
+    validator = AUDIT_VALIDATOR_0_3 if schema_version == "0.3" else AUDIT_VALIDATOR
+    errs = list(validator.iter_errors(base))
     assert not errs, f"test fixture invalid: {errs}"
     return base
 
@@ -137,7 +143,7 @@ def test_unwrap_returns_audit_event() -> None:
     assert unwrapped == ev
 
 
-def test_audit_event_types_match_current_v0_runtime_vocabulary() -> None:
+def test_audit_event_types_include_schema_vendored_hook_events() -> None:
     assert AUDIT_EVENT_TYPES == (
         "plugin.discovered",
         "plugin.installed",
@@ -146,14 +152,30 @@ def test_audit_event_types_match_current_v0_runtime_vocabulary() -> None:
         "plugin.permission_used",
         "plugin.completed",
         "plugin.failed",
+        "plugin.hook.blocked",
+        "plugin.hook.completed",
+        "plugin.hook.failed",
+        "plugin.hook.invoked",
     )
-    assert tuple(AUDIT_SCHEMA["properties"]["event_type"]["enum"]) == AUDIT_EVENT_TYPES
+    assert tuple(AUDIT_SCHEMA["properties"]["event_type"]["enum"]) == AUDIT_EVENT_TYPES[:7]
+    assert set(AUDIT_EVENT_TYPES) == set(AUDIT_SCHEMA_0_3["properties"]["event_type"]["enum"])
+
+
+def test_v0_3_hook_invoked_and_completed_round_trip() -> None:
+    for event_type in ("plugin.hook.invoked", "plugin.hook.completed"):
+        ev = _audit_event(event_type, schema_version="0.3")
+        env = wrap_plugin_event(ev, correlation_id=f"corr-{event_type}")
+        assert env["event_type"] == event_type
+        recovered = unwrap_plugin_event(env)
+        assert recovered == ev
+        assert not list(AUDIT_VALIDATOR_0_3.iter_errors(recovered))
 
 
 def test_round_trip_for_all_audit_event_types() -> None:
     """Round-trip every event type defined in the schema."""
     for event_type in AUDIT_EVENT_TYPES:
-        ev = _audit_event(event_type)
+        schema_version = "0.3" if event_type.startswith("plugin.hook.") else "0.1"
+        ev = _audit_event(event_type, schema_version=schema_version)
         env = wrap_plugin_event(ev, correlation_id=f"corr-{event_type}")
         recovered = unwrap_plugin_event(env)
         assert recovered == ev, f"{event_type} did not round-trip"
@@ -254,7 +276,8 @@ def test_envelope_event_type_matches_payload_event_type() -> None:
     (so the events_table.event_type column is queryable without parsing
     the JSON payload)."""
     for event_type in AUDIT_EVENT_TYPES:
-        ev = _audit_event(event_type)
+        schema_version = "0.3" if event_type.startswith("plugin.hook.") else "0.1"
+        ev = _audit_event(event_type, schema_version=schema_version)
         env = wrap_plugin_event(ev, correlation_id="x")
         assert env["event_type"] == env["payload"]["event_type"] == event_type
 

--- a/tests/unit/plugin/test_ledger_adapter.py
+++ b/tests/unit/plugin/test_ledger_adapter.py
@@ -143,7 +143,7 @@ def test_unwrap_returns_audit_event() -> None:
     assert unwrapped == ev
 
 
-def test_audit_event_types_include_schema_vendored_hook_events() -> None:
+def test_audit_event_types_include_current_runtime_events_only() -> None:
     assert AUDIT_EVENT_TYPES == (
         "plugin.discovered",
         "plugin.installed",
@@ -152,23 +152,16 @@ def test_audit_event_types_include_schema_vendored_hook_events() -> None:
         "plugin.permission_used",
         "plugin.completed",
         "plugin.failed",
-        "plugin.hook.blocked",
-        "plugin.hook.completed",
-        "plugin.hook.failed",
-        "plugin.hook.invoked",
     )
-    assert tuple(AUDIT_SCHEMA["properties"]["event_type"]["enum"]) == AUDIT_EVENT_TYPES[:7]
-    assert set(AUDIT_EVENT_TYPES) == set(AUDIT_SCHEMA_0_3["properties"]["event_type"]["enum"])
+    assert tuple(AUDIT_SCHEMA["properties"]["event_type"]["enum"]) == AUDIT_EVENT_TYPES
+    assert set(AUDIT_EVENT_TYPES) < set(AUDIT_SCHEMA_0_3["properties"]["event_type"]["enum"])
 
 
-def test_v0_3_hook_invoked_and_completed_round_trip() -> None:
+def test_v0_3_schema_accepts_future_hook_runtime_events() -> None:
     for event_type in ("plugin.hook.invoked", "plugin.hook.completed"):
         ev = _audit_event(event_type, schema_version="0.3")
-        env = wrap_plugin_event(ev, correlation_id=f"corr-{event_type}")
-        assert env["event_type"] == event_type
-        recovered = unwrap_plugin_event(env)
-        assert recovered == ev
-        assert not list(AUDIT_VALIDATOR_0_3.iter_errors(recovered))
+        assert event_type not in AUDIT_EVENT_TYPES
+        assert not list(AUDIT_VALIDATOR_0_3.iter_errors(ev))
 
 
 def test_round_trip_for_all_audit_event_types() -> None:

--- a/tests/unit/plugin/test_manifest_schema_0_3.py
+++ b/tests/unit/plugin/test_manifest_schema_0_3.py
@@ -207,8 +207,20 @@ class TestV03HookAuditEvents:
             "plugin.failed",
         )
 
-    def test_manifest_audit_events_accept_hook_wrapper_events(self, tmp_path: Path) -> None:
+    def test_manifest_audit_events_accept_hook_schema_vendored_events(self, tmp_path: Path) -> None:
         payload = _v03_manifest()
-        payload["audit"] = {"events": ["plugin.hook.blocked", "plugin.hook.failed"]}
+        payload["audit"] = {
+            "events": [
+                "plugin.hook.invoked",
+                "plugin.hook.completed",
+                "plugin.hook.blocked",
+                "plugin.hook.failed",
+            ]
+        }
         manifest = load_manifest(_write(tmp_path, payload))
-        assert manifest.audit.events == ("plugin.hook.blocked", "plugin.hook.failed")
+        assert manifest.audit.events == (
+            "plugin.hook.invoked",
+            "plugin.hook.completed",
+            "plugin.hook.blocked",
+            "plugin.hook.failed",
+        )


### PR DESCRIPTION
## Summary
- Add schema-vendored  and  event names for v0.3 plugin audit events.
- Expose runtime hook audit constants separately from outcome events.
- Keep hook dispatch out of this slice so #939 can review the audit vocabulary before runtime wiring.

Refs #939
Refs #961

## Scope
- Contract/schema only.
- No runtime hook dispatch.
- No deferred hooks.
- No plugin permission runtime emission changes.

## Test Plan
- ..................................                                       [100%]
34 passed in 0.28s
- All checks passed!
- Success: no issues found in 2 source files