### PR TITLE
fix: reject status-masking test pipelines

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -919,7 +919,14 @@ def _test_command_invocation(command: str) -> str | None:
     if not normalized:
         return None
 
-    direct = _test_invocation_from_prefix(_strip_command_output_plumbing(normalized))
+    direct_candidate = _strip_command_output_plumbing(normalized)
+    if (
+        _has_trailing_output_filter_pipeline(normalized)
+        and not _uses_pipefail(normalized)
+        and _test_invocation_from_prefix(direct_candidate) is not None
+    ):
+        direct_candidate = normalized
+    direct = _test_invocation_from_prefix(direct_candidate)
     if direct is not None:
         return direct
 
@@ -952,7 +959,14 @@ def _shell_command_body(command: str) -> str | None:
 def _test_invocation_from_shell_body(body: str) -> str | None:
     """Return a test invocation after conservative shell setup preambles."""
     for segment in _segments_after_safe_shell_preamble(body):
-        invocation = _test_invocation_from_prefix(_strip_command_output_plumbing(segment))
+        candidate = _strip_command_output_plumbing(segment)
+        if (
+            _has_trailing_output_filter_pipeline(segment)
+            and not _uses_pipefail(body)
+            and _test_invocation_from_prefix(candidate) is not None
+        ):
+            candidate = segment
+        invocation = _test_invocation_from_prefix(candidate)
         if invocation is not None:
             return invocation
         return None
@@ -973,7 +987,15 @@ def _single_command_after_safe_shell_preamble(command: str) -> str | None:
     segments = tuple(_segments_after_safe_shell_preamble(body))
     if len(segments) != 1:
         return None
-    return _normalized_evidence_text(_strip_command_output_plumbing(segments[0]))
+    segment = segments[0]
+    stripped = _strip_command_output_plumbing(segment)
+    if (
+        _has_trailing_output_filter_pipeline(segment)
+        and not _uses_pipefail(body)
+        and _looks_like_test_command(stripped)
+    ):
+        return None
+    return _normalized_evidence_text(stripped)
 
 
 def _segments_after_safe_shell_preamble(body: str) -> tuple[str, ...]:
@@ -998,6 +1020,8 @@ def _is_safe_test_command_preamble(segment: str) -> bool:
     if not parts:
         return True
     if parts[0] == "cd" and len(parts) == 2:
+        return True
+    if parts == ["set", "-o", "pipefail"]:
         return True
     if parts[0] == "export" and len(parts) > 1:
         return all(_is_env_assignment(part) for part in parts[1:])
@@ -1133,6 +1157,24 @@ def _strip_command_output_plumbing(command: str) -> str:
     return text
 
 
