### PR TITLE
feat(workflow): represent plugin actions as planned nodes

### DIFF
--- a/docs/agentos/workflow-ir-v1.md
+++ b/docs/agentos/workflow-ir-v1.md
@@ -48,6 +48,9 @@ SDK and does not add plugin dispatch behavior.
 - Plugin command execution remains outside this v1 IR surface.
 - Plugin nodes can be represented as planned nodes, but v1 does not execute
   them or grant permissions.
+- Plugin descriptor adapters may carry action/permission metadata into planned
+  `owner=plugin` nodes only when `dispatch_enabled=false`; entrypoint commands
+  are not runtime instructions in the IR.
 
 ## Non-goals for v1 follow-ups
 

--- a/src/ouroboros/orchestrator/workflow_ir_adapter.py
+++ b/src/ouroboros/orchestrator/workflow_ir_adapter.py
@@ -21,12 +21,19 @@ from ouroboros.orchestrator.workflow_ir import (
     WorkflowSpec,
     validate_workflow,
 )
+from ouroboros.plugin.manifest import PluginDescriptor
 
 DEFAULT_SEED_AC_INPUT_SCHEMA_REF = "ouroboros://schemas/seed-acceptance-criterion-input/v1"
 """Canonical input-schema reference used for current string AC dispatch nodes."""
 
 DEFAULT_SEED_AC_EVIDENCE_SCHEMA_REF = "ouroboros://schemas/seed-acceptance-evidence/v1"
 """Canonical evidence-schema reference used for current string AC dispatch nodes."""
