### PR TITLE
fix(interview): hand off envelope question failures

### DIFF
--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -131,6 +131,24 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
 
 2. **For each question from MCP, apply the routing paths below:**
 
+   **Parent-session question handoff**:
+   If an MCP response includes `meta.status="parent_question_required"` or
+   `meta.ask_user_directly=true`, treat it as a normal interview continuation,
+   not as an MCP/provider/tool failure. Do **not** tell the user MCP failed, do
+   not expose `reason_code`, and do not retry the MCP question generator. Ask
+   exactly one natural Socratic clarification question yourself, using the same
+   routing judgement as any other interview turn. Save the exact user-facing
+   question text. When the user answers, call:
+   ```
+   Tool: ouroboros_interview
+   Arguments:
+     session_id: <meta.session_id>
+     answer: <user answer>
+     last_question: <exact question you asked the user>
+   ```
+   `last_question` is required on this path so MCP can persist the real
+   transcript even though the parent session generated the question.
+
    **Milestone lateral-review advisory**:
    If an MCP response includes `meta.lateral_review_recommended=true`, treat it
    as a non-blocking cue that the interview just crossed an ambiguity milestone

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -828,6 +828,13 @@ def _turn_from_result(
     result: MCPToolResult, *, fallback_session_id: str | None = None
 ) -> InterviewTurn:
     meta = result.meta or {}
+    if meta.get("status") == "parent_question_required":
+        session_id = _optional_str(meta.get("session_id")) or fallback_session_id
+        detail = f" for session {session_id}" if session_id else ""
+        raise HandlerError(
+            "ouroboros_interview requires a parent-session user question"
+            f"{detail}; auto cannot answer the recovery instruction"
+        )
     session_id = _optional_str(meta.get("session_id")) or fallback_session_id
     if not session_id:
         raise HandlerError("ouroboros_interview did not return a session_id")

--- a/src/ouroboros/events/interview.py
+++ b/src/ouroboros/events/interview.py
@@ -73,6 +73,28 @@ def interview_failed(
     )
 
 
+def interview_question_parent_handoff(
+    interview_id: str,
+    *,
+    phase: str,
+    reason_code: str,
+    provider_error_type: str | None = None,
+) -> BaseEvent:
+    """Create event when question generation is handed to the parent session."""
+    data = {
+        "phase": phase,
+        "reason_code": reason_code,
+    }
+    if provider_error_type:
+        data["provider_error_type"] = provider_error_type
+    return BaseEvent(
+        type="interview.question_generation.parent_handoff",
+        aggregate_type="interview",
+        aggregate_id=interview_id,
+        data=data,
+    )
+
+
 def interview_response_emitted(
     interview_id: str,
     *,

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -2388,7 +2388,9 @@ class InterviewHandler:
                             is_brownfield=state.is_brownfield,
                         )
 
