### PR TITLE
feat(hitl): record init interview responses

### DIFF
--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -5,6 +5,7 @@ Supports both LiteLLM (external API) and Claude Code (Max Plan) modes.
 """
 
 import asyncio
+from datetime import UTC, datetime
 from enum import Enum, auto
 from pathlib import Path
 from typing import Annotated
@@ -27,11 +28,24 @@ from ouroboros.cli.formatters.panels import print_error, print_info, print_succe
 from ouroboros.cli.formatters.prompting import multiline_prompt_async
 from ouroboros.config import get_clarification_model, get_llm_backend
 from ouroboros.core.errors import ProviderError
+from ouroboros.core.hitl_contract import (
+    HumanInputKind,
+    HumanInputRequest,
+    HumanInputResponse,
+    HumanInputResponseKind,
+    HumanInputRiskClass,
+    HumanInputSource,
+)
 from ouroboros.core.initial_context import (
     load_pm_seed_as_context as _load_pm_seed_as_context_result,
 )
 from ouroboros.core.initial_context import (
     resolve_initial_context_input,
+)
+from ouroboros.events.hitl import (
+    create_hitl_answered_event,
+    create_hitl_cancelled_event,
+    create_hitl_requested_event,
 )
 from ouroboros.observability import LoggingConfig, configure_logging
 from ouroboros.providers import create_llm_adapter, resolve_llm_backend
@@ -171,9 +185,70 @@ def _get_adapter(
     return create_llm_adapter(backend=resolved_backend, cwd=Path.cwd())
 
 
+def _interview_hitl_request(
+    state: InterviewState,
+    *,
+    round_number: int,
+    question: str,
+    created_at: datetime | None = None,
+) -> HumanInputRequest:
+    return HumanInputRequest(
+        request_id=f"hitl_interview_{state.interview_id}_{round_number}",
+        session_id=state.interview_id,
+        run_id=state.interview_id,
+        invocation_id=f"interview-round-{round_number}",
+        created_by="ouroboros.init",
+        kind=HumanInputKind.FREE_TEXT,
+        source=HumanInputSource.INTERVIEW,
+        risk_class=HumanInputRiskClass.LOW,
+        question=question,
+        resume_target=f"init:interview:{state.interview_id}:round:{round_number}",
+        title=f"Interview round {round_number}",
+        surface="cli.init.interview",
+        created_at=created_at or datetime.now(UTC),
+    )
+
+
+def _interview_hitl_response(
+    request: HumanInputRequest,
+    response: str,
+    *,
+    received_at: datetime | None = None,
+) -> HumanInputResponse:
+    return HumanInputResponse(
+        request_id=request.request_id,
+        session_id=request.session_id,
+        run_id=request.run_id,
+        invocation_id=request.invocation_id,
+        actor="local-user",
+        response_kind=HumanInputResponseKind.TEXT,
+        text=response,
+        surface="cli.init.interview",
+        received_at=received_at or datetime.now(UTC),
+    )
+
+
+async def _append_hitl_events(event_store, events: list) -> None:
+    if event_store is None:
+        return
+    await event_store.append_batch(events)
+
+
+async def _get_init_event_store():
+    from ouroboros.persistence.event_store import EventStore
+
+    db_path = Path.home() / ".ouroboros" / "ouroboros.db"
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    event_store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+    await event_store.initialize()
+    return event_store
+
+
 async def _run_interview_loop(
     engine: InterviewEngine,
     state: InterviewState,
+    *,
+    event_store=None,
 ) -> InterviewState:
     """Run the interview question loop until completion or user exit.
 
