### PR TITLE
feat(cli): add ouroboros status run --json projection surface

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -602,21 +602,34 @@ ouroboros status auto AUTO_SESSION_ID
 ### `status run`
 
 Build a read-only Run/Stage/Step projection from persisted events. Provide at
-least one selector: `--session-id` or `--execution-id`.
+least one selector: a positional `RUN_ID` (treated as the execution anchor),
+`--execution-id`, or `--session-id`. The command is a thin surface over the
+`ouroboros_query_projection` MCP tool — `--json` output is byte-identical to
+what the MCP query returns for the same anchor.
 
 ```bash
-ouroboros status run (--session-id TEXT | --execution-id TEXT) [OPTIONS]
+ouroboros status run [RUN_ID] [--session-id TEXT | --execution-id TEXT] [OPTIONS]
 ```
 
 **Options:**
 
 | Option | Description |
 |--------|-------------|
-| `--session-id TEXT` | Orchestrator session ID to project; required unless `--execution-id` is provided |
-| `--execution-id TEXT` | Execution aggregate ID to project; required unless `--session-id` is provided |
+| `RUN_ID` | Optional positional execution anchor; equivalent to `--execution-id`. Cannot be combined with `--session-id` or a conflicting `--execution-id` |
+| `--session-id TEXT` | Orchestrator session ID to project; required unless `RUN_ID` or `--execution-id` is provided |
+| `--execution-id TEXT` | Execution aggregate ID to project; required unless `RUN_ID` or `--session-id` is provided |
 | `--seed-id TEXT` | Optional seed ID override for projection labels |
 | `--limit INTEGER` | Optional event count safety cap |
 | `--json` | Emit machine-readable projection JSON |
