### PR TITLE
fix(interview): defer lateral advisory side effects

### DIFF
--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -327,10 +327,11 @@ def _maybe_record_lateral_review_advisory(
 ) -> dict[str, Any] | None:
     """Return advisory meta for a first-time forward milestone transition.
 
-    This helper is intentionally deterministic and side-effect limited: it
-    records that an advisory was emitted for the target milestone, but it does
-    not invoke lateral thinking, block question generation, or alter the
-    interview answer/Seed contract.
+    This helper is intentionally deterministic and side-effect free: it only
+    computes whether the next response should carry an advisory. The caller
+    persists the advised milestone after it knows a question-bearing response
+    will actually be returned, so auto-complete and question-generation failure
+    paths do not consume the advisory without surfacing it.
     """
     current_milestone = _milestone_for_score(score)
     if previous_milestone is None or current_milestone is None:
@@ -344,7 +345,6 @@ def _maybe_record_lateral_review_advisory(
     if current_milestone in state.lateral_review_advised_milestones:
         return None
 
-    state.note_lateral_review_advisory(current_milestone)
     return {
         "lateral_review_recommended": True,
         "lateral_review_milestone": current_milestone,
@@ -2173,22 +2173,6 @@ class InterviewHandler:
                             previous_milestone=previous_milestone,
                             score=live_score,
                         )
-                        if lateral_review_meta is not None and live_score is not None:
-                            from ouroboros.events.interview import (
-                                interview_lateral_review_recommended,
-                            )
-
-                            self._emit_event_bg(
-                                interview_lateral_review_recommended(
-                                    session_id,
-                                    from_milestone=lateral_review_meta[
-                                        "lateral_review_from_milestone"
-                                    ],
-                                    to_milestone=lateral_review_meta["lateral_review_milestone"],
-                                    ambiguity_score=live_score.overall_score,
-                                    round_number=len(state.rounds),
-                                )
-                            )
                         if (
                             live_score is not None
                             and qualifies_for_seed_completion(
@@ -2255,6 +2239,23 @@ class InterviewHandler:
                     return Result.err(MCPToolError(error_msg, tool_name="ouroboros_interview"))
 
                 question = question_result.value
+                if lateral_review_meta is not None and live_score is not None:
+                    state.note_lateral_review_advisory(
+                        lateral_review_meta["lateral_review_milestone"]
+                    )
+                    from ouroboros.events.interview import (
+                        interview_lateral_review_recommended,
+                    )
+
+                    self._emit_event_bg(
+                        interview_lateral_review_recommended(
+                            session_id,
+                            from_milestone=lateral_review_meta["lateral_review_from_milestone"],
+                            to_milestone=lateral_review_meta["lateral_review_milestone"],
+                            ambiguity_score=live_score.overall_score,
+                            round_number=len(state.rounds),
+                        )
+                    )
                 display_question = _format_question_with_ambiguity(question, live_score)
 
                 # Save pending question as unanswered round for next resume

--- a/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
+++ b/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
@@ -54,7 +54,7 @@ def test_forward_milestone_transition_records_advisory_meta() -> None:
         "lateral_review_from_milestone": "initial",
         "lateral_review_reason": "first_forward_milestone_transition",
     }
-    assert state.lateral_review_advised_milestones == ["progress"]
+    assert state.lateral_review_advised_milestones == []
 
 
 def test_duplicate_milestone_transition_is_suppressed() -> None:
@@ -102,15 +102,21 @@ def test_same_milestone_transition_is_not_advisory() -> None:
 def test_only_three_forward_milestones_can_be_advised() -> None:
     state = InterviewState(interview_id="interview_test")
 
-    assert _maybe_record_lateral_review_advisory(
+    meta = _maybe_record_lateral_review_advisory(
         state, previous_milestone="initial", score=_score(0.35)
     )
-    assert _maybe_record_lateral_review_advisory(
+    assert meta
+    state.note_lateral_review_advisory(meta["lateral_review_milestone"])
+    meta = _maybe_record_lateral_review_advisory(
         state, previous_milestone="progress", score=_score(0.25)
     )
-    assert _maybe_record_lateral_review_advisory(
+    assert meta
+    state.note_lateral_review_advisory(meta["lateral_review_milestone"])
+    meta = _maybe_record_lateral_review_advisory(
         state, previous_milestone="refined", score=_score(0.15)
     )
+    assert meta
+    state.note_lateral_review_advisory(meta["lateral_review_milestone"])
 
     assert state.lateral_review_advised_milestones == ["progress", "refined", "ready"]
     assert len(state.lateral_review_advised_milestones) == 3
@@ -184,3 +190,51 @@ async def test_handler_surfaces_advisory_in_meta_without_question_text_leak() ->
     assert "lateral" not in result.value.content[0].text.lower()
     assert state.lateral_review_advised_milestones == ["progress"]
     handler._emit_event_bg.assert_called()
+
+
+async def test_handler_does_not_record_advisory_when_question_generation_fails() -> None:
+    state = InterviewState(
+        interview_id="sess-818",
+        ambiguity_score=None,
+        rounds=[
+            InterviewRound(round_number=1, question="Q1?", user_response="A1"),
+            InterviewRound(round_number=2, question="Q2?", user_response="A2"),
+            InterviewRound(round_number=3, question="Q3?", user_response=None),
+        ],
+    )
+
+    async def record_response(
+        state: InterviewState, user_response: str, question: str
+    ) -> Result[InterviewState, object]:
+        state.rounds.append(
+            InterviewRound(
+                round_number=state.current_round_number,
+                question=question,
+                user_response=user_response,
+            )
+        )
+        return Result.ok(state)
+
+    mock_engine = MagicMock()
+    mock_engine.load_state = AsyncMock(return_value=Result.ok(state))
+    mock_engine.record_response = AsyncMock(side_effect=record_response)
+    mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
+    mock_engine.ask_next_question = AsyncMock(
+        return_value=Result.err(Exception("empty response from provider"))
+    )
+
+    handler = InterviewHandler(interview_engine=mock_engine)
+    handler.llm_adapter = MagicMock()
+    handler._score_interview_state = AsyncMock(return_value=_score(0.35))  # type: ignore[method-assign]
+    handler._emit_event_bg = MagicMock()  # type: ignore[method-assign]
+
+    result = await handler.handle({"session_id": "sess-818", "answer": "A3"})
+
+    assert result.is_ok
+    assert result.value.is_error is True
+    assert "lateral_review_recommended" not in result.value.meta
+    assert state.lateral_review_advised_milestones == []
+    assert not any(
+        call.args[0].type == "interview.lateral_review.recommended"
+        for call in handler._emit_event_bg.call_args_list
+    )

--- a/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
+++ b/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
@@ -192,6 +192,59 @@ async def test_handler_surfaces_advisory_in_meta_without_question_text_leak() ->
     handler._emit_event_bg.assert_called()
 
 
+async def test_handler_does_not_record_advisory_before_auto_completion() -> None:
+    """Auto-completion should not consume a lateral advisory milestone."""
+    handler = InterviewHandler(llm_adapter=MagicMock())
+    handler._emit_event_bg = MagicMock()
+    state = InterviewState(
+        interview_id="sess-auto-complete",
+        ambiguity_score=0.45,
+        completion_candidate_streak=2,
+        rounds=[
+            InterviewRound(round_number=1, question="Q1", user_response="A1"),
+            InterviewRound(round_number=2, question="Q2", user_response="A2"),
+            InterviewRound(round_number=3, question="Ready?", user_response=None),
+        ],
+    )
+    ready_score = _score(0.15)
+
+    async def record_response(
+        state: InterviewState, user_response: str, question: str
+    ) -> Result[InterviewState, object]:
+        state.rounds.append(
+            InterviewRound(
+                round_number=state.current_round_number,
+                question=question,
+                user_response=user_response,
+            )
+        )
+        return Result.ok(state)
+
+    mock_engine = MagicMock()
+    mock_engine.load_state = AsyncMock(return_value=Result.ok(state))
+    mock_engine.record_response = AsyncMock(side_effect=record_response)
+    mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
+    mock_engine.complete_interview = AsyncMock(return_value=Result.ok(state))
+    mock_engine.ask_next_question = AsyncMock()
+
+    handler = InterviewHandler(interview_engine=mock_engine)
+    handler.llm_adapter = MagicMock()
+    handler._score_interview_state = AsyncMock(return_value=ready_score)  # type: ignore[method-assign]
+    handler._emit_event_bg = MagicMock()  # type: ignore[method-assign]
+
+    result = await handler.handle({"session_id": "sess-auto-complete", "answer": "This is ready."})
+
+    assert result.is_ok
+    assert result.value.meta["completed"] is True
+    assert state.lateral_review_advised_milestones == []
+    mock_engine.complete_interview.assert_awaited_once()
+    mock_engine.ask_next_question.assert_not_called()
+    assert not any(
+        call.args[0].type == "interview.lateral_review.recommended"
+        for call in handler._emit_event_bg.call_args_list
+    )
+
+
 async def test_handler_does_not_record_advisory_when_question_generation_fails() -> None:
     state = InterviewState(
         interview_id="sess-818",


### PR DESCRIPTION
## Summary
- Defers `lateral_review_advised_milestones` persistence and `interview.lateral_review.recommended` event emission until the handler is actually returning a question-bearing response.
- Keeps advisory computation side-effect-free so auto-complete and question-generation failure paths do not consume an advisory that the user never sees.
- Adds regression coverage for question-generation failure after an eligible milestone crossing.

## Context
Follow-up to #1128 and the ouroboros-agent design-note warning that advisory side effects were happening before successful question generation.

## Validation
- `uv run ruff check src/ouroboros/mcp/tools/authoring_handlers.py tests/unit/mcp/tools/test_interview_lateral_review_advisory.py`
- `uv run pytest tests/unit/mcp/tools/test_interview_lateral_review_advisory.py tests/unit/bigbang -q` — 548 passed
