### PR TITLE
fix(orchestrator): match command claims wrapped in output redirection/pager pipes

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -906,8 +906,17 @@ def _looks_like_test_command(command: str) -> bool:
 
 
 def _test_command_invocation(command: str) -> str | None:
-    """Return the backed inner test invocation for a direct or wrapped command."""
-    normalized = command.strip().lower()
+    """Return the backed inner test invocation for a direct or wrapped command.
+
+    Output plumbing (``2>&1``, ``| tail -20``) is peeled first so a clean
+    invocation can be extracted from a ``<cmd> 2>&1 | tail -20`` runtime
+    command. ``_strip_command_output_plumbing`` is deliberately narrow — only
+    presentation-only tails are peeled — so an evidence-altering filter such
+    as ``| grep passed`` survives the strip and is rejected downstream by
+    ``_test_invocation_from_prefix`` rather than being silently dropped.
+    """
+    stripped = _strip_command_output_plumbing(command)
+    normalized = stripped.lower()
     if not normalized:
         return None
 
@@ -1012,13 +1021,24 @@ def _strip_env_prefix(parts: list[str]) -> list[str]:
 
 
 def _test_invocation_from_prefix(command: str) -> str | None:
-    """Return a normalized test invocation only when it starts the command text."""
+    """Return a normalized test invocation only when it starts the command text.
+
+    Refuses to extract from commands that still contain a residual shell pipe
+    after presentation plumbing has been peeled (``pytest x | grep passed``).
+    A residual pipe means the runtime command is followed by an
+    evidence-transforming filter (``grep`` / ``wc`` / ``tee``); treating the
+    bare prefix as the clean test invocation there would let a filtered run
+    silently back a clean ``tests_passed`` / ``commands_run`` claim via the
+    ``startswith`` widening in ``_runtime_message_supports_command_claim``.
+    """
     try:
         parts = shlex.split(command)
     except ValueError:
         parts = command.replace('"', "").replace("'", "").split()
     parts = _strip_env_prefix(parts)
     if not parts:
+        return None
+    if "|" in parts:
         return None
 
     if parts[0] in {"pytest", "py.test", "tox", "nox"}:
@@ -1058,9 +1078,15 @@ def _looks_like_unittest_command(command: str) -> bool:
 
 # Output-only shell filters: a trailing pipe into one of these is presentation
 # or paging, not the work an evidence claim is about.
