### PR TITLE
fix(orchestrator): correlate verifier diagnostics

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -3537,6 +3537,7 @@ class ParallelACExecutor:
         log.info(
             "parallel_executor.dependency_graph",
             session_id=session_id,
+            execution_id=execution_id,
             total_acs=total_acs,
             dependency_edges=dependency_edges,
         )
@@ -5415,6 +5416,8 @@ Files present:
                 success = False
                 log.warning(
                     "parallel_executor.ac.verifier_rejected",
+                    session_id=session_id,
+                    execution_id=execution_id,
                     ac_index=ac_index,
                     depth=depth,
                     reason=fat_harness_error,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -6047,6 +6047,8 @@ class TestParallelACExecutor:
 
         log_mock.warning.assert_any_call(
             "parallel_executor.ac.verifier_rejected",
+            session_id="orch_123",
+            execution_id="",
             ac_index=0,
             depth=0,
             reason="Fat-harness verifier failed (claimed test command did not support the AC).",
@@ -6884,6 +6886,7 @@ class TestParallelACExecutor:
         log_mock.info.assert_any_call(
             "parallel_executor.dependency_graph",
             session_id="orch_dependency_log",
+            execution_id="exec_dependency_log",
             total_acs=2,
             dependency_edges=[{"ac_index": 1, "depends_on": (0,)}],
         )


### PR DESCRIPTION
## Summary

- add `session_id` and `execution_id` to `parallel_executor.ac.verifier_rejected`
- add `execution_id` to `parallel_executor.dependency_graph`
- update the diagnostics regression tests so verifier/dependency logs remain correlatable across concurrent or resumed executions

## Validation

- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run pytest tests/unit/orchestrator/test_parallel_executor.py::TestParallelACExecutor::test_fat_harness_mode_rejects_verifier_fail tests/unit/orchestrator/test_parallel_executor.py::TestParallelACExecutor::test_execute_parallel_logs_dependency_edges -q`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run pytest tests/unit/orchestrator/test_parallel_executor.py -q`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run ruff format --check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py`
- Current `origin/main` merge simulation with #1165 + this fix: `tests/unit/orchestrator/test_parallel_executor.py -q` -> 201 passed; ruff clean; `git diff --check` clean.