### PR TITLE
feat(runtime): RuntimeControls + wall-clock Watchdog runner (L2-1)

### DIFF
--- a/src/ouroboros/runtime/__init__.py
+++ b/src/ouroboros/runtime/__init__.py
@@ -1,0 +1,38 @@
+"""Runtime control substrate (L2 of #1157 / #1172).
+
+v1 ships the smallest possible watchdog:
+
+- One config (``RuntimeControls.session_wall_clock_seconds``).
+- One event family (``runtime.watchdog.cancel``).
+- One outcome (the session is cancelled when wall-clock budget elapses).
+
+Richer designs (3-timer ``idle``/``no_progress``/``safety``,
+4-directive ``WAIT``/``RETRY``/``UNSTUCK``/``CANCEL`` vocabulary,
+subscriber pattern, per-layer ad-hoc-timeout deprecation) are
+documented as v2 expansion in #1172 and added only when evidence of
+a stall slipping past wall-clock-only surfaces.
+"""
+
+from ouroboros.runtime.controls import (
+    DEFAULT_SESSION_WALL_CLOCK_SECONDS,
+    RuntimeControls,
+    load_runtime_controls,
+)
+from ouroboros.runtime.watchdog import (
+    WATCHDOG_AGGREGATE_TYPE,
+    WATCHDOG_CANCEL_EVENT_TYPE,
+    WATCHDOG_STOP_REASON_CODE,
+    Watchdog,
+    WatchdogDecision,
+)
+
+__all__ = [
+    "DEFAULT_SESSION_WALL_CLOCK_SECONDS",
+    "RuntimeControls",
+    "WATCHDOG_AGGREGATE_TYPE",
+    "WATCHDOG_CANCEL_EVENT_TYPE",
+    "WATCHDOG_STOP_REASON_CODE",
+    "Watchdog",
+    "WatchdogDecision",
+    "load_runtime_controls",
+]

