### PR TITLE
fix(orchestrator): tolerate gradle verifier evidence

### DIFF
--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1056,12 +1056,41 @@ def _strip_env_prefix(parts: list[str]) -> list[str]:
 
 def _has_gradle_or_maven_test_skip(parts: list[str]) -> bool:
     """Return True when a Gradle/Maven command explicitly disables tests."""
+
+    def maven_skip_property_disables_tests(value: str) -> bool:
+        normalized_value = value.lower()
+        if normalized_value in {"skiptests", "maven.test.skip"}:
+            return True
+        if normalized_value.startswith("skiptests=") or normalized_value.startswith(
+            "maven.test.skip="
+        ):
+            _, _, property_value = normalized_value.partition("=")
+            return property_value not in {"false", "0", "no", "off"}
+        return False
+
     for index, part in enumerate(parts):
         normalized = part.lower()
-        if normalized in {"-dskiptests", "-dskiptests=true", "-dmaven.test.skip=true"}:
+        if normalized == "-d" and index + 1 < len(parts):
+            if maven_skip_property_disables_tests(parts[index + 1]):
+                return True
+        if normalized == "--define" and index + 1 < len(parts):
+            if maven_skip_property_disables_tests(parts[index + 1]):
+                return True
+        if normalized.startswith("--define="):
+            _, _, define_value = normalized.partition("=")
+            if maven_skip_property_disables_tests(define_value):
+                return True
+        if normalized.startswith("-d") and maven_skip_property_disables_tests(normalized[2:]):
             return True
-        if normalized.startswith("-dskiptests=") or normalized.startswith("-dmaven.test.skip="):
-            return True
+        if normalized == "--exclude-task" and index + 1 < len(parts):
+            excluded_task = parts[index + 1].lower().lstrip(":")
+            if excluded_task == "test" or excluded_task.endswith(":test"):
+                return True
+        if normalized.startswith("--exclude-task="):
+            _, _, excluded_task = normalized.partition("=")
+            excluded_task = excluded_task.lstrip(":")
+            if excluded_task == "test" or excluded_task.endswith(":test"):
+                return True
         if normalized == "-x" and index + 1 < len(parts):
             excluded_task = parts[index + 1].lower().lstrip(":")
             if excluded_task == "test" or excluded_task.endswith(":test"):
@@ -1323,7 +1352,9 @@ def _text_contains_test_success(text: str) -> bool:
     """Return True when text contains a conservative test-success signal."""
     text = text.lower()
     zero_failure_pattern = (
-        r"\b(0\s+(failed|failures?|errors?)|no\s+(tests?\s+)?(failed|failures?|errors?))\b"
+        r"\b(0\s+(failed|failures?|errors?)|"
+        r"(failed|failures?|errors?)\s*:\s*0|"
+        r"no\s+(tests?\s+)?(failed|failures?|errors?))\b"
     )
     failure_scan_text = re.sub(zero_failure_pattern, "", text)
     if re.search(
@@ -1334,6 +1365,12 @@ def _text_contains_test_success(text: str) -> bool:
     ):
         return False
     if re.search(r"\b0\s+passed\b", text) and not re.search(r"\b[1-9]\d*\s+passed\b", text):
