### PR TITLE
test(orchestrator): expand workflow IR conformance harness

### DIFF
--- a/tests/conformance/__init__.py
+++ b/tests/conformance/__init__.py
@@ -1,0 +1,1 @@
+# Conformance test package — offline-deterministic harnesses for #956 / #1131.

--- a/tests/conformance/workflow_ir/__init__.py
+++ b/tests/conformance/workflow_ir/__init__.py
@@ -1,0 +1,21 @@
+# Workflow IR conformance harness — Wave 1 N-2 (parent #956, umbrella #1131).
+#
+# This package holds deterministic offline fixtures that lock down the
+# Workflow IR v1 boundary:
+#
+#   * Negative graph-shape fixtures (#956 validator MUST reject):
+#       - dangling edge
+#       - duplicate node id
+#       - unreachable terminal
+#       - missing schema ref (evidence/input)
+#       - illegal transition (self-loop)
+#
+#   * Positive runtime-shape fixtures (#956 lifecycle MUST accept):
+#       - legal node-state transitions
+#       - terminal-state-emitted-once
+#       - blocked / failed / cancelled / timed_out distinction
+#
+#   * Plugin firewall contract fixture (#939 boundary, read-only here):
+#       - blocked permission cannot present as success-node completion
+#
+# No network. No model providers. No live runner. No plugin dispatch.

