### PR TITLE
test(canonical): emit L0 summary and lock fixture failures

### DIFF
--- a/tests/canonical/README.md
+++ b/tests/canonical/README.md
@@ -32,7 +32,12 @@ uv run pytest tests/canonical/ -v
 
 This validates that every scenario directory has the required
 fixture files in the right shape. It does **not** invoke
-`ouroboros_auto`. Use this to catch fixture rot.
+`ouroboros_auto`. Use this to catch fixture rot. The run ends with a
+copyable status line per scenario, for example:
+
+```text
+CANONICAL cli-todo: shape_valid domain=cli completion=product_complete probes=headless_run,stdout_golden budget=1800s live=deferred_l0b
+```
 
 ### Full live run (manual, costs LLM tokens)
 

--- a/tests/canonical/conftest.py
+++ b/tests/canonical/conftest.py
@@ -79,6 +79,26 @@ class CanonicalScenario:
         return None
 
 
+def format_canonical_summary_line(scenario: CanonicalScenario) -> str:
+    """Return the copyable one-line status for a canonical scenario.
+
+    L0-a has no live ``ouroboros_auto`` invocation yet, so the summary
+    deliberately reports the current shape-check terminal instead of
+    pretending PRODUCT_COMPLETE has been exercised. The live terminal
+    can replace ``shape_valid`` in L0-b without changing the copyable
+    line contract.
+    """
+    probe_text = ",".join(scenario.runtime_probe_kinds) or "none"
+    return (
+        f"CANONICAL {scenario.slug}: shape_valid "
+        f"domain={scenario.domain_class} "
+        f"completion={scenario.completion_mode} "
+        f"probes={probe_text} "
+        f"budget={scenario.wall_clock_budget_seconds}s "
+        f"live=deferred_l0b"
+    )
+
+
 def _iter_scenario_dirs() -> Iterator[Path]:
     """Yield each ``tests/canonical/<slug>/`` directory in stable order."""
     for entry in sorted(_CANONICAL_ROOT.iterdir()):
@@ -192,3 +212,18 @@ def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:  # type: ignore[na
         scenarios,
         ids=[s.slug for s in scenarios],
     )
+
+
+def pytest_terminal_summary(terminalreporter: pytest.TerminalReporter) -> None:  # type: ignore[name-defined]
+    """Emit one copyable status line per canonical scenario.
+
+    This is the #1170 L0-a manual-reporting contract: after a maintainer
+    runs ``pytest tests/canonical/ -v``, the terminal output contains a
+    stable line that can be pasted into an SSOT or PR progress comment.
+    """
+    scenarios = tuple(_load_scenario(d) for d in _iter_scenario_dirs())
+    if not scenarios:
+        return
+    terminalreporter.write_sep("-", "canonical scenario summary")
+    for scenario in scenarios:
+        terminalreporter.write_line(format_canonical_summary_line(scenario))

--- a/tests/canonical/test_conftest.py
+++ b/tests/canonical/test_conftest.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from . import conftest as canonical_conftest
 from .conftest import _load_scenario, format_canonical_summary_line
 
 
@@ -23,6 +24,17 @@ def _scenario_dir(
 def _assert_load_fails(scenario_dir: Path, expected_message: str) -> None:
     with pytest.raises(pytest.fail.Exception, match=expected_message):
         _load_scenario(scenario_dir)
+
+
+class _RecordingTerminalReporter:
+    def __init__(self) -> None:
+        self.events: list[tuple[str, ...]] = []
+
+    def write_sep(self, sep: str, title: str) -> None:
+        self.events.append(("sep", sep, title))
+
+    def write_line(self, line: str) -> None:
+        self.events.append(("line", line))
 
 
 def test_load_scenario_rejects_missing_expected_yaml(tmp_path: Path) -> None:
@@ -79,3 +91,39 @@ def test_format_canonical_summary_line_is_copyable() -> None:
         "budget=1800s "
         "live=deferred_l0b"
     )
