### PR TITLE
fix(auto): close interview on ledger-only consensus at max_rounds

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -477,6 +477,29 @@ class AutoInterviewDriver:
             ambiguity_part = "ambiguity_score=unknown"
         open_gaps = ledger.open_gaps()
         gaps_part = f"open_gaps={open_gaps}" if open_gaps else "open_gaps=[]"
+        # PR-B1 / #821: ledger-only consensus — structural completeness overrides backend stylistic
+        # ambiguity at max_rounds. Recorded as non-blocking advisory via interview_closure_mode so
+        # the result envelope surfaces the closure mode.
+        if ledger_done and not backend_done:
+            log.info(
+                "auto.interview.ledger_only_closure",
+                auto_session_id=state.auto_session_id,
+                ambiguity_score=turn.ambiguity_score,
+                open_gaps=list(open_gaps),
+                interview_session_id=state.interview_session_id,
+            )
+            state.pending_question = None
+            state.interview_completed = True
+            state.interview_closure_mode = "ledger_only"
+            state.mark_progress(
+                f"interview closed on ledger-only consensus at round {self.max_rounds}"
+                f" (backend ambiguity={turn.ambiguity_score})",
+                tool_name="interview_driver",
+            )
+            self._save(state)
+            return AutoInterviewResult(
+                "seed_ready", state.interview_session_id, ledger, self.max_rounds
+            )
         if ledger_done:
             log.info(
                 "auto.interview.mutual_agreement_deadlock_at_max_rounds",

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -178,6 +178,7 @@ class AutoPipelineResult:
     run_subagent: dict[str, Any] | None = None
     current_round: int = 0
     pending_question: str | None = None
+    interview_closure_mode: str | None = None
     last_progress_message: str | None = None
     last_progress_at: str | None = None
     last_grade: str | None = None
@@ -2572,6 +2573,7 @@ class AutoPipeline:
             run_subagent=run_subagent or state.run_subagent or None,
             current_round=state.current_round,
             pending_question=state.pending_question,
+            interview_closure_mode=state.interview_closure_mode,
             last_progress_message=state.last_progress_message,
             last_progress_at=state.last_progress_at,
             last_grade=state.last_grade,

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -369,6 +369,8 @@ class AutoPipelineState:
     max_repair_rounds: int = 5
     interview_session_id: str | None = None
     interview_completed: bool = False
+    # PR-B1 / #821: "ledger_only" when interview closed on ledger consensus while backend refused; None otherwise.
+    interview_closure_mode: str | None = None
     seed_id: str | None = None
     seed_path: str | None = None
     seed_origin: SeedOrigin = SeedOrigin.NONE
@@ -879,6 +881,7 @@ class AutoPipelineState:
         payload.setdefault("lateral_input_hash", None)
         payload.setdefault("active_domain_profile_name", None)
         payload.setdefault("last_error_code", None)
+        payload.setdefault("interview_closure_mode", None)
         # RFC #809 Phase 2.2b — closed-loop recovery counters. Default the
         # three new fields so a pre-P2.2b state file loads as a fresh
         # recovery budget (round 0, no fingerprints, no personas tried).
@@ -1197,6 +1200,7 @@ class AutoPipelineState:
             "last_error",
             "last_error_code",
             "active_domain_profile_name",
+            "interview_closure_mode",
         )
         for field_name in optional_string_fields:
             value = getattr(self, field_name)

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -3956,9 +3956,7 @@ async def test_max_rounds_genuine_deadlock_still_blocks(tmp_path) -> None:
     async def answer(
         session_id: str, text: str, *, last_question: str | None = None
     ) -> InterviewTurn:  # noqa: ARG001
