### PR TITLE
feat(plugin): prompt for required trust grants on install

### DIFF
--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -42,6 +42,7 @@ from ouroboros.plugin.digest import (
 from ouroboros.plugin.ledger_adapter import wrap_plugin_event
 from ouroboros.plugin.lockfile import DEFAULT_LOCKFILE_PATH, LockEntry, Lockfile
 from ouroboros.plugin.manifest import (
+    Permission,
     PluginManifest,
     PluginManifestError,
     load_manifest,
@@ -1609,6 +1610,107 @@ def _install_one(
     return entry
 
 
+def _missing_required_permissions(
+    *,
+    manifest: PluginManifest,
+    entry: LockEntry,
+    trust: TrustStore,
+) -> list[Permission]:
+    required = [p for p in manifest.permissions if p.required]
+    if not required:
+        return []
+
+    record = trust.read(manifest.name)
+    granted = (
+        {g.scope for g in record.granted_scopes}
+        if record is not None
+        and record.matches_subject(
+            version=manifest.version,
+            source_type=entry.source_type,
+            source_identity=entry.source_identity,
+            artifact_digest=entry.artifact_digest,
+        )
+        else set()
+    )
+    return [p for p in required if p.scope not in granted]
+
+
+def _print_required_permissions(permissions: list[Permission]) -> None:
+    console.print("")
+    console.print("Required permissions:")
+    width = max(len(p.scope) for p in permissions)
+    for permission in permissions:
+        reason = permission.reason.strip() if permission.reason else permission.risk
+        console.print(f"  {permission.scope:<{width}}  {reason}")
+
+
+def _maybe_prompt_grant_required_permissions(
+    *,
+    manifest: PluginManifest,
+    entry: LockEntry,
+    trust: TrustStore,
+) -> None:
+    try:
+        missing = _missing_required_permissions(manifest=manifest, entry=entry, trust=trust)
+    except (ValueError, OSError) as exc:
+        console.print(
+            f"  [yellow]warning[/]: trust file for {manifest.name!r} is unreadable "
+            f"({exc}); required-permission prompt skipped. Re-grant scopes via "
+            f"`ooo plugin trust {manifest.name} --scope <...>` after fixing the file. "
+            f"The firewall blocks invocation until trust is re-granted."
+        )
+        return
+    if not missing:
+        return
+
+    _print_required_permissions(missing)
+    destructive = [p.scope for p in missing if p.risk == "destructive"]
+    if destructive:
+        console.print(
+            "  destructive scopes require an explicit trust command: "
+            f"`ooo plugin trust {manifest.name} --scope <scope>`",
+            markup=False,
+            highlight=False,
+        )
+        return
+
+    try:
+        approved = typer.confirm("Grant required permissions now?", default=False, abort=False)
+    except (EOFError, typer.Abort):
+        approved = False
+    if not approved:
+        console.print(
+            f"  run `ooo plugin trust {manifest.name} --scope <scope>` later",
+            markup=False,
+            highlight=False,
+        )
+        return
+
+    scopes = [p.scope for p in missing]
+    try:
+        record = trust.grant_many_and_clear_disable(
+            plugin=manifest.name,
+            version=manifest.version,
+            scopes=scopes,
+            granted_by="user:cli",
+            source_type=entry.source_type,
+            source_identity=entry.source_identity,
+            artifact_digest=entry.artifact_digest,
+        )
+    except (ValueError, OSError) as exc:
+        print_error(
+            f"could not write trust grant for {manifest.name!r}: {exc}. "
+            f"Inspect the trust file at {trust.root / manifest.name}, then "
+            f"re-run `ooo plugin trust {manifest.name} --scope <...>`."
+        )
+        raise typer.Exit(code=1) from exc
+
+    console.print(
+        f"  granted required scopes: {', '.join(scopes)} "
+        f"({len(record.granted_scopes)} total scope(s))"
+    )
+
+
 @app.command("add")
 def add_command(
     target: Annotated[
@@ -1815,7 +1917,7 @@ def add_command(
             # disk, and no lockfile entry to reflect either.
             artifact_digest = canonical_tree_hash(source_dir)
             with _atomic_install_with_rollback(source_dir, plugin_home):
-                _install_one(
+                installed_entry = _install_one(
                     manifest=manifest,
                     plugin_home=plugin_home,
                     lock=lock,
@@ -1866,6 +1968,11 @@ def add_command(
             new_artifact_digest=artifact_digest,
             trust=trust,
         )
+        _maybe_prompt_grant_required_permissions(
+            manifest=manifest,
+            entry=installed_entry,
+            trust=trust,
+        )
         # An install at any digest also clears the disable record for
         # this subject (per the RFC: "remove ALSO deletes any disable
         # record" and re-trust is the re-enable path). Keep the disable
@@ -1875,12 +1982,6 @@ def add_command(
         # `trust` and `remove` clear it (RFC: "Re-enabling is performed
         # by re-running ooo plugin trust").
         installed.append(f"{manifest.name} {manifest.version}")
-        required = [p.scope for p in manifest.permissions if p.required]
-        if required:
-            console.print(
-                f"  required scopes (run `ooo plugin trust {manifest.name} "
-                f"--scope <scope>`): {', '.join(required)}"
-            )
 
     print_success(f"Installed: {'; '.join(installed)}")
 

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -98,7 +98,7 @@ def test_add_anti_pattern_install_string_rejected(runner: CliRunner, tmp_path: P
 
 
 def test_add_local_path_with_plugin_flag(runner: CliRunner, tmp_path: Path) -> None:
-    """`add <local-repo>` with `--plugin <name>` installs without prompts."""
+    """`add <local-repo>` with `--plugin <name>` installs deterministically."""
     repo_root = tmp_path / "repo"
     _make_repo_layout(repo_root, [REFERENCE_MANIFEST])
     paths = _common_paths(tmp_path)
@@ -125,6 +125,125 @@ def test_add_local_path_with_plugin_flag(runner: CliRunner, tmp_path: Path) -> N
     assert entry.repository is None
     # Plugin home was copied.
     assert (paths["plugin_home_root"] / "github-pr-ops" / "ouroboros.plugin.json").is_file()
+
+
+def test_add_prompts_to_grant_missing_required_permissions(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    manifest = {
+        **REFERENCE_MANIFEST,
+        "permissions": [
+            {
+                "scope": "github:read",
+                "risk": "read_only",
+                "required": True,
+                "reason": "Inspect pull request metadata",
+            },
+        ],
+    }
+    repo_root = tmp_path / "repo"
+    _make_repo_layout(repo_root, [manifest])
+    paths = _common_paths(tmp_path)
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            "add",
+            str(repo_root),
+            "--plugin",
+            "github-pr-ops",
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--trust-root",
+            str(paths["trust_root"]),
+        ],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Required permissions:" in result.output
+    assert "github:read" in result.output
+    assert "Inspect pull request metadata" in result.output
+    assert "Grant required permissions now?" in result.output
+
+    record = TrustStore(root=paths["trust_root"]).read("github-pr-ops")
+    assert record is not None
+    assert record.has_scope("github:read")
+
+
+def test_add_decline_required_permission_prompt_leaves_plugin_installed_untrusted(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    repo_root = tmp_path / "repo"
+    _make_repo_layout(repo_root, [REFERENCE_MANIFEST])
+    paths = _common_paths(tmp_path)
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            "add",
+            str(repo_root),
+            "--plugin",
+            "github-pr-ops",
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--trust-root",
+            str(paths["trust_root"]),
+        ],
+        input="n\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Installed" in result.output
+    assert "run `ooo plugin trust github-pr-ops --scope <scope>` later" in result.output
+    assert TrustStore(root=paths["trust_root"]).read("github-pr-ops") is None
+
+
+def test_add_does_not_prompt_grant_for_destructive_required_permissions(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    manifest = {
+        **REFERENCE_MANIFEST,
+        "permissions": [
+            {
+                "scope": "github:pull_request:write",
+                "risk": "destructive",
+                "required": True,
+                "reason": "Modify pull requests",
+            },
+        ],
+    }
+    repo_root = tmp_path / "repo"
+    _make_repo_layout(repo_root, [manifest])
+    paths = _common_paths(tmp_path)
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            "add",
+            str(repo_root),
+            "--plugin",
+            "github-pr-ops",
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--trust-root",
+            str(paths["trust_root"]),
+        ],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Required permissions:" in result.output
+    assert "github:pull_request:write" in result.output
+    assert "destructive scopes require an explicit trust command" in result.output
+    assert "Grant required permissions now?" not in result.output
+    assert TrustStore(root=paths["trust_root"]).read("github-pr-ops") is None
 
 
 def test_add_duplicate_manifest_names_in_catalog_refused(runner: CliRunner, tmp_path: Path) -> None:
@@ -213,6 +332,36 @@ def test_install_local_directory(runner: CliRunner, tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert "github-pr-ops" in result.output
     assert "github-pr-ops" in Lockfile(paths["lockfile"]).read()
+
+
+def test_install_local_directory_does_not_prompt_or_grant_required_permissions(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    """`install` is the non-interactive primitive; trust stays explicit."""
+    plugin_dir = tmp_path / "github-pr-ops"
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "ouroboros.plugin.json").write_text(json.dumps(REFERENCE_MANIFEST))
+    paths = _common_paths(tmp_path)
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            "install",
+            str(plugin_dir),
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--trust-root",
+            str(paths["trust_root"]),
+        ],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Required permissions:" not in result.output
+    assert "Grant required permissions now?" not in result.output
+    assert TrustStore(root=paths["trust_root"]).read("github-pr-ops") is None
 
 
 def test_add_persists_absolute_plugin_home_for_relative_root(


### PR DESCRIPTION
## Summary
- Show missing required plugin permissions immediately after add/install, including manifest reasons.
- Let users grant non-destructive required scopes from the install flow with an explicit default-no prompt.
- Keep destructive required scopes on the deliberate `ooo plugin trust ...` path and preserve corrupt-trust install recovery behavior.

## Tests
- `uv run pytest tests/unit/cli/test_plugin_command_mutating.py -q`
- `uv run pytest tests/unit/plugin -q`
- `uv run ruff check src/ouroboros/cli/commands/plugin.py tests/unit/cli/test_plugin_command_mutating.py`
- Manual smoke: temp plugin repo with `filesystem:read` + `filesystem:write`, accepted prompt, verified trust.json scopes