### PR TITLE
feat(auto): ledger-derived task-class inference (L1-b)

### DIFF
--- a/src/ouroboros/auto/domain_inference.py
+++ b/src/ouroboros/auto/domain_inference.py
@@ -1,0 +1,312 @@
+"""Ledger-derived task-class inference (L1-b of #1157 / #1171).
+
+The Socratic interview already extracts structured `SeedDraftLedger`
+entries (`actors`, `inputs`, `outputs`, `runtime_context`, …) and
+*standardizes them toward canonical vocabulary* (e.g. "do you mean
+stdout, stderr, or both?"). L1-b derives the task class from those
+already-standardized entries by deterministic pattern matching — no
+new LLM call, no eval set, no accuracy floor.
+
+The matcher returns one of three outcomes:
+
+- ``DomainInference.single(...)`` — exactly one class predicate fired.
+- ``DomainInference.ambiguous(...)`` — multiple classes fired; the
+  interview driver should ask a disambiguation question (L1-c).
+- ``DomainInference.single(LIBRARY, reason="unmatched")`` — no
+  predicate fired; falls to the safest default and emits a
+  ``domain_unmatched`` telemetry signal so maintainers can grow the
+  catalog.
+
+Adding a new task class = adding a ``_matches_<name>`` function +
+registering it in ``_PATTERN_REGISTRY`` + a unit test. ~10 LoC PR per
+class, not an ML eval-set re-curation.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+
+from ouroboros.auto.ledger import LedgerSection, LedgerStatus, SeedDraftLedger
+from ouroboros.auto.task_classes import TaskClass
+
+__all__ = [
+    "DomainInference",
+    "derive_domain_from_ledger",
+    "register_pattern",
+]
+
+
+_PatternFn = Callable[[SeedDraftLedger], bool]
+
+
+@dataclass(frozen=True, slots=True)
+class DomainInference:
+    """Outcome of pattern-matching a ledger against the L1-a catalog.
+
+    ``classes`` carries every class whose predicate fired:
+
+    - len(classes) == 0 → unmatched; ``fallback`` carries the safe default
+      and ``reason == "unmatched"``.
+    - len(classes) == 1 → single, deterministic match; ``fallback`` is
+      ``None``.
+    - len(classes) >= 2 → ambiguous; ``fallback`` is ``None`` and the
+      interview driver should disambiguate before proceeding.
+    """
+
+    classes: frozenset[TaskClass]
+    reason: str
+    fallback: TaskClass | None = None
+    matched_signals: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def is_single(self) -> bool:
+        return len(self.classes) == 1
+
+    @property
+    def is_ambiguous(self) -> bool:
+        return len(self.classes) >= 2
+
+    @property
+    def is_unmatched(self) -> bool:
+        return len(self.classes) == 0
+
+    @property
+    def single(self) -> TaskClass | None:
+        """Return the single matched class, or ``fallback`` for unmatched.
+
+        Ambiguous outcomes return ``None`` — callers should branch on
+        :attr:`is_ambiguous` before reading this.
+        """
+        if self.is_single:
+            return next(iter(self.classes))
+        if self.is_unmatched:
+            return self.fallback
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Pattern functions — one per class. Each consumes the ledger's already-
+# standardized entries (lowercase substring matching after normalization)
+# and returns True iff *its* class is plausible.
+#
+# Patterns are intentionally conservative: a pattern can fire even when
+# another also fires (that produces an ambiguous DomainInference, which
+# the interview driver disambiguates). A class never fires when the
+# corresponding interview answer is absent or empty.
+# ---------------------------------------------------------------------------
+
+
+def _section_text(ledger: SeedDraftLedger, section: str) -> str:
+    """Return the concatenated active-entry text for *section*, lowercased.
+
+    Inactive statuses (WEAK / CONFLICTING / BLOCKED) are excluded — the
+    interview standardizer's confirmed/defaulted/inferred entries are what
+    represents the user's *current best understanding*.
+    """
+    sec: LedgerSection | None = ledger.sections.get(section)
+    if sec is None:
+        return ""
+    inactive = {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+    parts: list[str] = []
+    for entry in sec.entries:
+        if entry.status in inactive:
+            continue
+        if not entry.value:
+            continue
+        parts.append(entry.value)
+    return "\n".join(parts).lower()
+
+
+def _any_of(text: str, keywords: Iterable[str]) -> bool:
+    return any(keyword in text for keyword in keywords)
+
+
+def _goal_text(ledger: SeedDraftLedger) -> str:
+    return _section_text(ledger, "goal")
+
+
+def _matches_cli(ledger: SeedDraftLedger) -> bool:
+    outputs = _section_text(ledger, "outputs")
+    runtime = _section_text(ledger, "runtime_context")
+    if not (outputs or runtime):
+        return False
+    output_signal = _any_of(
+        outputs,
+        ("stdout", "exit code", "printed", "console output", "command output"),
+    )
+    runtime_signal = _any_of(runtime, ("shell", "terminal", "subprocess", "command line"))
+    goal_signal = _any_of(_goal_text(ledger), ("cli", "command line", "command-line"))
+    # CLI requires either explicit runtime *or* a goal+output combo.
+    return runtime_signal or (output_signal and (goal_signal or outputs))
+
+
+def _matches_webhook(ledger: SeedDraftLedger) -> bool:
+    inputs = _section_text(ledger, "inputs")
+    outputs = _section_text(ledger, "outputs")
+    goal = _goal_text(ledger)
+    if not (inputs or outputs or goal):
+        return False
+    has_webhook_in = _any_of(
+        inputs + " " + goal,
+        ("webhook", "http post", "incoming event", "event payload", "callback url"),
+    )
+    has_side_effect = _any_of(
+        outputs,
+        ("side effect", "db row", "database row", "log entry", "stored", "external call"),
+    )
+    return has_webhook_in and has_side_effect
+
+
+def _matches_web_service(ledger: SeedDraftLedger) -> bool:
+    outputs = _section_text(ledger, "outputs")
+    goal = _goal_text(ledger)
+    if not (outputs or goal):
+        return False
+    api_signal = _any_of(
+        outputs + " " + goal,
+        (
+            "rest endpoint",
+            "rest api",
+            "http response",
+            "json body",
+            "multiple endpoints",
+            "web service",
+            "web server",
+            "http server",
+        ),
+    )
+    return api_signal and not _matches_webhook(ledger)
+
+
+def _matches_data_pipeline(ledger: SeedDraftLedger) -> bool:
+    inputs = _section_text(ledger, "inputs")
+    outputs = _section_text(ledger, "outputs")
+    if not (inputs and outputs):
+        return False
+    input_signal = _any_of(
+        inputs,
+        ("dataset", "csv", "parquet", "log file", "log files", "input file", "batch"),
+    )
+    output_signal = _any_of(
+        outputs,
+        ("aggregated", "transformed", "parquet", "summarized", "rolled up", "output dataset"),
+    )
+    return input_signal and output_signal
+
+
+def _matches_game_2d(ledger: SeedDraftLedger) -> bool:
+    outputs = _section_text(ledger, "outputs")
+    goal = _goal_text(ledger)
+    if not (outputs or goal):
+        return False
+    return _any_of(
+        outputs + " " + goal,
+        ("render", "frame", "canvas", "screen", "game loop", "playable", "2d game", "scene"),
+    )
+
+
+def _matches_refactor_in_place(ledger: SeedDraftLedger) -> bool:
+    goal = _goal_text(ledger)
+    constraints = _section_text(ledger, "constraints")
+    if not goal:
+        return False
+    refactor_intent = _any_of(
+        goal,
+        ("refactor", "rewrite", "restructure", "extract module", "split module"),
+    )
+    preserve_behaviour = _any_of(
+        constraints + " " + goal,
+        ("preserve behavior", "preserve behaviour", "same tests", "behaviour preserved"),
+    )
+    # Intent alone is enough; the constraint just strengthens confidence.
+    return refactor_intent or (
+        # Some users phrase as a constraint without saying "refactor" in goal.
+        _any_of(goal, ("clean up", "tidy", "reorganize", "reorganise")) and preserve_behaviour
+    )
+
+
+def _matches_library(ledger: SeedDraftLedger) -> bool:
+    outputs = _section_text(ledger, "outputs")
+    goal = _goal_text(ledger)
+    if not (outputs or goal):
+        return False
+    return _any_of(
+        outputs + " " + goal,
+        (
+            "library",
+            "package",
+            "module",
+            "api surface",
+            "importable",
+            "public api",
+            "sdk",
+        ),
+    )
+
+
+_PATTERN_REGISTRY: dict[TaskClass, _PatternFn] = {
+    TaskClass.CLI: _matches_cli,
+    TaskClass.WEBHOOK: _matches_webhook,
+    TaskClass.WEB_SERVICE: _matches_web_service,
+    TaskClass.DATA_PIPELINE: _matches_data_pipeline,
+    TaskClass.GAME_2D: _matches_game_2d,
+    TaskClass.REFACTOR_IN_PLACE: _matches_refactor_in_place,
+    TaskClass.LIBRARY: _matches_library,
+}
+
+
+def register_pattern(task_class: TaskClass, pattern_fn: _PatternFn) -> None:
+    """Register a pattern function for *task_class*.
+
+    Intended for tests and future extension PRs that add a new
+    :class:`TaskClass` value. Production code should not call this — the
+    static :data:`_PATTERN_REGISTRY` covers the 7-class catalog
+    declared in #1173.
+    """
+    _PATTERN_REGISTRY[task_class] = pattern_fn
+
+
+def derive_domain_from_ledger(ledger: SeedDraftLedger) -> DomainInference:
+    """Run every registered pattern against *ledger* and classify.
+
+    Outcomes:
+
+    - **Single match** — exactly one pattern fired. Returns
+      ``DomainInference`` with ``classes = {that_class}`` and
+      ``reason = "single pattern match"``.
+    - **Ambiguous** — two or more patterns fired. Returns
+      ``DomainInference`` with the fired classes and
+      ``reason = "multiple patterns matched"``. The interview driver
+      should ask a disambiguation question (L1-c).
+    - **Unmatched** — no pattern fired. Returns ``DomainInference`` with
+      empty ``classes``, ``fallback = LIBRARY`` (the safest completion
+      gate), and ``reason = "unmatched"``. Callers should also emit a
+      ``domain_unmatched`` telemetry event.
+    """
+    fired: list[TaskClass] = []
+    signals: list[str] = []
+    for task_class, pattern_fn in _PATTERN_REGISTRY.items():
+        if pattern_fn(ledger):
+            fired.append(task_class)
+            signals.append(task_class.value)
+    if not fired:
+        return DomainInference(
+            classes=frozenset(),
+            reason="unmatched",
+            fallback=TaskClass.LIBRARY,
+            matched_signals=(),
+        )
+    if len(fired) == 1:
+        return DomainInference(
+            classes=frozenset(fired),
+            reason="single pattern match",
+            fallback=None,
+            matched_signals=tuple(signals),
+        )
+    return DomainInference(
+        classes=frozenset(fired),
+        reason="multiple patterns matched",
+        fallback=None,
+        matched_signals=tuple(signals),
+    )

--- a/tests/unit/auto/test_domain_inference.py
+++ b/tests/unit/auto/test_domain_inference.py
@@ -1,0 +1,245 @@
+"""Pattern-matcher tests for L1-b (#1171).
+
+Tests cover the four outcome shapes:
+
+- **Single match** — one class's predicate fires for a representative
+  ledger configuration.
+- **Ambiguous** — two predicates fire; ``DomainInference.is_ambiguous``
+  is True and the interview driver gets the disambiguation cue.
+- **Unmatched** — no predicate fires; falls to ``LIBRARY`` with
+  ``reason == "unmatched"``.
+- **Empty ledger** — bare ``from_goal`` ledger does not crash the
+  matcher.
+
+Adding a new task class requires adding a positive test here; the
+``test_every_task_class_has_a_pattern`` guard fails otherwise.
+"""
+
+from __future__ import annotations
+
+from ouroboros.auto.domain_inference import (
+    _PATTERN_REGISTRY,
+    DomainInference,
+    derive_domain_from_ledger,
+)
+from ouroboros.auto.ledger import (
+    LedgerEntry,
+    LedgerSource,
+    LedgerStatus,
+    SeedDraftLedger,
+)
+from ouroboros.auto.task_classes import TaskClass
+
+
+def _seed_section(
+    ledger: SeedDraftLedger,
+    section: str,
+    *,
+    value: str,
+    key: str | None = None,
+    status: LedgerStatus = LedgerStatus.CONFIRMED,
+    source: LedgerSource = LedgerSource.USER_PREFERENCE,
+    confidence: float = 0.9,
+) -> None:
+    """Convenience helper for tests — append a CONFIRMED entry to *section*."""
+    ledger.add_entry(
+        section,
+        LedgerEntry(
+            key=key or f"{section}.test_entry",
+            value=value,
+            source=source,
+            confidence=confidence,
+            status=status,
+        ),
+    )
+
+
+def _bare_ledger(goal: str = "Build a tiny local CLI") -> SeedDraftLedger:
+    return SeedDraftLedger.from_goal(goal)
+
+
+# ---------------------------------------------------------------------------
+# Single matches — one per task class
+# ---------------------------------------------------------------------------
+
+
+def test_single_match_cli() -> None:
+    ledger = _bare_ledger("Build a habit-tracker CLI tool")
+    _seed_section(ledger, "outputs", value="Deterministic stdout and exit code 0")
+    _seed_section(ledger, "runtime_context", value="Local shell / terminal")
+    result = derive_domain_from_ledger(ledger)
+    assert result.is_single
+    assert result.single is TaskClass.CLI
+
+
+def test_single_match_webhook() -> None:
+    ledger = _bare_ledger("Build a webhook receiver service")
+    _seed_section(ledger, "inputs", value="Incoming webhook POST payloads from GitHub")
+    _seed_section(ledger, "outputs", value="DB row stored per event; log entry appended")
+    result = derive_domain_from_ledger(ledger)
+    assert result.is_single
+    assert result.single is TaskClass.WEBHOOK
+
+
+def test_single_match_web_service() -> None:
+    ledger = _bare_ledger("Build a REST API for blog posts")
+    _seed_section(
+        ledger,
+        "outputs",
+        value="Multiple REST endpoints returning JSON body responses",
+    )
+    result = derive_domain_from_ledger(ledger)
+    assert result.is_single
+    assert result.single is TaskClass.WEB_SERVICE
+
+
+def test_single_match_data_pipeline() -> None:
+    ledger = _bare_ledger("Aggregate daily logs into Parquet")
+    _seed_section(ledger, "inputs", value="Dataset of log files split per day")
+    _seed_section(ledger, "outputs", value="Aggregated output dataset in Parquet")
+    result = derive_domain_from_ledger(ledger)
+    assert result.is_single
+    assert result.single is TaskClass.DATA_PIPELINE
+
+
+def test_single_match_game_2d() -> None:
+    ledger = _bare_ledger("Build a small 2D game scene")
+    _seed_section(
+        ledger,
+        "outputs",
+        value="Each frame renders a canvas with the playable scene state",
+    )
+    result = derive_domain_from_ledger(ledger)
+    assert result.is_single
+    assert result.single is TaskClass.GAME_2D
+
+
+def test_single_match_refactor_in_place() -> None:
+    ledger = _bare_ledger("Refactor src/foo into vertical slices")
+    _seed_section(
+        ledger,
+        "constraints",
+        value="Preserve behavior so the same tests keep passing",
+    )
+    result = derive_domain_from_ledger(ledger)
+    assert result.is_single
+    assert result.single is TaskClass.REFACTOR_IN_PLACE
+
+
+def test_single_match_library() -> None:
+    ledger = _bare_ledger("Publish a JSON-schema parsing library")
+    _seed_section(
+        ledger,
+        "outputs",
+        value="An importable Python package exposing a public API surface",
+    )
+    result = derive_domain_from_ledger(ledger)
+    assert result.is_single
+    assert result.single is TaskClass.LIBRARY
+
+
+# ---------------------------------------------------------------------------
+# Ambiguous and unmatched
+# ---------------------------------------------------------------------------
+
+
+def test_ambiguous_when_two_patterns_fire() -> None:
+    """A CLI that also exposes a webhook receiver — both CLI and
+    WEBHOOK fire. Matcher should surface the ambiguity; the interview
+    driver (L1-c) disambiguates."""
+    ledger = _bare_ledger("Build a CLI tool that also receives webhooks")
+    _seed_section(ledger, "outputs", value="Stdout shows status; DB row stored on each event")
+    _seed_section(ledger, "runtime_context", value="Local shell or background daemon")
+    _seed_section(ledger, "inputs", value="CLI args plus incoming webhook payloads")
+    result = derive_domain_from_ledger(ledger)
+    assert result.is_ambiguous
+    assert TaskClass.CLI in result.classes
+    assert TaskClass.WEBHOOK in result.classes
+    assert result.single is None
+    assert result.reason == "multiple patterns matched"
+
+
+def test_unmatched_falls_back_to_library() -> None:
+    """A ledger whose entries contain no task-class signal at all falls
+    to LIBRARY (safest completion gate) with ``reason='unmatched'``."""
+    ledger = _bare_ledger("Make a thing that does the thing")  # deliberately vague
+    # Add weak entries that should not fire any pattern — purposely free
+    # of canonical vocabulary.
+    _seed_section(ledger, "actors", value="Some user")
+    _seed_section(ledger, "constraints", value="Be nice")
+    result = derive_domain_from_ledger(ledger)
+    assert result.is_unmatched
+    assert result.single is TaskClass.LIBRARY
+    assert result.fallback is TaskClass.LIBRARY
+    assert result.reason == "unmatched"
+
+
+def test_empty_ledger_does_not_crash() -> None:
+    """A bare ``from_goal`` ledger with no extra entries: the matcher
+    must not raise, and the goal text alone may match no pattern (→
+    unmatched)."""
+    ledger = SeedDraftLedger.from_goal("")
+    result = derive_domain_from_ledger(ledger)
+    assert isinstance(result, DomainInference)
+
+
+# ---------------------------------------------------------------------------
+# Active-status discipline
+# ---------------------------------------------------------------------------
+
+
+def test_inactive_entries_do_not_trigger_patterns() -> None:
+    """Entries with WEAK / CONFLICTING / BLOCKED status must be ignored.
+
+    The interview's standardizer marks superseded answers as CONFLICTING;
+    those should not bleed into the inference output."""
+    ledger = _bare_ledger("Build a small project")
+    _seed_section(
+        ledger,
+        "outputs",
+        value="stdout exit code",  # would normally trigger CLI
+        status=LedgerStatus.CONFLICTING,
+    )
+    result = derive_domain_from_ledger(ledger)
+    # The CLI pattern depends on runtime_context too, but the outputs
+    # signal alone (CONFLICTING) must not fire any class.
+    assert TaskClass.CLI not in result.classes
+
+
+# ---------------------------------------------------------------------------
+# Registry invariants
+# ---------------------------------------------------------------------------
+
+
+def test_every_task_class_has_a_pattern() -> None:
+    """L1-b registry covers every L1-a TaskClass enum value. Adding a new
+    class without a pattern function (or vice versa) fails here."""
+    assert set(_PATTERN_REGISTRY.keys()) == set(TaskClass)
+
+
+def test_domain_inference_dataclass_properties() -> None:
+    """Spot-check the convenience properties exposed by DomainInference."""
+    single = DomainInference(
+        classes=frozenset({TaskClass.CLI}),
+        reason="single pattern match",
+    )
+    assert single.is_single
+    assert not single.is_ambiguous
+    assert not single.is_unmatched
+    assert single.single is TaskClass.CLI
+
+    ambiguous = DomainInference(
+        classes=frozenset({TaskClass.CLI, TaskClass.WEBHOOK}),
+        reason="multiple patterns matched",
+    )
+    assert ambiguous.is_ambiguous
+    assert not ambiguous.is_single
+    assert ambiguous.single is None
+
+    unmatched = DomainInference(
+        classes=frozenset(),
+        reason="unmatched",
+        fallback=TaskClass.LIBRARY,
+    )
+    assert unmatched.is_unmatched
+    assert unmatched.single is TaskClass.LIBRARY


### PR DESCRIPTION
## Summary

L1-b slice of #1171 — the ledger-derive substrate of #1157's L1 lane. Pattern-matches the Socratic interview's already-standardized ledger entries against the L1-a (#1173) catalog and returns one of three outcomes: **single** match, **ambiguous**, or **unmatched** (falls back to LIBRARY). **No new LLM call, no eval set, no accuracy floor.**

\`derive_domain_from_ledger\` runs every registered pattern function against the ledger's confirmed/defaulted/inferred entries (inactive statuses excluded) and returns a frozen \`DomainInference\` value:

- **Single match** — one \`_matches_<class>\` predicate fired.
- **Ambiguous** — two or more predicates fired; the interview driver (L1-c, future PR) should ask a disambiguation question rather than silently pick.
- **Unmatched** — no predicate fired; falls to LIBRARY (safest completion gate) with \`reason=\"unmatched\"\` for telemetry / catalog growth.

Adding a new task class = adding a \`_matches_<name>\` function + \`_PATTERN_REGISTRY\` entry + unit test. ~10 LoC PR per class.

## What lands

- \`src/ouroboros/auto/domain_inference.py\` (new): \`DomainInference\` frozen dataclass + 7 pattern functions + \`derive_domain_from_ledger\` entry point + \`register_pattern\` test/extension surface.
- \`tests/unit/auto/test_domain_inference.py\` (new): 13 tests — one positive case per class + ambiguous + unmatched + inactive-status discipline + registry-vs-enum guard.

## What is NOT in this PR

- Interview-driver disambiguation hook (consumes \`is_ambiguous\`) — deferred to L1-c, evidence-driven.
- Seed Architect AC injection (consumes \`DomainInference.single\`) — L1-d, separate PR.
- Result-envelope surface — L1-e, folded into L1-d PR.

## Test plan

- [x] \`uv run pytest tests/unit/auto/test_domain_inference.py -v\` → 13 passed.
- [x] \`uv run pytest tests/unit/auto -q\` → 905 passed (892 baseline + 13 new).
- [x] \`uv run ruff check\` on touched files → clean.
- [x] \`uv run ruff format\` on touched files → clean.
- [x] \`uv run mypy src/ouroboros/auto/domain_inference.py\` → clean.

Refs #1157 (L1 lane, ledger-derive redesign), #1171 (L1 design issue), #1173 (L1-a task-class catalog).