### PR TITLE
feat(outio): integration Outio platform — backend "outio" + rebrand "…

### DIFF
--- a/OUTIO.md
+++ b/OUTIO.md
@@ -1,0 +1,85 @@
+# OutioCode
+
+> Agent de code autonome qui planifie, édite, exécute et se corrige.
+> Branché sur ta plateforme [Outio](https://outio.app) — tes clés, tes
+> crédits, tes modèles. Aucune fuite vers OpenAI/Anthropic en direct.
+
+OutioCode est un fork rebrandé d'[Ouroboros](https://github.com/Q00/ouroboros)
+(MIT). Le moteur agentique est identique ; ce qui change, c'est la
+couche de routage des modèles — toutes les requêtes LLM passent par
+l'endpoint OpenAI-compatible d'Outio (`/api/v1/chat/completions`).
+
+## Installation
+
+```bash
+pipx install outio-code           # recommandé (isolé)
+# ou
+pip install outio-code             # dans ton venv courant
+```
+
+## Configuration (30 secondes)
+
+1. Va sur [outio.app/dashboard/settings?tab=integrations](https://outio.app/dashboard/settings?tab=integrations)
+   et crée une clé API. Elle commence par `outio_sk_…`.
+   *Nécessite un forfait Business* (l'API programmatique est gated).
+
+2. Exporte la clé dans ton shell :
+
+   ```bash
+   export OUTIO_API_KEY="outio_sk_..."
+   ```
+
+   Optionnel — si tu utilises une instance Outio self-hosted ou un
+   environnement non-prod :
+
+   ```bash
+   export OUTIO_API_BASE="https://outio.app/api/v1"  # défaut
+   ```
+
+3. C'est tout. Le défaut runtime est `outio` — aucune autre config requise.
+
+## Premier run
+
+```bash
+outio-code init                              # initialise un nouveau projet
+outio-code run seed.yaml                     # exécute le seed
+outio-code run seed.yaml --model claude-sonnet-4-5
+```
+
+Les `--model` acceptent les **slugs internes Outio** (`claude-sonnet-4-5`,
+`gpt-4o`, `gemini-2.5-pro`, etc.). Le catalogue complet est sur
+[outio.app/admin/models](https://outio.app/admin/models) si tu es admin,
+ou via l'API `GET https://outio.app/api/models`.
+
+## Coûts
+
+Chaque appel LLM débite tes crédits Outio selon les tarifs admin :
+- 1–30 crédits par 1M tokens prompt
+- 1–30 crédits par 1M tokens completion
+- Plancher 1 crédit par requête
+
+Tu peux suivre ta consommation en temps réel sur
+[outio.app/dashboard/plans](https://outio.app/dashboard/plans) ou via
+le champ `outio.creditsDebited` que renvoie chaque réponse.
+
+## Backends alternatifs
+
+Si tu préfères passer par ton compte Claude Code, Codex, Gemini CLI,
+Copilot CLI, Goose ou un LiteLLM en direct, change la variable d'env :
+
+```bash
+export OUROBOROS_RUNTIME=claude_code   # ou litellm, codex, gemini_cli…
+```
+
+Tous les backends Ouroboros upstream restent disponibles — OutioCode
+ajoute juste le backend `outio` et en fait le défaut.
+
+## Licence
+
+MIT, comme Ouroboros upstream. Le code applicatif (Outio platform)
+reste propriétaire à Outio ; le CLI lui-même est libre.
+
+## Crédits
+
+- Moteur agentique : [Ouroboros](https://github.com/Q00/ouroboros) par Q00 (MIT)
+- Plateforme + intégration : [Outio](https://outio.app)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,10 @@
 [project]
-name = "ouroboros-ai"
+name = "outio-code"
 dynamic = ["version"]
-description = "Specification-first workflow engine for AI coding agents. Works with Claude Code and Codex CLI."
-readme = "README.md"
+description = "OutioCode — autonomous code agent on the Outio platform. Specification-first workflow engine forked from Ouroboros (MIT)."
+readme = "OUTIO.md"
 authors = [
+    { name = "Outio", email = "support@outio.app" },
     { name = "Q00", email = "jqyu.lee@gmail.com" }
 ]
 requires-python = ">=3.12"
@@ -32,10 +33,16 @@ dashboard = [
 ]
 mcp = ["mcp>=1.26.0,<2.0.0"]
 tui = ["textual>=1.0.0,<9.0.0"]
-all = ["ouroboros-ai[claude,copilot,litellm,mcp,tui,dashboard]"]
+all = ["outio-code[claude,copilot,litellm,mcp,tui,dashboard]"]
 
 [project.scripts]
+# OutioCode est le rebranding du CLI Ouroboros. Le binaire principal
+# est `outio-code` ; `ouroboros` reste comme alias pour les utilisateurs
+# qui connaissaient le projet upstream.
+outio-code = "ouroboros.cli.main:app"
+outio = "ouroboros.cli.main:app"
 ouroboros = "ouroboros.cli.main:app"
+ooo = "ouroboros.cli.main:app"
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -244,6 +244,12 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         supports_llm=True,
         supports_interview_driver=False,
     ),
+    BackendCapability(
+        name="outio",
+        aliases=("outio_code", "outiocode"),
+        supports_llm=True,
+        supports_interview_driver=False,
+    ),
 )
 
 _BY_NAME: dict[str, BackendCapability] = {

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -1150,7 +1150,10 @@ def get_llm_backend() -> str:
         2. OUROBOROS_RUNTIME environment variable, when it names a runtime
            that also implements the LLM adapter contract
         3. config.yaml llm.backend
-        4. "claude_code"
+        4. "outio" — défaut OutioCode : la plateforme Outio expose un
+           endpoint OpenAI-compatible (clé OUTIO_API_KEY). Si l'env var
+           n'est pas définie, l'adapter lèvera une erreur explicite avec
+           le lien vers /dashboard/settings.
 
     Returns:
         Normalized LLM backend name.
@@ -1170,7 +1173,7 @@ def get_llm_backend() -> str:
         config = load_config()
         return config.llm.backend
     except ConfigError:
-        return "claude_code"
+        return "outio"
 
 
 def get_llm_permission_mode(backend: str | None = None) -> str:

--- a/src/ouroboros/providers/factory.py
+++ b/src/ouroboros/providers/factory.py
@@ -259,6 +259,45 @@ def create_llm_adapter(
             timeout=timeout,
             max_retries=max_retries,
         )
+    # Outio — endpoint OpenAI-compatible hébergé sur ton compte Outio.
+    # On délègue à LiteLLM (qui parle OpenAI-compatible) en pré-câblant
+    # api_base et api_key sur la plateforme Outio. C'est ce que le CLI
+    # `outio-code` utilise par défaut (cf. config/loader.py).
+    if resolved_backend == "outio":
+        import os
+
+        try:
+            from ouroboros.providers.litellm_adapter import LiteLLMAdapter
+        except ImportError as exc:
+            msg = (
+                "outio backend requires litellm. "
+                "Install with: pip install 'outio-code[litellm]' "
+                "(or 'ouroboros-ai[litellm]')"
+            )
+            raise RuntimeError(msg) from exc
+
+        outio_key = os.environ.get("OUTIO_API_KEY") or api_key
+        outio_base = (
+            os.environ.get("OUTIO_API_BASE")
+            or api_base
+            or "https://outio.app/api/v1"
+        )
+        if not outio_key:
+            msg = (
+                "Outio backend requires OUTIO_API_KEY env var. "
+                "Get one at https://outio.app/dashboard/settings?tab=integrations "
+                "(Business plan required)."
+            )
+            raise RuntimeError(msg)
+
+        return LiteLLMAdapter(
+            api_key=outio_key,
+            api_base=outio_base,
+            timeout=timeout,
+            max_retries=max_retries,
+            io_recorder=io_recorder,
+        )
+
     # litellm is the fallback
     try:
         from ouroboros.providers.litellm_adapter import LiteLLMAdapter


### PR DESCRIPTION
…outio-code"

Cinq changements minimalistes, aucun touchant la boucle agentique :

1. backends/capabilities.py — déclare le backend "outio" comme un LLM provider (alias: outio_code, outiocode). supports_llm=True.

2. providers/factory.py — gère resolved_backend == "outio" en instanciant LiteLLMAdapter pré-câblé sur l'API Outio : api_key  ← env OUTIO_API_KEY  (sinon erreur explicite avec lien /dashboard/settings) api_base ← env OUTIO_API_BASE (défaut https://outio.app/api/v1) LiteLLM gère déjà OpenAI-compatible — aucun nouveau code de provider.

3. config/loader.py — change le défaut fallback de "claude_code" à "outio". Un install fresh \`pipx install outio-code\` n'a donc plus qu'à définir OUTIO_API_KEY pour fonctionner. Si l'env var manque, l'adapter lève une RuntimeError avec l'URL settings.

4. pyproject.toml — rebrand : name=outio-code, binaires outio-code + outio + ouroboros (rétro-compat), readme=OUTIO.md, authors+=Outio.

5. OUTIO.md — README user-facing : install, config 30s, premier run, coûts crédits, backends alternatifs, licence, crédits Ouroboros.

Le package Python reste \`ouroboros\` (pas de renommage des imports) pour préserver la compat avec les upstream merges futurs.