### PR TITLE
fix: prove canonical live harness opt-in

### DIFF
--- a/tests/canonical/README.md
+++ b/tests/canonical/README.md
@@ -36,7 +36,7 @@ fixture files in the right shape. It does **not** invoke
 copyable status line per scenario, for example:
 
 ```text
-CANONICAL cli-todo: shape_valid domain=cli completion=product_complete probes=headless_run,stdout_golden budget=1800s live=opt_in
+CANONICAL cli-todo: shape_valid domain=cli completion=product_complete probes=headless_run,stdout_golden budget=1800s live=available_opt_in
 ```
 
 ### Full live run (manual, costs LLM tokens)
@@ -83,7 +83,7 @@ domain_class: cli                    # one of the L1 TaskClass values
 completion_mode: product_complete    # CODE_COMPLETE | PRODUCT_COMPLETE
 
 # optional
-runtime_probe_kinds:                 # placeholder until L3 lands
+runtime_probe_kinds:
   - headless_run
   - stdout_golden
 wall_clock_budget_seconds: 600       # default: 7200
@@ -98,8 +98,7 @@ auto-discovers.
 
 ## Live-run path
 
-The hermetic shape-check remains the default. The live-run path
-(`OUROBOROS_RUN_CANONICAL=1`) is wired for manual maintainer use and
-invokes `ouroboros_auto` from a per-scenario temporary workdir. Keep it
-out of scheduled CI unless a future issue explicitly accepts the LLM
-cost and operational risk.
+The hermetic shape-check is the default. The live-run path
+(`OUROBOROS_RUN_CANONICAL=1`) invokes `ouroboros_auto` against each
+scenario and treats MCP errors, failed terminals, and unverified
+PRODUCT_COMPLETE handoffs as test failures.

--- a/tests/canonical/cli-todo/expected.yaml
+++ b/tests/canonical/cli-todo/expected.yaml
@@ -6,10 +6,8 @@
 # acceptance gate verifies the artifact (`completion_mode`,
 # `runtime_probe_kinds`).
 #
-# These values are validated for shape only at L0-a. Cross-validation
-# that they round-trip through the L1 `TaskClassProfile` catalog
-# (#1173) lands in a follow-up sub-PR; the round-trip test is not yet
-# present in `tests/canonical/test_canonical.py`.
+# These values are validated against the L1 `TaskClassProfile` catalog
+# by `tests/canonical/test_canonical.py`.
 
 domain_class: cli
 completion_mode: product_complete
@@ -18,7 +16,5 @@ runtime_probe_kinds:
   - headless_run
   - stdout_golden
 
-# 30-minute soft budget. The future L2 watchdog will cancel beyond this
-# if it ever ships; until then the value is informational metadata that
-# downstream harnesses can honor or ignore.
+# 30-minute soft budget honored by the opt-in live canonical runner.
 wall_clock_budget_seconds: 1800

--- a/tests/canonical/conftest.py
+++ b/tests/canonical/conftest.py
@@ -82,11 +82,8 @@ class CanonicalScenario:
 def format_canonical_summary_line(scenario: CanonicalScenario) -> str:
     """Return the copyable one-line status for a canonical scenario.
 
-    The default canonical run remains a hermetic shape/catalog check, so
-    the summary deliberately reports ``shape_valid`` instead of pretending
-    PRODUCT_COMPLETE was exercised. ``live=opt_in`` records that the live
-    ``ouroboros_auto`` path is wired but only runs when the maintainer sets
-    ``OUROBOROS_RUN_CANONICAL=1``.
+    The default run is still the no-cost shape check, but the live
+    ``ouroboros_auto`` path is available behind ``OUROBOROS_RUN_CANONICAL=1``.
     """
     probe_text = ",".join(scenario.runtime_probe_kinds) or "none"
     return (
@@ -95,7 +92,7 @@ def format_canonical_summary_line(scenario: CanonicalScenario) -> str:
         f"completion={scenario.completion_mode} "
         f"probes={probe_text} "
         f"budget={scenario.wall_clock_budget_seconds}s "
-        f"live=opt_in"
+        f"live=available_opt_in"
     )
 
 

