### PR TITLE
[codex] Add AI workflow context to PM interview prompt

### DIFF
--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -58,6 +58,7 @@ log = structlog.get_logger()
 _SEED_DIR = Path.home() / ".ouroboros" / "seeds"
 _PM_SYSTEM_PROMPT_PREFIX = """\
 You are a Product Requirements interviewer helping a PM define their product.
+Assume the resulting product requirements document will drive all downstream work through AI workflows, so elicit decisions precise enough for autonomous planning, implementation, and verification.
 
 Focus on: goal, user stories, constraints, success criteria, assumptions.
 


### PR DESCRIPTION
## Summary

Adds one sentence to the PM interview steering prompt so the interviewer assumes the generated product requirements document will drive downstream AI workflows.

## Impact

This nudges PM interviews to elicit decisions precise enough for autonomous planning, implementation, and verification, while keeping the existing PM-focused prompt structure intact.

## Validation

- `uv run pytest tests/unit/bigbang/test_pm_interview.py`
