### PR TITLE
fix: align plugin version fallback with hatch vcs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "ouroboros",
       "description": "Transform vague ideas into validated seed specifications through Socratic questioning and ontological analysis",
-      "version": "0.39.1",
+      "version": "0.39.2",
       "author": {
         "name": "Q00",
         "email": "jqyu.lee@gmail.com"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ouroboros",
-  "version": "0.39.1",
+  "version": "0.39.2",
   "description": "Self-improving AI workflow system. Crystallize requirements before execution with Socratic interview, ambiguity scoring, and 3-stage evaluation.",
   "author": {
     "name": "Q00",

--- a/scripts/sync-plugin-version.py
+++ b/scripts/sync-plugin-version.py
@@ -35,7 +35,10 @@ def get_version() -> str:
     except (FileNotFoundError, subprocess.CalledProcessError):
         pass
 
-    # Fallback: parse git describe like hatch-vcs does
+    # Fallback: parse git describe like hatch-vcs does.
+    # dev-publish.yml intentionally runs this script before installing hatch,
+    # so this branch must preserve the same next-dev source version that the
+    # subsequent hatch-vcs package build will produce.
     try:
         result = subprocess.run(
             ["git", "describe", "--tags", "--match", "v*"],
@@ -44,19 +47,38 @@ def get_version() -> str:
             cwd=ROOT,
             check=True,
         )
-        desc = result.stdout.strip()  # e.g. v0.26.0b4-3-gabcdef
-        # Strip leading 'v'
-        desc = desc.lstrip("v")
-        # For exact tag match, return as-is
-        if "-" not in desc:
-            return desc
-        # For dev versions, extract base version
-        base = desc.split("-")[0]
-        return base
+        return version_from_git_describe(result.stdout.strip())
     except (FileNotFoundError, subprocess.CalledProcessError):
         pass
 
     sys.exit("Error: cannot determine version (no hatch, no git tags)")
+
+
+def version_from_git_describe(desc: str) -> str:
+    """Return a hatch-vcs compatible version from ``git describe`` output."""
+    normalized = desc.removeprefix("v")
+    match = re.fullmatch(r"(?P<base>.+)-(?P<distance>\d+)-g[0-9a-f]+(?:-dirty)?", normalized)
+    if match is None:
+        return normalized
+    next_version = _guess_next_dev_base(match.group("base"))
+    return f"{next_version}.dev{match.group('distance')}"
+
+
+def _guess_next_dev_base(version: str) -> str:
+    """Approximate hatch-vcs/setuptools-scm ``guess-next-dev`` for tags."""
+    match = re.fullmatch(r"(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)", version)
+    if match is not None:
+        patch = int(match.group("patch")) + 1
+        return f"{match.group('major')}.{match.group('minor')}.{patch}"
+
+    prerelease = re.fullmatch(
+        r"(?P<prefix>\d+\.\d+\.\d+(?P<label>a|alpha|b|beta|rc))(?P<num>\d+)",
+        version,
+    )
+    if prerelease is not None:
+        return f"{prerelease.group('prefix')}{int(prerelease.group('num')) + 1}"
+
+    return version
 
 
 def normalize_version(v: str) -> str:

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -282,7 +282,7 @@ A backup will be created: CLAUDE.md.bak
 **If "Preview first", show:**
 ````markdown
 <!-- ooo:START -->
-<!-- ooo:VERSION:0.39.1 -->
+<!-- ooo:VERSION:0.39.2 -->
 # Ouroboros — Specification-First AI Development
 
 > Before telling AI what to build, define what should be built.

--- a/tests/unit/scripts/test_sync_plugin_version.py
+++ b/tests/unit/scripts/test_sync_plugin_version.py
@@ -1,0 +1,24 @@
+"""Tests for sync-plugin-version script."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT_PATH = Path(__file__).parent.parent.parent.parent / "scripts" / "sync-plugin-version.py"
+_spec = importlib.util.spec_from_file_location("sync_plugin_version", str(_SCRIPT_PATH))
+sync_plugin_version = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(sync_plugin_version)
+
+
+def test_git_describe_fallback_uses_hatch_vcs_next_dev_version() -> None:
+    assert sync_plugin_version.version_from_git_describe("v0.39.1-28-gc05024d6") == ("0.39.2.dev28")
+
+
+def test_git_describe_fallback_preserves_exact_tag_version() -> None:
+    assert sync_plugin_version.version_from_git_describe("v0.39.1") == "0.39.1"
+
+
+def test_plugin_metadata_version_normalizes_dev_suffix_to_public_version() -> None:
+    assert sync_plugin_version.normalize_version("0.39.2.dev28") == "0.39.2"


### PR DESCRIPTION
## Summary
- fixes #1184 by making the no-hatch git-describe fallback produce hatch-vcs style next-dev source versions instead of the stale base tag
- syncs plugin.json, marketplace.json, and setup skill version marker from the corrected source
- adds unit coverage for exact-tag and next-dev fallback behavior

## Verification
- python3 scripts/sync-plugin-version.py --check
- uv run pytest tests/unit/scripts/test_sync_plugin_version.py tests/unit/scripts/test_version_check.py -q
- uv run ruff check scripts/sync-plugin-version.py tests/unit/scripts/test_sync_plugin_version.py