### PR TITLE
fix(canonical): call Result.is_ok/is_err as properties

### DIFF
--- a/tests/canonical/test_canonical.py
+++ b/tests/canonical/test_canonical.py
@@ -245,9 +245,9 @@ async def test_scenario_live_run_or_skip(
 
     result = await _invoke_ouroboros_auto(scenario, workdir)
 
-    assert result.is_ok(), (
+    assert result.is_ok, (
         f"{scenario.slug}: ouroboros_auto returned MCP error: "
-        f"{result.unwrap_err() if not result.is_ok() else 'unknown'}"
+        f"{result.error if result.is_err else 'unknown'}"
     )
 
     tool_result = result.unwrap()


### PR DESCRIPTION
## Summary
- `tests/canonical/test_canonical.py:248-252` was calling `result.is_ok()` and `result.unwrap_err()` as methods, but `Result.is_ok`/`is_err` are `@property` accessors in `src/ouroboros/core/types.py:70-78` and `unwrap_err` does not exist (only the `.error` property at line 102 exposes the err side).
- Live canonical runs (`OUROBOROS_RUN_CANONICAL=1 pytest tests/canonical/`) therefore raised `TypeError: 'bool' object is not callable` before any production failure evidence could surface — masking real regressions in `ooo auto` behind a test-harness type error.
- This bug was introduced in #1191 and was never exercised because the live canonical lane is opt-in.

## Why this matters
R1 evidence (gathered locally on `265aedb4`) shows that `ooo auto cli-todo` is currently BLOCKED at safe-default closure (separate regression; tracked in a follow-up issue). That blocker is only readable after this harness fix lands, otherwise pytest dies at the `is_ok()` call site before the AutoPipelineState/MCP envelope can be inspected.

## Test plan
- [x] `uv run pytest tests/canonical/ -v` (canonical live OFF, $0 token cost) — 17 passed, 1 skipped
- [ ] CI green
- [ ] (follow-up, separate PR/issue) `OUROBOROS_RUN_CANONICAL=1 pytest tests/canonical/ -k cli-todo` — surfaces the real `phase=blocked` evidence instead of `TypeError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)