### PR TITLE
feat(auto): centralize deterministic ledger conflict policy

### DIFF
--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -34,6 +34,26 @@ class LedgerStatus(StrEnum):
     BLOCKED = "blocked"
 
 
+SOURCE_PRIORITY: tuple[LedgerSource, ...] = (
+    LedgerSource.USER_GOAL,
+    LedgerSource.REPO_FACT,
+    LedgerSource.EXISTING_CONVENTION,
+    LedgerSource.NON_GOAL,
+    LedgerSource.USER_PREFERENCE,
+    LedgerSource.CONSERVATIVE_DEFAULT,
+    LedgerSource.INFERENCE,
+    LedgerSource.ASSUMPTION,
+    LedgerSource.BLOCKER,
+)
+"""Deterministic conflict priority for same-key ledger contradictions.
+
+Higher-priority sources are allowed to supersede lower-priority entries
+without a human decision. Same-priority ties fall back to confidence; exact
+source+confidence ties remain CONFLICTING so the interview driver blocks
+instead of inventing a merge.
+"""
+
+
 REQUIRED_SECTIONS = (
     "goal",
     "actors",
@@ -144,6 +164,52 @@ class LedgerEntry:
             msg = "ledger entry confidence must be between 0 and 1"
             raise ValueError(msg)
         return cls(**data)
+
+
+class ConflictResolution(StrEnum):
+    """Outcome of resolving a same-key ledger contradiction."""
+
+    SAME_VALUE = "same_value"
+    INCOMING_WINS = "incoming_wins"
+    EXISTING_WINS = "existing_wins"
+    BLOCKED = "blocked"
+    CONFLICTING = "conflicting"
+
+
+def resolve_conflict(existing: LedgerEntry, incoming: LedgerEntry) -> ConflictResolution:
+    """Resolve a same-key ledger conflict without model judgment.
+
+    The policy follows #809 Pillar B: source priority first, then confidence,
+    then CONFLICTING for exact ties. Incoming ``BLOCKED`` entries remain a
+    human-decision surface; earlier transient blockers can be retired by a
+    later non-blocked same-key answer.
+    """
+    if _normalize_conflict_value(existing.value) == _normalize_conflict_value(incoming.value):
+        return ConflictResolution.SAME_VALUE
+    if incoming.status == LedgerStatus.BLOCKED:
+        return ConflictResolution.BLOCKED
+    if existing.status == LedgerStatus.BLOCKED:
+        return ConflictResolution.INCOMING_WINS
+
+    existing_priority = _source_priority_index(existing.source)
+    incoming_priority = _source_priority_index(incoming.source)
+    if incoming_priority < existing_priority:
+        return ConflictResolution.INCOMING_WINS
+    if existing_priority < incoming_priority:
+        return ConflictResolution.EXISTING_WINS
+
+    if incoming.confidence > existing.confidence:
+        return ConflictResolution.INCOMING_WINS
+    if existing.confidence > incoming.confidence:
+        return ConflictResolution.EXISTING_WINS
+    return ConflictResolution.CONFLICTING
+
+
+def _source_priority_index(source: LedgerSource) -> int:
+    try:
+        return SOURCE_PRIORITY.index(source)
+    except ValueError:
+        return len(SOURCE_PRIORITY)
 
 
 @dataclass(slots=True)
@@ -271,20 +337,29 @@ class SeedDraftLedger:
                 )
         else:
             for existing in same_key_entries:
-                if entry.status == LedgerStatus.BLOCKED:
+                resolution = resolve_conflict(existing, entry)
+                if resolution is ConflictResolution.BLOCKED:
                     continue
-                if existing.status == LedgerStatus.BLOCKED:
+                if resolution is ConflictResolution.INCOMING_WINS:
                     existing.status = LedgerStatus.WEAK
