### PR TITLE
test(plugin): lock v0.3 lifecycle conformance

### DIFF
--- a/docs/rfc/userlevel-plugins.md
+++ b/docs/rfc/userlevel-plugins.md
@@ -505,7 +505,8 @@ MUST keep green before promoting more hook kinds. The baseline covers:
 - explicit `audit.events` lists that include every runtime-emitted command and
   hook event;
 - lifecycle permission trust-gate failures before any hook dispatch; and
-- timeout/error paths that persist only bounded hashes for hook output.
+- timeout, malformed-entrypoint, non-zero-exit, and startup-error paths that
+  keep hook output bounded to hashes when output exists.
 
 This matrix is a regression baseline, not a new feature surface. It MUST NOT
 promote deferred hook names or change v0.3 schema compatibility by itself.

--- a/docs/rfc/userlevel-plugins.md
+++ b/docs/rfc/userlevel-plugins.md
@@ -492,6 +492,24 @@ events:
 Core MUST NOT emit any new `plugin.hook.*` event until the upstream
 audit-event schema and vendored core copy both include that event name.
 
+### v0.3 lifecycle conformance baseline
+
+The v0.3 lifecycle wrapper has a compatibility matrix that future plugin work
+MUST keep green before promoting more hook kinds. The baseline covers:
+
+- manifests with no hooks, which keep the standard command audit sequence;
+- `before_invocation` fail-open observation, which records hook failure and
+  continues the original invocation;
+- `before_invocation` fail-closed policy, which blocks before `plugin.invoked`;
+- `after_invocation` fail-open observation after terminal command events;
+- explicit `audit.events` lists that include every runtime-emitted command and
+  hook event;
+- lifecycle permission trust-gate failures before any hook dispatch; and
+- timeout/error paths that persist only bounded hashes for hook output.
+
+This matrix is a regression baseline, not a new feature surface. It MUST NOT
+promote deferred hook names or change v0.3 schema compatibility by itself.
+
 ### Review boundary for follow-up PRs
 
 The hook rollout should remain reviewable:

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -19,7 +19,7 @@ from ouroboros.plugin.hooks import (
     HOOK_LIFECYCLE_READ_SCOPE,
 )
 from ouroboros.plugin.manifest import load_manifest
-from ouroboros.plugin.trust_store import TrustStore
+from ouroboros.plugin.trust_store import TrustRecord, TrustStore
 from ouroboros.plugin.userlevel_registry import (
     UserLevelProgramRegistry,
 )
@@ -117,6 +117,20 @@ def _hook_manifest_payload(schema_version: str) -> dict:
         },
     ]
     return payload
