### PR TITLE
feat(auto): surface defaulted_sections in AutoPipelineResult

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -204,6 +204,7 @@ class AutoPipelineResult:
     last_lateral_text: str | None = None
     assumptions: tuple[str, ...] = ()
     non_goals: tuple[str, ...] = ()
+    defaulted_sections: tuple[str, ...] = ()
     blocker: str | None = None
     stop_reason_code: str | None = None
     runtime_backend: str | None = None
@@ -2597,6 +2598,7 @@ class AutoPipeline:
             last_lateral_text=state.last_lateral_text,
             assumptions=tuple(ledger.assumptions()),
             non_goals=tuple(ledger.non_goals()),
+            defaulted_sections=tuple(ledger.summary().get("defaulted_sections", ())),
             blocker=blocker or state.last_error,
             stop_reason_code=state.last_error_code,
             runtime_backend=state.runtime_backend,

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1267,6 +1267,7 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
     meta["ledger_provenance"] = {
         source: list(sections) for source, sections in result.ledger_provenance.items()
     }
+    meta["defaulted_sections"] = list(result.defaulted_sections)
     meta["evidence_backed_sections"] = list(result.evidence_backed_sections)
     meta["assumption_only_sections"] = list(result.assumption_only_sections)
     return meta

--- a/tests/unit/auto/test_pipeline_defaulted_sections_surface.py
+++ b/tests/unit/auto/test_pipeline_defaulted_sections_surface.py
@@ -1,0 +1,124 @@
+"""Tests that AutoPipelineResult surfaces defaulted_sections from the ledger.
+
+Verifies that the ``defaulted_sections`` field on ``AutoPipelineResult`` is
+correctly populated from ``ledger.summary()["defaulted_sections"]`` and that it
+excludes entries with statuses other than DEFAULTED.
+"""
+
+from __future__ import annotations
+
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
+from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
+from ouroboros.auto.state import AutoPipelineState
+
+
+def _make_pipeline() -> AutoPipeline:
+    return AutoPipeline(
+        interview_driver=None,  # type: ignore[arg-type]
+        seed_generator=lambda _goal: None,  # type: ignore[arg-type]
+    )
+
+
+def _make_state(goal: str = "Build a local CLI") -> AutoPipelineState:
+    return AutoPipelineState(goal=goal, cwd="/tmp/proj")
+
+
+def _defaulted_entry(section: str) -> LedgerEntry:
+    return LedgerEntry(
+        key=f"{section}.test",
+        value=f"Safe default value for {section}",
+        source=LedgerSource.CONSERVATIVE_DEFAULT,
+        confidence=0.85,
+        status=LedgerStatus.DEFAULTED,
+    )
+
+
+def _confirmed_entry(section: str) -> LedgerEntry:
+    return LedgerEntry(
+        key=f"{section}.test",
+        value=f"Confirmed value for {section}",
+        source=LedgerSource.USER_GOAL,
+        confidence=0.95,
+        status=LedgerStatus.CONFIRMED,
+    )
+
+
+def _weak_entry(section: str) -> LedgerEntry:
+    return LedgerEntry(
+        key=f"{section}.test",
+        value=f"Weak value for {section}",
+        source=LedgerSource.ASSUMPTION,
+        confidence=0.3,
+        status=LedgerStatus.WEAK,
+    )
+
+
+def _inferred_entry(section: str) -> LedgerEntry:
+    return LedgerEntry(
+        key=f"{section}.test",
+        value=f"Inferred value for {section}",
+        source=LedgerSource.INFERENCE,
+        confidence=0.7,
+        status=LedgerStatus.INFERRED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: no DEFAULTED entries → defaulted_sections is empty
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_omits_defaulted_sections_when_none_defaulted() -> None:
+    """Result defaulted_sections is empty when ledger has no DEFAULTED entries."""
+    pipeline = _make_pipeline()
+    state = _make_state()
+    ledger = SeedDraftLedger.from_goal(state.goal)
+
+    # Add only CONFIRMED entries — no DEFAULTED ones.
+    ledger.add_entry("actors", _confirmed_entry("actors"))
+    ledger.add_entry("inputs", _confirmed_entry("inputs"))
+
+    result = pipeline._result(state, ledger)
+
+    assert isinstance(result, AutoPipelineResult)
+    assert result.defaulted_sections == ()
+
+
+# ---------------------------------------------------------------------------
+# Test 2: DEFAULTED entries → defaulted_sections surfaces them
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_surfaces_defaulted_sections_when_safe_default_filled() -> None:
+    """Result defaulted_sections contains sections filled by safe-default policy."""
+    pipeline = _make_pipeline()
+    state = _make_state()
+    ledger = SeedDraftLedger.from_goal(state.goal)
+
+    ledger.add_entry("runtime_context", _defaulted_entry("runtime_context"))
+    ledger.add_entry("failure_modes", _defaulted_entry("failure_modes"))
+
+    result = pipeline._result(state, ledger)
+
+    assert set(result.defaulted_sections) == {"runtime_context", "failure_modes"}
+
+
+# ---------------------------------------------------------------------------
+# Test 3: mixed ledger → only DEFAULTED sections appear
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_defaulted_sections_excludes_confirmed_and_weak() -> None:
+    """defaulted_sections contains only the DEFAULTED section, not CONFIRMED/WEAK/INFERRED."""
+    pipeline = _make_pipeline()
+    state = _make_state()
+    ledger = SeedDraftLedger.from_goal(state.goal)
+
+    ledger.add_entry("actors", _confirmed_entry("actors"))
+    ledger.add_entry("inputs", _weak_entry("inputs"))
+    ledger.add_entry("runtime_context", _defaulted_entry("runtime_context"))
+    ledger.add_entry("outputs", _inferred_entry("outputs"))
+
+    result = pipeline._result(state, ledger)
+
+    assert result.defaulted_sections == ("runtime_context",)

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -485,6 +485,7 @@ async def test_auto_handler_meta_exposes_auto_progress_fields(monkeypatch) -> No
         "run_session_id": "session_1",
         "pending_question": "Which runtime should be used?",
         "ledger_provenance": {},
+        "defaulted_sections": [],
         "evidence_backed_sections": [],
         "assumption_only_sections": [],
     }
