### PR TITLE
feat(tests): canonical acceptance harness skeleton (L0-a)

### DIFF
--- a/tests/canonical/README.md
+++ b/tests/canonical/README.md
@@ -1,0 +1,91 @@
+# Canonical acceptance scenarios
+
+Minimal manual test harness for `ooo auto` per the L0 design slice of
+[#1157](https://github.com/Q00/ouroboros/issues/1157) and
+[#1170](https://github.com/Q00/ouroboros/issues/1170).
+
+## What this is
+
+A directory of self-contained scenarios that the maintainer runs
+**manually** when assessing whether `ooo auto`'s SSOT acceptance gate
+holds. There is intentionally **no CI obligation**, no replay layer,
+and no scheduled execution.
+
+## What it is NOT
+
+- Not a continuous regression engine.
+- Not a nightly CI workflow.
+- Not a recorded-replay system.
+- Not a cost-budgeted live runner.
+
+If any of those becomes valuable later (evidence-driven follow-up
+issue required), it gets added then — not pre-built. See #1170
+*Self-audit note* for the rationale.
+
+## How to use
+
+### Quick shape-check (always runs in CI, no LLM cost)
+
+```sh
+uv run pytest tests/canonical/ -v
+```
+
+This validates that every scenario directory has the required
+fixture files in the right shape. It does **not** invoke
+`ouroboros_auto`. Use this to catch fixture rot.
+
+### Full live run (manual, costs LLM tokens)
+
+```sh
+OUROBOROS_RUN_CANONICAL=1 uv run pytest tests/canonical/ -v
+```
+
+This actually invokes the `ouroboros_auto` MCP tool against each
+scenario and asserts the documented terminal state. **Use sparingly**
+— each scenario consumes real LLM tokens (cli-todo ≈ \$1, kart-racer
+≈ \$5 with Sonnet-class models).
+
+### Run a single scenario
+
+```sh
+OUROBOROS_RUN_CANONICAL=1 uv run pytest tests/canonical/cli-todo/ -v
+```
+
+## Scenario directory shape
+
+Each `tests/canonical/<slug>/` directory contains:
+
+| File | Purpose |
+|---|---|
+| `goal.txt` | One-line goal string fed to `ooo auto`. No leading/trailing whitespace beyond a final newline. |
+| `expected.yaml` | Frozen metadata: `domain_class`, `completion_mode`, `runtime_probe_kinds`, optional `wall_clock_budget_seconds`. |
+| `env/` *(optional)* | Fixture files seeded into the temp workdir before `ouroboros_auto` is invoked. Often empty for greenfield scenarios. |
+
+`expected.yaml` schema (validated by `conftest.py`):
+
+```yaml
+# required
+domain_class: cli                    # one of the L1 TaskClass values
+completion_mode: product_complete    # CODE_COMPLETE | PRODUCT_COMPLETE
+
+# optional
+runtime_probe_kinds:                 # placeholder until L3 lands
+  - headless_run
+  - stdout_golden
+wall_clock_budget_seconds: 600       # default: 7200
+```
+
+## When to extend
+
+When a fifth scenario class (e.g. `desktop-app`) emerges as worth
+canonicalizing, add a new `<slug>/` directory + populate
+`expected.yaml`. No infrastructure change required. The runner
+auto-discovers.
+
+## Adding the live-run path
+
+The hermetic shape-check is in place from L0-a. The live-run path
+(`OUROBOROS_RUN_CANONICAL=1`) is wired but the actual
+`ouroboros_auto` invocation lands in L0-b once the maintainer has
+confirmed they want it; until then the live-run path skips with a
+typed reason so the harness contract stays observable.

--- a/tests/canonical/README.md
+++ b/tests/canonical/README.md
@@ -40,16 +40,26 @@ fixture files in the right shape. It does **not** invoke
 OUROBOROS_RUN_CANONICAL=1 uv run pytest tests/canonical/ -v
 ```
 
-This actually invokes the `ouroboros_auto` MCP tool against each
-scenario and asserts the documented terminal state. **Use sparingly**
-— each scenario consumes real LLM tokens (cli-todo ≈ \$1, kart-racer
-≈ \$5 with Sonnet-class models).
+Once the live wiring lands in L0-b, this command will invoke the
+`ouroboros_auto` MCP tool against each scenario and assert the
+documented terminal state — **use sparingly**, each scenario will
+consume real LLM tokens (cli-todo ≈ \$1, kart-racer ≈ \$5 with
+Sonnet-class models). **At L0-a (this PR) the opt-in still
+`pytest.skip`s with a typed reason** so the harness contract is
+observable without burning tokens; the shape-check tests still run.
 
 ### Run a single scenario
 
+All canonical tests live in `tests/canonical/test_canonical.py` and
+are parametrized per discovered scenario directory. Filter by slug
+with `-k`:
+
 ```sh
-OUROBOROS_RUN_CANONICAL=1 uv run pytest tests/canonical/cli-todo/ -v
+uv run pytest tests/canonical/ -v -k cli-todo
 ```
+
+Add `OUROBOROS_RUN_CANONICAL=1` once L0-b lands to opt into the live
+invocation for that scenario.
 
 ## Scenario directory shape
 

--- a/tests/canonical/cli-todo/expected.yaml
+++ b/tests/canonical/cli-todo/expected.yaml
@@ -1,0 +1,23 @@
+# L0 canonical acceptance scenario — cli-todo
+#
+# This scenario exercises the simplest end-to-end shape: a single-binary
+# CLI tool with deterministic stdout. The expected metadata below pins
+# what the auto pipeline must derive (`domain_class`) and how the
+# acceptance gate verifies the artifact (`completion_mode`,
+# `runtime_probe_kinds`).
+#
+# These values must round-trip with the L1 TaskClassProfile catalog —
+# `tests/canonical/test_canonical.py::test_scenario_completion_mode_matches_catalog`
+# enforces the constraint.
+
+domain_class: cli
+completion_mode: product_complete
+
+runtime_probe_kinds:
+  - headless_run
+  - stdout_golden
+
+# 30-minute soft budget. The future L2 watchdog will cancel beyond this
+# if it ever ships; until then the value is informational metadata that
+# downstream harnesses can honor or ignore.
+wall_clock_budget_seconds: 1800

--- a/tests/canonical/cli-todo/expected.yaml
+++ b/tests/canonical/cli-todo/expected.yaml
@@ -6,9 +6,10 @@
 # acceptance gate verifies the artifact (`completion_mode`,
 # `runtime_probe_kinds`).
 #
-# These values must round-trip with the L1 TaskClassProfile catalog —
-# `tests/canonical/test_canonical.py::test_scenario_completion_mode_matches_catalog`
-# enforces the constraint.
+# These values are validated for shape only at L0-a. Cross-validation
+# that they round-trip through the L1 `TaskClassProfile` catalog
+# (#1173) lands in a follow-up sub-PR; the round-trip test is not yet
+# present in `tests/canonical/test_canonical.py`.
 
 domain_class: cli
 completion_mode: product_complete

--- a/tests/canonical/cli-todo/goal.txt
+++ b/tests/canonical/cli-todo/goal.txt
@@ -1,0 +1,1 @@
+Build a small habit-tracker CLI that lets the user add, list, and check off habits, persisting them as JSON in the working directory.

--- a/tests/canonical/conftest.py
+++ b/tests/canonical/conftest.py
@@ -1,0 +1,194 @@
+"""Pytest fixtures for the canonical acceptance harness.
+
+L0-a slice of #1170 — provides scenario discovery + per-scenario
+fixture loading. The actual ``ouroboros_auto`` invocation lands
+in a follow-up sub-PR; this PR ships the discovery contract,
+fixture-shape validation, and the runner skeleton.
+
+Per-scenario fixture is parametrized via ``pytest_generate_tests`` so
+adding a new ``tests/canonical/<slug>/`` directory automatically
+extends test coverage with no code change.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+_CANONICAL_ROOT = Path(__file__).resolve().parent
+_REQUIRED_KEYS: frozenset[str] = frozenset({"domain_class", "completion_mode"})
+_VALID_COMPLETION_MODES: frozenset[str] = frozenset({"code_complete", "product_complete"})
+_DEFAULT_WALL_CLOCK_BUDGET_SECONDS = 7200
+_LIVE_RUN_ENV_VAR = "OUROBOROS_RUN_CANONICAL"
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalScenario:
+    """Frozen view of one ``tests/canonical/<slug>/`` directory.
+
+    The runner consumes this; ``expected.yaml`` becomes ``metadata``
+    after validation, so downstream test functions need not re-parse
+    YAML.
+    """
+
+    slug: str
+    directory: Path
+    goal: str
+    metadata: dict[str, object]
+
+    @property
+    def domain_class(self) -> str:
+        value = self.metadata["domain_class"]
+        assert isinstance(value, str)
+        return value
+
+    @property
+    def completion_mode(self) -> str:
+        value = self.metadata["completion_mode"]
+        assert isinstance(value, str)
+        return value
+
+    @property
+    def runtime_probe_kinds(self) -> tuple[str, ...]:
+        value = self.metadata.get("runtime_probe_kinds", ())
+        if not value:
+            return ()
+        assert isinstance(value, (list, tuple))
+        out: list[str] = []
+        for item in value:
+            assert isinstance(item, str)
+            out.append(item)
+        return tuple(out)
+
+    @property
+    def wall_clock_budget_seconds(self) -> int:
+        value = self.metadata.get("wall_clock_budget_seconds", _DEFAULT_WALL_CLOCK_BUDGET_SECONDS)
+        assert isinstance(value, int)
+        return value
+
+    @property
+    def env_dir(self) -> Path | None:
+        candidate = self.directory / "env"
+        if candidate.is_dir():
+            return candidate
+        return None
+
+
+def _iter_scenario_dirs() -> Iterator[Path]:
+    """Yield each ``tests/canonical/<slug>/`` directory in stable order."""
+    for entry in sorted(_CANONICAL_ROOT.iterdir()):
+        if not entry.is_dir():
+            continue
+        if entry.name.startswith(("_", ".")):
+            continue
+        if entry.name == "__pycache__":
+            continue
+        # A scenario directory must contain at least a goal.txt to count.
+        if not (entry / "goal.txt").is_file():
+            continue
+        yield entry
+
+
+def _load_scenario(directory: Path) -> CanonicalScenario:
+    """Read goal.txt + expected.yaml from *directory* and validate shape.
+
+    Validation errors are raised as ``pytest.fail`` so the harness
+    surfaces fixture rot as a test failure, not an import-time crash.
+    """
+    slug = directory.name
+    goal_path = directory / "goal.txt"
+    expected_path = directory / "expected.yaml"
+
+    if not expected_path.is_file():
+        pytest.fail(
+            f"canonical scenario {slug!r} is missing expected.yaml at {expected_path}",
+            pytrace=False,
+        )
+
+    goal = goal_path.read_text(encoding="utf-8").strip()
+    if not goal:
+        pytest.fail(
+            f"canonical scenario {slug!r} has empty goal.txt at {goal_path}",
+            pytrace=False,
+        )
+
+    try:
+        raw_metadata = yaml.safe_load(expected_path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:
+        pytest.fail(
+            f"canonical scenario {slug!r} expected.yaml does not parse: {exc}",
+            pytrace=False,
+        )
+
+    if not isinstance(raw_metadata, dict):
+        pytest.fail(
+            f"canonical scenario {slug!r} expected.yaml top-level must be a mapping; "
+            f"got {type(raw_metadata).__name__}",
+            pytrace=False,
+        )
+
+    missing_keys = _REQUIRED_KEYS - raw_metadata.keys()
+    if missing_keys:
+        pytest.fail(
+            f"canonical scenario {slug!r} expected.yaml is missing required keys: "
+            f"{sorted(missing_keys)}",
+            pytrace=False,
+        )
+
+    completion_mode = raw_metadata.get("completion_mode")
+    if completion_mode not in _VALID_COMPLETION_MODES:
+        pytest.fail(
+            f"canonical scenario {slug!r} expected.yaml has invalid completion_mode "
+            f"{completion_mode!r}; must be one of {sorted(_VALID_COMPLETION_MODES)}",
+            pytrace=False,
+        )
+
+    return CanonicalScenario(
+        slug=slug,
+        directory=directory,
+        goal=goal,
+        metadata=dict(raw_metadata),
+    )
+
+
+@pytest.fixture(scope="session")
+def canonical_scenarios() -> tuple[CanonicalScenario, ...]:
+    """Return every discovered scenario as a frozen tuple, in stable order."""
+    return tuple(_load_scenario(d) for d in _iter_scenario_dirs())
+
+
+@pytest.fixture
+def live_run_enabled() -> bool:
+    """True iff the operator opted into the live-run path.
+
+    The harness's two cost regimes:
+
+    - ``OUROBOROS_RUN_CANONICAL`` unset → hermetic shape-check only.
+      Validates fixture shape; never invokes ``ouroboros_auto``.
+    - ``OUROBOROS_RUN_CANONICAL=1`` → live invocation. Costs real LLM
+      tokens; the maintainer is expected to opt in explicitly.
+    """
+    return os.environ.get(_LIVE_RUN_ENV_VAR, "").strip() in {"1", "true", "yes"}
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:  # type: ignore[name-defined]
+    """Parametrize any test taking a ``scenario`` fixture over the discovered
+    canonical scenarios.
+
+    This lets ``test_canonical.py`` declare one test body per assertion
+    and have pytest fan it out automatically across every
+    ``tests/canonical/<slug>/`` directory.
+    """
+    if "scenario" not in metafunc.fixturenames:
+        return
+    scenarios = tuple(_load_scenario(d) for d in _iter_scenario_dirs())
+    metafunc.parametrize(
+        "scenario",
+        scenarios,
+        ids=[s.slug for s in scenarios],
+    )

--- a/tests/canonical/test_canonical.py
+++ b/tests/canonical/test_canonical.py
@@ -1,0 +1,127 @@
+"""Canonical acceptance tests.
+
+L0-a — minimal manual harness. Each test in this file runs once per
+discovered scenario in ``tests/canonical/<slug>/`` thanks to the
+``pytest_generate_tests`` hook in ``conftest.py``.
+
+Two cost regimes:
+
+- Hermetic (default): shape-checks only. Always runs in CI without
+  LLM cost. Catches fixture rot.
+- Live (``OUROBOROS_RUN_CANONICAL=1``): the maintainer-only path that
+  actually invokes ``ouroboros_auto`` and asserts the documented
+  terminal. Wiring for the invocation lands in a follow-up PR; for
+  now it ``pytest.skip``s with a typed reason so the harness contract
+  is visible without burning tokens.
+
+L1 catalog cross-validation (verifying ``expected.yaml``'s
+``domain_class`` round-trips through ``TaskClassProfile``) lands in a
+follow-up PR once #1173 (L1-a catalog data) merges to main. This PR
+keeps the harness self-contained.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from .conftest import CanonicalScenario
+
+
+def test_scenario_has_nonempty_goal(scenario: CanonicalScenario) -> None:
+    """``goal.txt`` is the canonical input to ``ooo auto``; it must
+    exist and have meaningful content beyond whitespace."""
+    assert scenario.goal, f"{scenario.slug}: goal.txt is empty after strip"
+    assert len(scenario.goal) >= 10, (
+        f"{scenario.slug}: goal.txt content is suspiciously short "
+        f"({len(scenario.goal)} chars); did you forget the real goal?"
+    )
+
+
+def test_scenario_domain_class_is_lowercase_snake(scenario: CanonicalScenario) -> None:
+    """``domain_class`` matches the lowercase snake_case shape that the
+    L1 catalog (#1173) emits. Pin the surface so a typo in
+    ``expected.yaml`` fails here rather than at runtime when the
+    inference hook is wired.
+
+    Cross-validation against the actual L1 ``TaskClass`` enum lands in
+    a follow-up PR after #1173 merges to main.
+    """
+    value = scenario.domain_class
+    assert value == value.lower(), f"{scenario.slug}: domain_class {value!r} must be lowercase"
+    assert value.replace("_", "").isalnum(), (
+        f"{scenario.slug}: domain_class {value!r} must be snake_case alphanumerics only"
+    )
+
+
+def test_scenario_completion_mode_is_canonical(scenario: CanonicalScenario) -> None:
+    """``completion_mode`` matches the L1 ``CompletionMode`` StrEnum
+    surface. Pinned as a string set here so the harness validates
+    without importing the catalog module."""
+    valid = {"code_complete", "product_complete"}
+    assert scenario.completion_mode in valid, (
+        f"{scenario.slug}: completion_mode {scenario.completion_mode!r} must be "
+        f"one of {sorted(valid)}"
+    )
+
+
+def test_scenario_runtime_probe_kinds_are_strings(
+    scenario: CanonicalScenario,
+) -> None:
+    """``runtime_probe_kinds`` is a tuple of plain strings. Cross-
+    validation against the L1 catalog's per-class probe whitelist
+    lands in a follow-up PR after #1173 merges; this test pins the
+    surface shape only."""
+    kinds = scenario.runtime_probe_kinds
+    assert isinstance(kinds, tuple)
+    for kind in kinds:
+        assert isinstance(kind, str), (
+            f"{scenario.slug}: runtime_probe_kinds entry {kind!r} must be a string"
+        )
+        assert kind == kind.lower(), (
+            f"{scenario.slug}: runtime_probe_kinds entry {kind!r} must be lowercase"
+        )
+
+
+def test_scenario_wall_clock_budget_is_positive(
+    scenario: CanonicalScenario,
+) -> None:
+    """The optional ``wall_clock_budget_seconds`` must be a positive
+    integer when present (or take its default). Zero / negative
+    budgets would cause the future L2 watchdog (#1172) to fire instantly."""
+    assert scenario.wall_clock_budget_seconds > 0, (
+        f"{scenario.slug}: wall_clock_budget_seconds must be positive; "
+        f"got {scenario.wall_clock_budget_seconds}"
+    )
+
+
+def test_canonical_matrix_is_nonempty(
+    canonical_scenarios: tuple[CanonicalScenario, ...],
+) -> None:
+    """The matrix must contain at least one scenario. Pins so a
+    fixture-file rename does not silently disable the harness."""
+    assert canonical_scenarios, (
+        "no canonical scenarios discovered under tests/canonical/; "
+        "either add a scenario directory or fix the discovery glob"
+    )
+
+
+def test_scenario_live_run_or_skip(
+    scenario: CanonicalScenario,
+    live_run_enabled: bool,
+) -> None:
+    """Live invocation of ``ouroboros_auto`` against the scenario.
+
+    Currently skipped unconditionally — wiring lands in a follow-up
+    sub-PR after the shape-check contract is exercised on `main`.
+    Once wired, this test asserts the documented terminal state for
+    the scenario when ``OUROBOROS_RUN_CANONICAL=1`` is set.
+    """
+    if not live_run_enabled:
+        pytest.skip(
+            "live canonical run disabled; set OUROBOROS_RUN_CANONICAL=1 to invoke "
+            "ouroboros_auto against this scenario"
+        )
+    pytest.skip(
+        f"live-run wiring for {scenario.slug} lands in the L0 follow-up sub-PR; "
+        f"shape-check above already validates fixture integrity"
+    )


### PR DESCRIPTION
## Summary

L0-a slice of #1170 — minimal manual acceptance harness per #1157's SSOT acceptance gate. Discovers `tests/canonical/<slug>/` directories, validates fixture shape, and parametrizes per-scenario test bodies. Ships one initial scenario (`cli-todo`).

The harness is intentionally narrow per the 2026-05-22 minimal-substrate audit (#1157):

- **No nightly CI workflow.** Maintainer runs manually.
- **No recorded-replay layer.** Live invocation costs tokens; opt-in via `OUROBOROS_RUN_CANONICAL=1`.
- **No cost budget tracking.** Each invocation is the operator's intent.
- **No refresh-rotation ownership policy.** No replay layer to refresh.
- **No divergence detection.** Single mode.

## What lands

- `tests/canonical/__init__.py` (empty package marker).
- `tests/canonical/README.md` — both cost regimes + scenario directory contract.
- `tests/canonical/conftest.py` — scenario discovery, `CanonicalScenario` frozen dataclass, `pytest_generate_tests` hook so new scenarios auto-parametrize, `live_run_enabled` fixture gating live invocation.
- `tests/canonical/test_canonical.py` — 6 shape-check assertions per scenario + live-run skip placeholder.
- `tests/canonical/cli-todo/goal.txt` + `expected.yaml` — first canonical scenario.

## What is NOT in this PR

- Live `ouroboros_auto` invocation wiring — follow-up sub-PR.
- L1 catalog cross-validation tests — follow-up after #1173 merges.
- Additional scenarios (`webhook-receiver`, `vertical-slice-refactor`, `2d-kart-racer`) — L0-b/c/d follow-ups.

## Test plan

- [x] `uv run pytest tests/canonical/ -v` → 6 passed, 1 skipped.
- [x] `uv run ruff check tests/canonical/` → clean.
- [x] `uv run ruff format tests/canonical/` → clean.
- [x] `uv run mypy tests/canonical/conftest.py tests/canonical/test_canonical.py` → clean.
- [x] Broad regression → 8578 passed, 3 skipped.

Refs #1157 (L0 lane), #1170 (L0 design issue), #1173 (L1-a catalog data — cross-validation tests follow).