### PR TITLE
fix(plugin): enforce runtime artifact env

### DIFF
--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -571,13 +571,12 @@ def invoke_plugin(
         # stable workspace/output contract for runtime artifacts.
         env["PYTHONDONTWRITEBYTECODE"] = "1"
         workdir = Path.cwd()
-        env.setdefault("OUROBOROS_PLUGIN_WORKDIR", str(workdir))
-        env.setdefault(
-            "OUROBOROS_PLUGIN_OUTPUT_DIR",
-            str(workdir / ".ouroboros" / "plugin-artifacts" / manifest.name),
+        env["OUROBOROS_PLUGIN_WORKDIR"] = str(workdir)
+        env["OUROBOROS_PLUGIN_OUTPUT_DIR"] = str(
+            workdir / ".ouroboros" / "plugin-artifacts" / manifest.name
         )
         if plugin_home is not None:
-            env.setdefault("OUROBOROS_PLUGIN_HOME", str(plugin_home))
+            env["OUROBOROS_PLUGIN_HOME"] = str(plugin_home)
         return env
 
     def _run_lifecycle_hooks(hook_kind: HookKind) -> tuple[bool, str]:

--- a/tests/unit/plugin/test_firewall.py
+++ b/tests/unit/plugin/test_firewall.py
@@ -845,6 +845,52 @@ def test_plugin_subprocess_receives_immutable_home_runtime_environment(
     )
 
 
+def test_plugin_runtime_environment_overrides_inherited_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Caller env cannot redirect plugin runtime artifacts into trusted homes."""
+    program = _make_program(tmp_path)
+    trust = TrustStore(root=tmp_path / "trust").grant(
+        plugin="github-pr-ops",
+        version="0.1.0",
+        scope="github:read",
+        granted_by="u",
+    )
+    plugin_home = tmp_path / "installed-plugin"
+    plugin_home.mkdir()
+    user_cwd = tmp_path / "workspace"
+    user_cwd.mkdir()
+    monkeypatch.chdir(user_cwd)
+    monkeypatch.setenv("OUROBOROS_PLUGIN_HOME", str(tmp_path / "stale-home"))
+    monkeypatch.setenv("OUROBOROS_PLUGIN_WORKDIR", str(tmp_path / "stale-workdir"))
+    monkeypatch.setenv("OUROBOROS_PLUGIN_OUTPUT_DIR", str(plugin_home / "artifacts"))
+    captured: dict = {}
+
+    def runner(argv, *args, **kwargs) -> subprocess.CompletedProcess:
+        captured["env"] = kwargs.get("env")
+        return subprocess.CompletedProcess(args=argv, returncode=0, stdout="{}", stderr="")
+
+    result = invoke_plugin(
+        program,
+        command_name="review",
+        argv=["https://example.com/pr/1"],
+        trust_record=trust,
+        event_sink=lambda _event: None,
+        correlation_id="corr-runtime-env-overrides",
+        subprocess_runner=runner,
+        plugin_home=plugin_home,
+    )
+
+    assert result.status == "success"
+    env = captured["env"]
+    assert env["OUROBOROS_PLUGIN_HOME"] == str(plugin_home)
+    assert env["OUROBOROS_PLUGIN_WORKDIR"] == str(user_cwd)
+    assert env["OUROBOROS_PLUGIN_OUTPUT_DIR"] == str(
+        user_cwd / ".ouroboros" / "plugin-artifacts" / "github-pr-ops"
+    )
+
+
 def test_trust_violation_only_emits_failed_no_invoked(tmp_path: Path) -> None:
     """Test 2: missing required scope → ONLY plugin.failed (status=blocked).
 


### PR DESCRIPTION
## Summary

- make the plugin firewall authoritative for `OUROBOROS_PLUGIN_HOME`, `OUROBOROS_PLUGIN_WORKDIR`, and `OUROBOROS_PLUGIN_OUTPUT_DIR`
- prevent inherited shell environment values from redirecting runtime artifacts into trusted plugin homes or stale paths
- add a regression test covering pre-set hostile/stale plugin env values

## Validation

- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run pytest tests/unit/plugin/test_firewall.py::test_plugin_subprocess_receives_immutable_home_runtime_environment tests/unit/plugin/test_firewall.py::test_plugin_runtime_environment_overrides_inherited_values -q`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run pytest tests/unit/plugin/test_firewall.py -q`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run ruff check src/ouroboros/plugin/firewall.py tests/unit/plugin/test_firewall.py`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run ruff format --check src/ouroboros/plugin/firewall.py tests/unit/plugin/test_firewall.py`
- `git diff --check`