-_OUTPUT_FILTER_COMMANDS = frozenset(
-    {"tail", "head", "cat", "less", "more", "tee", "wc", "grep", "egrep", "fgrep"}
-)
+#
+# Deliberately narrow: only filters that pass the output stream through (or
+# truncate it positionally) are allowed. ``grep``/``egrep``/``fgrep`` are
+# excluded because they can hide failure lines and make a filtered run back a
+# clean ``commands_run`` / ``tests_passed`` claim (e.g. ``pytest ... | grep
+# passed``). ``tee`` and ``wc`` are excluded for the same reason: ``tee`` can
+# redirect the stream and ``wc`` collapses it to a count, both of which alter
+# what the runtime would have observed and so weaken anti-fabrication.
+_OUTPUT_FILTER_COMMANDS = frozenset({"tail", "head", "cat", "less", "more"})
 
 # Trailing shell output redirection (``2>&1``, ``> log``, ``2> err``, ``&> out``).
 _TRAILING_REDIRECT_RE = re.compile(
@@ -1073,10 +1099,21 @@ def _strip_command_output_plumbing(command: str) -> str:
 
     Agents routinely run ``<cmd> 2>&1 | tail -20`` while their ``commands_run``
     evidence cites the clean ``<cmd>``. The trailing redirection and the
-    output-only filter pipe are presentation plumbing, not the work being
-    claimed, so they must not block a match. Deliberately conservative: only
-    trailing output redirections and pipes into a known output-filter command
-    are dropped, so meaningful pipelines (``a | python process.py``) are kept.
+    output-only pager pipe are presentation plumbing, not the work being
+    claimed, so they must not block a match. Deliberately conservative:
+
+    - Only trailing output redirections (``2>&1``, ``> log``, ``2> err``,
+      ``&> out``) and pipes into a pager-style filter listed in
+      ``_OUTPUT_FILTER_COMMANDS`` (``tail``/``head``/``cat``/``less``/``more``)
+      are dropped. These pass the underlying stream through (or truncate it
+      positionally), so the runtime evidence is unchanged in kind.
+    - Filters that *transform* the stream — ``grep`` family, ``wc``, ``tee`` —
+      are intentionally not stripped, because they can hide failure lines,
+      collapse the stream to a count, or divert it to a file, which would let
+      a filtered run back a clean ``commands_run`` / ``tests_passed`` claim.
+    - Meaningful pipelines such as ``a | python process.py`` are kept, so a
+      partial ``a`` claim is still not proven by an ``a | python process.py``
+      runtime command.
     """
     text = command.strip()
     if not text:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1056,6 +1056,47 @@ def _looks_like_unittest_command(command: str) -> bool:
     return _unittest_command_invocation(command) is not None
 
 
+# Output-only shell filters: a trailing pipe into one of these is presentation
+# or paging, not the work an evidence claim is about.
+_OUTPUT_FILTER_COMMANDS = frozenset(
+    {"tail", "head", "cat", "less", "more", "tee", "wc", "grep", "egrep", "fgrep"}
+)
+
+# Trailing shell output redirection (``2>&1``, ``> log``, ``2> err``, ``&> out``).
+_TRAILING_REDIRECT_RE = re.compile(
+    r"\s*(?:[0-9]*>{1,2}\s*(?:&[0-9]+|[^\s|]+)|&>{1,2}\s*[^\s|]+)\s*$"
+)
+
+
+def _strip_command_output_plumbing(command: str) -> str:
+    """Return a command with trailing output redirection and pager pipes removed.
+
+    Agents routinely run ``<cmd> 2>&1 | tail -20`` while their ``commands_run``
+    evidence cites the clean ``<cmd>``. The trailing redirection and the
+    output-only filter pipe are presentation plumbing, not the work being
+    claimed, so they must not block a match. Deliberately conservative: only
+    trailing output redirections and pipes into a known output-filter command
+    are dropped, so meaningful pipelines (``a | python process.py``) are kept.
+    """
+    text = command.strip()
+    if not text:
+        return text
+    # Peel output-only filter pipes from the tail (``... | tail -n 20``).
+    while "|" in text:
+        head, _, tail_segment = text.rpartition("|")
+        tail_tokens = tail_segment.split()
+        if tail_tokens and tail_tokens[0].lower() in _OUTPUT_FILTER_COMMANDS:
+            text = head.strip()
+            continue
+        break
+    # Peel trailing output redirections, possibly several (``2>&1 > log``).
+    prev: str | None = None
+    while prev != text:
+        prev = text
+        text = _TRAILING_REDIRECT_RE.sub("", text).strip()
+    return text
+
+
 def _normalized_command_claim_aliases(command: str) -> tuple[str, ...]:
     """Return normalized command forms that a concise evidence claim may use.
 
@@ -1075,6 +1116,14 @@ def _normalized_command_claim_aliases(command: str) -> tuple[str, ...]:
     test_invocation = _test_command_invocation(command)
     if test_invocation and test_invocation not in aliases:
         aliases.append(test_invocation)
+    # A recorded command may append output plumbing (``... 2>&1 | tail -20``)
+    # that a concise ``commands_run`` claim omits. Add plumbing-stripped variants
+    # so the two still match. Alias matching stays exact (set intersection), so
+    # this does not widen proof to arbitrary substrings.
+    for base in tuple(aliases):
+        stripped = _normalized_evidence_text(_strip_command_output_plumbing(base))
+        if stripped and stripped not in aliases:
+            aliases.append(stripped)
     return tuple(aliases)
 
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1155,16 +1155,10 @@ def test_command_claim_rejects_grep_filtered_run_as_clean_command() -> None:
         type="tool",
         content="Bash command started",
         tool_name="Bash",
-        data={
-            "tool_input": {
-                "command": "pytest tests/unit/test_foo.py | grep passed"
-            }
-        },
+        data={"tool_input": {"command": "pytest tests/unit/test_foo.py | grep passed"}},
     )
 
-    assert not _runtime_messages_support_command_claim(
-        "pytest tests/unit/test_foo.py", (message,)
-    )
+    assert not _runtime_messages_support_command_claim("pytest tests/unit/test_foo.py", (message,))
 
 
 def test_command_claim_rejects_grep_filtered_run_as_tests_passed_claim() -> None:
@@ -1179,11 +1173,7 @@ def test_command_claim_rejects_grep_filtered_run_as_tests_passed_claim() -> None
         type="tool",
         content="Bash command started",
         tool_name="Bash",
-        data={
-            "tool_input": {
-                "command": "pytest tests/unit/test_foo.py -x | grep PASSED"
-            }
-        },
+        data={"tool_input": {"command": "pytest tests/unit/test_foo.py -x | grep PASSED"}},
     )
 
     assert not _runtime_messages_support_command_claim(
@@ -1206,9 +1196,7 @@ def test_command_claim_rejects_wc_collapsed_run_as_clean_command() -> None:
         data={"tool_input": {"command": "pytest tests/unit/test_foo.py | wc -l"}},
     )
 
