### PR TITLE
fix(auto): let safe-default synthesis close interviews

### DIFF
--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -207,7 +207,12 @@ def _is_interview_completion_signal(answer: str | None) -> bool:
     """Return True when the answer explicitly asks to end the interview.
 
     Only ``[from-user]`` and prefix-less answers represent human intent to close.
-    The auto driver's ``_feature_acceptance_answer`` echoes the LLM question into
+    The one deterministic non-human exception is the auto driver's
+    ``[from-auto][safe-default-synthesis]`` payload, which is emitted only after
+    the driver has already accepted auditable safe defaults for the remaining
+    required gaps and must close the persisted interview in the same turn.
+
+    The auto driver's ordinary ``_feature_acceptance_answer`` echoes the LLM question into
     its answer text, which can accidentally include phrases like "no remaining
     ambiguity" and trip the shortfall branch. Gate the heuristic by prefix so
     ``[from-auto]`` / ``[from-code]`` / ``[from-research]`` answers — which carry
@@ -224,7 +229,18 @@ def _is_interview_completion_signal(answer: str | None) -> bool:
         return False
 
     stripped = answer.lstrip().lower()
-    if stripped.startswith("[from-") and not stripped.startswith("[from-user]"):
+    # Auto-generated answers normally must not express user intent to close, but
+    # the safe-default finalizer is the one deterministic exception: the auto
+    # driver has already decided the remaining required gaps are conservative
+    # defaults and now needs the persisted interview session to close in the
+    # same turn that records those defaults.  Keep this allowance tied to the
+    # explicit synthesis tag so ordinary ``[from-auto]`` answers remain guarded.
+    allow_auto_safe_default_completion = stripped.startswith("[from-auto][safe-default-synthesis]")
+    if (
+        stripped.startswith("[from-")
+        and not stripped.startswith("[from-user]")
+        and not allow_auto_safe_default_completion
+    ):
         return False
 
     normalized = _normalize_interview_answer(answer)

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -203,6 +203,14 @@ def _normalize_interview_answer(answer: str) -> str:
     return " ".join(re.findall(r"[a-z0-9']+", answer.lower()))
 
 
+def _is_safe_default_synthesis_completion(answer: str | None) -> bool:
+    """Return True for the auto driver's auditable safe-default close signal."""
+    return bool(
+        answer is not None
+        and answer.lstrip().lower().startswith("[from-auto][safe-default-synthesis]")
+    )
+
+
 def _is_interview_completion_signal(answer: str | None) -> bool:
     """Return True when the answer explicitly asks to end the interview.
 
@@ -235,7 +243,7 @@ def _is_interview_completion_signal(answer: str | None) -> bool:
     # defaults and now needs the persisted interview session to close in the
     # same turn that records those defaults.  Keep this allowance tied to the
     # explicit synthesis tag so ordinary ``[from-auto]`` answers remain guarded.
-    allow_auto_safe_default_completion = stripped.startswith("[from-auto][safe-default-synthesis]")
+    allow_auto_safe_default_completion = _is_safe_default_synthesis_completion(answer)
     if (
         stripped.startswith("[from-")
         and not stripped.startswith("[from-user]")
@@ -1927,6 +1935,7 @@ class InterviewHandler:
                 # If answer provided, record it first
                 if answer:
                     if _is_interview_completion_signal(answer):
+                        is_safe_default_synthesis = _is_safe_default_synthesis_completion(answer)
                         # Remember whether a round is awaiting an answer so we
                         # can pop it only on the branches that actually end
                         # the interview. Shortfall/refusal paths keep the
@@ -1964,6 +1973,16 @@ class InterviewHandler:
                             exit_score,
                             is_brownfield=state.is_brownfield,
                         ):
+                            if is_safe_default_synthesis:
+                                if has_pending_round:
+                                    state.rounds.pop()
+                                return await self._complete_interview_response(
+                                    engine,
+                                    state,
+                                    session_id,
+                                    exit_score,
+                                )
+
                             # Explicit 'done' with a qualifying score counts
                             # as an implicit stability signal — advance the
                             # streak so repeated 'done' inputs can progress

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
 from ouroboros.config.models import RuntimeControlsConfig
 from ouroboros.core.errors import ConfigError
 from ouroboros.core.types import Result
@@ -2112,6 +2113,78 @@ class TestInterviewHandlerCwd:
         cwd_param = next(p for p in defn.parameters if p.name == "cwd")
         assert cwd_param.required is False
         assert cwd_param.type == ToolInputType.STRING
+
+    async def test_safe_default_synthesis_closes_persisted_interview_without_second_done(
+        self,
+    ) -> None:
+        """Safe-default synthesis is the only auto completion signal that bypasses the done streak."""
+        handler = InterviewHandler()
+        handler._emit_event = AsyncMock()
+        state = InterviewState(
+            interview_id="sess-safe-default",
+            status=InterviewStatus.IN_PROGRESS,
+            ambiguity_score=0.12,
+            ambiguity_breakdown={
+                "goal_clarity": {
+                    "name": "Goal Clarity",
+                    "clarity_score": 0.9,
+                    "weight": 0.4,
+                    "justification": "clear",
+                },
+                "constraint_clarity": {
+                    "name": "Constraint Clarity",
+                    "clarity_score": 0.9,
+                    "weight": 0.3,
+                    "justification": "clear",
+                },
+                "success_criteria_clarity": {
+                    "name": "Success Criteria Clarity",
+                    "clarity_score": 0.9,
+                    "weight": 0.3,
+                    "justification": "clear",
+                },
+            },
+            completion_candidate_streak=0,
+            rounds=[
+                InterviewRound(
+                    round_number=1,
+                    question="What else should we know?",
+                    user_response=None,
+                )
+            ],
+        )
+
+        async def complete_interview(
+            current_state: InterviewState,
+        ) -> Result[InterviewState, Exception]:
+            current_state.status = InterviewStatus.COMPLETED
+            return Result.ok(current_state)
+
+        mock_engine = MagicMock()
+        mock_engine.load_state = AsyncMock(return_value=Result.ok(state))
+        mock_engine.complete_interview = AsyncMock(side_effect=complete_interview)
+        mock_engine.save_state = AsyncMock(return_value=MagicMock(is_ok=True, is_err=False))
+
+        with patch(
+            "ouroboros.mcp.tools.authoring_handlers.InterviewEngine",
+            return_value=mock_engine,
+        ):
+            result = await handler.handle(
+                {
+                    "session_id": "sess-safe-default",
+                    "answer": (
+                        "[from-auto][safe-default-synthesis] Mark the interview complete "
+                        "and hand off for seed generation."
+                    ),
+                }
+            )
+
+        assert result.is_ok
+        assert result.value.meta["completed"] is True
+        assert result.value.meta["seed_ready"] is True
+        assert state.status is InterviewStatus.COMPLETED
+        assert state.rounds == []
+        mock_engine.complete_interview.assert_awaited_once()
 
 
 class TestCancelExecutionHandler:

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -2090,6 +2090,11 @@ class TestInterviewHandlerCwd:
             ("Correct. No remaining ambiguity. Close the interview.", True),
             ("Yes. Lock it. Documentation-only outcomes. Done.", True),
             ("Not done yet.", False),
+            ("[from-auto][feature_acceptance] no remaining ambiguity; done", False),
+            (
+                "[from-auto][safe-default-synthesis] Mark the interview complete and hand off for seed generation.",
+                True,
+            ),
         ],
     )
     def test_interview_completion_signal_detection(self, answer: str, expected: bool) -> None:


### PR DESCRIPTION
## Summary
- Fixes a post-merge regression found while auditing #1122: the safe-default synthesis answer is intentionally emitted as `[from-auto][safe-default-synthesis]` and includes a completion phrase so the persisted interview closes in the same turn as the defaulted assumptions are recorded.
- A later/adjacent prefix guard made all non-`[from-user]` answers ineligible as completion signals, which preserved the ordinary `[from-auto]` safety property but also blocked this deterministic safe-default finalization path.
- Keeps the exception narrow: only the explicit `[from-auto][safe-default-synthesis]` prefix may reach the existing completion phrase detector; ordinary `[from-auto]`, `[from-code]`, and `[from-research]` answers remain default-denied.

## Validation
- `uv run pytest tests/unit/mcp/tools/test_definitions.py::TestInterviewHandlerCwd::test_interview_completion_signal_detection tests/unit/auto/test_interview_pipeline.py -q` — 143 passed
- `uv run ruff check src/ouroboros/mcp/tools/authoring_handlers.py tests/unit/mcp/tools/test_definitions.py` — passed
- `git diff --check` — passed

## Audit context
This was discovered during the #1122 audit requested against issue #961 / AgentOS SSOT direction. #1122 itself is already merged, so this PR is a minimal follow-up fix rather than an amendment commit on #1122.
