### PR TITLE
fix: persist runtime probe evidence

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 import hashlib
+import os
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,7 @@ from ouroboros.mcp.tools.qa import QAHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.tools.subagent import should_dispatch_via_plugin
 from ouroboros.mcp.types import MCPToolResult
+from ouroboros.orchestrator.runtime_evidence import HeadlessRunProbe, RuntimeEvidence
 from ouroboros.resilience.lateral import ThinkingPersona
 
 _SAFE_SEED_ID_FILENAME_CHARS = frozenset(
@@ -47,6 +49,34 @@ _SEED_FILENAME_STEM_MAX_BYTES = _SEED_FILENAME_COMPONENT_MAX_BYTES - len(
 
 class HandlerError(RuntimeError):
     """Raised when an MCP handler returns an error result."""
+
+
+class EnvRuntimeProbeRunner:
+    """Runtime probe runner configured through public CLI/MCP environment.
+
+    ``OUROBOROS_RUNTIME_PROBE_COMMAND`` opt-in keeps default behavior unchanged,
+    while giving production entrypoints a real probe path whose failures can
+    block PRODUCT_COMPLETE.
+    """
+
+    def __init__(self, *, env: dict[str, str] | None = None) -> None:
+        self._env = env if env is not None else os.environ
+
+    async def __call__(self, state: Any) -> tuple[RuntimeEvidence, ...]:
+        command = self._env.get("OUROBOROS_RUNTIME_PROBE_COMMAND")
+        if not command:
+            return ()
+        raw_timeout = self._env.get("OUROBOROS_RUNTIME_PROBE_TIMEOUT_SECONDS")
+        timeout: float | None = 60.0
+        if raw_timeout:
+            timeout = float(raw_timeout)
+        evidence = await asyncio.to_thread(
+            HeadlessRunProbe().run,
+            cwd=Path(state.cwd),
+            command=command,
+            timeout_seconds=timeout,
+        )
+        return (evidence,)
 
 
 class PartialInterviewStartError(HandlerError):

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -167,6 +167,16 @@ _DEFAULT_RALPH_PER_ITERATION_SECONDS = 1800.0
 _RALPH_RESUME_PEEK_SECONDS = 1.0
 
 
+def _runtime_probe_evidence_from_state(
+    state: AutoPipelineState,
+) -> tuple[RuntimeEvidence, ...]:
+    """Return validated persisted runtime probe evidence."""
+    evidence: list[RuntimeEvidence] = []
+    for item in state.runtime_probe_evidence:
+        evidence.append(RuntimeEvidence.from_dict(item))
+    return tuple(evidence)
+
+
 @dataclass(frozen=True, slots=True)
 class AutoPipelineResult:
     """Structured AutoPipeline result for CLI/MCP surfaces."""
@@ -337,7 +347,7 @@ class AutoPipeline:
         # L3-2 / #1176: clear any cached probe evidence from a prior
         # run so a re-used ``AutoPipeline`` instance does not leak
         # the previous session's evidence onto a new ``_result()``.
-        self._last_probe_evidence = ()
+        self._last_probe_evidence = _runtime_probe_evidence_from_state(state)
         # Push the same progress callback down into the interview driver so
         # the longest-running phase (auto interview rounds) emits live
         # snapshots through the same observer contract instead of forcing
@@ -1567,6 +1577,8 @@ class AutoPipeline:
             self._save(state)
             return msg
         self._last_probe_evidence = tuple(evidence) if evidence else ()
+        state.runtime_probe_evidence = [item.to_dict() for item in self._last_probe_evidence]
+        self._save(state)
         failures = tuple(item for item in self._last_probe_evidence if not item.passed)
         if not failures:
             return None
@@ -2872,7 +2884,8 @@ class AutoPipeline:
             ledger_provenance=ledger_provenance,
             evidence_backed_sections=tuple(summary.get("evidence_backed_sections", ())),
             assumption_only_sections=tuple(summary.get("assumption_only_sections", ())),
-            runtime_probe_evidence=self._last_probe_evidence,
+            runtime_probe_evidence=self._last_probe_evidence
+            or _runtime_probe_evidence_from_state(state),
         )
 
     def _attach_run_if_requested(self, state: AutoPipelineState) -> bool | None:

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -549,6 +549,9 @@ class AutoPipelineState:
     # Typed artifact for the next automated recovery step. Current PRs persist
     # this plan after QA/lateral failure; a follow-up redispatch PR consumes it.
     last_recovery_plan: dict[str, Any] | None = None
+    # L3-2 runtime probe evidence. Persisted so completed-session resume and
+    # result replay keep the acceptance evidence that gated PRODUCT_COMPLETE.
+    runtime_probe_evidence: list[dict[str, Any]] = field(default_factory=list)
 
     def phase_timeout_seconds(self, phase: AutoPhase) -> float:
         """Return the configured timeout for ``phase`` in seconds.
@@ -905,6 +908,7 @@ class AutoPipelineState:
         payload.setdefault("personas_invoked", [])
         payload.setdefault("recovery_guard_tripped", None)
         payload.setdefault("last_recovery_plan", None)
+        payload.setdefault("runtime_probe_evidence", [])
         # Convert the persisted ``deadline_at_epoch`` (epoch seconds) back into
         # a monotonic-clock value usable from this process. If the companion
         # epoch field is present, derive ``deadline_at`` from the offset
@@ -1159,6 +1163,22 @@ class AutoPipelineState:
             except Exception as exc:
                 msg = "last_recovery_plan must be a valid AutoRecoveryPlan object or null"
                 raise ValueError(msg) from exc
+        if not isinstance(self.runtime_probe_evidence, list):
+            msg = "runtime_probe_evidence must be a list"
+            raise ValueError(msg)
+        try:
+            from ouroboros.orchestrator.runtime_evidence import RuntimeEvidence
+
+            for item in self.runtime_probe_evidence:
+                if not isinstance(item, dict):
+                    msg = "runtime_probe_evidence entries must be objects"
+                    raise ValueError(msg)
+                RuntimeEvidence.from_dict(item)
+        except Exception as exc:
+            if isinstance(exc, ValueError):
+                raise
+            msg = "runtime_probe_evidence entries must be valid RuntimeEvidence objects"
+            raise ValueError(msg) from exc
         if self.recovery_guard_tripped is not None and (
             not isinstance(self.recovery_guard_tripped, str)
             or self.recovery_guard_tripped not in _VALID_RECOVERY_GUARD_TAGS

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -12,6 +12,7 @@ from rich.markup import escape as _rich_escape
 import typer
 
 from ouroboros.auto.adapters import (
+    EnvRuntimeProbeRunner,
     HandlerInterviewBackend,
     HandlerRalphPoller,
     HandlerRalphStarter,
@@ -527,6 +528,7 @@ async def _run_auto(
         complete_product=complete_product,
         progress_callback=progress_callback,
         watchdog=watchdog,
+        probe_runner=EnvRuntimeProbeRunner() if complete_product else None,
     )
     try:
         result = await pipeline.run(state)

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -15,6 +15,7 @@ from typing import Any
 from uuid import uuid4
 
 from ouroboros.auto.adapters import (
+    EnvRuntimeProbeRunner,
     HandlerEvaluator,
     HandlerInterviewBackend,
     HandlerLateralThinker,
@@ -503,6 +504,7 @@ class AutoHandler:
             evaluator=evaluator,
             lateral_thinker=lateral_thinker,
             watchdog=watchdog,
+            probe_runner=EnvRuntimeProbeRunner() if complete_product else None,
         )
         try:
             return await pipeline.run(state)

--- a/src/ouroboros/orchestrator/runtime_evidence.py
+++ b/src/ouroboros/orchestrator/runtime_evidence.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
+import json
 from pathlib import Path
 import shlex
 import subprocess
@@ -97,6 +98,56 @@ class RuntimeEvidence:
         if not self.probe_kind:
             msg = "probe_kind must be a non-empty string"
             raise ValueError(msg)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-safe persistence payload."""
+        return {
+            "probe_kind": self.probe_kind,
+            "passed": self.passed,
+            "summary": self.summary,
+            "duration_seconds": self.duration_seconds,
+            "payload": _json_safe_payload(self.payload),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, object]) -> RuntimeEvidence:
+        """Rehydrate persisted runtime evidence."""
+        payload = data.get("payload", {})
+        if not isinstance(payload, Mapping):
+            msg = "RuntimeEvidence.payload must be an object"
+            raise ValueError(msg)
+        probe_kind = data.get("probe_kind")
+        passed = data.get("passed")
+        summary = data.get("summary")
+        duration_seconds = data.get("duration_seconds", 0.0)
+        if not isinstance(probe_kind, str):
+            msg = "RuntimeEvidence.probe_kind must be a string"
+            raise ValueError(msg)
+        if type(passed) is not bool:
+            msg = "RuntimeEvidence.passed must be a boolean"
+            raise ValueError(msg)
+        if not isinstance(summary, str):
+            msg = "RuntimeEvidence.summary must be a string"
+            raise ValueError(msg)
+        if isinstance(duration_seconds, bool) or not isinstance(duration_seconds, int | float):
+            msg = "RuntimeEvidence.duration_seconds must be numeric"
+            raise ValueError(msg)
+        return cls(
+            probe_kind=probe_kind,
+            passed=passed,
+            summary=summary,
+            duration_seconds=float(duration_seconds),
+            payload=dict(payload),
+        )
+
+
+def _json_safe_payload(payload: Mapping[str, object]) -> dict[str, object]:
+    """Coerce probe payloads into JSON-compatible values."""
+    try:
+        json.dumps(payload)
+        return dict(payload)
+    except TypeError:
+        return json.loads(json.dumps(payload, default=str))
 
 
 class RuntimeProbe(Protocol):

