### PR TITLE
feat(auto): wall-clock watchdog integration in AutoPipeline (L2-2)

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import asdict, dataclass, field
+from datetime import datetime
 import inspect
 import threading
 import time
@@ -52,6 +53,10 @@ from ouroboros.auto.state import (
 )
 from ouroboros.core.seed import Seed
 from ouroboros.resilience.lateral import ThinkingPersona
+from ouroboros.runtime.watchdog import (
+    WATCHDOG_STOP_REASON_CODE,
+    Watchdog,
+)
 
 # RFC #809 Phase 2.2b — Stack 1 of 2 scope and invariants.
 #
@@ -284,6 +289,14 @@ class AutoPipeline:
     # the raw QA differences. See :class:`HandlerLateralThinker` in
     # adapters.py for the production wiring.
     lateral_thinker: LateralThinker | None = None
+    # L2-2 / #1172: wall-clock watchdog for the session. ``None`` means
+    # no watchdog (legacy behaviour). When wired, the pipeline checks
+    # ``watchdog.check(...)`` at ``run()`` entry; on fire the session
+    # transitions to BLOCKED with
+    # ``stop_reason_code = "watchdog_wall_clock_exceeded"``. The cancel
+    # event has already been appended to the EventStore by the watchdog
+    # itself, so the pipeline does no further side effect on fire.
+    watchdog: Watchdog | None = None
     _last_emitted_phase: str | None = field(default=None, init=False, repr=False)
     _last_emitted_grade: str | None = field(default=None, init=False, repr=False)
     _last_emitted_repair: int | None = field(default=None, init=False, repr=False)
@@ -303,6 +316,16 @@ class AutoPipeline:
             if state.ledger
             else SeedDraftLedger.from_goal(state.goal)
         )
+        # L2-2 / #1172: wall-clock watchdog check.
+        # Runs once per ``run()`` entry — both fresh sessions whose
+        # ``created_at`` is too long ago (resume after budget elapsed)
+        # and live sessions whose execution chose to re-enter the loop
+        # are caught here. The watchdog appends its ``runtime.watchdog.cancel``
+        # event itself; the pipeline only translates the decision into
+        # the BLOCKED transition + envelope ``stop_reason_code``.
+        watchdog_result = await self._check_watchdog(state, ledger)
+        if watchdog_result is not None:
+            return watchdog_result
         if self.skip_run and not state.skip_run:
             state.skip_run = True
         # Q00/ouroboros#773 (review-3): ``complete_product`` is durable session
@@ -1081,6 +1104,53 @@ class AutoPipeline:
             # timeout and no-handle paths share this same retry slot.
             self._save(state)
             retried = True
