### PR TITLE
feat(mcp): plumb force flag through ouroboros_generate_seed

### DIFF
--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -960,6 +960,13 @@ class GenerateSeedHandler:
             if effective_score is None:
                 effective_score = interview_state.ambiguity_score  # persisted
 
+            # force=True intentionally bypasses BOTH the ambiguity threshold
+            # AND the "no score / no answered rounds" completeness guard for
+            # this plugin path — broader than #1107's domain-layer scope, but
+            # matches the CLI ``init`` "Generate Seed anyway" opt-in which
+            # forwards the same flag past the same guards. The real ambiguity
+            # score is still recorded in seed metadata for provenance and the
+            # bypass is emitted to the audit log.
             if not interview_state.is_complete and not force:
                 answered_rounds = [r for r in interview_state.rounds if r.user_response is not None]
                 if effective_score is not None:

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -847,7 +847,8 @@ class GenerateSeedHandler:
             description=(
                 "Generate an immutable Seed from a completed interview session. "
                 "The seed contains structured requirements (goal, constraints, acceptance criteria) "
-                "extracted from the interview conversation. Generation requires ambiguity_score <= 0.2."
+                "extracted from the interview conversation. Generation requires ambiguity_score <= 0.2 "
+                "unless force=true is passed to deliberately bypass the gate."
             ),
             parameters=(
                 MCPToolParameter(
@@ -876,6 +877,18 @@ class GenerateSeedHandler:
                     required=False,
                     items={"type": "string"},
                 ),
+                MCPToolParameter(
+                    name="force",
+                    type=ToolInputType.BOOLEAN,
+                    description=(
+                        "Bypass the ambiguity-score threshold and generate the seed even "
+                        "when ambiguity_score > 0.2. Mirrors the CLI 'Generate Seed anyway' "
+                        "opt-in: the real score is still recorded in seed metadata for "
+                        "provenance, and the bypass is emitted to the audit log. "
+                        "Defaults to false."
+                    ),
+                    required=False,
+                ),
             ),
         )
 
@@ -901,6 +914,7 @@ class GenerateSeedHandler:
             )
 
         ambiguity_score_value = arguments.get("ambiguity_score")
+        force = bool(arguments.get("force", False))
         client_gate_status = get_client_gate_status(arguments)
         client_gate_error = _client_gate_error(client_gate_status)
         if client_gate_error is not None:
@@ -910,7 +924,14 @@ class GenerateSeedHandler:
             "mcp.tool.generate_seed",
             session_id=session_id,
             ambiguity_score=ambiguity_score_value,
+            force=force,
         )
+        if force:
+            log.warning(
+                "mcp.tool.generate_seed.force_bypass",
+                session_id=session_id,
+                caller_ambiguity_score=ambiguity_score_value,
+            )
 
         # --- Subagent dispatch: gate on runtime + opencode_mode ---
         if should_dispatch_via_plugin(self.agent_runtime_backend, self.opencode_mode):
@@ -939,7 +960,7 @@ class GenerateSeedHandler:
             if effective_score is None:
                 effective_score = interview_state.ambiguity_score  # persisted
 
-            if not interview_state.is_complete:
+            if not interview_state.is_complete and not force:
                 answered_rounds = [r for r in interview_state.rounds if r.user_response is not None]
                 if effective_score is not None:
                     # Have a score — enforce threshold
@@ -948,7 +969,8 @@ class GenerateSeedHandler:
                             MCPToolError(
                                 f"Ambiguity score {effective_score:.2f} exceeds "
                                 f"threshold {_THRESHOLD}. Continue interviewing "
-                                f"to reduce ambiguity before seed generation.",
+                                f"to reduce ambiguity before seed generation, "
+                                f"or pass force=true to bypass the gate.",
                                 tool_name="ouroboros_generate_seed",
                             )
                         )
@@ -970,6 +992,7 @@ class GenerateSeedHandler:
                 ambiguity_score=effective_score,
                 transcript=transcript,
                 client_gates=client_gate_status["accepted_client_gates"],