+
+
+def test_pytest_terminal_summary_emits_copyable_lines(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    scenario_dir = _scenario_dir(
+        tmp_path,
+        expected=(
+            "domain_class: cli\n"
+            "completion_mode: product_complete\n"
+            "runtime_probe_kinds:\n"
+            "  - headless_run\n"
+            "wall_clock_budget_seconds: 42\n"
+        ),
+    )
+    monkeypatch.setattr(
+        canonical_conftest,
+        "_iter_scenario_dirs",
+        lambda: iter((scenario_dir,)),
+    )
+    terminalreporter = _RecordingTerminalReporter()
+
+    canonical_conftest.pytest_terminal_summary(terminalreporter)  # type: ignore[arg-type]
+
+    assert terminalreporter.events == [
+        ("sep", "-", "canonical scenario summary"),
+        (
+            "line",
+            "CANONICAL broken-scenario: shape_valid "
+            "domain=cli "
+            "completion=product_complete "
+            "probes=headless_run "
+            "budget=42s "
+            "live=deferred_l0b",
+        ),
+    ]

--- a/tests/canonical/test_conftest.py
+++ b/tests/canonical/test_conftest.py
@@ -1,0 +1,81 @@
+"""Unit tests for canonical acceptance harness fixture loading."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from .conftest import _load_scenario, format_canonical_summary_line
+
+
+def _scenario_dir(
+    tmp_path: Path, *, goal: str = "Build a tiny CLI tool.", expected: str | None = None
+) -> Path:
+    scenario_dir = tmp_path / "broken-scenario"
+    scenario_dir.mkdir()
+    (scenario_dir / "goal.txt").write_text(goal, encoding="utf-8")
+    if expected is not None:
+        (scenario_dir / "expected.yaml").write_text(expected, encoding="utf-8")
+    return scenario_dir
+
+
+def _assert_load_fails(scenario_dir: Path, expected_message: str) -> None:
+    with pytest.raises(pytest.fail.Exception, match=expected_message):
+        _load_scenario(scenario_dir)
+
+
+def test_load_scenario_rejects_missing_expected_yaml(tmp_path: Path) -> None:
+    scenario_dir = _scenario_dir(tmp_path)
+
+    _assert_load_fails(scenario_dir, "missing expected.yaml")
+
+
+def test_load_scenario_rejects_empty_goal(tmp_path: Path) -> None:
+    scenario_dir = _scenario_dir(
+        tmp_path,
+        goal="   \n",
+        expected="domain_class: cli\ncompletion_mode: product_complete\n",
+    )
+
+    _assert_load_fails(scenario_dir, "empty goal.txt")
+
+
+def test_load_scenario_rejects_unparseable_yaml(tmp_path: Path) -> None:
+    scenario_dir = _scenario_dir(tmp_path, expected="domain_class: [unterminated\n")
+
+    _assert_load_fails(scenario_dir, "expected.yaml does not parse")
+
+
+def test_load_scenario_rejects_non_mapping_yaml(tmp_path: Path) -> None:
+    scenario_dir = _scenario_dir(tmp_path, expected="- cli\n- product_complete\n")
+
+    _assert_load_fails(scenario_dir, "top-level must be a mapping")
+
+
+def test_load_scenario_rejects_missing_required_keys(tmp_path: Path) -> None:
+    scenario_dir = _scenario_dir(tmp_path, expected="domain_class: cli\n")
+
+    _assert_load_fails(scenario_dir, "missing required keys")
+
+
+def test_load_scenario_rejects_invalid_completion_mode(tmp_path: Path) -> None:
+    scenario_dir = _scenario_dir(
+        tmp_path,
+        expected="domain_class: cli\ncompletion_mode: almost_done\n",
+    )
+
+    _assert_load_fails(scenario_dir, "invalid completion_mode")
+
+
+def test_format_canonical_summary_line_is_copyable() -> None:
+    scenario = _load_scenario(Path(__file__).resolve().parent / "cli-todo")
+
+    assert format_canonical_summary_line(scenario) == (
+        "CANONICAL cli-todo: shape_valid "
+        "domain=cli "
+        "completion=product_complete "
+        "probes=headless_run,stdout_golden "
+        "budget=1800s "
+        "live=deferred_l0b"
+    )


### PR DESCRIPTION
## Summary

Follow-up repair for merged #1174 after ouroboros-agent[bot]'s latest substantive review found two remaining L0-a blockers:

1. the canonical harness did not emit the #1170-required single copyable per-scenario summary line;
2. the schema loader's malformed-fixture rejection paths were behavior-defining but untested.

This PR keeps the #1157/#1170 minimal-substrate boundary intact: it does **not** wire live `ouroboros_auto`, does **not** add CI/replay/cost-budget machinery, and leaves live invocation deferred to L0-b.

## What changed

- Adds `format_canonical_summary_line()` and a `pytest_terminal_summary` hook that prints one copyable line per discovered scenario, e.g.:

  ```text
  CANONICAL cli-todo: shape_valid domain=cli completion=product_complete probes=headless_run,stdout_golden budget=1800s live=deferred_l0b
  ```

- Documents that summary line in `tests/canonical/README.md`.
- Adds focused tests for malformed fixture cases:
  - missing `expected.yaml`
  - empty `goal.txt`
  - YAML parse failure
  - non-mapping YAML root
  - missing required keys
  - invalid `completion_mode`
- Adds a formatter test pinning the copyable summary line.

## Roadmap / design alignment

- Aligns with #1170 acceptance criterion: "single human-readable summary line per scenario".
- Aligns with #1157 minimal-substrate self-audit by keeping L0-a hermetic and manual.
- Responds directly to #1174's post-merge bot review without expanding into L0-b live-run scope.

## Test plan

- [x] `uv run pytest tests/canonical/ -v` → 13 passed, 1 skipped, with canonical summary line printed.
- [x] `uv run ruff check tests/canonical/` → clean.
- [x] `uv run ruff format --check tests/canonical/` → clean.
- [x] `uv run mypy tests/canonical/conftest.py tests/canonical/test_canonical.py tests/canonical/test_conftest.py` → clean.

Refs #1174, #1170, #1157, #961.