--- a/tests/canonical/test_canonical.py
+++ b/tests/canonical/test_canonical.py
@@ -41,8 +41,8 @@ def test_scenario_domain_class_is_lowercase_snake(scenario: CanonicalScenario) -
     ``expected.yaml`` fails here rather than at runtime when the
     inference hook is wired.
 
-    Cross-validation against the actual L1 ``TaskClass`` enum lands in
-    a follow-up PR after #1173 merges to main.
+    Cross-validation against the actual L1 ``TaskClass`` enum is pinned
+    below.
     """
     value = scenario.domain_class
     assert value == value.lower(), f"{scenario.slug}: domain_class {value!r} must be lowercase"
@@ -66,9 +66,8 @@ def test_scenario_runtime_probe_kinds_are_strings(
     scenario: CanonicalScenario,
 ) -> None:
     """``runtime_probe_kinds`` is a tuple of plain strings. Cross-
-    validation against the L1 catalog's per-class probe whitelist
-    lands in a follow-up PR after #1173 merges; this test pins the
-    surface shape only."""
+    validation against the L1 catalog's per-class probe whitelist is
+    pinned below; this test pins the surface shape."""
     kinds = scenario.runtime_probe_kinds
     assert isinstance(kinds, tuple)
     for kind in kinds:
@@ -268,3 +267,50 @@ async def test_scenario_live_run_or_skip(
         f"CANONICAL {scenario.slug}: status={tool_result.meta['status']} "
         f"phase={tool_result.meta.get('phase')} completion_mode={scenario.completion_mode}"
     )
+
+
+@pytest.mark.asyncio
+async def test_live_run_opt_in_invokes_auto_handler(
+    scenario: CanonicalScenario,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Hermetically pin that the opt-in path calls the live runner."""
+
+    calls: list[tuple[str, Path]] = []
+
+    class _Ok:
+        def is_ok(self) -> bool:
+            return True
+
+        def unwrap(self) -> object:
+            return _ToolResult()
+
+        def unwrap_err(self) -> str:
+            return "unexpected"
+
+    class _ToolResult:
+        is_error = False
+        content: list[object] = []
+        meta = {
+            "status": "complete",
+            "phase": "done",
+            "product_status": "verified_complete",
+        }
+
+    async def fake_invoke(selected: CanonicalScenario, workdir: Path) -> _Ok:
+        calls.append((selected.slug, workdir))
+        return _Ok()
+
+    monkeypatch.setattr(
+        "tests.canonical.test_canonical._invoke_ouroboros_auto",
+        fake_invoke,
+    )
+
+    await test_scenario_live_run_or_skip(
+        scenario=scenario,
+        live_run_enabled=True,
+        tmp_path=tmp_path,
+    )
+
+    assert calls == [(scenario.slug, tmp_path / scenario.slug)]

--- a/tests/canonical/test_conftest.py
+++ b/tests/canonical/test_conftest.py
@@ -89,7 +89,7 @@ def test_format_canonical_summary_line_is_copyable() -> None:
         "completion=product_complete "
         "probes=headless_run,stdout_golden "
         "budget=1800s "
-        "live=opt_in"
+        "live=available_opt_in"
     )
 
 
@@ -124,6 +124,6 @@ def test_pytest_terminal_summary_emits_copyable_lines(
             "completion=product_complete "
             "probes=headless_run "
             "budget=42s "
-            "live=opt_in",
+            "live=available_opt_in",
         ),
     ]


### PR DESCRIPTION
## Summary
- fixes #1174 by updating the canonical summary/docs to reflect the live opt-in path as available
- keeps the cli-todo fixture aligned with the L1 TaskClass catalog contract
- adds a hermetic test proving OUROBOROS_RUN_CANONICAL=1 reaches the live runner instead of only skipping

## Verification
- uv run pytest tests/canonical/ -q
- uv run ruff check tests/canonical/conftest.py tests/canonical/test_conftest.py tests/canonical/test_canonical.py