### PR TITLE
fix(auto): route Ralph oscillation replay through UNSTUCK_LATERAL

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1348,41 +1348,16 @@ class AutoPipeline:
                 state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
             )
         if terminal_status == "failed" and stop_reason in _RALPH_BLOCKED_STOP_REASONS:
-            # L5-a / #1157: when Ralph terminates with ``oscillation_detected``
-            # and the session has a wired lateral thinker in complete-product
-            # mode, route through UNSTUCK_LATERAL first instead of bailing
-            # straight to BLOCKED. Mirrors the EVALUATE → UNSTUCK_LATERAL
-            # path at ``_evaluate_after_qa``. Other Ralph stop_reasons
-            # (iteration_timeout, wall_clock_exhausted, grade_regressing,
-            # max_generations reached) continue to BLOCKED unchanged because
-            # those terminals are budget exhaustions rather than
-            # spec-reframe candidates.
-            if (
-                stop_reason == "oscillation_detected"
-                and self.lateral_thinker is not None
-                and state.complete_product
-            ):
-                state.transition(
-                    AutoPhase.UNSTUCK_LATERAL,
-                    "Ralph oscillation_detected; invoking lateral persona for reframing",
-                )
-                self._save(state)
-                return await self._run_lateral(
-                    state,
-                    ledger,
-                    seed,
-                    qa_score=0.0,
-                    qa_verdict="oscillation_detected",
-                    qa_differences=(
-                        "Ralph oscillated between grade states without converging on A grade.",
-                    ),
-                    qa_suggestions=(
-                        "Reframe the Seed acceptance criteria so the grade oscillation pattern cannot recur.",
-                    ),
-                    cache_suffix="",
-                    review=review,
-                    run_subagent=run_subagent,
-                )
+            lateral_result = await self._maybe_route_ralph_oscillation_to_lateral(
+                state,
+                ledger,
+                stop_reason=stop_reason,
+                seed=seed,
+                review=review,
+                run_subagent=run_subagent,
+            )
+            if lateral_result is not None:
+                return lateral_result
             state.mark_blocked(stop_reason, tool_name="ralph_starter")
             self._save(state)
             return self._result(
@@ -1846,6 +1821,72 @@ class AutoPipeline:
         self._save(state)
         return self._result(
             state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
+        )
+
+    def _recover_seed_for_lateral(
+        self,
+        state: AutoPipelineState,
+        seed: Seed | None,
+    ) -> Seed | None:
+        if seed is not None:
+            return seed
+        if not state.seed_artifact:
+            return None
+        return self._normalize_execution_seed(state, Seed.from_dict(state.seed_artifact))
+
+    async def _maybe_route_ralph_oscillation_to_lateral(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        *,
+        stop_reason: str | None,
+        seed: Seed | None,
+        review: SeedReview | None,
+        run_subagent: dict[str, Any] | None,
+    ) -> AutoPipelineResult | None:
+        """Apply the L5-a Ralph oscillation → UNSTUCK_LATERAL contract.
+
+        Ralph terminal status is consumed in three places: fresh handoff,
+        resume polling, and re-attach observation. L5-a is a producer/consumer
+        contract over the terminal ``stop_reason``, so all three consumers
+        must route ``oscillation_detected`` through the same existing lateral
+        recovery substrate when the session is complete-product and a lateral
+        thinker is wired. Other blocked stop reasons remain direct BLOCKED
+        terminals because they represent budget exhaustion, not a spec
+        reframe candidate.
+        """
+        if (
+            stop_reason != "oscillation_detected"
+            or self.lateral_thinker is None
+            or not (state.complete_product or self.complete_product)
+        ):
+            return None
+        if self.complete_product and not state.complete_product:
+            state.complete_product = True
+        recovered_seed = self._recover_seed_for_lateral(state, seed)
+        if recovered_seed is None:
+            return None
+
+        state.transition(
+            AutoPhase.UNSTUCK_LATERAL,
+            "Ralph oscillation_detected; invoking lateral persona for reframing",
+        )
+        self._save(state)
+        return await self._run_lateral(
+            state,
+            ledger,
+            recovered_seed,
+            qa_score=0.0,
+            qa_verdict="oscillation_detected",
+            qa_differences=(
+                "Ralph oscillated between grade states without converging on A grade.",
+            ),
+            qa_suggestions=(
+                "Reframe the Seed acceptance criteria so the grade oscillation pattern cannot recur.",
+            ),
+            cache_suffix="",
+            review=review,
+            run_subagent=run_subagent,
         )
 
     async def _run_lateral(
@@ -2388,14 +2429,16 @@ class AutoPipeline:
                 self._save(state)
             return self._result(state, ledger, review=review, blocker=state.last_error)
         if terminal_status == "failed" and stop_reason in _RALPH_BLOCKED_STOP_REASONS:
-            # L5-a / #1157: the live ``_handoff_to_ralph`` path routes
-            # ``oscillation_detected`` through ``UNSTUCK_LATERAL`` when a
-            # lateral thinker is wired. The resume path intentionally does
-            # not yet plumb lateral recovery — instead it BLOCKED-s with
-            # ``tool_name="ralph_starter"``, which ``_recoverable_phase_for_tool``
-            # maps back to ``RALPH_HANDOFF`` so a re-resume retries Ralph
-            # from scratch rather than stranding the session. Extending
-            # lateral recovery into the resume path is reserved for L5-b.
+            lateral_result = await self._maybe_route_ralph_oscillation_to_lateral(
+                state,
+                ledger,
+                stop_reason=stop_reason,
+                seed=seed,
+                review=review,
+                run_subagent=None,
+            )
+            if lateral_result is not None:
+                return lateral_result
             state.mark_blocked(stop_reason, tool_name="ralph_starter")
             self._save(state)
             return self._result(state, ledger, review=review, blocker=state.last_error)
@@ -2518,13 +2561,16 @@ class AutoPipeline:
                 self._save(state)
             return self._result(state, ledger, blocker=state.last_error)
         if terminal_status == "failed" and stop_reason in _RALPH_BLOCKED_STOP_REASONS:
-            # L5-a / #1157: re-attach observes an already-dispatched Ralph
-            # job's terminal status and does not currently plumb
-            # ``oscillation_detected`` through ``UNSTUCK_LATERAL``. Falling
-            # through to BLOCKED with ``tool_name="ralph_starter"`` keeps
-            # the session resumable (``_recoverable_phase_for_tool`` maps
-            # ralph_starter back to RALPH_HANDOFF). Lateral recovery on
-            # the re-attach branch is reserved for L5-b.
+            lateral_result = await self._maybe_route_ralph_oscillation_to_lateral(
+                state,
+                ledger,
+                stop_reason=stop_reason,
+                seed=None,
+                review=None,
+                run_subagent=None,
+            )
+            if lateral_result is not None:
+                return lateral_result
             state.mark_blocked(stop_reason, tool_name="ralph_starter")
             self._save(state)
             return self._result(state, ledger, blocker=state.last_error)

--- a/tests/unit/auto/test_pipeline_oscillation_lateral.py
+++ b/tests/unit/auto/test_pipeline_oscillation_lateral.py
@@ -22,6 +22,7 @@ import pytest
 from ouroboros.auto.adapters import LateralResult
 from ouroboros.auto.grading import GradeResult, SeedGrade
 from ouroboros.auto.interview_driver import AutoInterviewResult
+from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipeline
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import AutoPhase, AutoPipelineState
@@ -96,6 +97,20 @@ def _state_at_run_phase(tmp_path) -> AutoPipelineState:
     state.last_grade = "A"
     state.transition(AutoPhase.REVIEW, "review")
     state.transition(AutoPhase.RUN, "run")
+    return state
+
+
+def _state_in_ralph_handoff(tmp_path) -> AutoPipelineState:
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_existing"
+    state.execution_id = "execution_existing"
+    state.run_session_id = "session_existing"
+    state.ralph_lineage_id = "ralph-seed_test_001-auto_abc"
+    state.ralph_job_id = "job_ralph_existing"
+    state.ralph_dispatch_mode = "job"
+    state.transition(AutoPhase.RALPH_HANDOFF, "persisted ralph checkpoint")
     return state
 
 
@@ -262,3 +277,123 @@ async def test_ralph_iteration_timeout_does_not_invoke_lateral(tmp_path) -> None
     assert result.status == "blocked"
     assert state.last_error == "iteration_timeout"
     assert state.last_tool_name == "ralph_starter"
+
+
+@pytest.mark.asyncio
+async def test_ralph_resume_oscillation_enters_unstuck_lateral_when_wired(tmp_path) -> None:
+    """L5-a applies to persisted resume polling, not only fresh handoff.
+
+    A client can disconnect after Ralph dispatch and resume only after the
+    background Ralph job has already reached ``oscillation_detected``. That
+    terminal snapshot has the same producer contract as the live handoff
+    result, so it must enter ``UNSTUCK_LATERAL`` instead of reverting to the
+    legacy direct-BLOCKED mapping.
+    """
+    state = _state_in_ralph_handoff(tmp_path)
+    captured_calls: list[dict[str, Any]] = []
+
+    async def ralph_resumer(*, job_id: str) -> dict[str, Any]:
+        return {
+            "job_id": job_id,
+            "lineage_id": state.ralph_lineage_id,
+            "dispatch_mode": "job",
+            "terminal_status": "failed",
+            "stop_reason": "oscillation_detected",
+        }
+
+    async def ralph_starter(_seed: Seed, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "job_id": "job_ralph_recovery",
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    async def lateral_thinker(**kwargs: Any) -> LateralResult:
+        captured_calls.append(dict(kwargs))
+        return LateralResult(
+            persona="architect",
+            approach_summary="Architect: break the oscillation loop",
+            text="The resumed Ralph snapshot still needs spec reframing.",
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        ralph_resumer=ralph_resumer,
+        complete_product=True,
+        lateral_thinker=lateral_thinker,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert captured_calls, "resume poll did not invoke lateral_thinker"
+    differences_text = str(captured_calls[0].get("qa_differences"))
+    assert "oscillat" in differences_text.lower()
+    assert state.last_lateral_persona == "architect"
+
+
+@pytest.mark.asyncio
+async def test_ralph_reattach_oscillation_enters_unstuck_lateral_when_wired(tmp_path) -> None:
+    """L5-a also applies to the direct re-attach terminal consumer.
+
+    ``_reattach_ralph_job`` observes a Ralph job that was already dispatched
+    before process death. If that observation returns ``oscillation_detected``,
+    it must share the same lateral recovery route as fresh handoff and resume
+    polling.
+    """
+    state = _state_in_ralph_handoff(tmp_path)
+    captured_calls: list[dict[str, Any]] = []
+    captured_attach: dict[str, Any] = {}
+
+    async def ralph_starter(_seed: Seed | None, **kwargs: Any) -> dict[str, Any]:
+        if "attach_job_id" not in kwargs:
+            return {
+                "job_id": "job_ralph_recovery",
+                "lineage_id": kwargs["lineage_id"],
+                "dispatch_mode": "job",
+                "terminal_status": "completed",
+                "stop_reason": "qa passed",
+            }
+        captured_attach.update(kwargs)
+        return {
+            "job_id": kwargs["attach_job_id"],
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "failed",
+            "stop_reason": "oscillation_detected",
+        }
+
+    async def lateral_thinker(**kwargs: Any) -> LateralResult:
+        captured_calls.append(dict(kwargs))
+        return LateralResult(
+            persona="architect",
+            approach_summary="Architect: reframe re-attached oscillation",
+            text="The re-attached Ralph result still needs lateral recovery.",
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+        lateral_thinker=lateral_thinker,
+    )
+
+    result = await pipeline._reattach_ralph_job(state, ledger=SeedDraftLedger.from_goal(state.goal))
+
+    assert captured_attach["attach_job_id"] == "job_ralph_existing"
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert captured_calls, "re-attach did not invoke lateral_thinker"
+    differences_text = str(captured_calls[0].get("qa_differences"))
+    assert "oscillat" in differences_text.lower()
+    assert state.last_lateral_persona == "architect"


### PR DESCRIPTION
## Summary

Follow-up correction to merged PR #1175 after the latest ouroboros-agent review correctly identified a persistence/replay contract gap.

PR #1175 implemented the L5-a live handoff route:

`Ralph failed + stop_reason="oscillation_detected" + complete_product + lateral_thinker -> UNSTUCK_LATERAL`

but the same Ralph terminal status could still be consumed by resume polling and the direct re-attach observer as a legacy direct `BLOCKED` outcome. Since #1157 defines L5-a as plumbing Ralph's existing `oscillation_detected` signal into the existing `ooo unstuck` substrate, the terminal consumer boundary needs to be consistent across fresh handoff, resume polling, and re-attach.

## What changed

- Added one shared helper in `src/ouroboros/auto/pipeline.py` for the L5-a Ralph oscillation route.
- Reused that helper from:
  - fresh `_handoff_to_ralph`,
  - `_poll_ralph_job` resume polling,
  - `_reattach_ralph_job` terminal observation.
- Recovered the persisted Seed artifact when a replay/re-attach path does not already have a `Seed` object in hand.
- Added regression tests proving resume polling and re-attach both invoke lateral recovery for `oscillation_detected` and can continue into the existing recovery redispatch path.

## Why this stays minimal-substrate

This intentionally does **not** add a new escalation ladder, new detector, new terminal taxonomy, or new state machine. It only makes the existing L5-a route single-sourced across the three existing Ralph terminal consumers. Other Ralph blocked reasons (`iteration_timeout`, `wall_clock_exhausted`, `grade_regressing`, `max_generations reached`) still go directly to `BLOCKED` as budget/regression terminals.

## Verification

- `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OUROBOROS_AI=0.0.0 SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run pytest tests/unit/auto/test_pipeline_oscillation_lateral.py tests/unit/auto/test_pipeline_ralph_handoff.py -q` → 46 passed
- `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OUROBOROS_AI=0.0.0 SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run pytest tests/unit/auto -q` → 907 passed
- `uv run ruff check src/ouroboros/auto/pipeline.py tests/unit/auto/test_pipeline_oscillation_lateral.py` → clean
- `uv run ruff format --check src/ouroboros/auto/pipeline.py tests/unit/auto/test_pipeline_oscillation_lateral.py` → clean
- `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_OUROBOROS_AI=0.0.0 SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run mypy src/ouroboros/auto/pipeline.py` → clean

Refs #1175, #1157, #961.
