### PR TITLE
feat(tests): L0 live-wire + L1 catalog cross-validate (P1)

### DIFF
--- a/tests/canonical/test_canonical.py
+++ b/tests/canonical/test_canonical.py
@@ -196,6 +196,7 @@ async def _invoke_ouroboros_auto(scenario: CanonicalScenario, workdir: Path) -> 
         "goal": scenario.goal,
         "cwd": str(workdir),
         "skip_run": False,
+        "complete_product": scenario.completion_mode == "product_complete",
         # Bounded budget so a stuck scenario does not hang the
         # operator. The watchdog (L2) catches anything past this on
         # its own.
@@ -245,6 +246,25 @@ async def test_scenario_live_run_or_skip(
     result = await _invoke_ouroboros_auto(scenario, workdir)
 
     assert result.is_ok(), (
-        f"{scenario.slug}: ouroboros_auto returned error: "
+        f"{scenario.slug}: ouroboros_auto returned MCP error: "
         f"{result.unwrap_err() if not result.is_ok() else 'unknown'}"
+    )
+
+    tool_result = result.unwrap()
+    assert not tool_result.is_error, (
+        f"{scenario.slug}: ouroboros_auto reached a failed/blocked terminal: "
+        f"{tool_result.content[0].text if tool_result.content else tool_result.meta}"
+    )
+    assert tool_result.meta["status"] == "complete", (
+        f"{scenario.slug}: expected complete terminal status; "
+        f"got {tool_result.meta.get('status')!r} with meta {tool_result.meta}"
+    )
+    if scenario.completion_mode == "product_complete":
+        assert tool_result.meta.get("product_status") != "not_verified_complete", (
+            f"{scenario.slug}: product_complete scenario must not stop at an "
+            f"unverified run handoff: {tool_result.meta}"
+        )
+    print(
+        f"CANONICAL {scenario.slug}: status={tool_result.meta['status']} "
+        f"phase={tool_result.meta.get('phase')} completion_mode={scenario.completion_mode}"
     )

--- a/tests/canonical/test_canonical.py
+++ b/tests/canonical/test_canonical.py
@@ -6,21 +6,19 @@ discovered scenario in ``tests/canonical/<slug>/`` thanks to the
 
 Two cost regimes:
 
-- Hermetic (default): shape-checks only. Always runs in CI without
-  LLM cost. Catches fixture rot.
+- Hermetic (default): shape-checks + L1 catalog cross-validation
+  only. Always runs in CI without LLM cost. Catches fixture rot
+  and L0 ↔ L1 contract drift.
 - Live (``OUROBOROS_RUN_CANONICAL=1``): the maintainer-only path that
-  actually invokes ``ouroboros_auto`` and asserts the documented
-  terminal. Wiring for the invocation lands in a follow-up PR; for
-  now it ``pytest.skip``s with a typed reason so the harness contract
-  is visible without burning tokens.
-
-L1 catalog cross-validation (verifying ``expected.yaml``'s
-``domain_class`` round-trips through ``TaskClassProfile``) lands in a
-follow-up PR once #1173 (L1-a catalog data) merges to main. This PR
-keeps the harness self-contained.
+  actually invokes the ``ouroboros_auto`` MCP tool against the
+  scenario and asserts the documented terminal state. Costs real
+  LLM tokens.
 """
 
 from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -105,23 +103,148 @@ def test_canonical_matrix_is_nonempty(
     )
 
 
-def test_scenario_live_run_or_skip(
+# ---------------------------------------------------------------------------
+# L1 catalog cross-validation (folded back in from #1170 L0-a deferred list)
+# ---------------------------------------------------------------------------
+
+
+def test_scenario_domain_class_resolves_in_l1_catalog(
+    scenario: CanonicalScenario,
+) -> None:
+    """``expected.yaml``'s ``domain_class`` must resolve to a real
+    :class:`TaskClass` value — otherwise the L1 inference output
+    cannot match it.
+
+    This is the L0 ↔ L1 contract pin: adding a scenario whose
+    ``domain_class`` is not in the catalog fails here, prompting
+    either a typo fix or an L1 catalog extension PR before the
+    scenario lands."""
+    from ouroboros.auto.task_classes import TaskClass
+
+    valid = {tc.value for tc in TaskClass}
+    assert scenario.domain_class in valid, (
+        f"{scenario.slug}: domain_class {scenario.domain_class!r} is not a "
+        f"known TaskClass; valid values are {sorted(valid)}"
+    )
+
+
+def test_scenario_completion_mode_matches_l1_catalog_default(
+    scenario: CanonicalScenario,
+) -> None:
+    """The scenario's declared ``completion_mode`` must match the L1
+    catalog default for its ``domain_class``. A mismatch means the
+    scenario is asserting a regime the catalog does not endorse."""
+    from ouroboros.auto.task_classes import (
+        TASK_CLASS_CATALOG,
+        CompletionMode,
+        TaskClass,
+    )
+
+    task_class = TaskClass(scenario.domain_class)
+    expected_mode = TASK_CLASS_CATALOG[task_class].default_completion_mode
+    actual_mode = CompletionMode(scenario.completion_mode)
+    assert actual_mode == expected_mode, (
+        f"{scenario.slug}: completion_mode {scenario.completion_mode!r} "
+        f"disagrees with TaskClass.{task_class.name} catalog default "
+        f"{expected_mode.value!r}"
+    )
+
+
+def test_scenario_runtime_probe_kinds_subset_of_l1_catalog(
+    scenario: CanonicalScenario,
+) -> None:
+    """Every ``runtime_probe_kinds`` entry in the scenario must be
+    declared in the L1 catalog for that ``domain_class``. Pins the
+    L0 ↔ L1 ↔ L3 contract: scenarios cannot invent ad-hoc probe
+    kinds sideways."""
+    from ouroboros.auto.task_classes import TASK_CLASS_CATALOG, TaskClass
+
+    task_class = TaskClass(scenario.domain_class)
+    allowed = set(TASK_CLASS_CATALOG[task_class].runtime_probe_kinds)
+    declared = set(scenario.runtime_probe_kinds)
+    unknown = declared - allowed
+    assert not unknown, (
+        f"{scenario.slug}: runtime_probe_kinds includes {sorted(unknown)} "
+        f"which are not declared for TaskClass.{task_class.name} in the "
+        f"catalog (allowed: {sorted(allowed)})"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live invocation (opt-in via OUROBOROS_RUN_CANONICAL=1)
+# ---------------------------------------------------------------------------
+
+
+async def _invoke_ouroboros_auto(scenario: CanonicalScenario, workdir: Path) -> Any:
+    """Programmatically invoke the ``ouroboros_auto`` MCP tool for a
+    canonical scenario. Returns the handler's ``Result`` so the test
+    can assert on its terminal shape.
+
+    Kept inside the test module (rather than under
+    ``tests/canonical/_runner.py``) because it is invoked only on the
+    opt-in live-run path and pulls in heavy MCP-handler dependencies.
+    """
+    from ouroboros.auto.state import AutoStore
+    from ouroboros.mcp.tools.auto_handler import AutoHandler
+
+    # Use a per-scenario, in-process store rooted under the operator's
+    # workdir so the run does not collide with concurrent ``ooo auto``
+    # invocations and so a re-run picks a fresh ``auto_session_id``.
+    store = AutoStore(workdir / ".ouroboros-canonical")
+    handler = AutoHandler(store=store)
+    arguments = {
+        "goal": scenario.goal,
+        "cwd": str(workdir),
+        "skip_run": False,
+        # Bounded budget so a stuck scenario does not hang the
+        # operator. The watchdog (L2) catches anything past this on
+        # its own.
+        "pipeline_timeout_seconds": float(scenario.wall_clock_budget_seconds),
+    }
+    return await handler.handle(arguments)
+
+
+@pytest.mark.asyncio
+async def test_scenario_live_run_or_skip(
     scenario: CanonicalScenario,
     live_run_enabled: bool,
+    tmp_path: Path,
 ) -> None:
     """Live invocation of ``ouroboros_auto`` against the scenario.
 
-    Currently skipped unconditionally — wiring lands in a follow-up
-    sub-PR after the shape-check contract is exercised on `main`.
-    Once wired, this test asserts the documented terminal state for
-    the scenario when ``OUROBOROS_RUN_CANONICAL=1`` is set.
+    Skipped by default — costs real LLM tokens. Set
+    ``OUROBOROS_RUN_CANONICAL=1`` to opt in. When enabled, the test:
+
+    1. Copies the scenario's ``env/`` fixture into a fresh ``tmp_path``.
+    2. Calls ``AutoHandler.handle({"goal": scenario.goal, ...})``.
+    3. Asserts the result is OK (not an MCP-level error) and that the
+       documented terminal status is reached.
+
+    Any LLM / MCP misconfiguration surfaces as a failure with the
+    underlying error message so the operator sees what's missing.
     """
     if not live_run_enabled:
         pytest.skip(
-            "live canonical run disabled; set OUROBOROS_RUN_CANONICAL=1 to invoke "
-            "ouroboros_auto against this scenario"
+            "live canonical run disabled; set OUROBOROS_RUN_CANONICAL=1 to "
+            "invoke ouroboros_auto against this scenario (costs real LLM tokens)"
         )
-    pytest.skip(
-        f"live-run wiring for {scenario.slug} lands in the L0 follow-up sub-PR; "
-        f"shape-check above already validates fixture integrity"
+
+    workdir = tmp_path / scenario.slug
+    workdir.mkdir(parents=True, exist_ok=True)
+    if scenario.env_dir is not None:
+        # Seed the env/ fixture into the run workdir if present.
+        for entry in scenario.env_dir.iterdir():
+            target = workdir / entry.name
+            if entry.is_dir():
+                import shutil
+
+                shutil.copytree(entry, target)
+            else:
+                target.write_bytes(entry.read_bytes())
+
+    result = await _invoke_ouroboros_auto(scenario, workdir)
+
+    assert result.is_ok(), (
+        f"{scenario.slug}: ouroboros_auto returned error: "
+        f"{result.unwrap_err() if not result.is_ok() else 'unknown'}"
     )


### PR DESCRIPTION
## Summary

L0 follow-up of #1170 — wires the \`OUROBOROS_RUN_CANONICAL=1\` path to programmatically invoke the \`ouroboros_auto\` MCP tool against a canonical scenario, and adds the L1 catalog cross-validation tests deferred from L0-a (#1174) until L1-a (#1173) was on main.

## What lands

- **L1 catalog cross-validate (always runs, hermetic):**
  - \`test_scenario_domain_class_resolves_in_l1_catalog\` — pins \`expected.yaml\` \`domain_class\` to a real \`TaskClass\` value.
  - \`test_scenario_completion_mode_matches_l1_catalog_default\` — pins \`completion_mode\` to the L1 catalog default for the scenario's class.
  - \`test_scenario_runtime_probe_kinds_subset_of_l1_catalog\` — pins \`runtime_probe_kinds\` to a subset of the catalog's declared probes.
- **Live-run wiring (opt-in via env var):** when \`OUROBOROS_RUN_CANONICAL=1\` is set, the test programmatically invokes \`AutoHandler.handle(...)\` with a goal/cwd/skip_run/pipeline_timeout_seconds arguments dict built from the scenario fixture. Result assertions surface MCP misconfiguration with the underlying error message.

## What is NOT in this PR

- Additional scenario fixtures (\`webhook-receiver\`, \`vertical-slice-refactor\`, \`2d-kart-racer\`) — fixtures are maintainer-curated example data, not substrate PRs.
- Probe runner wiring for the canonical workdir.
- Recorded-replay layer — deferred per #1170 minimal-substrate audit.

## Test plan

- [x] \`uv run pytest tests/canonical/ -v\` (hermetic default) → 9 passed, 1 skipped (live-run gate).
- [x] \`uv run ruff check tests/canonical/test_canonical.py\` → clean.
- [x] \`uv run ruff format tests/canonical/test_canonical.py\` → clean.
- [x] \`uv run mypy tests/canonical/test_canonical.py\` → clean.

Refs #1157 (L0 lane), #1170 (L0 design), #1174 (L0-a skeleton), #1173 (L1-a catalog).