### PR TITLE
fix(auto): expose active task class in MCP meta

### DIFF
--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1205,6 +1205,7 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         "blocker": result.blocker,
         "seed_path": result.seed_path,
         "seed_origin": result.seed_origin,
+        "active_task_class": result.active_task_class,
         "grade": result.grade,
         "last_grade": result.last_grade,
         "interview_session_id": result.interview_session_id,

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -477,6 +477,7 @@ async def test_auto_handler_meta_exposes_auto_progress_fields(monkeypatch) -> No
         "blocker": "waiting for interview answer",
         "seed_path": "/tmp/seed.yaml",
         "seed_origin": "none",
+        "active_task_class": None,
         "grade": "B",
         "last_grade": "B",
         "interview_session_id": "interview_1",
@@ -1376,6 +1377,37 @@ def test_auto_handler_meta_preserves_empty_defaulted_sections() -> None:
     )
 
     assert meta["defaulted_sections"] == []
+
+
+def test_auto_handler_meta_exposes_active_task_class() -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.mcp.tools.auto_handler import _result_meta
+
+    meta = _result_meta(
+        AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_test",
+            phase="complete",
+            active_task_class="cli",
+        )
+    )
+
+    assert meta["active_task_class"] == "cli"
+
+
+def test_auto_handler_meta_preserves_empty_active_task_class() -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.mcp.tools.auto_handler import _result_meta
+
+    meta = _result_meta(
+        AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_test",
+            phase="complete",
+        )
+    )
+
+    assert meta["active_task_class"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Surface `AutoPipelineResult.active_task_class` through MCP `_result_meta`.
- Preserve the field as `null` when inference was ambiguous or unavailable, so clients can distinguish an empty computed value from a missing protocol field.
- Add regression coverage for populated and empty active-task-class metadata.

## Review context
This follows up the post-v0.39.1 L1 task-class sequence. PR #1188 added `active_task_class` to `AutoPipelineResult` and persisted state, but the public MCP metadata envelope omitted it. That meant MCP clients could not observe the L1-e result-envelope surface without reaching into local state files.

## Validation
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run pytest tests/unit/auto/test_surface.py tests/unit/auto/test_pipeline_task_class_envelope.py -q` -> 91 passed
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run ruff check src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_surface.py` -> passed
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run ruff format --check src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_surface.py` -> passed
- `git diff --check` -> passed