### PR TITLE
feat(hitl): validate timeout events from replay

### DIFF
--- a/src/ouroboros/core/hitl_resume.py
+++ b/src/ouroboros/core/hitl_resume.py
@@ -71,9 +71,7 @@ def create_validated_hitl_timeout_event(
         raise HumanInputResumeValidationError("HITL timeout clock must be timezone-aware")
     elapsed = (now - request.created_at).total_seconds()
     if elapsed < request.timeout_seconds:
-        raise HumanInputResumeValidationError(
-            f"HITL request {request_id!r} has not expired"
-        )
+        raise HumanInputResumeValidationError(f"HITL request {request_id!r} has not expired")
     if request.timeout_action is HumanInputTimeoutAction.STAY_WAITING:
         raise HumanInputResumeValidationError(
             f"HITL request {request_id!r} uses timeout_action=stay_waiting; "

--- a/src/ouroboros/core/hitl_resume.py
+++ b/src/ouroboros/core/hitl_resume.py
@@ -22,7 +22,7 @@ from ouroboros.core.hitl_contract import (
 )
 from ouroboros.core.hitl_state import HumanInputSnapshot, HumanInputState, project_human_input_state
 from ouroboros.events.base import BaseEvent
-from ouroboros.events.hitl import create_hitl_answered_event
+from ouroboros.events.hitl import create_hitl_answered_event, create_hitl_timed_out_event
 
 
 class HumanInputResumeValidationError(ValueError):
@@ -45,6 +45,53 @@ def create_validated_hitl_resume_event(
     snapshot = pending_human_input_snapshot_for_response(events, response)
     request = human_input_request_from_snapshot(snapshot)
     return create_hitl_answered_event(request, response)
+
+
+def create_validated_hitl_timeout_event(
+    events: Iterable[BaseEvent],
+    *,
+    request_id: str,
+    now: datetime,
+    reason: str = "HITL request timed out",
+) -> BaseEvent:
+    """Return ``hitl.timed_out`` when a pending request has expired.
+
+    The helper is intentionally pure: callers provide replayed HITL history and
+    the current clock value, and receive the event they may append. No scheduler,
+    UI timer, or dispatch behavior is implied by this function.
+    """
+
+    snapshot = _pending_human_input_snapshot_by_id(events, request_id)
+    request = human_input_request_from_snapshot(snapshot)
+    if request.timeout_seconds is None:
+        raise HumanInputResumeValidationError(
+            f"HITL request {request_id!r} does not define timeout_seconds"
+        )
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise HumanInputResumeValidationError("HITL timeout clock must be timezone-aware")
+    elapsed = (now - request.created_at).total_seconds()
+    if elapsed < request.timeout_seconds:
+        raise HumanInputResumeValidationError(
+            f"HITL request {request_id!r} has not expired"
+        )
+    return create_hitl_timed_out_event(request, reason=reason)
+
+
+def _pending_human_input_snapshot_by_id(
+    events: Iterable[BaseEvent], request_id: str
+) -> HumanInputSnapshot:
+    snapshots = project_human_input_state(events)
+    matching = tuple(snapshot for snapshot in snapshots if snapshot.request_id == request_id)
+    if not matching:
+        raise HumanInputResumeValidationError(
+            f"HITL request {request_id!r} was not found in replayed state"
+        )
+    snapshot = matching[-1]
+    if snapshot.state is not HumanInputState.PENDING:
+        raise HumanInputResumeValidationError(
+            f"HITL request {request_id!r} is not pending; current state is {snapshot.state.value}"
+        )
+    return snapshot
 
 
 def pending_human_input_snapshot_for_response(
@@ -186,6 +233,7 @@ def _datetime_from_payload(value: Any, *, fallback: datetime) -> datetime:
 __all__ = [
     "HumanInputResumeValidationError",
     "create_validated_hitl_resume_event",
+    "create_validated_hitl_timeout_event",
     "human_input_request_from_snapshot",
     "pending_human_input_snapshot_for_response",
 ]

--- a/src/ouroboros/core/hitl_resume.py
+++ b/src/ouroboros/core/hitl_resume.py
@@ -74,6 +74,11 @@ def create_validated_hitl_timeout_event(
         raise HumanInputResumeValidationError(
             f"HITL request {request_id!r} has not expired"
         )
+    if request.timeout_action is HumanInputTimeoutAction.STAY_WAITING:
+        raise HumanInputResumeValidationError(
+            f"HITL request {request_id!r} uses timeout_action=stay_waiting; "
+            "no terminal timeout event should be emitted"
+        )
     return create_hitl_timed_out_event(request, reason=reason)
 
 

--- a/tests/unit/core/test_hitl_resume.py
+++ b/tests/unit/core/test_hitl_resume.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 import pytest
 
@@ -15,6 +15,7 @@ from ouroboros.core.hitl_contract import (
 from ouroboros.core.hitl_resume import (
     HumanInputResumeValidationError,
     create_validated_hitl_resume_event,
+    create_validated_hitl_timeout_event,
     human_input_request_from_snapshot,
     pending_human_input_snapshot_for_response,
 )
@@ -164,3 +165,57 @@ def test_create_validated_hitl_resume_event_answers_wait_with_naive_created_at()
     assert reconstructed.to_event_data()["created_at"] == "2026-05-19T12:30:00+00:00"
     assert event.type == "hitl.answered"
     assert event.aggregate_id == "hitl-1"
+
+
+def test_create_validated_hitl_timeout_event_accepts_expired_pending_request() -> None:
+    request = _request()
+    requested = create_hitl_requested_event(request)
+
+    event = create_validated_hitl_timeout_event(
+        [requested],
+        request_id="hitl-1",
+        now=request.created_at + timedelta(seconds=60),
+        reason="approval timed out",
+    )
+
+    assert event.type == "hitl.timed_out"
+    assert event.aggregate_id == "hitl-1"
+    assert event.data["reason"] == "approval timed out"
+    assert event.data["timeout_action"] == "stay_waiting"
+
+
+def test_create_validated_hitl_timeout_event_rejects_not_expired_request() -> None:
+    request = _request()
+    requested = create_hitl_requested_event(request)
+
+    with pytest.raises(HumanInputResumeValidationError, match="not expired"):
+        create_validated_hitl_timeout_event(
+            [requested],
+            request_id="hitl-1",
+            now=request.created_at + timedelta(seconds=59),
+        )
+
+
+def test_create_validated_hitl_timeout_event_rejects_terminal_request() -> None:
+    request = _request()
+    requested = create_hitl_requested_event(request)
+    answered = create_hitl_answered_event(request, _approval_response())
+
+    with pytest.raises(HumanInputResumeValidationError, match="not pending"):
+        create_validated_hitl_timeout_event(
+            [requested, answered],
+            request_id="hitl-1",
+            now=request.created_at + timedelta(seconds=120),
+        )
+
+
+def test_create_validated_hitl_timeout_event_requires_timezone_aware_clock() -> None:
+    request = _request()
+    requested = create_hitl_requested_event(request)
+
+    with pytest.raises(HumanInputResumeValidationError, match="timezone-aware"):
+        create_validated_hitl_timeout_event(
+            [requested],
+            request_id="hitl-1",
+            now=datetime(2026, 5, 18),
+        )

--- a/tests/unit/core/test_hitl_resume.py
+++ b/tests/unit/core/test_hitl_resume.py
@@ -11,6 +11,7 @@ from ouroboros.core.hitl_contract import (
     HumanInputResponseKind,
     HumanInputRiskClass,
     HumanInputSource,
+    HumanInputTimeoutAction,
 )
 from ouroboros.core.hitl_resume import (
     HumanInputResumeValidationError,
@@ -23,7 +24,10 @@ from ouroboros.core.hitl_state import HumanInputState, project_human_input_state
 from ouroboros.events.hitl import create_hitl_answered_event, create_hitl_requested_event
 
 
-def _request() -> HumanInputRequest:
+def _request(
+    *,
+    timeout_action: HumanInputTimeoutAction = HumanInputTimeoutAction.STAY_WAITING,
+) -> HumanInputRequest:
     return HumanInputRequest(
         request_id="hitl-1",
         session_id="session-1",
@@ -36,6 +40,7 @@ def _request() -> HumanInputRequest:
         question="Approve the plan?",
         resume_target="plan:approval",
         timeout_seconds=60,
+        timeout_action=timeout_action,
         payload={"plan_id": "plan-1"},
         created_at=datetime(2026, 5, 18, tzinfo=UTC),
     )
@@ -168,7 +173,7 @@ def test_create_validated_hitl_resume_event_answers_wait_with_naive_created_at()
 
 
 def test_create_validated_hitl_timeout_event_accepts_expired_pending_request() -> None:
-    request = _request()
+    request = _request(timeout_action=HumanInputTimeoutAction.EXPIRE_BLOCKED)
     requested = create_hitl_requested_event(request)
 
     event = create_validated_hitl_timeout_event(
@@ -181,7 +186,26 @@ def test_create_validated_hitl_timeout_event_accepts_expired_pending_request() -
     assert event.type == "hitl.timed_out"
     assert event.aggregate_id == "hitl-1"
     assert event.data["reason"] == "approval timed out"
-    assert event.data["timeout_action"] == "stay_waiting"
+    assert event.data["timeout_action"] == "expire_blocked"
+
+    snapshot = project_human_input_state([requested, event])[0]
+    assert snapshot.state is HumanInputState.TIMED_OUT
+    assert snapshot.is_terminal is True
+
+
+def test_create_validated_hitl_timeout_event_rejects_stay_waiting_request() -> None:
+    request = _request()
+    requested = create_hitl_requested_event(request)
+
+    with pytest.raises(
+        HumanInputResumeValidationError,
+        match="timeout_action=stay_waiting",
+    ):
+        create_validated_hitl_timeout_event(
+            [requested],
+            request_id="hitl-1",
+            now=request.created_at + timedelta(seconds=60),
+        )
 
 
 def test_create_validated_hitl_timeout_event_rejects_not_expired_request() -> None:


### PR DESCRIPTION
## Summary
- Add a pure replay-based helper that creates a validated `hitl.timed_out` event for expired pending requests.
- Reject missing, terminal, unexpired, and timezone-naive timeout decisions.
- Add focused timeout validation tests.

Refs #960
Refs #961

## Scope
- Pure helper/tests only.
- No scheduler, UI timer, or runtime dispatch changes.

## Test Plan
- `uv run pytest tests/unit/core/test_hitl_resume.py -q`
- `uv run ruff check src/ouroboros/core/hitl_resume.py tests/unit/core/test_hitl_resume.py`
- `uv run mypy src/ouroboros/core/hitl_resume.py tests/unit/core/test_hitl_resume.py`
