### PR TITLE
test(canonical): align live harness docs and result stub

### DIFF
--- a/tests/canonical/conftest.py
+++ b/tests/canonical/conftest.py
@@ -1,9 +1,9 @@
 """Pytest fixtures for the canonical acceptance harness.
 
 L0-a slice of #1170 — provides scenario discovery + per-scenario
-fixture loading. The actual ``ouroboros_auto`` invocation lands
-in a follow-up sub-PR; this PR ships the discovery contract,
-fixture-shape validation, and the runner skeleton.
+fixture loading. The live ``ouroboros_auto`` invocation is available
+through the explicit ``OUROBOROS_RUN_CANONICAL=1`` opt-in path; the
+default CI path remains hermetic and validates fixture shape.
 
 Per-scenario fixture is parametrized via ``pytest_generate_tests`` so
 adding a new ``tests/canonical/<slug>/`` directory automatically

--- a/tests/canonical/test_canonical.py
+++ b/tests/canonical/test_canonical.py
@@ -22,6 +22,8 @@ from typing import Any
 
 import pytest
 
+from ouroboros.core.types import Result
+
 from .conftest import CanonicalScenario
 
 
@@ -279,16 +281,6 @@ async def test_live_run_opt_in_invokes_auto_handler(
 
     calls: list[tuple[str, Path]] = []
 
-    class _Ok:
-        def is_ok(self) -> bool:
-            return True
-
-        def unwrap(self) -> object:
-            return _ToolResult()
-
-        def unwrap_err(self) -> str:
-            return "unexpected"
-
     class _ToolResult:
         is_error = False
         content: list[object] = []
@@ -298,9 +290,9 @@ async def test_live_run_opt_in_invokes_auto_handler(
             "product_status": "verified_complete",
         }
 
-    async def fake_invoke(selected: CanonicalScenario, workdir: Path) -> _Ok:
+    async def fake_invoke(selected: CanonicalScenario, workdir: Path) -> Result[object, str]:
         calls.append((selected.slug, workdir))
-        return _Ok()
+        return Result.ok(_ToolResult())
 
     monkeypatch.setattr(
         "tests.canonical.test_canonical._invoke_ouroboros_auto",


### PR DESCRIPTION
## Summary\n\n- Refreshes canonical fixture docs now that the live opt-in path exists.\n- Replaces the local Result-shaped _Ok stub with Result.ok so the harness test uses the real Result contract.\n\n## Changes\n\n- Updates tests/canonical/conftest.py docstring.\n- Updates tests/canonical/test_canonical.py to use Result.ok and property-based Result access.\n\n## Notes\n\nFollow-up for #1214 stale docs and the coordination note raised from #1218.