@@ -211,12 +286,35 @@ async def _run_interview_loop(
         console.print(f"[bold yellow]Q:[/] {question}")
         console.print()
 
+        hitl_request = _interview_hitl_request(state, round_number=current_round, question=question)
+        await _append_hitl_events(event_store, [create_hitl_requested_event(hitl_request)])
+
         # Get user response (multiline-safe for paste)
         response = await multiline_prompt_async("Your response")
 
         if not response.strip():
+            await _append_hitl_events(
+                event_store,
+                [
+                    create_hitl_cancelled_event(
+                        hitl_request,
+                        reason="Empty interview response rejected",
+                        actor="local-user",
+                    )
+                ],
+            )
             print_error("Response cannot be empty. Please try again.")
             continue
+
+        await _append_hitl_events(
+            event_store,
+            [
+                create_hitl_answered_event(
+                    hitl_request,
+                    _interview_hitl_response(hitl_request, response),
+                )
+            ],
+        )
 
         # Record response
         record_result = await engine.record_response(state, response, question)
@@ -303,7 +401,8 @@ async def _run_interview(
     console.print()
 
     # Run initial interview loop
-    state = await _run_interview_loop(engine, state)
+    event_store = await _get_init_event_store()
+    state = await _run_interview_loop(engine, state, event_store=event_store)
 
     # Outer loop for retry on high ambiguity
     while True:
@@ -344,7 +443,7 @@ async def _run_interview(
             await engine.save_state(state)  # Save status change immediately
 
             # Continue interview loop (reusing the same helper)
-            state = await _run_interview_loop(engine, state)
+            state = await _run_interview_loop(engine, state, event_store=event_store)
             continue
 
         if result == SeedGenerationResult.CANCELLED:

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -263,6 +263,7 @@ async def _run_interview_loop(
     state: InterviewState,
     *,
     event_store=None,
+    disabled_event_stores: set[int] | None = None,
 ) -> InterviewState:
     """Run the interview question loop until completion or user exit.
 
@@ -334,6 +335,8 @@ async def _run_interview_loop(
                 ),
             ],
         ):
+            if disabled_event_stores is not None and event_store is not None:
+                disabled_event_stores.add(id(event_store))
             event_store = None
 
         console.print()
@@ -409,69 +412,95 @@ async def _run_interview(
 
     # Run initial interview loop
     event_store = await _get_init_event_store()
-    state = await _run_interview_loop(engine, state, event_store=event_store)
+    disabled_event_stores: set[int] = set()
 
-    # Outer loop for retry on high ambiguity
-    while True:
-        # Interview complete
+    try:
+        loop_event_store = None if event_store is None else event_store
+        state = await _run_interview_loop(
+            engine,
+            state,
+            event_store=loop_event_store,
+            disabled_event_stores=disabled_event_stores,
+        )
+
+        # Outer loop for retry on high ambiguity
+        while True:
+            # Interview complete
+            console.print()
+            print_success("Interview completed!")
+            console.print(f"[muted]Total rounds: {len(state.rounds)}[/]")
+            console.print(f"[muted]Interview ID: {state.interview_id}[/]")
+
+            # Save final state
+            save_result = await engine.save_state(state)
+            if save_result.is_ok:
+                console.print(f"[muted]State saved to: {save_result.value}[/]")
+
+            console.print()
+
+            # Ask if user wants to proceed to Seed generation
+            should_generate_seed = Confirm.ask(
+                "[bold cyan]Proceed to generate Seed specification?[/]",
+                default=True,
+            )
+
+            if not should_generate_seed:
+                console.print(
+                    "[muted]You can resume later with:[/] "
+                    f"[bold]ouroboros init start --resume {state.interview_id}[/]"
+                )
+                return
+
+            # Generate Seed
+            seed_path, result = await _generate_seed_from_interview(state, llm_adapter, llm_backend)
+
+            if result == SeedGenerationResult.CONTINUE_INTERVIEW:
+                # Re-open interview for more questions
+                console.print()
+                print_info("Continuing interview to reduce ambiguity...")
+                state.status = InterviewStatus.IN_PROGRESS
+                await engine.save_state(state)  # Save status change immediately
+
+                # Continue interview loop (reusing the same helper)
+                loop_event_store = (
+                    None
+                    if event_store is None or id(event_store) in disabled_event_stores
+                    else event_store
+                )
+                state = await _run_interview_loop(
+                    engine,
+                    state,
+                    event_store=loop_event_store,
+                    disabled_event_stores=disabled_event_stores,
+                )
+                continue
+
+            if result == SeedGenerationResult.CANCELLED:
+                return
+
+            # Success - proceed to workflow
+            break
+
+        # Ask if user wants to start workflow
         console.print()
-        print_success("Interview completed!")
-        console.print(f"[muted]Total rounds: {len(state.rounds)}[/]")
-        console.print(f"[muted]Interview ID: {state.interview_id}[/]")
-
-        # Save final state
-        save_result = await engine.save_state(state)
-        if save_result.is_ok:
-            console.print(f"[muted]State saved to: {save_result.value}[/]")
-
-        console.print()
-
-        # Ask if user wants to proceed to Seed generation
-        should_generate_seed = Confirm.ask(
-            "[bold cyan]Proceed to generate Seed specification?[/]",
+        should_start_workflow = Confirm.ask(
+            "[bold cyan]Start workflow now?[/]",
             default=True,
         )
 
-        if not should_generate_seed:
-            console.print(
-                "[muted]You can resume later with:[/] "
-                f"[bold]ouroboros init start --resume {state.interview_id}[/]"
+        if should_start_workflow:
+            await _start_workflow(
+                seed_path,
+                use_orchestrator,
+                runtime_backend=workflow_runtime_backend,
             )
-            return
 
-        # Generate Seed
-        seed_path, result = await _generate_seed_from_interview(state, llm_adapter, llm_backend)
-
-        if result == SeedGenerationResult.CONTINUE_INTERVIEW:
-            # Re-open interview for more questions
-            console.print()
-            print_info("Continuing interview to reduce ambiguity...")
-            state.status = InterviewStatus.IN_PROGRESS
-            await engine.save_state(state)  # Save status change immediately
-
-            # Continue interview loop (reusing the same helper)
-            state = await _run_interview_loop(engine, state, event_store=event_store)
-            continue
-
-        if result == SeedGenerationResult.CANCELLED:
-            return
-
-        # Success - proceed to workflow
-        break
-
-    # Ask if user wants to start workflow
-    console.print()
-    should_start_workflow = Confirm.ask(
-        "[bold cyan]Start workflow now?[/]",
-        default=True,
-    )
-
-    if should_start_workflow:
-        await _start_workflow(
-            seed_path,
-            use_orchestrator,
-            runtime_backend=workflow_runtime_backend,
-        )
+    finally:
+        if event_store is not None:
+            try:
+                await event_store.close()
+            except Exception:
+                pass
 
 
 async def _generate_seed_from_interview(

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -305,6 +305,13 @@ async def _run_interview_loop(
             print_error("Response cannot be empty. Please try again.")
             continue
 
+        # Record response before logging a terminal HITL answer: only accepted
+        # interview transitions should become terminal HITL events.
+        record_result = await engine.record_response(state, response, question)
+        if record_result.is_err:
+            print_error(f"Failed to record response: {record_result.error.message}")
+            continue
+
         if not await _append_hitl_events(
             event_store,
             [
@@ -315,12 +322,6 @@ async def _run_interview_loop(
             ],
         ):
             event_store = None
-
-        # Record response
-        record_result = await engine.record_response(state, response, question)
-        if record_result.is_err:
-            print_error(f"Failed to record response: {record_result.error.message}")
-            continue
 
         state = record_result.value
 

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -295,8 +295,6 @@ async def _run_interview_loop(
         console.print()
 
         hitl_request = _interview_hitl_request(state, round_number=current_round, question=question)
-        if not await _append_hitl_events(event_store, [create_hitl_requested_event(hitl_request)]):
-            event_store = None
 
         # Get user response (multiline-safe for paste)
         response = await multiline_prompt_async("Your response")
@@ -305,8 +303,11 @@ async def _run_interview_loop(
             print_error("Response cannot be empty. Please try again.")
             continue
 
-        # Record response before logging a terminal HITL answer: only accepted
-        # interview transitions should become terminal HITL events.
+        # Record response before logging HITL lifecycle telemetry: only accepted
+        # interview transitions should become HITL events. Because CLI init is a
+        # synchronous local prompt (not an external durable wait), persist the
+        # request and accepted answer atomically to avoid orphaning pending
+        # requests when input aborts or telemetry writes fail.
         record_result = await engine.record_response(state, response, question)
         if record_result.is_err:
             print_error(f"Failed to record response: {record_result.error.message}")
@@ -315,10 +316,11 @@ async def _run_interview_loop(
         if not await _append_hitl_events(
             event_store,
             [
+                create_hitl_requested_event(hitl_request),
                 create_hitl_answered_event(
                     hitl_request,
                     _interview_hitl_response(hitl_request, response),
-                )
+                ),
             ],
         ):
             event_store = None

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -227,19 +227,28 @@ def _interview_hitl_response(
     )
 
 
-async def _append_hitl_events(event_store, events: list) -> None:
+async def _append_hitl_events(event_store, events: list) -> bool:
     if event_store is None:
-        return
-    await event_store.append_batch(events)
+        return True
+    try:
+        await event_store.append_batch(events)
+    except Exception as exc:  # noqa: BLE001 - HITL telemetry must not block CLI init.
+        print_warning(f"HITL telemetry persistence failed; continuing without it: {exc}")
+        return False
+    return True
 
 
 async def _get_init_event_store():
     from ouroboros.persistence.event_store import EventStore
 
-    db_path = Path.home() / ".ouroboros" / "ouroboros.db"
-    db_path.parent.mkdir(parents=True, exist_ok=True)
-    event_store = EventStore(f"sqlite+aiosqlite:///{db_path}")
-    await event_store.initialize()
+    try:
+        db_path = Path.home() / ".ouroboros" / "ouroboros.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        event_store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await event_store.initialize()
+    except Exception as exc:  # noqa: BLE001 - init interview must not depend on telemetry.
+        print_warning(f"HITL telemetry is unavailable; continuing without it: {exc}")
+        return None
     return event_store
 
 
@@ -286,7 +295,8 @@ async def _run_interview_loop(
         console.print()
 
         hitl_request = _interview_hitl_request(state, round_number=current_round, question=question)
-        await _append_hitl_events(event_store, [create_hitl_requested_event(hitl_request)])
+        if not await _append_hitl_events(event_store, [create_hitl_requested_event(hitl_request)]):
+            event_store = None
 
         # Get user response (multiline-safe for paste)
         response = await multiline_prompt_async("Your response")
@@ -295,7 +305,7 @@ async def _run_interview_loop(
             print_error("Response cannot be empty. Please try again.")
             continue
 
-        await _append_hitl_events(
+        if not await _append_hitl_events(
             event_store,
             [
                 create_hitl_answered_event(
@@ -303,7 +313,8 @@ async def _run_interview_loop(
                     _interview_hitl_response(hitl_request, response),
                 )
             ],
-        )
+        ):
+            event_store = None
 
         # Record response
         record_result = await engine.record_response(state, response, question)

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -241,12 +241,18 @@ async def _append_hitl_events(event_store, events: list) -> bool:
 async def _get_init_event_store():
     from ouroboros.persistence.event_store import EventStore
 
+    event_store = None
     try:
         db_path = Path.home() / ".ouroboros" / "ouroboros.db"
         db_path.parent.mkdir(parents=True, exist_ok=True)
         event_store = EventStore(f"sqlite+aiosqlite:///{db_path}")
         await event_store.initialize()
     except Exception as exc:  # noqa: BLE001 - init interview must not depend on telemetry.
+        if event_store is not None:
+            try:
+                await event_store.close()
+            except Exception:
+                pass
         print_warning(f"HITL telemetry is unavailable; continuing without it: {exc}")
         return None
     return event_store
@@ -303,17 +309,22 @@ async def _run_interview_loop(
             print_error("Response cannot be empty. Please try again.")
             continue
 
-        # Record response before logging HITL lifecycle telemetry: only accepted
-        # interview transitions should become HITL events. Because CLI init is a
-        # synchronous local prompt (not an external durable wait), persist the
-        # request and accepted answer atomically to avoid orphaning pending
-        # requests when input aborts or telemetry writes fail.
+        # Record and save the accepted response before best-effort HITL telemetry
+        # touches SQLite. CLI init's durable interview state must not wait behind
+        # telemetry locks/retries; HITL events are emitted only after the
+        # interview transition is durably saved.
         record_result = await engine.record_response(state, response, question)
         if record_result.is_err:
             print_error(f"Failed to record response: {record_result.error.message}")
             continue
 
-        if not await _append_hitl_events(
+        state = record_result.value
+
+        # Save state immediately after recording
+        save_result = await engine.save_state(state)
+        if save_result.is_err:
+            print_error(f"Warning: Failed to save state: {save_result.error.message}")
+        elif not await _append_hitl_events(
             event_store,
             [
                 create_hitl_requested_event(hitl_request),
@@ -324,13 +335,6 @@ async def _run_interview_loop(
             ],
         ):
             event_store = None
-
-        state = record_result.value
-
-        # Save state immediately after recording
-        save_result = await engine.save_state(state)
-        if save_result.is_err:
-            print_error(f"Warning: Failed to save state: {save_result.error.message}")
 
         console.print()
 

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -44,7 +44,6 @@ from ouroboros.core.initial_context import (
 )
 from ouroboros.events.hitl import (
     create_hitl_answered_event,
-    create_hitl_cancelled_event,
     create_hitl_requested_event,
 )
 from ouroboros.observability import LoggingConfig, configure_logging
@@ -293,16 +292,6 @@ async def _run_interview_loop(
         response = await multiline_prompt_async("Your response")
 
         if not response.strip():
-            await _append_hitl_events(
-                event_store,
-                [
-                    create_hitl_cancelled_event(
-                        hitl_request,
-                        reason="Empty interview response rejected",
-                        actor="local-user",
-                    )
-                ],
-            )
             print_error("Response cannot be empty. Please try again.")
             continue
 

--- a/tests/unit/cli/test_init_hitl.py
+++ b/tests/unit/cli/test_init_hitl.py
@@ -104,12 +104,14 @@ async def test_get_init_event_store_failure_continues_without_store(
     warnings: list[str] = []
     event_store = Mock()
     event_store.initialize = AsyncMock(side_effect=RuntimeError("db unavailable"))
+    event_store.close = AsyncMock()
 
     monkeypatch.setattr("ouroboros.cli.commands.init.print_warning", warnings.append)
     with patch("ouroboros.persistence.event_store.EventStore", return_value=event_store):
         result = await _get_init_event_store()
 
     assert result is None
+    event_store.close.assert_awaited_once()
     assert warnings == ["HITL telemetry is unavailable; continuing without it: db unavailable"]
 
 
@@ -259,6 +261,17 @@ async def test_prompt_abort_does_not_leave_pending_hitl_request(
 async def test_interview_loop_records_and_saves_answer_when_hitl_append_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    order: list[str] = []
+
+    class StoreFailsAfterSave:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def append_batch(self, events):
+            self.calls += 1
+            order.append("append")
+            raise RuntimeError("telemetry write failed")
+
     class FakeEngine:
         def __init__(self) -> None:
             self.recorded: list[tuple[int, str, str]] = []
@@ -285,6 +298,7 @@ async def test_interview_loop_records_and_saves_answer_when_hitl_append_fails(
             return Result.ok(state)
 
         async def save_state(self, state: InterviewState):
+            order.append("save")
             self.saved.append(state)
             return Result.ok(None)
 
@@ -295,12 +309,13 @@ async def test_interview_loop_records_and_saves_answer_when_hitl_append_fails(
     monkeypatch.setattr("ouroboros.cli.commands.init.print_warning", lambda _message: None)
 
     state = InterviewState(interview_id="interview_123")
-    store = FailingEventStore()
+    store = StoreFailsAfterSave()
     engine = FakeEngine()
 
     final_state = await _run_interview_loop(engine, state, event_store=store)
 
     assert store.calls == 1
+    assert order == ["save", "append"]
     assert engine.recorded == [(1, "Useful answer", "What should it do?")]
     assert engine.saved == [final_state]
     assert final_state.is_complete

--- a/tests/unit/cli/test_init_hitl.py
+++ b/tests/unit/cli/test_init_hitl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -167,6 +168,62 @@ async def test_empty_interview_response_retries_same_hitl_request_without_cancel
     assert {event.data["request_id"] for event in events} == {"hitl_interview_interview_123_1"}
     assert all(event.type != "hitl.cancelled" for event in events)
     assert engine.recorded == [(1, "Useful answer", "What should it do?")]
+    assert final_state.is_complete
+
+
+@pytest.mark.asyncio
+async def test_rejected_interview_response_retries_without_answered_event(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeEngine:
+        def __init__(self) -> None:
+            self.attempts = 0
+
+        async def ask_next_question(self, state: InterviewState):
+            return Result.ok("What should it do?")
+
+        async def record_response(
+            self,
+            state: InterviewState,
+            user_response: str,
+            question: str,
+        ):
+            self.attempts += 1
+            if self.attempts == 1:
+                return Result.err(SimpleNamespace(message="invalid response"))
+            state.rounds.append(
+                InterviewRound(
+                    round_number=state.current_round_number,
+                    question=question,
+                    user_response=user_response,
+                )
+            )
+            state.status = InterviewStatus.COMPLETED
+            return Result.ok(state)
+
+        async def save_state(self, state: InterviewState):
+            return Result.ok(None)
+
+    responses = iter(["too short", "Useful answer"])
+
+    async def fake_prompt(_prompt: str) -> str:
+        return next(responses)
+
+    monkeypatch.setattr("ouroboros.cli.commands.init.multiline_prompt_async", fake_prompt)
+
+    state = InterviewState(interview_id="interview_123")
+    store = FakeEventStore()
+    engine = FakeEngine()
+
+    final_state = await _run_interview_loop(engine, state, event_store=store)
+
+    events = [event for batch in store.batches for event in batch]
+    assert [event.type for event in events] == [
+        "hitl.requested",
+        "hitl.requested",
+        "hitl.answered",
+    ]
+    assert engine.attempts == 2
     assert final_state.is_complete
 
 

--- a/tests/unit/cli/test_init_hitl.py
+++ b/tests/unit/cli/test_init_hitl.py
@@ -162,7 +162,6 @@ async def test_empty_interview_response_retries_same_hitl_request_without_cancel
     events = [event for batch in store.batches for event in batch]
     assert [event.type for event in events] == [
         "hitl.requested",
-        "hitl.requested",
         "hitl.answered",
     ]
     assert {event.data["request_id"] for event in events} == {"hitl_interview_interview_123_1"}
@@ -220,11 +219,40 @@ async def test_rejected_interview_response_retries_without_answered_event(
     events = [event for batch in store.batches for event in batch]
     assert [event.type for event in events] == [
         "hitl.requested",
-        "hitl.requested",
         "hitl.answered",
     ]
     assert engine.attempts == 2
     assert final_state.is_complete
+
+
+@pytest.mark.asyncio
+async def test_prompt_abort_does_not_leave_pending_hitl_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeEngine:
+        async def ask_next_question(self, state: InterviewState):
+            return Result.ok("What should it do?")
+
+        async def record_response(
+            self,
+            state: InterviewState,
+            user_response: str,
+            question: str,
+        ):
+            raise AssertionError("record_response should not run after prompt abort")
+
+    async def fake_prompt(_prompt: str) -> str:
+        raise EOFError
+
+    monkeypatch.setattr("ouroboros.cli.commands.init.multiline_prompt_async", fake_prompt)
+
+    state = InterviewState(interview_id="interview_123")
+    store = FakeEventStore()
+
+    with pytest.raises(EOFError):
+        await _run_interview_loop(FakeEngine(), state, event_store=store)
+
+    assert store.batches == []
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_init_hitl.py
+++ b/tests/unit/cli/test_init_hitl.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
 from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
 from ouroboros.cli.commands.init import (
     _append_hitl_events,
+    _get_init_event_store,
     _interview_hitl_request,
     _interview_hitl_response,
     _run_interview_loop,
@@ -21,6 +23,15 @@ class FakeEventStore:
 
     async def append_batch(self, events):
         self.batches.append(list(events))
+
+
+class FailingEventStore:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def append_batch(self, events):
+        self.calls += 1
+        raise RuntimeError("telemetry write failed")
 
 
 def test_interview_hitl_request_response_contract() -> None:
@@ -49,7 +60,7 @@ def test_interview_hitl_request_response_contract() -> None:
 
 @pytest.mark.asyncio
 async def test_append_hitl_events_is_noop_without_event_store() -> None:
-    await _append_hitl_events(None, [])
+    assert await _append_hitl_events(None, [])
 
 
 @pytest.mark.asyncio
@@ -59,10 +70,46 @@ async def test_append_hitl_events_persists_requested_event() -> None:
     event = create_hitl_requested_event(request)
     store = FakeEventStore()
 
-    await _append_hitl_events(store, [event])
+    assert await _append_hitl_events(store, [event])
 
     assert len(store.batches) == 1
     assert store.batches[0][0].type == "hitl.requested"
+
+
+@pytest.mark.asyncio
+async def test_append_hitl_events_is_best_effort_on_append_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warnings: list[str] = []
+    monkeypatch.setattr("ouroboros.cli.commands.init.print_warning", warnings.append)
+
+    state = InterviewState(interview_id="interview_123")
+    request = _interview_hitl_request(state, round_number=1, question="Q?")
+    event = create_hitl_requested_event(request)
+    store = FailingEventStore()
+
+    assert not await _append_hitl_events(store, [event])
+
+    assert store.calls == 1
+    assert warnings == [
+        "HITL telemetry persistence failed; continuing without it: telemetry write failed"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_init_event_store_failure_continues_without_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    warnings: list[str] = []
+    event_store = Mock()
+    event_store.initialize = AsyncMock(side_effect=RuntimeError("db unavailable"))
+
+    monkeypatch.setattr("ouroboros.cli.commands.init.print_warning", warnings.append)
+    with patch("ouroboros.persistence.event_store.EventStore", return_value=event_store):
+        result = await _get_init_event_store()
+
+    assert result is None
+    assert warnings == ["HITL telemetry is unavailable; continuing without it: db unavailable"]
 
 
 @pytest.mark.asyncio
@@ -120,4 +167,55 @@ async def test_empty_interview_response_retries_same_hitl_request_without_cancel
     assert {event.data["request_id"] for event in events} == {"hitl_interview_interview_123_1"}
     assert all(event.type != "hitl.cancelled" for event in events)
     assert engine.recorded == [(1, "Useful answer", "What should it do?")]
+    assert final_state.is_complete
+
+
+@pytest.mark.asyncio
+async def test_interview_loop_records_and_saves_answer_when_hitl_append_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeEngine:
+        def __init__(self) -> None:
+            self.recorded: list[tuple[int, str, str]] = []
+            self.saved: list[InterviewState] = []
+
+        async def ask_next_question(self, state: InterviewState):
+            return Result.ok("What should it do?")
+
+        async def record_response(
+            self,
+            state: InterviewState,
+            user_response: str,
+            question: str,
+        ):
+            self.recorded.append((state.current_round_number, user_response, question))
+            state.rounds.append(
+                InterviewRound(
+                    round_number=state.current_round_number,
+                    question=question,
+                    user_response=user_response,
+                )
+            )
+            state.status = InterviewStatus.COMPLETED
+            return Result.ok(state)
+
+        async def save_state(self, state: InterviewState):
+            self.saved.append(state)
+            return Result.ok(None)
+
+    async def fake_prompt(_prompt: str) -> str:
+        return "Useful answer"
+
+    monkeypatch.setattr("ouroboros.cli.commands.init.multiline_prompt_async", fake_prompt)
+    monkeypatch.setattr("ouroboros.cli.commands.init.print_warning", lambda _message: None)
+
+    state = InterviewState(interview_id="interview_123")
+    store = FailingEventStore()
+    engine = FakeEngine()
+
+    final_state = await _run_interview_loop(engine, state, event_store=store)
+
+    assert store.calls == 1
+    assert engine.recorded == [(1, "Useful answer", "What should it do?")]
+    assert engine.saved == [final_state]
     assert final_state.is_complete

--- a/tests/unit/cli/test_init_hitl.py
+++ b/tests/unit/cli/test_init_hitl.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ouroboros.bigbang.interview import InterviewState
+from ouroboros.cli.commands.init import (
+    _append_hitl_events,
+    _interview_hitl_request,
+    _interview_hitl_response,
+)
+from ouroboros.events.hitl import create_hitl_answered_event, create_hitl_requested_event
+
+
+class FakeEventStore:
+    def __init__(self) -> None:
+        self.batches: list[list[object]] = []
+
+    async def append_batch(self, events):
+        self.batches.append(list(events))
+
+
+def test_interview_hitl_request_response_contract() -> None:
+    state = InterviewState(interview_id="interview_123", initial_context="Build a CLI")
+    created_at = datetime(2026, 5, 18, tzinfo=UTC)
+    request = _interview_hitl_request(
+        state,
+        round_number=2,
+        question="What should it do?",
+        created_at=created_at,
+    )
+
+    assert request.request_id == "hitl_interview_interview_123_2"
+    assert request.session_id == "interview_123"
+    assert request.run_id == "interview_123"
+    assert request.invocation_id == "interview-round-2"
+    assert request.source.value == "interview"
+    assert request.kind.value == "free_text"
+    assert request.resume_target == "init:interview:interview_123:round:2"
+
+    response = _interview_hitl_response(request, "It should lint files.", received_at=created_at)
+    event = create_hitl_answered_event(request, response)
+    assert event.type == "hitl.answered"
+    assert event.data["text"] == "It should lint files."
+
+
+@pytest.mark.asyncio
+async def test_append_hitl_events_is_noop_without_event_store() -> None:
+    await _append_hitl_events(None, [])
+
+
+@pytest.mark.asyncio
+async def test_append_hitl_events_persists_requested_event() -> None:
+    state = InterviewState(interview_id="interview_123")
+    request = _interview_hitl_request(state, round_number=1, question="Q?")
+    event = create_hitl_requested_event(request)
+    store = FakeEventStore()
+
+    await _append_hitl_events(store, [event])
+
+    assert len(store.batches) == 1
+    assert store.batches[0][0].type == "hitl.requested"

--- a/tests/unit/cli/test_init_hitl.py
+++ b/tests/unit/cli/test_init_hitl.py
@@ -4,12 +4,14 @@ from datetime import UTC, datetime
 
 import pytest
 
-from ouroboros.bigbang.interview import InterviewState
+from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
 from ouroboros.cli.commands.init import (
     _append_hitl_events,
     _interview_hitl_request,
     _interview_hitl_response,
+    _run_interview_loop,
 )
+from ouroboros.core.types import Result
 from ouroboros.events.hitl import create_hitl_answered_event, create_hitl_requested_event
 
 
@@ -61,3 +63,61 @@ async def test_append_hitl_events_persists_requested_event() -> None:
 
     assert len(store.batches) == 1
     assert store.batches[0][0].type == "hitl.requested"
+
+
+@pytest.mark.asyncio
+async def test_empty_interview_response_retries_same_hitl_request_without_cancelling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeEngine:
+        def __init__(self) -> None:
+            self.recorded: list[tuple[int, str, str]] = []
+            self.saved: list[InterviewState] = []
+
+        async def ask_next_question(self, state: InterviewState):
+            return Result.ok("What should it do?")
+
+        async def record_response(
+            self,
+            state: InterviewState,
+            user_response: str,
+            question: str,
+        ):
+            self.recorded.append((state.current_round_number, user_response, question))
+            state.rounds.append(
+                InterviewRound(
+                    round_number=state.current_round_number,
+                    question=question,
+                    user_response=user_response,
+                )
+            )
+            state.status = InterviewStatus.COMPLETED
+            return Result.ok(state)
+
+        async def save_state(self, state: InterviewState):
+            self.saved.append(state)
+            return Result.ok(None)
+
+    responses = iter(["   ", "Useful answer"])
+
+    async def fake_prompt(_prompt: str) -> str:
+        return next(responses)
+
+    monkeypatch.setattr("ouroboros.cli.commands.init.multiline_prompt_async", fake_prompt)
+
+    state = InterviewState(interview_id="interview_123")
+    store = FakeEventStore()
+    engine = FakeEngine()
+
+    final_state = await _run_interview_loop(engine, state, event_store=store)
+
+    events = [event for batch in store.batches for event in batch]
+    assert [event.type for event in events] == [
+        "hitl.requested",
+        "hitl.requested",
+        "hitl.answered",
+    ]
+    assert {event.data["request_id"] for event in events} == {"hitl_interview_interview_123_1"}
+    assert all(event.type != "hitl.cancelled" for event in events)
+    assert engine.recorded == [(1, "Useful answer", "What should it do?")]
+    assert final_state.is_complete


### PR DESCRIPTION
## Summary
- Persist typed HITL request/answer events around `ouroboros init` interview questions.
- Keep the existing CLI question renderer and user response flow unchanged.
- Add focused tests for the init interview HITL request/response contract.

Refs #960
Refs #961

## Scope
- One existing interview flow only.
- No renderer replacement.
- No plugin permission flow.

## Test Plan
- `uv run pytest tests/unit/cli/test_init_runtime.py tests/unit/cli/test_init_hitl.py -q`
- `uv run ruff check src/ouroboros/cli/commands/init.py tests/unit/cli/test_init_hitl.py`
- `uv run mypy src/ouroboros/cli/commands/init.py tests/unit/cli/test_init_hitl.py`