--- a/tests/conformance/workflow_ir/fixtures.py
+++ b/tests/conformance/workflow_ir/fixtures.py
@@ -1,0 +1,529 @@
+"""Deterministic offline fixture builders for the Workflow IR conformance harness.
+
+Each function in this module returns either:
+
+* a :class:`WorkflowSpec` (and optional lifecycle history) that, by construction,
+  exercises **one** named conformance rule from #956, or
+* a tuple of fixture metadata used by the plugin-firewall contract test.
+
+The helpers are pure, deterministic, and offline:
+
+* No network, model provider, plugin subprocess, or cloud credential is touched.
+* Timestamps are fixed via :data:`FIXTURE_EPOCH` so replays are reproducible.
+* No fixture mutates global state; each call returns fresh frozen models.
+
+Negative fixtures intentionally emit **invalid** specs so the validator's
+rejection contract can be asserted. Each negative builder returns a spec
+built via ``WorkflowSpec.model_construct(...)`` when the invalid shape would
+otherwise be caught at the per-model layer (e.g. duplicate node ids cause
+no pydantic error on their own — they are caught by ``validate_workflow``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Final
+
+from ouroboros.orchestrator.workflow_ir import (
+    EdgeKind,
+    NodeKind,
+    NodeOwner,
+    SourceKind,
+    WorkflowEdge,
+    WorkflowNode,
+    WorkflowSpec,
+)
+from ouroboros.orchestrator.workflow_lifecycle import (
+    WorkflowLifecycleEvent,
+    WorkflowLifecycleEventType,
+)
+
+FIXTURE_EPOCH: Final[datetime] = datetime(2026, 5, 19, 0, 0, 0, tzinfo=UTC)
+"""All conformance fixtures anchor lifecycle timestamps to this UTC epoch."""
+
+AGENT_INPUT_SCHEMA: Final[str] = "schema://conformance.agent.input.v1"
+AGENT_EVIDENCE_SCHEMA: Final[str] = "schema://conformance.agent.evidence.v1"
+VERIFIER_INPUT_SCHEMA: Final[str] = "schema://conformance.verifier.input.v1"
+VERIFIER_EVIDENCE_SCHEMA: Final[str] = "schema://conformance.verifier.evidence.v1"
+
+
+def _ts(offset_seconds: int) -> datetime:
+    """Return a deterministic UTC timestamp offset from :data:`FIXTURE_EPOCH`."""
+    return FIXTURE_EPOCH + timedelta(seconds=offset_seconds)
+
+
+# ---------------------------------------------------------------------------
+# Shared building blocks
+# ---------------------------------------------------------------------------
+
+
+def agent_task(node_id: str, *, name: str = "agent task") -> WorkflowNode:
+    """Return a minimally-valid agent task node."""
+    return WorkflowNode(
+        node_id=node_id,
+        kind=NodeKind.TASK,
+        owner=NodeOwner.AGENT,
+        name=name,
+        input_schema_ref=AGENT_INPUT_SCHEMA,
+        evidence_schema_ref=AGENT_EVIDENCE_SCHEMA,
+    )
+
+
+def verifier_task(node_id: str, *, name: str = "verifier task") -> WorkflowNode:
+    """Return a minimally-valid verifier task node."""
+    return WorkflowNode(
+        node_id=node_id,
+        kind=NodeKind.TASK,
+        owner=NodeOwner.VERIFIER,
+        name=name,
+        input_schema_ref=VERIFIER_INPUT_SCHEMA,
+        evidence_schema_ref=VERIFIER_EVIDENCE_SCHEMA,
+    )
+
+
+def harness_terminal(node_id: str = "terminal") -> WorkflowNode:
+    """Return a harness-owned terminal node."""
+    return WorkflowNode(
+        node_id=node_id,
+        kind=NodeKind.TERMINAL,
+        owner=NodeOwner.HARNESS,
+        name="run complete",
+    )
+
+
+def direct_edge(edge_id: str, source: str, target: str) -> WorkflowEdge:
+    """Return a direct edge between two known node ids."""
+    return WorkflowEdge(
+        edge_id=edge_id,
+        source=source,
+        target=target,
+        kind=EdgeKind.DIRECT,
+    )
+
+
+def terminal_edge(edge_id: str, source: str, target: str) -> WorkflowEdge:
+    """Return a terminal edge into the terminal node."""
+    return WorkflowEdge(
+        edge_id=edge_id,
+        source=source,
+        target=target,
+        kind=EdgeKind.TERMINAL,
+    )
+
+
+def linear_valid_spec() -> WorkflowSpec:
+    """Return a small, fully-valid linear spec used as the positive baseline.
+
+    Shape: ``agent_task -> verifier -> terminal``.
+    """
+    return WorkflowSpec(
+        spec_id="wfspec_linear_valid",
+        source=SourceKind.SYNTHETIC,
+        nodes=(
+            agent_task("task_agent"),
+            verifier_task("task_verify"),
+            harness_terminal("terminal"),
+        ),
+        edges=(
+            direct_edge("edge_agent_verify", "task_agent", "task_verify"),
+            terminal_edge("edge_verify_terminal", "task_verify", "terminal"),
+        ),
+        metadata={"fixture": "linear_valid"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Negative fixtures — each MUST be rejected by validate_workflow with a
+# specific error code.
+# ---------------------------------------------------------------------------
+
+
+def dangling_edge_spec() -> WorkflowSpec:
+    """An edge whose target is not declared in ``spec.nodes``."""
+    return WorkflowSpec(
+        spec_id="wfspec_dangling_edge",
+        source=SourceKind.SYNTHETIC,
+        nodes=(
+            agent_task("task_agent"),
+            harness_terminal("terminal"),
+        ),
+        edges=(
+            # Target node 'ghost' is intentionally never declared.
+            direct_edge("edge_agent_ghost", "task_agent", "ghost"),
+            terminal_edge("edge_agent_terminal", "task_agent", "terminal"),
+        ),
+        metadata={"fixture": "dangling_edge"},
+    )
+
+
+def duplicate_node_id_spec() -> WorkflowSpec:
+    """Two nodes share the same ``node_id`` after canonicalization.
+
+    Pydantic does not reject duplicate ids at the model level — they are
+    caught by :func:`validate_workflow`. We construct the spec normally
+    so the duplicate enters via the nodes tuple.
+    """
+    return WorkflowSpec(
+        spec_id="wfspec_duplicate_node_id",
+        source=SourceKind.SYNTHETIC,
+        nodes=(
+            agent_task("task_agent"),
+            # Same id again — duplicate by canonical identifier.
+            agent_task("task_agent", name="duplicate agent task"),
+            harness_terminal("terminal"),
+        ),
+        edges=(terminal_edge("edge_agent_terminal", "task_agent", "terminal"),),
+        metadata={"fixture": "duplicate_node_id"},
+    )
+
+
+def unreachable_terminal_spec() -> WorkflowSpec:
+    """A terminal node that no non-terminal node can reach."""
+    return WorkflowSpec(
+        spec_id="wfspec_unreachable_terminal",
+        source=SourceKind.SYNTHETIC,
+        nodes=(
+            agent_task("task_agent"),
+            verifier_task("task_verify"),
+            # Two terminals: one reachable, one isolated.
+            harness_terminal("terminal_reachable"),
+            harness_terminal("terminal_unreachable"),
+        ),
+        edges=(
+            direct_edge("edge_agent_verify", "task_agent", "task_verify"),
+            terminal_edge("edge_verify_reachable", "task_verify", "terminal_reachable"),
+            # No edge points at terminal_unreachable — by construction.
+        ),
+        metadata={"fixture": "unreachable_terminal"},
+    )
+
+
+def missing_schema_ref_spec() -> WorkflowSpec:
+    """An agent node missing its required schema refs.
+
+    Per-model validation also rejects this, but the spec-level validator
+    re-checks it idempotently so a tampered spec entering via
+    ``model_construct`` is still caught. We use ``model_construct`` here
+    to bypass the per-model gate and exercise the validator branch.
+    """
+    tampered_agent = WorkflowNode.model_construct(
+        schema_version=1,
+        node_id="task_agent",
+        kind=NodeKind.TASK,
+        owner=NodeOwner.AGENT,
+        name="agent missing schemas",
+        input_schema_ref=None,
+        evidence_schema_ref=None,
+        capability_envelope=(),
+    )
+    return WorkflowSpec.model_construct(
+        schema_version=1,
+        spec_id="wfspec_missing_schema_ref",
+        source=SourceKind.SYNTHETIC,
+        source_ref=None,
+        nodes=(
+            tampered_agent,
+            harness_terminal("terminal"),
+        ),
+        edges=(terminal_edge("edge_agent_terminal", "task_agent", "terminal"),),
+        metadata={"fixture": "missing_schema_ref"},
+    )
+
+
+def illegal_transition_spec() -> WorkflowSpec:
+    """A self-loop edge — the v1 IR forbids ``source == target`` transitions.
+
+    ``WorkflowEdge`` rejects self-loops at construction; ``model_construct``
+    skips that gate so we can prove the spec-level validator catches it too.
+    """
+    self_loop = WorkflowEdge.model_construct(
+        schema_version=1,
+        edge_id="edge_self_loop",
+        source="task_agent",
+        target="task_agent",
+        kind=EdgeKind.DIRECT,
+        condition=None,
+    )
+    return WorkflowSpec.model_construct(
+        schema_version=1,
+        spec_id="wfspec_illegal_transition",
+        source=SourceKind.SYNTHETIC,
+        source_ref=None,
+        nodes=(
+            agent_task("task_agent"),
+            harness_terminal("terminal"),
+        ),
+        edges=(
+            self_loop,
+            terminal_edge("edge_agent_terminal", "task_agent", "terminal"),
+        ),
+        metadata={"fixture": "illegal_transition"},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Positive fixtures — each MUST be accepted by the validator AND lifecycle
+# conformance check.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LifecycleFixture:
+    """One positive lifecycle fixture: a valid spec + a valid history.
+
+    Attributes:
+        name: Stable identifier for the fixture (used in pytest ids).
+        spec: A validator-passing :class:`WorkflowSpec`.
+        events: A lifecycle history that conforms to ``spec``.
+        expected_run_terminal: The expected terminal run event type
+            (``RUN_COMPLETED``, ``RUN_FAILED``, ``RUN_CANCELLED``).
+        expected_reason_code: Expected ``reason_code`` for non-completed
+            terminals (``None`` for ``RUN_COMPLETED``).
+    """
+
+    name: str
+    spec: WorkflowSpec
+    events: tuple[WorkflowLifecycleEvent, ...]
+    expected_run_terminal: WorkflowLifecycleEventType
+    expected_reason_code: str | None = None
+
+
+def _evt(
+    spec: WorkflowSpec,
+    event_type: WorkflowLifecycleEventType,
+    offset_seconds: int,
+    *,
+    node_id: str | None = None,
+    edge_id: str | None = None,
+    attempt: int | None = None,
+    reason_code: str | None = None,
+) -> WorkflowLifecycleEvent:
+    return WorkflowLifecycleEvent(
+        event_type=event_type,
+        workflow_id=spec.spec_id,
+        node_id=node_id,
+        edge_id=edge_id,
+        attempt=attempt,
+        reason_code=reason_code,
+        timestamp=_ts(offset_seconds),
+    )
+
+
+def positive_legal_transitions() -> LifecycleFixture:
+    """Legal node-state transitions: scheduled -> started -> completed."""
+    spec = linear_valid_spec()
+    events = (
+        _evt(spec, WorkflowLifecycleEventType.RUN_CREATED, 0),
+        _evt(spec, WorkflowLifecycleEventType.NODE_SCHEDULED, 1, node_id="task_agent"),
+        _evt(spec, WorkflowLifecycleEventType.NODE_STARTED, 2, node_id="task_agent", attempt=1),
+        _evt(spec, WorkflowLifecycleEventType.NODE_COMPLETED, 3, node_id="task_agent", attempt=1),
+        _evt(spec, WorkflowLifecycleEventType.EDGE_TRAVERSED, 4, edge_id="edge_agent_verify"),
+        _evt(spec, WorkflowLifecycleEventType.NODE_SCHEDULED, 5, node_id="task_verify"),
+        _evt(spec, WorkflowLifecycleEventType.NODE_STARTED, 6, node_id="task_verify", attempt=1),
+        _evt(spec, WorkflowLifecycleEventType.NODE_COMPLETED, 7, node_id="task_verify", attempt=1),
+        _evt(
+            spec,
+            WorkflowLifecycleEventType.EDGE_TRAVERSED,
+            8,
+            edge_id="edge_verify_terminal",
+        ),
+        _evt(spec, WorkflowLifecycleEventType.RUN_COMPLETED, 9),
+    )
+    return LifecycleFixture(
+        name="legal_transitions",
+        spec=spec,
+        events=events,
+        expected_run_terminal=WorkflowLifecycleEventType.RUN_COMPLETED,
+    )
+
+
+def positive_terminal_emitted_once() -> LifecycleFixture:
+    """Terminal-state-emitted-once: exactly one terminal run event per run."""
+    spec = linear_valid_spec()
+    events = (
+        _evt(spec, WorkflowLifecycleEventType.RUN_CREATED, 0),
+        _evt(spec, WorkflowLifecycleEventType.NODE_STARTED, 1, node_id="task_agent", attempt=1),
+        _evt(spec, WorkflowLifecycleEventType.NODE_COMPLETED, 2, node_id="task_agent", attempt=1),
+        _evt(spec, WorkflowLifecycleEventType.EDGE_TRAVERSED, 3, edge_id="edge_agent_verify"),
+        _evt(spec, WorkflowLifecycleEventType.NODE_STARTED, 4, node_id="task_verify", attempt=1),
+        _evt(spec, WorkflowLifecycleEventType.NODE_COMPLETED, 5, node_id="task_verify", attempt=1),
+        _evt(spec, WorkflowLifecycleEventType.EDGE_TRAVERSED, 6, edge_id="edge_verify_terminal"),
+        _evt(spec, WorkflowLifecycleEventType.RUN_COMPLETED, 7),
+    )
+    return LifecycleFixture(
+        name="terminal_emitted_once",
+        spec=spec,
+        events=events,
+        expected_run_terminal=WorkflowLifecycleEventType.RUN_COMPLETED,
+    )
+
+
+def positive_blocked_distinction() -> LifecycleFixture:
+    """Run blocked at the gate — no node ever started, terminates as FAILED.
+
+    ``blocked`` in lifecycle vocabulary is represented as a ``RUN_FAILED``
+    with ``reason_code='blocked'`` so #946 projection can distinguish it
+    from generic failures without inventing a new event family (out of
+    scope per #956 boundary).
+    """
+    spec = linear_valid_spec()
+    events = (
+        _evt(spec, WorkflowLifecycleEventType.RUN_CREATED, 0),
+        _evt(
+            spec,
+            WorkflowLifecycleEventType.RUN_FAILED,
+            1,
+            reason_code="blocked",
+        ),
+    )
+    return LifecycleFixture(
+        name="blocked_distinction",
+        spec=spec,
+        events=events,
+        expected_run_terminal=WorkflowLifecycleEventType.RUN_FAILED,
+        expected_reason_code="blocked",
+    )
+
+
+def positive_failed_distinction() -> LifecycleFixture:
+    """Run failed mid-execution — node failure surfaces as RUN_FAILED."""
+    spec = linear_valid_spec()
+    events = (
+        _evt(spec, WorkflowLifecycleEventType.RUN_CREATED, 0),
+        _evt(spec, WorkflowLifecycleEventType.NODE_STARTED, 1, node_id="task_agent", attempt=1),
+        _evt(
+            spec,
+            WorkflowLifecycleEventType.NODE_FAILED,
+            2,
+            node_id="task_agent",
+            attempt=1,
+            reason_code="execution_error",
+        ),
+        _evt(
+            spec,
+            WorkflowLifecycleEventType.RUN_FAILED,
+            3,
+            reason_code="node_failure",
+        ),
+    )
+    return LifecycleFixture(
+        name="failed_distinction",
+        spec=spec,
+        events=events,
+        expected_run_terminal=WorkflowLifecycleEventType.RUN_FAILED,
+        expected_reason_code="node_failure",
+    )
+
+
+def positive_cancelled_distinction() -> LifecycleFixture:
+    """Run cancelled by user — terminates as RUN_CANCELLED."""
+    spec = linear_valid_spec()
+    events = (
+        _evt(spec, WorkflowLifecycleEventType.RUN_CREATED, 0),
+        _evt(spec, WorkflowLifecycleEventType.NODE_STARTED, 1, node_id="task_agent", attempt=1),
+        _evt(
+            spec,
+            WorkflowLifecycleEventType.RUN_CANCELLED,
+            2,
+            reason_code="user_requested",
+        ),
+    )
+    return LifecycleFixture(
+        name="cancelled_distinction",
+        spec=spec,
+        events=events,
+        expected_run_terminal=WorkflowLifecycleEventType.RUN_CANCELLED,
+        expected_reason_code="user_requested",
+    )
+
+
+def positive_timed_out_distinction() -> LifecycleFixture:
+    """Run timed out — terminates as RUN_FAILED with reason_code='timed_out'.
+
+    The v1 IR lifecycle does not carry a separate RUN_TIMED_OUT event type;
+    timeout is represented by a RUN_FAILED whose ``reason_code`` discriminates
+    it from a generic execution failure. This locks the contract so a future
+    #946 projection layer can split the read model without an event-family
+    schema change.
+    """
+    spec = linear_valid_spec()
+    events = (
+        _evt(spec, WorkflowLifecycleEventType.RUN_CREATED, 0),
+        _evt(spec, WorkflowLifecycleEventType.NODE_STARTED, 1, node_id="task_agent", attempt=1),
+        _evt(
+            spec,
+            WorkflowLifecycleEventType.NODE_FAILED,
+            2,
+            node_id="task_agent",
+            attempt=1,
+            reason_code="timed_out",
+        ),
+        _evt(
+            spec,
+            WorkflowLifecycleEventType.RUN_FAILED,
+            3,
+            reason_code="timed_out",
+        ),
+    )
+    return LifecycleFixture(
+        name="timed_out_distinction",
+        spec=spec,
+        events=events,
+        expected_run_terminal=WorkflowLifecycleEventType.RUN_FAILED,
+        expected_reason_code="timed_out",
+    )
+
+
+def all_positive_fixtures() -> tuple[LifecycleFixture, ...]:
+    """Return every positive lifecycle fixture defined in this module."""
+    return (
+        positive_legal_transitions(),
+        positive_terminal_emitted_once(),
+        positive_blocked_distinction(),
+        positive_failed_distinction(),
+        positive_cancelled_distinction(),
+        positive_timed_out_distinction(),
+    )
+
+
+def terminal_run_event_types(
+    events: Iterable[WorkflowLifecycleEvent],
+) -> tuple[WorkflowLifecycleEvent, ...]:
+    """Return events whose type is a terminal run event."""
+    terminal_types = {
+        WorkflowLifecycleEventType.RUN_COMPLETED,
+        WorkflowLifecycleEventType.RUN_FAILED,
+        WorkflowLifecycleEventType.RUN_CANCELLED,
+    }
+    return tuple(event for event in events if event.event_type in terminal_types)
+
+
+__all__ = [
+    "AGENT_EVIDENCE_SCHEMA",
+    "AGENT_INPUT_SCHEMA",
+    "FIXTURE_EPOCH",
+    "LifecycleFixture",
+    "VERIFIER_EVIDENCE_SCHEMA",
+    "VERIFIER_INPUT_SCHEMA",
+    "agent_task",
+    "all_positive_fixtures",
+    "dangling_edge_spec",
+    "direct_edge",
+    "duplicate_node_id_spec",
+    "harness_terminal",
+    "illegal_transition_spec",
+    "linear_valid_spec",
+    "missing_schema_ref_spec",
+    "positive_blocked_distinction",
+    "positive_cancelled_distinction",
+    "positive_failed_distinction",
+    "positive_legal_transitions",
+    "positive_terminal_emitted_once",
+    "positive_timed_out_distinction",
+    "terminal_edge",
+    "terminal_run_event_types",
+    "unreachable_terminal_spec",
+    "verifier_task",
+]

--- a/tests/conformance/workflow_ir/fixtures.py
+++ b/tests/conformance/workflow_ir/fixtures.py
@@ -340,7 +340,14 @@ def positive_legal_transitions() -> LifecycleFixture:
 
 
 def positive_terminal_emitted_once() -> LifecycleFixture:
-    """Terminal-state-emitted-once: exactly one terminal run event per run."""
+    """Terminal-state-emitted-once: exactly one terminal run event per run.
+
+    This fixture intentionally includes only the minimal executable lifecycle
+    rows required to prove terminal cardinality. The fuller
+    ``positive_legal_transitions`` fixture covers the optional
+    ``NODE_SCHEDULED`` state; duplicating scheduling here would make this
+    fixture less focused without adding a new #956 rule assertion.
+    """
     spec = linear_valid_spec()
     events = (
         _evt(spec, WorkflowLifecycleEventType.RUN_CREATED, 0),

--- a/tests/conformance/workflow_ir/test_negative_fixtures.py
+++ b/tests/conformance/workflow_ir/test_negative_fixtures.py
@@ -1,0 +1,163 @@
+"""Negative Workflow IR conformance fixtures.
+
+Each fixture in this file MUST be rejected by ``validate_workflow`` with a
+specific, named error code from the locked #956 vocabulary. Conformance is
+proved by:
+
+  1. Asserting ``validate_workflow(spec).ok is False``.
+  2. Asserting the expected error code appears in the error list.
+  3. Asserting the error message is unambiguous: it names the failing
+     identifier (node id, edge id, or schema field) so debuggers can map
+     a validator verdict back to its root cause without re-running it.
+
+These tests are offline-deterministic: no network, no model providers, no
+subprocess, no plugin dispatch. Refs #1131, #956.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.workflow_ir import (
+    WorkflowValidationError,
+    validate_workflow,
+)
+from tests.conformance.workflow_ir.fixtures import (
+    dangling_edge_spec,
+    duplicate_node_id_spec,
+    illegal_transition_spec,
+    missing_schema_ref_spec,
+    unreachable_terminal_spec,
+)
+
+
+def _error_codes(errors: tuple[WorkflowValidationError, ...]) -> tuple[str, ...]:
+    return tuple(error.code for error in errors)
+
+
+def _find_error(errors: tuple[WorkflowValidationError, ...], code: str) -> WorkflowValidationError:
+    matches = tuple(error for error in errors if error.code == code)
+    assert matches, f"expected validator error code {code!r}; got {_error_codes(errors)!r}"
+    return matches[0]
+
+
+class TestDanglingEdgeFixture:
+    """Edges that reference unknown node ids must be flagged dangling."""
+
+    def test_validator_rejects(self) -> None:
+        result = validate_workflow(dangling_edge_spec())
+        assert result.ok is False, (
+            f"dangling edge fixture must fail validation; got {_error_codes(result.errors)!r}"
+        )
+
+    def test_emits_dangling_edge_code(self) -> None:
+        result = validate_workflow(dangling_edge_spec())
+        error = _find_error(result.errors, "dangling_edge")
+        # The unambiguous-message contract: the failing identifier is named.
+        assert "ghost" in error.message, (
+            f"dangling_edge message must name the unresolved node id; got {error.message!r}"
+        )
+        assert error.edge_id == "edge_agent_ghost"
+        assert error.node_id == "ghost"
+
+
+class TestDuplicateNodeIdFixture:
+    """Two nodes with the same canonical id must be rejected."""
+
+    def test_validator_rejects(self) -> None:
+        result = validate_workflow(duplicate_node_id_spec())
+        assert result.ok is False
+
+    def test_emits_duplicate_node_id_code(self) -> None:
+        result = validate_workflow(duplicate_node_id_spec())
+        error = _find_error(result.errors, "duplicate_node_id")
+        # The duplicate id is named in the message — not a generic phrase.
+        assert "task_agent" in error.message
+        assert error.node_id == "task_agent"
+
+
+class TestUnreachableTerminalFixture:
+    """A terminal node that no execution path can reach must be rejected."""
+
+    def test_validator_rejects(self) -> None:
+        result = validate_workflow(unreachable_terminal_spec())
+        assert result.ok is False
+
+    def test_emits_unreachable_terminal_code(self) -> None:
+        result = validate_workflow(unreachable_terminal_spec())
+        error = _find_error(result.errors, "unreachable_terminal")
+        # The unreachable terminal id is named in the message.
+        assert "terminal_unreachable" in error.message
+        assert error.node_id == "terminal_unreachable"
+
+
+class TestMissingSchemaRefFixture:
+    """Agent nodes missing input/evidence schema refs must be rejected."""
+
+    def test_validator_rejects(self) -> None:
+        result = validate_workflow(missing_schema_ref_spec())
+        assert result.ok is False
+
+    def test_emits_missing_schema_codes(self) -> None:
+        result = validate_workflow(missing_schema_ref_spec())
+        codes = set(_error_codes(result.errors))
+        # The fixture tampers the agent node to drop BOTH refs, so the
+        # validator must surface BOTH missing-schema codes for the same
+        # node id. This locks down the validator's separate-rule semantics.
+        assert "missing_evidence_schema" in codes
+        assert "missing_input_schema" in codes
+        for code in ("missing_evidence_schema", "missing_input_schema"):
+            error = _find_error(result.errors, code)
+            assert error.node_id == "task_agent"
+            # Message names the node id so callers can locate the failure.
+            assert "task_agent" in error.message
+
+
+class TestIllegalTransitionFixture:
+    """Self-loop transitions are illegal in v1 and must be rejected."""
+
+    def test_validator_rejects(self) -> None:
+        result = validate_workflow(illegal_transition_spec())
+        assert result.ok is False
+
+    def test_emits_self_loop_code(self) -> None:
+        result = validate_workflow(illegal_transition_spec())
+        error = _find_error(result.errors, "self_loop")
+        # The offending edge AND node are both surfaced for debugging.
+        assert error.edge_id == "edge_self_loop"
+        assert error.node_id == "task_agent"
+        assert "task_agent" in error.message
+
+
+@pytest.mark.parametrize(
+    ("builder", "expected_code"),
+    [
+        (dangling_edge_spec, "dangling_edge"),
+        (duplicate_node_id_spec, "duplicate_node_id"),
+        (unreachable_terminal_spec, "unreachable_terminal"),
+        (missing_schema_ref_spec, "missing_evidence_schema"),
+        (illegal_transition_spec, "self_loop"),
+    ],
+    ids=[
+        "dangling_edge",
+        "duplicate_node_id",
+        "unreachable_terminal",
+        "missing_schema_ref",
+        "illegal_transition",
+    ],
+)
+def test_negative_fixture_emits_expected_code(builder, expected_code: str) -> None:
+    """Each negative fixture surfaces its expected validator code.
+
+    This single parametrized assertion is the canonical 5-fixture coverage
+    proof required by issue #1131.
+    """
+    result = validate_workflow(builder())
+    assert result.ok is False, (
+        f"{builder.__name__} expected to fail validation, "
+        f"got {result.ok=}, errors={_error_codes(result.errors)!r}"
+    )
+    assert expected_code in _error_codes(result.errors), (
+        f"{builder.__name__} expected error code {expected_code!r}; "
+        f"got {_error_codes(result.errors)!r}"
+    )

