### PR TITLE
fix(orchestrator): bound workflow lifecycle reason_code/refs and nesting depth

### DIFF
--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -446,6 +446,13 @@ def _normalize_refs(values: Iterable[str]) -> tuple[str, ...]:
             msg = f"Workflow lifecycle refs exceed {MAX_WORKFLOW_LIFECYCLE_REF_COUNT} entries"
             raise ValueError(msg)
         ref = _normalize_non_blank(f"refs[{index}]", value)
+        if len(ref) > MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS:
+            msg = (
+                f"Workflow lifecycle refs exceed "
+                f"{MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS} characters "
+                f"at index {index}"
+            )
+            raise ValueError(msg)
         ref_bytes = ref.encode("utf-8")
         if len(ref_bytes) > MAX_WORKFLOW_LIFECYCLE_REF_BYTES:
             msg = f"Workflow lifecycle ref exceeds {MAX_WORKFLOW_LIFECYCLE_REF_BYTES} bytes"
@@ -557,16 +564,7 @@ class WorkflowLifecycleEvent(BaseModel, frozen=True):
         if isinstance(value, str) or not isinstance(value, Iterable):
             msg = "Workflow lifecycle refs must be an iterable of strings"
             raise TypeError(msg)
-        materialized = tuple(value)
-        for index, ref in enumerate(materialized):
-            if isinstance(ref, str) and len(ref) > MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS:
-                msg = (
-                    f"Workflow lifecycle refs exceed "
-                    f"{MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS} characters "
-                    f"at index {index}"
-                )
-                raise ValueError(msg)
-        return _normalize_refs(materialized)
+        return _normalize_refs(value)
 
     @field_validator("data", mode="before")
     @classmethod

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -33,7 +33,6 @@ MAX_WORKFLOW_LIFECYCLE_REF_BYTES: Final[int] = 512
 MAX_WORKFLOW_LIFECYCLE_REFS_BYTES: Final[int] = 4096
 MAX_WORKFLOW_LIFECYCLE_WORKFLOW_ID_LEN: Final[int] = 256
 MAX_WORKFLOW_LIFECYCLE_REASON_CODE_LEN: Final[int] = 1024
-MAX_WORKFLOW_LIFECYCLE_REFS_ENTRIES: Final[int] = 64
 MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS: Final[int] = 512
 _MAX_NESTING_DEPTH: Final[int] = 32
 
@@ -559,12 +558,6 @@ class WorkflowLifecycleEvent(BaseModel, frozen=True):
             msg = "Workflow lifecycle refs must be an iterable of strings"
             raise TypeError(msg)
         materialized = tuple(value)
