### PR TITLE
feat(interview): surface milestone lateral review advisories

### DIFF
--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -131,6 +131,19 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
 
 2. **For each question from MCP, apply the routing paths below:**
 
+   **Milestone lateral-review advisory**:
+   If an MCP response includes `meta.lateral_review_recommended=true`, treat it
+   as a non-blocking cue that the interview just crossed an ambiguity milestone
+   such as `initial -> progress`, `progress -> refined`, or `refined -> ready`.
+   The MCP tool is still only a question generator; it has not run lateral
+   personas, blocked the interview, or changed requirements. Before answering
+   the returned question, the main session may run `ooo lateral` / the
+   `ouroboros_lateral_think` MCP surface to inspect hidden assumptions for the
+   named `meta.lateral_review_milestone`, then fold only concrete, user-safe
+   findings into the next answer or user question. If lateral tooling is
+   unavailable or unnecessary, continue with the returned question; do not
+   restart the interview.
+
    **PATH 1 — Code Answer** (describe current state from codebase):
    When the question asks about existing tech stack, frameworks, dependencies,
    current patterns, architecture, or file structure:

--- a/src/ouroboros/bigbang/interview.py
+++ b/src/ouroboros/bigbang/interview.py
@@ -188,6 +188,7 @@ class InterviewState(BaseModel):
     ambiguity_score: float | None = Field(default=None, ge=0.0, le=1.0)
     ambiguity_breakdown: dict[str, Any] | None = None
     completion_candidate_streak: int = Field(default=0, ge=0)
+    lateral_review_advised_milestones: list[str] = Field(default_factory=list)
 
     @property
     def current_round_number(self) -> int:
@@ -235,6 +236,13 @@ class InterviewState(BaseModel):
         """Persist the latest ambiguity evaluation on the interview state."""
         self.ambiguity_score = score
         self.ambiguity_breakdown = breakdown
+        self.mark_updated()
+
+    def note_lateral_review_advisory(self, milestone: str) -> None:
+        """Persist that a milestone transition advisory has been emitted."""
+        if milestone in self.lateral_review_advised_milestones:
+            return
+        self.lateral_review_advised_milestones.append(milestone)
         self.mark_updated()
 
     def clear_stored_ambiguity(self) -> None:

--- a/src/ouroboros/events/interview.py
+++ b/src/ouroboros/events/interview.py
@@ -90,20 +90,6 @@ def interview_response_emitted(
     producing an empty-``thinking`` / ``stop_reason=tool_use`` turn after
     receiving an interview question) with response payload characteristics.
     See Q00/ouroboros#831 comment thread for the hang trace context.