--- a/tests/conformance/workflow_ir/test_plugin_firewall_contract.py
+++ b/tests/conformance/workflow_ir/test_plugin_firewall_contract.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 from datetime import timedelta
 import json
 from pathlib import Path
+from typing import Protocol
 
 import pytest
 
@@ -89,6 +90,10 @@ _BLOCKED_PLUGIN_MANIFEST: dict = {
         "command": "python -m conformance_blocked_plugin",
     },
 }
+
+
+class _PluginInvocationResult(Protocol):
+    status: str
 
 
 @pytest.fixture()
@@ -156,10 +161,70 @@ def test_blocked_invocation_emits_only_plugin_failed(blocked_plugin_program) -> 
     assert "plugin.completed" not in event_types
 
 
+def _workflow_history_from_plugin_result(
+    *,
+    spec: WorkflowSpec,
+    node_id: str,
+    result: _PluginInvocationResult,
+) -> tuple[WorkflowLifecycleEvent, ...]:
+    """Project a plugin firewall result into the harness lifecycle contract.
+
+    This helper is intentionally local to the conformance fixture: v1 does
+    not add live plugin dispatch or production projection behavior. It pins
+    the rule a future harness adapter must preserve — only an explicit
+    ``status='success'`` may become ``NODE_COMPLETED``. Permission-denied
+    blocked results stay on the failure path and carry a discriminating
+    ``plugin_blocked`` reason code.
+    """
+    status = result.status
+    if status == "success":
+        return (
+            WorkflowLifecycleEvent(
+                event_type=WorkflowLifecycleEventType.RUN_CREATED,
+                workflow_id=spec.spec_id,
+                timestamp=FIXTURE_EPOCH,
+            ),
+            WorkflowLifecycleEvent(
+                event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+                workflow_id=spec.spec_id,
+                node_id=node_id,
+                attempt=1,
+                timestamp=FIXTURE_EPOCH + timedelta(seconds=1),
+            ),
+            WorkflowLifecycleEvent(
+                event_type=WorkflowLifecycleEventType.RUN_COMPLETED,
+                workflow_id=spec.spec_id,
+                timestamp=FIXTURE_EPOCH + timedelta(seconds=2),
+            ),
+        )
+    reason_code = "plugin_blocked" if status == "blocked" else f"plugin_{status}"
+    return (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=FIXTURE_EPOCH,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_FAILED,
+            workflow_id=spec.spec_id,
+            node_id=node_id,
+            attempt=1,
+            reason_code=reason_code,
+            timestamp=FIXTURE_EPOCH + timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_FAILED,
+            workflow_id=spec.spec_id,
+            reason_code=reason_code,
+            timestamp=FIXTURE_EPOCH + timedelta(seconds=2),
+        ),
+    )
+
+
 def test_blocked_invocation_cannot_present_as_node_completion(
     blocked_plugin_program,
 ) -> None:
