### PR TITLE
feat(mcp): add start ralph tool alias

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1183,6 +1183,7 @@ def create_ouroboros_server(
         StartEvaluateHandler,
         StartEvolveStepHandler,
         StartExecuteSeedHandler,
+        StartRalphHandler,
     )
     from ouroboros.mcp.tools.pm_handler import PMInterviewHandler
     from ouroboros.mcp.tools.qa import QAHandler
@@ -1679,6 +1680,13 @@ def create_ouroboros_server(
         )
 
     ralph_handler = build_ralph_handler(resolved_runtime_backend, opencode_mode)
+    start_ralph_handler = StartRalphHandler(
+        evolve_handler=evolve_step,
+        event_store=event_store,
+        job_manager=job_manager,
+        agent_runtime_backend=resolved_runtime_backend,
+        opencode_mode=opencode_mode,
+    )
     interview = InterviewHandler(
         event_store=event_store,
         llm_adapter=llm_adapter,
@@ -1801,6 +1809,7 @@ def create_ouroboros_server(
             opencode_mode=opencode_mode,
         ),
         ralph_handler,
+        start_ralph_handler,
         LineageStatusHandler(
             event_store=event_store,
         ),

--- a/src/ouroboros/mcp/tools/__init__.py
+++ b/src/ouroboros/mcp/tools/__init__.py
@@ -32,6 +32,7 @@ from ouroboros.mcp.tools.definitions import (
     StartEvaluateHandler,
     StartEvolveStepHandler,
     StartExecuteSeedHandler,
+    StartRalphHandler,
     ac_tree_hud_handler,
     cancel_job_handler,
     evaluate_handler,
@@ -53,6 +54,7 @@ from ouroboros.mcp.tools.definitions import (
     start_evaluate_handler,
     start_evolve_step_handler,
     start_execute_seed_handler,
+    start_ralph_handler,
 )
 from ouroboros.mcp.tools.registry import ToolRegistry
 
@@ -77,6 +79,7 @@ __all__ = [
     "OUROBOROS_TOOLS",
     "QueryEventsHandler",
     "RalphHandler",
+    "StartRalphHandler",
     "SessionStatusHandler",
     "StartEvaluateHandler",
     "StartEvolveStepHandler",
@@ -99,6 +102,7 @@ __all__ = [
     "measure_drift_handler",
     "query_events_handler",
     "ralph_handler",
+    "start_ralph_handler",
     "session_status_handler",
     "start_evaluate_handler",
     "start_evolve_step_handler",

--- a/src/ouroboros/mcp/tools/definitions.py
+++ b/src/ouroboros/mcp/tools/definitions.py
@@ -59,7 +59,7 @@ from ouroboros.mcp.tools.query_handlers import (
     QueryEventsHandler,
     SessionStatusHandler,
 )
-from ouroboros.mcp.tools.ralph_handlers import RalphHandler
+from ouroboros.mcp.tools.ralph_handlers import RalphHandler, StartRalphHandler
 
 if TYPE_CHECKING:
     from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
@@ -369,6 +369,22 @@ def ralph_handler(
     )
 
 
+def start_ralph_handler(
+    *,
+    runtime_backend: str | None = None,
+    opencode_mode: str | None = None,
+) -> StartRalphHandler:
+    """Create a fire-and-forget Ralph start handler alias."""
+    return StartRalphHandler(
+        evolve_handler=EvolveStepHandler(
+            agent_runtime_backend=runtime_backend,
+            opencode_mode=opencode_mode,
+        ),
+        agent_runtime_backend=runtime_backend,
+        opencode_mode=opencode_mode,
+    )
+
+
 def lineage_status_handler() -> LineageStatusHandler:
     """Create a LineageStatusHandler instance."""
     return LineageStatusHandler()
@@ -406,6 +422,7 @@ OuroborosToolHandlers = tuple[
     | EvolveStepHandler
     | StartEvolveStepHandler
     | RalphHandler
+    | StartRalphHandler
     | LineageStatusHandler
     | EvolveRewindHandler
     | CancelExecutionHandler
@@ -534,6 +551,14 @@ def get_ouroboros_tools(
             opencode_mode=opencode_mode,
         ),
         RalphHandler(
+            evolve_handler=EvolveStepHandler(
+                agent_runtime_backend=runtime_backend,
+                opencode_mode=opencode_mode,
+            ),
+            agent_runtime_backend=runtime_backend,
+            opencode_mode=opencode_mode,
+        ),
+        StartRalphHandler(
             evolve_handler=EvolveStepHandler(
                 agent_runtime_backend=runtime_backend,
                 opencode_mode=opencode_mode,

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -465,6 +465,25 @@ class RalphHandler:
         )
 
 
+@dataclass
+class StartRalphHandler(RalphHandler):
+    """Compatibility fire-and-forget alias for the runtime-owned Ralph job surface."""
+
+    @property
+    def definition(self) -> MCPToolDefinition:
+        base = super().definition
+        return MCPToolDefinition(
+            name="ouroboros_start_ralph",
+            description=(
+                "Fire-and-forget alias for ouroboros_ralph. Starts the same "
+                "runtime-owned Ralph loop and returns a job_id immediately for "
+                "ouroboros_job_status, ouroboros_job_wait, ouroboros_job_result, "
+                "and ouroboros_cancel_job."
+            ),
+            parameters=base.parameters,
+        )
+
+
 def _normalize_lineage_id(value: Any) -> str:
     """Normalize user-provided lineage IDs before starting a mutating Ralph loop."""
     return value.strip() if isinstance(value, str) else ""

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -476,9 +476,12 @@ class StartRalphHandler(RalphHandler):
             name="ouroboros_start_ralph",
             description=(
                 "Fire-and-forget alias for ouroboros_ralph. Starts the same "
-                "runtime-owned Ralph loop and returns a job_id immediately for "
-                "ouroboros_job_status, ouroboros_job_wait, ouroboros_job_result, "
-                "and ouroboros_cancel_job."
+                "runtime-owned Ralph loop. In non-plugin runtimes, returns a "
+                "job_id immediately for ouroboros_job_status, ouroboros_job_wait, "
+                "ouroboros_job_result, and ouroboros_cancel_job. In OpenCode "
+                "plugin mode, delegates to a plugin child session and returns "
+                "job_id=None with status='delegated_to_plugin'; results are not "
+                "pollable via job_status/job_result."
             ),
             parameters=base.parameters,
         )

--- a/tests/integration/mcp/test_server_adapter.py
+++ b/tests/integration/mcp/test_server_adapter.py
@@ -505,6 +505,7 @@ class TestCreateOuroborosServer:
         "ouroboros_start_evaluate",
         "ouroboros_start_evolve_step",
         "ouroboros_start_execute_seed",
+        "ouroboros_start_ralph",
     }
 
     def test_creates_server_with_defaults(self) -> None:

--- a/tests/integration/mcp/test_server_adapter.py
+++ b/tests/integration/mcp/test_server_adapter.py
@@ -550,6 +550,19 @@ class TestCreateOuroborosServer:
         assert start_auto._inner_auto.generate_seed_handler is auto.generate_seed_handler
         assert start_auto._inner_auto.start_execute_seed_handler is auto.start_execute_seed_handler
 
+    def test_create_server_registers_start_ralph_alias(self) -> None:
+        """The composition root must expose the start_ralph alias too."""
+        from ouroboros.mcp.tools.ralph_handlers import RalphHandler, StartRalphHandler
+
+        server = create_ouroboros_server()
+
+        assert isinstance(server._tool_handlers["ouroboros_ralph"], RalphHandler)
+        assert isinstance(server._tool_handlers["ouroboros_start_ralph"], StartRalphHandler)
+        assert (
+            server._tool_handlers["ouroboros_start_ralph"].definition.description
+            == StartRalphHandler().definition.description
+        )
+
     def test_creates_server_with_custom_config(self) -> None:
         """Factory creates server with custom configuration."""
         server = create_ouroboros_server(

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -1503,6 +1503,8 @@ class TestCreateOuroborosServerOpenCodeMode:
             "ouroboros_lateral_think": "ouroboros.mcp.tools.definitions.LateralThinkHandler",
             "ouroboros_evolve_step": "ouroboros.mcp.tools.definitions.EvolveStepHandler",
             "ouroboros_start_evolve_step": "ouroboros.mcp.tools.definitions.StartEvolveStepHandler",
+            "ouroboros_ralph": "ouroboros.mcp.tools.definitions.RalphHandler",
+            "ouroboros_start_ralph": "ouroboros.mcp.tools.definitions.StartRalphHandler",
             "ouroboros_pm_interview": "ouroboros.mcp.tools.pm_handler.PMInterviewHandler",
             "ouroboros_qa": "ouroboros.mcp.tools.qa.QAHandler",
         }

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1497,6 +1497,7 @@ class TestOuroborosTools:
         "ouroboros_start_evaluate",
         "ouroboros_start_evolve_step",
         "ouroboros_start_execute_seed",
+        "ouroboros_start_ralph",
     }
 
     def test_ouroboros_tools_contains_all_handlers(self) -> None:
@@ -1532,6 +1533,9 @@ class TestOuroborosTools:
         assert PMInterviewHandler in handler_types
         assert QAHandler in handler_types
         assert RalphHandler in handler_types
+        from ouroboros.mcp.tools.ralph_handlers import StartRalphHandler
+
+        assert StartRalphHandler in handler_types
 
     def test_all_tools_have_unique_names(self) -> None:
         """All tools have unique names."""
@@ -2493,3 +2497,12 @@ class TestInterviewHandlerDrain:
         assert handler._closed is False
         await handler.close()
         assert handler._closed is True
+
+
+def test_default_tools_include_start_ralph_alias() -> None:
+    from ouroboros.mcp.tools.definitions import get_ouroboros_tools
+
+    names = [handler.definition.name for handler in get_ouroboros_tools(include_auto=False)]
+
+    assert "ouroboros_ralph" in names
+    assert "ouroboros_start_ralph" in names

--- a/tests/unit/mcp/tools/test_ralph_handler.py
+++ b/tests/unit/mcp/tools/test_ralph_handler.py
@@ -308,3 +308,15 @@ def test_ralph_handler_definition_is_public_tool() -> None:
     }
     assert "ouroboros_cancel_job" in handler.definition.description
     assert "ouroboros_job_cancel" not in handler.definition.description
+
+
+def test_start_ralph_handler_definition_is_fire_and_forget_alias() -> None:
+    from ouroboros.mcp.tools.ralph_handlers import StartRalphHandler
+
+    handler = StartRalphHandler(evolve_handler=_FakeEvolveHandler(["converged"]))  # type: ignore[arg-type]
+
+    assert handler.definition.name == "ouroboros_start_ralph"
+    assert tuple(param.name for param in handler.definition.parameters) == tuple(
+        param.name for param in RalphHandler().definition.parameters
+    )
+    assert "job_id" in handler.definition.description

--- a/tests/unit/mcp/tools/test_ralph_handler.py
+++ b/tests/unit/mcp/tools/test_ralph_handler.py
@@ -10,7 +10,7 @@ import pytest
 
 from ouroboros.core.types import Result
 from ouroboros.mcp.job_manager import JobManager, JobStatus
-from ouroboros.mcp.tools.ralph_handlers import RalphHandler
+from ouroboros.mcp.tools.ralph_handlers import RalphHandler, StartRalphHandler
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.persistence.event_store import EventStore
 from ouroboros.ralph_loop import RalphLoopConfig, RalphLoopRunner
@@ -278,6 +278,44 @@ async def test_ralph_handler_plugin_mode_delegates_without_local_job() -> None:
 
 
 @pytest.mark.asyncio
+async def test_start_ralph_handler_plugin_mode_delegates_without_local_job() -> None:
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    job_manager = JobManager(store)
+    evolve = _FakeEvolveHandler(["converged"])
+    handler = StartRalphHandler(
+        evolve_handler=evolve,  # type: ignore[arg-type]
+        event_store=store,
+        job_manager=job_manager,
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    try:
+        result = await handler.handle(
+            {
+                "lineage_id": "lin_start_plugin",
+                "seed_content": "goal: start plugin",
+                "max_generations": 3,
+            }
+        )
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert meta["job_id"] is None
+        assert meta["status"] == "delegated_to_plugin"
+        assert meta["dispatch_mode"] == "plugin"
+        assert meta["lineage_id"] == "lin_start_plugin"
+        assert meta["max_generations"] == 3
+        assert meta["_subagent"]["tool_name"] == "ouroboros_ralph"
+        assert meta["_subagent"]["context"]["seed_content"] == "goal: start plugin"
+        assert meta["_subagent"]["context"]["delegation_depth"] == 1
+        assert meta["_subagent"]["context"]["allow_nested_ouroboros_ralph"] is False
+        assert evolve.calls == []
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
 async def test_ralph_handler_rejects_excessive_max_generations() -> None:
     handler = RalphHandler(evolve_handler=_FakeEvolveHandler(["converged"]))  # type: ignore[arg-type]
 
@@ -311,8 +349,6 @@ def test_ralph_handler_definition_is_public_tool() -> None:
 
 
 def test_start_ralph_handler_definition_is_fire_and_forget_alias() -> None:
-    from ouroboros.mcp.tools.ralph_handlers import StartRalphHandler
-
     handler = StartRalphHandler(evolve_handler=_FakeEvolveHandler(["converged"]))  # type: ignore[arg-type]
 
     assert handler.definition.name == "ouroboros_start_ralph"
@@ -320,3 +356,7 @@ def test_start_ralph_handler_definition_is_fire_and_forget_alias() -> None:
         param.name for param in RalphHandler().definition.parameters
     )
     assert "job_id" in handler.definition.description
+    assert "OpenCode plugin mode" in handler.definition.description
+    assert "job_id=None" in handler.definition.description
+    assert "delegated_to_plugin" in handler.definition.description
+    assert "not pollable" in handler.definition.description

--- a/tests/unit/mcp/tools/test_round5_fixes.py
+++ b/tests/unit/mcp/tools/test_round5_fixes.py
@@ -237,11 +237,12 @@ class TestGetOuroborosToolsPluginWiring:
 
         tools = get_ouroboros_tools()
         names = {tool.definition.name for tool in tools}
-        assert len(tools) == 28
+        assert len(tools) == 29
         assert "ouroboros_auto" in names
         assert "ouroboros_query_projection" in names
         assert "ouroboros_start_auto" in names
         assert "ouroboros_start_evaluate" in names
+        assert "ouroboros_start_ralph" in names
         assert "ouroboros_channel_workflow" not in names
 
 


### PR DESCRIPTION
## Summary
- Add `ouroboros_start_ralph` as a fire-and-forget alias for the existing runtime-owned Ralph job surface.
- Register the alias in default MCP tool definitions and exports.
- Add tests proving the alias is available and keeps the same parameter contract as `ouroboros_ralph`.

Refs #925
Refs #961

## Scope
- Naming/registration alias only.
- No Ralph loop rewrite.
- No JobManager persistence changes.

## Test Plan
- `uv run pytest tests/unit/mcp/tools/test_ralph_handler.py tests/unit/mcp/tools/test_definitions.py -q`
- `uv run ruff check src/ouroboros/mcp/tools/ralph_handlers.py src/ouroboros/mcp/tools/definitions.py src/ouroboros/mcp/tools/__init__.py tests/unit/mcp/tools/test_ralph_handler.py tests/unit/mcp/tools/test_definitions.py`
- `uv run mypy src/ouroboros/mcp/tools/ralph_handlers.py src/ouroboros/mcp/tools/definitions.py`
