### PR TITLE
fix(hook): treat configured installs without prefs.json as returning users

### DIFF
--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -177,6 +177,9 @@ def _has_prior_install_state() -> bool:
     a user who configured Ouroboros but never finished (or skipped) the welcome
     is otherwise treated as first-time forever and re-nagged on every prompt.
     Any of these install signals means the user is past first-touch.
+
+    This helper deliberately has no ``try/except`` of its own: any exception
+    propagates to ``is_first_time``'s handler, which fails open to first-time.
     """
     ouro_dir = Path.home() / ".ouroboros"
     markers = ("config.yaml", "credentials.yaml", "ouroboros.db")
@@ -201,6 +204,11 @@ def is_first_time() -> bool:
             return not _has_prior_install_state()
         prefs = json.loads(prefs_path.read_text())
         if not isinstance(prefs, dict):
+            # Intentional asymmetry vs. the missing-prefs branch above: a
+            # malformed prefs.json stays first-time even when install markers
+            # exist. A corrupt prefs file is a stronger signal than orphan
+            # markers — re-running welcome rewrites it cleanly — so do NOT
+            # route this through _has_prior_install_state().
             return True
         if prefs.get("welcomeCompleted") or prefs.get("welcomeShown"):
             return False

--- a/scripts/keyword-detector.py
+++ b/scripts/keyword-detector.py
@@ -166,17 +166,39 @@ def is_mcp_configured() -> bool:
         return False
 
 
+def _has_prior_install_state() -> bool:
+    """Detect a prior Ouroboros install when ``prefs.json`` is absent.
+
+    A missing ``prefs.json`` usually means a genuine first run, but on its own
+    it is not sufficient: ``ooo setup`` and the MCP runtime can leave behind
+    config, credentials, or the event-sourcing database — and register the MCP
+    server — without ever writing ``prefs.json``. The welcome flow is the only
+    path that writes the ``welcomeCompleted`` gate-key, and it is skippable, so
+    a user who configured Ouroboros but never finished (or skipped) the welcome
+    is otherwise treated as first-time forever and re-nagged on every prompt.
+    Any of these install signals means the user is past first-touch.
+    """
+    ouro_dir = Path.home() / ".ouroboros"
+    markers = ("config.yaml", "credentials.yaml", "ouroboros.db")
+    if any((ouro_dir / marker).exists() for marker in markers):
+        return True
+    return is_mcp_configured()
+
+
 def is_first_time() -> bool:
     """Check if this is the user's first interaction.
 