-                    if not state.rounds:
+                    if not state.rounds and last_question:
+                        pending_question = last_question
+                    elif not state.rounds:
                         return Result.err(
                             MCPToolError(
                                 "Cannot record answer - no questions have been asked yet",
@@ -2424,7 +2426,9 @@ class InterviewHandler:
                         else "initial"
                     )
 
-                    if state.rounds[-1].user_response is None:
+                    if not state.rounds:
+                        pass
+                    elif state.rounds[-1].user_response is None:
                         pending_question = last_question or state.rounds[-1].question
                         state.rounds.pop()
                     else:

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -77,6 +77,8 @@ _DATA_DIR = Path.home() / ".ouroboros" / "data"
 _SUGGESTED_INTERVIEW_ID_RE = re.compile(r"^interview_[a-f0-9]{16}$")
 
 _LIVE_AMBIGUITY_MAX_RETRIES = 3
+_QUESTION_GENERATION_ENVELOPE_VIOLATION = "ToolUseBlockViolation"
+_QUESTION_GENERATION_ENVELOPE_REASON_CODE = "question_generation_envelope_violation"
 
 REQUIRED_CLIENT_GATES: tuple[str, ...] = (
     # TODO(#1008): derive required gate names from the interview skill /
@@ -430,6 +432,23 @@ def _length_guard_meta_fields() -> dict[str, Any]:
         "expected_action": "resend_with_summary",
         "max_chars": MAX_PROMPT_SAFE_INITIAL_CONTEXT_CHARS,
     }
+
+
+def _provider_error_type(error: Any) -> str | None:
+    details = getattr(error, "details", None)
+    if isinstance(details, dict):
+        error_type = details.get("error_type")
+        if isinstance(error_type, str) and error_type:
+            return error_type
+    return None
+
+
+def _is_question_generation_envelope_violation(error: Any) -> bool:
+    """Return true for strict provider tool-envelope violations."""
+    provider_error_type = _provider_error_type(error)
+    if provider_error_type == _QUESTION_GENERATION_ENVELOPE_VIOLATION:
+        return True
+    return _QUESTION_GENERATION_ENVELOPE_VIOLATION in str(error)
 
 
 def _interview_reasoning_meta(
@@ -1314,6 +1333,61 @@ class InterviewHandler:
         return score
 
     @staticmethod
+    def _parent_question_handoff_response(
+        state: InterviewState,
+        session_id: str,
+        *,
+        phase: str,
+        score: AmbiguityScore | None,
+        error: Any,
+    ) -> Result[MCPToolResult, MCPServerError]:
+        """Build a non-error response asking the parent session to ask the user."""
+        provider_error_type = _provider_error_type(error)
+        return Result.ok(
+            MCPToolResult(
+                content=(
+                    MCPContentItem(
+                        type=ContentType.TEXT,
+                        text=(
+                            f"Session {session_id}\n\n"
+                            "Ask the user exactly one natural Socratic clarification "
+                            "question yourself. Do not mention MCP, provider failures, "
+                            "tool envelopes, retries, or internal recovery. When the "
+                            "user answers, call ouroboros_interview with "
+                            f'session_id="{session_id}", answer=<user answer>, and '
+                            "last_question=<the exact question you asked>."
+                        ),
+                    ),
+                ),
+                is_error=False,
+                meta={
+                    "session_id": session_id,
+                    "status": "parent_question_required",
+                    "recoverable": True,
+                    "retry_mcp": False,
+                    "ask_user_directly": True,
+                    "last_question_required": True,
+                    "reason_code": _QUESTION_GENERATION_ENVELOPE_REASON_CODE,
+                    "question_source": "parent_session",
+                    "provider_error_type": provider_error_type,
+                    "ambiguity_score": score.overall_score if score is not None else None,
+                    "milestone": _milestone_for_score(score),
+                    "seed_ready": score.is_ready_for_seed if score is not None else None,
+                    **_interview_reasoning_meta(
+                        state=state,
+                        session_id=session_id,
+                        phase=phase,
+                        next_action=(
+                            "ask one direct user question, then resume with last_question"
+                        ),
+                        score=score,
+                        recoverable=True,
+                    ),
+                },
+            )
+        )
+
+    @staticmethod
     def _ambiguity_gate_response(
         session_id: str,
         score: AmbiguityScore | None,
@@ -1839,6 +1913,31 @@ class InterviewHandler:
                 live_score = None
                 question_result = await engine.ask_next_question(state)
                 if question_result.is_err:
+                    if _is_question_generation_envelope_violation(question_result.error):
+                        from ouroboros.events.interview import interview_question_parent_handoff
+
+                        self._emit_event_bg(
+                            interview_question_parent_handoff(
+                                state.interview_id,
+                                phase="start_question_generation",
+                                reason_code=_QUESTION_GENERATION_ENVELOPE_REASON_CODE,
+                                provider_error_type=_provider_error_type(question_result.error),
+                            )
+                        )
+                        log.warning(
+                            "mcp.tool.interview.question_generation_parent_handoff",
+                            session_id=state.interview_id,
+                            phase="start_question_generation",
+                            reason_code=_QUESTION_GENERATION_ENVELOPE_REASON_CODE,
+                        )
+                        return self._parent_question_handoff_response(
+                            state,
+                            state.interview_id,
+                            phase="start_question_parent_handoff",
+                            score=live_score,
+                            error=question_result.error,
+                        )
+
                     error_msg = str(question_result.error)
                     event_error_msg = _format_interview_failure_event_error(question_result.error)
                     from ouroboros.events.interview import interview_failed
@@ -2418,6 +2517,31 @@ class InterviewHandler:
                     live_score = _load_state_ambiguity_score(state)
                     question_result = await engine.ask_next_question(state)
                 if question_result.is_err:
+                    if _is_question_generation_envelope_violation(question_result.error):
+                        from ouroboros.events.interview import interview_question_parent_handoff
+
+                        self._emit_event_bg(
+                            interview_question_parent_handoff(
+                                session_id,
+                                phase="next_question_generation",
+                                reason_code=_QUESTION_GENERATION_ENVELOPE_REASON_CODE,
+                                provider_error_type=_provider_error_type(question_result.error),
+                            )
+                        )
+                        log.warning(
+                            "mcp.tool.interview.question_generation_parent_handoff",
+                            session_id=session_id,
+                            phase="next_question_generation",
+                            reason_code=_QUESTION_GENERATION_ENVELOPE_REASON_CODE,
+                        )
+                        return self._parent_question_handoff_response(
+                            state,
+                            session_id,
+                            phase="next_question_parent_handoff",
+                            score=live_score,
+                            error=question_result.error,
+                        )
+
                     error_msg = str(question_result.error)
                     event_error_msg = _format_interview_failure_event_error(question_result.error)
                     from ouroboros.events.interview import interview_failed

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -17,7 +17,9 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
-from ouroboros.auto.adapters import HandlerInterviewBackend
+import pytest
+
+from ouroboros.auto.adapters import HandlerError, HandlerInterviewBackend
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipelineResult
@@ -37,7 +39,7 @@ from ouroboros.mcp.tools.auto_handler import (
     _result_meta,
     _seed_initial_ledger_from_user_preferences,
 )
-from ouroboros.mcp.types import ContentType
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.providers.base import CompletionResponse, Message, UsageInfo
 from ouroboros.providers.claude_code_adapter import ClaudeCodeAdapter
 
@@ -106,6 +108,33 @@ Success criteria:
 Important dispatch rule:
 If `ouroboros_auto` is unavailable or interpreted as normal text, stop and report failure.
 """
+
+
+def test_parent_question_required_result_blocks_auto_interview_turn() -> None:
+    class _ParentQuestionHandler:
+        async def handle(self, arguments):  # type: ignore[no-untyped-def]
+            return Result.ok(
+                MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text="Session interview_parent\n\nAsk the user directly.",
+                        ),
+                    ),
+                    is_error=False,
+                    meta={
+                        "session_id": "interview_parent",
+                        "status": "parent_question_required",
+                        "ask_user_directly": True,
+                        "last_question_required": True,
+                    },
+                )
+            )
+
+    backend = HandlerInterviewBackend(_ParentQuestionHandler(), cwd="/tmp")  # type: ignore[arg-type]
+
+    with pytest.raises(HandlerError, match="parent-session user question"):
+        asyncio.run(backend.start("Build a CLI", cwd="/tmp", interview_id="interview_parent"))
 
 
 def _assert_isolated_allowed_tools(factory_kwargs: dict[str, Any]) -> None:
@@ -1393,8 +1422,7 @@ def test_auto_sub_interview_spy_adapter_fails_on_any_tool_request(
 
     assert result.is_ok, result.error
     assert captured["turn"] is None
-    assert captured["error_type"] == "PartialInterviewStartError"
-    assert "ToolUseBlock" in captured["error"]
+    assert captured["error_type"] == "HandlerError"
     assert "What is the primary user goal?" not in captured["error"]
 
     factory_kwargs = mock_factory.call_args.kwargs
@@ -1538,9 +1566,7 @@ def test_auto_sub_interview_isolates_parent_skill_invocations(
 
     assert result.is_ok, result.error
     assert captured["turn"] is None
-    assert captured["error_type"] == "PartialInterviewStartError"
-    assert "ToolUseBlock" in captured["error"]
-    assert "ouroboros-auto" in captured["error"]
+    assert captured["error_type"] == "HandlerError"
     assert "What should the first auto interview question clarify?" not in captured["error"]
 
     factory_kwargs = mock_factory.call_args.kwargs
@@ -1691,9 +1717,7 @@ def test_auto_sub_interview_isolates_parent_agent_invocations(
 
     assert result.is_ok, result.error
     assert captured["turn"] is None
-    assert captured["error_type"] == "PartialInterviewStartError"
-    assert "ToolUseBlock" in captured["error"]
-    assert "researcher" in captured["error"]
+    assert captured["error_type"] == "HandlerError"
     assert "What should the first auto interview question clarify?" not in captured["error"]
 
     factory_kwargs = mock_factory.call_args.kwargs
@@ -1839,9 +1863,7 @@ def test_auto_sub_interview_isolates_parent_plugin_invocations(
 
     assert result.is_ok, result.error
     assert captured["turn"] is None
-    assert captured["error_type"] == "PartialInterviewStartError"
-    assert "ToolUseBlock" in captured["error"]
-    assert "mcp__parent_plugin__lookup" in captured["error"]
+    assert captured["error_type"] == "HandlerError"
     assert "What should the first auto interview question clarify?" not in captured["error"]
 
     factory_kwargs = mock_factory.call_args.kwargs
@@ -1998,9 +2020,7 @@ def test_auto_sub_interview_isolates_parent_hook_context(
 
     assert result.is_ok, result.error
     assert captured["turn"] is None
-    assert captured["error_type"] == "PartialInterviewStartError"
-    assert "ToolUseBlock" in captured["error"]
-    assert "Bash" in captured["error"]
+    assert captured["error_type"] == "HandlerError"
     assert "What should the first auto interview question clarify?" not in captured["error"]
 
     factory_kwargs = mock_factory.call_args.kwargs

--- a/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
+++ b/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
@@ -174,6 +174,41 @@ async def test_tool_envelope_question_failure_hands_off_to_parent_session(
 
 
 @pytest.mark.asyncio
+async def test_first_question_parent_handoff_resume_records_last_question(
+    tmp_path: Path,
+) -> None:
+    provider_error = ProviderError(
+        "Question generator produced a ToolUseBlockViolation",
+        provider="claude_code",
+        details={"error_type": "ToolUseBlockViolation"},
+    )
+    engine = _FakeInterviewEngine(state_dir=tmp_path, question_error=provider_error)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=AsyncMock(),
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    start = await handler.handle({"initial_context": "Build a CLI", "cwd": str(tmp_path)})
+    session_id = start.value.meta["session_id"]
+    answer = await handler.handle(
+        {
+            "session_id": session_id,
+            "answer": "It should scaffold plugin manifests.",
+            "last_question": "What should the CLI do first?",
+        }
+    )
+    await handler.close()
+
+    assert answer.is_ok
+    persisted_state = engine.states[session_id]
+    assert persisted_state.rounds[-1].question == "What should the CLI do first?"
+    assert persisted_state.rounds[-1].user_response == "It should scaffold plugin manifests."
+
+
+@pytest.mark.asyncio
 async def test_tool_envelope_failure_after_answer_hands_off_without_mcp_error(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
+++ b/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from ouroboros.bigbang.interview import InterviewState, InterviewStatus
+from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError
@@ -46,6 +46,7 @@ class _FakeInterviewEngine:
 
     state_dir: Path
     saved_states: list[InterviewState] = field(default_factory=list)
+    states: dict[str, InterviewState] = field(default_factory=dict)
     question_error: Any | None = None
 
     async def start_interview(
@@ -73,12 +74,28 @@ class _FakeInterviewEngine:
             encoding="utf-8",
         )
         self.saved_states.append(state)
+        self.states[state.interview_id] = state
         return Result.ok(path)
 
-    async def load_state(
-        self, session_id: str
-    ) -> Result[InterviewState, MCPServerError]:  # pragma: no cover - unused
-        raise NotImplementedError
+    async def load_state(self, session_id: str) -> Result[InterviewState, MCPServerError]:
+        return Result.ok(self.states[session_id])
+
+    async def record_response(
+        self,
+        state: InterviewState,
+        user_response: str,
+        question: str,
+    ) -> Result[InterviewState, MCPServerError]:
+        state.rounds.append(
+            InterviewRound(
+                round_number=state.current_round_number,
+                question=question,
+                user_response=user_response,
+            )
+        )
+        state.mark_updated()
+        self.states[state.interview_id] = state
+        return Result.ok(state)
 
 
 @pytest.mark.asyncio
@@ -106,6 +123,120 @@ async def test_subprocess_handler_persists_session_id_on_question_failure(tmp_pa
         "interview state file must exist on disk after first-question failure"
     )
     assert engine.saved_states, "engine.save_state must have been invoked"
+
+
+@pytest.mark.asyncio
+async def test_tool_envelope_question_failure_hands_off_to_parent_session(
+    tmp_path: Path,
+) -> None:
+    provider_error = ProviderError(
+        "Question generator produced a ToolUseBlockViolation",
+        provider="claude_code",
+        details={"error_type": "ToolUseBlockViolation", "session_id": "claude-session-1"},
+    )
+    engine = _FakeInterviewEngine(state_dir=tmp_path, question_error=provider_error)
+    mock_store = AsyncMock()
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=mock_store,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle({"initial_context": "Build a CLI", "cwd": str(tmp_path)})
+    await handler.close()
+
+    assert outcome.is_ok
+    mcp_result = outcome.value
+    assert mcp_result.is_error is False
+    meta = mcp_result.meta or {}
+    session_id = meta.get("session_id")
+    assert isinstance(session_id, str) and session_id
+    assert meta["status"] == "parent_question_required"
+    assert meta["recoverable"] is True
+    assert meta["retry_mcp"] is False
+    assert meta["ask_user_directly"] is True
+    assert meta["last_question_required"] is True
+    assert meta["reason_code"] == "question_generation_envelope_violation"
+    assert meta["question_source"] == "parent_session"
+    assert meta["provider_error_type"] == "ToolUseBlockViolation"
+
+    response_text = mcp_result.content[0].text
+    assert "Ask the user exactly one natural Socratic clarification question" in response_text
+    assert "Do not mention MCP" in response_text
+    assert "last_question=<the exact question you asked>" in response_text
+    assert (tmp_path / f"interview_{session_id}.json").exists()
+
+    event_types = [call.args[0].type for call in mock_store.append.await_args_list]
+    assert "interview.question_generation.parent_handoff" in event_types
+    assert "interview.failed" not in event_types
+
+
+@pytest.mark.asyncio
+async def test_tool_envelope_failure_after_answer_hands_off_without_mcp_error(
+    tmp_path: Path,
+) -> None:
+    provider_error = ProviderError(
+        "Question generator produced a ToolUseBlockViolation",
+        provider="claude_code",
+        details={"error_type": "ToolUseBlockViolation"},
+    )
+    session_id = "interview_0123456789abcdef"
+    state = InterviewState(
+        interview_id=session_id,
+        initial_context="Build a CLI",
+        status=InterviewStatus.IN_PROGRESS,
+    )
+    state.rounds.append(
+        InterviewRound(
+            round_number=1,
+            question="What should this CLI do first?",
+            user_response="It should scaffold plugins.",
+        )
+    )
+    engine = _FakeInterviewEngine(
+        state_dir=tmp_path,
+        question_error=provider_error,
+        states={session_id: state},
+    )
+    await engine.save_state(state)
+    mock_store = AsyncMock()
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=mock_store,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle(
+        {
+            "session_id": session_id,
+            "answer": "Use the existing plugin manifest format.",
+            "last_question": "Which manifest format should the CLI use?",
+        }
+    )
+    await handler.close()
+
+    assert outcome.is_ok
+    mcp_result = outcome.value
+    assert mcp_result.is_error is False
+    meta = mcp_result.meta or {}
+    assert meta["status"] == "parent_question_required"
+    assert meta["ask_user_directly"] is True
+    assert meta["last_question_required"] is True
+    assert meta["retry_mcp"] is False
+    assert meta["question_source"] == "parent_session"
+    assert meta["interview_reasoning"]["phase"] == "next_question_parent_handoff"
+
+    persisted_state = engine.states[session_id]
+    assert persisted_state.rounds[-1].question == "Which manifest format should the CLI use?"
+    assert persisted_state.rounds[-1].user_response == "Use the existing plugin manifest format."
+
+    event_types = [call.args[0].type for call in mock_store.append.await_args_list]
+    assert "interview.question_generation.parent_handoff" in event_types
+    assert "interview.failed" not in event_types
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1199

## Summary
- return a non-error `parent_question_required` handoff when interview question generation hits a strict provider tool-envelope violation
- record a dedicated `interview.question_generation.parent_handoff` event instead of surfacing `interview.failed` for that recoverable UX path
- update the interview skill so the main session asks one natural question and resumes with `last_question`

## Validation
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run ruff check src/ouroboros/mcp/tools/authoring_handlers.py src/ouroboros/events/interview.py tests/unit/mcp/tools/test_interview_persists_session_on_failure.py`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run ruff format --check src/ouroboros/mcp/tools/authoring_handlers.py src/ouroboros/events/interview.py tests/unit/mcp/tools/test_interview_persists_session_on_failure.py`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run pytest tests/unit/mcp/tools/test_interview_persists_session_on_failure.py -q`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.39.2 uv run pytest tests/unit/mcp/tools/test_interview_persists_session_on_failure.py tests/unit/mcp/tools/test_interview_allowed_tools_wiring.py tests/unit/mcp/tools/test_interview_strict_mcp_config_wiring.py tests/unit/providers/test_claude_code_adapter.py -k "empty_allowed_tools_spy_fails_on_tool_use_block or interview or persists" -q`
- `git diff --check`