### PR TITLE
docs(installer): clarify PyPI prerelease lookup

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,7 +47,7 @@ elif [ -f "$(dirname "$0")/../pyproject.toml" ] && grep -q "name = \"ouroboros-a
   IS_LOCAL=true
 fi
 
-# Auto-detect: if PyPI's latest published version is a pre-release, allow
+# Auto-detect: if PyPI's info.version response is a pre-release, allow
 # pre-releases. On lookup/parsing failure, stay stable-only.
 PRE_FLAG=""
 if [ "$IS_LOCAL" = false ] && command -v curl &>/dev/null; then


### PR DESCRIPTION
## Summary\n\n- Clarifies the installer prerelease-selection comment from PR #1217.\n- Documents that the current lookup reads PyPI info.version and stays stable-only on lookup or parse failure.\n\n## Changes\n\n- Updates scripts/install.sh comment only.\n\n## Notes\n\nFollow-up for the non-blocking documentation item on #1217.