### PR TITLE
Document runtime delegation ownership contract

### DIFF
--- a/docs/rfc/runtime-delegation-contract.md
+++ b/docs/rfc/runtime-delegation-contract.md
@@ -1,0 +1,51 @@
+# Runtime delegation transition contract (#925)
+
+This RFC fixes the boundary between plugin-delegated work and JobManager-owned
+background jobs. It is intentionally a documentation/test slice: it does not
+rewrite Ralph, plugin, MCP, or scheduler runtime behavior.
+
+## Scope taxonomy
+
+| Scope | Owner | Subject id | Terminal authority | Cancellation/polling surface |
+|---|---|---|---|---|
+| `mcp_job` | `JobManager` | concrete `job_id` | `JobManager` terminal job event/result | `ouroboros_get_job_status`, `ouroboros_cancel_job` |
+| `plugin` | plugin firewall/bridge delegated child session | plugin or delegated session id | plugin bridge/firewall audit evidence, not a job terminal row | runtime-specific child-session controls; job tools do not apply |
+| `harness_runner` | local harness runner | execution/session id | harness execution state | execution cancellation/status tools |
+| `ralph` / `auto` / `team` | owning workflow controller | workflow/session id | workflow controller state | workflow-specific controls |
+
+A plugin delegation MUST NOT fabricate a `JobManager` job id merely to reuse
+job polling. If the bridge returns `status=delegated_to_plugin` and `job_id=None`,
+callers must treat that run as `runtime_scope=plugin` until a real owner emits
+separate evidence. Conversely, a real background job MUST use
+`runtime_scope=mcp_job` and the concrete `job_id` as its subject.
+
+## Transition evidence rules
+
+`RuntimeTransition` records the narrow boundary decision before a caller mutates
+runtime state. The event data must include `runtime_scope`, `subject_id`,
+`from_state`, `to_state`, `actor`, and bounded metadata. For terminal or
+cross-boundary changes, callers should require at least one `evidence_refs`
+entry that points at the owner surface:
+
+- `mcp_job`: `event://mcp.job.status/<job_id>` or equivalent JobManager event.
+- `plugin`: `event://plugin/<plugin_id>/delegated/<session_id>` or plugin audit
+  evidence from the bridge/firewall.
+- `harness_runner`: harness execution event or artifact reference.
+
+Missing evidence is a blocking contract failure, not a retryable polling issue.
+Stale revisions and snapshot drift remain retryable because the caller can reload
+state and re-evaluate. Existing terminal states remain terminal failures.
+
+## Plugin delegation vs JobManager non-goals
+
+This contract does **not**:
+
+1. move plugin child sessions into `JobManager`;
+2. add a scheduler for plugin-delegated work;
+3. change Ralph loop ownership;
+4. add plugin permission prompts; or
+5. reinterpret `JobManager` cancellation as plugin child-session cancellation.
+
+Future runtime work may build adapters on top of this boundary, but must keep
+plugin-delegated sessions and JobManager jobs distinguishable in persisted
+audit/event data.

--- a/docs/rfc/runtime-delegation-contract.md
+++ b/docs/rfc/runtime-delegation-contract.md
@@ -23,9 +23,11 @@ separate evidence. Conversely, a real background job MUST use
 
 `RuntimeTransition` records the narrow boundary decision before a caller mutates
 runtime state. The event data must include `runtime_scope`, `subject_id`,
-`from_state`, `to_state`, `actor`, and bounded metadata. For terminal or
-cross-boundary changes, callers should require at least one `evidence_refs`
-entry that points at the owner surface:
+`from_state`, `to_state`, `actor`, and bounded metadata. Terminal transitions
+require at least one `evidence_refs` entry by default when the caller supplies
+the terminal-state set to the validator. Callers may also opt in for additional
+cross-boundary changes before the terminal state. Evidence must point at the
+owner surface:
 
 - `mcp_job`: `event://mcp.job.status/<job_id>` or equivalent JobManager event.
 - `plugin`: `event://plugin/<plugin_id>/delegated/<session_id>` or plugin audit

