### PR TITLE
feat(plugin): classify terminal hook contract

### DIFF
--- a/docs/rfc/userlevel-plugins.md
+++ b/docs/rfc/userlevel-plugins.md
@@ -325,6 +325,12 @@ the contract and keeps review scope small.
 | `on_error` | When the wrapper sees a plugin/runtime error | Observability / recovery hint | `fail_open`; MUST NOT mask the original error | `plugin:lifecycle:read` | Deferred |
 | `on_cancel` | When a plugin invocation is cancelled | Observability / cleanup hint | `fail_open`; cleanup side effects require explicit permission | `plugin:lifecycle:read` or cleanup-specific scope | Deferred |
 
+`on_error` and `on_cancel` are the terminal-outcome subset of the deferred hook
+vocabulary. The current #939 contract keeps them non-runnable and rejected by
+v0.3 manifests: future promotion may observe terminal wrapper outcomes, but it
+must not mask the original error/cancellation result, grant cleanup authority,
+or add dispatch without a dedicated runtime slice.
+
 The following candidate hooks are intentionally **not** in the v1 hook
 vocabulary:
 

--- a/src/ouroboros/plugin/hooks.py
+++ b/src/ouroboros/plugin/hooks.py
@@ -82,6 +82,23 @@ class DeferredHookKind(StrEnum):
     ON_CANCEL = "on_cancel"
 
 