+
+    async def _check_watchdog(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+    ) -> AutoPipelineResult | None:
+        """L2-2 / #1172: wall-clock watchdog check at ``run()`` entry.
+
+        Returns:
+
+        - ``None`` if no watchdog is wired, or the watchdog did not
+          fire — the pipeline proceeds normally.
+        - A BLOCKED :class:`AutoPipelineResult` if the watchdog fired —
+          ``state.last_error_code`` is set to
+          :data:`WATCHDOG_STOP_REASON_CODE` so the envelope surface
+          (already plumbed by L4 / #1151) reports the typed terminal.
+
+        The watchdog itself owns the EventStore-side ``runtime.watchdog.cancel``
+        append; this helper only converts a returned ``WatchdogDecision``
+        into pipeline state transitions.
+        """
+        if self.watchdog is None:
+            return None
+        try:
+            started_at = datetime.fromisoformat(state.created_at)
+        except (TypeError, ValueError):
+            # A malformed ``created_at`` is a pre-watchdog state-validation
+            # concern; do not let the watchdog crash the run.
+            return None
+        decision = await self.watchdog.check(
+            session_id=state.auto_session_id,
+            session_started_at=started_at,
+        )
+        if decision is None:
+            return None
+        blocker = (
+            f"runtime watchdog cancelled session after "
+            f"{decision.elapsed_seconds}s (budget "
+            f"{decision.configured_budget_seconds}s)"
+        )
+        state.mark_blocked(
+            blocker,
+            tool_name="runtime_watchdog",
+            error_code=WATCHDOG_STOP_REASON_CODE,
+        )
+        self._save(state)
+        return self._result(state, ledger, blocker=state.last_error)
 
     def _deadline_capped_timeout(self, state: AutoPipelineState, phase_timeout: float) -> float:
         """Return ``phase_timeout`` capped by the remaining pipeline deadline.

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -47,6 +47,9 @@ from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, Intervie
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.orchestrator import resolve_agent_runtime_backend
+from ouroboros.persistence.event_store import EventStore
+from ouroboros.runtime.controls import load_runtime_controls
+from ouroboros.runtime.watchdog import Watchdog
 
 _STALE_COMPLETED_RALPH_HANDOFF_STATUSES = frozenset(
     {RUN_HANDOFF_STARTED_STATUS, "ralph_retry_after_blocker"}
@@ -498,6 +501,12 @@ async def _run_auto(
     # state forever. Sharing the handler reuses the same ``JobManager``
     # (and underlying ``EventStore``) so the poller sees the persisted job.
     ralph_resumer = HandlerRalphPoller(ralph_handler) if ralph_handler is not None else None
+    watchdog_event_store = EventStore()
+    await watchdog_event_store.initialize()
+    watchdog = Watchdog(
+        controls=load_runtime_controls(None),
+        event_appender=watchdog_event_store,
+    )
     pipeline = AutoPipeline(
         driver,
         HandlerSeedGenerator(generate_seed),
@@ -517,8 +526,12 @@ async def _run_auto(
         ralph_resumer=ralph_resumer,
         complete_product=complete_product,
         progress_callback=progress_callback,
+        watchdog=watchdog,
     )
-    result = await pipeline.run(state)
+    try:
+        result = await pipeline.run(state)
+    finally:
+        await watchdog_event_store.close()
     return result
 
 

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1714,6 +1714,7 @@ def create_ouroboros_server(
             opencode_mode=opencode_mode,
             mcp_manager=auto_mcp_manager,
             mcp_tool_prefix=auto_mcp_prefix,
+            event_store=event_store,
             ralph_handler_factory=build_ralph_handler,
         ),
         StartAutoHandler(

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -85,6 +85,8 @@ from ouroboros.orchestrator import resolve_agent_runtime_backend
 from ouroboros.orchestrator.agent_process import run_with_agent_process
 from ouroboros.orchestrator.heartbeat import current_process_identity, is_process_identity_alive
 from ouroboros.persistence.event_store import EventStore
+from ouroboros.runtime.controls import load_runtime_controls
+from ouroboros.runtime.watchdog import Watchdog
 
 _START_AUTO_PENDING_LEASE_SECONDS = 60.0
 
@@ -102,6 +104,7 @@ class AutoHandler:
     opencode_mode: str | None = field(default=None, repr=False)
     mcp_manager: object | None = field(default=None, repr=False)
     mcp_tool_prefix: str = ""
+    event_store: EventStore | None = field(default=None, repr=False)
     ralph_handler_factory: Callable[[str | None, str | None], RalphHandler] | None = field(
         default=None, repr=False
     )
@@ -473,6 +476,12 @@ class AutoHandler:
                 opencode_mode=opencode_mode,
             )
             lateral_thinker = HandlerLateralThinker(lateral_handler)
+        watchdog_event_store = self.event_store or EventStore()
+        await watchdog_event_store.initialize()
+        watchdog = Watchdog(
+            controls=load_runtime_controls(None),
+            event_appender=watchdog_event_store,
+        )
         pipeline = AutoPipeline(
             driver,
             HandlerSeedGenerator(generate_seed_handler),
@@ -493,8 +502,13 @@ class AutoHandler:
             complete_product=complete_product,
             evaluator=evaluator,
             lateral_thinker=lateral_thinker,
+            watchdog=watchdog,
         )
-        return await pipeline.run(state)
+        try:
+            return await pipeline.run(state)
+        finally:
+            if self.event_store is None:
+                await watchdog_event_store.close()
 
 
 @dataclass
@@ -548,6 +562,7 @@ class StartAutoHandler:
             opencode_mode=self.opencode_mode,
             mcp_manager=self.mcp_manager,
             mcp_tool_prefix=self.mcp_tool_prefix,
+            event_store=self._event_store,
             ralph_handler_factory=self.ralph_handler_factory,
         )
 
@@ -1200,6 +1215,8 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
     if handoff_only:
         meta["presentation_status"] = _presentation_status(result)
         meta["product_status"] = "not_verified_complete"
+    if result.stop_reason_code is not None:
+        meta["stop_reason_code"] = result.stop_reason_code
     if result.execution_job_status:
         meta["execution_job_status"] = result.execution_job_status
     if result.execution_job_error:

--- a/tests/unit/auto/test_pipeline_watchdog_integration.py
+++ b/tests/unit/auto/test_pipeline_watchdog_integration.py
@@ -1,0 +1,295 @@
+"""Integration tests for the L2-2 auto pipeline watchdog wiring (#1172).
+
+Pins:
+
+- An ``AutoPipeline`` constructed without a ``watchdog`` parameter
+  behaves identically to before the L2-2 integration — pure
+  backwards-compatibility guard.
+- A wired ``Watchdog`` whose budget has elapsed (relative to
+  ``state.created_at``) fires on the first ``run()`` call, transitions
+  the session to BLOCKED, and surfaces
+  ``stop_reason_code = "watchdog_wall_clock_exceeded"`` on the result
+  envelope.
+- The watchdog appends exactly one ``runtime.watchdog.cancel`` event.
+- A watchdog whose budget has *not* elapsed never fires.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ouroboros.auto.interview_driver import (
+    AutoInterviewDriver,
+    FunctionInterviewBackend,
+    InterviewTurn,
+)
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+from ouroboros.events.base import BaseEvent
+from ouroboros.runtime.controls import RuntimeControls
+from ouroboros.runtime.watchdog import (
+    WATCHDOG_AGGREGATE_TYPE,
+    WATCHDOG_CANCEL_EVENT_TYPE,
+    WATCHDOG_STOP_REASON_CODE,
+    Watchdog,
+)
+
+
+def _seed() -> Seed:
+    return Seed(
+        goal="Build a CLI",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=("Command prints stable output",),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior", weight=1.0),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(seed_id="seed_test_watchdog", ambiguity_score=0.12),
+    )
+
+
+class _CapturingAppender:
+    def __init__(self) -> None:
+        self.events: list[BaseEvent] = []
+
+    async def append(self, event: BaseEvent) -> None:
+        self.events.append(event)
+
+
+def _fill_ready(ledger: SeedDraftLedger) -> None:
+    from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus
+
+    for section, value in {
+        "actors": "Single local CLI user",
+        "inputs": "Command arguments",
+        "outputs": "Stable stdout and files",
+        "constraints": "Use existing project patterns",
+        "non_goals": "No cloud sync",
+        "acceptance_criteria": "Command prints stable output",
+        "verification_plan": "Run command-level tests",
+        "failure_modes": "Invalid input exits non-zero",
+        "runtime_context": "Existing repository runtime",
+    }.items():
+        source = (
+            LedgerSource.NON_GOAL if section == "non_goals" else LedgerSource.CONSERVATIVE_DEFAULT
+        )
+        ledger.add_entry(
+            section,
+            LedgerEntry(
+                key=f"{section}.test",
+                value=value,
+                source=source,
+                confidence=0.85,
+                status=LedgerStatus.DEFAULTED,
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_pipeline_without_watchdog_behaves_unchanged(tmp_path) -> None:
+    """No ``watchdog`` parameter → no behaviour change. Existing pipelines
+    that never set the field keep working."""
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", "interview_1", seed_ready=True, completed=True)
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(_session_id: str) -> Seed:
+        return _seed()
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        skip_run=True,
+        # no watchdog
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.stop_reason_code is None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_with_watchdog_under_budget_unchanged(tmp_path) -> None:
+    """Watchdog wired but budget not exceeded → no firing. Wire the
+    fixed ``now`` clock to a moment just inside the budget."""
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", "interview_2", seed_ready=True, completed=True)
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(_session_id: str) -> Seed:
+        return _seed()
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+
+    appender = _CapturingAppender()
+    # ``created_at`` already set to "now" by the state factory; wire
+    # the watchdog's clock to just *after* ``created_at`` but well
+    # inside the 1h budget.
+    started = datetime.fromisoformat(state.created_at)
+    watchdog = Watchdog(
+        controls=RuntimeControls(session_wall_clock_seconds=3600),
+        event_appender=appender,
+        now=lambda: started + timedelta(seconds=10),
+    )
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        skip_run=True,
+        watchdog=watchdog,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.stop_reason_code is None
+    assert appender.events == []
+
+
+@pytest.mark.asyncio
+async def test_pipeline_with_watchdog_over_budget_blocks(tmp_path) -> None:
+    """Watchdog wired with elapsed budget → fires at ``run()`` entry,
+    transitions to BLOCKED, surfaces the typed stop_reason_code on the
+    envelope, appends one ``runtime.watchdog.cancel`` event."""
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", "interview_3", seed_ready=True, completed=True)
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(_session_id: str) -> Seed:  # pragma: no cover - watchdog blocks first
+        raise AssertionError("seed_generator should not run when watchdog fires at entry")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    started = datetime.fromisoformat(state.created_at)
+
+    appender = _CapturingAppender()
+    watchdog = Watchdog(
+        controls=RuntimeControls(session_wall_clock_seconds=60),
+        event_appender=appender,
+        now=lambda: started + timedelta(seconds=120),
+    )
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        watchdog=watchdog,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert result.stop_reason_code == WATCHDOG_STOP_REASON_CODE
+    assert state.last_tool_name == "runtime_watchdog"
+    assert "120s" in (state.last_error or "")
+    assert "budget 60s" in (state.last_error or "")
+
+    # Exactly one event with the documented shape.
+    assert len(appender.events) == 1
+    event = appender.events[0]
+    assert event.type == WATCHDOG_CANCEL_EVENT_TYPE
+    assert event.aggregate_type == WATCHDOG_AGGREGATE_TYPE
+    assert event.aggregate_id == state.auto_session_id
+    assert event.data["reason"] == "wall_clock_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_with_disabled_watchdog_never_fires(tmp_path) -> None:
+    """A watchdog with ``session_wall_clock_seconds=0`` is the opt-out
+    knob — the pipeline must run normally even when the wall-clock has
+    elapsed past any plausible default."""
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", "interview_4", seed_ready=True, completed=True)
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(_session_id: str) -> Seed:
+        return _seed()
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+
+    appender = _CapturingAppender()
+    watchdog = Watchdog(
+        controls=RuntimeControls(session_wall_clock_seconds=0),
+        event_appender=appender,
+        now=lambda: datetime.now(UTC) + timedelta(days=30),
+    )
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        skip_run=True,
+        watchdog=watchdog,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert appender.events == []

--- a/tests/unit/auto/test_pipeline_watchdog_integration.py
+++ b/tests/unit/auto/test_pipeline_watchdog_integration.py
@@ -293,3 +293,44 @@ async def test_pipeline_with_disabled_watchdog_never_fires(tmp_path) -> None:
 
     assert result.status == "complete"
     assert appender.events == []
+
+
+@pytest.mark.asyncio
+async def test_mcp_auto_handler_wires_watchdog_to_event_store(tmp_path) -> None:
+    """Production MCP AutoHandler wiring must make the L2 watchdog active.
+
+    A resumed session whose persisted ``created_at`` is already beyond the
+    default 4h wall-clock budget should block before interview/seed work and
+    persist the watchdog cancel event to the handler's EventStore.
+    """
+
+    from ouroboros.mcp.tools.auto_handler import AutoHandler
+    from ouroboros.persistence.event_store import EventStore
+
+    store = AutoStore(tmp_path)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.created_at = (datetime.now(UTC) - timedelta(hours=5)).isoformat()
+    store.save(state)
+
+    event_store = EventStore("sqlite+aiosqlite:///:memory:")
+    await event_store.initialize()
+    try:
+        result = await AutoHandler(store=store, event_store=event_store).handle(
+            {"resume": state.auto_session_id}
+        )
+
+        assert result.is_ok
+        value = result.value
+        assert value.is_error is True
+        assert value.meta["status"] == "blocked"
+        assert value.meta["stop_reason_code"] == WATCHDOG_STOP_REASON_CODE
+
+        events = await event_store.query_events(
+            aggregate_id=state.auto_session_id,
+            event_type=WATCHDOG_CANCEL_EVENT_TYPE,
+        )
+        assert len(events) == 1
+        assert events[0].aggregate_type == WATCHDOG_AGGREGATE_TYPE
+        assert events[0].data["reason"] == "wall_clock_exceeded"
+    finally:
+        await event_store.close()


### PR DESCRIPTION
## Summary

L2-2 slice of #1172 — auto pipeline consumption of the L2-1 \`Watchdog\` substrate (#1178).

Wires the optional \`Watchdog\` into \`AutoPipeline\`:

- New optional \`watchdog: Watchdog | None = None\` field. Default \`None\` → zero behavior change.
- New private \`_check_watchdog(state, ledger)\` helper runs at \`run()\` entry. Parses \`state.created_at\` → calls watchdog → on a returned \`WatchdogDecision\` calls \`state.mark_blocked(..., error_code=WATCHDOG_STOP_REASON_CODE)\`, saves state, returns BLOCKED \`AutoPipelineResult\` — never running interview / seed / downstream phases.
- The watchdog itself appends the \`runtime.watchdog.cancel\` event; the pipeline only translates the decision into state transitions.

Single-point check at \`run()\` entry is the minimal v1 contract per the #1172 minimal-substrate redesign — catches the high-value case (resumed session with elapsed budget) without spreading boilerplate across every phase boundary.

## What lands

- \`src/ouroboros/auto/pipeline.py\`: \`Watchdog\` import + \`watchdog\` field + \`_check_watchdog\` private helper + \`run()\` entry call.
- \`tests/unit/auto/test_pipeline_watchdog_integration.py\` (new): 4 integration tests — no-watchdog backwards compat, under-budget no-op, over-budget BLOCKED + event + envelope, disabled-watchdog opt-out.

## What is NOT in this PR

- Per-phase watchdog checks — entry-only is enough for v1.
- MCP transport-timeout deprecation.
- AgentProcess cooperative cancellation handshake (#518).
- SKILL.md taxonomy update for the 9th stop_reason_code — bookkeeping follow-up.

## Test plan

- [x] \`uv run pytest tests/unit/auto/test_pipeline_watchdog_integration.py -v\` → 4 passed.
- [x] \`uv run pytest tests/unit/auto -q\` → 909 passed.
- [x] \`uv run ruff check\` on touched files → clean.
- [x] \`uv run ruff format\` on touched files → clean.
- [x] \`uv run mypy src/ouroboros/auto/pipeline.py\` → clean.

Refs #1157, #1172, #1178 (L2-1 substrate), #578 (RFC).