### PR TITLE
fix(auto): synthesize seed when authoring backend is unavailable

### DIFF
--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -433,6 +433,7 @@ def _high_risk_assumption_count(ledger: SeedDraftLedger) -> int:
         for section in ledger.sections.values()
         for entry in section.entries
         if entry.source == LedgerSource.ASSUMPTION
+        and section.name != "non_goals"
         and entry.status not in inactive_statuses
         and any(term in entry.value.lower() for term in risky_terms)
     )

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -266,6 +266,10 @@ class AutoInterviewDriver:
         except Exception as exc:
             self._record_evidence_based_session_id(state, exc, preassigned_id)
             action = "resume" if interview_tool_name == "interview.resume" else "start"
+            if action == "start":
+                fallback = self._try_close_after_backend_start_failure(state, ledger, exc)
+                if fallback is not None:
+                    return fallback
             blocker = f"interview {action} failed: {exc}"
             state.mark_blocked(blocker, tool_name=interview_tool_name)
             record_authoring_backend(state)
@@ -773,6 +777,55 @@ class AutoInterviewDriver:
         self._save(state)
         return AutoInterviewResult(
             "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
+        )
+
+    def _try_close_after_backend_start_failure(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        exc: Exception,
+    ) -> AutoInterviewResult | None:
+        """Close from deterministic ledger evidence when backend start is unavailable.
+
+        A start-time provider/config failure means the LLM interview never
+        produced a question, but it does not invalidate facts already present
+        in the initial goal or facts that the audited safe-default policy can
+        fill for benign local tasks. When those facts make the ledger complete,
+        proceed without a persisted interview transcript; the pipeline's ledger
+        Seed generator owns the next phase.
+        """
+        if not _is_authoring_backend_unavailable(exc):
+            return None
+        closure_mode = "ledger_only_no_backend"
+        if not ledger.is_seed_ready():
+            finalization = finalize_safe_defaultable_gaps(
+                ledger,
+                goal=state.goal,
+                provenance=f"auto interview backend start failed: {exc}",
+                pending_question=None,
+                active_profile=getattr(self.answerer, "active_profile", None),
+            )
+            if finalization is None or not finalization.completed or not ledger.is_seed_ready():
+                return None
+            closure_mode = "safe_default_no_backend"
+
+        state.ledger = ledger.to_dict()
+        state.pending_question = None
+        state.interview_completed = True
+        state.interview_closure_mode = closure_mode
+        state.mark_progress(
+            f"interview closed via {closure_mode} after backend start failure",
+            tool_name="interview_driver",
+        )
+        log.warning(
+            "auto.interview.backend_start_failed_ledger_fallback",
+            auto_session_id=state.auto_session_id,
+            closure_mode=closure_mode,
+            error=str(exc),
+        )
+        self._save(state)
+        return AutoInterviewResult(
+            "seed_ready", state.interview_session_id, ledger, state.current_round
         )
 
     def _answer_with_gap_steering(
@@ -1321,6 +1374,23 @@ _BROAD_PROMPT_RE = re.compile(
 def _can_steer_with_gap_prompt(question: str) -> bool:
     """Return True when ``question`` is broad enough to benefit from gap-targeted steering."""
     return bool(_BROAD_PROMPT_RE.search(question.lower()))
+
+
+def _is_authoring_backend_unavailable(exc: Exception) -> bool:
+    """Return True for provider/config failures that deterministic auto can bypass."""
+    text = str(exc).casefold()
+    markers = (
+        "config.toml",
+        "profile",
+        "codex",
+        "provider",
+        "api key",
+        "authentication",
+        "rate limit",
+        "connection refused",
+        "network",
+    )
+    return any(marker in text for marker in markers)
 
 
 _AUTO_ANSWER_LOG_LIMIT = 25

--- a/src/ouroboros/auto/ledger_seed.py
+++ b/src/ouroboros/auto/ledger_seed.py
@@ -1,0 +1,156 @@
+"""Deterministic Seed synthesis from an auto Seed Draft Ledger."""
+
+from __future__ import annotations
+
+import re
+from uuid import uuid4
+
+from ouroboros.auto.grading import deterministic_floor
+from ouroboros.auto.ledger import LedgerStatus, SeedDraftLedger
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+
+_INACTIVE_STATUSES: frozenset[LedgerStatus] = frozenset(
+    {
+        LedgerStatus.WEAK,
+        LedgerStatus.CONFLICTING,
+        LedgerStatus.BLOCKED,
+        LedgerStatus.MISSING,
+    }
+)
+
+
+def synthesize_seed_from_ledger(
+    ledger: SeedDraftLedger,
+    *,
+    interview_id: str | None = None,
+) -> Seed:
+    """Build a valid Seed directly from a complete auto ledger.
+
+    This is the fail-soft path for ``ooo auto`` when the authoring backend is
+    unavailable after the deterministic ledger has enough evidence to proceed.
+    The ledger remains the source of truth; this function performs no model or
+    external IO.
+    """
+    if not ledger.is_seed_ready():
+        msg = f"cannot synthesize Seed from incomplete ledger: {', '.join(ledger.open_gaps())}"
+        raise ValueError(msg)
+
+    goal = _latest_value(ledger, "goal")
+    constraints = _lines_from_section(ledger, "constraints")
+    non_goals = _lines_from_section(ledger, "non_goals")
+    if non_goals:
+        constraints = (*constraints, *[f"Non-goal: {item}" for item in non_goals])
+
+    acceptance_criteria = _lines_from_section(ledger, "acceptance_criteria")
+    verification_plan = _joined_section(ledger, "verification_plan")
+    failure_modes = _joined_section(ledger, "failure_modes")
+
+    return Seed(
+        goal=goal,
+        constraints=constraints,
+        acceptance_criteria=acceptance_criteria,
+        ontology_schema=OntologySchema(
+            name=_ontology_name(goal),
+            description="Auto-synthesized ontology from the completed Seed Draft Ledger.",
+            fields=(
+                OntologyField(
+                    name="actors",
+                    field_type="string",
+                    description=_joined_section(ledger, "actors"),
+                ),
+                OntologyField(
+                    name="inputs",
+                    field_type="string",
+                    description=_joined_section(ledger, "inputs"),
+                ),
+                OntologyField(
+                    name="outputs",
+                    field_type="string",
+                    description=_joined_section(ledger, "outputs"),
+                ),
+                OntologyField(
+                    name="runtime_context",
+                    field_type="string",
+                    description=_joined_section(ledger, "runtime_context"),
+                ),
+            ),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(
+                name="ledger_completeness",
+                description="All required Seed Draft Ledger sections are resolved before execution.",
+                weight=0.5,
+            ),
+            EvaluationPrinciple(
+                name="observable_verification",
+                description=verification_plan,
+                weight=0.5,
+            ),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="acceptance_verified",
+                description="All acceptance criteria pass under the verification plan.",
+                evaluation_criteria=verification_plan,
+            ),
+            ExitCondition(
+                name="failure_modes_absent",
+                description=f"Known failure modes are absent: {failure_modes}",
+                evaluation_criteria="No listed failure mode is observed in verification evidence.",
+            ),
+        ),
+        metadata=SeedMetadata(
+            seed_id=f"seed_{uuid4().hex[:12]}",
+            ambiguity_score=max(0.05, deterministic_floor(ledger)),
+            interview_id=interview_id,
+        ),
+    )
+
+
+def _latest_value(ledger: SeedDraftLedger, section_name: str) -> str:
+    values = _active_values(ledger, section_name)
+    if not values:
+        msg = f"ledger section has no active value: {section_name}"
+        raise ValueError(msg)
+    return values[-1]
+
+
+def _joined_section(ledger: SeedDraftLedger, section_name: str) -> str:
+    return "; ".join(_active_values(ledger, section_name))
+
+
+def _lines_from_section(ledger: SeedDraftLedger, section_name: str) -> tuple[str, ...]:
+    lines: list[str] = []
+    for value in _active_values(ledger, section_name):
+        parts = re.split(r"(?:\r?\n\s*[-*]\s+|\s*;\s+)", value)
+        for part in parts:
+            cleaned = part.strip(" \t\r\n-*:;.")
+            if cleaned:
+                lines.append(cleaned)
+    return tuple(dict.fromkeys(lines))
+
+
+def _active_values(ledger: SeedDraftLedger, section_name: str) -> tuple[str, ...]:
+    section = ledger.sections.get(section_name)
+    if section is None:
+        return ()
+    return tuple(
+        entry.value.strip()
+        for entry in section.entries
+        if entry.status not in _INACTIVE_STATUSES and entry.value.strip()
+    )
+
+
+def _ontology_name(goal: str) -> str:
+    words = re.findall(r"[A-Za-z0-9]+", goal.title())
+    name = "".join(words[:4]) or "AutoTask"
+    if not name[0].isalpha():
+        name = f"Auto{name}"
+    return name[:64]

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -586,14 +586,19 @@ class AutoPipeline:
                 state.arm_deadline()
                 self._save(state)
             if state.phase == AutoPhase.INTERVIEW and state.interview_completed:
-                if not state.interview_session_id:
+                no_backend_closure = state.interview_closure_mode in {
+                    "ledger_only_no_backend",
+                    "safe_default_no_backend",
+                }
+                ledger_ready = ledger.is_seed_ready()
+                if not state.interview_session_id and not (no_backend_closure and ledger_ready):
                     state.mark_blocked(
                         "Completed interview is missing interview_session_id",
                         tool_name="auto_pipeline",
                     )
                     self._save(state)
                     return self._result(state, ledger, blocker=state.last_error)
-                if not ledger.is_seed_ready():
+                if not ledger_ready:
                     gaps = ", ".join(ledger.open_gaps())
                     state.mark_blocked(
                         f"Completed interview has unresolved ledger gaps: {gaps}",

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -32,6 +32,7 @@ from ouroboros.auto.handoff_contract import (
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.lateral_routing import select_persona_for_qa_failure
 from ouroboros.auto.ledger import AssumptionRecord, SeedDraftLedger
+from ouroboros.auto.ledger_seed import synthesize_seed_from_ledger
 from ouroboros.auto.listeners import RALPH_CANCEL_BLOCKER_REASON, mirror_ralph_job_events
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.recovery_plan import (
@@ -135,6 +136,23 @@ def _seed_generator_accepts_force(seed_generator: SeedGenerator) -> bool:
         return True
     # A callable that accepts arbitrary ``**kwargs`` can also take ``force``.
     return any(p.kind is inspect.Parameter.VAR_KEYWORD for p in parameters.values())
+
+
+def _is_authoring_backend_unavailable(exc: Exception) -> bool:
+    """Return True for provider/config failures that ledger Seed fallback may bypass."""
+    text = str(exc).casefold()
+    markers = (
+        "config.toml",
+        "profile",
+        "codex",
+        "provider",
+        "api key",
+        "authentication",
+        "rate limit",
+        "connection refused",
+        "network",
+    )
+    return any(marker in text for marker in markers)
 
 
 class RunStarter(Protocol):
@@ -663,13 +681,46 @@ class AutoPipeline:
                 state.transition(AutoPhase.REVIEW, "resuming review from persisted Seed")
                 self._save(state)
             else:
-                if not state.interview_session_id:
-                    state.mark_failed(
-                        "seed generation cannot resume without interview_session_id",
-                        tool_name="seed_generator",
+                if (
+                    state.interview_closure_mode
+                    in {"ledger_only_no_backend", "safe_default_no_backend"}
+                    and ledger.is_seed_ready()
+                ):
+                    seed = synthesize_seed_from_ledger(
+                        ledger, interview_id=state.interview_session_id
+                    )
+                    seed = self._record_generated_seed(state, ledger, seed)
+                    state.mark_progress(
+                        "Seed generated from completed ledger without authoring backend",
+                        tool_name="ledger_seed_generator",
                     )
                     self._save(state)
-                    return self._result(state, ledger, blocker=state.last_error)
+                    state.transition(
+                        AutoPhase.REVIEW,
+                        f"reviewing Seed for required grade {state.required_grade}",
+                    )
+                    self._save(state)
+                    return await self.run(state)
+                if not state.interview_session_id:
+                    if not ledger.is_seed_ready():
+                        state.mark_failed(
+                            "seed generation cannot resume without interview_session_id",
+                            tool_name="seed_generator",
+                        )
+                        self._save(state)
+                        return self._result(state, ledger, blocker=state.last_error)
+                    seed = synthesize_seed_from_ledger(ledger)
+                    seed = self._record_generated_seed(state, ledger, seed)
+                    state.mark_progress(
+                        "Seed generated from completed ledger", tool_name="ledger_seed_generator"
+                    )
+                    self._save(state)
+                    state.transition(
+                        AutoPhase.REVIEW,
+                        f"reviewing Seed for required grade {state.required_grade}",
+                    )
+                    self._save(state)
+                    return await self.run(state)
                 seed_timeout = self._deadline_capped_timeout(state, self.seed_timeout_seconds)
                 # SSOT #1157 *Closure Policy* (2026-05-27): when the interview
                 # closed on ledger evidence (``ledger_only`` / ``safe_default``)
@@ -703,45 +754,27 @@ class AutoPipeline:
                     if not isinstance(seed, Seed):
                         msg = f"seed generator returned {type(seed).__name__}, expected Seed"
                         raise TypeError(msg)
-                    # Apply deterministic floor: the LLM-derived ambiguity_score
-                    # cannot fall below what code can objectively measure from the
-                    # ledger (open gaps, conflicting entries, assumption-only
-                    # sections). Seals self-rationalization at the A-grade gate.
-                    floor = deterministic_floor(ledger)
-                    if floor > seed.metadata.ambiguity_score:
-                        seed = seed.model_copy(
-                            update={
-                                "metadata": seed.metadata.model_copy(
-                                    update={"ambiguity_score": floor}
-                                ),
-                            }
-                        )
-                    seed = normalize_execution_acceptance(seed)
-                    state.seed_id = seed.metadata.seed_id
-                    state.seed_artifact = seed.to_dict()
-                    state.seed_origin = SeedOrigin.AUTO_PIPELINE
-                    # L1-d / #1171: derive the task class from the already-
-                    # standardized ledger and prepend the catalog's default
-                    # AC template to the Seed. Single match → apply that class;
-                    # unmatched → apply the safe LIBRARY fallback from L1-b;
-                    # ambiguous → leave the user's AC untouched until the
-                    # L1-c interview-driver disambiguation hook resolves it.
-                    # ``state.active_task_class`` is set only when a concrete
-                    # class/fallback actually fired, so the envelope does not
-                    # pretend an unresolved ambiguous class was active.
-                    _inference = derive_domain_from_ledger(ledger)
-                    _task_class = _inference.single
-                    if _task_class is not None:
-                        _applied = apply_default_ac_template(seed, _task_class)
-                        if _applied.injected_ac:
-                            seed = _applied.seed
-                            state.seed_id = seed.metadata.seed_id
-                            state.seed_artifact = seed.to_dict()
-                        state.active_task_class = _task_class.value
+                    seed = self._record_generated_seed(state, ledger, seed)
                 except TimeoutError as exc:
                     if self._enforce_deadline(state):
                         record_authoring_backend(state)
                         return self._result(state, ledger, blocker=state.last_error)
+                    if ledger.is_seed_ready() and _is_authoring_backend_unavailable(exc):
+                        seed = synthesize_seed_from_ledger(
+                            ledger, interview_id=state.interview_session_id
+                        )
+                        seed = self._record_generated_seed(state, ledger, seed)
+                        state.mark_progress(
+                            "Seed generated from completed ledger after seed generator timeout",
+                            tool_name="ledger_seed_generator",
+                        )
+                        self._save(state)
+                        state.transition(
+                            AutoPhase.REVIEW,
+                            f"reviewing Seed for required grade {state.required_grade}",
+                        )
+                        self._save(state)
+                        return await self.run(state)
                     state.mark_blocked(
                         f"seed generation timed out after {self.seed_timeout_seconds:.0f}s",
                         tool_name="seed_generator",
@@ -750,6 +783,22 @@ class AutoPipeline:
                     self._save(state)
                     return self._result(state, ledger, blocker=str(exc) or state.last_error)
                 except Exception as exc:
+                    if ledger.is_seed_ready() and _is_authoring_backend_unavailable(exc):
+                        seed = synthesize_seed_from_ledger(
+                            ledger, interview_id=state.interview_session_id
+                        )
+                        seed = self._record_generated_seed(state, ledger, seed)
+                        state.mark_progress(
+                            f"Seed generated from completed ledger after seed generator failure: {exc}",
+                            tool_name="ledger_seed_generator",
+                        )
+                        self._save(state)
+                        state.transition(
+                            AutoPhase.REVIEW,
+                            f"reviewing Seed for required grade {state.required_grade}",
+                        )
+                        self._save(state)
+                        return await self.run(state)
                     message = f"seed generation failed: {exc}"
                     if _is_seed_generation_blocker(exc):
                         state.mark_blocked(message, tool_name="seed_generator")
@@ -2850,6 +2899,38 @@ class AutoPipeline:
             state.seed_artifact = normalized.to_dict()
             self._save(state)
         return normalized
+
+    def _record_generated_seed(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        seed: Seed,
+    ) -> Seed:
+        """Persist a newly generated Seed and apply deterministic auto enrichments."""
+        floor = deterministic_floor(ledger)
+        if floor > seed.metadata.ambiguity_score:
+            seed = seed.model_copy(
+                update={
+                    "metadata": seed.metadata.model_copy(update={"ambiguity_score": floor}),
+                }
+            )
+        seed = normalize_execution_acceptance(seed)
+        state.seed_id = seed.metadata.seed_id
+        state.seed_artifact = seed.to_dict()
+        state.seed_origin = SeedOrigin.AUTO_PIPELINE
+
+        # L1-d / #1171: derive the task class from the standardized ledger
+        # and prepend the catalog's default AC template to the Seed.
+        inference = derive_domain_from_ledger(ledger)
+        task_class = inference.single
+        if task_class is not None:
+            applied = apply_default_ac_template(seed, task_class)
+            if applied.injected_ac:
+                seed = applied.seed
+                state.seed_id = seed.metadata.seed_id
+                state.seed_artifact = seed.to_dict()
+            state.active_task_class = task_class.value
+        return seed
 
     def _load_seed(self, state: AutoPipelineState, seed_path: str) -> Seed | None:
         if self.seed_loader is None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -759,7 +759,7 @@ class AutoPipeline:
                     if self._enforce_deadline(state):
                         record_authoring_backend(state)
                         return self._result(state, ledger, blocker=state.last_error)
-                    if ledger.is_seed_ready() and _is_authoring_backend_unavailable(exc):
+                    if ledger.is_seed_ready():
                         seed = synthesize_seed_from_ledger(
                             ledger, interview_id=state.interview_session_id
                         )

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -3324,6 +3324,63 @@ async def test_pipeline_forwards_force_to_seed_generator_on_ledger_only_closure(
 
 
 @pytest.mark.asyncio
+async def test_pipeline_synthesizes_seed_when_completed_ledger_generator_times_out(
+    tmp_path,
+) -> None:
+    """A completed ledger must bypass seed-authoring backend timeouts.
+
+    ``asyncio.wait_for`` raises a bare ``TimeoutError`` with an empty string,
+    so the timeout path cannot depend on provider/config marker text. Once the
+    ledger is seed-ready and the top-level pipeline deadline still has budget,
+    the deterministic ledger Seed fallback is the fail-soft boundary.
+    """
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "What else should we know?",
+            "interview_timeout_fallback",
+            seed_ready=False,
+            completed=False,
+            ambiguity_score=0.40,
+        )
+
+    async def answer(session_id, text, *, last_question=None):  # noqa: ARG001
+        raise AssertionError("complete ledger should close on round 0 without answering")
+
+    async def generate_seed(session_id: str, *, force: bool = False) -> Seed:  # noqa: ARG001
+        await asyncio.sleep(1)
+        raise AssertionError("wait_for should time out before this returns")
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
+        return {"job_id": "job_timeout_fallback", "execution_id": "exec_timeout_fallback"}
+
+    state = AutoPipelineState(goal="Build a habit-tracker CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=4,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        seed_timeout_seconds=0.01,
+    )
+
+    result = await pipeline.run(state)
+
+    assert state.interview_closure_mode == "ledger_only"
+    assert state.seed_origin == "auto_pipeline"
+    assert state.seed_artifact is not None
+    assert result.status in ("complete", "blocked", "seed_ready")
+    assert "seed generation timed out" not in (result.blocker or "")
+
+
+@pytest.mark.asyncio
 async def test_pipeline_does_not_force_seed_generator_on_mutual_agreement_closure(
     tmp_path,
 ) -> None:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -4544,6 +4544,42 @@ async def test_interview_driver_closes_with_safe_defaults_when_start_backend_una
 
 
 @pytest.mark.asyncio
+async def test_pipeline_resumes_no_backend_completed_interview_without_session_id(
+    tmp_path,
+) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("no-backend completed resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("no-backend completed resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("complete no-backend ledger should synthesize without handler")
+
+    state = AutoPipelineState(goal="Build a small local CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview closed after backend start failure")
+    state.interview_completed = True
+    state.interview_closure_mode = "safe_default_no_backend"
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    store = AutoStore(tmp_path)
+    store.save(state)
+    reloaded = store.load(state.auto_session_id)
+    assert reloaded is not None
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=store)
+    pipeline = AutoPipeline(driver, generate_seed, store=store, skip_run=True)
+
+    result = await pipeline.run(reloaded)
+
+    assert result.status == "complete"
+    assert result.seed_origin == "auto_pipeline"
+    assert result.interview_session_id is None
+    assert reloaded.seed_artifact is not None
+    assert reloaded.phase == AutoPhase.COMPLETE
+
+
+@pytest.mark.asyncio
 async def test_interview_driver_persists_partial_session_id_on_start_failure(tmp_path) -> None:
     """A handler-level partial-success error keeps the pre-allocated id on state."""
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2712,7 +2712,9 @@ async def test_pipeline_refuses_run_resume_without_a_grade(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_pipeline_seed_generation_resume_requires_interview_session_id(tmp_path) -> None:
+async def test_pipeline_seed_generation_resume_requires_interview_session_id_for_incomplete_ledger(
+    tmp_path,
+) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("seed resume should not restart interview")
 
@@ -2727,7 +2729,6 @@ async def test_pipeline_seed_generation_resume_requires_interview_session_id(tmp
     state.interview_completed = True
     state.transition(AutoPhase.SEED_GENERATION, "seed")
     ledger = SeedDraftLedger.from_goal(state.goal)
-    _fill_ready(ledger)
     state.ledger = ledger.to_dict()
     driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
     pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
@@ -2736,6 +2737,42 @@ async def test_pipeline_seed_generation_resume_requires_interview_session_id(tmp
 
     assert result.status == "failed"
     assert "interview_session_id" in (result.blocker or "")
+
+
+@pytest.mark.asyncio
+async def test_pipeline_seed_generation_without_interview_session_synthesizes_complete_ledger(
+    tmp_path,
+) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("seed resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("seed resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("complete ledger should synthesize without handler seed generation")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_completed = True
+    state.interview_closure_mode = "safe_default_no_backend"
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.seed_origin == "auto_pipeline"
+    assert result.interview_session_id is None
+    assert state.seed_artifact is not None
+    seed = Seed.from_dict(state.seed_artifact)
+    assert seed.goal == "Build a CLI"
+    assert seed.acceptance_criteria
+    assert result.grade == "A"
 
 
 @pytest.mark.asyncio
@@ -4390,7 +4427,7 @@ async def test_interview_driver_clears_session_id_when_backend_rejects_without_p
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("answer must not run when start fails")
 
-    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state = AutoPipelineState(goal="Deploy to production", cwd=str(tmp_path))
     ledger = SeedDraftLedger.from_goal(state.goal)
     store = AutoStore(tmp_path)
     # Probe always returns False — no on-disk evidence of persistence.
@@ -4412,6 +4449,41 @@ async def test_interview_driver_clears_session_id_when_backend_rejects_without_p
     reloaded = store.load(state.auto_session_id)
     assert reloaded is not None
     assert reloaded.interview_session_id is None
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_closes_with_safe_defaults_when_start_backend_unavailable(
+    tmp_path,
+) -> None:
+    """Backend start failure should not block benign goals that safe-default can close."""
+
+    async def start(goal: str, cwd: str, *, interview_id: str | None = None) -> InterviewTurn:  # noqa: ARG001
+        raise RuntimeError("codex profile failed before first question")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("answer must not run when start fails")
+
+    state = AutoPipelineState(goal="Build a small local CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    store = AutoStore(tmp_path)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer, is_session_persisted=lambda _id: False),
+        store=store,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert state.phase == AutoPhase.INTERVIEW
+    assert state.interview_session_id is None
+    assert state.interview_completed is True
+    assert state.interview_closure_mode == "safe_default_no_backend"
+    assert ledger.is_seed_ready()
+
+    reloaded = store.load(state.auto_session_id)
+    assert reloaded is not None
+    assert reloaded.interview_closure_mode == "safe_default_no_backend"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary\n- add deterministic Seed synthesis from a completed auto ledger\n- let auto close benign start-time authoring backend failures through safe defaults instead of blocking immediately\n- preserve strict failure behavior for incomplete ledgers and malformed/non-provider seed generation errors\n\n## Verification\n- uv run ruff check src/ouroboros/auto/grading.py src/ouroboros/auto/interview_driver.py src/ouroboros/auto/pipeline.py src/ouroboros/auto/ledger_seed.py tests/unit/auto/test_interview_pipeline.py\n- uv run pytest tests/unit/auto tests/unit/cli/test_auto_command.py tests/unit/cli/test_auto_runtime_dispatch.py tests/unit/mcp/tools/test_auto_handler_ralph_runtime.py tests/unit/mcp/tools/test_auto_interview_construction.py tests/unit/mcp/tools/test_start_auto.py tests/integration/auto -q\n- real smoke: uv --directory /Users/jaegyu.lee/Project/ouroboros-gemini3 run ouroboros auto "Create a Python module hello_auto.py with hello_auto() returning 'hello from ooo auto', plus pytest coverage in tests/test_hello_auto.py; verification command is uv run pytest tests/test_hello_auto.py." --skip-run --quiet --timeout 60\n\nSmoke result: completed with status=complete, Seed grade=A, despite the reproduced Codex profile config error at interview start.