+
+DEFAULT_PLUGIN_ACTION_INPUT_SCHEMA_REF = "ouroboros://schemas/plugin-action-input/v1"
+"""Contract ref for plugin action nodes represented in Workflow IR."""
+
+DEFAULT_PLUGIN_ACTION_EVIDENCE_SCHEMA_REF = "ouroboros://schemas/plugin-action-evidence/v1"
+"""Contract ref for evidence expected from plugin action nodes."""
 
 
 def workflow_spec_from_seed(
@@ -164,6 +171,125 @@ def workflow_spec_from_seed(
     return spec
 
 
+def workflow_spec_from_plugin_descriptor(
+    descriptor: PluginDescriptor,
+    *,
+    input_schema_ref: str = DEFAULT_PLUGIN_ACTION_INPUT_SCHEMA_REF,
+    evidence_schema_ref: str = DEFAULT_PLUGIN_ACTION_EVIDENCE_SCHEMA_REF,
+    metadata: Mapping[str, Any] | None = None,
+) -> WorkflowSpec:
+    """Project a plugin descriptor into contract-only Workflow IR metadata.
+
+    The adapter represents plugin actions as planned plugin-owned nodes so #956
+    can reason about graph shape without granting permissions or dispatching the
+    plugin runtime. It consumes only the read-only manifest descriptor from #939.
+
+    Raises:
+        ValueError: If the descriptor has no actions or emits an invalid spec.
+    """
+    if not descriptor.actions:
+        msg = "Plugin descriptor must contain at least one action to project Workflow IR"
+        raise ValueError(msg)
+
+    nodes: list[WorkflowNode] = []
+    edges: list[WorkflowEdge] = []
+    terminal_node = WorkflowNode(
+        node_id=f"plugin_{_slug(descriptor.plugin_id)}_terminal",
+        kind=NodeKind.TERMINAL,
+        owner=NodeOwner.HARNESS,
+        name=f"Plugin {descriptor.name} planning complete",
+        metadata={
+            "plugin_id": descriptor.plugin_id,
+            "component_id": descriptor.component_id,
+            "dispatch_enabled": False,
+        },
+    )
+
+    declared_permission_scopes = tuple(permission.scope for permission in descriptor.permissions_declared)
+    lifecycle_hook_names = tuple(hook.name for hook in descriptor.lifecycle_hooks)
+    capability_names = tuple(capability.name for capability in descriptor.capabilities_declared)
+
+    for action in descriptor.actions:
+        node_id = f"plugin_{_slug(descriptor.plugin_id)}_{_slug(action.namespace)}_{_slug(action.name)}"
+        nodes.append(
+            WorkflowNode(
+                node_id=node_id,
+                kind=NodeKind.TASK,
+                owner=NodeOwner.PLUGIN,
+                name=f"{action.namespace} {action.name}",
+                input_schema_ref=input_schema_ref,
+                evidence_schema_ref=evidence_schema_ref,
+                capability_envelope=capability_names,
+                runtime_hints={
+                    "dispatch_enabled": False,
+                    "contract_only": True,
+                },
+                metadata={
+                    "plugin_id": descriptor.plugin_id,
+                    "component_id": descriptor.component_id,
+                    "plugin_name": descriptor.name,
+                    "plugin_version": descriptor.version,
+                    "schema_version": descriptor.schema_version,
+                    "action_id": action.action_id,
+                    "namespace": action.namespace,
+                    "command_name": action.name,
+                    "risk": action.risk,
+                    "requires_confirmation": action.requires_confirmation,
+                    "declared_permission_scopes": declared_permission_scopes,
+                    "required_permission_scopes": action.required_permissions,
+                    "optional_permission_scopes": action.optional_permissions,
+                    "lifecycle_hook_names": lifecycle_hook_names,
+                    "dispatch_enabled": False,
+                },
+            )
+        )
+        edges.append(
+            WorkflowEdge(
+                edge_id=f"edge_{node_id}_{terminal_node.node_id}",
+                source=node_id,
+                target=terminal_node.node_id,
+                kind=EdgeKind.TERMINAL,
+                metadata={
+                    "plugin_id": descriptor.plugin_id,
+                    "action_id": action.action_id,
+                    "dispatch_enabled": False,
+                },
+            )
+        )
+
+    spec_metadata: dict[str, Any] = dict(metadata or {})
+    spec_metadata.update(
+        {
+            "plugin_id": descriptor.plugin_id,
+            "component_id": descriptor.component_id,
+            "plugin_name": descriptor.name,
+            "plugin_version": descriptor.version,
+            "schema_version": descriptor.schema_version,
+            "actions_count": len(descriptor.actions),
+            "dispatch_enabled": False,
+        }
+    )
+    spec = WorkflowSpec(
+        spec_id=f"wfspec_plugin_{_slug(descriptor.plugin_id)}",
+        source=SourceKind.PLUGIN,
+        source_ref=descriptor.plugin_id,
+        nodes=(*nodes, terminal_node),
+        edges=tuple(edges),
+        metadata=spec_metadata,
+    )
+    validation = validate_workflow(spec)
+    if not validation.ok:
+        details = ", ".join(error.code for error in validation.errors)
+        msg = f"Plugin descriptor projected to invalid WorkflowSpec: {details}"
+        raise ValueError(msg)
+    return spec
+
+
+def _slug(value: str) -> str:
+    normalized = "_".join(part for part in value.strip().replace(":", "_").split() if part)
+    return "".join(char if char.isalnum() or char == "_" else "_" for char in normalized) or "plugin"
+
+
 def _normalize_acceptance_criteria(criteria: tuple[str, ...]) -> tuple[str, ...]:
     normalized: list[str] = []
     for zero_based_index, criterion in enumerate(criteria):
@@ -183,7 +309,10 @@ def _normalize_acceptance_criteria(criteria: tuple[str, ...]) -> tuple[str, ...]
 
 
 __all__ = [
+    "DEFAULT_PLUGIN_ACTION_EVIDENCE_SCHEMA_REF",
+    "DEFAULT_PLUGIN_ACTION_INPUT_SCHEMA_REF",
     "DEFAULT_SEED_AC_EVIDENCE_SCHEMA_REF",
     "DEFAULT_SEED_AC_INPUT_SCHEMA_REF",
+    "workflow_spec_from_plugin_descriptor",
     "workflow_spec_from_seed",
 ]

--- a/src/ouroboros/orchestrator/workflow_ir_adapter.py
+++ b/src/ouroboros/orchestrator/workflow_ir_adapter.py
@@ -190,11 +190,13 @@ def workflow_spec_from_plugin_descriptor(
     if not descriptor.actions:
         msg = "Plugin descriptor must contain at least one action to project Workflow IR"
         raise ValueError(msg)
+    _validate_registered_plugin_action_contract(descriptor)
 
     nodes: list[WorkflowNode] = []
     edges: list[WorkflowEdge] = []
+    plugin_id_segment = _identifier_segment(descriptor.plugin_id)
     terminal_node = WorkflowNode(
-        node_id=f"plugin_{_slug(descriptor.plugin_id)}_terminal",
+        node_id=f"plugin_{plugin_id_segment}_terminal",
         kind=NodeKind.TERMINAL,
         owner=NodeOwner.HARNESS,
         name=f"Plugin {descriptor.name} planning complete",
@@ -205,12 +207,17 @@ def workflow_spec_from_plugin_descriptor(
         },
     )
 
-    declared_permission_scopes = tuple(permission.scope for permission in descriptor.permissions_declared)
+    declared_permission_scopes = tuple(
+        permission.scope for permission in descriptor.permissions_declared
+    )
     lifecycle_hook_names = tuple(hook.name for hook in descriptor.lifecycle_hooks)
     capability_names = tuple(capability.name for capability in descriptor.capabilities_declared)
 
     for action in descriptor.actions:
-        node_id = f"plugin_{_slug(descriptor.plugin_id)}_{_slug(action.namespace)}_{_slug(action.name)}"
+        node_id = (
+            f"plugin_{plugin_id_segment}_"
+            f"{_identifier_segment(action.namespace)}_{_identifier_segment(action.name)}"
+        )
         nodes.append(
             WorkflowNode(
                 node_id=node_id,
@@ -270,7 +277,7 @@ def workflow_spec_from_plugin_descriptor(
         }
     )
     spec = WorkflowSpec(
-        spec_id=f"wfspec_plugin_{_slug(descriptor.plugin_id)}",
+        spec_id=f"wfspec_plugin_{plugin_id_segment}",
         source=SourceKind.PLUGIN,
         source_ref=descriptor.plugin_id,
         nodes=(*nodes, terminal_node),
@@ -285,9 +292,33 @@ def workflow_spec_from_plugin_descriptor(
     return spec
 
 
-def _slug(value: str) -> str:
-    normalized = "_".join(part for part in value.strip().replace(":", "_").split() if part)
-    return "".join(char if char.isalnum() or char == "_" else "_" for char in normalized) or "plugin"
+def _validate_registered_plugin_action_contract(descriptor: PluginDescriptor) -> None:
+    """Mirror the registry's registered-plugin action-shape invariants."""
+    namespaces = {action.namespace for action in descriptor.actions}
+    if len(namespaces) != 1:
+        msg = (
+            f"Plugin descriptor {descriptor.plugin_id!r} declares multiple namespaces "
+            f"{sorted(namespaces)}; one plugin must own one namespace"
+        )
+        raise ValueError(msg)
+
+    seen_names: set[str] = set()
+    duplicate_names: list[str] = []
+    for action in descriptor.actions:
+        if action.name in seen_names and action.name not in duplicate_names:
+            duplicate_names.append(action.name)
+        seen_names.add(action.name)
+    if duplicate_names:
+        msg = (
+            f"Plugin descriptor {descriptor.plugin_id!r} declares duplicate command name(s): "
+            f"{sorted(duplicate_names)}"
+        )
+        raise ValueError(msg)
+
+
+def _identifier_segment(value: str) -> str:
+    """Encode one identifier segment without collapsing punctuation or boundaries."""
+    return "u" + value.encode("utf-8").hex()
 
 
 def _normalize_acceptance_criteria(criteria: tuple[str, ...]) -> tuple[str, ...]:

--- a/tests/unit/orchestrator/test_workflow_ir_plugin_adapter.py
+++ b/tests/unit/orchestrator/test_workflow_ir_plugin_adapter.py
@@ -1,0 +1,72 @@
+"""Tests for plugin descriptor -> Workflow IR contract projection."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.orchestrator.workflow_ir import NodeKind, NodeOwner, SourceKind, validate_workflow
+from ouroboros.orchestrator.workflow_ir_adapter import (
+    DEFAULT_PLUGIN_ACTION_EVIDENCE_SCHEMA_REF,
+    DEFAULT_PLUGIN_ACTION_INPUT_SCHEMA_REF,
+    workflow_spec_from_plugin_descriptor,
+)
+from ouroboros.plugin.manifest import load_manifest
+from tests.unit.plugin.test_manifest import REFERENCE_MANIFEST
+
+
+def _write(tmp_path: Path, payload: dict) -> Path:
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_text(json.dumps(payload))
+    return target
+
+
+def test_plugin_descriptor_projects_contract_only_plugin_nodes(tmp_path: Path) -> None:
+    manifest = load_manifest(_write(tmp_path, REFERENCE_MANIFEST))
+    descriptor = manifest.to_descriptor()
+
+    spec = workflow_spec_from_plugin_descriptor(descriptor)
+
+    assert validate_workflow(spec).ok is True
+    assert spec.source is SourceKind.PLUGIN
+    assert spec.source_ref == descriptor.plugin_id
+    assert spec.metadata["plugin_id"] == descriptor.plugin_id
+    assert spec.metadata["dispatch_enabled"] is False
+
+    plugin_node = spec.nodes[0]
+    assert plugin_node.kind is NodeKind.TASK
+    assert plugin_node.owner is NodeOwner.PLUGIN
+    assert plugin_node.input_schema_ref == DEFAULT_PLUGIN_ACTION_INPUT_SCHEMA_REF
+    assert plugin_node.evidence_schema_ref == DEFAULT_PLUGIN_ACTION_EVIDENCE_SCHEMA_REF
+    assert plugin_node.runtime_hints["contract_only"] is True
+    assert plugin_node.runtime_hints["dispatch_enabled"] is False
+    assert plugin_node.metadata["action_id"] == "github-pr-ops:github-pr:review"
+    assert plugin_node.metadata["required_permission_scopes"] == ("github:read",)
+    assert plugin_node.metadata["dispatch_enabled"] is False
+
+    terminal_node = spec.nodes[-1]
+    assert terminal_node.kind is NodeKind.TERMINAL
+    assert spec.edges[0].source == plugin_node.node_id
+    assert spec.edges[0].target == terminal_node.node_id
+    assert spec.edges[0].metadata["dispatch_enabled"] is False
+
+
+def test_plugin_descriptor_projection_is_metadata_only_not_entrypoint_dispatch(tmp_path: Path) -> None:
+    manifest = load_manifest(_write(tmp_path, REFERENCE_MANIFEST))
+
+    spec_json = workflow_spec_from_plugin_descriptor(manifest.to_descriptor()).model_dump_json()
+
+    assert "python -m github_pr_ops" not in spec_json
+    assert "dispatch_enabled" in spec_json
+    assert "github-pr-ops" in spec_json
+
+
+def test_plugin_descriptor_requires_at_least_one_action(tmp_path: Path) -> None:
+    manifest = load_manifest(_write(tmp_path, REFERENCE_MANIFEST))
+    descriptor = replace(manifest.to_descriptor(), actions=())
+
+    with pytest.raises(ValueError, match="at least one action"):
+        workflow_spec_from_plugin_descriptor(descriptor)

--- a/tests/unit/orchestrator/test_workflow_ir_plugin_adapter.py
+++ b/tests/unit/orchestrator/test_workflow_ir_plugin_adapter.py
@@ -54,7 +54,9 @@ def test_plugin_descriptor_projects_contract_only_plugin_nodes(tmp_path: Path) -
     assert spec.edges[0].metadata["dispatch_enabled"] is False
 
 
-def test_plugin_descriptor_projection_is_metadata_only_not_entrypoint_dispatch(tmp_path: Path) -> None:
+def test_plugin_descriptor_projection_is_metadata_only_not_entrypoint_dispatch(
+    tmp_path: Path,
+) -> None:
     manifest = load_manifest(_write(tmp_path, REFERENCE_MANIFEST))
 
     spec_json = workflow_spec_from_plugin_descriptor(manifest.to_descriptor()).model_dump_json()
@@ -62,6 +64,75 @@ def test_plugin_descriptor_projection_is_metadata_only_not_entrypoint_dispatch(t
     assert "python -m github_pr_ops" not in spec_json
     assert "dispatch_enabled" in spec_json
     assert "github-pr-ops" in spec_json
+
+
+def test_plugin_descriptor_ids_are_collision_proof_for_registered_action_shape(
+    tmp_path: Path,
+) -> None:
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["commands"] = [
+        {
+            **payload["commands"][0],
+            "namespace": "github-pr",
+            "name": "review",
+            "usage": "ooo github-pr review",
+        },
+        {
+            **payload["commands"][0],
+            "namespace": "github-pr",
+            "name": "review-deep",
+            "usage": "ooo github-pr review-deep",
+        },
+    ]
+    manifest = load_manifest(_write(tmp_path, payload))
+
+    spec = workflow_spec_from_plugin_descriptor(manifest.to_descriptor())
+
+    assert validate_workflow(spec).ok is True
+    task_nodes = [node for node in spec.nodes if node.kind is NodeKind.TASK]
+    assert len(task_nodes) == 2
+    assert len({node.node_id for node in task_nodes}) == 2
+    assert len({edge.edge_id for edge in spec.edges}) == 2
+    assert {(node.metadata["namespace"], node.metadata["command_name"]) for node in task_nodes} == {
+        ("github-pr", "review"),
+        ("github-pr", "review-deep"),
+    }
+
+
+def test_plugin_descriptor_rejects_unregistered_multi_namespace_shape(
+    tmp_path: Path,
+) -> None:
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["commands"] = [
+        {
+            **payload["commands"][0],
+            "namespace": "abc-d",
+            "name": "ef",
+            "usage": "ooo abc-d ef",
+        },
+        {
+            **payload["commands"][0],
+            "namespace": "abc",
+            "name": "d-ef",
+            "usage": "ooo abc d-ef",
+        },
+    ]
+    manifest = load_manifest(_write(tmp_path, payload))
+
+    with pytest.raises(ValueError, match="multiple namespaces"):
+        workflow_spec_from_plugin_descriptor(manifest.to_descriptor())
+
+
+def test_plugin_descriptor_rejects_duplicate_command_names(tmp_path: Path) -> None:
+    payload = json.loads(json.dumps(REFERENCE_MANIFEST))
+    payload["commands"] = [
+        {**payload["commands"][0], "usage": "ooo github-pr review"},
+        {**payload["commands"][0], "usage": "ooo github-pr review-again"},
+    ]
+    manifest = load_manifest(_write(tmp_path, payload))
+
+    with pytest.raises(ValueError, match="duplicate command name"):
+        workflow_spec_from_plugin_descriptor(manifest.to_descriptor())
 
 
 def test_plugin_descriptor_requires_at_least_one_action(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary\n- add a contract-only adapter from #939 plugin descriptors into #956 Workflow IR plugin-owned task nodes\n- carry plugin/action/permission metadata with dispatch_enabled=false and no entrypoint command dispatch hints\n- document the plugin metadata boundary in the Workflow IR v1 note\n\n## Scope\n- Workflow IR planning metadata only\n- No plugin execution, permission grant, lifecycle dispatch, audit behavior, or runtime default change\n\n## Tests\n- uv run pytest tests/unit/orchestrator/test_workflow_ir_plugin_adapter.py tests/unit/plugin/test_manifest_descriptor.py tests/unit/orchestrator/test_workflow_ir_adapter.py -q\n- uv run ruff check src/ouroboros/orchestrator/workflow_ir_adapter.py tests/unit/orchestrator/test_workflow_ir_plugin_adapter.py\n- git diff --check\n\nCovers the #956 plugin-node metadata contract-only follow-up.\n