-        return InterviewTurn(
-            "Still need more info", session_id, seed_ready=False, completed=False
-        )
+        return InterviewTurn("Still need more info", session_id, seed_ready=False, completed=False)
 
     state = AutoPipelineState(
         goal="Deploy the service to production and configure the required credentials",

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1514,14 +1514,11 @@ async def test_interview_driver_blocks_when_backend_never_marks_ready(tmp_path) 
 
     result = await driver.run(state, ledger)
 
-    assert result.status == "blocked"
-    blocker = result.blocker or ""
-    # Ledger is pre-filled (`_fill_ready`) so ledger_done is True, but the
-    # mock backend never sends a completion flag — the mutual-agreement gate
-    # refuses closure and emits the structured diagnostic naming both states.
-    assert "without closure" in blocker
-    assert "backend_done=False" in blocker
-    assert "ledger_done=True" in blocker
+    # PR-B1 / #821: ledger pre-filled + backend never closes → ledger-only closure, not blocked.
+    assert result.status == "seed_ready"
+    assert state.interview_completed is True
+    assert state.interview_closure_mode == "ledger_only"
+    assert state.phase != AutoPhase.BLOCKED
 
 
 @pytest.mark.asyncio
@@ -3919,3 +3916,64 @@ async def test_pipeline_normalizes_persisted_seed_artifact_on_resume(tmp_path) -
     criteria_text = "\n".join(resumed_seed.acceptance_criteria)
     assert "Final report includes auto session id" not in criteria_text
     assert "CLI exits 2 on invalid flags" in criteria_text
+
+
+@pytest.mark.asyncio
+async def test_max_rounds_ledger_only_consensus_closes_interview(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_ledger_only")
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "Still not sure", session_id, seed_ready=False, completed=False, ambiguity_score=0.45
+        )
+
+    state = AutoPipelineState(goal=_fully_specified_hello_goal(), cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    assert ledger.is_seed_ready(), "pre-condition: goal text must pre-fill the ledger"
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=2,
+        timeout_seconds=5,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert state.interview_completed is True
+    assert state.interview_closure_mode == "ledger_only"
+    assert state.phase != AutoPhase.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_max_rounds_genuine_deadlock_still_blocks(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_deadlock")
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "Still need more info", session_id, seed_ready=False, completed=False
+        )
+
+    state = AutoPipelineState(
+        goal="Deploy the service to production and configure the required credentials",
+        cwd=str(tmp_path),
+    )
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=2,
+        timeout_seconds=5,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.interview_closure_mode is None
+    assert "max_rounds" in (result.blocker or "")

--- a/tests/unit/auto/test_safe_default_observability.py
+++ b/tests/unit/auto/test_safe_default_observability.py
@@ -71,13 +71,14 @@ def _ledger_all_filled_except(
 
 @pytest.mark.asyncio
 async def test_safe_default_logs_no_gaps_to_default(tmp_path) -> None:
-    """Ledger already seed-ready but backend keeps asking → mutual-agreement deadlock path.
+    """Ledger already seed-ready but backend keeps asking → ledger-only closure path (PR-B1).
 
     The driver enters the safe-default fallback block after max_rounds with
     backend_done=False and ledger_done=True.  ``finalize_safe_defaultable_gaps``
     returns an empty defaulted_sections (no gaps to fill), so the driver emits
-    ``no_gaps_to_default``.  Because ledger_done=True at the final blocker path
-    the driver also emits ``mutual_agreement_deadlock_at_max_rounds``.
+    ``no_gaps_to_default``.  PR-B1 / #821: because ledger_done=True and
+    backend_done=False, the driver now takes the ledger-only closure path and
+    emits ``ledger_only_closure`` instead of blocking.
     """
     # Ledger is fully filled — is_seed_ready() returns True from round 0.
     ledger = _ledger_all_filled_except()
@@ -106,11 +107,11 @@ async def test_safe_default_logs_no_gaps_to_default(tmp_path) -> None:
     events = [e["event"] for e in captured]
     assert "auto.interview.safe_default.entered" in events
     assert "auto.interview.safe_default.no_gaps_to_default" in events
-    assert "auto.interview.mutual_agreement_deadlock_at_max_rounds" in events
+    assert "auto.interview.ledger_only_closure" in events
 
-    # Behaviour unchanged: blocked because backend never agreed.
-    assert result.status == "blocked"
-    assert "without closure" in (result.blocker or "")
+    # PR-B1 / #821: ledger-only consensus closes the interview rather than blocking.
+    assert result.status == "seed_ready"
+    assert state.interview_closure_mode == "ledger_only"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Close the auto interview when ``max_rounds`` is exhausted with ledger-side completeness already met but the backend still refusing to declare closure.
- Record the closure path on the result envelope via ``interview_closure_mode="ledger_only"`` so callers can audit which interviews used the new path.
- Preserve the genuine-deadlock blocker (both sides refusing) unchanged.

## Why this scope
Live ``ooo auto`` runs against the #821 acceptance matrix observed this exact case via the ``auto.interview.mutual_agreement_deadlock_at_max_rounds`` event shipped in #1138 (PR-A instrumentation). The #962 mutual-agreement closure gate was designed to avoid fabricated unilateral closures; in this case there is no fabrication — the auto answerer has filled the ledger via explicit answers and the backend simply refuses to update its own ambiguity reading. The #821 autonomy contract requires that ``ooo auto`` reach COMPLETE for locally-reproducible, safe-defaultable goals; this PR closes that contract for the ledger-only consensus case.

## What is NOT done here
- No change to the safe-default finalization fallback (PR-B2 will address the ``ledger_done=False`` cases #3-6 after the next live re-observation).
- No new envelope fields besides ``interview_closure_mode``.
- No taxonomy/stop_reason change (PR-E).
- No source-tag promotion (deferred PR-C2).

## Test Plan
- [x] ``uv run pytest tests/unit/auto/test_interview_pipeline.py -v -k "ledger_only or genuine_deadlock"`` (2 new tests pass)
- [x] ``uv run pytest tests/unit/auto tests/integration/auto -q`` (baseline 897 + 2 new = 899, no regression)
- [x] ``uv run ruff check`` on touched files
- [x] ``uv run mypy`` on touched files

Refs #821, #962, #1138.