-
-    Args:
-        interview_id: Session id.
-        response_kind: One of ``"start"`` / ``"resume_pending"`` /
-            ``"answer"`` -- which build path produced the response.
-        round_number: Round count at emission time (``len(state.rounds)``).
-        payload_chars: Total characters in the response text body.
-        transcript_chars: Sum of ``len(question) + len(user_response)`` for
-            every round in ``state.rounds``, including pending questions with
-            no response yet.
-        ambiguity_prefix_present: ``True`` when the response text begins
-            with ``(ambiguity: ...)``.
-        is_length_guard: ``True`` when the response carries the
-            ``INITIAL_CONTEXT_SUMMARY_QUESTION`` meta-directive.
     """
     return BaseEvent(
         type="interview.response.emitted",
@@ -116,5 +102,33 @@ def interview_response_emitted(
             "transcript_chars": transcript_chars,
             "ambiguity_prefix_present": ambiguity_prefix_present,
             "is_length_guard": is_length_guard,
+        },
+    )
+
+
+def interview_lateral_review_recommended(
+    interview_id: str,
+    *,
+    from_milestone: str,
+    to_milestone: str,
+    ambiguity_score: float,
+    round_number: int,
+) -> BaseEvent:
+    """Create event when a milestone transition recommends lateral review.
+
+    The event is advisory only: it records that the main/session layer may run
+    a lateral review between interview turns, but it does not imply that the
+    interview handler invoked lateral thinking or blocked question generation.
+    """
+    return BaseEvent(
+        type="interview.lateral_review.recommended",
+        aggregate_type="interview",
+        aggregate_id=interview_id,
+        data={
+            "from_milestone": from_milestone,
+            "to_milestone": to_milestone,
+            "ambiguity_score": ambiguity_score,
+            "round_number": round_number,
+            "reason": "first_forward_milestone_transition",
         },
     )

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -2091,10 +2091,15 @@ class InterviewHandler:
                     # answer to the previously-answered question, corrupting
                     # the transcript. Require the caller to supply the
                     # question via ``last_question``.
+                    # If this is the first live ambiguity score, the interview
+                    # is crossing from the implicit starting milestone.  Treat
+                    # the absent stored score as ``initial`` so the normal first
+                    # ``initial -> progress/refined/ready`` transition can
+                    # surface the advisory instead of being skipped forever.
                     previous_milestone = (
                         get_milestone(state.ambiguity_score)[0].value
                         if state.ambiguity_score is not None
-                        else None
+                        else "initial"
                     )
 
                     if state.rounds[-1].user_response is None:

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -311,6 +311,48 @@ def _milestone_for_score(score: AmbiguityScore | None) -> str | None:
     return milestone.value
 
 
+_MILESTONE_RANKS = {
+    "initial": 0,
+    "progress": 1,
+    "refined": 2,
+    "ready": 3,
+}
+
+
+def _maybe_record_lateral_review_advisory(
+    state: InterviewState,
+    *,
+    previous_milestone: str | None,
+    score: AmbiguityScore | None,
+) -> dict[str, Any] | None:
+    """Return advisory meta for a first-time forward milestone transition.
+
+    This helper is intentionally deterministic and side-effect limited: it
+    records that an advisory was emitted for the target milestone, but it does
+    not invoke lateral thinking, block question generation, or alter the
+    interview answer/Seed contract.
+    """
+    current_milestone = _milestone_for_score(score)
+    if previous_milestone is None or current_milestone is None:
+        return None
+
+    previous_rank = _MILESTONE_RANKS.get(previous_milestone)
+    current_rank = _MILESTONE_RANKS.get(current_milestone)
+    if previous_rank is None or current_rank is None or current_rank <= previous_rank:
+        return None
+
+    if current_milestone in state.lateral_review_advised_milestones:
+        return None
+
+    state.note_lateral_review_advisory(current_milestone)
+    return {
+        "lateral_review_recommended": True,
+        "lateral_review_milestone": current_milestone,
+        "lateral_review_from_milestone": previous_milestone,
+        "lateral_review_reason": "first_forward_milestone_transition",
+    }
+
+
 def _compute_transcript_chars(state: InterviewState) -> int:
     """Sum question + user_response length over every round in ``state``.
 
@@ -1864,6 +1906,8 @@ class InterviewHandler:
                         )
                     )
 
+                lateral_review_meta: dict[str, Any] | None = None
+
                 # If answer provided, record it first
                 if answer:
                     if _is_interview_completion_signal(answer):
@@ -2047,6 +2091,12 @@ class InterviewHandler:
                     # answer to the previously-answered question, corrupting
                     # the transcript. Require the caller to supply the
                     # question via ``last_question``.
+                    previous_milestone = (
+                        get_milestone(state.ambiguity_score)[0].value
+                        if state.ambiguity_score is not None
+                        else None
+                    )
+
                     if state.rounds[-1].user_response is None:
                         pending_question = last_question or state.rounds[-1].question
                         state.rounds.pop()
@@ -2113,6 +2163,27 @@ class InterviewHandler:
                         # Running them in parallel would give the question
                         # generator stale routing context.
                         live_score = await self._score_interview_state(llm_adapter, state)
