### PR TITLE
fix(persistence): sanitize Windows-reserved chars in checkpoint seed_id (fixes #1155)

### DIFF
--- a/src/ouroboros/persistence/checkpoint.py
+++ b/src/ouroboros/persistence/checkpoint.py
@@ -183,8 +183,9 @@ class CheckpointStore:
     def _sanitize_seed_id(seed_id: str, *, max_len: int | None = None) -> str:
         """Sanitize seed_id to prevent path traversal attacks.
 
-        Strips null bytes, removes path separators and parent-directory
-        sequences, and caps length so that the **full** checkpoint
+        Strips null bytes, removes path separators, Windows-reserved
+        filename characters and parent-directory sequences, and caps
+        length so that the **full** checkpoint
         filename (prefix + seed + suffix) stays within the 255-byte
         filesystem limit.  When truncation is needed a SHA-256 hash
         fragment is appended to keep the mapping collision-resistant.
@@ -211,8 +212,13 @@ class CheckpointStore:
         # so that inputs like "x/../../PWNED" are neutralised.
         sanitized = sanitized.replace("..", "")
 
-        # Replace path separators with underscores
-        sanitized = re.sub(r"[/\\]", "_", sanitized)
+        # Replace path separators AND Windows-reserved filename characters
+        # (: * ? " < > |) with underscores. On POSIX only "/" is illegal in a
+        # filename, but Windows forbids these too; without stripping them a
+        # colon-bearing seed_id (e.g. an MCP cancel-checkpoint id like
+        # "..._cancel:mcp_job:job_<id>") yields an invalid path and the write
+        # fails with WinError 123. See https://github.com/Q00/ouroboros/issues/1155
+        sanitized = re.sub(r'[/\\:*?"<>|]', "_", sanitized)
 
         # Cap length to the remaining filename budget.
         # When truncation is required, append a hash suffix for collision resistance.

--- a/tests/unit/persistence/test_checkpoint.py
+++ b/tests/unit/persistence/test_checkpoint.py
@@ -231,6 +231,38 @@ class TestCheckpointStorePathTraversal:
         expected = checkpoint_store._base_path / "checkpoint_x___PWNED.json"
         assert expected.exists()
 
+    def test_colon_in_seed_id_is_sanitized(self, checkpoint_store: CheckpointStore) -> None:
+        """Regression (#1155): a colon-bearing seed_id (e.g. an MCP cancel-checkpoint
+        id) is sanitized so the checkpoint is writable on Windows (WinError 123)."""
+        seed_id = "ouroboros_agent_process_cancel:mcp_job:job_19a927b41098"
+        cp = CheckpointData.create(seed_id, "phase1", {"a": 1})
+        result = checkpoint_store.save(cp)
+        assert result.is_ok
+        # Colons -> underscores -> a filename valid on every platform.
+        expected = (
+            checkpoint_store._base_path
+            / "checkpoint_ouroboros_agent_process_cancel_mcp_job_job_19a927b41098.json"
+        )
+        assert expected.exists()
+        # And it round-trips through load() (which re-sanitizes identically).
+        load_result = checkpoint_store.load(seed_id)
+        assert load_result.is_ok
+        assert load_result.value.phase == "phase1"
+
+    @pytest.mark.parametrize("reserved", [":", "*", "?", '"', "<", ">", "|"])
+    def test_windows_reserved_chars_are_sanitized(
+        self, checkpoint_store: CheckpointStore, reserved: str
+    ) -> None:
+        """seed_ids with Windows-reserved filename characters are sanitized so the
+        on-disk checkpoint path is valid on Windows."""
+        cp = CheckpointData.create(f"seed{reserved}id", "phase1", {"a": 1})
+        result = checkpoint_store.save(cp)
+        assert result.is_ok
+        # The reserved char must not survive into the filename.
+        path = checkpoint_store._get_checkpoint_path(f"seed{reserved}id")
+        assert reserved not in path.name
+        assert path.exists()
+
     def test_traversal_does_not_escape_base_dir(self, checkpoint_store: CheckpointStore) -> None:
         """No checkpoint file is created outside the base directory."""
         cp = CheckpointData.create("../../../etc/passwd", "phase1", {})


### PR DESCRIPTION
## Summary

`CheckpointStore._sanitize_seed_id` only replaced POSIX path separators (`/`, `\`), leaving Windows-reserved filename characters (`:` `*` `?` `"` `<` `>` `|`) intact. On Windows the resulting checkpoint path is invalid and the write fails with `WinError 123`.

This is hit **deterministically** during MCP background-job execution: the agent-process *cancel* checkpoint uses a `seed_id` like `ouroboros_agent_process_cancel:mcp_job:job_<id>`, whose colons break the path. `interview` -> seed generation works, but `execute_seed` over MCP always fails on Windows.

Fixes #1155.

## Change

- Extend the sanitization regex from `r"[/\\]"` to `r'[/\\:*?"<>|]'` so reserved characters become `_`.
- Update the docstring to mention Windows-reserved characters.

## Tests

Added to `TestCheckpointStorePathTraversal`:
- `test_colon_in_seed_id_is_sanitized` — the exact failing seed_id now saves and round-trips through `load()`.
- `test_windows_reserved_chars_are_sanitized` — parametrized over `: * ? " < > |`.

`tests/unit/persistence/test_checkpoint.py`: **45 passed** locally (CPython 3.14, Windows 11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
