### PR TITLE
fix(runtime): surface malformed tool-use turns

### DIFF
--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -50,6 +50,7 @@ from ouroboros.providers.base import (
     UsageInfo,
 )
 from ouroboros.providers.profiles import resolve_completion_profile_result
+from ouroboros.providers.tool_use_diagnostics import diagnose_tool_use_turn
 
 log = structlog.get_logger(__name__)
 
@@ -921,6 +922,26 @@ class ClaudeCodeAdapter:
                     session_id = msg_data.get("session_id")
 
                 elif class_name == "AssistantMessage":
+                    diagnostic = diagnose_tool_use_turn(sdk_message, provider="claude_code")
+                    if diagnostic.is_malformed:
+                        error_result = ProviderError(
+                            message=diagnostic.reason,
+                            details={
+                                **diagnostic.to_dict(),
+                                "session_id": session_id,
+                                "error_type": "MalformedToolUseTurn",
+                                "max_turns": options_kwargs["max_turns"],
+                                "cwd": self._cwd,
+                            },
+                        )
+                        log.warning(
+                            "claude_code_adapter.malformed_tool_use_turn",
+                            session_id=session_id,
+                            retryable=diagnostic.retryable,
+                            stop_reason=diagnostic.stop_reason,
+                            tool_use_count=diagnostic.tool_use_count,
+                        )
+                        continue
                     # Extract text content and tool use
                     content_blocks = getattr(sdk_message, "content", [])
                     for block in content_blocks:

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -899,6 +899,12 @@ class ClaudeCodeAdapter:
         finish_reason = "stop"
         raw_response: dict[str, object] = {"session_id": None}
 
+        def _has_malformed_tool_use_error() -> bool:
+            return (
+                error_result is not None
+                and error_result.details.get("error_type") == "MalformedToolUseTurn"
+            )
+
         # Wrap query() to skip unknown message types (e.g., rate_limit_event)
         # that the SDK doesn't recognize yet. Without this, a single
         # MessageParseError inside the generator kills the entire request.
@@ -952,6 +958,8 @@ class ClaudeCodeAdapter:
                         if block_type == "TextBlock":
                             text = getattr(block, "text", "")
                             content += text
+                            if text and _has_malformed_tool_use_error():
+                                error_result = None
                             # Callback for thinking/reasoning
                             if self._on_message and text.strip():
                                 self._on_message("thinking", text.strip())
@@ -996,6 +1004,8 @@ class ClaudeCodeAdapter:
 
                     # Check for errors - don't break, just record.
                     is_error = getattr(sdk_message, "is_error", False)
+                    if not is_error and _has_malformed_tool_use_error():
+                        error_result = None
                     if is_error:
                         subtype = getattr(sdk_message, "subtype", None)
                         stop_reason = getattr(sdk_message, "stop_reason", None)
@@ -1025,6 +1035,8 @@ class ClaudeCodeAdapter:
                                 max_turns=self._max_turns,
                                 stop_reason=stop_reason,
                             )
+                            if _has_malformed_tool_use_error():
+                                error_result = None
                             continue
 
                         error_msg = (
@@ -1045,10 +1057,7 @@ class ClaudeCodeAdapter:
                             subtype=subtype,
                             partial_rejected=bool(partial_content),
                         )
-                        if (
-                            error_result is not None
-                            and error_result.details.get("error_type") == "MalformedToolUseTurn"
-                        ):
+                        if _has_malformed_tool_use_error():
                             continue
                         error_result = ProviderError(
                             message=error_msg,

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -1057,7 +1057,7 @@ class ClaudeCodeAdapter:
                             subtype=subtype,
                             partial_rejected=bool(partial_content),
                         )
-                        if _has_malformed_tool_use_error():
+                        if _has_malformed_tool_use_error() and subtype == "error_max_turns":
                             continue
                         error_result = ProviderError(
                             message=error_msg,

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -291,6 +291,9 @@ class ClaudeCodeAdapter:
         if stderr:
             return False
 
+        if error.details.get("retryable") is True:
+            return True
+
         message = error.message.lower()
         is_cli_process_exit = error_type in {"ProcessError", "CalledProcessError"}
         return is_cli_process_exit and "command failed with exit code" in message
@@ -1042,6 +1045,11 @@ class ClaudeCodeAdapter:
                             subtype=subtype,
                             partial_rejected=bool(partial_content),
                         )