+def _has_trailing_output_filter_pipeline(command: str) -> bool:
+    """Return True when ``command`` ends in a pager-style output pipe."""
+    text = command.strip()
+    while "|" in text:
+        head, _, tail_segment = text.rpartition("|")
+        tail_tokens = tail_segment.split()
+        if tail_tokens and tail_tokens[0].lower() in _OUTPUT_FILTER_COMMANDS:
+            return True
+        text = head.strip()
+    return False
+
+
+def _uses_pipefail(command: str) -> bool:
+    """Return True when shell text explicitly preserves upstream pipe status."""
+    normalized = _normalized_evidence_text(command)
+    return "pipefail" in normalized
+
+
 def _normalized_command_claim_aliases(command: str) -> tuple[str, ...]:
     """Return normalized command forms that a concise evidence claim may use.
 
@@ -1158,6 +1200,14 @@ def _normalized_command_claim_aliases(command: str) -> tuple[str, ...]:
     # this does not widen proof to arbitrary substrings.
     for base in tuple(aliases):
         stripped = _normalized_evidence_text(_strip_command_output_plumbing(base))
+        if (
+            stripped
+            and stripped != base
+            and _has_trailing_output_filter_pipeline(base)
+            and _looks_like_test_command(stripped)
+            and not _uses_pipefail(base)
+        ):
+            continue
         if stripped and stripped not in aliases:
             aliases.append(stripped)
     return tuple(aliases)

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1171,8 +1171,14 @@ def _has_trailing_output_filter_pipeline(command: str) -> bool:
 
 def _uses_pipefail(command: str) -> bool:
     """Return True when shell text explicitly preserves upstream pipe status."""
-    normalized = _normalized_evidence_text(command)
-    return "pipefail" in normalized
+    for segment in re.split(r"\s*(?:&&|;)\s*", command.strip()):
+        try:
+            parts = shlex.split(segment)
+        except ValueError:
+            continue
+        if parts == ["set", "-o", "pipefail"]:
+            return True
+    return False
 
 
 def _normalized_command_claim_aliases(command: str) -> tuple[str, ...]:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -922,7 +922,7 @@ def _test_command_invocation(command: str) -> str | None:
     direct_candidate = _strip_command_output_plumbing(normalized)
     if (
         _has_trailing_output_filter_pipeline(normalized)
-        and not _uses_pipefail(normalized)
+        and not _output_filter_pipeline_is_pipefail_protected(normalized)
         and _test_invocation_from_prefix(direct_candidate) is not None
     ):
         direct_candidate = normalized
@@ -958,11 +958,11 @@ def _shell_command_body(command: str) -> str | None:
 
 def _test_invocation_from_shell_body(body: str) -> str | None:
     """Return a test invocation after conservative shell setup preambles."""
-    for segment in _segments_after_safe_shell_preamble(body):
+    for segment, pipefail_enabled in _segments_after_safe_shell_preamble_with_pipefail(body):
         candidate = _strip_command_output_plumbing(segment)
         if (
             _has_trailing_output_filter_pipeline(segment)
-            and not _uses_pipefail(body)
+            and not pipefail_enabled
             and _test_invocation_from_prefix(candidate) is not None
         ):
             candidate = segment
@@ -991,7 +991,7 @@ def _single_command_after_safe_shell_preamble(command: str) -> str | None:
     stripped = _strip_command_output_plumbing(segment)
     if (
         _has_trailing_output_filter_pipeline(segment)
-        and not _uses_pipefail(body)
+        and not _output_filter_pipeline_is_pipefail_protected(body)
         and _looks_like_test_command(stripped)
     ):
         return None
@@ -1000,14 +1000,24 @@ def _single_command_after_safe_shell_preamble(command: str) -> str | None:
 
 def _segments_after_safe_shell_preamble(body: str) -> tuple[str, ...]:
     """Return non-preamble shell segments after setup-only commands."""
-    remaining: list[str] = []
+    return tuple(
+        segment for segment, _pipefail_enabled in _segments_after_safe_shell_preamble_with_pipefail(body)
+    )
+
+
+def _segments_after_safe_shell_preamble_with_pipefail(body: str) -> tuple[tuple[str, bool], ...]:
+    """Return non-preamble segments with pipefail state active before each one."""
+    remaining: list[tuple[str, bool]] = []
+    pipefail_enabled = False
     for segment in re.split(r"\s*&&\s*", body.strip()):
         normalized_segment = segment.strip()
         if not normalized_segment:
             continue
         if not remaining and _is_safe_test_command_preamble(normalized_segment):
+            if _is_pipefail_preamble(normalized_segment):
+                pipefail_enabled = True
             continue
-        remaining.append(normalized_segment)
+        remaining.append((normalized_segment, pipefail_enabled))
     return tuple(remaining)
 
 
@@ -1021,7 +1031,7 @@ def _is_safe_test_command_preamble(segment: str) -> bool:
         return True
     if parts[0] == "cd" and len(parts) == 2:
         return True
-    if parts == ["set", "-o", "pipefail"]:
+    if _is_pipefail_parts(parts):
         return True
     if parts[0] == "export" and len(parts) > 1:
         return all(_is_env_assignment(part) for part in parts[1:])
@@ -1169,6 +1179,21 @@ def _has_trailing_output_filter_pipeline(command: str) -> bool:
     return False
 
 
+def _output_filter_pipeline_is_pipefail_protected(command: str) -> bool:
+    """Return True when pipefail is enabled before the first stripped pipeline."""
+    pipefail_enabled = False
+    for segment in re.split(r"\s*(?:&&|;)\s*", command.strip()):
+        normalized_segment = segment.strip()
+        if not normalized_segment:
+            continue
+        if _is_pipefail_preamble(normalized_segment):
+            pipefail_enabled = True
+            continue
+        if _has_trailing_output_filter_pipeline(normalized_segment):
+            return pipefail_enabled
+    return False
+
+
 def _uses_pipefail(command: str) -> bool:
     """Return True when shell text explicitly preserves upstream pipe status."""
     for segment in re.split(r"\s*(?:&&|;)\s*", command.strip()):
@@ -1176,9 +1201,21 @@ def _uses_pipefail(command: str) -> bool:
             parts = shlex.split(segment)
         except ValueError:
             continue
-        if parts == ["set", "-o", "pipefail"]:
+        if _is_pipefail_parts(parts):
             return True
     return False
+
+
+def _is_pipefail_preamble(segment: str) -> bool:
+    try:
+        parts = shlex.split(segment)
+    except ValueError:
+        return False
+    return _is_pipefail_parts(parts)
+
+
+def _is_pipefail_parts(parts: list[str]) -> bool:
+    return parts == ["set", "-o", "pipefail"]
 
 
 def _normalized_command_claim_aliases(command: str) -> tuple[str, ...]:
@@ -1211,7 +1248,7 @@ def _normalized_command_claim_aliases(command: str) -> tuple[str, ...]:
             and stripped != base
             and _has_trailing_output_filter_pipeline(base)
             and _looks_like_test_command(stripped)
-            and not _uses_pipefail(base)
+            and not _output_filter_pipeline_is_pipefail_protected(base)
         ):
             continue
         if stripped and stripped not in aliases:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1001,7 +1001,8 @@ def _single_command_after_safe_shell_preamble(command: str) -> str | None:
 def _segments_after_safe_shell_preamble(body: str) -> tuple[str, ...]:
     """Return non-preamble shell segments after setup-only commands."""
     return tuple(
-        segment for segment, _pipefail_enabled in _segments_after_safe_shell_preamble_with_pipefail(body)
+        segment
+        for segment, _pipefail_enabled in _segments_after_safe_shell_preamble_with_pipefail(body)
     )
 
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1202,6 +1202,26 @@ def test_test_invocation_rejects_status_masking_output_pipe() -> None:
     assert not _runtime_messages_support_command_claim("pytest tests/test_foo.py", (message,))
 
 
+def test_test_invocation_rejects_pipefail_text_without_shell_option() -> None:
+    """The pipefail guard must prove a shell option, not arbitrary command text."""
+    message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={
+            "tool_input": {
+                "command": (
+                    "/bin/bash -lc 'cd /workspace && "
+                    "pytest tests/test_pipefail.py 2>&1 | cat # pipefail mentioned'"
+                )
+            },
+            "exit_code": 0,
+        },
+    )
+
+    assert not _runtime_messages_support_command_claim("pytest tests/test_pipefail.py", (message,))
+
+
 def test_command_claim_keeps_meaningful_pipeline_segments() -> None:
     """Only output-filter pipes are stripped; real pipelines are not over-matched."""
     message = AgentMessage(

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1166,20 +1166,40 @@ def test_command_claim_rejects_inner_command_after_safe_preamble_with_grep_filte
     assert not _runtime_messages_support_command_claim("pytest tests/test_foo.py", (message,))
 
 
-def test_test_invocation_supports_shell_preamble_with_output_plumbing() -> None:
-    """``tests_passed`` matching keeps shell-wrapper parity with commands_run."""
+def test_test_invocation_supports_shell_preamble_with_pipefail_output_plumbing() -> None:
+    """Test proof can strip pager plumbing only when pipefail preserves status."""
     message = AgentMessage(
         type="tool",
         content="Bash command started",
         tool_name="Bash",
         data={
             "tool_input": {
-                "command": "/bin/bash -lc 'cd /workspace && pytest tests/test_foo.py 2>&1 | tail -20'"
+                "command": (
+                    "/bin/bash -lc 'set -o pipefail && cd /workspace && "
+                    "pytest tests/test_foo.py 2>&1 | tail -20'"
+                )
             }
         },
     )
 
     assert _runtime_messages_support_command_claim("pytest tests/test_foo.py", (message,))
+
+
+def test_test_invocation_rejects_status_masking_output_pipe() -> None:
+    """A clean pytest claim is not proven by a pipeline whose final filter can mask failure."""
+    message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={
+            "tool_input": {
+                "command": "/bin/bash -lc 'cd /workspace && pytest tests/test_foo.py | cat'"
+            },
+            "exit_code": 0,
+        },
+    )
+
+    assert not _runtime_messages_support_command_claim("pytest tests/test_foo.py", (message,))
 
 
 def test_command_claim_keeps_meaningful_pipeline_segments() -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1222,6 +1222,26 @@ def test_test_invocation_rejects_pipefail_text_without_shell_option() -> None:
     assert not _runtime_messages_support_command_claim("pytest tests/test_pipefail.py", (message,))
 
 
+def test_test_invocation_rejects_pipefail_set_after_output_pipe() -> None:
+    """Pipefail must be enabled before the pipeline it is meant to protect."""
+    message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={
+            "tool_input": {
+                "command": (
+                    "/bin/bash -lc 'cd /workspace && "
+                    "pytest tests/test_foo.py 2>&1 | cat && set -o pipefail'"
+                )
+            },
+            "exit_code": 0,
+        },
+    )
+
+    assert not _runtime_messages_support_command_claim("pytest tests/test_foo.py", (message,))
+
+
 def test_command_claim_keeps_meaningful_pipeline_segments() -> None:
     """Only output-filter pipes are stripped; real pipelines are not over-matched."""
     message = AgentMessage(


### PR DESCRIPTION
## Summary
- keep presentation plumbing aliases for non-test commands and pipefail-protected test commands
- reject clean pytest/test proof when a trailing output pipe can mask the upstream command status
- cover the status-masking `pytest ... | cat` regression

## Original PR blocker coverage
Addresses the anti-fabrication command proof blocker reported on #1186.

## Verification
- uv run pytest tests/unit/orchestrator/test_parallel_executor.py -q
- uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py