-    assert not _runtime_messages_support_command_claim(
-        "pytest tests/unit/test_foo.py", (message,)
-    )
+    assert not _runtime_messages_support_command_claim("pytest tests/unit/test_foo.py", (message,))
 
 
 def test_command_claim_rejects_tee_redirected_run_as_clean_command() -> None:
@@ -1223,16 +1211,10 @@ def test_command_claim_rejects_tee_redirected_run_as_clean_command() -> None:
         type="tool",
         content="Bash command started",
         tool_name="Bash",
-        data={
-            "tool_input": {
-                "command": "pytest tests/unit/test_foo.py | tee pytest.log"
-            }
-        },
+        data={"tool_input": {"command": "pytest tests/unit/test_foo.py | tee pytest.log"}},
     )
 
-    assert not _runtime_messages_support_command_claim(
-        "pytest tests/unit/test_foo.py", (message,)
-    )
+    assert not _runtime_messages_support_command_claim("pytest tests/unit/test_foo.py", (message,))
 
 
 class TestProfileAwareDecompositionAudit:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1142,6 +1142,99 @@ def test_command_claim_keeps_meaningful_pipeline_segments() -> None:
     assert not _runtime_messages_support_command_claim("python gen.py", (message,))
 
 
+def test_command_claim_rejects_grep_filtered_run_as_clean_command() -> None:
+    """A ``... | grep <token>`` run must not back a clean ``commands_run`` claim.
+
+    ``grep`` can hide failure output and rewrite the evidence stream the
+    verifier sees, so treating it as removable presentation plumbing would
+    weaken the anti-fabrication boundary: a filtered ``pytest tests/foo.py |
+    grep passed`` run could "prove" the clean ``pytest tests/foo.py`` claim
+    even when the unfiltered run had failures.
+    """
+    message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={
+            "tool_input": {
+                "command": "pytest tests/unit/test_foo.py | grep passed"
+            }
+        },
+    )
+
+    assert not _runtime_messages_support_command_claim(
+        "pytest tests/unit/test_foo.py", (message,)
+    )
+
+
+def test_command_claim_rejects_grep_filtered_run_as_tests_passed_claim() -> None:
+    """A grep-filtered test run must not back a ``tests_passed`` claim either.
+
+    ``_normalized_command_claim_aliases`` is also consumed on the
+    ``tests_passed`` path, so the same anti-fabrication invariant has to hold
+    there: a grep-filtered run is not equivalent to the unfiltered test
+    command for evidence-matching purposes.
+    """
+    message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={
+            "tool_input": {
+                "command": "pytest tests/unit/test_foo.py -x | grep PASSED"
+            }
+        },
+    )
+
+    assert not _runtime_messages_support_command_claim(
+        "pytest tests/unit/test_foo.py -x", (message,)
+    )
+
+
+def test_command_claim_rejects_wc_collapsed_run_as_clean_command() -> None:
+    """``... | wc -l`` collapses the evidence stream to a count and must not match.
+
+    ``wc`` discards every line of the underlying output, so a verifier looking
+    at the runtime transcript would no longer see the unfiltered command's
+    output. Treating ``wc`` as removable plumbing would let a filtered run
+    silently back a clean ``commands_run`` claim.
+    """
+    message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={"tool_input": {"command": "pytest tests/unit/test_foo.py | wc -l"}},
+    )
+
+    assert not _runtime_messages_support_command_claim(
+        "pytest tests/unit/test_foo.py", (message,)
+    )
+
+
+def test_command_claim_rejects_tee_redirected_run_as_clean_command() -> None:
+    """``... | tee out.log`` diverts the evidence stream and must not back a claim.
+
+    ``tee`` is a side-effecting redirector, not presentation-only output
+    filtering — the file write means the unfiltered runtime stream is no
+    longer the only observable evidence. Keep alias matching strict so the
+    filtered command does not prove a clean ``commands_run`` claim.
+    """
+    message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={
+            "tool_input": {
+                "command": "pytest tests/unit/test_foo.py | tee pytest.log"
+            }
+        },
+    )
+
+    assert not _runtime_messages_support_command_claim(
+        "pytest tests/unit/test_foo.py", (message,)
+    )
+
+
 class TestProfileAwareDecompositionAudit:
     @pytest.mark.asyncio
     async def test_level_started_event_records_active_decomposition_profile(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1099,6 +1099,49 @@ def test_command_claim_rejects_inner_command_after_non_setup_preamble() -> None:
     )
 
 