@@ -1343,6 +1344,37 @@ def test_auto_handler_meta_exposes_run_reconciliation_fields() -> None:
     assert meta["run_reconciliation_status"] == "unsupported"
     assert meta["run_reconciliation_source"] == "generic"
     assert meta["run_reconciled_at"] == "2026-05-07T00:00:00+00:00"
+
+
+def test_auto_handler_meta_exposes_defaulted_sections_as_list() -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.mcp.tools.auto_handler import _result_meta
+
+    meta = _result_meta(
+        AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_test",
+            phase="complete",
+            defaulted_sections=("runtime_context", "failure_modes"),
+        )
+    )
+
+    assert meta["defaulted_sections"] == ["runtime_context", "failure_modes"]
+
+
+def test_auto_handler_meta_preserves_empty_defaulted_sections() -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.mcp.tools.auto_handler import _result_meta
+
+    meta = _result_meta(
+        AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_test",
+            phase="complete",
+        )
+    )
+
+    assert meta["defaulted_sections"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add ``defaulted_sections: tuple[str, ...] = ()`` field to ``AutoPipelineResult``.
- Populate it from ``ledger.summary()["defaulted_sections"]`` in ``_result()``.
- Zero behavior change. No ledger or signature changes.

## Why this scope
Live ``ooo auto`` runs against the #821 acceptance matrix observed that callers could not tell from the result meta whether the safe-default policy fired or which sections were auto-filled. The ledger already tracks them; the auto pipeline just was not propagating the field. This PR closes #821 acceptance criterion #3 for the ``defaulted_sections[]`` half.

## What is NOT done here
- No ``[from-auto][source]`` provenance promotion on ``assumptions[]`` — deferred to a follow-up because it requires a ``ledger.assumptions()`` return-type change with broader surface impact.
- No closure-mode field (PR-B1 adds ``interview_closure_mode``).
- No taxonomy/stop_reason_code change (PR-E).

## Test Plan
- [x] ``uv run pytest tests/unit/auto/test_pipeline_defaulted_sections_surface.py -v`` (3 new tests pass)
- [x] ``uv run pytest tests/unit/auto tests/integration/auto -q`` (no regression)
- [x] ``uv run ruff check`` on touched files
- [x] ``uv run mypy`` on touched files

Refs #821, #763, #1138.