+                        lateral_review_meta = _maybe_record_lateral_review_advisory(
+                            state,
+                            previous_milestone=previous_milestone,
+                            score=live_score,
+                        )
+                        if lateral_review_meta is not None and live_score is not None:
+                            from ouroboros.events.interview import (
+                                interview_lateral_review_recommended,
+                            )
+
+                            self._emit_event_bg(
+                                interview_lateral_review_recommended(
+                                    session_id,
+                                    from_milestone=lateral_review_meta[
+                                        "lateral_review_from_milestone"
+                                    ],
+                                    to_milestone=lateral_review_meta["lateral_review_milestone"],
+                                    ambiguity_score=live_score.overall_score,
+                                    round_number=len(state.rounds),
+                                )
+                            )
                         if (
                             live_score is not None
                             and qualifies_for_seed_completion(
@@ -2222,6 +2293,9 @@ class InterviewHandler:
                     # guard meta-directive.  ``is_error`` stays ``False`` so
                     # the auto driver's ``answer()`` path is not raised on.
                     answer_meta.update(_length_guard_meta_fields())
+
+                if lateral_review_meta is not None:
+                    answer_meta.update(lateral_review_meta)
 
                 answer_response_text = f"Session {session_id}\n\n{display_question}"
                 # Q00/ouroboros#831 (diagnostics): response-shape event for

--- a/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
+++ b/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
@@ -140,7 +140,10 @@ def test_advisory_event_is_structured_and_non_blocking() -> None:
 async def test_handler_surfaces_advisory_in_meta_without_question_text_leak() -> None:
     state = InterviewState(
         interview_id="sess-817",
-        ambiguity_score=0.45,
+        # No stored ambiguity yet: this is the normal first live scoring path
+        # after MIN_ROUNDS_BEFORE_EARLY_EXIT. The handler should treat it as
+        # crossing from the implicit ``initial`` milestone.
+        ambiguity_score=None,
         rounds=[
             InterviewRound(round_number=1, question="Q1?", user_response="A1"),
             InterviewRound(round_number=2, question="Q2?", user_response="A2"),

--- a/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
+++ b/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
@@ -1,0 +1,183 @@
+"""Milestone-transition lateral review advisory tests for #817."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBreakdown
+from ouroboros.bigbang.interview import InterviewRound, InterviewState
+from ouroboros.core.types import Result
+from ouroboros.events.interview import interview_lateral_review_recommended
+from ouroboros.mcp.tools.authoring_handlers import (
+    InterviewHandler,
+    _maybe_record_lateral_review_advisory,
+)
+
+
+def _score(value: float) -> AmbiguityScore:
+    clarity = 1.0 - value
+    return AmbiguityScore(
+        overall_score=value,
+        breakdown=ScoreBreakdown(
+            goal_clarity=ComponentScore(
+                name="Goal Clarity",
+                clarity_score=clarity,
+                weight=0.4,
+                justification="test",
+            ),
+            constraint_clarity=ComponentScore(
+                name="Constraint Clarity",
+                clarity_score=clarity,
+                weight=0.3,
+                justification="test",
+            ),
+            success_criteria_clarity=ComponentScore(
+                name="Success Criteria Clarity",
+                clarity_score=clarity,
+                weight=0.3,
+                justification="test",
+            ),
+        ),
+    )
+
+
+def test_forward_milestone_transition_records_advisory_meta() -> None:
+    state = InterviewState(interview_id="interview_test")
+
+    meta = _maybe_record_lateral_review_advisory(
+        state,
+        previous_milestone="initial",
+        score=_score(0.35),
+    )
+
+    assert meta == {
+        "lateral_review_recommended": True,
+        "lateral_review_milestone": "progress",
+        "lateral_review_from_milestone": "initial",
+        "lateral_review_reason": "first_forward_milestone_transition",
+    }
+    assert state.lateral_review_advised_milestones == ["progress"]
+
+
+def test_duplicate_milestone_transition_is_suppressed() -> None:
+    state = InterviewState(
+        interview_id="interview_test",
+        lateral_review_advised_milestones=["progress"],
+    )
+
+    meta = _maybe_record_lateral_review_advisory(
+        state,
+        previous_milestone="initial",
+        score=_score(0.35),
+    )
+
+    assert meta is None
+    assert state.lateral_review_advised_milestones == ["progress"]
+
+
+def test_backward_transition_is_not_advisory() -> None:
+    state = InterviewState(interview_id="interview_test")
+
+    meta = _maybe_record_lateral_review_advisory(
+        state,
+        previous_milestone="refined",
+        score=_score(0.35),
+    )
+
+    assert meta is None
+    assert state.lateral_review_advised_milestones == []
+
+
+def test_same_milestone_transition_is_not_advisory() -> None:
+    state = InterviewState(interview_id="interview_test")
+
+    meta = _maybe_record_lateral_review_advisory(
+        state,
+        previous_milestone="progress",
+        score=_score(0.35),
+    )
+
+    assert meta is None
+    assert state.lateral_review_advised_milestones == []
+
+
+def test_only_three_forward_milestones_can_be_advised() -> None:
+    state = InterviewState(interview_id="interview_test")
+
+    assert _maybe_record_lateral_review_advisory(
+        state, previous_milestone="initial", score=_score(0.35)
+    )
+    assert _maybe_record_lateral_review_advisory(
+        state, previous_milestone="progress", score=_score(0.25)
+    )
+    assert _maybe_record_lateral_review_advisory(
+        state, previous_milestone="refined", score=_score(0.15)
+    )
+
+    assert state.lateral_review_advised_milestones == ["progress", "refined", "ready"]
+    assert len(state.lateral_review_advised_milestones) == 3
+
+
+def test_advisory_event_is_structured_and_non_blocking() -> None:
+    event = interview_lateral_review_recommended(
+        "interview_test",
+        from_milestone="progress",
+        to_milestone="refined",
+        ambiguity_score=0.25,
+        round_number=4,
+    )
+
+    assert event.type == "interview.lateral_review.recommended"
+    assert event.aggregate_type == "interview"
+    assert event.aggregate_id == "interview_test"
+    assert event.data == {
+        "from_milestone": "progress",
+        "to_milestone": "refined",
+        "ambiguity_score": 0.25,
+        "round_number": 4,
+        "reason": "first_forward_milestone_transition",
+    }
+
+
+async def test_handler_surfaces_advisory_in_meta_without_question_text_leak() -> None:
+    state = InterviewState(
+        interview_id="sess-817",
+        ambiguity_score=0.45,
+        rounds=[
+            InterviewRound(round_number=1, question="Q1?", user_response="A1"),
+            InterviewRound(round_number=2, question="Q2?", user_response="A2"),
+            InterviewRound(round_number=3, question="Q3?", user_response=None),
+        ],
+    )
+
+    async def record_response(
+        state: InterviewState, user_response: str, question: str
+    ) -> Result[InterviewState, object]:
+        state.rounds.append(
+            InterviewRound(
+                round_number=state.current_round_number,
+                question=question,
+                user_response=user_response,
+            )
+        )
+        return Result.ok(state)
+
+    mock_engine = MagicMock()
+    mock_engine.load_state = AsyncMock(return_value=Result.ok(state))
+    mock_engine.record_response = AsyncMock(side_effect=record_response)
+    mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
+    mock_engine.ask_next_question = AsyncMock(return_value=Result.ok("What edge case remains?"))
+
+    handler = InterviewHandler(interview_engine=mock_engine)
+    handler.llm_adapter = MagicMock()
+    handler._score_interview_state = AsyncMock(return_value=_score(0.35))  # type: ignore[method-assign]
+    handler._emit_event_bg = MagicMock()  # type: ignore[method-assign]
+
+    result = await handler.handle({"session_id": "sess-817", "answer": "A3"})
+
+    assert result.is_ok
+    assert result.value.meta["lateral_review_recommended"] is True
+    assert result.value.meta["lateral_review_from_milestone"] == "initial"
+    assert result.value.meta["lateral_review_milestone"] == "progress"
+    assert result.value.meta["lateral_review_reason"] == "first_forward_milestone_transition"
+    assert "lateral" not in result.value.content[0].text.lower()
+    assert state.lateral_review_advised_milestones == ["progress"]
+    handler._emit_event_bg.assert_called()


### PR DESCRIPTION
## Summary

- Add a deterministic, persisted advisory for first-time forward ambiguity milestone transitions during `ouroboros_interview`.
- Surface the advisory as structured MCP response meta and an `interview.lateral_review.recommended` event.
- Document that the main/session layer may run lateral review between turns while the MCP handler remains a single-question generator.

## Scope

Refs #817.

This intentionally keeps #817 narrow:

- no heuristic stagnation detector;
- no direct `ooo lateral` / `ouroboros_lateral_think` invocation inside the interview handler;
- no blocking/pause behavior;
- no user-facing lateral note injected into question text;
- no Seed, `ooo auto`, Ralph, QA, or acceptance-criteria changes.

## Verification

- `uv run ruff check src/ouroboros/bigbang/interview.py src/ouroboros/events/interview.py src/ouroboros/mcp/tools/authoring_handlers.py tests/unit/mcp/tools/test_interview_lateral_review_advisory.py`
- `uv run mypy src/ouroboros/bigbang/interview.py src/ouroboros/events/interview.py src/ouroboros/mcp/tools/authoring_handlers.py tests/unit/mcp/tools/test_interview_lateral_review_advisory.py`
- `uv run pytest tests/unit/mcp/tools/test_interview_lateral_review_advisory.py tests/unit/bigbang/test_interview.py::TestInterviewState tests/unit/bigbang/test_interview.py::TestInterviewEngineSystemPrompt::test_system_prompt_includes_live_ambiguity_snapshot tests/unit/mcp/tools/test_interview_done_streak.py -q`
- `git diff --check`

## Notes

The advisory is designed as a routing cue, not an execution hook. If `meta.lateral_review_recommended=true`, the active interview skill/main session can decide whether to call the lateral MCP surface before answering the returned question.
