### PR TITLE
fix(test): sort pm handler imports

### DIFF
--- a/tests/unit/mcp/tools/test_pm_handler.py
+++ b/tests/unit/mcp/tools/test_pm_handler.py
@@ -17,8 +17,8 @@ from ouroboros.bigbang.question_classifier import (
 from ouroboros.core.types import Result
 from ouroboros.mcp.tools.pm_handler import (
     _DATA_DIR,
-    PMInterviewHandler,
     PM_UNCERTAINTY_GUIDANCE,
+    PMInterviewHandler,
     _check_completion,
     _compute_deferred_diff,
     _detect_action,


### PR DESCRIPTION
Fixes the Ruff import-order failure currently inherited by new PRs from main.\n\nValidation:\n- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run ruff check src/ tests/`