+                force=force,
             )
             await emit_subagent_dispatched_event(
                 self.event_store,
@@ -982,6 +1005,7 @@ class GenerateSeedHandler:
                     "session_id": session_id,
                     "status": "delegated_to_subagent",
                     "dispatch_mode": "plugin",
+                    "force": force,
                     **client_gate_status,
                 },
             )
@@ -1064,8 +1088,10 @@ class GenerateSeedHandler:
                 model=get_clarification_model(self.llm_backend),
             )
 
-            # Generate seed
-            seed_result = await generator.generate(state, ambiguity_score)
+            # Generate seed; force bypasses the ambiguity threshold gate inside
+            # SeedGenerator.generate while still stamping the real score into
+            # SeedMetadata for provenance.
+            seed_result = await generator.generate(state, ambiguity_score, force=force)
 
             if seed_result.is_err:
                 error = seed_result.error
@@ -1113,6 +1139,7 @@ class GenerateSeedHandler:
                         "seed_id": seed.metadata.seed_id,
                         "interview_id": seed.metadata.interview_id,
                         "ambiguity_score": seed.metadata.ambiguity_score,
+                        "force": force,
                         **client_gate_status,
                     },
                 )

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -658,8 +658,15 @@ def build_generate_seed_subagent(
     ambiguity_score: float | None = None,
     transcript: str = "",
     client_gates: tuple[str, ...] = (),
+    force: bool = False,
 ) -> SubagentPayload:
-    """Build subagent payload for seed generation from interview."""
+    """Build subagent payload for seed generation from interview.
+
+    When ``force=True``, the prompt explicitly tells the subagent that the
+    ambiguity-score gate has been bypassed by deliberate caller opt-in (mirrors
+    the CLI ``init`` "Generate Seed anyway" path) so the subagent does not
+    re-impose the threshold check on its end.
+    """
     from ouroboros.agents.loader import load_agent_prompt
 
     system_prompt = load_agent_prompt("seed-architect")
