### PR TITLE
fix(orchestrator): extend AC stall watchdog budget

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1476,7 +1476,7 @@ _AC_RUNTIME_SCOPE_METADATA_KEYS = frozenset(
 _AC_RUNTIME_RESUME_METADATA_KEYS = frozenset({"runtime_event_type", "server_session_id"})
 
 # Stall detection constants
-STALL_TIMEOUT_SECONDS: float = 300.0  # 5 minutes of silence → stall
+STALL_TIMEOUT_SECONDS: float = 900.0  # 15 minutes of silence → stall for realistic test suites
 HEARTBEAT_INTERVAL_SECONDS: float = 30.0  # Heartbeat emission interval
 MAX_STALL_RETRIES: int = 2  # Max retries after stall (3 total attempts)
 _STALL_SENTINEL = "__STALL_DETECTED__"  # Sentinel error for stall results

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -41,6 +41,11 @@ from ouroboros.orchestrator.profile_loader import EvidenceSchema, load_profile
 from ouroboros.orchestrator.verifier import VerifierVerdict
 
 
+def test_stall_timeout_default_allows_realistic_test_suites() -> None:
+    """The default stall watchdog should not kill long quiet test commands too early."""
+    assert STALL_TIMEOUT_SECONDS == 900.0
+
+
 def _make_seed(*acceptance_criteria: str) -> Seed:
     """Build a minimal seed for parallel executor tests."""
     return Seed(


### PR DESCRIPTION
## Summary
- Raise the parallel executor AC stall watchdog default from 300s to 900s so realistic Testcontainers/CI-style suites have enough quiet runtime budget.
- Add a regression test locking the default stall budget at 900s.

Closes #1232

## Test plan
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py -q` — 202 passed
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py` — passed
- `uv run ruff format --check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py` — passed

_Posted by [agentos-roadmap-warden](https://github.com/Q00/ouroboros/blob/main/agents/agentos-roadmap-warden.md) — bot. Reply with `/warden ignore` to suppress further comments on this thread._