### PR TITLE
fix: prompt required grants during plugin install

### DIFF
--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -1688,15 +1688,18 @@ def _maybe_prompt_grant_required_permissions(
 
     scopes = [p.scope for p in missing]
     try:
-        record = trust.grant_many_and_clear_disable(
-            plugin=manifest.name,
-            version=manifest.version,
-            scopes=scopes,
-            granted_by="user:cli",
-            source_type=entry.source_type,
-            source_identity=entry.source_identity,
-            artifact_digest=entry.artifact_digest,
-        )
+        was_disabled = trust.is_disabled(manifest.name)
+        record = None
+        for scope in scopes:
+            record = trust.grant(
+                plugin=manifest.name,
+                version=manifest.version,
+                scope=scope,
+                granted_by="user:cli",
+                source_type=entry.source_type,
+                source_identity=entry.source_identity,
+                artifact_digest=entry.artifact_digest,
+            )
     except (ValueError, OSError) as exc:
         print_error(
             f"could not write trust grant for {manifest.name!r}: {exc}. "
@@ -1705,10 +1708,18 @@ def _maybe_prompt_grant_required_permissions(
         )
         raise typer.Exit(code=1) from exc
 
+    assert record is not None
     console.print(
         f"  granted required scopes: {', '.join(scopes)} "
         f"({len(record.granted_scopes)} total scope(s))"
     )
+    if was_disabled:
+        console.print(
+            "  plugin remains disabled; re-enable explicitly with "
+            f"`ooo plugin trust {manifest.name}`",
+            markup=False,
+            highlight=False,
+        )
 
 
 @app.command("add")
@@ -2220,7 +2231,7 @@ def _install_from_local_directory(
     try:
         artifact_digest = canonical_tree_hash(src)
         with _atomic_install_with_rollback(src, plugin_home):
-            _install_one(
+            installed_entry = _install_one(
                 manifest=manifest,
                 plugin_home=plugin_home,
                 lock=lock,
@@ -2251,6 +2262,11 @@ def _install_from_local_directory(
         new_source_type=manifest_source_type,
         new_source_identity=source_identity,
         new_artifact_digest=artifact_digest,
+        trust=trust,
+    )
+    _maybe_prompt_grant_required_permissions(
+        manifest=manifest,
+        entry=installed_entry,
         trust=trust,
     )
     print_success(f"Installed: {manifest.name} {manifest.version}")
@@ -2314,7 +2330,7 @@ def _install_named_from_local_path(
         # Digest, plugin_home swap, lockfile commit — all wrapped.
         artifact_digest = canonical_tree_hash(candidate_root)
         with _atomic_install_with_rollback(candidate_root, plugin_home):
-            _install_one(
+            installed_entry = _install_one(
                 manifest=manifest,
                 plugin_home=plugin_home,
                 lock=lock,
@@ -2345,6 +2361,11 @@ def _install_named_from_local_path(
         new_source_type=manifest_source_type,
         new_source_identity=source_identity,
         new_artifact_digest=artifact_digest,
+        trust=trust,
+    )
+    _maybe_prompt_grant_required_permissions(
+        manifest=manifest,
+        entry=installed_entry,
         trust=trust,
     )
     print_success(f"Installed: {manifest.name} {manifest.version}")
@@ -2422,7 +2443,7 @@ def _install_named_from_url(
         # Digest, plugin_home swap, lockfile commit — all wrapped.
         artifact_digest = canonical_tree_hash(source_dir)
         with _atomic_install_with_rollback(source_dir, plugin_home):
-            _install_one(
+            installed_entry = _install_one(
                 manifest=manifest,
                 plugin_home=plugin_home,
                 lock=lock,
@@ -2453,6 +2474,11 @@ def _install_named_from_url(
         new_source_type=manifest_source_type,
         new_source_identity=source_identity,
         new_artifact_digest=artifact_digest,
+        trust=trust,
+    )
+    _maybe_prompt_grant_required_permissions(
+        manifest=manifest,
+        entry=installed_entry,
         trust=trust,
     )
     print_success(f"Installed: {manifest.name} {manifest.version}")

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -1649,6 +1649,7 @@ def _maybe_prompt_grant_required_permissions(
     manifest: PluginManifest,
     entry: LockEntry,
     trust: TrustStore,
+    interactive: bool,
 ) -> None:
     try:
         missing = _missing_required_permissions(manifest=manifest, entry=entry, trust=trust)
@@ -1664,6 +1665,14 @@ def _maybe_prompt_grant_required_permissions(
         return
 
     _print_required_permissions(missing)
+    if not interactive:
+        console.print(
+            f"  run `ooo plugin trust {manifest.name} --scope <scope>` to grant required scopes",
+            markup=False,
+            highlight=False,
+        )
+        return
+
     destructive = [p.scope for p in missing if p.risk == "destructive"]
     if destructive:
         console.print(
@@ -1983,6 +1992,7 @@ def add_command(
             manifest=manifest,
             entry=installed_entry,
             trust=trust,
+            interactive=True,
         )
         # An install at any digest also clears the disable record for
         # this subject (per the RFC: "remove ALSO deletes any disable
@@ -2268,6 +2278,7 @@ def _install_from_local_directory(
         manifest=manifest,
         entry=installed_entry,
         trust=trust,
+        interactive=False,
     )
     print_success(f"Installed: {manifest.name} {manifest.version}")
 
@@ -2367,6 +2378,7 @@ def _install_named_from_local_path(
         manifest=manifest,
         entry=installed_entry,
         trust=trust,
+        interactive=False,
     )
     print_success(f"Installed: {manifest.name} {manifest.version}")
 
@@ -2480,6 +2492,7 @@ def _install_named_from_url(
         manifest=manifest,
         entry=installed_entry,
         trust=trust,
+        interactive=False,
     )
     print_success(f"Installed: {manifest.name} {manifest.version}")
 

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -384,10 +384,10 @@ def test_install_local_directory(runner: CliRunner, tmp_path: Path) -> None:
     assert "github-pr-ops" in Lockfile(paths["lockfile"]).read()
 
 
-def test_install_local_directory_prompts_and_grants_required_permissions(
+def test_install_local_directory_lists_required_permissions_without_prompting(
     runner: CliRunner, tmp_path: Path
 ) -> None:
-    """`install` surfaces the same required-permission prompt as `add`."""
+    """`install` remains non-interactive and never consumes stdin for trust."""
     plugin_dir = tmp_path / "github-pr-ops"
     plugin_dir.mkdir(parents=True, exist_ok=True)
     (plugin_dir / "ouroboros.plugin.json").write_text(json.dumps(REFERENCE_MANIFEST))
@@ -405,15 +405,14 @@ def test_install_local_directory_prompts_and_grants_required_permissions(
             "--trust-root",
             str(paths["trust_root"]),
         ],
-        input="y\n",
     )
 
     assert result.exit_code == 0, result.output
     assert "Required permissions:" in result.output
-    assert "Grant required permissions now?" in result.output
+    assert "Grant required permissions now?" not in result.output
+    assert "ooo plugin trust github-pr-ops --scope <scope>" in result.output
     record = TrustStore(root=paths["trust_root"]).read("github-pr-ops")
-    assert record is not None
-    assert record.has_scope("github:read")
+    assert record is None
 
 
 def test_add_persists_absolute_plugin_home_for_relative_root(
@@ -1676,7 +1675,7 @@ def test_install_named_with_from_local_path(runner: CliRunner, tmp_path: Path) -
     )
 
 
-def test_install_direct_directory_prompts_to_grant_required_permissions(
+def test_install_direct_directory_lists_required_permissions_without_prompting(
     runner: CliRunner, tmp_path: Path
 ) -> None:
     manifest = {
@@ -1707,18 +1706,17 @@ def test_install_direct_directory_prompts_to_grant_required_permissions(
             "--trust-root",
             str(paths["trust_root"]),
         ],
-        input="y\n",
     )
 
     assert result.exit_code == 0, result.output
     assert "Required permissions:" in result.output
-    assert "Grant required permissions now?" in result.output
+    assert "Grant required permissions now?" not in result.output
+    assert "ooo plugin trust github-pr-ops --scope <scope>" in result.output
     record = TrustStore(root=paths["trust_root"]).read("github-pr-ops")
-    assert record is not None
-    assert record.has_scope("github:read")
+    assert record is None
 
 
-def test_install_named_from_local_path_prompts_to_grant_required_permissions(
+def test_install_named_from_local_path_lists_required_permissions_without_prompting(
     runner: CliRunner, tmp_path: Path
 ) -> None:
     manifest = {
@@ -1753,14 +1751,14 @@ def test_install_named_from_local_path_prompts_to_grant_required_permissions(
             "--catalog-state",
             str(tmp_path / "catalog-state.json"),
         ],
-        input="y\n",
     )
 
     assert result.exit_code == 0, result.output
     assert "Required permissions:" in result.output
+    assert "Grant required permissions now?" not in result.output
+    assert "ooo plugin trust github-pr-ops --scope <scope>" in result.output
     record = TrustStore(root=paths["trust_root"]).read("github-pr-ops")
-    assert record is not None
-    assert record.has_scope("github:read")
+    assert record is None
 
 
 def test_install_default_form_resolves_via_known_catalog(runner: CliRunner, tmp_path: Path) -> None:
@@ -1823,7 +1821,7 @@ def test_install_default_form_resolves_via_known_catalog(runner: CliRunner, tmp_
     assert "github-pr-ops" in Lockfile(paths["lockfile"]).read()
 
 
-def test_install_default_form_prompts_to_grant_required_permissions(
+def test_install_default_form_lists_required_permissions_without_prompting(
     runner: CliRunner, tmp_path: Path
 ) -> None:
     manifest = {
@@ -1888,15 +1886,14 @@ def test_install_default_form_prompts_to_grant_required_permissions(
             "--catalog-state",
             str(catalog_state),
         ],
-        input="y\n",
     )
 
     assert result.exit_code == 0, result.output
     assert "Required permissions:" in result.output
-    assert "Grant required permissions now?" in result.output
+    assert "Grant required permissions now?" not in result.output
+    assert "ooo plugin trust github-pr-ops --scope <scope>" in result.output
     record = TrustStore(root=paths["trust_root"]).read("github-pr-ops")
-    assert record is not None
-    assert record.has_scope("github:read")
+    assert record is None
 
 
 def test_install_named_default_form_with_no_known_catalog_errors(

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -173,6 +173,56 @@ def test_add_prompts_to_grant_missing_required_permissions(
     assert record.has_scope("github:read")
 
 
+def test_add_required_permission_prompt_does_not_reenable_disabled_plugin(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    manifest = {
+        **REFERENCE_MANIFEST,
+        "permissions": [
+            {
+                "scope": "github:read",
+                "risk": "read_only",
+                "required": True,
+                "reason": "Inspect pull request metadata",
+            },
+        ],
+    }
+    repo_root = tmp_path / "repo"
+    _make_repo_layout(repo_root, [manifest])
+    paths = _common_paths(tmp_path)
+    trust = TrustStore(root=paths["trust_root"])
+    trust.write_disable(
+        "github-pr-ops",
+        source_type="local_path",
+        source_identity=str(repo_root / "plugins" / "github-pr-ops"),
+        disabled_by="user:test",
+    )
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            "add",
+            str(repo_root),
+            "--plugin",
+            "github-pr-ops",
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--trust-root",
+            str(paths["trust_root"]),
+        ],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "plugin remains disabled" in result.output
+    record = trust.read("github-pr-ops")
+    assert record is not None
+    assert record.has_scope("github:read")
+    assert trust.is_disabled("github-pr-ops")
+
+
 def test_add_decline_required_permission_prompt_leaves_plugin_installed_untrusted(
     runner: CliRunner, tmp_path: Path
 ) -> None:
@@ -334,10 +384,10 @@ def test_install_local_directory(runner: CliRunner, tmp_path: Path) -> None:
     assert "github-pr-ops" in Lockfile(paths["lockfile"]).read()
 
 
-def test_install_local_directory_does_not_prompt_or_grant_required_permissions(
+def test_install_local_directory_prompts_and_grants_required_permissions(
     runner: CliRunner, tmp_path: Path
 ) -> None:
-    """`install` is the non-interactive primitive; trust stays explicit."""
+    """`install` surfaces the same required-permission prompt as `add`."""
     plugin_dir = tmp_path / "github-pr-ops"
     plugin_dir.mkdir(parents=True, exist_ok=True)
     (plugin_dir / "ouroboros.plugin.json").write_text(json.dumps(REFERENCE_MANIFEST))
@@ -359,9 +409,11 @@ def test_install_local_directory_does_not_prompt_or_grant_required_permissions(
     )
 
     assert result.exit_code == 0, result.output
-    assert "Required permissions:" not in result.output
-    assert "Grant required permissions now?" not in result.output
-    assert TrustStore(root=paths["trust_root"]).read("github-pr-ops") is None
+    assert "Required permissions:" in result.output
+    assert "Grant required permissions now?" in result.output
+    record = TrustStore(root=paths["trust_root"]).read("github-pr-ops")
+    assert record is not None
+    assert record.has_scope("github:read")
 
 
 def test_add_persists_absolute_plugin_home_for_relative_root(
@@ -1624,6 +1676,93 @@ def test_install_named_with_from_local_path(runner: CliRunner, tmp_path: Path) -
     )
 
 
+def test_install_direct_directory_prompts_to_grant_required_permissions(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    manifest = {
+        **REFERENCE_MANIFEST,
+        "permissions": [
+            {
+                "scope": "github:read",
+                "risk": "read_only",
+                "required": True,
+                "reason": "Inspect pull request metadata",
+            },
+        ],
+    }
+    paths = _common_paths(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "ouroboros.plugin.json").write_text(json.dumps(manifest))
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            "install",
+            str(src),
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--trust-root",
+            str(paths["trust_root"]),
+        ],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Required permissions:" in result.output
+    assert "Grant required permissions now?" in result.output
+    record = TrustStore(root=paths["trust_root"]).read("github-pr-ops")
+    assert record is not None
+    assert record.has_scope("github:read")
+
+
+def test_install_named_from_local_path_prompts_to_grant_required_permissions(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    manifest = {
+        **REFERENCE_MANIFEST,
+        "permissions": [
+            {
+                "scope": "github:read",
+                "risk": "read_only",
+                "required": True,
+                "reason": "Inspect pull request metadata",
+            },
+        ],
+    }
+    paths = _common_paths(tmp_path)
+    src = tmp_path / "src"
+    src.mkdir()
+    (src / "ouroboros.plugin.json").write_text(json.dumps(manifest))
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            "install",
+            "github-pr-ops",
+            "--from",
+            str(src.resolve()),
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--trust-root",
+            str(paths["trust_root"]),
+            "--catalog-state",
+            str(tmp_path / "catalog-state.json"),
+        ],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Required permissions:" in result.output
+    record = TrustStore(root=paths["trust_root"]).read("github-pr-ops")
+    assert record is not None
+    assert record.has_scope("github:read")
+
+
 def test_install_default_form_resolves_via_known_catalog(runner: CliRunner, tmp_path: Path) -> None:
     """After `ooo plugin add` registers a catalog, `install <name>` with no
     `--from` must resolve through the catalog and re-install — the
@@ -1682,6 +1821,82 @@ def test_install_default_form_resolves_via_known_catalog(runner: CliRunner, tmp_
     )
     assert result.exit_code == 0, result.output
     assert "github-pr-ops" in Lockfile(paths["lockfile"]).read()
+
+
+def test_install_default_form_prompts_to_grant_required_permissions(
+    runner: CliRunner, tmp_path: Path
+) -> None:
+    manifest = {
+        **REFERENCE_MANIFEST,
+        "permissions": [
+            {
+                "scope": "github:read",
+                "risk": "read_only",
+                "required": True,
+                "reason": "Inspect pull request metadata",
+            },
+        ],
+    }
+    paths = _common_paths(tmp_path)
+    repo_root = tmp_path / "repo"
+    _make_repo_layout(repo_root, [manifest])
+    catalog_state = tmp_path / "catalog-state.json"
+    add_result = runner.invoke(
+        plugin_app,
+        [
+            "add",
+            str(repo_root),
+            "--plugin",
+            "github-pr-ops",
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--trust-root",
+            str(paths["trust_root"]),
+            "--catalog-state",
+            str(catalog_state),
+        ],
+        input="n\n",
+    )
+    assert add_result.exit_code == 0, add_result.output
+    runner.invoke(
+        plugin_app,
+        [
+            "remove",
+            "github-pr-ops",
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--trust-root",
+            str(paths["trust_root"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+        ],
+    )
+
+    result = runner.invoke(
+        plugin_app,
+        [
+            "install",
+            "github-pr-ops",
+            "--lockfile",
+            str(paths["lockfile"]),
+            "--plugin-home-root",
+            str(paths["plugin_home_root"]),
+            "--trust-root",
+            str(paths["trust_root"]),
+            "--catalog-state",
+            str(catalog_state),
+        ],
+        input="y\n",
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Required permissions:" in result.output
+    assert "Grant required permissions now?" in result.output
+    record = TrustStore(root=paths["trust_root"]).read("github-pr-ops")
+    assert record is not None
+    assert record.has_scope("github:read")
 
 
 def test_install_named_default_form_with_no_known_catalog_errors(


### PR DESCRIPTION
## Summary
- wire required-permission display/prompt into plugin install direct-directory, named local, and catalog-resolved paths
- keep add/install prompt grants from clearing disable records so re-enable remains explicit via ooo plugin trust
- add focused coverage for install prompts and disabled-plugin behavior

## Original PR blocker coverage
Addresses the required-permission install-flow blockers reported on #1141.

## Verification
- uv run pytest tests/unit/cli/test_plugin_command_mutating.py -q
- uv run ruff check src/ouroboros/cli/commands/plugin.py tests/unit/cli/test_plugin_command_mutating.py
