### PR TITLE
fix: preserve MCP tool metadata across transport

### DIFF
--- a/src/ouroboros/mcp/client/adapter.py
+++ b/src/ouroboros/mcp/client/adapter.py
@@ -541,6 +541,7 @@ class MCPClientAdapter:
         return MCPToolResult(
             content=tuple(content_items),
             is_error=getattr(result, "isError", False),
+            meta=getattr(result, "meta", {}) or {},
         )
 
     async def list_resources(self) -> Result[Sequence[MCPResourceDefinition], MCPClientError]:

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -66,6 +66,21 @@ def _safe_cwd() -> Path:
     return cwd
 
 
+def _to_fastmcp_tool_result(tool_result: MCPToolResult) -> Any:
+    """Convert internal tool results to MCP SDK results without dropping meta."""
+    try:
+        from mcp.types import CallToolResult, TextContent
+    except ImportError as exc:  # pragma: no cover - start() already checks this path.
+        msg = "mcp package not installed. Install with: pip install 'ouroboros-ai[mcp]'"
+        raise RuntimeError(msg) from exc
+
+    return CallToolResult(
+        content=[TextContent(type="text", text=tool_result.text_content)],
+        isError=tool_result.is_error,
+        _meta=tool_result.meta or None,
+    )
+
+
 def _default_interview_state_dir() -> Path:
     """Return the global interview state directory for MCP handlers."""
     from ouroboros.config.models import get_config_dir
@@ -920,7 +935,7 @@ class MCPServerAdapter:
                     if result.is_ok:
                         # Convert MCPToolResult to FastMCP format
                         tool_result = result.value
-                        return tool_result.text_content
+                        return _to_fastmcp_tool_result(tool_result)
                     else:
                         # Raise so FastMCP returns a proper MCP error response
                         # with isError: true, instead of a success with error text.

--- a/tests/unit/mcp/client/test_adapter.py
+++ b/tests/unit/mcp/client/test_adapter.py
@@ -121,6 +121,24 @@ class TestMCPClientAdapterParsing:
         assert result.content[0].text == "Hello, world!"
         assert result.is_error is False
 
+    def test_parse_tool_result_preserves_meta(self) -> None:
+        """SDK result metadata is restored into MCPToolResult.meta."""
+        adapter = MCPClientAdapter()
+        mock_result = MagicMock()
+        mock_content = MagicMock()
+        mock_content.text = "Question?"
+        mock_result.content = [mock_content]
+        mock_result.isError = False
+        mock_result.meta = {
+            "internal_reasoning": ["phase: start"],
+            "interview_reasoning": {"phase": "start"},
+        }
+
+        result = adapter._parse_tool_result(mock_result, "ouroboros_interview")
+
+        assert result.meta["internal_reasoning"] == ["phase: start"]
+        assert result.meta["interview_reasoning"]["phase"] == "start"
+
 
 class TestMCPClientAdapterRetry:
     """Test MCPClientAdapter retry behavior."""

--- a/tests/unit/mcp/server/test_adapter.py
+++ b/tests/unit/mcp/server/test_adapter.py
@@ -23,6 +23,7 @@ from ouroboros.mcp.server.adapter import (
     _project_dir_from_artifact,
     _project_dir_from_seed,
     _safe_cwd,
+    _to_fastmcp_tool_result,
     validate_transport,
 )
 from ouroboros.mcp.types import (
@@ -720,6 +721,18 @@ class TestMCPServerAdapterTools:
         assert result.is_ok
         assert result.value.text_content == "Success"
         handler.handle_mock.assert_called_once_with({"input": "test"})
+
+    def test_fastmcp_tool_result_preserves_meta(self) -> None:
+        """FastMCP boundary conversion must not drop MCPToolResult.meta."""
+        result = MCPToolResult(
+            content=(MCPContentItem(type=ContentType.TEXT, text="Success"),),
+            meta={"internal_reasoning": ["phase: start"]},
+        )
+
+        converted = _to_fastmcp_tool_result(result)
+
+        assert converted.content[0].text == "Success"
+        assert converted.meta == {"internal_reasoning": ["phase: start"]}
 
     async def test_call_tool_scopes_io_journal_recorder_from_runtime_context(self) -> None:
         """MCP tool calls provide per-call journal identity to shared adapters."""


### PR DESCRIPTION
## Summary
- return MCP SDK CallToolResult from FastMCP wrappers so MCPToolResult.meta survives the served boundary
- restore SDK result meta in MCPClientAdapter parsing
- cover server and client metadata preservation for interview reasoning surfaces

## Original PR blocker coverage
Addresses the MCP interview reasoning transport blocker reported on #1140.

## Verification
- uv run --extra mcp pytest tests/unit/mcp/server/test_adapter.py tests/unit/mcp/client/test_adapter.py tests/unit/mcp/tools/test_interview_response_diagnostics.py -q
- uv run ruff check src/ouroboros/mcp/server/adapter.py src/ouroboros/mcp/client/adapter.py tests/unit/mcp/server/test_adapter.py tests/unit/mcp/client/test_adapter.py