--- a/tests/unit/auto/test_pipeline_runtime_probe_envelope.py
+++ b/tests/unit/auto/test_pipeline_runtime_probe_envelope.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import pytest
 
-from ouroboros.auto.adapters import EvaluateResult
+from ouroboros.auto.adapters import EnvRuntimeProbeRunner, EvaluateResult
 from ouroboros.auto.grading import GradeResult, SeedGrade
 from ouroboros.auto.interview_driver import (
     AutoInterviewDriver,
@@ -382,3 +382,87 @@ async def test_evaluate_complete_path_invokes_probe_runner(tmp_path) -> None:
     assert result.status == "complete"
     assert len(result.runtime_probe_evidence) == 1
     assert invocations == ["evaluate"]
+
+
+@pytest.mark.asyncio
+async def test_completed_resume_preserves_persisted_probe_evidence(tmp_path) -> None:
+    """A completed session replay keeps runtime_probe_evidence from state."""
+
+    async def probe_runner(state: AutoPipelineState) -> tuple[RuntimeEvidence, ...]:  # noqa: ARG001
+        return (
+            RuntimeEvidence(
+                probe_kind="headless_run",
+                passed=True,
+                summary="headless run exit_code=0 (duration 0.01s)",
+                payload={"exit_code": 0, "outcome": "completed"},
+            ),
+        )
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", "interview_pe6", seed_ready=True, completed=True)
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(_session_id: str) -> Seed:
+        return _seed()
+
+    store = AutoStore(tmp_path)
+    state = _state_at_clean_start(tmp_path)
+    pipeline = AutoPipeline(
+        AutoInterviewDriver(
+            FunctionInterviewBackend(start, answer),
+            store=store,
+            max_rounds=1,
+        ),
+        generate_seed,
+        reviewer=_PassReviewer(),
+        run_starter=_run_starter_ok,
+        ralph_starter=_ralph_starter_completed,
+        complete_product=True,
+        store=store,
+        probe_runner=probe_runner,
+    )
+
+    first = await pipeline.run(state)
+    persisted = store.load(first.auto_session_id)
+    assert persisted is not None
+
+    replay = AutoPipeline(
+        AutoInterviewDriver(
+            FunctionInterviewBackend(start, answer),
+            store=store,
+            max_rounds=1,
+        ),
+        generate_seed,
+        reviewer=_PassReviewer(),
+        run_starter=_run_starter_ok,
+        ralph_starter=_ralph_starter_completed,
+        complete_product=True,
+        store=store,
+    )
+
+    second = await replay.run(persisted)
+
+    assert second.status == "complete"
+    assert len(second.runtime_probe_evidence) == 1
+    assert second.runtime_probe_evidence[0].summary == "headless run exit_code=0 (duration 0.01s)"
+
+
+@pytest.mark.asyncio
+async def test_env_runtime_probe_runner_blocks_public_entrypoint_failures(tmp_path) -> None:
+    """Public composition runner executes configured command and returns failing evidence."""
+    runner = EnvRuntimeProbeRunner(
+        env={
+            "OUROBOROS_RUNTIME_PROBE_COMMAND": "python -c 'import sys; sys.exit(7)'",
+            "OUROBOROS_RUNTIME_PROBE_TIMEOUT_SECONDS": "5",
+        }
+    )
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+
+    evidence = await runner(state)
+
+    assert len(evidence) == 1
+    assert evidence[0].probe_kind == "headless_run"
+    assert evidence[0].passed is False
+    assert evidence[0].payload["exit_code"] == 7


### PR DESCRIPTION
## Summary
- fixes #1190 runtime probe durability by persisting runtime_probe_evidence into AutoPipelineState
- preserves persisted probe evidence when completed sessions are replayed/resumed
- adds an opt-in public CLI/MCP runtime probe runner via OUROBOROS_RUNTIME_PROBE_COMMAND for PRODUCT_COMPLETE validation

## Verification
- uv run ruff check src/ouroboros/auto/pipeline.py src/ouroboros/auto/state.py src/ouroboros/auto/adapters.py src/ouroboros/orchestrator/runtime_evidence.py src/ouroboros/cli/commands/auto.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_pipeline_runtime_probe_envelope.py
- uv run pytest tests/unit/auto/test_pipeline_runtime_probe_envelope.py tests/unit/orchestrator/test_runtime_evidence.py -q