+        return False
+    if re.search(r"\btask\s+[:\w.-]*test\b[^\n]*(no-source|skipped)\b", text):
+        return False
+    if re.search(r"\b0\s+tests?\s+(completed|run|executed)\b", text):
+        return False
+    if re.search(r"\bno\s+tests?\s+(found|run|executed)\b", text):
         return False
     return bool(
         re.search(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1353,7 +1353,7 @@ def _text_contains_test_success(text: str) -> bool:
     text = text.lower()
     zero_failure_pattern = (
         r"\b(0\s+(failed|failures?|errors?)|"
-        r"(failed|failures?|errors?)\s*:\s*0|"
+        r"(failed|failures?|errors?)\s*[:=]\s*0|"
         r"no\s+(tests?\s+)?(failed|failures?|errors?))\b"
     )
     failure_scan_text = re.sub(zero_failure_pattern, "", text)

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1054,6 +1054,25 @@ def _strip_env_prefix(parts: list[str]) -> list[str]:
     return parts[index:]
 
 
+def _has_gradle_or_maven_test_skip(parts: list[str]) -> bool:
+    """Return True when a Gradle/Maven command explicitly disables tests."""
+    for index, part in enumerate(parts):
+        normalized = part.lower()
+        if normalized in {"-dskiptests", "-dskiptests=true", "-dmaven.test.skip=true"}:
+            return True
+        if normalized.startswith("-dskiptests=") or normalized.startswith("-dmaven.test.skip="):
+            return True
+        if normalized == "-x" and index + 1 < len(parts):
+            excluded_task = parts[index + 1].lower().lstrip(":")
+            if excluded_task == "test" or excluded_task.endswith(":test"):
+                return True
+        if normalized.startswith("-x") and len(normalized) > 2:
+            excluded_task = normalized[2:].lstrip(":")
+            if excluded_task == "test" or excluded_task.endswith(":test"):
+                return True
+    return False
+
+
 def _test_invocation_from_prefix(command: str) -> str | None:
     """Return a normalized test invocation only when it starts the command text.
 
@@ -1091,6 +1110,13 @@ def _test_invocation_from_prefix(command: str) -> str | None:
         }
     ):
         return _normalized_evidence_text(" ".join(parts))
+    executable = Path(parts[0]).name
+    if (
+        executable in {"gradle", "gradlew", "mvn", "mvnw"}
+        and not _has_gradle_or_maven_test_skip(parts[1:])
+        and any(part in {"test", "check", "verify"} or part.endswith(":test") for part in parts[1:])
+    ):
+        return _normalized_evidence_text(" ".join(parts))
     return None
 
 
@@ -1126,6 +1152,27 @@ _OUTPUT_FILTER_COMMANDS = frozenset({"tail", "head", "cat", "less", "more"})
 _TRAILING_REDIRECT_RE = re.compile(
     r"\s*(?:[0-9]*>{1,2}\s*(?:&[0-9]+|[^\s|]+)|&>{1,2}\s*[^\s|]+)\s*$"
 )
+
+
+def _normalized_shell_words_text(command: str) -> str | None:
+    """Return a quote-insensitive normalized argv spelling for one shell command.
+
+    This keeps command evidence matching exact at the argv level while allowing
+    common shell spelling differences such as ``--tests "ClassName"`` versus
+    ``--tests ClassName``. Commands that cannot be parsed, still contain a
+    pipeline, or contain shell control operators are left to the stricter raw
+    aliases.
+    """
+    text = command.strip()
+    if not text:
+        return None
+    try:
+        parts = shlex.split(text)
+    except ValueError:
+        return None
+    if not parts or any(part in {"|", "&&", ";", "||"} for part in parts):
+        return None
+    return _normalized_evidence_text(" ".join(parts))
 
 
 def _strip_command_output_plumbing(command: str) -> str:
@@ -1231,19 +1278,27 @@ def _normalized_command_claim_aliases(command: str) -> tuple[str, ...]:
     """
     normalized = _normalized_evidence_text(command)
     aliases = [normalized] if normalized else []
+
+    def append_alias(candidate: str | None) -> None:
+        if candidate and candidate not in aliases:
+            aliases.append(candidate)
+
+    append_alias(_normalized_shell_words_text(command))
     shell_body = _shell_command_body(command)
     normalized_shell_body = _normalized_evidence_text(shell_body) if shell_body else None
-    if normalized_shell_body and normalized_shell_body not in aliases:
-        aliases.append(normalized_shell_body)
+    append_alias(normalized_shell_body)
+    append_alias(_normalized_shell_words_text(shell_body) if shell_body else None)
     test_invocation = _test_command_invocation(command)
-    if test_invocation and test_invocation not in aliases:
-        aliases.append(test_invocation)
+    append_alias(test_invocation)
     # A recorded command may append output plumbing (``... 2>&1 | tail -20``)
     # that a concise ``commands_run`` claim omits. Add plumbing-stripped variants
     # so the two still match. Alias matching stays exact (set intersection), so
-    # this does not widen proof to arbitrary substrings.
+    # this does not widen proof to arbitrary substrings. Also add argv-normalized
+    # plumbing-stripped forms so quoted arguments in the runtime command match
+    # unquoted evidence claims for the same argv vector.
     for base in tuple(aliases):
-        stripped = _normalized_evidence_text(_strip_command_output_plumbing(base))
+        stripped_raw = _strip_command_output_plumbing(base)
+        stripped = _normalized_evidence_text(stripped_raw)
         if (
             stripped
             and stripped != base
@@ -1252,8 +1307,8 @@ def _normalized_command_claim_aliases(command: str) -> tuple[str, ...]:
             and not _output_filter_pipeline_is_pipefail_protected(base)
         ):
             continue
-        if stripped and stripped not in aliases:
-            aliases.append(stripped)
+        append_alias(stripped)
+        append_alias(_normalized_shell_words_text(stripped_raw))
     return tuple(aliases)
 
 
@@ -1281,7 +1336,11 @@ def _text_contains_test_success(text: str) -> bool:
     if re.search(r"\b0\s+passed\b", text) and not re.search(r"\b[1-9]\d*\s+passed\b", text):
         return False
     return bool(
-        re.search(r"\b([1-9]\d*\s+passed|passed|pass|success|succeeded)\b|exit\s*code\s*0", text)
+        re.search(
+            r"\b([1-9]\d*\s+passed|passed|pass|success|successful|succeeded)\b|"
+            r"\bbuild\s+successful\b|exit\s*code\s*0",
+            text,
+        )
         or re.search(r"\bran\s+[1-9]\d*\s+tests?\b[\s\S]*\bok\b", text)
     )
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -837,6 +837,8 @@ def _make_replaying_event_store() -> tuple[AsyncMock, list[BaseEvent]]:
         ("0 failed, 0 errors, 1 passed", True),
         ("Tests run: 3, Failures: 0, Errors: 0, Skipped: 0", False),
         ("Tests run: 3, Failures: 1, Errors: 0, Skipped: 0", False),
+        ("Tests run: 3, Failures: 0, Errors: 0, Skipped: 0\n[INFO] BUILD SUCCESS", True),
+        ("Tests run: 3, Failures=0, Errors=0, Skipped=0\n[INFO] BUILD SUCCESS", True),
         ("no errors, 3 passed", True),
         ("no tests failed, 3 passed", True),
         ("exit code 0", True),

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -34,6 +34,7 @@ from ouroboros.orchestrator.parallel_executor import (
     _effective_evidence_schema_for_ac,
     _message_contains_test_success,
     _runtime_messages_support_command_claim,
+    _runtime_messages_support_test_claim,
     render_parallel_completion_message,
     render_parallel_verification_report,
 )
@@ -1101,6 +1102,59 @@ def test_command_claim_rejects_inner_command_after_non_setup_preamble() -> None:
     assert not _runtime_messages_support_command_claim(
         "python scripts/generate.py",
         (message,),
+    )
+
+
+def test_gradle_command_claim_supports_quoted_target_and_tail_pipe() -> None:
+    """A clean Gradle claim matches a quoted runtime command with output plumbing."""
+    message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={
+            "tool_input": {
+                "command": (
+                    './gradlew test --tests "com.example.app.unit.SomeNewTest" -i 2>&1 | tail -100'
+                )
+            }
+        },
+    )
+
+    assert _runtime_messages_support_command_claim(
+        "./gradlew test --tests com.example.app.unit.SomeNewTest -i",
+        (message,),
+    )
+
+
+def test_gradle_tests_passed_claim_supports_class_target_and_build_success() -> None:
+    """Gradle BUILD SUCCESSFUL output can back a class-level tests_passed claim."""
+    command_message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={
+            "tool_input": {
+                "command": (
+                    './gradlew test --tests "com.example.app.unit.SomeNewTest" -i 2>&1 | tail -100'
+                )
+            }
+        },
+    )
+    result_message = AgentMessage(
+        type="tool_result",
+        content="> Task :test\nBUILD SUCCESSFUL in 8s",
+        tool_name=None,
+        data={
+            "subtype": "tool_result",
+            "output": "> Task :test\nBUILD SUCCESSFUL in 8s",
+        },
+    )
+
+    assert _runtime_messages_support_test_claim(
+        value="com.example.app.unit.SomeNewTest",
+        backed_commands=("./gradlew test --tests com.example.app.unit.SomeNewTest -i",),
+        messages=(command_message, result_message),
+        task_cwd=None,
     )
 
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -835,6 +835,8 @@ def _make_replaying_event_store() -> tuple[AsyncMock, list[BaseEvent]]:
         ("3 passed in 1.2s", True),
         ("0 failed, 3 passed", True),
         ("0 failed, 0 errors, 1 passed", True),