@@ -671,6 +678,16 @@ def build_generate_seed_subagent(
     transcript_section = ""
     if transcript:
         transcript_section = f"\n## Interview Transcript\n{transcript}\n"
+
+    force_note = ""
+    if force:
+        force_note = (
+            "\n## Ambiguity Gate Bypassed\n"
+            "The caller has explicitly bypassed the ambiguity-score threshold. "
+            "Generate the seed even if the score exceeds 0.2; the real score "
+            "is still recorded in seed metadata for provenance. Do not refuse "
+            "on ambiguity grounds.\n"
+        )
 
     prompt = f"""{system_prompt}
 
@@ -684,7 +701,7 @@ criteria, ontology schema, evaluation principles, and exit conditions.
 
 ## Session ID
 {session_id}
-{ambiguity_note}{transcript_section}
+{ambiguity_note}{transcript_section}{force_note}
 Extract all requirements from the interview conversation and produce a
 complete YAML seed specification. The seed should be precise enough for
 autonomous execution."""
@@ -693,6 +710,7 @@ autonomous execution."""
         "session_id": session_id,
         "ambiguity_score": ambiguity_score,
         "client_gates": client_gates,
+        "force": force,
     }
 
     return build_subagent_payload(

--- a/tests/unit/mcp/tools/test_generate_seed_force_flag.py
+++ b/tests/unit/mcp/tools/test_generate_seed_force_flag.py
@@ -1,0 +1,331 @@
+"""Tests for the ``force`` flag on the ``ouroboros_generate_seed`` MCP tool.
+
+The flag mirrors the CLI ``init`` "Generate Seed anyway" opt-in: when set, the
+ambiguity-score threshold is bypassed in both the plugin/subagent dispatch
+path and the in-process generation path, the real score is still recorded in
+seed metadata, and the bypass is emitted to the audit log.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBreakdown
+from ouroboros.bigbang.interview import InterviewState, InterviewStatus
+from ouroboros.core.types import Result
+from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler
+from ouroboros.mcp.tools.subagent import build_generate_seed_subagent
+from ouroboros.mcp.types import ToolInputType
+
+# ---------------------------------------------------------------------------
+# Tool definition exposes the force parameter
+# ---------------------------------------------------------------------------
+
+
+class TestDefinitionExposesForce:
+    """The MCP tool schema advertises ``force`` as an optional boolean."""
+
+    def test_force_parameter_present(self) -> None:
+        params = {p.name: p for p in GenerateSeedHandler().definition.parameters}
+        assert "force" in params
+
+    def test_force_parameter_is_optional_boolean(self) -> None:
+        param = next(p for p in GenerateSeedHandler().definition.parameters if p.name == "force")
+        assert param.type == ToolInputType.BOOLEAN
+        assert param.required is False
+
+    def test_description_mentions_bypass(self) -> None:
+        defn = GenerateSeedHandler().definition
+        assert "force" in defn.description.lower()
+
+
+# ---------------------------------------------------------------------------
+# Subagent payload builder honors force
+# ---------------------------------------------------------------------------
+
+
+class TestBuildGenerateSeedSubagentForce:
+    """``build_generate_seed_subagent`` plumbs ``force`` into context + prompt."""
+
+    def test_force_defaults_to_false_in_context(self) -> None:
+        payload = build_generate_seed_subagent(session_id="sess-1")
+        assert payload.context["force"] is False
+
+    def test_force_true_recorded_in_context(self) -> None:
+        payload = build_generate_seed_subagent(session_id="sess-1", force=True)
+        assert payload.context["force"] is True
+
+    def test_force_true_adds_bypass_note_to_prompt(self) -> None:
+        payload = build_generate_seed_subagent(session_id="sess-1", force=True)
+        assert "Ambiguity Gate Bypassed" in payload.prompt
+        assert "bypassed the ambiguity-score threshold" in payload.prompt
+
+    def test_force_false_omits_bypass_note(self) -> None:
+        payload = build_generate_seed_subagent(session_id="sess-1", force=False)
+        assert "Ambiguity Gate Bypassed" not in payload.prompt
+
+
+# ---------------------------------------------------------------------------
+# Plugin/subagent dispatch path
+# ---------------------------------------------------------------------------
+
+
+def _state_with_persisted_score(
+    *,
+    session_id: str,
+    score: float,
+    completed: bool,
+) -> InterviewState:
+    state = InterviewState(
+        interview_id=session_id,
+        initial_context="ctx",
+        status=(InterviewStatus.COMPLETED if completed else InterviewStatus.IN_PROGRESS),
+        ambiguity_score=score,
+    )
+    return state
+
+
+@pytest.fixture
+def plugin_handler() -> GenerateSeedHandler:
+    return GenerateSeedHandler(agent_runtime_backend="opencode", opencode_mode="plugin")
+
+
+class TestPluginPathForce:
+    """Plugin/subagent dispatch path respects ``force``."""
+
+    @pytest.mark.asyncio
+    async def test_high_ambiguity_without_force_returns_error_on_incomplete(
+        self, plugin_handler: GenerateSeedHandler
+    ) -> None:
+        """Sanity check: without force, the threshold gate still rejects."""
+        state = _state_with_persisted_score(session_id="sess-high", score=0.8, completed=False)
+        with patch(
+            "ouroboros.mcp.tools.authoring_handlers._plugin_load_state",
+            AsyncMock(return_value=Result.ok(state)),
+        ):
+            result = await plugin_handler.handle({"session_id": "sess-high"})
+
+        assert result.is_err
+        assert "exceeds" in result.error.message
+        # Caller-facing hint should mention the new force escape hatch.
+        assert "force=true" in result.error.message
+
+    @pytest.mark.asyncio
+    async def test_high_ambiguity_with_force_bypasses_gate(
+        self, plugin_handler: GenerateSeedHandler
+    ) -> None:
+        state = _state_with_persisted_score(session_id="sess-high", score=0.8, completed=False)
+        with patch(
+            "ouroboros.mcp.tools.authoring_handlers._plugin_load_state",
+            AsyncMock(return_value=Result.ok(state)),
+        ):
+            result = await plugin_handler.handle({"session_id": "sess-high", "force": True})
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert meta["force"] is True
+        ctx = meta["_subagent"]["context"]
+        assert ctx["force"] is True
+        # Bypass note must reach the subagent so it does not re-impose the gate.
+        assert "Ambiguity Gate Bypassed" in meta["_subagent"]["prompt"]
+
+    @pytest.mark.asyncio
+    async def test_force_default_false_in_response_shape(
+        self, plugin_handler: GenerateSeedHandler
+    ) -> None:
+        state = _state_with_persisted_score(session_id="sess-clear", score=0.1, completed=True)
+        with patch(
+            "ouroboros.mcp.tools.authoring_handlers._plugin_load_state",
+            AsyncMock(return_value=Result.ok(state)),
+        ):
+            result = await plugin_handler.handle({"session_id": "sess-clear"})
+
+        assert result.is_ok
+        assert result.value.meta["force"] is False
+        assert result.value.meta["_subagent"]["context"]["force"] is False
+
+
+# ---------------------------------------------------------------------------
+# In-process generation path
+# ---------------------------------------------------------------------------
+
+
+class _GeneratorSpy:
+    """Captures the kwargs passed to ``SeedGenerator.generate``."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, object]] = []
+
+    async def generate(
+        self,
+        state: InterviewState,
+        ambiguity_score: AmbiguityScore,
+        *,
+        force: bool = False,
+        **_: object,
+    ) -> Result:
+        self.calls.append(
+            {
+                "session_id": state.interview_id,
+                "score": ambiguity_score.overall_score,
+                "force": force,
+            }
+        )
+        # Stop here; the surrounding handler logic for serialization is not
+        # under test. Returning an error short-circuits the YAML rendering
+        # while still exercising the kwarg propagation path.
+        from ouroboros.core.errors import ValidationError
+
+        return Result.err(
+            ValidationError(
+                "spy stop",
+                field="test",
+                details={"interview_id": state.interview_id},
+            )
+        )
+
+
+class _InterviewEngineStub:
+    """Returns a fully-populated ``InterviewState`` for the handler to use."""
+
+    def __init__(self, state: InterviewState) -> None:
+        self._state = state
+
+    async def load_state(self, session_id: str) -> Result:
+        return Result.ok(self._state)
+
+    async def save_state(self, state: InterviewState) -> Result:
+        return Result.ok(None)
+
+
+def _stored_ambiguity_state(*, session_id: str, score: float) -> InterviewState:
+    state = InterviewState(
+        interview_id=session_id,
+        initial_context="ctx",
+        status=InterviewStatus.COMPLETED,
+    )
+    breakdown = ScoreBreakdown(
+        goal_clarity=ComponentScore(
+            name="goal_clarity",
+            clarity_score=1.0 - score,
+            weight=0.40,
+            justification="seed",
+        ),
+        constraint_clarity=ComponentScore(
+            name="constraint_clarity",
+            clarity_score=1.0 - score,
+            weight=0.30,
+            justification="seed",
+        ),
+        success_criteria_clarity=ComponentScore(
+            name="success_criteria_clarity",
+            clarity_score=1.0 - score,
+            weight=0.30,
+            justification="seed",
+        ),
+    )
+    state.store_ambiguity(score=score, breakdown=breakdown.model_dump(mode="json"))
+    return state
+
+
+class TestInProcessPathForce:
+    """In-process generation propagates ``force`` to ``SeedGenerator.generate``."""
+
+    @pytest.mark.asyncio
+    async def test_force_false_by_default(self) -> None:
+        spy = _GeneratorSpy()
+        state = _stored_ambiguity_state(session_id="sess-A", score=0.1)
+        handler = GenerateSeedHandler(
+            interview_engine=_InterviewEngineStub(state),
+            seed_generator=spy,  # type: ignore[arg-type]
+            llm_adapter=object(),  # type: ignore[arg-type]
+        )
+
+        result = await handler.handle({"session_id": "sess-A"})
+
+        assert result.is_err  # spy short-circuits
+        assert spy.calls == [{"session_id": "sess-A", "score": 0.1, "force": False}]
+
+    @pytest.mark.asyncio
+    async def test_force_true_propagates_to_generator(self) -> None:
+        spy = _GeneratorSpy()
+        # High persisted ambiguity ensures the generator's own gate would
+        # reject without force; the kwarg is what unlocks generation.
+        state = _stored_ambiguity_state(session_id="sess-B", score=0.85)
+        handler = GenerateSeedHandler(
+            interview_engine=_InterviewEngineStub(state),
+            seed_generator=spy,  # type: ignore[arg-type]
+            llm_adapter=object(),  # type: ignore[arg-type]
+        )
+
+        result = await handler.handle({"session_id": "sess-B", "force": True})
+
+        assert result.is_err  # spy short-circuits
+        assert spy.calls == [{"session_id": "sess-B", "score": 0.85, "force": True}]
+
+    @pytest.mark.asyncio
+    async def test_force_truthy_coerced_to_bool(self) -> None:
+        """Non-boolean truthy values must be coerced (defensive)."""
+        spy = _GeneratorSpy()
+        state = _stored_ambiguity_state(session_id="sess-C", score=0.5)
+        handler = GenerateSeedHandler(
+            interview_engine=_InterviewEngineStub(state),
+            seed_generator=spy,  # type: ignore[arg-type]
+            llm_adapter=object(),  # type: ignore[arg-type]
+        )
+
+        await handler.handle({"session_id": "sess-C", "force": 1})
+
+        assert spy.calls[0]["force"] is True
+
+
+# ---------------------------------------------------------------------------
+# Audit logging
+# ---------------------------------------------------------------------------
+
+
+class TestForceAuditLogging:
+    """Force opt-in must surface in the audit trail for incident review."""
+
+    @pytest.mark.asyncio
+    async def test_force_bypass_log_emitted(self) -> None:
+        spy = _GeneratorSpy()
+        state = _stored_ambiguity_state(session_id="sess-audit", score=0.9)
+        handler = GenerateSeedHandler(
+            interview_engine=_InterviewEngineStub(state),
+            seed_generator=spy,  # type: ignore[arg-type]
+            llm_adapter=object(),  # type: ignore[arg-type]
+        )
+
+        with patch("ouroboros.mcp.tools.authoring_handlers.log.warning") as mock_warning:
+            await handler.handle({"session_id": "sess-audit", "force": True})
+
+        bypass_calls = [
+            call
+            for call in mock_warning.call_args_list
+            if call.args and call.args[0] == "mcp.tool.generate_seed.force_bypass"
+        ]
+        assert len(bypass_calls) == 1
+        assert bypass_calls[0].kwargs["session_id"] == "sess-audit"
+
+    @pytest.mark.asyncio
+    async def test_force_bypass_log_absent_when_not_forced(self) -> None:
+        spy = _GeneratorSpy()
+        state = _stored_ambiguity_state(session_id="sess-no-audit", score=0.1)
+        handler = GenerateSeedHandler(
+            interview_engine=_InterviewEngineStub(state),
+            seed_generator=spy,  # type: ignore[arg-type]
+            llm_adapter=object(),  # type: ignore[arg-type]
+        )
+
+        with patch("ouroboros.mcp.tools.authoring_handlers.log.warning") as mock_warning:
+            await handler.handle({"session_id": "sess-no-audit"})
+
+        bypass_calls = [
+            call
+            for call in mock_warning.call_args_list
+            if call.args and call.args[0] == "mcp.tool.generate_seed.force_bypass"
+        ]
+        assert bypass_calls == []

--- a/tests/unit/mcp/tools/test_generate_seed_force_flag.py
+++ b/tests/unit/mcp/tools/test_generate_seed_force_flag.py
@@ -8,6 +8,7 @@ seed metadata, and the bypass is emitted to the audit log.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -279,6 +280,118 @@ class TestInProcessPathForce:
         await handler.handle({"session_id": "sess-C", "force": 1})
 
         assert spy.calls[0]["force"] is True
+
+
+# ---------------------------------------------------------------------------
+# In-process success path stamps ``force`` into result metadata
+# ---------------------------------------------------------------------------
+
+
+class _SuccessfulGeneratorSpy:
+    """Returns ``Result.ok(fake_seed)`` so the handler reaches the success
+    branch that builds the public response metadata.
+
+    The fake seed only exposes the attributes the handler reads
+    (``metadata.seed_id``, ``metadata.interview_id``,
+    ``metadata.ambiguity_score``, ``goal``, ``to_dict()``); nothing else
+    about real :class:`Seed` serialization is under test here.
+    """
+
+    def __init__(self, *, seed_id: str, interview_id: str, ambiguity: float, goal: str) -> None:
+        self.calls: list[dict[str, object]] = []
+        self._seed = SimpleNamespace(
+            metadata=SimpleNamespace(
+                seed_id=seed_id,
+                interview_id=interview_id,
+                ambiguity_score=ambiguity,
+            ),
+            goal=goal,
+            to_dict=lambda: {
+                "goal": goal,
+                "metadata": {"seed_id": seed_id, "interview_id": interview_id},
+            },
+        )
+
+    async def generate(
+        self,
+        state: InterviewState,
+        ambiguity_score: AmbiguityScore,
+        *,
+        force: bool = False,
+        **_: object,
+    ) -> Result:
+        self.calls.append(
+            {
+                "session_id": state.interview_id,
+                "score": ambiguity_score.overall_score,
+                "force": force,
+            }
+        )
+        return Result.ok(self._seed)
+
+
+class TestInProcessSuccessPathMeta:
+    """In-process success path echoes ``force`` into the MCP response meta.
+
+    These tests exercise the public response contract added at
+    ``authoring_handlers.py`` where the success branch returns ``meta`` with
+    ``{"seed_id", "interview_id", "ambiguity_score", "force", ...}``. The
+    :class:`_GeneratorSpy` cases above short-circuit on ``ValidationError``
+    before this branch runs, so without these tests the success-path
+    metadata contract is uncovered.
+    """
+
+    @pytest.mark.asyncio
+    async def test_force_true_echoed_in_success_meta(self) -> None:
+        spy = _SuccessfulGeneratorSpy(
+            seed_id="seed-force-on",
+            interview_id="sess-success-force",
+            ambiguity=0.85,
+            goal="bypass gate via force",
+        )
+        state = _stored_ambiguity_state(session_id="sess-success-force", score=0.85)
+        handler = GenerateSeedHandler(
+            interview_engine=_InterviewEngineStub(state),
+            seed_generator=spy,  # type: ignore[arg-type]
+            llm_adapter=object(),  # type: ignore[arg-type]
+        )
+
+        result = await handler.handle({"session_id": "sess-success-force", "force": True})
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert meta["force"] is True
+        assert meta["seed_id"] == "seed-force-on"
+        assert meta["interview_id"] == "sess-success-force"
+        # The real (high) ambiguity score is preserved in metadata even
+        # though the gate was bypassed — provenance is intact.
+        assert meta["ambiguity_score"] == pytest.approx(0.85)
+        assert spy.calls == [{"session_id": "sess-success-force", "score": 0.85, "force": True}]
+
+    @pytest.mark.asyncio
+    async def test_force_false_echoed_in_success_meta(self) -> None:
+        spy = _SuccessfulGeneratorSpy(
+            seed_id="seed-default",
+            interview_id="sess-success-noforce",
+            ambiguity=0.1,
+            goal="gated happy path",
+        )
+        state = _stored_ambiguity_state(session_id="sess-success-noforce", score=0.1)
+        handler = GenerateSeedHandler(
+            interview_engine=_InterviewEngineStub(state),
+            seed_generator=spy,  # type: ignore[arg-type]
+            llm_adapter=object(),  # type: ignore[arg-type]
+        )
+
+        result = await handler.handle({"session_id": "sess-success-noforce"})
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert meta["force"] is False
+        assert meta["seed_id"] == "seed-default"
+        assert meta["interview_id"] == "sess-success-noforce"
+        assert meta["ambiguity_score"] == pytest.approx(0.1)
+        assert spy.calls == [{"session_id": "sess-success-noforce", "score": 0.1, "force": False}]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds an optional `force: boolean` parameter to the `ouroboros_generate_seed` MCP tool so callers can deliberately bypass the ambiguity-score threshold from the MCP surface, mirroring the CLI `init` "Generate Seed anyway" opt-in.
- In the in-process path, `force` is forwarded to `SeedGenerator.generate(..., force=...)` (the kwarg added in #1107). In the plugin/subagent dispatch path, the server-side threshold check is skipped when `force=true` and the flag is propagated into the subagent payload context + prompt so the child does not re-impose the gate.
- Every bypass emits `mcp.tool.generate_seed.force_bypass` at WARNING level for incident-time audit, and the `force` value is echoed into the result `meta` and subagent `response_shape` for downstream observability.

## Scope of the bypass (CLI parity)

`force=true` in the plugin/subagent dispatch path intentionally bypasses **both** the ambiguity threshold **and** the "no answered rounds / no score" completeness guard on incomplete interviews — this is broader than PR #1107's domain-layer framing, which scoped the bypass to the ambiguity gate only. The widening is deliberate: the CLI `init` "Generate Seed anyway" path forwards the same flag past the same guards (see `cli/commands/init.py:571`), so the MCP surface is now at CLI parity rather than a stricter subset. The real ambiguity score is still stamped into `SeedMetadata.ambiguity_score` for provenance, and each bypass emits the `mcp.tool.generate_seed.force_bypass` WARNING for audit. An inline comment on the bypass branch records this scope explicitly so future readers don't treat it as a silent expansion over #1107.

## Why

PR #1107 added the `force` kwarg to `SeedGenerator.generate` to replace the `FORCED_SCORE_VALUE` hack, but only the CLI (`init.py:571`) wires it — there was no way to express "generate anyway" through the MCP tool. The defense in #210 (ignore caller-supplied `ambiguity_score`) still applies and is unchanged; `force` is a separate, explicit opt-in with its own audit log.

`force` defaults to `false`, so existing callers and the LLM-bypass guarantees from #210 are byte-identical with the prior behavior.

## Test plan

- [x] `tests/unit/mcp/tools/test_generate_seed_force_flag.py` (15 new tests): tool definition exposes `force` as optional boolean; subagent builder defaults `force` to `false`, threads `true` into context, and only injects the "Ambiguity Gate Bypassed" note when forced; plugin path rejects high ambiguity without force, accepts it with force, surfaces `force=true` in meta + subagent context; in-process path propagates `force` (incl. truthy coercion) into `SeedGenerator.generate`; `mcp.tool.generate_seed.force_bypass` audit log emitted only when forced.
- [x] `pytest tests/unit/mcp/tools/test_subagent.py tests/unit/mcp/tools/test_handler_subagent_wiring.py tests/unit/mcp/tools/test_client_gates.py tests/unit/mcp/tools/test_definitions.py tests/unit/mcp/tools/test_authoring_allowed_tools_wiring.py` — 239 passed, 0 regressions.
- [x] `ruff check` / `ruff format --check` / `mypy` clean on changed files.