-    Older onboarding flows wrote ``welcomeShown`` or other preference keys without
-    ``welcomeCompleted``. Treat any valid existing prefs as a non-first-run state
-    so upgrades do not repeatedly auto-trigger the welcome experience.
+    Older onboarding flows wrote ``welcomeShown`` or other preference keys
+    without ``welcomeCompleted``. Treat any valid existing prefs as a
+    non-first-run state so upgrades do not repeatedly auto-trigger the welcome
+    experience. When ``prefs.json`` is missing entirely, fall back to other
+    install signals (see ``_has_prior_install_state``) so a configured user who
+    never completed the welcome flow is not nagged on every prompt.
     """
     try:
         prefs_path = Path.home() / ".ouroboros" / "prefs.json"
         if not prefs_path.exists():
-            return True
+            return not _has_prior_install_state()
         prefs = json.loads(prefs_path.read_text())
         if not isinstance(prefs, dict):
             return True

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -84,6 +84,20 @@ class TestFirstTimePrefs:
         with patch.object(_mod.Path, "home", return_value=tmp_path):
             assert is_first_time() is True
 
+    def test_malformed_prefs_stays_first_time_despite_install_markers(self, tmp_path):
+        # Intentional asymmetry guard: a malformed prefs.json (valid JSON that
+        # parses to a non-dict) stays first-time even when install markers are
+        # present, because re-running welcome rewrites the corrupt file cleanly.
+        # Pins the contract so the malformed branch is not "fixed" by routing
+        # it through _has_prior_install_state().
+        ouro_dir = tmp_path / ".ouroboros"
+        ouro_dir.mkdir()
+        (ouro_dir / "config.yaml").write_text("version: 1\n")
+        (ouro_dir / "prefs.json").write_text('["not", "a", "dict"]')
+
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert is_first_time() is True
+
 
 class TestDetectKeywords:
     def test_ooo_qa_detected(self):

--- a/tests/unit/scripts/test_keyword_detector.py
+++ b/tests/unit/scripts/test_keyword_detector.py
@@ -46,6 +46,44 @@ class TestFirstTimePrefs:
         with patch.object(_mod.Path, "home", return_value=tmp_path):
             assert is_first_time() is False
 
+    def test_missing_prefs_but_config_yaml_marks_not_first_time(self, tmp_path):
+        # ``ooo setup`` writes config.yaml, but only the (skippable) welcome
+        # flow writes welcomeCompleted. A configured user without prefs.json
+        # must not be treated as first-time, otherwise the welcome suggestion
+        # is re-injected on every keyword-less prompt forever.
+        ouro_dir = tmp_path / ".ouroboros"
+        ouro_dir.mkdir()
+        (ouro_dir / "config.yaml").write_text("version: 1\n")
+
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert is_first_time() is False
+
+    def test_missing_prefs_but_db_marks_not_first_time(self, tmp_path):
+        # The event-sourcing DB only exists once the MCP runtime has done real
+        # work — an unambiguous "already used Ouroboros" signal.
+        ouro_dir = tmp_path / ".ouroboros"
+        ouro_dir.mkdir()
+        (ouro_dir / "ouroboros.db").write_bytes(b"")
+
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert is_first_time() is False
+
+    def test_missing_prefs_but_mcp_registered_marks_not_first_time(self, tmp_path):
+        # MCP registered in ~/.claude/mcp.json means setup has already run.
+        claude_dir = tmp_path / ".claude"
+        claude_dir.mkdir()
+        (claude_dir / "mcp.json").write_text('{"mcpServers": {"ouroboros": {}}}')
+
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert is_first_time() is False
+
+    def test_pristine_home_is_still_first_time(self, tmp_path):
+        # Regression guard for the discriminator: a truly empty home (no prefs,
+        # no install artifacts, no MCP registration) is still a genuine first
+        # run and SHOULD surface the welcome experience.
+        with patch.object(_mod.Path, "home", return_value=tmp_path):
+            assert is_first_time() is True
+
 
 class TestDetectKeywords:
     def test_ooo_qa_detected(self):


### PR DESCRIPTION
## Summary

`scripts/keyword-detector.py` injects the welcome `<skill-suggestion>` block on
**every keyword-less prompt** (and every `/ouroboros:*` slash command) while
`is_first_time()` returns `True`. `is_first_time()` treats a **missing**
`~/.ouroboros/prefs.json` as a genuine first run — but a fully-configured user can
legitimately have no `prefs.json`, so the welcome suggestion fires forever, across
every session.

This is the same class of bug as #659 (fixed in #663), for the sub-case #663 did
not cover: `prefs.json` **never created at all**, rather than created without
`welcomeCompleted`.

## Impact

`welcomeCompleted` / `welcomeShown` are only written by the (skippable) welcome
flow. A user who ran `ooo setup` — which registers the MCP server and writes
`~/.ouroboros/config.yaml`, `credentials.yaml`, and `ouroboros.db` — but skipped
the welcome has no `prefs.json`, so:

- every keyword-less prompt gets the welcome block prepended;
- every `/ouroboros:*` command (no natural-language keyword match) gets it too;
- it persists across sessions indefinitely.

Observed in the wild: `~/.ouroboros/` fully populated (`config.yaml`,
`credentials.yaml`, `ouroboros.db`, `mcp-server.pid`) with `ouroboros` registered
in `~/.claude/mcp.json`, but no `prefs.json` — the nag fired on every prompt.

## Root cause

```python
prefs_path = Path.home() / ".ouroboros" / "prefs.json"
if not prefs_path.exists():
    return True            # fires for configured-but-no-prefs installs
```

#659 itself suggested an `ouroboros.db` heuristic as one option; #663 took the
lighter `welcomeShown` + `not bool(prefs)` migration, which only helps when
`prefs.json` already exists.

## Fix

Add `_has_prior_install_state()`. When `prefs.json` is absent, consult concrete
install signals before declaring a first run:

- `~/.ouroboros/config.yaml`, `credentials.yaml`, or `ouroboros.db` exists, or
- the MCP server is registered (`is_mcp_configured()`).

A pristine home still returns `True`, so genuinely new users still get the
welcome experience; the existing `test_missing_prefs_file_is_first_time` is
preserved unchanged.

## Testing

4 new cases in `TestFirstTimePrefs` (`tests/unit/scripts/test_keyword_detector.py`):
config.yaml / ouroboros.db / MCP-registered → not first-time; pristine home →
still first-time (regression guard).

```
uv run pytest tests/unit/scripts/test_keyword_detector.py -q   # 39 passed
uv run pytest tests/unit/scripts/ -q                            # 165 passed
uv run ruff check scripts/ tests/ && uv run ruff format --check # clean
```

Verified red→green: the three "configured" tests fail on `main` and pass with
this change.

Relates to #659.