-    """A blocked plugin invocation cannot be encoded as NODE_COMPLETED.
+    """A blocked plugin invocation is projected as failure, never completion.
 
     This is the load-bearing #1131 contract: when the harness projects
     plugin-firewall outcomes into Workflow IR lifecycle rows, it MUST map
@@ -167,19 +232,6 @@ def test_blocked_invocation_cannot_present_as_node_completion(
     reason_code). Encoding a blocked invocation as ``NODE_COMPLETED``
     would silently project a permission denial as a successful run, which
     is exactly the boundary #939 + #956 are designed to prevent.
-
-    We assert this by:
-      1. Running the firewall and recording its blocked status.
-      2. Building a *legal* lifecycle history that maps the blocked
-         outcome to ``NODE_FAILED`` + ``RUN_FAILED`` — conformance check
-         must accept it.
-      3. Building an *illegal* lifecycle history that maps the same
-         blocked outcome to ``NODE_COMPLETED`` + ``RUN_COMPLETED`` — the
-         workflow validator/spec construction will not raise (the graph
-         shape is fine), but the lifecycle is semantically wrong, so the
-         harness MUST refuse to emit it. We enforce this with an
-         assertion that the firewall result.status is NOT 'success', i.e.
-         no caller can derive a 'completed' lifecycle from this result.
     """
     events: list[dict] = []
     result = invoke_plugin(
@@ -199,43 +251,25 @@ def test_blocked_invocation_cannot_present_as_node_completion(
     spec_result = validate_workflow(spec)
     assert spec_result.ok, f"plugin-node spec must validate cleanly; got {spec_result.errors!r}"
 
-    # 2. Legal projection: blocked -> NODE_FAILED + RUN_FAILED(blocked).
-    blocked_history = (
-        WorkflowLifecycleEvent(
-            event_type=WorkflowLifecycleEventType.RUN_CREATED,
-            workflow_id=spec.spec_id,
-            timestamp=FIXTURE_EPOCH,
-        ),
-        WorkflowLifecycleEvent(
-            event_type=WorkflowLifecycleEventType.NODE_FAILED,
-            workflow_id=spec.spec_id,
-            node_id="plugin_task",
-            attempt=1,
-            reason_code="plugin_blocked",
-            timestamp=FIXTURE_EPOCH + timedelta(seconds=1),
-        ),
-        WorkflowLifecycleEvent(
-            event_type=WorkflowLifecycleEventType.RUN_FAILED,
-            workflow_id=spec.spec_id,
-            reason_code="plugin_blocked",
-            timestamp=FIXTURE_EPOCH + timedelta(seconds=2),
-        ),
+    # 2. Harness projection contract: blocked -> NODE_FAILED + RUN_FAILED.
+    blocked_history = _workflow_history_from_plugin_result(
+        spec=spec,
+        node_id="plugin_task",
+        result=result,
     )
+    projected_types = tuple(event.event_type for event in blocked_history)
+    assert WorkflowLifecycleEventType.NODE_FAILED in projected_types
+    assert WorkflowLifecycleEventType.RUN_FAILED in projected_types
+    assert WorkflowLifecycleEventType.NODE_COMPLETED not in projected_types
+    assert WorkflowLifecycleEventType.RUN_COMPLETED not in projected_types
+    assert blocked_history[1].reason_code == "plugin_blocked"
+    assert blocked_history[2].reason_code == "plugin_blocked"
+
+    # 3. The projected blocked lifecycle remains legal Workflow IR history.
     report = validate_workflow_lifecycle_conformance(spec, blocked_history)
     assert report.ok, (
         "legal blocked projection (NODE_FAILED + RUN_FAILED) must conform; "
         f"got errors={[i.code for i in report.errors]!r}"
-    )
-
-    # 3. The illegal projection is blocked at the source: a caller cannot
-    # build a 'completed' lifecycle from a 'blocked' InvocationResult
-    # because the firewall never reports success on the blocked path. The
-    # assertion below is the single chokepoint the rest of the harness
-    # depends on — if it ever fails, plugin permission denials could
-    # silently project as successful node completions.
-    assert result.status != "success", (
-        "BLOCKED plugin invocations cannot be projected as NODE_COMPLETED — "
-        "the firewall must never return status='success' on the blocked path."
     )
 
 

--- a/tests/conformance/workflow_ir/test_plugin_firewall_contract.py
+++ b/tests/conformance/workflow_ir/test_plugin_firewall_contract.py
@@ -1,0 +1,286 @@
+"""Plugin firewall contract fixture (read-only, harness-side).
+
+This test exists at the #939 / #956 boundary. It does NOT change plugin
+dispatch behavior (which lives on #939) and does NOT introduce a new event
+family. It locks ONE invariant the conformance harness depends on:
+
+    A plugin invocation that is blocked at the permission gate
+    cannot be projected as a successful workflow-node completion.
+
+Concretely:
+
+  * ``invoke_plugin`` MUST return ``status="blocked"`` when a required
+    permission is not trusted.
+  * The blocked path MUST emit only ``plugin.failed`` with
+    ``result.status == "blocked"``. It MUST NOT emit ``plugin.invoked``
+    or ``plugin.completed``.
+  * When a harness builds a Workflow IR lifecycle history from a blocked
+    invocation, it cannot legally emit a ``workflow.node.completed`` for
+    the plugin-owned node — only ``workflow.node.failed`` with a
+    ``reason_code`` derived from the firewall's blocked outcome.
+
+The test is offline-deterministic: a temporary plugin manifest is written
+to ``tmp_path``, no network/cloud is touched, and the firewall is invoked
+with no trust record so the blocked path is exercised by construction.
+
+Refs #1131, #956, #939 (read-only boundary).
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.orchestrator.workflow_ir import (
+    NodeKind,
+    NodeOwner,
+    SourceKind,
+    WorkflowNode,
+    WorkflowSpec,
+    validate_workflow,
+)
+from ouroboros.orchestrator.workflow_lifecycle import (
+    WorkflowLifecycleEvent,
+    WorkflowLifecycleEventType,
+    validate_workflow_lifecycle_conformance,
+)
+from ouroboros.plugin.firewall import invoke_plugin
+from ouroboros.plugin.manifest import load_manifest
+from ouroboros.plugin.userlevel_registry import UserLevelProgramRegistry
+from tests.conformance.workflow_ir.fixtures import (
+    AGENT_EVIDENCE_SCHEMA,
+    AGENT_INPUT_SCHEMA,
+    FIXTURE_EPOCH,
+    harness_terminal,
+    terminal_edge,
+)
+
+PLUGIN_INPUT_SCHEMA = "schema://conformance.plugin.input.v1"
+PLUGIN_EVIDENCE_SCHEMA = "schema://conformance.plugin.evidence.v1"
+
+# Minimal manifest with one required permission and one command. The plugin
+# command is read-only (no destructive confirmation gate needed) so the
+# blocked path is the only contract under test.
+_BLOCKED_PLUGIN_MANIFEST: dict = {
+    "schema_version": "0.1",
+    "name": "conformance-blocked-plugin",
+    "version": "0.0.1",
+    "source": {
+        "type": "local_path",
+        "path": "plugins/conformance-blocked-plugin",
+    },
+    "commands": [
+        {
+            "namespace": "conformance",
+            "name": "noop",
+            "summary": "Never runs — used only to exercise the blocked path.",
+            "usage": "ooo conformance noop",
+            "risk": "read_only",
+            "requires_confirmation": False,
+        }
+    ],
+    "capabilities": [],
+    "permissions": [
+        {
+            "scope": "conformance:required",
+            "risk": "read_only",
+            "required": True,
+        }
+    ],
+    "entrypoint": {
+        "type": "command",
+        "command": "python -m conformance_blocked_plugin",
+    },
+}
+
+
+@pytest.fixture()
+def blocked_plugin_program(tmp_path: Path):
+    """Write the manifest to tmp and register it without granting trust."""
+    plugin_root = tmp_path / "plugin"
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    manifest_path = plugin_root / "ouroboros.plugin.json"
+    manifest_path.write_text(json.dumps(_BLOCKED_PLUGIN_MANIFEST))
+    manifest = load_manifest(manifest_path)
+    registry = UserLevelProgramRegistry()
+    return registry.register(manifest)
+
+
+def _plugin_node_spec() -> WorkflowSpec:
+    """Build a small spec containing a plugin-owned task + terminal."""
+    plugin_node = WorkflowNode(
+        node_id="plugin_task",
+        kind=NodeKind.TASK,
+        owner=NodeOwner.PLUGIN,
+        name="blocked plugin task",
+        input_schema_ref=PLUGIN_INPUT_SCHEMA,
+        evidence_schema_ref=PLUGIN_EVIDENCE_SCHEMA,
+    )
+    terminal = harness_terminal("terminal")
+    return WorkflowSpec(
+        spec_id="wfspec_plugin_blocked",
+        source=SourceKind.SYNTHETIC,
+        nodes=(plugin_node, terminal),
+        edges=(
+            terminal_edge(
+                "edge_plugin_terminal",
+                "plugin_task",
+                "terminal",
+            ),
+        ),
+        metadata={"fixture": "plugin_firewall_blocked"},
+    )
+
+
+def test_blocked_invocation_emits_only_plugin_failed(blocked_plugin_program) -> None:
+    """The firewall's blocked path emits exactly one plugin.failed event."""
+    events: list[dict] = []
+    result = invoke_plugin(
+        blocked_plugin_program,
+        command_name="noop",
+        argv=[],
+        # No trust record — required permission is missing by construction.
+        trust_record=None,
+        event_sink=events.append,
+        correlation_id="conformance-blocked",
+    )
+    assert result.status == "blocked", f"expected status='blocked'; got {result.status!r}"
+    event_types = [event["event_type"] for event in events]
+    assert event_types == ["plugin.failed"], (
+        f"blocked path must emit exactly one plugin.failed event; got {event_types!r}"
+    )
+    assert events[0]["result"]["status"] == "blocked", (
+        f"blocked-path plugin.failed must carry result.status='blocked'; "
+        f"got {events[0]['result']!r}"
+    )
+    # The contract chokepoint: no plugin.invoked AND no plugin.completed
+    # may appear when the firewall blocks at the trust gate.
+    assert "plugin.invoked" not in event_types
+    assert "plugin.completed" not in event_types
+
+
+def test_blocked_invocation_cannot_present_as_node_completion(
+    blocked_plugin_program,
+) -> None:
+    """A blocked plugin invocation cannot be encoded as NODE_COMPLETED.
+
+    This is the load-bearing #1131 contract: when the harness projects
+    plugin-firewall outcomes into Workflow IR lifecycle rows, it MUST map
+    ``status='blocked'`` to ``NODE_FAILED`` (with a discriminating
+    reason_code). Encoding a blocked invocation as ``NODE_COMPLETED``
+    would silently project a permission denial as a successful run, which
+    is exactly the boundary #939 + #956 are designed to prevent.
+
+    We assert this by:
+      1. Running the firewall and recording its blocked status.
+      2. Building a *legal* lifecycle history that maps the blocked
+         outcome to ``NODE_FAILED`` + ``RUN_FAILED`` — conformance check
+         must accept it.
+      3. Building an *illegal* lifecycle history that maps the same
+         blocked outcome to ``NODE_COMPLETED`` + ``RUN_COMPLETED`` — the
+         workflow validator/spec construction will not raise (the graph
+         shape is fine), but the lifecycle is semantically wrong, so the
+         harness MUST refuse to emit it. We enforce this with an
+         assertion that the firewall result.status is NOT 'success', i.e.
+         no caller can derive a 'completed' lifecycle from this result.
+    """
+    events: list[dict] = []
+    result = invoke_plugin(
+        blocked_plugin_program,
+        command_name="noop",
+        argv=[],
+        trust_record=None,
+        event_sink=events.append,
+        correlation_id="conformance-blocked-2",
+    )
+    # The firewall outcome the harness MUST consume.
+    assert result.status == "blocked"
+    assert result.exit_code is None
+
+    # 1. Spec-level: the plugin-node spec is valid in isolation.
+    spec = _plugin_node_spec()
+    spec_result = validate_workflow(spec)
+    assert spec_result.ok, f"plugin-node spec must validate cleanly; got {spec_result.errors!r}"
+
+    # 2. Legal projection: blocked -> NODE_FAILED + RUN_FAILED(blocked).
+    blocked_history = (
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            timestamp=FIXTURE_EPOCH,
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_FAILED,
+            workflow_id=spec.spec_id,
+            node_id="plugin_task",
+            attempt=1,
+            reason_code="plugin_blocked",
+            timestamp=FIXTURE_EPOCH + timedelta(seconds=1),
+        ),
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_FAILED,
+            workflow_id=spec.spec_id,
+            reason_code="plugin_blocked",
+            timestamp=FIXTURE_EPOCH + timedelta(seconds=2),
+        ),
+    )
+    report = validate_workflow_lifecycle_conformance(spec, blocked_history)
+    assert report.ok, (
+        "legal blocked projection (NODE_FAILED + RUN_FAILED) must conform; "
+        f"got errors={[i.code for i in report.errors]!r}"
+    )
+
+    # 3. The illegal projection is blocked at the source: a caller cannot
+    # build a 'completed' lifecycle from a 'blocked' InvocationResult
+    # because the firewall never reports success on the blocked path. The
+    # assertion below is the single chokepoint the rest of the harness
+    # depends on — if it ever fails, plugin permission denials could
+    # silently project as successful node completions.
+    assert result.status != "success", (
+        "BLOCKED plugin invocations cannot be projected as NODE_COMPLETED — "
+        "the firewall must never return status='success' on the blocked path."
+    )
+
+
+def test_blocked_event_carries_plugin_command_identity(blocked_plugin_program) -> None:
+    """The single emitted plugin.failed event names the plugin + command.
+
+    Without this, a downstream projector could not map a blocked event back
+    to the workflow node it was scheduled for — the projection would have
+    to guess identity from correlation_id alone, which violates the #956
+    boundary contract that lifecycle rows carry stable node identity.
+    """
+    events: list[dict] = []
+    invoke_plugin(
+        blocked_plugin_program,
+        command_name="noop",
+        argv=[],
+        trust_record=None,
+        event_sink=events.append,
+        correlation_id="conformance-blocked-3",
+    )
+    assert len(events) == 1
+    event = events[0]
+    assert event["plugin"]["name"] == "conformance-blocked-plugin"
+    command = event["command"]
+    # The blocked path is the source of truth for plugin+command identity.
+    # The firewall may attach an empty argv summary when argv=[] was passed,
+    # so we assert namespace/name precisely and tolerate the bounded
+    # argv/argv_summary observability fields the audit schema allows.
+    assert command["namespace"] == "conformance"
+    assert command["name"] == "noop"
+    assert event["trust_state"] == "installed"
+    assert event["result"]["status"] == "blocked"
+    # The blocked message MUST name the missing scope so a CLI surface
+    # can render an unambiguous remediation hint.
+    assert "conformance:required" in event["result"]["message"]
+
+
+# Quiet pyflakes "unused import" warnings for the shared schema constants:
+# they are documented as the canonical refs the plugin node fixture builds on
+# and are imported here so they remain referenced even if the helper module
+# changes.
+assert AGENT_INPUT_SCHEMA and AGENT_EVIDENCE_SCHEMA

