### PR TITLE
feat(auto): task-class catalog data (L1-a)

### DIFF
--- a/src/ouroboros/auto/task_classes.py
+++ b/src/ouroboros/auto/task_classes.py
@@ -18,14 +18,28 @@ Design constraints honored:
   not via re-curating a training corpus.
 - **Decoupled from `domain_profile.DomainProfile`.** The existing
   `DomainProfile` is a *meta-domain* concept (coding / research /
-  design); task classes are *within-meta-domain* shapes (cli / webhook
-  / game-2d / ...). Both layers can coexist.
+  design) and carries cross-domain machinery (`repo_context_extractor`,
+  `intent_classifier`, `vague_terms`, `detector`, `verifiable_predicates`,
+  `safe_defaults`). Task classes are *within-meta-domain* shapes
+  (cli / webhook / game-2d / ...) and carry only shape-specific data
+  (completion mode, default AC, probe-kind hints). The two taxonomies
+  are orthogonal; `safe_defaults` remains intentionally on the
+  meta-domain layer and is not duplicated here. The earlier #1171
+  schema sketch listed `safe_defaults` as a per-class field, but on
+  implementation review that field is meta-domain-scoped (e.g.
+  "default to pytest" applies to all coding task classes equally) and
+  belongs on `DomainProfile`, not on this catalog.
 - **`default_ac_template` is `tuple[str, ...]` matching
   `Seed.acceptance_criteria` exactly.** No new AC dataclass is needed
   because the Seed already accepts plain strings.
 - **`runtime_probe_kinds` is a `tuple[str, ...]` placeholder.** L3 is
   still pending its minimal-substrate audit; the strings stay
   human-readable for now and become a typed enum when L3 lands.