+
+**Exit codes** (Wave-1 #946 S2 contract):
+
+| Code | Meaning |
+|------|---------|
+| `0` | Projection rendered successfully |
+| `1` | Generic projection failure surfaced by the MCP handler |
+| `2` | Unknown run anchor — no events match the requested `RUN_ID` / selectors |
+| `64` | Malformed input — missing selectors or conflicting `RUN_ID` / option combination |
 
 ### `status health`
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -608,16 +608,21 @@ least one selector: a positional `RUN_ID` (treated as the execution anchor),
 what the MCP query returns for the same anchor.
 
 ```bash
-ouroboros status run [RUN_ID] [--session-id TEXT | --execution-id TEXT] [OPTIONS]
+ouroboros status run [RUN_ID] [--session-id TEXT] [--execution-id TEXT] [OPTIONS]
 ```
+
+**Arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `RUN_ID` | No | Positional execution anchor; maps to `execution_id`. Cannot be combined with `--session-id` or a conflicting `--execution-id` |
 
 **Options:**
 
 | Option | Description |
 |--------|-------------|
-| `RUN_ID` | Optional positional execution anchor; equivalent to `--execution-id`. Cannot be combined with `--session-id` or a conflicting `--execution-id` |
-| `--session-id TEXT` | Orchestrator session ID to project; required unless `RUN_ID` or `--execution-id` is provided |
-| `--execution-id TEXT` | Execution aggregate ID to project; required unless `RUN_ID` or `--session-id` is provided |
+| `--session-id TEXT` | Orchestrator session ID to project; required unless `RUN_ID` or `--execution-id` is provided. May be combined with `--execution-id` when the MCP projection handler needs session narrowing |
+| `--execution-id TEXT` | Execution aggregate ID to project; required unless `RUN_ID` or `--session-id` is provided. May be combined with `--session-id` for session narrowing |
 | `--seed-id TEXT` | Optional seed ID override for projection labels |
 | `--limit INTEGER` | Optional event count safety cap |
 | `--json` | Emit machine-readable projection JSON |

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -117,8 +117,35 @@ def auto(
     typer.echo(_format_auto_status(state), nl=False)
 
 
+# Exit codes for `ouroboros status run`. These mirror Wave-1 #946 S2:
+#   * ``0`` — projection rendered successfully.
+#   * ``2`` — run anchor (run_id / execution_id / session_id) is unknown.
+#   * ``64`` — malformed input (missing or conflicting selectors).
+# Any other handler failure surfaces as exit code ``1`` so existing callers
+# that already special-case generic failure keep working.
+_STATUS_RUN_EXIT_OK = 0
+_STATUS_RUN_EXIT_GENERIC_ERROR = 1
+_STATUS_RUN_EXIT_UNKNOWN_RUN = 2
+_STATUS_RUN_EXIT_MALFORMED_INPUT = 64
+
+
+def _is_unknown_run_error(message: str) -> bool:
+    lowered = message.lower()
+    return "no events found" in lowered
+
+
 @app.command(name="run")
 def run_projection(
+    run_id: Annotated[
+        str | None,
+        typer.Argument(
+            metavar="[RUN_ID]",
+            help=(
+                "Optional run anchor (execution aggregate ID). Equivalent to "
+                "passing --execution-id; mutually exclusive with --session-id."
+            ),
+        ),
+    ] = None,
     session_id: Annotated[
         str | None,
         typer.Option("--session-id", help="Optional orchestrator session ID to project."),
@@ -140,7 +167,35 @@ def run_projection(
         typer.Option("--json", help="Emit machine-readable projection JSON."),
     ] = False,
 ) -> None:
-    """Build a read-only Run/Stage/Step projection from persisted events."""
+    """Build a read-only Run/Stage/Step projection from persisted events.
+
+    The CLI is a thin surface over ``ouroboros_query_projection``: the same
+    run anchor returns byte-identical JSON between the MCP query and this
+    command when ``--json`` is set. Exit codes follow the Wave-1 #946 S2
+    convention (``0`` ok, ``2`` unknown run, ``64`` malformed input).
+    """
+
+    if run_id is not None:
+        if execution_id is not None and execution_id != run_id:
+            print_error(
+                "Run projection failed: RUN_ID and --execution-id refer to "
+                "different anchors; provide only one."
+            )
+            raise typer.Exit(_STATUS_RUN_EXIT_MALFORMED_INPUT)
+        if session_id is not None:
+            print_error(
+                "Run projection failed: RUN_ID positional cannot be combined "
+                "with --session-id; pass either a run anchor or a session."
+            )
+            raise typer.Exit(_STATUS_RUN_EXIT_MALFORMED_INPUT)
+        execution_id = run_id
+
+    if session_id is None and execution_id is None:
+        print_error(
+            "Run projection failed: a RUN_ID (execution anchor), "
+            "--execution-id, or --session-id is required."
+        )
+        raise typer.Exit(_STATUS_RUN_EXIT_MALFORMED_INPUT)
 
     arguments: dict[str, Any] = {}
     if session_id is not None:
@@ -154,8 +209,11 @@ def run_projection(
 
     result = asyncio.run(ProjectionQueryHandler().handle(arguments))
     if result.is_err:
-        print_error(f"Run projection failed: {result.error}")
-        raise typer.Exit(1)
+        message = str(result.error)
+        print_error(f"Run projection failed: {message}")
+        if _is_unknown_run_error(message):
+            raise typer.Exit(_STATUS_RUN_EXIT_UNKNOWN_RUN)
+        raise typer.Exit(_STATUS_RUN_EXIT_GENERIC_ERROR)
 
     tool_result = result.value
     if json_output:

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -364,13 +364,15 @@ class TestStatusRunProjectionCommand:
             from ouroboros.core.types import Result
             from ouroboros.mcp.errors import MCPToolError
 
-            return Result.err(MCPToolError("session_id or execution_id is required"))
+            return Result.err(MCPToolError("projection backend exploded"))
 
         with patch("ouroboros.cli.commands.status.ProjectionQueryHandler.handle", fake_handle):
-            result = runner.invoke(app, ["status", "run", "--json"])
+            result = runner.invoke(app, ["status", "run", "--execution-id", "exec_x", "--json"])
 
+        # Handler-side errors that are not the dedicated "unknown run" path
+        # remain on exit code 1 — see Wave-1 #946 S2 exit-code contract.
         assert result.exit_code == 1
-        assert "session_id or execution_id is required" in result.output
+        assert "projection backend exploded" in result.output
 
 
 class TestWorkflowIRCommands:

--- a/tests/unit/cli/test_status_run.py
+++ b/tests/unit/cli/test_status_run.py
@@ -1,0 +1,186 @@
+"""Tests for ``ouroboros status run`` — Wave-1 #946 S2 thin CLI surface.
+
+These tests pin the contract that the CLI is a thin wrapper over
+``ouroboros_query_projection``:
+
+* The same arguments produce byte-identical JSON between the MCP handler
+  and the CLI ``--json`` output (golden test).
+* Exit codes follow the documented convention: ``0`` for success, ``2``
+  for an unknown run anchor, ``64`` for malformed input.
+* The positional ``RUN_ID`` argument is shorthand for ``--execution-id``.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from ouroboros.cli.main import app
+from ouroboros.core.types import Result
+from ouroboros.mcp.errors import MCPToolError
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+
+runner = CliRunner(env={"COLUMNS": "240"})
+
+
+def _golden_meta(run_id: str = "run_golden", execution_id: str = "exec_golden") -> dict:
+    """Build a representative projection meta payload for golden comparisons."""
+
+    return {
+        "session_id": None,
+        "execution_id": execution_id,
+        "seed_id": "seed_golden",
+        "seed_id_source": "event",
+        "event_count": 3,
+        "limit": None,
+        "run": {
+            "run_id": run_id,
+            "seed_id": "seed_golden",
+            "goal": "Golden goal",
+            "schema_version": 1,
+        },
+        "stages": [
+            {
+                "stage_id": "stage_golden",
+                "run_id": run_id,
+                "kind": "execute",
+            }
+        ],
+        "steps": [
+            {
+                "step_id": "step_golden",
+                "run_id": run_id,
+                "stage_id": "stage_golden",
+                "kind": "tool_call",
+                "name": "shell",
+                "ok": True,
+            }
+        ],
+        "artifacts": [],
+        "verdicts": [],
+    }
+
+
+class _RecordingHandler:
+    """Stand-in for ``ProjectionQueryHandler`` that records call args."""
+
+    def __init__(self, result: Result):
+        self.result = result
+        self.last_arguments: dict | None = None
+
+
+def _patched_runner(handler: _RecordingHandler):
+    async def fake_handle(_self, arguments):  # noqa: D401 - test double
+        handler.last_arguments = dict(arguments)
+        return handler.result
+
+    return patch(
+        "ouroboros.cli.commands.status.ProjectionQueryHandler.handle",
+        fake_handle,
+    )
+
+
+def test_status_run_json_matches_mcp_handler_output() -> None:
+    """Golden test: CLI ``--json`` must reproduce the MCP meta payload exactly."""
+
+    meta = _golden_meta()
+    mcp_payload = MCPToolResult(
+        content=(MCPContentItem(type=ContentType.TEXT, text="Run Projection\nRun: run_golden"),),
+        meta=meta,
+    )
+    handler = _RecordingHandler(Result.ok(mcp_payload))
+
+    with _patched_runner(handler):
+        result = runner.invoke(
+            app,
+            ["status", "run", "exec_golden", "--json"],
+        )
+
+    assert result.exit_code == 0
+    parsed = json.loads(result.output)
+    assert parsed == meta
+    # The CLI must serialize via the same key ordering it documents.
+    assert result.output.rstrip("\n") == json.dumps(meta, indent=2, sort_keys=True)
+
+
+def test_status_run_positional_maps_to_execution_id() -> None:
+    """The positional ``RUN_ID`` is shorthand for ``--execution-id``."""
+
+    mcp_payload = MCPToolResult(content=(), meta=_golden_meta())
+    handler = _RecordingHandler(Result.ok(mcp_payload))
+
+    with _patched_runner(handler):
+        result = runner.invoke(app, ["status", "run", "exec_golden", "--json"])
+
+    assert result.exit_code == 0
+    assert handler.last_arguments == {"execution_id": "exec_golden"}
+
+
+def test_status_run_unknown_run_id_exits_with_code_2() -> None:
+    """Unknown run anchors map to exit code ``2``."""
+
+    handler = _RecordingHandler(Result.err(MCPToolError("No events found for projection query")))
+
+    with _patched_runner(handler):
+        result = runner.invoke(app, ["status", "run", "exec_missing", "--json"])
+
+    assert result.exit_code == 2
+    assert "No events found" in result.output
+
+
+def test_status_run_missing_selector_exits_with_code_64() -> None:
+    """Malformed input (no selector at all) maps to exit code ``64``."""
+
+    result = runner.invoke(app, ["status", "run", "--json"])
+
+    assert result.exit_code == 64
+    assert "required" in result.output.lower()
+
+
+def test_status_run_conflicting_selectors_exit_with_code_64() -> None:
+    """RUN_ID combined with --session-id is malformed input."""
+
+    result = runner.invoke(
+        app,
+        ["status", "run", "exec_golden", "--session-id", "session_xyz", "--json"],
+    )
+
+    assert result.exit_code == 64
+    assert "session" in result.output.lower()
+
+
+def test_status_run_conflicting_execution_id_exits_with_code_64() -> None:
+    """RUN_ID and a different --execution-id must be flagged as malformed."""
+
+    result = runner.invoke(
+        app,
+        [
+            "status",
+            "run",
+            "exec_golden",
+            "--execution-id",
+            "exec_other",
+            "--json",
+        ],
+    )
+
+    assert result.exit_code == 64
+    assert "different" in result.output.lower()
+
+
+def test_status_run_session_id_only_still_supported() -> None:
+    """Legacy ``--session-id`` invocations remain valid (no positional)."""
+
+    mcp_payload = MCPToolResult(content=(), meta=_golden_meta())
+    handler = _RecordingHandler(Result.ok(mcp_payload))
+
+    with _patched_runner(handler):
+        result = runner.invoke(
+            app,
+            ["status", "run", "--session-id", "session_legacy", "--json"],
+        )
+
+    assert result.exit_code == 0
+    assert handler.last_arguments == {"session_id": "session_legacy"}


### PR DESCRIPTION
## Slot

#946 Wave-1 **S2** — *Status JSON CLI* follow-up from
`docs/agentos/projection-followups.md`.

## Summary

- Extends `ouroboros status run` with an optional positional `RUN_ID`
  argument (treated as the execution anchor, mirroring how stable run IDs
  are derived from execution events in projection-v1).
- Pins the Wave-1 exit-code contract: `0` ok, `2` unknown run anchor,
  `64` malformed input. Generic handler failures remain on `1` so existing
  callers that special-case generic failure keep working.
- Reuses the existing `ouroboros_query_projection` MCP handler unchanged.
  No caching, no writes, no new query semantics.

## Scope boundary

In-scope (per `docs/agentos/projection-v1-scope.md` /
`docs/agentos/projection-followups.md`):

- Thin CLI surface over the existing read-only projection query.
- Documented exit codes in `docs/cli-reference.md`.
- Golden test that pins byte-identical `--json` output between the MCP
  handler meta payload and the CLI.

Out-of-scope (deliberately):

- TUI / pretty-printing without `--json`.
- Projection caching, writes, or new query semantics.
- Any change to the MCP handler.

## Test plan

- [x] `python -m pytest tests/unit/cli/ -q` — 932 passed locally.
- [x] New file `tests/unit/cli/test_status_run.py` covering:
  - Golden test: `--json` output equals `json.dumps(meta, indent=2, sort_keys=True)` from the patched MCP handler.
  - Positional `RUN_ID` maps to `--execution-id` in handler arguments.
  - Unknown anchor (`No events found …`) → exit code `2`.
  - Missing selector / `RUN_ID` + `--session-id` / `RUN_ID` + conflicting `--execution-id` → exit code `64`.
  - Legacy `--session-id` invocation still works.
- [x] Existing `test_status_run_reports_projection_errors` updated to
  exercise a real handler-side error (exit code `1`) now that malformed
  input is caught up-front.

## Refs

Refs #1131, #946.