+        ("Tests run: 3, Failures: 0, Errors: 0, Skipped: 0", False),
+        ("Tests run: 3, Failures: 1, Errors: 0, Skipped: 0", False),
         ("no errors, 3 passed", True),
         ("no tests failed, 3 passed", True),
         ("exit code 0", True),
@@ -1114,7 +1116,8 @@ def test_gradle_command_claim_supports_quoted_target_and_tail_pipe() -> None:
         data={
             "tool_input": {
                 "command": (
-                    './gradlew test --tests "com.example.app.unit.SomeNewTest" -i 2>&1 | tail -100'
+                    "/bin/bash -lc 'set -o pipefail && ./gradlew test "
+                    '--tests "com.example.app.unit.SomeNewTest" -i 2>&1 | tail -100\''
                 )
             }
         },
@@ -1135,7 +1138,8 @@ def test_gradle_tests_passed_claim_supports_class_target_and_build_success() -> 
         data={
             "tool_input": {
                 "command": (
-                    './gradlew test --tests "com.example.app.unit.SomeNewTest" -i 2>&1 | tail -100'
+                    "/bin/bash -lc 'set -o pipefail && ./gradlew test "
+                    '--tests "com.example.app.unit.SomeNewTest" -i 2>&1 | tail -100\''
                 )
             }
         },
