### PR TITLE
fix(tests): align canonical live-run evidence

### DIFF
--- a/tests/canonical/README.md
+++ b/tests/canonical/README.md
@@ -36,7 +36,7 @@ fixture files in the right shape. It does **not** invoke
 copyable status line per scenario, for example:
 
 ```text
-CANONICAL cli-todo: shape_valid domain=cli completion=product_complete probes=headless_run,stdout_golden budget=1800s live=deferred_l0b
+CANONICAL cli-todo: shape_valid domain=cli completion=product_complete probes=headless_run,stdout_golden budget=1800s live=opt_in
 ```
 
 ### Full live run (manual, costs LLM tokens)
@@ -45,13 +45,12 @@ CANONICAL cli-todo: shape_valid domain=cli completion=product_complete probes=he
 OUROBOROS_RUN_CANONICAL=1 uv run pytest tests/canonical/ -v
 ```
 
-Once the live wiring lands in L0-b, this command will invoke the
-`ouroboros_auto` MCP tool against each scenario and assert the
-documented terminal state — **use sparingly**, each scenario will
-consume real LLM tokens (cli-todo ≈ \$1, kart-racer ≈ \$5 with
-Sonnet-class models). **At L0-a (this PR) the opt-in still
-`pytest.skip`s with a typed reason** so the harness contract is
-observable without burning tokens; the shape-check tests still run.
+This command invokes the `ouroboros_auto` MCP tool against each
+scenario and asserts the documented terminal state — **use sparingly**,
+each scenario will consume real LLM tokens (cli-todo ≈ \$1,
+kart-racer ≈ \$5 with Sonnet-class models). Without the environment
+variable, the live test skips and only the hermetic shape/catalog checks
+run.
 
 ### Run a single scenario
 
@@ -63,8 +62,8 @@ with `-k`:
 uv run pytest tests/canonical/ -v -k cli-todo
 ```
 
-Add `OUROBOROS_RUN_CANONICAL=1` once L0-b lands to opt into the live
-invocation for that scenario.
+Add `OUROBOROS_RUN_CANONICAL=1` to opt into the live invocation for
+that scenario.
 
 ## Scenario directory shape
 
@@ -97,10 +96,10 @@ canonicalizing, add a new `<slug>/` directory + populate
 `expected.yaml`. No infrastructure change required. The runner
 auto-discovers.
 
-## Adding the live-run path
+## Live-run path
 
-The hermetic shape-check is in place from L0-a. The live-run path
-(`OUROBOROS_RUN_CANONICAL=1`) is wired but the actual
-`ouroboros_auto` invocation lands in L0-b once the maintainer has
-confirmed they want it; until then the live-run path skips with a
-typed reason so the harness contract stays observable.
+The hermetic shape-check remains the default. The live-run path
+(`OUROBOROS_RUN_CANONICAL=1`) is wired for manual maintainer use and
+invokes `ouroboros_auto` from a per-scenario temporary workdir. Keep it
+out of scheduled CI unless a future issue explicitly accepts the LLM
+cost and operational risk.

--- a/tests/canonical/conftest.py
+++ b/tests/canonical/conftest.py
@@ -82,11 +82,11 @@ class CanonicalScenario:
 def format_canonical_summary_line(scenario: CanonicalScenario) -> str:
     """Return the copyable one-line status for a canonical scenario.
 
-    L0-a has no live ``ouroboros_auto`` invocation yet, so the summary
-    deliberately reports the current shape-check terminal instead of
-    pretending PRODUCT_COMPLETE has been exercised. The live terminal
-    can replace ``shape_valid`` in L0-b without changing the copyable
-    line contract.
+    The default canonical run remains a hermetic shape/catalog check, so
+    the summary deliberately reports ``shape_valid`` instead of pretending
+    PRODUCT_COMPLETE was exercised. ``live=opt_in`` records that the live
+    ``ouroboros_auto`` path is wired but only runs when the maintainer sets
+    ``OUROBOROS_RUN_CANONICAL=1``.
     """
     probe_text = ",".join(scenario.runtime_probe_kinds) or "none"
     return (
@@ -95,7 +95,7 @@ def format_canonical_summary_line(scenario: CanonicalScenario) -> str:
         f"completion={scenario.completion_mode} "
         f"probes={probe_text} "
         f"budget={scenario.wall_clock_budget_seconds}s "
-        f"live=deferred_l0b"
+        f"live=opt_in"
     )
 
 

--- a/tests/canonical/test_conftest.py
+++ b/tests/canonical/test_conftest.py
@@ -89,7 +89,7 @@ def test_format_canonical_summary_line_is_copyable() -> None:
         "completion=product_complete "
         "probes=headless_run,stdout_golden "
         "budget=1800s "
-        "live=deferred_l0b"
+        "live=opt_in"
     )
 
 
@@ -124,6 +124,6 @@ def test_pytest_terminal_summary_emits_copyable_lines(
             "completion=product_complete "
             "probes=headless_run "
             "budget=42s "
-            "live=deferred_l0b",
+            "live=opt_in",
         ),
     ]


### PR DESCRIPTION
## Summary
- Update canonical harness docs now that PR #1191 wired the opt-in live `ouroboros_auto` path.
- Change the copyable canonical summary marker from `live=deferred_l0b` to `live=opt_in`.
- Update summary-line regression tests so PR/SSOT evidence cannot keep advertising a deferred live path after it is wired.

## Review context
This follows up the post-v0.39.1 canonical harness sequence: #1174 added the L0 skeleton, #1182 added copyable summary evidence, and #1191 wired the opt-in live run. After #1191, the README and summary line still said the live run was deferred to L0-b, which could mislead maintainers reading the canonical acceptance evidence.

## Validation
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run pytest tests/canonical/ -q` -> 17 passed, 1 skipped
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run pytest tests/canonical/ -q -k cli-todo` -> 8 passed, 1 skipped, 9 deselected
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run ruff check tests/canonical/` -> passed
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run ruff format --check tests/canonical/` -> passed
- `git diff --check` -> passed
- `rg -n "deferred_l0b|Once the live wiring lands|actual invocation lands|once L0-b lands|skips with a typed reason" tests/canonical` -> no matches