### PR TITLE
feat(projection): surface context checkpoint anchors

### DIFF
--- a/docs/agentos/projection-followups.md
+++ b/docs/agentos/projection-followups.md
@@ -31,7 +31,7 @@ The #946 baseline is a read-only projection stack over persisted events:
 | Status JSON CLI | Expose the existing projection query through a thin `ouroboros status run ... --json` surface. | Reuse projection semantics; no cache or writes. |
 | Mechanical-evaluation fixture | Prove a small execution/evaluation history projects to run, step, artifact, verdict, and source event IDs. | Offline/local fixture only. |
 | StepSnapshot/session/runtime views | Add bounded derived views for post-step state, session health, runtime handle, and resume-token metadata. | Later views; do not block artifact/verdict or CLI JSON work. |
-| Context/checkpoint anchors | Surface context pack and checkpoint references as projection metadata. | Read-only anchors; no second context state model. |
+| Context/checkpoint anchors | Surface context pack and checkpoint references as projection metadata. | Read-only anchors only; no resume authority, raw context payloads, checkpoint writes, or second context state model. |
 | Optional exporter sinks | Feed OTEL or other exporters from projections. | Optional/lazy, disabled by default, never source of truth. |
 
 ## Explicit anti-actions

--- a/src/ouroboros/harness/projection_builder.py
+++ b/src/ouroboros/harness/projection_builder.py
@@ -605,7 +605,11 @@ def _artifact_from_event(
         size_bytes=_optional_int(event.data.get("size_bytes")),
         digest=_optional_str(event.data.get("digest")),
         summary=_optional_str(event.data.get("summary")) or "",
-        metadata={"source_event_id": event.id, "event_type": event.type},
+        metadata={
+            "source_event_id": event.id,
+            "event_type": event.type,
+            **_anchor_metadata(event.data),
+        },
     )
 
 
