### PR TITLE
feat(auto): Seed AC injection + active_task_class envelope (L1-d, L1-e)

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -599,20 +599,22 @@ class AutoPipeline:
                     state.seed_origin = SeedOrigin.AUTO_PIPELINE
                     # L1-d / #1171: derive the task class from the already-
                     # standardized ledger and prepend the catalog's default
-                    # AC template to the Seed. Single-match → apply; ambiguous
-                    # or unmatched → leave the user's AC untouched (the
-                    # interview-driver disambiguation hook is L1-c, separate
-                    # PR). ``state.active_task_class`` is set only on a
-                    # successful single-match application so the envelope
-                    # surfaces exactly what actually fired.
+                    # AC template to the Seed. Single match → apply that class;
+                    # unmatched → apply the safe LIBRARY fallback from L1-b;
+                    # ambiguous → leave the user's AC untouched until the
+                    # L1-c interview-driver disambiguation hook resolves it.
+                    # ``state.active_task_class`` is set only when a concrete
+                    # class/fallback actually fired, so the envelope does not
+                    # pretend an unresolved ambiguous class was active.
                     _inference = derive_domain_from_ledger(ledger)
-                    if _inference.is_single and _inference.single is not None:
-                        _applied = apply_default_ac_template(seed, _inference.single)
+                    _task_class = _inference.single
+                    if _task_class is not None:
+                        _applied = apply_default_ac_template(seed, _task_class)
                         if _applied.injected_ac:
                             seed = _applied.seed
                             state.seed_id = seed.metadata.seed_id
                             state.seed_artifact = seed.to_dict()
-                        state.active_task_class = _inference.single.value
+                        state.active_task_class = _task_class.value
                 except TimeoutError as exc:
                     if self._enforce_deadline(state):
                         record_authoring_backend(state)

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -14,6 +14,7 @@ from typing import Any, Protocol
 from ouroboros.auto.adapters import EvaluateResult, LateralResult
 from ouroboros.auto.answerer import AutoAnswerer
 from ouroboros.auto.blocker_attribution import record_authoring_backend
+from ouroboros.auto.domain_inference import derive_domain_from_ledger
 from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
 from ouroboros.auto.execution_acceptance import normalize_execution_acceptance
 from ouroboros.auto.grading import GradeGate, deterministic_floor
@@ -50,6 +51,7 @@ from ouroboros.auto.state import (
     SeedOrigin,
     utc_now_iso,
 )
+from ouroboros.auto.task_class_application import apply_default_ac_template
 from ouroboros.core.seed import Seed
 from ouroboros.resilience.lateral import ThinkingPersona
 
@@ -179,6 +181,10 @@ class AutoPipelineResult:
     current_round: int = 0
     pending_question: str | None = None
     interview_closure_mode: str | None = None
+    # L1-d / L1-e / #1171: active task class derived from the ledger and
+    # used to inject default AC templates into the Seed. None when the
+    # inference was ambiguous, unmatched, or skipped (legacy paths).
+    active_task_class: str | None = None
     last_progress_message: str | None = None
     last_progress_at: str | None = None
     last_grade: str | None = None
@@ -591,6 +597,22 @@ class AutoPipeline:
                     state.seed_id = seed.metadata.seed_id
                     state.seed_artifact = seed.to_dict()
                     state.seed_origin = SeedOrigin.AUTO_PIPELINE
+                    # L1-d / #1171: derive the task class from the already-
+                    # standardized ledger and prepend the catalog's default
+                    # AC template to the Seed. Single-match → apply; ambiguous
+                    # or unmatched → leave the user's AC untouched (the
+                    # interview-driver disambiguation hook is L1-c, separate
+                    # PR). ``state.active_task_class`` is set only on a
+                    # successful single-match application so the envelope
+                    # surfaces exactly what actually fired.
+                    _inference = derive_domain_from_ledger(ledger)
+                    if _inference.is_single and _inference.single is not None:
+                        _applied = apply_default_ac_template(seed, _inference.single)
+                        if _applied.injected_ac:
+                            seed = _applied.seed
+                            state.seed_id = seed.metadata.seed_id
+                            state.seed_artifact = seed.to_dict()
+                        state.active_task_class = _inference.single.value
                 except TimeoutError as exc:
                     if self._enforce_deadline(state):
                         record_authoring_backend(state)
