### PR TITLE
instrument(auto): emit structured-log events at safe-default decision points

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -354,6 +354,17 @@ class AutoInterviewDriver:
                 "seed_ready", state.interview_session_id, ledger, self.max_rounds
             )
 
+        open_gaps = ledger.open_gaps()
+        log.info(
+            "auto.interview.safe_default.entered",
+            auto_session_id=state.auto_session_id,
+            backend_done=backend_done,
+            ledger_done=ledger_done,
+            open_gaps=list(open_gaps),
+            ambiguity_score=turn.ambiguity_score,
+            max_rounds=self.max_rounds,
+        )
+
         finalization = None
         if not backend_done:
             finalization = finalize_safe_defaultable_gaps(
@@ -363,8 +374,30 @@ class AutoInterviewDriver:
                 pending_question=turn.question,
                 active_profile=getattr(self.answerer, "active_profile", None),
             )
+        else:
+            log.info(
+                "auto.interview.safe_default.skipped_backend_done",
+                auto_session_id=state.auto_session_id,
+                open_gaps=list(open_gaps),
+            )
+
+        if finalization is not None:
+            if not finalization.defaulted_sections and not finalization.unsafe_gaps:
+                log.info(
+                    "auto.interview.safe_default.no_gaps_to_default",
+                    auto_session_id=state.auto_session_id,
+                    ledger_done=ledger_done,
+                )
+            if finalization.unsafe_gaps:
+                log.info(
+                    "auto.interview.safe_default.unsafe_context_observed",
+                    auto_session_id=state.auto_session_id,
+                    unsafe_gaps=finalization.unsafe_gaps,
+                )
+
         if finalization is not None and finalization.completed and ledger.is_seed_ready():
             synthesis = build_safe_default_synthesis(finalization)
+            synthesis_pushed = False
             if synthesis and state.interview_session_id:
                 try:
                     synthesis_turn = _validate_turn(
@@ -381,6 +414,7 @@ class AutoInterviewDriver:
                             tool_name="interview.safe_default_synthesis",
                         )
                     )
+                    synthesis_pushed = True
                 except Exception as exc:  # noqa: BLE001 - preserve transcript/ledger SSOT
                     _revert_safe_default_entries(ledger, finalization.defaulted_sections)
                     blocker = (
@@ -394,6 +428,7 @@ class AutoInterviewDriver:
                         interview_session_id=state.interview_session_id,
                         defaulted_sections=finalization.defaulted_sections,
                         error=str(exc),
+                        synthesis_pushed=False,
                     )
                     state.ledger = ledger.to_dict()
                     state.mark_blocked(blocker, tool_name="interview.safe_default_synthesis")
@@ -417,6 +452,12 @@ class AutoInterviewDriver:
                     return AutoInterviewResult(
                         "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
                     )
+            log.info(
+                "auto.interview.safe_default.closed",
+                auto_session_id=state.auto_session_id,
+                defaulted_sections=finalization.defaulted_sections,
+                synthesis_pushed=synthesis_pushed,
+            )
             state.ledger = ledger.to_dict()
             state.pending_question = None
             state.interview_completed = True
@@ -436,6 +477,15 @@ class AutoInterviewDriver:
             ambiguity_part = "ambiguity_score=unknown"
         open_gaps = ledger.open_gaps()
         gaps_part = f"open_gaps={open_gaps}" if open_gaps else "open_gaps=[]"
