### PR TITLE
fix(cli): register qa command

### DIFF
--- a/src/ouroboros/cli/commands/__init__.py
+++ b/src/ouroboros/cli/commands/__init__.py
@@ -5,6 +5,7 @@ This module contains the command group implementations:
 - run: Execute workflows
 - config: Manage configuration
 - status: Check system status
+- qa: General-purpose QA verdicts
 - mcp: MCP server management
 - pm: Generate Product Requirements Documents
 - setup: Brownfield repository scanning and registration

--- a/src/ouroboros/cli/commands/qa.py
+++ b/src/ouroboros/cli/commands/qa.py
@@ -1,0 +1,105 @@
+"""CLI wrapper for the Ouroboros QA MCP tool.
+
+This command delegates to ``ouroboros.mcp.tools.qa.QAHandler`` so CLI and MCP
+QA share the same judge prompt, parsing, thresholds, and result format.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from ouroboros.cli.formatters import console
+from ouroboros.mcp.tools.qa import DEFAULT_PASS_THRESHOLD, QAHandler
+
+
+def _read_text_or_literal(value: str) -> str:
+    path = Path(value).expanduser()
+    if path.exists() and path.is_file():
+        return path.read_text(encoding="utf-8")
+    return value
+
+
+def qa_command(
+    artifact: Annotated[
+        str,
+        typer.Argument(help="Artifact text or path to a file to evaluate."),
+    ],
+    quality_bar: Annotated[
+        str,
+        typer.Option(
+            "--quality-bar",
+            "-q",
+            help="Natural-language description of what PASS means.",
+        ),
+    ] = "Artifact should be correct, complete, internally consistent, and fit for its stated purpose.",
+    artifact_type: Annotated[
+        str,
+        typer.Option(
+            "--artifact-type",
+            "-t",
+            help="Artifact type: code, api_response, document, screenshot, test_output, custom.",
+        ),
+    ] = "code",
+    reference: Annotated[
+        str | None,
+        typer.Option(
+            "--reference",
+            "-r",
+            help="Optional reference text or path for comparison.",
+        ),
+    ] = None,
+    pass_threshold: Annotated[
+        float,
+        typer.Option(
+            "--pass-threshold",
+            help="Score threshold for PASS verdict.",
+            min=0.0,
+            max=1.0,
+        ),
+    ] = DEFAULT_PASS_THRESHOLD,
+    qa_session_id: Annotated[
+        str | None,
+        typer.Option(
+            "--qa-session-id",
+            help="Existing QA session ID for iterative checks.",
+        ),
+    ] = None,
+    seed_content: Annotated[
+        str | None,
+        typer.Option(
+            "--seed-content",
+            help="Optional Seed YAML text or path for additional context.",
+        ),
+    ] = None,
+) -> None:
+    """Run a QA verdict using the same implementation as the MCP tool."""
+    args: dict[str, object] = {
+        "artifact": _read_text_or_literal(artifact),
+        "quality_bar": quality_bar,
+        "artifact_type": artifact_type,
+        "pass_threshold": pass_threshold,
+    }
+    if reference is not None:
+        args["reference"] = _read_text_or_literal(reference)
+    if qa_session_id is not None:
+        args["qa_session_id"] = qa_session_id
+    if seed_content is not None:
+        args["seed_content"] = _read_text_or_literal(seed_content)
+
+    result = asyncio.run(QAHandler().handle(args))
+    if result.is_err:
+        console.print(f"[red]QA failed:[/] {result.error}")
+        raise typer.Exit(code=1)
+
+    tool_result = result.value
+    for item in tool_result.content:
+        if getattr(item, "text", None):
+            console.print(item.text, markup=False, highlight=False)
+
+    meta = tool_result.meta or {}
+    if meta.get("passed") is False:
+        raise typer.Exit(code=2)

--- a/src/ouroboros/cli/main.py
+++ b/src/ouroboros/cli/main.py
@@ -31,6 +31,7 @@ from ouroboros.cli.commands import (
     mcp,
     plugin,
     pm,
+    qa,
     resume,
     run,
     setup,
@@ -90,6 +91,7 @@ app.add_typer(setup.app, name="setup")
 app.add_typer(detect.app, name="detect")
 app.add_typer(tui.app, name="tui")
 app.add_typer(pm.app, name="pm")
+app.command(name="qa", help="General-purpose QA verdict for any artifact.")(qa.qa_command)
 app.add_typer(plugin.app, name="plugin")
 app.add_typer(resume.app, name="resume")
 app.add_typer(uninstall.app, name="uninstall")

--- a/tests/e2e/test_cli_commands.py
+++ b/tests/e2e/test_cli_commands.py
@@ -9,8 +9,9 @@ This module tests the complete CLI command execution including:
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import typer
 from typer.testing import CliRunner
@@ -85,6 +86,67 @@ class TestCLIBasics:
         assert result.exit_code == 0
         assert "runtime" in result.output.lower()
         assert "llm-backend" in result.output.lower()
+
+    def test_qa_help(self) -> None:
+        """Test that the top-level qa command is registered."""
+        result = runner.invoke(app, ["qa", "--help"])
+        assert result.exit_code == 0
+        assert "quality-bar" in result.output
+        assert "artifact-type" in result.output
+
+    def test_qa_command_delegates_to_mcp_handler(self, tmp_path: Path) -> None:
+        """The CLI wrapper should reuse the MCP QA handler and file-loading semantics."""
+        artifact = tmp_path / "artifact.txt"
+        artifact.write_text("candidate artifact", encoding="utf-8")
+        reference = tmp_path / "reference.txt"
+        reference.write_text("golden reference", encoding="utf-8")
+        seed = tmp_path / "seed.yaml"
+        seed.write_text("goal: test\n", encoding="utf-8")
+        handler_result = SimpleNamespace(
+            is_err=False,
+            value=SimpleNamespace(
+                content=[SimpleNamespace(text="QA Verdict [PASS]")],
+                meta={"passed": True},
+            ),
+        )
+
+        with patch(
+            "ouroboros.cli.commands.qa.QAHandler.handle",
+            new=AsyncMock(return_value=handler_result),
+        ) as mock_handle:
+            result = runner.invoke(
+                app,
+                [
+                    "qa",
+                    str(artifact),
+                    "--quality-bar",
+                    "Must match the reference.",
+                    "--artifact-type",
+                    "document",
+                    "--reference",
+                    str(reference),
+                    "--pass-threshold",
+                    "0.5",
+                    "--qa-session-id",
+                    "qa-session-test",
+                    "--seed-content",
+                    str(seed),
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "QA Verdict [PASS]" in result.output
+        mock_handle.assert_awaited_once()
+        call_args = mock_handle.await_args.args[0]
+        assert call_args == {
+            "artifact": "candidate artifact",
+            "quality_bar": "Must match the reference.",
+            "artifact_type": "document",
+            "pass_threshold": 0.5,
+            "reference": "golden reference",
+            "qa_session_id": "qa-session-test",
+            "seed_content": "goal: test\n",
+        }
 
 
 class TestInitCommand:


### PR DESCRIPTION
## Summary
- add a top-level `ouroboros qa` CLI wrapper that delegates to the MCP QAHandler
- register the command in the main Typer app
- cover help output and handler delegation/file-loading semantics with CLI tests

## Test Plan
- `uv run ruff check src/ouroboros/cli/main.py src/ouroboros/cli/commands/qa.py src/ouroboros/cli/commands/__init__.py tests/e2e/test_cli_commands.py`
- `uv run pytest tests/e2e/test_cli_commands.py -q`
- `uv run ouroboros --help | grep -E '^│ qa|qa' | head -5`
- `uv run ouroboros qa --help`