+                        if (
+                            error_result is not None
+                            and error_result.details.get("error_type") == "MalformedToolUseTurn"
+                        ):
+                            continue
                         error_result = ProviderError(
                             message=error_msg,
                             details={

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -1782,3 +1782,39 @@ class TestProviderErrorFormatDetails:
         rendered = error.format_details()
         # Should not contain the raw dict representation
         assert "(details:" not in rendered
+
+    @pytest.mark.asyncio
+    async def test_malformed_tool_use_assistant_message_surfaces_retryable_diagnostic(self) -> None:
+        """AssistantMessage stop_reason=tool_use without ToolUseBlock is a runtime diagnostic."""
+        adapter = ClaudeCodeAdapter(max_turns=5)
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def malformed_tool_use_query(*args, **kwargs):
+            assistant_msg = MagicMock()
+            type(assistant_msg).__name__ = "AssistantMessage"
+            assistant_msg.stop_reason = "tool_use"
+            assistant_msg.content = []
+            yield assistant_msg
+
+        sdk_module = _make_sdk_mock(
+            mock_options_cls, MagicMock(side_effect=malformed_tool_use_query)
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            result = await adapter._execute_single_request("test prompt", config)
+
+        assert result.is_err
+        assert result.error.details["error_type"] == "MalformedToolUseTurn"
+        assert result.error.details["provider"] == "claude_code"
+        assert result.error.details["stop_reason"] == "tool_use"
+        assert result.error.details["tool_use_count"] == 0
+        assert result.error.details["is_malformed"] is True
+        assert result.error.details["retryable"] is True

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -1867,6 +1867,50 @@ class TestProviderErrorFormatDetails:
         assert "subtype" not in result.error.details
 
     @pytest.mark.asyncio
+    async def test_malformed_tool_use_diagnostic_does_not_mask_later_terminal_error(self) -> None:
+        """Concrete terminal SDK errors must override stale malformed-turn candidates."""
+        adapter = ClaudeCodeAdapter(max_turns=5)
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def malformed_then_auth_error_query(*args, **kwargs):
+            assistant_msg = MagicMock()
+            type(assistant_msg).__name__ = "AssistantMessage"
+            assistant_msg.stop_reason = "tool_use"
+            assistant_msg.content = []
+            yield assistant_msg
+
+            result_msg = MagicMock()
+            type(result_msg).__name__ = "ResultMessage"
+            result_msg.structured_output = None
+            result_msg.result = "Authentication failed"
+            result_msg.is_error = True
+            result_msg.subtype = "error_during_execution"
+            result_msg.errors = ["Invalid API key"]
+            result_msg.stop_reason = None
+            yield result_msg
+
+        sdk_module = _make_sdk_mock(
+            mock_options_cls, MagicMock(side_effect=malformed_then_auth_error_query)
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            result = await adapter._execute_single_request("test prompt", config)
+
+        assert result.is_err
+        assert result.error.message == "Authentication failed"
+        assert result.error.details["subtype"] == "error_during_execution"
+        assert result.error.details["errors"] == ["Invalid API key"]
+        assert result.error.details.get("error_type") != "MalformedToolUseTurn"
+
+    @pytest.mark.asyncio
     async def test_malformed_tool_use_diagnostic_clears_after_later_success(self) -> None:
         """A transient malformed assistant turn must not override a later successful result."""
         adapter = ClaudeCodeAdapter(max_turns=5)

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -1867,6 +1867,96 @@ class TestProviderErrorFormatDetails:
         assert "subtype" not in result.error.details
 
     @pytest.mark.asyncio
+    async def test_malformed_tool_use_diagnostic_clears_after_later_success(self) -> None:
+        """A transient malformed assistant turn must not override a later successful result."""
+        adapter = ClaudeCodeAdapter(max_turns=5)
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def malformed_then_success_query(*args, **kwargs):
+            assistant_msg = MagicMock()
+            type(assistant_msg).__name__ = "AssistantMessage"
+            assistant_msg.stop_reason = "tool_use"
+            assistant_msg.content = []
+            yield assistant_msg
+
+            result_msg = MagicMock()
+            type(result_msg).__name__ = "ResultMessage"
+            result_msg.structured_output = None
+            result_msg.result = "recovered response"
+            result_msg.is_error = False
+            yield result_msg
+
+        sdk_module = _make_sdk_mock(
+            mock_options_cls, MagicMock(side_effect=malformed_then_success_query)
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            result = await adapter._execute_single_request("test prompt", config)
+
+        assert result.is_ok
+        assert result.value.content == "recovered response"
+        assert result.value.finish_reason == "stop"
+
+    @pytest.mark.asyncio
+    async def test_malformed_tool_use_diagnostic_clears_after_later_partial_content(self) -> None:
+        """A malformed-turn candidate must not mask an accepted max-turns partial result."""
+        adapter = ClaudeCodeAdapter(max_turns=5)
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        class TextBlock:
+            text = "usable partial response"
+
+        async def malformed_then_partial_query(*args, **kwargs):
+            malformed_msg = MagicMock()
+            type(malformed_msg).__name__ = "AssistantMessage"
+            malformed_msg.stop_reason = "tool_use"
+            malformed_msg.content = []
+            yield malformed_msg
+
+            text_msg = MagicMock()
+            type(text_msg).__name__ = "AssistantMessage"
+            text_msg.stop_reason = "end_turn"
+            text_msg.content = [TextBlock()]
+            yield text_msg
+
+            result_msg = MagicMock()
+            type(result_msg).__name__ = "ResultMessage"
+            result_msg.structured_output = None
+            result_msg.result = ""
+            result_msg.is_error = True
+            result_msg.subtype = "error_max_turns"
+            result_msg.errors = ["Reached maximum number of turns (5)"]
+            result_msg.stop_reason = "end_turn"
+            yield result_msg
+
+        sdk_module = _make_sdk_mock(
+            mock_options_cls, MagicMock(side_effect=malformed_then_partial_query)
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            result = await adapter._execute_single_request("test prompt", config)
+
+        assert result.is_ok
+        assert result.value.content == "usable partial response"
+        assert result.value.finish_reason == "length"
+
+    @pytest.mark.asyncio
     async def test_complete_retries_retryable_malformed_diagnostic_then_succeeds(self) -> None:
         """complete() retries ProviderError details marked retryable before returning success."""
         adapter = ClaudeCodeAdapter()

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -1818,3 +1818,85 @@ class TestProviderErrorFormatDetails:
         assert result.error.details["tool_use_count"] == 0
         assert result.error.details["is_malformed"] is True
         assert result.error.details["retryable"] is True
+
+    @pytest.mark.asyncio
+    async def test_malformed_tool_use_diagnostic_survives_later_max_turns_error(self) -> None:
+        """A specific malformed-tool diagnostic is not overwritten by SDK max-turns errors."""
+        adapter = ClaudeCodeAdapter(max_turns=5)
+        config = CompletionConfig(model="claude-sonnet-4-6")
+
+        mock_options_cls = MagicMock()
+
+        async def malformed_then_max_turns_query(*args, **kwargs):
+            assistant_msg = MagicMock()
+            type(assistant_msg).__name__ = "AssistantMessage"
+            assistant_msg.stop_reason = "tool_use"
+            assistant_msg.content = []
+            yield assistant_msg
+
+            result_msg = MagicMock()
+            type(result_msg).__name__ = "ResultMessage"
+            result_msg.structured_output = None
+            result_msg.result = ""
+            result_msg.is_error = True
+            result_msg.subtype = "error_max_turns"
+            result_msg.errors = ["Reached maximum number of turns (5)"]
+            result_msg.stop_reason = "tool_use"
+            yield result_msg
+
+        sdk_module = _make_sdk_mock(
+            mock_options_cls, MagicMock(side_effect=malformed_then_max_turns_query)
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            result = await adapter._execute_single_request("test prompt", config)
+
+        assert result.is_err
+        assert result.error.message == (
+            "stop_reason=tool_use but no tool_use content blocks were present"
+        )
+        assert result.error.details["error_type"] == "MalformedToolUseTurn"
+        assert result.error.details["provider"] == "claude_code"
+        assert result.error.details["retryable"] is True
+        assert "subtype" not in result.error.details
+
+    @pytest.mark.asyncio
+    async def test_complete_retries_retryable_malformed_diagnostic_then_succeeds(self) -> None:
+        """complete() retries ProviderError details marked retryable before returning success."""
+        adapter = ClaudeCodeAdapter()
+        config = CompletionConfig(model="claude-sonnet-4-6")
+        messages = [Message(role=MessageRole.USER, content="test prompt")]
+        retryable_error = ProviderError(
+            "stop_reason=tool_use but no tool_use content blocks were present",
+            details={
+                "error_type": "MalformedToolUseTurn",
+                "retryable": True,
+            },
+        )
+
+        adapter._execute_single_request = AsyncMock(
+            side_effect=[
+                Result.err(retryable_error),
+                _ok_completion_result("recovered response"),
+            ]
+        )
+
+        with (
+            patch.dict("sys.modules", {"claude_agent_sdk": MagicMock()}),
+            patch(
+                "ouroboros.providers.claude_code_adapter.asyncio.sleep",
+                new_callable=AsyncMock,
+            ) as mock_sleep,
+        ):
+            result = await adapter.complete(messages, config)
+
+        assert result.is_ok
+        assert result.value.content == "recovered response"
+        assert adapter._execute_single_request.await_count == 2
+        mock_sleep.assert_awaited_once()


### PR DESCRIPTION
## Summary
- Consume the #972 malformed tool-use diagnostic in the Claude Code adapter.
- Surface `stop_reason=tool_use` with zero tool-use content blocks as a structured retryable `MalformedToolUseTurn` ProviderError.
- Add regression coverage for the assistant-message malformed-turn boundary.

Refs #925
Refs #961

## Scope
- Claude runtime diagnostic wiring only.
- No JobManager lifecycle changes.
- No automatic retry-loop behavior change.

## Test Plan
- `uv run pytest tests/unit/providers/test_tool_use_diagnostics.py tests/unit/providers/test_claude_code_adapter.py -q`
- `uv run ruff check src/ouroboros/providers/claude_code_adapter.py src/ouroboros/providers/tool_use_diagnostics.py tests/unit/providers/test_claude_code_adapter.py tests/unit/providers/test_tool_use_diagnostics.py`
- `uv run mypy src/ouroboros/providers/claude_code_adapter.py src/ouroboros/providers/tool_use_diagnostics.py`
