### PR TITLE
fix: keep plugin artifact hooks self-contained

### DIFF
--- a/.claude-plugin/skills/auto/SKILL.md
+++ b/.claude-plugin/skills/auto/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: auto
+description: "Automatically converge from goal to A-grade Seed and execute it"
+mcp_tool: ouroboros_auto
+mcp_args:
+  goal: "$goal"
+  resume: "$resume"
+  cwd: "$CWD"
+  max_interview_rounds: "$max_interview_rounds"
+  max_repair_rounds: "$max_repair_rounds"
+  skip_run: "$skip_run"
+  complete_product: "$complete_product"
+  pipeline_timeout_seconds: "$pipeline_timeout_seconds"
+---
+
+# /ouroboros:auto
+
+Run the full-quality auto pipeline from a single task description.
+
+## Dispatch requirement
+
+This skill must be executed by invoking MCP tool `ouroboros_auto`. Do not
+manually inspect repositories, run shell commands, query GitHub, edit files, or
+otherwise emulate the auto pipeline as a substitute.
+
+If `ouroboros_auto` is unavailable, stop and report that the required MCP tool
+is unavailable. A manual fallback is not an `ooo auto` run.
+
+If `ouroboros_auto` is invoked successfully but returns `blocked`, `failed`, or
+another terminal auto-session status, report that auto-session status and the
+tool's blocker. Do not label that outcome as MCP dispatch failure; dispatch
+failure means the MCP tool could not be invoked.
+
+## Usage
+
+```text
+ooo auto "Build a local-first habit tracker CLI"
+ooo auto --resume auto_abc123
+ooo auto "Build a local-first habit tracker CLI" --skip-run
+ooo auto "Build a local-first habit tracker CLI" --complete-product
+/ouroboros:auto "Build a local-first habit tracker CLI"
+```
+
+## CLI flag → MCP arg translation
+
+When the user types `ooo auto` with CLI-style flags inside chat, translate to MCP arguments before invoking `ouroboros_auto`:
+
+| CLI flag | MCP arg | Type |
+|----------|---------|------|
+| `--complete-product` | `complete_product=true` | boolean |
+| `--skip-run` | `skip_run=true` | boolean |
+| `--max-interview-rounds N` | `max_interview_rounds=N` | integer |
+| `--max-repair-rounds N` | `max_repair_rounds=N` | integer |
+| `--pipeline-timeout-seconds X` | `pipeline_timeout_seconds=X` | number |
+| `--resume <id>` | `resume=<id>` | string |
+
+`--max-generations` is **not** a flag for `ooo auto`; it belongs to `ooo ralph`. When `complete_product=true`, the chained Ralph uses its built-in default (10 generations) bounded by `pipeline_timeout_seconds` or Ralph's own per-iteration / wall-clock budgets.
+
+`--pipeline-timeout-seconds` is accepted only when starting a session. Passing it with `--resume` is rejected because the original deadline is preserved across process restarts.
+
+## Behavior
+
+1. Starts an auto session.
+2. Runs bounded Socratic interview rounds with source-tagged auto answers.
+3. Generates a Seed.
+4. Reviews and repairs until A-grade or blocked.
+5. Starts execution only after A-grade.
+6. When `complete_product=true`, chains RUN → RALPH_HANDOFF after a successful run handoff and waits for a terminal Ralph status so a single invocation iterates Ralph until QA passes, convergence, or a budget bound trips. A QA-pass on the executed product completes the auto session; recognized failure modes (`iteration_timeout`, `wall_clock_exhausted`, `oscillation_detected`, `grade_regressing`, `max_generations reached`) block the auto session with the matching `stop_reason` in `last_error` so operators can resume after the cause is addressed.
+
+### Canonical stop_reason_code taxonomy
+
+| Layer | Code | Surface | Meaning |
+|---|---|---|---|
+| Interview | `interview_max_rounds_exhausted` | `last_error_code`, `result.stop_reason_code` | Auto interview ran `max_interview_rounds` without ledger+backend mutual closure, no section was safely defaultable, and no partial defaults applied — i.e. genuine deadlock with nothing the policy could close. |
+| Interview | `interview_unsafe_gaps_remain` | `last_error_code`, `result.stop_reason_code` | Auto interview ran `max_interview_rounds` with at least one section safely defaultable and at least one section remaining unsafe (e.g. CONFLICTING ledger entry, production/credential context). Partial defaults are rolled back so the persisted transcript and ledger stay aligned; resume can address the unsafe gap and re-run. |
+| Interview | `interview_phase_deadline` | `last_error_code`, `result.stop_reason_code` | Interview phase exceeded its per-phase timeout. |
+| Ralph | `iteration_timeout` | blocker text + (future) `result.stop_reason_code` | A single Ralph iteration exceeded its per-iteration timeout. |
+| Ralph | `wall_clock_exhausted` | blocker text + (future) `result.stop_reason_code` | The Ralph wall-clock budget was exhausted before convergence. |
+| Ralph | `oscillation_detected` | blocker text + (future) `result.stop_reason_code` | Ralph oscillated between two grade states without making progress. |
+| Ralph | `grade_regressing` | blocker text + (future) `result.stop_reason_code` | A subsequent Ralph generation produced a strictly worse grade than its predecessor. |
+| Ralph | `max_generations reached` | blocker text + (future) `result.stop_reason_code` | Ralph hit its configured generation cap before reaching A grade. |
+
+Blockers without a canonical code keep using the free-form ``last_error`` text. Ralph-layer codes are surfaced via blocker text today; their result-envelope promotion is tracked as a follow-up.
+
+### Interview closure mode taxonomy
+
+When `result.status == "seed_ready"`, `result.interview_closure_mode` distinguishes how the interview was closed:
+
+| Value | Meaning |
+|---|---|
+| `None` | Mutual agreement — both the backend and the ledger declared the seed ready in the same round. The default healthy path. |
+| `"ledger_only"` | PR-B1 / #1148: `max_rounds` hit; the ledger was structurally complete but the backend refused to declare closure. The interview closes on ledger-only consensus. Defaulted sections (if any) are tagged in `result.defaulted_sections`. |
+| `"safe_default"` | PR-B2: `max_rounds` hit; the safe-default policy successfully filled every remaining required gap with auditable assumptions. Synthesis was pushed back into the persisted transcript so the seed generator sees the same assumptions the ledger records. Defaulted sections are tagged in `result.defaulted_sections`. |
+
+Genuine-deadlock and partial-unsafe outcomes do **not** set `interview_closure_mode`; they reach a `blocked` terminal with the matching `stop_reason_code` above instead.
+
+### Assumption-source provenance (PR-C2 / #1157)
+
+`result.assumptions: tuple[str, ...]` (the existing list of assumption texts) is now accompanied by `result.assumption_sources: tuple[AssumptionRecord, ...]`, where each `AssumptionRecord` is a frozen dataclass with:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `text` | `str` | The assumption text (same surface as the corresponding `assumptions` entry where present). |
+| `source` | `str` | One of `"assumption"` (auto-answerer fallback), `"inference"` (model reasoning), `"conservative_default"` (safe-default policy). These are the three assumption-class `LedgerSource` values that produce `assumption_only_sections`. |
+| `confidence` | `float` | Per-entry confidence as recorded by the ledger. |
+
+`assumption_sources` is a *broader* surface than `assumptions` — it includes inference- and conservative-default-class entries that `assumptions` (filtered to `LedgerSource.ASSUMPTION` only) does not surface. Callers wanting to know *which assumptions the system made on the user's behalf* should read `assumption_sources`; callers preserving the older string-only contract continue to read `assumptions`.
+
+The pipeline must not hang indefinitely: all loops are bounded and timeout failures return a resumable `auto_session_id`. Resume with `ooo auto --resume <auto_session_id>`. Use `--skip-run` to stop after the A-grade Seed. Use `--complete-product` to drive the full Interview → Seed → Run → Ralph → Product chain on a single `ooo auto` invocation; the chained Ralph loop honors the same wall-clock deadline as the parent auto session (`--timeout`). The CLI-only `--show-ledger` flag prints assumptions/non-goals; MCP skill responses already include the same ledger summary when available.

