### PR TITLE
fix(auto): clear stale stop reason codes

### DIFF
--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -598,6 +598,8 @@ class AutoPipelineState:
         self.updated_at = now
         self.last_progress_message = message
         self.last_error = error
+        if next_phase is not AutoPhase.BLOCKED:
+            self.last_error_code = None
         # Authoring-backend attribution is scoped to the most recent
         # authoring failure; reset on every transition so a later
         # non-authoring blocker (grade_gate, seed_saver, run_starter)

--- a/tests/unit/auto/test_stop_reason_code.py
+++ b/tests/unit/auto/test_stop_reason_code.py
@@ -176,3 +176,33 @@ async def test_blockers_without_canonical_code_leave_stop_reason_code_none(tmp_p
     assert result.stop_reason_code is None
     assert result.blocker is not None
     assert "pipeline budget exhausted" in result.blocker
+
+
+def test_recovery_transition_clears_stale_stop_reason_code(tmp_path) -> None:
+    """A recovered session must not keep reporting an old blocker code."""
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.mark_blocked(
+        "interview phase exceeded 600s timeout",
+        tool_name="interview.run",
+        error_code="interview_phase_deadline",
+    )
+
+    state.recover(AutoPhase.INTERVIEW, "retrying interview")
+
+    assert state.last_error is None
+    assert state.last_error_code is None
+
+
+def test_failed_transition_clears_stale_stop_reason_code(tmp_path) -> None:
+    """A later hard failure must not inherit an earlier blocker code."""
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.last_error_code = "interview_phase_deadline"
+
+    state.mark_failed("seed generation crashed", tool_name="seed_generator")
+
+    assert state.last_error == "seed generation crashed"
+    assert state.last_error_code is None


### PR DESCRIPTION
## Summary
- Clear `AutoPipelineState.last_error_code` whenever the session transitions out of `BLOCKED`.
- Add regression coverage for recovery and later hard-failure transitions so `AutoPipelineResult.stop_reason_code` cannot report a stale interview blocker.

## Review context
This follows up the post-v0.39.1 `stop_reason_code` surface from PR #1151. The public result envelope copies `state.last_error_code`; without clearing it on non-blocked transitions, a resumed session could recover or fail for a different reason while still exposing an old canonical interview blocker code.

## Validation
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run pytest tests/unit/auto/test_stop_reason_code.py tests/unit/auto/test_pipeline_watchdog_integration.py tests/unit/auto/test_surface.py -q` -> 96 passed
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run pytest tests/unit/auto tests/unit/mcp/tools/test_generate_seed_force_flag.py tests/unit/orchestrator/test_parallel_executor.py tests/unit/orchestrator/test_runtime_evidence.py tests/unit/plugin tests/unit/runtime tests/canonical -q` -> 1677 passed, 2 skipped
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run ruff check src/ouroboros/auto/state.py tests/unit/auto/test_stop_reason_code.py` -> passed
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run ruff format --check src/ouroboros/auto/state.py tests/unit/auto/test_stop_reason_code.py` -> passed
- `git diff --check` -> passed