### PR TITLE
feat(orchestrator): runtime acceptance evidence (L3-1)

### DIFF
--- a/src/ouroboros/orchestrator/runtime_evidence.py
+++ b/src/ouroboros/orchestrator/runtime_evidence.py
@@ -1,0 +1,304 @@
+"""Runtime acceptance evidence (L3-1 of #1157 / #1176).
+
+The existing :mod:`ouroboros.orchestrator.evidence_schema` substrate
+ships unit-test evidence (``EvidenceRecord`` — a permissive mapping
+container). L3 adds a *sibling* substrate for **runtime acceptance
+evidence**: the artifact actually ran, and here's what came out.
+
+v1 ships *one* probe kind: :class:`HeadlessRunProbe`. Per #1176's
+minimal-substrate audit, ``sim_trace`` / ``render_hash`` / ``api_smoke``
+each open as their own follow-up issue *only when a canonical scenario
+demonstrates ``headless_run`` cannot cover it*.
+
+The L1-a catalog (#1173) already declares per-class
+``runtime_probe_kinds`` strings. This module:
+
+1. Defines :class:`RuntimeEvidence` (frozen dataclass) — what a probe
+   returns.
+2. Defines :class:`HeadlessRunProbe` — subprocess + stdout / stderr /
+   exit_code / duration capture, with a wall-clock timeout.
+3. Defines :func:`probes_for_task_class` — given a :class:`TaskClass`,
+   return the bound probe instances. v1 maps ``headless_run`` →
+   :class:`HeadlessRunProbe` and leaves every other declared kind as a
+   no-op deferred placeholder (so adding ``sim_trace`` later is a
+   one-line registry change).
+
+L3-2 wires :class:`RuntimeEvidence` into the Track A verifier's grade
+input and onto the result envelope.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+import shlex
+import subprocess
+import time
+from typing import Protocol
+
+from ouroboros.auto.task_classes import TASK_CLASS_CATALOG, TaskClass
+
+__all__ = [
+    "HEADLESS_RUN_PROBE_KIND",
+    "DeferredProbe",
+    "HeadlessRunProbe",
+    "RuntimeEvidence",
+    "RuntimeProbe",
+    "probes_for_task_class",
+]
+
+
+HEADLESS_RUN_PROBE_KIND: str = "headless_run"
+"""The sole v1 probe-kind identifier. Future probe kinds (``sim_trace``,
+``render_hash``, ``api_smoke``) each ship as their own follow-up
+under the #1176 v2 expansion path."""
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeEvidence:
+    """Outcome of one runtime probe invocation.
+
+    Attributes
+    ----------
+    probe_kind:
+        Catalog identifier for the probe that produced this evidence
+        (e.g. ``"headless_run"``). Matches one of the strings declared
+        in :attr:`ouroboros.auto.task_classes.TaskClassProfile.runtime_probe_kinds`.
+    passed:
+        ``True`` iff the probe judges the artifact as running correctly
+        per its own contract. ``HeadlessRunProbe`` defines this as
+        ``exit_code == 0`` *and* the command completed within the
+        wall-clock budget.
+    summary:
+        One-line human-readable summary the verifier can surface
+        without re-parsing the structured payload.
+    duration_seconds:
+        Wall-clock elapsed time of the probe in seconds (float,
+        non-negative). ``0.0`` for probes that did not run a
+        subprocess.
+    payload:
+        Probe-specific structured data (stdout, exit code, sim trace,
+        screenshot hash, …). Kept open as ``dict[str, Any]`` so future
+        probe kinds can ship payloads without re-versioning the
+        ``RuntimeEvidence`` schema.
+    """
+
+    probe_kind: str
+    passed: bool
+    summary: str
+    duration_seconds: float = 0.0
+    payload: Mapping[str, object] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.duration_seconds < 0:
+            msg = f"duration_seconds must be >= 0; got {self.duration_seconds}"
+            raise ValueError(msg)
+        if not self.probe_kind:
+            msg = "probe_kind must be a non-empty string"
+            raise ValueError(msg)
+
+
+class RuntimeProbe(Protocol):
+    """Protocol for runtime probes.
+
+    Probes are synchronous — they wrap a subprocess or in-memory check
+    and return :class:`RuntimeEvidence`. The L3-2 verifier integration
+    invokes them at grade-input time after the artifact's tests have
+    passed.
+    """
+
+    @property
+    def kind(self) -> str: ...
+
+    def run(
+        self,
+        *,
+        cwd: Path,
+        command: Sequence[str] | str,
+        timeout_seconds: float | None = None,
+    ) -> RuntimeEvidence: ...
+
+
+@dataclass(frozen=True, slots=True)
+class HeadlessRunProbe:
+    """Subprocess-based runtime probe — the v1 default.
+
+    Invokes the documented command, captures stdout / stderr /
+    exit_code / duration, and judges PASS iff the command completed
+    within *timeout_seconds* with exit code 0.
+
+    The probe is intentionally narrow: it does *not* parse stdout,
+    diff against goldens, or assert structural invariants. Those are
+    layered on top via the Track A verifier's existing AC machinery —
+    this probe just answers *"does the thing actually run?"*.
+    """
+
+    kind: str = HEADLESS_RUN_PROBE_KIND
+
+    def run(
+        self,
+        *,
+        cwd: Path,
+        command: Sequence[str] | str,
+        timeout_seconds: float | None = None,
+    ) -> RuntimeEvidence:
+        """Execute *command* in *cwd* with *timeout_seconds* budget.
+
+        Parameters
+        ----------
+        cwd:
+            Working directory for the subprocess. Must exist; the probe
+            does not create it.
+        command:
+            Either a pre-tokenized list (``["python", "-m", "myapp"]``)
+            or a shell-style string (``"python -m myapp --flag"``).
+            Strings are tokenized via :func:`shlex.split`.
+        timeout_seconds:
+            Wall-clock budget. ``None`` means *no timeout*; tests should
+            always pass a finite value to avoid hangs. The canonical
+            scenario YAML's ``wall_clock_budget_seconds`` is the
+            natural value.
+        """
+        if not cwd.is_dir():
+            msg = f"HeadlessRunProbe cwd does not exist: {cwd}"
+            raise FileNotFoundError(msg)
+        argv = shlex.split(command) if isinstance(command, str) else list(command)
+        if not argv:
+            msg = "HeadlessRunProbe command must produce at least one argv token"
+            raise ValueError(msg)
+
+        start = time.monotonic()
+        try:
+            completed = subprocess.run(  # noqa: S603 - intentional probe invocation
+                argv,
+                cwd=str(cwd),
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+                check=False,
+            )
+        except subprocess.TimeoutExpired as exc:
+            duration = time.monotonic() - start
+            return RuntimeEvidence(
+                probe_kind=self.kind,
+                passed=False,
+                summary=(
+                    f"headless run timed out after {duration:.1f}s (budget {timeout_seconds}s)"
+                ),
+                duration_seconds=duration,
+                payload={
+                    "argv": argv,
+                    "timeout_seconds": timeout_seconds,
+                    "stdout_preview": _truncate(exc.stdout or ""),
+                    "stderr_preview": _truncate(exc.stderr or ""),
+                    "outcome": "timeout",
+                },
+            )
+        duration = time.monotonic() - start
+        passed = completed.returncode == 0
+        summary = f"headless run exit_code={completed.returncode} (duration {duration:.2f}s)"
+        return RuntimeEvidence(
+            probe_kind=self.kind,
+            passed=passed,
+            summary=summary,
+            duration_seconds=duration,
+            payload={
+                "argv": argv,
+                "exit_code": completed.returncode,
+                "stdout_preview": _truncate(completed.stdout or ""),
+                "stderr_preview": _truncate(completed.stderr or ""),
+                "outcome": "completed",
+            },
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class DeferredProbe:
+    """Placeholder for probe kinds declared in the L1 catalog but not
+    yet implemented in this v1 (per #1176 minimal-substrate audit).
+
+    Calling :meth:`run` on a deferred probe returns a probe-PASS
+    :class:`RuntimeEvidence` with ``outcome = "deferred"`` so the
+    verifier can flag the gap without failing the grade. The L3
+    follow-up that implements ``sim_trace`` / ``render_hash`` /
+    ``api_smoke`` swaps the registry entry from :class:`DeferredProbe`
+    to the real implementation; no consumer needs to change.
+    """
+
+    kind: str
+
+    def run(
+        self,
+        *,
+        cwd: Path,  # noqa: ARG002 - matches RuntimeProbe protocol
+        command: Sequence[str] | str = (),  # noqa: ARG002 - matches RuntimeProbe protocol
+        timeout_seconds: float | None = None,  # noqa: ARG002 - matches RuntimeProbe protocol
+    ) -> RuntimeEvidence:
+        return RuntimeEvidence(
+            probe_kind=self.kind,
+            passed=True,
+            summary=f"probe kind {self.kind!r} is deferred to a future L3 follow-up",
+            duration_seconds=0.0,
+            payload={"outcome": "deferred"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# L1 → probe binding registry
+# ---------------------------------------------------------------------------
+
+
+def _build_probe_registry() -> dict[str, RuntimeProbe]:
+    """Singleton registry of probe-kind → probe instance.
+
+    v1: ``HEADLESS_RUN_PROBE_KIND`` → :class:`HeadlessRunProbe`. Every
+    other kind declared in the L1 catalog gets a :class:`DeferredProbe`
+    fallback so consumers calling :func:`probes_for_task_class` never
+    crash with KeyError on a catalog entry that points at a not-yet-
+    implemented probe.
+    """
+    registry: dict[str, RuntimeProbe] = {
+        HEADLESS_RUN_PROBE_KIND: HeadlessRunProbe(),
+    }
+    # Sweep the L1 catalog and register a DeferredProbe for every
+    # declared kind we do not implement yet.
+    for profile in TASK_CLASS_CATALOG.values():
+        for kind in profile.runtime_probe_kinds:
+            if kind not in registry:
+                registry[kind] = DeferredProbe(kind=kind)
+    return registry
+
+
+_PROBE_REGISTRY: dict[str, RuntimeProbe] = _build_probe_registry()
+
+
+def probes_for_task_class(task_class: TaskClass) -> tuple[RuntimeProbe, ...]:
+    """Return the probe instances bound to *task_class* by the L1 catalog.
+
+    Looks up :attr:`TaskClassProfile.runtime_probe_kinds` and resolves
+    each kind through the in-process registry. Returns a tuple in
+    catalog declaration order so the L3-2 verifier can deterministically
+    iterate them.
+
+    For v1, every class either binds :class:`HeadlessRunProbe` or a
+    :class:`DeferredProbe`; the verifier sees a PASS from either, and
+    the human reading the evidence bundle sees ``outcome = "deferred"``
+    for the kinds that have not yet been implemented.
+    """
+    profile = TASK_CLASS_CATALOG[task_class]
+    return tuple(_PROBE_REGISTRY[kind] for kind in profile.runtime_probe_kinds)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+_PREVIEW_MAX_CHARS = 2_000
+
+
+def _truncate(text: str) -> str:
+    if len(text) <= _PREVIEW_MAX_CHARS:
+        return text
+    return text[:_PREVIEW_MAX_CHARS] + f"… [truncated, {len(text) - _PREVIEW_MAX_CHARS} more chars]"

--- a/tests/unit/orchestrator/test_runtime_evidence.py
+++ b/tests/unit/orchestrator/test_runtime_evidence.py
@@ -1,0 +1,199 @@
+"""Tests for L3-1 runtime evidence substrate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ouroboros.auto.task_classes import TaskClass
+from ouroboros.orchestrator.runtime_evidence import (
+    HEADLESS_RUN_PROBE_KIND,
+    DeferredProbe,
+    HeadlessRunProbe,
+    RuntimeEvidence,
+    probes_for_task_class,
+)
+
+# ---------------------------------------------------------------------------
+# RuntimeEvidence dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_evidence_shape() -> None:
+    evidence = RuntimeEvidence(
+        probe_kind="headless_run",
+        passed=True,
+        summary="ok",
+        duration_seconds=0.42,
+        payload={"exit_code": 0},
+    )
+    assert evidence.probe_kind == "headless_run"
+    assert evidence.passed is True
+    assert evidence.summary == "ok"
+    assert evidence.duration_seconds == 0.42
+    assert evidence.payload["exit_code"] == 0
+
+
+def test_runtime_evidence_rejects_negative_duration() -> None:
+    with pytest.raises(ValueError, match=">= 0"):
+        RuntimeEvidence(
+            probe_kind="headless_run",
+            passed=False,
+            summary="bogus",
+            duration_seconds=-0.1,
+        )
+
+
+def test_runtime_evidence_rejects_empty_probe_kind() -> None:
+    with pytest.raises(ValueError, match="non-empty"):
+        RuntimeEvidence(probe_kind="", passed=True, summary="")
+
+
+def test_runtime_evidence_is_frozen() -> None:
+    evidence = RuntimeEvidence(probe_kind="headless_run", passed=True, summary="ok")
+    with pytest.raises(Exception):  # noqa: BLE001 - frozen
+        evidence.passed = False  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# HeadlessRunProbe — happy paths and failure modes
+# ---------------------------------------------------------------------------
+
+
+def test_headless_run_success(tmp_path: Path) -> None:
+    """``true`` (POSIX) exits 0 → probe passes; duration > 0."""
+    probe = HeadlessRunProbe()
+    evidence = probe.run(cwd=tmp_path, command=["python", "-c", "import sys; sys.exit(0)"])
+    assert evidence.probe_kind == HEADLESS_RUN_PROBE_KIND
+    assert evidence.passed is True
+    assert evidence.payload["exit_code"] == 0
+    assert evidence.payload["outcome"] == "completed"
+    assert evidence.duration_seconds >= 0
+    assert "exit_code=0" in evidence.summary
+
+
+def test_headless_run_nonzero_exit_fails(tmp_path: Path) -> None:
+    probe = HeadlessRunProbe()
+    evidence = probe.run(cwd=tmp_path, command=["python", "-c", "import sys; sys.exit(7)"])
+    assert evidence.passed is False
+    assert evidence.payload["exit_code"] == 7
+    assert "exit_code=7" in evidence.summary
+
+
+def test_headless_run_captures_stdout(tmp_path: Path) -> None:
+    probe = HeadlessRunProbe()
+    evidence = probe.run(
+        cwd=tmp_path,
+        command=["python", "-c", "print('hello world')"],
+    )
+    assert evidence.passed is True
+    assert "hello world" in evidence.payload["stdout_preview"]
+
+
+def test_headless_run_captures_stderr(tmp_path: Path) -> None:
+    probe = HeadlessRunProbe()
+    evidence = probe.run(
+        cwd=tmp_path,
+        command=[
+            "python",
+            "-c",
+            "import sys; sys.stderr.write('errline'); sys.exit(2)",
+        ],
+    )
+    assert evidence.passed is False
+    assert "errline" in evidence.payload["stderr_preview"]
+
+
+def test_headless_run_string_command_is_tokenized(tmp_path: Path) -> None:
+    """A shell-style string command is tokenized via ``shlex.split`` —
+    *not* run through a shell — so it stays free of injection
+    surprises."""
+    probe = HeadlessRunProbe()
+    evidence = probe.run(cwd=tmp_path, command="python -c 'print(\"shlex ok\")'")
+    assert evidence.passed is True
+    assert "shlex ok" in evidence.payload["stdout_preview"]
+
+
+def test_headless_run_timeout(tmp_path: Path) -> None:
+    """A command that exceeds *timeout_seconds* yields a probe-FAIL with
+    ``outcome = "timeout"``. Uses a tiny budget so the test is fast."""
+    probe = HeadlessRunProbe()
+    evidence = probe.run(
+        cwd=tmp_path,
+        command=["python", "-c", "import time; time.sleep(5)"],
+        timeout_seconds=0.5,
+    )
+    assert evidence.passed is False
+    assert evidence.payload["outcome"] == "timeout"
+    assert "timed out" in evidence.summary
+
+
+def test_headless_run_missing_cwd_raises(tmp_path: Path) -> None:
+    probe = HeadlessRunProbe()
+    with pytest.raises(FileNotFoundError):
+        probe.run(cwd=tmp_path / "does_not_exist", command=["echo", "x"])
+
+
+def test_headless_run_empty_command_rejected(tmp_path: Path) -> None:
+    probe = HeadlessRunProbe()
+    with pytest.raises(ValueError, match="at least one argv token"):
+        probe.run(cwd=tmp_path, command=[])
+
+
+# ---------------------------------------------------------------------------
+# DeferredProbe — placeholder for non-v1 probe kinds
+# ---------------------------------------------------------------------------
+
+
+def test_deferred_probe_returns_passing_evidence(tmp_path: Path) -> None:
+    """A :class:`DeferredProbe` represents a catalog-declared probe kind
+    that L3 v1 has not yet implemented (e.g. ``sim_trace``). Calling
+    :meth:`run` must succeed with a clearly-marked ``outcome ==
+    "deferred"`` rather than crashing the verifier."""
+    probe = DeferredProbe(kind="sim_trace")
+    evidence = probe.run(cwd=tmp_path, command=())
+    assert evidence.probe_kind == "sim_trace"
+    assert evidence.passed is True
+    assert evidence.payload["outcome"] == "deferred"
+    assert "deferred" in evidence.summary
+
+
+# ---------------------------------------------------------------------------
+# L1 binding registry
+# ---------------------------------------------------------------------------
+
+
+def test_probes_for_cli_uses_headless_run() -> None:
+    """The CLI catalog declares ``headless_run`` first — the binding
+    returns a :class:`HeadlessRunProbe` for that slot."""
+    probes = probes_for_task_class(TaskClass.CLI)
+    assert any(isinstance(p, HeadlessRunProbe) for p in probes)
+
+
+def test_every_task_class_resolves_without_crash() -> None:
+    """Every L1-a catalog entry must resolve via :func:`probes_for_task_class`.
+    Either the probe kind is implemented (real probe) or it falls
+    through to :class:`DeferredProbe`. KeyError here means a catalog
+    growth landed without updating the L3 registry."""
+    for task_class in TaskClass:
+        probes = probes_for_task_class(task_class)
+        # At minimum, every PRODUCT-class declares at least one probe.
+        # ``library`` declares ``import_smoke`` / ``unit_tests`` which
+        # both fall through to ``DeferredProbe`` in v1.
+        for probe in probes:
+            assert isinstance(probe, (HeadlessRunProbe, DeferredProbe))
+
+
+def test_deferred_kinds_route_to_deferred_probe() -> None:
+    """``sim_trace`` is declared in the catalog for ``game_2d`` but not
+    implemented in v1 — must route to :class:`DeferredProbe`."""
+    probes = probes_for_task_class(TaskClass.GAME_2D)
+    sim_probes = [p for p in probes if p.kind == "sim_trace"]
+    assert sim_probes  # the catalog still declares it
+    assert all(isinstance(p, DeferredProbe) for p in sim_probes)
+
+
+def test_headless_run_kind_constant() -> None:
+    """Pin the constant — L3-2 (verifier integration) imports it."""
+    assert HEADLESS_RUN_PROBE_KIND == "headless_run"


### PR DESCRIPTION
## Summary

L3-1 slice of #1176 — runtime-evidence substrate of #1157's L3 lane. Adds a sibling module to the existing \`orchestrator/evidence_schema.py\` (unit-test evidence) for **runtime acceptance evidence**: the artifact actually ran, and here's what came out.

v1 ships **one** probe kind — \`HeadlessRunProbe\` (subprocess + stdout/stderr/exit_code/duration capture). Other catalog-declared kinds (\`sim_trace\`, \`api_smoke\`, \`import_smoke\`, \`unit_tests\`, \`stdout_golden\`, \`output_fixture_diff\`, \`side_effect_probe\`, \`test_suite_parity\`) route through \`DeferredProbe\` — a PASS-with-\`outcome=\"deferred\"\` placeholder L3-2's verifier surfaces visibly. Real implementations land as v2 expansion follow-ups gated on evidence per #1176.

## What lands

- \`src/ouroboros/orchestrator/runtime_evidence.py\` (new):
  - \`RuntimeEvidence\` frozen dataclass + invariants.
  - \`RuntimeProbe\` Protocol.
  - \`HeadlessRunProbe\` — subprocess + timeout + truncated stdout/stderr previews + \`outcome\` field.
  - \`DeferredProbe\` — placeholder for unimplemented catalog kinds.
  - \`probes_for_task_class(task_class)\` L1 binding lookup.
- \`tests/unit/orchestrator/test_runtime_evidence.py\` (17 tests).

## What is NOT in this PR

- Track A verifier integration — L3-2 follow-up.
- \`AutoPipelineResult.runtime_probe_evidence\` envelope field — L3-2.
- \`sim_trace\` / \`render_hash\` / \`api_smoke\` real implementations — v2 expansion per #1176.
- L0 canonical scenario probe wiring — L0 live-run follow-up.

## Test plan

- [x] \`uv run pytest tests/unit/orchestrator/test_runtime_evidence.py -v\` → 17 passed.
- [x] \`uv run pytest tests/unit/orchestrator -q\` → 1671 passed, 1 skipped.
- [x] \`uv run ruff check\` on touched files → clean.
- [x] \`uv run ruff format\` on touched files → clean.
- [x] \`uv run mypy src/ouroboros/orchestrator/runtime_evidence.py\` → clean.

Refs #1157 (L3 lane), #1176 (L3 design issue), #1173 (L1-a catalog).