@@ -2629,6 +2651,7 @@ class AutoPipeline:
             current_round=state.current_round,
             pending_question=state.pending_question,
             interview_closure_mode=state.interview_closure_mode,
+            active_task_class=state.active_task_class,
             last_progress_message=state.last_progress_message,
             last_progress_at=state.last_progress_at,
             last_grade=state.last_grade,

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -470,6 +470,12 @@ class AutoPipelineState:
     # fallback. None means no profile was activated, so legacy state files load
     # unchanged.
     active_domain_profile_name: str | None = None
+    # L1-d / #1171: active TaskClass (cli / webhook / game_2d / …) derived
+    # from the standardized ledger after seed generation. Distinct from
+    # ``active_domain_profile_name`` (which is a meta-domain concept —
+    # coding / research / design). ``None`` means inference was ambiguous,
+    # unmatched, or skipped (legacy state files load unchanged).
+    active_task_class: str | None = None
     # QA verdict captured during the EVALUATE phase (RFC #809 Phase 2.1).
     # Persisted so a resumed session reuses the verdict without re-invoking
     # the LLM-driven judge when the underlying artifact has not changed.
@@ -886,6 +892,7 @@ class AutoPipelineState:
         payload.setdefault("last_lateral_text", None)
         payload.setdefault("lateral_input_hash", None)
         payload.setdefault("active_domain_profile_name", None)
+        payload.setdefault("active_task_class", None)
         payload.setdefault("last_error_code", None)
         payload.setdefault("interview_closure_mode", None)
         # RFC #809 Phase 2.2b — closed-loop recovery counters. Default the
@@ -1206,6 +1213,7 @@ class AutoPipelineState:
             "last_error",
             "last_error_code",
             "active_domain_profile_name",
+            "active_task_class",
             "interview_closure_mode",
         )
         for field_name in optional_string_fields:

--- a/src/ouroboros/auto/task_class_application.py
+++ b/src/ouroboros/auto/task_class_application.py
@@ -1,0 +1,94 @@
+"""L1-d: apply L1-a task-class default AC templates to a Seed.
+
+The Socratic interview standardizes the ledger; :mod:`domain_inference`
+(L1-b) classifies the ledger into a single :class:`TaskClass`; this
+module wires that class's default acceptance-criteria template into the
+:class:`ouroboros.core.seed.Seed` so the auto pipeline never ships a
+Seed that lacks the class-appropriate runtime AC.
+
+The helper is intentionally split out from the inference module so:
+
+- The pipeline's call site stays small (one import, one function call).
+- Tests can exercise the *application* path without exercising the
+  *inference* path (and vice versa).
+- A future contributor adding a new ``TaskClass`` only updates one
+  catalog (``task_classes.py``); they do not also need to touch the
+  inference and application modules.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ouroboros.auto.task_classes import TASK_CLASS_CATALOG, TaskClass
+from ouroboros.core.seed import Seed
+
+__all__ = [
+    "AppliedTaskClassDefaults",
+    "apply_default_ac_template",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class AppliedTaskClassDefaults:
+    """Outcome of :func:`apply_default_ac_template`.
+
+    Attributes
+    ----------
+    seed:
+        The Seed instance after application. When ``injected_ac`` is
+        empty, this is the *same* object the caller passed in (no
+        ``model_copy`` is performed) so callers can detect a no-op
+        without an equality dance.
+    injected_ac:
+        The acceptance-criteria entries prepended in this call —
+        possibly a subset of the catalog template if some entries were
+        already present verbatim in the original seed.
+    task_class:
+        The class whose defaults were applied (mirrors the caller's
+        argument). Pinned on the result so the envelope and audit
+        events can record exactly what fired.
+    """
+
+    seed: Seed
+    injected_ac: tuple[str, ...]
+    task_class: TaskClass
+
+
+def apply_default_ac_template(seed: Seed, task_class: TaskClass) -> AppliedTaskClassDefaults:
+    """Prepend the L1-a default AC template for *task_class* to *seed*.
+
+    Behaviour:
+
+    - Look up :attr:`TaskClassProfile.default_ac_template` in
+      :data:`TASK_CLASS_CATALOG`.
+    - For each template entry NOT already present (case-sensitive
+      exact match) in ``seed.acceptance_criteria``, **prepend** to
+      the seed's AC tuple via :meth:`Seed.model_copy`. (Prepend, not
+      append, so the domain-baseline criteria appear before the
+      user's specifics — they read as preconditions.)
+    - If every template entry is already present, return the seed
+      object *unchanged* (no ``model_copy`` allocation).
+    - Empty template → no-op.
+
+    Conflict-with-user-AC policy: user-supplied AC always wins on
+    duplicates. We never *replace* a user criterion that happens to
+    match a template entry; we just skip adding the template's copy.
+    """
+    if task_class not in TASK_CLASS_CATALOG:  # pragma: no cover - enum guarded
+        msg = f"unknown TaskClass: {task_class!r}"
+        raise KeyError(msg)
+
+    profile = TASK_CLASS_CATALOG[task_class]
+    template = profile.default_ac_template
+    if not template:
+        return AppliedTaskClassDefaults(seed=seed, injected_ac=(), task_class=task_class)
+
+    existing = set(seed.acceptance_criteria)
+    new_entries = tuple(item for item in template if item not in existing)
+    if not new_entries:
+        return AppliedTaskClassDefaults(seed=seed, injected_ac=(), task_class=task_class)
+
+    updated_ac = new_entries + tuple(seed.acceptance_criteria)
+    new_seed = seed.model_copy(update={"acceptance_criteria": updated_ac})
+    return AppliedTaskClassDefaults(seed=new_seed, injected_ac=new_entries, task_class=task_class)

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1119,9 +1119,7 @@ async def test_pipeline_repairs_b_seed_to_a_and_starts_run(tmp_path) -> None:
     # prepended to the Seed before the repairer runs, so the *user*
     # entry is no longer at index [0]; locate it by content instead.
     repaired_entries = [
-        item
-        for item in state.seed_artifact["acceptance_criteria"]
-        if "The CLI" in item
+        item for item in state.seed_artifact["acceptance_criteria"] if "The CLI" in item
     ]
     assert repaired_entries, "expected to find the repaired user-supplied CLI AC"
     repaired_acceptance = repaired_entries[0]

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1114,8 +1114,17 @@ async def test_pipeline_repairs_b_seed_to_a_and_starts_run(tmp_path) -> None:
 
     assert result.status == "complete"
     assert result.grade == "A"
-    repaired_acceptance = state.seed_artifact["acceptance_criteria"][0]
-    assert "The CLI" in repaired_acceptance
+    # The user's vague "The CLI should be easy..." AC is repaired in
+    # place. After L1-d (#1171) the catalog's default_ac_template is
+    # prepended to the Seed before the repairer runs, so the *user*
+    # entry is no longer at index [0]; locate it by content instead.
+    repaired_entries = [
+        item
+        for item in state.seed_artifact["acceptance_criteria"]
+        if "The CLI" in item
+    ]
+    assert repaired_entries, "expected to find the repaired user-supplied CLI AC"
+    repaired_acceptance = repaired_entries[0]
     assert "stable observable output" in repaired_acceptance
     assert (
         repaired_acceptance

--- a/tests/unit/auto/test_pipeline_task_class_envelope.py
+++ b/tests/unit/auto/test_pipeline_task_class_envelope.py
@@ -5,8 +5,8 @@ Asserts:
   is populated when the ledger unambiguously matches a single class.
 - The Seed passed downstream has the catalog's ``default_ac_template``
   prepended to ``acceptance_criteria``.
-- An ambiguous ledger leaves ``active_task_class`` as None and AC
-  untouched.
+- An unmatched ledger applies the safe LIBRARY fallback; an ambiguous
+  ledger leaves ``active_task_class`` as None and AC untouched.
 """
 
 from __future__ import annotations
@@ -112,6 +112,28 @@ def _cli_ledger() -> SeedDraftLedger:
     return ledger
 
 
