### PR TITLE
feat(auto): additive assumption_sources provenance surface (PR-C2)

### DIFF
--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -94,4 +94,16 @@ When `result.status == "seed_ready"`, `result.interview_closure_mode` distinguis
 
 Genuine-deadlock and partial-unsafe outcomes do **not** set `interview_closure_mode`; they reach a `blocked` terminal with the matching `stop_reason_code` above instead.
 
+### Assumption-source provenance (PR-C2 / #1157)
+
+`result.assumptions: tuple[str, ...]` (the existing list of assumption texts) is now accompanied by `result.assumption_sources: tuple[AssumptionRecord, ...]`, where each `AssumptionRecord` is a frozen dataclass with:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `text` | `str` | The assumption text (same surface as the corresponding `assumptions` entry where present). |
+| `source` | `str` | One of `"assumption"` (auto-answerer fallback), `"inference"` (model reasoning), `"conservative_default"` (safe-default policy). These are the three assumption-class `LedgerSource` values that produce `assumption_only_sections`. |
+| `confidence` | `float` | Per-entry confidence as recorded by the ledger. |
+
+`assumption_sources` is a *broader* surface than `assumptions` — it includes inference- and conservative-default-class entries that `assumptions` (filtered to `LedgerSource.ASSUMPTION` only) does not surface. Callers wanting to know *which assumptions the system made on the user's behalf* should read `assumption_sources`; callers preserving the older string-only contract continue to read `assumptions`.
+
 The pipeline must not hang indefinitely: all loops are bounded and timeout failures return a resumable `auto_session_id`. Resume with `ooo auto --resume <auto_session_id>`. Use `--skip-run` to stop after the A-grade Seed. Use `--complete-product` to drive the full Interview → Seed → Run → Ralph → Product chain on a single `ooo auto` invocation; the chained Ralph loop honors the same wall-clock deadline as the parent auto session (`--timeout`). The CLI-only `--show-ledger` flag prints assumptions/non-goals; MCP skill responses already include the same ledger summary when available.

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -103,6 +103,29 @@ _RESOLVED_STATUSES: frozenset[LedgerStatus] = frozenset(
 )
 
 
+@dataclass(frozen=True, slots=True)
+class AssumptionRecord:
+    """Auditable provenance for an assumption-class ledger entry.
+
+    Surfaced via :meth:`SeedDraftLedger.assumption_sources` and
+    :attr:`ouroboros.auto.pipeline.AutoPipelineResult.assumption_sources`
+    so callers can distinguish *what the system assumed for them* from
+    *what the user/repo confirmed*. PR-C2 of #1157.
+
+    ``source`` is the string form of one of the assumption-class
+    :class:`LedgerSource` values — ``assumption`` (auto-answerer
+    fallback), ``inference`` (model reasoning), or
+    ``conservative_default`` (safe-default policy). These three are
+    precisely the sources that, per :data:`_EVIDENCE_BACKED_SOURCES`,
+    are not evidence-backed and therefore contribute to
+    ``assumption_only_sections`` in :meth:`SeedDraftLedger.summary`.
+    """
+
+    text: str
+    source: str
+    confidence: float
+
+
 @dataclass(slots=True)
 class LedgerEntry:
     """A single machine-readable fact in the Seed Draft Ledger."""
@@ -409,6 +432,55 @@ class SeedDraftLedger:
     def assumptions(self) -> list[str]:
         """Return assumption entry values."""
         return self._values_for_sources({LedgerSource.ASSUMPTION})