+TERMINAL_DEFERRED_HOOK_KINDS: Final[frozenset[DeferredHookKind]] = frozenset(
+    {DeferredHookKind.ON_ERROR, DeferredHookKind.ON_CANCEL}
+)
+"""Deferred hooks that observe terminal plugin-wrapper outcomes only.
+
+These hooks are contractually distinct from tool-call and artifact/state
+interception hooks. They may eventually observe errors or cancellation, but they
+are not v1 hooks, cannot mask the original error/cancel result, and are not
+accepted by v0.3 manifests.
+"""
+
+TERMINAL_DEFERRED_HOOK_NAMES: Final[frozenset[str]] = frozenset(
+    hook.value for hook in TERMINAL_DEFERRED_HOOK_KINDS
+)
+"""String names for deferred terminal outcome hooks."""
+
+
 class ExcludedHookKind(StrEnum):
     """Candidate hook names explicitly excluded from the v1 vocabulary.
 
@@ -176,6 +193,16 @@ def is_deferred_hook_kind(value: str) -> bool:
     return value in {kind.value for kind in DeferredHookKind}
 
 
+def is_terminal_deferred_hook_kind(value: str) -> bool:
+    """Return True iff ``value`` names a deferred terminal outcome hook.
+
+    ``on_error`` and ``on_cancel`` are intentionally kept outside the v1
+    manifest/runtime vocabulary. This helper gives validators, docs, and future
+    migration code a precise contract bucket without making the hooks runnable.
+    """
+    return value in TERMINAL_DEFERRED_HOOK_NAMES
+
+
 def is_excluded_hook_kind(value: str) -> bool:
     """Return True iff ``value`` names an explicitly excluded hook."""
     return value in {kind.value for kind in ExcludedHookKind}
@@ -209,6 +236,8 @@ __all__ = [
     "HOOK_LIFECYCLE_SCOPES",
     "HOOK_OUTCOME_AUDIT_EVENTS",
     "HOOK_RUNTIME_AUDIT_EVENTS",
+    "TERMINAL_DEFERRED_HOOK_KINDS",
+    "TERMINAL_DEFERRED_HOOK_NAMES",
     "DeferredHookKind",
     "ExcludedHookKind",
     "HookFailurePolicy",
@@ -216,6 +245,7 @@ __all__ = [
     "is_deferred_hook_kind",
     "is_excluded_hook_kind",
     "is_hook_lifecycle_scope",
+    "is_terminal_deferred_hook_kind",
     "is_v1_failure_policy",
     "is_v1_hook_kind",
 ]

--- a/tests/unit/plugin/test_hooks_contract.py
+++ b/tests/unit/plugin/test_hooks_contract.py
@@ -25,12 +25,15 @@ from ouroboros.plugin.hooks import (
     HOOK_INVOKED_EVENT,
     HOOK_OUTCOME_AUDIT_EVENTS,
     HOOK_RUNTIME_AUDIT_EVENTS,
+    TERMINAL_DEFERRED_HOOK_KINDS,
+    TERMINAL_DEFERRED_HOOK_NAMES,
     DeferredHookKind,
     ExcludedHookKind,
     HookFailurePolicy,
     HookKind,
     is_deferred_hook_kind,
     is_excluded_hook_kind,
+    is_terminal_deferred_hook_kind,
     is_v1_failure_policy,
     is_v1_hook_kind,
 )
@@ -43,6 +46,16 @@ class TestHookKindEnumeration:
             "before_invocation",
             "after_invocation",
         }
+
+
+
+    def test_terminal_deferred_hook_set_is_exact(self) -> None:
+        assert {"on_error", "on_cancel"} == TERMINAL_DEFERRED_HOOK_NAMES
+        assert {kind.value for kind in TERMINAL_DEFERRED_HOOK_KINDS} == {
+            "on_error",
+            "on_cancel",
+        }
+        assert {kind.value for kind in DeferredHookKind} > TERMINAL_DEFERRED_HOOK_NAMES
 
     def test_deferred_hook_set_is_exact(self) -> None:
         assert {kind.value for kind in DeferredHookKind} == {
@@ -110,6 +123,15 @@ class TestRoutingHelpers:
         assert not is_v1_hook_kind("before_tool_call")
         assert not is_v1_hook_kind("on_event")
         assert not is_v1_hook_kind("unknown_hook")
+
+
+    def test_terminal_deferred_hook_kind_router(self) -> None:
+        assert is_terminal_deferred_hook_kind("on_error")
+        assert is_terminal_deferred_hook_kind("on_cancel")
+        assert not is_terminal_deferred_hook_kind("before_tool_call")
+        assert not is_terminal_deferred_hook_kind("before_invocation")
+        assert not is_v1_hook_kind("on_error")
+        assert not is_v1_hook_kind("on_cancel")
 
     def test_deferred_hook_kind_router(self) -> None:
         assert is_deferred_hook_kind("before_tool_call")

--- a/tests/unit/plugin/test_hooks_contract.py
+++ b/tests/unit/plugin/test_hooks_contract.py
@@ -47,8 +47,6 @@ class TestHookKindEnumeration:
             "after_invocation",
         }
 
-
-
     def test_terminal_deferred_hook_set_is_exact(self) -> None:
         assert {"on_error", "on_cancel"} == TERMINAL_DEFERRED_HOOK_NAMES
         assert {kind.value for kind in TERMINAL_DEFERRED_HOOK_KINDS} == {
@@ -123,7 +121,6 @@ class TestRoutingHelpers:
         assert not is_v1_hook_kind("before_tool_call")
         assert not is_v1_hook_kind("on_event")
         assert not is_v1_hook_kind("unknown_hook")
-
 
     def test_terminal_deferred_hook_kind_router(self) -> None:
         assert is_terminal_deferred_hook_kind("on_error")


### PR DESCRIPTION
## Summary\n- classify on_error/on_cancel as the terminal-outcome subset of deferred plugin hooks\n- add a precise helper and contract tests without promoting them into the v0.3 runnable HookKind vocabulary\n- document that terminal hooks remain non-runnable and must not mask original errors/cancellations\n\n## Scope\n- Contract-only #939 classification\n- No manifest acceptance change, no runtime dispatch, no permission grant, no cleanup side effects\n\n## Tests\n- uv run pytest tests/unit/plugin/test_hooks_contract.py tests/unit/plugin/test_manifest_schema_0_3.py tests/unit/plugin/test_manifest_hook_validation.py -q\n- uv run ruff check src/ouroboros/plugin/hooks.py tests/unit/plugin/test_hooks_contract.py\n- git diff --check\n\nCovers the #939 on_error/on_cancel contract-only follow-up.\n