--- a/src/ouroboros/runtime/controls.py
+++ b/src/ouroboros/runtime/controls.py
@@ -1,0 +1,122 @@
+"""Runtime control configuration (L2 v1).
+
+A single wall-clock budget per ``ooo auto`` session. Loaded from a
+YAML fixture in tests; falls back to :data:`DEFAULT_SESSION_WALL_CLOCK_SECONDS`
+when the caller does not supply one.
+
+The v2 expansion path (idle / no-progress / safety split, directive
+vocabulary, subscriber pattern) is intentionally absent here — adding
+fields prematurely is the same over-engineering reflex that produced
+the earlier draft this minimal version supersedes. See #1172 for the
+deferral rationale.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+__all__ = [
+    "DEFAULT_SESSION_WALL_CLOCK_SECONDS",
+    "RuntimeControls",
+    "load_runtime_controls",
+]
+
+DEFAULT_SESSION_WALL_CLOCK_SECONDS: int = 4 * 60 * 60  # 4 hours
+"""Default per-session wall-clock budget. Generous enough for canonical
+cli-todo / webhook-receiver / refactor-in-place runs, tight enough that
+a truly hung session is caught within an operator's working day.
+
+Set to ``0`` to disable the wall-clock watchdog. The dataclass invariant
+rejects negative values."""
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeControls:
+    """Frozen v1 runtime-control configuration.
+
+    Attributes
+    ----------
+    session_wall_clock_seconds:
+        Maximum elapsed wall-clock seconds before the watchdog cancels
+        the session. ``0`` disables the watchdog entirely (no
+        cancellation regardless of elapsed time). Negative values are
+        rejected at construction time.
+    """
+
+    session_wall_clock_seconds: int = DEFAULT_SESSION_WALL_CLOCK_SECONDS
+
+    def __post_init__(self) -> None:
+        if self.session_wall_clock_seconds < 0:
+            msg = (
+                "RuntimeControls.session_wall_clock_seconds must be >= 0; "
+                f"got {self.session_wall_clock_seconds}"
+            )
+            raise ValueError(msg)
+
+    @property
+    def watchdog_enabled(self) -> bool:
+        """True iff the wall-clock watchdog should fire."""
+        return self.session_wall_clock_seconds > 0
+
+
+def load_runtime_controls(path: Path | str | None = None) -> RuntimeControls:
+    """Load :class:`RuntimeControls` from a YAML fixture at *path*.
+
+    The expected YAML layout (kept intentionally narrow for v1):
+
+    .. code-block:: yaml
+
+        runtime_controls:
+          session_wall_clock_seconds: 14400   # 4h default
+
+    Behaviour:
+
+    - ``path is None`` → return ``RuntimeControls()`` with defaults.
+    - ``path`` exists but no ``runtime_controls`` key → defaults.
+    - YAML parse error → ``ValueError`` so callers fail loudly.
+    - Unrecognized keys under ``runtime_controls`` → ``ValueError``;
+      the v2 expansion path adds new keys only through code review.
+    """
+    if path is None:
+        return RuntimeControls()
+    resolved = Path(path)
+    if not resolved.is_file():
+        msg = f"runtime_controls config not found at {resolved}"
+        raise FileNotFoundError(msg)
+    try:
+        raw: Any = yaml.safe_load(resolved.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        msg = f"runtime_controls config at {resolved} does not parse as YAML: {exc}"
+        raise ValueError(msg) from exc
+    if raw is None:
+        return RuntimeControls()
+    if not isinstance(raw, dict):
+        msg = (
+            f"runtime_controls config at {resolved} must be a YAML mapping; "
+            f"got {type(raw).__name__}"
+        )
+        raise ValueError(msg)
+    block: Any = raw.get("runtime_controls", {})
+    if not isinstance(block, dict):
+        msg = f"runtime_controls block at {resolved} must be a mapping; got {type(block).__name__}"
+        raise ValueError(msg)
+    allowed = {"session_wall_clock_seconds"}
+    unknown = set(block.keys()) - allowed
+    if unknown:
+        msg = (
+            f"runtime_controls config at {resolved} contains unknown keys "
+            f"{sorted(unknown)}; allowed keys: {sorted(allowed)}"
+        )
+        raise ValueError(msg)
+    budget = block.get("session_wall_clock_seconds", DEFAULT_SESSION_WALL_CLOCK_SECONDS)
+    if not isinstance(budget, int):
+        msg = (
+            "runtime_controls.session_wall_clock_seconds must be an integer; "
+            f"got {type(budget).__name__}"
+        )
+        raise ValueError(msg)
+    return RuntimeControls(session_wall_clock_seconds=budget)

--- a/src/ouroboros/runtime/watchdog.py
+++ b/src/ouroboros/runtime/watchdog.py
@@ -1,0 +1,208 @@
+"""Wall-clock watchdog for ``ooo auto`` sessions (L2 v1 of #1157 / #1172).
+
+The :class:`Watchdog` is checked at phase boundaries in the auto
+pipeline's main loop (integration lands in L2-2, this PR ships the
+runner). On each check it compares ``now() - session_started_at``
+against :attr:`RuntimeControls.session_wall_clock_seconds`; if exceeded
+*and* the watchdog has not yet fired for this session, it appends a
+:data:`WATCHDOG_CANCEL_EVENT_TYPE` event to the EventStore and returns
+a :class:`WatchdogDecision`.
+
+Resume semantics
+----------------
+
+Timer state is *implicit* in the session's persisted ``created_at``
+timestamp (``AutoPipelineState.created_at``) and the EventStore. On
+resume, the watchdog reads the same ``created_at`` value and re-checks
+against ``now()`` — a session paused inside the budget but resumed
+*after* it elapses fires the cancellation immediately at the next
+check, with no separate serialization step. See #1172 for the
+fuller rationale (the earlier draft proposed restarting from the
+resume moment; that was wrong and the redesign explicitly corrects
+it).
+
+Idempotency
+-----------
+
+The watchdog records its decision in-memory after firing
+(``_fired_sessions``) so a follow-up check on the same session does
+not append a duplicate event. The cancellation is recoverable across
+process restarts via EventStore replay; the in-memory guard only
+protects against duplicates within a single pipeline run.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Protocol
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.runtime.controls import RuntimeControls
+
+__all__ = [
+    "WATCHDOG_AGGREGATE_TYPE",
+    "WATCHDOG_CANCEL_EVENT_TYPE",
+    "WATCHDOG_STOP_REASON_CODE",
+    "Watchdog",
+    "WatchdogDecision",
+]
+
+
+WATCHDOG_AGGREGATE_TYPE: str = "runtime_control"
+"""EventStore ``aggregate_type`` for watchdog events. Confirmed additive
+to the v1 projection vocabulary via #1172 / #946 informational comment."""
+
+WATCHDOG_CANCEL_EVENT_TYPE: str = "runtime.watchdog.cancel"
+"""Sole event family for the watchdog in v1. The v2 expansion path
+(WAIT / RETRY / UNSTUCK directives) is intentionally absent."""
+
+WATCHDOG_STOP_REASON_CODE: str = "watchdog_wall_clock_exceeded"
+"""Adds the 9th canonical stop_reason_code. The auto pipeline
+(L2-2 follow-up) sets this on the result envelope when a watchdog
+cancel event is observed."""
+
+
+class _EventAppender(Protocol):
+    """Minimal protocol the watchdog needs from the EventStore.
+
+    Only ``append`` is consumed. Real production code passes the live
+    :class:`ouroboros.persistence.event_store.EventStore` instance;
+    tests pass a stub that captures appended events.
+    """
+
+    async def append(self, event: BaseEvent) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class WatchdogDecision:
+    """Outcome of a single :meth:`Watchdog.check` call when the budget
+    was exceeded.
+
+    Attributes
+    ----------
+    session_id:
+        The cancelled session's ``auto_session_id``.
+    fired_at:
+        Wall-clock UTC moment of the firing decision.
+    elapsed_seconds:
+        Integer floor of ``fired_at - session_started_at``.
+    configured_budget_seconds:
+        The :attr:`RuntimeControls.session_wall_clock_seconds` that
+        was active when the watchdog fired.
+    """
+
+    session_id: str
+    fired_at: datetime
+    elapsed_seconds: int
+    configured_budget_seconds: int
+
+    @property
+    def stop_reason_code(self) -> str:
+        """The 9th canonical stop_reason_code for the envelope surface."""
+        return WATCHDOG_STOP_REASON_CODE
+
+
+class Watchdog:
+    """Wall-clock watchdog for ``ooo auto`` sessions.
+
+    Lifecycle:
+
+    1. ``ooo auto`` instantiates one ``Watchdog`` per pipeline run
+       with the active :class:`RuntimeControls` and a reference to the
+       EventStore.
+    2. At each phase boundary the pipeline calls
+       :meth:`check`. If the budget has elapsed and the session has
+       not already fired, the watchdog appends a
+       ``runtime.watchdog.cancel`` event and returns the decision.
+    3. The pipeline transitions to BLOCKED with
+       ``stop_reason_code = "watchdog_wall_clock_exceeded"`` (L2-2).
+
+    The watchdog never re-fires for the same ``session_id`` within a
+    single ``Watchdog`` instance.
+    """
+
+    def __init__(
+        self,
+        controls: RuntimeControls,
+        event_appender: _EventAppender,
+        *,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        """
+        Parameters
+        ----------
+        controls:
+            The active runtime-control configuration.
+        event_appender:
+            Anything satisfying the :class:`_EventAppender` protocol —
+            in production this is the live EventStore.
+        now:
+            Optional clock injection point (``() -> datetime``). Defaults
+            to ``datetime.now(UTC)``. Tests pass a frozen ``now`` to
+            exercise the budget-exceeded path without sleeping.
+        """
+        self._controls = controls
+        self._appender = event_appender
+        self._now: Callable[[], datetime] = now or (lambda: datetime.now(UTC))
+        self._fired_sessions: set[str] = set()
+
+    @property
+    def controls(self) -> RuntimeControls:
+        return self._controls
+
+    async def check(
+        self,
+        *,
+        session_id: str,
+        session_started_at: datetime,
+    ) -> WatchdogDecision | None:
+        """Return a :class:`WatchdogDecision` iff the watchdog fires now.
+
+        Returns ``None`` for any of the following:
+
+        - The watchdog is disabled (``session_wall_clock_seconds == 0``).
+        - The elapsed time is still under budget.
+        - The watchdog has already fired for *session_id* on this
+          ``Watchdog`` instance.
+
+        Side effect: when the watchdog *does* fire, exactly one
+        ``runtime.watchdog.cancel`` event is appended to the
+        configured event appender.
+        """
+        if not self._controls.watchdog_enabled:
+            return None
+        if session_id in self._fired_sessions:
+            return None
+        now = self._now()
+        elapsed_seconds = int((now - session_started_at).total_seconds())
+        budget = self._controls.session_wall_clock_seconds
+        if elapsed_seconds <= budget:
+            return None
+        decision = WatchdogDecision(
+            session_id=session_id,
+            fired_at=now,
+            elapsed_seconds=elapsed_seconds,
+            configured_budget_seconds=budget,
+        )
+        event = BaseEvent(
+            type=WATCHDOG_CANCEL_EVENT_TYPE,
+            aggregate_type=WATCHDOG_AGGREGATE_TYPE,
+            aggregate_id=session_id,
+            data={
+                "reason": "wall_clock_exceeded",
+                "session_started_at": session_started_at.isoformat(),
+                "fired_at": now.isoformat(),
+                "elapsed_seconds": elapsed_seconds,
+                "configured_budget_seconds": budget,
+            },
+        )
+        await self._appender.append(event)
+        self._fired_sessions.add(session_id)
+        return decision
+
+    def has_fired_for(self, session_id: str) -> bool:
+        """Test/inspection helper — True iff this instance has already
+        fired the watchdog for *session_id*."""
+        return session_id in self._fired_sessions

--- a/tests/unit/runtime/test_controls.py
+++ b/tests/unit/runtime/test_controls.py
@@ -1,0 +1,140 @@
+"""Tests for :class:`RuntimeControls` and :func:`load_runtime_controls`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from ouroboros.runtime.controls import (
+    DEFAULT_SESSION_WALL_CLOCK_SECONDS,
+    RuntimeControls,
+    load_runtime_controls,
+)
+
+
+def test_default_constructor() -> None:
+    """Bare ``RuntimeControls()`` carries the documented default."""
+    controls = RuntimeControls()
+    assert controls.session_wall_clock_seconds == DEFAULT_SESSION_WALL_CLOCK_SECONDS
+    assert controls.watchdog_enabled
+
+
+def test_explicit_constructor() -> None:
+    controls = RuntimeControls(session_wall_clock_seconds=600)
+    assert controls.session_wall_clock_seconds == 600
+    assert controls.watchdog_enabled
+
+
+def test_zero_disables_watchdog() -> None:
+    """``session_wall_clock_seconds == 0`` is the explicit disable knob."""
+    controls = RuntimeControls(session_wall_clock_seconds=0)
+    assert controls.session_wall_clock_seconds == 0
+    assert not controls.watchdog_enabled
+
+
+def test_negative_rejected() -> None:
+    with pytest.raises(ValueError, match=">= 0"):
+        RuntimeControls(session_wall_clock_seconds=-1)
+
+
+def test_load_returns_defaults_when_path_is_none() -> None:
+    assert load_runtime_controls(None) == RuntimeControls()
+
+
+def test_load_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_runtime_controls(tmp_path / "nope.yaml")
+
+
+def test_load_yaml_fixture(tmp_path: Path) -> None:
+    fixture = tmp_path / "runtime_controls.yaml"
+    fixture.write_text("runtime_controls:\n  session_wall_clock_seconds: 600\n")
+    controls = load_runtime_controls(fixture)
+    assert controls.session_wall_clock_seconds == 600
+
+
+def test_load_empty_yaml_returns_defaults(tmp_path: Path) -> None:
+    fixture = tmp_path / "empty.yaml"
+    fixture.write_text("")
+    assert load_runtime_controls(fixture) == RuntimeControls()
+
+
+def test_load_missing_block_returns_defaults(tmp_path: Path) -> None:
+    fixture = tmp_path / "no_block.yaml"
+    fixture.write_text("unrelated_key: value\n")
+    # Missing ``runtime_controls`` mapping → defaults.
+    assert load_runtime_controls(fixture) == RuntimeControls()
+
+
+def test_load_invalid_yaml_raises(tmp_path: Path) -> None:
+    fixture = tmp_path / "bad.yaml"
+    fixture.write_text("runtime_controls: [this, isn't, a, mapping\n")
+    with pytest.raises(ValueError):
+        load_runtime_controls(fixture)
+
+
+def test_load_non_mapping_top_level_raises(tmp_path: Path) -> None:
+    fixture = tmp_path / "list_top.yaml"
+    fixture.write_text("- a\n- b\n")
+    with pytest.raises(ValueError, match="must be a YAML mapping"):
+        load_runtime_controls(fixture)
+
+
+def test_load_non_mapping_block_raises(tmp_path: Path) -> None:
+    fixture = tmp_path / "list_block.yaml"
+    fixture.write_text("runtime_controls:\n  - 600\n")
+    with pytest.raises(ValueError, match="must be a mapping"):
+        load_runtime_controls(fixture)
+
+
+def test_load_unknown_key_rejected(tmp_path: Path) -> None:
+    """Unknown keys under ``runtime_controls`` are rejected — v2 expansion
+    keys (idle/no_progress/safety, directive vocabulary, …) require code
+    review to land, not silent acceptance."""
+    fixture = tmp_path / "extra_key.yaml"
+    fixture.write_text(
+        "runtime_controls:\n"
+        "  session_wall_clock_seconds: 600\n"
+        "  idle_timeout_seconds: 60\n"  # v2 expansion path; not yet here.
+    )
+    with pytest.raises(ValueError, match="idle_timeout_seconds"):
+        load_runtime_controls(fixture)
+
+
+def test_load_non_integer_budget_rejected(tmp_path: Path) -> None:
+    fixture = tmp_path / "string_budget.yaml"
+    fixture.write_text("runtime_controls:\n  session_wall_clock_seconds: '600'\n")
+    with pytest.raises(ValueError, match="must be an integer"):
+        load_runtime_controls(fixture)
+
+
+def test_runtime_controls_is_frozen() -> None:
+    """``RuntimeControls`` is a frozen dataclass — accidental mutation by
+    a consumer must raise rather than silently shift the contract."""
+    controls = RuntimeControls(session_wall_clock_seconds=600)
+    with pytest.raises(Exception):  # noqa: BLE001 - frozen dataclass raises FrozenInstanceError
+        controls.session_wall_clock_seconds = 900  # type: ignore[misc]
+
+
+def test_load_explicit_zero_disable(tmp_path: Path) -> None:
+    fixture = tmp_path / "disabled.yaml"
+    fixture.write_text("runtime_controls:\n  session_wall_clock_seconds: 0\n")
+    controls = load_runtime_controls(fixture)
+    assert not controls.watchdog_enabled
+
+
+def test_default_budget_is_four_hours() -> None:
+    """Pin the documented default — changes here ripple through every
+    operator's invocation, so the value gets a regression guard."""
+    assert DEFAULT_SESSION_WALL_CLOCK_SECONDS == 4 * 60 * 60
+
+
+# ``yaml`` import is exercised indirectly; keep this so an environment
+# missing PyYAML fails the suite loudly here rather than mid-pipeline.
+def test_yaml_dependency_available() -> None:
+    import yaml as _yaml  # noqa: PLC0415 — intentional probe
+
+    parsed: Any = _yaml.safe_load("x: 1")
+    assert parsed == {"x": 1}

--- a/tests/unit/runtime/test_watchdog.py
+++ b/tests/unit/runtime/test_watchdog.py
@@ -1,0 +1,201 @@
+"""Tests for the :class:`Watchdog` runner."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.runtime.controls import RuntimeControls
+from ouroboros.runtime.watchdog import (
+    WATCHDOG_AGGREGATE_TYPE,
+    WATCHDOG_CANCEL_EVENT_TYPE,
+    WATCHDOG_STOP_REASON_CODE,
+    Watchdog,
+    WatchdogDecision,
+)
+
+
+class _CapturingAppender:
+    """Test double for ``EventStore.append`` — records every appended event."""
+
+    def __init__(self) -> None:
+        self.events: list[BaseEvent] = []
+
+    async def append(self, event: BaseEvent) -> None:
+        self.events.append(event)
+
+
+def _fixed_now(value: datetime):
+    return lambda: value
+
+
+@pytest.mark.asyncio
+async def test_under_budget_does_not_fire() -> None:
+    started = datetime(2026, 5, 22, 10, 0, 0, tzinfo=UTC)
+    now = started + timedelta(seconds=30)
+    appender = _CapturingAppender()
+    watchdog = Watchdog(
+        controls=RuntimeControls(session_wall_clock_seconds=600),
+        event_appender=appender,
+        now=_fixed_now(now),
+    )
+
+    decision = await watchdog.check(session_id="auto_001", session_started_at=started)
+
+    assert decision is None
+    assert appender.events == []
+    assert not watchdog.has_fired_for("auto_001")
+
+
+@pytest.mark.asyncio
+async def test_exact_budget_does_not_fire() -> None:
+    """At ``elapsed == budget`` the watchdog must NOT fire — strict
+    inequality reserves the precise budget boundary for the session's
+    own clean exit. Off-by-one mistakes here would cancel sessions that
+    finish *exactly* on budget."""
+    started = datetime(2026, 5, 22, 10, 0, 0, tzinfo=UTC)
+    now = started + timedelta(seconds=600)
+    appender = _CapturingAppender()
+    watchdog = Watchdog(
+        controls=RuntimeControls(session_wall_clock_seconds=600),
+        event_appender=appender,
+        now=_fixed_now(now),
+    )
+
+    decision = await watchdog.check(session_id="auto_001", session_started_at=started)
+
+    assert decision is None
+    assert appender.events == []
+
+
+@pytest.mark.asyncio
+async def test_over_budget_fires_and_appends_event() -> None:
+    started = datetime(2026, 5, 22, 10, 0, 0, tzinfo=UTC)
+    now = started + timedelta(seconds=601)
+    appender = _CapturingAppender()
+    watchdog = Watchdog(
+        controls=RuntimeControls(session_wall_clock_seconds=600),
+        event_appender=appender,
+        now=_fixed_now(now),
+    )
+
+    decision = await watchdog.check(session_id="auto_001", session_started_at=started)
+
+    assert isinstance(decision, WatchdogDecision)
+    assert decision.session_id == "auto_001"
+    assert decision.fired_at == now
+    assert decision.elapsed_seconds == 601
+    assert decision.configured_budget_seconds == 600
+    assert decision.stop_reason_code == WATCHDOG_STOP_REASON_CODE
+
+    # Exactly one event appended; shape matches the documented contract.
+    assert len(appender.events) == 1
+    event = appender.events[0]
+    assert event.type == WATCHDOG_CANCEL_EVENT_TYPE
+    assert event.aggregate_type == WATCHDOG_AGGREGATE_TYPE
+    assert event.aggregate_id == "auto_001"
+    assert event.data["reason"] == "wall_clock_exceeded"
+    assert event.data["elapsed_seconds"] == 601
+    assert event.data["configured_budget_seconds"] == 600
+    assert event.data["fired_at"] == now.isoformat()
+    assert event.data["session_started_at"] == started.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_idempotent_within_instance() -> None:
+    """A second check on the same session does not append a duplicate
+    event — the in-memory ``_fired_sessions`` guard catches it."""
+    started = datetime(2026, 5, 22, 10, 0, 0, tzinfo=UTC)
+    appender = _CapturingAppender()
+    watchdog = Watchdog(
+        controls=RuntimeControls(session_wall_clock_seconds=10),
+        event_appender=appender,
+        now=_fixed_now(started + timedelta(seconds=60)),
+    )
+
+    first = await watchdog.check(session_id="auto_dup", session_started_at=started)
+    second = await watchdog.check(session_id="auto_dup", session_started_at=started)
+
+    assert first is not None
+    assert second is None
+    assert len(appender.events) == 1
+    assert watchdog.has_fired_for("auto_dup")
+
+
+@pytest.mark.asyncio
+async def test_multiple_sessions_tracked_separately() -> None:
+    started = datetime(2026, 5, 22, 10, 0, 0, tzinfo=UTC)
+    appender = _CapturingAppender()
+    watchdog = Watchdog(
+        controls=RuntimeControls(session_wall_clock_seconds=10),
+        event_appender=appender,
+        now=_fixed_now(started + timedelta(seconds=60)),
+    )
+
+    a = await watchdog.check(session_id="auto_A", session_started_at=started)
+    b = await watchdog.check(session_id="auto_B", session_started_at=started)
+
+    assert a is not None
+    assert b is not None
+    assert len(appender.events) == 2
+    assert {e.aggregate_id for e in appender.events} == {"auto_A", "auto_B"}
+
+
+@pytest.mark.asyncio
+async def test_disabled_watchdog_never_fires() -> None:
+    """``session_wall_clock_seconds == 0`` opts out — no event, no
+    decision, no internal state change."""
+    started = datetime(2026, 5, 22, 10, 0, 0, tzinfo=UTC)
+    appender = _CapturingAppender()
+    watchdog = Watchdog(
+        controls=RuntimeControls(session_wall_clock_seconds=0),
+        event_appender=appender,
+        now=_fixed_now(started + timedelta(days=7)),
+    )
+
+    decision = await watchdog.check(session_id="auto_off", session_started_at=started)
+
+    assert decision is None
+    assert appender.events == []
+    assert not watchdog.has_fired_for("auto_off")
+
+
+@pytest.mark.asyncio
+async def test_resume_re_fires_when_elapsed_exceeds_after_paused_gap() -> None:
+    """Resume semantics: a session that was paused inside the budget but
+    resumed *after* it elapses must fire on the next check. The
+    ``Watchdog`` instance does not persist state across pipeline runs;
+    a *new* ``Watchdog`` instance after resume will see a fresh
+    ``_fired_sessions`` set and fire on the next check past budget."""
+    started = datetime(2026, 5, 22, 10, 0, 0, tzinfo=UTC)
+    appender = _CapturingAppender()
+
+    # First instance (pre-pause): under budget, does nothing.
+    pre = Watchdog(
+        controls=RuntimeControls(session_wall_clock_seconds=600),
+        event_appender=appender,
+        now=_fixed_now(started + timedelta(seconds=120)),
+    )
+    assert await pre.check(session_id="auto_resume", session_started_at=started) is None
+
+    # Process pauses, resumes a long time later → new ``Watchdog`` instance.
+    post = Watchdog(
+        controls=RuntimeControls(session_wall_clock_seconds=600),
+        event_appender=appender,
+        now=_fixed_now(started + timedelta(seconds=900)),
+    )
+    decision = await post.check(session_id="auto_resume", session_started_at=started)
+
+    assert decision is not None
+    assert decision.elapsed_seconds == 900
+    assert len(appender.events) == 1
+
+
+def test_constants_documented() -> None:
+    """Pin the public constants — the L2-2 pipeline-integration PR
+    imports them by name, so a rename here is a contract break."""
+    assert WATCHDOG_AGGREGATE_TYPE == "runtime_control"
+    assert WATCHDOG_CANCEL_EVENT_TYPE == "runtime.watchdog.cancel"
+    assert WATCHDOG_STOP_REASON_CODE == "watchdog_wall_clock_exceeded"


### PR DESCRIPTION
## Summary

L2-1 slice of #1172 — the minimal new substrate of #1157's L2 lane.

Adds the smallest possible watchdog substrate that satisfies the SSOT invariant *\"long-running run never stalls without a recorded reason\"*:

- **One config knob**: \`RuntimeControls.session_wall_clock_seconds\` (defaults to 4h; \`0\` disables).
- **One EventStore event family**: \`runtime.watchdog.cancel\` on \`aggregate_type = \"runtime_control\"\` (verified additive to projection v1 vocabulary per #946 informational comment).
- **One new stop_reason_code**: \`watchdog_wall_clock_exceeded\` — the 9th canonical code, consumed by L2-2's pipeline integration follow-up.

Richer designs (3-timer split, 4-directive vocabulary, subscriber pattern) deferred to v2 expansion per #1172.

## What lands

- \`src/ouroboros/runtime/__init__.py\` (new package).
- \`src/ouroboros/runtime/controls.py\`: \`RuntimeControls\` frozen dataclass + \`load_runtime_controls\` YAML loader that rejects unknown keys.
- \`src/ouroboros/runtime/watchdog.py\`: \`Watchdog\` runner with injectable \`now\` clock, idempotent \`_fired_sessions\` guard, documented event-append contract. Constants \`WATCHDOG_AGGREGATE_TYPE\` / \`WATCHDOG_CANCEL_EVENT_TYPE\` / \`WATCHDOG_STOP_REASON_CODE\` exported for L2-2.
- \`tests/unit/runtime/test_controls.py\` (17 tests) + \`test_watchdog.py\` (9 tests).

## Resume semantics

Timer state implicit in \`AutoPipelineState.created_at\`. A fresh \`Watchdog\` on resume re-checks against \`now()\` — a paused session resumed past budget fires immediately at the next check. The earlier draft proposed restarting from the resume moment; the redesign explicitly corrects it.

## What is NOT in this PR

- Auto pipeline integration (\`interview_driver\` / \`evolve\` / \`ralph_handoff\` subscribing) — L2-2.
- MCP adapter transport-cap deprecation — deferred per #1172 evidence-driven rule.
- Cooperative cancellation via AgentProcess (#518) — out of scope.

## Test plan

- [x] \`uv run pytest tests/unit/runtime/ -v\` → 26 passed.
- [x] \`uv run pytest tests/unit -q --ignore=tests/unit/tui\` → 9258 passed, 2 skipped.
- [x] \`uv run ruff check\` on touched files → clean.
- [x] \`uv run ruff format\` on touched files → clean.
- [x] \`uv run mypy src/ouroboros/runtime/\` → clean.

Refs #1157 (L2 lane), #1172 (L2 roadmap), #578 (RFC lifted), #946 (additive confirmation).