@@ -634,7 +638,11 @@ def _verdict_from_event(
     missing_artifact_ids = tuple(
         artifact_id for artifact_id in recorded_artifact_ids if artifact_id not in artifact_ids
     )
-    metadata: dict[str, Any] = {"source_event_id": event.id, "event_type": event.type}
+    metadata: dict[str, Any] = {
+        "source_event_id": event.id,
+        "event_type": event.type,
+        **_anchor_metadata(event.data),
+    }
     if missing_artifact_ids:
         metadata["missing_evidence_artifact_ids"] = missing_artifact_ids
         metadata["recorded_evidence_artifact_ids"] = recorded_artifact_ids
@@ -652,6 +660,38 @@ def _verdict_from_event(
         recorded_at=event.timestamp,
         metadata=metadata,
     )
+
+
+def _anchor_metadata(data: dict[str, Any]) -> dict[str, str]:
+    """Extract bounded read-only context/checkpoint anchors from event payloads.
+
+    Anchors are projection metadata only: they identify context packs or
+    checkpoints mentioned by the source event without granting resume authority,
+    mutating state, or introducing a second context model. Values are short
+    string references; raw payloads, nested objects, and oversized values are
+    intentionally ignored.
+    """
+    anchors: dict[str, str] = {}
+    for key in (
+        "context_pack_ref",
+        "context_pack_id",
+        "checkpoint_ref",
+        "checkpoint_id",
+        "checkpoint_uri",
+    ):
+        value = _bounded_anchor_value(data.get(key))
+        if value is not None:
+            anchors[key] = value
+    return anchors
+
+
+def _bounded_anchor_value(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not stripped or len(stripped) > 512:
+        return None
+    return stripped
 
 
 def _verdict_outcome(data: dict[str, Any]) -> VerdictOutcome | None:

--- a/tests/unit/harness/test_projection_builder.py
+++ b/tests/unit/harness/test_projection_builder.py
@@ -614,3 +614,77 @@ class TestArtifactAndVerdictProjection:
 
         assert result.run.verdict_id is None
         assert result.verdicts == ()
+
+    def test_artifact_and_verdict_surface_bounded_context_checkpoint_anchors(self) -> None:
+        t0 = datetime.now(UTC)
+        events = [
+            _tool_started(call_id="c_anchor", tool_name="Bash", when=t0),
+            _tool_returned(call_id="c_anchor", tool_name="Bash", when=t0 + timedelta(seconds=1)),
+            BaseEvent(
+                id="evt_anchor_artifact",
+                type="harness.artifact.recorded",
+                timestamp=t0 + timedelta(seconds=2),
+                aggregate_type="execution",
+                aggregate_id="exec_1",
+                data={
+                    "call_id": "c_anchor",
+                    "artifact_id": "artifact_anchor",
+                    "context_pack_ref": "ctx://packs/run-1",
+                    "checkpoint_ref": "chk://run-1/step-1",
+                    "raw_context_pack": {"prompt": "must not be projected"},
+                    "checkpoint_payload": "must not be projected",
+                },
+            ),
+            BaseEvent(
+                id="evt_anchor_verdict",
+                type="harness.verdict.recorded",
+                timestamp=t0 + timedelta(seconds=3),
+                aggregate_type="execution",
+                aggregate_id="exec_1",
+                data={
+                    "scope": "run",
+                    "outcome": "pass",
+                    "evidence_artifact_ids": ["artifact_anchor"],
+                    "context_pack_id": "ctx-pack-1",
+                    "checkpoint_id": "checkpoint-1",
+                },
+            ),
+        ]
+
+        result = build_projection(events, seed_id="seed_abc")
+
+        artifact = result.artifacts[0]
+        assert artifact.metadata["context_pack_ref"] == "ctx://packs/run-1"
+        assert artifact.metadata["checkpoint_ref"] == "chk://run-1/step-1"
+        assert "raw_context_pack" not in artifact.metadata
+        assert "checkpoint_payload" not in artifact.metadata
+
+        verdict = result.verdicts[0]
+        assert verdict.metadata["context_pack_id"] == "ctx-pack-1"
+        assert verdict.metadata["checkpoint_id"] == "checkpoint-1"
+
+    def test_anchor_metadata_ignores_nested_and_oversized_values(self) -> None:
+        t0 = datetime.now(UTC)
+        events = [
+            _tool_started(call_id="c_anchor", tool_name="Bash", when=t0),
+            _tool_returned(call_id="c_anchor", tool_name="Bash", when=t0 + timedelta(seconds=1)),
+            BaseEvent(
+                id="evt_anchor_artifact",
+                type="harness.artifact.recorded",
+                timestamp=t0 + timedelta(seconds=2),
+                aggregate_type="execution",
+                aggregate_id="exec_1",
+                data={
+                    "call_id": "c_anchor",
+                    "artifact_id": "artifact_anchor",
+                    "context_pack_ref": {"ref": "nested"},
+                    "checkpoint_ref": "x" * 513,
+                },
+            ),
+        ]
+
+        result = build_projection(events, seed_id="seed_abc")
+
+        artifact = result.artifacts[0]
+        assert "context_pack_ref" not in artifact.metadata
+        assert "checkpoint_ref" not in artifact.metadata


### PR DESCRIPTION
## Summary\n- expose bounded context/checkpoint references on artifact and verdict projection metadata\n- ignore raw, nested, and oversized payload values so projection remains an inspection read model\n- tighten the #946 follow-up note around anchor boundaries\n\n## Scope\n- Read-only metadata anchors only\n- No resume authority, checkpoint writes, raw context state, cache, or runtime behavior changes\n\n## Tests\n- uv run pytest tests/unit/harness/test_projection_builder.py -q\n- uv run ruff check src/ouroboros/harness/projection_builder.py tests/unit/harness/test_projection_builder.py\n- git diff --check\n\nCovers the context/checkpoint anchor follow-up slice of #946.\n