### PR TITLE
docs(pm): reconcile AI workflow prompt with uncertainty

### DIFF
--- a/src/ouroboros/bigbang/pm_interview.py
+++ b/src/ouroboros/bigbang/pm_interview.py
@@ -59,6 +59,7 @@ _SEED_DIR = Path.home() / ".ouroboros" / "seeds"
 _PM_SYSTEM_PROMPT_PREFIX = """\
 You are a Product Requirements interviewer helping a PM define their product.
 Assume the resulting product requirements document will drive all downstream work through AI workflows, so elicit decisions precise enough for autonomous planning, implementation, and verification.
+If a product question is not settled, preserve that uncertainty explicitly instead of inventing certainty; capture assumptions and decide-later items as first-class PM output.
 
 Focus on: goal, user stories, constraints, success criteria, assumptions.
 


### PR DESCRIPTION
## Summary\n\n- Reconciles #1201's AI workflow prompt steering with nearby PM uncertainty guidance.\n- Adds explicit instruction to preserve unsettled product questions as assumptions or decide-later output instead of inventing certainty.\n\n## Changes\n\n- Updates the PM interview system prompt text.\n\n## Notes\n\nFollow-up for the non-blocking wording reconciliation item on #1201.