+
+
+def _grant_trust_scopes(tmp_path: Path, *scopes: str) -> TrustRecord:
+    trust_store = TrustStore(root=tmp_path / "trust")
+    trust = None
+    for scope in scopes:
+        trust = trust_store.grant(
+            plugin="github-pr-ops",
+            version="0.1.0",
+            scope=scope,
+            granted_by="user:test",
+        )
+    assert trust is not None
+    return trust
 
 
 def _fake_runner(
@@ -582,6 +596,143 @@ def test_v03_fail_closed_before_hook_timeout_blocks_without_command_launch(
     serialized = json.dumps(events)
     assert "partial hook stdout" not in serialized
     assert "partial hook stderr" not in serialized
+
+
+def test_v03_fail_closed_before_hook_unparseable_command_blocks_without_launch(
+    tmp_path: Path,
+) -> None:
+    payload = _hook_manifest_payload("0.3")
+    payload["hooks"][0]["entrypoint"]["command"] = "python -m 'unterminated"
+    program = _make_program(tmp_path, payload)
+    trust = _grant_trust_scopes(
+        tmp_path,
+        "github:read",
+        HOOK_LIFECYCLE_POLICY_SCOPE,
+        HOOK_LIFECYCLE_READ_SCOPE,
+    )
+    calls: list[list[str]] = []
+
+    def runner(argv, *args, **kwargs) -> subprocess.CompletedProcess:  # noqa: ARG001
+        calls.append(list(argv))
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-v03-hook-unparseable-closed",
+        subprocess_runner=runner,
+    )
+
+    assert result.status == "blocked"
+    assert calls == []
+    assert [event["event_type"] for event in events] == [
+        "plugin.hook.invoked",
+        "plugin.hook.blocked",
+    ]
+    assert "not parseable" in events[1]["result"]["message"]
+
+
+def test_v03_fail_open_before_hook_nonzero_records_hashes_and_continues(
+    tmp_path: Path,
+) -> None:
+    payload = _hook_manifest_payload("0.3")
+    payload["hooks"][0]["failure_policy"] = "fail_open"
+    payload["hooks"][0]["permissions"] = [HOOK_LIFECYCLE_READ_SCOPE]
+    payload["permissions"] = [
+        permission
+        for permission in payload["permissions"]
+        if permission["scope"] != HOOK_LIFECYCLE_POLICY_SCOPE
+    ]
+    program = _make_program(tmp_path, payload)
+    trust = _grant_trust_scopes(tmp_path, "github:read", HOOK_LIFECYCLE_READ_SCOPE)
+
+    def runner(argv, *args, **kwargs) -> subprocess.CompletedProcess:  # noqa: ARG001
+        if argv[:3] == ["python", "-m", "hook_before"]:
+            return subprocess.CompletedProcess(
+                args=argv,
+                returncode=23,
+                stdout="raw hook stdout",
+                stderr="raw hook stderr",
+            )
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-v03-hook-nonzero-open",
+        subprocess_runner=runner,
+    )
+
+    assert result.status == "success"
+    assert [event["event_type"] for event in events] == [
+        "plugin.hook.invoked",
+        "plugin.hook.failed",
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.permission_used",
+        "plugin.completed",
+        "plugin.hook.invoked",
+        "plugin.hook.completed",
+    ]
+    failed = events[1]
+    assert "exited with code 23" in failed["result"]["message"]
+    assert failed["provenance"]["returncode"] == "23"
+    assert failed["provenance"]["stdout_sha256"] == hashlib.sha256(b"raw hook stdout").hexdigest()
+    assert failed["provenance"]["stderr_sha256"] == hashlib.sha256(b"raw hook stderr").hexdigest()
+    serialized = json.dumps(events)
+    assert "raw hook stdout" not in serialized
+    assert "raw hook stderr" not in serialized
+
+
+def test_v03_fail_open_after_hook_startup_error_records_failure_after_command(
+    tmp_path: Path,
+) -> None:
+    program = _make_program(tmp_path, _hook_manifest_payload("0.3"))
+    trust = _grant_trust_scopes(
+        tmp_path,
+        "github:read",
+        HOOK_LIFECYCLE_POLICY_SCOPE,
+        HOOK_LIFECYCLE_READ_SCOPE,
+    )
+
+    def runner(argv, *args, **kwargs) -> subprocess.CompletedProcess:  # noqa: ARG001
+        if argv[:3] == ["python", "-m", "hook_after"]:
+            raise OSError("hook binary unavailable")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-v03-after-hook-startup-error",
+        subprocess_runner=runner,
+    )
+
+    assert result.status == "success"
+    assert [event["event_type"] for event in events] == [
+        "plugin.hook.invoked",
+        "plugin.hook.completed",
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.permission_used",
+        "plugin.permission_used",
+        "plugin.completed",
+        "plugin.hook.invoked",
+        "plugin.hook.failed",
+    ]
+    assert events[-1]["result"]["status"] == "failed"
+    assert "failed to start" in events[-1]["result"]["message"]
 
 
 def test_v03_fail_open_before_hook_timeout_records_failure_and_continues(

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -13,7 +13,11 @@ from ouroboros.plugin.firewall import (
     DEFAULT_PLUGIN_INVOCATION_TIMEOUT_SECONDS,
     invoke_plugin,
 )
-from ouroboros.plugin.hooks import HOOK_LIFECYCLE_POLICY_SCOPE, HOOK_LIFECYCLE_READ_SCOPE
+from ouroboros.plugin.hooks import (
+    HOOK_EVENT_TYPES,
+    HOOK_LIFECYCLE_POLICY_SCOPE,
+    HOOK_LIFECYCLE_READ_SCOPE,
+)
 from ouroboros.plugin.manifest import load_manifest
 from ouroboros.plugin.trust_store import TrustStore
 from ouroboros.plugin.userlevel_registry import (
@@ -399,6 +403,242 @@ def test_v03_after_hook_runs_after_terminal_failed_event(tmp_path: Path) -> None
         "plugin.hook.completed",
     ]
     assert events[6]["result"]["status"] == "failed"
+
+
+def test_v03_no_hooks_keeps_standard_command_audit_sequence(tmp_path: Path) -> None:
+    """Conformance baseline: v0.3 alone must not imply hook dispatch."""
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["schema_version"] = "0.3"
+    program = _make_program(tmp_path, payload)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-v03-no-hooks",
+        subprocess_runner=_fake_runner(stdout="ok"),
+    )
+
+    assert result.status == "success"
+    assert [event["event_type"] for event in events] == [
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.completed",
+    ]
+
+
+def test_v03_explicit_complete_audit_event_allowlist_conforms(tmp_path: Path) -> None:
+    """Explicit v0.3 audit.events may narrow only if every emitted event remains listed."""
+    payload = _hook_manifest_payload("0.3")
+    payload["audit"] = {
+        "events": [
+            "plugin.invoked",
+            "plugin.permission_used",
+            "plugin.completed",
+            "plugin.failed",
+            *sorted(HOOK_EVENT_TYPES),
+        ]
+    }
+    program = _make_program(tmp_path, payload)
+    trust_store = TrustStore(root=tmp_path / "trust")
+    trust = trust_store.grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    trust = trust_store.grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope=HOOK_LIFECYCLE_POLICY_SCOPE,
+        granted_by="user:test",
+    )
+    trust = trust_store.grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope=HOOK_LIFECYCLE_READ_SCOPE,
+        granted_by="user:test",
+    )
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-v03-explicit-audit",
+        subprocess_runner=_fake_runner(stdout="ok"),
+    )
+
+    assert result.status == "success"
+    assert [event["event_type"] for event in events] == [
+        "plugin.hook.invoked",
+        "plugin.hook.completed",
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.permission_used",
+        "plugin.permission_used",
+        "plugin.completed",
+        "plugin.hook.invoked",
+        "plugin.hook.completed",
+    ]
+
+
+def test_v03_missing_lifecycle_trust_blocks_before_hook_dispatch(tmp_path: Path) -> None:
+    program = _make_program(tmp_path, _hook_manifest_payload("0.3"))
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    calls: list[list[str]] = []
+
+    def runner(argv, *args, **kwargs) -> subprocess.CompletedProcess:
+        calls.append(list(argv))
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-v03-missing-hook-trust",
+        subprocess_runner=runner,
+    )
+
+    assert result.status == "blocked"
+    assert calls == []
+    assert [event["event_type"] for event in events] == ["plugin.failed"]
+    assert "plugin:lifecycle:read" in result.message
+    assert "plugin.hook.invoked" not in {event["event_type"] for event in events}
+
+
+def test_v03_fail_closed_before_hook_timeout_blocks_without_command_launch(
+    tmp_path: Path,
+) -> None:
+    program = _make_program(tmp_path, _hook_manifest_payload("0.3"))
+    trust_store = TrustStore(root=tmp_path / "trust")
+    trust = trust_store.grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    trust = trust_store.grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope=HOOK_LIFECYCLE_POLICY_SCOPE,
+        granted_by="user:test",
+    )
+    trust = trust_store.grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope=HOOK_LIFECYCLE_READ_SCOPE,
+        granted_by="user:test",
+    )
+
+    def runner(argv, *args, **kwargs) -> subprocess.CompletedProcess:
+        if argv[:3] == ["python", "-m", "hook_before"]:
+            raise subprocess.TimeoutExpired(
+                cmd=argv,
+                timeout=kwargs["timeout"],
+                output=b"partial hook stdout",
+                stderr=b"partial hook stderr",
+            )
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-v03-hook-timeout-closed",
+        subprocess_runner=runner,
+    )
+
+    assert result.status == "blocked"
+    assert [event["event_type"] for event in events] == [
+        "plugin.hook.invoked",
+        "plugin.hook.blocked",
+    ]
+    blocked = events[1]
+    assert "timed out" in blocked["result"]["message"]
+    assert "stdout_sha256" in blocked["provenance"]
+    serialized = json.dumps(events)
+    assert "partial hook stdout" not in serialized
+    assert "partial hook stderr" not in serialized
+
+
+def test_v03_fail_open_before_hook_timeout_records_failure_and_continues(
+    tmp_path: Path,
+) -> None:
+    payload = _hook_manifest_payload("0.3")
+    payload["hooks"][0]["failure_policy"] = "fail_open"
+    payload["hooks"][0]["permissions"] = [HOOK_LIFECYCLE_READ_SCOPE]
+    payload["permissions"] = [
+        permission
+        for permission in payload["permissions"]
+        if permission["scope"] != HOOK_LIFECYCLE_POLICY_SCOPE
+    ]
+    program = _make_program(tmp_path, payload)
+    trust_store = TrustStore(root=tmp_path / "trust")
+    trust = trust_store.grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="user:test",
+    )
+    trust = trust_store.grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope=HOOK_LIFECYCLE_READ_SCOPE,
+        granted_by="user:test",
+    )
+
+    def runner(argv, *args, **kwargs) -> subprocess.CompletedProcess:
+        if argv[:3] == ["python", "-m", "hook_before"]:
+            raise subprocess.TimeoutExpired(cmd=argv, timeout=kwargs["timeout"])
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="", stderr="")
+
+    events: list[dict] = []
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=events.append,
+        correlation_id="corr-v03-hook-timeout-open",
+        subprocess_runner=runner,
+    )
+
+    assert result.status == "success"
+    assert [event["event_type"] for event in events] == [
+        "plugin.hook.invoked",
+        "plugin.hook.failed",
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.permission_used",
+        "plugin.completed",
+        "plugin.hook.invoked",
+        "plugin.hook.completed",
+    ]
+    assert events[1]["result"]["status"] == "failed"
+    assert "timed out" in events[1]["result"]["message"]
 
 
 def test_trust_violation_only_emits_failed_no_invoked(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add v0.3 lifecycle wrapper conformance coverage for no-hooks, explicit audit allowlists, lifecycle trust-gate failures, and hook timeout policies
- document the v0.3 lifecycle conformance baseline in the plugin RFC
- keep the matrix scoped to the existing `before_invocation` / `after_invocation` wrapper

## Scope
- #939 follow-up PR B from the scope decision.
- No deferred hook promotion, no new hook dispatch, no schema widening, no plugin runtime behavior change outside tests/docs.

## Verification
- `uv run pytest tests/unit/plugin/test_firewall.py tests/unit/plugin/test_manifest_schema_0_3.py tests/integration/plugin/test_e2e.py -q`
- `uv run ruff check docs/rfc/userlevel-plugins.md tests/unit/plugin/test_firewall.py src/ouroboros/plugin/firewall.py`
- `uv run mypy src/ouroboros/plugin/firewall.py`

## Note
`tests/unit/plugin/test_firewall.py` has pre-existing mypy issues unrelated to this PR, so mypy verification is scoped to the production firewall module.