+        if ledger_done:
+            log.info(
+                "auto.interview.mutual_agreement_deadlock_at_max_rounds",
+                auto_session_id=state.auto_session_id,
+                backend_done=backend_done,
+                ledger_done=ledger_done,
+                open_gaps=list(open_gaps),
+                ambiguity_score=turn.ambiguity_score,
+            )
         blocker = (
             f"auto interview reached max_rounds={self.max_rounds} without closure: "
             f"backend_done={backend_done} ({ambiguity_part}), "

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -346,17 +346,13 @@ def _unsafe_context_reason(
     for reason, pattern in _UNSAFE_CONTEXT_PATTERNS:
         match = re.search(pattern, context)
         if match:
-            matched_token = match.group(0)
-            if len(matched_token) > 80:
-                matched_token = matched_token[:80]
-            text_prefix = context[:120]
-            if len(context) > 120:
-                text_prefix = text_prefix + "..."
             log.info(
                 "auto.safe_default.unsafe_context_match",
                 pattern_name=reason,
-                matched_text_prefix=text_prefix,
-                matched_token=matched_token,
+                context_length=len(context),
+                match_start=match.start(),
+                match_end=match.end(),
+                matched_length=match.end() - match.start(),
             )
             return reason
     return None

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -8,6 +8,8 @@ import re
 from typing import TYPE_CHECKING
 import unicodedata
 
+import structlog
+
 from ouroboros.auto.ledger import (
     LedgerEntry,
     LedgerSource,
@@ -19,6 +21,8 @@ from ouroboros.auto.ledger import (
 # Callers that pass ``active_profile`` will have already imported DomainProfile.
 if TYPE_CHECKING:
     from ouroboros.auto.domain_profile import DomainProfile
+
+log = structlog.get_logger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -340,7 +344,20 @@ def _unsafe_context_reason(
     ).lower()
     context = _strip_negated_clauses(context)
     for reason, pattern in _UNSAFE_CONTEXT_PATTERNS:
-        if re.search(pattern, context):
+        match = re.search(pattern, context)
+        if match:
+            matched_token = match.group(0)
+            if len(matched_token) > 80:
+                matched_token = matched_token[:80]
+            text_prefix = context[:120]
+            if len(context) > 120:
+                text_prefix = text_prefix + "..."
+            log.info(
+                "auto.safe_default.unsafe_context_match",
+                pattern_name=reason,
+                matched_text_prefix=text_prefix,
+                matched_token=matched_token,
+            )
             return reason
     return None
 

--- a/tests/unit/auto/test_safe_default_observability.py
+++ b/tests/unit/auto/test_safe_default_observability.py
@@ -1,0 +1,198 @@
+"""Observability tests for safe-default finalization structured-log events.
+
+Verifies that the structured-log events added by PR-A (instrumentation) are
+emitted at the correct decision points inside ``AutoInterviewDriver.run`` and
+``_unsafe_context_reason``.  Zero behaviour change is asserted by checking
+that existing result semantics (status, blocker strings) are unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+from structlog.testing import capture_logs
+
+from ouroboros.auto.interview_driver import (
+    AutoInterviewDriver,
+    FunctionInterviewBackend,
+    InterviewTurn,
+)
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
+from ouroboros.auto.safe_defaults import _unsafe_context_reason
+from ouroboros.auto.state import AutoPipelineState, AutoStore
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ledger_with_goal_only(goal: str = "Build a local CLI") -> SeedDraftLedger:
+    """Ledger with only the goal filled — all other required sections are open gaps."""
+    return SeedDraftLedger.from_goal(goal)
+
+
+def _ledger_all_filled_except(
+    goal: str = "Build a local CLI", *, skip: str | None = None
+) -> SeedDraftLedger:
+    """Ledger with all required sections filled except *skip* (if given)."""
+    ledger = SeedDraftLedger.from_goal(goal)
+    for section, value in {
+        "actors": "Single local CLI user",
+        "inputs": "Command arguments",
+        "outputs": "Stable stdout and files",
+        "constraints": "Use existing project patterns",
+        "non_goals": "No cloud sync",
+        "acceptance_criteria": "Command prints stable output",
+        "verification_plan": "Run command-level tests",
+        "failure_modes": "Invalid input exits non-zero",
+        "runtime_context": "Existing repository runtime",
+    }.items():
+        if section == skip:
+            continue
+        source = (
+            LedgerSource.NON_GOAL if section == "non_goals" else LedgerSource.CONSERVATIVE_DEFAULT
+        )
+        ledger.add_entry(
+            section,
+            LedgerEntry(
+                key=f"{section}.test",
+                value=value,
+                source=source,
+                confidence=0.85,
+                status=LedgerStatus.DEFAULTED,
+            ),
+        )
+    return ledger
+
+
+# ---------------------------------------------------------------------------
+# Test 1: no_gaps_to_default + mutual_agreement_deadlock_at_max_rounds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_safe_default_logs_no_gaps_to_default(tmp_path) -> None:
+    """Ledger already seed-ready but backend keeps asking → mutual-agreement deadlock path.
+
+    The driver enters the safe-default fallback block after max_rounds with
+    backend_done=False and ledger_done=True.  ``finalize_safe_defaultable_gaps``
+    returns an empty defaulted_sections (no gaps to fill), so the driver emits
+    ``no_gaps_to_default``.  Because ledger_done=True at the final blocker path
+    the driver also emits ``mutual_agreement_deadlock_at_max_rounds``.
+    """
+    # Ledger is fully filled — is_seed_ready() returns True from round 0.
+    ledger = _ledger_all_filled_except()
+    assert ledger.is_seed_ready()
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What else should we know?", "interview_deadlock")
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        # Backend never signals completion — it keeps asking.
+        return InterviewTurn("What else should we know?", session_id, seed_ready=False)
+
+    state = AutoPipelineState(goal="Build a local CLI", cwd=str(tmp_path))
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    with capture_logs() as captured:
+        result = await driver.run(state, ledger)
+
+    events = [e["event"] for e in captured]
+    assert "auto.interview.safe_default.entered" in events
+    assert "auto.interview.safe_default.no_gaps_to_default" in events
+    assert "auto.interview.mutual_agreement_deadlock_at_max_rounds" in events
+
+    # Behaviour unchanged: blocked because backend never agreed.
+    assert result.status == "blocked"
+    assert "without closure" in (result.blocker or "")
+
+
+# ---------------------------------------------------------------------------
+# Test 2: safe_default.closed path with defaulted_sections field
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_safe_default_logs_closed_path(tmp_path) -> None:
+    """Benign goal with no pre-filled ledger; backend keeps asking at max_rounds=1.
+
+    After max_rounds the driver calls ``finalize_safe_defaultable_gaps``, which
+    fills all open gaps including ``runtime_context``.  The synthesis push succeeds.
+    The driver emits ``safe_default.entered`` and ``safe_default.closed`` (with
+    ``defaulted_sections`` including ``runtime_context``), and the result status is
+    ``seed_ready``.
+    """
+    ledger = SeedDraftLedger.from_goal("Build a tiny local CLI")
+    assert not ledger.is_seed_ready()
+    assert "runtime_context" in ledger.open_gaps()
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What else should we know?", "interview_closable")
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        if "[safe-default-synthesis]" in text:
+            return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+        return InterviewTurn("What else should we know?", session_id, seed_ready=False)
+
+    state = AutoPipelineState(goal="Build a tiny local CLI", cwd=str(tmp_path))
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    with capture_logs() as captured:
+        result = await driver.run(state, ledger)
+
+    events = [e["event"] for e in captured]
+    assert "auto.interview.safe_default.entered" in events
+    assert "auto.interview.safe_default.closed" in events
+
+    # Verify the defaulted_sections field on the closed event includes runtime_context.
+    closed_events = [e for e in captured if e["event"] == "auto.interview.safe_default.closed"]
+    assert len(closed_events) == 1
+    defaulted = closed_events[0]["defaulted_sections"]
+    assert "runtime_context" in defaulted
+
+    # Behaviour unchanged: seed ready after safe-default closure.
+    assert result.status == "seed_ready"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: unsafe_context_match logs pattern_name
+# ---------------------------------------------------------------------------
+
+
+def test_unsafe_context_match_logs_pattern_name() -> None:
+    """Goal containing 'deploy to production' triggers the unsafe-context gate.
+
+    ``_unsafe_context_reason`` must emit ``auto.safe_default.unsafe_context_match``
+    with ``pattern_name == 'ambiguous external side effect'``.
+    """
+    ledger = SeedDraftLedger.from_goal("deploy to production")
+
+    with capture_logs() as captured:
+        reason = _unsafe_context_reason(
+            ledger,
+            goal="deploy to production",
+            pending_question=None,
+        )
+
+    assert reason is not None
+
+    match_events = [
+        e for e in captured if e["event"] == "auto.safe_default.unsafe_context_match"
+    ]
+    assert len(match_events) >= 1
+    assert match_events[0]["pattern_name"] == "ambiguous external side effect"
+    assert "matched_token" in match_events[0]
+    assert "matched_text_prefix" in match_events[0]

--- a/tests/unit/auto/test_safe_default_observability.py
+++ b/tests/unit/auto/test_safe_default_observability.py
@@ -168,31 +168,96 @@ async def test_safe_default_logs_closed_path(tmp_path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Test 3: unsafe_context_match logs pattern_name
+# Test 3: unsafe_context_match logs pattern_name and safe metrics
 # ---------------------------------------------------------------------------
 
 
-def test_unsafe_context_match_logs_pattern_name() -> None:
-    """Goal containing 'deploy to production' triggers the unsafe-context gate.
+def test_unsafe_context_match_logs_pattern_name_without_raw_text() -> None:
+    """Unsafe context logs bounded diagnostics without raw user/secret text.
 
     ``_unsafe_context_reason`` must emit ``auto.safe_default.unsafe_context_match``
-    with ``pattern_name == 'ambiguous external side effect'``.
+    with ``pattern_name`` and useful metrics, but must not include raw goal,
+    answer, ledger, or matched-token text.
     """
-    ledger = SeedDraftLedger.from_goal("deploy to production")
+    raw_secret = "sk_live_review_secret_12345"
+    raw_goal = f"Build a local CLI that uses the customer access token {raw_secret}"
+    ledger = SeedDraftLedger.from_goal(raw_goal)
+    ledger.record_qa(
+        "Which credential should the CLI use?",
+        f"Use the access token {raw_secret} from the user.",
+    )
 
     with capture_logs() as captured:
         reason = _unsafe_context_reason(
             ledger,
-            goal="deploy to production",
+            goal=raw_goal,
             pending_question=None,
         )
 
-    assert reason is not None
+    assert reason == "credentials/secrets"
 
-    match_events = [
-        e for e in captured if e["event"] == "auto.safe_default.unsafe_context_match"
+    match_events = [e for e in captured if e["event"] == "auto.safe_default.unsafe_context_match"]
+    assert len(match_events) == 1
+    event = match_events[0]
+    assert event["pattern_name"] == "credentials/secrets"
+    assert event["context_length"] > 0
+    assert event["match_start"] >= 0
+    assert event["match_end"] > event["match_start"]
+    assert event["matched_length"] == event["match_end"] - event["match_start"]
+    assert "context_sha256" not in event
+    assert "match_sha256" not in event
+    assert "matched_token" not in event
+    assert "matched_text_prefix" not in event
+    event_repr = repr(event)
+    assert raw_secret not in event_repr
+    assert raw_goal not in event_repr
+    assert "Which credential should the CLI use?" not in event_repr
+    assert "Use the access token" not in event_repr
+
+
+# ---------------------------------------------------------------------------
+# Test 4: unsafe_context_observed emitted when finalization stays blocked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_safe_default_logs_unsafe_context_observed_without_raw_text(tmp_path) -> None:
+    """Unsafe finalization emits the blocking event without raw user/secret text."""
+    raw_secret = "prod-token-please-do-not-log"
+    raw_goal = f"Use the customer access token {raw_secret} for a local helper"
+    ledger = SeedDraftLedger.from_goal(raw_goal)
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("Which token should it use?", "interview_unsafe")
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("Which token should it use?", session_id, seed_ready=False)
+
+    state = AutoPipelineState(goal=raw_goal, cwd=str(tmp_path))
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    with capture_logs() as captured:
+        result = await driver.run(state, ledger)
+
+    events = [e["event"] for e in captured]
+    assert "auto.interview.safe_default.entered" in events
+    assert "auto.interview.safe_default.unsafe_context_observed" in events
+
+    unsafe_events = [
+        e for e in captured if e["event"] == "auto.interview.safe_default.unsafe_context_observed"
     ]
-    assert len(match_events) >= 1
-    assert match_events[0]["pattern_name"] == "ambiguous external side effect"
-    assert "matched_token" in match_events[0]
-    assert "matched_text_prefix" in match_events[0]
+    assert len(unsafe_events) == 1
+    assert unsafe_events[0]["unsafe_gaps"]
+    unsafe_event_repr = repr(unsafe_events[0])
+    assert raw_secret not in unsafe_event_repr
+    assert raw_goal not in unsafe_event_repr
+
+    assert result.status == "blocked"
+    assert "without closure" in (result.blocker or "")


### PR DESCRIPTION
## Summary
- Add structured-log events at the safe-default finalization decision points in `interview_driver.py` and the unsafe-context gate in `safe_defaults.py`.
- Keep the change instrumentation-only: no new closure policy, result-envelope surface, state field, or control-flow branch.
- Tighten unsafe-context observability so structured logs remain content-free: the unsafe-context match event now emits only categorical/positional metrics (`pattern_name`, `context_length`, `match_start`, `match_end`, `matched_length`) and no raw prefixes, matched text, or raw-text-derived digests.

## Scope relative to #961 / AgentOS
This PR should be read as a narrow Track B auto-observability slice that supports the post-#1122/#1129 safe-default re-observation work. It is **not** an AgentOS Track C implementation and should not be treated as resolving the #961 roadmap/meta SSOT.

## Why this scope
Live `ooo auto` runs from the #821 acceptance set blocked at INTERVIEW, and the safe-default fallback added by #1122 did not expose enough structured evidence to distinguish:

1. no remaining defaultable sections / mutual-agreement deadlock with `ledger_done=True`,
2. unsafe-context gate trips, or
3. synthesis push timeout / non-closure.

This PR makes those decision points observable so a later live re-run can produce actionable evidence. No fix is attempted here.

## What is NOT done here (deliberate)
- No closure-policy change.
- No AgentOS Track C orchestration/runtime architecture change.
- No surface/envelope change to result meta.
- No taxonomy/stop_reason change.
- No claim that these unit tests are #821/#809 live/full-chain smoke evidence; they are synthetic instrumentation regression coverage only.
- No live-replay regression suite (deferred until the relevant closure fixes land).

## Test Plan
- [x] `uv run ruff format --check src/ouroboros/auto/safe_defaults.py tests/unit/auto/test_safe_default_observability.py`
- [x] `uv run ruff check src/ouroboros/auto/safe_defaults.py tests/unit/auto/test_safe_default_observability.py`
- [x] `uv run pytest tests/unit/auto/test_safe_default_observability.py -q` (4 tests)
- [x] CI: Ruff Lint, MyPy Type Check, Bridge TypeScript, Python 3.12/3.13/3.14 tests, boundary/envelope checks all pass on `f049f267`.

Refs #821, #809, #961, #1122, #1129.
