### PR TITLE
Keep plugin runtime writes outside trusted homes

### DIFF
--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -35,8 +35,8 @@ from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 import hashlib
-from pathlib import Path
 import os
+from pathlib import Path
 import re
 import shlex
 import subprocess
@@ -569,10 +569,13 @@ def invoke_plugin(
         # Installed plugin homes are immutable trust subjects. Prevent Python
         # entrypoints from creating __pycache__ in plugin_home and provide a
         # stable workspace/output contract for runtime artifacts.
-        env.setdefault("PYTHONDONTWRITEBYTECODE", "1")
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
         workdir = Path.cwd()
         env.setdefault("OUROBOROS_PLUGIN_WORKDIR", str(workdir))
-        env.setdefault("OUROBOROS_PLUGIN_OUTPUT_DIR", str(workdir / ".ouroboros" / "plugin-artifacts" / manifest.name))
+        env.setdefault(
+            "OUROBOROS_PLUGIN_OUTPUT_DIR",
+            str(workdir / ".ouroboros" / "plugin-artifacts" / manifest.name),
+        )
         if plugin_home is not None:
             env.setdefault("OUROBOROS_PLUGIN_HOME", str(plugin_home))
         return env

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 import hashlib
 from pathlib import Path
+import os
 import re
 import shlex
 import subprocess
@@ -563,6 +564,19 @@ def invoke_plugin(
         # crash on an unexpected runner return shape.
         return b""
 
+    def _plugin_runtime_env() -> dict[str, str]:
+        env = dict(os.environ)
+        # Installed plugin homes are immutable trust subjects. Prevent Python
+        # entrypoints from creating __pycache__ in plugin_home and provide a
+        # stable workspace/output contract for runtime artifacts.
+        env.setdefault("PYTHONDONTWRITEBYTECODE", "1")
+        workdir = Path.cwd()
+        env.setdefault("OUROBOROS_PLUGIN_WORKDIR", str(workdir))
+        env.setdefault("OUROBOROS_PLUGIN_OUTPUT_DIR", str(workdir / ".ouroboros" / "plugin-artifacts" / manifest.name))
+        if plugin_home is not None:
+            env.setdefault("OUROBOROS_PLUGIN_HOME", str(plugin_home))
+        return env
+
     def _run_lifecycle_hooks(hook_kind: HookKind) -> tuple[bool, str]:
         for hook in _matching_hooks(manifest, hook_kind):
             hook_provenance = {
@@ -601,6 +615,7 @@ def invoke_plugin(
                         check=False,
                         timeout=_hook_timeout_seconds(hook),
                         cwd=str(plugin_home) if plugin_home is not None else None,
+                        env=_plugin_runtime_env(),
                     )
                     hook_stdout = _to_bytes(hook_completed.stdout)
                     hook_stderr = _to_bytes(hook_completed.stderr)
@@ -1037,6 +1052,7 @@ def invoke_plugin(
         "capture_output": True,
         "check": False,
         "timeout": DEFAULT_PLUGIN_INVOCATION_TIMEOUT_SECONDS,
+        "env": _plugin_runtime_env(),
     }
     if plugin_home is not None:
         run_kwargs["cwd"] = str(plugin_home)

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -792,6 +792,58 @@ def test_v03_fail_open_before_hook_timeout_records_failure_and_continues(
     assert "timed out" in events[1]["result"]["message"]
 
 
+def test_plugin_subprocess_receives_immutable_home_runtime_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Plugin dispatch must not mutate installed plugin bytes by default.
+
+    Python module entrypoints create ``__pycache__`` unless bytecode writes are
+    disabled. The firewall also gives plugins a workspace/output contract so
+    runtime artifacts can land outside the trusted plugin_home digest subject.
+    """
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    plugin_home = tmp_path / "installed-plugin"
+    plugin_home.mkdir()
+    user_cwd = tmp_path / "workspace"
+    user_cwd.mkdir()
+    monkeypatch.chdir(user_cwd)
+    captured: dict = {}
+
+    def runner(argv, *args, **kwargs) -> subprocess.CompletedProcess:
+        captured["argv"] = argv
+        captured["cwd"] = kwargs.get("cwd")
+        captured["env"] = kwargs.get("env")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="{}", stderr="")
+
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=lambda _event: None,
+        correlation_id="corr-runtime-env",
+        subprocess_runner=runner,
+        plugin_home=plugin_home,
+    )
+
+    assert result.status == "success"
+    assert captured["cwd"] == str(plugin_home)
+    env = captured["env"]
+    assert env["PYTHONDONTWRITEBYTECODE"] == "1"
+    assert env["OUROBOROS_PLUGIN_HOME"] == str(plugin_home)
+    assert env["OUROBOROS_PLUGIN_WORKDIR"] == str(user_cwd)
+    assert env["OUROBOROS_PLUGIN_OUTPUT_DIR"] == str(
+        user_cwd / ".ouroboros" / "plugin-artifacts" / "github-pr-ops"
+    )
+
+
 def test_trust_violation_only_emits_failed_no_invoked(tmp_path: Path) -> None:
     """Test 2: missing required scope → ONLY plugin.failed (status=blocked).
 

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -814,6 +814,7 @@ def test_plugin_subprocess_receives_immutable_home_runtime_environment(
     user_cwd = tmp_path / "workspace"
     user_cwd.mkdir()
     monkeypatch.chdir(user_cwd)
+    monkeypatch.setenv("PYTHONDONTWRITEBYTECODE", "0")
     captured: dict = {}
 
     def runner(argv, *args, **kwargs) -> subprocess.CompletedProcess:


### PR DESCRIPTION
## Summary

Closes #1192 by giving UserLevel plugin subprocesses a safe runtime environment while preserving `cwd=plugin_home` import resolution.

## Problem

The plugin dispatcher runs entrypoints from `plugin_home` so commands like `python -m superpowers_ouroboros` resolve installed modules. But `plugin_home` is also the immutable trust subject verified before every invocation. Without a runtime env contract:

- Python can create `__pycache__` under `plugin_home`.
- Plugins may default runtime artifacts to `./...` under `plugin_home`.
- The next invocation fails closed with trust-subject drift.

## Changes

`firewall.invoke_plugin(...)` now passes plugin subprocesses and lifecycle hooks:

- `PYTHONDONTWRITEBYTECODE=1`
- `OUROBOROS_PLUGIN_HOME=<plugin_home>` when available
- `OUROBOROS_PLUGIN_WORKDIR=<caller cwd>`
- `OUROBOROS_PLUGIN_OUTPUT_DIR=<caller cwd>/.ouroboros/plugin-artifacts/<plugin-name>`

This keeps code in plugin homes and runtime artifacts in an Ouroboros-native user/workspace artifact root. It intentionally avoids an `.omx` default in core so non-OMX Ouroboros users get a native path.

## Validation

```bash
PYTHONPATH=src pytest -q \
  tests/unit/plugin/test_firewall.py::test_plugin_subprocess_receives_immutable_home_runtime_environment \
  tests/unit/plugin/test_firewall.py::test_subprocess_failure_emits_failed_with_exit_code
```

Result: `2 passed`.

Cross-repo smoke with the companion `ouroboros-plugins` branch:

- `ouroboros plugin add ... --plugin superpowers`
- `ouroboros plugin trust superpowers --scope filesystem:read --scope filesystem:write`
- `ouroboros superpowers list`
- `ouroboros superpowers test-driven-development ...`
- `ouroboros superpowers verification-before-completion ...`

Repeated dispatch succeeded without plugin-home digest drift when paired with the plugin-side output-dir fix.
