### PR TITLE
fix(auto): surface assumption_sources through envelope clients

### DIFF
--- a/src/ouroboros/auto/__init__.py
+++ b/src/ouroboros/auto/__init__.py
@@ -19,7 +19,12 @@ if TYPE_CHECKING:
         AutoInterviewResult,
         InterviewTurn,
     )
-    from ouroboros.auto.ledger import LedgerEntry, LedgerSection, SeedDraftLedger
+    from ouroboros.auto.ledger import (
+        AssumptionRecord,
+        LedgerEntry,
+        LedgerSection,
+        SeedDraftLedger,
+    )
     from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
     from ouroboros.auto.seed_repairer import RepairResult, SeedRepairer
     from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
@@ -37,6 +42,7 @@ __all__ = [
     "AutoPipelineState",
     "AutoPolicy",
     "AutoStore",
+    "AssumptionRecord",
     "GradeGate",
     "InterviewTurn",
     "GradeResult",
@@ -63,6 +69,7 @@ _EXPORTS = {
     "AutoPipelineState": "ouroboros.auto.state",
     "AutoPolicy": "ouroboros.auto.state",
     "AutoStore": "ouroboros.auto.state",
+    "AssumptionRecord": "ouroboros.auto.ledger",
     "GradeGate": "ouroboros.auto.grading",
     "GradeResult": "ouroboros.auto.grading",
     "InterviewTurn": "ouroboros.auto.interview_driver",

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -749,6 +749,14 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
             console.print("Assumptions:")
             for item in result.assumptions:
                 console.print(f"  - {item}")
+        if result.assumption_sources:
+            console.print("Assumption sources:")
+            for record in result.assumption_sources:
+                console.print(
+                    f"  - source={_rich_escape(record.source)}; "
+                    f"confidence={record.confidence:.2f}; "
+                    f"text={_rich_escape(record.text)}"
+                )
         if result.non_goals:
             console.print("Non-goals:")
             for item in result.non_goals:

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1270,6 +1270,10 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
     meta["defaulted_sections"] = list(result.defaulted_sections)
     meta["evidence_backed_sections"] = list(result.evidence_backed_sections)
     meta["assumption_only_sections"] = list(result.assumption_only_sections)
+    meta["assumption_sources"] = [
+        {"text": record.text, "source": record.source, "confidence": record.confidence}
+        for record in result.assumption_sources
+    ]
     return meta
 
 

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1933,6 +1933,7 @@ def test_format_result_omits_evidence_block_when_unknown() -> None:
 @pytest.mark.asyncio
 async def test_auto_handler_meta_exposes_ledger_provenance_breakdown(monkeypatch) -> None:
     async def fake_run(self, arguments):  # noqa: ARG001
+        from ouroboros.auto.ledger import AssumptionRecord
         from ouroboros.auto.pipeline import AutoPipelineResult
 
         return AutoPipelineResult(
@@ -1946,6 +1947,13 @@ async def test_auto_handler_meta_exposes_ledger_provenance_breakdown(monkeypatch
             },
             evidence_backed_sections=("actors", "goal", "runtime_context"),
             assumption_only_sections=("constraints",),
+            assumption_sources=(
+                AssumptionRecord(
+                    text="Use existing project patterns",
+                    source="conservative_default",
+                    confidence=0.85,
+                ),
+            ),
         )
 
     monkeypatch.setattr(AutoHandler, "_run", fake_run)
@@ -1961,6 +1969,13 @@ async def test_auto_handler_meta_exposes_ledger_provenance_breakdown(monkeypatch
     }
     assert meta["evidence_backed_sections"] == ["actors", "goal", "runtime_context"]
     assert meta["assumption_only_sections"] == ["constraints"]
+    assert meta["assumption_sources"] == [
+        {
+            "text": "Use existing project patterns",
+            "source": "conservative_default",
+            "confidence": 0.85,
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -1990,6 +2005,19 @@ async def test_auto_handler_meta_always_emits_provenance_keys_when_empty(monkeyp
     assert meta["ledger_provenance"] == {}
     assert meta["evidence_backed_sections"] == []
     assert meta["assumption_only_sections"] == []
+    assert meta["assumption_sources"] == []
+
+
+def test_auto_public_api_exports_assumption_record() -> None:
+    from ouroboros.auto import AssumptionRecord
+
+    record = AssumptionRecord(
+        text="Use existing project patterns", source="assumption", confidence=0.7
+    )
+
+    assert record.text == "Use existing project patterns"
+    assert record.source == "assumption"
+    assert record.confidence == 0.7
 
 
 def test_auto_save_seed_encodes_path_traversal_seed_id_inside_seed_dir(

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -488,6 +488,7 @@ async def test_auto_handler_meta_exposes_auto_progress_fields(monkeypatch) -> No
         "defaulted_sections": [],
         "evidence_backed_sections": [],
         "assumption_only_sections": [],
+        "assumption_sources": [],
     }
 
 

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -550,6 +550,11 @@ def test_print_result_show_ledger_renders_assumption_sources() -> None:
                 source="conservative_default",
                 confidence=0.85,
             ),
+            AssumptionRecord(
+                text="Use [project] defaults",
+                source="assumption[ledger]",
+                confidence=0.7,
+            ),
         ),
     )
 
@@ -557,6 +562,9 @@ def test_print_result_show_ledger_renders_assumption_sources() -> None:
 
     assert "Assumption sources:" in output
     assert ("source=conservative_default; confidence=0.85; text=Existing patterns") in output
+    assert (
+        "source=assumption[ledger]; confidence=0.70; text=Use [project] defaults"
+    ) in output
 
 
 def test_print_status_resume_capability_partial() -> None:

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -562,9 +562,7 @@ def test_print_result_show_ledger_renders_assumption_sources() -> None:
 
     assert "Assumption sources:" in output
     assert ("source=conservative_default; confidence=0.85; text=Existing patterns") in output
-    assert (
-        "source=assumption[ledger]; confidence=0.70; text=Use [project] defaults"
-    ) in output
+    assert ("source=assumption[ledger]; confidence=0.70; text=Use [project] defaults") in output
 
 
 def test_print_status_resume_capability_partial() -> None:

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -500,6 +500,15 @@ def _capture_result(result: AutoPipelineResult) -> str:
     return _plain(capture.get())
 
 
+def _capture_result_with_ledger(result: AutoPipelineResult) -> str:
+    """Capture :func:`_print_result` with the optional ledger block enabled."""
+    from ouroboros.cli.formatters import console
+
+    with console.capture() as capture:
+        _print_result(result, show_ledger=True)
+    return _plain(capture.get())
+
+
 def _state_in_phase(phase: AutoPhase) -> AutoPipelineState:
     state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
     state.auto_session_id = "auto_render"
@@ -526,6 +535,28 @@ def test_print_status_resume_capability_resume() -> None:
     assert "Resume (partial)" not in output
     assert "Retry:" not in output
     assert "Start fresh" not in output
+
+
+def test_print_result_show_ledger_renders_assumption_sources() -> None:
+    from ouroboros.auto.ledger import AssumptionRecord
+
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_assumptions",
+        phase="complete",
+        assumption_sources=(
+            AssumptionRecord(
+                text="Existing patterns",
+                source="conservative_default",
+                confidence=0.85,
+            ),
+        ),
+    )
+
+    output = _capture_result_with_ledger(result)
+
+    assert "Assumption sources:" in output
+    assert ("source=conservative_default; confidence=0.85; text=Existing patterns") in output
 
 
 def test_print_status_resume_capability_partial() -> None:


### PR DESCRIPTION
## Summary

Follow-up to merged #1169 after re-reviewing it against the #961 / #1157 SSOT direction.

#1169 correctly added the ledger-level `AssumptionRecord` and the typed `AutoPipelineResult.assumption_sources` field, but the L4 Auto Envelope v2 SSOT now says the lane is frozen and consumed by CLI, MCP, and future UI surfaces. Leaving the field only on the internal result object makes the lane paper-complete for MCP clients.

This PR closes that narrow envelope gap:

- exports `AssumptionRecord` from `ouroboros.auto` alongside the other public auto primitives;
- emits `meta.assumption_sources` from the MCP auto handler as `[{text, source, confidence}]` records, always present as `[]` when empty;
- renders the records in CLI `ooo auto --show-ledger` output;
- adds focused coverage for MCP meta, empty meta, public export, and CLI ledger rendering.

## Why this is not over-engineering

This does not add a new policy, classifier, schema family, or control plane. It only routes the already-computed #1169 field through the same envelope channels used by the other L4 fields (`defaulted_sections`, `evidence_backed_sections`, `assumption_only_sections`).

## Test plan

- [x] `uv run ruff check src/ouroboros/auto/__init__.py src/ouroboros/mcp/tools/auto_handler.py src/ouroboros/cli/commands/auto.py tests/unit/auto/test_surface.py tests/unit/cli/test_auto_command.py`
- [x] `uv run pytest tests/unit/auto/test_surface.py -k "ledger_provenance_breakdown or always_emits_provenance_keys or public_api_exports_assumption_record" -q`
- [x] `uv run pytest tests/unit/cli/test_auto_command.py -k "assumption_sources" -q`
- [x] `uv run pytest tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_interview_pipeline.py -k "assumption_sources or assumption_class or surfaces_assumption" -q`
- [x] `uv run mypy src/ouroboros/auto/__init__.py src/ouroboros/mcp/tools/auto_handler.py src/ouroboros/cli/commands/auto.py src/ouroboros/auto/ledger.py src/ouroboros/auto/pipeline.py`

Refs #1169, #1157, #961.
