### PR TITLE
test(projection): lock mechanical evaluation fixture

### DIFF
--- a/docs/agentos/projection-followups.md
+++ b/docs/agentos/projection-followups.md
@@ -29,7 +29,7 @@ The #946 baseline is a read-only projection stack over persisted events:
 | --- | --- | --- |
 | Artifact/Verdict projection | Populate existing `ArtifactRecord` and `VerdictRecord` outputs from persisted evidence/evaluation-like events. | Read-model only; no new evidence schema or verifier policy. |
 | Status JSON CLI | Expose the existing projection query through a thin `ouroboros status run ... --json` surface. | Reuse projection semantics; no cache or writes. |
-| Mechanical-evaluation fixture | Prove a small execution/evaluation history projects to run, step, artifact, verdict, and source event IDs. | Offline/local fixture only. |
+| Mechanical-evaluation fixture | Prove a small execution/evaluation history projects to run, step, artifact, verdict, and source event IDs. | Offline/local fixture only. Landed by the #946 mechanical fixture follow-up. |
 | StepSnapshot/session/runtime views | Add bounded derived views for post-step state, session health, runtime handle, and resume-token metadata. | Later views; do not block artifact/verdict or CLI JSON work. |
 | Context/checkpoint anchors | Surface context pack and checkpoint references as projection metadata. | Read-only anchors; no second context state model. |
 | Optional exporter sinks | Feed OTEL or other exporters from projections. | Optional/lazy, disabled by default, never source of truth. |

--- a/tests/fixtures/projection/mechanical_evaluation_events.json
+++ b/tests/fixtures/projection/mechanical_evaluation_events.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "evt_mech_tool_start",
+    "type": "tool.call.started",
+    "timestamp": "2026-05-18T00:00:00Z",
+    "aggregate_type": "execution",
+    "aggregate_id": "exec_mechanical_eval",
+    "data": {
+      "call_id": "mechanical_pytest",
+      "tool_name": "Bash",
+      "args_preview": "pytest tests/unit/harness/test_projection_builder.py"
+    }
+  },
+  {
+    "id": "evt_mech_tool_return",
+    "type": "tool.call.returned",
+    "timestamp": "2026-05-18T00:00:02Z",
+    "aggregate_type": "execution",
+    "aggregate_id": "exec_mechanical_eval",
+    "data": {
+      "call_id": "mechanical_pytest",
+      "tool_name": "Bash",
+      "is_error": false,
+      "duration_ms": 2000,
+      "result_preview": "1 passed"
+    }
+  },
+  {
+    "id": "evt_mech_artifact",
+    "type": "harness.artifact.recorded",
+    "timestamp": "2026-05-18T00:00:03Z",
+    "aggregate_type": "execution",
+    "aggregate_id": "exec_mechanical_eval",
+    "data": {
+      "call_id": "mechanical_pytest",
+      "artifact_id": "artifact_mechanical_pytest_json",
+      "kind": "evidence",
+      "path": "artifacts/mechanical-pytest.json",
+      "media_type": "application/json",
+      "summary": "mechanical pytest evidence"
+    }
+  },
+  {
+    "id": "evt_mech_verdict",
+    "type": "harness.verdict.recorded",
+    "timestamp": "2026-05-18T00:00:04Z",
+    "aggregate_type": "execution",
+    "aggregate_id": "exec_mechanical_eval",
+    "data": {
+      "verdict_id": "verdict_mechanical_eval",
+      "scope": "run",
+      "outcome": "pass",
+      "rationale": "mechanical fixture projected with source evidence",
+      "evidence_event_ids": ["evt_mech_artifact"],
+      "evidence_artifact_ids": ["artifact_mechanical_pytest_json"]
+    }
+  }
+]

--- a/tests/unit/harness/test_projection_builder.py
+++ b/tests/unit/harness/test_projection_builder.py
@@ -17,6 +17,8 @@ Covers the contract from issue #946 PR-1b:
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+import json
+from pathlib import Path
 
 import pytest
 
@@ -614,3 +616,53 @@ class TestArtifactAndVerdictProjection:
 
         assert result.run.verdict_id is None
         assert result.verdicts == ()
+
+
+class TestMechanicalEvaluationFixture:
+    def test_fixture_projects_run_step_artifact_verdict_and_source_events(self) -> None:
+        fixture_path = (
+            Path(__file__).parents[2]
+            / "fixtures"
+            / "projection"
+            / "mechanical_evaluation_events.json"
+        )
+        raw_events = json.loads(fixture_path.read_text())
+        events = [
+            BaseEvent(
+                id=item["id"],
+                type=item["type"],
+                timestamp=datetime.fromisoformat(item["timestamp"].replace("Z", "+00:00")),
+                aggregate_type=item["aggregate_type"],
+                aggregate_id=item["aggregate_id"],
+                data=item["data"],
+            )
+            for item in raw_events
+        ]
+
+        result = build_projection(events, seed_id="seed_mechanical_eval")
+
+        assert result.run.seed_id == "seed_mechanical_eval"
+        assert result.run.stage_ids == (result.stages[0].stage_id,)
+        assert result.run.verdict_id == "verdict_mechanical_eval"
+        assert len(result.steps) == 1
+        assert len(result.artifacts) == 1
+        assert len(result.verdicts) == 1
+
+        step = result.steps[0]
+        assert step.kind is StepKind.SHELL_COMMAND
+        assert step.source_event_ids == ("evt_mech_tool_start", "evt_mech_tool_return")
+        assert step.artifact_ids == ("artifact_mechanical_pytest_json",)
+
+        artifact = result.artifacts[0]
+        assert artifact.step_id == step.step_id
+        assert artifact.metadata["source_event_id"] == "evt_mech_artifact"
+
+        verdict = result.verdicts[0]
+        assert verdict.outcome is VerdictOutcome.PASS
+        assert verdict.evidence_event_ids == ("evt_mech_verdict", "evt_mech_artifact")
+        assert verdict.evidence_artifact_ids == ("artifact_mechanical_pytest_json",)
+
+        replayed = build_projection(events, seed_id="seed_mechanical_eval")
+        assert replayed.run.run_id == result.run.run_id
+        assert replayed.stages[0].stage_id == result.stages[0].stage_id
+        assert replayed.steps[0].step_id == step.step_id


### PR DESCRIPTION
## Summary\n- add a deterministic #946 mechanical evaluation fixture with tool, artifact, and verdict events\n- assert projection rebuilds run/stage/step/artifact/verdict links and source event IDs\n- mark the projection follow-up queue slot as covered by this bounded fixture\n\n## Scope\n- Offline/local fixture only\n- Read-model verification only\n- No new projection schema, cache, runtime behavior, or evidence policy\n\n## Tests\n- uv run pytest tests/unit/harness/test_projection_builder.py -q\n- uv run ruff check tests/unit/harness/test_projection_builder.py\n- git diff --check\n\nCloses follow-up slice of #946.\n