### PR TITLE
docs(agentos): mark completed projection follow-up slots

### DIFF
--- a/docs/agentos/projection-followups.md
+++ b/docs/agentos/projection-followups.md
@@ -34,7 +34,7 @@ the ✅ markers (or the linked PRs) before scheduling new work against a slot.
 | --- | --- | --- |
 | Artifact/Verdict projection | ✅ shipped via #1061. Populate existing `ArtifactRecord` and `VerdictRecord` outputs from persisted evidence/evaluation-like events. | Read-model only; no new evidence schema or verifier policy. |
 | Status JSON CLI | ✅ shipped via #1064. Expose the existing projection query through a thin `ouroboros status run ... --json` surface. | Reuse projection semantics; no cache or writes. |
-| Mechanical-evaluation fixture | open PR #1132. Prove a small execution/evaluation history projects to run, step, artifact, verdict, and source event IDs. | Offline/local fixture only. Landed by the #946 mechanical fixture follow-up. |
+| Mechanical-evaluation fixture | Open in PR #1132 until merged. Prove a small execution/evaluation history projects to run, step, artifact, verdict, and source event IDs. | Offline/local read-model fixture only; EventStore remains the source of truth and this slot does not create a new AgentOS surface. |
 | StepSnapshot/session/runtime views | Add bounded derived views for post-step state, session health, runtime handle, and resume-token metadata. | Later views; do not block artifact/verdict or CLI JSON work. |
 | Context/checkpoint anchors | Surface context pack and checkpoint references as projection metadata. | Read-only anchors only; no resume authority, raw context payloads, checkpoint writes, or second context state model. |
 | Optional exporter sinks | Feed OTEL or other exporters from projections. | Optional/lazy, disabled by default, never source of truth. |

--- a/docs/agentos/projection-followups.md
+++ b/docs/agentos/projection-followups.md
@@ -25,11 +25,16 @@ The #946 baseline is a read-only projection stack over persisted events:
 
 ## Next safe PR slots
 
+Slots marked ✅ have shipped; the implementing PR number is noted inline. Slots
+without ✅ remain open and are eligible follow-up work under the boundaries
+above. This table lists eligible slots, not just unimplemented ones — consult
+the ✅ markers (or the linked PRs) before scheduling new work against a slot.
+
 | Slot | Purpose | Boundary |
 | --- | --- | --- |
-| Artifact/Verdict projection | Populate existing `ArtifactRecord` and `VerdictRecord` outputs from persisted evidence/evaluation-like events. | Read-model only; no new evidence schema or verifier policy. |
-| Status JSON CLI | Expose the existing projection query through a thin `ouroboros status run ... --json` surface. | Reuse projection semantics; no cache or writes. |
-| Mechanical-evaluation fixture | Prove a small execution/evaluation history projects to run, step, artifact, verdict, and source event IDs. | Offline/local fixture only. Landed by the #946 mechanical fixture follow-up. |
+| Artifact/Verdict projection | ✅ shipped via #1061. Populate existing `ArtifactRecord` and `VerdictRecord` outputs from persisted evidence/evaluation-like events. | Read-model only; no new evidence schema or verifier policy. |
+| Status JSON CLI | ✅ shipped via #1064. Expose the existing projection query through a thin `ouroboros status run ... --json` surface. | Reuse projection semantics; no cache or writes. |
+| Mechanical-evaluation fixture | open PR #1132. Prove a small execution/evaluation history projects to run, step, artifact, verdict, and source event IDs. | Offline/local fixture only. Landed by the #946 mechanical fixture follow-up. |
 | StepSnapshot/session/runtime views | Add bounded derived views for post-step state, session health, runtime handle, and resume-token metadata. | Later views; do not block artifact/verdict or CLI JSON work. |
 | Context/checkpoint anchors | Surface context pack and checkpoint references as projection metadata. | Read-only anchors only; no resume authority, raw context payloads, checkpoint writes, or second context state model. |
 | Optional exporter sinks | Feed OTEL or other exporters from projections. | Optional/lazy, disabled by default, never source of truth. |


### PR DESCRIPTION
## Summary

Updates `docs/agentos/projection-followups.md` so the "Next safe PR slots" table reflects which slots have already shipped vs. which remain open. The Wave 1 plan in #1131 treated this table as a list of "next safe slots" to schedule, but it actually lists eligible slots regardless of implementation state — so #1061 (Artifact/Verdict populator) and #1064 (Status JSON CLI) were planned again even though they had already shipped.

Refs #1131, #946 (parent: #946).

## Changes

- Mark **Artifact/Verdict projection** as ✅ shipped via #1061.
- Mark **Status JSON CLI** as ✅ shipped via #1064.
- Clarify **Mechanical-evaluation fixture** as open in PR #1132 until that PR merges, and remove the stale wording that implied the slot had already landed.
- Add a short note above the table explaining the ✅ convention so future planners see the shipped vs open distinction at a glance.
- Preserve the remaining slots (StepSnapshot/session/runtime views, Context/checkpoint anchors, Optional exporter sinks) and the "Explicit anti-actions" / "Review checklist" boundaries.

## Out of scope

- No code changes.
- No other doc files touched.
- No change to slot semantics, boundary rules, or v1 scope.
- No new slots added.
- No new AgentOS surface or source of truth.

## Test plan

- [x] `git diff --check -- docs/agentos/projection-followups.md`
- [x] Local invariant check confirms the #1132 row says "Open in PR #1132 until merged", preserves "EventStore remains the source of truth", and says the slot does not create a new AgentOS surface.
- [x] GitHub Actions on head `f5732096fb80a00db001fa679484add848868b43`: Ruff Lint, MyPy Type Check, Bridge TypeScript, Python 3.12/3.13/3.14 tests, `enforce-envelope`, and `enforce-boundary` all passed.