--- a/.claude-plugin/skills/brownfield/SKILL.md
+++ b/.claude-plugin/skills/brownfield/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: brownfield
+description: "Scan and manage brownfield repository/worktree defaults for interviews"
+---
+
+# /ouroboros:brownfield
+
+Scan a root directory for existing git repositories and linked worktrees, then manage default repos used as context in interviews.
+
+## Usage
+
+```
+ooo brownfield                # Scan repos and set defaults
+ooo brownfield scan           # Scan only (no default selection)
+ooo brownfield defaults       # Show current defaults
+ooo brownfield set 6,18,19   # Set defaults by repo numbers
+ooo brownfield detect [path]  # Author mechanical.toml via one AI call
+```
+
+**Trigger keywords:** "brownfield", "scan repos", "default repos", "brownfield scan", "mechanical detect"
+
+---
+
+## How It Works
+
+### Default flow (`ooo brownfield` with no args)
+
+**Step 1: Scan**
+
+Show scanning indicator:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Scanning for Existing Projects...
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Looking for git repositories and worktrees under the scan root directory.
+Linked worktrees reported by discovered normal repo roots may also be registered, even outside the scan root directory.
+Local repos and repos with any remote name are eligible.
+This may take a moment...
+```
+
+**Implementation — use MCP tools only, do NOT use CLI or Python scripts:**
+
+1. Load the brownfield MCP tool: `ToolSearch query: "+ouroboros brownfield"`
+2. Call scan+register:
+   ```
+   Tool: ouroboros_brownfield
+   Arguments: { "action": "scan" }
+   ```
+   This walks `scan_root` for valid seed repos/worktrees and registers them in DB. For each discovered normal repo root with a `.git` directory, Git-reported linked worktrees are also considered, even when they live outside `scan_root`. A linked worktree found under `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`. Existing defaults are preserved.
+
+The scan response `text` already contains a pre-formatted numbered list with `[default]` markers. **Do NOT make any additional MCP calls to list or query repos.**
+
+**Display the repos in a plain-text 2-column grid** (NOT a markdown table). Use a code block so columns align. Example:
+
+```
+Scan complete. 8 repositories registered.
+
+ 1. repo-alpha                   5. repo-epsilon
+ 2. repo-bravo *                 6. repo-foxtrot
+ 3. repo-charlie                 7. repo-golf *
+ 4. repo-delta                   8. repo-hotel
+```
+
+Include `*` markers for defaults exactly as they appear in the scan response.
+
+**If no repos found**, show:
+```
+No git repositories or worktrees found.
+```
+Then stop.
+
+### Scan boundaries
+
+- The filesystem walk starts at `scan_root`; when omitted, `scan_root` defaults to the current user's home directory.
+- Repositories are only discovered directly by walking directories inside `scan_root`.
+- Dot-prefixed directories and known noisy directories such as `node_modules` are not walked as seed locations.
+- Git worktrees are different: once a normal repo root with a `.git` directory is discovered, Ouroboros runs `git worktree list --porcelain` and may register those linked worktrees even if their paths are outside `scan_root`.
+- A linked worktree found inside `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`.
+- Local repos, repos without remotes, and repos whose remotes are not named `origin` are all eligible.
+
+**Step 2: Default Selection**
+
+**IMMEDIATELY after showing the list**, use `AskUserQuestion` with the current default numbers from the scan response.
+
+**If defaults exist**, show them as the recommended option:
+
+```json
+{
+  "questions": [{
+    "question": "Which repos to set as default for interviews? Enter numbers like '6, 18, 19'.",
+    "header": "Default Repos",
+    "options": [
+      {"label": "<current default numbers> (Recommended)", "description": "<current default names>"},
+      {"label": "None", "description": "No default repos — interviews will run in greenfield mode"}
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+**If no defaults exist**, do NOT show a "(Recommended)" option — offer "None" and "Select repos" instead:
+
+```json
+{
+  "questions": [{
+    "question": "Which repos to set as default for interviews? Enter numbers like '6, 18, 19'.",
+    "header": "Default Repos",
+    "options": [
+      {"label": "None", "description": "No default repos — interviews will run in greenfield mode"},
+      {"label": "Select repos", "description": "Type repo numbers to set as default"}
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+The user can select the recommended defaults (if any), choose "None", or type custom numbers.
+
+After the user responds, use ONE MCP call to update all defaults at once:
+
+```
+Tool: ouroboros_brownfield
+Arguments: { "action": "set_defaults", "indices": "<comma-separated IDs>" }
+```
+
+Example: if the user picks IDs 6, 18, 19 → `{ "action": "set_defaults", "indices": "6,18,19" }`
+
+This clears all existing defaults and sets the selected repos as default in one call.
+
+If "None" → `{ "action": "set_defaults", "indices": "" }` to clear all defaults.
+
+**Step 3: Confirmation**
+
+```
+Brownfield defaults updated!
+Defaults: grape, podo-app, podo-backend
+
+These repos will be used as context in interviews.
+```
+
+Or if "None" selected:
+```
+No default repos set. Interviews will run in greenfield mode.
+You can set defaults anytime with: ooo brownfield
+```
+
+---
+
+### Subcommand: `scan`
+
+Scan only, no default selection prompt. Show the numbered list and stop.
+
+---
+
+### Subcommand: `defaults`
+
+Load the brownfield MCP tool and call:
+```
+Tool: ouroboros_brownfield
+Arguments: { "action": "scan" }
+```
+
+Display only the repos marked with `*` (defaults). If none, show:
+```
+No default repos set. Run 'ooo brownfield' to configure.
+```
+
+---
+
+### Subcommand: `set <indices>`
+
+Directly set defaults without scanning. Parse the comma-separated indices from the user's input and call:
+
+```
+Tool: ouroboros_brownfield
+Arguments: { "action": "set_defaults", "indices": "<indices>" }
+```
+
+Show confirmation with updated defaults.
+
+---
+
+### Subcommand: `detect [path]`
+
+Runs one AI call against the target directory (defaults to the user's cwd)
+and writes `.ouroboros/mechanical.toml` with validated lint / build / test /
+static / coverage commands. Stage 1 of evaluation reads this file verbatim,
+so the toml is the authoritative Stage 1 contract — no hardcoded language
+presets exist anymore.
+
+Ouroboros auto-runs this detect the first time `ouroboros_evaluate` is
+invoked without a toml present, so most users never need to call it
+directly. Run it explicitly when:
+
+- you want to pre-author the toml before the first evaluate,
+- you moved to a new build tool and want to refresh (`--force`),
+- you want to review/edit the commands before Stage 1 trusts them.
+
+**Implementation:** invoke the CLI via Bash.
+
+```
+uvx --from ouroboros-ai ouroboros detect [path]
+# or, if already installed:
+ouroboros detect [path] [--force]
+```
+
+Then print the resulting `.ouroboros/mechanical.toml` contents so the user
+can confirm the proposed commands or hand-edit them.
+
+If detect reports "could not propose any verifiable commands", surface the
+reason (no manifests found, LLM unavailable, every proposal dropped) and
+suggest the user write a minimal toml by hand — any single entry like
+`test = "pytest -q"` is enough to opt back in to Stage 1 for that check.

--- a/.claude-plugin/skills/cancel/SKILL.md
+++ b/.claude-plugin/skills/cancel/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: cancel
+description: "Cancel stuck or orphaned executions"
+---
+
+# /ouroboros:cancel
+
+Cancel stuck or orphaned executions by session ID, cancel all running sessions, or interactively pick from active executions.
+
+## Usage
+
+```
+/ouroboros:cancel                          # Interactive: list active, pick one
+/ouroboros:cancel <execution_id>           # Cancel specific execution
+/ouroboros:cancel --all                    # Cancel all running executions
+```
+
+**Trigger keywords:** "cancel execution", "kill session", "stop running", "abort execution"
+
+## How It Works
+
+This skill interacts **directly with the event store** (not via MCP tool) to emit cancellation events. It uses the CLI command under the hood.
+
+Three modes:
+
+1. **Bare (no args)**: Lists all active (running/paused) executions in a numbered table and prompts you to pick one to cancel
+2. **Explicit (`execution_id`)**: Cancels the specified execution immediately
+3. **`--all` flag**: Cancels every running or paused execution at once
+
+## Instructions
+
+When the user invokes this skill:
+
+1. Determine which mode to use:
+   - If the user provided an execution/session ID: **Explicit mode**
+   - If the user says "cancel all" or "cancel everything": **--all mode**
+   - If no ID given and not "all": **Bare mode** (interactive listing)
+
+2. Run the appropriate CLI command using Bash:
+
+   **Bare mode** (interactive):
+   ```bash
+   ouroboros cancel execution
+   ```
+   This will list active executions and prompt for selection.
+
+   **Explicit mode** (specific execution):
+   ```bash
+   ouroboros cancel execution <execution_id>
+   ```
+
+   **Cancel all mode**:
+   ```bash
+   ouroboros cancel execution --all
+   ```
+
+   **With custom reason**:
+   ```bash
+   ouroboros cancel execution <execution_id> --reason "Stuck for 2 hours"
+   ```
+
+3. Present results to the user:
+   - Show which executions were cancelled
+   - If bare mode, show the list and selection prompt
+   - If no active executions, inform the user
+
+4. End with a next-step suggestion:
+   - After cancellation: `📍 Cancelled — use ooo status to verify, or ooo run to start fresh`
+   - No active sessions: `📍 No active executions — use ooo run to start a new one`
+
+## State Transitions
+
+Only sessions in `running` or `paused` status can be cancelled. Sessions that are already `completed`, `failed`, or `cancelled` are skipped with a warning.
+
+## Fallback (No Database)
+
+If the event store database does not exist:
+
+```
+No Ouroboros database found at ~/.ouroboros/ouroboros.db.
+Run an execution first with: /ouroboros:run
+```
+
+## Example
+
+```
+User: cancel that stuck execution
+
+> ouroboros cancel execution
+
+Active Executions
+┌───┬──────────────────┬──────────────┬─────────┬─────────┬──────────────┐
+│ # │ Session ID       │ Execution ID │ Seed ID │ Status  │ Started      │
+├───┼──────────────────┼──────────────┼─────────┼─────────┼──────────────┤
+│ 1 │ sess-abc-123     │ exec-001     │ seed-42 │ running │ 2024-01-15   │
+│ 2 │ sess-def-456     │ exec-002     │ seed-99 │ paused  │ 2024-01-14   │
+└───┴──────────────────┴──────────────┴─────────┴─────────┴──────────────┘
+
+Enter number to cancel (1-2), or 'q' to quit: 1
+Cancel session sess-abc-123 (running)? [y/N]: y
+✓ Cancelled execution: sess-abc-123
+
+📍 Cancelled — use `ooo status` to verify, or `ooo run` to start fresh
+```

--- a/.claude-plugin/skills/evaluate/SKILL.md
+++ b/.claude-plugin/skills/evaluate/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: evaluate
+description: "Evaluate execution with three-stage verification pipeline"
+---
+
+# /ouroboros:evaluate
+
+Evaluate an execution session using the three-stage verification pipeline.
+
+## Usage
+
+```
+/ouroboros:evaluate <session_id> [artifact]
+```
+
+**Trigger keywords:** "evaluate this", "3-stage check"
+
+## How It Works
+
+The evaluation pipeline runs three progressive stages:
+
+1. **Stage 1: Mechanical Verification** ($0 cost)
+   - Lint checks, build validation, test execution
+   - Static analysis, coverage measurement
+   - Fails fast if mechanical checks don't pass
+
+2. **Stage 2: Semantic Evaluation** (Standard tier)
+   - AC compliance assessment
+   - Goal alignment scoring
+   - Drift measurement
+   - Reasoning explanation
+
+3. **Stage 3: Multi-Model Consensus** (Frontier tier, optional)
+   - Multiple models vote on approval
+   - Only triggered by uncertainty or manual request
+   - Majority ratio determines outcome
+
+## Instructions
+
+When the user invokes this skill:
+
+### Load MCP Tools (Required first)
+
+The Ouroboros MCP tools are often registered as **deferred tools** that must be explicitly loaded before use. **You MUST perform this step before proceeding.**
+
+1. Use the `ToolSearch` tool to find and load the evaluate MCP tool:
+   ```
+   ToolSearch query: "+ouroboros evaluate"
+   ```
+2. The tool will typically be named `mcp__plugin_ouroboros_ouroboros__ouroboros_evaluate` (with a plugin prefix). After ToolSearch returns, the tool becomes callable.
+3. If ToolSearch finds the tool → proceed with the MCP-based evaluation below. If not → skip to **Fallback** section.
+
+**IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
+
+### Evaluation Steps
+
+1. Determine what to evaluate:
+   - If `session_id` provided: Use it directly
+   - If no session_id: Check conversation for recent execution session IDs
+
+2. Gather the artifact to evaluate:
+   - If user specifies a file: Read it with Read tool
+   - If recent execution output exists in conversation: Use that
+   - Ask user if unclear what to evaluate
+
+3. Call the `ouroboros_evaluate` MCP tool:
+   ```
+   Tool: ouroboros_evaluate
+   Arguments:
+     session_id: <session ID>
+     artifact: <the code/output to evaluate>
+     seed_content: <original seed YAML, if available>
+     acceptance_criterion: <specific AC to check, optional>
+     artifact_type: "code"  (or "docs", "config")
+     trigger_consensus: false  (true if user requests Stage 3)
+   ```
+
+4. Present results clearly:
+   - Show each stage's pass/fail status
+   - Highlight the final approval decision
+   - If rejected, explain the failure reason
+   - Suggest fixes if evaluation fails
+   - Always end with a 📍 suggestion based on the outcome:
+     - **APPROVED**: `📍 Done! Your implementation passes all checks. Optional: ooo evolve to iteratively refine`
+     - **REJECTED at Stage 1** (mechanical, `code_changes_detected: true`): `📍 Next: Fix the build/test failures above, then ooo evaluate — or ooo ralph for automated fix loop`
+     - **REJECTED at Stage 1** (mechanical, `code_changes_detected: false`): `📍 Next: Run ooo run first to produce code, then ooo evaluate`
+     - **REJECTED at Stage 2** (semantic): `📍 Next: ooo run to re-execute with fixes — or ooo evolve for iterative refinement`
+     - **REJECTED at Stage 3** (consensus): `📍 Next: ooo interview to re-examine requirements — or ooo unstuck to challenge assumptions`
+
+## Fallback (No MCP Server)
+
+If the MCP server is not available, use the `ouroboros:evaluator` agent to perform a prompt-based evaluation:
+
+1. Delegate to `ouroboros:evaluator` agent
+2. The agent performs qualitative evaluation based on the seed spec
+3. Results are advisory (no numerical scoring without Python core)
+
+## Example
+
+```
+User: /ouroboros:evaluate sess-abc-123
+
+Evaluation Results
+============================================================
+Final Approval: APPROVED
+Highest Stage Completed: 2
+
+Stage 1: Mechanical Verification
+  [PASS] lint: No issues found
+  [PASS] build: Build successful
+  [PASS] test: 12/12 tests passing
+
+Stage 2: Semantic Evaluation
+  Score: 0.85
+  AC Compliance: YES
+  Goal Alignment: 0.90
+  Drift Score: 0.08
+
+📍 Done! Your implementation passes all checks. Optional: `ooo evolve` to iteratively refine
+```

--- a/.claude-plugin/skills/evolve/SKILL.md
+++ b/.claude-plugin/skills/evolve/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: evolve
+description: "Start or monitor an evolutionary development loop"
+---
+
+# ooo evolve - Evolutionary Loop
+
+## Description
+Start, monitor, or rewind an evolutionary development loop. The loop iteratively
+refines the ontology and acceptance criteria across generations until convergence.
+
+## Flow
+```
+Gen 1: Interview → Seed(O₁) → Execute → Evaluate
+Gen 2: Wonder → Reflect → Seed(O₂) → Execute → Evaluate
+Gen 3: Wonder → Reflect → Seed(O₃) → Execute → Evaluate
+...until ontology converges (similarity ≥ 0.95) or max 30 generations
+```
+
+## Usage
+
+### Start a new evolutionary loop
+```
+ooo evolve "build a task management CLI"
+```
+
+### Fast mode (ontology-only, no execution)
+```
+ooo evolve "build a task management CLI" --no-execute
+```
+
+### Check lineage status
+```
+ooo evolve --status <lineage_id>
+```
+
+### Rewind to a previous generation
+```
+ooo evolve --rewind <lineage_id> <generation_number>
+```
+
+## Instructions
+
+### Load MCP Tools (Required before Path A/B decision)
+
+The Ouroboros MCP tools are often registered as **deferred tools** that must be explicitly loaded before use. **You MUST perform this step before deciding between Path A and Path B.**
+
+1. Use the `ToolSearch` tool to find and load the evolve MCP tools:
+   ```
+   ToolSearch query: "+ouroboros evolve"
+   ```
+2. The tools will typically be named with prefix `mcp__plugin_ouroboros_ouroboros__` (e.g., `ouroboros_evolve_step`, `ouroboros_interview`, `ouroboros_generate_seed`). After ToolSearch returns, the tools become callable.
+3. If ToolSearch finds the tools → proceed to **Path A**. If not → proceed to **Path B**.
+
+**IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
+
+### Path A: MCP Available (loaded via ToolSearch above)
+
+**Starting a new evolutionary loop:**
+1. Parse the user's input as `initial_context`
+2. Run the interview: call `ouroboros_interview` with `initial_context`
+3. Complete the interview (3+ rounds until ambiguity ≤ 0.2)
+4. Generate seed: call `ouroboros_generate_seed` with the `session_id`
+5. Call `ouroboros_evolve_step` with:
+   - `lineage_id`: new unique ID (e.g., `lin_<seed_id>`)
+   - `seed_content`: the generated seed YAML
+   - `execute`: `true` (default) for full Execute→Evaluate pipeline,
+     `false` for fast ontology-only evolution (no seed execution)
+6. Check the `action` in the response:
+   - `continue` → Call `ouroboros_evolve_step` again with just `lineage_id`
+   - `converged` → Evolution complete! Display final ontology
+   - `stagnated` → Ontology unchanged for 3+ gens. Consider `ouroboros_lateral_think`
+   - `exhausted` → Max 30 generations reached. Display best result
+   - `failed` → Check error, possibly retry
+7. **Repeat step 6** until action ≠ `continue`
+8. When the loop terminates, display a result summary with next step:
+   - `converged`: `📍 Next: Ontology converged! Run ooo evaluate for formal verification`
+   - `stagnated`: `📍 Next: ooo unstuck to break through, then ooo evolve --status <lineage_id> to resume`
+   - `exhausted`: `📍 Next: ooo evaluate to check best result — or ooo unstuck to try a new approach`
+   - `failed`: `📍 Next: Check the error above. ooo status to inspect session, or ooo unstuck if blocked`
+
+**Checking status:**
+1. Call `ouroboros_lineage_status` with the `lineage_id`
+2. Display: generation count, ontology evolution, convergence progress
+
+**Rewinding:**
+1. Call `ouroboros_evolve_step` with:
+   - `lineage_id`: the lineage to continue from a rewind point
+   - `seed_content`: the seed YAML from the target generation
+   (Future: dedicated `ouroboros_evolve_rewind` tool)
+
+### Path B: Plugin-only (no MCP tools available)
+
+If MCP tools are not available, explain the evolutionary loop concept and
+suggest installing the Ouroboros MCP server. See [Getting Started](docs/getting-started.md) for install options, then run:
+
+```
+ouroboros mcp serve
+```
+
+Then add to your runtime's MCP configuration (e.g., `~/.claude/mcp.json` for Claude Code).
+
+## Key Concepts
+
+- **Wonder**: "What do we still not know?" - examines evaluation results
+  to identify ontological gaps and hidden assumptions
+- **Reflect**: "How should the ontology evolve?" - proposes specific
+  mutations to fields, acceptance criteria, and constraints
+- **Convergence**: Loop stops when ontology similarity ≥ 0.95 between
+  consecutive generations, or after 30 generations max
+- **Rewind**: Each generation is a snapshot. You can rewind to any
+  generation and branch evolution from there
+- **evolve_step**: Runs exactly ONE generation per call. Designed for
+  Ralph integration — state is fully reconstructed from events between calls
+- **execute flag**: `true` (default) runs full Execute→Evaluate each generation.
+  `false` skips execution for fast ontology exploration. Previous generation's
+  execution output is fed into Wonder/Reflect for informed evolution
+- **QA verdict**: Each generation's response includes a QA Verdict section
+  (when `execute=true` and `skip_qa` is not set). Use the QA score to track
+  quality progression across generations. Pass `skip_qa: true` to disable

--- a/.claude-plugin/skills/help/SKILL.md
+++ b/.claude-plugin/skills/help/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: help
+description: "Full reference guide for Ouroboros commands and agents"
+---
+
+# /ouroboros:help
+
+Full reference guide for Ouroboros power users.
+
+## Usage
+
+```
+ooo help
+/ouroboros:help
+```
+
+## What Is Ouroboros?
+
+Ouroboros is a **requirement crystallization engine** for AI workflows. It transforms vague ideas into validated specifications through:
+
+1. **Socratic Interview** - Exposes hidden assumptions
+2. **Seed Generation** - Creates immutable specifications
+3. **PAL Routing** - Auto-escalates/descends model complexity
+4. **Lateral Thinking** - 5 personas to break stagnation
+5. **3-Stage Evaluation** - Mechanical > Semantic > Consensus
+
+## All Commands
+
+### Core Commands
+
+| Command | Purpose | Mode |
+|---------|---------|------|
+| `ooo` | Welcome + quick start | Plugin |
+| `ooo interview` | Socratic requirement clarification | Plugin |
+| `ooo seed` | Generate validated seed spec | Plugin |
+| `ooo run` | Execute seed workflow | MCP |
+| `ooo evaluate` | 3-stage verification | MCP |
+| `ooo unstuck` | 5 lateral thinking personas | Plugin |
+| `ooo status` | Session status + drift check | MCP |
+| `ooo resume-session` | List in-flight sessions and re-attach commands | CLI |
+| `ooo setup` | Installation wizard | Plugin |
+| `ooo welcome` | First-touch welcome guide | Plugin |
+| `ooo tutorial` | Interactive hands-on learning | Plugin |
+| `ooo help` | This reference guide | Plugin |
+| `ooo pm` | PM-focused interview + PRD generation | MCP |
+| `ooo qa` | General-purpose QA verdict for any artifact | Plugin |
+| `ooo cancel` | Cancel stuck or orphaned executions | CLI |
+| `ooo update` | Check for updates + upgrade to latest | Plugin |
+| `ooo brownfield` | Scan and manage brownfield repo defaults | MCP |
+| `ooo publish` | Publish Seed as GitHub Issues for teams | Plugin |
+
+### Evolutionary Loop
+
+| Command | Purpose | Mode |
+|---------|---------|------|
+| `ooo evolve` | Start/monitor evolutionary development loop | MCP |
+| `ooo ralph` | Client-driven loop until verified (uses background evolve_step jobs) | Plugin + MCP |
+
+**Plugin** = Works immediately after `ooo setup`.
+**MCP** = Requires `ooo setup` (Python >= 3.12 auto-detected). Run setup once to unlock all features.
+
+## Natural Language Triggers
+
+| Phrase | Triggers |
+|--------|----------|
+| "interview me", "clarify requirements", "socratic interview" | `ooo interview` |
+| "crystallize", "generate seed", "create seed", "freeze requirements" | `ooo seed` |
+| "ouroboros run", "execute seed", "run seed", "run workflow" | `ooo run` |
+| "evaluate this", "3-stage check", "verify execution" | `ooo evaluate` |
+| "think sideways", "i'm stuck", "break through", "lateral thinking" | `ooo unstuck` |
+| "am I drifting?", "drift check", "session status" | `ooo status` |
+
+### Utility Triggers
+
+| Phrase | Triggers |
+|--------|----------|
+| "write prd", "pm interview", "product requirements", "create prd" | `ooo pm` |
+| "qa check", "quality check" | `ooo qa` |
+| "cancel execution", "stop job", "kill stuck", "abort execution" | `ooo cancel` |
+| "in-flight sessions", "mcp disconnected", "lost Ouroboros execution" | `ooo resume-session` |
+| "update ouroboros", "upgrade ouroboros" | `ooo update` |
+| "brownfield defaults", "brownfield scan" | `ooo brownfield` |
+| "publish to github", "create issues from seed", "seed to issues" | `ooo publish` |
+
+### Loop Triggers
+
+| Phrase | Triggers |
+|--------|----------|
+| "ralph", "don't stop", "must complete", "until it works", "keep going" | `ooo ralph` |
+| "evolve", "evolutionary loop", "iterate until converged" | `ooo evolve` |
+
+## Available Skills
+
+### Core Skills
+
+| Skill | Purpose | Mode |
+|-------|---------|------|
+| `/ouroboros:welcome` | First-touch welcome experience | Plugin |
+| `/ouroboros:interview` | Socratic requirement clarification | Plugin |
+| `/ouroboros:seed` | Generate validated seed spec | Plugin |
+| `/ouroboros:run` | Execute seed workflow | MCP |
+| `/ouroboros:evaluate` | 3-stage verification | MCP |
+| `/ouroboros:unstuck` | 5 lateral thinking personas | Plugin |
+| `/ouroboros:status` | Session status + drift check | MCP |
+| `/ouroboros:resume-session` | List in-flight sessions and re-attach commands | CLI |
+| `/ouroboros:setup` | Installation wizard | Plugin |
+| `/ouroboros:tutorial` | Interactive hands-on learning | Plugin |
+| `/ouroboros:help` | This guide | Plugin |
+| `/ouroboros:pm` | PM-focused interview + PRD generation | MCP |
+| `/ouroboros:qa` | General-purpose QA verdict for any artifact | Plugin |
+| `/ouroboros:cancel` | Cancel stuck or orphaned executions | CLI |
+| `/ouroboros:update` | Check for updates + upgrade to latest | Plugin |
+| `/ouroboros:brownfield` | Scan and manage brownfield repo defaults | MCP |
+| `/ouroboros:publish` | Publish Seed as GitHub Issues for teams | Plugin |
+
+### Loop Skills
+
+| Skill | Purpose | Best For |
+|-------|---------|----------|
+| `/ouroboros:ralph` | Client-driven loop over background evolve_step jobs | "Don't stop", must complete |
+| `/ouroboros:evolve` | Evolutionary ontology refinement | Spec iteration until convergence |
+
+## Available Agents
+
+| Agent | Purpose |
+|-------|---------|
+| `ouroboros:socratic-interviewer` | Exposes hidden assumptions through questioning |
+| `ouroboros:ontologist` | Finds root problems vs symptoms |
+| `ouroboros:seed-architect` | Crystallizes requirements into seed specs |
+| `ouroboros:evaluator` | Three-stage verification |
+| `ouroboros:contrarian` | "Are we solving the wrong problem?" |
+| `ouroboros:hacker` | "Make it work first, elegance later" |
+| `ouroboros:simplifier` | "Cut scope to absolute minimum" |
+| `ouroboros:researcher` | "Stop coding, start investigating" |
+| `ouroboros:architect` | "Question the foundation, redesign if needed" |
+
+## Setup
+
+After installing Ouroboros, run `ooo setup` once to register the MCP server.
+This connects your runtime backend to the Ouroboros Python core and unlocks all features.
+
+```
+ooo setup    # One-time setup (~1 minute)
+```

--- a/.claude-plugin/skills/interview/SKILL.md
+++ b/.claude-plugin/skills/interview/SKILL.md
@@ -1,0 +1,657 @@
+---
+name: interview
+description: "Socratic interview to crystallize vague requirements"
+mcp_tool: ouroboros_interview
+mcp_args:
+  initial_context: "$1"
+  cwd: "$CWD"
+---
+
+# /ouroboros:interview
+
+Socratic interview to crystallize vague requirements into clear specifications.
+
+
+## Required Skill Capabilities
+
+- `ask_user` — ask human-judgment questions through the active runtime's user-question surface.
+- `inspect_code` — answer repo-local factual questions from exact local files before asking the user.
+- `call_mcp` — use Ouroboros MCP tools for persistent interview state and seed generation.
+- `web_research` — fetch current external facts only when the interview genuinely depends on them.
+- `run_shell` — run bounded local commands for version checks and repository inspection.
+- `refine_answer` — confirm structured interpretations of free-text answers before forwarding them.
+- `maintain_ledger` — keep ambiguity, gates, and unresolved decisions visible in the main session.
+- `run_closure_gate` — audit readiness locally even when MCP reports `seed-ready`.
+- `restate_goal` — restate the goal and require explicit approval before seed generation.
+
+## Non-Skippable Gates
+
+- Refine free-text answers that carry scope, constraints, or decisions.
+- Maintain a visible ambiguity ledger in the main session.
+- Treat MCP `seed-ready` as permission to audit closure, not as completion.
+- Apply Seed Closer criteria before suggesting or running seed generation.
+- Run the Restate gate before seed generation.
+- Require explicit user approval before suggesting or running seed generation.
+
+## Usage
+
+```
+ooo interview [topic]
+/ouroboros:interview [topic]
+```
+
+**Trigger keywords:** "interview me", "clarify requirements"
+
+## Instructions
+
+When the user invokes this skill:
+
+### Step 0: Version Check (runs before interview)
+
+Before starting the interview, check if a newer version is available:
+
+```bash
+# Fetch latest release tag from GitHub (timeout 3s to avoid blocking)
+curl -s --max-time 3 https://api.github.com/repos/Q00/ouroboros/releases/latest | grep -o '"tag_name": "[^"]*"' | head -1
+```
+
+Compare the result with the current version in the active runtime's local plugin metadata (for Claude installs this is `.claude-plugin/plugin.json`).
+- If a newer version exists, ask the user through the active runtime's `ask_user` capability:
+  ```json
+  {
+    "questions": [{
+      "question": "Ouroboros <latest> is available (current: <local>). Update before starting?",
+      "header": "Update",
+      "options": [
+        {"label": "Update now", "description": "Update plugin to latest version (restart required to apply)"},
+        {"label": "Skip, start interview", "description": "Continue with current version"}
+      ],
+      "multiSelect": false
+    }]
+  }
+  ```
+  - If "Update now":
+    - On Claude-plugin installs only:
+      1. Run `claude plugin marketplace update ouroboros` via the active runtime's `run_shell` capability (refresh marketplace index). If this fails, tell the user "⚠️ Marketplace refresh failed, continuing…" and proceed.
+      2. Run `claude plugin update ouroboros@ouroboros` via the active runtime's `run_shell` capability (update plugin/skills). If this fails, inform the user and stop — do NOT proceed to the package-manager step.
+    - On non-Claude runtimes, skip Claude plugin commands and proceed directly to the package-manager step for `ouroboros-ai`; do not require Claude-only commands or tools.
+    3. Detect the user's Python package manager and upgrade the MCP server:
+       - Check which tool installed `ouroboros-ai` by running these in order:
+         - `uv tool list 2>/dev/null | grep "^ouroboros-ai "` → if found, use `uv tool upgrade ouroboros-ai`
+         - `pipx list 2>/dev/null | grep "^  ouroboros-ai "` → if found, use `pipx upgrade ouroboros-ai`
+         - Otherwise, print: "Also upgrade the MCP server: `pip install --upgrade ouroboros-ai`" (do NOT run pip automatically)
+    4. Tell the user: "Updated! Restart your session to apply, then run `ooo interview` again."
+  - If "Skip": proceed immediately.
+- If versions match, the check fails (network error, timeout, rate limit 403/429), or parsing fails/returns empty: **silently skip** and proceed.
+
+Then choose the execution path:
+
+### Step 0.5: Load MCP Tools (Required before Path A/B decision)
+
+The Ouroboros MCP tools are often registered as **deferred tools** that must be explicitly loaded before use. **You MUST perform this step before deciding between Path A and Path B.**
+
+1. Use the active runtime's tool-discovery capability to find and load the interview MCP tool:
+   ```
+   tool discovery query: "+ouroboros interview"
+   ```
+   This searches for tools with "ouroboros" in the name related to "interview".
+
+2. The tool will typically be named `mcp__plugin_ouroboros_ouroboros__ouroboros_interview` (with a plugin prefix). After runtime tool discovery returns, the tool becomes callable.
+
+3. If runtime tool discovery finds the tool → proceed to **Path A**.
+   If runtime tool discovery returns no matching tools → proceed to **Path B**.
+
+**IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
+
+### Path A: MCP Mode (Preferred)
+
+If the `ouroboros_interview` MCP tool is available (loaded via runtime tool discovery above), use it for persistent, structured interviews.
+
+**Architecture**: MCP is a pure question generator. You (the main session) are the answerer and router.
+
+```
+MCP (question generator) ←→ You (answerer + router) ←→ User (human judgment only)
+```
+
+**Role split**:
+- **MCP**: Generates Socratic questions, manages interview state, scores ambiguity. Does NOT read code.
+- **You (main session)**: Receives MCP questions, answers them by reading code through the active runtime's `inspect_code` capability, or routes to the user when human judgment is needed.
+- **User**: Only answers questions that require human decisions (goals, acceptance criteria, business logic, preferences).
+
+#### Interview Flow
+
+1. **Start a new interview**:
+   ```
+   Tool: ouroboros_interview
+   Arguments:
+     initial_context: <user's topic or idea>
+     cwd: <current working directory>
+   ```
+   Returns a session ID and the first question.
+
+2. **For each question from MCP, apply the routing paths below:**
+
+   **Milestone lateral-review advisory**:
+   If an MCP response includes `meta.lateral_review_recommended=true`, treat it
+   as a non-blocking cue that the interview just crossed an ambiguity milestone
+   such as `initial -> progress`, `progress -> refined`, or `refined -> ready`.
+   The MCP tool is still only a question generator; it has not run lateral
+   personas, blocked the interview, or changed requirements. Before answering
+   the returned question, the main session may run `ooo lateral` / the
+   `ouroboros_lateral_think` MCP surface to inspect hidden assumptions for the
+   named `meta.lateral_review_milestone`, then fold only concrete, user-safe
+   findings into the next answer or user question. If lateral tooling is
+   unavailable or unnecessary, continue with the returned question; do not
+   restart the interview.
+
+   **PATH 1 — Code Answer** (describe current state from codebase):
+   When the question asks about existing tech stack, frameworks, dependencies,
+   current patterns, architecture, or file structure:
+   - Use the active runtime's `inspect_code` capability to find the factual answer
+   - **Description, not prescription**: "The project uses JWT" is fact.
+     "The new feature should also use JWT" is a DECISION — route to PATH 2.
+   - Evaluate confidence and choose sub-path:
+
+   **PATH 1a — Auto-confirm** (high-confidence factual, no user block):
+   When ALL of the following are true:
+   - The answer is found as an **exact match** in a manifest or config file
+     (e.g., `pyproject.toml`, `package.json`, `Dockerfile`, `go.mod`, `.env.example`)
+   - The answer is **purely descriptive** — it describes what exists, not what
+     the new feature should do
+   - There is **no ambiguity** — a single, clear answer (not multiple candidates)
+
+   Then:
+   - Send the answer to MCP immediately with `[from-code][auto-confirmed]` prefix
+   - Display a brief notification to the user (do NOT block):
+     `"ℹ️ Auto-confirmed: Python 3.12, FastAPI framework (pyproject.toml)"`
+   - The user can correct at any time by saying "that's wrong" — re-send correction to MCP
+   - Increment the auto-confirm counter (see Dialectic Rhythm Guard below)
+
+   Examples of auto-confirmable facts:
+   - Programming language (from pyproject.toml, package.json, go.mod)
+   - Framework (from dependencies in manifest)
+   - Python/Node version (from config files)
+   - Package manager (from lock files present)
+   - CI/CD tool (from .github/workflows/, Jenkinsfile, etc.)
+
+   **PATH 1b — Code Confirmation** (medium/low confidence, user confirms):
+   When the codebase has relevant information but confidence is not high enough
+   for auto-confirm (inferred from patterns, multiple candidates, or no manifest match):
+   - Present findings to user as a **confirmation question** through the active runtime's `ask_user` capability:
+     ```json
+     {
+       "questions": [{
+         "question": "MCP asks: What auth method does the project use?\n\nI found: JWT-based auth in src/auth/jwt.py\n\nIs this correct?",
+         "header": "Q<N> — Code Confirmation",
+         "options": [
+           {"label": "Yes, correct", "description": "Use this as the answer"},
+           {"label": "No, let me correct", "description": "I'll provide the right answer"}
+         ],
+         "multiSelect": false
+       }]
+     }
+     ```
+   - Prefix answer with `[from-code]` when sending to MCP
+   - If the user picks "Yes, correct", send the concise factual answer with
+     `[from-code]` and do not apply the Refine gate. Increment the
+     auto-confirm counter (see Dialectic Rhythm Guard below).
+   - If the user picks "No, let me correct", immediately use the `ask_user` capability to collect the corrected answer as free text:
+     ```json
+     {
+       "questions": [{
+         "question": "What should I send instead for this MCP question?\n\nMCP asks: What auth method does the project use?\n\nInclude any reasoning, constraints, or scope that should be preserved.",
+         "header": "Q<N> — Correction"
+       }]
+     }
+     ```
+   - Route the correction text through the Refine gate before sending it to
+     MCP. Send the multi-section payload with `[from-user][refined]` (the
+     human is now the source of the corrected answer).
+   - If the user supplies a correction directly without using the option, treat
+     that free text the same way: Refine first, then send with
+     `[from-user][refined]`.
+   - Reset the Dialectic Rhythm Guard counter to 0 because the corrected
+     answer is direct user judgment, even though it was initiated from a code
+     or research confirmation path.
+
+   **PATH 2 — Human Judgment** (decisions only humans can make):
+   When the question asks about goals, vision, acceptance criteria, business logic,
+   preferences, tradeoffs, scope, or desired behavior for NEW features:
+   - Present question directly to user through the active runtime's `ask_user` capability with suggested options
+   - Prefix answer with `[from-user]` when sending to MCP
+
+   **PATH 3 — Code + Judgment** (facts exist but interpretation needed):
+   When code contains relevant facts BUT the question also requires judgment
+   (e.g., "I see a saga pattern in orders/. Should payments use the same?"):
+   - Use the active runtime's `inspect_code` capability to read relevant code first
+   - Present BOTH the code findings AND the question to user
+   - If any part of the question requires judgment, route the ENTIRE question to user
+   - Prefix answer with `[from-user]` (human made the decision)
+
+   **PATH 4 — Research Interlude** (external knowledge needed):
+   When the question asks about third-party APIs, pricing models, library
+   capabilities, version compatibility, security advisories, or industry
+   standards that are NOT answerable from the local codebase:
+   - Use the active runtime's `web_research` capability to gather external information
+   - Present findings to user as a **confirmation question** through the active runtime's `ask_user` capability
+     (same pattern as PATH 1, but with web sources instead of code):
+     ```json
+     {
+       "questions": [{
+         "question": "MCP asks: What rate limits does the Stripe API have?\n\nI found: Stripe allows 100 read ops/sec and 25 write ops/sec in live mode.\n\nIs this correct?",
+         "header": "Q<N> — Research Confirmation",
+         "options": [
+           {"label": "Yes, correct", "description": "Use this as the answer"},
+           {"label": "No, let me correct", "description": "I'll provide the right answer"}
+         ],
+         "multiSelect": false
+       }]
+     }
+     ```
+   - Prefix answer with `[from-research]` when sending to MCP
+   - If the user picks "Yes, correct", send the concise factual answer with
+     `[from-research]` and do not apply the Refine gate. Increment the
+     auto-confirm counter (see Dialectic Rhythm Guard below).
+   - If the user picks "No, let me correct", immediately use the `ask_user` capability to collect the corrected answer as free text:
+     ```json
+     {
+       "questions": [{
+         "question": "What should I send instead for this MCP question?\n\nMCP asks: What rate limits does the Stripe API have?\n\nInclude any source correction, reasoning, constraints, or scope that should be preserved.",
+         "header": "Q<N> — Research Correction"
+       }]
+     }
+     ```
+   - Route the correction text through the Refine gate before sending it to
+     MCP. Send the multi-section payload with `[from-user][refined]` (the
+     human is now the source of the corrected answer).
+   - If the user supplies a correction directly without using the option, treat
+     that free text the same way: Refine first, then send with
+     `[from-user][refined]`.
+   - Reset the Dialectic Rhythm Guard counter to 0 because the corrected
+     answer is direct user judgment, even though it was initiated from a code
+     or research confirmation path.
+   - **Facts, not decisions**: "Stripe rate limit is 100 req/s" is research.
+     "We should use Stripe" is a DECISION — route to PATH 2.
+
+   **When in doubt, use PATH 2.** It's safer to ask the user than to guess.
+
+3. **Send the answer back to MCP**:
+
+   **Payload format — preserve the user's reasoning, do NOT compress to one line.**
+   MCP cannot read code, browse the web, or call tools. The text you send is
+   the only context MCP has when generating the next question. A one-line
+   answer collapses the user's reasoning, constraints, and scope decisions
+   into a label, which degrades both the next question's quality and the
+   ambiguity scoring. Send the user's full reasoning, structured.
+
+   Single-line answers are OK only for **PATH 1a auto-confirmed facts**,
+   **PATH 1b / PATH 4 pre-built option confirmations** where the factual
+   answer is already explicit, and short PATH 2 answers that have no reasoning
+   or constraints attached (e.g., "Yes" / "No" / "Python 3.12"). User
+   corrections, free-text reasoning, constraints, or scope decisions must be
+   sent as the multi-section payload below after the Refine gate.
+
+   ```
+   Tool: ouroboros_interview
+   Arguments:
+     session_id: <session ID>
+     answer: |
+       [from-user][refined]
+       Decision: Stripe Billing.
+
+       Reasoning:
+       - Subscription is the core business model.
+       - Stripe bundles invoice/dunning/tax — avoids building those.
+
+       Constraints (user-stated):
+       - 30% Korean MAU, KRW required.
+       - Revenue recognition automation OUT OF SCOPE this quarter.
+
+       Out of scope (user-stated):
+       - Refund policy changes, tax-invoice issuance.
+
+       Codebase context (main session verified):
+       - src/billing/ does not exist yet.
+       - src/payments/toss_adapter.py is one-shot KRW only.
+   ```
+
+   Short-answer cases (single-line OK):
+   ```
+   "[from-code][auto-confirmed] Python 3.12, FastAPI (pyproject.toml)"
+   "[from-code] JWT-based auth in src/auth/jwt.py"
+   "[from-research] Stripe allows 100 read ops/sec and 25 write ops/sec in live mode"
+   "[from-user] Yes"
+   ```
+
+   Append `[refined]` to an existing valid prefix (`[from-code]`,
+   `[from-user]`, or `[from-research]`) only when the answer has been through
+   the Refine gate (see Step 4). MCP records the answer, generates the next
+   question, and returns it.
+
+4. **Refine before forwarding** (free-text answers only):
+
+   When the user gives a free-text answer that carries reasoning, constraints,
+   or scope decisions, do NOT forward it to MCP unmodified and do NOT compress
+   it to a label. Structure it into the multi-section payload above, then ask
+   the user a single `ask_user` capability to confirm nothing is lost:
+
+   ```json
+   {
+     "questions": [{
+       "question": "I structured your answer as follows before sending it to MCP:\n\n<multi-section payload>\n\nIs anything missing or misrepresented?",
+       "header": "Refine — preserve the structure of your answer",
+       "options": [
+         {"label": "Send as-is", "description": "The structure captures my answer faithfully"},
+         {"label": "Add to Constraints", "description": "I want to add a constraint I forgot"},
+         {"label": "Add to Out of scope", "description": "I want to mark something explicitly out of scope"},
+         {"label": "Add context", "description": "I want to add reasoning, code context, or research context"},
+         {"label": "Rewrite", "description": "Let me re-state the answer"}
+       ],
+       "multiSelect": false
+     }]
+   }
+   ```
+
+   The Refine gate replaces "compress to one line" with "preserve the user's
+   reasoning, surface anything missing." It is skipped for:
+   - PATH 1a auto-confirmed facts
+   - PATH 1b / PATH 4 confirmation answers where the user picked a pre-built
+     option (the structure is already explicit)
+   - Short PATH 2 answers (e.g., "Yes" / single proper noun) with no
+     reasoning attached
+
+   **Exception — Restate corrections never skip Refine, regardless of length.**
+   Any free-text follow-up collected by the Step 9 Restate gate
+   ("Adjust wording" / "Missing scope") must go through Refine before being
+   forwarded to MCP. Even a short correction like
+   `"Exclude retry scheduling from the seed."` carries scope/boundary
+   information that MCP needs in structured form during the reopen call, so
+   the short-PATH-2 exemption above does NOT apply to Restate corrections.
+   A single-line Restate correction that bypasses Refine would forward
+   `[from-user]` instead of `[from-user][refined]` and would not trigger the
+   `last_question` reopen, leaving MCP on stale pre-correction state when
+   the seed is generated.
+
+   Refine-passed answers count as direct user judgment — they reset the
+   Dialectic Rhythm Guard counter to 0 (see below).
+
+   If the user picks "Add to Constraints", "Add to Out of scope", "Add context",
+   or "Rewrite", do not infer the missing text from the option label. Immediately
+   use the `ask_user` capability for one follow-up to collect the exact text:
+   ```json
+   {
+     "questions": [{
+       "question": "What text should I add or change before sending this to MCP?\n\nCurrent structured answer:\n\n<multi-section payload>",
+       "header": "Refine — Missing Text"
+     }]
+   }
+   ```
+   Apply the follow-up text to the structured payload, then ask the Refine gate
+   once more. Do not send the payload to MCP while the user is still telling
+   you that required text is missing or the answer should be rewritten. If the
+   second Refine response again says "Add to Constraints", "Add to Out of
+   scope", "Add context", or "Rewrite", ask a targeted PATH 2 follow-up for the
+   exact missing text and withhold the MCP answer until the user either
+   supplies that text or explicitly accepts the structured payload. The
+   `Add context` option is handled identically to the other three on the
+   second pass — never infer omitted content from the option label, and prefer
+   stopping over forwarding a payload the user has identified as incomplete.
+
+5. **Mark the answer as Refine-passed**:
+   Append `[refined]` to the prefix when sending the structured payload to
+   MCP (e.g., `[from-user][refined]`). MCP treats refined answers as
+   high-confidence ground truth for ambiguity scoring.
+
+6. **Keep a visible ambiguity ledger**:
+   Track independent ambiguity tracks (scope, constraints, outputs, verification).
+   Do NOT let the interview collapse onto a single subtopic.
+
+7. **Repeat steps 2-6** until the user says "done" or MCP signals seed-ready.
+
+8. **Seed-ready Acceptance Guard**:
+   When MCP signals seed-ready, do NOT relay completion blindly. Before
+   announcing completion or suggesting `ooo seed`, apply the canonical Seed
+   Closer criteria from `src/ouroboros/agents/seed-closer.md` as the single
+   source of truth for closure readiness. Run the check from the main session's
+   perspective, including any code, research, or brownfield context MCP did not
+   see.
+
+   If any material decision remains unresolved, do not announce seed-ready.
+   If the local challenge finds a material gap, explicitly override the MCP
+   signal: `"MCP says seed-ready, but I am not accepting it yet because <gap>."`
+   Explain the gap briefly and ask the single highest-impact follow-up question,
+   routed through PATH 2 or PATH 3 as appropriate.
+
+9. **Restate gate** (only after Seed-ready Acceptance Guard passes):
+
+   Once the Acceptance Guard passes, do not jump straight to `ooo seed`.
+   First restate the agreed goal as a single sentence and ask the user to
+   confirm it captures the decision. This is the one place where compression
+   to a single line is the goal — every other answer in the interview was
+   sent to MCP in full multi-section form (see Step 3), and now we collapse
+   the accumulated agreement into a one-line goal that another person could
+   read and arrive at the same outcome.
+
+   ```json
+   {
+     "questions": [{
+       "question": "Based on the answers we agreed on, here is a one-sentence restatement of the goal:\n\n  goal: <one-sentence restatement>\n\nIf someone else read only this line, would they arrive at the same outcome you have in mind?",
+       "header": "Restate — one-line goal before seed",
+       "options": [
+         {"label": "Yes, generate seed", "description": "The line captures the goal; proceed to ooo seed"},
+         {"label": "Adjust wording", "description": "The intent is right but I want to change words"},
+         {"label": "Missing scope", "description": "A condition or boundary is missing from the line"}
+       ],
+       "multiSelect": false
+     }]
+   }
+   ```
+
+   Only after the user accepts the restated line do you suggest `ooo seed`.
+   If the user picks "Adjust wording", immediately use the `ask_user` capability
+   to collect the replacement wording:
+   ```json
+   {
+     "questions": [{
+       "question": "How should the one-sentence goal be worded instead?\n\nCurrent line:\n  goal: <one-sentence restatement>",
+       "header": "Restate — Wording"
+     }]
+   }
+   ```
+
+   If the user picks "Missing scope", immediately use the `ask_user` capability
+   to collect the missing condition or boundary:
+   ```json
+   {
+     "questions": [{
+       "question": "What scope, condition, or boundary is missing from the one-sentence goal?\n\nCurrent line:\n  goal: <one-sentence restatement>",
+       "header": "Restate — Scope"
+     }]
+   }
+   ```
+
+   Treat the follow-up text as a real interview correction, not a local-only
+   wording tweak. Route the follow-up text through the Refine gate before
+   forwarding it. **The Step 4 short-PATH-2 skip rule does NOT apply here,
+   even if the correction is a single sentence** — a bare reply like
+   `"Exclude retry scheduling from the seed."` still encodes a boundary
+   decision that must reach MCP as `[from-user][refined]` with the reopen
+   `last_question`; sending it as `[from-user]` would leave MCP on the stale
+   pre-correction state. Then build the same structured multi-section
+   payload from Step 3 using the canonical five-section schema —
+   - **Decision**: the corrected one-line goal verbatim.
+   - **Reasoning**: why the wording/scope changed (carry over the user's
+     correction text, do not paraphrase).
+   - **Constraints (user-stated)**: any constraint introduced or tightened
+     by the correction.
+   - **Out of scope (user-stated)**: anything the correction marks as
+     explicitly excluded.
+   - **Codebase context (main session verified)**: the file paths, configs,
+     or facts the main session checked while preparing the restated goal, or
+     omit the section entirely if no code reference is involved.
+   Send that structured restate correction back to MCP with
+   `[from-user][refined]`, preserving the corrected goal line and the user's
+   stated wording or missing scope. Because this is a post-seed-ready follow-up
+   that MCP did not generate, call `ouroboros_interview` with both the
+   structured `answer` and `last_question` set to the exact local Restate
+   follow-up prompt you asked (for example, the "How should the one-sentence
+   goal be worded instead?" or "What scope, condition, or boundary is missing?"
+   question). Without `last_question`, the handler must reject the reopen rather
+   than attach the correction to a stale MCP question. Then return to Step 7 so
+   MCP can update its interview state and the Seed-ready Acceptance Guard can
+   run again against the updated state. Do not proceed directly to `ooo seed`
+   from the stale pre-correction MCP state.
+
+   After MCP returns seed-ready again and the Acceptance Guard still passes, ask
+   the Restate gate once more with the corrected goal line. Do not loop more
+   than twice; if alignment is not reached, route back to PATH 2 with a targeted
+   question instead of forcing a goal line.
+
+10. **Prefer stopping over over-interviewing**:
+   When the Restate gate passes, suggest `ooo seed`.
+
+11. After completion, suggest the next step:
+   `📍 Next: ooo seed to crystallize these requirements into a specification`
+
+#### Dialectic Rhythm Guard
+
+Track consecutive non-user answers (PATH 1a auto-confirms, PATH 1b code
+confirmations, and PATH 4 research confirmations). If **3 consecutive questions**
+were answered without direct user judgment (PATH 1a, 1b, or PATH 4), the next
+question MUST be routed to **PATH 2** (directly to user), even if it appears
+code- or research-answerable.
+
+This preserves the Socratic dialectic rhythm — the interview is with the human,
+not the codebase or external docs. Auto-confirmed answers especially need this
+guard: if the AI answers too many questions on its own, the user loses awareness
+of what the AI is assuming about their project.
+
+Reset the counter whenever user answers directly (PATH 2 or PATH 3), or when a
+PATH 1b / PATH 4 correction is routed through the Refine gate and sent as
+`[from-user][refined]`. Only accepted code/research confirmations advance the
+non-user streak.
+
+#### Retry on Failure
+
+If MCP returns `is_error=true` with `meta.recoverable=true`:
+1. Tell user: "Question generation encountered an issue. Retrying..."
+2. Call `ouroboros_interview(session_id=...)` to resume (max 2 retries).
+   State (including any recorded answers) is persisted before the error,
+   so resuming will not lose progress.
+3. If still failing: "MCP is having trouble. Switching to direct interview mode."
+   Then switch to Path B and continue from where you left off.
+
+**Special case — `meta.reason == "initial_context_too_large"`**: When the
+response carries this `meta.reason` (with `meta.recoverable=true` and
+`is_error=false` — the wire success/failure axis is intentionally **not**
+flipped, to keep existing callers like the auto driver working), the text
+body is a meta-directive asking *you* to re-send a shorter context — it is
+**NOT** an interview question. Do not route it through the active runtime's `ask_user` capability.
+Instead, produce a concise summary of the original `initial_context`
+(≤ `meta.max_chars` characters; covers goal, constraints, success criteria)
+and re-call `ouroboros_interview` with `session_id=<from meta>` and the
+summary as `answer`. The next response will contain the real first question.
+
+**Advantages of MCP mode**: State persists to disk, ambiguity scoring, direct `ooo seed` integration via session ID. Code-enriched confirmation questions reduce user burden — only human-judgment questions require user input.
+
+### Path B: Plugin Fallback (No MCP Server)
+
+If the MCP tool is NOT available, fall back to agent-based interview:
+
+1. Read `src/ouroboros/agents/socratic-interviewer.md` and adopt that role
+2. **Pre-scan the codebase**: Use the active runtime's `inspect_code` capability to check for config files (`pyproject.toml`, `package.json`, `go.mod`, etc.). If found, inspect key files and incorporate findings into your questions as confirmation-style ("I see X. Should I assume Y?") rather than open-ended discovery ("Do you have X?")
+3. Ask clarifying questions based on the user's topic and codebase context
+4. **Present each question using the active runtime's `ask_user` capability** with contextually relevant suggested answers (same format as Path A step 2)
+5. Use the active runtime's `inspect_code` and `web_research` capabilities to explore further context if needed
+6. Maintain the same ambiguity ledger and breadth-check behavior as in Path A:
+   - Track multiple independent ambiguity threads
+   - Revisit unresolved threads every few rounds
+   - Do not let one detailed subtopic crowd out the rest of the original request
+7. **Apply the Refine gate** (Path A Step 4) to free-text user answers before
+   absorbing them into your running understanding. The structure preservation
+   matters less here than in Path A (no MCP relay), but the "did I miss any
+   reasoning, constraints, or scope?" check still surfaces gaps.
+8. Prefer closure only after applying the Seed-ready Acceptance Guard above.
+   Then **apply the Restate gate** (Path A Step 9): collapse the agreed answers
+   into a one-sentence goal and confirm with the user before suggesting `ooo seed`.
+   In fallback mode there is no MCP state to refresh, so if the user picks
+   "Adjust wording" or "Missing scope", ask the same follow-up questions from
+   Step 9, apply the correction directly to the local interview ledger and
+   one-sentence goal, rerun the Seed-ready Acceptance Guard locally, and ask the
+   Restate gate again with the corrected goal line. Do not try to "send it back
+   to MCP" in Path B; the conversation context is the source of truth.
+9. Continue until the user says "done"
+10. Interview results live in conversation context (not persisted)
+11. After completion, suggest the next step in `📍 Next:` format:
+   `📍 Next: ooo seed to crystallize these requirements into a specification`
+
+## Interviewer Behavior
+
+**MCP (question generator)** is ONLY a questioner:
+- Always generates a question targeting the biggest source of ambiguity
+- Preserves breadth across independent ambiguity tracks
+- NEVER writes code, edits files, or runs commands
+
+**You (main session)** are a Socratic facilitator:
+- Read `src/ouroboros/agents/socratic-interviewer.md` to understand the interview methodology
+- You CAN use the active runtime's `inspect_code` capability to scan the codebase for answering MCP questions
+- For high-confidence factual questions (PATH 1a), auto-confirm and notify the user
+- For all other questions, present to user as confirmation or direct question
+- You NEVER make decisions on behalf of the user — auto-confirm is for FACTS only
+- You are the final gate on MCP seed-ready signals: apply the canonical Seed
+  Closer criteria before suggesting `ooo seed`
+- The Dialectic Rhythm Guard prevents over-automation: after 3 consecutive
+  non-user answers, the next question MUST go directly to the user
+
+## Example Session
+
+```
+User: ooo interview Add payment module to existing project
+
+MCP Q1: "Is this a greenfield or brownfield project?"
+→ PATH 1a: exact match in pyproject.toml + src/ directory
+→ ℹ️ Auto-confirmed: Brownfield, Python 3.12 / FastAPI (pyproject.toml)
+→ [from-code][auto-confirmed] sent to MCP (counter: 1)
+
+MCP Q2: "What payment provider will you use?"
+→ PATH 2: human decision — no code can answer this
+→ User: "Stripe"
+→ [from-user] sent to MCP (counter reset to 0)
+
+MCP Q3: "What authentication method does the project use?"
+→ PATH 1b: found src/auth/jwt.py but inferred (not manifest)
+→ "I found JWT-based auth in src/auth/jwt.py. Is this correct?"
+→ User: "Yes, correct"
+→ [from-code] sent to MCP (counter: 1)
+
+MCP Q4: "How should payment failures affect order state?"
+→ PATH 2: design decision
+→ User: "Saga pattern for rollback"
+→ Refine gate structures the answer
+→ User: "Add to Out of scope"
+→ Follow-up asks for exact missing text
+→ User: "Do not build automatic retry scheduling yet"
+→ Refine gate runs once more, then [from-user][refined] sent to MCP (counter reset to 0)
+
+MCP Q5: "What are the acceptance criteria for this feature?"
+→ PATH 2: requires human judgment
+→ User: "Successful Stripe charge, webhook handling, refund support"
+→ Refine gate passes; [from-user][refined] sent to MCP
+
+MCP signals seed-ready; Acceptance Guard passes
+→ Restate: "Add Stripe payments with charges, webhooks, refunds, and failed-payment rollback."
+→ User: "Missing scope"
+→ Follow-up asks for exact missing scope
+→ User: "Exclude retry scheduling from the seed."
+→ Refine gate structures the restate correction
+→ [from-user][refined] restate correction sent to MCP; return to Step 7/Seed-ready guard
+→ MCP signals seed-ready again; Acceptance Guard still passes
+→ Restate again: "Add Stripe payments with charges, webhooks, refunds, failed-payment rollback, and no retry scheduling."
+→ User: "Yes, generate seed"
+
+📍 Next: `ooo seed` to crystallize these requirements into a specification
+```
+
+## Next Steps
+
+After interview completion, use `ooo seed` to generate the Seed specification.

--- a/.claude-plugin/skills/pm/SKILL.md
+++ b/.claude-plugin/skills/pm/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: pm
+description: "Generate a PM through guided PM-focused interview with automatic question classification. Use when the user says 'ooo pm', 'prd', 'product requirements', or wants to create a PRD/PM document."
+---
+
+# /ouroboros:pm
+
+PM-focused Socratic interview that produces a Product Requirements Document.
+
+## Instructions
+
+### Step 1: Load MCP Tool
+
+```
+ToolSearch query: "+ouroboros pm_interview"
+```
+
+If not found → **diagnose before telling user to run setup**:
+
+1. Check if MCP is already configured:
+   ```bash
+   grep -q '"ouroboros"' ~/.claude/mcp.json 2>/dev/null && echo "CONFIGURED" || echo "NOT_CONFIGURED"
+   ```
+
+2. **If NOT_CONFIGURED** → tell user to run `ooo setup` first. Stop.
+
+3. **If CONFIGURED** → MCP is registered but the server isn't connecting. Do NOT tell the user to run `ooo setup` again. Instead show:
+   ```
+   Ouroboros MCP is configured but not connected.
+
+   Try these steps in order:
+   1. Restart Claude Code (Cmd+Shift+P → "Reload Window" or close/reopen terminal)
+   2. Check MCP status: type /mcp in Claude Code
+   3. If ouroboros shows "error", try: ooo update
+   4. If still failing, re-run: ooo setup
+   ```
+   Stop.
+
+### Step 2: Start Interview
+
+```
+Tool: ouroboros_pm_interview
+Arguments:
+  initial_context: <user's topic or idea>
+  cwd: <current working directory>
+```
+
+### Step 3: Loop
+
+After every MCP response, do these three things:
+
+**A. Show alerts** (if present in `meta`):
+- `meta.deferred_this_round` → print `[DEV → deferred] "question"`
+- `meta.decide_later_this_round` → print `[DEV → decide-later] "question"`
+- `meta.pending_reframe` → print `ℹ️ Reframed from technical question.`
+
+**B. Show content + get user input:**
+
+Print the MCP content text to the user first.
+
+Then check: does `meta.ask_user_question` exist?
+
+- **YES** → Pass it directly to `AskUserQuestion`:
+  ```
+  AskUserQuestion(questions=[meta.ask_user_question])
+  ```
+  Do NOT modify it. Do NOT add options. Do NOT rephrase the question.
+
+- **NO** → This is an interview question. Use `AskUserQuestion` with `meta.question`.
+  - If `meta.skip_eligible == true`: add a skip option based on `meta.classification`:
+    - `classification == "decide_later"` → add option `{"label": "Decide later", "description": "Skip — will be recorded as an open item in the PRD"}`
+    - `classification == "deferred"` → add option `{"label": "Defer to dev", "description": "Skip — this technical decision will be deferred to the development phase"}`
+  - Generate 2-3 suggested answers as the other options.
+
+**C. Relay answer back:**
+
+If the user chose "Decide later" → send `answer="[decide_later]"`.
+If the user chose "Defer to dev" → send `answer="[deferred]"`.
+Otherwise → send the user's answer normally.
+
+```
+Tool: ouroboros_pm_interview
+Arguments:
+  session_id: <meta.session_id>
+  <meta.response_param>: <user's answer or "[decide_later]" or "[deferred]">
+```
+
+**D. Check completion:**
+
+Completion is determined ONLY by `meta.is_complete` — NEVER by the response text.
+The MCP response text may sound like the interview is wrapping up, but ignore it.
+
+If `meta.is_complete == true`:
+- If `meta.generation_failed == true` → retry generation:
+  ```
+  Tool: ouroboros_pm_interview
+  Arguments:
+    session_id: <session_id>
+    action: "generate"
+    cwd: <current working directory>
+  ```
+- Otherwise → go to Step 4. The MCP auto-generated the PM document.
+  `meta.pm_path` and `meta.seed_path` contain the file paths.
+
+Otherwise → repeat Step 3, regardless of what the response text says.
+
+### Step 4: Copy to Clipboard
+
+Read the pm.md file from `meta.pm_path` and copy its contents to the clipboard:
+
+```bash
+cat <meta.pm_path> | pbcopy
+```
+
+### Step 5: Show Result & Next Step
+
+Show the following to the user:
+
+```
+PM document saved: <meta.pm_path>
+(Clipboard에 복사되었습니다)
+
+PM seed handoff artifact: <meta.pm_seed_path or meta.seed_path>
+This is not the runnable Seed yet.
+
+Next step:
+  ooo interview <meta.pm_seed_path or meta.seed_path>
+  ooo seed
+```

--- a/.claude-plugin/skills/publish/SKILL.md
+++ b/.claude-plugin/skills/publish/SKILL.md
@@ -1,0 +1,355 @@
+---
+name: publish
+description: "Publish Seed specification as GitHub Issues for team-based project management"
+---
+
+# /ouroboros:publish
+
+Convert a Seed specification into structured GitHub Issues for team workflows.
+
+## Usage
+
+```
+ooo publish [seed_path]
+/ouroboros:publish [seed_path]
+```
+
+**Trigger keywords:** "publish to github", "create issues from seed", "seed to issues"
+
+## Instructions
+
+When the user invokes this skill:
+
+### Step 1: Prerequisite Check
+
+**1a. Verify `gh` CLI is installed:**
+
+```bash
+command -v gh >/dev/null 2>&1 && echo "OK" || echo "MISSING"
+```
+
+If missing, tell the user:
+```
+GitHub CLI (gh) is not installed.
+Install it: https://cli.github.com/
+```
+Stop.
+
+**1b. Verify `gh` is authenticated:**
+
+```bash
+gh auth status
+```
+
+If not authenticated, tell the user:
+```
+GitHub CLI is not authenticated. Run: gh auth login
+```
+Stop.
+
+### Step 2: Locate the Seed
+
+Ouroboros stores seeds in `~/.ouroboros/seeds/`:
+- **Interview seeds**: `~/.ouroboros/seeds/{seed_id}.yaml` (YAML)
+- **PM seeds**: `~/.ouroboros/seeds/pm_seed_{id}.json` (JSON)
+
+Determine the Seed source in this priority order:
+
+1. **Explicit path argument**: If the user provided a file path (`.yaml` or `.json`), read it directly
+2. **Most recent seed file**: Search for the most recent seed in the standard location:
+   ```bash
+   ls -t ~/.ouroboros/seeds/*.yaml ~/.ouroboros/seeds/*.json 2>/dev/null | head -5
+   ```
+   If multiple seeds exist, present the top candidates via AskUserQuestion and let the user choose.
+3. **Conversation context**: If `ooo seed` or `ooo pm` was just run in this conversation and the seed path was reported, use that path.
+
+If no seed is found:
+```
+No Seed found. Run `ooo seed` or `ooo pm` first to generate a specification.
+```
+Stop.
+
+### Step 3: Parse the Seed
+
+Detect the file format by extension and parse accordingly:
+
+**For YAML seeds** (from `ooo interview` + `ooo seed`):
+Read the YAML file and extract:
+- `goal` → Epic title and description
+- `constraints` → Listed in Epic body
+- `acceptance_criteria` → Checklist items in Epic + distributed to Task issues
+- `ontology_schema` → Documentation section in Epic
+- `evaluation_principles` → Quality criteria reference
+- `exit_conditions` → Definition of Done
+- `metadata.ambiguity_score` → Confidence indicator
+- `metadata.seed_id` → Used for duplicate detection
+
+**For JSON seeds** (from `ooo pm`):
+Read the JSON file and extract fields using the actual `PMSeed` schema:
+
+| PMSeed field | Maps to |
+|-------------|---------|
+| `pm_id` | Seed identifier (for duplicate detection) |
+| `product_name` | Epic title prefix |
+| `goal` | Epic Goal section |
+| `constraints` | Epic Constraints section (array of strings) |
+| `success_criteria` | Acceptance Criteria checklist (array of strings) |
+| `user_stories` | User Stories section (array of `{persona, action, benefit}`) |
+| `deferred_items` | Deferred Items section (array of strings) |
+| `decide_later_items` | Open Questions section (array of strings) |
+| `assumptions` | Assumptions section (array of strings) |
+
+Format user stories as: "As a **{persona}**, I want to **{action}**, so that **{benefit}**."
+
+If any field is missing or empty, omit that section from the Epic body rather than failing.
+
+### Step 4: Detect Repository
+
+**4a. Attempt auto-detection from current directory:**
+
+```bash
+gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null
+```
+
+**4b. Present the target repo choice via AskUserQuestion:**
+
+If auto-detection succeeded:
+```json
+{
+  "questions": [{
+    "question": "Publish Seed as GitHub Issues to this repository?",
+    "header": "Target Repository",
+    "options": [
+      {"label": "<detected_repo>", "description": "Use current repository"},
+      {"label": "Other", "description": "I'll specify a different owner/repo"}
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+If auto-detection failed (not in a git repo):
+```json
+{
+  "questions": [{
+    "question": "Which GitHub repository should the issues be created in? (format: owner/repo)",
+    "header": "Target Repository"
+  }]
+}
+```
+
+If the user chose "Other", ask:
+```json
+{
+  "questions": [{
+    "question": "Enter the target repository (format: owner/repo):",
+    "header": "Target Repository"
+  }]
+}
+```
+
+Store the resolved repository as `TARGET_REPO`. **All subsequent `gh` commands MUST include `-R <TARGET_REPO>`** to ensure they target the correct repository.
+
+### Step 5: Duplicate Check
+
+Before creating issues, check if this seed was already published:
+
+```bash
+gh issue list -R <TARGET_REPO> --label "ouroboros" --state all --search "<seed_id or pm_id>" --limit 5 --json number,title,state
+```
+
+The search uses the seed's unique identifier (`metadata.seed_id` for YAML seeds, `pm_id` for JSON seeds). This works because Step 7 persists the identifier in the Epic body (see the `Seed ID` field in the Epic template).
+
+If matching issues are found, warn the user via AskUserQuestion:
+```json
+{
+  "questions": [{
+    "question": "Found existing Ouroboros issues that may be from the same seed:\n\n<list of matching issues>\n\nCreate new issues anyway?",
+    "header": "Duplicate Warning",
+    "options": [
+      {"label": "Create anyway", "description": "Proceed with new issues"},
+      {"label": "Cancel", "description": "Do not create duplicate issues"}
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+If "Cancel": Stop.
+
+### Step 6: Plan Issue Structure
+
+Before creating issues, present the planned structure to the user for review.
+
+**6a. Break down acceptance criteria into Task groups:**
+
+Analyze the acceptance criteria and group them into logical implementation units. Each unit becomes a Task issue. Use your understanding of the domain to create meaningful groupings (e.g., group by feature area, layer, or dependency order).
+
+**6b. Present the plan via AskUserQuestion:**
+
+```json
+{
+  "questions": [{
+    "question": "Here's the planned issue structure:\n\n**Epic**: <goal summary>\n\n**Tasks**:\n1. <task_1_title> — <brief scope>\n2. <task_2_title> — <brief scope>\n3. <task_3_title> — <brief scope>\n\nProceed with creating these issues?",
+    "header": "Issue Plan",
+    "options": [
+      {"label": "Create issues", "description": "Publish to GitHub now"},
+      {"label": "Modify plan", "description": "I want to adjust the structure first"}
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+If "Modify plan": Ask what to change, adjust, and re-present.
+
+### Step 7: Create GitHub Issues
+
+**IMPORTANT**: Every `gh` command in this step MUST include `-R <TARGET_REPO>`.
+
+**Issue number extraction**: `gh issue create` outputs a URL like `https://github.com/owner/repo/issues/42`. Extract the issue number by parsing the trailing digits:
+```bash
+EPIC_URL=$(gh issue create -R <TARGET_REPO> --title "..." --label "..." --body "...")
+EPIC_NUM=$(echo "$EPIC_URL" | grep -o '[0-9]*$')
+```
+Apply the same extraction pattern for every Task issue created.
+
+**7a. Create labels (if they don't exist):**
+
+```bash
+gh label create "ouroboros" -R <TARGET_REPO> --description "Created by Ouroboros publish" --color "6f42c1" 2>/dev/null || true
+gh label create "epic" -R <TARGET_REPO> --description "Epic / parent issue" --color "0075ca" 2>/dev/null || true
+gh label create "task" -R <TARGET_REPO> --description "Implementation task" --color "008672" 2>/dev/null || true
+```
+
+**7b. Create the Epic issue:**
+
+```bash
+gh issue create -R <TARGET_REPO> \
+  --title "[Epic] <goal_summary>" \
+  --label "ouroboros,epic" \
+  --body "$(cat <<'BODY'
+## Goal
+
+<goal from seed>
+
+## Constraints
+
+<constraints as bullet list>
+
+## Acceptance Criteria
+
+- [ ] <criterion_1>
+- [ ] <criterion_2>
+- ...
+
+## Ontology
+
+| Field | Type | Description |
+|-------|------|-------------|
+| <field_name> | <type> | <description> |
+
+## Evaluation Principles
+
+| Principle | Weight | Description |
+|-----------|--------|-------------|
+| <name> | <weight> | <description> |
+
+## Exit Conditions
+
+<exit conditions as bullet list>
+
+---
+
+**Seed ID**: `<seed_id or pm_id>` | **Ambiguity Score**: <score> | **Seed**: `<seed_file_path>`
+*Generated by [Ouroboros](https://github.com/Q00/ouroboros) via `ooo publish`*
+BODY
+)"
+```
+
+Capture the Epic issue number from the output.
+
+**7c. Create Task issues (one per implementation unit):**
+
+For each task:
+
+```bash
+gh issue create -R <TARGET_REPO> \
+  --title "[Task] <task_title>" \
+  --label "ouroboros,task" \
+  --body "$(cat <<'BODY'
+Parent: #<epic_number>
+
+## Scope
+
+<what this task covers>
+
+## Acceptance Criteria
+
+- [ ] <specific_criterion_1>
+- [ ] <specific_criterion_2>
+
+## Test Checklist
+
+- [ ] <test_1>
+- [ ] <test_2>
+- [ ] <test_3>
+
+## Pass Criteria
+
+<measurable conditions for this task to be considered done>
+
+---
+
+*Part of [Epic] #<epic_number> | Generated by [Ouroboros](https://github.com/Q00/ouroboros) via `ooo publish`*
+BODY
+)"
+```
+
+**7d. Update Epic with task links:**
+
+After all tasks are created, add a comment to the Epic:
+
+```bash
+gh issue comment <epic_number> -R <TARGET_REPO> --body "$(cat <<'BODY'
+## Implementation Tasks
+
+- [ ] #<task_1_number> — <task_1_title>
+- [ ] #<task_2_number> — <task_2_title>
+- [ ] #<task_3_number> — <task_3_title>
+
+Track overall progress by checking off tasks as their issues are closed.
+BODY
+)"
+```
+
+### Step 8: Summary
+
+Present the results:
+
+```
+Published to <TARGET_REPO>:
+
+  #<epic>  [Epic] <goal_summary>
+    ├── #<task_1>  [Task] <task_1_title>
+    ├── #<task_2>  [Task] <task_2_title>
+    └── #<task_3>  [Task] <task_3_title>
+
+View: https://github.com/<TARGET_REPO>/issues/<epic>
+```
+
+Then suggest next steps:
+
+```
+Next steps:
+  - Assign tasks to team members on GitHub
+  - Use GitHub Projects board for tracking
+  - Run `ooo run` for AI-assisted implementation of individual tasks
+```
+
+## Notes
+
+- **No MCP required**: This skill works entirely through `gh` CLI
+- **Non-destructive**: Creates new issues only, never modifies existing ones
+- **Cross-repo support**: All `gh` commands use `-R <TARGET_REPO>`, so seeds can be published to any repository the user has write access to
+- **Works with both seed formats**: YAML seeds from `ooo seed` and JSON seeds from `ooo pm` are both supported — the parser auto-detects format by file extension

--- a/.claude-plugin/skills/qa/SKILL.md
+++ b/.claude-plugin/skills/qa/SKILL.md
@@ -1,0 +1,176 @@
+---
+name: qa
+description: "General-purpose QA verdict for any artifact type"
+---
+
+# /ouroboros:qa
+
+Standalone quality assessment for any artifact — code, documents, API responses, test output, or custom content. Unlike `ooo evaluate` (3-stage formal verification pipeline), `ooo qa` is a fast single-pass verdict with actionable suggestions.
+
+## Usage
+
+```
+ooo qa [file_path | artifact_text]
+ooo qa                                     # evaluate recent execution output
+/ouroboros:qa [file_path | artifact_text]   # plugin mode
+```
+
+**Trigger keywords:** "ooo qa", "qa check", "quality check"
+
+## How It Works
+
+The QA Judge evaluates an artifact against a quality bar and returns a structured verdict:
+
+1. **Parse the Quality Bar** — What EXACTLY must be true to pass?
+2. **Assess Dimensions** — Correctness, Completeness, Quality, Intent Alignment, Domain-Specific
+3. **Render Verdict** — Score (0.0-1.0) with PASS / REVISE / FAIL
+4. **Determine Loop Action** — `done` (pass), `continue` (revise), `escalate` (fail)
+
+### Verdict Thresholds
+
+| Score Range  | Verdict | Loop Action |
+|--------------|---------|-------------|
+| >= 0.80      | PASS    | done        |
+| 0.40 - 0.79  | REVISE  | continue    |
+| < 0.40       | FAIL    | escalate    |
+
+## Instructions
+
+When the user invokes this skill:
+
+### Step 0: Determine execution mode
+
+This skill works in two modes. Determine which one **before** attempting any tool calls:
+
+- **MCP mode** — If `ToolSearch` is available, try loading the QA MCP tool:
+  ```
+  ToolSearch query: "+ouroboros qa"
+  ```
+  If found (typically named `mcp__plugin_ouroboros_ouroboros__ouroboros_qa`), proceed with **QA Steps** below.
+
+- **Fallback mode** — If `ToolSearch` is not available, or it finds no matching tool, skip directly to the **Fallback** section. This skill is designed to work without MCP setup.
+
+### QA Steps (MCP mode)
+
+1. **Determine the artifact to evaluate:**
+   - If user provides a file path: Read the file with Read tool
+   - If user provides inline text: Use that directly
+   - If no artifact specified: Look for the most recent execution output in conversation context
+   - Ask user if unclear what to evaluate
+
+2. **Determine the quality bar:**
+   - If a seed YAML is available in context: Extract acceptance criteria from it
+   - If user specifies a quality bar: Use that
+   - If neither: Ask the user "What does 'good' mean for this artifact?"
+
+3. **Determine artifact type:**
+   - `code` — source code files
+   - `test_output` — test results, CI output
+   - `document` — specs, docs, READMEs
+   - `api_response` — API responses, JSON payloads
+   - `screenshot` — visual artifacts
+   - `custom` — anything else
+
+4. **Call the `ouroboros_qa` MCP tool:**
+   ```
+   Tool: ouroboros_qa
+   Arguments:
+     artifact: <the content to evaluate>
+     quality_bar: <what 'pass' means>
+     artifact_type: "code"  (or other type)
+     reference: <optional reference for comparison>
+     pass_threshold: 0.80  (adjustable)
+     seed_content: <seed YAML if available>
+   ```
+
+5. **Present results clearly:**
+   - Show the score and verdict prominently
+   - List dimension scores
+   - Highlight specific differences found
+   - Show actionable suggestions
+   - End with next step guidance based on verdict:
+     - **PASS (done)**: `Next: Your artifact meets the quality bar. Proceed with confidence.`
+     - **REVISE (continue)**: `Next: Address the suggestions above, then run ooo qa again to re-check.`
+     - **FAIL (escalate)**: `Next: Fundamental issues detected. Consider ooo interview to re-examine requirements, or ooo unstuck to challenge assumptions.`
+
+### Iterative QA Loop
+
+For iterative usage, track the `qa_session_id` and `iteration_history` from the response meta:
+
+1. First call returns `qa_session_id` and `iteration_entry` in meta
+2. On subsequent calls, pass `qa_session_id` and accumulated `iteration_history`
+3. Continue until verdict is `pass` or `fail`
+
+In fallback mode, generate a `qa-<uuid4_short>` session ID on the first run and maintain iteration count in conversation context to preserve the same iterative contract.
+
+## Fallback (No MCP Server)
+
+If the MCP server is not available, adopt the `ouroboros:qa-judge` agent role directly:
+
+1. Read the canonical agent definition: `<project-root>/src/ouroboros/agents/qa-judge.md`
+   (This is the same prompt used by the MCP QA tool, ensuring consistent verdicts.)
+2. Follow the QA Judge framework to evaluate the artifact
+3. Output the verdict in the standard format (must match MCP output shape):
+
+```
+QA Verdict [Iteration N]
+========================
+Session: qa-<id>
+Score: X.XX / 1.00 [PASS/REVISE/FAIL]
+Verdict: pass/revise/fail
+Threshold: 0.80
+
+Dimensions:
+  Correctness:      X.XX
+  Completeness:     X.XX
+  Quality:          X.XX
+  Intent Alignment: X.XX
+  Domain-Specific:  X.XX
+
+Differences:
+  - <specific difference>
+
+Suggestions:
+  - <actionable fix>
+
+Reasoning: <1-3 sentence summary>
+
+Loop Action: done/continue/escalate
+```
+
+## Example
+
+```
+User: ooo qa src/main.py
+
+QA Verdict [Iteration 1]
+============================================================
+Session: qa-a1b2c3d4
+Score: 0.72 / 1.00 [REVISE]
+Verdict: revise
+Threshold: 0.80
+
+Dimensions:
+  Correctness:           0.85
+  Completeness:          0.60
+  Quality:               0.75
+  Intent Alignment:      0.80
+  Domain-Specific:       0.60
+
+Differences:
+  - Missing error handling for network timeout in fetch_data()
+  - No input validation on user_id parameter
+  - Type hints missing on 3 public functions
+
+Suggestions:
+  - Add try/except with TimeoutError in fetch_data() (line 42)
+  - Add isinstance check for user_id at function entry
+  - Add return type annotations to get_user(), fetch_data(), process_result()
+
+Reasoning: Core logic is correct but lacks defensive programming
+patterns expected for production code.
+
+Loop Action: continue
+
+Next: Address the suggestions above, then run `ooo qa` again to re-check.
+```

--- a/.claude-plugin/skills/ralph/SKILL.md
+++ b/.claude-plugin/skills/ralph/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: ralph
+description: "MCP-owned Ralph loop around background evolve_step jobs"
+mcp_tool: ouroboros_ralph
+mcp_args:
+  lineage_id: "$lineage_id"
+---
+
+# /ouroboros:ralph
+
+MCP-owned Ralph loop around background `evolve_step` jobs. "The boulder never stops."
+
+## Usage
+
+```
+ooo ralph --lineage-id <lineage_id>
+/ouroboros:ralph --lineage-id <lineage_id>
+
+# For a plain natural-language request, run `ooo interview` + `ooo seed` first,
+# then call the MCP tool with a fresh lineage_id and the validated Seed YAML.
+```
+
+**Trigger keywords:** "ralph", "don't stop", "must complete", "until it works", "keep going"
+
+## How It Works
+
+Ralph is owned by the `ouroboros_ralph` MCP tool. In non-plugin runtimes, the
+tool starts one background Ralph job, runs repeated `evolve_step` generations
+inside that job, and stops only when QA passes, convergence is reached, a
+terminal evolution action occurs, cancellation is requested, or
+`max_generations` is reached. In OpenCode plugin mode, the MCP tool returns a
+`delegated_to_plugin` envelope with `job_id=None`; the bridge plugin dispatches
+a child Task session that owns the loop instead of creating a local JobManager
+job.
+
+The client skill should not reimplement the loop. Deterministic frontmatter
+dispatch is limited to the router's named `--lineage-id` option so raw trailing
+text is never treated as lineage identity. Raw natural-language
+`ooo ralph "<request>"` input must flow through the validated Seed path before
+any mutating Ralph loop starts. Until a lineage id and optional Seed YAML are
+prepared, `ouroboros_ralph` returns structured input guidance instead of
+starting a job. Once the inputs are prepared, start the MCP-owned Ralph surface
+once, then follow either the returned job tools path or the OpenCode Task widget
+path.
+
+## Instructions
+
+When the user invokes this skill:
+
+### Load MCP Tools (Required first)
+
+The Ouroboros MCP tools are often registered as deferred tools that must be
+explicitly loaded before use. Do this before preparing input or calling Ralph:
+
+1. Use the `ToolSearch` tool to find and load the Ralph/job MCP tools:
+   ```
+   ToolSearch query: "+ouroboros ralph job"
+   ```
+2. The loaded tools may be exposed under plugin-prefixed names such as
+   `mcp__plugin_ouroboros_ouroboros__ouroboros_ralph`. Use the actual tool
+   names returned by `ToolSearch`; the bare names below are the canonical MCP
+   tool names for documentation.
+3. Confirm that `ouroboros_ralph` and the job tools (`ouroboros_job_wait`,
+   `ouroboros_job_status`, `ouroboros_job_result`, and
+   `ouroboros_cancel_job`) are callable. If the tools are unavailable, stop and
+   tell the user that Ralph requires the Ouroboros MCP runtime.
+
+### Ralph Flow
+
+1. **Prepare lineage input**:
+   - If the user provides an existing `lineage_id` and explicitly wants to
+     continue it, reuse that `lineage_id` and omit `seed_content` unless they
+     explicitly provide an updated Seed.
+   - If the user provides Seed YAML for a new Ralph run, use it as
+     `seed_content` and generate a fresh `lineage_id` for this run. Keep
+     `lineage_id` separate from Seed, interview, and session IDs so separate
+     Ralph runs over the same Seed do not collide.
+   - If the user provides only a plain natural-language request, do not treat
+     it as a direct `ooo ralph "<request>"` command, do not freehand Seed YAML,
+     and do not pass raw text as `seed_content`. Route through the authoritative
+     Seed path first: `ooo interview` to capture requirements, then `ooo seed` /
+     `ouroboros_generate_seed` to produce validated Seed YAML with the normal
+     ambiguity gate. After Seed generation, call the MCP tool with a fresh
+     `lineage_id` and that validated Seed YAML as `seed_content`; do not use the
+     raw request text. If an interview/seed session already exists in context,
+     reuse that validated Seed output instead of regenerating it.
+
+2. **Start Ralph** by calling `ouroboros_ralph` with:
+   - `lineage_id`: existing lineage id for an explicit continuation, otherwise a
+     freshly generated stable id for this Ralph run, such as
+     `ralph-<short-slug>-<uuid>`; do not use a Seed/interview id by itself
+   - `seed_content`: valid Seed YAML for generation 1 when starting a new lineage
+   - `execute`: default `true`
+   - `parallel`: default `true`
+   - `skip_qa`: default `false`
+   - `project_dir`: explicit target project directory when known
+   - `max_generations`: default `10` unless the user requests a tighter bound
+
+3. **Handle the start response**:
+   - If `response.meta.job_id` is present, report it concisely and retain the
+     job cursor from `response.meta.cursor`:
+
+     ```
+     [Ralph] Started background loop: <job_id>
+     Lineage: <lineage_id>
+     ```
+
+   - If `response.meta.status == "delegated_to_plugin"` and
+     `response.meta.job_id is None`, report that OpenCode plugin mode delegated
+     the loop to a child Task session. Do not call `ouroboros_job_wait`,
+     `ouroboros_job_result`, or `ouroboros_cancel_job` without a job id; follow
+     the host Task widget/session lifecycle instead.
+
+4. **Monitor non-plugin job progress** with job tooling when a `job_id` exists:
+   - `ouroboros_job_wait(job_id, cursor, timeout_seconds=120)` for long polling;
+     after every wait/status response, update `cursor = response.meta.cursor`
+   - `ouroboros_job_status(job_id)` for a quick status check
+   - `ouroboros_job_result(job_id)` when the job is terminal
+   - `ouroboros_cancel_job(job_id)` if the user says stop/cancel
+
+5. **On non-plugin job termination**, fetch `ouroboros_job_result(job_id)` and
+   summarize the final job result and next step:
+   - Success / convergence: summarize the final generation output, QA verdict,
+     and any `worktree_path` / `worktree_branch` returned in job metadata. Do not
+     present `ooo evaluate` as an automatic next step for Ralph results: the
+     Ralph job contract preserves the evolution `lineage_id`, but it does not
+     reliably preserve a separate execution `session_id` for the evaluate
+     workflow. If a valid execution `session_id` is explicitly available from a
+     separate run result, keep it distinct from the Ralph `lineage_id` and follow
+     the `ooo evaluate <session_id>` contract; otherwise state that formal
+     evaluation needs a real execution session and should not be invoked from the
+     Ralph lineage id alone.
+   - Max generations / failure: summarize the stop reason and suggest
+     `ooo unstuck`, `ooo interview`, or a narrower Ralph retry
+   - Cancelled: confirm cancellation and preserve the job id for later inspection
+
+6. **On OpenCode plugin delegation**, rely on the child Task result as the
+   terminal surface. Summarize the Task completion/error state and lineage id; do
+   not claim a local Ralph job can be polled or cancelled.
+
+## Tool Mapping
+
+| Skill action | MCP tool |
+| --- | --- |
+| Start Ralph loop | `ouroboros_ralph` |
+| Wait for progress | `ouroboros_job_wait` |
+| Fetch final result | `ouroboros_job_result` |
+| Cancel loop | `ouroboros_cancel_job` |
+| Inspect current status | `ouroboros_job_status` |
+
+## The Boulder Never Stops
+
+This is the key phrase. Ralph does not give up:
+
+- Each failure is data for the next attempt.
+- Verification drives the loop.
+- Only success, convergence, terminal failure, cancellation, or max-generation
+  limits stop it.

--- a/.claude-plugin/skills/resume-session/SKILL.md
+++ b/.claude-plugin/skills/resume-session/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: resume-session
+description: "List in-flight Ouroboros sessions and show the commands needed to re-attach after MCP disconnect"
+---
+
+# /ouroboros:resume-session
+
+Recover in-flight Ouroboros sessions after an unexpected MCP server disconnect.
+
+Claude Code reserves `/resume` for its built-in session picker. This skill
+intentionally uses `resume-session` so it does not shadow that native command.
+
+## Usage
+
+```
+ooo resume-session
+ooo resume-session --all
+/ouroboros:resume-session
+```
+
+**Trigger keywords:** "in-flight Ouroboros sessions", "re-attach", "mcp disconnected", "lost Ouroboros execution"
+
+## How It Works
+
+`ooo resume-session` reads the EventStore directly (no MCP server required) and lists
+every session that is still in a `running` or `paused` state. The command is
+strictly read-only — it never creates the data directory, never writes
+schema, and never appends events. Its job is to surface the identifiers you
+need to re-attach.
+
+- `ooo resume-session` shows the 20 most recent active sessions.
+- `ooo resume-session --all` shows every active session.
+
+## Instructions
+
+When the user invokes this skill:
+
+1. Run the CLI command:
+
+   ```
+   ouroboros resume
+   ```
+
+   This reads `~/.ouroboros/ouroboros.db` directly — the MCP server does **not**
+   need to be running.
+
+2. If sessions are listed, enter the number of the session you want to work
+   with. The command prints both the `session_id` and the `exec_id`, along
+   with the two re-attach paths.
+
+3. Pick the right re-attach path:
+
+   - **Inspect only** (read-only interactive monitor):
+
+     ```
+     ouroboros tui monitor
+     ```
+
+     Launches the TUI and lets you pick the session to inspect. The
+     `ouroboros status execution <exec_id>` command is *registered* but its
+     handler is still a placeholder in `src/ouroboros/cli/commands/status.py`
+     (it only prints "Would show details for execution: …"), so it is
+     intentionally not surfaced here. Follow-up tracked as a separate issue.
+
+   - **Resume execution** (requires the original seed file):
+
+     ```
+     ouroboros run workflow --orchestrator --resume <session_id> <seed.yaml>
+     ```
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0`  | Success — sessions listed, or no sessions found |
+| `1`  | Invalid user selection (non-numeric or out-of-range) |
+| `2`  | EventStore exists but could not be opened or read |
+
+## Fallback (No sessions found)
+
+If the command reports "No in-flight sessions found", the execution either
+completed, failed, was cancelled, or the EventStore has never been created.
+To browse historical sessions interactively, use the TUI monitor:
+
+```
+ouroboros tui monitor
+```
+
+## Example
+
+```
+User: ooo resume-session
+
+┌─────────────────────── In-Flight Sessions ───────────────────────┐
+│  #  Session ID          Execution ID        Status    Started    │
+│  1  sess-abc123         exec-xyz789         running   2026-04-15 │
+└───────────────────────────────────────────────────────────────────┘
+
+Enter number to re-attach (1-1), or 'q' to quit: 1
+
+╭─ Re-attach ────────────────────────────────────────────────────────────────╮
+│ Session ID:   sess-abc123                                                  │
+│ Execution ID: exec-xyz789                                                  │
+│                                                                            │
+│ Inspect (read-only interactive monitor):                                   │
+│     ouroboros tui monitor                                                  │
+│                                                                            │
+│ Resume execution (requires the original seed file):                        │
+│     ouroboros run workflow --orchestrator --resume sess-abc123 seed-001    │
+╰────────────────────────────────────────────────────────────────────────────╯
+```
+
+## Next Steps
+
+After you have the identifiers:
+
+- `ouroboros tui monitor` — launch the TUI and pick the session to inspect
+- `ouroboros run workflow --orchestrator --resume <session_id> <seed.yaml>` — resume execution
+- `ooo evaluate` — evaluate results once the execution completes
+- `ooo cancel execution <exec_id>` — cancel if the session is stuck

--- a/.claude-plugin/skills/run/SKILL.md
+++ b/.claude-plugin/skills/run/SKILL.md
@@ -1,0 +1,294 @@
+---
+name: run
+description: "Execute a Seed specification through the workflow engine"
+mcp_tool: ouroboros_execute_seed
+mcp_args:
+  seed_path: "$1"
+  cwd: "$CWD"
+---
+
+# /ouroboros:run
+
+Execute a Seed specification through the Ouroboros workflow engine.
+
+## Usage
+
+```
+/ouroboros:run [seed_file_or_content]
+```
+
+**Trigger keywords:** "ouroboros run", "execute seed"
+
+## How It Works
+
+1. **Input**: Provide seed YAML content directly or a path to a `.yaml` file
+2. **Validation**: Seed is parsed and validated (goal, constraints, acceptance criteria, ontology)
+3. **Execution**: The orchestrator runs the workflow with PAL routing
+4. **Progress**: Real-time progress updates via session tracking
+5. **Result**: Execution summary with pass/fail status
+
+## Instructions
+
+When the user invokes this skill:
+
+### Load MCP Tools (Required first)
+
+The Ouroboros MCP tools are often registered as **deferred tools** that must be explicitly loaded before use. **You MUST perform this step before proceeding.**
+
+1. Use the `ToolSearch` tool to find and load the execution MCP tools:
+   ```
+   ToolSearch query: "+ouroboros execute"
+   ```
+2. The tools will typically be named with prefix `mcp__plugin_ouroboros_ouroboros__` (e.g., `ouroboros_execute_seed`, `ouroboros_session_status`). After ToolSearch returns, the tools become callable.
+3. If ToolSearch finds the tools → proceed with the steps below. If not → skip to **Fallback** section.
+
+**IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
+
+### Execution Steps
+
+1. **Detect git workflow** (before any code changes):
+   - Read the project's `CLAUDE.md` for git workflow preferences
+   - If PR-based workflow detected and currently on `main`/`master`:
+     - Create a feature branch: `ooo/run/<session_id>`
+     - All code changes go to this branch
+   - If no preference: use current branch (backward compatible)
+
+2. Check if the user provided seed content or a file path:
+   - If a file path: Read the file with the Read tool
+   - If inline YAML: Use directly
+   - If neither: Check conversation history for a recently generated seed
+
+3. **Start background execution** with `ouroboros_start_execute_seed`:
+   ```
+   Tool: ouroboros_start_execute_seed
+   Arguments:
+     seed_content: <the seed YAML>
+     model_tier: "medium"  (or as specified by user)
+     max_iterations: 10    (or as specified by user)
+   ```
+   This returns immediately with a `job_id`, `session_id`, and `execution_id`.
+
+4. If resuming an existing session, include `session_id`:
+   ```
+   Tool: ouroboros_start_execute_seed
+   Arguments:
+     seed_content: <the seed YAML>
+     session_id: <existing session ID>
+   ```
+
+5. **Recommended monitoring stance: relay compact progress in the main session.**
+
+   After IDs are returned, print only this short handoff:
+
+   ```
+   Execution started in background.
+   Job ID: <job_id>
+   Session ID: <session_id>
+   Execution ID: <execution_id>
+
+   I will wait in low-token relay mode and report only meaningful state changes.
+   For full details later: `ouroboros_ac_tree_hud(session_id=<session_id>)`
+   ```
+
+   Rationale: the main chat session must wait for MCP calls. Frequent full-tree
+   polling burns context without improving execution. The user usually wants
+   "what is it doing now?" rather than the whole tree, so use compact job
+   read-model snapshots and narrate them like a brief live relay.
+
+6. **Low-token relay loop with `ouroboros_job_wait` (recommended default).**
+
+   Use `ouroboros_job_wait`, not repeated `ouroboros_ac_tree_hud`, for routine
+   monitoring. Keep the latest cursor and previous progress counters from the
+   tool meta payload.
+
+   This loop is intentionally harness/model friendly:
+   - Treat `response.meta` as the source of truth.
+   - Do not parse `response.text` for counts, status, or cursor.
+   - Use `response.text` only as a human-readable current-message hint.
+   - Keep all local monitor state in simple scalar variables.
+   - Emit at most one short relay message per changed response.
+   - Always continue to final `ouroboros_job_result` after a terminal status.
+
+   ```
+   cursor = <cursor from start/status response, or 0>
+   prev_status = "running"
+   prev_phase = null
+   prev_ac_completed = 0
+   prev_sub_ac_completed = 0
+   prev_message = null
+
+   loop:
+     Tool: ouroboros_job_wait
+     Arguments:
+       job_id: <job_id from step 3>
+       cursor: <cursor>
+       timeout_seconds: 180
+       view: "summary"
+
+     cursor = response.meta.cursor
+
+     if response.meta.changed is false:
+       # Do not narrate unless the user explicitly asked for heartbeat updates.
+       continue
+
+     status = response.meta.status
+     phase = response.meta.current_phase
+     ac_completed = response.meta.ac_completed
+     ac_total = response.meta.ac_total
+     sub_ac_completed = response.meta.sub_ac_completed
+     sub_ac_total = response.meta.sub_ac_total
+     # The metadata field names remain legacy-compatible; relay them to users as Task/Subtask progress.
+     message_hint = first non-empty non-metadata line from response.text, or null
+
+     # Build one short relay update from structured fields.
+     if status in ["completed", "failed", "cancelled", "interrupted"]:
+       print terminal_relay(status, phase, ac_completed, ac_total, sub_ac_completed, sub_ac_total)
+       break
+
+     if ac_completed > prev_ac_completed:
+       print task_progress_relay(phase, ac_completed, ac_total, sub_ac_completed, sub_ac_total, message_hint)
+     elif sub_ac_completed > prev_sub_ac_completed:
+       print subtask_progress_relay(phase, ac_completed, ac_total, sub_ac_completed, sub_ac_total, message_hint)
+     elif phase != prev_phase or status != prev_status:
+       print phase_or_status_relay(status, phase, ac_completed, ac_total, sub_ac_completed, sub_ac_total)
+     elif message_hint != prev_message:
+       print current_work_relay(phase, ac_completed, ac_total, sub_ac_completed, sub_ac_total, message_hint)
+
+     prev_status = status
+     prev_phase = phase
+     prev_ac_completed = ac_completed or prev_ac_completed
+     prev_sub_ac_completed = sub_ac_completed or prev_sub_ac_completed
+     prev_message = message_hint or prev_message
+   ```
+
+   Notes:
+   - `timeout_seconds: 180` means the MCP call can block for up to 3 minutes.
+     This keeps the main session available often enough for a live relay while
+     still avoiding noisy polling.
+   - Use `view: "compact"` for very long jobs or when the user only wants a
+     heartbeat. The raw tool may still return legacy text such as
+     `job_x | running | AC 3/17`; relay that to users as Task progress.
+   - Use `view: "summary"` for normal monitoring. It includes the job message
+     plus Task/Subtask counts derived from legacy `ac_completed`/`sub_ac_completed`
+     metadata fields.
+   - Use `view: "full"` only when the user asks for detailed job status.
+
+   Relay style examples:
+   - `In progress: Deliver is at Task 1/3 and Subtask 12/16. Current work is the Subtask 3 regression test.`
+   - `Level update: parallel level 1/1 has finished, and Task progress advanced to 3/3.`
+   - `Completed: execution finished. Fetching the final job result now.`
+
+   Relay output contract for other harnesses/models:
+   - One update should be 1-2 sentences or 1 compact line.
+   - Include `phase`, Task completed/total and Subtask completed/total when present.
+   - Include the current work hint only if it changes.
+   - Never include the full task tree in routine relay output.
+   - Never include raw JSON, raw meta dumps, or repeated unchanged cursor lines.
+   - Terminal statuses must be explicit: completed, failed, cancelled, or interrupted.
+
+   Do not paste the full raw tool output unless the user asks for raw status.
+   Do not add speculative ETA unless the tool provides one.
+
+7. **Use `ouroboros_ac_tree_hud` only for manual drill-down or anomaly checks.**
+
+   Do not call full tree HUD in the normal polling loop.
+
+   Use these targeted calls:
+
+   ```
+   # Explicit short HUD, useful for a one-off check
+   Tool: ouroboros_ac_tree_hud
+   Arguments:
+     session_id: <session_id>
+     cursor: <cursor>
+     view: "summary"
+
+   # Lowest-token one-line HUD
+   Tool: ouroboros_ac_tree_hud
+   Arguments:
+     session_id: <session_id>
+     cursor: <cursor>
+     view: "compact"
+
+   # Full tree only when user asks "show details", progress looks stuck,
+   # or debugging requires seeing the task/subtask structure.
+   Tool: ouroboros_ac_tree_hud
+   Arguments:
+     session_id: <session_id>
+     cursor: <cursor>
+     view: "tree"
+     max_nodes: 30
+   ```
+
+   Treat `unchanged cursor=<cursor>` from explicit compact/summary views as a
+   no-op. Do not explain it to the user unless they explicitly asked for
+   heartbeat messages.
+
+8. **Fetch final result** with `ouroboros_job_result`:
+   ```
+   Tool: ouroboros_job_result
+   Arguments:
+     job_id: <job_id>
+   ```
+
+9. Present the execution results to the user:
+   - Show success/failure status
+   - Show session ID (for later status checks)
+   - Show execution summary
+
+10. **Post-execution QA** (automatic):
+   `ouroboros_start_execute_seed` automatically runs QA after successful execution.
+   The QA verdict is included in the final job result text.
+   To skip: pass `skip_qa: true` to the tool.
+
+   Present QA verdict with next step:
+   - **PASS**: `Next: ooo evaluate <session_id> for formal 3-stage verification`
+   - **REVISE**: Show differences/suggestions, then `Next: Fix the issues above, then ooo run to retry -- or ooo unstuck if blocked`
+   - **FAIL/ESCALATE**: `Next: Review failures above, then ooo run to retry -- or ooo unstuck if blocked`
+
+## Fallback (No MCP Server)
+
+If the MCP server is not available, inform the user:
+
+```
+Ouroboros MCP server is not configured.
+To enable full execution mode, run: /ouroboros:setup
+
+Without MCP, you can still:
+- Use /ouroboros:interview for requirement clarification
+- Use /ouroboros:seed to generate specifications
+- Manually implement the seed specification
+```
+
+## Example
+
+```
+User: /ouroboros:run seed.yaml
+
+[Reads seed.yaml, validates, starts background execution]
+
+Background execution started.
+Job ID: job_a1b2c3d4e5f6
+Session ID: orch_x1y2z3
+Execution ID: exec_m1n2o3
+
+[Relay]
+In progress: Deliver is at Task 1/3 and Subtask 12/16.
+Current work is finishing the workflow routing Subtask.
+
+[Relay]
+Level update: parallel level 1/1 has finished, and Task progress advanced to 3/3.
+Execution is complete. Fetching the final job result now.
+
+[Fetching final result...]
+
+Result:
+  Seed Execution SUCCESS
+  ========================
+  Session ID: orch_x1y2z3
+  Goal: Build a CLI task manager
+  Duration: 45.2s
+  Messages Processed: 12
+
+  Next: `ooo evaluate orch_x1y2z3` for formal 3-stage verification
+```

--- a/.claude-plugin/skills/seed/SKILL.md
+++ b/.claude-plugin/skills/seed/SKILL.md
@@ -1,0 +1,418 @@
+---
+name: seed
+description: "Generate validated Seed specifications from interview results"
+mcp_tool: ouroboros_generate_seed
+mcp_args:
+  session_id: "$1"
+---
+
+# /ouroboros:seed
+
+Generate validated Seed specifications from interview results.
+
+## Required Skill Capabilities
+
+- `ask_user` — ask human-judgment questions through the active runtime's user-question surface.
+- `inspect_code` — read repo-local agent roles and recover exact context from local files before guessing.
+- `call_mcp` — use available Ouroboros MCP tools directly, including runtime tool discovery when a deferred MCP surface must be loaded.
+- `run_shell` — run bounded local commands for audit-trail writes and setup steps.
+- `refine_answer` — confirm free-form user decisions before treating them as accepted seed revisions.
+- `maintain_ledger` — keep QA scores, candidate decisions, rejected proposals, and audit trail keys visible.
+
+## Usage
+
+```
+ooo seed [session_id]
+/ouroboros:seed [session_id]
+```
+
+**Trigger keywords:** "crystallize", "generate seed"
+
+## Instructions
+
+When the user invokes this skill:
+
+### Load MCP Tools (Required before Path A/B decision)
+
+The Ouroboros MCP tools are often registered as **deferred tools** that must be explicitly loaded before use. **You MUST perform this step before deciding between Path A and Path B.**
+
+1. Use the active runtime's `call_mcp` capability to find and load the seed generation MCP tool through runtime tool discovery when needed:
+   ```
+   tool discovery query: "+ouroboros seed"
+   ```
+2. The tool will typically be named `mcp__plugin_ouroboros_ouroboros__ouroboros_generate_seed` (with a plugin prefix). After runtime tool discovery returns, the tool becomes callable through the active runtime's `call_mcp` capability.
+3. If runtime tool discovery finds the tool → proceed to **Path A**. If not → proceed to **Path B**.
+
+**IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
+
+### Path A: MCP Mode (Preferred)
+
+If the `ouroboros_generate_seed` MCP tool is available (loaded via runtime tool discovery above):
+
+1. Determine the interview session:
+   - If `session_id` provided: Use it directly
+   - If no session_id: Check conversation for a recent `ouroboros_interview` session ID
+   - If none found: Ask the user
+
+2. Call the MCP tool through the active runtime's `call_mcp` capability:
+   ```
+   Tool: ouroboros_generate_seed
+   Arguments:
+     session_id: <interview session ID>
+   ```
+
+3. The tool extracts requirements from persisted interview state, calculates ambiguity score, and generates the Seed YAML.
+
+   **Seed generation response shapes**: Branch only after an actual Seed YAML artifact is available.
+   - If the response has `status: "delegated_to_subagent"` and `dispatch_mode: "plugin"`, keep the returned `session_id`, wait for the plugin-managed subagent result, then extract the Seed YAML from that result. Do not enter the QA loop using the delegation envelope as the artifact.
+   - If the response directly contains Seed YAML, extract that YAML directly.
+   - If neither shape yields Seed YAML, stop and ask the user to resume generation or provide the missing artifact; do not fabricate a seed just to satisfy the QA loop.
+
+4. Continue immediately into the required QA Refinement Loop. Do not present the seed as final, ask for acceptance, or proceed to "After Seed Generation" until QA exits with PASS or the user explicitly accepts a below-threshold best attempt at the loop boundary.
+
+**Advantages of MCP mode**: Automated ambiguity scoring (must be <= 0.2), structured extraction from persisted interview state, reproducible.
+
+### Path B: Plugin Fallback (No MCP Server)
+
+If the MCP tool is NOT available, fall back to agent-based generation:
+
+1. Read `src/ouroboros/agents/seed-architect.md` and adopt that role.
+2. Recover the interview requirements before drafting; do not invent missing context:
+   - If `session_id` was provided, first identify context for that same session: use current-thread interview Q&A only when it clearly belongs to that `session_id`, and use current-thread corrections only when they explicitly amend that same interview or seed request.
+   - If same-session conversation context is incomplete, use the active runtime's `inspect_code` / `run_shell` capabilities to look for persisted interview artifacts under the Ouroboros data directory (for example `~/.ouroboros/data/`), exported session artifacts, or other exact local records for that ID.
+   - If both same-session conversation context and a persisted artifact are available, merge them conservatively: keep the persisted transcript as evidence, but let explicit same-thread user corrections or clarifications supersede older persisted wording.
+   - If no `session_id` was provided, use current-thread interview Q&A only when it is complete enough to identify one coherent interview; otherwise ask which interview or requirements summary should be seeded.
+   - If no matching artifact is found, or if local artifacts plus matching conversation history still do not provide enough requirements, ask the user for the missing interview transcript / concise requirement summary, or ask them to run or resume `ooo interview`. Do not generate a seed from an absent or mismatched transcript.
+3. Generate a Seed YAML specification from the recovered requirements.
+4. Continue immediately into the required QA Refinement Loop. Do not present the seed as final, ask for acceptance, or proceed to "After Seed Generation" until QA exits with PASS or the user explicitly accepts a below-threshold best attempt at the loop boundary.
+
+### QA Refinement Loop (Required after generation)
+
+After Path A or Path B produces a seed, **do not present it as final yet**. Run a QA loop until the seed passes a high quality bar.
+
+The first generation (Path A `ouroboros_generate_seed` or Path B agent role) runs **exactly once** and establishes the seed's ontology. From there on, **all revisions are direct YAML edits by you (main session)** — do not call `ouroboros_generate_seed` again. It does not accept revision hints, and re-running it would discard the established ontology.
+
+**Threshold for seed**: `pass_threshold: 0.90` (stricter than default 0.80 — seeds are structural specs and must be precise).
+
+**Max iterations**: 5. Track the highest-scoring seed across all iterations (the "best attempt"). If still not PASS after 5, present that best attempt with its QA verdict and ask the user: accept it as-is, make one final manual edit and accept it below threshold, or escalate to `ooo interview` / `ooo unstuck`. If the user chooses one final manual edit, apply exactly that user-specified edit, present the complete edited Seed YAML in a fenced `yaml` block, and ask for explicit below-threshold acceptance; do not start a sixth QA iteration, rerun QA, or claim the result passed unless the user explicitly asks to rerun QA despite the max-iteration cap. If the user accepts any below-threshold attempt, present the complete accepted Seed YAML in a fenced `yaml` block before proceeding to "After Seed Generation".
+
+The seed sits inside the **Define** diamond of Double Diamond — where expansion (Wonder) and convergence (Reflect/Refine/Restate) both happen in service of a single sharp specification. Expansion is not the enemy; **unchecked expansion that bypasses the user gate is.** The four-phase cycle plus User Adoption Gate is the workflow's primary safeguard.
+
+**Loop**:
+
+1. Establish the QA evaluator for this run:
+   - **MCP QA mode**: Load the QA tool via the active runtime's `call_mcp` capability using runtime tool discovery query `"+ouroboros qa"` if not already loaded.
+   - **Fallback QA mode**: If MCP is unavailable, read `src/ouroboros/agents/qa-judge.md`, adopt that evaluator role, and return its exact JSON schema: lowercase `verdict` (`pass`/`revise`/`fail`), numeric `score`, `dimensions`, `differences`, `suggestions`, and `reasoning`. In this mode there is no MCP-owned `qa_session_id`; track iteration history in the audit block and local loop ledger instead.
+
+2. Obtain a QA verdict using the available mode:
+
+   **MCP QA mode** — call QA on the generated seed through the active runtime's `call_mcp` capability:
+   ```
+   Tool: ouroboros_qa
+   Arguments:
+     artifact: <the seed YAML>
+     quality_bar: "Seed must be internally consistent, acceptance_criteria must be measurable and testable, constraints must be concrete (no vague terms), ontology_schema must cover all entities referenced in goal/criteria, and there must be no contradictions between fields."
+     artifact_type: "document"
+     pass_threshold: 0.90
+     seed_content: <the seed YAML>
+     qa_session_id: <reuse across iterations>
+     iteration_history: <accumulated>
+   ```
+
+   **Fallback QA mode** — skip the tool call and evaluate the current seed text under the QA Judge role from step 1, using the same quality bar and threshold. Treat the locally produced verdict exactly like the MCP verdict for the PASS/REVISE/FAIL branch below.
+
+   **QA response shapes**: Branch only after a usable verdict is available.
+   - In MCP QA mode, if the response has `status: "delegated_to_subagent"` and no verdict payload, keep the returned `qa_session_id`, wait for the plugin-managed subagent result, then parse that result as the QA verdict. Do not treat the delegation envelope itself as PASS/REVISE/FAIL.
+   - In MCP QA mode, if the response already includes a scored verdict, parse that inline verdict directly.
+   - In fallback QA mode, parse the exact QA Judge JSON. Normalize `verdict` to uppercase only for the branch labels below (`pass`→PASS, `revise`→REVISE, `fail`→FAIL). Treat `differences` as blocking/revision issues and `suggestions` as proposed fixes; do not add non-schema fields such as `loop_action`.
+   - In all modes, append the parsed verdict plus applied/rejected revision decisions to `iteration_history` before the next QA pass.
+
+3. Branch on verdict:
+   - **PASS (>= 0.90)**: Exit loop. Present the final validated Seed YAML to the user, then proceed to "After Seed Generation" below.
+   - **REVISE (0.40–0.89)**: Run the **Wonder → Reflect → Refine → Restate** cycle below, then loop back to step 2.
+   - **FAIL (< 0.40)**: Stop the loop. The seed has fundamental issues that regeneration likely won't fix. Show the full verdict and recommend `ooo interview` to revisit requirements, or `ooo unstuck` to challenge assumptions. Do not proceed to celebration.
+
+4. On iteration N >= 3, briefly tell the user "Refining seed (iteration N/5)..." so they know progress is being made — but do not dump full verdicts each round; only deltas.
+
+5. After PASS, show a one-line summary of the journey: `Seed passed QA at iteration N/5 with score X.XX.`
+
+6. Immediately after that PASS summary, present the complete final validated Seed YAML in a fenced `yaml` block. This must happen before any "After Seed Generation" celebration, star prompt, setup prompt, or next-step text.
+
+#### Wonder → Reflect → Refine → Restate (REVISE branch)
+
+This revision loop mirrors the Double Diamond Define cycle: **diverge via multiple perspectives first, then converge through debate, user decision, and structural application.** Revisions must NEVER be auto-applied by the main session alone — *"No candidate is accepted by default."* (Symposium User Adoption Gate)
+
+Four explicit phases per iteration:
+- **Wonder** — diverge: collect raw proposals from independent sources
+- **Reflect** — debate: surface where sources agree and where they conflict
+- **Refine** — user gate: human picks which proposals enter the next seed
+- **Restate** — apply: edit YAML in place with accepted items only
+
+**Phase 1 — Wonder (diverge): collect raw proposals from available sources**
+
+**Source 1 — QA Judge** (structural, external)
+The `suggestions` from the QA verdict. These are gaps, contradictions, and quality issues in the YAML itself. QA cannot see the interview.
+
+**Source 2 — Socrates** (dialectical, user-intent evidence)
+You are Socrates — the Socratic facilitator lens from `skills/interview/SKILL.md` and `src/ouroboros/agents/socratic-interviewer.md`. Review the current seed YAML against verifiable interview evidence, in this order:
+
+1. If a `session_id` exists, first use available persisted interview/session state for that session. Path A may run from `ooo seed <session_id>` in a fresh conversation, so persisted state can be the only reliable dialectic record.
+2. Use conversation memory when it is available in the current thread.
+3. If no persisted state or conversation evidence is available for a point, mark Socrates output as `no Socrates-only proposal: dialectic context unavailable` for that point. Do not invent user preferences, rejected scope, or interview nuance.
+
+From the available evidence, surface 2–4 items neither QA nor lateral personas can see:
+- Did the user emphasize a constraint that got softened or dropped?
+- Did something the user explicitly rejected sneak back in?
+- Did the seed flatten nuance the user spent multiple turns clarifying?
+- Are there silent assumptions the user never agreed to?
+- Does wording contradict stated priorities (e.g., "MVP in a week" but 8 acceptance criteria)?
+
+If QA and Socrates conflict, do not resolve the conflict silently in Wonder. Carry both candidates into Reflect as a divergent signal, cite the available evidence for each side, and let the Refine user gate choose the resolution. Do not assume the Socratic lens is automatically authoritative; QA can be correct when no user-intent evidence contradicts it.
+
+**Source 3 — `ouroboros_lateral_think` (independent perspectives, MCP-only when available)**
+Attempt to load the MCP tool with the active runtime's `call_mcp` capability using runtime tool discovery query `"+ouroboros lateral"` if needed. If the tool loads, call it through the active runtime's `call_mcp` capability to collect 5 independent MCP personas or isolated perspectives:
+
+```
+Tool: ouroboros_lateral_think
+Arguments:
+  problem_context: |
+    Seed is in REVISE state (QA score X.XX, threshold 0.90).
+    Current seed YAML:
+    <YAML>
+    QA suggestions:
+    - <suggestion 1>
+    - <suggestion 2>
+    Original user goal from interview: <recall>
+  current_approach: "The seed as currently drafted (above)."
+  persona: "all"
+  failed_attempts:
+    - <previously rejected candidate from earlier iterations>
+    - ...
+```
+
+The 5 personas return distinct revision angles:
+- **hacker**: unconventional workarounds (e.g., reframe a constraint instead of adding criteria)
+- **researcher**: knowledge the seed assumes but doesn't pin down
+- **simplifier**: criteria/constraints to *remove* for sharper convergence
+- **architect**: structural reorganization without expansion
+- **contrarian**: challenges to assumptions the seed treats as settled
+
+**Parsing persona outputs when lateral MCP is available**: Each persona returns free-form prose, not a structured list. After the parallel call returns, read each persona's text and extract its concrete proposals into discrete candidates (one revision per candidate, not bundled). If a persona's output is purely abstract advice with no actionable revision, drop it from the candidate list rather than inventing one. Aim for 1–2 candidates per persona — if a persona produced 5, pick the 2 most concrete and discard the rest.
+
+**Lateral response shapes**: `ouroboros_lateral_think` does not have one universal synchronous shape. After calling it with all personas, branch on the returned shape before extracting candidates:
+
+- **Plugin delegation**: If the response has `status: "delegated_to_subagent"`, `dispatch_mode: "plugin"`, and an `_subagents` array, wait for every plugin-managed subagent result. Extract concrete revision candidates from those returned persona texts. Do not attempt to parse candidates from the envelope prompts themselves.
+- **Inline fallback with dispatch block**: If the response returns markdown `content` plus the hidden sentinel `<!-- ouroboros-lateral-inline-dispatch-v1 base64 ... -->`, keep the visible markdown as the lateral scaffold. If the active runtime can dispatch isolated subagents, decode the sentinel JSON (`dispatch_mode`, `persona_count`, `payloads`) and send each `payload.prompt` + `payload.context` through that isolated subagent surface, then extract candidates from the returned persona texts. If the runtime cannot dispatch subagents, synthesize candidates directly from the visible inline persona sections.
+- **Inline fallback without dispatch block**: Treat the returned markdown as the complete lateral output and synthesize candidates directly from the visible persona sections. Do not split solely on `---` if doing so would corrupt user-provided content; prefer section headers and visible persona boundaries.
+
+If runtime tool discovery cannot load `ouroboros_lateral_think`, do not emulate lateral personas or read persona files directly. Record `no lateral proposals: MCP lateral tool unavailable` as Source 3 output and proceed with QA plus Socrates/available sources. The QA refinement loop remains required, and the User Adoption Gate still applies to any proposed revision.
+
+**Phase 2 — Reflect (debate): structure proposals by agreement and conflict**
+
+Do not just dedupe. Read all proposals from the available Wonder sources (Sources 1–2, plus Source 3 only when `ouroboros_lateral_think` loaded successfully) and surface the *structure of the debate*:
+
+- **Convergent signals (strong)**: same revision proposed by ≥2 independent sources. Example: QA says "criterion 3 is unmeasurable" AND simplifier says "drop criterion 3 or sharpen it" → strong signal to act on criterion 3.
+- **Divergent signals (decisions)**: sources conflict. Example: researcher says "add User entity to ontology" but simplifier says "remove the User reference from goal — single-user implied". This is a decision the *user* must resolve, not the main session.
+- **Singleton signals (weaker)**: one source only. Keep but mark as weaker.
+- **Balance signal**: count expansion proposals (add) vs convergence proposals (sharpen/remove). Show the ratio above the user gate as information, not warning — e.g., `Balance: 4 expand / 2 sharpen / 1 remove`. Both directions are legitimate; the user decides what mix to accept.
+
+Output of Reflect: a tagged candidate list with per-item metadata `(sources_backing, type=expand|sharpen|remove|resolve_conflict)`.
+
+**Phase 3 — Refine (User Adoption Gate)**
+
+Use the active runtime's `ask_user` capability with executable single-choice questions only. Do not ask one multi-select question or present options that can be selected contradictorily.
+
+Ask sequential single-choice questions in this order:
+
+1. For each conflict group, ask one question with exactly one option per mutually exclusive resolution plus "Leave unchanged"; handle the runtime's free-form "Other" response if available. Record the chosen option as accepted and mark the other options in that group rejected.
+2. For non-conflicting convergent signals, ask one single-choice batch question: "Apply all strong non-conflicting revisions, review one by one, or skip them?" If the user chooses review, ask each revision as a Yes/No/Other single-choice question.
+3. For singleton signals, ask one single-choice batch question: "Review singleton revisions one by one, skip all singleton revisions, or other?" If the user chooses review, ask each revision as a Yes/No/Other single-choice question.
+4. Always include a skip option at the batch level: "None of the above / keep current seed for now". If selected during a REVISE iteration, skip applying this candidate batch and return to QA or the max-iteration boundary; do not treat it as below-threshold acceptance unless the user separately chooses an explicit "accept current seed below threshold" option at the loop boundary.
+
+Convergent signals still appear first in summaries, conflicts second, singletons last. Conflict questions must be asked before any non-conflicting batch is applied so contradictory revisions cannot both enter the next seed.
+
+```
+Iteration N/5 — QA score X.XX (REVISE)
+
+Which revisions should enter the next seed?
+(Nothing accepted by default. Questions are single-choice and may be sequential.)
+
+Strong (multiple sources agree):
+A. [QA + Simplifier] Criterion 3 "easy to use" — sharpen to measurable predicate
+B. [QA + Socrates] Re-add "single-user only" constraint dropped from iter-0
+
+Conflicts (mutually exclusive — pick at most one per group):
+C1. [Researcher] Add User entity to ontology
+C2. [Simplifier] Remove User reference from goal (single-user implied)
+C3. Neither — leave ontology untouched on this point
+
+Singletons:
+D. [Contrarian] Constraint "no external DB" contradicts criterion 7
+E. [Architect] Group 3 user-management criteria under one parent
+F. [Hacker] Replace "user authentication" with "device-local key file"
+
+Other:
+G. None of the above (exit loop with current seed)
+H. Other — describe a different change
+```
+
+Portable gate example:
+
+```json
+{
+  "questions": [{
+    "question": "Conflict: how should the seed handle User in the ontology?",
+    "header": "Conflict C",
+    "options": [
+      {"label": "Add User", "description": "Accept C1 and reject C2/C3"},
+      {"label": "Remove User", "description": "Accept C2 and reject C1/C3"},
+      {"label": "Leave unchanged", "description": "Accept C3 and reject C1/C2"}
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+Balance line shown above the question: `Balance: 4 expand / 2 sharpen / 1 remove` (informational, not a warning).
+
+Track all rejected candidates across iterations and pass them as `failed_attempts` to subsequent `ouroboros_lateral_think` calls when the MCP lateral tool is available, so personas don't re-propose them.
+
+**Phase 4 — Restate (apply accepted only)**
+
+Edit the previous seed YAML in place. Apply ONLY user-accepted items. Do not start from scratch. Do not lose fields that were already correct. Do not call `ouroboros_generate_seed` again — that tool runs only at iter-0.
+
+If the user skips all proposed revisions for a REVISE iteration, keep the current seed unchanged for that iteration and continue the loop or max-iteration boundary. Exit below threshold only after an explicit loop-boundary acceptance choice such as "accept current seed below threshold"; before proceeding to "After Seed Generation", present the complete accepted Seed YAML in a fenced `yaml` block so the accepted artifact is explicit.
+
+Common edit shapes (both expansion and convergence are legitimate when the user accepted them):
+- Sharpen: replace vague phrase with measurable predicate (`"fast"` → `"p95 latency < 200ms"`)
+- Tighten: harden a soft constraint (`"some kind of storage"` → `"SQLite, single file, no server"`)
+- Make implicit explicit: surface a silent assumption as a constraint
+- Remove: drop a contradicting or redundant criterion
+- Expand (when accepted): add an ontology entity, criterion, or constraint that fills a gap the user confirmed
+
+**Audit trail**
+
+After each revision, append a brief audit block to `~/.ouroboros/seed-revisions/<revision_key>.md` (create the directory if it doesn't exist) capturing: iteration N, QA score, all candidates with source tag, user's accept/reject decisions, and the resulting diff vs. previous iteration. This makes the convergence path inspectable and lets the user replay decisions later.
+
+Choose `revision_key` deterministically:
+- If `session_id` exists, use that exact `session_id`.
+- If no `session_id` exists (common in Path B), derive a stable seed label from the seed goal or project name plus the current UTC timestamp, for example `<slugified-goal>-YYYYMMDDTHHMMSSZ`. Once derived, reuse the same key for every iteration in the current seed run.
+- If the filesystem write is unavailable, include the same audit block in the assistant response instead of silently dropping it.
+
+Format:
+```markdown
+## Iteration N — score X.XX
+
+### Candidates
+- [A] [QA+Simplifier] sharpen criterion 3 — **accepted**
+- [B] [Socrates] re-add single-user constraint — **accepted**
+- [C1] [Researcher] add User entity — rejected
+- [C2] [Simplifier] remove User from goal — **accepted**
+- [D] [Contrarian] resolve no-DB / criterion-7 conflict — rejected
+- ...
+
+### Diff vs. iteration N-1
+- criteria[2]: "easy to use" → "first-time user completes flow in < 3 clicks"
+- constraints: + "single-user only"
+- goal: "...for users..." → "...for the single operator..."
+```
+
+## Seed Components
+
+The seed contains:
+
+- **GOAL**: Clear primary objective
+- **CONSTRAINTS**: Hard limitations (e.g., Python >= 3.12, no external DB)
+- **ACCEPTANCE_CRITERIA**: Measurable success criteria
+- **ONTOLOGY_SCHEMA**: Data structure definition (name, fields, types)
+- **EVALUATION_PRINCIPLES**: Quality principles with weights
+- **EXIT_CONDITIONS**: When the workflow should terminate
+- **METADATA**: Version, timestamp, ambiguity score, interview ID
+
+## Example Output
+
+```yaml
+goal: Build a CLI task management tool
+constraints:
+  - Python >= 3.12
+  - No external database
+  - SQLite for persistence
+acceptance_criteria:
+  - Tasks can be created
+  - Tasks can be listed
+  - Tasks can be marked complete
+ontology_schema:
+  name: TaskManager
+  description: Task management domain model
+  fields:
+    - name: tasks
+      type: array
+      description: List of tasks
+    - name: title
+      type: string
+      description: Task title
+metadata:
+  ambiguity_score: 0.15
+```
+
+## After Seed Generation
+
+On successful seed generation, first announce:
+
+```
+Your seed has been crystallized!
+```
+
+Then check `~/.ouroboros/prefs.json` for `star_asked`. If `star_asked` is not set to `true`, use the active runtime's `ask_user` capability with this single question:
+
+```json
+{
+  "questions": [{
+    "question": "If Ouroboros helped clarify your thinking, a GitHub star supports continued development. Ready to unlock Full Mode?",
+    "header": "Next step",
+    "options": [
+      {
+        "label": "\u2b50 Star & Setup",
+        "description": "Star on GitHub + run ooo setup to enable run, evaluate, status"
+      },
+      {
+        "label": "Just Setup",
+        "description": "Skip star, go straight to ooo setup for Full Mode"
+      }
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+- **Star & Setup**: Run `gh api -X PUT /user/starred/Q00/ouroboros`, merge `{"star_asked": true}` into `~/.ouroboros/prefs.json`, then read and execute `skills/setup/SKILL.md`
+- **Just Setup**: Merge `{"star_asked": true}` into `~/.ouroboros/prefs.json`, then read and execute `skills/setup/SKILL.md`
+- **Other** (user provides custom text): Merge `{"star_asked": true}` into `~/.ouroboros/prefs.json`, skip setup
+
+Create `~/.ouroboros/` directory if it doesn't exist. Preserve existing keys such as `welcomeShown`, `welcomeCompleted`, and `welcomeVersion` when updating `star_asked`:
+
+```bash
+python3 - <<'PY'
+import json, os
+path = os.path.expanduser('~/.ouroboros/prefs.json')
+os.makedirs(os.path.dirname(path), exist_ok=True)
+try:
+    with open(path, encoding='utf-8') as f:
+        prefs = json.load(f)
+    if not isinstance(prefs, dict):
+        prefs = {}
+except Exception:
+    prefs = {}
+prefs['star_asked'] = True
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(prefs, f, indent=2)
+    f.write('\n')
+PY
+```
+
+If `star_asked` is already `true`, skip the question and just announce:
+
+```
+Your seed has been crystallized!
+📍 Next: `ooo run` to execute this seed (requires `ooo setup` first)
+```

--- a/.claude-plugin/skills/setup/SKILL.md
+++ b/.claude-plugin/skills/setup/SKILL.md
@@ -1,0 +1,647 @@
+---
+name: setup
+description: "Guided onboarding wizard for Ouroboros setup"
+---
+
+# /ouroboros:setup
+
+Guided onboarding wizard that converts users into power users.
+
+> **Standalone users** (Codex, pip install): Use `ouroboros setup --runtime codex` in your terminal instead.
+> This skill runs inside a Claude Code session. For other runtime backends, the CLI `ouroboros setup` command handles configuration.
+> For full install and onboarding instructions, see [Getting Started](docs/getting-started.md).
+
+> **GitHub Copilot CLI users**: Run `ouroboros setup --runtime copilot` (after `pipx install 'ouroboros-ai[mcp]'` or `uv tool install 'ouroboros-ai[mcp]'`). Setup will:
+>
+> 1. Live-discover available models from the GitHub Copilot models API (uses `gh auth token`) and let you pick a default. A bundled fallback list is used when offline.
+> 2. Write `orchestrator.runtime_backend = copilot` and `llm.backend = copilot` plus your chosen default into `~/.ouroboros/config.yaml`.
+> 3. Register the MCP server in `~/.copilot/mcp-config.json` so the next `copilot` session can call `ooo ...` skills.
+>
+> Hyphen Anthropic IDs that the Ouroboros defaults use (for example `claude-opus-4-6`) are auto-mapped at runtime to the dotted form Copilot CLI expects (`claude-opus-4.6`), so existing config files keep working when you switch backends.
+
+## Usage
+
+```
+ooo setup
+/ouroboros:setup
+/ouroboros:setup --uninstall
+```
+
+> **Note**: Setup does two things:
+> 1. **MCP server registration** (`~/.claude/mcp.json`) — one-time, global across all projects
+> 2. **CLAUDE.md integration** (optional) — per-project, adds an Ouroboros command reference block
+>
+> After the first run, you only need to re-run setup in new projects if you want the CLAUDE.md integration.
+
+---
+
+## Setup Wizard Flow
+
+When the user invokes this skill, guide them through an enhanced 6-step wizard with progressive disclosure and celebration checkpoints.
+
+---
+
+### Step 0: Welcome & Motivation (The Hook)
+
+Start with energy and clear value:
+
+```
+Welcome to Ouroboros Setup!
+
+Let's unlock your full AI development potential.
+
+What you'll get:
+- Visual TUI dashboard for real-time progress tracking
+- 3-stage evaluation pipeline for quality assurance
+- Drift detection to keep projects on track
+- Cost optimization (85% savings on average)
+
+Setup takes ~2 minutes. Let's go!
+```
+
+---
+
+### Step 0.5: Community Support
+
+Before we begin, check `~/.ouroboros/prefs.json` for `star_asked`. If not `true`, use **AskUserQuestion**:
+
+```json
+{
+  "questions": [{
+    "question": "Ouroboros is free and open-source. A GitHub star helps other developers discover it. Star the repo?",
+    "header": "Community",
+    "options": [
+      {
+        "label": "Star on GitHub",
+        "description": "Takes 1 second — helps the project grow"
+      },
+      {
+        "label": "Skip for now",
+        "description": "Continue with setup"
+      }
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+- **Star on GitHub**: Run `gh api -X PUT /user/starred/Q00/ouroboros`, then merge `{"star_asked": true}` into `~/.ouroboros/prefs.json`
+- **Skip for now**: Merge `{"star_asked": true}` into `~/.ouroboros/prefs.json`
+- **Other**: Merge `{"star_asked": true}` into `~/.ouroboros/prefs.json`
+
+Create `~/.ouroboros/` directory if it doesn't exist. Preserve any existing keys such as `welcomeShown`, `welcomeCompleted`, and `welcomeVersion` when updating `star_asked`:
+
+```bash
+python3 - <<'PY'
+import json, os
+path = os.path.expanduser('~/.ouroboros/prefs.json')
+os.makedirs(os.path.dirname(path), exist_ok=True)
+try:
+    with open(path, encoding='utf-8') as f:
+        prefs = json.load(f)
+    if not isinstance(prefs, dict):
+        prefs = {}
+except Exception:
+    prefs = {}
+prefs['star_asked'] = True
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(prefs, f, indent=2)
+    f.write('\n')
+PY
+```
+
+If `star_asked` is already `true`, skip this step silently.
+
+---
+
+### Step 1: Environment Detection
+
+Check the user's environment with clear feedback:
+
+```bash
+python3 --version
+which uvx 2>/dev/null && uvx --version 2>/dev/null
+which claude 2>/dev/null
+```
+
+**IMPORTANT: If system Python is < 3.12 but uvx is available, also check uv-managed Python:**
+
+```bash
+uv python list 2>/dev/null | grep "cpython-3.1[2-9]"
+```
+
+If `uv python list` shows Python >= 3.12 available, this counts as **Full Mode** because `uvx ouroboros-ai mcp serve` automatically uses uv-managed Python >= 3.12 (not system Python).
+
+**Report results with personality:**
+
+```
+Environment Detected:
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+System Python 3.11         [!] Below 3.12
+uv Python 3.12+            [✓] Available (uvx will use this)
+uvx package runner         [✓] Available
+Runtime backend            [✓] Detected
+
+→ Full Mode Available (via uvx + uv-managed Python >= 3.12)
+```
+
+**Decision Matrix:**
+
+| Environment | Mode | Action |
+|:------------|:-----|:-------|
+| uvx + Python >= 3.12 | **Ready** | Proceed to MCP registration (uvx mode — extras always included) |
+| No uvx + `ouroboros` binary in PATH | **Check deps** | Verify `[claude]` extras, then proceed (binary mode) |
+| No uvx + Python >= 3.12 + `python3 -m ouroboros` works | **Check deps** | Verify `[claude]` extras, then proceed (pip mode) |
+| uvx + Python < 3.12 only | **Install needed** | Run `uv python install 3.12` then proceed |
+| No uvx + no ouroboros binary + no pip package | **Install needed** | Install uv first, then proceed |
+
+**For binary/pip modes — verify `[claude]` extras are installed:**
+
+Check method depends on how ouroboros was installed:
+```bash
+# Detect install method
+pipx list 2>/dev/null | grep -q ouroboros && echo "PIPX" || echo "NOT_PIPX"
+```
+
+- **pipx users** (binary mode, installed via pipx):
+  ```bash
+  pipx runpip ouroboros-ai show claude-agent-sdk 2>/dev/null && echo "DEPS_OK" || echo "DEPS_MISSING"
+  ```
+  If `DEPS_MISSING`: `pipx install --force ouroboros-ai[claude]`
+
+- **pip users** (pip mode):
+  ```bash
+  python3 -c "import claude_agent_sdk" 2>/dev/null && echo "DEPS_OK" || echo "DEPS_MISSING"
+  ```
+  If `DEPS_MISSING`: `python3 -m pip install ouroboros-ai[claude]`
+
+If deps are missing and the user doesn't want to fix manually, recommend uv. Prefer
+package-manager paths over the vendor pipe-to-shell when the user's environment supports
+them (pipx > pip > brew > vendor one-liner):
+```
+Or install uv (recommended — handles deps automatically). Any one of:
+  pipx install uv
+  pip install --user uv
+  brew install uv          # macOS / Linuxbrew
+  curl -LsSf https://astral.sh/uv/install.sh | sh   # vendor one-liner (last resort)
+Then re-run: ooo setup
+```
+
+**IMPORTANT**: The MCP server requires one of: (1) uvx, (2) ouroboros binary in PATH, or (3) ouroboros pip-installed. For options 2 and 3, the `[claude]` extra must also be installed. If none are available, guide the user to install uv — do NOT write a non-working fallback to mcp.json.
+
+**If prerequisites are missing, show:**
+```
+Ouroboros requires uvx (recommended) or the ouroboros package installed.
+
+Quick install (< 1 minute) — install uv via any of:
+  pipx install uv
+  pip install --user uv
+  brew install uv          # macOS / Linuxbrew
+  curl -LsSf https://astral.sh/uv/install.sh | sh   # vendor one-liner (last resort)
+Then:
+  uv python install 3.12
+
+Then re-run: ooo setup
+```
+
+**Celebration Checkpoint 1:**
+```
+Great news! You're ready for the full Ouroboros experience.
+```
+
+---
+
+### Step 2: MCP Server Registration
+
+Check if `~/.claude/mcp.json` exists:
+
+```bash
+ls -la ~/.claude/mcp.json 2>/dev/null && echo "EXISTS" || echo "NOT_FOUND"
+```
+
+**Show progress:**
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Registering MCP Server...
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Connecting Ouroboros Python core to your runtime backend.
+This enables:
+
+  Visual TUI Dashboard    [Watch execution in real-time]
+  3-Stage Evaluation     [Mechanical → Semantic → Consensus]
+  Drift Detection        [Alert when projects go off-track]
+  Session Replay         [Debug any execution from events]
+```
+
+**Automatically create or update `~/.claude/mcp.json`** (user-level, works across all projects).
+
+Choose the MCP command based on how ouroboros is installed (check in order):
+1. If `which uvx` succeeds: `{"command": "uvx", "args": ["--from", "ouroboros-ai[claude]", "ouroboros", "mcp", "serve"]}`
+2. If `which ouroboros` succeeds: `{"command": "ouroboros", "args": ["mcp", "serve"]}`
+3. If `python3 -c "import ouroboros"` succeeds: `{"command": "python3", "args": ["-m", "ouroboros", "mcp", "serve"]}`
+4. If none of the above → **do NOT write to mcp.json**. Instead show the prerequisites message from Step 1 and stop.
+
+If `~/.claude/mcp.json` already exists, read it, **always overwrite the `ouroboros` key** with the entry above (to fix stale args from older versions), and preserve all other server entries.
+
+**Celebration Checkpoint 2:**
+```
+MCP Server Registered! You can now:
+- Run ooo run for visual TUI execution
+- Run ooo evaluate for 3-stage verification
+- Run ooo status for drift tracking
+```
+
+---
+
+### Step 3: CLAUDE.md Integration (Optional)
+
+Ask with clear value proposition:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  CLAUDE.md Integration
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Add Ouroboros quick-reference to your CLAUDE.md?
+
+This gives you instant command reminders without leaving
+your project context.
+
+What gets added (~40 lines):
+- Philosophy and pipeline overview
+- Command routing table with lazy-loaded agents
+- Agent catalog summary
+
+A backup will be created: CLAUDE.md.bak
+
+[Integrate / Skip / Preview first]
+```
+
+**If "Preview first", show:**
+````markdown
+<!-- ooo:START -->
+<!-- ooo:VERSION:0.39.1 -->
+# Ouroboros — Specification-First AI Development
+
+> Before telling AI what to build, define what should be built.
+> As Socrates asked 2,500 years ago — "What do you truly know?"
+> Ouroboros turns that question into an evolutionary AI workflow engine.
+
+Most AI coding fails at the input, not the output. Ouroboros fixes this by
+**exposing hidden assumptions before any code is written**.
+
+1. **Socratic Clarity** — Question until ambiguity ≤ 0.2
+2. **Ontological Precision** — Solve the root problem, not symptoms
+3. **Evolutionary Loops** — Each evaluation cycle feeds back into better specs
+
+```
+Interview → Seed → Execute → Evaluate
+    ↑                           ↓
+    └─── Evolutionary Loop ─────┘
+```
+
+## ooo Commands
+
+Each command loads its agent/MCP on-demand. Details in each skill file.
+
+| Command | Loads |
+|---------|-------|
+| `ooo` | — |
+| `ooo interview` | `ouroboros:socratic-interviewer` |
+| `ooo seed` | `ouroboros:seed-architect` |
+| `ooo run` | MCP required |
+| `ooo evolve` | MCP: `evolve_step` |
+| `ooo evaluate` | `ouroboros:evaluator` |
+| `ooo unstuck` | `ouroboros:{persona}` |
+| `ooo status` | MCP: `session_status` |
+| `ooo setup` | — |
+| `ooo help` | — |
+
+## Agents
+
+Loaded on-demand — not preloaded.
+
+**Core**: socratic-interviewer, ontologist, seed-architect, evaluator,
+wonder, reflect, advocate, contrarian, judge
+**Support**: hacker, simplifier, researcher, architect
+<!-- ooo:END -->
+````
+
+**If Integrate:**
+1. Backup existing CLAUDE.md to CLAUDE.md.bak
+2. Append the block above
+3. Confirm successful integration
+
+**Celebration Checkpoint 3:**
+```
+CLAUDE.md updated! You now have instant Ouroboros reference
+available in every project.
+```
+
+---
+
+### Step 4: Quick Verification
+
+Run verification with visual feedback:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Verifying Setup...
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+Check skills are loadable:
+```bash
+ls skills/ | wc -l  # Should show 12+ skills
+```
+
+Check agents are available:
+```bash
+ls src/ouroboros/agents/*.md | wc -l  # Should show 20+ bundled agents
+```
+
+Check MCP registration (if enabled):
+```bash
+cat ~/.claude/mcp.json | grep -q ouroboros && echo "MCP: ✓" || echo "MCP: ✗"
+```
+
+---
+
+### Step 5: Success Summary
+
+Display with celebration:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Ouroboros Setup Complete!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Mode:                     Full Mode (Python >= 3.12 + MCP)
+Skills Registered:        15 workflow skills
+Agents Available:         9 specialized agents
+MCP Server:               ✓ Registered
+CLAUDE.md:                ✓ Integrated
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  You're Ready to Go!
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Start your first project:
+  ooo interview "your project idea"
+
+Learn what's possible:
+  ooo help
+
+Try the interactive tutorial:
+  ooo tutorial
+
+Join the community:
+  Star us on GitHub! github.com/Q00/ouroboros
+```
+
+---
+
+### Step 5.5: Brownfield Repository Scan
+
+Scan a root directory for existing git repositories and linked worktrees, then register them in the Ouroboros DB. This enables interviews to use brownfield context for existing projects.
+
+**Show scanning indicator:**
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Scanning for Existing Projects...
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+Looking for git repositories and worktrees under the scan root directory.
+Linked worktrees reported by discovered normal repo roots may also be registered, even outside the scan root directory.
+Local repos and repos with any remote name are eligible.
+This may take a moment...
+```
+
+**Implementation — use MCP tools only, do NOT use CLI or Python scripts:**
+
+1. Load the brownfield MCP tool: `ToolSearch query: "+ouroboros brownfield"`
+2. Call scan+register:
+   ```
+   Tool: ouroboros_brownfield
+   Arguments: { "action": "scan" }
+   ```
+   This walks `scan_root` for valid seed repos/worktrees and registers them in DB. For each discovered normal repo root with a `.git` directory, Git-reported linked worktrees are also considered, even when they live outside `scan_root`. A linked worktree found under `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`. Existing defaults are preserved.
+
+**Scan boundaries:**
+- The filesystem walk starts at `scan_root`; when omitted, `scan_root` defaults to the current user's home directory.
+- Repositories are only discovered directly by walking directories inside `scan_root`.
+- Dot-prefixed directories and known noisy directories such as `node_modules` are not walked as seed locations.
+- Git worktrees are different: once a normal repo root with a `.git` directory is discovered, Ouroboros runs `git worktree list --porcelain` and may register those linked worktrees even if their paths are outside `scan_root`.
+- A linked worktree found inside `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`.
+- Local repos, repos without remotes, and repos whose remotes are not named `origin` are all eligible.
+
+The scan response `text` already contains a pre-formatted numbered list with `[default]` markers. **Do NOT make any additional MCP calls to list or query repos.**
+
+**Display the repos in a plain-text 2-column grid** (NOT a markdown table). Use a code block so columns align. Example:
+
+```
+Scan complete. 8 repositories registered.
+
+ 1. repo-alpha                   5. repo-epsilon
+ 2. repo-bravo *                 6. repo-foxtrot
+ 3. repo-charlie                 7. repo-golf *
+ 4. repo-delta                   8. repo-hotel
+```
+
+Include `*` markers for defaults exactly as they appear in the scan response. Do not summarize or truncate the list. The user needs to see all repo numbers to pick defaults.
+
+**If no repos found**, skip the default selection prompt and proceed to Step 6.
+
+**Default repo selection — IMMEDIATELY after showing the list:**
+
+Use `AskUserQuestion` with the current default numbers from the scan response.
+
+**If defaults exist**, show them as the recommended option:
+
+```json
+{
+  "questions": [{
+    "question": "Which repos to set as default for interviews? Enter numbers like '6, 18, 19'.",
+    "header": "Default Repos",
+    "options": [
+      {"label": "<current default numbers> (Recommended)", "description": "<current default names>"},
+      {"label": "None", "description": "Clear all defaults — interviews will run in greenfield mode"},
+      {"label": "Select repos", "description": "Type repo numbers to set as default"}
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+**If no defaults exist**, do NOT show a "(Recommended)" option — offer "None" and "Select repos" instead:
+
+```json
+{
+  "questions": [{
+    "question": "Which repos to set as default for interviews? Enter numbers like '6, 18, 19'.",
+    "header": "Default Repos",
+    "options": [
+      {"label": "None", "description": "No default repos — interviews will run in greenfield mode"},
+      {"label": "Select repos", "description": "Type repo numbers to set as default"}
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+The user can select the recommended defaults (if any), choose "None", or type custom numbers.
+
+After the user responds, use ONE MCP call to update all defaults at once:
+
+```
+Tool: ouroboros_brownfield
+Arguments: { "action": "set_defaults", "indices": "<comma-separated IDs>" }
+```
+
+Example: if the user picks IDs 6, 18, 19 → `{ "action": "set_defaults", "indices": "6,18,19" }`
+
+This clears all existing defaults and sets the selected repos as default in one call.
+
+If "none" → `{ "action": "set_defaults", "indices": "" }` to clear all defaults.
+
+**Celebration Checkpoint 5.5:**
+```
+Brownfield defaults updated!
+Defaults: podo-app, podo-backend, grape
+
+These repos will be used as context in interviews.
+```
+
+Or if "none" selected:
+```
+No default repos set. interviews will run in greenfield mode.
+You can set defaults anytime by running ooo setup again.
+```
+
+---
+
+### Step 6: First Project Nudge
+
+Encourage immediate action:
+
+```
+
+Your first Ouroboros project is waiting!
+
+The best way to learn is by doing. Try:
+
+  ooo interview "Build a CLI tool for [something you need]"
+
+Or explore examples:
+  ooo tutorial
+
+You're going to love seeing vague ideas turn into
+crystal-clear specifications. Let's build something amazing!
+```
+
+---
+
+## Progressive Disclosure Schedule
+
+Reveal features gradually to avoid overwhelm:
+
+### Immediate (Plugin Mode)
+- `ooo interview` - Socratic clarification
+- `ooo seed` - Specification generation
+- `ooo unstuck` - Lateral thinking
+
+### After Setup (MCP Mode)
+- `ooo run` - TUI execution
+- `ooo evaluate` - 3-stage verification
+- `ooo status` - Drift tracking
+
+### Power User (Discover organically)
+- Evolutionary loop and ralph persistence
+- Cost prediction and optimization
+- Session replay and debugging
+- Custom agents and skills
+
+---
+
+## Uninstall
+
+When invoked with `--uninstall`:
+
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  Ouroboros Uninstall
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+This will remove:
+- MCP server registration from ~/.claude/mcp.json
+- Ouroboros block from CLAUDE.md
+
+This will NOT remove:
+- Plugin files in .claude-plugin/
+- Any generated seeds or projects
+- Your project data
+
+Uninstall Ouroboros configuration? [Yes / No]
+```
+
+If Yes:
+1. Remove `ouroboros` entry from `~/.claude/mcp.json` (if exists)
+2. Remove `<!-- ooo:START -->` to `<!-- ooo:END -->` block from CLAUDE.md (if exists)
+3. Confirm: "Ouroboros plugin configuration removed. To remove plugin files, run: claude plugin uninstall ouroboros"
+
+---
+
+## Setup Troubleshooting
+
+### "python3: command not found"
+```
+Plugin mode still works! You can use:
+- ooo interview
+- ooo seed
+- ooo unstuck
+
+For Full Mode, install Python >= 3.12:
+  macOS: brew install python@3.12
+  Ubuntu: sudo apt install python3.12
+  Windows: python.org/downloads
+```
+
+### "uvx: command not found"
+```
+uvx is recommended but not required. Alternative:
+
+Install Ouroboros globally (see docs/getting-started.md for all options):
+  pip install ouroboros-ai
+
+Then update ~/.claude/mcp.json with:
+  "command": "python"
+  "args": ["-m", "ouroboros", "mcp", "serve"]
+```
+
+### "~/.claude/mcp.json conflicts"
+```
+Ouroboros will merge with existing MCP servers.
+If you see issues, share your ~/.claude/mcp.json content and
+we'll help you resolve conflicts.
+```
+
+---
+
+## Conversion Metrics Track
+
+Track these checkpoints for conversion optimization:
+
+- [ ] Started setup (skill invoked)
+- [ ] Environment detected successfully
+- [ ] MCP server registration accepted
+- [ ] CLAUDE.md integration accepted
+- [ ] Verification passed
+- [ ] Brownfield repos scanned and registered
+- [ ] Default brownfield repo selected
+- [ ] First project started (ooo interview)
+- [ ] First seed generated (ooo seed)
+- [ ] First execution completed (ooo run)
+
+A fully converted user = all checkpoints passed

--- a/.claude-plugin/skills/status/SKILL.md
+++ b/.claude-plugin/skills/status/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: status
+description: "Check session status and measure goal drift"
+mcp_tool: ouroboros_session_status
+mcp_args:
+  session_id: "$1"
+---
+
+# /ouroboros:status
+
+Check session status and measure goal drift.
+
+## Usage
+
+```
+/ouroboros:status [session_id]
+```
+
+**Trigger keywords:** "am I drifting?", "session status", "drift check"
+
+## How It Works
+
+1. **Session Status**: Queries the current state of an execution session
+2. **Drift Measurement**: Measures how far the execution has deviated from the original seed goal
+
+## Instructions
+
+When the user invokes this skill:
+
+### Load MCP Tools (Required first)
+
+The Ouroboros MCP tools are often registered as **deferred tools** that must be explicitly loaded before use. **You MUST perform this step before proceeding.**
+
+1. Use the `ToolSearch` tool to find and load the status MCP tools:
+   ```
+   ToolSearch query: "+ouroboros session status"
+   ```
+2. The tools will typically be named with prefix `mcp__plugin_ouroboros_ouroboros__` (e.g., `ouroboros_session_status`, `ouroboros_measure_drift`). After ToolSearch returns, the tools become callable.
+3. If ToolSearch finds the tools → proceed with the steps below. If not → skip to **Fallback** section.
+
+**IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
+
+### Status Steps
+
+1. Determine the session to check:
+   - If `session_id` provided: Use it directly
+   - If no session_id: Check conversation for recent session IDs
+   - If none found: Ask user for the session ID
+
+2. Call `ouroboros_session_status` MCP tool:
+   ```
+   Tool: ouroboros_session_status
+   Arguments:
+     session_id: <session ID>
+   ```
+
+3. If the user asks about drift (or says "am I drifting?"), also call `ouroboros_measure_drift`:
+   ```
+   Tool: ouroboros_measure_drift
+   Arguments:
+     session_id: <session ID>
+     current_output: <current execution output or file contents>
+     seed_content: <original seed YAML>
+     constraint_violations: []  (any known violations)
+     current_concepts: []       (concepts in current output)
+   ```
+
+4. Present results:
+   - Show session status (running, completed, failed)
+   - Show progress information
+   - If drift measured, show the drift report
+   - If drift exceeds threshold (0.3), warn and suggest actions
+   - End with a `📍` next-step based on context:
+     - No drift measured: `📍 Session active — say "am I drifting?" to measure drift, or continue with ooo run`
+     - Drift ≤ 0.3: `📍 On track — continue with ooo run or ooo evaluate when ready`
+     - Drift > 0.3: `📍 Warning: significant drift detected. Consider ooo interview to re-clarify, or ooo evolve to course-correct`
+
+## Drift Thresholds
+
+| Combined Drift | Status | Action |
+|----------------|--------|--------|
+| 0.0 - 0.15 | Excellent | On track |
+| 0.15 - 0.30 | Acceptable | Monitor closely |
+| 0.30+ | Exceeded | Consider consensus review or course correction |
+
+## Fallback (No MCP Server)
+
+If the MCP server is not available:
+
+```
+Session tracking requires the Ouroboros MCP server.
+Run /ouroboros:setup to configure.
+
+Without MCP, you can manually check drift by comparing
+your current implementation against the seed specification.
+```
+
+## Example
+
+```
+User: am I drifting?
+
+Session: sess-abc-123
+Status: running
+Seed ID: seed-456
+Messages Processed: 8
+
+Drift Measurement Report
+========================
+Combined Drift: 0.12
+Status: ACCEPTABLE
+
+Component Breakdown:
+  Goal Drift: 0.08 (50% weight)
+  Constraint Drift: 0.10 (30% weight)
+  Ontology Drift: 0.20 (20% weight)
+
+You're on track. Goal alignment is strong.
+
+📍 On track — continue with `ooo run` or `ooo evaluate` when ready
+```

--- a/.claude-plugin/skills/tutorial/SKILL.md
+++ b/.claude-plugin/skills/tutorial/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: tutorial
+description: "Interactive tutorial teaching Ouroboros hands-on"
+---
+
+# /ouroboros:tutorial
+
+Interactive tutorial that teaches Ouroboros through hands-on experience.
+
+## Usage
+
+```
+ooo tutorial
+/ouroboros:tutorial
+```
+
+## Tutorial Flow
+
+When this skill is invoked, guide the user through a learn-by-doing tutorial with progressive disclosure.
+
+---
+
+## Phase 1: The Hook (30 seconds)
+
+Start with enthusiasm and immediate value:
+
+```
+Welcome to the Ouroboros Tutorial!
+
+In the next 5 minutes, you'll:
+- Transform a vague idea into a precise specification
+- See Ouroboros expose hidden assumptions you didn't know you had
+- Generate a validated Seed ready for AI execution
+
+Let's start with YOUR idea. What's something you've been wanting to build?
+
+[Wait for user response - any project idea works]
+```
+
+---
+
+## Phase 2: The Interview Experience (2 minutes)
+
+Once they share an idea, immediately start a simplified interview:
+
+```
+Great choice! Let me show you how Ouroboros thinks about this.
+
+[Ask 3-4 targeted Socratic questions about their idea]
+- "What's the primary problem this solves?"
+- "Who are the main users?"
+- "What's the one feature that would make this useful immediately?"
+
+Notice something? Each question exposed an assumption you hadn't articulated.
+This is the "aha moment" - requirements clarity BEFORE writing code.
+```
+
+---
+
+## Phase 3: The Quick Win (1 minute)
+
+Generate a mini-seed to show immediate value:
+
+```
+Based on your answers, here's what we've uncovered:
+
+[Display a simplified seed structure]
+
+Goal: [their goal refined]
+Constraints: [3 key constraints they mentioned]
+Success Criteria: [2-3 clear metrics]
+
+Ambiguity Score: 0.XX [show progress from vague to clear]
+
+This seed is now ready for AI execution. No more "build me X" and hoping for the best!
+```
+
+---
+
+## Phase 4: Feature Discovery (1 minute)
+
+Progressive disclosure of features:
+
+```
+
+Now that you've seen the core magic, here's what else Ouroboros can do:
+
+Immediate Wins (Available Now):
+- ooo unstuck    - 5 lateral thinking personas when you're blocked
+- ooo seed       - Generate full specifications from interviews
+- ooo evolve     - Evolutionary loop until ontology converges
+
+Advanced Features (Setup Required):
+- ooo run        - Execute with visual TUI dashboard
+- ooo evaluate   - 3-stage quality verification
+- ooo status     - Track project drift in real-time
+
+Want to try any of these now? Or shall I show you the full workflow?
+```
+
+---
+
+## Phase 5: The Real Workflow (30 seconds)
+
+Show the complete pipeline:
+
+```
+
+The Complete Ouroboros Workflow:
+
+Idea → Interview → Seed → Route → Execute → Evaluate
+  ↓        ↓         ↓       ↓        ↓         ↓
+Vague    Clear    Frozen   Right    Build    Verified
+      Assumptions   Spec    Model    Visibly     Quality
+
+5 commands from idea to validated result:
+1. ooo interview "your idea"        # Expose assumptions
+2. ooo seed                        # Crystallize spec
+3. ooo run                         # Execute with TUI
+4. ooo evaluate                    # 3-stage verification
+5. ooo status                      # Check drift
+
+Ready to try your first real project?
+```
+
+---
+
+## Phase 6: Call to Action
+
+```
+
+Your First Real Project awaits!
+
+Pick a path:
+
+Path A: Start Fresh
+  ooo interview "your actual project idea"
+
+Path B: Learn More
+  ooo help    # Full command reference
+
+Path C: Setup Full Features
+  ooo setup   # Enable TUI, evaluation, drift tracking
+
+Which path interests you?
+```
+
+---
+
+## Tutorial Principles
+
+1. **Immediate Value** - Show something useful in the first 30 seconds
+2. **Learn by Doing** - Don't just explain, have them experience it
+3. **Progressive Disclosure** - Reveal features gradually, not all at once
+4. **Quick Wins** - Celebrate small milestones throughout
+5. **Clear Next Steps** - Always give them a specific action to take
+
+---
+
+## Tutorial Checkpoints
+
+Track progress through these checkpoints:
+
+- [ ] User shares an idea
+- [ ] User experiences the "aha moment" of exposed assumptions
+- [ ] User sees their first mini-seed generated
+- [ ] User understands the value proposition
+- [ ] User chooses a next step (path A, B, or C)
+
+---
+
+## Common Tutorial Responses
+
+### "I don't have a project idea"
+```
+No problem! Let's use a classic example: a task management CLI.
+
+[Continue tutorial with task management CLI example]
+```
+
+### "This seems complicated"
+```
+It's actually simpler than it sounds. Let me show you the 3 commands you'll use 90% of the time:
+
+1. ooo interview "idea"  # Clarify what you want
+2. ooo seed             # Generate the spec
+3. ooo run              # Build it
+
+Everything else is optional power-user features.
+```
+
+### "How is this different from just prompting Claude?"
+```
+Great question! The difference is:
+
+Without Ouroboros:
+  "Build me a task CLI" → Claude guesses → You realize it's wrong → Rewrite prompt → Repeat
+
+With Ouroboros:
+  Interview → Hidden assumptions exposed → Precise spec → Claude builds exactly what you want → First try
+
+The interview saves you hours of iteration.
+```
+
+---
+
+## Success Metrics
+
+A successful tutorial ends when:
+- User has experienced the interview process
+- User understands the seed specification concept
+- User knows their next step
+- User feels confident to try their real project
+
+## Tutorial Variations
+
+### For Technical Users
+- Emphasize the TUI dashboard and evolutionary loop
+- Show cost optimization features (PAL Router)
+- Highlight evaluation pipeline
+
+### For Non-Technical Users
+- Focus on the interview and clarification process
+- Emphasize the "translate ideas to specs" value
+- Minimize technical jargon
+
+### For OMC Users
+- Highlight key differences (TUI, specs, cost optimization)
+- Show migration path from OMC commands
+- Compare feature sets side-by-side

--- a/.claude-plugin/skills/unstuck/SKILL.md
+++ b/.claude-plugin/skills/unstuck/SKILL.md
@@ -1,0 +1,266 @@
+---
+name: unstuck
+description: "Break through stagnation with lateral thinking personas — single or multi-persona debate"
+---
+
+# /ouroboros:unstuck
+
+Break through stagnation with lateral thinking personas. Two modes:
+- **Solo** — one persona reframes the problem (fast, cheap).
+- **Debate** — multiple personas run in parallel as sub-agents and the user picks the verdict (visual, thorough).
+
+## Usage
+
+```
+ooo lateral                       # debate (default) — all 5 lateral personas
+ooo lateral <persona>             # solo — single persona
+ooo lateral debate <p1> <p2> ...  # debate with explicit members
+ooo lateral @<preset>             # debate with preset (Phase 1: only @all = 5 personas)
+```
+
+Trigger keywords: "I'm stuck", "think sideways", "ooo lateral", "/ouroboros:unstuck".
+
+## Personas (Lateral Pool)
+
+The lateral pool is **stateless mindset personas only** — five reframing lenses. Stateful roles (evaluator, qa-judge, ontologist, socratic-interviewer, etc.) are NOT mixed into this pool; they have their own SKILLs.
+
+| Persona | Style | When to Use |
+|---------|-------|-------------|
+| **hacker** | "Make it work first, elegance later" | When overthinking blocks progress |
+| **researcher** | "What information are we missing?" | When the problem is unclear |
+| **simplifier** | "Cut scope, return to MVP" | When complexity is overwhelming |
+| **architect** | "Restructure the approach entirely" | When the current design is wrong |
+| **contrarian** | "What if we're solving the wrong problem?" | When assumptions need challenging |
+
+## When to Call
+
+**Direct user invocation** — `ooo lateral …` from the prompt.
+
+**Autonomous chain from another SKILL** — when you (the main session) are operating in another SKILL's persona (e.g., `socratic-interviewer` during `ooo interview`, or any agent role) and judge that the current question requires multi-perspective deliberation, you MAY invoke this SKILL on your own. No forced trigger; this is your self-assessment. After the debate, summarize the options for the user, return to the original SKILL's flow, and let the user decide. The user will see the sub-agent fan-out as it happens — that visibility is the point.
+
+## Instructions
+
+### Step 1 — Parse args → mode
+
+Parse the user's argument string (or your autonomous-chain intent) into a mode (solo / debate):
+
+| Input | Mode | Members |
+|---|---|---|
+| no args | `debate` | all 5 lateral personas |
+| `debate` (keyword alone) | `debate` | all 5 lateral personas |
+| `<persona>` (e.g., `hacker`) | `solo` | that one persona |
+| `debate <p1> <p2> ...` | `debate` | the listed personas |
+| `@all` | `debate` | all 5 lateral personas |
+| `@<unknown-preset>` | error | reject + list known presets |
+| `<unknown-persona>` | error | reject + list the 5 lateral personas |
+| `<persona1> <persona2> ...` (no `debate` keyword) | error | reject + suggest `ooo lateral debate <p1> <p2>` |
+
+Validate every persona name against the lateral pool above. If invalid, emit a brief error message naming the valid personas — do NOT silently coerce. Multiple persona tokens without the explicit `debate` keyword are rejected to keep the syntax unambiguous.
+
+### Step 2 — Gather required context **before** the MCP call
+
+`ouroboros_lateral_think` hard-fails if either `problem_context` or `current_approach` is empty (`evaluation_handlers.py:1324, 1333`). A bare `ooo lateral` from a fresh session has neither — calling MCP directly would crash before any persona work. Resolve both fields *before* Step 3, in this order:
+
+1. **Reuse session state.** If a parent SKILL is invoking this one (autonomous chain) or the current Claude Code / Codex session has clearly recent stuck-point context, extract it. Build:
+   - `problem_context` — what the user is stuck on (1–3 sentences, current state of the world).
+   - `current_approach` — what has been tried so far (1–3 sentences). For a brand-new attempt, this can be `"none yet — first attempt"`.
+   - `failed_attempts` (optional) — short list of prior failures, when the user has volunteered them.
+2. **If either field is unrecoverable**, ask the user *one* short combined question before going further (this applies to both solo and debate — the handler requires both fields either way):
+   > "Two things I need before lateral thinking can run: (1) what are you stuck on right now, (2) what have you already tried? A sentence each is enough."
+   Wait for the answer. Do **not** invent or paraphrase past turns into these fields if you are not certain — `current_approach="not specified"` is acceptable, fabricated content is not.
+3. Only when both fields are populated, proceed to Step 3.
+
+This pre-call branch applies to solo *and* debate. Skipping it makes `ooo lateral` (no args, fresh session) reliably error.
+
+### Step 3 — Always call `ouroboros_lateral_think` (routing contract)
+
+Per the `ooo` routing contract in `src/ouroboros/codex/ouroboros.md`, every `ooo lateral` invocation MUST route through the MCP tool — solo *and* debate, in every runtime. This SKILL never substitutes a direct sub-agent fan-out for the MCP call.
+
+1. Call `ToolSearch` with query `"+ouroboros lateral"` to load `ouroboros_lateral_think` (often prefixed, e.g., `mcp__plugin_ouroboros_ouroboros__ouroboros_lateral_think`). Deferred tools won't appear until `ToolSearch` runs.
+2. Invoke the tool with the parsed mode and the context from Step 2:
+   - **Solo**: `persona=<one>`, `problem_context`, `current_approach`, `failed_attempts`.
+   - **Debate**: `personas=[...]`, `problem_context`, `current_approach`, `failed_attempts`.
+3. If `ToolSearch` cannot load the tool, **stop and report that the MCP dispatch surface is broken** — same rule the contract applies to `ooo auto`. Do not improvise a sub-agent fan-out as a workaround; that bypasses the contract the bot review explicitly flagged.
+
+The MCP call is cheap. The handler's inline path is a *deterministic prompt builder* — it constructs per-persona reframing prompts via `LateralThinker.generate_alternative` (`src/ouroboros/mcp/tools/evaluation_handlers.py:1444+`); it does not run an LLM rollout.
+
+### Step 4 — Branch on the handler's response shape
+
+The handler picks one of two response shapes based on `should_dispatch_via_plugin(...)` (`src/ouroboros/mcp/tools/subagent.py:186-218`). You do not choose; you observe and act. The envelope key further depends on the mode you called with — solo and debate are not symmetric:
+
+| Mode | Plugin response | Inline response |
+|---|---|---|
+| Solo (`persona=...`) | single `_subagent` envelope (one object) — `evaluation_handlers.py:1536-1563` | single `# Lateral Thinking: <approach>` block in `content` |
+| Debate (`personas=[...]`) | `_subagents` array (N objects) — `evaluation_handlers.py:1414+` | N blocks joined by `\n\n---\n\n` in `content`, **plus** an appended hidden dispatch block carrying the same canonical N payloads (see "Inline dispatch block" below) |
+
+**Inline dispatch block (debate, inline response only).** The handler appends a versioned, sentinel-bracketed dispatch block to the end of `content` so that callers can recover the canonical structured payloads even though the FastMCP adapter drops `meta` on the wire (`src/ouroboros/mcp/server/adapter.py:923`, `src/ouroboros/mcp/tools/subagent.py:141-144`). Format:
+
+```
+<!-- ouroboros-lateral-inline-dispatch-v1 base64
+<base64-encoded-JSON>
+-->
+```
+
+Two pieces matter:
+
+- **Hidden HTML comment** — markdown viewers render nothing for `<!-- ... -->`, so the block doesn't pollute the human-visible output.
+- **Base64 body** — base64's alphabet is `[A-Za-z0-9+/=]`, which can never produce the sequence `-->`. So even if a user-supplied `problem_context` or `current_approach` contains `-->` (HTML/JS debugging is the obvious case), the encoded body cannot prematurely close the wrapper and leak the dispatch into the visible markdown.
+
+Decoded, the body is JSON:
+
+```json
+{"dispatch_mode": "inline_fallback", "persona_count": N, "payloads": [...]}
+```
+
+To recover: locate the substring between `<!-- ouroboros-lateral-inline-dispatch-v1 base64\n` and `\n-->` at the end of `content`, base64-decode it, then `JSON.parse`. (See `tests/unit/mcp/tools/test_lateral_think_handler.py::_extract_inline_dispatch` for the canonical extraction helper.)
+
+#### Shape A — `dispatch_mode = "plugin"` (OpenCode plugin mode only)
+
+The plugin runtime spawns Task panes automatically from whichever envelope the handler emitted. You only need to read the right key and await the result(s):
+
+##### Solo (plugin)
+
+The response carries a single `_subagent` object (singular) — `{tool_name, title, prompt, agent, model, context}` — produced by `build_subagent_result` (`evaluation_handlers.py:1554+`). The plugin spawns one Task pane. Await its single result, then present the persona's reframing.
+
+##### Debate (plugin)
+
+The response carries a `_subagents` array (plural) — `[{tool_name, title, prompt, agent, model, context}, ...]` — produced by `build_multi_subagent_result` (`evaluation_handlers.py:1419+`). The plugin spawns N Task panes in parallel. Await all N results, then synthesize per the **Synthesize** block below.
+
+If you expected plugin mode but the response is inline text (neither `_subagent` nor `_subagents`), you are not actually in plugin mode — fall through to Shape B; do not wait for an envelope that will not arrive.
+
+#### Shape B — inline response (Claude Code, Codex CLI, OpenCode subprocess, every other runtime)
+
+The handler ran the prompt builder internally and returned ready-to-use markdown:
+
+- Solo response: a single `# Lateral Thinking: <approach>` block followed by the reframing prompt.
+- Debate response (`dispatch_mode = "inline_fallback"`): N such blocks concatenated with `\n\n---\n\n` separators.
+
+##### Solo (any runtime)
+
+Present the persona's approach summary, reframing prompt, questions to consider, and a `📍 Next:` suggestion routing back to the workflow.
+
+##### Debate, runtime supports sub-agent dispatch (Claude Code Task tool, Codex CLI sub-agent, etc.)
+
+This is the **default debate UX for Claude Code and Codex**. The MCP call has already happened (Step 3), so the routing contract is satisfied; this step only changes how the *already-built* canonical prompts are rendered to the user.
+
+Recover the structured dispatch from the inline dispatch block appended to `content` (see the "Inline dispatch block" note above the table). Each entry under `payloads[]` is a `{tool_name, title, prompt, agent, model, context}` dict; `prompt` is self-contained — it carries the **same canonical reframing plus the "Task for you (subagent)" wrapper** that plugin mode dispatches via `_subagents` (asking for a concrete plan, the biggest assumption challenged, and a one-line verdict). Same builder, byte-identical prompts across runtimes.
+
+Driving fan-out from this dispatch block — instead of from the joined human-display text — avoids two pitfalls the bot review surfaced:
+- **Separator collision** — `\n\n---\n\n` can legitimately appear inside a user-supplied `problem_context` or `current_approach`, so splitting the joined text would over-fragment and corrupt prompts. The dispatch block uses a unique versioned sentinel that user content cannot collide with.
+- **Behavioral drift across runtimes** — the dispatch block carries the same canonical payloads `_subagents` carries, so debate results don't diverge by environment.
+
+1. Locate the dispatch block at the end of the MCP response's `content` text — the substring between `<!-- ouroboros-lateral-inline-dispatch-v1 base64\n` and `\n-->`. Base64-decode the captured body, then `JSON.parse` to get `{dispatch_mode, persona_count, payloads}`. If the block is missing (older handler that pre-dates the v1 sentinel), fall through to the constrained-runtime path below — *do not* split the joined text.
+2. Surface a short "what the lateral toolkit suggests" header to the user, with the markdown above the dispatch block, so the MCP call is visible as a real product surface, not silent.
+3. In a **single message**, emit N parallel `Task` calls (`general-purpose` subagent) — one per entry in `payloads`. Each Task receives the payload's `prompt` verbatim plus the payload's `context` so the persona is grounded. Strict isolation per Task. The user sees "Running N agents…".
+4. Wait for all N to return.
+5. (Optional) **Round 2 cross-attack** — only if Round 1 answers diverge meaningfully. Dispatch a second N-fan-out where each persona receives short summaries of the other answers and is asked: "Identify one weakness in each. ≤200 words." Skip if Round 1 already converges.
+6. Synthesize per the **Synthesize** block below.
+
+##### Debate, runtime cannot dispatch sub-agents (constrained subprocess, no Task surface)
+
+Present the concatenated markdown the handler returned, as-is — no parsing required, the user reads the whole text. There is no per-persona visualization and no Round 2 cross-attack — both require a sub-agent surface. Synthesize directly from the inline text.
+
+##### Synthesize (debate, all shapes)
+
+Do **not** auto-emit a verdict. Present:
+
+```
+## Debate result — N personas
+
+### Options
+- **Option A** (from <persona>): <one-liner>
+- **Option B** (from <persona>): <one-liner>
+- …
+
+### Disagreements
+- <persona X> vs <persona Y>: <what they disagree about>
+
+### Recommended (with reasoning)
+<your single best read of the debate, clearly labeled as your
+recommendation, not a verdict>
+
+📍 Next: pick an option, or `ooo lateral debate <subset>` to drill into a disagreement
+```
+
+The verdict is the user's. Never auto-progress to the next workflow step on the user's behalf — wait for their choice.
+
+## Persona-selection heuristics (when args are empty and you must pick one for solo)
+
+You only need this if a parent SKILL or the user explicitly requests *one* persona but doesn't name one. In debate mode, no selection needed (use all 5).
+
+- Repeated similar failures → **contrarian** (challenge assumptions)
+- Too many options → **simplifier** (reduce scope)
+- Missing information → **researcher** (seek data)
+- Analysis paralysis → **hacker** (just make it work)
+- Structural issues → **architect** (redesign)
+
+## When MCP is unavailable
+
+The contract is "fail loud, don't substitute": if `ouroboros_lateral_think` cannot be loaded via `ToolSearch`, stop and report that the MCP dispatch surface is broken. Do not improvise either solo or debate by reading persona files directly when MCP-driven invocation was requested — that re-introduces the contract bypass the bot review flagged.
+
+The one exception, retained for documented offline use: a parent SKILL operating in degraded-offline mode that has *already* announced it cannot reach MCP MAY read `src/ouroboros/agents/<persona>.md` and adopt that persona inline for solo reframing. This is not a fallback for `ooo lateral`; it's a degraded helper for a parent SKILL that has already given up on MCP. Debate has no offline equivalent — report the broken surface and stop.
+
+## Examples
+
+### Solo
+```
+User: I'm stuck on the database schema design.
+> ooo lateral simplifier
+
+# Lateral Thinking: Reduce to Minimum Viable Schema
+Start with exactly 2 tables. If you can't build the core feature
+with 2 tables, you haven't found the core feature yet.
+
+📍 Next: try this, then `ooo run` — or `ooo interview` to re-examine.
+```
+
+### Debate (default — Claude Code / Codex CLI)
+```
+> ooo lateral
+
+[Step 2: Confirm problem_context + current_approach are present;
+ ask the user one short combined question if not]
+[ToolSearch loads ouroboros_lateral_think]
+[Call ouroboros_lateral_think(personas=[hacker,researcher,simplifier,architect,contrarian], ...)]
+[Handler returns: content = N persona blocks joined by ---,
+                  followed by hidden <!-- ouroboros-lateral-inline-dispatch-v1 base64
+                  <base64 body> --> sentinel block]
+[Extract via the sentinel; base64-decode then JSON.parse → payloads[]]
+[Single message: 5 parallel Task calls — one per payloads[] entry,
+ each Task receives payload.prompt + payload.context verbatim;
+ the visible markdown is shown to the user as the lateral scaffold]
+[User sees "Running 5 agents…"]
+[Round 1 returns]
+
+## Debate result — 5 personas
+### Options
+- A (hacker): ship the 50-line version, defer correctness
+- B (architect): the data model is wrong, redesign before coding
+- C (simplifier): cut feature X, the rest fits in one file
+- D (researcher): we don't have user data; instrument first
+- E (contrarian): are users actually asking for this?
+
+### Disagreements
+- hacker vs architect: ship-first vs redesign-first
+- contrarian vs all: whether the problem is real
+
+### Recommended
+Lean toward C+E: validate the need (E) before scoping (C); A and B
+both assume the feature is wanted.
+
+📍 Next: pick an option, or `ooo lateral debate hacker contrarian` to drill in.
+```
+
+### Autonomous chain from interview
+```
+[ooo interview mid-flow; main session is wearing the socratic-interviewer persona]
+[Main session judges that the next question is too tangled — multiple
+ reframings could be valid and asking the user to disambiguate would itself
+ be confusing. It chains to this SKILL on its own.]
+
+(autonomous) ooo lateral
+[5-agent debate runs in parallel sub-agents; the user sees "Running 5 agents…"]
+[Main session presents options + disagreements + a recommendation]
+[User picks an option — or asks for a follow-up debate]
+[Main session resumes the interview with the chosen framing]
+```

--- a/.claude-plugin/skills/update/SKILL.md
+++ b/.claude-plugin/skills/update/SKILL.md
@@ -1,0 +1,187 @@
+---
+name: update
+description: "Check for updates and upgrade Ouroboros to the latest version"
+---
+
+# /ouroboros:update
+
+Check for updates and upgrade Ouroboros (PyPI package + runtime integration).
+
+## Usage
+
+```
+ooo update
+/ouroboros:update
+```
+
+**Trigger keywords:** "ooo update", "update ouroboros", "upgrade ouroboros"
+
+## Instructions
+
+When the user invokes this skill:
+
+1. **Check current version**:
+
+   First, try reading the version from the CLI binary (works for all install methods):
+   ```bash
+   ouroboros --version 2>/dev/null
+   ```
+
+   If that fails, try the plugin version:
+   ```bash
+   cat .claude-plugin/plugin.json 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('version','unknown'))" 2>/dev/null
+   ```
+
+   If both fail, the package is not installed — skip to step 3.
+
+2. **Check latest version on PyPI**:
+
+   First, determine if the current installed version is a pre-release (contains `a`, `b`, `rc`, or `dev`).
+
+   If the current version **is a pre-release**, scan all PyPI releases to find the latest (including betas):
+   ```bash
+   python3 -c "
+   import json, ssl, urllib.request
+   from packaging.version import Version
+   ctx = ssl.create_default_context()
+   data = json.loads(urllib.request.urlopen('https://pypi.org/pypi/ouroboros-ai/json', timeout=5, context=ctx).read())
+   versions = [Version(v) for v in data.get('releases', {}) if data['releases'][v]]
+   print(str(max(versions)) if versions else data['info']['version'])
+   "
+   ```
+
+   If the current version **is stable**, use the standard latest:
+   ```bash
+   python3 -c "
+   import json, ssl, urllib.request
+   ctx = ssl.create_default_context()
+   data = json.loads(urllib.request.urlopen('https://pypi.org/pypi/ouroboros-ai/json', timeout=5, context=ctx).read())
+   print(data['info']['version'])
+   "
+   ```
+
+3. **Compare and report**:
+
+   If already on the latest version:
+   ```
+   Ouroboros is up to date (v0.X.Y)
+   ```
+
+   If a newer version is available, show:
+   ```
+   Update available: v0.X.Y → v0.X.Z
+
+   Changes: https://github.com/Q00/ouroboros/releases/tag/v0.X.Z
+   ```
+
+   Then ask the user with AskUserQuestion:
+   - **"Update now"** — Proceed with update
+   - **"Skip"** — Do nothing
+
+4. **Run update** (if user chose to update):
+
+   a. **Update PyPI package** — detect the original install method and preserve `[claude]` extras:
+
+   Check which installer was used:
+   ```bash
+   uv tool list 2>/dev/null | grep -q ouroboros && echo "uv"
+   pipx list 2>/dev/null | grep -q ouroboros && echo "pipx"
+   ```
+
+   > This skill runs inside Claude Code, so always use `ouroboros-ai[claude]`
+   > (includes `claude-agent-sdk` and `anthropic` required for MCP tools).
+
+   - If installed via **uv tool** (most common with install.sh):
+     ```bash
+     # For pre-release targets:
+     uv tool install --upgrade --prerelease=allow ouroboros-ai[claude]
+     # For stable targets:
+     uv tool install --upgrade ouroboros-ai[claude]
+     ```
+
+   - If installed via **pipx**:
+     > `pipx upgrade` cannot add extras to an existing venv — use `install --force` to reinstall with extras.
+     ```bash
+     # For pre-release targets:
+     pipx install --force --pip-args='--pre' ouroboros-ai[claude]
+     # For stable targets:
+     pipx install --force ouroboros-ai[claude]
+     ```
+
+   - If installed via **pip** (fallback):
+     ```bash
+     # For pre-release targets:
+     python3 -m pip install --upgrade --pre ouroboros-ai[claude]
+     # For stable targets:
+     python3 -m pip install --upgrade ouroboros-ai[claude]
+     ```
+
+   > **Note**: The `[claude]` extra is critical — it installs `claude-agent-sdk` and
+   > `anthropic` which are required for MCP tool execution. Omitting it causes MCP
+   > tools to fail silently at call time.
+
+   b. **Update runtime integration**:
+
+   For Claude Code:
+   ```bash
+   claude plugin marketplace update ouroboros 2>/dev/null || true
+   claude plugin install ouroboros@ouroboros
+   ```
+
+   For Codex CLI (re-install skills/rules to ~/.codex/):
+   ```bash
+   ouroboros setup --runtime codex --non-interactive
+   ```
+
+   c. **Refresh MCP server config** (fixes stale args from older versions):
+
+   Run the same setup command used in step b to ensure MCP config is current:
+
+   For Claude Code:
+   ```bash
+   ouroboros setup --runtime claude --non-interactive
+   ```
+
+   For Codex CLI (already handled by step b above — skip this step).
+
+   This ensures `~/.claude/mcp.json` has the latest MCP command and args
+   (e.g., `ouroboros-ai[claude]` extras). Skips if already up to date.
+
+   d. **Verify and update CLAUDE.md version marker**:
+   ```bash
+   NEW_VERSION=$(ouroboros --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[a-z0-9.]*')
+   echo "Installed: v$NEW_VERSION"
+
+   if [ -n "$NEW_VERSION" ] && grep -q "ooo:VERSION" CLAUDE.md 2>/dev/null; then
+     OLD_VERSION=$(grep "ooo:VERSION" CLAUDE.md | sed 's/.*ooo:VERSION:\(.*\) -->/\1/' | tr -d ' ')
+     if [ "$OLD_VERSION" != "$NEW_VERSION" ]; then
+       sed -i.bak "s/<!-- ooo:VERSION:.*-->/<!-- ooo:VERSION:$NEW_VERSION -->/" CLAUDE.md && rm -f CLAUDE.md.bak
+       echo "CLAUDE.md version marker updated: v$OLD_VERSION → v$NEW_VERSION"
+     else
+       echo "CLAUDE.md version marker already up to date (v$NEW_VERSION)"
+     fi
+   fi
+   ```
+
+   > **Note**: This only updates the version marker. If the block content itself
+   > changed between versions, the user should run `ooo setup` to regenerate it.
+
+5. **Post-update guidance**:
+   ```
+   Updated to v0.X.Z
+
+   Restart your Claude Code session to apply the update.
+   (Close this session and start a new one with `claude`)
+
+   If CLAUDE.md block content changed, regenerate it:
+     ooo setup
+
+   Run `ooo help` to see what's new.
+   ```
+
+## Notes
+
+- The update check uses PyPI as the source of truth for the latest version.
+- Plugin update (Claude Code) pulls the latest from the marketplace.
+- No data is lost during updates — event stores and session data are preserved.
+- **Always use the same installer** that was used for the original installation (uv tool > pipx > pip).

--- a/.claude-plugin/skills/welcome/SKILL.md
+++ b/.claude-plugin/skills/welcome/SKILL.md
@@ -1,0 +1,353 @@
+---
+name: welcome
+description: "First-touch experience for new Ouroboros users"
+---
+
+# /ouroboros:welcome
+
+Interactive onboarding for new Ouroboros users.
+
+## Usage
+
+```
+/ouroboros:welcome              # First-time or update onboarding
+/ouroboros:welcome --skip       # Skip welcome, mark as shown
+/ouroboros:welcome --force      # Force re-run welcome even if shown
+```
+
+## Instructions
+
+When this skill is invoked, follow this flow:
+
+---
+
+### Pre-Check: Already Completed?
+
+First, check `~/.ouroboros/prefs.json` for `welcomeCompleted`. For upgrades from older releases, also treat legacy `welcomeShown: true` as completed so the welcome prompt does not reappear forever:
+
+```bash
+PREFFILE="$HOME/.ouroboros/prefs.json"
+
+if [ -f "$PREFFILE" ]; then
+  WELCOME_COMPLETED=$(python3 - <<'PY'
+import json, os
+path = os.path.expanduser('~/.ouroboros/prefs.json')
+try:
+    prefs = json.load(open(path, encoding='utf-8'))
+except Exception:
+    prefs = {}
+if not isinstance(prefs, dict):
+    prefs = {}
+print(prefs.get('welcomeCompleted') or ('legacy-welcomeShown' if prefs.get('welcomeShown') else ''))
+PY
+)
+  WELCOME_VERSION=$(python3 - <<'PY'
+import json, os
+path = os.path.expanduser('~/.ouroboros/prefs.json')
+try:
+    prefs = json.load(open(path, encoding='utf-8'))
+except Exception:
+    prefs = {}
+if not isinstance(prefs, dict):
+    prefs = {}
+print(prefs.get('welcomeVersion') or '')
+PY
+)
+
+  if [ -n "$WELCOME_COMPLETED" ] && [ "$WELCOME_COMPLETED" != "null" ]; then
+    ALREADY_COMPLETED="true"
+  fi
+fi
+```
+
+**If `ALREADY_COMPLETED` is true AND no `--force` flag:**
+
+Use **AskUserQuestion**:
+```json
+{
+  "questions": [{
+    "question": "Ouroboros welcome was already completed on $WELCOME_COMPLETED. What would you like to do?",
+    "header": "Welcome",
+    "options": [
+      { "label": "Skip", "description": "Continue to work (recommended)" },
+      { "label": "Re-run welcome", "description": "Go through the interactive onboarding again" }
+    ],
+    "multiSelect": false
+  }]
+}
+```
+- **Skip**: Mark as complete and exit
+- **Re-run welcome**: Continue to Step 1 below
+
+**If `--skip` flag present:**
+- Merge `welcomeShown: true`, `welcomeCompleted: <current timestamp>`, and `welcomeVersion` into `~/.ouroboros/prefs.json` without deleting existing keys:
+  ```bash
+python3 - <<'PY'
+import json, os
+from datetime import UTC, datetime
+path = os.path.expanduser('~/.ouroboros/prefs.json')
+os.makedirs(os.path.dirname(path), exist_ok=True)
+try:
+    with open(path, encoding='utf-8') as f:
+        prefs = json.load(f)
+    if not isinstance(prefs, dict):
+        prefs = {}
+except Exception:
+    prefs = {}
+prefs.update({
+    'welcomeShown': True,
+    'welcomeCompleted': datetime.now(UTC).isoformat(),
+    'welcomeVersion': '0.36.0',
+})
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(prefs, f, indent=2)
+    f.write('\n')
+PY
+  ```
+- Show brief message:
+  ```
+  Ouroboros welcome skipped.
+  Run /ouroboros:welcome --force to re-run onboarding.
+  ```
+- Exit
+
+---
+
+### Step 1: Welcome Banner
+
+Display:
+
+```
+Welcome to Ouroboros!
+
+The serpent that eats itself -- better every loop.
+
+Most AI coding fails at the input, not the output.
+Ouroboros fixes this by exposing hidden assumptions
+BEFORE any code is written.
+
+Interview -> Seed -> Execute -> Evaluate
+    ^                            |
+    +---- Evolutionary Loop -----+
+```
+
+---
+
+### Step 2: Persona Detection
+
+**AskUserQuestion**:
+```json
+{
+  "questions": [{
+    "question": "What brings you to Ouroboros?",
+    "header": "Welcome",
+    "options": [
+      {
+        "label": "New project idea",
+        "description": "I have a vague idea and want to crystallize it into a clear spec"
+      },
+      {
+        "label": "Tired of rewriting prompts",
+        "description": "AI keeps building the wrong thing because my requirements are unclear"
+      },
+      {
+        "label": "Just exploring",
+        "description": "Heard about Ouroboros and want to see what it does"
+      }
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+Give brief personalized response (1-2 sentences) based on choice.
+
+---
+
+### Step 3: MCP Check
+
+```bash
+cat ~/.claude/mcp.json 2>/dev/null | grep -q ouroboros && echo "MCP_OK" || echo "MCP_MISSING"
+```
+
+**If MCP_MISSING**, **AskUserQuestion**:
+```json
+{
+  "questions": [{
+    "question": "Ouroboros has a Python backend for advanced features (TUI dashboard, 3-stage evaluation, drift tracking). Set it up now?",
+    "header": "MCP Setup",
+    "options": [
+      { "label": "Set up now (Recommended)", "description": "Register MCP server (requires Python >= 3.12)" },
+      { "label": "Skip for now", "description": "Use basic features first (interview, seed, unstuck)" }
+    ],
+    "multiSelect": false
+  }]
+}
+```
+- **Set up now**: Read and execute `skills/setup/SKILL.md`, then return to Step 4
+- **Skip for now**: Continue to Step 4
+
+---
+
+### Step 4: Quick Reference
+
+```
+Available Commands:
++---------------------------------------------------+
+| Command         | What It Does                     |
+|-----------------|----------------------------------|
+| ooo interview   | Socratic Q&A -- expose hidden    |
+|                 | assumptions in your requirements |
+| ooo seed        | Crystallize answers into spec    |
+| ooo run         | Execute with visual TUI          |
+| ooo evaluate    | 3-stage verification             |
+| ooo unstuck     | Lateral thinking when stuck      |
+| ooo help        | Full command reference           |
++---------------------------------------------------+
+```
+
+---
+
+### Step 5: First Action
+
+**AskUserQuestion**:
+```json
+{
+  "questions": [{
+    "question": "What would you like to do first?",
+    "header": "Get started",
+    "options": [
+      { "label": "Start a project", "description": "Run a Socratic interview on your idea right now" },
+      { "label": "Try the tutorial", "description": "Interactive hands-on learning with a sample project" },
+      { "label": "Read the docs", "description": "Full command reference and architecture overview" }
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+Based on choice:
+- **Start a project**: Ask "What do you want to build?" → execute `skills/interview/SKILL.md`
+- **Try the tutorial**: Execute `skills/tutorial/SKILL.md`
+- **Read the docs**: Execute `skills/help/SKILL.md`
+
+---
+
+### Step 6: GitHub Star (Last Step)
+
+Check `gh` availability first:
+```bash
+gh auth status &>/dev/null && echo "GH_OK" || echo "GH_MISSING"
+```
+
+**If `GH_OK` AND `star_asked` not true:**
+
+**AskUserQuestion**:
+```json
+{
+  "questions": [{
+    "question": "If you're enjoying Ouroboros, would you like to star it on GitHub?",
+    "header": "Community",
+    "options": [
+      { "label": "Star on GitHub", "description": "Takes 1 second -- helps the project grow" },
+      { "label": "Maybe later", "description": "Skip for now" }
+    ],
+    "multiSelect": false
+  }]
+}
+```
+
+- **Star on GitHub**: `gh api -X PUT /user/starred/Q00/ouroboros`
+- Both choices: merge the welcome completion fields into `~/.ouroboros/prefs.json` without deleting existing keys. Set `star_asked: true` after either star prompt choice so the star prompt is not repeated:
+  ```bash
+python3 - <<'PY'
+import json, os
+from datetime import UTC, datetime
+path = os.path.expanduser('~/.ouroboros/prefs.json')
+os.makedirs(os.path.dirname(path), exist_ok=True)
+try:
+    with open(path, encoding='utf-8') as f:
+        prefs = json.load(f)
+    if not isinstance(prefs, dict):
+        prefs = {}
+except Exception:
+    prefs = {}
+prefs.update({
+    'star_asked': True,
+    'welcomeShown': True,
+    'welcomeCompleted': datetime.now(UTC).isoformat(),
+    'welcomeVersion': '0.36.0',
+})
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(prefs, f, indent=2)
+    f.write('\n')
+PY
+  ```
+
+**If `GH_MISSING` or `star_asked` is true:**
+Merge the welcome completion fields into `~/.ouroboros/prefs.json` without deleting existing keys:
+  ```bash
+python3 - <<'PY'
+import json, os
+from datetime import UTC, datetime
+path = os.path.expanduser('~/.ouroboros/prefs.json')
+os.makedirs(os.path.dirname(path), exist_ok=True)
+try:
+    with open(path, encoding='utf-8') as f:
+        prefs = json.load(f)
+    if not isinstance(prefs, dict):
+        prefs = {}
+except Exception:
+    prefs = {}
+prefs.update({
+    'welcomeShown': True,
+    'welcomeCompleted': datetime.now(UTC).isoformat(),
+    'welcomeVersion': '0.36.0',
+})
+with open(path, 'w', encoding='utf-8') as f:
+    json.dump(prefs, f, indent=2)
+    f.write('\n')
+PY
+  ```
+
+---
+
+### Completion Message
+
+```
+Ouroboros Setup Complete!
+
+MAGIC KEYWORDS (optional shortcuts):
+Just include these naturally in your request:
+
+| Keyword | Effect | Example |
+|---------|--------|---------|
+| interview | Socratic Q&A | "interview me about my app idea" |
+| seed | Crystallize spec | "seed the requirements" |
+| evaluate | 3-stage check | "evaluate this implementation" |
+| stuck | Lateral thinking | "I'm stuck on the auth flow" |
+
+REAL-TIME MONITORING (TUI):
+When running ooo run or ooo evolve, open a separate terminal:
+  uvx --from 'ouroboros-ai[tui]' ouroboros tui monitor
+Press 1-4 to switch screens (Dashboard, Execution, Logs, Debug).
+
+READY TO BUILD:
+- ooo interview "your project idea"
+- ooo tutorial  # Interactive learning
+- ooo help      # Full reference
+```
+
+---
+
+## Prefs File Structure
+
+`~/.ouroboros/prefs.json`:
+```json
+{
+  "welcomeShown": true,
+  "welcomeCompleted": "2025-02-23T15:30:00+09:00",
+  "welcomeVersion": "0.36.0",
+  "star_asked": true
+}
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.py\"",
+            "command": "ROOT=\"${CLAUDE_PLUGIN_ROOT:-$PWD}\"; python3 \"$ROOT/scripts/keyword-detector.py\" || python \"$ROOT/scripts/keyword-detector.py\"",
             "timeout": 5
           }
         ]
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/scripts/drift-monitor.py\" || python \"${CLAUDE_PLUGIN_ROOT}/scripts/drift-monitor.py\"",
+            "command": "ROOT=\"${CLAUDE_PLUGIN_ROOT:-$PWD}\"; python3 \"$ROOT/scripts/drift-monitor.py\" || python \"$ROOT/scripts/drift-monitor.py\"",
             "timeout": 3
           }
         ]

--- a/tests/unit/scripts/test_claude_hook_settings.py
+++ b/tests/unit/scripts/test_claude_hook_settings.py
@@ -16,12 +16,13 @@ def _hook_commands() -> list[str]:
     return commands
 
 
-def test_plugin_hooks_use_plugin_root_for_bundled_scripts() -> None:
-    """Hooks must not resolve bundled scripts relative to the user's project cwd."""
+def test_plugin_hooks_prefer_plugin_root_and_fallback_to_repo_root() -> None:
+    """Hooks must work both inside plugin runtime and normal repo checkouts."""
     commands = _hook_commands()
 
-    assert any("${CLAUDE_PLUGIN_ROOT}/scripts/keyword-detector.py" in cmd for cmd in commands)
-    assert any("${CLAUDE_PLUGIN_ROOT}/scripts/drift-monitor.py" in cmd for cmd in commands)
+    assert any('ROOT="${CLAUDE_PLUGIN_ROOT:-$PWD}"' in cmd for cmd in commands)
+    assert any('"$ROOT/scripts/keyword-detector.py"' in cmd for cmd in commands)
+    assert any('"$ROOT/scripts/drift-monitor.py"' in cmd for cmd in commands)
     assert all("CLAUDE_PROJECT_DIR" not in cmd for cmd in commands)
     assert all("cd " not in cmd for cmd in commands)
 
@@ -30,5 +31,5 @@ def test_plugin_hooks_fall_back_to_unversioned_python() -> None:
     """Prefer python3 where available, but fall back for Windows installs."""
     commands = _hook_commands()
 
-    assert all(cmd.startswith("python3 ") for cmd in commands)
+    assert all("python3 " in cmd for cmd in commands)
     assert all(" || python " in cmd for cmd in commands)


### PR DESCRIPTION
## Summary
- make repo Claude hooks work when CLAUDE_PLUGIN_ROOT is unset by falling back to the checkout cwd
- include the declared skills directory inside the .claude-plugin artifact so plugin.json skills path resolves for artifact installs

## Original PR blocker coverage
Addresses plugin artifact / local hook blockers reported on #1136 and #1187. Version drift was rechecked with scripts/sync-plugin-version.py --check and is currently clean on main.

## Verification
- python3 -m json.tool .claude/settings.json >/dev/null
- test -f .claude-plugin/skills/setup/SKILL.md
- test -f .claude-plugin/skills/auto/SKILL.md
