### PR TITLE
feat(auto): canonical stop_reason_code for interview-layer blockers

### DIFF
--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -67,4 +67,18 @@ When the user types `ooo auto` with CLI-style flags inside chat, translate to MC
 5. Starts execution only after A-grade.
 6. When `complete_product=true`, chains RUN → RALPH_HANDOFF after a successful run handoff and waits for a terminal Ralph status so a single invocation iterates Ralph until QA passes, convergence, or a budget bound trips. A QA-pass on the executed product completes the auto session; recognized failure modes (`iteration_timeout`, `wall_clock_exhausted`, `oscillation_detected`, `grade_regressing`, `max_generations reached`) block the auto session with the matching `stop_reason` in `last_error` so operators can resume after the cause is addressed.
 
+### Canonical stop_reason_code taxonomy
+
+| Layer | Code | Surface | Meaning |
+|---|---|---|---|
+| Interview | `interview_max_rounds_exhausted` | `last_error_code`, `result.stop_reason_code` | Auto interview ran `max_interview_rounds` without ledger+backend mutual closure or safe-default fallback. |
+| Interview | `interview_phase_deadline` | `last_error_code`, `result.stop_reason_code` | Interview phase exceeded its per-phase timeout. |
+| Ralph | `iteration_timeout` | blocker text + (future) `result.stop_reason_code` | A single Ralph iteration exceeded its per-iteration timeout. |
+| Ralph | `wall_clock_exhausted` | blocker text + (future) `result.stop_reason_code` | The Ralph wall-clock budget was exhausted before convergence. |
+| Ralph | `oscillation_detected` | blocker text + (future) `result.stop_reason_code` | Ralph oscillated between two grade states without making progress. |
+| Ralph | `grade_regressing` | blocker text + (future) `result.stop_reason_code` | A subsequent Ralph generation produced a strictly worse grade than its predecessor. |
+| Ralph | `max_generations reached` | blocker text + (future) `result.stop_reason_code` | Ralph hit its configured generation cap before reaching A grade. |
+
+Blockers without a canonical code keep using the free-form ``last_error`` text. Ralph-layer codes are surfaced via blocker text today; their result-envelope promotion is tracked as a follow-up.
+
 The pipeline must not hang indefinitely: all loops are bounded and timeout failures return a resumable `auto_session_id`. Resume with `ooo auto --resume <auto_session_id>`. Use `--skip-run` to stop after the A-grade Seed. Use `--complete-product` to drive the full Interview → Seed → Run → Ralph → Product chain on a single `ooo auto` invocation; the chained Ralph loop honors the same wall-clock deadline as the parent auto session (`--timeout`). The CLI-only `--show-ledger` flag prints assumptions/non-goals; MCP skill responses already include the same ledger summary when available.

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -491,7 +491,11 @@ class AutoInterviewDriver:
             f"backend_done={backend_done} ({ambiguity_part}), "
             f"ledger_done={ledger_done} ({gaps_part})"
         )
