### PR TITLE
fix: log safe-default synthesis nonclosure

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -445,6 +445,15 @@ class AutoInterviewDriver:
                         "safe-default synthesis did not close the persisted interview: "
                         "backend_done=False, ledger defaults rolled back"
                     )
+                    log.warning(
+                        "auto.interview.safe_default_synthesis_nonclosure",
+                        auto_session_id=state.auto_session_id,
+                        interview_session_id=state.interview_session_id,
+                        defaulted_sections=finalization.defaulted_sections,
+                        backend_seed_ready=bool(synthesis_turn.seed_ready),
+                        backend_completed=bool(synthesis_turn.completed),
+                        synthesis_pushed=synthesis_pushed,
+                    )
                     state.ledger = ledger.to_dict()
                     state.mark_blocked(blocker, tool_name="interview.safe_default_synthesis")
                     record_authoring_backend(state)

--- a/tests/unit/auto/test_safe_default_observability.py
+++ b/tests/unit/auto/test_safe_default_observability.py
@@ -168,6 +168,45 @@ async def test_safe_default_logs_closed_path(tmp_path) -> None:
     assert result.status == "seed_ready"
 
 
+@pytest.mark.asyncio
+async def test_safe_default_logs_synthesis_nonclosure(tmp_path) -> None:
+    """Backend response that accepts synthesis but keeps interviewing is structured-log visible."""
+    ledger = SeedDraftLedger.from_goal("Build a tiny local CLI")
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What else should we know?", "interview_nonclosure")
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        if "[safe-default-synthesis]" in text:
+            return InterviewTurn("Still need more", session_id, seed_ready=False, completed=False)
+        return InterviewTurn("What else should we know?", session_id, seed_ready=False)
+
+    state = AutoPipelineState(goal="Build a tiny local CLI", cwd=str(tmp_path))
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    with capture_logs() as captured:
+        result = await driver.run(state, ledger)
+
+    events = [e["event"] for e in captured]
+    assert "auto.interview.safe_default_synthesis_nonclosure" in events
+    nonclosure = [
+        e for e in captured if e["event"] == "auto.interview.safe_default_synthesis_nonclosure"
+    ][0]
+    assert nonclosure["synthesis_pushed"] is True
+    assert nonclosure["backend_seed_ready"] is False
+    assert nonclosure["backend_completed"] is False
+    assert nonclosure["defaulted_sections"]
+    assert result.status == "blocked"
+    assert "did not close" in (result.blocker or "")
+
+
 # ---------------------------------------------------------------------------
 # Test 3: unsafe_context_match logs pattern_name and safe metrics
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- emit a structured auto.interview.safe_default_synthesis_nonclosure event when backend.answer accepts synthesis but does not close the interview
- include bounded categorical fields for synthesis_pushed, backend_seed_ready, backend_completed, and defaulted_sections
- add a focused observability regression test

## Original PR blocker coverage
Addresses the safe-default synthesis non-closure observability blocker reported on #1138.

## Verification
- uv run pytest tests/unit/auto/test_safe_default_observability.py -q
- uv run ruff check src/ouroboros/auto/interview_driver.py tests/unit/auto/test_safe_default_observability.py
