### PR TITLE
Specify plugin permission HITL contract

### DIFF
--- a/docs/rfc/userlevel-plugins.md
+++ b/docs/rfc/userlevel-plugins.md
@@ -413,9 +413,50 @@ not trusted blocks before plugin-controlled code runs. Additional rules:
    underlying command would use.
 4. Hook output is advisory unless the hook is declared as a policy hook and the
    caller explicitly consumes the decision.
-5. Plugin permission approval is not implemented here. Required permission
-   denial remains fail-closed at the firewall; future HITL approval must route
-   through #960 rather than adding a hook-local prompt.
+5. Plugin permission approval is specified by the typed HITL contract below.
+   This RFC still does not implement a plugin prompt renderer; until a caller
+   wires a #960 HITL surface, required permission denial remains fail-closed at
+   the firewall rather than falling back to a hook-local prompt.
+
+
+### Plugin permission HITL contract (#960)
+
+When the plugin firewall needs human permission approval, it must express that
+wait through the shared `hitl.*` event contract instead of prompting from plugin
+code. This section is a contract/specification slice only; it does not add a
+plugin prompt runtime, scheduler, or UI renderer.
+
+Required request fields:
+
+| HITL field | Required value for plugin permission waits |
+|---|---|
+| `type` | `hitl.requested` |
+| `kind` | `approval` for ordinary permission grants; `destructive_confirmation` when the requested scope can delete, overwrite, deploy to production, or otherwise cause irreversible side effects |
+| `source` | `plugin_firewall` |
+| `required_permission` | the exact manifest/firewall scope being requested, for example `plugin:lifecycle:read` or `external:production:deploy` |
+| `risk_class` | `low` for read-only local inspection; `material_branch` for local mutation or policy-changing scopes; `credential_gated` for secret/credential authority; `external_production` for non-destructive production/external effects; `destructive` for irreversible deletion, overwrite, or production deployment |
+| `resume_target` | a firewall-owned target such as `plugin-firewall:permission:<session-or-invocation-id>` |
+| `surface` | the renderer that owns the question, for example `plugin.firewall.permission`, `cli.plugin.permission`, or a future MCP/TUI permission surface |
+| `payload` | bounded, non-secret metadata such as `plugin_id`, `permission_scope`, `permission_reason`, and `invocation_id` |
+
+Responses must be recorded as `hitl.answered` with `response_kind=approval`.
+`approval_decision=true` resumes the firewall path that originally requested the
+permission; `approval_decision=false` is a denial and must remain fail-closed.
+Aborted renderers must persist `hitl.cancelled`; expired permission waits must
+persist `hitl.timed_out` and use the contract's timeout action rather than
+letting plugin code continue silently.
+
+Secret material must not be stored in HITL payloads or answers. If the user must
+provide credentials, the permission request should point at a credential-gated
+external surface and persist only a non-secret reference or denial reason.
+
+Non-goals for this slice:
+
+1. no plugin-controlled `input()`/prompt fallback;
+2. no bypass of manifest permission validation;
+3. no persistence of tokens, API keys, or credential values;
+4. no scheduler or UI implementation for pending plugin waits; and
+5. no conversion of plugin permission waits into JobManager jobs.
 
 ### Hook audit events
 

--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -15,7 +15,7 @@ import json
 from types import MappingProxyType
 from typing import Any, ClassVar, Self, cast
 
