### PR TITLE
fix(auto): honor prompt-declared non_goals in unsafe-context matcher

### DIFF
--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -124,6 +124,8 @@ _PROMPT_SECTION_HEADER = re.compile(
     r"^\s*(?:[-*•]\s+)?[A-Za-z][A-Za-z0-9_ -]{0,40}\s*:(?:\s|$)",
 )
 
+_PROMPT_LIST_ITEM = re.compile(r"^\s*(?:[-*•]|\d+[.)])\s+")
+
 
 _UNSAFE_CONTEXT_PATTERNS: tuple[tuple[str, str], ...] = (
     (
@@ -593,10 +595,15 @@ def _strip_prompt_non_goal_sections(text: str) -> str:
     The helper recognises a non-goal section header
     (``non_goals:``, ``non-goals:``, ``non goals:``, ``excludes:`` or
     ``out-of-scope:``) at the start of a line (allowing leading
-    whitespace or a list bullet) and drops every subsequent line until
-    one of these terminators is reached:
+    whitespace or a list bullet). Inline header bodies are stripped on
+    that line only. Separate section bodies are stripped only while their
+    continuation is structurally clear: indented lines or list items. This
+    intentionally fails closed for unindented prose following an inline or
+    empty non-goal header, because such prose may be active unsafe scope.
+    A multi-line body ends when one of these terminators is reached:
 
     * a blank line, or
+    * an unindented non-list line, or
     * a non-empty line that begins another labelled section header
       (``actors:``, ``inputs:``, ``- constraints:``, …), which is then
       preserved.
@@ -609,8 +616,11 @@ def _strip_prompt_non_goal_sections(text: str) -> str:
     out: list[str] = []
     skipping = False
     for line in lines:
-        if _PROMPT_NON_GOAL_HEADER.search(line):
-            skipping = True
+        header_match = _PROMPT_NON_GOAL_HEADER.search(line)
+        if header_match:
+            # Inline body belongs to this line only; do not let it swallow
+            # following active prose.
+            skipping = not line[header_match.end() :].strip()
             continue
         if not skipping:
             out.append(line)
@@ -624,8 +634,14 @@ def _strip_prompt_non_goal_sections(text: str) -> str:
             skipping = False
             out.append(line)
             continue
-        # Still inside the non-goal body (continuation line, bullet, …);
-        # drop it from the matcher input.
+        if line[:1].isspace() or _PROMPT_LIST_ITEM.match(line):
+            # Still inside a structurally clear non-goal body; drop it
+            # from the matcher input.
+            continue
+        # Unindented prose after a non-goal header is ambiguous and may be
+        # active scope. Fail closed by preserving it for matching.
+        skipping = False
+        out.append(line)
     return "\n".join(out)
 
 

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -104,6 +104,27 @@ _SAFE_DEFAULTS: dict[str, _DefaultSpec] = {
     ),
 }
 
