### PR TITLE
docs(installer): clarify PyPI prerelease lookup

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -47,7 +47,7 @@ elif [ -f "$(dirname "$0")/../pyproject.toml" ] && grep -q "name = \"ouroboros-a
   IS_LOCAL=true
 fi
 
-# Auto-detect: if PyPI's latest published version is a pre-release, allow
+# Auto-detect: if PyPI's info.version response is a pre-release, allow
 # pre-releases. On lookup/parsing failure, stay stable-only.
 PRE_FLAG=""
 if [ "$IS_LOCAL" = false ] && command -v curl &>/dev/null; then


### PR DESCRIPTION
Follow-up for #1217.\n\nAddresses the approved non-blocking documentation finding by tightening the installer comment to match the stable-only PyPI lookup behavior.\n\nSupersedes closed stacked PR #1228, which GitHub closed when the parent branch was deleted after #1217 merged.