--- a/tests/conformance/workflow_ir/test_plugin_firewall_contract.py
+++ b/tests/conformance/workflow_ir/test_plugin_firewall_contract.py
@@ -50,13 +50,7 @@ from ouroboros.orchestrator.workflow_lifecycle import (
 from ouroboros.plugin.firewall import invoke_plugin
 from ouroboros.plugin.manifest import load_manifest
 from ouroboros.plugin.userlevel_registry import UserLevelProgramRegistry
-from tests.conformance.workflow_ir.fixtures import (
-    AGENT_EVIDENCE_SCHEMA,
-    AGENT_INPUT_SCHEMA,
-    FIXTURE_EPOCH,
-    harness_terminal,
-    terminal_edge,
-)
+from tests.conformance.workflow_ir.fixtures import FIXTURE_EPOCH, harness_terminal, terminal_edge
 
 PLUGIN_INPUT_SCHEMA = "schema://conformance.plugin.input.v1"
 PLUGIN_EVIDENCE_SCHEMA = "schema://conformance.plugin.evidence.v1"
@@ -277,10 +271,3 @@ def test_blocked_event_carries_plugin_command_identity(blocked_plugin_program) -
     # The blocked message MUST name the missing scope so a CLI surface
     # can render an unambiguous remediation hint.
     assert "conformance:required" in event["result"]["message"]
-
-
-# Quiet pyflakes "unused import" warnings for the shared schema constants:
-# they are documented as the canonical refs the plugin node fixture builds on
-# and are imported here so they remain referenced even if the helper module
-# changes.
-assert AGENT_INPUT_SCHEMA and AGENT_EVIDENCE_SCHEMA

--- a/tests/conformance/workflow_ir/test_positive_fixtures.py
+++ b/tests/conformance/workflow_ir/test_positive_fixtures.py
@@ -1,0 +1,236 @@
+"""Positive Workflow IR conformance fixtures.
+
+These fixtures pair a valid :class:`WorkflowSpec` with a legal lifecycle
+history and assert two contracts simultaneously:
+
+  1. ``validate_workflow(spec)`` returns ``ok=True`` with no errors.
+  2. ``validate_workflow_lifecycle_conformance(spec, events)`` returns
+     ``ok=True`` with no errors — the lifecycle rows conform to the graph.
+
+Coverage:
+
+  * legal node-state transitions (scheduled -> started -> completed)
+  * terminal-state-emitted-once (exactly one terminal run event per run)
+  * blocked vs. failed vs. cancelled vs. timed_out distinction (4 fixtures)
+
+Together with the negative suite, this gives the 5+5 fixture count required
+by issue #1131. The tests are offline-deterministic: no network, no model
+providers, no subprocess, no plugin dispatch. Refs #1131, #956.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+from ouroboros.orchestrator.workflow_ir import validate_workflow
+from ouroboros.orchestrator.workflow_lifecycle import (
+    WorkflowLifecycleEventType,
+    validate_workflow_lifecycle_conformance,
+)
+from tests.conformance.workflow_ir.fixtures import (
+    LifecycleFixture,
+    all_positive_fixtures,
+    positive_blocked_distinction,
+    positive_cancelled_distinction,
+    positive_failed_distinction,
+    positive_legal_transitions,
+    positive_terminal_emitted_once,
+    positive_timed_out_distinction,
+    terminal_run_event_types,
+)
+
+
+def _fixture_id(fixture: LifecycleFixture) -> str:
+    return fixture.name
+
+
+# ---------------------------------------------------------------------------
+# Spec-level acceptance: every positive fixture must validate cleanly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    all_positive_fixtures(),
+    ids=lambda f: _fixture_id(f),
+)
+def test_positive_spec_validates(fixture: LifecycleFixture) -> None:
+    result = validate_workflow(fixture.spec)
+    assert result.ok, (
+        f"{fixture.name}: spec must validate cleanly; got errors="
+        f"{tuple(e.code for e in result.errors)!r}"
+    )
+    assert result.errors == ()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle-level acceptance: histories must conform to the spec.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    all_positive_fixtures(),
+    ids=lambda f: _fixture_id(f),
+)
+def test_positive_lifecycle_conforms(fixture: LifecycleFixture) -> None:
+    report = validate_workflow_lifecycle_conformance(fixture.spec, fixture.events)
+    error_codes = tuple(issue.code for issue in report.errors)
+    assert report.ok, f"{fixture.name}: lifecycle history must conform; got errors={error_codes!r}"
+    assert report.errors == ()
+
+
+# ---------------------------------------------------------------------------
+# Terminal-emitted-once: every positive run history terminates with exactly
+# one terminal run event, and that event is the expected discriminator.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    all_positive_fixtures(),
+    ids=lambda f: _fixture_id(f),
+)
+def test_terminal_run_event_emitted_once(fixture: LifecycleFixture) -> None:
+    terminals = terminal_run_event_types(fixture.events)
+    assert len(terminals) == 1, (
+        f"{fixture.name}: expected exactly one terminal run event; got "
+        f"{[t.event_type.value for t in terminals]!r}"
+    )
+    terminal = terminals[0]
+    assert terminal.event_type is fixture.expected_run_terminal, (
+        f"{fixture.name}: expected terminal type {fixture.expected_run_terminal.value!r}; "
+        f"got {terminal.event_type.value!r}"
+    )
+    if fixture.expected_reason_code is not None:
+        assert terminal.reason_code == fixture.expected_reason_code, (
+            f"{fixture.name}: expected reason_code "
+            f"{fixture.expected_reason_code!r}; got {terminal.reason_code!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Legal-transition fixture: scheduled -> started -> completed sequencing.
+# ---------------------------------------------------------------------------
+
+
+def test_legal_transitions_sequence_per_node() -> None:
+    """The legal-transitions fixture exercises the full node lifecycle path.
+
+    For each task node we expect the canonical scheduled -> started ->
+    completed order, with no failed/retried in between.
+    """
+    fixture = positive_legal_transitions()
+    by_node: dict[str, list[WorkflowLifecycleEventType]] = {}
+    for event in fixture.events:
+        if event.node_id is None:
+            continue
+        by_node.setdefault(event.node_id, []).append(event.event_type)
+    assert set(by_node) == {"task_agent", "task_verify"}
+    expected_sequence = [
+        WorkflowLifecycleEventType.NODE_SCHEDULED,
+        WorkflowLifecycleEventType.NODE_STARTED,
+        WorkflowLifecycleEventType.NODE_COMPLETED,
+    ]
+    for node_id, sequence in by_node.items():
+        assert sequence == expected_sequence, (
+            f"node {node_id!r} expected lifecycle {[e.value for e in expected_sequence]!r}; "
+            f"got {[e.value for e in sequence]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Blocked / failed / cancelled / timed_out distinction.
+# ---------------------------------------------------------------------------
+
+
+def test_blocked_distinction_has_no_started_node() -> None:
+    """Blocked runs never start a node — only RUN_CREATED + RUN_FAILED(blocked)."""
+    fixture = positive_blocked_distinction()
+    started = [
+        event
+        for event in fixture.events
+        if event.event_type is WorkflowLifecycleEventType.NODE_STARTED
+    ]
+    assert started == [], (
+        "blocked-distinction fixture must not contain NODE_STARTED events; "
+        f"got {[e.node_id for e in started]!r}"
+    )
+    terminals = terminal_run_event_types(fixture.events)
+    assert len(terminals) == 1
+    assert terminals[0].event_type is WorkflowLifecycleEventType.RUN_FAILED
+    assert terminals[0].reason_code == "blocked"
+
+
+def test_failed_distinction_carries_node_failure() -> None:
+    """A failed-mid-execution run includes at least one NODE_FAILED event."""
+    fixture = positive_failed_distinction()
+    failed_node_events = [
+        event
+        for event in fixture.events
+        if event.event_type is WorkflowLifecycleEventType.NODE_FAILED
+    ]
+    assert failed_node_events, "failed-distinction fixture must include NODE_FAILED"
+    assert all(e.reason_code is not None for e in failed_node_events), (
+        "NODE_FAILED events must carry a reason_code per lifecycle schema"
+    )
+
+
+def test_cancelled_distinction_terminates_as_cancelled() -> None:
+    """Cancelled runs MUST terminate with RUN_CANCELLED, not RUN_FAILED."""
+    fixture = positive_cancelled_distinction()
+    terminals = terminal_run_event_types(fixture.events)
+    assert len(terminals) == 1
+    assert terminals[0].event_type is WorkflowLifecycleEventType.RUN_CANCELLED
+    assert terminals[0].reason_code == "user_requested"
+
+
+def test_timed_out_distinction_disambiguates_via_reason_code() -> None:
+    """Timed-out is represented as RUN_FAILED + reason_code='timed_out'.
+
+    The v1 IR intentionally does NOT introduce a new RUN_TIMED_OUT event
+    family (out of scope per #956 / #1131). This test pins the encoding so
+    a future #946 projection can split the read model without an event-
+    family schema change.
+    """
+    fixture = positive_timed_out_distinction()
+    terminals = terminal_run_event_types(fixture.events)
+    assert len(terminals) == 1
+    assert terminals[0].event_type is WorkflowLifecycleEventType.RUN_FAILED
+    assert terminals[0].reason_code == "timed_out"
+
+
+def test_distinct_terminal_outcomes_cover_four_classes() -> None:
+    """The four distinction fixtures must use four distinct (event,reason) pairs.
+
+    Locks the contract that blocked / failed / cancelled / timed_out are
+    encoded distinguishably in lifecycle history — there is no collision
+    that would prevent a downstream projection from telling them apart.
+    """
+    fixtures = (
+        positive_blocked_distinction(),
+        positive_failed_distinction(),
+        positive_cancelled_distinction(),
+        positive_timed_out_distinction(),
+    )
+    pairs = []
+    for fixture in fixtures:
+        terminals = terminal_run_event_types(fixture.events)
+        assert len(terminals) == 1, f"{fixture.name}: expected exactly one terminal event"
+        pairs.append((terminals[0].event_type, terminals[0].reason_code))
+    counts = Counter(pairs)
+    duplicates = {pair: count for pair, count in counts.items() if count > 1}
+    assert not duplicates, (
+        "blocked/failed/cancelled/timed_out fixtures must be distinguishable; "
+        f"got duplicate terminal encodings: {duplicates!r}"
+    )
+
+
+def test_terminal_emitted_once_fixture_has_single_terminal() -> None:
+    """The dedicated terminal-emitted-once fixture asserts the count rule literally."""
+    fixture = positive_terminal_emitted_once()
+    terminals = terminal_run_event_types(fixture.events)
+    assert len(terminals) == 1
+    assert terminals[0].event_type is WorkflowLifecycleEventType.RUN_COMPLETED


### PR DESCRIPTION
## Summary

Wave 1 N-2 — adds an offline, deterministic conformance harness under
`tests/conformance/workflow_ir/` that locks the #956 Workflow IR v1
boundary without changing schema, validator logic, or production
behavior.

- **5 negative fixtures** (each rejected by `validate_workflow` with the
  locked #956 error code, with assertions that the failing identifier is
  named in the message):
  - dangling edge
  - duplicate node id
  - unreachable terminal
  - missing schema ref (`missing_evidence_schema` + `missing_input_schema`)
  - illegal transition (self-loop)
- **5 positive fixtures** (each accepted by `validate_workflow` AND
  `validate_workflow_lifecycle_conformance`):
  - legal node-state transitions (scheduled -> started -> completed)
  - terminal-state-emitted-once
  - blocked / failed / cancelled / timed_out distinction (4 fixtures
    using distinct `(event_type, reason_code)` encodings so a future
    #946 projection can split the read model without a new event family)
- **Plugin firewall contract fixture**: proves that a blocked-permission
  invocation through `invoke_plugin` cannot be projected as a successful
  workflow node completion — the firewall never returns `status="success"`
  on the blocked path, the only emitted event is `plugin.failed`
  (`result.status="blocked"`), and the canonical lifecycle projection
  for a blocked outcome is `NODE_FAILED` + `RUN_FAILED` (not
  `NODE_COMPLETED`).

All fixtures are deterministic, offline, with no network, no model
provider, no credentials, no subprocess, and no plugin dispatch. Timestamps
anchor to a fixed UTC epoch so replays are reproducible.

## Scope guards

- ❌ No Workflow IR schema change.
- ❌ No `schema_version` bump.
- ❌ No HITL fixtures (#960).
- ❌ No live runner / new event family / plugin dispatch behavior.
- ✅ Validator logic untouched; the harness asserts the existing locked
  rules.

## Test plan

- [x] `python -m pytest tests/conformance/workflow_ir/ -q` — 43 passed
- [x] `python -m pytest tests/unit/orchestrator/ -q` — 1615 passed, 1 skipped (baseline preserved)
- [x] `ruff check tests/conformance/` — clean
- [x] `ruff format --check tests/conformance/` — clean
- [x] `mypy tests/conformance/` — no issues

Refs #1131, #956.