--- a/src/ouroboros/core/runtime_transition.py
+++ b/src/ouroboros/core/runtime_transition.py
@@ -20,7 +20,9 @@ from typing import Any, Final, cast
 
 RUNTIME_TRANSITION_SCHEMA_VERSION: Final[int] = 1
 MAX_RUNTIME_TRANSITION_PAYLOAD_BYTES: Final[int] = 8192
-_CONCRETE_JOB_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"^job-[A-Za-z0-9][A-Za-z0-9_.:-]*$")
+_CONCRETE_JOB_ID_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^(?:job_[0-9a-f]{12}|job-[A-Za-z0-9][A-Za-z0-9_.:-]*)$"
+)
 
 _SECRET_KEYS: Final[frozenset[str]] = frozenset(
     {

--- a/src/ouroboros/core/runtime_transition.py
+++ b/src/ouroboros/core/runtime_transition.py
@@ -20,6 +20,7 @@ from typing import Any, Final, cast
 
 RUNTIME_TRANSITION_SCHEMA_VERSION: Final[int] = 1
 MAX_RUNTIME_TRANSITION_PAYLOAD_BYTES: Final[int] = 8192
+_CONCRETE_JOB_ID_PATTERN: Final[re.Pattern[str]] = re.compile(r"^job-[A-Za-z0-9][A-Za-z0-9_.:-]*$")
 
 _SECRET_KEYS: Final[frozenset[str]] = frozenset(
     {
@@ -200,6 +201,18 @@ def _normalize_refs(values: Iterable[str]) -> tuple[str, ...]:
         seen.add(ref)
         normalized.append(ref)
     return tuple(normalized)
+
+
+def _looks_like_concrete_job_id(value: object) -> bool:
+    return isinstance(value, str) and _CONCRETE_JOB_ID_PATTERN.fullmatch(value) is not None
+
+
+def _plugin_reuses_concrete_job_id(transition: RuntimeTransition) -> bool:
+    if transition.runtime_scope is not RuntimeScope.PLUGIN:
+        return False
+    if _looks_like_concrete_job_id(transition.subject_id):
+        return True
+    return _looks_like_concrete_job_id(transition.metadata.get("job_id"))
 
 
 @dataclass(frozen=True, slots=True)
@@ -390,6 +403,19 @@ def evaluate_runtime_transition(
     if isinstance(terminal_states, str | bytes):
         raise TypeError("RuntimeTransition terminal_states must be an iterable of strings")
     terminal_set = {_require_non_blank("terminal_state", state) for state in terminal_states}
+    if _plugin_reuses_concrete_job_id(transition):
+        return RuntimeTransitionResult(
+            transition=transition,
+            decision=RuntimeTransitionDecision.REJECTED,
+            failure_class=RuntimeFailureClass.BLOCKING,
+            failure_kind=RuntimeTransitionFailureKind.INVALID_SCOPE,
+            message=(
+                "plugin runtime transitions must use plugin child-session subjects, "
+                "not concrete JobManager job ids"
+            ),
+            current_revision=current_revision,
+            current_state=normalized_current,
+        )
     if normalized_current in terminal_set:
         return RuntimeTransitionResult(
             transition=transition,
@@ -427,7 +453,7 @@ def evaluate_runtime_transition(
             current_revision=current_revision,
             current_state=normalized_current,
         )
-    if require_evidence and not transition.evidence_refs:
+    if (require_evidence or transition.to_state in terminal_set) and not transition.evidence_refs:
         return RuntimeTransitionResult(
             transition=transition,
             decision=RuntimeTransitionDecision.REJECTED,

--- a/tests/unit/core/test_runtime_transition.py
+++ b/tests/unit/core/test_runtime_transition.py
@@ -230,6 +230,92 @@ def test_missing_required_evidence_is_blocking() -> None:
     assert result.failure_kind is RuntimeTransitionFailureKind.MISSING_EVIDENCE
 
 
+def test_plugin_delegation_transition_is_not_a_jobmanager_job() -> None:
+    transition = _transition(
+        runtime_scope=RuntimeScope.PLUGIN,
+        subject_id="plugin:opencode-ralph/session-42",
+        from_state="delegated",
+        to_state="completed",
+        reason="plugin child session reported completion",
+        actor=RuntimeTransitionActor.PLUGIN,
+        expected_revision=None,
+        evidence_refs=("event://plugin/opencode-ralph/delegated/session-42/completed",),
+        metadata={
+            "delegation_mode": "plugin_child_session",
+            "job_id": None,
+            "owner": "opencode_plugin_bridge",
+        },
+    )
+
+    result = evaluate_runtime_transition(
+        transition,
+        current_state="delegated",
+        allowed_transitions=(("delegated", "completed"), ("delegated", "blocked")),
+        terminal_states=("completed", "failed", "cancelled"),
+        require_evidence=True,
+    )
+
+    event_data = result.to_event_data()
+    assert result.accepted is True
+    assert transition.aggregate_id == "plugin:plugin:opencode-ralph/session-42"
+    assert event_data["runtime_scope"] == "plugin"
+    assert event_data["subject_id"] == "plugin:opencode-ralph/session-42"
+    assert event_data["metadata"] == {
+        "delegation_mode": "plugin_child_session",
+        "job_id": None,
+        "owner": "opencode_plugin_bridge",
+    }
+
+
+def test_jobmanager_transition_uses_concrete_mcp_job_subject() -> None:
+    transition = _transition(
+        runtime_scope=RuntimeScope.MCP_JOB,
+        subject_id="job-ralph-123",
+        from_state="running",
+        to_state="completed",
+        reason="JobManager persisted terminal result",
+        actor=RuntimeTransitionActor.SYSTEM,
+        expected_revision=None,
+        evidence_refs=("event://mcp.job.status/job-ralph-123/completed",),
+        metadata={"result_ref": "job://job-ralph-123/result"},
+    )
+
+    result = evaluate_runtime_transition(
+        transition,
+        current_state="running",
+        allowed_transitions=(("running", "completed"), ("running", "failed")),
+        terminal_states=("completed", "failed", "cancelled"),
+        require_evidence=True,
+    )
+
+    assert result.accepted is True
+    assert transition.aggregate_id == "mcp_job:job-ralph-123"
+    assert result.to_event_data()["runtime_scope"] == "mcp_job"
+
+
+def test_plugin_terminal_transition_without_bridge_evidence_is_blocking() -> None:
+    result = evaluate_runtime_transition(
+        _transition(
+            runtime_scope=RuntimeScope.PLUGIN,
+            subject_id="plugin:opencode-ralph/session-42",
+            from_state="delegated",
+            to_state="completed",
+            reason="plugin child session reported completion",
+            actor=RuntimeTransitionActor.PLUGIN,
+            expected_revision=None,
+            evidence_refs=(),
+        ),
+        current_state="delegated",
+        allowed_transitions=(("delegated", "completed"), ("delegated", "blocked")),
+        terminal_states=("completed", "failed", "cancelled"),
+        require_evidence=True,
+    )
+
+    assert result.accepted is False
+    assert result.failure_class is RuntimeFailureClass.BLOCKING
+    assert result.failure_kind is RuntimeTransitionFailureKind.MISSING_EVIDENCE
+
+
 def test_validation_rejects_noop_duplicate_evidence_and_secret_metadata() -> None:
     with pytest.raises(ValueError, match="from_state and to_state must differ"):
         _transition(from_state="running", to_state="running")

--- a/tests/unit/core/test_runtime_transition.py
+++ b/tests/unit/core/test_runtime_transition.py
@@ -271,7 +271,7 @@ def test_plugin_transition_rejects_concrete_job_subject_id() -> None:
     result = evaluate_runtime_transition(
         _transition(
             runtime_scope=RuntimeScope.PLUGIN,
-            subject_id="job-ralph-123",
+            subject_id="job_012345abcdef",
             from_state="delegated",
             to_state="blocked",
             reason="plugin child session reported blocked state",
@@ -289,7 +289,30 @@ def test_plugin_transition_rejects_concrete_job_subject_id() -> None:
     assert "JobManager job ids" in result.message
 
 
-def test_plugin_transition_rejects_concrete_job_metadata_id() -> None:
+def test_plugin_transition_rejects_production_job_metadata_id_regression() -> None:
+    result = evaluate_runtime_transition(
+        _transition(
+            runtime_scope=RuntimeScope.PLUGIN,
+            subject_id="plugin:opencode-ralph/session-42",
+            from_state="delegated",
+            to_state="blocked",
+            reason="plugin child session reported blocked state",
+            actor=RuntimeTransitionActor.PLUGIN,
+            expected_revision=None,
+            evidence_refs=("event://plugin/opencode-ralph/delegated/session-42/blocked",),
+            metadata={"job_id": "job_012345abcdef"},
+        ),
+        current_state="delegated",
+        allowed_transitions=(("delegated", "blocked"),),
+    )
+
+    assert result.accepted is False
+    assert result.failure_class is RuntimeFailureClass.BLOCKING
+    assert result.failure_kind is RuntimeTransitionFailureKind.INVALID_SCOPE
+    assert "JobManager job ids" in result.message
+
+
+def test_plugin_transition_still_rejects_legacy_job_metadata_id() -> None:
     result = evaluate_runtime_transition(
         _transition(
             runtime_scope=RuntimeScope.PLUGIN,
@@ -315,14 +338,14 @@ def test_plugin_transition_rejects_concrete_job_metadata_id() -> None:
 def test_jobmanager_transition_uses_concrete_mcp_job_subject() -> None:
     transition = _transition(
         runtime_scope=RuntimeScope.MCP_JOB,
-        subject_id="job-ralph-123",
+        subject_id="job_012345abcdef",
         from_state="running",
         to_state="completed",
         reason="JobManager persisted terminal result",
         actor=RuntimeTransitionActor.SYSTEM,
         expected_revision=None,
-        evidence_refs=("event://mcp.job.status/job-ralph-123/completed",),
-        metadata={"result_ref": "job://job-ralph-123/result"},
+        evidence_refs=("event://mcp.job.status/job_012345abcdef/completed",),
+        metadata={"result_ref": "job://job_012345abcdef/result"},
     )
 
     result = evaluate_runtime_transition(
@@ -334,7 +357,7 @@ def test_jobmanager_transition_uses_concrete_mcp_job_subject() -> None:
     )
 
     assert result.accepted is True
-    assert transition.aggregate_id == "mcp_job:job-ralph-123"
+    assert transition.aggregate_id == "mcp_job:job_012345abcdef"
     assert result.to_event_data()["runtime_scope"] == "mcp_job"
 
 

--- a/tests/unit/core/test_runtime_transition.py
+++ b/tests/unit/core/test_runtime_transition.py
@@ -267,6 +267,51 @@ def test_plugin_delegation_transition_is_not_a_jobmanager_job() -> None:
     }
 
 
+def test_plugin_transition_rejects_concrete_job_subject_id() -> None:
+    result = evaluate_runtime_transition(
+        _transition(
+            runtime_scope=RuntimeScope.PLUGIN,
+            subject_id="job-ralph-123",
+            from_state="delegated",
+            to_state="blocked",
+            reason="plugin child session reported blocked state",
+            actor=RuntimeTransitionActor.PLUGIN,
+            expected_revision=None,
+            evidence_refs=("event://plugin/opencode-ralph/delegated/session-42/blocked",),
+        ),
+        current_state="delegated",
+        allowed_transitions=(("delegated", "blocked"),),
+    )
+
+    assert result.accepted is False
+    assert result.failure_class is RuntimeFailureClass.BLOCKING
+    assert result.failure_kind is RuntimeTransitionFailureKind.INVALID_SCOPE
+    assert "JobManager job ids" in result.message
+
+
+def test_plugin_transition_rejects_concrete_job_metadata_id() -> None:
+    result = evaluate_runtime_transition(
+        _transition(
+            runtime_scope=RuntimeScope.PLUGIN,
+            subject_id="plugin:opencode-ralph/session-42",
+            from_state="delegated",
+            to_state="blocked",
+            reason="plugin child session reported blocked state",
+            actor=RuntimeTransitionActor.PLUGIN,
+            expected_revision=None,
+            evidence_refs=("event://plugin/opencode-ralph/delegated/session-42/blocked",),
+            metadata={"job_id": "job-ralph-123"},
+        ),
+        current_state="delegated",
+        allowed_transitions=(("delegated", "blocked"),),
+    )
+
+    assert result.accepted is False
+    assert result.failure_class is RuntimeFailureClass.BLOCKING
+    assert result.failure_kind is RuntimeTransitionFailureKind.INVALID_SCOPE
+    assert "JobManager job ids" in result.message
+
+
 def test_jobmanager_transition_uses_concrete_mcp_job_subject() -> None:
     transition = _transition(
         runtime_scope=RuntimeScope.MCP_JOB,
@@ -293,7 +338,7 @@ def test_jobmanager_transition_uses_concrete_mcp_job_subject() -> None:
     assert result.to_event_data()["runtime_scope"] == "mcp_job"
 
 
-def test_plugin_terminal_transition_without_bridge_evidence_is_blocking() -> None:
+def test_plugin_terminal_transition_without_bridge_evidence_is_blocking_by_default() -> None:
     result = evaluate_runtime_transition(
         _transition(
             runtime_scope=RuntimeScope.PLUGIN,
@@ -308,12 +353,47 @@ def test_plugin_terminal_transition_without_bridge_evidence_is_blocking() -> Non
         current_state="delegated",
         allowed_transitions=(("delegated", "completed"), ("delegated", "blocked")),
         terminal_states=("completed", "failed", "cancelled"),
-        require_evidence=True,
     )
 
     assert result.accepted is False
     assert result.failure_class is RuntimeFailureClass.BLOCKING
     assert result.failure_kind is RuntimeTransitionFailureKind.MISSING_EVIDENCE
+
+
+def test_mcp_job_terminal_transition_without_evidence_is_blocking_by_default() -> None:
+    result = evaluate_runtime_transition(
+        _transition(
+            from_state="running",
+            to_state="completed",
+            reason="JobManager persisted terminal result",
+            actor=RuntimeTransitionActor.SYSTEM,
+            expected_revision=None,
+            evidence_refs=(),
+        ),
+        current_state="running",
+        allowed_transitions=(("running", "completed"), ("running", "failed")),
+        terminal_states=("completed", "failed", "cancelled"),
+    )
+
+    assert result.accepted is False
+    assert result.failure_class is RuntimeFailureClass.BLOCKING
+    assert result.failure_kind is RuntimeTransitionFailureKind.MISSING_EVIDENCE
+
+
+def test_non_terminal_transition_without_evidence_is_allowed_by_default() -> None:
+    result = evaluate_runtime_transition(
+        _transition(
+            from_state="pending",
+            to_state="running",
+            expected_revision=None,
+            evidence_refs=(),
+        ),
+        current_state="pending",
+        allowed_transitions=_ALLOWED,
+        terminal_states=("completed", "failed", "cancelled"),
+    )
+
+    assert result.accepted is True
 
 
 def test_validation_rejects_noop_duplicate_evidence_and_secret_metadata() -> None:


### PR DESCRIPTION
## Summary
- document the #925 plugin delegation vs JobManager runtime ownership boundary
- add runtime transition tests proving plugin-delegated child sessions stay `runtime_scope=plugin`
- add JobManager and missing-evidence examples to lock terminal authority behavior

## Scope
- No runtime rewrite, scheduler change, Ralph loop change, or plugin prompt behavior.
- Contract-only docs/tests for #925-C.

## Verification
- `uv run pytest tests/unit/core/test_runtime_transition.py -q`
- `uv run ruff check tests/unit/core/test_runtime_transition.py src/ouroboros/core/runtime_transition.py`
- `uv run mypy src/ouroboros/core/runtime_transition.py tests/unit/core/test_runtime_transition.py`