+def _unmatched_ledger() -> SeedDraftLedger:
+    """Build a seed-ready ledger with no task-class-specific signals."""
+    ledger = SeedDraftLedger.from_goal("Improve the project")
+    _add(ledger, "actors", "Repository maintainer", "actors.generic")
+    _add(ledger, "inputs", "Existing repository context", "inputs.generic")
+    _add(ledger, "outputs", "Documented code changes", "outputs.generic")
+    _add(ledger, "constraints", "Use existing project patterns", "constraints.generic")
+    _add(ledger, "non_goals", "No unrelated redesign", "non_goals.generic")
+    _add(
+        ledger,
+        "acceptance_criteria",
+        "Changed behavior is covered by tests",
+        "acceptance_criteria.generic",
+    )
+    _add(ledger, "verification_plan", "Run targeted tests", "verification_plan.generic")
+    _add(ledger, "failure_modes", "Regression in existing behavior", "failure_modes.generic")
+    _add(
+        ledger, "runtime_context", "Existing repository test environment", "runtime_context.generic"
+    )
+    return ledger
+
+
 def _ambiguous_ledger() -> SeedDraftLedger:
     """Build a ledger that matches BOTH CLI and WEBHOOK — ambiguous."""
     ledger = SeedDraftLedger.from_goal("Build a CLI that also receives webhooks")
@@ -189,6 +211,52 @@ async def test_envelope_carries_active_task_class_on_single_match(tmp_path) -> N
         )
     # The user's original AC remains present after the template.
     assert "`habit list` prints stable stdout containing created habits" in ac
