### PR TITLE
fix(auto): generalize safe-default stop reason

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -32,7 +32,7 @@ from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 
 log = structlog.get_logger(__name__)
 
-INTERVIEW_SAFE_DEFAULT_SYNTHESIS_STOP_REASON_CODE = "interview_safe_default_synthesis_nonclosure"
+INTERVIEW_SAFE_DEFAULT_SYNTHESIS_STOP_REASON_CODE = "interview_safe_default_synthesis_incomplete"
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -846,7 +846,7 @@ async def test_interview_driver_rolls_back_defaults_when_synthesis_sync_fails(tm
     assert result.status == "blocked"
     assert state.interview_completed is False
     assert "transcript sync failed" in (result.blocker or "")
-    assert state.last_error_code == "interview_safe_default_synthesis_nonclosure"
+    assert state.last_error_code == "interview_safe_default_synthesis_incomplete"
     assert ledger.open_gaps()
     assert not any(
         entry.key == f"{section_name}.safe_default_finalization"
@@ -882,7 +882,7 @@ async def test_interview_driver_blocks_when_synthesis_does_not_close_backend(tmp
     assert state.interview_completed is False
     assert state.pending_question == "Still need one more thing"
     assert "did not close the persisted interview" in (result.blocker or "")
-    assert state.last_error_code == "interview_safe_default_synthesis_nonclosure"
+    assert state.last_error_code == "interview_safe_default_synthesis_incomplete"
     assert ledger.open_gaps()
     assert not any(
         entry.key == f"{section_name}.safe_default_finalization"


### PR DESCRIPTION
Follow-up for #1220.\n\nRenames the safe-default synthesis stop reason from `nonclosure` to `incomplete` so it covers both transcript-sync failure and backend nonclosure paths.\n\nValidation:\n- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run pytest tests/unit/auto/test_interview_pipeline.py::test_interview_driver_rolls_back_defaults_when_synthesis_sync_fails tests/unit/auto/test_interview_pipeline.py::test_interview_driver_blocks_when_synthesis_does_not_close_backend -q`