### PR TITLE
test(auto): cover #821 short-goal interview convergence matrix

### DIFF
--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -335,7 +335,7 @@ def _goal_tokens(value: str) -> set[str]:
     }
     tokens = {
         token
-        for token in re.findall(r"[a-z0-9]+", value.casefold())
+        for token in re.findall(r"[^\W_]+", value.casefold())
         if len(token) >= 2 and token not in stopwords
     }
     if "cli" in tokens:

--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -333,11 +333,15 @@ def _goal_tokens(value: str) -> set[str]:
         "the",
         "to",
     }
-    tokens = {
-        token
-        for token in re.findall(r"[^\W_]+", value.casefold())
-        if len(token) >= 2 and token not in stopwords
-    }
+    tokens = set()
+    for token in re.findall(r"[^\W_]+", value.casefold()):
+        if len(token) >= 2 and token not in stopwords:
+            tokens.add(token)
+        tokens.update(
+            ascii_token
+            for ascii_token in re.findall(r"[a-z0-9]+", token)
+            if len(ascii_token) >= 2 and ascii_token not in stopwords
+        )
     if "cli" in tokens:
         tokens.update({"command", "line", "interface"})
     if {"command", "line", "interface"} <= tokens:

--- a/tests/unit/auto/test_821_acceptance_matrix.py
+++ b/tests/unit/auto/test_821_acceptance_matrix.py
@@ -79,12 +79,13 @@ def _matrix_seed(goal: str) -> Seed:
 async def test_821_acceptance_matrix_short_goals_do_not_stop_at_interview(
     tmp_path, goal: str
 ) -> None:
-    """The #821 six-goal matrix must advance beyond INTERVIEW without legacy gap blockers.
+    """The #821 six-goal matrix must complete a mocked RUN handoff.
 
     The backend is deterministic and local: it keeps asking broad follow-ups until
     the driver has had enough turns to fill the Seed draft ledger, then reports
-    completion.  The run starter is also mocked so this covers the auto pipeline
-    through a downstream RUN handoff without invoking an LLM or external API.
+    completion. The run starter returns durable handles, so each goal must reach
+    COMPLETE with a clean blocker/error state instead of merely ending outside
+    INTERVIEW.
     """
 
     answers: list[str] = []
@@ -134,20 +135,15 @@ async def test_821_acceptance_matrix_short_goals_do_not_stop_at_interview(
         if item
     )
 
-    assert state.phase is not AutoPhase.INTERVIEW
-    assert result.phase != AutoPhase.INTERVIEW.value
-    assert result.status in {
-        AutoPhase.COMPLETE.value,
-        AutoPhase.BLOCKED.value,
-        AutoPhase.FAILED.value,
-    }
+    assert state.phase is AutoPhase.COMPLETE
+    assert result.phase == AutoPhase.COMPLETE.value
+    assert result.status == AutoPhase.COMPLETE.value
+    assert result.blocker is None
+    assert state.last_error is None
     assert state.last_tool_name != "interview_driver"
-    if result.status == AutoPhase.COMPLETE.value:
-        assert state.job_id == "job_821"
-        assert state.execution_id == "exec_821"
-        assert state.run_session_id == "run_821"
-    else:
-        assert state.last_tool_name in {"grade_gate", "run_starter", "ralph_starter", "evaluator"}
+    assert state.job_id == "job_821"
+    assert state.execution_id == "exec_821"
+    assert state.run_session_id == "run_821"
     assert _LEGACY_MAX_ROUNDS_BLOCKER not in terminal_text
     assert _BARE_UNRESOLVED_GAPS not in terminal_text
     assert persisted_ledger.open_gaps() == []

--- a/tests/unit/auto/test_821_acceptance_matrix.py
+++ b/tests/unit/auto/test_821_acceptance_matrix.py
@@ -1,0 +1,158 @@
+"""Regression coverage for #821 short-goal auto interview convergence."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.interview_driver import (
+    AutoInterviewDriver,
+    FunctionInterviewBackend,
+    InterviewTurn,
+)
+from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+_LEGACY_MAX_ROUNDS_BLOCKER = "auto interview reached max rounds with unresolved gaps"
+_BARE_UNRESOLVED_GAPS = "unresolved gaps:"
+
+_ACCEPTANCE_MATRIX_GOALS = (
+    "build me a CLI tool that tracks daily habits with streak counting",
+    "make me a markdown todo CLI with add/list/done commands",
+    "一個本地 markdown 待辦事項 CLI",
+    "로컬 markdown todo CLI를 만들어줘",
+    """
+    로컬에서 실행되는 간단한 카트 레이싱 게임을 만들어줘.
+    범위: 키보드로 좌우 이동, 장애물 피하기, 점수 증가.
+    비범위: 온라인 멀티플레이, 결제, 서버 배포.
+    성공 기준: 로컬에서 실행 가능하고, 충돌 시 게임오버가 표시된다.
+    검증: 로컬 명령으로 테스트 또는 실행 확인이 가능해야 한다.
+    """.strip(),
+    "a static html page with a counter that survives refresh via localStorage",
+)
+
+
+def _matrix_seed(goal: str) -> Seed:
+    return Seed(
+        goal=goal,
+        constraints=("Keep execution local and use the repository's existing conventions.",),
+        acceptance_criteria=(
+            "A local command or smoke check exits 0 and demonstrates the requested behavior.",
+        ),
+        ontology_schema=OntologySchema(
+            name="Auto821AcceptanceTask",
+            description="Local product/task generated from a short auto goal.",
+            fields=(
+                OntologyField(
+                    name="requested_behavior",
+                    field_type="string",
+                    description="User-visible behavior requested by the goal.",
+                ),
+            ),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(
+                name="local_verifiability", description="Behavior is locally checkable."
+            ),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Local verification completed.",
+                evaluation_criteria="All acceptance criteria have observable local evidence.",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.10),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("goal", _ACCEPTANCE_MATRIX_GOALS)
+async def test_821_acceptance_matrix_short_goals_do_not_stop_at_interview(
+    tmp_path, goal: str
+) -> None:
+    """The #821 six-goal matrix must advance beyond INTERVIEW without legacy gap blockers.
+
+    The backend is deterministic and local: it keeps asking broad follow-ups until
+    the driver has had enough turns to fill the Seed draft ledger, then reports
+    completion.  The run starter is also mocked so this covers the auto pipeline
+    through a downstream RUN handoff without invoking an LLM or external API.
+    """
+
+    answers: list[str] = []
+
+    async def start(start_goal: str, cwd: str, *, interview_id: str | None = None) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What else should we know?", interview_id or "interview_821")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        answers.append(text)
+        completed = len(answers) >= 5
+        return InterviewTurn(
+            "What else should we know?",
+            session_id,
+            seed_ready=completed,
+            completed=completed,
+        )
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _matrix_seed(goal)
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        return {
+            "job_id": "job_821",
+            "execution_id": "exec_821",
+            "session_id": "run_821",
+        }
+
+    state = AutoPipelineState(goal=goal, cwd=str(tmp_path))
+    store = AutoStore(tmp_path)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=store,
+        max_rounds=12,
+        timeout_seconds=1,
+    )
+    pipeline = AutoPipeline(driver, generate_seed, run_starter=run_seed, store=store)
+
+    result = await pipeline.run(state)
+    persisted_ledger = SeedDraftLedger.from_dict(state.ledger)
+    terminal_text = "\n".join(
+        item
+        for item in (
+            result.blocker,
+            state.last_error,
+            result.last_progress_message,
+        )
+        if item
+    )
+
+    assert state.phase is not AutoPhase.INTERVIEW
+    assert result.phase != AutoPhase.INTERVIEW.value
+    assert result.status in {
+        AutoPhase.COMPLETE.value,
+        AutoPhase.BLOCKED.value,
+        AutoPhase.FAILED.value,
+    }
+    assert state.last_tool_name != "interview_driver"
+    if result.status == AutoPhase.COMPLETE.value:
+        assert state.job_id == "job_821"
+        assert state.execution_id == "exec_821"
+        assert state.run_session_id == "run_821"
+    else:
+        assert state.last_tool_name in {"grade_gate", "run_starter", "ralph_starter", "evaluator"}
+    assert _LEGACY_MAX_ROUNDS_BLOCKER not in terminal_text
+    assert _BARE_UNRESOLVED_GAPS not in terminal_text
+    assert persisted_ledger.open_gaps() == []
+    assert any(
+        entry.status == LedgerStatus.DEFAULTED
+        for section in persisted_ledger.sections.values()
+        for entry in section.entries
+    )

