### PR TITLE
docs(mcp): refresh metadata transport comments

### DIFF
--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -1466,10 +1466,9 @@ class LateralThinkHandler(BridgeAwareMixin):
             # too, so non-plugin runtimes (Claude Code, Codex CLI, OpenCode
             # subprocess) can drive their own sub-agent fan-out from the
             # same structured prompts that plugin mode dispatches via
-            # `_subagents`. The FastMCP adapter only forwards `text_content`
-            # to the wire (`adapter.py:923`); `meta` is dropped. So the
-            # dispatch payload has to ride inside `content` to survive
-            # transport.
+            # `_subagents`. The FastMCP adapter now preserves `meta`, but
+            # older bridge consumers still read only `text_content`, so the
+            # dispatch payload continues to ride inside `content`.
             #
             # Format: a hidden HTML-comment block with a versioned sentinel,
             # carrying the dispatch JSON base64-encoded inside the comment.

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -194,10 +194,10 @@ def build_subagent_result(
 ) -> Result:
     """Wrap a SubagentPayload into an MCPToolResult for MCP transport.
 
-    The payload is serialized as JSON text in the content field because the
-    FastMCP adapter only passes ``text_content`` through to the wire — the
-    ``meta`` dict is lost. The bridge plugin parses JSON from the text to
-    detect the ``_subagent`` key.
+    The payload is serialized as JSON text in the content field so bridge
+    clients can parse the ``_subagent`` key directly. ``meta`` is preserved
+    by the FastMCP adapter for structured clients, but content JSON remains
+    the compatibility surface for plugin bridge dispatch.
 
     Public-contract preservation (#442): when ``response_shape`` is provided,
     the natural tool response fields (e.g. ``session_id``, ``job_id``,


### PR DESCRIPTION
## Summary\n\n- Updates stale comments that still said FastMCP metadata is dropped.\n- Clarifies that meta is now preserved while content JSON remains a bridge compatibility surface.\n\n## Changes\n\n- Refreshes comments in subagent and evaluation handler paths.\n\n## Notes\n\nFollow-up for the non-blocking documentation item on #1210.