### PR TITLE
fix(auto): let ledger fallback survive timeouts and resume

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -22,7 +22,7 @@ from ouroboros.mcp.tools.authoring_handlers import (
     InterviewHandler,
 )
 from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
-from ouroboros.mcp.tools.execution_handlers import StartExecuteSeedHandler
+from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler
 from ouroboros.mcp.tools.qa import QAHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.tools.subagent import should_dispatch_via_plugin
@@ -237,7 +237,44 @@ class HandlerRunStarter:
             "job_id": _optional_str(meta.get("job_id")),
             "session_id": _optional_str(meta.get("session_id")),
             "execution_id": _optional_str(meta.get("execution_id")),
+            "status": _optional_str(meta.get("status")),
         }
+        if isinstance(meta.get("success"), bool):
+            run_meta["success"] = meta["success"]
+        if isinstance(meta.get("_subagent"), dict):
+            run_meta["_subagent"] = meta["_subagent"]
+        return run_meta
+
+
+class HandlerSynchronousRunStarter:
+    """Callable run starter backed by inline ``ouroboros_execute_seed`` execution."""
+
+    synchronous_execution = True
+
+    def __init__(self, handler: ExecuteSeedHandler, *, cwd: str) -> None:
+        self.handler = handler
+        self.cwd = cwd
+
+    async def __call__(self, seed: Seed, *, idempotency_key: str = "") -> dict[str, object]:  # noqa: ARG002
+        seed_yaml = yaml.dump(
+            seed.to_dict(), default_flow_style=False, allow_unicode=True, sort_keys=False
+        )
+        result = _unwrap(
+            await self.handler.handle(
+                {"seed_content": seed_yaml, "cwd": self.cwd},
+                synchronous=True,
+            ),
+            tool_name="ouroboros_execute_seed",
+        )
+        meta = result.meta or {}
+        run_meta: dict[str, object] = {
+            "job_id": None,
+            "session_id": _optional_str(meta.get("session_id")),
+            "execution_id": _optional_str(meta.get("execution_id")),
+            "status": _optional_str(meta.get("status")),
+        }
+        if isinstance(meta.get("success"), bool):
+            run_meta["success"] = meta["success"]
         if isinstance(meta.get("_subagent"), dict):
             run_meta["_subagent"] = meta["_subagent"]
         return run_meta
@@ -311,7 +348,7 @@ class HandlerRalphStarter:
                         "status": "reattaching",
                     }
                 )
