### PR TITLE
feat(plugin): expose manifest descriptor projection

### DIFF
--- a/docs/rfc/userlevel-plugins.md
+++ b/docs/rfc/userlevel-plugins.md
@@ -492,6 +492,19 @@ events:
 Core MUST NOT emit any new `plugin.hook.*` event until the upstream
 audit-event schema and vendored core copy both include that event name.
 
+### Plugin descriptor/action projection
+
+The plugin manifest also projects into a harness-readable descriptor without
+executing plugin code. This read model is the bridge between manifest validation
+and future conformance checks: it exposes `plugin_id`, schema version, source,
+entrypoint, declared capabilities, declared permissions, lifecycle hooks, audit
+events, and command-level action descriptors.
+
+Descriptor projection is intentionally not a dispatch surface. It MUST NOT import
+plugin modules, invoke entrypoint commands, grant permissions, or widen the v0.3
+hook vocabulary. Runtime permission checks, hook execution, and audit emission
+remain owned by the firewall.
+
 ### Review boundary for follow-up PRs
 
 The hook rollout should remain reviewable:

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -187,6 +187,53 @@ class AuditSpec:
 
 
 @dataclass(frozen=True)
+class PluginActionDescriptor:
+    """Read-only action projection for one manifest command.
+
+    The descriptor is intentionally derived only from validated manifest data.
+    It must not import plugin modules or execute entrypoints.
+    """
+
+    action_id: str
+    namespace: str
+    name: str
+    summary: str
+    usage: str
+    risk: str
+    requires_confirmation: bool
+    arguments: tuple[CommandArgument, ...]
+    entrypoint: Entrypoint
+    required_permissions: tuple[str, ...]
+    optional_permissions: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PluginDescriptor:
+    """Harness-readable plugin component/action projection.
+
+    This is a validation/read-model contract for plugin discovery and future
+    conformance checks. It does not grant permissions, dispatch hooks, or run the
+    plugin entrypoint.
+    """
+
+    component_id: str
+    plugin_id: str
+    kind: str
+    name: str
+    version: str
+    schema_version: str
+    source: SourceSpec
+    entrypoint: Entrypoint
+    actions: tuple[PluginActionDescriptor, ...]
+    capabilities_declared: tuple[Capability, ...]
+    permissions_declared: tuple[Permission, ...]
+    lifecycle_hooks: tuple[HookSpec, ...]
+    audit_events: tuple[str, ...]
+    compatibility: tuple[str, ...]
+    description: str = ""
+
+
+@dataclass(frozen=True)
 class PluginManifest:
     """Frozen representation of a validated plugin manifest.
 
@@ -209,6 +256,55 @@ class PluginManifest:
     description: str = ""
     audit: AuditSpec = field(default_factory=AuditSpec.standard_four_events)
     hooks: tuple[HookSpec, ...] = ()
+
+    def to_descriptor(self) -> PluginDescriptor:
+        """Project this manifest into a pure component/action descriptor."""
+        return plugin_descriptor_from_manifest(self)
+
+
+def plugin_descriptor_from_manifest(manifest: PluginManifest) -> PluginDescriptor:
+    """Return a pure read-model descriptor for a validated plugin manifest.
+
+    The projection is manifest-only by design: it reuses frozen dataclasses from
+    ``load_manifest`` and never imports plugin code or executes entrypoint
+    commands.
+    """
+
+    required_permissions = tuple(p.scope for p in manifest.permissions if p.required)
+    optional_permissions = tuple(p.scope for p in manifest.permissions if not p.required)
+    actions = tuple(
+        PluginActionDescriptor(
+            action_id=f"{manifest.name}:{command.namespace}:{command.name}",
+            namespace=command.namespace,
+            name=command.name,
+            summary=command.summary,
+            usage=command.usage,
+            risk=command.risk,
+            requires_confirmation=command.requires_confirmation,
+            arguments=command.arguments,
+            entrypoint=manifest.entrypoint,
+            required_permissions=required_permissions,
+            optional_permissions=optional_permissions,
+        )
+        for command in manifest.commands
+    )
+    return PluginDescriptor(
+        component_id=manifest.name,
+        plugin_id=manifest.name,
+        kind="plugin",
+        name=manifest.name,
+        version=manifest.version,
+        schema_version=manifest.schema_version,
+        source=manifest.source,
+        entrypoint=manifest.entrypoint,
+        actions=actions,
+        capabilities_declared=manifest.capabilities,
+        permissions_declared=manifest.permissions,
+        lifecycle_hooks=manifest.hooks,
+        audit_events=manifest.audit.events,
+        compatibility=SUPPORTED_SCHEMA_VERSIONS,
+        description=manifest.description,
+    )
 
 
 def _load_schema(schema_version: str, *, manifest_path: str | Path) -> dict[str, Any]:
@@ -850,10 +946,13 @@ __all__ = [
     "Entrypoint",
     "HookSpec",
     "Permission",
+    "PluginActionDescriptor",
+    "PluginDescriptor",
     "PluginManifest",
     "PluginManifestError",
     "SourceSpec",
     "AuditSpec",
     "load_manifest",
+    "plugin_descriptor_from_manifest",
     "SUPPORTED_SCHEMA_VERSIONS",
 ]

--- a/tests/unit/plugin/test_manifest_descriptor.py
+++ b/tests/unit/plugin/test_manifest_descriptor.py
@@ -1,0 +1,142 @@
+"""Tests for read-only plugin descriptor/action projection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ouroboros.plugin.hooks import (
+    HOOK_COMPLETED_EVENT,
+    HOOK_FAILED_EVENT,
+    HOOK_INVOKED_EVENT,
+    HOOK_LIFECYCLE_POLICY_SCOPE,
+    HOOK_LIFECYCLE_READ_SCOPE,
+)
+from ouroboros.plugin.manifest import (
+    SUPPORTED_SCHEMA_VERSIONS,
+    PluginActionDescriptor,
+    PluginDescriptor,
+    load_manifest,
+    plugin_descriptor_from_manifest,
+)
+from tests.unit.plugin.test_manifest import REFERENCE_MANIFEST
+
+
+def _write(tmp_path: Path, payload: dict) -> Path:
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_text(json.dumps(payload))
+    return target
+
+
+def _v03_manifest_with_hooks() -> dict:
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["schema_version"] = "0.3"
+    payload["permissions"].extend(
+        [
+            {
+                "scope": HOOK_LIFECYCLE_READ_SCOPE,
+                "risk": "read_only",
+                "required": True,
+                "reason": "Allow lifecycle hook observation.",
+            },
+            {
+                "scope": HOOK_LIFECYCLE_POLICY_SCOPE,
+                "risk": "read_only",
+                "required": True,
+                "reason": "Allow lifecycle policy decisions.",
+            },
+            {
+                "scope": "github:write",
+                "risk": "write",
+                "required": False,
+                "reason": "Optional mutation scope.",
+            },
+        ]
+    )
+    payload["hooks"] = [
+        {
+            "name": "before_invocation",
+            "entrypoint": {"type": "command", "command": "python before_hook.py"},
+            "failure_policy": "fail_closed",
+            "permissions": [HOOK_LIFECYCLE_POLICY_SCOPE],
+            "timeout_seconds": 5,
+        },
+        {
+            "name": "after_invocation",
+            "entrypoint": {"type": "command", "command": "python after_hook.py"},
+            "failure_policy": "fail_open",
+            "permissions": [HOOK_LIFECYCLE_READ_SCOPE],
+            "timeout_seconds": 5,
+        },
+    ]
+    return payload
+
+
+def test_manifest_projects_descriptor_without_runtime_execution(tmp_path: Path) -> None:
+    manifest = load_manifest(_write(tmp_path, _v03_manifest_with_hooks()))
+
+    descriptor = plugin_descriptor_from_manifest(manifest)
+
+    assert isinstance(descriptor, PluginDescriptor)
+    assert descriptor.component_id == "github-pr-ops"
+    assert descriptor.plugin_id == "github-pr-ops"
+    assert descriptor.kind == "plugin"
+    assert descriptor.schema_version == "0.3"
+    assert descriptor.source.type == "local_path"
+    assert descriptor.entrypoint.command == "python -m github_pr_ops"
+    assert descriptor.capabilities_declared == manifest.capabilities
+    assert descriptor.permissions_declared == manifest.permissions
+    assert descriptor.lifecycle_hooks == manifest.hooks
+    assert descriptor.audit_events == manifest.audit.events
+    assert descriptor.compatibility == SUPPORTED_SCHEMA_VERSIONS
+
+
+def test_descriptor_projects_command_as_harness_action(tmp_path: Path) -> None:
+    manifest = load_manifest(_write(tmp_path, _v03_manifest_with_hooks()))
+
+    action = manifest.to_descriptor().actions[0]
+
+    assert isinstance(action, PluginActionDescriptor)
+    assert action.action_id == "github-pr-ops:github-pr:review"
+    assert action.namespace == "github-pr"
+    assert action.name == "review"
+    assert action.usage == "ooo github-pr review <pull-request-url>"
+    assert action.risk == "read_only"
+    assert action.entrypoint.command == "python -m github_pr_ops"
+    assert action.required_permissions == (
+        "github:read",
+        HOOK_LIFECYCLE_READ_SCOPE,
+        HOOK_LIFECYCLE_POLICY_SCOPE,
+    )
+    assert action.optional_permissions == ("github:write",)
+    assert [argument.name for argument in action.arguments] == ["pull_request_url"]
+
+
+def test_descriptor_reflects_schema_default_audit_events(tmp_path: Path) -> None:
+    manifest = load_manifest(_write(tmp_path, _v03_manifest_with_hooks()))
+
+    descriptor = manifest.to_descriptor()
+
+    assert HOOK_INVOKED_EVENT in descriptor.audit_events
+    assert HOOK_COMPLETED_EVENT in descriptor.audit_events
+    assert HOOK_FAILED_EVENT in descriptor.audit_events
+    assert "plugin.invoked" in descriptor.audit_events
+    assert "plugin.completed" in descriptor.audit_events
+
+
+def test_v01_descriptor_has_no_hooks_and_standard_action_projection(tmp_path: Path) -> None:
+    manifest = load_manifest(_write(tmp_path, REFERENCE_MANIFEST))
+
+    descriptor = manifest.to_descriptor()
+
+    assert descriptor.schema_version == "0.1"
+    assert descriptor.lifecycle_hooks == ()
+    assert descriptor.audit_events == (
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.completed",
+        "plugin.failed",
+    )
+    assert len(descriptor.actions) == 1
+    assert descriptor.actions[0].required_permissions == ("github:read",)
+    assert descriptor.actions[0].optional_permissions == ()


### PR DESCRIPTION
## Summary
- add a pure `PluginDescriptor` / `PluginActionDescriptor` projection for validated plugin manifests
- expose manifest fields needed by harness/conformance consumers without importing or executing plugin code
- document descriptor projection as non-dispatch, non-permission-granting read model

## Scope
- #939 follow-up PR A from the scope decision.
- No new hook kinds, no runtime dispatch changes, no permission grants, no Workflow IR execution behavior.

## Verification
- `uv run pytest tests/unit/plugin/test_manifest_descriptor.py tests/unit/plugin/test_manifest.py tests/unit/plugin/test_manifest_schema_0_3.py -q`
- `uv run ruff check src/ouroboros/plugin/manifest.py tests/unit/plugin/test_manifest_descriptor.py`
- `uv run mypy src/ouroboros/plugin/manifest.py tests/unit/plugin/test_manifest_descriptor.py`
