### PR TITLE
docs(auto): align convergence contract with safe-default closure

### DIFF
--- a/docs/auto-interview-convergence-contract.md
+++ b/docs/auto-interview-convergence-contract.md
@@ -56,15 +56,22 @@ actionable blocked state.
 ## Stalled gap-reduction loops
 
 The interview backend may keep asking generic follow-up questions (`What else?`,
-`Any additional context?`) even after auto answers become repetitive.  The driver
+`Any additional context?`) even after auto answers become repetitive. The driver
 must treat unchanged required gaps as a convergence signal:
 
 - steer generic follow-ups toward the highest-priority open gap;
 - recognize repeated generic fallback answers as a stall signal that should trigger gap-directed steering;
-- when the round cap is reached, report the unresolved sections explicitly.
+- at the round cap, close only the gaps covered by auditable safe defaults and
+  push the synthesis back into the persisted interview transcript before
+  returning `seed_ready`;
+- block if any remaining gap is unsafe, conflicting, not covered by the
+  safe-default policy, or if the persisted interview does not accept the
+  synthesis as closed.
 
-The blocked reason should name the gaps or unsafe decision, not only say that the
-maximum round count was reached.
+The blocked reason should name the unsafe or unresolved decision, not only say
+that the maximum round count was reached. Ledger defaults must be rolled back
+when the transcript cannot be synchronized so the Seed Draft Ledger and the
+persisted interview remain a single source of truth.
 
 ## Regression coverage
 
@@ -75,6 +82,8 @@ maximum round count was reached.
   entry) when no bounded repo facts are supplied;
 - unsafe credential/production-authority questions blocking immediately on the
   first turn with a ``credential or secret value required`` reason;
-- stalled generic ``What else?`` follow-up loops producing a round-cap blocker
-  that names the unresolved required sections rather than just reporting that
-  ``max_rounds`` was reached.
+- stalled generic ``What else?`` follow-up loops reaching `seed_ready` for benign
+  local goals only after safe-default synthesis closes the persisted interview;
+- transcript-sync failures, accepted-but-not-closed synthesis turns, partial
+  unsafe gaps, and unsafe credential/production goals blocking with defaults
+  rolled back.

--- a/docs/auto-interview-convergence-contract.md
+++ b/docs/auto-interview-convergence-contract.md
@@ -7,7 +7,9 @@ blocker.
 
 This contract is intentionally domain-agnostic.  It describes how the auto
 interview behaves for broad benign work, unsafe work, and stalled loops without
-encoding prompt-specific defaults.
+encoding prompt-specific defaults. It is a Track B `ooo auto` convergence
+contract, not an AgentOS substrate, projection, runtime tier-gate, or plugin
+lifecycle contract.
 
 ## Required-section outcomes
 


### PR DESCRIPTION
## Summary

Post-merge audit follow-up for #1122 against the #961 AgentOS SSOT / Track B direction.

#1122 originally changed benign `ooo auto` max-round stalls to close through audited safe defaults. The current implementation has since been hardened by the #1122 follow-up commit, #1129, and later Track B slices: safe-default synthesis must be pushed into the persisted interview transcript, the returned turn must confirm `seed_ready`/`completed`, and any sync/non-closure/partial-unsafe path rolls ledger defaults back before blocking.

This docs-only PR updates `docs/auto-interview-convergence-contract.md` so the written contract matches the now-current SSOT behavior instead of the stale pre-#1122 expectation that every generic stalled loop must end as a round-cap blocker.

## AgentOS / #961 fit

- #961 records #1122/#1129 as merged Track B / `ooo auto` safe-default interview-closure follow-ups outside Track C AgentOS tier gates.
- This PR does not add an AgentOS substrate surface, projection layer, runtime primitive, or broad roadmap scope.
- The change only reconciles the auto-interview convergence documentation with the already-merged implementation and regression suite.

## Over-engineering check

- No new abstraction, dependency, runtime behavior, or framework choice.
- Narrows documentation to the existing invariant: safe defaults can close benign local stalls only when the persisted interview transcript accepts the synthesis; otherwise defaults are rolled back and the session blocks.
- Keeps unsafe/conflicting/non-policy gaps explicit blockers.

## Verification

- `uv run pytest tests/unit/auto/test_interview_pipeline.py tests/unit/mcp/tools/test_definitions.py -q` — 262 passed
- `uv run ruff check src/ouroboros/auto/interview_driver.py src/ouroboros/auto/safe_defaults.py tests/unit/auto/test_interview_pipeline.py tests/unit/mcp/tools/test_definitions.py` — passed

## Review focus

Please verify that the convergence contract now matches the current #1122/#1129 safe-default SSOT and does not imply any new AgentOS Track C scope.