+
+# Line-anchored marker for a user-declared non-goal / exclusion section in
+# a free-form goal string. Examples that match:
+#   ``non_goals: …``         ``non-goals: …``        ``Non Goals: …``
+#   ``excludes: …``          ``Out-of-scope: …``     ``- non_goals:``
+# The trailing colon is required so that prose that merely mentions
+# ``non-goals`` in a sentence is not mistaken for a section header.
+_PROMPT_NON_GOAL_HEADER = re.compile(
+    r"^\s*(?:[-*•]\s+)?(?:non[ _-]?goals?|excludes?|out[ _-]?of[ _-]?scope)\s*:",
+    re.IGNORECASE,
+)
+
+# Any other line-anchored ``<label>:`` header, used to detect the *next*
+# section that ends a multi-line non-goals body. Matches things like
+# ``actors:``, ``inputs:``, ``- constraints:`` while leaving body lines
+# such as ``  - production deploy`` unmatched.
+_PROMPT_SECTION_HEADER = re.compile(
+    r"^\s*(?:[-*•]\s+)?[A-Za-z][A-Za-z0-9_ -]{0,40}\s*:(?:\s|$)",
+)
+
+
 _UNSAFE_CONTEXT_PATTERNS: tuple[tuple[str, str], ...] = (
     (
         "credentials/secrets",
@@ -319,9 +340,18 @@ def _unsafe_context_reason(
     interview questions and the still-open ``pending_question``, because a
     clarifying question like "should this deploy to production?" does not
     authorize a deploy — only the answer does. It also ignores ``NON_GOAL``
-    entries because confirmed non-goals are explicit *exclusions*; treating
-    "non-goals are credentials and production deployment" as active unsafe
-    scope would invert the user's intent.
+    ledger entries because confirmed non-goals are explicit *exclusions*;
+    treating "non-goals are credentials and production deployment" as active
+    unsafe scope would invert the user's intent.
+
+    The same exclusion principle is applied at the *string* level to any
+    ``non_goals: …`` / ``excludes: …`` / ``out-of-scope: …`` section in the
+    free-form ``goal`` argument — see :func:`_strip_prompt_non_goal_sections`
+    for the rationale. Without this pre-pass, a caller that already declares
+    its non-goals in the goal string (e.g. a handoff prompt body) would have
+    those exclusions silently flipped into "active unsafe scope" because the
+    interview has not yet had a chance to register them as ``NON_GOAL``
+    ledger entries.
     """
     # NFKC compatibility decomposition collapses fullwidth/half-width Latin,
     # ligatures and other compatibility variants onto their canonical ASCII
@@ -330,12 +360,13 @@ def _unsafe_context_reason(
     # block, U+FF21..U+FF5A) or ``ﬁnalize`` (the ``fi`` ligature U+FB01).
     # Without the normalization step ``\b(deploy|production|...)\b`` would
     # not match those forms, defeating the gate's purpose.
+    sanitized_goal = _strip_prompt_non_goal_sections(goal)
     context = unicodedata.normalize(
         "NFKC",
         "\n".join(
             value
             for value in (
-                goal,
+                sanitized_goal,
                 *_unsafe_ledger_values(ledger),
                 *_interview_answers(ledger),
             )
@@ -542,6 +573,60 @@ _NEGATION_CLAUSE_PATTERN = re.compile(
     r")",
     re.IGNORECASE,
 )
+
+
+def _strip_prompt_non_goal_sections(text: str) -> str:
+    """Remove user-declared non-goal sections from a goal string before
+    unsafe-context matching.
+
+    :func:`_unsafe_context_reason` already excludes ledger ``NON_GOAL``
+    entries on the documented principle that confirmed non-goals are
+    explicit *exclusions* and must not be treated as active unsafe scope.
+    That exclusion only fires after the interview has structured those
+    exclusions into the ledger. Callers that pre-declare their non-goals
+    inside the free-form goal string — typically scripted invocations or
+    handoff prompts that bundle the seven canonical interview slots in
+    the request body — would otherwise see the same words leak into the
+    matcher input before the interview ever ran, flipping the gate into
+    an unsafe-context block on the user's own exclusion text.
+
+    The helper recognises a non-goal section header
+    (``non_goals:``, ``non-goals:``, ``non goals:``, ``excludes:`` or
+    ``out-of-scope:``) at the start of a line (allowing leading
+    whitespace or a list bullet) and drops every subsequent line until
+    one of these terminators is reached:
+
+    * a blank line, or
+    * a non-empty line that begins another labelled section header
+      (``actors:``, ``inputs:``, ``- constraints:``, …), which is then
+      preserved.
+
+    Free-form prose that merely mentions ``non-goals`` mid-sentence does
+    not match because the regex is line-anchored and requires a trailing
+    colon.
+    """
+    lines = text.splitlines()
+    out: list[str] = []
+    skipping = False
+    for line in lines:
+        if _PROMPT_NON_GOAL_HEADER.search(line):
+            skipping = True
+            continue
+        if not skipping:
+            out.append(line)
+            continue
+        # We are inside a non-goal block — decide whether to keep skipping.
+        if not line.strip():
+            skipping = False
+            continue
+        if _PROMPT_SECTION_HEADER.match(line):
+            # A new section starts — stop skipping, keep this line.
+            skipping = False
+            out.append(line)
+            continue
+        # Still inside the non-goal body (continuation line, bullet, …);
+        # drop it from the matcher input.
+    return "\n".join(out)
 
 
 def _strip_negated_clauses(text: str) -> str:

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -629,14 +629,20 @@ def _strip_prompt_non_goal_sections(text: str) -> str:
         if not line.strip():
             skipping = False
             continue
+        if line[:1].isspace():
+            # Still inside a structurally clear non-goal body; drop it
+            # from the matcher input. This must run before section-header
+            # detection so indented YAML-ish body lines such as
+            # ``  deploy: production`` stay scoped under non-goals.
+            continue
         if _PROMPT_SECTION_HEADER.match(line):
             # A new section starts — stop skipping, keep this line.
             skipping = False
             out.append(line)
             continue
-        if line[:1].isspace() or _PROMPT_LIST_ITEM.match(line):
-            # Still inside a structurally clear non-goal body; drop it
-            # from the matcher input.
+        if _PROMPT_LIST_ITEM.match(line):
+            # Unindented non-labelled list items still belong to the
+            # non-goal body.
             continue
         # Unindented prose after a non-goal header is ambiguous and may be
         # active scope. Fail closed by preserving it for matching.

--- a/tests/unit/auto/test_safe_defaults_prompt_non_goals.py
+++ b/tests/unit/auto/test_safe_defaults_prompt_non_goals.py
@@ -84,6 +84,20 @@ def test_strip_handles_bullet_list_body() -> None:
     assert "keep changes local" in sanitized
 
 
+def test_strip_handles_indented_labelled_body_lines() -> None:
+    text = (
+        "Goal: refactor module Y.\n"
+        "non_goals:\n"
+        "  deploy: production\n"
+        "  credentials: customer secrets\n"
+        "actors: local CLI operator\n"
+    )
+    sanitized = _strip_prompt_non_goal_sections(text)
+    assert "deploy: production" not in sanitized
+    assert "credentials: customer secrets" not in sanitized
+    assert "actors: local CLI operator" in sanitized
+
+
 def test_strip_terminates_on_blank_line() -> None:
     text = (
         "Goal line.\n"

--- a/tests/unit/auto/test_safe_defaults_prompt_non_goals.py
+++ b/tests/unit/auto/test_safe_defaults_prompt_non_goals.py
@@ -96,6 +96,17 @@ def test_strip_terminates_on_blank_line() -> None:
     assert "Resume narrative about retry behaviour." in sanitized
 
 
+def test_strip_preserves_unindented_active_scope_after_inline_header() -> None:
+    text = (
+        "Goal: Build a local CLI.\n"
+        "non_goals: do not use credentials\n"
+        "Deploy to production after the tests pass.\n"
+    )
+    sanitized = _strip_prompt_non_goal_sections(text)
+    assert "credentials" not in sanitized.lower()
+    assert "Deploy to production after the tests pass." in sanitized
+
+
 def test_strip_leaves_inline_prose_mention_alone() -> None:
     # No trailing colon, no line-anchored header => the helper must not
     # remove anything; otherwise it would mangle ordinary prose.
@@ -134,6 +145,20 @@ def test_active_goal_deploy_phrase_still_trips_unsafe_matcher(
     # Without any non-goals header, the matcher must still catch a real
     # deploy intent in the goal text.
     goal = "Deploy the retry behaviour to production"
+    assert (
+        _unsafe_context_reason(empty_ledger, goal=goal, pending_question=None)
+        == "ambiguous external side effect"
+    )
+
+
+def test_active_scope_after_inline_non_goals_still_trips_unsafe_matcher(
+    empty_ledger: SeedDraftLedger,
+) -> None:
+    goal = (
+        "Goal: Build a local CLI.\n"
+        "non_goals: do not use credentials\n"
+        "Deploy to production after the tests pass.\n"
+    )
     assert (
         _unsafe_context_reason(empty_ledger, goal=goal, pending_question=None)
         == "ambiguous external side effect"

--- a/tests/unit/auto/test_safe_defaults_prompt_non_goals.py
+++ b/tests/unit/auto/test_safe_defaults_prompt_non_goals.py
@@ -1,0 +1,167 @@
+"""Tests for ``_unsafe_context_reason`` behaviour with user-declared non-goal
+sections inside the free-form ``goal`` argument.
+
+The detector already documents that ``NON_GOAL`` ledger entries are excluded
+from the unsafe-context scope because confirmed non-goals are explicit
+exclusions, not active unsafe scope. This module asserts that the same
+exclusion principle holds when the caller pre-declares those non-goals in
+the goal string — the standard shape for handoff-prepared prompts and
+scripted ``ooo auto`` invocations that bundle the seven canonical interview
+slots in the request body before the interview has had a chance to register
+them as ``NON_GOAL`` ledger entries.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.safe_defaults import (
+    _strip_prompt_non_goal_sections,
+    _unsafe_context_reason,
+)
+
+
+@pytest.fixture
+def empty_ledger() -> SeedDraftLedger:
+    """A goal-only ledger with no active or NON_GOAL entries yet."""
+    return SeedDraftLedger.from_goal("placeholder")
+
+
+# ---------------------------------------------------------------------------
+# Helper-level behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_strip_removes_inline_non_goals_section() -> None:
+    text = (
+        "Add bounded retry behaviour to a network client.\n"
+        "non_goals: implementing a production deploy, mutating remote git state\n"
+        "actors: single local CLI operator\n"
+    )
+    sanitized = _strip_prompt_non_goal_sections(text)
+    assert "production deploy" not in sanitized.lower()
+    assert "mutating remote git state" not in sanitized.lower()
+    # Surrounding sections must survive untouched.
+    assert "Add bounded retry behaviour to a network client." in sanitized
+    assert "actors: single local CLI operator" in sanitized
+
+
+@pytest.mark.parametrize(
+    "header",
+    [
+        "non_goals:",
+        "non-goals:",
+        "non goals:",
+        "Non_Goals:",
+        "Excludes:",
+        "excludes:",
+        "Out-of-scope:",
+        "out of scope:",
+    ],
+)
+def test_strip_recognises_header_variants(header: str) -> None:
+    text = f"goal text\n{header} ship a deploy webhook\nactors: ops\n"
+    sanitized = _strip_prompt_non_goal_sections(text)
+    assert "deploy" not in sanitized.lower(), header
+    assert "actors: ops" in sanitized
+
+
+def test_strip_handles_bullet_list_body() -> None:
+    text = (
+        "Goal: refactor module Y.\n"
+        "- non_goals:\n"
+        "  - implementing a production deploy\n"
+        "  - mutating remote git state\n"
+        "- constraints:\n"
+        "  - keep changes local\n"
+    )
+    sanitized = _strip_prompt_non_goal_sections(text)
+    assert "implementing a production deploy" not in sanitized
+    assert "mutating remote git state" not in sanitized
+    # The next labelled section and its body survive.
+    assert "constraints" in sanitized
+    assert "keep changes local" in sanitized
+
+
+def test_strip_terminates_on_blank_line() -> None:
+    text = (
+        "Goal line.\n"
+        "non_goals: deploy, publish, push live\n"
+        "\n"
+        "Resume narrative about retry behaviour.\n"
+    )
+    sanitized = _strip_prompt_non_goal_sections(text)
+    assert "deploy" not in sanitized.lower()
+    assert "Resume narrative about retry behaviour." in sanitized
+
+
+def test_strip_leaves_inline_prose_mention_alone() -> None:
+    # No trailing colon, no line-anchored header => the helper must not
+    # remove anything; otherwise it would mangle ordinary prose.
+    text = "We will discuss non-goals later in the document."
+    assert _strip_prompt_non_goal_sections(text) == text
+
+
+def test_strip_is_idempotent() -> None:
+    text = "Goal.\nnon_goals: deploy, publish\nactors: human + agent\n"
+    once = _strip_prompt_non_goal_sections(text)
+    twice = _strip_prompt_non_goal_sections(once)
+    assert once == twice
+
+
+# ---------------------------------------------------------------------------
+# Integration with _unsafe_context_reason
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_non_goals_section_does_not_trip_unsafe_matcher(
+    empty_ledger: SeedDraftLedger,
+) -> None:
+    goal = (
+        "Add bounded retry behaviour to a network client.\n"
+        "non_goals: implementing a production deploy, mutating remote git state, "
+        "calling external services\n"
+        "actors: single local CLI operator\n"
+        "constraints: filesystem:read and filesystem:write only; no live merge or PR mutation\n"
+    )
+    assert _unsafe_context_reason(empty_ledger, goal=goal, pending_question=None) is None
+
+
+def test_active_goal_deploy_phrase_still_trips_unsafe_matcher(
+    empty_ledger: SeedDraftLedger,
+) -> None:
+    # Without any non-goals header, the matcher must still catch a real
+    # deploy intent in the goal text.
+    goal = "Deploy the retry behaviour to production"
+    assert (
+        _unsafe_context_reason(empty_ledger, goal=goal, pending_question=None)
+        == "ambiguous external side effect"
+    )
+
+
+def test_constraints_section_with_active_deploy_still_trips_matcher(
+    empty_ledger: SeedDraftLedger,
+) -> None:
+    # A non-non-goal section that mentions a side-effect phrase must NOT
+    # be stripped — only the non_goals section is special-cased.
+    goal = "Refactor module Y.\nconstraints: must deploy to production after merging\n"
+    assert (
+        _unsafe_context_reason(empty_ledger, goal=goal, pending_question=None)
+        == "ambiguous external side effect"
+    )
+
+
+def test_multiple_non_goal_sections_are_each_stripped(
+    empty_ledger: SeedDraftLedger,
+) -> None:
+    # A caller may, intentionally or not, repeat the header. Both must be
+    # respected so the matcher does not trip on either body.
+    goal = (
+        "Add retry to network client.\n"
+        "non_goals: implementing a production deploy\n"
+        "actors: single CLI operator\n"
+        "excludes: publishing release notes, sending webhooks\n"
+        "inputs: handoff.md\n"
+    )
+    assert _unsafe_context_reason(empty_ledger, goal=goal, pending_question=None) is None


### PR DESCRIPTION
## Summary

- Apply the existing \`NON_GOAL\` ledger exclusion *at the string level* to any \`non_goals:\` / \`excludes:\` / \`out-of-scope:\` section in the free-form \`goal\` argument of \`_unsafe_context_reason\`.
- Add a line-anchored \`_strip_prompt_non_goal_sections\` helper next to \`_strip_negated_clauses\`, used as a pre-pass before the existing NFKC normalization / negation stripping / regex bank.
- Extend the \`_unsafe_context_reason\` docstring to document why prompt-pre-declared non-goals receive the same exclusion as ledger \`NON_GOAL\` entries.
- New tests at \`tests/unit/auto/test_safe_defaults_prompt_non_goals.py\` (17 cases) covering header variants, bullet-list bodies, blank-line termination, inline-prose preservation, idempotency, and four \`_unsafe_context_reason\` integration cases.

## Why

\`_unsafe_context_reason\` already documents that ledger \`NON_GOAL\` entries are excluded because confirmed non-goals are explicit *exclusions*, not active unsafe scope. That exclusion only fires after the interview has structured the user's exclusion text into the ledger.

Callers that pre-declare their non-goals inside the free-form goal string — handoff prompts, scripted \`ooo auto --skip-run\` invocations, and any caller that bundles the seven canonical interview slots in the request body — leak those exclusion words into the matcher *before* the interview can register them. The matcher then trips on the user's own exclusion text and blocks the run with \`auto.interview.safe_default.unsafe_context_match pattern_name='ambiguous external side effect'\`.

This is the structural blocker behind every L3-style downstream-handoff verification on the \`ouroboros-plugins\` AgentOS assimilation issues that touch an externally-effecting domain.

## Reproduction (before the fix)

Recorded against \`origin/main\` of \`Q00/ouroboros-plugins\` \`67f776d\` with installed \`ouroboros-ai 0.39.1\`:

\`\`\`bash
ouroboros auto --skip-run --max-interview-rounds 8 --runtime codex \\
  \"Add bounded retry behaviour to a network client.
   non_goals: implementing a production deploy, mutating remote git state, calling external services
   actors: single local CLI operator
   inputs: handoff.md
   outputs: an A-grade execution Seed and a verification plan
   constraints: filesystem:read and filesystem:write only; no live merge or PR mutation
   failure_modes: retry storm; idempotency violation; missing audit event
   runtime_context: codex runtime, dry-run preferred\"
\`\`\`

Observed:

\`\`\`
[auto] interview — interview round 8/8
[auto] interview — answered round 8/8 from conservative_default
[auto] blocked — auto interview reached max_rounds=8 without closure:
  backend_done=False (ambiguity_score=0.228),
  ledger_done=False (open_gaps=['actors', 'inputs', 'outputs',
                                 'failure_modes', 'runtime_context'])

auto.interview.safe_default.unsafe_context_observed
  unsafe_gaps=(
    'actors: unsafe default context (ambiguous external side effect)',
    'inputs: unsafe default context (ambiguous external side effect)',
    'outputs: unsafe default context (ambiguous external side effect)',
    'failure_modes: unsafe default context (ambiguous external side effect)',
    'runtime_context: unsafe default context (ambiguous external side effect)'
  )
\`\`\`

\`safe_defaults.py\` fires on \`deploy\` inside the user's own \`non_goals:\` body. \`_strip_negated_clauses\` does not help here because the user did not phrase it as a negation (\`No deploy\`) — they declared a structural exclusion (\`non_goals: deploy\`), which is a different shape than what the negation stripper covers.

After this fix the same prompt closes through the normal safe-default path because the non-goals body is excluded from matcher input — matching what the ledger \`NON_GOAL\` exclusion already promises.

## Scope

- Only the matcher input is touched. The unsafe-pattern bank, the NFKC normalization, the negation stripper, and the \`_unsafe_ledger_values\` / \`_interview_answers\` projections are unchanged.
- Header recognition is line-anchored and requires a trailing colon (\`non_goals:\`, \`Excludes:\`, etc.), so ordinary prose that says \`We will discuss non-goals later\` is untouched.
- Section termination is conservative: blank line, or another labelled \`<name>:\` line (including bullet form \`- constraints:\`). Bullet-body lines under the non-goals header are dropped.
- Constraints / actors / inputs / outputs / etc. sections are **not** stripped — only the explicit non-goals / excludes / out-of-scope class. A \`constraints: must deploy to production\` line still trips the matcher, as it should.

## Out of scope

- The synthesis-ack closure bug fixed by #1220 (close \`safe_default\` synthesis ack even when backend ack is non-terminal). This PR addresses a *different* failure path: the matcher fires *before* the synthesis ack pathway is even reached, because \`unsafe_gaps\` is non-empty when the user pre-declared non-goals.
- Adding a CLI surface (e.g. \`--accept-pre-filled-slots\`). The string-level exclusion is a strict superset of what such a flag would do, and it requires no opt-in.
- Seeding the ledger from prompt-level slot markers (\`actors:\`, \`inputs:\`, …) before the interview. That is a broader change and orthogonal to closing the matcher false-positive.

## Test plan

- \`uv run pytest tests/unit/auto/test_safe_defaults_prompt_non_goals.py -q\` — **17 new tests pass**, covering helper variants and \`_unsafe_context_reason\` integration.
- \`uv run pytest tests/unit/auto/test_safe_default_observability.py tests/unit/auto/test_safe_defaults_domain_profile.py tests/unit/auto/test_interview_pipeline.py -q\` — **153 existing tests still pass**, no regression.
- \`uv run ruff check src/ouroboros/auto/safe_defaults.py tests/unit/auto/test_safe_defaults_prompt_non_goals.py\` — clean.
- \`uv run ruff format --check src/ouroboros/auto/safe_defaults.py tests/unit/auto/test_safe_defaults_prompt_non_goals.py\` — both formatted.
- \`uv run mypy src/ouroboros/auto/safe_defaults.py\` — no issues.

## Refs

- Symptom-side trace: [ouroboros-plugins#28 verdict comment](https://github.com/Q00/ouroboros-plugins/issues/28#issuecomment-4532580049) (Superpowers AgentOS L3a, originally diagnosed as a plugin failure and traced back to this matcher).
- Related work: #1220 (close safe-default synthesis ack — addresses the *next* failure mode along the same code path). These are complementary; either alone is not sufficient to close L3a for externally-effecting domains.