-                    existing.rationale = (
-                        existing.rationale or "Superseded by a later same-key answer."
+                    existing.rationale = existing.rationale or (
+                        "Superseded by deterministic source-priority/confidence policy."
+                    )
+                    continue
+                if resolution is ConflictResolution.EXISTING_WINS:
+                    entry.status = LedgerStatus.WEAK
+                    entry.rationale = entry.rationale or (
+                        "Superseded by deterministic source-priority/confidence policy."
                     )
                     continue
                 existing.status = LedgerStatus.CONFLICTING
                 entry.status = LedgerStatus.CONFLICTING
-                existing.rationale = (
-                    existing.rationale or "Conflicts with another auto ledger answer."
+                existing.rationale = existing.rationale or (
+                    "Conflicts with another same-priority auto ledger answer."
                 )
-                entry.rationale = entry.rationale or "Conflicts with another auto ledger answer."
+                entry.rationale = entry.rationale or (
+                    "Conflicts with another same-priority auto ledger answer."
+                )
         section.entries.append(entry)
 
     def record_qa(self, question: str, answer: str) -> None:

--- a/tests/unit/auto/test_user_preference_and_floor.py
+++ b/tests/unit/auto/test_user_preference_and_floor.py
@@ -22,10 +22,12 @@ from ouroboros.auto.answerer import (
 )
 from ouroboros.auto.grading import GradeGate, SeedGrade, deterministic_floor
 from ouroboros.auto.ledger import (
+    SOURCE_PRIORITY,
     LedgerEntry,
     LedgerSource,
     LedgerStatus,
     SeedDraftLedger,
+    resolve_conflict,
 )
 from ouroboros.core.seed import (
     EvaluationPrinciple,
@@ -168,6 +170,185 @@ def test_count_active_conflicting_entries_returns_count_across_sections() -> Non
         ),
     )
     assert ledger.count_active_conflicting_entries() == 2
+
+
+# ---------------------------------------------------------------------------
+# deterministic conflict policy
+# ---------------------------------------------------------------------------
+
+
+def test_source_priority_places_user_preference_between_convention_and_default() -> None:
+    assert SOURCE_PRIORITY.index(LedgerSource.EXISTING_CONVENTION) < SOURCE_PRIORITY.index(
+        LedgerSource.USER_PREFERENCE
+    )
+    assert SOURCE_PRIORITY.index(LedgerSource.USER_PREFERENCE) < SOURCE_PRIORITY.index(
+        LedgerSource.CONSERVATIVE_DEFAULT
+    )
+
+
+def test_higher_priority_incoming_entry_supersedes_lower_priority_existing() -> None:
+    ledger = SeedDraftLedger()
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.storage",
+            value="Use a local JSON file",
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.85,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.storage",
+            value="Use SQLite because the repo already depends on it",
+            source=LedgerSource.REPO_FACT,
+            confidence=0.70,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+
+    entries = ledger.sections["constraints"].entries
+    assert entries[0].status is LedgerStatus.WEAK
+    assert entries[1].status is LedgerStatus.CONFIRMED
+    assert ledger.sections["constraints"].status() is LedgerStatus.CONFIRMED
+
+
+def test_higher_priority_existing_entry_supersedes_lower_priority_incoming() -> None:
+    ledger = SeedDraftLedger()
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.storage",
+            value="Use SQLite because the repo already depends on it",
+            source=LedgerSource.REPO_FACT,
+            confidence=0.70,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.storage",
+            value="Use a local JSON file",
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.95,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+
+    entries = ledger.sections["constraints"].entries
+    assert entries[0].status is LedgerStatus.CONFIRMED
+    assert entries[1].status is LedgerStatus.WEAK
+    assert ledger.sections["constraints"].status() is LedgerStatus.CONFIRMED
+
+
+def test_later_grounded_answer_clears_prior_same_key_blocker() -> None:
+    ledger = SeedDraftLedger()
+    ledger.add_entry(
+        "runtime_context",
+        LedgerEntry(
+            key="runtime.python",
+            value="Python version unknown; cannot proceed",
+            source=LedgerSource.BLOCKER,
+            confidence=1.0,
+            status=LedgerStatus.BLOCKED,
+        ),
+    )
+    ledger.add_entry(
+        "runtime_context",
+        LedgerEntry(
+            key="runtime.python",
+            value="Python 3.13 from pyproject.toml",
+            source=LedgerSource.REPO_FACT,
+            confidence=0.90,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+
+    entries = ledger.sections["runtime_context"].entries
+    assert entries[0].status is LedgerStatus.WEAK
+    assert entries[1].status is LedgerStatus.CONFIRMED
+    assert ledger.sections["runtime_context"].status() is LedgerStatus.CONFIRMED
+
+
+def test_same_priority_higher_confidence_wins() -> None:
+    ledger = SeedDraftLedger()
+    ledger.add_entry(
+        "runtime_context",
+        LedgerEntry(
+            key="runtime.python",
+            value="Python 3.12",
+            source=LedgerSource.REPO_FACT,
+            confidence=0.60,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+    ledger.add_entry(
+        "runtime_context",
+        LedgerEntry(
+            key="runtime.python",
+            value="Python 3.13",
+            source=LedgerSource.REPO_FACT,
+            confidence=0.90,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+
+    entries = ledger.sections["runtime_context"].entries
+    assert entries[0].status is LedgerStatus.WEAK
+    assert entries[1].status is LedgerStatus.CONFIRMED
+
+
+def test_same_priority_same_confidence_stays_conflicting_for_human_resolution() -> None:
+    ledger = SeedDraftLedger()
+    ledger.add_entry(
+        "runtime_context",
+        LedgerEntry(
+            key="runtime.python",
+            value="Python 3.12",
+            source=LedgerSource.REPO_FACT,
+            confidence=0.80,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+    ledger.add_entry(
+        "runtime_context",
+        LedgerEntry(
+            key="runtime.python",
+            value="Python 3.13",
+            source=LedgerSource.REPO_FACT,
+            confidence=0.80,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+
+    entries = ledger.sections["runtime_context"].entries
+    assert entries[0].status is LedgerStatus.CONFLICTING
+    assert entries[1].status is LedgerStatus.CONFLICTING
+    assert ledger.sections["runtime_context"].status() is LedgerStatus.CONFLICTING
+    assert "runtime_context" in ledger.open_gaps()
+    assert ledger.count_active_conflicting_entries() == 2
+
+
+def test_resolve_conflict_reports_same_value_without_marking_conflict() -> None:
+    existing = LedgerEntry(
+        key="outputs.format",
+        value="Stable stdout",
+        source=LedgerSource.CONSERVATIVE_DEFAULT,
+        confidence=0.80,
+        status=LedgerStatus.DEFAULTED,
+    )
+    incoming = LedgerEntry(
+        key="outputs.format",
+        value=" stable  stdout ",
+        source=LedgerSource.ASSUMPTION,
+        confidence=0.50,
+        status=LedgerStatus.INFERRED,
+    )
+
+    assert resolve_conflict(existing, incoming).value == "same_value"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `SOURCE_PRIORITY` as the deterministic same-key ledger conflict policy for #809 Pillar B.
- Add `resolve_conflict(...)` so contradictions resolve by source priority, then confidence, then remain `CONFLICTING` for human resolution on exact ties.
- Keep later user-confirmed answers as an explicit override and preserve existing conflict pressure for deterministic floor / safe-default blocking.

## Scope

Included:
- Central ledger conflict policy in `src/ouroboros/auto/ledger.py`.
- Priority positioning for `USER_PREFERENCE` below `EXISTING_CONVENTION` and above `CONSERVATIVE_DEFAULT`.
- Regression tests for incoming-wins, existing-wins, confidence tiebreaks, exact-tie conflicts, same-value handling, and preserved interview conflict blocker behavior.

Excluded:
- LLM-based conflict merging.
- Seed regeneration.
- Auto recovery redispatch; that is tracked in #1120.
- DomainProfile migration work.

## Test Plan

- `uv run pytest tests/unit/auto/test_user_preference_and_floor.py tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_interview_pipeline.py::test_interview_driver_blocks_on_conflict_when_backend_signals_premature_closure -q`
- `uv run ruff format --check src/ouroboros/auto/ledger.py tests/unit/auto/test_user_preference_and_floor.py`
- `uv run ruff check src/ouroboros/auto/ledger.py tests/unit/auto/test_user_preference_and_floor.py`
- `git diff --check`

Refs #809.
