### PR TITLE
feat(orchestrator): record durable workflow lifecycle events

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -111,6 +111,58 @@ Emitted periodically during execution with runtime progress.
 | `progress` | `object` | Nested progress state (structure varies by runtime) |
 | `progress.runtime_status` | `string?` | Runtime-reported status when available |
 
+### workflow.run.created / completed / failed / cancelled
+
+Durable lifecycle events for #956 Workflow IR runs. All events share the
+``workflow_ir`` aggregate type and use ``WorkflowSpec.spec_id`` as
+``aggregate_id``. See ``docs/agentos/workflow-ir-v1.md`` for the boundary
+contract; ``#1131`` adds the durable lifecycle family on top.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workflow_id` | `string` | ``WorkflowSpec.spec_id`` (mirrors ``aggregate_id``) |
+| `schema_version` | `int` | Lifecycle schema version (currently `1`) |
+| `timestamp` | `string` | ISO 8601 UTC timestamp |
+| `reason_code` | `string?` | Required on `run.failed` and `run.cancelled` |
+| `refs` | `string[]?` | Bounded ``ControlContract`` / ``IOJournal`` ids — never raw payload |
+
+### workflow.node.scheduled / started / completed / failed / retried
+
+Per-node lifecycle records anchored to a ``WorkflowNode.node_id``.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `workflow_id` | `string` | ``WorkflowSpec.spec_id`` (mirrors ``aggregate_id``) |
+| `node_id` | `string` | ``WorkflowNode.node_id`` |
+| `attempt` | `int?` | Node attempt number (>= 1); absent on run-level events |
+| `reason_code` | `string?` | Required on `node.failed` and `node.retried` |
+| `data` | `object?` | Bounded, redacted hints — raw prompt/stdout/stderr/credentials are rejected by validation |
+
+### workflow.edge.traversed
+
+Records that an ``WorkflowEdge.edge_id`` was traversed during execution.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `edge_id` | `string` | ``WorkflowEdge.edge_id`` |
+| `attempt` | `int?` | Source node attempt at traversal time |
+
+### workflow.checkpoint.saved
+
+Links a checkpoint save to its ``CheckpointStore`` reference ids.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `refs` | `string[]` | One or more bounded checkpoint references |
+
+The lifecycle family is registered on the EventStore via
+``append_workflow_lifecycle_event`` / ``replay_workflow_lifecycle``. No
+existing event family is modified. Payloads are size-bounded
+(``MAX_WORKFLOW_LIFECYCLE_DATA_BYTES``) and reject replay-unsafe keys
+(``stdout``, ``stderr``, ``prompt``, ``api_key``, ``token`` and similar
+secret/raw-output names) so durable lifecycle history can be replayed
+without leaking raw payload material.
+
 ## Adding new event types
 
 When introducing a new event type:

--- a/docs/events.md
+++ b/docs/events.md
@@ -116,7 +116,7 @@ Emitted periodically during execution with runtime progress.
 Durable lifecycle events for #956 Workflow IR runs. All events share the
 ``workflow_ir`` aggregate type and use ``WorkflowSpec.spec_id`` as
 ``aggregate_id``. See ``docs/agentos/workflow-ir-v1.md`` for the boundary
-contract; ``#1131`` adds the durable lifecycle family on top.
+contract; ``#1134`` adds the durable lifecycle family on top.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -158,10 +158,10 @@ Links a checkpoint save to its ``CheckpointStore`` reference ids.
 The lifecycle family is registered on the EventStore via
 ``append_workflow_lifecycle_event`` / ``replay_workflow_lifecycle``. No
 existing event family is modified. Payloads are size-bounded
