### PR TITLE
docs(auto): align L1 task-class follow-up labels

### DIFF
--- a/src/ouroboros/auto/task_classes.py
+++ b/src/ouroboros/auto/task_classes.py
@@ -8,8 +8,9 @@ default acceptance criteria and the runtime evidence layer (L3) can
 bind class-appropriate probes.
 
 This module is **catalog data only** (L1-a sub-PR of #1171). It does
-*not* implement domain inference from the ledger (L1-b), the Seed AC
-injection hook (L1-c), or the result-envelope surface (L1-d).
+*not* implement domain inference from the ledger (L1-b), interview-driver
+disambiguation (L1-c), the Seed AC injection hook (L1-d), or the
+result-envelope surface (L1-e).
 
 Design constraints honored:
 

--- a/tests/unit/auto/test_task_classes.py
+++ b/tests/unit/auto/test_task_classes.py
@@ -5,9 +5,10 @@ value has exactly one :class:`TaskClassProfile`, each profile's
 ``default_ac_template`` is a non-empty tuple of plain strings, and
 each ``default_completion_mode`` resolves to the documented enum.
 
-They do **not** exercise domain inference (that's L1-b) or AC
-injection (that's L1-c). Adding a new task class without a matching
-unit test below will fail ``test_task_classes_match_catalog``.
+They do **not** exercise domain inference (that's L1-b),
+interview-driver disambiguation (that's L1-c), or AC injection
+(that's L1-d). Adding a new task class without a matching unit test
+below will fail ``test_task_classes_match_catalog``.
 """
 
 from __future__ import annotations
@@ -41,7 +42,7 @@ def test_catalog_entry_shape(task_class: TaskClass) -> None:
     assert profile.name == task_class.value
     assert isinstance(profile.default_completion_mode, CompletionMode)
     # AC template must be a non-empty tuple of plain strings — matches
-    # ``Seed.acceptance_criteria``'s shape exactly so L1-c can prepend
+    # ``Seed.acceptance_criteria``'s shape exactly so L1-d can prepend
     # entries without any type coercion.
     assert isinstance(profile.default_ac_template, tuple)
     assert profile.default_ac_template, f"{task_class.value} has empty default_ac_template"


### PR DESCRIPTION
## Summary

Follow-up to merged PR #1173 after rechecking it against #961's AgentOS SSOT posture, #1171's L1 slice breakdown, and the latest ouroboros-agent design notes.

PR #1173 is already merged and was approved as a narrow Track B L1-a follow-up outside Track C tier gates. The remaining bot design note was traceability-only: the task-class module docstring named Seed AC injection/result-envelope as L1-c/L1-d, while #1171 reserves:

- L1-b: ledger-derived domain inference
- L1-c: interview-driver disambiguation
- L1-d: Seed AC injection
- L1-e: result-envelope plumbing

This PR corrects those comments/docstrings only. It does not change catalog behavior, schema, serialized task-class values, tests, runtime wiring, or dependencies.

## AgentOS / SSOT assessment

- #961 currently records #1173/#1174/#1175 as merged narrow #1157 Track B follow-ups outside Track C tier gates.
- #961 continues to treat itself as a roadmap/meta SSOT, not a direct implementation surface.
- #1173's catalog-only substrate remains aligned with that posture: no classifier, no LLM, no eval set, no telemetry, no caller wiring.
- The only remaining issue was documentation traceability against #1171's L1-c/L1-d/L1-e labels.

## Over-engineering check

This is intentionally the smallest follow-up: two doc/comment edits. I rejected schema changes (`safe_defaults`) and serialized-value churn (hyphenated enum values) because ouroboros-agent already withdrew those as blockers after the PR documented the DomainProfile/task-class split and the underscore serialization convention.

## Verification

- `uv run ruff check src/ouroboros/auto/task_classes.py tests/unit/auto/test_task_classes.py`
- `uv run ruff format --check src/ouroboros/auto/task_classes.py tests/unit/auto/test_task_classes.py`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run pytest tests/unit/auto/test_task_classes.py -q` → 13 passed
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run mypy src/ouroboros/auto/task_classes.py`

Refs #1173, #1171, #1157, #961.