-        state.mark_blocked(blocker, tool_name="interview_driver")
+        state.mark_blocked(
+            blocker,
+            tool_name="interview_driver",
+            error_code="interview_max_rounds_exhausted",
+        )
         record_authoring_backend(state)
         self._save(state)
         return AutoInterviewResult(

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -204,6 +204,7 @@ class AutoPipelineResult:
     assumptions: tuple[str, ...] = ()
     non_goals: tuple[str, ...] = ()
     blocker: str | None = None
+    stop_reason_code: str | None = None
     runtime_backend: str | None = None
     opencode_mode: str | None = None
     invoked_by: str = "direct"
@@ -497,6 +498,7 @@ class AutoPipeline:
                     state.mark_blocked(
                         f"interview phase exceeded {interview_phase_timeout:.0f}s",
                         tool_name="interview_driver",
+                        error_code="interview_phase_deadline",
                     )
                     self._save(state)
                     return self._result(state, ledger, blocker=state.last_error)
@@ -2594,6 +2596,7 @@ class AutoPipeline:
             assumptions=tuple(ledger.assumptions()),
             non_goals=tuple(ledger.non_goals()),
             blocker=blocker or state.last_error,
+            stop_reason_code=state.last_error_code,
             runtime_backend=state.runtime_backend,
             opencode_mode=state.opencode_mode,
             invoked_by=state.invoked_by(),

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -422,6 +422,10 @@ class AutoPipelineState:
     pending_question: str | None = None
     last_tool_name: str | None = None
     last_error: str | None = None
+    last_error_code: str | None = None
+    # Canonical stop-reason code for the most recent blocker, when one of the
+    # documented codes applies. None for blockers without a canonical code
+    # (those keep using the free-form ``last_error`` string).
     last_authoring_backend: str | None = None
     last_progress_message: str = "created"
     phase_started_at: str = field(default_factory=utc_now_iso)
@@ -600,9 +604,16 @@ class AutoPipelineState:
         """Move a session back to a valid recoverable phase."""
         self.transition(next_phase, message)
 
-    def mark_blocked(self, message: str, *, tool_name: str | None = None) -> None:
+    def mark_blocked(
+        self,
+        message: str,
+        *,
+        tool_name: str | None = None,
+        error_code: str | None = None,
+    ) -> None:
         """Transition to blocked with actionable diagnostics."""
         self.last_tool_name = tool_name
+        self.last_error_code = error_code
         self.transition(AutoPhase.BLOCKED, message, error=message)
 
     def mark_failed(self, message: str, *, tool_name: str | None = None) -> None:
@@ -867,6 +878,7 @@ class AutoPipelineState:
         payload.setdefault("last_lateral_text", None)
         payload.setdefault("lateral_input_hash", None)
         payload.setdefault("active_domain_profile_name", None)
+        payload.setdefault("last_error_code", None)
         # RFC #809 Phase 2.2b — closed-loop recovery counters. Default the
         # three new fields so a pre-P2.2b state file loads as a fresh
         # recovery budget (round 0, no fingerprints, no personas tried).
@@ -1183,6 +1195,7 @@ class AutoPipelineState:
             "pending_question",
             "last_tool_name",
             "last_error",
+            "last_error_code",
             "active_domain_profile_name",
         )
         for field_name in optional_string_fields:

--- a/tests/unit/auto/test_stop_reason_code.py
+++ b/tests/unit/auto/test_stop_reason_code.py
@@ -1,0 +1,177 @@
+"""Tests for canonical stop_reason_code on interview-layer blockers.
+
+Covers the two interview-layer canonical codes surfaced via
+``AutoPipelineResult.stop_reason_code`` and ``AutoPipelineState.last_error_code``,
+plus a regression guard that blockers without a canonical code leave
+``stop_reason_code`` at ``None``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from ouroboros.auto.interview_driver import (
+    AutoInterviewDriver,
+    FunctionInterviewBackend,
+    InterviewTurn,
+)
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+
+# ---------------------------------------------------------------------------
+# Shared stubs
+# ---------------------------------------------------------------------------
+
+
+async def _blocked_seed_generator(session_id: str):  # noqa: ARG001
+    raise AssertionError("seed generator must not be called in these tests")
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — interview_max_rounds_exhausted
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interview_max_rounds_exhausted_sets_stop_reason_code(tmp_path) -> None:
+    """AutoPipeline result carries ``interview_max_rounds_exhausted`` when the
+    driver exhausts ``max_rounds`` with an unsafe-context goal so safe-default
+    finalization cannot close the ledger.
+    """
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "session_1")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        # Backend never declares closure — seed_ready stays False.
+        return InterviewTurn("What else?", session_id, seed_ready=False)
+
+    # Unsafe-context goal prevents safe-default finalization from closing the
+    # ledger, so the driver is forced to emit the max_rounds_exhausted blocker.
+    state = AutoPipelineState(
+        goal="Deploy the service to production and configure the required credentials",
+        cwd=str(tmp_path),
+    )
+    store = AutoStore(tmp_path)
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=store,
+        max_rounds=2,
+        timeout_seconds=5,
+    )
+    pipeline = AutoPipeline(driver, _blocked_seed_generator, store=store)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert result.stop_reason_code == "interview_max_rounds_exhausted"
+    assert state.last_error_code == "interview_max_rounds_exhausted"
+    assert result.blocker is not None
+    assert "without closure" in result.blocker
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — interview_phase_deadline
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_interview_phase_deadline_sets_stop_reason_code(tmp_path) -> None:
+    """AutoPipeline result carries ``interview_phase_deadline`` when the interview
+    phase exceeds its configured per-phase timeout.
+    """
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        # Sleep longer than the phase timeout so asyncio.wait_for trips.
+        await asyncio.sleep(3600)
+        raise AssertionError("interview.start should have been cancelled by phase timeout")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("answer should never be called")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    # Set a tiny per-phase timeout for INTERVIEW so the wait_for fires quickly.
+    state.timeout_seconds_by_phase[AutoPhase.INTERVIEW.value] = 1
+    # Arm the top-level deadline far in the future so it does NOT fire first
+    # and hijack the blocker attribution.
+    import time
+
+    state.deadline_at = time.monotonic() + 3600
+    state.deadline_at_epoch = time.time() + 3600
+    # Put the state into INTERVIEW phase so the pipeline enters interview logic.
+    state.transition(AutoPhase.INTERVIEW, "starting interview")
+
+    store = AutoStore(tmp_path)
+
+    class _SlowDriver:
+        """Interview driver that wraps a FunctionBackend but sleeps in run()."""
+
+        progress_callback = None
+
+        async def run(self, _state, _ledger):  # noqa: ARG002
+            await asyncio.sleep(3600)
+            raise AssertionError("must be cancelled by phase timeout")
+
+    pipeline = AutoPipeline(_SlowDriver(), _blocked_seed_generator, store=store)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert result.stop_reason_code == "interview_phase_deadline"
+    assert state.last_error_code == "interview_phase_deadline"
+    assert result.blocker is not None
+    assert "interview phase exceeded" in result.blocker
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — blockers without a canonical code leave stop_reason_code None
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blockers_without_canonical_code_leave_stop_reason_code_none(tmp_path) -> None:
+    """Blockers that do not have a canonical code must leave ``stop_reason_code``
+    at ``None`` while still populating ``result.blocker``.
+
+    Uses a pre-blocked state at SEED_GENERATION (grade_gate style) to exercise
+    the ``_result()`` path without touching the interview-layer call sites.
+    """
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("interview must not run when already blocked")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("interview must not run when already blocked")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+
+    # Mark blocked WITHOUT an error_code. Use a tool_name that is not in the
+    # recoverable-tool map (returns None from _recoverable_phase_for_tool) so
+    # the pipeline returns this blocked state directly without trying to resume
+    # into a subsequent phase.
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_blocked(
+        "pipeline budget exhausted before completion",
+        tool_name="pipeline_deadline",
+    )
+    # No error_code set — last_error_code must stay None.
+    assert state.last_error_code is None
+
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=store,
+    )
+    pipeline = AutoPipeline(driver, _blocked_seed_generator, store=store)
+
+    result = await pipeline.run(state)
+
+    # The blocked state is terminal — pipeline returns it directly.
+    assert result.status == "blocked"
+    assert result.stop_reason_code is None
+    assert result.blocker is not None
+    assert "pipeline budget exhausted" in result.blocker

--- a/tests/unit/auto/test_stop_reason_code.py
+++ b/tests/unit/auto/test_stop_reason_code.py
@@ -139,6 +139,7 @@ async def test_blockers_without_canonical_code_leave_stop_reason_code_none(tmp_p
     Uses a pre-blocked state at SEED_GENERATION (grade_gate style) to exercise
     the ``_result()`` path without touching the interview-layer call sites.
     """