-(``MAX_WORKFLOW_LIFECYCLE_DATA_BYTES``) and reject replay-unsafe keys
-(``stdout``, ``stderr``, ``prompt``, ``api_key``, ``token`` and similar
-secret/raw-output names) so durable lifecycle history can be replayed
-without leaking raw payload material.
+(``MAX_WORKFLOW_LIFECYCLE_DATA_BYTES``), refs are count/per-ref/serialized
+size-bounded, and both reject replay-unsafe names (``stdout``, ``stderr``,
+``prompt``, ``api_key``, ``token`` and similar secret/raw-output names) so
+durable lifecycle history can be replayed without leaking raw payload material.
 
 ## Adding new event types
 

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -28,6 +28,9 @@ from ouroboros.orchestrator.workflow_ir import (
 
 WORKFLOW_LIFECYCLE_SCHEMA_VERSION: Final[int] = 1
 MAX_WORKFLOW_LIFECYCLE_DATA_BYTES: Final[int] = 8192
+MAX_WORKFLOW_LIFECYCLE_REF_COUNT: Final[int] = 16
+MAX_WORKFLOW_LIFECYCLE_REF_BYTES: Final[int] = 512
+MAX_WORKFLOW_LIFECYCLE_REFS_BYTES: Final[int] = 4096
 
 WORKFLOW_LIFECYCLE_AGGREGATE_TYPE: Final[str] = "workflow_ir"
 """EventStore aggregate-type bucket for #956 Workflow IR lifecycle events.
@@ -168,8 +171,21 @@ _EVENT_SORT_ORDER: Final[dict[WorkflowLifecycleEventType, int]] = {
 }
 
 
-def _event_sort_key(event: WorkflowLifecycleEvent) -> tuple[datetime, int, str]:
-    return (event.timestamp, _EVENT_SORT_ORDER[event.event_type], event.event_type.value)
+def _event_sort_key(
+    event: WorkflowLifecycleEvent,
+) -> tuple[datetime, int, str, str, str, str, int, str, tuple[str, ...], str]:
+    return (
+        event.timestamp,
+        _EVENT_SORT_ORDER[event.event_type],
+        event.event_type.value,
+        event.workflow_id,
+        event.node_id or "",
+        event.edge_id or "",
+        event.attempt or 0,
+        event.reason_code or "",
+        event.refs,
+        _canonical_json(event.data),
+    )
 
 
 def _run_boundary_group_order(
@@ -332,6 +348,27 @@ def _is_replay_unsafe_key(key: str) -> bool:
     return normalized in _REPLAY_UNSAFE_KEYS or normalized.endswith(_REPLAY_UNSAFE_SUFFIXES)
 
 
+def _canonical_json(value: Any) -> str:
+    if isinstance(value, Mapping):
+        value = {key: json.loads(_canonical_json(item)) for key, item in value.items()}
+    elif isinstance(value, tuple):
+        value = [json.loads(_canonical_json(item)) for item in value]
+    return json.dumps(value, allow_nan=False, separators=(",", ":"), sort_keys=True)
+
+
+def _is_replay_unsafe_ref(ref: str) -> bool:
+    normalized = ref.strip().lower()
+    tokenized = "".join(character if character.isalnum() else "_" for character in normalized)
+    tokens = tuple(token for token in tokenized.split("_") if token)
+    candidates = {tokenized, *tokens}
+    candidates.update(
+        "_".join(tokens[start:end])
+        for start in range(len(tokens))
+        for end in range(start + 1, len(tokens) + 1)
+    )
+    return any(_is_replay_unsafe_key(candidate) for candidate in candidates)
+
+
 def _normalize_json_value(name: str, value: Any, path: str) -> JsonValue:
     if value is None or isinstance(value, str | int | bool):
         return value
@@ -380,7 +417,7 @@ def _normalize_data(value: Mapping[str, Any]) -> Mapping[str, FrozenJsonValue]:
         msg = "Workflow lifecycle data must be a mapping"
         raise TypeError(msg)
     normalized = _normalize_json_value("data", value, "data")
-    encoded = json.dumps(normalized, allow_nan=False, separators=(",", ":")).encode("utf-8")
+    encoded = _canonical_json(normalized).encode("utf-8")
     if len(encoded) > MAX_WORKFLOW_LIFECYCLE_DATA_BYTES:
         msg = f"Workflow lifecycle data exceeds {MAX_WORKFLOW_LIFECYCLE_DATA_BYTES} bytes"
         raise ValueError(msg)
@@ -395,12 +432,26 @@ def _normalize_refs(values: Iterable[str]) -> tuple[str, ...]:
     normalized: list[str] = []
     seen: set[str] = set()
     for index, value in enumerate(values):
+        if index >= MAX_WORKFLOW_LIFECYCLE_REF_COUNT:
+            msg = f"Workflow lifecycle refs exceed {MAX_WORKFLOW_LIFECYCLE_REF_COUNT} entries"
+            raise ValueError(msg)
         ref = _normalize_non_blank(f"refs[{index}]", value)
+        ref_bytes = ref.encode("utf-8")
+        if len(ref_bytes) > MAX_WORKFLOW_LIFECYCLE_REF_BYTES:
+            msg = f"Workflow lifecycle ref exceeds {MAX_WORKFLOW_LIFECYCLE_REF_BYTES} bytes"
+            raise ValueError(msg)
+        if _is_replay_unsafe_ref(ref):
+            msg = f"Workflow lifecycle refs must not persist replay-unsafe ref {ref!r}"
+            raise ValueError(msg)
         if ref in seen:
             msg = f"Workflow lifecycle refs must be unique: {ref!r}"
             raise ValueError(msg)
         seen.add(ref)
         normalized.append(ref)
+    encoded = _canonical_json(normalized).encode("utf-8")
+    if len(encoded) > MAX_WORKFLOW_LIFECYCLE_REFS_BYTES:
+        msg = f"Workflow lifecycle refs exceed {MAX_WORKFLOW_LIFECYCLE_REFS_BYTES} bytes"
+        raise ValueError(msg)
     return tuple(normalized)
 
 
@@ -1043,6 +1094,9 @@ def project_workflow_lifecycle(
 
 __all__ = [
     "MAX_WORKFLOW_LIFECYCLE_DATA_BYTES",
+    "MAX_WORKFLOW_LIFECYCLE_REF_BYTES",
+    "MAX_WORKFLOW_LIFECYCLE_REF_COUNT",
+    "MAX_WORKFLOW_LIFECYCLE_REFS_BYTES",
     "WORKFLOW_LIFECYCLE_AGGREGATE_TYPE",
     "WORKFLOW_LIFECYCLE_EVENT_TYPES",
     "WORKFLOW_LIFECYCLE_SCHEMA_VERSION",

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -29,6 +29,16 @@ from ouroboros.orchestrator.workflow_ir import (
 WORKFLOW_LIFECYCLE_SCHEMA_VERSION: Final[int] = 1
 MAX_WORKFLOW_LIFECYCLE_DATA_BYTES: Final[int] = 8192
 
+WORKFLOW_LIFECYCLE_AGGREGATE_TYPE: Final[str] = "workflow_ir"
+"""EventStore aggregate-type bucket for #956 Workflow IR lifecycle events.
+
+This is the durable event-family anchor that pairs with
+``WorkflowLifecycleEvent.to_base_event()``. It is intentionally distinct
+from the runtime ``execution`` / ``session`` aggregates so existing event
+families are untouched and downstream projections can filter the
+lifecycle stream without scanning unrelated families.
+"""
+
 _REPLAY_UNSAFE_KEYS: Final[frozenset[str]] = frozenset(
     {
         "api_key",
@@ -103,6 +113,12 @@ class WorkflowRunLifecycleState(StrEnum):
     COMPLETED = "completed"
     FAILED = "failed"
     CANCELLED = "cancelled"
+
+
+WORKFLOW_LIFECYCLE_EVENT_TYPES: Final[frozenset[str]] = frozenset(
+    member.value for member in WorkflowLifecycleEventType
+)
+"""Stable set of event-type strings persisted by the lifecycle family."""
 
 
 _NODE_EVENT_TYPES: Final[frozenset[WorkflowLifecycleEventType]] = frozenset(
@@ -540,12 +556,58 @@ class WorkflowLifecycleEvent(BaseModel, frozen=True):
     def to_base_event(self) -> BaseEvent:
         return BaseEvent(
             type=self.event_type.value,
-            aggregate_type="workflow_ir",
+            aggregate_type=WORKFLOW_LIFECYCLE_AGGREGATE_TYPE,
             timestamp=self.timestamp,
             aggregate_id=self.aggregate_id,
             data=self.to_event_data(),
             event_version=self.schema_version,
         )
+
+    @classmethod
+    def from_base_event(cls, base: BaseEvent) -> WorkflowLifecycleEvent:
+        """Rehydrate a lifecycle event from a persisted ``BaseEvent``.
+
+        Foreign event families are rejected so callers can safely pass a
+        mixed EventStore replay and surface a clear error if a row is
+        misrouted.
+        """
+        if base.aggregate_type != WORKFLOW_LIFECYCLE_AGGREGATE_TYPE:
+            msg = (
+                "BaseEvent is not from the workflow lifecycle family: "
+                f"aggregate_type={base.aggregate_type!r}"
+            )
+            raise ValueError(msg)
+        if base.type not in WORKFLOW_LIFECYCLE_EVENT_TYPES:
+            msg = f"BaseEvent type {base.type!r} is not a workflow lifecycle event type"
+            raise ValueError(msg)
+
+        payload = dict(base.data)
+        payload.pop("workflow_id", None)
+        payload.pop("schema_version", None)
+        payload.pop("timestamp", None)
+        timestamp = base.timestamp
+        if isinstance(timestamp, datetime) and (
+            timestamp.tzinfo is None or timestamp.utcoffset() is None
+        ):
+            # ``BaseEvent`` is created from EventStore rows whose SQLite
+            # backend drops tzinfo on roundtrip. Lifecycle events are
+            # canonically UTC, so reattach UTC before re-validating.
+            timestamp = timestamp.replace(tzinfo=UTC)
+        kwargs: dict[str, Any] = {
+            "event_type": WorkflowLifecycleEventType(base.type),
+            "workflow_id": base.aggregate_id,
+            "schema_version": base.event_version or WORKFLOW_LIFECYCLE_SCHEMA_VERSION,
+            "timestamp": timestamp,
+        }
+        for key in ("node_id", "edge_id", "attempt", "reason_code"):
+            if key in payload:
+                kwargs[key] = payload[key]
+        refs = payload.get("refs")
+        if refs is not None:
+            kwargs["refs"] = tuple(refs) if not isinstance(refs, tuple) else refs
+        if "data" in payload and payload["data"] is not None:
+            kwargs["data"] = payload["data"]
+        return cls(**kwargs)
 
 
 def lifecycle_event_for_spec(
@@ -853,18 +915,150 @@ def validate_workflow_lifecycle_conformance(
     )
 
 
+class WorkflowEdgeTraversalRecord(BaseModel, frozen=True):
+    """Projected record of a single edge traversal."""
+
+    edge_id: str
+    attempt: int | None = None
+    timestamp: datetime
+
+
+class WorkflowCheckpointRecord(BaseModel, frozen=True):
+    """Projected record of a single checkpoint save."""
+
+    refs: tuple[str, ...]
+    timestamp: datetime
+
+
+class WorkflowLifecycleProjection(BaseModel, frozen=True):
+    """Deterministic projection of a lifecycle event slice.
+
+    The projection is intentionally bounded: it carries no raw payload,
+    only durable, replay-safe identifiers (``ControlContract`` /
+    ``CheckpointStore`` / ``IOJournal`` refs already live on
+    :class:`WorkflowLifecycleEvent`). Two replays of the same event slice
+    produce the same projection, modulo input ordering — see
+    :func:`project_workflow_lifecycle`.
+    """
+
+    workflow_id: str
+    run_state: WorkflowRunLifecycleState | None = None
+    terminal_reason_code: str | None = None
+    node_states: Mapping[str, WorkflowNodeLifecycleState] = Field(default_factory=dict)
+    node_attempts: Mapping[str, int] = Field(default_factory=dict)
+    traversed_edges: tuple[WorkflowEdgeTraversalRecord, ...] = Field(default_factory=tuple)
+    checkpoints: tuple[WorkflowCheckpointRecord, ...] = Field(default_factory=tuple)
+    event_count: int = 0
+
+    def is_terminal(self) -> bool:
+        return self.run_state in {
+            WorkflowRunLifecycleState.COMPLETED,
+            WorkflowRunLifecycleState.FAILED,
+            WorkflowRunLifecycleState.CANCELLED,
+        }
+
+
+def project_workflow_lifecycle(
+    workflow_id: str,
+    events: Iterable[WorkflowLifecycleEvent],
+) -> WorkflowLifecycleProjection:
+    """Deterministically project a lifecycle event slice into a summary.
+
+    The projection rebuilds the same lifecycle slice regardless of input
+    iteration order: events are filtered to ``workflow_id`` and sorted by
+    the same canonical key used elsewhere in this module.
+    """
+    workflow_id = _normalize_non_blank("workflow_id", workflow_id)
+    scoped = tuple(
+        sorted(
+            (event for event in events if event.workflow_id == workflow_id),
+            key=_event_sort_key,
+        )
+    )
+
+    node_states: dict[str, WorkflowNodeLifecycleState] = {}
+    node_attempts: dict[str, int] = {}
+    traversed_edges: list[WorkflowEdgeTraversalRecord] = []
+    checkpoints: list[WorkflowCheckpointRecord] = []
+    run_state: WorkflowRunLifecycleState | None = None
+    terminal_reason_code: str | None = None
+
+    for event in scoped:
+        if event.event_type is WorkflowLifecycleEventType.RUN_CREATED:
+            # Fresh run boundary resets the projection so a replay of a
+            # restart segment converges on the latest run only.
+            node_states = {}
+            node_attempts = {}
+            traversed_edges = []
+            checkpoints = []
+            run_state = WorkflowRunLifecycleState.CREATED
+            terminal_reason_code = None
+            continue
+        if event.event_type is WorkflowLifecycleEventType.RUN_COMPLETED:
+            run_state = WorkflowRunLifecycleState.COMPLETED
+            terminal_reason_code = event.reason_code
+            continue
+        if event.event_type is WorkflowLifecycleEventType.RUN_FAILED:
+            run_state = WorkflowRunLifecycleState.FAILED
+            terminal_reason_code = event.reason_code
+            continue
+        if event.event_type is WorkflowLifecycleEventType.RUN_CANCELLED:
+            run_state = WorkflowRunLifecycleState.CANCELLED
+            terminal_reason_code = event.reason_code
+            continue
+        if event.event_type in _NODE_EVENT_TYPES and event.node_id is not None:
+            node_states[event.node_id] = _NODE_STATE_BY_EVENT[event.event_type]
+            if event.attempt is not None:
+                node_attempts[event.node_id] = event.attempt
+            continue
+        if event.event_type is WorkflowLifecycleEventType.EDGE_TRAVERSED and event.edge_id:
+            traversed_edges.append(
+                WorkflowEdgeTraversalRecord(
+                    edge_id=event.edge_id,
+                    attempt=event.attempt,
+                    timestamp=event.timestamp,
+                )
+            )
+            continue
+        if event.event_type is WorkflowLifecycleEventType.CHECKPOINT_SAVED:
+            checkpoints.append(
+                WorkflowCheckpointRecord(
+                    refs=event.refs,
+                    timestamp=event.timestamp,
+                )
+            )
+            continue
+
+    return WorkflowLifecycleProjection(
+        workflow_id=workflow_id,
+        run_state=run_state,
+        terminal_reason_code=terminal_reason_code,
+        node_states=MappingProxyType(dict(node_states)),
+        node_attempts=MappingProxyType(dict(node_attempts)),
+        traversed_edges=tuple(traversed_edges),
+        checkpoints=tuple(checkpoints),
+        event_count=len(scoped),
+    )
+
+
 __all__ = [
     "MAX_WORKFLOW_LIFECYCLE_DATA_BYTES",
+    "WORKFLOW_LIFECYCLE_AGGREGATE_TYPE",
+    "WORKFLOW_LIFECYCLE_EVENT_TYPES",
     "WORKFLOW_LIFECYCLE_SCHEMA_VERSION",
+    "WorkflowCheckpointRecord",
     "WorkflowConformanceIssue",
     "WorkflowConformanceReport",
+    "WorkflowEdgeTraversalRecord",
     "WorkflowLifecycleEvent",
     "WorkflowLifecycleEventType",
+    "WorkflowLifecycleProjection",
     "WorkflowNodeLifecycleState",
     "WorkflowRunLifecycleState",
     "completed_node_ids",
     "effective_node_states",
     "lifecycle_event_for_spec",
     "next_runnable_node_ids",
+    "project_workflow_lifecycle",
     "validate_workflow_lifecycle_conformance",
 ]

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -1035,6 +1035,83 @@ class EventStore:
                 details={"event_type": "lineage.created"},
             ) from e
 
+    async def append_workflow_lifecycle_event(
+        self,
+        lifecycle_event: Any,
+    ) -> None:
+        """Append a workflow IR lifecycle event to the durable event family.
+
+        This is an additive registration of the #956 workflow lifecycle
+        event family. The helper accepts a
+        ``WorkflowLifecycleEvent`` and persists it through the existing
+        :meth:`append` path so no new database column or table is
+        introduced. The event is routed under the
+        ``WORKFLOW_LIFECYCLE_AGGREGATE_TYPE`` aggregate, leaving all other
+        event families untouched.
+
+        Args:
+            lifecycle_event: A
+                :class:`ouroboros.orchestrator.workflow_lifecycle.WorkflowLifecycleEvent`.
+                Imported lazily to avoid an import cycle between
+                ``persistence`` and ``orchestrator``.
+
+        Raises:
+            PersistenceError: If the append operation fails.
+        """
+        from ouroboros.orchestrator.workflow_lifecycle import (
+            WORKFLOW_LIFECYCLE_AGGREGATE_TYPE,
+            WORKFLOW_LIFECYCLE_EVENT_TYPES,
+            WorkflowLifecycleEvent,
+        )
+
+        if not isinstance(lifecycle_event, WorkflowLifecycleEvent):
+            raise PersistenceError(
+                "append_workflow_lifecycle_event requires a WorkflowLifecycleEvent.",
+                operation="append_workflow_lifecycle_event",
+                details={"received_type": type(lifecycle_event).__name__},
+            )
+
+        base_event = lifecycle_event.to_base_event()
+        # Defensive registration check: every persisted lifecycle row
+        # belongs to the workflow IR family and uses a registered event
+        # type. Foreign or unknown event types must be rejected before
+        # they reach the existing event-store sanitization layer.
+        if base_event.aggregate_type != WORKFLOW_LIFECYCLE_AGGREGATE_TYPE:
+            raise PersistenceError(
+                "Workflow lifecycle event has an unexpected aggregate_type.",
+                operation="append_workflow_lifecycle_event",
+                details={
+                    "expected": WORKFLOW_LIFECYCLE_AGGREGATE_TYPE,
+                    "received": base_event.aggregate_type,
+                },
+            )
+        if base_event.type not in WORKFLOW_LIFECYCLE_EVENT_TYPES:
+            raise PersistenceError(
+                "Workflow lifecycle event_type is not registered.",
+                operation="append_workflow_lifecycle_event",
+                details={"event_type": base_event.type},
+            )
+        await self.append(base_event)
+
+    async def replay_workflow_lifecycle(
+        self,
+        workflow_id: str,
+    ) -> list[Any]:
+        """Replay durable workflow lifecycle events for a workflow id.
+
+        Returns a list of
+        :class:`ouroboros.orchestrator.workflow_lifecycle.WorkflowLifecycleEvent`
+        instances rehydrated from persisted ``BaseEvent`` rows. Other
+        event families are not consulted.
+        """
+        from ouroboros.orchestrator.workflow_lifecycle import (
+            WORKFLOW_LIFECYCLE_AGGREGATE_TYPE,
+            WorkflowLifecycleEvent,
+        )
+
+        base_events = await self.replay(WORKFLOW_LIFECYCLE_AGGREGATE_TYPE, workflow_id)
+        return [WorkflowLifecycleEvent.from_base_event(base) for base in base_events]
+
     async def replay_lineage(self, lineage_id: str) -> list[BaseEvent]:
         """Replay all events for a lineage aggregate.
 

--- a/tests/unit/orchestrator/test_workflow_lifecycle_events.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_events.py
@@ -33,6 +33,8 @@ from ouroboros.orchestrator.workflow_ir import (
 )
 from ouroboros.orchestrator.workflow_lifecycle import (
     MAX_WORKFLOW_LIFECYCLE_DATA_BYTES,
+    MAX_WORKFLOW_LIFECYCLE_REF_BYTES,
+    MAX_WORKFLOW_LIFECYCLE_REF_COUNT,
     WORKFLOW_LIFECYCLE_AGGREGATE_TYPE,
     WORKFLOW_LIFECYCLE_EVENT_TYPES,
     WorkflowLifecycleEvent,
@@ -422,6 +424,77 @@ def test_projection_is_deterministic_across_input_orderings() -> None:
     assert project_workflow_lifecycle(spec.spec_id, mixed) == canonical
 
 
+def test_projection_tie_breaks_same_timestamp_node_attempts() -> None:
+    spec = _spec()
+    timestamp = _t(1)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=_t(0),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=2,
+            refs=("control://contract/node-a/attempt-2",),
+            timestamp=timestamp,
+            data={"hint": "b"},
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=1,
+            refs=("control://contract/node-a/attempt-1",),
+            timestamp=timestamp,
+            data={"hint": "a"},
+        ),
+    )
+
+    canonical = project_workflow_lifecycle(spec.spec_id, events)
+
+    assert project_workflow_lifecycle(spec.spec_id, tuple(reversed(events))) == canonical
+    assert canonical.node_attempts["node_a"] == 2
+
+
+def test_projection_tie_breaks_same_timestamp_edge_traversals() -> None:
+    spec = _spec()
+    timestamp = _t(1)
+    events = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=_t(0),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id=spec.spec_id,
+            edge_id="edge_b_end",
+            attempt=1,
+            refs=("io://journal/edge-b-end",),
+            timestamp=timestamp,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id=spec.spec_id,
+            edge_id="edge_a_b",
+            attempt=1,
+            refs=("io://journal/edge-a-b",),
+            timestamp=timestamp,
+        ),
+    )
+
+    canonical = project_workflow_lifecycle(spec.spec_id, events)
+
+    assert project_workflow_lifecycle(spec.spec_id, tuple(reversed(events))) == canonical
+    assert tuple(record.edge_id for record in canonical.traversed_edges) == (
+        "edge_a_b",
+        "edge_b_end",
+    )
+
+
 @pytest.mark.asyncio
 async def test_round_trip_through_event_store_rebuilds_identical_projection() -> None:
     spec = _spec()