+def test_command_claim_supports_command_with_output_redirection_and_pager_pipe() -> None:
+    """A clean ``commands_run`` claim matches a run wrapped in ``2>&1 | tail``.
+
+    Regression: agents routinely run ``<cmd> 2>&1 | tail -20`` while citing the
+    clean ``<cmd>`` in evidence. The trailing redirection and output-only pager
+    pipe must not block the match (which previously failed the whole AC as
+    FABRICATION_SUSPECTED).
+    """
+    message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={
+            "tool_input": {
+                "command": (
+                    "python -m ruff check src/poc/structure_extractor.py "
+                    "tests/test_structure_and_draft_substance.py 2>&1 | tail -20"
+                )
+            }
+        },
+    )
+
+    assert _runtime_messages_support_command_claim(
+        "python -m ruff check src/poc/structure_extractor.py "
+        "tests/test_structure_and_draft_substance.py",
+        (message,),
+    )
+
+
+def test_command_claim_keeps_meaningful_pipeline_segments() -> None:
+    """Only output-filter pipes are stripped; real pipelines are not over-matched."""
+    message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={"tool_input": {"command": "python gen.py | python process.py"}},
+    )
+
+    # ``process.py`` is not an output filter, so the pipe stays and the partial
+    # ``python gen.py`` claim is not proven by this runtime command.
+    assert not _runtime_messages_support_command_claim("python gen.py", (message,))
+
+
 class TestProfileAwareDecompositionAudit:
     @pytest.mark.asyncio
     async def test_level_started_event_records_active_decomposition_profile(self) -> None:


### PR DESCRIPTION
## Problem

In fat-harness mode the atomic verifier matches `commands_run` evidence against the runtime transcript through **exact** command aliases (`_normalized_command_claim_aliases` → `_runtime_message_supports_command_claim`).

Agents routinely run a command with output plumbing — e.g. `python -m ruff check src/foo.py tests/test_foo.py 2>&1 | tail -20` — while their evidence cites the clean `python -m ruff check src/foo.py tests/test_foo.py`. The trailing `2>&1` redirection and the `| tail -20` pager pipe make the two strings differ, so the claim is rejected as `FABRICATION_SUSPECTED` and the whole AC fails on correct work.

Observed in production: a sub-AC ran (and the transcript records)
```
python -m ruff check src/poc/structure_extractor.py tests/test_structure_and_draft_substance.py 2>&1 | tail -20
```
but the evidence claim omitted the `2>&1 | tail -20`, and the verifier reported `unsupported evidence claims: commands_run: python -m ruff check src/poc/structure_extractor.py ...`.

## Fix

`_normalized_command_claim_aliases` now also emits a **plumbing-stripped** alias via a new `_strip_command_output_plumbing` helper that removes:
- trailing output redirections — `2>&1`, `> log`, `2> err`, `&> out`, etc.
- a trailing pipe into a known output-filter command — `tail`, `head`, `cat`, `less`, `more`, `tee`, `wc`, `grep`, `egrep`, `fgrep`.

Because the stripped alias is added symmetrically to both the claim and the runtime command, `<cmd>` and `<cmd> 2>&1 | tail -20` now share an alias and match.

**Conservative by design / anti-fabrication preserved:**
- Alias matching stays **exact** (set intersection), not substring containment — the existing "no partial-substring proof" invariant holds.
- Only trailing output redirections and pipes into a known output-filter command are dropped. Meaningful pipelines such as `python gen.py | python process.py` are kept, so a partial `python gen.py` claim is still not proven.

## Tests

- `test_command_claim_supports_command_with_output_redirection_and_pager_pipe` — the clean claim now matches a `... 2>&1 | tail -20` run (fails on `main`, passes with this change).
- `test_command_claim_keeps_meaningful_pipeline_segments` — a real `a | python process.py` pipeline is **not** over-matched by a partial claim (guards against widening proof).
- Existing command-claim and fat-harness verifier tests continue to pass.

## Context

Relates to #1164 (implementer `subtype=success` rejected by the executor, then cascades `dependency_failed`). This PR addresses one root cause of that rejection in the verifier's command-matching logic. Companion to #1166, which lets a transcript-proven test run back node-id `tests_passed` claims; this PR lets a redirected/piped command back its clean `commands_run` claim. They are independent and can land in either order.

> Note: 3 pre-existing failures in `tests/unit/orchestrator/test_parallel_executor.py` (`*_normalizes_workspace_absolute_file_claim`, `*_rejects_unscoped_file_and_failed_test_command`, `*_accepts_wrapped_broad_pytest_for_current_test_file`) are unrelated Windows path-resolution issues in the local test harness; they fail identically on unmodified `main` and are untouched here.