+
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("interview must not run when already blocked")
 


### PR DESCRIPTION
## Summary
- Add two interview-layer canonical codes: ``interview_max_rounds_exhausted`` and ``interview_phase_deadline``.
- Add optional keyword-only ``error_code`` to ``state.mark_blocked`` and ``last_error_code`` field on ``AutoPipelineState``.
- Add ``stop_reason_code: str | None = None`` to ``AutoPipelineResult`` and populate it in ``_result()``.
- Document the 7-code total taxonomy in ``skills/auto/SKILL.md``.

## Why this scope
``skills/auto/SKILL.md`` documents 5 Ralph-layer canonical stop reasons but the interview layer uses two free-form blocker strings that are not in the documented taxonomy. Live ``ooo auto`` runs against the #821 acceptance matrix scored 0/7 on the "stop in COMPLETE or one of the canonical 5" criterion partly because the interview layer was outside the taxonomy entirely. This PR closes that surface gap so observers and result-envelope consumers can programmatically classify the interview-layer terminal conditions.

## What is NOT done here
- Only the 2 interview-layer call sites are wired. The other ~28 ``state.mark_blocked`` call sites remain code-less in this PR — Ralph-layer code marking (the existing 5 stop_reason texts already match the canonical names) is a follow-up.
- No change to any existing blocker text string.
- No new closure-mode field (PR-B1).
- No defaulted_sections surface (PR-C).

## Test Plan
- [x] ``uv run pytest tests/unit/auto/test_stop_reason_code.py -v`` (3 new tests pass)
- [x] ``uv run pytest tests/unit/auto tests/integration/auto -q`` (no regression: 897 → 900)
- [x] ``uv run ruff check`` on touched files
- [x] ``uv run mypy`` on touched files

Refs #821, #908, #1138.