@@ -483,6 +556,50 @@ def test_lifecycle_event_rejects_oversized_payload() -> None:
             workflow_id=spec.spec_id,
             node_id="node_a",
             data=payload,
+        )
+
+
+@pytest.mark.parametrize(
+    "refs",
+    [
+        tuple(
+            f"control://contract/ref-{index}"
+            for index in range(MAX_WORKFLOW_LIFECYCLE_REF_COUNT + 1)
+        ),
+        ("control://contract/" + ("x" * MAX_WORKFLOW_LIFECYCLE_REF_BYTES),),
+        tuple(
+            "control://contract/" + ("x" * (MAX_WORKFLOW_LIFECYCLE_REF_BYTES - 32)) + str(index)
+            for index in range(MAX_WORKFLOW_LIFECYCLE_REF_COUNT)
+        ),
+    ],
+)
+def test_lifecycle_event_rejects_oversized_refs(refs: tuple[str, ...]) -> None:
+    spec = _spec()
+    with pytest.raises(ValidationError, match="refs? exceed"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            refs=refs,
+        )
+
+
+@pytest.mark.parametrize(
+    "refs",
+    [
+        ("control://contract/raw-stdout/run-1",),
+        ("io://journal/raw_prompt/run-1",),
+        ("checkpoint://store/api_key/run-1",),
+        ("control://contract/password/value",),
+        ("io://journal/bearer-token/run-1",),
+    ],
+)
+def test_lifecycle_event_rejects_unsafe_refs(refs: tuple[str, ...]) -> None:
+    spec = _spec()
+    with pytest.raises(ValidationError, match="replay-unsafe ref"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            refs=refs,
         )
 
 

