### PR TITLE
feat(auto): safe-default lateral escalation substrate (#1248 PR-A, additive, behavior unchanged)

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -7,8 +7,13 @@ from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 import inspect
 import re
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 from uuid import uuid4
+
+if TYPE_CHECKING:
+    # Imported under TYPE_CHECKING to avoid a runtime cycle: adapters.py
+    # imports ``InterviewBackend`` / ``InterviewTurn`` from this module.
+    from ouroboros.auto.adapters import LateralResult
 
 import structlog
 
@@ -33,6 +38,22 @@ from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 log = structlog.get_logger(__name__)
 
 INTERVIEW_SAFE_DEFAULT_SYNTHESIS_STOP_REASON_CODE = "interview_safe_default_synthesis_incomplete"
+
+# Issue #1248 — L5 ladder typed terminal for a safe-default lateral escalation
+# that exhausted every available persona without resolving the matcher fire.
+# Mirrors the runtime ``watchdog_wall_clock_exceeded`` / interview
+# ``interview_unsafe_gaps_remain`` patterns: a module-level const so callers
+# emit the same string, and so the alphabet of valid stop_reason_code values
+# can be discovered by reading the module surface.
+UNSTUCK_EXHAUSTED_STOP_REASON_CODE = "unstuck_exhausted"
+
+# Structural alias for the production lateral-thinker callable. Mirrors the
+# alias declared on ``ouroboros.auto.pipeline``; duplicated locally because
+# ``adapters.LateralResult`` cannot be imported at module load time without
+# creating a cycle (adapters imports ``InterviewBackend`` from this module).
+# At runtime the alias is just ``Callable[..., Awaitable[Any]]``; the typing
+# block above gives mypy the precise return type.
+LateralThinker = Callable[..., Awaitable["LateralResult"]]
 
 
 @dataclass(frozen=True, slots=True)
@@ -105,6 +126,14 @@ class AutoInterviewDriver:
     timeout_seconds: float = 60.0
     max_rounds: int = 12
     progress_callback: AutoProgressCallback | None = None
+    # Issue #1248 — optional lateral-thinker handle used by the safe-default
+    # escalation path to disambiguate matcher-fire false positives from
+    # real unsafe scope before falling to BLOCKED. ``None`` preserves the
+    # pre-issue behavior (matcher fire → immediate
+    # ``interview_unsafe_gaps_remain`` BLOCKED), so existing call sites and
+    # tests that construct the driver without this argument are unaffected.
+    # The behavior change that consumes this field ships in a separate PR.
+    lateral_thinker: LateralThinker | None = None
     _last_emitted_message: str | None = field(default=None, init=False, repr=False)
 
     def _emit(self, state: AutoPipelineState) -> None:

--- a/src/ouroboros/auto/lateral_routing.py
+++ b/src/ouroboros/auto/lateral_routing.py
@@ -160,7 +160,65 @@ def select_persona_for_qa_failure(
     return None
 
 
+# Selection order for the safe-default unsafe-context matcher escalation
+# (Issue #1248). Distinct from the QA-failure pattern selector because the
+# safe-default matcher fires on lexical false positives in the matcher input
+# (e.g. the word "contract" inside an SE phrase like "acceptance contract"),
+# not on a QA failure shape. The two personas best suited to disambiguating
+# *"is this benign vocabulary, or genuinely unsafe scope?"* are:
+#
+# * **CONTRARIAN** — inverts the matcher's assumption ("this looks unsafe")
+#   and asks whether the surrounding context actually authorizes the unsafe
+#   reading. First because false positives are the dominant case.
+# * **ARCHITECT** — restructures the ledger framing if CONTRARIAN cannot
+#   resolve the call, surfacing the scope decision instead of leaving the
+#   matcher to guess.
+#
+# After both have been tried in the same session, the caller transitions to
+# BLOCKED with stop_reason_code ``unstuck_exhausted`` — the L5 invariant's
+# typed terminal rather than another regex stalemate.
+_SAFE_DEFAULT_BLOCK_CHAIN: tuple[ThinkingPersona, ...] = (
+    ThinkingPersona.CONTRARIAN,
+    ThinkingPersona.ARCHITECT,
+)
+
+
+def select_persona_for_safe_default_block(
+    *,
+    already_tried_personas: Sequence[ThinkingPersona] = (),
+) -> ThinkingPersona | None:
+    """Pick a persona for a safe-default unsafe-context matcher fire.
+
+    Issue #1248 — when ``_unsafe_context_reason()`` flags a safe-default
+    closure attempt, the L5 ladder requires escalation through a lateral
+    persona before falling to BLOCKED. This selector is the matcher's
+    equivalent of :func:`select_persona_for_qa_failure`, but tailored to a
+    *matcher self-trigger* signal (not a QA failure shape):
+
+    1. **CONTRARIAN** — first attempt. Optimised for lexical false
+       positives (e.g. "acceptance contract", "license: MIT", "SOC2
+       compliance check") that share vocabulary with the matcher's
+       alternation bank but do not assert active unsafe scope.
+    2. **ARCHITECT** — second attempt. Restructures the ledger framing
+       when CONTRARIAN's inversion was already tried and a non-trivial
+       scope decision remains.
+    3. ``None`` — both attempts exhausted. The caller surfaces a typed
+       ``unstuck_exhausted`` BLOCKED.
+
+    Deterministic: same ``already_tried_personas`` always yields the same
+    result, so the resume contract (mapped through
+    ``state.personas_invoked``) holds without persisting a separate
+    routing hint.
+    """
+    tried = frozenset(already_tried_personas)
+    for persona in _SAFE_DEFAULT_BLOCK_CHAIN:
+        if persona not in tried:
+            return persona
+    return None
+
+
 __all__ = [
     "classify_qa_failure_to_pattern",
     "select_persona_for_qa_failure",
+    "select_persona_for_safe_default_block",
 ]

--- a/tests/unit/auto/test_lateral_routing_safe_default.py
+++ b/tests/unit/auto/test_lateral_routing_safe_default.py
@@ -1,0 +1,84 @@
+"""Unit tests for the safe-default unsafe-context lateral persona selector.
+
+Issue #1248 — substrate-only PR (no behavior change). The selector picks
+``ThinkingPersona`` values to escalate a ``_unsafe_context_reason()`` fire
+through, instead of letting the safe-default closure die in place. These
+tests pin the selection contract; the behavior PR that consumes the
+selector lands separately.
+"""
+
+from __future__ import annotations
+
+from ouroboros.auto.lateral_routing import select_persona_for_safe_default_block
+from ouroboros.resilience.lateral import ThinkingPersona
+
+
+def test_selects_contrarian_first_when_nothing_tried() -> None:
+    """First escalation prefers CONTRARIAN — best fit for matcher false positives."""
+    assert select_persona_for_safe_default_block() is ThinkingPersona.CONTRARIAN
+
+
+def test_selects_architect_after_contrarian_tried() -> None:
+    """Second escalation prefers ARCHITECT once CONTRARIAN is exhausted."""
+    assert (
+        select_persona_for_safe_default_block(
+            already_tried_personas=(ThinkingPersona.CONTRARIAN,),
+        )
+        is ThinkingPersona.ARCHITECT
+    )
+
+
+def test_returns_none_when_chain_exhausted() -> None:
+    """No further persona is offered after both escalation slots fire.
+
+    The caller transitions to BLOCKED with ``unstuck_exhausted`` instead
+    of recycling a stale persona.
+    """
+    assert (
+        select_persona_for_safe_default_block(
+            already_tried_personas=(
+                ThinkingPersona.CONTRARIAN,
+                ThinkingPersona.ARCHITECT,
+            ),
+        )
+        is None
+    )
+
+
+def test_extra_unrelated_personas_in_history_do_not_advance_chain() -> None:
+    """Irrelevant personas (HACKER/RESEARCHER/SIMPLIFIER) in history are ignored.
+
+    The safe-default chain only consumes its own two slots — the chain is
+    independent of the QA-failure chain so concurrent EVALUATE rounds do
+    not bleed exhaustion state across.
+    """
+    assert (
+        select_persona_for_safe_default_block(
+            already_tried_personas=(
+                ThinkingPersona.HACKER,
+                ThinkingPersona.RESEARCHER,
+                ThinkingPersona.SIMPLIFIER,
+            ),
+        )
+        is ThinkingPersona.CONTRARIAN
+    )
+
+
+def test_selector_is_deterministic_across_calls() -> None:
+    """Same input always yields the same output — required by the resume contract."""
+    first = select_persona_for_safe_default_block()
+    second = select_persona_for_safe_default_block()
+    assert first is second
+
+
+def test_order_of_already_tried_does_not_matter() -> None:
+    """Selection is set-based, not order-based."""
+    forward = select_persona_for_safe_default_block(
+        already_tried_personas=(ThinkingPersona.CONTRARIAN,),
+    )
+    reverse = select_persona_for_safe_default_block(
+        already_tried_personas=(ThinkingPersona.ARCHITECT,),
+    )
+    # CONTRARIAN tried -> ARCHITECT next; ARCHITECT tried -> CONTRARIAN next.
+    assert forward is ThinkingPersona.ARCHITECT
+    assert reverse is ThinkingPersona.CONTRARIAN


### PR DESCRIPTION
## Summary

Additive substrate for #1248. **No behavior change.** The follow-up PR-B consumes these substrate bits to route `_unsafe_context_reason()` matcher fires through a lateral persona instead of letting the safe-default closure die in place (SSOT #1157 L5 invariant).

Refs #1248, SSOT #1157.

## What ships

- **New selector** `select_persona_for_safe_default_block(*, already_tried_personas)` in `src/ouroboros/auto/lateral_routing.py`. Deterministic `CONTRARIAN → ARCHITECT → None` chain. Distinct from `select_persona_for_qa_failure` because the input signal is a matcher fire (lexical false positive vs real unsafe scope), not a QA failure shape.
- **New module-level constant** `UNSTUCK_EXHAUSTED_STOP_REASON_CODE = "unstuck_exhausted"` in `src/ouroboros/auto/interview_driver.py`, mirroring the existing `INTERVIEW_SAFE_DEFAULT_SYNTHESIS_STOP_REASON_CODE` and `WATCHDOG_STOP_REASON_CODE` pattern (alphabet discoverable from module surface).
- **New optional field** `lateral_thinker: LateralThinker | None = None` on `AutoInterviewDriver` dataclass. `LateralThinker` is aliased locally because `adapters.LateralResult` cannot be imported at module load without creating a cycle (adapters imports `InterviewBackend` from `interview_driver`). The runtime type is `Callable[..., Awaitable[Any]]`; the precise return type is supplied to mypy via a `TYPE_CHECKING` block.
- **Unit tests** in `tests/unit/auto/test_lateral_routing_safe_default.py` pinning the selector chain (CONTRARIAN first, ARCHITECT fallback, `None` when exhausted, set-based selection independent of unrelated personas in history).

## Why this is safe to land standalone

- The new field defaults to `None`, so every existing call site (`mcp/tools/auto_handler.py:415`, `cli/commands/auto.py:475`, all unit tests under `tests/unit/auto/`) stays on the exact pre-existing code path.
- The new selector is pure, deterministic, no I/O, no shared state. Same input always yields the same output, so the resume contract is preserved without persisting a separate routing hint.
- The new constant adds an additional valid value to the typed `stop_reason_code` alphabet but is not yet emitted anywhere.
- 0 new EventStore event families, 0 new `AutoPhase` values, 0 changes to L4 envelope fields, 0 changes to the resume contract.

## Why this is not over-engineered

- Adds ~120 LoC across 3 files (1 selector + 1 constant + 1 field + 1 test module).
- Reuses existing `ThinkingPersona` enum, `personas_invoked` state, and the `LateralThinker` callable shape from `pipeline.py`. No new abstractions.
- Out of scope:
  - Regex tightening of `_UNSAFE_CONTEXT_PATTERNS` (explicitly rejected as whack-a-mole — see #1248 *Why not just tighten the regex*).
  - Behavior wiring (the call site that consumes `lateral_thinker`) — ships in PR-B.
  - Driver construction at `auto_handler.py` / `cli/commands/auto.py` — only updated in PR-B when the field is actually consumed.

## Verification

```
$ SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run pytest \
    tests/unit/auto/test_lateral_routing_safe_default.py -v
# 6 passed

$ SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run pytest \
    tests/unit/auto/test_interview_pipeline.py \
    tests/unit/auto/test_safe_default_observability.py \
    tests/unit/auto/test_safe_defaults_domain_profile.py -q
# 155 passed

$ uv run ruff check src/ouroboros/auto/lateral_routing.py \
    src/ouroboros/auto/interview_driver.py \
    tests/unit/auto/test_lateral_routing_safe_default.py
# All checks passed

$ uv run ruff format --check src/ouroboros/auto/lateral_routing.py \
    src/ouroboros/auto/interview_driver.py \
    tests/unit/auto/test_lateral_routing_safe_default.py
# 3 files already formatted

$ uv run mypy src/ouroboros/auto/lateral_routing.py \
    src/ouroboros/auto/interview_driver.py
# Success: no issues found in 2 source files
```

## Test plan

- [x] New selector unit tests pass (6 cases).
- [x] No regression in `test_interview_pipeline.py` (covers the existing safe-default closure path — exercised here because the driver dataclass shape changed).
- [x] No regression in `test_safe_default_observability.py` and `test_safe_defaults_domain_profile.py`.
- [x] Ruff lint + format clean.
- [x] Mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