-HITL_CONTRACT_SCHEMA_VERSION = 1
+HITL_CONTRACT_SCHEMA_VERSION = 2
 MAX_HITL_PAYLOAD_BYTES = 8192
 _SECRET_KEY_NAMES = frozenset(
     {
@@ -222,9 +222,10 @@ class HumanInputRequest:
         normal constructor remains strict for fresh requests.
         """
 
-        if kwargs.get("schema_version", HITL_CONTRACT_SCHEMA_VERSION) != 1:
+        schema_version = kwargs.get("schema_version", 1)
+        if schema_version != 1:
             raise ValueError("legacy HITL request replay only supports schema_version=1")
-        return cls(**kwargs, _legacy_schema_v1_replay=True)
+        return cls(**{**kwargs, "schema_version": 1}, _legacy_schema_v1_replay=True)
 
     @classmethod
     def from_persisted_event_data(cls, **kwargs: Any) -> Self:

--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -226,6 +226,44 @@ class HumanInputRequest:
             raise ValueError("legacy HITL request replay only supports schema_version=1")
         return cls(**kwargs, _legacy_schema_v1_replay=True)
 
+    @classmethod
+    def from_persisted_event_data(cls, **kwargs: Any) -> Self:
+        """Rehydrate a request from persisted event data.
+
+        Fresh requests must always use the strict constructor.  Persisted replay
+        only relaxes early schema v1 plugin-firewall approval records that are
+        missing fields later required by the v1 permission contract.
+        """
+
+        if cls._requires_legacy_schema_v1_plugin_firewall_replay(kwargs):
+            return cls.from_persisted_schema_v1(**kwargs)
+        return cls(**kwargs)
+
+    @staticmethod
+    def _requires_legacy_schema_v1_plugin_firewall_replay(kwargs: Mapping[str, Any]) -> bool:
+        if kwargs.get("schema_version", HITL_CONTRACT_SCHEMA_VERSION) != 1:
+            return False
+        source = kwargs.get("source")
+        if source not in {HumanInputSource.PLUGIN_FIREWALL, HumanInputSource.PLUGIN_FIREWALL.value}:
+            return False
+
+        kind = kwargs.get("kind")
+        if kind not in {
+            HumanInputKind.APPROVAL,
+            HumanInputKind.DESTRUCTIVE_CONFIRMATION,
+            HumanInputKind.APPROVAL.value,
+            HumanInputKind.DESTRUCTIVE_CONFIRMATION.value,
+        }:
+            return False
+
+        payload = kwargs.get("payload", {})
+        permission_scope = payload.get("permission_scope") if isinstance(payload, Mapping) else None
+        return (
+            kwargs.get("required_permission") is None
+            or kwargs.get("surface") is None
+            or permission_scope is None
+        )
+
     def __post_init__(self, _legacy_schema_v1_replay: bool) -> None:
         if type(self.schema_version) is not int or self.schema_version < 1:
             raise ValueError("HumanInputRequest schema_version must be a positive integer")

--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -8,12 +8,12 @@ payloads without choosing a renderer (CLI, MCP, TUI, or structured question).
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 from datetime import UTC, datetime
 from enum import StrEnum
 import json
 from types import MappingProxyType
-from typing import Any, ClassVar, cast
+from typing import Any, ClassVar, Self, cast
 
 HITL_CONTRACT_SCHEMA_VERSION = 1
 MAX_HITL_PAYLOAD_BYTES = 8192
@@ -207,12 +207,26 @@ class HumanInputRequest:
     surface: str | None = None
     payload: Mapping[str, FrozenJsonValue] = field(default_factory=dict)
     created_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    _legacy_schema_v1_replay: InitVar[bool] = False
 
     REQUESTED_EVENT_TYPE: ClassVar[str] = "hitl.requested"
     TIMED_OUT_EVENT_TYPE: ClassVar[str] = "hitl.timed_out"
     CANCELLED_EVENT_TYPE: ClassVar[str] = "hitl.cancelled"
 
-    def __post_init__(self) -> None:
+    @classmethod
+    def from_persisted_schema_v1(cls, **kwargs: Any) -> Self:
+        """Rehydrate a schema v1 request from already-persisted event data.
+
+        Early v1 plugin-firewall approval events did not persist all fields that
+        new requests must include.  Keep that compatibility path explicit so the
+        normal constructor remains strict for fresh requests.
+        """
+
+        if kwargs.get("schema_version", HITL_CONTRACT_SCHEMA_VERSION) != 1:
+            raise ValueError("legacy HITL request replay only supports schema_version=1")
+        return cls(**kwargs, _legacy_schema_v1_replay=True)
+
+    def __post_init__(self, _legacy_schema_v1_replay: bool) -> None:
         if type(self.schema_version) is not int or self.schema_version < 1:
             raise ValueError("HumanInputRequest schema_version must be a positive integer")
         if not isinstance(self.kind, HumanInputKind):
@@ -256,16 +270,24 @@ class HumanInputRequest:
             raise ValueError("select HumanInputRequest requires at least one option")
         object.__setattr__(self, "options", _normalize_string_tuple("options", self.options))
         object.__setattr__(self, "payload", _ensure_json_safe_payload("payload", self.payload))
-        self._validate_source_specific_contract()
+        self._validate_source_specific_contract(
+            allow_legacy_schema_v1_replay=_legacy_schema_v1_replay
+        )
         object.__setattr__(
             self, "created_at", _normalize_utc_datetime("created_at", self.created_at)
         )
 
-    def _validate_source_specific_contract(self) -> None:
+    def _validate_source_specific_contract(
+        self, *, allow_legacy_schema_v1_replay: bool = False
+    ) -> None:
         if self.source is not HumanInputSource.PLUGIN_FIREWALL or self.kind not in {
             HumanInputKind.APPROVAL,
             HumanInputKind.DESTRUCTIVE_CONFIRMATION,
         }:
+            return
+
+        if allow_legacy_schema_v1_replay and self.schema_version == 1:
+            self._validate_legacy_plugin_firewall_replay_contract()
             return
 
         if self.required_permission is None:
@@ -279,6 +301,17 @@ class HumanInputRequest:
 
         permission_scope = self.payload.get("permission_scope")
         if permission_scope != self.required_permission:
+            raise ValueError(
+                "plugin_firewall approval HumanInputRequest payload permission_scope "
+                "must match required_permission"
+            )
+
+    def _validate_legacy_plugin_firewall_replay_contract(self) -> None:
+        if self.required_permission is None:
+            return
+
+        permission_scope = self.payload.get("permission_scope")
+        if permission_scope is not None and permission_scope != self.required_permission:
             raise ValueError(
                 "plugin_firewall approval HumanInputRequest payload permission_scope "
                 "must match required_permission"

--- a/src/ouroboros/core/hitl_contract.py
+++ b/src/ouroboros/core/hitl_contract.py
@@ -256,9 +256,33 @@ class HumanInputRequest:
             raise ValueError("select HumanInputRequest requires at least one option")
         object.__setattr__(self, "options", _normalize_string_tuple("options", self.options))
         object.__setattr__(self, "payload", _ensure_json_safe_payload("payload", self.payload))
+        self._validate_source_specific_contract()
         object.__setattr__(
             self, "created_at", _normalize_utc_datetime("created_at", self.created_at)
         )
+
+    def _validate_source_specific_contract(self) -> None:
+        if self.source is not HumanInputSource.PLUGIN_FIREWALL or self.kind not in {
+            HumanInputKind.APPROVAL,
+            HumanInputKind.DESTRUCTIVE_CONFIRMATION,
+        }:
+            return
+
+        if self.required_permission is None:
+            raise ValueError(
+                "plugin_firewall approval HumanInputRequest requires required_permission"
+            )
+        if self.surface is None:
+            raise ValueError("plugin_firewall approval HumanInputRequest requires surface")
+        if not self.payload:
+            raise ValueError("plugin_firewall approval HumanInputRequest requires payload")
+
+        permission_scope = self.payload.get("permission_scope")
+        if permission_scope != self.required_permission:
+            raise ValueError(
+                "plugin_firewall approval HumanInputRequest payload permission_scope "
+                "must match required_permission"
+            )
 
     @property
     def aggregate_id(self) -> str:

--- a/src/ouroboros/core/hitl_resume.py
+++ b/src/ouroboros/core/hitl_resume.py
@@ -82,31 +82,35 @@ def human_input_request_from_snapshot(snapshot: HumanInputSnapshot) -> HumanInpu
 
     data = snapshot.request
     try:
-        return HumanInputRequest.from_persisted_event_data(
-            request_id=_required_str(data, "request_id"),
-            session_id=_required_str(data, "session_id"),
-            schema_version=data.get("schema_version", 1),
-            run_id=_optional_str(data.get("run_id")),
-            invocation_id=_optional_str(data.get("invocation_id")),
-            created_by=_required_str(data, "created_by"),
-            kind=HumanInputKind(_required_str(data, "kind")),
-            source=HumanInputSource(_required_str(data, "source")),
-            risk_class=HumanInputRiskClass(_required_str(data, "risk_class")),
-            question=_required_str(data, "question"),
-            resume_target=_required_str(data, "resume_target"),
-            title=_optional_str(data.get("title")),
-            body=_optional_str(data.get("body")),
-            options=_string_tuple(data.get("options", ())),
-            required_permission=_optional_str(data.get("required_permission")),
-            timeout_seconds=_optional_int(data.get("timeout_seconds")),
-            timeout_action=HumanInputTimeoutAction(
+        request_kwargs = {
+            "request_id": _required_str(data, "request_id"),
+            "session_id": _required_str(data, "session_id"),
+            "run_id": _optional_str(data.get("run_id")),
+            "invocation_id": _optional_str(data.get("invocation_id")),
+            "created_by": _required_str(data, "created_by"),
+            "kind": HumanInputKind(_required_str(data, "kind")),
+            "source": HumanInputSource(_required_str(data, "source")),
+            "risk_class": HumanInputRiskClass(_required_str(data, "risk_class")),
+            "question": _required_str(data, "question"),
+            "resume_target": _required_str(data, "resume_target"),
+            "title": _optional_str(data.get("title")),
+            "body": _optional_str(data.get("body")),
+            "options": _string_tuple(data.get("options", ())),
+            "required_permission": _optional_str(data.get("required_permission")),
+            "timeout_seconds": _optional_int(data.get("timeout_seconds")),
+            "timeout_action": HumanInputTimeoutAction(
                 _optional_str(data.get("timeout_action"))
                 or HumanInputTimeoutAction.STAY_WAITING.value
             ),
-            surface=_optional_str(data.get("surface")),
-            payload=_plain_mapping(data.get("payload", {})),
-            created_at=_datetime_from_payload(data.get("created_at"), fallback=snapshot.created_at),
-        )
+            "surface": _optional_str(data.get("surface")),
+            "payload": _plain_mapping(data.get("payload", {})),
+            "created_at": _datetime_from_payload(
+                data.get("created_at"), fallback=snapshot.created_at
+            ),
+        }
+        if "schema_version" in data:
+            request_kwargs["schema_version"] = data["schema_version"]
+        return HumanInputRequest.from_persisted_event_data(**request_kwargs)
     except (TypeError, ValueError) as exc:
         raise HumanInputResumeValidationError(
             f"HITL request {snapshot.request_id!r} cannot be reconstructed from persisted state"

--- a/src/ouroboros/core/hitl_resume.py
+++ b/src/ouroboros/core/hitl_resume.py
@@ -82,7 +82,7 @@ def human_input_request_from_snapshot(snapshot: HumanInputSnapshot) -> HumanInpu
 
     data = snapshot.request
     try:
-        return HumanInputRequest.from_persisted_schema_v1(
+        return HumanInputRequest.from_persisted_event_data(
             request_id=_required_str(data, "request_id"),
             session_id=_required_str(data, "session_id"),
             schema_version=data.get("schema_version", 1),

--- a/src/ouroboros/core/hitl_resume.py
+++ b/src/ouroboros/core/hitl_resume.py
@@ -82,9 +82,10 @@ def human_input_request_from_snapshot(snapshot: HumanInputSnapshot) -> HumanInpu
 
     data = snapshot.request
     try:
-        return HumanInputRequest(
+        return HumanInputRequest.from_persisted_schema_v1(
             request_id=_required_str(data, "request_id"),
             session_id=_required_str(data, "session_id"),
+            schema_version=data.get("schema_version", 1),
             run_id=_optional_str(data.get("run_id")),
             invocation_id=_optional_str(data.get("invocation_id")),
             created_by=_required_str(data, "created_by"),

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -208,29 +208,31 @@ def _requested_event_matches_contract(event: BaseEvent, request_id: str) -> bool
         if not isinstance(payload, Mapping):
             return False
         timeout_seconds = event.data.get("timeout_seconds")
-        HumanInputRequest.from_persisted_event_data(
-            request_id=request_id,
-            session_id=_required_str(event.data, "session_id", event.id),
-            schema_version=event.data.get("schema_version", 1),
-            run_id=_optional_str(event.data.get("run_id")),
-            invocation_id=_optional_str(event.data.get("invocation_id")),
-            created_by=_required_str(event.data, "created_by", event.id),
-            kind=HumanInputKind(event.data.get("kind")),
-            source=HumanInputSource(event.data.get("source")),
-            risk_class=HumanInputRiskClass(event.data.get("risk_class")),
-            question=_required_str(event.data, "question", event.id),
-            resume_target=_required_str(event.data, "resume_target", event.id),
-            title=_optional_str(event.data.get("title")),
-            body=_optional_str(event.data.get("body")),
-            options=tuple(options),
-            required_permission=_optional_str(event.data.get("required_permission")),
-            timeout_seconds=timeout_seconds if timeout_seconds is not None else None,
-            timeout_action=HumanInputTimeoutAction(
+        request_kwargs: dict[str, Any] = {
+            "request_id": request_id,
+            "session_id": _required_str(event.data, "session_id", event.id),
+            "run_id": _optional_str(event.data.get("run_id")),
+            "invocation_id": _optional_str(event.data.get("invocation_id")),
+            "created_by": _required_str(event.data, "created_by", event.id),
+            "kind": HumanInputKind(event.data.get("kind")),
+            "source": HumanInputSource(event.data.get("source")),
+            "risk_class": HumanInputRiskClass(event.data.get("risk_class")),
+            "question": _required_str(event.data, "question", event.id),
+            "resume_target": _required_str(event.data, "resume_target", event.id),
+            "title": _optional_str(event.data.get("title")),
+            "body": _optional_str(event.data.get("body")),
+            "options": tuple(options),
+            "required_permission": _optional_str(event.data.get("required_permission")),
+            "timeout_seconds": timeout_seconds if timeout_seconds is not None else None,
+            "timeout_action": HumanInputTimeoutAction(
                 event.data.get("timeout_action", HumanInputTimeoutAction.STAY_WAITING.value)
             ),
-            surface=_optional_str(event.data.get("surface")),
-            payload=payload,
-        )
+            "surface": _optional_str(event.data.get("surface")),
+            "payload": payload,
+        }
+        if "schema_version" in event.data:
+            request_kwargs["schema_version"] = event.data["schema_version"]
+        HumanInputRequest.from_persisted_event_data(**request_kwargs)
     except (TypeError, ValueError):
         return False
     return True

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -208,9 +208,10 @@ def _requested_event_matches_contract(event: BaseEvent, request_id: str) -> bool
         if not isinstance(payload, Mapping):
             return False
         timeout_seconds = event.data.get("timeout_seconds")
-        HumanInputRequest(
+        HumanInputRequest.from_persisted_schema_v1(
             request_id=request_id,
             session_id=_required_str(event.data, "session_id", event.id),
+            schema_version=event.data.get("schema_version", 1),
             run_id=_optional_str(event.data.get("run_id")),
             invocation_id=_optional_str(event.data.get("invocation_id")),
             created_by=_required_str(event.data, "created_by", event.id),

--- a/src/ouroboros/core/hitl_state.py
+++ b/src/ouroboros/core/hitl_state.py
@@ -208,7 +208,7 @@ def _requested_event_matches_contract(event: BaseEvent, request_id: str) -> bool
         if not isinstance(payload, Mapping):
             return False
         timeout_seconds = event.data.get("timeout_seconds")
-        HumanInputRequest.from_persisted_schema_v1(
+        HumanInputRequest.from_persisted_event_data(
             request_id=request_id,
             session_id=_required_str(event.data, "session_id", event.id),
             schema_version=event.data.get("schema_version", 1),

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -331,6 +331,22 @@ def test_plugin_permission_request_requires_required_permission() -> None:
         )
 
 
+def test_fresh_destructive_plugin_permission_request_requires_required_permission() -> None:
+    with pytest.raises(ValueError, match="required_permission"):
+        HumanInputRequest(
+            request_id="hitl-plugin-permission-2",
+            session_id="plugin-session-2",
+            created_by="plugin-firewall",
+            kind=HumanInputKind.DESTRUCTIVE_CONFIRMATION,
+            source=HumanInputSource.PLUGIN_FIREWALL,
+            risk_class=HumanInputRiskClass.DESTRUCTIVE,
+            question="Allow plugin deployer to run external production deployment?",
+            resume_target="plugin-firewall:permission:plugin-session-2",
+            surface="plugin.firewall.permission",
+            payload={"permission_scope": "external:production:deploy"},
+        )
+
+
 def test_plugin_permission_request_requires_surface() -> None:
     with pytest.raises(ValueError, match="surface"):
         HumanInputRequest(

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -225,6 +225,80 @@ def test_request_allows_benign_token_metadata_keys() -> None:
     assert request.to_event_data()["payload"] == {"token_count": 1024, "token_limit": 4096}
 
 
+def test_plugin_permission_request_uses_firewall_hitl_contract() -> None:
+    request = HumanInputRequest(
+        request_id="hitl-plugin-permission-1",
+        session_id="plugin-session-1",
+        run_id="run-1",
+        invocation_id="plugin.invoke.install",
+        created_by="plugin-firewall",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLUGIN_FIREWALL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Allow plugin acme.docs to use plugin:lifecycle:read?",
+        required_permission="plugin:lifecycle:read",
+        resume_target="plugin-firewall:permission:plugin-session-1",
+        surface="plugin.firewall.permission",
+        payload={
+            "plugin_id": "acme.docs",
+            "permission_scope": "plugin:lifecycle:read",
+            "permission_reason": "inspect declared lifecycle hooks",
+        },
+        created_at=datetime(2026, 5, 18, tzinfo=UTC),
+    )
+
+    data = request.to_event_data()
+
+    assert data["kind"] == "approval"
+    assert data["source"] == "plugin_firewall"
+    assert data["risk_class"] == "material_branch"
+    assert data["required_permission"] == "plugin:lifecycle:read"
+    assert data["surface"] == "plugin.firewall.permission"
+    assert data["payload"] == {
+        "plugin_id": "acme.docs",
+        "permission_scope": "plugin:lifecycle:read",
+        "permission_reason": "inspect declared lifecycle hooks",
+    }
+
+
+def test_plugin_destructive_permission_request_uses_destructive_confirmation() -> None:
+    request = HumanInputRequest(
+        request_id="hitl-plugin-permission-2",
+        session_id="plugin-session-2",
+        created_by="plugin-firewall",
+        kind=HumanInputKind.DESTRUCTIVE_CONFIRMATION,
+        source=HumanInputSource.PLUGIN_FIREWALL,
+        risk_class=HumanInputRiskClass.DESTRUCTIVE,
+        question="Allow plugin deployer to run external production deployment?",
+        required_permission="external:production:deploy",
+        resume_target="plugin-firewall:permission:plugin-session-2",
+        surface="plugin.firewall.permission",
+        payload={"plugin_id": "deployer", "permission_scope": "external:production:deploy"},
+        created_at=datetime(2026, 5, 18, tzinfo=UTC),
+    )
+    response = HumanInputResponse(
+        request_id=request.request_id,
+        session_id=request.session_id,
+        actor="local-user",
+        response_kind=HumanInputResponseKind.APPROVAL,
+        approval_decision=False,
+        surface="plugin.firewall.permission",
+        payload={"decision_reason": "outside approved deployment window"},
+        received_at=datetime(2026, 5, 18, 0, 1, tzinfo=UTC),
+    )
+
+    requested = request.to_event_data()
+    answered = response.to_event_data()
+
+    assert requested["kind"] == "destructive_confirmation"
+    assert requested["source"] == "plugin_firewall"
+    assert requested["risk_class"] == "destructive"
+    assert requested["required_permission"] == "external:production:deploy"
+    assert answered["response_kind"] == "approval"
+    assert answered["approval_decision"] is False
+    assert answered["surface"] == "plugin.firewall.permission"
+
+
 def test_request_accepts_mapping_payloads_and_freezes_normalized_copy() -> None:
     source: dict[str, object] = {"items": ["alpha", {"count": 1}]}
     request = HumanInputRequest(

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -8,6 +8,7 @@ from types import MappingProxyType
 import pytest
 
 from ouroboros.core.hitl_contract import (
+    HITL_CONTRACT_SCHEMA_VERSION,
     MAX_HITL_PAYLOAD_BYTES,
     HumanInputKind,
     HumanInputRequest,
@@ -42,6 +43,9 @@ def test_human_input_request_serializes_wait_contract() -> None:
     data = request.to_event_data()
 
     assert request.aggregate_id == "hitl-1"
+    assert request.schema_version == 2
+    assert data["schema_version"] == 2
+    assert HITL_CONTRACT_SCHEMA_VERSION == 2
     assert data["kind"] == "single_select"
     assert data["source"] == "interview"
     assert data["risk_class"] == "material_branch"
@@ -265,6 +269,7 @@ def test_plugin_permission_request_uses_firewall_hitl_contract() -> None:
 
     data = request.to_event_data()
 
+    assert data["schema_version"] == 2
     assert data["kind"] == "approval"
     assert data["source"] == "plugin_firewall"
     assert data["risk_class"] == "material_branch"
@@ -422,6 +427,22 @@ def test_persisted_schema_v2_plugin_permission_request_rejects_missing_fields() 
             request_id="hitl-plugin-permission-v2",
             session_id="plugin-session-1",
             schema_version=2,
+            created_by="plugin-firewall",
+            kind=HumanInputKind.APPROVAL,
+            source=HumanInputSource.PLUGIN_FIREWALL,
+            risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+            question="Allow plugin acme.docs to use plugin:lifecycle:read?",
+            resume_target="plugin-firewall:permission:plugin-session-1",
+            surface="plugin.firewall.permission",
+            payload={"plugin_id": "acme.docs", "permission_scope": "plugin:lifecycle:read"},
+        )
+
+
+def test_persisted_plugin_permission_request_without_schema_version_is_strict() -> None:
+    with pytest.raises(ValueError, match="required_permission"):
+        HumanInputRequest.from_persisted_event_data(
+            request_id="hitl-plugin-permission-v2",
+            session_id="plugin-session-1",
             created_by="plugin-firewall",
             kind=HumanInputKind.APPROVAL,
             source=HumanInputSource.PLUGIN_FIREWALL,

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -200,12 +200,18 @@ def test_request_allows_secret_marker_words_in_plain_values() -> None:
         source=HumanInputSource.PLUGIN_FIREWALL,
         risk_class=HumanInputRiskClass.CREDENTIAL_GATED,
         question="Approve?",
+        required_permission="plugin:credential:check",
         resume_target="plugin:permission",
-        payload={"reason": "token budget exceeded; credential check required"},
+        surface="plugin.firewall.permission",
+        payload={
+            "permission_scope": "plugin:credential:check",
+            "reason": "token budget exceeded; credential check required",
+        },
     )
 
     assert request.to_event_data()["payload"] == {
-        "reason": "token budget exceeded; credential check required"
+        "permission_scope": "plugin:credential:check",
+        "reason": "token budget exceeded; credential check required",
     }
 
 
@@ -218,11 +224,21 @@ def test_request_allows_benign_token_metadata_keys() -> None:
         source=HumanInputSource.PLUGIN_FIREWALL,
         risk_class=HumanInputRiskClass.LOW,
         question="Approve?",
+        required_permission="plugin:tokens:inspect",
         resume_target="plugin:permission",
-        payload={"token_count": 1024, "token_limit": 4096},
+        surface="plugin.firewall.permission",
+        payload={
+            "permission_scope": "plugin:tokens:inspect",
+            "token_count": 1024,
+            "token_limit": 4096,
+        },
     )
 
-    assert request.to_event_data()["payload"] == {"token_count": 1024, "token_limit": 4096}
+    assert request.to_event_data()["payload"] == {
+        "permission_scope": "plugin:tokens:inspect",
+        "token_count": 1024,
+        "token_limit": 4096,
+    }
 
 
 def test_plugin_permission_request_uses_firewall_hitl_contract() -> None:
@@ -297,6 +313,71 @@ def test_plugin_destructive_permission_request_uses_destructive_confirmation() -
     assert answered["response_kind"] == "approval"
     assert answered["approval_decision"] is False
     assert answered["surface"] == "plugin.firewall.permission"
+
+
+def test_plugin_permission_request_requires_required_permission() -> None:
+    with pytest.raises(ValueError, match="required_permission"):
+        HumanInputRequest(
+            request_id="hitl-plugin-permission-1",
+            session_id="plugin-session-1",
+            created_by="plugin-firewall",
+            kind=HumanInputKind.APPROVAL,
+            source=HumanInputSource.PLUGIN_FIREWALL,
+            risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+            question="Allow plugin acme.docs to use plugin:lifecycle:read?",
+            resume_target="plugin-firewall:permission:plugin-session-1",
+            surface="plugin.firewall.permission",
+            payload={"permission_scope": "plugin:lifecycle:read"},
+        )
+
+
+def test_plugin_permission_request_requires_surface() -> None:
+    with pytest.raises(ValueError, match="surface"):
+        HumanInputRequest(
+            request_id="hitl-plugin-permission-1",
+            session_id="plugin-session-1",
+            created_by="plugin-firewall",
+            kind=HumanInputKind.APPROVAL,
+            source=HumanInputSource.PLUGIN_FIREWALL,
+            risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+            question="Allow plugin acme.docs to use plugin:lifecycle:read?",
+            required_permission="plugin:lifecycle:read",
+            resume_target="plugin-firewall:permission:plugin-session-1",
+            payload={"permission_scope": "plugin:lifecycle:read"},
+        )
+
+
+def test_plugin_permission_request_requires_payload() -> None:
+    with pytest.raises(ValueError, match="payload"):
+        HumanInputRequest(
+            request_id="hitl-plugin-permission-1",
+            session_id="plugin-session-1",
+            created_by="plugin-firewall",
+            kind=HumanInputKind.APPROVAL,
+            source=HumanInputSource.PLUGIN_FIREWALL,
+            risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+            question="Allow plugin acme.docs to use plugin:lifecycle:read?",
+            required_permission="plugin:lifecycle:read",
+            resume_target="plugin-firewall:permission:plugin-session-1",
+            surface="plugin.firewall.permission",
+        )
+
+
+def test_plugin_permission_request_requires_payload_permission_scope_match() -> None:
+    with pytest.raises(ValueError, match="permission_scope"):
+        HumanInputRequest(
+            request_id="hitl-plugin-permission-1",
+            session_id="plugin-session-1",
+            created_by="plugin-firewall",
+            kind=HumanInputKind.APPROVAL,
+            source=HumanInputSource.PLUGIN_FIREWALL,
+            risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+            question="Allow plugin acme.docs to use plugin:lifecycle:read?",
+            required_permission="plugin:lifecycle:read",
+            resume_target="plugin-firewall:permission:plugin-session-1",
+            surface="plugin.firewall.permission",
+            payload={"permission_scope": "plugin:lifecycle:write"},
+        )
 
 
 def test_request_accepts_mapping_payloads_and_freezes_normalized_copy() -> None:

--- a/tests/unit/core/test_hitl_contract.py
+++ b/tests/unit/core/test_hitl_contract.py
@@ -396,6 +396,43 @@ def test_plugin_permission_request_requires_payload_permission_scope_match() -> 
         )
 
 
+def test_persisted_schema_v2_plugin_permission_request_uses_strict_constructor() -> None:
+    request = HumanInputRequest.from_persisted_event_data(
+        request_id="hitl-plugin-permission-v2",
+        session_id="plugin-session-1",
+        schema_version=2,
+        created_by="plugin-firewall",
+        kind=HumanInputKind.APPROVAL,
+        source=HumanInputSource.PLUGIN_FIREWALL,
+        risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+        question="Allow plugin acme.docs to use plugin:lifecycle:read?",
+        required_permission="plugin:lifecycle:read",
+        resume_target="plugin-firewall:permission:plugin-session-1",
+        surface="plugin.firewall.permission",
+        payload={"plugin_id": "acme.docs", "permission_scope": "plugin:lifecycle:read"},
+    )
+
+    assert request.schema_version == 2
+    assert request.required_permission == "plugin:lifecycle:read"
+
+
+def test_persisted_schema_v2_plugin_permission_request_rejects_missing_fields() -> None:
+    with pytest.raises(ValueError, match="required_permission"):
+        HumanInputRequest.from_persisted_event_data(
+            request_id="hitl-plugin-permission-v2",
+            session_id="plugin-session-1",
+            schema_version=2,
+            created_by="plugin-firewall",
+            kind=HumanInputKind.APPROVAL,
+            source=HumanInputSource.PLUGIN_FIREWALL,
+            risk_class=HumanInputRiskClass.MATERIAL_BRANCH,
+            question="Allow plugin acme.docs to use plugin:lifecycle:read?",
+            resume_target="plugin-firewall:permission:plugin-session-1",
+            surface="plugin.firewall.permission",
+            payload={"plugin_id": "acme.docs", "permission_scope": "plugin:lifecycle:read"},
+        )
+
+
 def test_request_accepts_mapping_payloads_and_freezes_normalized_copy() -> None:
     source: dict[str, object] = {"items": ["alpha", {"count": 1}]}
     request = HumanInputRequest(

--- a/tests/unit/core/test_hitl_resume.py
+++ b/tests/unit/core/test_hitl_resume.py
@@ -235,6 +235,35 @@ def test_human_input_request_from_schema_v2_plugin_firewall_snapshot_rejects_mis
         human_input_request_from_snapshot(snapshot)
 
 
+def test_human_input_request_from_unversioned_plugin_firewall_snapshot_rejects_missing_fields() -> (
+    None
+):
+    snapshot = HumanInputSnapshot(
+        request_id="hitl-plugin-unversioned",
+        state=HumanInputState.PENDING,
+        request_event_id="evt_plugin_unversioned_requested",
+        updated_event_id="evt_plugin_unversioned_requested",
+        created_at=datetime(2026, 5, 18, tzinfo=UTC),
+        updated_at=datetime(2026, 5, 18, tzinfo=UTC),
+        session_id="plugin-session-1",
+        resume_target="plugin-firewall:permission:plugin-session-1",
+        request={
+            "request_id": "hitl-plugin-unversioned",
+            "session_id": "plugin-session-1",
+            "created_by": "plugin-firewall",
+            "kind": "approval",
+            "source": "plugin_firewall",
+            "risk_class": "material_branch",
+            "question": "Allow plugin acme.docs to use plugin:lifecycle:read?",
+            "resume_target": "plugin-firewall:permission:plugin-session-1",
+            "payload": {"plugin_id": "acme.docs"},
+        },
+    )
+
+    with pytest.raises(HumanInputResumeValidationError, match="cannot be reconstructed"):
+        human_input_request_from_snapshot(snapshot)
+
+
 def test_create_validated_hitl_resume_event_answers_wait_with_malformed_created_at() -> None:
     base_requested = create_hitl_requested_event(_request())
     requested = base_requested.model_copy(

--- a/tests/unit/core/test_hitl_resume.py
+++ b/tests/unit/core/test_hitl_resume.py
@@ -19,6 +19,7 @@ from ouroboros.core.hitl_resume import (
     pending_human_input_snapshot_for_response,
 )
 from ouroboros.core.hitl_state import HumanInputState, project_human_input_state
+from ouroboros.events.base import BaseEvent
 from ouroboros.events.hitl import create_hitl_answered_event, create_hitl_requested_event
 
 
@@ -116,6 +117,48 @@ def test_human_input_request_from_snapshot_reconstructs_persisted_contract() -> 
     assert reconstructed.risk_class is HumanInputRiskClass.MATERIAL_BRANCH
     assert reconstructed.payload["plan_id"] == "plan-1"
     assert reconstructed.to_event_data()["created_at"] == "2026-05-18T00:00:00+00:00"
+
+
+def test_human_input_request_from_legacy_plugin_firewall_snapshot_accepts_missing_new_fields() -> None:
+    requested = BaseEvent(
+        type="hitl.requested",
+        aggregate_type="hitl",
+        aggregate_id="hitl-legacy-plugin",
+        data={
+            "schema_version": 1,
+            "request_id": "hitl-legacy-plugin",
+            "session_id": "plugin-session-1",
+            "created_by": "plugin-firewall",
+            "kind": "destructive_confirmation",
+            "source": "plugin_firewall",
+            "risk_class": "destructive",
+            "question": "Allow plugin deployer to run external production deployment?",
+            "resume_target": "plugin-firewall:permission:plugin-session-1",
+            "payload": {"plugin_id": "deployer"},
+        },
+        timestamp=datetime(2026, 5, 18, tzinfo=UTC),
+    )
+    snapshot = project_human_input_state([requested])[0]
+
+    reconstructed = human_input_request_from_snapshot(snapshot)
+    event = create_validated_hitl_resume_event(
+        [requested],
+        HumanInputResponse(
+            request_id="hitl-legacy-plugin",
+            session_id="plugin-session-1",
+            actor="local-user",
+            response_kind=HumanInputResponseKind.APPROVAL,
+            approval_decision=True,
+        ),
+    )
+
+    assert reconstructed.kind is HumanInputKind.DESTRUCTIVE_CONFIRMATION
+    assert reconstructed.source is HumanInputSource.PLUGIN_FIREWALL
+    assert reconstructed.required_permission is None
+    assert reconstructed.surface is None
+    assert reconstructed.payload == {"plugin_id": "deployer"}
+    assert event.type == "hitl.answered"
+    assert event.aggregate_id == "hitl-legacy-plugin"
 
 
 def test_create_validated_hitl_resume_event_answers_wait_with_malformed_created_at() -> None:

--- a/tests/unit/core/test_hitl_resume.py
+++ b/tests/unit/core/test_hitl_resume.py
@@ -119,7 +119,9 @@ def test_human_input_request_from_snapshot_reconstructs_persisted_contract() -> 
     assert reconstructed.to_event_data()["created_at"] == "2026-05-18T00:00:00+00:00"
 
 
-def test_human_input_request_from_legacy_plugin_firewall_snapshot_accepts_missing_new_fields() -> None:
+def test_human_input_request_from_legacy_plugin_firewall_snapshot_accepts_missing_new_fields() -> (
+    None
+):
     requested = BaseEvent(
         type="hitl.requested",
         aggregate_type="hitl",

--- a/tests/unit/core/test_hitl_resume.py
+++ b/tests/unit/core/test_hitl_resume.py
@@ -18,7 +18,11 @@ from ouroboros.core.hitl_resume import (
     human_input_request_from_snapshot,
     pending_human_input_snapshot_for_response,
 )
-from ouroboros.core.hitl_state import HumanInputState, project_human_input_state
+from ouroboros.core.hitl_state import (
+    HumanInputSnapshot,
+    HumanInputState,
+    project_human_input_state,
+)
 from ouroboros.events.base import BaseEvent
 from ouroboros.events.hitl import create_hitl_answered_event, create_hitl_requested_event
 
@@ -161,6 +165,74 @@ def test_human_input_request_from_legacy_plugin_firewall_snapshot_accepts_missin
     assert reconstructed.payload == {"plugin_id": "deployer"}
     assert event.type == "hitl.answered"
     assert event.aggregate_id == "hitl-legacy-plugin"
+
+
+def test_human_input_request_from_schema_v2_plugin_firewall_snapshot_reconstructs() -> None:
+    requested = BaseEvent(
+        type="hitl.requested",
+        aggregate_type="hitl",
+        aggregate_id="hitl-plugin-v2",
+        data={
+            "schema_version": 2,
+            "request_id": "hitl-plugin-v2",
+            "session_id": "plugin-session-1",
+            "created_by": "plugin-firewall",
+            "kind": "approval",
+            "source": "plugin_firewall",
+            "risk_class": "material_branch",
+            "question": "Allow plugin acme.docs to use plugin:lifecycle:read?",
+            "required_permission": "plugin:lifecycle:read",
+            "resume_target": "plugin-firewall:permission:plugin-session-1",
+            "surface": "plugin.firewall.permission",
+            "payload": {
+                "plugin_id": "acme.docs",
+                "permission_scope": "plugin:lifecycle:read",
+            },
+        },
+        timestamp=datetime(2026, 5, 18, tzinfo=UTC),
+    )
+    snapshot = project_human_input_state([requested])[0]
+
+    reconstructed = human_input_request_from_snapshot(snapshot)
+
+    assert reconstructed.schema_version == 2
+    assert reconstructed.source is HumanInputSource.PLUGIN_FIREWALL
+    assert reconstructed.required_permission == "plugin:lifecycle:read"
+    assert reconstructed.payload["permission_scope"] == "plugin:lifecycle:read"
+
+
+def test_human_input_request_from_schema_v2_plugin_firewall_snapshot_rejects_missing_fields() -> (
+    None
+):
+    snapshot = HumanInputSnapshot(
+        request_id="hitl-plugin-v2",
+        state=HumanInputState.PENDING,
+        request_event_id="evt_plugin_v2_requested",
+        updated_event_id="evt_plugin_v2_requested",
+        created_at=datetime(2026, 5, 18, tzinfo=UTC),
+        updated_at=datetime(2026, 5, 18, tzinfo=UTC),
+        session_id="plugin-session-1",
+        resume_target="plugin-firewall:permission:plugin-session-1",
+        request={
+            "schema_version": 2,
+            "request_id": "hitl-plugin-v2",
+            "session_id": "plugin-session-1",
+            "created_by": "plugin-firewall",
+            "kind": "approval",
+            "source": "plugin_firewall",
+            "risk_class": "material_branch",
+            "question": "Allow plugin acme.docs to use plugin:lifecycle:read?",
+            "resume_target": "plugin-firewall:permission:plugin-session-1",
+            "surface": "plugin.firewall.permission",
+            "payload": {
+                "plugin_id": "acme.docs",
+                "permission_scope": "plugin:lifecycle:read",
+            },
+        },
+    )
+
+    with pytest.raises(HumanInputResumeValidationError, match="cannot be reconstructed"):
+        human_input_request_from_snapshot(snapshot)
 
 
 def test_create_validated_hitl_resume_event_answers_wait_with_malformed_created_at() -> None:

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -75,6 +75,39 @@ def test_projects_pending_request_snapshot() -> None:
     assert snapshot.request["payload"] == {"nested": {"count": 1}}
 
 
+def test_projects_legacy_schema_v1_plugin_firewall_request_missing_new_fields() -> None:
+    event = _with_time(
+        BaseEvent(
+            type="hitl.requested",
+            aggregate_type="hitl",
+            aggregate_id="hitl-legacy-plugin",
+            data={
+                "schema_version": 1,
+                "request_id": "hitl-legacy-plugin",
+                "session_id": "plugin-session-1",
+                "created_by": "plugin-firewall",
+                "kind": "approval",
+                "source": "plugin_firewall",
+                "risk_class": "material_branch",
+                "question": "Allow plugin acme.docs to use plugin:lifecycle:read?",
+                "resume_target": "plugin-firewall:permission:plugin-session-1",
+                "payload": {"plugin_id": "acme.docs"},
+            },
+        ),
+        0,
+        "evt_legacy_plugin_requested",
+    )
+
+    snapshots = project_human_input_state([event])
+
+    assert len(snapshots) == 1
+    snapshot = snapshots[0]
+    assert snapshot.request_id == "hitl-legacy-plugin"
+    assert snapshot.state is HumanInputState.PENDING
+    assert snapshot.request["source"] == "plugin_firewall"
+    assert snapshot.request["payload"] == {"plugin_id": "acme.docs"}
+
+
 def test_answered_event_closes_request_with_response_payload() -> None:
     request = _request()
     events = [

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -108,6 +108,31 @@ def test_projects_legacy_schema_v1_plugin_firewall_request_missing_new_fields() 
     assert snapshot.request["payload"] == {"plugin_id": "acme.docs"}
 
 
+def test_rejects_unversioned_plugin_firewall_request_missing_permission_contract() -> None:
+    event = _with_time(
+        BaseEvent(
+            type="hitl.requested",
+            aggregate_type="hitl",
+            aggregate_id="hitl-plugin-unversioned",
+            data={
+                "request_id": "hitl-plugin-unversioned",
+                "session_id": "plugin-session-1",
+                "created_by": "plugin-firewall",
+                "kind": "approval",
+                "source": "plugin_firewall",
+                "risk_class": "material_branch",
+                "question": "Allow plugin acme.docs to use plugin:lifecycle:read?",
+                "resume_target": "plugin-firewall:permission:plugin-session-1",
+                "payload": {"plugin_id": "acme.docs"},
+            },
+        ),
+        0,
+        "evt_plugin_unversioned_requested",
+    )
+
+    assert project_human_input_state([event]) == ()
+
+
 def test_projects_schema_v2_plugin_firewall_request_with_complete_permission_contract() -> None:
     event = _with_time(
         BaseEvent(

--- a/tests/unit/core/test_hitl_state.py
+++ b/tests/unit/core/test_hitl_state.py
@@ -108,6 +108,74 @@ def test_projects_legacy_schema_v1_plugin_firewall_request_missing_new_fields() 
     assert snapshot.request["payload"] == {"plugin_id": "acme.docs"}
 
 
+def test_projects_schema_v2_plugin_firewall_request_with_complete_permission_contract() -> None:
+    event = _with_time(
+        BaseEvent(
+            type="hitl.requested",
+            aggregate_type="hitl",
+            aggregate_id="hitl-plugin-v2",
+            data={
+                "schema_version": 2,
+                "request_id": "hitl-plugin-v2",
+                "session_id": "plugin-session-1",
+                "created_by": "plugin-firewall",
+                "kind": "approval",
+                "source": "plugin_firewall",
+                "risk_class": "material_branch",
+                "question": "Allow plugin acme.docs to use plugin:lifecycle:read?",
+                "required_permission": "plugin:lifecycle:read",
+                "resume_target": "plugin-firewall:permission:plugin-session-1",
+                "surface": "plugin.firewall.permission",
+                "payload": {
+                    "plugin_id": "acme.docs",
+                    "permission_scope": "plugin:lifecycle:read",
+                },
+            },
+        ),
+        0,
+        "evt_plugin_v2_requested",
+    )
+
+    snapshots = project_human_input_state([event])
+
+    assert len(snapshots) == 1
+    snapshot = snapshots[0]
+    assert snapshot.request_id == "hitl-plugin-v2"
+    assert snapshot.state is HumanInputState.PENDING
+    assert snapshot.request["schema_version"] == 2
+    assert snapshot.request["required_permission"] == "plugin:lifecycle:read"
+
+
+def test_rejects_schema_v2_plugin_firewall_request_missing_permission_contract() -> None:
+    event = _with_time(
+        BaseEvent(
+            type="hitl.requested",
+            aggregate_type="hitl",
+            aggregate_id="hitl-plugin-v2",
+            data={
+                "schema_version": 2,
+                "request_id": "hitl-plugin-v2",
+                "session_id": "plugin-session-1",
+                "created_by": "plugin-firewall",
+                "kind": "approval",
+                "source": "plugin_firewall",
+                "risk_class": "material_branch",
+                "question": "Allow plugin acme.docs to use plugin:lifecycle:read?",
+                "resume_target": "plugin-firewall:permission:plugin-session-1",
+                "surface": "plugin.firewall.permission",
+                "payload": {
+                    "plugin_id": "acme.docs",
+                    "permission_scope": "plugin:lifecycle:read",
+                },
+            },
+        ),
+        0,
+        "evt_plugin_v2_requested",
+    )
+
+    assert project_human_input_state([event]) == ()
+
+
 def test_answered_event_closes_request_with_response_payload() -> None:
     request = _request()
     events = [

--- a/tests/unit/evolution/test_generation_watchdog.py
+++ b/tests/unit/evolution/test_generation_watchdog.py
@@ -500,8 +500,12 @@ async def test_ac_heartbeat_aggregate_resets_idle_timeout(
 
 
 @pytest.mark.asyncio
-async def test_parent_execution_child_events_reset_idle_timeout() -> None:
+async def test_parent_execution_child_events_reset_idle_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Child execution scopes linked by parent_execution_id prove generation liveness."""
+    clock = _FakeMonotonicClock()
+    monkeypatch.setattr(watchdog_module, "time", SimpleNamespace(monotonic=clock))
     event_store = await _store()
     session_id = "session-child-exec"
     execution_id = "evolve:lin-child:generation:1"
@@ -516,9 +520,11 @@ async def test_parent_execution_child_events_reset_idle_timeout() -> None:
         await event_store.append(_session_started(session_id, execution_id))
         for count in range(1, 5):
             await asyncio.sleep(0.04)
+            clock.advance(0.04)
             await event_store.append(
                 _subagent_started(f"evolve_lin_child_generation_1_child_{count}", execution_id)
             )
+        clock.advance(0.04)
         return "done"
 
     assert await watchdog.watch(child_work()) == "done"


### PR DESCRIPTION
## Summary
- specify plugin permission waits through the shared typed HITL contract
- document approval/destructive-confirmation field mapping, risk classes, fail-closed responses, cancellation, and timeout semantics
- add contract tests for plugin firewall permission requests and destructive permission denials

## Scope
- No plugin prompt runtime, scheduler, UI renderer, or firewall behavior rewrite.
- Contract/docs/tests only for #960-C.

## Verification
- `uv run pytest tests/unit/core/test_hitl_contract.py tests/unit/core/test_hitl_resume.py tests/unit/core/test_hitl_state.py -q`
- `uv run ruff check tests/unit/core/test_hitl_contract.py src/ouroboros/core/hitl_contract.py`
- `uv run mypy src/ouroboros/core/hitl_contract.py tests/unit/core/test_hitl_contract.py`
