### PR TITLE
feat(auto): consume lateral recovery plans for Ralph redispatch

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -33,6 +33,8 @@ from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.listeners import RALPH_CANCEL_BLOCKER_REASON, mirror_ralph_job_events
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.recovery_plan import (
+    AutoRecoveryPlan,
+    RecoveryPlanAction,
     build_lateral_recovery_plan,
     build_manual_recovery_plan,
 )
@@ -53,22 +55,15 @@ from ouroboros.resilience.lateral import ThinkingPersona
 
 # RFC #809 Phase 2.2b — Stack 1 of 2 scope and invariants.
 #
-# **Scope of this module's recovery wiring.** P2.2b lands in two stacked
-# PRs. This file is Stack 1: the deterministic *guards* and *multi-persona
-# advisory* path. There is intentionally no automated Ralph re-dispatch
-# here — when EVALUATE fails, ``_run_lateral`` records the persona's
-# advisory and the session ends in ``BLOCKED``. The four guards
+# **Scope of this module's recovery wiring.** P2.2b landed in two stacked
+# PRs. Stack 1 added the deterministic *guards* and *multi-persona
+# advisory* path. Stack 2 consumes the typed ``AutoRecoveryPlan`` produced
+# by lateral advice: safe ``ralph_redispatch`` plans are routed into a
+# fresh Ralph handoff and then back through EVALUATE, while manual or
+# unsafe plans still terminate as BLOCKED. The four guards
 # (``MAX_EVALUATE_ROUNDS``, same-fingerprint twice, per-persona-once,
-# ``state.deadline_at``) bound the surface so a future Stack 2, which
-# wires the lateral advice into a fresh Ralph job and a new EVALUATE
-# round, cannot loop unboundedly or revisit a stale persona. Without
-# Stack 2 present, ``evaluate_round`` typically increments to 1 in a
-# single session and the fingerprint guard is exercised only on
-# ``--resume`` against the same artifact; both become load-bearing once
-# Stack 2 lands. Naming this PR a "closed loop" was a documentation
-# overstatement caught in code review; the loop *closes* when Stack 2
-# ships, and Stack 1 is the bounded-advisory step that makes Stack 2
-# safe to land.
+# ``state.deadline_at``) bound that closed loop so redispatch cannot loop
+# unboundedly or revisit a stale persona.
 #
 # **Operator-choice cue.** Suffixed onto every recovery-loop BLOCKED
 # message so the operator sees their next move without having to read
@@ -1823,21 +1818,21 @@ class AutoPipeline:
         review: SeedReview | None,
         run_subagent: dict[str, Any] | None,
     ) -> AutoPipelineResult:
-        """Invoke the persona-driven lateral advisor and finalize as BLOCKED.
+        """Invoke the persona-driven lateral advisor and consume its plan.
 
-        Phase 2.2 advisory layer — when ``ouroboros_qa`` rules the run
+        Phase 2.2 recovery layer — when ``ouroboros_qa`` rules the run
         artifact did not satisfy the Seed AC, this method picks a persona
         deterministically from the QA-failure shape (via
         :func:`select_persona_for_qa_failure`) and asks
         ``ouroboros_lateral_think`` for a reframing prompt. The persona's
-        output is persisted on :class:`AutoPipelineState` and surfaced in
-        the final BLOCKED message so the operator (or a future P2.2b
-        automated recovery layer) sees actionable next steps rather than
-        the raw QA differences.
+        output is persisted on :class:`AutoPipelineState` as a typed
+        recovery plan. Dispatchable plans re-enter Ralph; manual or unsafe
+        plans surface actionable BLOCKED guidance instead of raw QA
+        differences.
 