@@ -1153,6 +1157,131 @@ def test_gradle_tests_passed_claim_supports_class_target_and_build_success() -> 
     assert _runtime_messages_support_test_claim(
         value="com.example.app.unit.SomeNewTest",
         backed_commands=("./gradlew test --tests com.example.app.unit.SomeNewTest -i",),
+        messages=(command_message, result_message),
+        task_cwd=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("runtime_command", "claimed_command"),
+    (
+        ("./gradlew test -x test", "./gradlew test -x test"),
+        ("./gradlew check -x test", "./gradlew check -x test"),
+        ("./gradlew test --exclude-task test", "./gradlew test --exclude-task test"),
+        ("./gradlew check --exclude-task :test", "./gradlew check --exclude-task :test"),
+        ("mvn -DskipTests verify", "mvn -DskipTests verify"),
+        ("mvn -D skipTests test", "mvn -D skipTests test"),
+        ("mvn -Dmaven.test.skip=true test", "mvn -Dmaven.test.skip=true test"),
+        ("mvn --define skipTests test", "mvn --define skipTests test"),
+        ("mvn --define=skipTests=true test", "mvn --define=skipTests=true test"),
+    ),
+)
+def test_gradle_maven_tests_passed_rejects_skip_test_invocations(
+    runtime_command: str,
+    claimed_command: str,
+) -> None:
+    """Build success cannot prove tests_passed when the command skipped tests."""
+    command_message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={"tool_input": {"command": runtime_command}},
+    )
+    result_message = AgentMessage(
+        type="tool_result",
+        content="BUILD SUCCESSFUL in 8s",
+        tool_name=None,
+        data={"subtype": "tool_result", "output": "BUILD SUCCESSFUL in 8s"},
+    )
+
+    assert not _runtime_messages_support_test_claim(
+        value=claimed_command,
+        backed_commands=(claimed_command,),
+        messages=(command_message, result_message),
+        task_cwd=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "mvn -DskipTests=false test",
+        "mvn -Dmaven.test.skip=false test",
+    ),
+)
+def test_maven_tests_passed_supports_explicit_false_skip_properties(command: str) -> None:
+    """Explicit false Maven skip properties still run tests and can prove success."""
+    command_message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={"tool_input": {"command": command}},
+    )
+    result_message = AgentMessage(
+        type="tool_result",
+        content="[INFO] BUILD SUCCESS",
+        tool_name=None,
+        data={"subtype": "tool_result", "output": "[INFO] BUILD SUCCESS"},
+    )
+
+    assert _runtime_messages_support_test_claim(
+        value=command,
+        backed_commands=(command,),
+        messages=(command_message, result_message),
+        task_cwd=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "output",
+    (
+        "> Task :test NO-SOURCE\nBUILD SUCCESSFUL in 1s",
+        "> Task :test SKIPPED\nBUILD SUCCESSFUL in 1s",
+        "0 tests completed\nBUILD SUCCESSFUL",
+    ),
+)
+def test_gradle_tests_passed_rejects_successful_build_with_no_tests(output: str) -> None:
+    """Gradle build success without executed tests cannot prove tests_passed."""
+    command_message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={"tool_input": {"command": "./gradlew test"}},
+    )
+    result_message = AgentMessage(
+        type="tool_result",
+        content=output,
+        tool_name=None,
+        data={"subtype": "tool_result", "output": output},
+    )
+
+    assert not _runtime_messages_support_test_claim(
+        value="./gradlew test",
+        backed_commands=("./gradlew test",),
+        messages=(command_message, result_message),
+        task_cwd=None,
+    )
+
+
+def test_maven_tests_passed_supports_surefire_zero_failure_summary() -> None:
+    """Standard Surefire zero-failure fields plus build success prove Maven tests."""
+    output = "[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0\n[INFO] BUILD SUCCESS"
+    command_message = AgentMessage(
+        type="tool",
+        content="Bash command started",
+        tool_name="Bash",
+        data={"tool_input": {"command": "mvn test"}},
+    )
+    result_message = AgentMessage(
+        type="tool_result",
+        content=output,
+        tool_name=None,
+        data={"subtype": "tool_result", "output": output},
+    )
+
+    assert _runtime_messages_support_test_claim(
+        value="mvn test",
+        backed_commands=("mvn test",),
         messages=(command_message, result_message),
         task_cwd=None,
     )


### PR DESCRIPTION
## Summary
- Normalize shell argv spellings so quoted runtime arguments match equivalent unquoted command evidence.
- Recognize Gradle/Maven test commands as test invocations for verifier anchoring.
- Treat Gradle `BUILD SUCCESSFUL` output as a conservative test-success signal and cover the reported quoted + pipefail-protected tail-pipe case with regressions.
- Preserve the merged status-masking pipeline gate from #1208: unprotected test pipelines still do not prove clean command evidence.

Refs #1234

## Test plan
- `uv run pytest tests/unit/orchestrator/test_parallel_executor.py -q` — 207 passed
- `uv run ruff check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py` — passed
- `uv run ruff format --check src/ouroboros/orchestrator/parallel_executor.py tests/unit/orchestrator/test_parallel_executor.py` — passed

_Posted by [agentos-roadmap-warden](https://github.com/Q00/ouroboros/blob/main/agents/agentos-roadmap-warden.md) — bot. Reply with `/warden ignore` to suppress further comments on this thread._