--- a/tests/unit/auto/test_821_acceptance_matrix.py
+++ b/tests/unit/auto/test_821_acceptance_matrix.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from ouroboros.auto.grading import _seed_goal_matches_ledger
 from ouroboros.auto.interview_driver import (
     AutoInterviewDriver,
     FunctionInterviewBackend,
@@ -38,6 +39,12 @@ _ACCEPTANCE_MATRIX_GOALS = (
     """.strip(),
     "a static html page with a counter that survives refresh via localStorage",
 )
+
+
+def test_korean_mixed_script_goal_preserves_cli_alias_for_grading() -> None:
+    ledger = SeedDraftLedger.from_goal("로컬 markdown todo CLI를 만들어줘")
+
+    assert _seed_goal_matches_ledger("markdown todo cli", ledger)
 
 
 def _matrix_seed(goal: str) -> Seed:


### PR DESCRIPTION
## Summary

- Add deterministic regression coverage for the six #821 `ooo auto` acceptance-matrix goals.
- Verify each goal advances beyond the auto `INTERVIEW` phase without the legacy unresolved-gaps interview blocker.
- Keep the test local/mocked: no LLM, Codex, MCP, or external API calls.

## What this proves

This PR proves that the documented #821 matrix no longer terminates under the fixed test runtime with:

- `auto interview reached max rounds with unresolved gaps`
- bare `unresolved gaps:`
- final `AutoPhase.INTERVIEW`

It also verifies that the ledger has no open gaps and that defaulted ledger entries are present.

## What this does not prove

- It does not prove live Codex execution.
- It does not prove full product completion for every goal.
- It does not exercise #1045.
- It does not claim #821 can be closed by itself.

## Test Plan

- `uv run pytest tests/unit/auto/test_821_acceptance_matrix.py -q`
- `uv run ruff check tests/unit/auto/test_821_acceptance_matrix.py`
- `uv run pytest tests/unit/auto/test_821_acceptance_matrix.py tests/unit/auto/test_interview_pipeline.py::test_convergence_contract_broad_benign_goal_resolves_with_safe_assumptions tests/unit/auto/test_interview_pipeline.py::test_convergence_contract_stalled_generic_followups_report_actionable_gaps -q`

Refs #821.
