### PR TITLE
fix(auto): close safe-defaultable interview gaps at max rounds

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -367,19 +367,27 @@ class AutoInterviewDriver:
             synthesis = build_safe_default_synthesis(finalization)
             if synthesis and state.interview_session_id:
                 try:
-                    await self._with_timeout(
-                        self.backend.answer(
-                            state.interview_session_id,
-                            synthesis,
-                            last_question=(
-                                "[driver safe-default finalization: "
-                                f"max_rounds={self.max_rounds}]"
+                    synthesis_turn = _validate_turn(
+                        await self._with_timeout(
+                            self.backend.answer(
+                                state.interview_session_id,
+                                synthesis,
+                                last_question=(
+                                    "[driver safe-default finalization: "
+                                    f"max_rounds={self.max_rounds}]"
+                                ),
                             ),
-                        ),
-                        state,
-                        tool_name="interview.safe_default_synthesis",
+                            state,
+                            tool_name="interview.safe_default_synthesis",
+                        )
                     )
-                except Exception as exc:  # noqa: BLE001 - non-blocking transcript sync
+                except Exception as exc:  # noqa: BLE001 - preserve transcript/ledger SSOT
+                    _revert_safe_default_entries(ledger, finalization.defaulted_sections)
+                    blocker = (
+                        "safe-default synthesis transcript sync failed; "
+                        f"rolled back defaulted sections: {', '.join(finalization.defaulted_sections)}; "
+                        f"error={exc}"
+                    )
                     log.warning(
                         "auto.interview.safe_default_synthesis_failed",
                         auto_session_id=state.auto_session_id,
@@ -387,10 +395,27 @@ class AutoInterviewDriver:
                         defaulted_sections=finalization.defaulted_sections,
                         error=str(exc),
                     )
-                    state.mark_progress(
-                        "safe-default synthesis transcript sync failed; "
-                        "continuing with persisted auto ledger defaults",
-                        tool_name="interview.safe_default_synthesis",
+                    state.ledger = ledger.to_dict()
+                    state.mark_blocked(blocker, tool_name="interview.safe_default_synthesis")
+                    record_authoring_backend(state)
+                    self._save(state)
+                    return AutoInterviewResult(
+                        "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
+                    )
+                state.interview_session_id = synthesis_turn.session_id
+                state.pending_question = synthesis_turn.question
+                if not (synthesis_turn.seed_ready or synthesis_turn.completed):
+                    _revert_safe_default_entries(ledger, finalization.defaulted_sections)
+                    blocker = (
+                        "safe-default synthesis did not close the persisted interview: "
+                        "backend_done=False, ledger defaults rolled back"
+                    )
+                    state.ledger = ledger.to_dict()
+                    state.mark_blocked(blocker, tool_name="interview.safe_default_synthesis")
+                    record_authoring_backend(state)
+                    self._save(state)
+                    return AutoInterviewResult(
+                        "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
                     )
             state.ledger = ledger.to_dict()
             state.pending_question = None

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -24,6 +24,10 @@ from ouroboros.auto.gap_detector import GapDetector
 from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.repo_context import repo_auto_answer_context
+from ouroboros.auto.safe_defaults import (
+    build_safe_default_synthesis,
+    finalize_safe_defaultable_gaps,
+)
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 
 log = structlog.get_logger(__name__)
@@ -332,12 +336,70 @@ class AutoInterviewDriver:
             state.pending_question = turn.question
             self._save(state)
 
-        # max_rounds exhausted — one final closure check, then diagnostic blocker.
+        # max_rounds exhausted — one final closure check, then safe-default
+        # finalization for autonomous ``ooo auto``.  The manual
+        # ``ooo interview`` path remains strict/fail-closed in its own driver;
+        # this auto driver is allowed to close missing/weak required sections
+        # when the goal is local, reversible, and covered by the audited
+        # safe-default policy.  This is intentionally after the bounded
+        # interview loop: explicit/backend-provided answers always win first,
+        # and defaults are only the final escape from a benign stalled dialog.
         backend_done = turn.seed_ready or turn.completed
         ledger_done = ledger.is_seed_ready()
         if backend_done and ledger_done:
             state.pending_question = None
             state.interview_completed = True
+            self._save(state)
+            return AutoInterviewResult(
+                "seed_ready", state.interview_session_id, ledger, self.max_rounds
+            )
+
+        finalization = None
+        if not backend_done:
+            finalization = finalize_safe_defaultable_gaps(
+                ledger,
+                goal=state.goal,
+                provenance=f"auto interview max_rounds={self.max_rounds}",
+                pending_question=turn.question,
+                active_profile=getattr(self.answerer, "active_profile", None),
+            )
+        if finalization is not None and finalization.completed and ledger.is_seed_ready():
+            synthesis = build_safe_default_synthesis(finalization)
+            if synthesis and state.interview_session_id:
+                try:
+                    await self._with_timeout(
+                        self.backend.answer(
+                            state.interview_session_id,
+                            synthesis,
+                            last_question=(
+                                "[driver safe-default finalization: "
+                                f"max_rounds={self.max_rounds}]"
+                            ),
+                        ),
+                        state,
+                        tool_name="interview.safe_default_synthesis",
+                    )
+                except Exception as exc:  # noqa: BLE001 - non-blocking transcript sync
+                    log.warning(
+                        "auto.interview.safe_default_synthesis_failed",
+                        auto_session_id=state.auto_session_id,
+                        interview_session_id=state.interview_session_id,
+                        defaulted_sections=finalization.defaulted_sections,
+                        error=str(exc),
+                    )
+                    state.mark_progress(
+                        "safe-default synthesis transcript sync failed; "
+                        "continuing with persisted auto ledger defaults",
+                        tool_name="interview.safe_default_synthesis",
+                    )
+            state.ledger = ledger.to_dict()
+            state.pending_question = None
+            state.interview_completed = True
+            state.mark_progress(
+                "safe-default finalization closed interview gaps: "
+                + ", ".join(finalization.defaulted_sections),
+                tool_name="interview_driver",
+            )
             self._save(state)
             return AutoInterviewResult(
                 "seed_ready", state.interview_session_id, ledger, self.max_rounds

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -717,6 +717,8 @@ async def test_interview_driver_finalizes_safe_defaults_after_benign_max_rounds(
         session_id: str, text: str, *, last_question: str | None = None
     ) -> InterviewTurn:  # noqa: ARG001
         answers.append(text)
+        if "[safe-default-synthesis]" in text:
+            return InterviewTurn("done", session_id, seed_ready=True, completed=True)
         return InterviewTurn("What else should we know?", session_id, seed_ready=False)
 
     state = AutoPipelineState(goal="Build a tiny local CLI", cwd=str(tmp_path))
@@ -743,7 +745,7 @@ async def test_interview_driver_finalizes_safe_defaults_after_benign_max_rounds(
 
 
 @pytest.mark.asyncio
-async def test_interview_driver_keeps_defaults_when_synthesis_sync_fails(tmp_path) -> None:
+async def test_interview_driver_rolls_back_defaults_when_synthesis_sync_fails(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("What else should we know?", "interview_defaults")
 
@@ -765,12 +767,48 @@ async def test_interview_driver_keeps_defaults_when_synthesis_sync_fails(tmp_pat
 
     result = await driver.run(state, ledger)
 
-    assert result.status == "seed_ready"
-    assert state.interview_completed is True
-    assert ledger.open_gaps() == []
-    assert any(
-        entry.status == LedgerStatus.DEFAULTED
-        for section in ledger.sections.values()
+    assert result.status == "blocked"
+    assert state.interview_completed is False
+    assert "transcript sync failed" in (result.blocker or "")
+    assert ledger.open_gaps()
+    assert not any(
+        entry.key == f"{section_name}.safe_default_finalization"
+        for section_name, section in ledger.sections.items()
+        for entry in section.entries
+    )
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_blocks_when_synthesis_does_not_close_backend(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What else should we know?", "interview_defaults")
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "Still need one more thing", session_id, seed_ready=False, completed=False
+        )
+
+    state = AutoPipelineState(goal="Build a tiny local CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.interview_completed is False
+    assert state.pending_question == "Still need one more thing"
+    assert "did not close the persisted interview" in (result.blocker or "")
+    assert ledger.open_gaps()
+    assert not any(
+        entry.key == f"{section_name}.safe_default_finalization"
+        for section_name, section in ledger.sections.items()
         for entry in section.entries
     )
 
@@ -3813,6 +3851,8 @@ async def test_convergence_contract_stalled_generic_followups_report_actionable_
         return InterviewTurn("What else should we know?", "interview_contract")
 
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        if "[safe-default-synthesis]" in text:
+            return InterviewTurn("done", session_id, seed_ready=True, completed=True)
         return InterviewTurn("What else should we know?", session_id)
 
     state = AutoPipelineState(

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -705,6 +705,77 @@ def test_safe_default_non_goals_do_not_make_later_finalization_unsafe() -> None:
 
 
 @pytest.mark.asyncio
+async def test_interview_driver_finalizes_safe_defaults_after_benign_max_rounds(
+    tmp_path,
+) -> None:
+    answers: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What else should we know?", "interview_defaults")
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        answers.append(text)
+        return InterviewTurn("What else should we know?", session_id, seed_ready=False)
+
+    state = AutoPipelineState(goal="Build a tiny local CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert state.interview_completed is True
+    assert state.pending_question is None
+    assert ledger.open_gaps() == []
+    assert any(
+        entry.status == LedgerStatus.DEFAULTED
+        and entry.key == "runtime_context.safe_default_finalization"
+        for entry in ledger.sections["runtime_context"].entries
+    )
+    assert any("[safe-default-synthesis]" in answer for answer in answers)
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_keeps_defaults_when_synthesis_sync_fails(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What else should we know?", "interview_defaults")
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        if "[safe-default-synthesis]" in text:
+            raise RuntimeError("transcript unavailable")
+        return InterviewTurn("What else should we know?", session_id, seed_ready=False)
+
+    state = AutoPipelineState(goal="Build a tiny local CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert state.interview_completed is True
+    assert ledger.open_gaps() == []
+    assert any(
+        entry.status == LedgerStatus.DEFAULTED
+        for section in ledger.sections.values()
+        for entry in section.entries
+    )
+
+
+@pytest.mark.asyncio
 async def test_interview_driver_keeps_unsafe_gaps_blocking_after_max_rounds(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("What should we verify?", "interview_1")
@@ -729,11 +800,8 @@ async def test_interview_driver_keeps_unsafe_gaps_blocking_after_max_rounds(tmp_
     assert result.status == "blocked"
     assert state.phase == AutoPhase.BLOCKED
     blocker = result.blocker or ""
-    # New mutual-agreement closure gate emits a structured diagnostic naming
-    # both readiness states and the unresolved sections. The auto path no
-    # longer attempts safe-default finalization, so the goal's unsafe-context
-    # words ("production"/"credentials") cannot sneak a closure through —
-    # the diagnostic blocker is the only terminal outcome here.
+    # Safe-default finalization is allowed for benign auto goals, but the
+    # unsafe-context gate must keep production/credential asks blocked.
     assert "without closure" in blocker
     assert "ledger_done=False" in blocker
     assert "open_gaps=" in blocker
@@ -3730,13 +3798,15 @@ async def test_convergence_contract_unsafe_authority_question_blocks(tmp_path) -
 async def test_convergence_contract_stalled_generic_followups_report_actionable_gaps(
     tmp_path,
 ) -> None:
-    """Generic ``What else?`` follow-up loops must blocker on unresolved sections.
+    """Generic benign follow-up loops close via audited safe defaults.
 
     This pins the documented stall pattern from
-    ``docs/auto-interview-convergence-contract.md``: when the backend keeps asking
-    ``What else?`` / ``Any additional context?``-style questions and required
-    sections never resolve, the round-cap blocker has to name the unresolved
-    gaps, not just say that ``max_rounds`` was reached.
+    ``docs/auto-interview-convergence-contract.md`` after #821's autonomy
+    contract: when the backend keeps asking ``What else?``-style questions for a
+    local/reversible goal, the auto driver must not strand the session in
+    INTERVIEW.  It closes safe-defaultable gaps and lets the pipeline continue
+    to Seed generation.  Unsafe or conflicting goals are covered by separate
+    blocking tests.
     """
 
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
@@ -3759,18 +3829,16 @@ async def test_convergence_contract_stalled_generic_followups_report_actionable_
 
     result = await driver.run(state, ledger)
 
-    blocker = result.blocker or ""
-    assert result.status == "blocked"
-    assert state.phase == AutoPhase.BLOCKED
-    # New diagnostic format names both readiness states and lists the open
-    # gap sections so callers can decide whether to raise max_rounds or
-    # sharpen the goal — preserving the convergence contract that stalls
-    # must surface actionable section names, not just "reached max_rounds".
-    assert "without closure" in blocker
-    assert "open_gaps=" in blocker
-    open_gaps = ledger.open_gaps()
-    assert open_gaps, "stalled generic loop must leave at least one open required gap"
-    assert any(section in blocker for section in open_gaps)
+    assert result.status == "seed_ready"
+    assert state.phase == AutoPhase.INTERVIEW
+    assert state.interview_completed is True
+    assert state.pending_question is None
+    assert ledger.open_gaps() == []
+    assert any(
+        entry.status == LedgerStatus.DEFAULTED
+        for section in ledger.sections.values()
+        for entry in section.entries
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Finalize safe-defaultable auto interview gaps when the backend keeps asking through `max_rounds` and the audited safe-default policy can make the ledger Seed-ready.
- Persist a safe-default synthesis back to the interview transcript when possible, but keep the ledger defaults if that transcript sync fails.
- Preserve existing blocking behavior for unsafe context, conflicting/missing goal paths, and backend-completed/ledger-incomplete disagreement.

## Why this scope

Live observation showed `ooo auto` dispatch now reaches `ouroboros_auto`, but benign goals still stall in `INTERVIEW` before Seed generation:

```text
auto interview reached max_rounds=12 without closure
backend_done=False
ledger_done=False
open_gaps=['actors', 'inputs', 'outputs', 'runtime_context']
```

This PR addresses that observed blocker only. It intentionally does **not** change the packaged `ooo auto -> ouroboros_auto` dispatch contract, direct-auto lease behavior, `ouroboros_start_auto`, RUN/Ralph/EVALUATE, or self-healing Stack 2.

## Follow-up work deliberately left out

- Re-observe live `ooo auto --complete-product` after this lands.
- If the Codex 120s MCP boundary still prevents reliable observation, open a separate PR for background `ouroboros_start_auto` routing/status guidance.
- Only after runs reach `EVALUATE`/`UNSTUCK_LATERAL`, scope the self-healing Stack 2 redispatch PR.

## Test Plan

- [x] `uv run pytest tests/unit/auto/test_interview_pipeline.py tests/unit/auto/test_821_acceptance_matrix.py tests/unit/auto/test_safe_defaults_domain_profile.py -q`
- [x] `uv run pytest tests/unit/mcp/tools/test_start_auto.py tests/unit/router/test_packaged_auto_dispatch.py -q`
- [x] `uv run ruff check src/ouroboros/auto/interview_driver.py tests/unit/auto/test_interview_pipeline.py`

Refs #821.