+
+    def assumption_sources(self) -> list[AssumptionRecord]:
+        """Return active assumption-class entries with provenance attached.
+
+        PR-C2 / #1157: auditable companion to :meth:`assumptions` (which
+        returns plain ``list[str]`` for backwards-compatible callers). The
+        returned records cover every active entry whose source is one of
+        the three assumption-class :class:`LedgerSource` values —
+        ``ASSUMPTION``, ``INFERENCE``, ``CONSERVATIVE_DEFAULT`` — i.e. the
+        sources that produce ``assumption_only_sections`` in
+        :meth:`summary`. Entries whose status is in
+        :data:`_INACTIVE_STATUSES` (WEAK / CONFLICTING / BLOCKED) are
+        excluded, matching the active-set semantics used by
+        :meth:`_values_for_sources`.
+
+        Same-text deduplication uses the same normalization as
+        :meth:`_values_for_sources` so the textual surface stays in lockstep
+        with :meth:`assumptions` for the ``LedgerSource.ASSUMPTION`` subset.
+        """
+        sources = {
+            LedgerSource.ASSUMPTION,
+            LedgerSource.INFERENCE,
+            LedgerSource.CONSERVATIVE_DEFAULT,
+        }
+        resolved: dict[tuple[str, str], AssumptionRecord] = {}
+        for section in self.sections.values():
+            for entry in section.entries:
+                if entry.source not in sources or entry.status in _INACTIVE_STATUSES:
+                    continue
+                source_str = (
+                    entry.source.value
+                    if isinstance(entry.source, LedgerSource)
+                    else str(entry.source)
+                )
+                resolved[(section.name, entry.key)] = AssumptionRecord(
+                    text=entry.value,
+                    source=source_str,
+                    confidence=entry.confidence,
+                )
+
+        seen: set[str] = set()
+        out: list[AssumptionRecord] = []
+        for record in resolved.values():
+            normalized = _normalize_conflict_value(record.text)
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            out.append(record)
+        return out
 
     def non_goals(self) -> list[str]:
         """Return non-goal entry values."""

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -29,7 +29,7 @@ from ouroboros.auto.handoff_contract import (
 )
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.lateral_routing import select_persona_for_qa_failure
-from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.ledger import AssumptionRecord, SeedDraftLedger
 from ouroboros.auto.listeners import RALPH_CANCEL_BLOCKER_REASON, mirror_ralph_job_events
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.recovery_plan import (
@@ -203,6 +203,10 @@ class AutoPipelineResult:
     last_lateral_approach_summary: str | None = None
     last_lateral_text: str | None = None
     assumptions: tuple[str, ...] = ()
+    # PR-C2 / #1157: auditable companion to ``assumptions`` that carries the
+    # ledger source (``assumption`` / ``inference`` / ``conservative_default``)
+    # and confidence per entry. Additive — ``assumptions`` is unchanged.
+    assumption_sources: tuple[AssumptionRecord, ...] = ()
     non_goals: tuple[str, ...] = ()
     defaulted_sections: tuple[str, ...] = ()
     blocker: str | None = None
@@ -2597,6 +2601,7 @@ class AutoPipeline:
             last_lateral_approach_summary=state.last_lateral_approach_summary,
             last_lateral_text=state.last_lateral_text,
             assumptions=tuple(ledger.assumptions()),
+            assumption_sources=tuple(ledger.assumption_sources()),
             non_goals=tuple(ledger.non_goals()),
             defaulted_sections=tuple(ledger.summary().get("defaulted_sections", ())),
             blocker=blocker or state.last_error,

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1304,6 +1304,77 @@ async def test_pipeline_skip_run_stops_after_a_grade_seed(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_pipeline_result_surfaces_assumption_sources_with_provenance(tmp_path) -> None:
+    """PR-C2 / #1157: ``AutoPipelineResult.assumption_sources`` carries the
+    ledger's assumption-class entries with the source tag intact. The legacy
+    ``assumptions`` field stays exactly as it was — only the additive
+    ``assumption_sources`` surface broadens to inference- and
+    conservative-default-class entries."""
+    from ouroboros.auto.ledger import AssumptionRecord
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_assumptions")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    # Add one entry from each of the three assumption-class sources. The
+    # ASSUMPTION entry has unique text so the legacy ``assumptions`` field
+    # still surfaces it.
+    ledger.add_entry(
+        "actors",
+        LedgerEntry(
+            key="actors.auto_assumption",
+            value="Primary actor is a single local developer",
+            source=LedgerSource.ASSUMPTION,
+            confidence=0.7,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+    ledger.add_entry(
+        "outputs",
+        LedgerEntry(
+            key="outputs.inference_extra",
+            value="Outputs are stdout-only by inference",
+            source=LedgerSource.INFERENCE,
+            confidence=0.6,
+            status=LedgerStatus.INFERRED,
+        ),
+    )
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path), max_rounds=1
+    )
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+
+    # ``assumption_sources`` is a tuple of ``AssumptionRecord``s with the
+    # source tag intact for every assumption-class entry.
+    assert all(isinstance(rec, AssumptionRecord) for rec in result.assumption_sources)
+    by_text = {rec.text: rec for rec in result.assumption_sources}
+    assert by_text["Primary actor is a single local developer"].source == "assumption"
+    assert by_text["Outputs are stdout-only by inference"].source == "inference"
+    # ``_fill_ready`` populates eight sections via CONSERVATIVE_DEFAULT, so at
+    # least one conservative-default record must surface alongside the
+    # explicit ASSUMPTION/INFERENCE entries above.
+    assert any(rec.source == "conservative_default" for rec in result.assumption_sources)
+
+    # Backwards-compat guard: ``assumptions`` continues to return only the
+    # ASSUMPTION-source subset as plain strings (no shape change).
+    assert "Primary actor is a single local developer" in result.assumptions
+    assert "Outputs are stdout-only by inference" not in result.assumptions
+
+
+@pytest.mark.asyncio
 async def test_pipeline_uses_explicit_goal_facts_before_completed_interview(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("done", "interview_hello", seed_ready=True, completed=True)

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -2328,3 +2328,152 @@ def test_auto_answerer_allows_qualified_compliance_policy_features() -> None:
         answer = answerer.answer(question, ledger)
         assert answer.blocker is None, question
         assert answer.source != AutoAnswerSource.BLOCKER, question
+
+
+# ---------------------------------------------------------------------------
+# PR-C2 / #1157: assumption_sources() — additive provenance surface.
+# ---------------------------------------------------------------------------
+
+
+def test_assumption_sources_returns_records_for_all_three_assumption_class_sources() -> None:
+    """``assumption_sources()`` must surface ``ASSUMPTION``, ``INFERENCE``,
+    and ``CONSERVATIVE_DEFAULT`` entries with their source tag intact.
+    ``assumptions()`` continues to return only the ``ASSUMPTION`` subset
+    (backwards-compatibility guard)."""
+    from ouroboros.auto.ledger import AssumptionRecord
+
+    ledger = SeedDraftLedger.from_goal("Build a tiny local CLI")
+    ledger.add_entry(
+        "actors",
+        LedgerEntry(
+            key="actors.assumption",
+            value="Primary actor is a single local developer",
+            source=LedgerSource.ASSUMPTION,
+            confidence=0.7,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+    ledger.add_entry(
+        "outputs",
+        LedgerEntry(
+            key="outputs.inference",
+            value="Outputs are stdout-only",
+            source=LedgerSource.INFERENCE,
+            confidence=0.6,
+            status=LedgerStatus.INFERRED,
+        ),
+    )
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.conservative_default",
+            value="Use existing project patterns",
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.85,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+
+    records = ledger.assumption_sources()
+    assert all(isinstance(rec, AssumptionRecord) for rec in records)
+    by_text = {rec.text: rec for rec in records}
+
+    assert by_text["Primary actor is a single local developer"].source == "assumption"
+    assert by_text["Outputs are stdout-only"].source == "inference"
+    assert by_text["Use existing project patterns"].source == "conservative_default"
+
+    # confidence is preserved verbatim per entry.
+    assert by_text["Primary actor is a single local developer"].confidence == 0.7
+    assert by_text["Outputs are stdout-only"].confidence == 0.6
+    assert by_text["Use existing project patterns"].confidence == 0.85
+
+    # Backwards-compat guard: ``assumptions()`` is unchanged in scope —
+    # only the ASSUMPTION-source entry appears there.
+    assert ledger.assumptions() == ["Primary actor is a single local developer"]
+
+
+def test_assumption_sources_skips_inactive_and_evidence_backed_entries() -> None:
+    """Entries with WEAK / CONFLICTING / BLOCKED status are excluded
+    (active-set semantics, matching ``_values_for_sources``). Evidence-backed
+    sources (USER_GOAL / REPO_FACT / USER_PREFERENCE / NON_GOAL) are also
+    excluded — they are not assumption-class."""
+    ledger = SeedDraftLedger.from_goal("Build a tiny local CLI")
+    # WEAK assumption — must be skipped.
+    ledger.add_entry(
+        "actors",
+        LedgerEntry(
+            key="actors.assumption_weak",
+            value="Weak placeholder text",
+            source=LedgerSource.ASSUMPTION,
+            confidence=0.3,
+            status=LedgerStatus.WEAK,
+        ),
+    )
+    # CONFLICTING inference — must be skipped.
+    ledger.add_entry(
+        "outputs",
+        LedgerEntry(
+            key="outputs.conflict",
+            value="Conflicting inferred output shape",
+            source=LedgerSource.INFERENCE,
+            confidence=0.5,
+            status=LedgerStatus.CONFLICTING,
+        ),
+    )
+    # USER_PREFERENCE is evidence-backed — must be skipped regardless of status.
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.user_pref",
+            value="User explicitly said no new deps",
+            source=LedgerSource.USER_PREFERENCE,
+            confidence=1.0,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+    # An active conservative_default — must be the only thing returned.
+    ledger.add_entry(
+        "runtime_context",
+        LedgerEntry(
+            key="runtime_context.conservative_default",
+            value="Existing repository runtime",
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.85,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+
+    records = ledger.assumption_sources()
+    assert [rec.text for rec in records] == ["Existing repository runtime"]
+    assert records[0].source == "conservative_default"
+
+
+def test_assumption_sources_dedupes_same_text_across_sections() -> None:
+    """Same-text deduplication uses the same normalization as
+    :meth:`assumptions` so the textual surface stays in lockstep with
+    :meth:`assumptions` for the ASSUMPTION subset."""
+    ledger = SeedDraftLedger.from_goal("Build a tiny local CLI")
+    ledger.add_entry(
+        "actors",
+        LedgerEntry(
+            key="actors.dup_assumption",
+            value="Single local CLI user",
+            source=LedgerSource.ASSUMPTION,
+            confidence=0.7,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+    ledger.add_entry(
+        "inputs",
+        LedgerEntry(
+            key="inputs.dup_assumption",
+            value="single local cli user",  # case-insensitive duplicate
+            source=LedgerSource.ASSUMPTION,
+            confidence=0.7,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+
+    records = ledger.assumption_sources()
+    assert len(records) == 1
+    assert records[0].text == "Single local CLI user"

--- a/tests/unit/auto/test_pipeline_evaluate.py
+++ b/tests/unit/auto/test_pipeline_evaluate.py
@@ -118,10 +118,10 @@ class _PassReviewer(SeedReviewer):
 class _StubLedger:
     """Minimal ledger stub for direct ``_run_evaluate`` calls.
 
-    The pipeline only calls ``summary()``, ``assumptions()``, and ``non_goals()``
-    on the ledger inside ``_result()`` (via ``ledger.summary()``). All return
-    empty so the test focuses on EVALUATE transition behaviour rather than
-    ledger-summary coverage."""
+    The pipeline calls ``summary()``, ``assumptions()``, ``assumption_sources()``
+    (PR-C2 / #1157), and ``non_goals()`` on the ledger inside ``_result()``. All
+    return empty so the test focuses on EVALUATE transition behaviour rather
+    than ledger-summary coverage."""
 
     def summary(self) -> dict[str, Any]:
         return {
@@ -131,6 +131,9 @@ class _StubLedger:
         }
 
     def assumptions(self) -> list[str]:
+        return []
+
+    def assumption_sources(self) -> list[Any]:
         return []
 
     def non_goals(self) -> list[str]:

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -165,6 +165,13 @@ class _StubLedger:
     def assumptions(self) -> list[str]:
         return []
 
+    def assumption_sources(self) -> list[Any]:
+        # PR-C2 / #1157: stub satisfies the additive provenance surface
+        # consumed by ``AutoPipeline._result()``. Returns an empty list for
+        # the same reason ``assumptions()`` does — this stub is for tests
+        # that do not exercise ledger content.
+        return []
+
     def non_goals(self) -> list[str]:
         return []
 


### PR DESCRIPTION
## Summary

PR-C2 of the L4 Auto Envelope v2 freeze (#1157, #821).

Add an auditable companion to ``AutoPipelineResult.assumptions`` so callers can distinguish *what the system assumed for them* from *what the user / repo confirmed*. The existing string-only ``assumptions`` field is **unchanged** — this is a strictly **additive** new field.

Each ``AssumptionRecord`` is a frozen dataclass carrying:

- ``text`` — the assumption text
- ``source`` — one of ``"assumption"`` (auto-answerer fallback), ``"inference"`` (model reasoning), ``"conservative_default"`` (safe-default policy). These are the three assumption-class ``LedgerSource`` values that, per ``_EVIDENCE_BACKED_SOURCES``, do *not* count as evidence-backed and therefore land in ``assumption_only_sections``.
- ``confidence`` — per-entry confidence as recorded by the ledger.

Why ``assumption_sources`` is broader than ``assumptions``: ``assumptions()`` filters to ``LedgerSource.ASSUMPTION`` only (backwards-compatible string surface). The new ``assumption_sources()`` broadens to **all three** assumption-class sources so the surface answers the actual user question ("which of these did the system make up?") rather than just the narrow auto-answerer-fallback subset.

## Why this scope

Closes the documented PR-C2 gap from the #1157 living SSOT. After PR-B2 (#1167) and this PR, the L4 Envelope v2 lane has all five planned envelope fields in place:

| Field | PR | Status |
|---|---|---|
| ``stop_reason_code`` | #1151 | 🟢 merged |
| ``interview_closure_mode`` | #1148 + #1167 (``safe_default``) | 🟢 merged |
| ``defaulted_sections`` | #1146 | 🟢 merged |
| ``assumption_sources`` | this PR | 🟡 in flight |
| (none — surface complete) | — | — |

## What is NOT done here

- No schema change, no manifest change, no breaking change to existing ``assumptions`` callers.
- CLI / MCP rendering of ``assumption_sources`` is intentionally deferred to a follow-up — this PR plumbs the envelope only. The CLI/MCP ``assumptions`` bullet list at ``src/ouroboros/cli/commands/auto.py:748`` and ``src/ouroboros/mcp/tools/auto_handler.py:1940`` still works unchanged.
- No change to the ``assumptions()`` / ``_values_for_sources()`` filter — the existing ``ledger.assumptions().count(\"CLI user\")`` assertion in ``test_ledger_grading_answerer.py:1182`` remains valid (regression-guarded by the new ``test_assumption_sources_returns_records_for_all_three_assumption_class_sources``).

## Scope

- ``src/ouroboros/auto/ledger.py``: new ``AssumptionRecord`` frozen dataclass; new ``SeedDraftLedger.assumption_sources()`` method using the same inactive-status and dedupe semantics as ``_values_for_sources``.
- ``src/ouroboros/auto/pipeline.py``: import ``AssumptionRecord``; add ``assumption_sources: tuple[AssumptionRecord, ...] = ()`` field next to ``assumptions``; populate in ``_result()``.
- ``skills/auto/SKILL.md``: new "Assumption-source provenance" subsection documenting the field shape and source vocabulary.
- ``tests/unit/auto/test_ledger_grading_answerer.py``: three new tests covering all three source kinds, inactive/evidence-backed exclusion, and same-text dedupe across sections.
- ``tests/unit/auto/test_interview_pipeline.py``: one new end-to-end pipeline test that asserts the legacy ``assumptions`` field is unchanged in scope and the new ``assumption_sources`` carries the source tag intact.
- ``tests/unit/auto/test_pipeline_lateral.py`` and ``tests/unit/auto/test_pipeline_evaluate.py``: extend the existing ``_StubLedger`` test doubles with the new ``assumption_sources`` method so they remain compatible with the additive ``_result()`` consumer.

## Test plan

- [x] ``uv run pytest tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_interview_pipeline.py -k "assumption_sources or assumption_class or surfaces_assumption" -q`` → 4 passed
- [x] ``uv run pytest tests/unit/auto tests/integration/auto -q`` → 912 passed (baseline 908 + 4 new)
- [x] ``uv run ruff check`` on touched files → clean
- [x] ``uv run ruff format`` on touched files → no changes
- [x] ``uv run mypy src/ouroboros/auto/ledger.py src/ouroboros/auto/pipeline.py`` → clean

Refs #1157 (L4 lane), #821 (autonomy acceptance matrix), #1146 (PR-C ``defaulted_sections``), #1148 (PR-B1 ``ledger_only``), #1151 (PR-E ``stop_reason_code``), #1167 (PR-B2 ``safe_default`` closure).