### PR TITLE
test(auto): assert runtime probe metadata shape

### DIFF
--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -20,11 +20,13 @@ from ouroboros.mcp.tools.auto_handler import (
     _authoring_interview_handler,
     _authoring_seed_handler,
     _execution_start_handler,
+    _result_meta,
     _resolve_cwd,
     _safe_default_cwd,
 )
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.orchestrator.runtime_evidence import RuntimeEvidence
 
 
 def test_cli_auto_runtime_enum_matches_supported_backends() -> None:
@@ -492,6 +494,37 @@ async def test_auto_handler_meta_exposes_auto_progress_fields(monkeypatch) -> No
         "assumption_sources": [],
         "runtime_probe_evidence": [],
     }
+
+
+def test_result_meta_serializes_runtime_probe_evidence_shape() -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+
+    meta = _result_meta(
+        AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_probe",
+            phase="complete",
+            runtime_probe_evidence=(
+                RuntimeEvidence(
+                    probe_kind="headless_run",
+                    passed=True,
+                    summary="headless run exit_code=0 (duration 0.01s)",
+                    duration_seconds=0.01,
+                    payload={"exit_code": 0, "stdout_preview": "ok"},
+                ),
+            ),
+        )
+    )
+
+    assert meta["runtime_probe_evidence"] == [
+        {
+            "probe_kind": "headless_run",
+            "passed": True,
+            "summary": "headless run exit_code=0 (duration 0.01s)",
+            "duration_seconds": 0.01,
+            "payload": {"exit_code": 0, "stdout_preview": "ok"},
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -20,8 +20,8 @@ from ouroboros.mcp.tools.auto_handler import (
     _authoring_interview_handler,
     _authoring_seed_handler,
     _execution_start_handler,
-    _result_meta,
     _resolve_cwd,
+    _result_meta,
     _safe_default_cwd,
 )
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler


### PR DESCRIPTION
## Summary

- Adds direct MCP metadata coverage for the runtime_probe_evidence shape introduced by #1205.
- Pins probe kind, pass status, summary, duration, and payload serialization so clients can rely on the public result contract.

## Changes

- Covers _result_meta with a RuntimeEvidence fixture in tests/unit/auto/test_surface.py.

## Notes

Follow-up for the non-blocking review item on #1205.