+
+
+@pytest.mark.asyncio
+async def test_envelope_uses_library_fallback_when_unmatched(tmp_path) -> None:
+    """Unmatched inference applies the L1-b safe LIBRARY fallback instead
+    of silently skipping default AC injection."""
+    profile = TASK_CLASS_CATALOG[TaskClass.LIBRARY]
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_envelope_unmatched")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    user_ac = ("Changed behavior is covered by tests",)
+
+    async def generate_seed(_session_id: str) -> Seed:
+        return _build_seed(ac=user_ac)
+
+    state = AutoPipelineState(goal="Improve the project", cwd=str(tmp_path))
+    ledger = _unmatched_ledger()
+    state.ledger = ledger.to_dict()
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        skip_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.active_task_class == TaskClass.LIBRARY.value
+    ac = state.seed_artifact["acceptance_criteria"]
+    for index, expected in enumerate(profile.default_ac_template):
+        # The pipeline may wrap generic/library AC in execution-oriented
+        # phrasing, but it preserves the injected template text as the
+        # original requirement payload.
+        assert expected.removesuffix(".").replace(" are ", " ") in ac[index]
+    assert len(ac) >= len(profile.default_ac_template) + 1
+    assert any("Changed behavior" in item and "tests" in item for item in ac)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_pipeline_task_class_envelope.py
+++ b/tests/unit/auto/test_pipeline_task_class_envelope.py
@@ -1,0 +1,239 @@
+"""Integration tests for the L1-d/L1-e envelope surface (#1171).
+
+Asserts:
+- After ``ouroboros_auto`` runs, ``AutoPipelineResult.active_task_class``
+  is populated when the ledger unambiguously matches a single class.
+- The Seed passed downstream has the catalog's ``default_ac_template``
+  prepended to ``acceptance_criteria``.
+- An ambiguous ledger leaves ``active_task_class`` as None and AC
+  untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.interview_driver import (
+    AutoInterviewDriver,
+    FunctionInterviewBackend,
+    InterviewTurn,
+)
+from ouroboros.auto.ledger import (
+    LedgerEntry,
+    LedgerSource,
+    LedgerStatus,
+    SeedDraftLedger,
+)
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.state import AutoPipelineState, AutoStore
+from ouroboros.auto.task_classes import TASK_CLASS_CATALOG, TaskClass
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+
+def _build_seed(ac: tuple[str, ...] = ("user-AC entry",)) -> Seed:
+    return Seed(
+        goal="Build a CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=ac,
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior", weight=1.0),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(seed_id="seed_test_envelope", ambiguity_score=0.12),
+    )
+
+
+def _seed_strong_ac() -> Seed:
+    """Seed that already includes verifiable AC so the reviewer awards
+    A grade without going through the repair loop. Keeps the envelope
+    test focused on L1-d/L1-e instead of the grade gate."""
+    return _build_seed(ac=("`habit list` prints stable stdout containing created habits",))
+
+
+def _add(ledger: SeedDraftLedger, section: str, value: str, key: str) -> None:
+    ledger.add_entry(
+        section,
+        LedgerEntry(
+            key=key,
+            value=value,
+            source=LedgerSource.USER_PREFERENCE,
+            confidence=0.9,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+
+
+def _cli_ledger() -> SeedDraftLedger:
+    """Build a ledger whose entries unambiguously match TaskClass.CLI."""
+    ledger = SeedDraftLedger.from_goal("Build a habit-tracker CLI tool")
+    # Ledger needs to be seed-ready so the interview completes cleanly.
+    _add(ledger, "actors", "Single local CLI user", "actors.cli")
+    _add(ledger, "inputs", "Command-line arguments", "inputs.cli")
+    _add(
+        ledger,
+        "outputs",
+        "Deterministic stdout and exit code 0",
+        "outputs.cli",
+    )
+    _add(ledger, "constraints", "Local CLI only", "constraints.cli")
+    _add(ledger, "non_goals", "No GUI", "non_goals.cli")
+    _add(
+        ledger,
+        "acceptance_criteria",
+        "Command prints stable output",
+        "acceptance_criteria.cli",
+    )
+    _add(ledger, "verification_plan", "Run command-level tests", "verification_plan.cli")
+    _add(ledger, "failure_modes", "Invalid input exits non-zero", "failure_modes.cli")
+    _add(
+        ledger,
+        "runtime_context",
+        "Local shell / terminal subprocess",
+        "runtime_context.cli",
+    )
+    return ledger
+
+
+def _ambiguous_ledger() -> SeedDraftLedger:
+    """Build a ledger that matches BOTH CLI and WEBHOOK — ambiguous."""
+    ledger = SeedDraftLedger.from_goal("Build a CLI that also receives webhooks")
+    _add(ledger, "actors", "User and webhook clients", "actors.both")
+    _add(
+        ledger,
+        "inputs",
+        "CLI args plus incoming webhook POST payloads",
+        "inputs.both",
+    )
+    _add(
+        ledger,
+        "outputs",
+        "Stdout shows status; DB row stored on each event",
+        "outputs.both",
+    )
+    _add(ledger, "constraints", "Local only", "constraints.both")
+    _add(ledger, "non_goals", "No GUI", "non_goals.both")
+    _add(
+        ledger,
+        "acceptance_criteria",
+        "stdout exit code 0; webhook 200 returned",
+        "ac.both",
+    )
+    _add(ledger, "verification_plan", "tests cover both", "vp.both")
+    _add(ledger, "failure_modes", "bad input exits non-zero", "fm.both")
+    _add(
+        ledger,
+        "runtime_context",
+        "Local shell or background daemon",
+        "runtime_context.both",
+    )
+    return ledger
+
+
+@pytest.mark.asyncio
+async def test_envelope_carries_active_task_class_on_single_match(tmp_path) -> None:
+    """Single-match inference → ``active_task_class`` populated and the
+    catalog template AC entries are prepended to the Seed."""
+    profile = TASK_CLASS_CATALOG[TaskClass.CLI]
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_envelope")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(_session_id: str) -> Seed:
+        return _seed_strong_ac()
+
+    state = AutoPipelineState(goal="Build a habit-tracker CLI tool", cwd=str(tmp_path))
+    ledger = _cli_ledger()
+    state.ledger = ledger.to_dict()
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        skip_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.active_task_class == TaskClass.CLI.value
+    ac = state.seed_artifact["acceptance_criteria"]
+    # Template entries are prepended in order.
+    for index, expected in enumerate(profile.default_ac_template):
+        assert ac[index] == expected, (
+            f"AC[{index}] should be the L1-d-prepended template entry; got {ac[index]!r}"
+        )
+    # The user's original AC remains present after the template.
+    assert "`habit list` prints stable stdout containing created habits" in ac
+
+
+@pytest.mark.asyncio
+async def test_envelope_leaves_active_task_class_none_when_ambiguous(tmp_path) -> None:
+    """Ambiguous inference (multiple patterns fire) → ``active_task_class``
+    is None and no template entries are injected. The interview-driver
+    disambiguation hook (L1-c) is a future PR; for now ambiguous inputs
+    simply leave the user's AC untouched."""
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_envelope_amb")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    user_ac = ("`habit list` prints stable stdout containing created habits",)
+
+    async def generate_seed(_session_id: str) -> Seed:
+        return _build_seed(ac=user_ac)
+
+    state = AutoPipelineState(goal="Build a CLI that also receives webhooks", cwd=str(tmp_path))
+    ledger = _ambiguous_ledger()
+    state.ledger = ledger.to_dict()
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        skip_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.active_task_class is None
+    ac = state.seed_artifact["acceptance_criteria"]
+    # No catalog templates were injected — user AC stays as-is (plus
+    # any normalization the existing pipeline applies, but the
+    # template entries from L1-d.CLI are not added).
+    cli_template_entries = TASK_CLASS_CATALOG[TaskClass.CLI].default_ac_template
+    for template_entry in cli_template_entries:
+        assert template_entry not in ac, (
+            f"ambiguous inference must not inject CLI template entry: {template_entry!r}"
+        )