-        if len(materialized) > MAX_WORKFLOW_LIFECYCLE_REFS_ENTRIES:
-            msg = (
-                f"Workflow lifecycle refs exceed "
-                f"{MAX_WORKFLOW_LIFECYCLE_REFS_ENTRIES} entries"
-            )
-            raise ValueError(msg)
         for index, ref in enumerate(materialized):
             if isinstance(ref, str) and len(ref) > MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS:
                 msg = (
@@ -1143,7 +1136,6 @@ __all__ = [
     "MAX_WORKFLOW_LIFECYCLE_REF_COUNT",
     "MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS",
     "MAX_WORKFLOW_LIFECYCLE_REFS_BYTES",
-    "MAX_WORKFLOW_LIFECYCLE_REFS_ENTRIES",
     "MAX_WORKFLOW_LIFECYCLE_WORKFLOW_ID_LEN",
     "WORKFLOW_LIFECYCLE_AGGREGATE_TYPE",
     "WORKFLOW_LIFECYCLE_EVENT_TYPES",

--- a/src/ouroboros/orchestrator/workflow_lifecycle.py
+++ b/src/ouroboros/orchestrator/workflow_lifecycle.py
@@ -31,6 +31,11 @@ MAX_WORKFLOW_LIFECYCLE_DATA_BYTES: Final[int] = 8192
 MAX_WORKFLOW_LIFECYCLE_REF_COUNT: Final[int] = 16
 MAX_WORKFLOW_LIFECYCLE_REF_BYTES: Final[int] = 512
 MAX_WORKFLOW_LIFECYCLE_REFS_BYTES: Final[int] = 4096
+MAX_WORKFLOW_LIFECYCLE_WORKFLOW_ID_LEN: Final[int] = 256
+MAX_WORKFLOW_LIFECYCLE_REASON_CODE_LEN: Final[int] = 1024
+MAX_WORKFLOW_LIFECYCLE_REFS_ENTRIES: Final[int] = 64
+MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS: Final[int] = 512
+_MAX_NESTING_DEPTH: Final[int] = 32
 
 WORKFLOW_LIFECYCLE_AGGREGATE_TYPE: Final[str] = "workflow_ir"
 """EventStore aggregate-type bucket for #956 Workflow IR lifecycle events.
@@ -369,7 +374,13 @@ def _is_replay_unsafe_ref(ref: str) -> bool:
     return any(_is_replay_unsafe_key(candidate) for candidate in candidates)
 
 
-def _normalize_json_value(name: str, value: Any, path: str) -> JsonValue:
+def _normalize_json_value(name: str, value: Any, path: str, _depth: int = 0) -> JsonValue:
+    if _depth > _MAX_NESTING_DEPTH:
+        msg = (
+            f"Workflow lifecycle {name} value at {path} exceeds maximum nesting depth "
+            f"of {_MAX_NESTING_DEPTH}"
+        )
+        raise ValueError(msg)
     if value is None or isinstance(value, str | int | bool):
         return value
     if isinstance(value, float):
@@ -385,11 +396,11 @@ def _normalize_json_value(name: str, value: Any, path: str) -> JsonValue:
             if _is_replay_unsafe_key(key):
                 msg = f"Workflow lifecycle {name} must not persist replay-unsafe key {key!r}"
                 raise ValueError(msg)
-            normalized[key] = _normalize_json_value(name, item, f"{path}.{key}")
+            normalized[key] = _normalize_json_value(name, item, f"{path}.{key}", _depth + 1)
         return normalized
     if isinstance(value, list | tuple):
         return [
-            _normalize_json_value(name, item, f"{path}[{index}]")
+            _normalize_json_value(name, item, f"{path}[{index}]", _depth + 1)
             for index, item in enumerate(value)
         ]
     msg = f"Workflow lifecycle {name} value at {path} must be JSON serializable"
@@ -514,12 +525,30 @@ class WorkflowLifecycleEvent(BaseModel, frozen=True):
     @field_validator("workflow_id")
     @classmethod
     def _workflow_id_non_blank(cls, value: str) -> str:
-        return _normalize_non_blank("workflow_id", value)
+        normalized = _normalize_non_blank("workflow_id", value)
+        if len(normalized) > MAX_WORKFLOW_LIFECYCLE_WORKFLOW_ID_LEN:
+            msg = (
+                f"Workflow lifecycle workflow_id exceeds "
+                f"{MAX_WORKFLOW_LIFECYCLE_WORKFLOW_ID_LEN} characters"
+            )
+            raise ValueError(msg)
+        return normalized
 
     @field_validator("node_id", "edge_id", "reason_code")
     @classmethod
     def _optional_fields_non_blank(cls, value: str | None, info: Any) -> str | None:
-        return _normalize_optional_non_blank(str(info.field_name), value)
+        normalized = _normalize_optional_non_blank(str(info.field_name), value)
+        if (
+            normalized is not None
+            and info.field_name == "reason_code"
+            and len(normalized) > MAX_WORKFLOW_LIFECYCLE_REASON_CODE_LEN
+        ):
+            msg = (
+                f"Workflow lifecycle reason_code exceeds "
+                f"{MAX_WORKFLOW_LIFECYCLE_REASON_CODE_LEN} characters"
+            )
+            raise ValueError(msg)
+        return normalized
 
     @field_validator("refs", mode="before")
     @classmethod
@@ -529,7 +558,22 @@ class WorkflowLifecycleEvent(BaseModel, frozen=True):
         if isinstance(value, str) or not isinstance(value, Iterable):
             msg = "Workflow lifecycle refs must be an iterable of strings"
             raise TypeError(msg)
-        return _normalize_refs(value)
+        materialized = tuple(value)
+        if len(materialized) > MAX_WORKFLOW_LIFECYCLE_REFS_ENTRIES:
+            msg = (
+                f"Workflow lifecycle refs exceed "
+                f"{MAX_WORKFLOW_LIFECYCLE_REFS_ENTRIES} entries"
+            )
+            raise ValueError(msg)
+        for index, ref in enumerate(materialized):
+            if isinstance(ref, str) and len(ref) > MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS:
+                msg = (
+                    f"Workflow lifecycle refs exceed "
+                    f"{MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS} characters "
+                    f"at index {index}"
+                )
+                raise ValueError(msg)
+        return _normalize_refs(materialized)
 
     @field_validator("data", mode="before")
     @classmethod
@@ -1094,9 +1138,13 @@ def project_workflow_lifecycle(
 
 __all__ = [
     "MAX_WORKFLOW_LIFECYCLE_DATA_BYTES",
+    "MAX_WORKFLOW_LIFECYCLE_REASON_CODE_LEN",
     "MAX_WORKFLOW_LIFECYCLE_REF_BYTES",
     "MAX_WORKFLOW_LIFECYCLE_REF_COUNT",
+    "MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS",
     "MAX_WORKFLOW_LIFECYCLE_REFS_BYTES",
+    "MAX_WORKFLOW_LIFECYCLE_REFS_ENTRIES",
+    "MAX_WORKFLOW_LIFECYCLE_WORKFLOW_ID_LEN",
     "WORKFLOW_LIFECYCLE_AGGREGATE_TYPE",
     "WORKFLOW_LIFECYCLE_EVENT_TYPES",
     "WORKFLOW_LIFECYCLE_SCHEMA_VERSION",

--- a/tests/unit/orchestrator/test_workflow_lifecycle_events.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_events.py
@@ -711,6 +711,29 @@ def test_lifecycle_event_rejects_too_many_refs_entries() -> None:
         )
 
 
+def test_lifecycle_event_rejects_large_ref_generator_without_full_materialization() -> None:
+    spec = _spec()
+    yielded = 0
+
+    def refs():
+        nonlocal yielded
+        for index in range(10_000):
+            yielded += 1
+            yield f"control://contract/ref-{index}"
+
+    with pytest.raises(
+        ValidationError,
+        match=f"refs exceed {MAX_WORKFLOW_LIFECYCLE_REF_COUNT} entries",
+    ):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            refs=refs(),
+        )
+
+    assert yielded == MAX_WORKFLOW_LIFECYCLE_REF_COUNT + 1
+
+
 def test_lifecycle_event_rejects_individual_ref_over_char_bound() -> None:
     """A single oversized ref string is rejected at the validator entry point."""
     spec = _spec()

--- a/tests/unit/orchestrator/test_workflow_lifecycle_events.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_events.py
@@ -37,7 +37,6 @@ from ouroboros.orchestrator.workflow_lifecycle import (
     MAX_WORKFLOW_LIFECYCLE_REF_BYTES,
     MAX_WORKFLOW_LIFECYCLE_REF_COUNT,
     MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS,
-    MAX_WORKFLOW_LIFECYCLE_REFS_ENTRIES,
     MAX_WORKFLOW_LIFECYCLE_WORKFLOW_ID_LEN,
     WORKFLOW_LIFECYCLE_AGGREGATE_TYPE,
     WORKFLOW_LIFECYCLE_EVENT_TYPES,
@@ -690,13 +689,22 @@ def test_lifecycle_event_rejects_oversized_workflow_id() -> None:
 
 
 def test_lifecycle_event_rejects_too_many_refs_entries() -> None:
-    """Ref count above the hardened ceiling is rejected at the validator."""
+    """Ref count above ``MAX_WORKFLOW_LIFECYCLE_REF_COUNT`` is rejected.
+
+    Exercises the pre-existing per-event ref-count ceiling (the operative
+    bound is ``MAX_WORKFLOW_LIFECYCLE_REF_COUNT``). The input size is the
+    smallest value that trips the limit so a regression that loosens the
+    bound by even one slot is caught.
+    """
     spec = _spec()
     refs = tuple(
         f"control://contract/ref-{index}"
-        for index in range(MAX_WORKFLOW_LIFECYCLE_REFS_ENTRIES + 1)
+        for index in range(MAX_WORKFLOW_LIFECYCLE_REF_COUNT + 1)
     )
-    with pytest.raises(ValidationError, match="refs exceed"):
+    with pytest.raises(
+        ValidationError,
+        match=f"refs exceed {MAX_WORKFLOW_LIFECYCLE_REF_COUNT} entries",
+    ):
         WorkflowLifecycleEvent(
             event_type=WorkflowLifecycleEventType.RUN_CREATED,
             workflow_id=spec.spec_id,

--- a/tests/unit/orchestrator/test_workflow_lifecycle_events.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_events.py
@@ -33,8 +33,12 @@ from ouroboros.orchestrator.workflow_ir import (
 )
 from ouroboros.orchestrator.workflow_lifecycle import (
     MAX_WORKFLOW_LIFECYCLE_DATA_BYTES,
+    MAX_WORKFLOW_LIFECYCLE_REASON_CODE_LEN,
     MAX_WORKFLOW_LIFECYCLE_REF_BYTES,
     MAX_WORKFLOW_LIFECYCLE_REF_COUNT,
+    MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS,
+    MAX_WORKFLOW_LIFECYCLE_REFS_ENTRIES,
+    MAX_WORKFLOW_LIFECYCLE_WORKFLOW_ID_LEN,
     WORKFLOW_LIFECYCLE_AGGREGATE_TYPE,
     WORKFLOW_LIFECYCLE_EVENT_TYPES,
     WorkflowLifecycleEvent,
@@ -656,3 +660,73 @@ async def test_persisted_db_row_payload_contains_no_raw_streams() -> None:
             assert needle not in serialized, (
                 f"persisted DB row leaks forbidden substring {needle!r}: {serialized!r}"
             )
+
+
+# ---------------------------------------------------------------------------
+# Wave 2 #1142 / #956 — hardened storage-DoS / recursion bounds
+# ---------------------------------------------------------------------------
+
+
+def test_lifecycle_event_rejects_oversized_reason_code() -> None:
+    """Reason code over the bound is rejected to prevent storage DoS."""
+    spec = _spec()
+    oversized = "x" * (MAX_WORKFLOW_LIFECYCLE_REASON_CODE_LEN + 1)
+    with pytest.raises(ValidationError, match="reason_code exceeds"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_FAILED,
+            workflow_id=spec.spec_id,
+            reason_code=oversized,
+        )
+
+
+def test_lifecycle_event_rejects_oversized_workflow_id() -> None:
+    """Workflow id over the bound is rejected to prevent storage DoS."""
+    oversized = "wf_" + ("x" * MAX_WORKFLOW_LIFECYCLE_WORKFLOW_ID_LEN)
+    with pytest.raises(ValidationError, match="workflow_id exceeds"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=oversized,
+        )
+
+
+def test_lifecycle_event_rejects_too_many_refs_entries() -> None:
+    """Ref count above the hardened ceiling is rejected at the validator."""
+    spec = _spec()
+    refs = tuple(
+        f"control://contract/ref-{index}"
+        for index in range(MAX_WORKFLOW_LIFECYCLE_REFS_ENTRIES + 1)
+    )
+    with pytest.raises(ValidationError, match="refs exceed"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            refs=refs,
+        )
+
+
+def test_lifecycle_event_rejects_individual_ref_over_char_bound() -> None:
+    """A single oversized ref string is rejected at the validator entry point."""
+    spec = _spec()
+    refs = ("x" * (MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS + 1),)
+    with pytest.raises(ValidationError, match="refs exceed"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.RUN_CREATED,
+            workflow_id=spec.spec_id,
+            refs=refs,
+        )
+
+
+def test_lifecycle_event_rejects_deeply_nested_data_no_recursion_error() -> None:
+    """A 33-level nested ``data`` mapping is rejected cleanly without RecursionError."""
+    spec = _spec()
+    # Build a dict nested deeper than _MAX_NESTING_DEPTH (32).
+    payload: dict[str, object] = {"leaf": "value"}
+    for _ in range(33):
+        payload = {"nested": payload}
+    with pytest.raises(ValidationError, match="nesting depth"):
+        WorkflowLifecycleEvent(
+            event_type=WorkflowLifecycleEventType.NODE_COMPLETED,
+            workflow_id=spec.spec_id,
+            node_id="node_a",
+            data=payload,
+        )

--- a/tests/unit/orchestrator/test_workflow_lifecycle_events.py
+++ b/tests/unit/orchestrator/test_workflow_lifecycle_events.py
@@ -698,8 +698,7 @@ def test_lifecycle_event_rejects_too_many_refs_entries() -> None:
     """
     spec = _spec()
     refs = tuple(
-        f"control://contract/ref-{index}"
-        for index in range(MAX_WORKFLOW_LIFECYCLE_REF_COUNT + 1)
+        f"control://contract/ref-{index}" for index in range(MAX_WORKFLOW_LIFECYCLE_REF_COUNT + 1)
     )
     with pytest.raises(
         ValidationError,


### PR DESCRIPTION
## Summary

Wave 2 hardening for the #956 Workflow IR lifecycle event family. Addresses the security review of PR #1134, which flagged the lifecycle event model as accepting unbounded `reason_code`, `refs`, and `workflow_id` (storage DoS vector — HIGH), and `_normalize_json_value` as recursing without a depth cap (RecursionError under extreme nesting — MEDIUM).

Scope is intentionally narrow: validator-level bounds only, no schema bump, no blocklist additions, no changes to event consumers, `replay_workflow_lifecycle`, or `append_workflow_lifecycle_event`.

## Changes

- New `Final` bounds near `MAX_WORKFLOW_LIFECYCLE_DATA_BYTES`:
  - `MAX_WORKFLOW_LIFECYCLE_WORKFLOW_ID_LEN = 256`
  - `MAX_WORKFLOW_LIFECYCLE_REASON_CODE_LEN = 1024`
  - `MAX_WORKFLOW_LIFECYCLE_REFS_ENTRIES = 64`
  - `MAX_WORKFLOW_LIFECYCLE_REF_LEN_CHARS = 512`
  - `_MAX_NESTING_DEPTH = 32`
- `WorkflowLifecycleEvent._workflow_id_non_blank`: rejects values longer than 256 chars after strip.
- `WorkflowLifecycleEvent._optional_fields_non_blank`: rejects `reason_code` longer than 1024 chars.
- `WorkflowLifecycleEvent._coerce_refs`: materializes the iterable once, rejects > 64 entries, and rejects any individual `str` ref over 512 chars at the validator entry point (defense-in-depth in front of the existing byte-count check in `_normalize_refs`).
- `_normalize_json_value` now accepts `_depth: int = 0` and raises `ValueError` when `_depth > _MAX_NESTING_DEPTH`. Recursive calls pass `_depth=_depth + 1`. This prevents `RecursionError` on adversarial deeply-nested `data` payloads.

## Test plan

- [x] `python -m pytest tests/unit/orchestrator/test_workflow_lifecycle_events.py -q` — 36 passed (31 existing + 5 new negative tests)
- [x] `python -m pytest tests/unit/orchestrator/ -q` — 1651 passed, 1 skipped (no regressions)
- [x] `python -m pytest tests/conformance/workflow_ir/ -q` — 43 passed
- [x] New negative tests cover each new bound: oversized `reason_code`, oversized `workflow_id`, > 64 refs entries, individual ref > 512 chars, and a 33-level nested dict rejected cleanly with `ValidationError` (no `RecursionError`).

Refs #1142, #956. Closes the #1134 security HIGH finding on unbounded fields and MEDIUM on nesting depth.