-        Idempotent on resume: same persona + same QA shape hashes to the
-        same ``lateral_input_hash``; a cache hit returns the persisted
-        persona text without re-invoking the tool.
+        Resume is intentionally not a cache replay: previous personas are
+        stored in ``state.personas_invoked`` so a recovered UNSTUCK_LATERAL
+        phase selects a different angle unless a guard has already tripped.
 
         On timeout / handler error / transient adapter error → BLOCKED with
         ``tool_name="lateral_thinker"`` so the resume contract (mapped by
@@ -2008,9 +2003,10 @@ class AutoPipeline:
             state.personas_invoked.append(persona.value)
         self._save(state)
 
-        return self._finalize_lateral(
+        return await self._finalize_lateral(
             state,
             ledger,
+            seed,
             review=review,
             run_subagent=run_subagent,
             qa_score=qa_score,
@@ -2021,10 +2017,11 @@ class AutoPipeline:
             from_cache=False,
         )
 
-    def _finalize_lateral(
+    async def _finalize_lateral(
         self,
         state: AutoPipelineState,
         ledger: SeedDraftLedger,
+        seed: Seed,
         *,
         review: SeedReview | None,
         run_subagent: dict[str, Any] | None,
@@ -2035,25 +2032,17 @@ class AutoPipeline:
         cache_suffix: str,
         from_cache: bool,
     ) -> AutoPipelineResult:
-        """Build the BLOCKED summary that surfaces the persona's reframing.
+        """Consume a lateral recovery plan or block with manual guidance.
 
-        RFC #809 Phase 2.2b — Stack 1 of 2 endpoint. This method is the
-        *final* step of the advisory path: the persona's advice is
-        persisted in ledger/state and the session transitions to
-        BLOCKED. There is no automated Ralph re-dispatch in this PR; the
-        operator inspects the persona reframing and decides their next
-        move (the two-choice cue suffixed below). Stack 2 will replace
-        this terminal block with a Ralph re-dispatch that injects the
-        persona advice into a fresh evolve job and re-enters EVALUATE,
-        at which point the round/fingerprint/persona-once guards land
-        in their load-bearing role. The behavior here is deliberately
-        bounded so Stack 2 can layer on top without rewriting the
-        endpoint semantics.
+        Safe ``ralph_redispatch`` plans are the closed-loop Stack 2 path:
+        the persona's advice is persisted, added to a dispatch-only Seed
+        constraint, and sent through a fresh Ralph handoff that returns to
+        EVALUATE. Manual / unsafe plans remain terminal BLOCKED guidance.
         """
         lateral_suffix = " [lateral cached]" if from_cache else ""
         persona_name = state.last_lateral_persona or "unknown"
         approach = state.last_lateral_approach_summary or ""
-        state.last_recovery_plan = build_lateral_recovery_plan(
+        recovery_plan = build_lateral_recovery_plan(
             qa_score=qa_score,
             qa_verdict=qa_verdict,
             differences=tuple(qa_differences),
@@ -2061,7 +2050,43 @@ class AutoPipeline:
             persona=persona_name,
             approach_summary=approach,
             lateral_text=state.last_lateral_text or "",
-        ).to_dict()
+        )
+        state.last_recovery_plan = recovery_plan.to_dict()
+        self._save(state)
+
+        if self._can_redispatch_recovery_plan(recovery_plan):
+            if self.ralph_starter is None:
+                _prepare_recovery_redispatch(state)
+                state.mark_blocked(
+                    "recovery plan requested Ralph redispatch but no ralph starter is configured; "
+                    f"{_RECOVERY_BLOCKED_CHOICES}",
+                    tool_name="ralph_starter",
+                )
+                self._save(state)
+                return self._result(
+                    state,
+                    ledger,
+                    review=review,
+                    blocker=state.last_error,
+                    run_subagent=run_subagent,
+                )
+            recovery_seed = _seed_with_recovery_constraint(seed, recovery_plan)
+            _prepare_recovery_redispatch(state)
+            state.mark_progress(
+                "consuming lateral recovery plan via fresh Ralph redispatch",
+                tool_name="ralph_starter",
+            )
+            self._save(state)
+            return await self._handoff_to_ralph(
+                state,
+                ledger,
+                recovery_seed,
+                review,
+                run_subagent=run_subagent,
+                reattach_terminal=False,
+                reuse_existing=False,
+            )
+
         summary_parts = [
             f"evaluator did not pass: {qa_verdict} (score {qa_score:.2f}){cache_suffix}",
             f"lateral persona {persona_name}{lateral_suffix}: {approach}"
@@ -2084,6 +2109,15 @@ class AutoPipeline:
         self._save(state)
         return self._result(
             state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
+        )
+
+    @staticmethod
+    def _can_redispatch_recovery_plan(plan: AutoRecoveryPlan) -> bool:
+        """Return True when a persisted plan is safe to consume automatically."""
+        return (
+            plan.action is RecoveryPlanAction.RALPH_REDISPATCH
+            and plan.safe_to_redispatch
+            and bool(plan.instruction.strip())
         )
 
     async def _resume_ralph_handoff(
@@ -2829,6 +2863,36 @@ def _has_reconciliable_ralph_resume_checkpoint(state: AutoPipelineState) -> bool
     if state.phase is not AutoPhase.RALPH_HANDOFF:
         return False
     return state.ralph_job_id is not None or state.ralph_dispatch_mode == "plugin"
+
+
+def _prepare_recovery_redispatch(state: AutoPipelineState) -> None:
+    """Clear prior Ralph handles so recovery starts a fresh bounded attempt."""
+    state.ralph_job_id = None
+    state.ralph_lineage_id = None
+    state.ralph_dispatch_mode = None
+    state.ralph_job_status = None
+    state.ralph_stop_reason = None
+    state.ralph_current_generation = None
+    state.ralph_last_event_at = None
+    state.run_handoff_guidance = None
+    state.run_handoff_status = "ralph_retry_after_blocker"
+
+
+def _seed_with_recovery_constraint(seed: Seed, plan: AutoRecoveryPlan) -> Seed:
+    """Return a dispatch-only Seed carrying bounded lateral recovery advice.
+
+    The recovery advice must not relax the Seed's goal or acceptance
+    criteria. Encoding it as an additional hard constraint gives Ralph the
+    reframing context while preserving the user-approved ACs that EVALUATE
+    will grade after redispatch.
+    """
+    instruction = plan.instruction.strip()
+    constraint = (
+        "[auto recovery] Previous QA failed. Use this lateral recovery "
+        "instruction to change implementation/verification approach without "
+        f"relaxing the goal or acceptance criteria: {instruction}"
+    )
+    return seed.model_copy(update={"constraints": (*seed.constraints, constraint)})
 
 
 def _first_nonempty(*values: str | None) -> str | None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1477,10 +1477,11 @@ class AutoPipeline:
             and artifact_hash is not None
             and state.evaluate_artifact_hash != artifact_hash
         ):
-            state.recovery_guard_tripped = None
-            state.evaluate_round = 0
-            state.failure_fingerprints = []
-            state.personas_invoked = []
+            if not _is_active_recovery_redispatch(state):
+                state.recovery_guard_tripped = None
+                state.evaluate_round = 0
+                state.failure_fingerprints = []
+                state.personas_invoked = []
 
         # RFC #809 Phase 2.2b — sticky guard check (post-reset). If the
         # previous round exhausted a recovery guard AND the artifact
@@ -2211,6 +2212,20 @@ class AutoPipeline:
                 reattach_terminal=True,
             )
 
+        if (
+            state.run_handoff_status == "ralph_retry_after_blocker"
+            and self.ralph_starter is None
+            and not state.ralph_job_id
+            and not state.ralph_lineage_id
+        ):
+            state.mark_blocked(
+                "Ralph handoff retry requires a configured ralph starter; "
+                f"{_RECOVERY_BLOCKED_CHOICES}",
+                tool_name="ralph_starter",
+            )
+            self._save(state)
+            return self._result(state, ledger, review=review, blocker=state.last_error)
+
         handle = state.ralph_job_id or state.ralph_lineage_id
         if handle:
             state.run_handoff_guidance = (
@@ -2863,6 +2878,19 @@ def _has_reconciliable_ralph_resume_checkpoint(state: AutoPipelineState) -> bool
     if state.phase is not AutoPhase.RALPH_HANDOFF:
         return False
     return state.ralph_job_id is not None or state.ralph_dispatch_mode == "plugin"
+
+
+def _is_active_recovery_redispatch(state: AutoPipelineState) -> bool:
+    """Return True while a safe lateral plan is driving a Ralph redispatch."""
+    if state.run_handoff_status != "ralph_retry_after_blocker":
+        return False
+    if not isinstance(state.last_recovery_plan, dict):
+        return False
+    try:
+        plan = AutoRecoveryPlan.from_dict(state.last_recovery_plan)
+    except ValueError:
+        return False
+    return AutoPipeline._can_redispatch_recovery_plan(plan)
 
 
 def _prepare_recovery_redispatch(state: AutoPipelineState) -> None:

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -306,14 +306,15 @@ _ALLOWED_TRANSITIONS: dict[AutoPhase, set[AutoPhase]] = {
         AutoPhase.FAILED,
     },
     # RFC #809 Phase 2.2b — UNSTUCK_LATERAL is no longer a terminal advisory
-    # phase. It now dispatches one of two outcomes inside the bounded
-    # retry budget: back to EVALUATE for another round under a different
-    # persona, or BLOCKED when a recovery guard trips
-    # (``MAX_EVALUATE_ROUNDS``, duplicate failure fingerprint, persona
-    # exhaustion, or wall-clock budget). SEED_REGENERATE is deliberately
-    # not part of this set — see the ``AutoPhase`` comment block above for
-    # the spec-first rationale behind that omission.
+    # phase. It now dispatches one of three outcomes inside the bounded
+    # retry budget: a fresh RALPH_HANDOFF that re-enters EVALUATE, a direct
+    # EVALUATE re-entry for recovered artifacts, or BLOCKED when a recovery
+    # guard trips (``MAX_EVALUATE_ROUNDS``, duplicate failure fingerprint,
+    # persona exhaustion, or wall-clock budget). SEED_REGENERATE is
+    # deliberately not part of this set — see the ``AutoPhase`` comment
+    # block above for the spec-first rationale behind that omission.
     AutoPhase.UNSTUCK_LATERAL: {
+        AutoPhase.RALPH_HANDOFF,
         AutoPhase.EVALUATE,
         AutoPhase.COMPLETE,
         AutoPhase.BLOCKED,

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -176,8 +176,9 @@ class _StubLedger:
 def test_unstuck_lateral_phase_in_allowed_transitions() -> None:
     assert AutoPhase.UNSTUCK_LATERAL in _ALLOWED_TRANSITIONS[AutoPhase.EVALUATE]
     # RFC #809 Phase 2.2b — UNSTUCK_LATERAL became a retry dispatcher:
-    # back to EVALUATE for another round under a different persona, or
-    # BLOCKED when a recovery guard trips. SEED_REGENERATE is intentionally
+    # into a fresh RALPH_HANDOFF that returns through EVALUATE, directly back
+    # to EVALUATE for recovered artifacts, or BLOCKED when a recovery guard
+    # trips. SEED_REGENERATE is intentionally
     # absent (see the AutoPhase deferral comment): an automatic Seed
     # rewrite is a reward-hacking surface that mutates the spec the user
     # explicitly agreed to. The pipeline instead surfaces the operator
@@ -189,6 +190,7 @@ def test_unstuck_lateral_phase_in_allowed_transitions() -> None:
     # resume is a separate change.
 
     assert _ALLOWED_TRANSITIONS[AutoPhase.UNSTUCK_LATERAL] == {
+        AutoPhase.RALPH_HANDOFF,
         AutoPhase.EVALUATE,
         AutoPhase.COMPLETE,
         AutoPhase.BLOCKED,
@@ -343,10 +345,10 @@ async def test_pipeline_qa_fail_enters_unstuck_lateral_and_blocks_with_persona(t
             suggestions=("try CLI build via swift test",),
         )
 
-    captured_call: dict[str, Any] = {}
+    captured_calls: list[dict[str, Any]] = []
 
     async def lateral_thinker(**kwargs: Any) -> LateralResult:
-        captured_call.update(kwargs)
+        captured_calls.append(dict(kwargs))
         return LateralResult(
             persona="hacker",
             approach_summary="Hacker: Finds unconventional workarounds",
@@ -372,16 +374,79 @@ async def test_pipeline_qa_fail_enters_unstuck_lateral_and_blocks_with_persona(t
     assert "Hacker: Finds unconventional workarounds" in state.last_lateral_approach_summary
     assert "hacker" in (state.last_error or "")
     # Lateral thinker was called with the correct persona
-    assert captured_call["persona"] is ThinkingPersona.HACKER
-    assert "Xcode" in str(captured_call["qa_differences"])
+    assert captured_calls[0]["persona"] is ThinkingPersona.HACKER
+    assert "Xcode" in str(captured_calls[0]["qa_differences"])
     # MCP-facing result fields populated
     assert result.last_lateral_persona == "hacker"
     assert result.last_lateral_text is not None
-    assert state.last_recovery_plan is not None
-    assert state.last_recovery_plan["action"] == "ralph_redispatch"
-    assert state.last_recovery_plan["safe_to_redispatch"] is True
-    assert state.last_recovery_plan["persona"] == "hacker"
-    assert "Reframe the verification path" in state.last_recovery_plan["instruction"]
+    assert state.recovery_guard_tripped == "personas_exhausted"
+    assert state.last_recovery_plan is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_consumes_lateral_plan_with_fresh_ralph_redispatch(tmp_path) -> None:
+    """A dispatchable lateral recovery plan should close the recovery loop.
+
+    First Ralph output fails EVALUATE, lateral advice produces a safe
+    ``ralph_redispatch`` plan, the plan is consumed by a fresh Ralph handoff,
+    and the second Ralph output re-enters EVALUATE and passes.
+    """
+    state = _state_at_run_phase(tmp_path)
+    eval_calls = 0
+    ralph_seeds: list[Seed] = []
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        nonlocal eval_calls
+        eval_calls += 1
+        if eval_calls == 1:
+            return EvaluateResult(
+                passed=False,
+                score=0.30,
+                verdict="fail",
+                differences=("Xcode is not available in the sandbox",),
+                suggestions=("try CLI build via swift test",),
+            )
+        return EvaluateResult(passed=True, score=0.95, verdict="pass")
+
+    async def lateral_thinker(**kwargs: Any) -> LateralResult:  # noqa: ARG001
+        return LateralResult(
+            persona="hacker",
+            approach_summary="Use a smaller CLI verification path",
+            text="Run the CLI directly and capture stdout instead of relying on Xcode.",
+        )
+
+    async def ralph_starter(seed: Seed, **kwargs: Any) -> dict[str, Any]:
+        ralph_seeds.append(seed)
+        return {
+            "job_id": f"job_ralph_{len(ralph_seeds)}",
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+            "result_text": f"artifact {len(ralph_seeds)}",
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+        evaluator=evaluator,
+        lateral_thinker=lateral_thinker,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert eval_calls == 2
+    assert len(ralph_seeds) == 2
+    assert ralph_seeds[1].acceptance_criteria == ralph_seeds[0].acceptance_criteria
+    assert any("[auto recovery]" in constraint for constraint in ralph_seeds[1].constraints)
+    assert any("Run the CLI directly" in constraint for constraint in ralph_seeds[1].constraints)
+    assert state.last_recovery_plan is None
 
 
 @pytest.mark.asyncio
@@ -799,13 +864,23 @@ async def test_pipeline_lateral_resume_with_same_persona_reinvokes_handler(tmp_p
         _seed_generator_unused,
         run_starter=_run_starter_ok,
         reviewer=_PassReviewer(),
-        ralph_starter=_ralph_starter(),
+        ralph_starter=None,
         complete_product=True,
         evaluator=evaluator,
         lateral_thinker=lateral_thinker,
     )
 
-    await pipeline.run(state)
+    state.complete_product = True
+    state.phase = AutoPhase.EVALUATE
+    await pipeline._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=_build_seed(),
+        review=None,
+        run_subagent=None,
+        ralph_result_text="artifact",
+        stop_reason="qa failed",
+    )
     assert call_count == 1
     assert state.last_lateral_text == "advice text 1"
 
@@ -856,13 +931,23 @@ async def test_pipeline_lateral_re_runs_when_qa_differences_change(tmp_path) -> 
         _seed_generator_unused,
         run_starter=_run_starter_ok,
         reviewer=_PassReviewer(),
-        ralph_starter=_ralph_starter(),
+        ralph_starter=None,
         complete_product=True,
         evaluator=evaluator,
         lateral_thinker=lateral_thinker,
     )
 
-    await pipeline.run(state)
+    state.complete_product = True
+    state.phase = AutoPhase.EVALUATE
+    await pipeline._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=_build_seed(),
+        review=None,
+        run_subagent=None,
+        ralph_result_text="artifact",
+        stop_reason="qa failed",
+    )
     assert call_count == 1
 
     state.phase = AutoPhase.UNSTUCK_LATERAL
@@ -1017,14 +1102,24 @@ async def test_lateral_cache_invalidated_when_evaluate_artifact_changes(tmp_path
         _seed_generator_unused,
         run_starter=_run_starter_ok,
         reviewer=_PassReviewer(),
-        ralph_starter=_ralph_starter(result_text="artifact A"),
+        ralph_starter=None,
         complete_product=True,
         evaluator=evaluator,
         lateral_thinker=lateral_thinker,
     )
 
     # First run: artifact A → QA fail → lateral called, advice cached
-    await pipeline.run(state)
+    state.complete_product = True
+    state.phase = AutoPhase.EVALUATE
+    await pipeline._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=_build_seed(),
+        review=None,
+        run_subagent=None,
+        ralph_result_text="artifact A",
+        stop_reason="qa failed",
+    )
     assert eval_calls == 1
     assert lateral_calls == 1
     a_lateral_hash = state.lateral_input_hash
@@ -1040,6 +1135,7 @@ async def test_lateral_cache_invalidated_when_evaluate_artifact_changes(tmp_path
     # evaluate-artifact hash change must invalidate the lateral cache;
     # otherwise "advice for round 1" (about artifact A) would be reused
     # against artifact B.
+    state.complete_product = True
     state.phase = AutoPhase.EVALUATE
     await pipeline._run_evaluate(
         state,
@@ -1408,13 +1504,23 @@ async def test_recovery_personas_invoked_persists_after_lateral(tmp_path) -> Non
         _seed_generator_unused,
         run_starter=_run_starter_ok,
         reviewer=_PassReviewer(),
-        ralph_starter=_ralph_starter(result_text="artifact"),
+        ralph_starter=None,
         complete_product=True,
         evaluator=evaluator,
         lateral_thinker=lateral_thinker,
     )
 
-    await pipeline.run(state)
+    state.complete_product = True
+    state.phase = AutoPhase.EVALUATE
+    await pipeline._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=_build_seed(),
+        review=None,
+        run_subagent=None,
+        ralph_result_text="artifact",
+        stop_reason="qa failed",
+    )
 
     # The persona selected on this round is now persisted.
     assert state.personas_invoked == [ThinkingPersona.HACKER.value]

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -28,6 +28,7 @@ from ouroboros.auto.pipeline import AutoPipeline
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import (
     _ALLOWED_TRANSITIONS,
+    MAX_EVALUATE_ROUNDS,
     AutoPhase,
     AutoPipelineState,
     AutoResumeCapability,
@@ -447,6 +448,98 @@ async def test_pipeline_consumes_lateral_plan_with_fresh_ralph_redispatch(tmp_pa
     assert any("[auto recovery]" in constraint for constraint in ralph_seeds[1].constraints)
     assert any("Run the CLI directly" in constraint for constraint in ralph_seeds[1].constraints)
     assert state.last_recovery_plan is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_redispatch_fresh_artifact_preserves_loop_budget(tmp_path) -> None:
+    """Automated recovery redispatches must not reset the recovery guards.
+
+    Fresh Ralph artifacts normally clear stale operator-driven exhaustion, but
+    a safe lateral ``ralph_redispatch`` plan is part of the same closed loop. A
+    changed artifact from that path must still respect the existing round,
+    fingerprint, and persona budgets.
+    """
+    state = _state_at_run_phase(tmp_path)
+    state.phase = AutoPhase.EVALUATE
+    state.run_handoff_status = "ralph_retry_after_blocker"
+    state.last_recovery_plan = {
+        "action": "ralph_redispatch",
+        "safe_to_redispatch": True,
+        "reason": "safe lateral retry",
+        "qa_score": 0.30,
+        "qa_verdict": "fail",
+        "differences": ["old failure"],
+        "suggestions": ["try another route"],
+        "persona": "hacker",
+        "instruction": "Use a CLI-only verification path.",
+    }
+    state.evaluate_artifact_hash = "stale_hash_does_not_match_new_artifact"
+    state.evaluate_round = MAX_EVALUATE_ROUNDS
+    state.failure_fingerprints = ["fp1", "fp2", "fp3"]
+    state.personas_invoked = [ThinkingPersona.HACKER.value]
+
+    eval_calls = 0
+
+    async def evaluator(seed: Seed, artifact: str) -> EvaluateResult:  # noqa: ARG001
+        nonlocal eval_calls
+        eval_calls += 1
+        return EvaluateResult(passed=True, score=0.95, verdict="pass")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=_ralph_starter(),
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    result = await pipeline._run_evaluate(
+        state,
+        ledger=_StubLedger(),
+        seed=_build_seed(),
+        review=None,
+        run_subagent=None,
+        ralph_result_text="brand new recovery artifact bytes",
+        stop_reason=None,
+    )
+
+    assert result.status == "blocked"
+    assert eval_calls == 0
+    assert state.recovery_guard_tripped == "round_budget"
+    assert state.evaluate_round == MAX_EVALUATE_ROUNDS
+    assert state.failure_fingerprints == ["fp1", "fp2", "fp3"]
+    assert state.personas_invoked == [ThinkingPersona.HACKER.value]
+
+
+@pytest.mark.asyncio
+async def test_recovery_redispatch_without_starter_resume_stays_blocked(tmp_path) -> None:
+    """A no-starter recovery retry must not resume into guidance-only limbo."""
+    state = _state_at_run_phase(tmp_path)
+    state.phase = AutoPhase.RALPH_HANDOFF
+    state.run_handoff_status = "ralph_retry_after_blocker"
+    state.ralph_job_id = None
+    state.ralph_lineage_id = None
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=None,
+        complete_product=True,
+        evaluator=None,
+    )
+
+    result = await pipeline._resume_ralph_handoff(
+        state, ledger=_StubLedger(), review=None, seed=_build_seed()
+    )
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "ralph_starter"
+    assert "requires a configured ralph starter" in (state.last_error or "")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Consume safe `AutoRecoveryPlan(action=ralph_redispatch)` artifacts instead of ending every lateral recovery path as advisory-only `BLOCKED`.
- Route dispatchable lateral advice into a fresh Ralph handoff, then re-enter `EVALUATE` through the existing complete-product grading path.
- Preserve manual/unsafe recovery behavior: empty/manual plans still block with operator guidance, and the existing round/fingerprint/persona/deadline guards remain the loop boundary.

## Scope

This is the #809 next implementation slice for the typed recovery-plan path.

Included:
- `UNSTUCK_LATERAL -> RALPH_HANDOFF -> EVALUATE` transition support.
- Fresh Ralph redispatch after a safe lateral plan.
- Dispatch-only recovery constraint carrying persona advice without changing goal or acceptance criteria.
- Regression coverage for successful redispatch and existing guard/cache behavior.

Excluded:
- Seed auto-regeneration.
- Acceptance-criteria relaxation.
- Ledger conflict policy centralization; that remains the next PR slice.
- Live Codex/MCP smoke; #821 residual live/full-chain evidence remains separate.

## Test Plan

- `uv run pytest tests/unit/auto/test_pipeline_lateral.py tests/unit/auto/test_recovery_plan.py -q`
- `uv run pytest tests/unit/auto/test_pipeline_lateral.py tests/unit/auto/test_pipeline_evaluate.py tests/unit/auto/test_pipeline_ralph_handoff.py tests/unit/auto/test_recovery_plan.py -q`
- `uv run ruff format --check src/ouroboros/auto/pipeline.py src/ouroboros/auto/state.py tests/unit/auto/test_pipeline_lateral.py`
- `uv run ruff check src/ouroboros/auto/pipeline.py src/ouroboros/auto/state.py tests/unit/auto/test_pipeline_lateral.py`
- `git diff --check`

Refs #809.