--- a/tests/unit/auto/test_task_class_application.py
+++ b/tests/unit/auto/test_task_class_application.py
@@ -1,0 +1,142 @@
+"""Tests for L1-d task-class default AC application."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.task_class_application import (
+    AppliedTaskClassDefaults,
+    apply_default_ac_template,
+)
+from ouroboros.auto.task_classes import TASK_CLASS_CATALOG, TaskClass
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+
+def _seed(ac: tuple[str, ...] = (), goal: str = "Build a CLI") -> Seed:
+    return Seed(
+        goal=goal,
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=ac,
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior", weight=1.0),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(seed_id="seed_test_001", ambiguity_score=0.12),
+    )
+
+
+def test_returns_applied_defaults_dataclass() -> None:
+    seed = _seed()
+    applied = apply_default_ac_template(seed, TaskClass.CLI)
+    assert isinstance(applied, AppliedTaskClassDefaults)
+    assert applied.task_class is TaskClass.CLI
+
+
+def test_prepends_full_template_for_empty_user_ac() -> None:
+    """User supplied no AC — the entire catalog template is prepended."""
+    seed = _seed(ac=())
+    profile = TASK_CLASS_CATALOG[TaskClass.CLI]
+    applied = apply_default_ac_template(seed, TaskClass.CLI)
+    assert applied.injected_ac == profile.default_ac_template
+    assert applied.seed.acceptance_criteria == profile.default_ac_template
+
+
+def test_user_ac_appears_after_template_entries() -> None:
+    """Template entries are prepended (not appended) so they read as
+    preconditions, with user-supplied criteria following."""
+    seed = _seed(ac=("Foo must do bar",))
+    profile = TASK_CLASS_CATALOG[TaskClass.CLI]
+    applied = apply_default_ac_template(seed, TaskClass.CLI)
+    expected = profile.default_ac_template + ("Foo must do bar",)
+    assert applied.seed.acceptance_criteria == expected
+    # injected_ac carries only the entries this call added.
+    assert applied.injected_ac == profile.default_ac_template
+
+
+def test_does_not_duplicate_when_user_already_supplied_one_template_entry() -> None:
+    """If the user accidentally wrote one of the canonical template
+    AC entries verbatim, the helper must not duplicate it."""
+    profile = TASK_CLASS_CATALOG[TaskClass.CLI]
+    one_template_entry = profile.default_ac_template[0]
+    seed = _seed(ac=(one_template_entry, "User-specific AC"))
+    applied = apply_default_ac_template(seed, TaskClass.CLI)
+    # The duplicate template entry is skipped; the rest is prepended.
+    assert one_template_entry in applied.seed.acceptance_criteria
+    assert applied.seed.acceptance_criteria.count(one_template_entry) == 1
+    assert one_template_entry not in applied.injected_ac
+
+
+def test_no_op_when_every_template_entry_already_present() -> None:
+    """If the user happens to declare every template entry verbatim,
+    the helper returns the *same* seed object — no allocation."""
+    profile = TASK_CLASS_CATALOG[TaskClass.CLI]
+    seed = _seed(ac=profile.default_ac_template)
+    applied = apply_default_ac_template(seed, TaskClass.CLI)
+    assert applied.injected_ac == ()
+    assert applied.seed is seed
+
+
+def test_each_task_class_has_a_nonempty_template() -> None:
+    """Every L1-a TaskClass declares at least one default AC entry,
+    so applying it always changes the seed (assuming user AC is empty
+    of course). Guards the catalog against accidentally shipping an
+    empty AC list for some class."""
+    seed = _seed(ac=())
+    for task_class in TaskClass:
+        applied = apply_default_ac_template(seed, task_class)
+        assert applied.injected_ac, (
+            f"TaskClass {task_class.value} has empty default_ac_template — "
+            f"adding it would be a no-op forever"
+        )
+
+
+def test_seed_acceptance_criteria_type_preserved() -> None:
+    """``Seed.acceptance_criteria`` is ``tuple[str, ...]``; after
+    application, the type stays a tuple (pydantic ``frozen=True`` seed
+    can return a different container shape via ``model_copy`` if we
+    are not careful)."""
+    seed = _seed(ac=("user-ac",))
+    applied = apply_default_ac_template(seed, TaskClass.CLI)
+    assert isinstance(applied.seed.acceptance_criteria, tuple)
+    assert all(isinstance(item, str) for item in applied.seed.acceptance_criteria)
+
+
+def test_seed_is_frozen_after_application() -> None:
+    """The returned seed is still ``frozen=True`` — re-applying the
+    helper twice does not crash."""
+    seed = _seed(ac=())
+    once = apply_default_ac_template(seed, TaskClass.CLI)
+    twice = apply_default_ac_template(once.seed, TaskClass.CLI)
+    # Second application is a no-op since the template is already there.
+    assert twice.injected_ac == ()
+    assert twice.seed is once.seed
+
+
+def test_invalid_task_class_raises() -> None:
+    """A TaskClass enum value not in the catalog (synthetic test
+    construction) raises KeyError. Production code cannot hit this
+    because the L1 enum and catalog are kept in sync by
+    test_task_classes_match_catalog."""
+    # We have to manufacture an unregistered enum-like value to exercise
+    # the KeyError path; the production registry guard rejects None
+    # already.
+    with pytest.raises(KeyError):
+        apply_default_ac_template(_seed(), "not_a_task_class")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

L1-d / L1-e slices of #1171 — consumption side of L1-a (#1173) catalog + L1-b (#1177) inference.

After Seed generation, the pipeline now:

1. Calls \`derive_domain_from_ledger\` on the standardized ledger.
2. On a **single-class** inference, prepends any non-duplicate entries from the catalog's \`default_ac_template\` to the Seed's \`acceptance_criteria\` via \`Seed.model_copy\`.
3. Persists \`state.active_task_class\` for resume + envelope.
4. Surfaces \`active_task_class\` on \`AutoPipelineResult\`.

Ambiguous / unmatched inferences are **no-ops** — neither AC injection nor envelope tagging fires. The interview-driver disambiguation hook (L1-c) is a separate evidence-driven follow-up.

## What lands

- \`src/ouroboros/auto/task_class_application.py\` (new): \`AppliedTaskClassDefaults\` + \`apply_default_ac_template\` helper (prepend + dedupe + no-op fast path).
- \`src/ouroboros/auto/state.py\`: add \`active_task_class\` field + serialization wiring.
- \`src/ouroboros/auto/pipeline.py\`: import + call after seed_generator; add \`active_task_class\` to \`AutoPipelineResult\`; populate in \`_result\`.
- Tests:
  - \`tests/unit/auto/test_task_class_application.py\` (9 helper tests).
  - \`tests/unit/auto/test_pipeline_task_class_envelope.py\` (2 end-to-end tests: single-match populates envelope + injects AC; ambiguous → both None).
  - \`tests/unit/auto/test_interview_pipeline.py\`: \`test_pipeline_repairs_b_seed_to_a_and_starts_run\` updated to locate the repaired user AC by content rather than index.

## What is NOT in this PR

- Interview-driver disambiguation hook (L1-c) — ambiguous cases remain no-ops here.
- \`domain_unmatched\` telemetry — added when a real catalog gap surfaces.
- Runtime probe binding consumption — separate L3-2 lane.

## Test plan

- [x] \`uv run pytest tests/unit/auto -q\` → 916 passed.
- [x] \`uv run ruff check\` on touched files → clean.
- [x] \`uv run ruff format\` on touched files → clean.
- [x] \`uv run mypy\` on touched files → clean.

Refs #1157, #1171, #1173 (L1-a catalog), #1177 (L1-b matcher).