### PR TITLE
chore(ci): enforce ooo auto R-run section per RFC #1256 §I5

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,9 +21,16 @@ slowdown observed in the PR-A/B/β/γ merge train (#1258).
 
 If your PR does NOT touch `src/ouroboros/auto/`, delete this whole section.
 
-If it does, fill in the table below. A baseline R-run is at
-`~/.ooo-observability/` or in #1258 evidence; capture a fresh run on your
-branch with:
+If it does, fill in the table below. Every metric row must have ALL
+three comparison cells (Baseline, This PR, Ratio) populated — partially
+filled rows (e.g. only `Baseline=TBD` with blank PR/Ratio) are rejected
+by the gate. For substrate-only PRs that genuinely have no per-round
+comparison, fill every cell explicitly (`N/A | N/A | n/a`) so the
+intent is auditable; one filled cell with two blanks is treated as
+"author skipped the requirement".
+
+A baseline R-run is at `~/.ooo-observability/` or in #1258 evidence;
+capture a fresh run on your branch with:
 
     OUROBOROS_RUN_CANONICAL=1 uv run pytest tests/canonical/ -k cli-todo -v
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,46 @@
+<!-- Thanks for contributing to Ouroboros! Fill in the sections below. -->
+
+## Summary
+
+<!-- 1-3 sentences. What does this PR do and why? -->
+
+## Test plan
+
+<!-- Bulleted checklist of how this PR was verified. -->
+- [ ] `uv run pytest tests/ -q` passes
+- [ ] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/` clean
+- [ ] `uv run mypy src/` clean (or noted exception)
+
+## R-run comparison (required for `src/ouroboros/auto/` changes)
+
+<!--
+RFC #1256 §I5 requires every PR that touches `src/ouroboros/auto/` to include
+a per-round wall-clock comparison against the latest canonical baseline.
+This guards against silent performance regressions like the ~3× per-round
+slowdown observed in the PR-A/B/β/γ merge train (#1258).
+
+If your PR does NOT touch `src/ouroboros/auto/`, delete this whole section.
+
+If it does, fill in the table below. A baseline R-run is at
+`~/.ooo-observability/` or in #1258 evidence; capture a fresh run on your
+branch with:
+
+    OUROBOROS_RUN_CANONICAL=1 uv run pytest tests/canonical/ -k cli-todo -v
+
+The §I5 budget is 1.5× the latest baseline per-round cost. Greater
+regressions require a separate performance budget RFC.
+-->
+
+| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
+|--------------------------------|-----------------------|-----------------------|----------|
+| Rounds completed in 600 s      |                       |                       |          |
+| Per-round wall-clock (s/round) |                       |                       |          |
+| Terminal reason                |                       |                       |          |
+| EventStore event count         |                       |                       |          |
+
+Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation /
+[ ] N/A (PR does not touch `src/ouroboros/auto/`)
+
+## Related issues
+
+<!-- Link issues this PR closes or references, e.g. "Fixes #1234", "Refs #1256". -->

--- a/.github/workflows/auto-perf-budget.yml
+++ b/.github/workflows/auto-perf-budget.yml
@@ -8,6 +8,13 @@ name: ooo-auto-perf-budget
 on:
   pull_request:
     branches: [main]
+    # The check reads the PR body, so it must rerun whenever the body
+    # can change. Default `pull_request` activity types only fire on
+    # `opened`, `synchronize`, and `reopened` — they do NOT fire on
+    # `edited`, which means a contributor could land a previously
+    # passing PR by deleting the R-run section after a successful run.
+    # Listing `edited` explicitly closes that bypass per the bot review.
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read

--- a/.github/workflows/auto-perf-budget.yml
+++ b/.github/workflows/auto-perf-budget.yml
@@ -1,0 +1,33 @@
+name: ooo-auto-perf-budget
+
+# Enforces RFC #1256 §I5: PRs touching `src/ouroboros/auto/` must include
+# an R-run comparison section in the PR body so silent per-round
+# wall-clock regressions (as observed in the PR-A/B/β/γ merge train, #1258)
+# cannot land without explicit per-round cost data.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  enforce-perf-budget:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need full history so the script can diff against origin/main
+          # to enumerate changed paths.
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Enforce R-run comparison section
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+        run: python3 scripts/check-auto-perf-budget.py

--- a/scripts/check-auto-perf-budget.py
+++ b/scripts/check-auto-perf-budget.py
@@ -82,20 +82,38 @@ def _changed_paths_from_event(event: dict) -> list[str]:
     return [line for line in out.stdout.splitlines() if line.strip()]
 
 
+REQUIRED_COMPARISON_COLUMNS = 3  # Baseline | This PR | Ratio
+
+
 def _section_present(body: str) -> bool:
     if SECTION_HEADER not in body:
         return False
-    # Require at least one metric row to be filled in (any non-empty cell
-    # between the metric name and the next pipe). A blank table is the
-    # default template and indicates the author skipped the requirement.
+    # Every required metric row must have ALL three comparison-bearing
+    # cells (Baseline, This PR, Ratio) populated. Accepting a row where
+    # only one cell is non-empty — e.g. `Baseline=TBD` with the PR and
+    # Ratio columns blank — would let an applicable PR pass without
+    # supplying any actual side-by-side measurement, which is the exact
+    # process bypass §I5 exists to close (bot review on commit
+    # 074e24bd flagged this as the remaining blocker after the prior
+    # `any() → all()` patch went only halfway).
+    #
+    # Authors who genuinely want to mark a row as "not applicable" (e.g.
+    # substrate-only PRs) must fill every cell — `N/A | N/A | n/a` is
+    # accepted; one filled cell with two blanks is not.
     section = body.split(SECTION_HEADER, 1)[1]
     for token in REQUIRED_METRIC_TOKENS:
         if token not in section:
             return False
         line = next((row for row in section.splitlines() if token in row), "")
-        # Markdown table row: `| Metric ... | val | val | val |`
+        # Markdown table row: `| Metric ... | Baseline | This PR | Ratio |`.
+        # The leading and trailing pipes produce empty boundary cells;
+        # the metric name sits at index 1; the three comparison cells
+        # follow at index 2..4. We require every comparison cell to be
+        # non-empty.
         cells = [c.strip() for c in line.split("|")][2:-1]
-        if not any(cells):
+        if len(cells) < REQUIRED_COMPARISON_COLUMNS:
+            return False
+        if not all(cells[:REQUIRED_COMPARISON_COLUMNS]):
             return False
     return True
 

--- a/scripts/check-auto-perf-budget.py
+++ b/scripts/check-auto-perf-budget.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Enforce RFC #1256 §I5 — PRs touching ``src/ouroboros/auto/`` must
+include an R-run comparison section in the PR body.
+
+The check is intentionally minimal: it does not parse the table, run any
+benchmarks, or compare against historical baselines. It only verifies the
+**presence** of the structured section so reviewers see the per-round
+wall-clock data inline. Numerical regression detection lives in #1258
+follow-up tooling.
+
+The check runs in two contexts:
+
+1. **Pull request CI** — receives the PR body via ``GITHUB_EVENT_PATH`` and
+   verifies the R-run section + filled-in table when changed paths include
+   ``src/ouroboros/auto/``.
+2. **Local dry-run** — invoked manually as
+   ``python3 scripts/check-auto-perf-budget.py --body <file>``; used when
+   developing the workflow itself.
+
+Exit codes:
+    0 — compliant or not applicable
+    1 — applicable but the PR body is missing the R-run section
+    2 — unexpected error reading inputs
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+AUTO_PATH_PREFIX = "src/ouroboros/auto/"
+SECTION_HEADER = "## R-run comparison"
+REQUIRED_METRIC_TOKENS = (
+    "Rounds completed",
+    "Per-round wall-clock",
+    "Terminal reason",
+)
+
+
+def _changed_paths_from_event(event: dict) -> list[str]:
+    """Return the list of changed paths for the PR described by ``event``.
+
+    Uses ``git diff --name-only`` against the merge base; this is more
+    accurate than walking the GitHub API and works for any fork that mirrors
+    the upstream main branch.
+    """
+
+    pr = event.get("pull_request") or {}
+    base = (pr.get("base") or {}).get("ref") or "main"
+
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", f"origin/{base}...HEAD"],
+            capture_output=True,
+            check=True,
+            text=True,
+        )
+        return [line for line in out.stdout.splitlines() if line.strip()]
+    except subprocess.CalledProcessError:
+        # If the merge base is missing locally, fall back to the GitHub
+        # event-supplied changed_files list. CI workflows do a full
+        # checkout, so this path is rarely taken.
+        return []
+
+
+def _section_present(body: str) -> bool:
+    if SECTION_HEADER not in body:
+        return False
+    # Require at least one metric row to be filled in (any non-empty cell
+    # between the metric name and the next pipe). A blank table is the
+    # default template and indicates the author skipped the requirement.
+    section = body.split(SECTION_HEADER, 1)[1]
+    for token in REQUIRED_METRIC_TOKENS:
+        if token not in section:
+            return False
+        line = next((row for row in section.splitlines() if token in row), "")
+        # Markdown table row: `| Metric ... | val | val | val |`
+        cells = [c.strip() for c in line.split("|")][2:-1]
+        if not any(cells):
+            return False
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--body",
+        type=Path,
+        help="Optional path to a PR body file (local dry-run).",
+    )
+    args = parser.parse_args()
+
+    # Determine changed paths + PR body.
+    body = ""
+    changed: list[str] = []
+
+    if args.body is not None:
+        body = args.body.read_text(encoding="utf-8")
+        # Local dry-run: read changed paths from git working tree vs main.
+        try:
+            out = subprocess.run(
+                ["git", "diff", "--name-only", "origin/main...HEAD"],
+                capture_output=True,
+                check=True,
+                text=True,
+            )
+            changed = [line for line in out.stdout.splitlines() if line.strip()]
+        except subprocess.CalledProcessError:
+            changed = []
+    else:
+        event_path = os.environ.get("GITHUB_EVENT_PATH")
+        if not event_path or not Path(event_path).is_file():
+            print(
+                "check-auto-perf-budget: no GITHUB_EVENT_PATH and no --body; nothing to check.",
+                file=sys.stderr,
+            )
+            return 0
+        try:
+            event = json.loads(Path(event_path).read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"check-auto-perf-budget: failed to parse event: {exc}", file=sys.stderr)
+            return 2
+        pr = event.get("pull_request") or {}
+        body = pr.get("body") or ""
+        changed = _changed_paths_from_event(event)
+
+    applies = any(path.startswith(AUTO_PATH_PREFIX) for path in changed)
+    if not applies:
+        print(
+            "check-auto-perf-budget: PR does not touch "
+            f"`{AUTO_PATH_PREFIX}` — section not required."
+        )
+        return 0
+
+    if _section_present(body):
+        print(
+            "check-auto-perf-budget: PR touches "
+            f"`{AUTO_PATH_PREFIX}` and includes a filled R-run comparison "
+            "section — OK."
+        )
+        return 0
+
+    print(
+        "check-auto-perf-budget: PR touches "
+        f"`{AUTO_PATH_PREFIX}` but the R-run comparison section in the PR "
+        "body is missing or has no filled metrics.\n"
+        "Per RFC #1256 §I5, every PR to `src/ouroboros/auto/` must include "
+        "a per-round wall-clock comparison against the latest canonical "
+        "baseline. See `.github/PULL_REQUEST_TEMPLATE.md` for the table "
+        "format, or capture a fresh R-run with:\n"
+        "    OUROBOROS_RUN_CANONICAL=1 uv run pytest tests/canonical/ "
+        "-k cli-todo -v",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-auto-perf-budget.py
+++ b/scripts/check-auto-perf-budget.py
@@ -33,8 +33,16 @@ import argparse
 import json
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
+
+# Strip ``<!-- ... -->`` comments before parsing. DOTALL because PR
+# bodies wrap multi-line guidance blocks. Bot review on commit dc191d02
+# (req_1779887927_132) flagged that hidden comments could carry fully
+# populated metric rows while the visible table stayed blank — the
+# parser must validate visible evidence only.
+_HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.DOTALL)
 
 AUTO_PATH_PREFIX = "src/ouroboros/auto/"
 SECTION_HEADER = "## R-run comparison"
@@ -93,7 +101,24 @@ def _changed_paths_from_event(event: dict) -> list[str]:
 REQUIRED_COMPARISON_COLUMNS = 3  # Baseline | This PR | Ratio
 
 
+def _strip_html_comments(text: str) -> str:
+    """Return ``text`` with every ``<!-- ... -->`` comment removed.
+
+    The R-run contract is that **reviewers see the comparison data
+    inline**. A caller-controlled PR body can otherwise hide a fully
+    populated metric table inside an HTML comment, leave the visible
+    Markdown table blank, and still pass the gate — bot review on
+    commit dc191d02 verified this exact bypass against the prior
+    parser. Stripping comments here closes the loophole.
+    """
+    return _HTML_COMMENT_RE.sub("", text)
+
+
 def _section_present(body: str) -> bool:
+    # The HTML-comment scrub must run BEFORE the header check so a
+    # body whose only ``## R-run comparison`` reference lives inside a
+    # commented-out instructions block also fails the gate.
+    body = _strip_html_comments(body)
     if SECTION_HEADER not in body:
         return False
     # Every required metric row must have ALL three comparison-bearing

--- a/scripts/check-auto-perf-budget.py
+++ b/scripts/check-auto-perf-budget.py
@@ -42,6 +42,14 @@ REQUIRED_METRIC_TOKENS = (
     "Rounds completed",
     "Per-round wall-clock",
     "Terminal reason",
+    # Bot review on commit c860fa6b (req_1779887321_129) flagged that
+    # the parser must enforce every metric row the template asks for.
+    # ``EventStore event count`` was in the template at
+    # ``.github/PULL_REQUEST_TEMPLATE.md`` but missing here, so an
+    # applicable auto PR could leave it blank and still pass. Adding
+    # the token closes that bypass; the template and parser are now
+    # one list.
+    "EventStore event count",
 )
 
 

--- a/scripts/check-auto-perf-budget.py
+++ b/scripts/check-auto-perf-budget.py
@@ -20,7 +20,11 @@ The check runs in two contexts:
 Exit codes:
     0 — compliant or not applicable
     1 — applicable but the PR body is missing the R-run section
-    2 — unexpected error reading inputs
+    2 — unexpected error reading inputs OR changed-path discovery failed
+        (the gate fails closed: if we cannot enumerate changed files, we
+        cannot prove the PR is non-applicable, so we refuse to silently
+        return 0 — this is the bot-review blocker that flagged the
+        prior fail-open behavior)
 """
 
 from __future__ import annotations
@@ -41,12 +45,25 @@ REQUIRED_METRIC_TOKENS = (
 )
 
 
+class ChangedPathsUnavailable(RuntimeError):
+    """Raised when changed-path discovery cannot produce a definitive
+    list. The caller must treat this as fail-closed (exit 2) rather
+    than as "no auto/ files changed" — the latter is a silent bypass."""
+
+
 def _changed_paths_from_event(event: dict) -> list[str]:
     """Return the list of changed paths for the PR described by ``event``.
 
     Uses ``git diff --name-only`` against the merge base; this is more
-    accurate than walking the GitHub API and works for any fork that mirrors
-    the upstream main branch.
+    accurate than walking the GitHub API and works for any fork that
+    mirrors the upstream main branch.
+
+    Fails closed: if the diff cannot be enumerated, raises
+    :class:`ChangedPathsUnavailable` so the caller surfaces the
+    discovery failure as a CI error (exit 2) instead of silently
+    treating the PR as non-applicable. The earlier fail-open behavior
+    was flagged as a guard bypass — a checkout/ref layout failure
+    would have disabled the budget requirement without anyone noticing.
     """
 
     pr = event.get("pull_request") or {}
@@ -59,12 +76,10 @@ def _changed_paths_from_event(event: dict) -> list[str]:
             check=True,
             text=True,
         )
-        return [line for line in out.stdout.splitlines() if line.strip()]
-    except subprocess.CalledProcessError:
-        # If the merge base is missing locally, fall back to the GitHub
-        # event-supplied changed_files list. CI workflows do a full
-        # checkout, so this path is rarely taken.
-        return []
+    except (subprocess.CalledProcessError, OSError) as exc:
+        raise ChangedPathsUnavailable(f"git diff against origin/{base} failed: {exc}") from exc
+
+    return [line for line in out.stdout.splitlines() if line.strip()]
 
 
 def _section_present(body: str) -> bool:
@@ -100,7 +115,12 @@ def main() -> int:
 
     if args.body is not None:
         body = args.body.read_text(encoding="utf-8")
-        # Local dry-run: read changed paths from git working tree vs main.
+        # Local dry-run: read changed paths from git working tree vs
+        # main. A dev-mode failure is informative, not load-bearing —
+        # we still surface it to stderr so the operator sees why the
+        # decision was made, but we exit 2 (fail closed) to match the
+        # CI contract: indeterminate inputs never produce a silent
+        # pass.
         try:
             out = subprocess.run(
                 ["git", "diff", "--name-only", "origin/main...HEAD"],
@@ -109,8 +129,15 @@ def main() -> int:
                 text=True,
             )
             changed = [line for line in out.stdout.splitlines() if line.strip()]
-        except subprocess.CalledProcessError:
-            changed = []
+        except (subprocess.CalledProcessError, OSError) as exc:
+            print(
+                "check-auto-perf-budget: local --body dry-run could not "
+                f"enumerate changed paths via git: {exc}. "
+                "Fix the local checkout (e.g., `git fetch origin main`) "
+                "or run in CI where origin/main is always available.",
+                file=sys.stderr,
+            )
+            return 2
     else:
         event_path = os.environ.get("GITHUB_EVENT_PATH")
         if not event_path or not Path(event_path).is_file():
@@ -126,7 +153,17 @@ def main() -> int:
             return 2
         pr = event.get("pull_request") or {}
         body = pr.get("body") or ""
-        changed = _changed_paths_from_event(event)
+        try:
+            changed = _changed_paths_from_event(event)
+        except ChangedPathsUnavailable as exc:
+            print(
+                "check-auto-perf-budget: could not enumerate changed "
+                f"paths — {exc}. Refusing to silently treat the PR as "
+                f"non-applicable; ensure the workflow checks out with "
+                "`fetch-depth: 0` and that origin/main is reachable.",
+                file=sys.stderr,
+            )
+            return 2
 
     applies = any(path.startswith(AUTO_PATH_PREFIX) for path in changed)
     if not applies:

--- a/tests/unit/scripts/test_check_auto_perf_budget.py
+++ b/tests/unit/scripts/test_check_auto_perf_budget.py
@@ -1,0 +1,275 @@
+"""Self-tests for ``scripts/check-auto-perf-budget.py``.
+
+This guard enforces RFC #1256 §I5: every PR touching
+``src/ouroboros/auto/`` must include a filled R-run comparison section
+in the PR body. Two design properties make the test surface
+load-bearing:
+
+1. **Applicability detection** is what decides whether the gate runs
+   at all. Mis-classifying an auto/-touching PR as "not applicable"
+   is a silent bypass.
+2. **Fail-closed on indeterminate inputs** is the bot-review blocker:
+   if ``git diff`` cannot enumerate changed files, the script must
+   refuse to return 0. The earlier behavior (silent empty list →
+   "not applicable" → exit 0) was the exact bypass class flagged.
+
+Both properties are pinned here alongside the section-presence
+parser so a future refactor that loosens either contract trips
+these tests.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "check-auto-perf-budget.py"
+
+
+def _load_module():
+    """Load the hyphenated script as a module so we can call ``main()``
+    and the inner helpers directly without spawning a subprocess."""
+    spec = importlib.util.spec_from_file_location("check_auto_perf_budget", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[union-attr]
+    return module
+
+
+# --- _section_present ---------------------------------------------------
+
+
+def test_section_present_returns_true_for_filled_table() -> None:
+    """A real PR body with all three required metric rows filled
+    passes the presence check."""
+    module = _load_module()
+    body = (
+        "## Summary\nstuff\n"
+        "## R-run comparison\n\n"
+        "| Metric | Baseline | This PR | Ratio |\n"
+        "|---|---|---|---|\n"
+        "| Rounds completed in 600 s | 100 | 95 | 0.95 |\n"
+        "| Per-round wall-clock (s/round) | 6.0 | 6.3 | 1.05 |\n"
+        "| Terminal reason | ready | ready | n/a |\n"
+    )
+    assert module._section_present(body) is True
+
+
+def test_section_present_returns_false_when_header_missing() -> None:
+    module = _load_module()
+    assert module._section_present("## Summary\nno table here") is False
+
+
+def test_section_present_returns_false_for_blank_template_table() -> None:
+    """Empty cells (the default template) MUST not pass — that was the
+    explicit author-skipped-the-requirement signal we're guarding."""
+    module = _load_module()
+    body = (
+        "## R-run comparison\n\n"
+        "| Metric | Baseline | This PR | Ratio |\n"
+        "|---|---|---|---|\n"
+        "| Rounds completed in 600 s |  |  |  |\n"
+        "| Per-round wall-clock (s/round) |  |  |  |\n"
+        "| Terminal reason |  |  |  |\n"
+    )
+    assert module._section_present(body) is False
+
+
+def test_section_present_returns_false_when_metric_row_missing() -> None:
+    """Header present but a required metric row absent → not compliant.
+
+    Authors deleting a row to dodge filling it must not pass the gate.
+    """
+    module = _load_module()
+    body = (
+        "## R-run comparison\n\n"
+        "| Metric | Baseline | This PR | Ratio |\n"
+        "|---|---|---|---|\n"
+        "| Rounds completed in 600 s | 100 | 95 | 0.95 |\n"
+        # "Per-round wall-clock" row removed
+        "| Terminal reason | ready | ready | n/a |\n"
+    )
+    assert module._section_present(body) is False
+
+
+# --- _changed_paths_from_event fail-closed contract ---------------------
+
+
+def test_changed_paths_raises_when_git_diff_fails() -> None:
+    """Bot-review blocker #2: a git-diff failure MUST raise the
+    ChangedPathsUnavailable sentinel so the caller can fail closed.
+    The prior behavior (silent empty list) silently disabled the gate
+    on every checkout/ref-layout failure."""
+    module = _load_module()
+
+    fake_event = {"pull_request": {"base": {"ref": "main"}}}
+    with patch.object(
+        module.subprocess,
+        "run",
+        side_effect=subprocess.CalledProcessError(128, ["git", "diff"]),
+    ):
+        with pytest.raises(module.ChangedPathsUnavailable):
+            module._changed_paths_from_event(fake_event)
+
+
+def test_changed_paths_raises_when_git_binary_missing() -> None:
+    """The OSError path (``git`` not installed, broken PATH) is also
+    indeterminate and must raise rather than return ``[]``."""
+    module = _load_module()
+    fake_event = {"pull_request": {"base": {"ref": "main"}}}
+    with patch.object(module.subprocess, "run", side_effect=OSError("no git binary")):
+        with pytest.raises(module.ChangedPathsUnavailable):
+            module._changed_paths_from_event(fake_event)
+
+
+def test_changed_paths_returns_split_lines_on_success() -> None:
+    """Happy path: the helper returns one entry per changed file with
+    blank lines stripped."""
+    module = _load_module()
+    fake_event = {"pull_request": {"base": {"ref": "main"}}}
+    completed = subprocess.CompletedProcess(
+        args=[],
+        returncode=0,
+        stdout="src/ouroboros/auto/pipeline.py\nREADME.md\n\n",
+        stderr="",
+    )
+    with patch.object(module.subprocess, "run", return_value=completed):
+        result = module._changed_paths_from_event(fake_event)
+    assert result == ["src/ouroboros/auto/pipeline.py", "README.md"]
+
+
+# --- main() applicability + exit-code matrix ----------------------------
+
+
+def _write_event(tmp_path: Path, *, body: str) -> Path:
+    event = {"pull_request": {"body": body, "base": {"ref": "main"}}}
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps(event), encoding="utf-8")
+    return event_path
+
+
+def test_main_returns_zero_for_pr_not_touching_auto(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A PR with only non-auto changes is not applicable → exit 0."""
+    module = _load_module()
+    event_path = _write_event(tmp_path, body="## Summary\ndocs only")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setattr(module.sys, "argv", ["check-auto-perf-budget.py"])
+
+    with patch.object(module, "_changed_paths_from_event", return_value=["README.md"]):
+        assert module.main() == 0
+
+
+def test_main_returns_zero_for_auto_pr_with_filled_section(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An applicable PR with a filled R-run section passes."""
+    module = _load_module()
+    body = (
+        "## Summary\n"
+        "## R-run comparison\n\n"
+        "| Metric | Baseline | This PR | Ratio |\n"
+        "|---|---|---|---|\n"
+        "| Rounds completed in 600 s | 100 | 95 | 0.95 |\n"
+        "| Per-round wall-clock (s/round) | 6.0 | 6.3 | 1.05 |\n"
+        "| Terminal reason | ready | ready | n/a |\n"
+    )
+    event_path = _write_event(tmp_path, body=body)
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setattr(module.sys, "argv", ["check-auto-perf-budget.py"])
+
+    with patch.object(
+        module, "_changed_paths_from_event", return_value=["src/ouroboros/auto/pipeline.py"]
+    ):
+        assert module.main() == 0
+
+
+def test_main_returns_one_for_auto_pr_without_section(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The headline contract: an applicable PR missing the section
+    fails the gate with exit 1."""
+    module = _load_module()
+    event_path = _write_event(tmp_path, body="## Summary\nno R-run table")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setattr(module.sys, "argv", ["check-auto-perf-budget.py"])
+
+    with patch.object(
+        module, "_changed_paths_from_event", return_value=["src/ouroboros/auto/pipeline.py"]
+    ):
+        assert module.main() == 1
+
+
+def test_main_fails_closed_when_path_discovery_unavailable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Bot-review blocker pin: an indeterminate changed-paths result
+    must exit 2, NOT 0. This is the regression class the prior
+    fail-open behavior shipped — ``git diff`` failing silently
+    disabled the gate."""
+    module = _load_module()
+    event_path = _write_event(tmp_path, body="anything")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setattr(module.sys, "argv", ["check-auto-perf-budget.py"])
+
+    with patch.object(
+        module,
+        "_changed_paths_from_event",
+        side_effect=module.ChangedPathsUnavailable("git not reachable"),
+    ):
+        assert module.main() == 2
+
+
+def test_main_returns_zero_when_no_event_and_no_body(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Local-invocation guard: no GITHUB_EVENT_PATH and no --body is
+    not an error — there's nothing to evaluate, so the script
+    no-ops with exit 0 and a stderr note."""
+    module = _load_module()
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+    monkeypatch.setattr(module.sys, "argv", ["check-auto-perf-budget.py"])
+    assert module.main() == 0
+
+
+def test_main_returns_two_on_malformed_event_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A corrupt event payload is an indeterminate input → exit 2."""
+    module = _load_module()
+    event_path = tmp_path / "event.json"
+    event_path.write_text("{ not json", encoding="utf-8")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setattr(module.sys, "argv", ["check-auto-perf-budget.py"])
+    assert module.main() == 2
+
+
+# --- --body local dry-run mode ------------------------------------------
+
+
+def test_main_body_mode_fails_closed_on_git_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The --body local dry-run path also fails closed on git error.
+
+    Otherwise developers using the script locally would see "OK" even
+    when their checkout cannot enumerate changed files, masking the
+    same indeterminate-input bypass class as the CI path.
+    """
+    module = _load_module()
+    body_file = tmp_path / "body.md"
+    body_file.write_text("## Summary\nlocal", encoding="utf-8")
+    monkeypatch.setattr(module.sys, "argv", ["check-auto-perf-budget.py", "--body", str(body_file)])
+
+    with patch.object(
+        module.subprocess,
+        "run",
+        side_effect=subprocess.CalledProcessError(1, ["git", "diff"]),
+    ):
+        assert module.main() == 2

--- a/tests/unit/scripts/test_check_auto_perf_budget.py
+++ b/tests/unit/scripts/test_check_auto_perf_budget.py
@@ -45,7 +45,7 @@ def _load_module():
 
 
 def test_section_present_returns_true_for_filled_table() -> None:
-    """A real PR body with all three required metric rows filled
+    """A real PR body with all four required metric rows filled
     passes the presence check."""
     module = _load_module()
     body = (
@@ -56,6 +56,7 @@ def test_section_present_returns_true_for_filled_table() -> None:
         "| Rounds completed in 600 s | 100 | 95 | 0.95 |\n"
         "| Per-round wall-clock (s/round) | 6.0 | 6.3 | 1.05 |\n"
         "| Terminal reason | ready | ready | n/a |\n"
+        "| EventStore event count | 0 | 2 | n/a |\n"
     )
     assert module._section_present(body) is True
 
@@ -149,6 +150,7 @@ def test_section_present_accepts_explicit_na_in_every_cell() -> None:
         "| Rounds completed in 600 s | N/A | N/A | n/a |\n"
         "| Per-round wall-clock (s/round) | N/A | N/A | n/a |\n"
         "| Terminal reason | N/A | N/A | n/a |\n"
+        "| EventStore event count | N/A | N/A | n/a |\n"
     )
     assert module._section_present(body) is True
 
@@ -164,8 +166,48 @@ def test_section_present_returns_false_when_one_row_partial_others_filled() -> N
         "| Rounds completed in 600 s | 100 | 95 | 0.95 |\n"
         "| Per-round wall-clock (s/round) | 6.0 |  |  |\n"  # partial
         "| Terminal reason | ready | ready | n/a |\n"
+        "| EventStore event count | 0 | 0 | n/a |\n"
     )
     assert module._section_present(body) is False
+
+
+def test_section_present_returns_false_when_eventstore_row_blank() -> None:
+    """Bot-review blocker (commit c860fa6b → req_1779887321_129):
+    every metric row in the template MUST be enforced by the parser.
+    ``EventStore event count`` was in the template but missing from
+    ``REQUIRED_METRIC_TOKENS``, which let an applicable auto PR leave
+    that row entirely blank and still pass — exactly the
+    template/parser misalignment the bot probed.
+    """
+    module = _load_module()
+    body = (
+        "## R-run comparison\n\n"
+        "| Metric | Baseline | This PR | Ratio |\n"
+        "|---|---|---|---|\n"
+        "| Rounds completed in 600 s | 100 | 95 | 0.95 |\n"
+        "| Per-round wall-clock (s/round) | 6.0 | 6.3 | 1.05 |\n"
+        "| Terminal reason | ready | ready | n/a |\n"
+        "| EventStore event count |  |  |  |\n"  # entirely blank
+    )
+    assert module._section_present(body) is False
+
+
+def test_required_metric_tokens_matches_template() -> None:
+    """Meta-contract: every metric row name in the PR template must
+    appear in ``REQUIRED_METRIC_TOKENS``. Catches the exact
+    template-vs-parser drift that the bot flagged — adding a row to
+    the template without updating the token list would silently
+    reopen the bypass."""
+    module = _load_module()
+    template = (REPO_ROOT / ".github" / "PULL_REQUEST_TEMPLATE.md").read_text(encoding="utf-8")
+    assert "## R-run comparison" in template
+    section = template.split("## R-run comparison", 1)[1]
+    for token in module.REQUIRED_METRIC_TOKENS:
+        assert token in section, (
+            f"template missing required metric row {token!r} — either "
+            f"add the row to PULL_REQUEST_TEMPLATE.md or drop it from "
+            f"REQUIRED_METRIC_TOKENS"
+        )
 
 
 # --- _changed_paths_from_event fail-closed contract ---------------------
@@ -250,6 +292,7 @@ def test_main_returns_zero_for_auto_pr_with_filled_section(
         "| Rounds completed in 600 s | 100 | 95 | 0.95 |\n"
         "| Per-round wall-clock (s/round) | 6.0 | 6.3 | 1.05 |\n"
         "| Terminal reason | ready | ready | n/a |\n"
+        "| EventStore event count | 0 | 2 | n/a |\n"
     )
     event_path = _write_event(tmp_path, body=body)
     monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))

--- a/tests/unit/scripts/test_check_auto_perf_budget.py
+++ b/tests/unit/scripts/test_check_auto_perf_budget.py
@@ -97,6 +97,77 @@ def test_section_present_returns_false_when_metric_row_missing() -> None:
     assert module._section_present(body) is False
 
 
+def test_section_present_returns_false_for_partially_filled_rows() -> None:
+    """Bot-review blocker (commit 074e24bd → req_1779886636_125): a row
+    where only ONE of the three comparison cells is non-empty (e.g.
+    ``Baseline=TBD`` with PR and Ratio blank) MUST be rejected.
+
+    The prior ``any(cells)`` check accepted this shape, which let an
+    applicable PR pass the gate with a placeholder in one column and
+    no actual side-by-side measurement — the exact §I5 process
+    bypass the gate exists to prevent.
+    """
+    module = _load_module()
+    body = (
+        "## R-run comparison\n\n"
+        "| Metric | Baseline | This PR | Ratio |\n"
+        "|---|---|---|---|\n"
+        "| Rounds completed in 600 s | TBD |  |  |\n"
+        "| Per-round wall-clock (s/round) | TBD |  |  |\n"
+        "| Terminal reason | TBD |  |  |\n"
+    )
+    assert module._section_present(body) is False
+
+
+def test_section_present_returns_false_when_only_ratio_missing() -> None:
+    """Two filled, one blank still fails. The contract is ALL three
+    comparison cells populated — the Ratio column is what makes the
+    measurement comparable, so it cannot be left empty even when
+    Baseline and This PR are both filled."""
+    module = _load_module()
+    body = (
+        "## R-run comparison\n\n"
+        "| Metric | Baseline | This PR | Ratio |\n"
+        "|---|---|---|---|\n"
+        "| Rounds completed in 600 s | 100 | 95 |  |\n"
+        "| Per-round wall-clock (s/round) | 6.0 | 6.3 |  |\n"
+        "| Terminal reason | ready | ready |  |\n"
+    )
+    assert module._section_present(body) is False
+
+
+def test_section_present_accepts_explicit_na_in_every_cell() -> None:
+    """Authors who genuinely have no comparison (e.g. substrate-only
+    PRs) must mark every cell explicitly. Filling all three with
+    ``N/A`` / ``n/a`` is auditable and accepted; one filled cell with
+    two blanks is not."""
+    module = _load_module()
+    body = (
+        "## R-run comparison\n\n"
+        "| Metric | Baseline | This PR | Ratio |\n"
+        "|---|---|---|---|\n"
+        "| Rounds completed in 600 s | N/A | N/A | n/a |\n"
+        "| Per-round wall-clock (s/round) | N/A | N/A | n/a |\n"
+        "| Terminal reason | N/A | N/A | n/a |\n"
+    )
+    assert module._section_present(body) is True
+
+
+def test_section_present_returns_false_when_one_row_partial_others_filled() -> None:
+    """Even a single partially-filled row inside an otherwise complete
+    table fails the gate — the contract is per-row, not aggregate."""
+    module = _load_module()
+    body = (
+        "## R-run comparison\n\n"
+        "| Metric | Baseline | This PR | Ratio |\n"
+        "|---|---|---|---|\n"
+        "| Rounds completed in 600 s | 100 | 95 | 0.95 |\n"
+        "| Per-round wall-clock (s/round) | 6.0 |  |  |\n"  # partial
+        "| Terminal reason | ready | ready | n/a |\n"
+    )
+    assert module._section_present(body) is False
+
+
 # --- _changed_paths_from_event fail-closed contract ---------------------
 
 

--- a/tests/unit/scripts/test_check_auto_perf_budget.py
+++ b/tests/unit/scripts/test_check_auto_perf_budget.py
@@ -192,6 +192,73 @@ def test_section_present_returns_false_when_eventstore_row_blank() -> None:
     assert module._section_present(body) is False
 
 
+def test_section_present_rejects_hidden_html_comment_rows() -> None:
+    """Bot-review blocker (commit dc191d02 → req_1779887927_132): a
+    caller-controlled PR body must not be able to satisfy the gate by
+    hiding fully populated rows inside ``<!-- ... -->`` while the
+    visible Markdown table stays blank. The R-run contract is that
+    reviewers see the comparison data INLINE, not in source-view
+    comments."""
+    module = _load_module()
+    body = (
+        "## R-run comparison\n\n"
+        "<!--\n"
+        "| Metric | Baseline | This PR | Ratio |\n"
+        "|---|---|---|---|\n"
+        "| Rounds completed in 600 s | 100 | 95 | 0.95 |\n"
+        "| Per-round wall-clock (s/round) | 6.0 | 6.3 | 1.05 |\n"
+        "| Terminal reason | ready | ready | n/a |\n"
+        "| EventStore event count | 0 | 2 | n/a |\n"
+        "-->\n\n"
+        "| Metric | Baseline | This PR | Ratio |\n"
+        "|---|---|---|---|\n"
+        "| Rounds completed in 600 s |  |  |  |\n"
+        "| Per-round wall-clock (s/round) |  |  |  |\n"
+        "| Terminal reason |  |  |  |\n"
+        "| EventStore event count |  |  |  |\n"
+    )
+    assert module._section_present(body) is False
+
+
+def test_section_present_rejects_section_header_inside_html_comment() -> None:
+    """Conjugate of the above: the section header itself, if only
+    present inside a comment, must not satisfy the gate. Stripping
+    comments before the header check is what closes this corner."""
+    module = _load_module()
+    body = (
+        "## Summary\nno visible R-run section\n\n"
+        "<!--\n"
+        "## R-run comparison\n"
+        "| Metric | Baseline | This PR | Ratio |\n"
+        "|---|---|---|---|\n"
+        "| Rounds completed in 600 s | 100 | 95 | 0.95 |\n"
+        "| Per-round wall-clock (s/round) | 6.0 | 6.3 | 1.05 |\n"
+        "| Terminal reason | ready | ready | n/a |\n"
+        "| EventStore event count | 0 | 2 | n/a |\n"
+        "-->\n"
+    )
+    assert module._section_present(body) is False
+
+
+def test_section_present_accepts_table_with_unrelated_html_comments() -> None:
+    """Stripping HTML comments must not break the happy path: a body
+    with comment-wrapped guidance ABOVE a fully filled visible table
+    must still pass. (Regression guard for over-eager comment
+    handling.)"""
+    module = _load_module()
+    body = (
+        "## R-run comparison\n\n"
+        "<!-- Guidance: fill all four rows; see PULL_REQUEST_TEMPLATE.md -->\n\n"
+        "| Metric | Baseline | This PR | Ratio |\n"
+        "|---|---|---|---|\n"
+        "| Rounds completed in 600 s | 100 | 95 | 0.95 |\n"
+        "| Per-round wall-clock (s/round) | 6.0 | 6.3 | 1.05 |\n"
+        "| Terminal reason | ready | ready | n/a |\n"
+        "| EventStore event count | 0 | 2 | n/a |\n"
+    )
+    assert module._section_present(body) is True
+
+
 def test_required_metric_tokens_matches_template() -> None:
     """Meta-contract: every metric row name in the PR template must
     appear in ``REQUIRED_METRIC_TOKENS``. Catches the exact


### PR DESCRIPTION
## Summary

Implements **RFC #1256 §I5** enforcement: every PR touching
`src/ouroboros/auto/` must include an R-run comparison section in the
PR body so silent per-round wall-clock regressions (#1258, observed
as ~3× slowdown across the PR-A/B/β/γ merge train) cannot land
without explicit per-round cost data inline.

## Changes

* `.github/PULL_REQUEST_TEMPLATE.md` — new template introduces the
  4-metric R-run table and instructions for capturing a fresh run.
* `scripts/check-auto-perf-budget.py` — minimal Python lint that
  verifies the section is present and has at least one filled cell
  when the PR's changed paths include `src/ouroboros/auto/`. Local
  dry-run via `--body <file>` for workflow development.
* `.github/workflows/auto-perf-budget.yml` — `pull_request` workflow
  that blocks merge when the section is missing for applicable PRs.

## Scope

The check is **presence-only**. It does not parse the metric values,
run benchmarks, or compare against historical baselines. Numerical
1.5× budget enforcement against historical R-runs is a separate
follow-up tracked in #1258. This PR ships the enforcement surface so
the next perf-touching PR cannot land without explicit data.

## Test plan

- [x] Dry-run on synthetic body with no auto/ changes → exit 0 (section not required)
- [x] Dry-run on synthetic body with auto/ change + missing section → exit 1
- [x] Dry-run on synthetic body with auto/ change + filled section → exit 0
- [x] `uv run ruff check scripts/check-auto-perf-budget.py` → clean
- [x] `uv run ruff format --check scripts/check-auto-perf-budget.py` → clean
- [ ] (Post-merge) Confirm workflow blocks a follow-up PR that touches `src/ouroboros/auto/` without the section

## R-run comparison

N/A — this PR does not touch `src/ouroboros/auto/`.

## Related issues

- Refs #1256 (RFC §I5 — performance budget invariant)
- Refs #1258 (R3 evidence of ~3× per-round regression that motivated §I5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
