### PR TITLE
fix(orchestrator): preserve shell-preamble command proof after output plumbing

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -915,12 +915,11 @@ def _test_command_invocation(command: str) -> str | None:
     as ``| grep passed`` survives the strip and is rejected downstream by
     ``_test_invocation_from_prefix`` rather than being silently dropped.
     """
-    stripped = _strip_command_output_plumbing(command)
-    normalized = stripped.lower()
+    normalized = command.strip().lower()
     if not normalized:
         return None
 
-    direct = _test_invocation_from_prefix(normalized)
+    direct = _test_invocation_from_prefix(_strip_command_output_plumbing(normalized))
     if direct is not None:
         return direct
 
@@ -953,7 +952,7 @@ def _shell_command_body(command: str) -> str | None:
 def _test_invocation_from_shell_body(body: str) -> str | None:
     """Return a test invocation after conservative shell setup preambles."""
     for segment in _segments_after_safe_shell_preamble(body):
-        invocation = _test_invocation_from_prefix(segment)
+        invocation = _test_invocation_from_prefix(_strip_command_output_plumbing(segment))
         if invocation is not None:
             return invocation
         return None
@@ -974,7 +973,7 @@ def _single_command_after_safe_shell_preamble(command: str) -> str | None:
     segments = tuple(_segments_after_safe_shell_preamble(body))
     if len(segments) != 1:
         return None
-    return _normalized_evidence_text(segments[0])
+    return _normalized_evidence_text(_strip_command_output_plumbing(segments[0]))
 
 
 def _segments_after_safe_shell_preamble(body: str) -> tuple[str, ...]:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1128,6 +1128,60 @@ def test_command_claim_supports_command_with_output_redirection_and_pager_pipe()
     )
 
 
+def test_command_claim_supports_inner_command_after_safe_preamble_with_output_plumbing() -> None:
+    """Safe shell preambles still peel presentation-only output plumbing."""
+    message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={
+            "tool_input": {
+                "command": (
+                    "/bin/bash -lc 'cd /workspace && python -m ruff check "
+                    "src/foo.py tests/test_foo.py 2>&1 | tail -20'"
+                )
+            }
+        },
+    )
+
+    assert _runtime_messages_support_command_claim(
+        "python -m ruff check src/foo.py tests/test_foo.py",
+        (message,),
+    )
+
+
+def test_command_claim_rejects_inner_command_after_safe_preamble_with_grep_filter() -> None:
+    """Shell-wrapper peeling must not strip evidence-transforming filters."""
+    message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={
+            "tool_input": {
+                "command": "/bin/bash -lc 'cd /workspace && pytest tests/test_foo.py | grep PASSED'"
+            }
+        },
+    )
+
+    assert not _runtime_messages_support_command_claim("pytest tests/test_foo.py", (message,))
+
+
+def test_test_invocation_supports_shell_preamble_with_output_plumbing() -> None:
+    """``tests_passed`` matching keeps shell-wrapper parity with commands_run."""
+    message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={
+            "tool_input": {
+                "command": "/bin/bash -lc 'cd /workspace && pytest tests/test_foo.py 2>&1 | tail -20'"
+            }
+        },
+    )
+
+    assert _runtime_messages_support_command_claim("pytest tests/test_foo.py", (message,))
+
+
 def test_command_claim_keeps_meaningful_pipeline_segments() -> None:
     """Only output-filter pipes are stripped; real pipelines are not over-matched."""
     message = AgentMessage(


### PR DESCRIPTION
## Why

PR #1168 was already merged, but the latest post-merge `ouroboros-agent[bot]` review on #1168 found one real remaining blocker: clean command claims still fail when the runtime command is shell-wrapped with a safe setup preamble and trailing presentation plumbing, for example:

```bash
/bin/bash -lc 'cd /workspace && python -m ruff check src/foo.py tests/test_foo.py 2>&1 | tail -20'
```

That is still within the #1168 / #1164 fat-harness verifier evidence lane and matches #961 Track A direction: narrow runtime-backed verifier hardening, not a new AgentOS substrate surface.

## Fix

- Keep direct command behavior from #1168 unchanged.
- For shell-wrapped commands, peel presentation-only plumbing after safe setup preambles are removed, so the inner command can back the clean claim.
- Apply the same inner-segment peeling to test invocation extraction, preserving `tests_passed` parity.
- Keep evidence-transforming filters such as `grep`, `wc`, and `tee` unstripped; residual pipes still fail extraction.

## Why this is not over-engineered

This is a two-function boundary repair plus three regression tests. It does not add a new parser, workflow surface, dependency, public API, or AgentOS control-plane concept. It only restores parity between the already-existing safe shell preamble contract and the #1168 output-plumbing contract.

## Tests

- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run ruff format src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run pytest -q tests/unit/orchestrator/test_parallel_executor.py` → 200 passed
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run mypy src/ouroboros/orchestrator/parallel_executor.py`

Fixes the post-merge blocker from #1168.