+- **Serialization uses underscored identifiers** (`web_service`,
+  `data_pipeline`, `game_2d`, `refactor_in_place`) so `TaskClass.value`
+  is a valid Python identifier and a JSON-safe ledger key. Prose docs
+  in #1157 / #1171 may render the same names with hyphens; both refer
+  to the same class.
 """
 
 from __future__ import annotations

--- a/src/ouroboros/auto/task_classes.py
+++ b/src/ouroboros/auto/task_classes.py
@@ -1,0 +1,219 @@
+"""Task-class catalog for L1 of #1157.
+
+`ooo auto` historically treated every goal as if it were a library with
+unit-test acceptance. L1 of the Meta SSOT (#1157) introduces a *task
+class* concept — a coarse classification of *what shape of artifact the
+goal produces* — so the Seed Architect can inject class-appropriate
+default acceptance criteria and the runtime evidence layer (L3) can
+bind class-appropriate probes.
+
+This module is **catalog data only** (L1-a sub-PR of #1171). It does
+*not* implement domain inference from the ledger (L1-b), the Seed AC
+injection hook (L1-c), or the result-envelope surface (L1-d).
+
+Design constraints honored:
+
+- **Plain strings, no LLM, no eval set.** The 7-class enum is frozen at
+  this PR; growth happens via PR-per-class (~10 LoC + a unit test),
+  not via re-curating a training corpus.
+- **Decoupled from `domain_profile.DomainProfile`.** The existing
+  `DomainProfile` is a *meta-domain* concept (coding / research /
+  design); task classes are *within-meta-domain* shapes (cli / webhook
+  / game-2d / ...). Both layers can coexist.
+- **`default_ac_template` is `tuple[str, ...]` matching
+  `Seed.acceptance_criteria` exactly.** No new AC dataclass is needed
+  because the Seed already accepts plain strings.
+- **`runtime_probe_kinds` is a `tuple[str, ...]` placeholder.** L3 is
+  still pending its minimal-substrate audit; the strings stay
+  human-readable for now and become a typed enum when L3 lands.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+
+__all__ = [
+    "CompletionMode",
+    "TASK_CLASS_CATALOG",
+    "TaskClass",
+    "TaskClassProfile",
+    "get_task_class_profile",
+]
+
+
+class CompletionMode(StrEnum):
+    """How a task is judged "done".
+
+    - ``CODE_COMPLETE``: tests + lint + (for libraries) a usable API surface.
+      Sufficient when the goal is a library / refactor whose value is fully
+      captured by passing tests.
+    - ``PRODUCT_COMPLETE``: ``CODE_COMPLETE`` *plus* a runtime acceptance
+      probe (L3) demonstrates the produced artifact actually runs. Used
+      for CLIs / services / games / pipelines where the user's value
+      comes from execution, not just compilation.
+    """
+
+    CODE_COMPLETE = "code_complete"
+    PRODUCT_COMPLETE = "product_complete"
+
+
+class TaskClass(StrEnum):
+    """Canonical task classes for L1-a.
+
+    Frozen at this PR. Additional classes (``game_3d``, ``desktop_app``,
+    ``notebook_analysis``, ...) land as their own follow-up PRs of
+    ~10 LoC plus a unit test once a canonical scenario demonstrates
+    real need.
+    """
+
+    LIBRARY = "library"
+    CLI = "cli"
+    WEB_SERVICE = "web_service"
+    WEBHOOK = "webhook"
+    DATA_PIPELINE = "data_pipeline"
+    GAME_2D = "game_2d"
+    REFACTOR_IN_PLACE = "refactor_in_place"
+
+
+@dataclass(frozen=True, slots=True)
+class TaskClassProfile:
+    """Per-class catalog entry.
+
+    Attributes
+    ----------
+    name:
+        The :class:`TaskClass` value, surfaced as a plain string for
+        downstream envelope consumers that should not import the enum.
+    default_completion_mode:
+        Which :class:`CompletionMode` the auto pipeline uses when this
+        class is inferred and the user did not pick a mode explicitly.
+    default_ac_template:
+        The acceptance criteria the Seed Architect prepends to the
+        user-supplied AC when this class is active. Plain strings to
+        match ``Seed.acceptance_criteria``'s shape exactly.
+    runtime_probe_kinds:
+        Placeholder identifiers (plain strings) for the runtime probes
+        L3 will bind to this class. The set is intentionally narrow at
+        v1; L3's design audit (#1157 freshness sync 2026-05-22) will
+        likely converge on ``headless_run`` plus a small number of
+        scenario-specific add-ons rather than the original 4-probe
+        ambition.
+    """
+
+    name: str
+    default_completion_mode: CompletionMode
+    default_ac_template: tuple[str, ...]
+    runtime_probe_kinds: tuple[str, ...]
+
+
+def _profile(
+    *,
+    name: TaskClass,
+    completion: CompletionMode,
+    ac_template: tuple[str, ...],
+    probes: tuple[str, ...],
+) -> TaskClassProfile:
+    return TaskClassProfile(
+        name=name.value,
+        default_completion_mode=completion,
+        default_ac_template=ac_template,
+        runtime_probe_kinds=probes,
+    )
+
+
+_CATALOG: dict[TaskClass, TaskClassProfile] = {
+    TaskClass.LIBRARY: _profile(
+        name=TaskClass.LIBRARY,
+        completion=CompletionMode.CODE_COMPLETE,
+        ac_template=(
+            "All public API symbols are importable from the documented module path.",
+            "Unit tests cover every public function/method's primary success path.",
+            "`ruff check` and the project's type-check command exit 0.",
+        ),
+        probes=("import_smoke", "unit_tests"),
+    ),
+    TaskClass.CLI: _profile(
+        name=TaskClass.CLI,
+        completion=CompletionMode.PRODUCT_COMPLETE,
+        ac_template=(
+            "Invoking the command with the documented arguments exits with status 0.",
+            "Stdout is deterministic for a given input (no embedded timestamps, no random ids).",
+            "An invalid argument exits with a non-zero status and prints a human-readable error.",
+        ),
+        probes=("headless_run", "stdout_golden"),
+    ),
+    TaskClass.WEB_SERVICE: _profile(
+        name=TaskClass.WEB_SERVICE,
+        completion=CompletionMode.PRODUCT_COMPLETE,
+        ac_template=(
+            "Each documented endpoint returns the contracted response shape under a smoke request.",
+            "An unknown endpoint returns 404; a malformed body returns 4xx (not 5xx).",
+            "The service starts and shuts down cleanly via the documented launch command.",
+        ),
+        probes=("headless_run", "api_smoke"),
+    ),
+    TaskClass.WEBHOOK: _profile(
+        name=TaskClass.WEBHOOK,
+        completion=CompletionMode.PRODUCT_COMPLETE,
+        ac_template=(
+            "Posting the documented payload to the receiver endpoint returns 2xx.",
+            "The documented side effect (DB row / file write / external call) is observable after the request.",
+            "An invalid payload returns a 4xx without raising an unhandled exception.",
+        ),
+        probes=("api_smoke", "side_effect_probe"),
+    ),
+    TaskClass.DATA_PIPELINE: _profile(
+        name=TaskClass.DATA_PIPELINE,
+        completion=CompletionMode.PRODUCT_COMPLETE,
+        ac_template=(
+            "Running the pipeline against the input fixture produces an output that matches the expected shape exactly.",
+            "Re-running with the same input is deterministic (no time/random drift).",
+            "An empty or malformed input is rejected with a clear error rather than producing partial output.",
+        ),
+        probes=("headless_run", "output_fixture_diff"),
+    ),
+    TaskClass.GAME_2D: _profile(
+        name=TaskClass.GAME_2D,
+        completion=CompletionMode.PRODUCT_COMPLETE,
+        ac_template=(
+            "A headless simulation of N input ticks produces a state-change trace (player position, score, or scene transition).",
+            "The game's main loop terminates cleanly on a quit signal (no hang, no crash).",
+            "The runnable build (script or browser bundle) launches without missing-asset errors.",
+        ),
+        probes=("sim_trace", "headless_run"),
+    ),
+    TaskClass.REFACTOR_IN_PLACE: _profile(
+        name=TaskClass.REFACTOR_IN_PLACE,
+        completion=CompletionMode.CODE_COMPLETE,
+        ac_template=(
+            "The full pre-existing test suite passes after the refactor with no skips added.",
+            "Public API surface (importable symbols, function signatures) is preserved unless the refactor goal explicitly broadens it.",
+            "No new top-level dependencies are added unless explicitly requested.",
+        ),
+        probes=("test_suite_parity",),
+    ),
+}
+
+
+TASK_CLASS_CATALOG: Mapping[TaskClass, TaskClassProfile] = MappingProxyType(_CATALOG)
+"""Immutable view of the frozen 7-class catalog.
+
+Callers should treat this as the authoritative source of per-class
+defaults. Adding a class = adding an entry here + a unit test. Modifying
+an existing class's ``default_ac_template`` is allowed but should be
+audited against existing canonical scenarios that pin those AC.
+"""
+
+
+def get_task_class_profile(task_class: TaskClass) -> TaskClassProfile:
+    """Return the catalog entry for *task_class*.
+
+    Raises ``KeyError`` if *task_class* is not in the catalog — that
+    should not happen for any value of the :class:`TaskClass` enum
+    because the enum and catalog are kept in lockstep (enforced by
+    ``test_task_classes_match_catalog``).
+    """
+    return TASK_CLASS_CATALOG[task_class]

--- a/tests/unit/auto/test_task_classes.py
+++ b/tests/unit/auto/test_task_classes.py
@@ -1,0 +1,106 @@
+"""Catalog-shape tests for the L1-a frozen task-class catalog.
+
+These tests pin the *shape* of the catalog: every :class:`TaskClass`
+value has exactly one :class:`TaskClassProfile`, each profile's
+``default_ac_template`` is a non-empty tuple of plain strings, and
+each ``default_completion_mode`` resolves to the documented enum.
+
+They do **not** exercise domain inference (that's L1-b) or AC
+injection (that's L1-c). Adding a new task class without a matching
+unit test below will fail ``test_task_classes_match_catalog``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.task_classes import (
+    TASK_CLASS_CATALOG,
+    CompletionMode,
+    TaskClass,
+    TaskClassProfile,
+    get_task_class_profile,
+)
+
+
+def test_task_classes_match_catalog() -> None:
+    """Every :class:`TaskClass` enum value has a catalog entry, and the
+    catalog has no orphan entries. Adding a class without a profile
+    (or vice versa) fails here."""
+    assert set(TASK_CLASS_CATALOG.keys()) == set(TaskClass)
+
+
+@pytest.mark.parametrize("task_class", list(TaskClass))
+def test_catalog_entry_shape(task_class: TaskClass) -> None:
+    """Each catalog entry has the required shape: non-empty AC template,
+    declared completion mode, declared probe kinds, and ``name`` matching
+    the enum value (string-equality, not identity)."""
+    profile = get_task_class_profile(task_class)
+
+    assert isinstance(profile, TaskClassProfile)
+    assert profile.name == task_class.value
+    assert isinstance(profile.default_completion_mode, CompletionMode)
+    # AC template must be a non-empty tuple of plain strings — matches
+    # ``Seed.acceptance_criteria``'s shape exactly so L1-c can prepend
+    # entries without any type coercion.
+    assert isinstance(profile.default_ac_template, tuple)
+    assert profile.default_ac_template, f"{task_class.value} has empty default_ac_template"
+    assert all(isinstance(item, str) for item in profile.default_ac_template)
+    assert all(item.strip() for item in profile.default_ac_template), (
+        f"{task_class.value} default_ac_template has empty/whitespace entries"
+    )
+    # Probe kinds is a tuple of plain strings (placeholder until L3 lands
+    # a typed enum). Empty is allowed for forward-compat.
+    assert isinstance(profile.runtime_probe_kinds, tuple)
+    assert all(isinstance(item, str) for item in profile.runtime_probe_kinds)
+
+
+def test_library_class_is_code_complete() -> None:
+    """``library`` is the only class with ``CODE_COMPLETE`` plus
+    ``refactor_in_place`` — every other class is ``PRODUCT_COMPLETE``."""
+    code_complete = {
+        tc
+        for tc in TaskClass
+        if get_task_class_profile(tc).default_completion_mode == CompletionMode.CODE_COMPLETE
+    }
+    assert code_complete == {TaskClass.LIBRARY, TaskClass.REFACTOR_IN_PLACE}
+
+
+def test_catalog_is_immutable_view() -> None:
+    """``TASK_CLASS_CATALOG`` is a ``MappingProxyType`` view that callers
+    cannot mutate directly. Pin so a future refactor does not regress
+    immutability."""
+    with pytest.raises(TypeError):
+        TASK_CLASS_CATALOG[TaskClass.LIBRARY] = TaskClassProfile(  # type: ignore[index]
+            name="bogus",
+            default_completion_mode=CompletionMode.CODE_COMPLETE,
+            default_ac_template=("never",),
+            runtime_probe_kinds=(),
+        )
+
+
+def test_completion_modes_are_string_enum() -> None:
+    """``CompletionMode`` is a ``StrEnum`` so values serialize as plain
+    strings into ``AutoPipelineResult`` envelope fields without a custom
+    encoder."""
+    assert CompletionMode.CODE_COMPLETE == "code_complete"
+    assert CompletionMode.PRODUCT_COMPLETE == "product_complete"
+
+
+def test_task_class_is_string_enum() -> None:
+    """``TaskClass`` is a ``StrEnum`` so values can be used as catalog
+    keys, JSON values, and ledger entries without coercion."""
+    assert TaskClass.CLI == "cli"
+    assert TaskClass.WEB_SERVICE == "web_service"
+    assert TaskClass.REFACTOR_IN_PLACE == "refactor_in_place"
+
+
+def test_webhook_and_web_service_are_distinct_in_catalog() -> None:
+    """L1 design decision (#1171) keeps ``webhook`` and ``web_service``
+    separate because their probe bindings differ (side-effect vs
+    request-shape). Pin so a future merge requires explicit re-decision."""
+    webhook = get_task_class_profile(TaskClass.WEBHOOK)
+    web_service = get_task_class_profile(TaskClass.WEB_SERVICE)
+    assert webhook.runtime_probe_kinds != web_service.runtime_probe_kinds
+    assert "side_effect_probe" in webhook.runtime_probe_kinds
+    assert "api_smoke" in web_service.runtime_probe_kinds


### PR DESCRIPTION
## Summary

L1-a slice of #1171 — the ledger-derive redesign of #1157's L1 lane.

Introduces the 7-class **task-class catalog** as catalog data only. Frozen enum + per-class profile + immutable lookup table. **No inference, no LLM, no eval set, no telemetry** — those belong to later L1-b/c/d sub-PRs and the ledger-derive design explicitly forbids a separate classifier model.

The catalog is a *task-class* concept, distinct from the existing `DomainProfile` *meta-domain* concept (coding / research / design). Both layers can coexist; this PR introduces the `task_classes` module as a sibling, not an extension.

## Why this is small

Per the Ouroboros minimal-substrate principle re-emphasized in the 2026-05-22 SSOT self-audit (#1157), L1 was scoped down from a classifier + eval set + accuracy floor + opt-in telemetry pipeline to **pattern matching against the interview's standardized ledger**. This PR is the smallest possible substrate that downstream L1-b (the `derive_domain_from_ledger` pattern matcher) and L1-c (the Seed AC injection hook) can consume.

## What lands

- `src/ouroboros/auto/task_classes.py` (new):
  - `CompletionMode` StrEnum: `CODE_COMPLETE` / `PRODUCT_COMPLETE`.
  - `TaskClass` StrEnum: 7 frozen classes (`library`, `cli`, `web_service`, `webhook`, `data_pipeline`, `game_2d`, `refactor_in_place`). Deferred classes (`game_3d`, `desktop_app`, `notebook_analysis`) per #1171.
  - `TaskClassProfile` frozen dataclass: `name`, `default_completion_mode`, `default_ac_template` (`tuple[str, ...]` matching `Seed.acceptance_criteria` exactly), `runtime_probe_kinds` (plain-string placeholder until L3 lands).
  - `TASK_CLASS_CATALOG`: immutable `MappingProxyType` over a private dict.
- `tests/unit/auto/test_task_classes.py` (new): 13 tests covering catalog shape, completion-mode invariants, immutability, StrEnum behavior, webhook-vs-web-service distinction pin.

## What is NOT in this PR

- Pattern-matching `derive_domain_from_ledger` — L1-b.
- Interview-driver disambiguation hook — L1-c.
- Seed Architect AC injection — L1-d.
- Result-envelope surface (`AutoPipelineResult.active_task_class`) — L1-e.

## Test plan

- [x] `uv run pytest tests/unit/auto/test_task_classes.py -v` → 13 passed.
- [x] `uv run pytest tests/unit/auto -q` → 889 passed.
- [x] `uv run ruff check` on touched files → clean.
- [x] `uv run ruff format` on touched files → no changes.
- [x] `uv run mypy src/ouroboros/auto/task_classes.py` → clean.

Refs #1157 (L1 lane), #1171 (L1 design issue), #849 (existing DomainProfile contract — preserved untouched).