### PR TITLE
[codex] Preserve PM select_repos session id

### DIFF
--- a/src/ouroboros/mcp/tools/pm_handler.py
+++ b/src/ouroboros/mcp/tools/pm_handler.py
@@ -714,6 +714,7 @@ class PMInterviewHandler:
         cwd: str,
         *,
         selected_repos: list[str] | None = None,
+        interview_id: str | None = None,
     ) -> Result[MCPToolResult, MCPServerError]:
         """Start a new PM interview session.
 
@@ -761,6 +762,7 @@ class PMInterviewHandler:
 
         result = await engine.ask_opening_and_start(
             user_response=initial_context,
+            interview_id=interview_id,
             brownfield_repos=brownfield_repos,
         )
         if result.is_err:
@@ -1016,6 +1018,7 @@ class PMInterviewHandler:
             saved_context,
             cwd,
             selected_repos=selected_repos,
+            interview_id=session_id,
         )
 
     # ──────────────────────────────────────────────────────────────

--- a/tests/unit/mcp/tools/test_pm_handler.py
+++ b/tests/unit/mcp/tools/test_pm_handler.py
@@ -772,3 +772,40 @@ class TestDetectAction:
             }
         )
         assert result == "start"
+
+
+class TestSelectReposSessionContinuity:
+    """Regression coverage for the in-process 2-step PM start flow."""
+
+    async def test_select_repos_continues_existing_session_id(self, tmp_path: Path) -> None:
+        """Step 2 must start the interview under the session created in step 1."""
+        session_id = "interview_existing_session"
+        _save_pm_meta(
+            session_id,
+            engine=None,
+            cwd="/tmp/project",
+            data_dir=tmp_path,
+            extra={"initial_context": "Build a planning app"},
+        )
+
+        engine = _make_engine_stub()
+        engine.ask_opening_and_start = AsyncMock(return_value=Result.ok(_make_state(session_id)))
+        engine.ask_next_question = AsyncMock(return_value=Result.ok("What should it do first?"))
+        engine.save_state = AsyncMock(return_value=Result.ok(None))
+
+        handler = PMInterviewHandler(pm_engine=engine, data_dir=tmp_path)
+        result = await handler._handle_select_repos(
+            engine,
+            selected_repos=[],
+            session_id=session_id,
+            initial_context=None,
+            cwd="/tmp/project",
+        )
+
+        assert result.is_ok
+        engine.ask_opening_and_start.assert_awaited_once_with(
+            user_response="Build a planning app",
+            interview_id=session_id,
+            brownfield_repos=None,
+        )
+        assert result.value.meta["session_id"] == session_id


### PR DESCRIPTION
## Purpose

Preserve the public PM MCP session contract for the `select_repos` path. When a client starts the two-step PM flow and then submits selected repositories, the interview should continue under the same `session_id` that was created in step 1.

This preserves the PM `session_id` as the continuation handle for the `select_repos` flow. A client that sends the original PM `session_id` after repository selection should continue the same persisted interview state instead of creating a second interview under a fresh ID.

## Contents

- Thread the optional `interview_id` through `PMInterviewHandler._handle_start()` into `PMInterviewEngine.ask_opening_and_start()`.
- Pass the existing PM `session_id` as that `interview_id` from the in-process `select_repos` continuation path.
- Keep the interview state aligned with the caller-provided PM session handle instead of letting the inner interview engine allocate a fresh ID during repository selection.
- Add regression coverage proving that `select_repos` starts the interview under the caller-provided session ID. The intent is to keep the exposed MCP parameter path stable even though the current PM skill usually starts with `initial_context + cwd` and default brownfield repositories.

## Success Criteria

- `select_repos` no longer creates a fresh interview ID when continuing an existing pre-start PM session.
- Resume/generate callers can keep using the original PM session handle after repository selection.
- Regression tests cover the session-continuity contract.
- Validation passes:
  - `uv run pytest tests/unit/mcp/tools/test_pm_handler.py -q`
  - `uv run pytest tests/unit/mcp/tools/test_handler_subagent_wiring.py tests/unit/mcp/tools/test_round5_fixes.py -q`