-            terminal_meta = await _wait_for_job_terminal(
+            terminal_meta = await _wait_for_job_terminal_with_cancel_cleanup(
                 job_manager,
                 existing_job_id,
                 timeout_seconds=max_total_seconds,
@@ -411,7 +448,7 @@ class HandlerRalphStarter:
         if max_total_seconds is None:
             terminal_meta = await _wait_for_job_terminal(job_manager, job_id)
         else:
-            terminal_meta = await _wait_for_job_terminal(
+            terminal_meta = await _wait_for_job_terminal_with_cancel_cleanup(
                 job_manager,
                 job_id,
                 timeout_seconds=max_total_seconds,
@@ -471,7 +508,7 @@ class HandlerRalphPoller:
         if max_total_seconds is None:
             terminal_meta = await _wait_for_job_terminal(job_manager, job_id)
         else:
-            terminal_meta = await _wait_for_job_terminal(
+            terminal_meta = await _wait_for_job_terminal_with_cancel_cleanup(
                 job_manager,
                 job_id,
                 timeout_seconds=max_total_seconds,
@@ -743,6 +780,7 @@ async def _wait_for_job_terminal(
     *,
     poll_interval: float = 0.05,
     timeout_seconds: float | None = None,
+    cancel_on_timeout: bool = False,
 ) -> dict[str, Any]:
     """Poll the job manager until ``job_id`` reaches a terminal state.
 
@@ -774,6 +812,8 @@ async def _wait_for_job_terminal(
         if deadline is not None:
             remaining = deadline - loop.time()
             if remaining <= 0:
+                if cancel_on_timeout:
+                    await _cancel_job_after_terminal_wait_timeout(job_manager, job_id)
                 return {
                     "job_id": job_id,
                     "status": "failed",
@@ -782,6 +822,35 @@ async def _wait_for_job_terminal(
             await asyncio.sleep(min(poll_interval, remaining))
             continue
         await asyncio.sleep(poll_interval)
+
+
+async def _wait_for_job_terminal_with_cancel_cleanup(
+    job_manager: JobManager,
+    job_id: str,
+    *,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    try:
+        return await _wait_for_job_terminal(
+            job_manager,
+            job_id,
+            timeout_seconds=timeout_seconds,
+            cancel_on_timeout=True,
+        )
+    except asyncio.CancelledError:
+        await _cancel_job_after_terminal_wait_timeout(job_manager, job_id)
+        raise
+
+
+async def _cancel_job_after_terminal_wait_timeout(job_manager: JobManager, job_id: str) -> None:
+    """Best-effort cleanup for jobs that outlive the auto pipeline deadline."""
+    cancel_job = getattr(job_manager, "cancel_job", None)
+    if cancel_job is None:
+        return
+    try:
+        await cancel_job(job_id)
+    except Exception:
+        return
 
 
 def _terminal_job_status(status: JobStatus) -> str:

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
+import contextlib
 from dataclasses import dataclass
 import hashlib
 import os
@@ -290,17 +291,29 @@ class HandlerSynchronousRunStarter:
             )
         )
         task.add_done_callback(_consume_background_result)
-        while True:
-            done, _pending = await asyncio.wait(
-                {task},
-                timeout=max(0.1, self.terminal_poll_interval_seconds),
-            )
-            if done:
-                result = _unwrap(await task, tool_name="ouroboros_execute_seed")
-                break
-            recovered = await self.recover_timed_out_run()
-            if recovered is not None:
-                return recovered
+        try:
+            while True:
+                done, _pending = await asyncio.wait(
+                    {task},
+                    timeout=max(0.1, self.terminal_poll_interval_seconds),
+                )
+                if done:
+                    result = _unwrap(await task, tool_name="ouroboros_execute_seed")
+                    break
+                recovered = await self.recover_timed_out_run()
+                if recovered is not None:
+                    return recovered
+        except asyncio.CancelledError:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            if self._latest_run_meta is not None:
+                self._latest_run_meta = {
+                    **self._latest_run_meta,
+                    "status": "cancelled",
+                    "success": False,
+                }
+            raise
         meta = result.meta or {}
         run_meta: dict[str, object] = {
             "job_id": None,

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -9,6 +9,7 @@ import hashlib
 import os
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 import yaml
 
@@ -28,6 +29,8 @@ from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.tools.subagent import should_dispatch_via_plugin
 from ouroboros.mcp.types import MCPToolResult
 from ouroboros.orchestrator.runtime_evidence import HeadlessRunProbe, RuntimeEvidence
+from ouroboros.orchestrator.session import SessionRepository, SessionStatus
+from ouroboros.persistence.event_store import EventStore
 from ouroboros.resilience.lateral import ThinkingPersona
 
 _SAFE_SEED_ID_FILENAME_CHARS = frozenset(
@@ -251,33 +254,115 @@ class HandlerSynchronousRunStarter:
 
     synchronous_execution = True
 
-    def __init__(self, handler: ExecuteSeedHandler, *, cwd: str) -> None:
+    def __init__(
+        self,
+        handler: ExecuteSeedHandler,
+        *,
+        cwd: str,
+        skip_qa: bool = True,
+        terminal_poll_interval_seconds: float = 2.0,
+    ) -> None:
         self.handler = handler
         self.cwd = cwd
+        self.skip_qa = skip_qa
+        self.terminal_poll_interval_seconds = terminal_poll_interval_seconds
+        self._latest_run_meta: dict[str, object] | None = None
 
     async def __call__(self, seed: Seed, *, idempotency_key: str = "") -> dict[str, object]:  # noqa: ARG002
         seed_yaml = yaml.dump(
             seed.to_dict(), default_flow_style=False, allow_unicode=True, sort_keys=False
         )
-        result = _unwrap(
-            await self.handler.handle(
-                {"seed_content": seed_yaml, "cwd": self.cwd},
+        session_id = f"orch_{uuid4().hex[:12]}"
+        execution_id = f"exec_{uuid4().hex[:12]}"
+        self._latest_run_meta = {
+            "job_id": None,
+            "session_id": session_id,
+            "execution_id": execution_id,
+            "status": "running",
+            "_allow_deadline_completion_grace": True,
+        }
+        task = asyncio.create_task(
+            self.handler.handle(
+                {"seed_content": seed_yaml, "cwd": self.cwd, "skip_qa": self.skip_qa},
+                execution_id=execution_id,
+                session_id_override=session_id,
                 synchronous=True,
-            ),
-            tool_name="ouroboros_execute_seed",
+            )
         )
+        task.add_done_callback(_consume_background_result)
+        while True:
+            done, _pending = await asyncio.wait(
+                {task},
+                timeout=max(0.1, self.terminal_poll_interval_seconds),
+            )
+            if done:
+                result = _unwrap(await task, tool_name="ouroboros_execute_seed")
+                break
+            recovered = await self.recover_timed_out_run()
+            if recovered is not None:
+                return recovered
         meta = result.meta or {}
         run_meta: dict[str, object] = {
             "job_id": None,
             "session_id": _optional_str(meta.get("session_id")),
             "execution_id": _optional_str(meta.get("execution_id")),
             "status": _optional_str(meta.get("status")),
+            "_allow_deadline_completion_grace": True,
         }
         if isinstance(meta.get("success"), bool):
             run_meta["success"] = meta["success"]
         if isinstance(meta.get("_subagent"), dict):
             run_meta["_subagent"] = meta["_subagent"]
+        self._latest_run_meta = dict(run_meta)
         return run_meta
+
+    async def recover_timed_out_run(self) -> dict[str, object] | None:
+        """Recover terminal metadata if inline execution finished during handler teardown."""
+        latest = self._latest_run_meta
+        if not latest:
+            return None
+        session_id = _optional_str(latest.get("session_id"))
+        execution_id = _optional_str(latest.get("execution_id"))
+        if not session_id:
+            return None
+
+        event_store = EventStore()
+        try:
+            await event_store.initialize()
+            result = await SessionRepository(event_store).reconstruct_session(session_id)
+        finally:
+            close_result = event_store.close()
+            if asyncio.iscoroutine(close_result):
+                await close_result
+        if result.is_err:
+            return None
+
+        tracker = result.value
+        if tracker.status == SessionStatus.RUNNING:
+            return None
+        status = tracker.status.value
+        recovered: dict[str, object] = {
+            "job_id": None,
+            "session_id": tracker.session_id,
+            "execution_id": execution_id or tracker.execution_id,
+            "status": status,
+            "_allow_deadline_completion_grace": True,
+        }
+        if tracker.status == SessionStatus.COMPLETED:
+            recovered["success"] = True
+        elif tracker.status in (SessionStatus.FAILED, SessionStatus.CANCELLED):
+            recovered["success"] = False
+        self._latest_run_meta = dict(recovered)
+        return recovered
+
+
+def _consume_background_result(task: asyncio.Task[Any]) -> None:
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        return
+    except Exception:
+        return
 
 
 class HandlerRalphStarter:

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -6,7 +6,7 @@ from ouroboros.auto.task_class_application import (
     has_explicit_verification_contract,
     has_explicit_verification_text,
 )
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import ExitCondition, Seed
 
 _AUTO_WRAPPER_CRITERIA = frozenset(
     {
@@ -147,6 +147,12 @@ _MINIMAL_VERIFICATION_METADATA_CONSTRAINT = (
     "needed to run the exact verification command is allowed."
 )
 
+_REAL_VERIFICATION_TOOL_CONSTRAINT = (
+    "Use the real verification tool named by the exact command; do not satisfy it "
+    "with a local shim or replacement executable. Minimal project metadata and "
+    "dependencies needed for that tool are allowed."
+)
+
 
 def _relax_minimality_constraints_for_exact_verification(seed: Seed) -> Seed:
     """Allow the smallest runnable test metadata for exact verification commands.
@@ -168,11 +174,18 @@ def _relax_minimality_constraints_for_exact_verification(seed: Seed) -> Seed:
             continue
         filtered.append(constraint)
 
-    if not relaxed:
+    exit_conditions, exit_relaxed = _relax_exit_conditions_for_exact_verification(
+        seed.exit_conditions
+    )
+    if not relaxed and not exit_relaxed:
         return seed
+    if _REAL_VERIFICATION_TOOL_CONSTRAINT not in filtered:
+        filtered.append(_REAL_VERIFICATION_TOOL_CONSTRAINT)
     if _MINIMAL_VERIFICATION_METADATA_CONSTRAINT not in filtered:
         filtered.append(_MINIMAL_VERIFICATION_METADATA_CONSTRAINT)
-    return seed.model_copy(update={"constraints": tuple(filtered)})
+    return seed.model_copy(
+        update={"constraints": tuple(filtered), "exit_conditions": exit_conditions}
+    )
 
 
 def _drop_repaired_fragments_when_exact_verification_exists(
@@ -282,9 +295,35 @@ def _is_overstrict_exact_verification_constraint(constraint: str) -> bool:
         or ("no additional files" in key)
         or ("avoid new dependencies" in key)
         or ("no new dependencies" in key)
+        or ("do not add new dependencies" in key)
         or ("no additional" in key and "dependencies" in key)
         or ("implementation limited to" in key and "test" in key)
     )
+
+
+def _relax_exit_conditions_for_exact_verification(
+    exit_conditions: tuple[ExitCondition, ...],
+) -> tuple[tuple[ExitCondition, ...], bool]:
+    updated: list[ExitCondition] = []
+    relaxed = False
+    for condition in exit_conditions:
+        if _is_overstrict_exact_verification_constraint(condition.evaluation_criteria):
+            relaxed = True
+            updated.append(
+                condition.model_copy(
+                    update={
+                        "evaluation_criteria": (
+                            "No unrelated dependencies, frameworks, deployment targets, "
+                            "credentials, or external side effects are introduced; "
+                            "minimal project metadata and dependencies needed to run the "
+                            "exact verification command are allowed."
+                        )
+                    }
+                )
+            )
+            continue
+        updated.append(condition)
+    return tuple(updated), relaxed
 
 
 def _normalize_known_observation_execution_line(criterion: str) -> str:

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from ouroboros.auto.task_class_application import (
+    has_explicit_verification_contract,
+    has_explicit_verification_text,
+)
 from ouroboros.core.seed import Seed
 
 _AUTO_WRAPPER_CRITERIA = frozenset(
@@ -122,10 +126,81 @@ def normalize_execution_acceptance(seed: Seed) -> Seed:
     context.
     """
     criteria = tuple(ac for ac in seed.acceptance_criteria if ac and ac.strip())
-    if not criteria or not _has_auto_wrapper_context(seed.goal, criteria):
+    if not criteria:
+        return seed
+
+    seed = _relax_minimality_constraints_for_exact_verification(seed)
+    seed = _drop_repaired_fragments_when_exact_verification_exists(seed, criteria)
+    criteria = tuple(seed.acceptance_criteria)
+
+    if not _has_auto_wrapper_context(seed.goal, criteria):
         return seed
 
     filtered = normalize_observation_execution_criteria(criteria, context_text=seed.goal)
+    if not filtered or filtered == criteria:
+        return seed
+    return seed.model_copy(update={"acceptance_criteria": filtered})
+
+
+_MINIMAL_VERIFICATION_METADATA_CONSTRAINT = (
+    "Do not add unrelated files, dependencies, or behavior; minimal project metadata "
+    "needed to run the exact verification command is allowed."
+)
+
+
+def _relax_minimality_constraints_for_exact_verification(seed: Seed) -> Seed:
+    """Allow the smallest runnable test metadata for exact verification commands.
+
+    In a clean greenfield cwd, an exact command such as ``uv run pytest ...`` may
+    require project metadata declaring pytest. Seed repair/generation sometimes
+    adds broad "no extra files/dependencies" constraints that make that command
+    impossible. Keep the scope guard, but phrase it so verification metadata is
+    permitted.
+    """
+    if not has_explicit_verification_contract(seed):
+        return seed
+
+    filtered: list[str] = []
+    relaxed = False
+    for constraint in seed.constraints:
+        if _is_overstrict_exact_verification_constraint(constraint):
+            relaxed = True
+            continue
+        filtered.append(constraint)
+
+    if not relaxed:
+        return seed
+    if _MINIMAL_VERIFICATION_METADATA_CONSTRAINT not in filtered:
+        filtered.append(_MINIMAL_VERIFICATION_METADATA_CONSTRAINT)
+    return seed.model_copy(update={"constraints": tuple(filtered)})
+
+
+def _drop_repaired_fragments_when_exact_verification_exists(
+    seed: Seed,
+    criteria: tuple[str, ...],
+) -> Seed:
+    """Remove repairer-split requirement fragments behind an exact test command.
+
+    The Seed repairer can turn one concrete criterion such as "create these
+    files and run this exact pytest command" into multiple generic
+    "command/API check proves original requirement" ACs. When a Seed already
+    contains a non-repaired executable verification command, those fragments
+    only expand runtime work without adding a stronger contract.
+    """
+    if not has_explicit_verification_contract(seed):
+        return seed
+    if not any(
+        _contains_explicit_verification_command(criterion)
+        and not _is_seed_repairer_original_requirement_line(criterion)
+        for criterion in criteria
+    ):
+        return seed
+
+    filtered = tuple(
+        criterion
+        for criterion in criteria
+        if not _is_seed_repairer_original_requirement_line(criterion)
+    )
     if not filtered or filtered == criteria:
         return seed
     return seed.model_copy(update={"acceptance_criteria": filtered})
@@ -196,6 +271,22 @@ def _criterion_key(criterion: str) -> str:
     return " ".join(criterion.casefold().strip().rstrip(".").split())
 
 
+def _contains_explicit_verification_command(criterion: str) -> bool:
+    return has_explicit_verification_text(criterion)
+
+
+def _is_overstrict_exact_verification_constraint(constraint: str) -> bool:
+    key = _criterion_key(constraint)
+    return (
+        ("no extra files" in key)
+        or ("no additional files" in key)
+        or ("avoid new dependencies" in key)
+        or ("no new dependencies" in key)
+        or ("no additional" in key and "dependencies" in key)
+        or ("implementation limited to" in key and "test" in key)
+    )
+
+
 def _normalize_known_observation_execution_line(criterion: str) -> str:
     """Canonicalize only known-equivalent hello_auto execution AC phrasings."""
     key = _criterion_key(criterion)
@@ -238,13 +329,21 @@ def _is_hello_auto_observation_unit_line(criterion: str) -> bool:
 def _is_observation_report_wrapper(criterion: str) -> bool:
     """Return true for repairer-wrapped observation report requirements."""
     key = _criterion_key(criterion)
-    if not key.startswith(_SEED_REPAIRER_ORIGINAL_REQUIREMENT_PREFIX):
+    if not _is_seed_repairer_original_requirement_key(key):
         return False
     return "observation report" in key or "plain chat summary" in key
 
 
 def _unwrap_seed_repairer_original_requirement(criterion: str) -> str:
     key = _criterion_key(criterion)
-    if not key.startswith(_SEED_REPAIRER_ORIGINAL_REQUIREMENT_PREFIX):
+    if not _is_seed_repairer_original_requirement_key(key):
         return criterion
     return key.removeprefix(_SEED_REPAIRER_ORIGINAL_REQUIREMENT_PREFIX)
+
+
+def _is_seed_repairer_original_requirement_line(criterion: str) -> bool:
+    return _is_seed_repairer_original_requirement_key(_criterion_key(criterion))
+
+
+def _is_seed_repairer_original_requirement_key(key: str) -> bool:
+    return key.startswith(_SEED_REPAIRER_ORIGINAL_REQUIREMENT_PREFIX)

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from ouroboros.auto.task_class_application import (
     has_explicit_verification_contract,
     has_explicit_verification_text,
@@ -63,7 +65,7 @@ _OBSERVATION_CONTEXT_ALTERNATES = (
 
 _CANONICAL_HELLO_AUTO_OBSERVATION_AC = (
     "Create `hello_auto.py` and `tests/test_hello_auto.py` so "
-    "`hello_auto() -> str` returns exactly `hello from ooo auto`, "
+    "`hello_auto() -> str` returns exactly `{return_value}`, "
     "the test imports `hello_auto` and asserts that exact value, and "
     "the exact command `uv run pytest tests/test_hello_auto.py` passes."
 )
@@ -254,7 +256,8 @@ def normalize_observation_execution_criteria(
         passthrough = [
             line for line in execution_lines if not _is_hello_auto_observation_unit_line(line)
         ]
-        return tuple(dict.fromkeys((_CANONICAL_HELLO_AUTO_OBSERVATION_AC, *passthrough)))
+        canonical = _canonical_hello_auto_observation_ac(context_text, tuple(execution_lines))
+        return tuple(dict.fromkeys((canonical, *passthrough)))
 
     normalized = [_normalize_known_observation_execution_line(line) for line in execution_lines]
     return tuple(dict.fromkeys(normalized))
@@ -350,6 +353,23 @@ def _normalize_known_observation_execution_line(criterion: str) -> str:
     if key in _HELLO_AUTO_PYTEST_EQUIVALENTS:
         return "The exact command `uv run pytest tests/test_hello_auto.py` passes."
     return criterion
+
+
+def _canonical_hello_auto_observation_ac(context_text: str, criteria: tuple[str, ...]) -> str:
+    return_value = _extract_hello_auto_return_value("\n".join((context_text, *criteria)))
+    return _CANONICAL_HELLO_AUTO_OBSERVATION_AC.format(return_value=return_value)
+
+
+def _extract_hello_auto_return_value(text: str) -> str:
+    for pattern in (
+        r"hello_auto\(\)(?:\s*->\s*str)?\s+returns?\s+exactly\s+[`'\"]([^`'\"]+)[`'\"]",
+        r"returning\s+exactly\s+[`'\"]([^`'\"]+)[`'\"]",
+        r"must\s+return\s+exactly\s+[`'\"]([^`'\"]+)[`'\"]",
+    ):
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match:
+            return match.group(1).strip()
+    return "hello from ooo auto"
 
 
 def _is_observation_report_only_line(criterion: str) -> bool:

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -129,7 +129,7 @@ def normalize_execution_acceptance(seed: Seed) -> Seed:
     if not criteria:
         return seed
 
-    seed = _relax_minimality_constraints_for_exact_verification(seed)
+    seed = _relax_minimality_constraints_for_exact_verification(seed, criteria)
     seed = _drop_repaired_fragments_when_exact_verification_exists(seed, criteria)
     criteria = tuple(seed.acceptance_criteria)
 
@@ -154,7 +154,10 @@ _REAL_VERIFICATION_TOOL_CONSTRAINT = (
 )
 
 
-def _relax_minimality_constraints_for_exact_verification(seed: Seed) -> Seed:
+def _relax_minimality_constraints_for_exact_verification(
+    seed: Seed,
+    criteria: tuple[str, ...],
+) -> Seed:
     """Allow the smallest runnable test metadata for exact verification commands.
 
     In a clean greenfield cwd, an exact command such as ``uv run pytest ...`` may
@@ -177,9 +180,10 @@ def _relax_minimality_constraints_for_exact_verification(seed: Seed) -> Seed:
     exit_conditions, exit_relaxed = _relax_exit_conditions_for_exact_verification(
         seed.exit_conditions
     )
-    if not relaxed and not exit_relaxed:
+    add_real_tool_guard = _has_non_repaired_exact_verification_criterion(criteria)
+    if not relaxed and not exit_relaxed and not add_real_tool_guard:
         return seed
-    if _REAL_VERIFICATION_TOOL_CONSTRAINT not in filtered:
+    if add_real_tool_guard and _REAL_VERIFICATION_TOOL_CONSTRAINT not in filtered:
         filtered.append(_REAL_VERIFICATION_TOOL_CONSTRAINT)
     if _MINIMAL_VERIFICATION_METADATA_CONSTRAINT not in filtered:
         filtered.append(_MINIMAL_VERIFICATION_METADATA_CONSTRAINT)
@@ -286,6 +290,14 @@ def _criterion_key(criterion: str) -> str:
 
 def _contains_explicit_verification_command(criterion: str) -> bool:
     return has_explicit_verification_text(criterion)
+
+
+def _has_non_repaired_exact_verification_criterion(criteria: tuple[str, ...]) -> bool:
+    return any(
+        _contains_explicit_verification_command(criterion)
+        and not _is_seed_repairer_original_requirement_line(criterion)
+        for criterion in criteria
+    )
 
 
 def _is_overstrict_exact_verification_constraint(constraint: str) -> bool:

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -41,6 +41,7 @@ from ouroboros.resilience.lateral import ThinkingPersona
 log = structlog.get_logger(__name__)
 
 INTERVIEW_SAFE_DEFAULT_SYNTHESIS_STOP_REASON_CODE = "interview_safe_default_synthesis_incomplete"
+BACKEND_READY_AMBIGUITY_THRESHOLD = 0.20
 
 # Issue #1248 — L5 ladder typed terminal for a safe-default lateral escalation
 # that exhausted every available persona without resolving the matcher fire.
@@ -256,6 +257,10 @@ class AutoInterviewDriver:
                 self._save(state)
         except TimeoutError as exc:
             self._record_evidence_based_session_id(state, exc, preassigned_id)
+            if interview_tool_name == "interview.start":
+                fallback = self._try_close_after_backend_start_failure(state, ledger, exc)
+                if fallback is not None:
+                    return fallback
             message = str(exc)
             state.mark_blocked(message, tool_name=interview_tool_name)
             record_authoring_backend(state)
@@ -355,6 +360,14 @@ class AutoInterviewDriver:
             self._save(state)
 
             if backend_done and not ledger_done:
+                backend_ready_defaults = await self._try_close_backend_ready_safe_defaults(
+                    state,
+                    ledger,
+                    turn,
+                )
+                if backend_ready_defaults is not None:
+                    return backend_ready_defaults
+
                 # Backend said done but ledger isn't — pick the first detected
                 # gap and answer it. This drives the backend to reopen with
                 # substantive new content; we never accept closure unilaterally.
@@ -1143,6 +1156,122 @@ class AutoInterviewDriver:
 
         return finalization
 
+    async def _try_close_backend_ready_safe_defaults(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        turn: InterviewTurn,
+    ) -> AutoInterviewResult | None:
+        """Close benign remaining gaps after a low-ambiguity backend completion.
+
+        Backend completion alone is not enough to close auto interviews: the
+        ledger still owns structural readiness. When the backend also reports a
+        concrete ambiguity score at the seed threshold, any remaining
+        missing/weak sections are safe to route through the same audited
+        safe-default finalizer used at max_rounds. Unsafe/conflicting gaps keep
+        the existing gap-reopen path.
+        """
+        if turn.ambiguity_score is None or turn.ambiguity_score > BACKEND_READY_AMBIGUITY_THRESHOLD:
+            return None
+        if ledger.is_seed_ready():
+            return None
+
+        finalization = finalize_safe_defaultable_gaps(
+            ledger,
+            goal=state.goal,
+            provenance=(
+                "backend readiness "
+                f"ambiguity_score={turn.ambiguity_score:.2f} "
+                f"round={state.current_round}"
+            ),
+            pending_question=turn.question,
+            active_profile=getattr(self.answerer, "active_profile", None),
+        )
+        if not finalization.completed or not ledger.is_seed_ready():
+            _revert_safe_default_entries(ledger, finalization.defaulted_sections)
+            log.info(
+                "auto.interview.backend_ready_safe_default.skipped",
+                auto_session_id=state.auto_session_id,
+                ambiguity_score=turn.ambiguity_score,
+                defaulted_sections=finalization.defaulted_sections,
+                unsafe_gaps=finalization.unsafe_gaps,
+                open_gaps=ledger.open_gaps(),
+            )
+            return None
+
+        synthesis = build_safe_default_synthesis(finalization)
+        if synthesis and state.interview_session_id:
+            try:
+                synthesis_turn = _validate_turn(
+                    await self._with_timeout(
+                        self.backend.answer(
+                            state.interview_session_id,
+                            synthesis,
+                            last_question=(
+                                "[driver safe-default finalization: "
+                                f"backend_ambiguity={turn.ambiguity_score:.2f}]"
+                            ),
+                        ),
+                        state,
+                        tool_name="interview.backend_ready_safe_default_synthesis",
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001 - keep ledger/transcript in sync
+                _revert_safe_default_entries(ledger, finalization.defaulted_sections)
+                blocker = (
+                    "backend-ready safe-default synthesis transcript sync failed; "
+                    f"rolled back defaulted sections: {', '.join(finalization.defaulted_sections)}; "
+                    f"error={exc}"
+                )
+                state.ledger = ledger.to_dict()
+                state.mark_blocked(
+                    blocker,
+                    tool_name="interview.backend_ready_safe_default_synthesis",
+                    error_code=INTERVIEW_SAFE_DEFAULT_SYNTHESIS_STOP_REASON_CODE,
+                )
+                record_authoring_backend(state)
+                self._save(state)
+                return AutoInterviewResult(
+                    "blocked", state.interview_session_id, ledger, state.current_round, blocker
+                )
+            state.interview_session_id = synthesis_turn.session_id
+            state.pending_question = synthesis_turn.question
+            if not (synthesis_turn.seed_ready or synthesis_turn.completed):
+                _revert_safe_default_entries(ledger, finalization.defaulted_sections)
+                blocker = (
+                    "backend-ready safe-default synthesis did not close the persisted interview: "
+                    "ledger defaults rolled back"
+                )
+                state.ledger = ledger.to_dict()
+                state.mark_blocked(
+                    blocker,
+                    tool_name="interview.backend_ready_safe_default_synthesis",
+                    error_code=INTERVIEW_SAFE_DEFAULT_SYNTHESIS_STOP_REASON_CODE,
+                )
+                record_authoring_backend(state)
+                self._save(state)
+                return AutoInterviewResult(
+                    "blocked", state.interview_session_id, ledger, state.current_round, blocker
+                )
+
+        log.info(
+            "auto.interview.backend_ready_safe_default.closed",
+            auto_session_id=state.auto_session_id,
+            ambiguity_score=turn.ambiguity_score,
+            defaulted_sections=finalization.defaulted_sections,
+        )
+        state.ledger = ledger.to_dict()
+        state.pending_question = None
+        state.interview_completed = True
+        state.interview_closure_mode = "safe_default"
+        state.mark_progress(
+            "backend-ready safe-default finalization closed interview gaps: "
+            + ", ".join(finalization.defaulted_sections),
+            tool_name="interview_driver",
+        )
+        self._save(state)
+        return AutoInterviewResult("seed_ready", state.interview_session_id, ledger, state.current_round)
+
     async def _with_timeout(
         self, awaitable: Awaitable[InterviewTurn], state: AutoPipelineState, *, tool_name: str
     ) -> InterviewTurn:
@@ -1384,6 +1513,8 @@ def _is_authoring_backend_unavailable(exc: Exception) -> bool:
         "profile",
         "codex",
         "provider",
+        "timed out",
+        "timeout",
         "api key",
         "authentication",
         "rate limit",

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -822,6 +822,18 @@ class AutoInterviewDriver:
                 return None
             closure_mode = "safe_default_no_backend"
 
+        # SSOT transcript/ledger boundary: this fallback never pushes
+        # safe-default synthesis through ``backend.answer`` (the backend is
+        # by definition unavailable here), so any probe-confirmed
+        # ``interview_session_id`` recorded by ``_record_evidence_based_session_id``
+        # points at a persisted interview file that holds only the silent
+        # start frame — none of the facts that produced the closed ledger.
+        # Advertising that id as Seed lineage would have downstream consumers
+        # treat the empty backend transcript as the source of the Seed.
+        # Clear the id so the result envelope and persisted state
+        # represent the actual lineage: ledger-only, no backend transcript.
+        cleared_session_id = state.interview_session_id
+        state.interview_session_id = None
         state.ledger = ledger.to_dict()
         state.pending_question = None
         state.interview_completed = True
@@ -835,10 +847,11 @@ class AutoInterviewDriver:
             auto_session_id=state.auto_session_id,
             closure_mode=closure_mode,
             error=str(exc),
+            cleared_session_id=cleared_session_id,
         )
         self._save(state)
         return AutoInterviewResult(
-            "seed_ready", state.interview_session_id, ledger, state.current_round
+            "seed_ready", None, ledger, state.current_round
         )
 
     def _answer_with_gap_steering(

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1295,6 +1295,31 @@ class AutoPipeline:
                             blocker=state.last_error,
                             run_subagent=run_subagent,
                         )
+                    # ``paused`` is mapped from ``SessionStatus.PAUSED`` by
+                    # :class:`ExecuteSeedHandler` with ``success=None`` — the
+                    # synchronous execution is waiting on operator input and
+                    # has NOT reached terminal success. Treat it as
+                    # non-terminal and block the Ralph handoff (and the
+                    # synchronous-complete short-circuit below): handing off
+                    # here would start the persistence loop while the run
+                    # session is still pending resume, decoupling Ralph from
+                    # the actual product run. The owned job is left running
+                    # (do not cancel — the operator may still resume it);
+                    # callers can re-enter the pipeline after resume.
+                    if self.complete_product and run_status == "paused":
+                        state.mark_blocked(
+                            "run execution paused before Ralph handoff; "
+                            "resume the paused run before continuing",
+                            tool_name="run_starter",
+                        )
+                        self._save(state)
+                        return self._result(
+                            state,
+                            ledger,
+                            review=review,
+                            blocker=state.last_error,
+                            run_subagent=run_subagent,
+                        )
                     if (
                         self.complete_product
                         and bool(getattr(self.run_starter, "synchronous_execution", False))

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -224,7 +224,7 @@ _DEFAULT_RALPH_PER_ITERATION_SECONDS = 1800.0
 # and still need a small amount of handler teardown time to return terminal
 # metadata. This grace applies only to synchronous execution starters; async
 # handoff starters still use the strict enqueue timeout.
-_SYNCHRONOUS_RUN_COMPLETION_GRACE_SECONDS = 60.0
+_SYNCHRONOUS_RUN_COMPLETION_GRACE_SECONDS = 300.0
 
 # Q00/ouroboros#782 review-12 BLOCKING #1: when the top-level deadline has
 # already expired but a persisted Ralph job awaits reconciliation, give the
@@ -1355,26 +1355,33 @@ class AutoPipeline:
                     msg = f"run starter returned {type(run_meta).__name__}, expected dict"
                     raise TypeError(msg)
             except TimeoutError as exc:
-                if self._enforce_deadline(state):
+                recovered_run_meta = await _recover_timed_out_synchronous_run(
+                    self.run_starter,
+                    timeout_seconds=5.0,
+                )
+                if recovered_run_meta is not None:
+                    run_meta = recovered_run_meta
+                elif self._enforce_deadline(state):
                     return self._result(state, ledger, review=review, blocker=state.last_error)
-                _mark_unknown_run_handoff(state, status=UNKNOWN_TIMEOUT_STATUS)
-                if retried:
-                    state.run_handoff_guidance = (
-                        f"{state.run_handoff_guidance or ''} "
-                        f"{RETRY_GUIDANCE_PHRASE} {idempotency_key}"
-                    ).strip()
-                    state.mark_blocked(
-                        f"run start timed out after {run_start_timeout:.0f}s; "
-                        f"{RETRY_GUIDANCE_PHRASE} {idempotency_key}",
-                        tool_name="run_starter",
-                    )
-                    self._save(state)
-                    return self._result(
-                        state,
-                        ledger,
-                        review=review,
-                        blocker=state.last_error or str(exc),
-                    )
+                else:
+                    _mark_unknown_run_handoff(state, status=UNKNOWN_TIMEOUT_STATUS)
+                    if retried:
+                        state.run_handoff_guidance = (
+                            f"{state.run_handoff_guidance or ''} "
+                            f"{RETRY_GUIDANCE_PHRASE} {idempotency_key}"
+                        ).strip()
+                        state.mark_blocked(
+                            f"run start timed out after {run_start_timeout:.0f}s; "
+                            f"{RETRY_GUIDANCE_PHRASE} {idempotency_key}",
+                            tool_name="run_starter",
+                        )
+                        self._save(state)
+                        return self._result(
+                            state,
+                            ledger,
+                            review=review,
+                            blocker=state.last_error or str(exc),
+                        )
             except Exception as exc:
                 if retried:
                     # Retry attempt itself raised — bound is exhausted. The
@@ -1515,7 +1522,14 @@ class AutoPipeline:
                         # surfaces ``pipeline_timeout`` BLOCKED instead of
                         # advertising the over-budget run as a successful
                         # complete-product outcome.
-                        if self._enforce_deadline(state):
+                        if (
+                            state.is_deadline_expired()
+                            and not (
+                                _allows_synchronous_completion_grace(run_meta)
+                                and _within_synchronous_completion_grace(state)
+                            )
+                            and self._enforce_deadline(state)
+                        ):
                             return self._result(
                                 state,
                                 ledger,
@@ -3633,6 +3647,31 @@ def _arm_legacy_missing_deadline(state: AutoPipelineState) -> bool:
         return False
     state.arm_deadline()
     return True
+
+
+def _allows_synchronous_completion_grace(run_meta: dict[str, Any]) -> bool:
+    return bool(run_meta.get("_allow_deadline_completion_grace"))
+
+
+def _within_synchronous_completion_grace(state: AutoPipelineState) -> bool:
+    if state.deadline_at is None:
+        return False
+    return 0.0 <= time.monotonic() - state.deadline_at <= _SYNCHRONOUS_RUN_COMPLETION_GRACE_SECONDS
+
+
+async def _recover_timed_out_synchronous_run(
+    adapter: object | None,
+    *,
+    timeout_seconds: float,
+) -> dict[str, Any] | None:
+    recover = getattr(adapter, "recover_timed_out_run", None)
+    if not callable(recover):
+        return None
+    try:
+        recovered = await asyncio.wait_for(recover(), timeout=timeout_seconds)
+    except (Exception, TimeoutError):
+        return None
+    return recovered if isinstance(recovered, dict) else None
 
 
 def _has_reconciliable_ralph_resume_checkpoint(state: AutoPipelineState) -> bool:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1132,6 +1132,47 @@ class AutoPipeline:
                                     blocker=state.last_error,
                                     run_subagent=None,
                                 )
+                    else:
+                        # Synchronous starters
+                        # (``HandlerSynchronousRunStarter``) return
+                        # ``job_id=None`` while still persisting
+                        # ``execution_id`` / ``run_session_id``, so the
+                        # fresh-path terminal-success validation relies on
+                        # the starter's returned dict — there is no
+                        # job-manager snapshot to reconcile against on
+                        # resume. A resume that reaches this branch with no
+                        # persisted ``job_id`` is therefore unreconcilable:
+                        # the most common cause is a fresh-path BLOCK on
+                        # paused/failed/non-terminal synchronous
+                        # execution, after which
+                        # ``_recoverable_phase_for_tool("run_starter")``
+                        # returns ``AutoPhase.RUN`` and re-enters the
+                        # persisted-handle branch. Dispatching Ralph from
+                        # ``execution_id``/``run_session_id`` alone would
+                        # advertise a non-terminal product run as ready
+                        # for the persistence loop, breaking the same
+                        # contract the fresh-path paused guard enforces.
+                        # Block with actionable guidance instead — the
+                        # operator must resolve the synchronous run
+                        # itself (resume it, or wipe the persisted handle)
+                        # before complete-product can continue.
+                        state.mark_blocked(
+                            "Cannot resume complete-product Ralph handoff for "
+                            "jobless synchronous execution: no job-manager "
+                            "snapshot is available to verify the persisted "
+                            "execution_id/run_session_id reached terminal "
+                            "success. Resume the synchronous run to completion "
+                            "or clear the persisted handle before retrying.",
+                            tool_name="run_starter",
+                        )
+                        self._save(state)
+                        return self._result(
+                            state,
+                            ledger,
+                            review=review,
+                            blocker=state.last_error,
+                            run_subagent=None,
+                        )
                     return await self._handoff_to_ralph(
                         state, ledger, seed, review, run_subagent=None
                     )

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1325,6 +1325,27 @@ class AutoPipeline:
                         and bool(getattr(self.run_starter, "synchronous_execution", False))
                         and run_success is True
                     ):
+                        # ``_run_start_timeout`` adds
+                        # ``_SYNCHRONOUS_RUN_COMPLETION_GRACE_SECONDS`` on top of
+                        # the remaining deadline so the inline ``await`` can
+                        # finish handler teardown without tripping
+                        # ``asyncio.wait_for``. That grace is intended for
+                        # teardown, not for extra execution budget: a
+                        # synchronous run that returns ``success=True`` AFTER
+                        # ``deadline_at`` has passed has still exceeded the
+                        # top-level ``pipeline_timeout`` contract. Enforce the
+                        # deadline before persisting COMPLETE so the envelope
+                        # surfaces ``pipeline_timeout`` BLOCKED instead of
+                        # advertising the over-budget run as a successful
+                        # complete-product outcome.
+                        if self._enforce_deadline(state):
+                            return self._result(
+                                state,
+                                ledger,
+                                review=review,
+                                blocker=state.last_error,
+                                run_subagent=run_subagent,
+                            )
                         state.run_handoff_status = "completed"
                         state.run_handoff_guidance = None
                         state.transition(

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1052,6 +1052,86 @@ class AutoPipeline:
                         )
                         self._save(state)
                         return self._result(state, ledger, review=review, blocker=state.last_error)
+                    # Persisted run handles prove the execute_seed job was
+                    # *dispatched*, not that it reached terminal success.
+                    # The fresh-path RUN → RALPH_HANDOFF contract
+                    # (lines ~1242-1340) refuses to hand off to Ralph until
+                    # the owned run job has finished successfully — paused
+                    # and queued/running/cancel_requested both BLOCK with
+                    # ``tool_name="run_starter"``, which
+                    # ``_recoverable_phase_for_tool`` maps back to ``RUN``.
+                    # Without re-polling here, a resume after one of those
+                    # blockers would walk past the gate and start Ralph
+                    # against a still-pending product run. Mirror the
+                    # fresh-path snapshot poll + status gate so resume and
+                    # fresh dispatch share the same terminal-success
+                    # contract.
+                    if state.job_id:
+                        terminal_run_meta = await _wait_owned_run_job_terminal(
+                            self.run_starter,
+                            state.job_id,
+                            timeout_seconds=self._deadline_capped_timeout(
+                                state, state.phase_timeout_seconds(AutoPhase.RUN)
+                            ),
+                        )
+                        if self._enforce_deadline(state):
+                            return self._result(
+                                state, ledger, review=review, blocker=state.last_error
+                            )
+                        if terminal_run_meta is not None:
+                            run_status_resume = _optional_str(terminal_run_meta.get("status"))
+                            run_success_resume = terminal_run_meta.get("success")
+                            failed_run_statuses = {"failed", "cancelled", "interrupted"}
+                            if run_success_resume is False or (
+                                run_status_resume in failed_run_statuses
+                            ):
+                                resolved_status = run_status_resume or "failed"
+                                state.mark_blocked(
+                                    "resumed run execution finished unsuccessfully "
+                                    f"before Ralph handoff: {resolved_status}",
+                                    tool_name="run_starter",
+                                )
+                                self._save(state)
+                                return self._result(
+                                    state,
+                                    ledger,
+                                    review=review,
+                                    blocker=state.last_error,
+                                    run_subagent=None,
+                                )
+                            incomplete_run_statuses = {
+                                "queued",
+                                "running",
+                                "cancel_requested",
+                            }
+                            if run_status_resume in incomplete_run_statuses:
+                                state.mark_blocked(
+                                    "resumed run execution did not finish "
+                                    f"before Ralph handoff: {run_status_resume}",
+                                    tool_name="run_starter",
+                                )
+                                self._save(state)
+                                return self._result(
+                                    state,
+                                    ledger,
+                                    review=review,
+                                    blocker=state.last_error,
+                                    run_subagent=None,
+                                )
+                            if run_status_resume == "paused":
+                                state.mark_blocked(
+                                    "resumed run execution paused before Ralph handoff; "
+                                    "resume the paused run before continuing",
+                                    tool_name="run_starter",
+                                )
+                                self._save(state)
+                                return self._result(
+                                    state,
+                                    ledger,
+                                    review=review,
+                                    blocker=state.last_error,
+                                    run_subagent=None,
+                                )
                     return await self._handoff_to_ralph(
                         state, ledger, seed, review, run_subagent=None
                     )

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -53,7 +53,10 @@ from ouroboros.auto.state import (
     SeedOrigin,
     utc_now_iso,
 )
-from ouroboros.auto.task_class_application import apply_default_ac_template
+from ouroboros.auto.task_class_application import (
+    apply_default_ac_template,
+    has_explicit_verification_contract,
+)
 from ouroboros.core.seed import Seed
 from ouroboros.orchestrator.runtime_evidence import RuntimeEvidence
 from ouroboros.resilience.lateral import ThinkingPersona
@@ -155,6 +158,10 @@ def _is_authoring_backend_unavailable(exc: Exception) -> bool:
     return any(marker in text for marker in markers)
 
 
+def _is_no_backend_interview_closure(state: AutoPipelineState) -> bool:
+    return state.interview_closure_mode in {"ledger_only_no_backend", "safe_default_no_backend"}
+
+
 class RunStarter(Protocol):
     """Protocol for run-starter callables.
 
@@ -213,6 +220,11 @@ _MIN_RALPH_MAX_TOTAL_SECONDS = 1.0
 # the top-level pipeline deadline contract pinned by Q00/ouroboros#779.
 _MIN_RALPH_PER_ITERATION_SECONDS = 30.0
 _DEFAULT_RALPH_PER_ITERATION_SECONDS = 1800.0
+# Inline complete-product execution may finish the worker task at the deadline
+# and still need a small amount of handler teardown time to return terminal
+# metadata. This grace applies only to synchronous execution starters; async
+# handoff starters still use the strict enqueue timeout.
+_SYNCHRONOUS_RUN_COMPLETION_GRACE_SECONDS = 60.0
 
 # Q00/ouroboros#782 review-12 BLOCKING #1: when the top-level deadline has
 # already expired but a persisted Ralph job awaits reconciliation, give the
@@ -587,13 +599,20 @@ class AutoPipeline:
                 self._save(state)
             if state.phase == AutoPhase.INTERVIEW and state.interview_completed:
                 if not state.interview_session_id:
-                    state.mark_blocked(
-                        "Completed interview is missing interview_session_id",
-                        tool_name="auto_pipeline",
-                    )
-                    self._save(state)
-                    return self._result(state, ledger, blocker=state.last_error)
-                if not ledger.is_seed_ready():
+                    if _is_no_backend_interview_closure(state) and ledger.is_seed_ready():
+                        state.transition(
+                            AutoPhase.SEED_GENERATION,
+                            "resuming Seed generation after no-backend interview closure",
+                        )
+                        self._save(state)
+                    else:
+                        state.mark_blocked(
+                            "Completed interview is missing interview_session_id",
+                            tool_name="auto_pipeline",
+                        )
+                        self._save(state)
+                        return self._result(state, ledger, blocker=state.last_error)
+                elif not ledger.is_seed_ready():
                     gaps = ", ".join(ledger.open_gaps())
                     state.mark_blocked(
                         f"Completed interview has unresolved ledger gaps: {gaps}",
@@ -601,10 +620,12 @@ class AutoPipeline:
                     )
                     self._save(state)
                     return self._result(state, ledger, blocker=state.last_error)
-                state.transition(
-                    AutoPhase.SEED_GENERATION, "resuming Seed generation after completed interview"
-                )
-                self._save(state)
+                else:
+                    state.transition(
+                        AutoPhase.SEED_GENERATION,
+                        "resuming Seed generation after completed interview",
+                    )
+                    self._save(state)
             else:
                 _answerer = getattr(self.interview_driver, "answerer", None)
                 if _answerer is not None:
@@ -759,7 +780,7 @@ class AutoPipeline:
                     if self._enforce_deadline(state):
                         record_authoring_backend(state)
                         return self._result(state, ledger, blocker=state.last_error)
-                    if ledger.is_seed_ready() and _is_authoring_backend_unavailable(exc):
+                    if ledger.is_seed_ready():
                         seed = synthesize_seed_from_ledger(
                             ledger, interview_id=state.interview_session_id
                         )
@@ -1144,7 +1165,7 @@ class AutoPipeline:
             state.run_start_attempted = True
             self._save(state)
             run_meta: dict[str, Any] | None = None
-            run_start_timeout = self._deadline_capped_timeout(state, self.run_start_timeout_seconds)
+            run_start_timeout = self._run_start_timeout(state)
             try:
                 run_kwargs: dict[str, Any] = {}
                 if _accepts_keyword(self.run_starter, IDEMPOTENCY_KWARG_NAME):
@@ -1166,7 +1187,7 @@ class AutoPipeline:
                         f"{RETRY_GUIDANCE_PHRASE} {idempotency_key}"
                     ).strip()
                     state.mark_blocked(
-                        f"run start timed out after {self.run_start_timeout_seconds:.0f}s; "
+                        f"run start timed out after {run_start_timeout:.0f}s; "
                         f"{RETRY_GUIDANCE_PHRASE} {idempotency_key}",
                         tool_name="run_starter",
                     )
@@ -1225,6 +1246,73 @@ class AutoPipeline:
                 if any((state.job_id, state.execution_id, state.run_session_id)):
                     state.run_handoff_status = RUN_HANDOFF_STARTED_STATUS
                     state.run_handoff_guidance = None
+                    if self.complete_product and state.job_id:
+                        terminal_run_meta = await _wait_owned_run_job_terminal(
+                            self.run_starter,
+                            state.job_id,
+                            timeout_seconds=self._deadline_capped_timeout(
+                                state, state.phase_timeout_seconds(AutoPhase.RUN)
+                            ),
+                        )
+                        if terminal_run_meta is not None:
+                            run_meta.update(terminal_run_meta)
+                            if self._enforce_deadline(state):
+                                return self._result(
+                                    state, ledger, review=review, blocker=state.last_error
+                                )
+                    run_success = run_meta.get("success")
+                    run_status = _optional_str(run_meta.get("status"))
+                    failed_run_statuses = {"failed", "cancelled", "interrupted"}
+                    if self.complete_product and (
+                        run_success is False or run_status in failed_run_statuses
+                    ):
+                        run_status = _optional_str(run_meta.get("status")) or "failed"
+                        state.mark_blocked(
+                            f"run execution finished unsuccessfully before Ralph handoff: {run_status}",
+                            tool_name="run_starter",
+                        )
+                        self._save(state)
+                        return self._result(
+                            state,
+                            ledger,
+                            review=review,
+                            blocker=state.last_error,
+                            run_subagent=run_subagent,
+                        )
+                    incomplete_run_statuses = {"queued", "running", "cancel_requested"}
+                    if self.complete_product and run_status in incomplete_run_statuses:
+                        state.mark_blocked(
+                            "run execution did not finish before Ralph handoff: "
+                            f"{run_status}",
+                            tool_name="run_starter",
+                        )
+                        self._save(state)
+                        await _cancel_owned_run_job(self.run_starter, state.job_id)
+                        return self._result(
+                            state,
+                            ledger,
+                            review=review,
+                            blocker=state.last_error,
+                            run_subagent=run_subagent,
+                        )
+                    if (
+                        self.complete_product
+                        and bool(getattr(self.run_starter, "synchronous_execution", False))
+                        and run_success is True
+                    ):
+                        state.run_handoff_status = "completed"
+                        state.run_handoff_guidance = None
+                        state.transition(
+                            AutoPhase.COMPLETE,
+                            "synchronous execution completed for complete-product run",
+                        )
+                        self._save(state)
+                        return self._result(
+                            state,
+                            ledger,
+                            review=review,
+                            run_subagent=run_subagent,
+                        )
                     # Q00/ouroboros#773: when ``--complete-product`` is set
                     # and a ralph starter is configured, chain RUN →
                     # RALPH_HANDOFF instead of going straight to COMPLETE.
@@ -1345,6 +1433,23 @@ class AutoPipeline:
         if remaining <= 0:
             return 0.0
         return float(min(float(phase_timeout), remaining))
+
+    def _run_start_timeout(self, state: AutoPipelineState) -> float:
+        """Return the timeout budget for the run starter invocation.
+
+        Async run starters only enqueue work, so they keep the short
+        ``run_start_timeout_seconds`` budget. The CLI complete-product path can
+        use a synchronous starter that owns the actual execution; treat that as
+        RUN phase work and let the top-level pipeline deadline bound it.
+        """
+        if self.complete_product and bool(
+            getattr(self.run_starter, "synchronous_execution", False)
+        ):
+            remaining = self._remaining_deadline_seconds(state)
+            if remaining is not None:
+                return remaining + _SYNCHRONOUS_RUN_COMPLETION_GRACE_SECONDS
+            return float(state.phase_timeout_seconds(AutoPhase.RUN))
+        return self._deadline_capped_timeout(state, self.run_start_timeout_seconds)
 
     async def _handoff_to_ralph(
         self,
@@ -1502,6 +1607,8 @@ class AutoPipeline:
             # server-side (the dispatch checkpoint above persisted its
             # handle). Resume will then poll it via ``_resume_ralph_handoff``
             # rather than treating the session as terminally lost.
+            await _cancel_ralph_status_mirror(ralph_mirror_task)
+            await _cancel_owned_ralph_job(self.ralph_starter, state.ralph_job_id)
             if self._enforce_deadline(state):
                 return self._result(
                     state,
@@ -2662,6 +2769,7 @@ class AutoPipeline:
                 ralph_meta = await asyncio.wait_for(poll_call, timeout=poll_timeout)
         except TimeoutError:
             await _cancel_ralph_status_mirror(ralph_mirror_task)
+            await _cancel_owned_ralph_job(self.ralph_resumer, state.ralph_job_id)
             if self._enforce_deadline(state):
                 return self._result(state, ledger, review=review, blocker=state.last_error)
             state.mark_blocked(
@@ -2924,11 +3032,12 @@ class AutoPipeline:
         inference = derive_domain_from_ledger(ledger)
         task_class = inference.single
         if task_class is not None:
-            applied = apply_default_ac_template(seed, task_class)
-            if applied.injected_ac:
-                seed = applied.seed
-                state.seed_id = seed.metadata.seed_id
-                state.seed_artifact = seed.to_dict()
+            if not has_explicit_verification_contract(seed):
+                applied = apply_default_ac_template(seed, task_class)
+                if applied.injected_ac:
+                    seed = applied.seed
+                    state.seed_id = seed.metadata.seed_id
+                    state.seed_artifact = seed.to_dict()
             state.active_task_class = task_class.value
         return seed
 
@@ -3411,6 +3520,61 @@ async def _cancel_ralph_status_mirror(task: asyncio.Task[None] | None) -> None:
     task.cancel()
     with suppress(asyncio.CancelledError):
         await task
+
+
+async def _cancel_owned_ralph_job(adapter: object | None, job_id: str | None) -> None:
+    if not job_id:
+        return
+    handler = getattr(adapter, "handler", None)
+    job_manager = getattr(handler, "_job_manager", None)
+    cancel_job = getattr(job_manager, "cancel_job", None)
+    if cancel_job is None:
+        return
+    try:
+        await asyncio.wait_for(cancel_job(job_id), timeout=5.0)
+    except (Exception, TimeoutError):
+        return
+
+
+async def _cancel_owned_run_job(adapter: object | None, job_id: str | None) -> None:
+    if not job_id:
+        return
+    handler = getattr(adapter, "handler", None)
+    job_manager = getattr(handler, "_job_manager", None)
+    cancel_job = getattr(job_manager, "cancel_job", None)
+    if cancel_job is None:
+        return
+    try:
+        await asyncio.wait_for(cancel_job(job_id), timeout=5.0)
+    except (Exception, TimeoutError):
+        return
+
+
+async def _wait_owned_run_job_terminal(
+    adapter: object | None,
+    job_id: str,
+    *,
+    timeout_seconds: float,
+) -> dict[str, Any] | None:
+    handler = getattr(adapter, "handler", None)
+    job_manager = getattr(handler, "_job_manager", None)
+    get_snapshot = getattr(job_manager, "get_snapshot", None)
+    if get_snapshot is None:
+        return None
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max(0.0, timeout_seconds)
+    while True:
+        snapshot = await get_snapshot(job_id)
+        if getattr(snapshot, "is_terminal", False):
+            meta = dict(getattr(snapshot, "result_meta", None) or {})
+            status = getattr(getattr(snapshot, "status", None), "value", None)
+            if isinstance(status, str):
+                meta.setdefault("status", status)
+            return meta
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return {"status": "running"}
+        await asyncio.sleep(min(0.1, remaining))
 
 
 def _artifact_text(value: object) -> str | None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1078,60 +1078,116 @@ class AutoPipeline:
                             return self._result(
                                 state, ledger, review=review, blocker=state.last_error
                             )
-                        if terminal_run_meta is not None:
-                            run_status_resume = _optional_str(terminal_run_meta.get("status"))
-                            run_success_resume = terminal_run_meta.get("success")
-                            failed_run_statuses = {"failed", "cancelled", "interrupted"}
-                            if run_success_resume is False or (
-                                run_status_resume in failed_run_statuses
-                            ):
-                                resolved_status = run_status_resume or "failed"
-                                state.mark_blocked(
-                                    "resumed run execution finished unsuccessfully "
-                                    f"before Ralph handoff: {resolved_status}",
-                                    tool_name="run_starter",
-                                )
-                                self._save(state)
-                                return self._result(
-                                    state,
-                                    ledger,
-                                    review=review,
-                                    blocker=state.last_error,
-                                    run_subagent=None,
-                                )
-                            incomplete_run_statuses = {
-                                "queued",
-                                "running",
-                                "cancel_requested",
-                            }
-                            if run_status_resume in incomplete_run_statuses:
-                                state.mark_blocked(
-                                    "resumed run execution did not finish "
-                                    f"before Ralph handoff: {run_status_resume}",
-                                    tool_name="run_starter",
-                                )
-                                self._save(state)
-                                return self._result(
-                                    state,
-                                    ledger,
-                                    review=review,
-                                    blocker=state.last_error,
-                                    run_subagent=None,
-                                )
-                            if run_status_resume == "paused":
-                                state.mark_blocked(
-                                    "resumed run execution paused before Ralph handoff; "
-                                    "resume the paused run before continuing",
-                                    tool_name="run_starter",
-                                )
-                                self._save(state)
-                                return self._result(
-                                    state,
-                                    ledger,
-                                    review=review,
-                                    blocker=state.last_error,
-                                    run_subagent=None,
-                                )
+                        # ``_wait_owned_run_job_terminal`` returns ``None``
+                        # when the configured run starter does not expose
+                        # ``handler._job_manager.get_snapshot``. The bot
+                        # review explicitly flags this as "treats an
+                        # unverified persisted run handle as enough to
+                        # start Ralph" — a persisted ``job_id`` proves
+                        # *dispatch*, not terminal success. Without a
+                        # reconciliation channel the resume cannot prove
+                        # the run finished successfully, so refuse the
+                        # Ralph handoff just as the jobless-synchronous
+                        # branch below does for ``execution_id``-only
+                        # handles.
+                        if terminal_run_meta is None:
+                            state.mark_blocked(
+                                "Cannot resume complete-product Ralph handoff: "
+                                "the owned run job snapshot is unavailable "
+                                f"(job_id={state.job_id!r}) so the persisted run "
+                                "handle cannot be confirmed as terminal-success. "
+                                "Resolve the run job to a terminal state, or clear "
+                                "the persisted handle before retrying.",
+                                tool_name="run_starter",
+                            )
+                            self._save(state)
+                            return self._result(
+                                state,
+                                ledger,
+                                review=review,
+                                blocker=state.last_error,
+                                run_subagent=None,
+                            )
+                        run_status_resume = _optional_str(terminal_run_meta.get("status"))
+                        run_success_resume = terminal_run_meta.get("success")
+                        failed_run_statuses = {"failed", "cancelled", "interrupted"}
+                        if run_success_resume is False or (
+                            run_status_resume in failed_run_statuses
+                        ):
+                            resolved_status = run_status_resume or "failed"
+                            state.mark_blocked(
+                                "resumed run execution finished unsuccessfully "
+                                f"before Ralph handoff: {resolved_status}",
+                                tool_name="run_starter",
+                            )
+                            self._save(state)
+                            return self._result(
+                                state,
+                                ledger,
+                                review=review,
+                                blocker=state.last_error,
+                                run_subagent=None,
+                            )
+                        incomplete_run_statuses = {
+                            "queued",
+                            "running",
+                            "cancel_requested",
+                        }
+                        if run_status_resume in incomplete_run_statuses:
+                            state.mark_blocked(
+                                "resumed run execution did not finish "
+                                f"before Ralph handoff: {run_status_resume}",
+                                tool_name="run_starter",
+                            )
+                            self._save(state)
+                            return self._result(
+                                state,
+                                ledger,
+                                review=review,
+                                blocker=state.last_error,
+                                run_subagent=None,
+                            )
+                        if run_status_resume == "paused":
+                            state.mark_blocked(
+                                "resumed run execution paused before Ralph handoff; "
+                                "resume the paused run before continuing",
+                                tool_name="run_starter",
+                            )
+                            self._save(state)
+                            return self._result(
+                                state,
+                                ledger,
+                                review=review,
+                                blocker=state.last_error,
+                                run_subagent=None,
+                            )
+                        # Allowlist-style terminal-success check: a poll
+                        # that returned terminal metadata but does not
+                        # advertise an explicit success signal (e.g. the
+                        # snapshot's ``result_meta`` is empty or carries
+                        # an unknown status) is NOT evidence the product
+                        # run reached terminal success. Refuse the
+                        # handoff just like the unreconcilable cases
+                        # above so a malformed or unfamiliar snapshot
+                        # cannot pass the gate by omission.
+                        if run_success_resume is not True and run_status_resume != "completed":
+                            state.mark_blocked(
+                                "Cannot resume complete-product Ralph handoff: "
+                                "owned run job snapshot did not confirm terminal "
+                                f"success (status={run_status_resume!r}, "
+                                f"success={run_success_resume!r}). Resolve the run "
+                                "to terminal-success or clear the persisted handle "
+                                "before retrying.",
+                                tool_name="run_starter",
+                            )
+                            self._save(state)
+                            return self._result(
+                                state,
+                                ledger,
+                                review=review,
+                                blocker=state.last_error,
+                                run_subagent=None,
+                            )
                     else:
                         # Synchronous starters
                         # (``HandlerSynchronousRunStarter``) return

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -375,6 +375,7 @@ def _unsafe_context_reason(
             if value.strip()
         ),
     ).lower()
+    context = _strip_benign_software_contract_phrases(context)
     context = _strip_negated_clauses(context)
     for reason, pattern in _UNSAFE_CONTEXT_PATTERNS:
         match = re.search(pattern, context)
@@ -389,6 +390,18 @@ def _unsafe_context_reason(
             )
             return reason
     return None
+
+
+_BENIGN_SOFTWARE_CONTRACT_RE = re.compile(
+    r"\b(?:acceptance|test|testing|verification|api|runtime|interface|import|command|"
+    r"behavior|behavioral|software|code|seed|handoff|resume)\s+contract\b"
+    r"|\bcontract\s+(?:test|tests|testing)\b",
+)
+
+
+def _strip_benign_software_contract_phrases(text: str) -> str:
+    """Remove software-engineering uses of "contract" before legal-risk matching."""
+    return _BENIGN_SOFTWARE_CONTRACT_RE.sub(" ", text)
 
 
 # Imperative verbs that mark a *new* action clause when they follow a comma.

--- a/src/ouroboros/auto/task_class_application.py
+++ b/src/ouroboros/auto/task_class_application.py
@@ -19,6 +19,7 @@ The helper is intentionally split out from the inference module so:
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 
 from ouroboros.auto.task_classes import TASK_CLASS_CATALOG, TaskClass
 from ouroboros.core.seed import Seed
@@ -26,6 +27,8 @@ from ouroboros.core.seed import Seed
 __all__ = [
     "AppliedTaskClassDefaults",
     "apply_default_ac_template",
+    "has_explicit_verification_contract",
+    "has_explicit_verification_text",
 ]
 
 
@@ -92,3 +95,41 @@ def apply_default_ac_template(seed: Seed, task_class: TaskClass) -> AppliedTaskC
     updated_ac = new_entries + tuple(seed.acceptance_criteria)
     new_seed = seed.model_copy(update={"acceptance_criteria": updated_ac})
     return AppliedTaskClassDefaults(seed=new_seed, injected_ac=new_entries, task_class=task_class)
+
+
+_EXPLICIT_VERIFICATION_COMMAND_RE = re.compile(
+    r"\b("
+    r"uv\s+run\s+pytest|pytest|python\s+-m\s+pytest|"
+    r"npm\s+test|pnpm\s+test|yarn\s+test|bun\s+test|"
+    r"go\s+test|cargo\s+test|cargo\s+nextest|"
+    r"ruff\s+check|mypy|pyright|basedpyright|tsc\b|"
+    r"vitest|jest|playwright\s+test"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def has_explicit_verification_contract(seed: Seed) -> bool:
+    """Return True when the Seed already names concrete verification commands.
+
+    Task-class default ACs are a safety net for underspecified Seeds. When the
+    user has already provided an exact local verification command, prepending a
+    broad class template can expand the runtime contract beyond the requested
+    task and make simple ``ooo auto`` jobs spend their whole budget on generic
+    quality checks. This detector is intentionally command-based, not a vague
+    "tests mentioned" heuristic, so generic requirements such as "covered by
+    tests" still receive task-class defaults.
+    """
+    parts: list[str] = [
+        seed.goal,
+        *seed.constraints,
+        *seed.acceptance_criteria,
+        *(condition.evaluation_criteria for condition in seed.exit_conditions),
+    ]
+    text = "\n".join(part for part in parts if isinstance(part, str) and part.strip())
+    return has_explicit_verification_text(text)
+
+
+def has_explicit_verification_text(text: str) -> bool:
+    """Return True when *text* contains a concrete local verification command."""
+    return bool(_EXPLICIT_VERIFICATION_COMMAND_RE.search(text))

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -18,6 +18,7 @@ from ouroboros.auto.adapters import (
     HandlerRalphStarter,
     HandlerRunStarter,
     HandlerSeedGenerator,
+    HandlerSynchronousRunStarter,
     load_seed,
     save_seed,
 )
@@ -511,7 +512,11 @@ async def _run_auto(
     pipeline = AutoPipeline(
         driver,
         HandlerSeedGenerator(generate_seed),
-        run_starter=HandlerRunStarter(start_execute, cwd=state.cwd),
+        run_starter=(
+            HandlerSynchronousRunStarter(execute_seed, cwd=state.cwd)
+            if complete_product
+            else HandlerRunStarter(start_execute, cwd=state.cwd)
+        ),
         store=store,
         repairer=SeedRepairer(max_repair_rounds=max_repair_rounds),
         seed_saver=save_seed,

--- a/src/ouroboros/persistence/checkpoint.py
+++ b/src/ouroboros/persistence/checkpoint.py
@@ -311,7 +311,8 @@ class CheckpointStore:
 
             # Log corruption details for debugging
             error = result.error
-            print(f"Checkpoint corruption at level {level} for {seed_id}: {error.message}")
+            if error.details.get("reason") != "missing":
+                print(f"Checkpoint corruption at level {level} for {seed_id}: {error.message}")
 
         # No valid checkpoint found at any level
         return Result.err(
@@ -344,7 +345,7 @@ class CheckpointStore:
                 PersistenceError(
                     f"Checkpoint not found at level {level}",
                     operation="read",
-                    details={"seed_id": seed_id, "level": level},
+                    details={"seed_id": seed_id, "level": level, "reason": "missing"},
                 )
             )
 

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -867,6 +867,7 @@ class EventStore:
         resolved_execution_id = execution_id or await self._resolve_execution_id_for_session(
             session_id,
         )
+        session_started_at = await self._resolve_session_started_at(session_id)
 
         conditions = _session_related_event_conditions(session_id, resolved_execution_id)
 
@@ -877,6 +878,8 @@ class EventStore:
                     .where(or_(*conditions))
                     .order_by(events_table.c.timestamp.desc())
                 )
+                if session_started_at is not None:
+                    query = query.where(events_table.c.timestamp >= session_started_at)
 
                 if event_type:
                     query = query.where(events_table.c.event_type == event_type)
@@ -1047,6 +1050,27 @@ class EventStore:
                 if isinstance(execution_id, str) and execution_id:
                     return execution_id
             return None
+
+    async def _resolve_session_started_at(self, session_id: str) -> Any | None:
+        """Return the persisted start timestamp for a session, if available."""
+        if self._engine is None:
+            raise PersistenceError(
+                "EventStore not initialized. Call initialize() first.",
+                operation="resolve_session_started_at",
+            )
+
+        async with self._engine.begin() as conn:
+            query = (
+                select(events_table.c.timestamp)
+                .where(events_table.c.aggregate_type == "session")
+                .where(events_table.c.aggregate_id == session_id)
+                .where(events_table.c.event_type == "orchestrator.session.started")
+                .order_by(events_table.c.timestamp.asc())
+                .limit(1)
+            )
+            result = await conn.execute(query)
+            row = result.first()
+            return row[0] if row is not None else None
 
     async def get_all_lineages(self) -> list[BaseEvent]:
         """Get all lineage creation events.

--- a/tests/unit/auto/test_adapters_client_gates.py
+++ b/tests/unit/auto/test_adapters_client_gates.py
@@ -123,6 +123,42 @@ async def test_synchronous_run_starter_returns_persisted_terminal_meta_before_te
 
 
 @pytest.mark.asyncio
+async def test_synchronous_run_starter_cancels_inner_execute_seed_on_outer_cancel(
+    tmp_path,
+) -> None:
+    """A timed-out auto pipeline must not leave inline execution running."""
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    handler = AsyncMock()
+
+    async def hanging_handle(*_args: object, **_kwargs: object) -> object:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    handler.handle = AsyncMock(side_effect=hanging_handle)
+    starter = HandlerSynchronousRunStarter(
+        handler,
+        cwd=str(tmp_path),
+        terminal_poll_interval_seconds=60,
+    )
+
+    call_task = asyncio.create_task(starter(_FakeSeed()))  # type: ignore[arg-type]
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    call_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await call_task
+    await asyncio.wait_for(cancelled.wait(), timeout=1)
+    assert starter._latest_run_meta is not None
+    assert starter._latest_run_meta["status"] == "cancelled"
+    assert starter._latest_run_meta["success"] is False
+
+
+@pytest.mark.asyncio
 async def test_auto_interview_backend_forwards_last_question_for_reopened_answers(
     tmp_path,
 ) -> None:

--- a/tests/unit/auto/test_adapters_client_gates.py
+++ b/tests/unit/auto/test_adapters_client_gates.py
@@ -2,14 +2,25 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
 
-from ouroboros.auto.adapters import HandlerError, HandlerInterviewBackend, HandlerSeedGenerator
+from ouroboros.auto.adapters import (
+    HandlerError,
+    HandlerInterviewBackend,
+    HandlerSeedGenerator,
+    HandlerSynchronousRunStarter,
+)
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPToolError
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+
+
+class _FakeSeed:
+    def to_dict(self) -> dict[str, object]:
+        return {"goal": "Create hello_auto.py", "acceptance_criteria": ()}
 
 
 @pytest.mark.asyncio
@@ -44,6 +55,71 @@ async def test_auto_interview_backend_ignores_seed_ready_client_gate_metadata(tm
 
     assert turn.session_id == "interview_auto"
     assert turn.seed_ready is True
+
+
+@pytest.mark.asyncio
+async def test_synchronous_run_starter_skips_execute_seed_qa(tmp_path) -> None:
+    """Auto complete-product uses exact execution evidence, not execute_seed QA teardown."""
+    handler = AsyncMock()
+    handler.handle = AsyncMock(
+        return_value=Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="done"),),
+                is_error=False,
+                meta={
+                    "session_id": "orch_sync",
+                    "execution_id": "exec_sync",
+                    "status": "completed",
+                    "success": True,
+                },
+            )
+        )
+    )
+    starter = HandlerSynchronousRunStarter(handler, cwd=str(tmp_path))
+
+    result = await starter(_FakeSeed())  # type: ignore[arg-type]
+
+    arguments = handler.handle.await_args.args[0]
+    assert arguments["skip_qa"] is True
+    assert result["status"] == "completed"
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_synchronous_run_starter_returns_persisted_terminal_meta_before_teardown(
+    tmp_path,
+) -> None:
+    """Auto does not wait for execute_seed teardown after the session is terminal."""
+    handler = AsyncMock()
+
+    async def slow_handle(*_args: object, **_kwargs: object) -> object:
+        await asyncio.sleep(60)
+        raise AssertionError("terminal recovery should return first")
+
+    handler.handle = AsyncMock(side_effect=slow_handle)
+
+    class RecoveringStarter(HandlerSynchronousRunStarter):
+        async def recover_timed_out_run(self) -> dict[str, object] | None:
+            return {
+                "job_id": None,
+                "session_id": "orch_recovered",
+                "execution_id": "exec_recovered",
+                "status": "completed",
+                "success": True,
+                "_allow_deadline_completion_grace": True,
+            }
+
+    starter = RecoveringStarter(
+        handler,
+        cwd=str(tmp_path),
+        terminal_poll_interval_seconds=0.1,
+    )
+
+    result = await starter(_FakeSeed())  # type: ignore[arg-type]
+
+    assert result["session_id"] == "orch_recovered"
+    assert result["execution_id"] == "exec_recovered"
+    assert result["success"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_adapters_ralph_poller.py
+++ b/tests/unit/auto/test_adapters_ralph_poller.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -75,3 +76,69 @@ async def test_handler_ralph_poller_prefers_generations_over_iterations(
     result = await poller(job_id="job_ralph_existing")
 
     assert result["current_generation"] == 10
+
+
+@pytest.mark.asyncio
+async def test_wait_for_job_terminal_cancels_live_job_on_timeout() -> None:
+    """A deadline-expired auto handoff must not leave the in-process Ralph job alive."""
+
+    class _RunningSnapshot:
+        is_terminal = False
+
+    class _TimeoutJobManager:
+        def __init__(self) -> None:
+            self.cancelled: list[str] = []
+
+        async def get_snapshot(self, _job_id: str) -> _RunningSnapshot:
+            return _RunningSnapshot()
+
+        async def cancel_job(self, job_id: str) -> _RunningSnapshot:
+            self.cancelled.append(job_id)
+            return _RunningSnapshot()
+
+    job_manager = _TimeoutJobManager()
+
+    result = await adapters._wait_for_job_terminal(  # noqa: SLF001
+        job_manager,  # type: ignore[arg-type]
+        "job_ralph_timeout",
+        poll_interval=0,
+        timeout_seconds=0.001,
+        cancel_on_timeout=True,
+    )
+
+    assert result["status"] == "failed"
+    assert result["stop_reason"] == "wall_clock_exhausted"
+    assert job_manager.cancelled == ["job_ralph_timeout"]
+
+
+@pytest.mark.asyncio
+async def test_wait_for_job_terminal_cleans_up_when_outer_wait_cancels() -> None:
+    """The auto pipeline wraps Ralph handoff in wait_for, so adapter cancellation must clean up."""
+
+    class _RunningSnapshot:
+        is_terminal = False
+
+    class _CancellableJobManager:
+        def __init__(self) -> None:
+            self.cancelled: list[str] = []
+
+        async def get_snapshot(self, _job_id: str) -> _RunningSnapshot:
+            return _RunningSnapshot()
+
+        async def cancel_job(self, job_id: str) -> _RunningSnapshot:
+            self.cancelled.append(job_id)
+            return _RunningSnapshot()
+
+    job_manager = _CancellableJobManager()
+
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(
+            adapters._wait_for_job_terminal_with_cancel_cleanup(  # noqa: SLF001
+                job_manager,  # type: ignore[arg-type]
+                "job_ralph_outer_timeout",
+                timeout_seconds=60,
+            ),
+            timeout=0.001,
+        )
+
+    assert job_manager.cancelled == ["job_ralph_outer_timeout"]

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -271,6 +271,23 @@ def test_normalize_execution_acceptance_keeps_minimality_constraints_without_exa
     assert normalize_execution_acceptance(seed) is seed
 
 
+def test_normalize_execution_acceptance_adds_real_tool_guard_for_exact_ac() -> None:
+    seed = _seed("The exact command `uv run pytest tests/test_hello_auto.py` passes.").model_copy(
+        update={"constraints": ("Keep scope to the requested files",)}
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.constraints == (
+        "Keep scope to the requested files",
+        "Use the real verification tool named by the exact command; do not satisfy it "
+        "with a local shim or replacement executable. Minimal project metadata and "
+        "dependencies needed for that tool are allowed.",
+        "Do not add unrelated files, dependencies, or behavior; minimal project metadata "
+        "needed to run the exact verification command is allowed.",
+    )
+
+
 def test_normalize_execution_acceptance_keeps_repaired_fragments_without_exact_ac_command() -> None:
     seed = _seed(
         "A command/API check returns stable observable output or artifacts proving the original requirement for hello_auto.py exists at repository root.",

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -198,6 +198,73 @@ def test_normalize_execution_acceptance_unwraps_repaired_observation_criteria() 
     assert normalized.acceptance_criteria == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
 
 
+def test_normalize_execution_acceptance_drops_repaired_fragments_with_exact_command() -> None:
+    exact_contract = (
+        "Create `hello_auto.py` and `tests/test_hello_auto.py` so "
+        "`hello_auto() -> str` returns exactly `hello from ooo auto`, "
+        "the test imports `hello_auto` and asserts that exact value, and "
+        "the exact command `uv run pytest tests/test_hello_auto.py` passes."
+    )
+    seed = _seed(
+        exact_contract,
+        "A command/API check returns stable observable output or artifacts proving the original requirement for hello_auto.py exists at repository root.",
+        "A command/API check returns stable observable output or artifacts proving the original requirement for hello_auto() function exists.",
+        "A command/API check returns stable observable output or artifacts proving the original requirement for Test imports exactly from hello_auto import hello_auto.",
+    ).model_copy(update={"goal": "Create a tiny Python module and exact pytest verification."})
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == (exact_contract,)
+
+
+def test_normalize_execution_acceptance_relaxes_conflicting_minimality_constraints() -> None:
+    seed = _seed(
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+    ).model_copy(
+        update={
+            "constraints": (
+                "No extra files or behavior beyond the exact return-value test",
+                "Avoid new dependencies",
+                "Verification command must be uv run pytest tests/test_hello_auto.py",
+            ),
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.constraints == (
+        "Verification command must be uv run pytest tests/test_hello_auto.py",
+        "Do not add unrelated files, dependencies, or behavior; minimal project metadata "
+        "needed to run the exact verification command is allowed.",
+    )
+
+
+def test_normalize_execution_acceptance_keeps_minimality_constraints_without_exact_command() -> None:
+    seed = _seed("Tests cover the behavior.").model_copy(
+        update={
+            "constraints": (
+                "No extra files or behavior beyond the exact return-value test",
+                "Avoid new dependencies",
+            ),
+        }
+    )
+
+    assert normalize_execution_acceptance(seed) is seed
+
+
+def test_normalize_execution_acceptance_keeps_repaired_fragments_without_exact_ac_command() -> None:
+    seed = _seed(
+        "A command/API check returns stable observable output or artifacts proving the original requirement for hello_auto.py exists at repository root.",
+        "A command/API check returns stable observable output or artifacts proving the original requirement for Test imports exactly from hello_auto import hello_auto.",
+    ).model_copy(
+        update={
+            "constraints": ("Verification command must be uv run pytest tests/test_hello_auto.py",),
+        }
+    )
+
+    assert normalize_execution_acceptance(seed) is seed
+
+
 def test_normalize_execution_acceptance_keeps_original_when_filter_would_empty() -> None:
     seed = _seed("Final report includes auto session id and seed id.")
 

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -225,7 +225,18 @@ def test_normalize_execution_acceptance_relaxes_conflicting_minimality_constrain
             "constraints": (
                 "No extra files or behavior beyond the exact return-value test",
                 "Avoid new dependencies",
+                "Do not add new dependencies",
                 "Verification command must be uv run pytest tests/test_hello_auto.py",
+            ),
+            "exit_conditions": (
+                ExitCondition(
+                    name="scope_preserved",
+                    description="No unauthorized expansion occurred",
+                    evaluation_criteria=(
+                        "no new dependencies, frameworks, deployment targets, credentials, "
+                        "or external side effects are introduced"
+                    ),
+                ),
             ),
         }
     )
@@ -234,8 +245,16 @@ def test_normalize_execution_acceptance_relaxes_conflicting_minimality_constrain
 
     assert normalized.constraints == (
         "Verification command must be uv run pytest tests/test_hello_auto.py",
+        "Use the real verification tool named by the exact command; do not satisfy it "
+        "with a local shim or replacement executable. Minimal project metadata and "
+        "dependencies needed for that tool are allowed.",
         "Do not add unrelated files, dependencies, or behavior; minimal project metadata "
         "needed to run the exact verification command is allowed.",
+    )
+    assert normalized.exit_conditions[0].evaluation_criteria == (
+        "No unrelated dependencies, frameworks, deployment targets, credentials, or external "
+        "side effects are introduced; minimal project metadata and dependencies needed to run "
+        "the exact verification command are allowed."
     )
 
 

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -61,6 +61,35 @@ def test_normalize_execution_acceptance_drops_auto_report_criteria() -> None:
     assert normalized.acceptance_criteria == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
 
 
+def test_normalize_execution_acceptance_preserves_requested_hello_auto_value() -> None:
+    seed = _seed(
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+    ).model_copy(
+        update={
+            "goal": (
+                "Create hello_auto.py with hello_auto() returning exactly "
+                "'hello from ooo auto fresh'. Create tests/test_hello_auto.py "
+                "importing hello_auto and asserting that exact value. Verification "
+                "command is uv run pytest tests/test_hello_auto.py."
+            ),
+            "constraints": (
+                "hello_auto() must return exactly 'hello from ooo auto fresh'",
+            ),
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == (
+        "Create `hello_auto.py` and `tests/test_hello_auto.py` so "
+        "`hello_auto() -> str` returns exactly `hello from ooo auto fresh`, "
+        "the test imports `hello_auto` and asserts that exact value, and "
+        "the exact command `uv run pytest tests/test_hello_auto.py` passes.",
+    )
+
+
 def test_normalize_execution_acceptance_drops_observation_report_metadata() -> None:
     seed = _seed(
         "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -939,7 +939,7 @@ async def test_interview_driver_blocks_on_backend_timeout(tmp_path) -> None:
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("done", session_id, seed_ready=True)
 
-    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state = AutoPipelineState(goal="Deploy to production", cwd=str(tmp_path))
     ledger = SeedDraftLedger.from_goal(state.goal)
     driver = AutoInterviewDriver(
         FunctionInterviewBackend(start, answer),
@@ -964,7 +964,7 @@ async def test_interview_driver_timeout_message_records_state_policy_source(tmp_
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("done", session_id, seed_ready=True)
 
-    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state = AutoPipelineState(goal="Deploy to production", cwd=str(tmp_path))
     ledger = SeedDraftLedger.from_goal(state.goal)
     driver = AutoInterviewDriver(
         FunctionInterviewBackend(start, answer),
@@ -978,6 +978,35 @@ async def test_interview_driver_timeout_message_records_state_policy_source(tmp_
     assert "interview.start timed out after 0s" in blocker
     assert "policy: state.timeout_seconds_by_phase[interview]" in blocker
     assert state.last_error == blocker
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_closes_with_safe_defaults_when_start_times_out(
+    tmp_path,
+) -> None:
+    async def start(goal: str, cwd: str, *, interview_id: str | None = None) -> InterviewTurn:  # noqa: ARG001
+        await asyncio.sleep(0.05)
+        return InterviewTurn("What should we verify?", interview_id or "interview_timeout")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("answer must not run when start times out")
+
+    state = AutoPipelineState(goal="Build a small local CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    store = AutoStore(tmp_path)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer, is_session_persisted=lambda _id: False),
+        store=store,
+        timeout_seconds=0.001,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert result.blocker is None
+    assert state.interview_session_id is None
+    assert state.interview_closure_mode == "safe_default_no_backend"
+    assert ledger.is_seed_ready()
 
 
 @pytest.mark.asyncio
@@ -2776,6 +2805,76 @@ async def test_pipeline_seed_generation_without_interview_session_synthesizes_co
 
 
 @pytest.mark.asyncio
+async def test_pipeline_resumes_no_backend_interview_closure_without_session_id(
+    tmp_path,
+) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("no-backend resume should synthesize without handler seed generation")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_completed = True
+    state.interview_closure_mode = "safe_default_no_backend"
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase == AutoPhase.COMPLETE
+    assert result.interview_session_id is None
+    assert state.seed_artifact is not None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_seed_generation_timeout_falls_back_to_completed_ledger(
+    tmp_path,
+) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("seed phase should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("seed phase should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        await asyncio.sleep(0.05)
+        return _seed()
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_timeout_seed"
+    state.interview_completed = True
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        skip_run=True,
+        seed_timeout_seconds=0.001,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+    assert state.last_tool_name == "ledger_seed_generator"
+    assert state.seed_artifact is not None
+
+
+@pytest.mark.asyncio
 async def test_pipeline_retry_after_blocked_run_start_replay_from_seed_path(tmp_path) -> None:
     """Resuming a blocked run-start session retries the run starter once."""
 
@@ -3690,6 +3789,58 @@ async def test_interview_driver_supplies_last_question_for_seed_ready_gap_reopen
 
 
 @pytest.mark.asyncio
+async def test_backend_ready_low_ambiguity_closes_safe_defaultable_gaps(tmp_path) -> None:
+    """Low-ambiguity backend completion should not reopen on benign safe gaps."""
+    observed_last_questions: list[str | None] = []
+    observed_answers: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "ready",
+            "interview_backend_ready_defaults",
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.16,
+        )
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        observed_last_questions.append(last_question)
+        observed_answers.append(text)
+        return InterviewTurn(
+            "done",
+            session_id,
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.16,
+        )
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    ledger.sections["non_goals"].entries.clear()
+    ledger.sections["failure_modes"].entries.clear()
+    ledger.sections["runtime_context"].entries.clear()
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=3,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert state.interview_closure_mode == "safe_default"
+    assert ledger.is_seed_ready()
+    assert observed_last_questions == [
+        "[driver safe-default finalization: backend_ambiguity=0.16]"
+    ]
+    assert observed_answers and "[safe-default-synthesis]" in observed_answers[0]
+
+
+@pytest.mark.asyncio
 async def test_interview_driver_does_not_replace_specific_verification_answer_with_gap_prompt(
     tmp_path,
 ) -> None:
@@ -4397,8 +4548,9 @@ async def test_interview_driver_keeps_session_id_when_probe_confirms_persistence
 
     result = await driver.run(state, ledger)
 
-    assert result.status == "blocked"
+    assert result.status == "seed_ready"
     assert state.interview_session_id, "probe-confirmed id must be saved on auto state"
+    assert state.interview_closure_mode == "safe_default_no_backend"
     assert received_ids == [state.interview_session_id], (
         "backend.start must receive the pre-allocated interview_id so the "
         "persisted interview file matches auto state"
@@ -4501,7 +4653,7 @@ async def test_interview_driver_persists_partial_session_id_on_start_failure(tmp
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("answer must not be called when start fails")
 
-    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state = AutoPipelineState(goal="Deploy to production", cwd=str(tmp_path))
     ledger = SeedDraftLedger.from_goal(state.goal)
     store = AutoStore(tmp_path)
     driver = AutoInterviewDriver(

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -4509,15 +4509,28 @@ async def test_invalid_reconcile_on_complete_does_not_poison_future_resume(tmp_p
 
 
 @pytest.mark.asyncio
-async def test_interview_driver_keeps_session_id_when_probe_confirms_persistence(
+async def test_interview_driver_clears_probe_confirmed_id_on_safe_default_no_backend_closure(
     tmp_path,
 ) -> None:
-    """Driver retains the pre-allocated id only when persistence is verifiable.
+    """No-backend safe-default closure must not advertise an unsynced transcript.
 
-    Models the issue's primary scenario: the driver's ``asyncio.wait_for``
-    cancels the backend mid-flight, but the engine has already persisted
-    the interview state.  The driver must consult ``is_session_persisted``
-    to confirm before saving the id on auto state.
+    Models the start-time timeout where the engine persisted a session file
+    before the driver's ``asyncio.wait_for`` cancelled the backend
+    mid-flight. ``is_session_persisted`` confirms the file exists, so
+    ``_record_evidence_based_session_id`` saves the pre-allocated id on
+    auto state. The safe-default fallback then closes the ledger
+    deterministically *without* pushing the synthesis through
+    ``backend.answer``.
+
+    The persisted backend file therefore contains only the silent start
+    frame — none of the facts that produced the closed ledger. Leaving
+    ``interview_session_id`` populated on the seed_ready envelope would
+    advertise that empty transcript as the Seed's interview lineage,
+    contradicting the SSOT contract that the existing safe-default path
+    enforces by rolling back if ``backend.answer`` sync fails. The driver
+    must instead clear the id when it closes via
+    ``safe_default_no_backend`` (or ``ledger_only_no_backend``), so the
+    envelope and reloaded state both report no backend lineage.
     """
 
     received_ids: list[str | None] = []
@@ -4549,16 +4562,28 @@ async def test_interview_driver_keeps_session_id_when_probe_confirms_persistence
     result = await driver.run(state, ledger)
 
     assert result.status == "seed_ready"
-    assert state.interview_session_id, "probe-confirmed id must be saved on auto state"
+    assert result.session_id is None, (
+        "result envelope must not advertise an unsynchronized backend transcript "
+        "as Seed lineage"
+    )
+    assert state.interview_session_id is None, (
+        "auto state must clear the probe-confirmed id on no-backend safe-default "
+        "closure because the persisted interview never received the synthesis"
+    )
     assert state.interview_closure_mode == "safe_default_no_backend"
-    assert received_ids == [state.interview_session_id], (
-        "backend.start must receive the pre-allocated interview_id so the "
-        "persisted interview file matches auto state"
+    # The driver still forwards the pre-allocated id to backend.start; that
+    # contract (engine.start_interview must honour the supplied id when it
+    # persists the file before failing) is independent of the lineage-clear
+    # decision above.
+    assert len(received_ids) == 1
+    assert received_ids[0] is not None and received_ids[0] in persisted_ids, (
+        "backend.start must receive the pre-allocated interview_id so any "
+        "persisted file matches what the driver probed"
     )
 
     reloaded = store.load(state.auto_session_id)
     assert reloaded is not None
-    assert reloaded.interview_session_id == state.interview_session_id
+    assert reloaded.interview_session_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -655,6 +655,51 @@ async def test_complete_product_blocks_when_initial_run_reports_failure(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_complete_product_blocks_when_synchronous_run_is_paused(tmp_path) -> None:
+    """A paused synchronous execution is non-terminal — do not hand off to Ralph.
+
+    ``ExecuteSeedHandler`` maps :class:`SessionStatus.PAUSED` to
+    ``status="paused"`` / ``success=None`` — the run is waiting on
+    operator input, not finished. The previous guard only blocked the
+    ``failed/cancelled/interrupted`` and ``queued/running/cancel_requested``
+    sets, so ``paused`` fell through and started Ralph against a
+    still-pending product run. Block the handoff and leave the owned job
+    alone (operator may still resume it).
+    """
+
+    state = _state_at_run_phase(tmp_path)
+
+    async def paused_run_starter(_seed: Seed) -> dict[str, Any]:
+        return {
+            "job_id": "job_run_paused",
+            "session_id": "exec_session_paused",
+            "execution_id": "execution_paused",
+            "status": "paused",
+            "success": None,
+        }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("ralph_starter must not run while execution is paused")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=paused_run_starter,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "paused" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
 async def test_complete_product_synchronous_run_uses_pipeline_deadline_not_handoff_timeout(
     tmp_path,
 ) -> None:

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -1815,6 +1815,64 @@ async def test_run_resume_with_persisted_handle_blocks_when_owned_job_still_runn
 
 
 @pytest.mark.asyncio
+async def test_run_resume_with_jobless_sync_handle_blocks_complete_product_ralph(
+    tmp_path,
+) -> None:
+    """Jobless synchronous executions cannot be reconciled on resume.
+
+    ``HandlerSynchronousRunStarter`` always returns ``job_id=None`` and
+    relies on the starter's returned dict for terminal-success
+    validation. On resume that dict is gone, so persisted
+    ``execution_id``/``run_session_id`` alone are not evidence of
+    terminal success — they only prove an execution session existed.
+    Most often this branch is reached after the fresh-path paused/failed
+    guard blocked the synchronous run; ``_recoverable_phase_for_tool``
+    sends the resume back into RUN, where without an explicit guard
+    Ralph would launch against the still-pending product session.
+    Resume must block until the operator resolves the synchronous run
+    itself.
+    """
+
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = None
+    state.execution_id = "execution_paused_sync"
+    state.run_session_id = "session_paused_sync"
+    state.complete_product = True
+
+    class JoblessSyncStarter:
+        synchronous_execution = True
+
+        async def __call__(
+            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+        ) -> dict[str, Any]:
+            raise AssertionError("resume must not redispatch a synchronous run")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError(
+            "ralph_starter must not run while jobless sync execution is unreconcilable"
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=JoblessSyncStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "jobless synchronous execution" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
 async def test_run_resume_with_persisted_handle_blocks_when_owned_job_failed(
     tmp_path,
 ) -> None:

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -828,6 +828,105 @@ async def test_complete_product_synchronous_success_after_deadline_blocks_as_tim
 
 
 @pytest.mark.asyncio
+async def test_first_party_synchronous_success_within_grace_completes(tmp_path) -> None:
+    """First-party inline execution may return terminal metadata during teardown grace."""
+    state = _state_at_run_phase(tmp_path)
+
+    class FirstPartySyncStarter:
+        synchronous_execution = True
+
+        async def __call__(
+            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+        ) -> dict[str, Any]:
+            state.deadline_at = time.monotonic() - 1.0
+            state.deadline_at_epoch = time.time() - 1.0
+            return {
+                "job_id": None,
+                "session_id": "sync_grace",
+                "execution_id": "sync_grace_exec",
+                "status": "completed",
+                "success": True,
+                "_allow_deadline_completion_grace": True,
+            }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("successful first-party sync execution must not dispatch Ralph")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=FirstPartySyncStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.run_handoff_status == "completed"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.last_tool_name != PIPELINE_DEADLINE_TOOL_NAME
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
+async def test_first_party_synchronous_timeout_recovers_completed_session(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If inline handler teardown times out, recover terminal session metadata."""
+    monkeypatch.setattr(pipeline_module, "_SYNCHRONOUS_RUN_COMPLETION_GRACE_SECONDS", 0.05)
+    state = _state_at_run_phase(tmp_path)
+    state.deadline_at = time.monotonic() + 0.2
+    state.deadline_at_epoch = time.time() + 0.2
+
+    class TimeoutAfterCompletionStarter:
+        synchronous_execution = True
+
+        async def __call__(
+            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+        ) -> dict[str, Any]:
+            await asyncio.sleep(1.0)
+            raise AssertionError("wait_for should time out first")
+
+        async def recover_timed_out_run(self) -> dict[str, Any]:
+            state.deadline_at = time.monotonic() - 0.01
+            state.deadline_at_epoch = time.time() - 0.01
+            return {
+                "job_id": None,
+                "session_id": "sync_recovered",
+                "execution_id": "sync_recovered_exec",
+                "status": "completed",
+                "success": True,
+                "_allow_deadline_completion_grace": True,
+            }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("successful recovered sync execution must not dispatch Ralph")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=TimeoutAfterCompletionStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+        run_start_timeout_seconds=0.001,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.run_handoff_status == "completed"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.execution_id == "sync_recovered_exec"
+    assert state.run_session_id == "sync_recovered"
+    assert state.last_tool_name != PIPELINE_DEADLINE_TOOL_NAME
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
 async def test_complete_product_waits_for_owned_run_job_before_ralph(tmp_path) -> None:
     """A queued execute_seed job must reach terminal success before Ralph starts."""
     state = _state_at_run_phase(tmp_path)

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -43,6 +43,7 @@ from ouroboros.core.seed import (
     SeedMetadata,
 )
 from ouroboros.events.base import BaseEvent
+from ouroboros.mcp.job_manager import JobStatus
 
 
 def _build_seed(seed_id: str = "seed_test_001") -> Seed:
@@ -619,6 +620,202 @@ async def test_ralph_handoff_resume_does_not_dispatch_duplicate_work(tmp_path) -
 
 
 @pytest.mark.asyncio
+async def test_complete_product_blocks_when_initial_run_reports_failure(tmp_path) -> None:
+    """Do not launch Ralph when the synchronous run handoff already failed."""
+    state = _state_at_run_phase(tmp_path)
+
+    async def failed_run_starter(_seed: Seed) -> dict[str, Any]:
+        return {
+            "job_id": "job_run_failed",
+            "session_id": "exec_session_failed",
+            "execution_id": "execution_failed",
+            "status": "failed",
+            "success": False,
+        }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("ralph_starter must not run after failed execution")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=failed_run_starter,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "finished unsuccessfully" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
+async def test_complete_product_synchronous_run_uses_pipeline_deadline_not_handoff_timeout(
+    tmp_path,
+) -> None:
+    """Inline complete-product execution is terminal RUN work, not quick enqueue work."""
+    state = _state_at_run_phase(tmp_path)
+    state.pipeline_timeout_seconds = 120.0
+    state.arm_deadline()
+
+    class SlowSynchronousRunStarter:
+        synchronous_execution = True
+
+        async def __call__(
+            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+        ) -> dict[str, Any]:
+            await asyncio.sleep(0.02)
+            return {
+                "job_id": None,
+                "session_id": "sync_session",
+                "execution_id": "sync_exec",
+                "status": "completed",
+                "success": True,
+            }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("successful synchronous run must not dispatch Ralph")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=SlowSynchronousRunStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+        run_start_timeout_seconds=0.001,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.run_handoff_status == "completed"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.execution_id == "sync_exec"
+    assert state.run_handoff_status == "completed"
+    assert state.ralph_job_id is None
+    assert state.last_tool_name != "run_starter"
+
+
+def test_complete_product_synchronous_run_timeout_has_completion_grace(tmp_path) -> None:
+    """Synchronous run teardown gets a small grace beyond the strict deadline."""
+    state = _state_at_run_phase(tmp_path)
+    state.deadline_at = time.monotonic() + 5.0
+
+    class SynchronousRunStarter:
+        synchronous_execution = True
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=SynchronousRunStarter(),
+        reviewer=_PassReviewer(),
+        complete_product=True,
+        run_start_timeout_seconds=0.001,
+    )
+
+    assert pipeline._run_start_timeout(state) > 5.0
+
+
+@pytest.mark.asyncio
+async def test_complete_product_waits_for_owned_run_job_before_ralph(tmp_path) -> None:
+    """A queued execute_seed job must reach terminal success before Ralph starts."""
+    state = _state_at_run_phase(tmp_path)
+
+    class _RunSnapshot:
+        is_terminal = True
+        status = JobStatus.FAILED
+        result_meta = {"status": "failed", "success": False}
+
+    class _RunJobManager:
+        async def get_snapshot(self, job_id: str) -> _RunSnapshot:
+            assert job_id == "job_run_background"
+            return _RunSnapshot()
+
+    class _RunHandler:
+        _job_manager = _RunJobManager()
+
+    class BackgroundRunStarter:
+        handler = _RunHandler()
+
+        async def __call__(self, _seed: Seed) -> dict[str, Any]:
+            return {
+                "job_id": "job_run_background",
+                "session_id": "exec_session_background",
+                "execution_id": "execution_background",
+                "status": "queued",
+            }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("ralph_starter must not run before failed run is surfaced")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=BackgroundRunStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.last_tool_name == "run_starter"
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
+async def test_complete_product_blocks_when_owned_run_job_is_still_running(tmp_path) -> None:
+    """Do not start Ralph against an unfinished execute_seed job."""
+    state = _state_at_run_phase(tmp_path)
+    cancelled_jobs: list[str] = []
+
+    class _RunJobManager:
+        async def cancel_job(self, job_id: str) -> None:
+            cancelled_jobs.append(job_id)
+
+    class _RunHandler:
+        _job_manager = _RunJobManager()
+
+    class BackgroundRunStarter:
+        handler = _RunHandler()
+
+        async def __call__(self, _seed: Seed) -> dict[str, Any]:
+            return {
+                "job_id": "job_run_background",
+                "session_id": "exec_session_background",
+                "execution_id": "execution_background",
+                "status": "queued",
+            }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("ralph_starter must not run while execution is still running")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=BackgroundRunStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.last_tool_name == "run_starter"
+    assert "did not finish" in (state.last_error or "")
+    assert state.ralph_job_id is None
+    assert cancelled_jobs == ["job_run_background"]
+
+
+@pytest.mark.asyncio
 async def test_insufficient_ralph_deadline_budget_blocks_as_pipeline_timeout(tmp_path) -> None:
     state = _state_at_run_phase(tmp_path)
     state.deadline_at = time.monotonic() + 0.25
@@ -1143,6 +1340,74 @@ async def test_ralph_handoff_resume_poller_cancels_status_mirror_on_poll_error(
     assert state.phase is AutoPhase.FAILED
     assert state.last_error == "ralph resume poll failed: snapshot unavailable"
     assert event_store.cancelled is True
+
+
+@pytest.mark.asyncio
+async def test_fresh_ralph_handoff_timeout_cancels_status_mirror(tmp_path) -> None:
+    """A deadline timeout during fresh Ralph handoff must not leave the mirror running."""
+    state = _state_at_run_phase(tmp_path)
+    state.deadline_at = time.monotonic() + 1.05
+    state.deadline_at_epoch = time.time() + 1.05
+    auto_store = AutoStore(tmp_path)
+    event_store = _ResumeMirrorEventStore(state)
+    event_store.block_first_fetch = True
+    cancelled_jobs: list[str] = []
+
+    class _JobManager:
+        async def cancel_job(self, job_id: str) -> None:
+            cancelled_jobs.append(job_id)
+
+    class _Handler:
+        _job_manager = _JobManager()
+
+    class SlowStarter:
+        job_event_store = event_store
+        handler = _Handler()
+
+        async def __call__(
+            self,
+            seed: Seed,  # noqa: ARG002
+            *,
+            lineage_id: str,
+            on_dispatched,
+            **_kwargs: Any,
+        ) -> dict[str, Any]:
+            on_dispatched(
+                {
+                    "job_id": "job_fresh_timeout",
+                    "lineage_id": lineage_id,
+                    "dispatch_mode": "job",
+                }
+            )
+            await asyncio.wait_for(event_store.started.wait(), timeout=1.0)
+            await asyncio.sleep(2.0)
+            return {
+                "job_id": "job_fresh_timeout",
+                "lineage_id": lineage_id,
+                "dispatch_mode": "job",
+                "terminal_status": "completed",
+                "stop_reason": "qa passed",
+            }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        store=auto_store,
+        reviewer=_PassReviewer(),
+        ralph_starter=SlowStarter(),
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == PIPELINE_DEADLINE_TOOL_NAME
+    assert "pipeline_timeout" in (state.last_error or "")
+    assert state.ralph_job_id == "job_fresh_timeout"
+    assert event_store.cancelled is True
+    assert cancelled_jobs == ["job_fresh_timeout"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -768,6 +768,66 @@ def test_complete_product_synchronous_run_timeout_has_completion_grace(tmp_path)
 
 
 @pytest.mark.asyncio
+async def test_complete_product_synchronous_success_after_deadline_blocks_as_timeout(
+    tmp_path,
+) -> None:
+    """Sync completion grace must not turn into extra execution budget.
+
+    ``_run_start_timeout`` adds ``_SYNCHRONOUS_RUN_COMPLETION_GRACE_SECONDS``
+    on top of the remaining pipeline deadline so the inline ``await`` for a
+    synchronous starter can finish handler teardown without
+    ``asyncio.wait_for`` tripping. The grace is for teardown only — a
+    synchronous run that returns ``success=True`` AFTER ``deadline_at`` has
+    already passed has still exceeded the public ``pipeline_timeout``
+    contract. The pre-COMPLETE deadline gate must catch that case and
+    surface ``pipeline_timeout`` BLOCKED instead of recording the
+    over-budget run as complete.
+    """
+
+    state = _state_at_run_phase(tmp_path)
+
+    class OverBudgetSyncStarter:
+        synchronous_execution = True
+
+        async def __call__(
+            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+        ) -> dict[str, Any]:
+            # Backdate the deadline as if the inline await had run past it
+            # within the synchronous completion grace; returning success here
+            # would otherwise mark COMPLETE without re-checking the deadline.
+            state.deadline_at = time.monotonic() - 1.0
+            state.deadline_at_epoch = time.time() - 1.0
+            return {
+                "job_id": None,
+                "session_id": "sync_over_budget",
+                "execution_id": "sync_over_budget_exec",
+                "status": "completed",
+                "success": True,
+            }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("ralph_starter must not run when sync execution is over deadline")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=OverBudgetSyncStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.is_deadline_expired()
+    assert state.last_tool_name == PIPELINE_DEADLINE_TOOL_NAME
+    assert "pipeline_timeout" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
 async def test_complete_product_waits_for_owned_run_job_before_ralph(tmp_path) -> None:
     """A queued execute_seed job must reach terminal success before Ralph starts."""
     state = _state_at_run_phase(tmp_path)

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -1615,12 +1615,54 @@ async def test_ralph_handoff_resume_falls_back_to_guidance_without_resumer(tmp_p
 # ---------------------------------------------------------------------------
 
 
+def _terminal_success_run_starter(job_id: str = "job_run_existing") -> Any:
+    """Build a run_starter adapter whose owned-job snapshot reports terminal success.
+
+    Mirrors the production ``HandlerRunStarter`` / ``HandlerSynchronousRunStarter``
+    shape: ``adapter.handler._job_manager.get_snapshot(job_id)`` returns a
+    snapshot whose ``is_terminal`` is True and ``result_meta`` advertises
+    ``status="completed"`` / ``success=True``. The starter callable itself
+    raises so the test proves resume does NOT redispatch the run job; the
+    only signal feeding the resume gate is the persisted run handle plus
+    the snapshot poll.
+    """
+
+    class _RunSnapshot:
+        is_terminal = True
+        status = JobStatus.COMPLETED
+        result_meta = {"status": "completed", "success": True}
+
+    class _RunJobManager:
+        async def get_snapshot(self, snapshot_job_id: str) -> _RunSnapshot:
+            assert snapshot_job_id == job_id
+            return _RunSnapshot()
+
+    class _RunHandler:
+        _job_manager = _RunJobManager()
+
+    class TerminalSuccessStarter:
+        handler = _RunHandler()
+
+        async def __call__(self, _seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not start a duplicate run")
+
+    return TerminalSuccessStarter()
+
+
 @pytest.mark.asyncio
 async def test_run_resume_with_persisted_handle_and_complete_product_dispatches_ralph(
     tmp_path,
 ) -> None:
     """RUN resume with persisted run handles MUST honor ``complete_product``
-    and continue to RALPH_HANDOFF, not short-circuit to COMPLETE."""
+    and continue to RALPH_HANDOFF, not short-circuit to COMPLETE.
+
+    The resume gate now mirrors the fresh-path contract by polling the
+    owned-job snapshot for terminal success before invoking Ralph; this
+    test wires a snapshot that reports ``status="completed"`` /
+    ``success=True`` so the handoff proceeds and proves the happy path
+    still works.
+    """
+
     state = _state_at_run_phase(tmp_path)
     state.run_start_attempted = True
     state.run_handoff_status = "started"
@@ -1642,13 +1684,10 @@ async def test_run_resume_with_persisted_handle_and_complete_product_dispatches_
             "stop_reason": "qa passed",
         }
 
-    async def run_starter(_seed: Seed, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
-        raise AssertionError("resume must not start a duplicate run")
-
     pipeline = AutoPipeline(
         _StubInterviewDriver(),
         _seed_generator_unused,
-        run_starter=run_starter,
+        run_starter=_terminal_success_run_starter("job_run_existing"),
         reviewer=_PassReviewer(),
         ralph_starter=ralph_starter,
         complete_product=True,
@@ -1660,6 +1699,170 @@ async def test_run_resume_with_persisted_handle_and_complete_product_dispatches_
     assert result.status == "complete"
     assert state.phase is AutoPhase.COMPLETE
     assert state.ralph_job_id == "job_ralph_resumed"
+
+
+@pytest.mark.asyncio
+async def test_run_resume_with_persisted_handle_blocks_when_owned_job_paused(
+    tmp_path,
+) -> None:
+    """Resume MUST NOT hand off to Ralph when the owned run job is paused.
+
+    Mirrors the fresh-path paused guard. A paused complete-product run
+    means the operator must resume the run itself before Ralph can take
+    over.
+    """
+
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_paused_resume"
+    state.execution_id = "execution_paused_resume"
+    state.complete_product = True
+
+    class _RunSnapshot:
+        is_terminal = True
+        status = JobStatus.COMPLETED  # status enum value irrelevant; result_meta wins
+        result_meta = {"status": "paused", "success": None}
+
+    class _RunJobManager:
+        async def get_snapshot(self, _job_id: str) -> _RunSnapshot:
+            return _RunSnapshot()
+
+    class _RunHandler:
+        _job_manager = _RunJobManager()
+
+    class PausedSnapshotStarter:
+        handler = _RunHandler()
+
+        async def __call__(self, _seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not start a duplicate run")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("ralph_starter must not run while resumed execution is paused")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=PausedSnapshotStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "paused" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
+async def test_run_resume_with_persisted_handle_blocks_when_owned_job_still_running(
+    tmp_path,
+) -> None:
+    """Resume MUST block when the owned run job is still queued/running.
+
+    The snapshot returns ``status="running"`` to model a poll that did not
+    observe terminal completion within the per-phase budget — the fresh
+    path treats this identically and we mirror that contract.
+    """
+
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_pending_resume"
+    state.complete_product = True
+
+    class _RunSnapshot:
+        is_terminal = False
+        status = JobStatus.RUNNING
+        result_meta: dict[str, Any] = {}
+
+    class _RunJobManager:
+        async def get_snapshot(self, _job_id: str) -> _RunSnapshot:
+            return _RunSnapshot()
+
+    class _RunHandler:
+        _job_manager = _RunJobManager()
+
+    class RunningSnapshotStarter:
+        handler = _RunHandler()
+
+        async def __call__(self, _seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not start a duplicate run")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("ralph_starter must not run while resumed execution is still pending")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=RunningSnapshotStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "did not finish" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
+async def test_run_resume_with_persisted_handle_blocks_when_owned_job_failed(
+    tmp_path,
+) -> None:
+    """Resume MUST surface a failed owned run job instead of starting Ralph."""
+
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_failed_resume"
+    state.complete_product = True
+
+    class _RunSnapshot:
+        is_terminal = True
+        status = JobStatus.FAILED
+        result_meta = {"status": "failed", "success": False}
+
+    class _RunJobManager:
+        async def get_snapshot(self, _job_id: str) -> _RunSnapshot:
+            return _RunSnapshot()
+
+    class _RunHandler:
+        _job_manager = _RunJobManager()
+
+    class FailedSnapshotStarter:
+        handler = _RunHandler()
+
+        async def __call__(self, _seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not start a duplicate run")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("ralph_starter must not run after a failed resumed execution")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=FailedSnapshotStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "finished unsuccessfully" in (state.last_error or "")
+    assert state.ralph_job_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -1815,6 +1815,127 @@ async def test_run_resume_with_persisted_handle_blocks_when_owned_job_still_runn
 
 
 @pytest.mark.asyncio
+async def test_run_resume_with_persisted_job_id_blocks_when_starter_has_no_snapshot_api(
+    tmp_path,
+) -> None:
+    """Persisted ``job_id`` without a job-manager snapshot must not satisfy the resume gate.
+
+    A persisted ``job_id`` proves the execute_seed job was dispatched,
+    not that it reached terminal success. When the configured run
+    starter does not expose ``handler._job_manager.get_snapshot``,
+    ``_wait_owned_run_job_terminal`` returns ``None`` and the resume
+    branch cannot reconcile the owned-job lifecycle. Without an
+    explicit guard the previous resume path would walk past the
+    terminal check and start Ralph on dispatch evidence alone; the new
+    contract refuses the handoff in that case, mirroring the
+    jobless-synchronous branch.
+    """
+
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_unpollable"
+    state.execution_id = "execution_unpollable"
+    state.run_session_id = "session_unpollable"
+    state.complete_product = True
+
+    class UnpollableStarter:
+        # No ``handler`` attribute => ``_wait_owned_run_job_terminal``
+        # returns None because ``get_snapshot`` cannot be resolved.
+
+        async def __call__(self, _seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not redispatch the run job")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError(
+            "ralph_starter must not run when the owned job cannot be reconciled"
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=UnpollableStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "snapshot is unavailable" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
+async def test_run_resume_blocks_when_snapshot_does_not_confirm_terminal_success(
+    tmp_path,
+) -> None:
+    """An ambiguous terminal snapshot (no ``success=True`` / no ``status=completed``) must NOT pass the gate.
+
+    ``_wait_owned_run_job_terminal`` may return ``result_meta`` that is
+    empty or carries an unfamiliar status (e.g. an adapter that flips
+    ``is_terminal`` but does not populate the success/status keys auto
+    consumes). Such a payload is not evidence of terminal success and
+    must be treated as unreconcilable, not silently fall through to the
+    Ralph handoff. This guards the resume gate against snapshot shapes
+    that bypass the failed/paused/queued allowlist by omission.
+    """
+
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_ambiguous"
+    state.complete_product = True
+
+    class _RunSnapshot:
+        is_terminal = True
+        # status enum unset and result_meta empty: ``_wait_owned_run_job_terminal``
+        # produces ``{}`` because the snapshot has nothing to ``setdefault`` from,
+        # and the resume gate sees neither ``success=True`` nor
+        # ``status="completed"``.
+        status = None
+        result_meta: dict[str, Any] = {}
+
+    class _RunJobManager:
+        async def get_snapshot(self, _job_id: str) -> _RunSnapshot:
+            return _RunSnapshot()
+
+    class _RunHandler:
+        _job_manager = _RunJobManager()
+
+    class AmbiguousSnapshotStarter:
+        handler = _RunHandler()
+
+        async def __call__(self, _seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not redispatch the run job")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError(
+            "ralph_starter must not run when the snapshot does not confirm terminal success"
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=AmbiguousSnapshotStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "did not confirm terminal success" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
 async def test_run_resume_with_jobless_sync_handle_blocks_complete_product_ralph(
     tmp_path,
 ) -> None:

--- a/tests/unit/auto/test_pipeline_task_class_envelope.py
+++ b/tests/unit/auto/test_pipeline_task_class_envelope.py
@@ -214,6 +214,70 @@ async def test_envelope_carries_active_task_class_on_single_match(tmp_path) -> N
 
 
 @pytest.mark.asyncio
+async def test_envelope_skips_default_ac_when_seed_has_exact_verification_command(
+    tmp_path,
+) -> None:
+    """Concrete user verification commands should not gain broad class defaults."""
+    profile = TASK_CLASS_CATALOG[TaskClass.LIBRARY]
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_exact_command")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    user_ac = (
+        "Create `hello_auto.py` and `tests/test_hello_auto.py` so "
+        "`hello_auto() -> str` returns exactly `hello from ooo auto`, "
+        "the test imports `hello_auto` and asserts that exact value, and "
+        "the exact command `uv run pytest tests/test_hello_auto.py` passes.",
+    )
+
+    async def generate_seed(_session_id: str) -> Seed:
+        seed = _build_seed(ac=user_ac)
+        return seed.model_copy(
+            update={
+                "goal": (
+                    "Create hello_auto.py with hello_auto() returning exactly "
+                    "'hello from ooo auto'. Verification command is "
+                    "uv run pytest tests/test_hello_auto.py."
+                )
+            }
+        )
+
+    state = AutoPipelineState(
+        goal=(
+            "Create hello_auto.py with hello_auto() returning exactly "
+            "'hello from ooo auto'. Verification command is "
+            "uv run pytest tests/test_hello_auto.py."
+        ),
+        cwd=str(tmp_path),
+    )
+    ledger = _unmatched_ledger()
+    state.ledger = ledger.to_dict()
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        skip_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.active_task_class == TaskClass.LIBRARY.value
+    ac = state.seed_artifact["acceptance_criteria"]
+    assert ac == list(user_ac)
+    for template_entry in profile.default_ac_template:
+        assert template_entry not in ac
+
+
+@pytest.mark.asyncio
 async def test_envelope_uses_library_fallback_when_unmatched(tmp_path) -> None:
     """Unmatched inference applies the L1-b safe LIBRARY fallback instead
     of silently skipping default AC injection."""

--- a/tests/unit/auto/test_safe_default_lateral_escalation.py
+++ b/tests/unit/auto/test_safe_default_lateral_escalation.py
@@ -69,7 +69,7 @@ def _ledger_with_matcher_trigger(goal: str = "Build a habit-tracker CLI") -> See
         "outputs": "Stable stdout and a JSON file",
         "constraints": "Use existing project patterns; no new dependencies",
         "acceptance_criteria": (
-            "Should we define the acceptance contract as: success prints "
+            "Should we define the contract for success as: success prints "
             "one fixed stdout line; failure prints one fixed stderr line "
             "and exits 1?"
         ),

--- a/tests/unit/auto/test_safe_default_observability.py
+++ b/tests/unit/auto/test_safe_default_observability.py
@@ -262,6 +262,28 @@ def test_unsafe_context_match_logs_pattern_name_without_raw_text() -> None:
     assert "Use the access token" not in event_repr
 
 
+def test_unsafe_context_ignores_benign_software_contract_terms() -> None:
+    """Software test/acceptance contracts are not legal authority."""
+    goal = (
+        "Create a local pytest file and define the acceptance contract as: "
+        "the exact verification command passes."
+    )
+    ledger = SeedDraftLedger.from_goal(goal)
+
+    assert _unsafe_context_reason(ledger, goal=goal, pending_question=None) is None
+
+
+def test_unsafe_context_still_flags_legal_contract_terms() -> None:
+    """Narrowing software-contract terms must not clear legal contract risk."""
+    goal = "Draft a legal contract review checklist for liability clauses."
+    ledger = SeedDraftLedger.from_goal(goal)
+
+    assert (
+        _unsafe_context_reason(ledger, goal=goal, pending_question=None)
+        == "legal/medical judgment"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Test 4: unsafe_context_observed emitted when finalization stays blocked
 # ---------------------------------------------------------------------------

--- a/tests/unit/persistence/test_checkpoint.py
+++ b/tests/unit/persistence/test_checkpoint.py
@@ -158,13 +158,14 @@ class TestCheckpointStore:
         assert loaded.state == sample_checkpoint.state
 
     def test_load_returns_error_for_nonexistent_checkpoint(
-        self, checkpoint_store: CheckpointStore
+        self, checkpoint_store: CheckpointStore, capsys: pytest.CaptureFixture[str]
     ) -> None:
         """CheckpointStore.load() returns error for nonexistent checkpoint."""
         result = checkpoint_store.load("nonexistent-seed")
         assert result.is_err
         # Message indicates no valid checkpoint was found
         assert "no valid checkpoint" in result.error.message.lower()
+        assert "Checkpoint corruption" not in capsys.readouterr().out
 
     def test_load_validates_integrity(
         self, checkpoint_store: CheckpointStore, sample_checkpoint: CheckpointData

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -1,6 +1,7 @@
 """Unit tests for ouroboros.persistence.event_store module."""
 
 import asyncio
+from datetime import UTC, datetime, timedelta
 import logging
 
 import pytest
@@ -784,6 +785,53 @@ class TestSessionRelatedEvents:
         assert f"{execution_scope}_level_1_coordinator_reconciliation" in aggregate_ids
         assert f"{execution_scope}_child_0" in aggregate_ids
         assert "other_evolve_ac_0" not in aggregate_ids
+
+    async def test_session_related_events_are_bounded_by_session_start(
+        self,
+        event_store: EventStore,
+    ) -> None:
+        """Historical payload matches should not force full-history session scans."""
+        session_id = "sess-bounded-related"
+        execution_id = "exec-bounded-related"
+        session_started_at = datetime.now(UTC)
+        await event_store.append(
+            BaseEvent(
+                type="execution.ac.heartbeat",
+                timestamp=session_started_at - timedelta(days=1),
+                aggregate_type="execution",
+                aggregate_id="old-runtime-scope",
+                data={"session_id": session_id, "message_count": 1},
+            )
+        )
+        await event_store.append(
+            BaseEvent(
+                type="orchestrator.session.started",
+                timestamp=session_started_at,
+                aggregate_type="session",
+                aggregate_id=session_id,
+                data={"execution_id": execution_id, "seed_id": "seed-bounded-related"},
+            )
+        )
+        await event_store.append(
+            BaseEvent(
+                type="execution.ac.heartbeat",
+                timestamp=session_started_at + timedelta(seconds=1),
+                aggregate_type="execution",
+                aggregate_id="new-runtime-scope",
+                data={"session_id": session_id, "message_count": 1},
+            )
+        )
+
+        result = await event_store.query_session_related_events(
+            session_id,
+            execution_id=execution_id,
+            limit=None,
+        )
+        aggregate_ids = {event.aggregate_id for event in result}
+
+        assert "new-runtime-scope" in aggregate_ids
+        assert session_id in aggregate_ids
+        assert "old-runtime-scope" not in aggregate_ids
 
     async def test_execution_related_events_include_child_scopes(
         self,


### PR DESCRIPTION
## Summary
- Keep auto moving when interview start or seed generation times out by falling back to completed-ledger/safe-default synthesis when the ledger proves the goal is seed-ready.
- Preserve lineage boundaries for no-backend interview closure by clearing unsynchronized backend session ids before deterministic Seed generation.
- Tighten complete-product run handoff so Ralph only starts after terminal-success evidence, including resume paths, paused/running/failed states, unreconcilable job handles, and synchronous deadline handling.
- Add cleanup for timed-out owned work: cancel stale Ralph/job waits and cancel the inner synchronous `execute_seed` task when the outer auto pipeline times out.
- Keep exact verification contracts intact by relaxing only the runtime metadata needed to run explicit verification commands and bounding session-event recovery to the current session window.

## Verification
- `uv run ruff check src/ouroboros/auto/adapters.py tests/unit/auto/test_adapters_client_gates.py`
- `uv run pytest tests/unit/auto/test_adapters_client_gates.py -q`
- `uv run pytest tests/unit/auto/test_adapters_client_gates.py tests/unit/auto/test_pipeline_ralph_handoff.py tests/unit/auto/test_interview_pipeline.py tests/unit/persistence/test_event_store.py -q` (`265 passed`)
- `uv run pytest tests/test_hello_auto.py -q`
- Real `ooo auto --complete-product --quiet --timeout 420` smoke completed successfully with run handoff status `completed`.

## Review Status
- Latest head `b76697a8` is approved by `ouroboros-agent[bot]`.