--- a/tests/unit/orchestrator/test_workflow_lifecycle_events.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_events.py
@@ -1,0 +1,541 @@
+"""Durable lifecycle-event tests for the #956 Workflow IR family.
+
+These tests pin the contract introduced by the #1131 / #956 wave-1 PR:
+durable workflow lifecycle events flow through the existing EventStore,
+replay roundtrips deterministically, and the event family stays
+bounded/redacted at the persistence boundary.
+
+Scope guardrails:
+
+* No live ``parallel_executor`` dispatch is exercised.
+* No other event family is created or mutated.
+* No raw prompt / stdout / stderr / credential is ever persisted; the
+  fixture asserts those are rejected at the model boundary.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import json
+
+from pydantic import ValidationError
+import pytest
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.orchestrator.workflow_ir import (
+    EdgeKind,
+    NodeKind,
+    NodeOwner,
+    SourceKind,
+    WorkflowEdge,
+    WorkflowNode,
+    WorkflowSpec,
+)
+from ouroboros.orchestrator.workflow_lifecycle import (
+    MAX_WORKFLOW_LIFECYCLE_DATA_BYTES,
+    WORKFLOW_LIFECYCLE_AGGREGATE_TYPE,
+    WORKFLOW_LIFECYCLE_EVENT_TYPES,
+    WorkflowLifecycleEvent,
+    WorkflowLifecycleEventType,
+    WorkflowLifecycleProjection,
+    WorkflowNodeLifecycleState,
+    WorkflowRunLifecycleState,
+    project_workflow_lifecycle,
+)
+from ouroboros.persistence.event_store import EventStore
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _task(node_id: str) -> WorkflowNode:
+    return WorkflowNode(
+        node_id=node_id,
+        kind=NodeKind.TASK,
+        owner=NodeOwner.AGENT,
+        input_schema_ref="schema://input.agent.v1",
+        evidence_schema_ref="schema://evidence.agent.v1",
+    )
+
+
+def _terminal(node_id: str = "end") -> WorkflowNode:
+    return WorkflowNode(node_id=node_id, kind=NodeKind.TERMINAL, owner=NodeOwner.HARNESS)
+
+
+def _spec() -> WorkflowSpec:
+    return WorkflowSpec(
+        spec_id="wfspec_durable",
+        source=SourceKind.SYNTHETIC,
+        nodes=(_task("node_a"), _task("node_b"), _terminal()),
+        edges=(
+            WorkflowEdge(edge_id="edge_a_b", source="node_a", target="node_b"),
+            WorkflowEdge(
+                edge_id="edge_b_end",
+                source="node_b",
+                target="end",
+                kind=EdgeKind.TERMINAL,
+            ),
+        ),
+    )
+
+
+def _t(offset_seconds: int) -> datetime:
+    return datetime(2026, 5, 19, tzinfo=UTC) + timedelta(seconds=offset_seconds)
+
+
+def _completed_run_events(spec: WorkflowSpec) -> tuple[WorkflowLifecycleEvent, ...]:
+    return (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=_t(0),
+            refs=("control://contract/run/completed", "io://journal/run/completed"),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_SCHEDULED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=1,
+            timestamp=_t(1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=1,
+            timestamp=_t(2),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=1,
+            timestamp=_t(3),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            workflow_id=spec.spec_id,
+            edge_id="edge_a_b",
+            attempt=1,
+            timestamp=_t(4),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_b",
+            attempt=1,
+            timestamp=_t(5),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.CHECKPOINT_SAVED,
+            workflow_id=spec.spec_id,
+            refs=("checkpoint://store/run/1",),
+            timestamp=_t(6),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_b",
+            attempt=1,
+            timestamp=_t(7),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+            workflow_id=spec.spec_id,
+            timestamp=_t(8),
+        ),
+    )
+
+
+def _failed_run_events(spec: WorkflowSpec) -> tuple[WorkflowLifecycleEvent, ...]:
+    return (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=_t(0),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=1,
+            timestamp=_t(1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_FAILED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=1,
+            reason_code="tool_timeout",
+            timestamp=_t(2),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_FAILED,
+            workflow_id=spec.spec_id,
+            reason_code="node_failure",
+            timestamp=_t(3),
+        ),
+    )
+
+
+def _retried_run_events(spec: WorkflowSpec) -> tuple[WorkflowLifecycleEvent, ...]:
+    return (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=_t(0),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_STARTED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=1,
+            timestamp=_t(1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_FAILED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=1,
+            reason_code="tool_timeout",
+            timestamp=_t(2),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_RETRIED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=2,
+            reason_code="bounded_retry",
+            timestamp=_t(3),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=2,
+            timestamp=_t(4),
+        ),
+    )
+
+
+def _cancelled_run_events(spec: WorkflowSpec) -> tuple[WorkflowLifecycleEvent, ...]:
+    return (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=_t(0),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_SCHEDULED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            attempt=1,
+            timestamp=_t(1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CANCELLED,
+            workflow_id=spec.spec_id,
+            reason_code="user_cancelled",
+            timestamp=_t(2),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Family registration / EventStore wiring
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_lifecycle_family_registration_constants() -> None:
+    assert WORKFLOW_LIFECYCLE_AGGREGATE_TYPE == "workflow_ir"
+    expected = {
+        "workflow.run.created",
+        "workflow.run.completed",
+        "workflow.run.failed",
+        "workflow.run.cancelled",
+        "workflow.node.scheduled",
+        "workflow.node.started",
+        "workflow.node.completed",
+        "workflow.node.failed",
+        "workflow.node.retried",
+        "workflow.edge.traversed",
+        "workflow.checkpoint.saved",
+    }
+    assert expected == WORKFLOW_LIFECYCLE_EVENT_TYPES
+
+
+def test_lifecycle_event_round_trips_through_base_event() -> None:
+    spec = _spec()
+    event = WorkflowLifecycleEvent(
+        event_type=WorkflowLifecycleEventType.NODE_RETRIED,
+        workflow_id=spec.spec_id,
+        node_id="node_a",
+        attempt=2,
+        reason_code="bounded_retry",
+        refs=("control://contract/run/1",),
+        timestamp=_t(3),
+        data={"hint": "retry"},
+    )
+    base = event.to_base_event()
+    rehydrated = WorkflowLifecycleEvent.from_base_event(base)
+    assert rehydrated == event
+    base_payload = base.to_db_dict()
+    rehydrated_payload = rehydrated.to_base_event().to_db_dict()
+    # Identity ids are random per BaseEvent; compare the durable fields.
+    base_payload.pop("id", None)
+    rehydrated_payload.pop("id", None)
+    assert rehydrated_payload == base_payload
+
+
+def test_from_base_event_rejects_foreign_family() -> None:
+    foreign = BaseEvent(
+        type="orchestrator.session.started",
+        aggregate_type="session",
+        aggregate_id="sess-1",
+        data={"execution_id": "exec-1"},
+    )
+    with pytest.raises(ValueError, match="not from the workflow lifecycle family"):
+        WorkflowLifecycleEvent.from_base_event(foreign)
+
+
+def test_from_base_event_rejects_unregistered_event_type() -> None:
+    rogue = BaseEvent(
+        type="workflow.node.unknown",
+        aggregate_type=WORKFLOW_LIFECYCLE_AGGREGATE_TYPE,
+        aggregate_id="wfspec_durable",
+        data={"workflow_id": "wfspec_durable"},
+    )
+    with pytest.raises(ValueError, match="not a workflow lifecycle event type"):
+        WorkflowLifecycleEvent.from_base_event(rogue)
+
+
+@pytest.mark.asyncio
+async def test_event_store_records_and_replays_lifecycle_family() -> None:
+    spec = _spec()
+    events = _completed_run_events(spec)
+
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    try:
+        for event in events:
+            await store.append_workflow_lifecycle_event(event)
+
+        replayed = await store.replay_workflow_lifecycle(spec.spec_id)
+        assert replayed == list(events)
+
+        # Other event families must remain untouched: an unrelated session
+        # event coexists without being returned by the workflow lifecycle
+        # replay.
+        session_event = BaseEvent(
+            type="orchestrator.session.started",
+            aggregate_type="session",
+            aggregate_id="sess-x",
+            data={"execution_id": "exec-x", "seed_id": "seed-x"},
+        )
+        await store.append(session_event)
+        again = await store.replay_workflow_lifecycle(spec.spec_id)
+        assert again == list(events)
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_event_store_helper_rejects_non_lifecycle_event() -> None:
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    try:
+        with pytest.raises(Exception, match="requires a WorkflowLifecycleEvent"):
+            await store.append_workflow_lifecycle_event(object())
+    finally:
+        await store.close()
+
+
+# ---------------------------------------------------------------------------
+# Replay fixture: distinguishes completed / failed / retried / cancelled
+# ---------------------------------------------------------------------------
+
+
+def test_replay_distinguishes_completed_failed_retried_cancelled() -> None:
+    spec = _spec()
+
+    completed = project_workflow_lifecycle(spec.spec_id, _completed_run_events(spec))
+    failed = project_workflow_lifecycle(spec.spec_id, _failed_run_events(spec))
+    retried = project_workflow_lifecycle(spec.spec_id, _retried_run_events(spec))
+    cancelled = project_workflow_lifecycle(spec.spec_id, _cancelled_run_events(spec))
+
+    assert completed.run_state is WorkflowRunLifecycleState.COMPLETED
+    assert completed.is_terminal()
+    assert completed.node_states["node_a"] is WorkflowNodeLifecycleState.COMPLETED
+    assert completed.node_states["node_b"] is WorkflowNodeLifecycleState.COMPLETED
+    assert tuple(record.edge_id for record in completed.traversed_edges) == ("edge_a_b",)
+    assert tuple(record.refs for record in completed.checkpoints) == (
+        ("checkpoint://store/run/1",),
+    )
+
+    assert failed.run_state is WorkflowRunLifecycleState.FAILED
+    assert failed.terminal_reason_code == "node_failure"
+    assert failed.node_states["node_a"] is WorkflowNodeLifecycleState.FAILED
+    assert failed.is_terminal()
+
+    # Retried run is not terminal yet — the most recent retry attempt
+    # completed but the run itself never received a terminal event.
+    assert retried.run_state is WorkflowRunLifecycleState.CREATED
+    assert not retried.is_terminal()
+    assert retried.node_states["node_a"] is WorkflowNodeLifecycleState.COMPLETED
+    assert retried.node_attempts["node_a"] == 2
+
+    assert cancelled.run_state is WorkflowRunLifecycleState.CANCELLED
+    assert cancelled.terminal_reason_code == "user_cancelled"
+    assert cancelled.is_terminal()
+
+
+# ---------------------------------------------------------------------------
+# Deterministic rebuild from the same event slice
+# ---------------------------------------------------------------------------
+
+
+def test_projection_is_deterministic_across_input_orderings() -> None:
+    spec = _spec()
+    events = _completed_run_events(spec)
+    canonical = project_workflow_lifecycle(spec.spec_id, events)
+
+    # Shuffle a few permutations: reversed and event-type-sorted. Both
+    # must converge to the same projection because the function sorts
+    # by the canonical key. Duplicate inputs are intentionally NOT
+    # exercised here — they are a different event slice and would
+    # legitimately change ``event_count``.
+    permutations: tuple[tuple[WorkflowLifecycleEvent, ...], ...] = (
+        tuple(reversed(events)),
+        tuple(sorted(events, key=lambda event: event.event_type.value)),
+    )
+    for permutation in permutations:
+        assert project_workflow_lifecycle(spec.spec_id, permutation) == canonical
+
+    # Foreign workflow ids in the same slice are ignored.
+    foreign = WorkflowLifecycleEvent(
+        event_type=WorkflowLifecycleEventType.RUN_CREATED,
+        workflow_id="wfspec_other",
+        timestamp=_t(100),
+    )
+    mixed = events + (foreign,)
+    assert project_workflow_lifecycle(spec.spec_id, mixed) == canonical
+
+
+@pytest.mark.asyncio
+async def test_round_trip_through_event_store_rebuilds_identical_projection() -> None:
+    spec = _spec()
+    events = _completed_run_events(spec)
+    expected = project_workflow_lifecycle(spec.spec_id, events)
+
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    try:
+        for event in events:
+            await store.append_workflow_lifecycle_event(event)
+        replayed = await store.replay_workflow_lifecycle(spec.spec_id)
+    finally:
+        await store.close()
+
+    rebuilt = project_workflow_lifecycle(spec.spec_id, replayed)
+    assert rebuilt == expected
+    assert isinstance(rebuilt, WorkflowLifecycleProjection)
+
+
+# ---------------------------------------------------------------------------
+# Bounded / redacted payload contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"stdout": "hello"},
+        {"stderr": "boom"},
+        {"prompt": "leak"},
+        {"raw_prompt": "leak"},
+        {"raw_stdout": "leak"},
+        {"api_key": "secret"},
+        {"credentials": "secret"},
+        {"nested": {"password": "secret"}},
+        {"nested": [{"refresh_token": "secret"}]},
+    ],
+)
+def test_lifecycle_event_rejects_raw_prompt_stdout_stderr_and_credentials(
+    data: dict[str, object],
+) -> None:
+    spec = _spec()
+    with pytest.raises(ValidationError, match="replay-unsafe key"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            data=data,
+        )
+
+
+def test_lifecycle_event_rejects_oversized_payload() -> None:
+    spec = _spec()
+    payload = {"hint": "x" * (MAX_WORKFLOW_LIFECYCLE_DATA_BYTES + 1)}
+    with pytest.raises(ValidationError, match="exceeds"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            data=payload,
+        )
+
+
+def test_persisted_payload_carries_only_bounded_identifiers() -> None:
+    spec = _spec()
+    events = _completed_run_events(spec)
+    forbidden_substrings = (
+        "stdout",
+        "stderr",
+        "raw_prompt",
+        "api_key",
+        "credential",
+        "password",
+        "secret",
+        "bearer_token",
+    )
+
+    for event in events:
+        base = event.to_base_event()
+        payload = base.to_db_dict()["payload"]
+        serialized = json.dumps(payload, sort_keys=True)
+        # The payload must not name or carry any raw stdio/credential
+        # leak channel. The redaction is asserted on the persisted
+        # representation so a regression in event serialization is caught
+        # before it reaches the event store.
+        for needle in forbidden_substrings:
+            assert needle not in serialized.lower(), (
+                f"persisted payload contains forbidden substring {needle!r}: {serialized!r}"
+            )
+        # The bounded refs payload only carries opaque, replay-safe
+        # identifiers (ControlContract / CheckpointStore / IOJournal).
+        for ref in payload.get("refs", ()):
+            assert "://" in ref
+            assert "secret" not in ref.lower()
+            assert "password" not in ref.lower()
+
+
+@pytest.mark.asyncio
+async def test_persisted_db_row_payload_contains_no_raw_streams() -> None:
+    spec = _spec()
+    events = _completed_run_events(spec)
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    try:
+        for event in events:
+            await store.append_workflow_lifecycle_event(event)
+        rows = await store.replay(WORKFLOW_LIFECYCLE_AGGREGATE_TYPE, spec.spec_id)
+    finally:
+        await store.close()
+
+    for row in rows:
+        serialized = json.dumps(row.data, sort_keys=True).lower()
+        for needle in ("stdout", "stderr", "raw_prompt", "credential", "password", "api_key"):
+            assert needle not in serialized, (
+                f"persisted DB row leaks forbidden substring {needle!r}: {serialized!r}"
+            )


### PR DESCRIPTION
## Summary

Adds the durable workflow lifecycle event family for the #956 Workflow IR. Lifecycle events are persisted through the existing `EventStore` under a new `workflow_ir` aggregate type and can be replayed and projected deterministically without any change to live `parallel_executor` dispatch or any existing event family.

Refs #1131, #956.

### Scope

- `WorkflowLifecycleEvent` now serializes through a registered family (`WORKFLOW_LIFECYCLE_AGGREGATE_TYPE = "workflow_ir"`, `WORKFLOW_LIFECYCLE_EVENT_TYPES`) and exposes `from_base_event` for replay.
- `WorkflowLifecycleProjection` + `project_workflow_lifecycle` rebuild run/node/edge/checkpoint state from a lifecycle slice deterministically.
- `EventStore.append_workflow_lifecycle_event` / `replay_workflow_lifecycle` register the new family additively. No other event family is created or modified.
- Payloads are size-bounded and replay-unsafe keys (`stdout`, `stderr`, `prompt`, credentials, tokens) are rejected at the model boundary — proven by fixture.
- Lifecycle events carry only opaque `ControlContract` / `CheckpointStore` / `IOJournal` reference ids via `refs`.

### Out of scope (intentionally untouched)

- `parallel_executor` dispatch, node execution, live workflow behavior.
- Plugin lifecycle dispatch (#939), HITL authority (#960), evidence schema (#830/#978), workflow IR schema.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/unit/orchestrator/ -q` — 1636 passed, 1 skipped.
- [x] `PYTHONPATH=src python -m pytest tests/unit/orchestrator/test_workflow_lifecycle_events.py -q` — 21 passed.
- [x] `PYTHONPATH=src python -m pytest tests/unit/persistence/ -q` — 154 passed.
- [x] `ruff check` + `ruff format --check` clean on all touched files.
- [x] Replay fixture distinguishes `completed` / `failed` / `retried` / `cancelled` runs.
- [x] Same event slice rebuilds the same `WorkflowLifecycleProjection` regardless of input ordering.
- [x] Persisted-payload fixture asserts no raw `stdout` / `stderr` / `prompt` / credential substring leaks at either the `BaseEvent.to_db_dict()` layer or the round-trip SQLite layer.