### PR TITLE
fix(auto): make L1 cli predicate match on goal signal alone (PR-ζ-A; #1170 R2 follow-up)

### DIFF
--- a/src/ouroboros/auto/domain_inference.py
+++ b/src/ouroboros/auto/domain_inference.py
@@ -72,7 +72,12 @@ _NEGATED_CLI_GOAL_RE = re.compile(
     r"can[’']?t|cannot|"
     r"doesn[’']?t|don[’']?t|didn[’']?t|"
     r"instead\s+of|rather\s+than)"
-    r"(?:\s+(?:be|being|become|a|an|the|just|only|really|actually|"
+    # "just" / "only" are intentionally NOT connectors: they flip the
+    # phrase into an affirmative expansion ("not just a CLI", "not only
+    # a CLI" — both mean *and a CLI* + something else), so they must
+    # block the negation strip rather than be absorbed into it (PR
+    # #1264 review round 5).
+    r"(?:\s+(?:be|being|become|a|an|the|really|actually|"
     r"have|has|had|need|needs|to|of)){0,5}"
     r"\s+(?:cli|command[\s\-]line)\b"
 )

--- a/src/ouroboros/auto/domain_inference.py
+++ b/src/ouroboros/auto/domain_inference.py
@@ -45,28 +45,35 @@ _CLI_GOAL_TOKEN_RE = re.compile(r"\bcli\b")
 _CLI_GOAL_PHRASE_RE = re.compile(r"\bcommand[\s\-]line\b")
 
 # Explicit-negation pattern matching common natural-language denials of
-# the CLI signal. Covers two shapes:
+# the CLI signal. Covers three shapes:
 #
 #   1. Direct negation: "not a CLI", "no CLI", "never a CLI",
-#      "isn't a CLI", "won't be a CLI", and the same wrapping
-#      "command line" / "command-line".
+#      "isn't a CLI", "won't be a CLI".
 #   2. Modal/copular negation: "should not be a CLI", "must not be a
 #      CLI", "shouldn't be a CLI", "cannot be a CLI", "doesn't have to
-#      be a CLI" — up to four short connector words ("be", "being",
-#      "become", "a/an/the", "just/only/really/actually", "have to")
-#      may appear between the negation cue and the CLI token.
+#      be a CLI".
+#   3. Exclusion phrasing: "without a CLI", "excluding a CLI", "sans
+#      CLI", "instead of a CLI", "rather than a CLI".
+#
+# Each variant works the same way for the multi-word "command line" /
+# "command-line" phrase. Up to five whitelisted connector tokens may
+# appear between the cue and the CLI signal so e.g. "should not be a
+# CLI" or "instead of being a CLI" both collapse.
 #
 # Matched spans are removed from the goal text before re-applying the
 # positive regexes, so a goal like
-#     "Build a Python library that should not be a CLI"
-# does not classify as CLI (PR #1264 review blockers, rounds 2-3).
+#     "Build a Python library, without a CLI"
+# does not classify as CLI (PR #1264 review blockers, rounds 2-4).
 _NEGATED_CLI_GOAL_RE = re.compile(
     r"\b(?:not|no|never|"
+    r"without|excluding|sans|"
     r"isn[’']?t|aren[’']?t|wasn[’']?t|weren[’']?t|"
     r"won[’']?t|wouldn[’']?t|shouldn[’']?t|"
     r"can[’']?t|cannot|"
-    r"doesn[’']?t|don[’']?t|didn[’']?t)"
-    r"(?:\s+(?:be|being|become|a|an|the|just|only|really|actually|have|has|had|need|needs|to)){0,5}"
+    r"doesn[’']?t|don[’']?t|didn[’']?t|"
+    r"instead\s+of|rather\s+than)"
+    r"(?:\s+(?:be|being|become|a|an|the|just|only|really|actually|"
+    r"have|has|had|need|needs|to|of)){0,5}"
     r"\s+(?:cli|command[\s\-]line)\b"
 )
 

--- a/src/ouroboros/auto/domain_inference.py
+++ b/src/ouroboros/auto/domain_inference.py
@@ -45,42 +45,56 @@ _CLI_GOAL_TOKEN_RE = re.compile(r"\bcli\b")
 _CLI_GOAL_PHRASE_RE = re.compile(r"\bcommand[\s\-]line\b")
 
 # Explicit-negation pattern matching common natural-language denials of
-# the CLI signal. Covers three shapes:
+# the CLI signal. The earlier whitelist-of-connectors strategy
+# (rounds 2-6) proved too narrow — every review round surfaced another
+# descriptive participle that was missing from the list ("intended",
+# "meant", "designed", "exposed", "for", …). Switching to a generic
+# distance-bounded path with an *affirmative-qualifier blocklist* is
+# both more robust and easier to reason about:
 #
-#   1. Direct negation: "not a CLI", "no CLI", "never a CLI",
-#      "isn't a CLI", "won't be a CLI".
-#   2. Modal/copular negation: "should not be a CLI", "must not be a
-#      CLI", "shouldn't be a CLI", "cannot be a CLI", "doesn't have to
-#      be a CLI".
-#   3. Exclusion phrasing: "without a CLI", "excluding a CLI", "sans
-#      CLI", "instead of a CLI", "rather than a CLI".
+#   <negation cue>   <path of up to 7 tokens>   <cli|command-line>
 #
-# Each variant works the same way for the multi-word "command line" /
-# "command-line" phrase. Up to five whitelisted connector tokens may
-# appear between the cue and the CLI signal so e.g. "should not be a
-# CLI" or "instead of being a CLI" both collapse.
+# The strip is *suppressed* if the path contains an affirmative-flip
+# qualifier — "just", "only", "also", "rather", "but" — because those
+# tokens turn the phrase into an affirmative expansion ("not just a
+# CLI", "not only a CLI", "not a webhook but rather a CLI") that
+# genuinely asserts CLI. Those cases must keep their CLI signal.
 #
-# Matched spans are removed from the goal text before re-applying the
-# positive regexes, so a goal like
-#     "Build a Python library, without a CLI"
-# does not classify as CLI (PR #1264 review blockers, rounds 2-4).
-_NEGATED_CLI_GOAL_RE = re.compile(
-    r"\b(?:not|no|never|"
+# Covers the shapes flagged across rounds 2-7:
+#   - Direct:           "not a CLI", "no CLI", "never a CLI",
+#                       "isn't a CLI".
+#   - Modal/copular:    "should not be a CLI", "cannot be a CLI",
+#                       "shouldn't be a CLI", "doesn't have to be a CLI".
+#   - Exclusion:        "without a CLI", "excluding a CLI", "sans CLI",
+#                       "instead of a CLI", "rather than a CLI".
+#   - Participle:       "not intended to be a CLI", "not meant to be
+#                       a CLI", "not designed to be a CLI",
+#                       "not exposed as a CLI", "not for CLI use".
+#
+# Each variant also works for the multi-word "command line" /
+# "command-line" phrase. See PR #1264 review rounds 2-7.
+_NEGATION_CUE_FRAGMENT = (
+    r"(?:not|no|never|"
     r"without|excluding|sans|"
     r"isn[’']?t|aren[’']?t|wasn[’']?t|weren[’']?t|"
     r"won[’']?t|wouldn[’']?t|shouldn[’']?t|"
     r"can[’']?t|cannot|"
     r"doesn[’']?t|don[’']?t|didn[’']?t|"
     r"instead\s+of|rather\s+than)"
-    # "just" / "only" are intentionally NOT connectors: they flip the
-    # phrase into an affirmative expansion ("not just a CLI", "not only
-    # a CLI" — both mean *and a CLI* + something else), so they must
-    # block the negation strip rather than be absorbed into it (PR
-    # #1264 review round 5).
-    r"(?:\s+(?:be|being|become|a|an|the|really|actually|"
-    r"have|has|had|need|needs|to|of)){0,5}"
+)
+_NEGATED_CLI_GOAL_RE = re.compile(
+    rf"\b(?P<cue>{_NEGATION_CUE_FRAGMENT})"
+    r"(?P<path>(?:\s+\S+){0,7}?)"  # Up to 7 intervening tokens (non-greedy).
     r"\s+(?:cli|command[\s\-]line)\b"
 )
+
+# Words that, when they appear in the intervening path between a
+# negation cue and the CLI signal, flip the phrase into an affirmative
+# expansion. "not just a CLI" / "not only a CLI" mean "a CLI AND
+# something else"; "but rather a CLI" / "not X but a CLI" mean "the
+# tool IS a CLI". When any of these appears in a candidate strip span,
+# the strip is suppressed so the positive CLI signal survives.
+_AFFIRMATIVE_FLIP_RE = re.compile(r"\b(?:just|only|also|rather|but)\b")
 
 # Prefix-style negation ("non-CLI" / "non CLI" / "non-command-line").
 # `\b` boundaries prevent false matches on unrelated words containing
@@ -106,7 +120,26 @@ def _goal_has_unnegated_cli_signal(goal_text: str) -> bool:
     )
     if not has_signal:
         return False
-    stripped = _NEGATED_CLI_GOAL_RE.sub(" ", goal_text)
+
+    def _strip_if_not_affirmative(match: re.Match[str]) -> str:
+        """Drop the matched negation span unless its **path** (the text
+        between the negation cue and the CLI token) contains an
+        affirmative-flip qualifier (just/only/also/rather/but), in
+        which case the phrase is actually an affirmative expansion and
+        the CLI signal must survive.
+
+        The cue itself ("rather than", "instead of", …) is excluded
+        from the affirmative check on purpose — otherwise the
+        "rather" inside the cue "rather than" would mis-block the
+        strip for legitimate negation phrases like "rather than a
+        CLI".
+        """
+        path = match.group("path") or ""
+        if _AFFIRMATIVE_FLIP_RE.search(path):
+            return match.group(0)
+        return " "
+
+    stripped = _NEGATED_CLI_GOAL_RE.sub(_strip_if_not_affirmative, goal_text)
     stripped = _NEGATED_CLI_PREFIX_RE.sub(" ", stripped)
     return bool(_CLI_GOAL_TOKEN_RE.search(stripped)) or bool(_CLI_GOAL_PHRASE_RE.search(stripped))
 

--- a/src/ouroboros/auto/domain_inference.py
+++ b/src/ouroboros/auto/domain_inference.py
@@ -38,6 +38,43 @@ from ouroboros.auto.task_classes import TaskClass
 # #1264 / #1170 R2 follow-up).
 _CLI_GOAL_TOKEN_RE = re.compile(r"\bcli\b")
 
+# Multi-word "command line" / "command-line" phrase regex. Not vulnerable
+# to the substring-false-friend class, but folded into the same negation
+# pipeline below so "not a command-line tool" is rejected consistently
+# with "not a CLI".
+_CLI_GOAL_PHRASE_RE = re.compile(r"\bcommand[\s\-]line\b")
+
+# Explicit-negation pattern matching common natural-language denials of
+# the CLI signal: "not a CLI", "no CLI", "never a CLI", "isn't a CLI",
+# and the same shapes wrapping "command line" / "command-line". The
+# match is removed from the goal text before re-applying the positive
+# regexes, so a goal like
+#     "Build a Python client library for the Foo API, not a CLI"
+# does not classify as CLI (PR #1264 second-round review blocker).
+_NEGATED_CLI_GOAL_RE = re.compile(
+    r"\b(?:not|no|never|isn[’']?t|aren[’']?t|won[’']?t)"
+    r"\s+(?:an?\s+)?(?:cli|command[\s\-]line)\b"
+)
+
+
+def _goal_has_unnegated_cli_signal(goal_text: str) -> bool:
+    """Return True iff *goal_text* contains a CLI signal that is not
+    inside a recognized negation clause.
+
+    Strategy: detect any positive CLI signal (token or multi-word
+    phrase), then strip recognized negation wrappers from the text and
+    re-check. If a positive signal survives the strip, the goal
+    genuinely asserts CLI.
+    """
+    has_signal = bool(_CLI_GOAL_TOKEN_RE.search(goal_text)) or bool(
+        _CLI_GOAL_PHRASE_RE.search(goal_text)
+    )
+    if not has_signal:
+        return False
+    stripped = _NEGATED_CLI_GOAL_RE.sub(" ", goal_text)
+    return bool(_CLI_GOAL_TOKEN_RE.search(stripped)) or bool(_CLI_GOAL_PHRASE_RE.search(stripped))
+
+
 __all__ = [
     "DomainInference",
     "derive_domain_from_ledger",
@@ -147,14 +184,14 @@ def _matches_cli(ledger: SeedDraftLedger) -> bool:
     )
     runtime_signal = _any_of(runtime, ("shell", "terminal", "subprocess", "command line"))
     # Goal-side CLI signal: token-bounded "cli" OR explicit "command line"
-    # / "command-line" multi-word phrase. Substring-only matching against
-    # "cli" would false-positive on "client", "click", "clinic", etc.,
-    # which would shadow LIBRARY for legitimate "Python client library"
-    # goals (PR #1264 review blocker).
+    # / "command-line" multi-word phrase, with explicit-negation
+    # stripping. Substring-only matching against "cli" would false-
+    # positive on "client", "click", "clinic", etc. (first-round PR
+    # #1264 blocker), and naked token matching still classifies "not a
+    # CLI" / "no CLI" goals as CLI (second-round PR #1264 blocker), so
+    # both classes route through `_goal_has_unnegated_cli_signal`.
     goal_text = _goal_text(ledger)
-    goal_signal = bool(_CLI_GOAL_TOKEN_RE.search(goal_text)) or _any_of(
-        goal_text, ("command line", "command-line")
-    )
+    goal_signal = _goal_has_unnegated_cli_signal(goal_text)
     # Each of the three signals is independently sufficient once the
     # ledger-evidence gate above is satisfied. The earlier form
     # `runtime_signal or (output_signal and (goal_signal or outputs))`

--- a/src/ouroboros/auto/domain_inference.py
+++ b/src/ouroboros/auto/domain_inference.py
@@ -26,9 +26,17 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
+import re
 
 from ouroboros.auto.ledger import LedgerSection, LedgerStatus, SeedDraftLedger
 from ouroboros.auto.task_classes import TaskClass
+
+# Word-boundary token regex for the single-word "cli" goal signal. Avoids
+# false-positive substring matches against words that happen to contain
+# the letters "cli" (e.g. "client", "click", "clinic", "command-clinic")
+# now that `goal_signal` is independently sufficient (see review on PR
+# #1264 / #1170 R2 follow-up).
+_CLI_GOAL_TOKEN_RE = re.compile(r"\bcli\b")
 
 __all__ = [
     "DomainInference",
@@ -138,7 +146,15 @@ def _matches_cli(ledger: SeedDraftLedger) -> bool:
         ("stdout", "exit code", "printed", "console output", "command output"),
     )
     runtime_signal = _any_of(runtime, ("shell", "terminal", "subprocess", "command line"))
-    goal_signal = _any_of(_goal_text(ledger), ("cli", "command line", "command-line"))
+    # Goal-side CLI signal: token-bounded "cli" OR explicit "command line"
+    # / "command-line" multi-word phrase. Substring-only matching against
+    # "cli" would false-positive on "client", "click", "clinic", etc.,
+    # which would shadow LIBRARY for legitimate "Python client library"
+    # goals (PR #1264 review blocker).
+    goal_text = _goal_text(ledger)
+    goal_signal = bool(_CLI_GOAL_TOKEN_RE.search(goal_text)) or _any_of(
+        goal_text, ("command line", "command-line")
+    )
     # Each of the three signals is independently sufficient once the
     # ledger-evidence gate above is satisfied. The earlier form
     # `runtime_signal or (output_signal and (goal_signal or outputs))`

--- a/src/ouroboros/auto/domain_inference.py
+++ b/src/ouroboros/auto/domain_inference.py
@@ -45,15 +45,29 @@ _CLI_GOAL_TOKEN_RE = re.compile(r"\bcli\b")
 _CLI_GOAL_PHRASE_RE = re.compile(r"\bcommand[\s\-]line\b")
 
 # Explicit-negation pattern matching common natural-language denials of
-# the CLI signal: "not a CLI", "no CLI", "never a CLI", "isn't a CLI",
-# and the same shapes wrapping "command line" / "command-line". The
-# match is removed from the goal text before re-applying the positive
-# regexes, so a goal like
-#     "Build a Python client library for the Foo API, not a CLI"
-# does not classify as CLI (PR #1264 second-round review blocker).
+# the CLI signal. Covers two shapes:
+#
+#   1. Direct negation: "not a CLI", "no CLI", "never a CLI",
+#      "isn't a CLI", "won't be a CLI", and the same wrapping
+#      "command line" / "command-line".
+#   2. Modal/copular negation: "should not be a CLI", "must not be a
+#      CLI", "shouldn't be a CLI", "cannot be a CLI", "doesn't have to
+#      be a CLI" — up to four short connector words ("be", "being",
+#      "become", "a/an/the", "just/only/really/actually", "have to")
+#      may appear between the negation cue and the CLI token.
+#
+# Matched spans are removed from the goal text before re-applying the
+# positive regexes, so a goal like
+#     "Build a Python library that should not be a CLI"
+# does not classify as CLI (PR #1264 review blockers, rounds 2-3).
 _NEGATED_CLI_GOAL_RE = re.compile(
-    r"\b(?:not|no|never|isn[’']?t|aren[’']?t|won[’']?t)"
-    r"\s+(?:an?\s+)?(?:cli|command[\s\-]line)\b"
+    r"\b(?:not|no|never|"
+    r"isn[’']?t|aren[’']?t|wasn[’']?t|weren[’']?t|"
+    r"won[’']?t|wouldn[’']?t|shouldn[’']?t|"
+    r"can[’']?t|cannot|"
+    r"doesn[’']?t|don[’']?t|didn[’']?t)"
+    r"(?:\s+(?:be|being|become|a|an|the|just|only|really|actually|have|has|had|need|needs|to)){0,5}"
+    r"\s+(?:cli|command[\s\-]line)\b"
 )
 
 

--- a/src/ouroboros/auto/domain_inference.py
+++ b/src/ouroboros/auto/domain_inference.py
@@ -82,6 +82,15 @@ _NEGATED_CLI_GOAL_RE = re.compile(
     r"\s+(?:cli|command[\s\-]line)\b"
 )
 
+# Prefix-style negation ("non-CLI" / "non CLI" / "non-command-line").
+# `\b` boundaries prevent false matches on unrelated words containing
+# the letters (e.g. "non-client" or "non-clinic" — the `cli\b` boundary
+# fails because the following letters extend the word). Tracked
+# separately from `_NEGATED_CLI_GOAL_RE` because the cue ("non") is
+# directly fused to the CLI token rather than separated by connectors.
+# See PR #1264 review round 6.
+_NEGATED_CLI_PREFIX_RE = re.compile(r"\bnon[\s\-]?(?:cli|command[\s\-]line)\b")
+
 
 def _goal_has_unnegated_cli_signal(goal_text: str) -> bool:
     """Return True iff *goal_text* contains a CLI signal that is not
@@ -98,6 +107,7 @@ def _goal_has_unnegated_cli_signal(goal_text: str) -> bool:
     if not has_signal:
         return False
     stripped = _NEGATED_CLI_GOAL_RE.sub(" ", goal_text)
+    stripped = _NEGATED_CLI_PREFIX_RE.sub(" ", stripped)
     return bool(_CLI_GOAL_TOKEN_RE.search(stripped)) or bool(_CLI_GOAL_PHRASE_RE.search(stripped))
 
 

--- a/src/ouroboros/auto/domain_inference.py
+++ b/src/ouroboros/auto/domain_inference.py
@@ -130,6 +130,8 @@ def _matches_cli(ledger: SeedDraftLedger) -> bool:
     outputs = _section_text(ledger, "outputs")
     runtime = _section_text(ledger, "runtime_context")
     if not (outputs or runtime):
+        # Gate: require *some* ledger-side evidence beyond the goal text
+        # so single-word "cli" mentions in goal cannot classify alone.
         return False
     output_signal = _any_of(
         outputs,
@@ -137,8 +139,14 @@ def _matches_cli(ledger: SeedDraftLedger) -> bool:
     )
     runtime_signal = _any_of(runtime, ("shell", "terminal", "subprocess", "command line"))
     goal_signal = _any_of(_goal_text(ledger), ("cli", "command line", "command-line"))
-    # CLI requires either explicit runtime *or* a goal+output combo.
-    return runtime_signal or (output_signal and (goal_signal or outputs))
+    # Each of the three signals is independently sufficient once the
+    # ledger-evidence gate above is satisfied. The earlier form
+    # `runtime_signal or (output_signal and (goal_signal or outputs))`
+    # made `goal_signal` dead code (outputs is already non-empty past
+    # the gate), which blocked cli-todo on ledger_only closures whose
+    # conservative-default outputs lack stdout/exit-code vocabulary.
+    # See #1170 R2 evidence and #1157 closure policy.
+    return runtime_signal or goal_signal or output_signal
 
 
 def _matches_webhook(ledger: SeedDraftLedger) -> bool:
@@ -231,12 +239,16 @@ def _matches_library(ledger: SeedDraftLedger) -> bool:
     goal = _goal_text(ledger)
     if not (outputs or goal):
         return False
+    # "module" intentionally omitted — it is a generic Python term used
+    # for any code unit (including CLI entry points) and produced too
+    # many false positives that shadowed cli / web_service inference
+    # under ledger_only closures. The remaining keywords are
+    # library-distinctive surface terms. See #1170 R2 evidence.
     return _any_of(
         outputs + " " + goal,
         (
             "library",
             "package",
-            "module",
             "api surface",
             "importable",
             "public api",

--- a/tests/unit/auto/test_domain_inference.py
+++ b/tests/unit/auto/test_domain_inference.py
@@ -529,3 +529,64 @@ def test_cli_still_matches_when_negated_mention_appears_alongside_positive_one()
     _seed_section(ledger, "outputs", value="Persistent JSON state file")
     result = derive_domain_from_ledger(ledger)
     assert TaskClass.CLI in result.classes
+
+
+# ---------------------------------------------------------------------------
+# PR-ζ-A third-round design-notes regression locks (#1264 modal/copular
+# negation gap).
+#
+# After the direct-negation pass (above), the bot's design notes still
+# flagged modal/copular negation forms — "should not be a CLI",
+# "shouldn't be a CLI", "cannot be a CLI", "must not be a CLI" — where
+# short connector words ("be", "a") sit between the negation cue and
+# the CLI token. The negation regex now allows up to five whitelisted
+# connectors between the cue and the CLI signal, which closes the
+# residual design-notes weak point.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_does_not_match_on_modal_copular_negation() -> None:
+    """Bot's named modal/copular scenarios — distance-1 to distance-3
+    connectors between the negation cue and the CLI token."""
+    for goal in (
+        "Build a Python library that should not be a CLI",
+        "Build a Python library that shouldn't be a CLI",
+        "Build a Python library that must not be a CLI",
+        "Build a Python library that cannot be a CLI",
+        "Build a Python library that can't be a CLI",
+        "Build a Python library that doesn't have to be a CLI",
+        "Build a Python library that doesn't need to be a CLI",
+        "Build a Python library that wouldn't be a CLI",
+        "Build a Python library that won't be a CLI",
+        # Same shapes wrapping the multi-word command-line phrase.
+        "Build a Python library that should not be a command line tool",
+        "Build a Python library that shouldn't be a command-line tool",
+    ):
+        ledger = _bare_ledger(goal)
+        _seed_section(
+            ledger,
+            "outputs",
+            value="An importable Python package exposing a public API surface",
+        )
+        result = derive_domain_from_ledger(ledger)
+        assert TaskClass.CLI not in result.classes, (
+            f"modal-negated goal must not match cli: goal={goal!r}, result={result}"
+        )
+
+
+def test_cli_still_matches_on_positive_modal_goal() -> None:
+    """Positive lock: when the modal/copular phrase asserts CLI rather
+    than negates it ("should be a CLI"), the goal MUST still classify
+    as CLI — only *negated* shapes should be stripped."""
+    for goal in (
+        "Build a tool that should be a CLI",
+        "Build a tool that must be a CLI",
+        "Build a tool that has to be a CLI",
+        "Build a tool that needs to be a CLI",
+    ):
+        ledger = _bare_ledger(goal)
+        _seed_section(ledger, "outputs", value="Persistent JSON state file")
+        result = derive_domain_from_ledger(ledger)
+        assert TaskClass.CLI in result.classes, (
+            f"positive modal goal must still match cli: goal={goal!r}, result={result}"
+        )

--- a/tests/unit/auto/test_domain_inference.py
+++ b/tests/unit/auto/test_domain_inference.py
@@ -590,3 +590,42 @@ def test_cli_still_matches_on_positive_modal_goal() -> None:
         assert TaskClass.CLI in result.classes, (
             f"positive modal goal must still match cli: goal={goal!r}, result={result}"
         )
+
+
+# ---------------------------------------------------------------------------
+# PR-ζ-A fourth-round review-feedback regression locks (#1264 exclusion
+# phrasing blocker).
+#
+# After the modal/copular pass (above), the bot flagged a further
+# exclusion-phrasing class: "without a CLI", "excluding a CLI",
+# "instead of a CLI", "rather than a CLI", "sans CLI". The negation
+# regex now treats these as additional negation cues alongside the
+# round-2/3 forms, so all of them strip cleanly.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_does_not_match_on_exclusion_phrasing() -> None:
+    """Bot's named scenario (`Build a Python library, without a CLI`) +
+    the other common exclusion shapes — each must drop CLI from the
+    classification."""
+    for goal in (
+        "Build a Python library, without a CLI",
+        "Build a Python library, excluding a CLI",
+        "Build a Python library, sans CLI",
+        "Build a Python library, instead of a CLI",
+        "Build a Python library, rather than a CLI",
+        # Multi-word "command line" / "command-line" variants.
+        "Build a Python library, without a command line tool",
+        "Build a Python library, instead of a command-line tool",
+        "Build a Python library, rather than a command line tool",
+    ):
+        ledger = _bare_ledger(goal)
+        _seed_section(
+            ledger,
+            "outputs",
+            value="An importable Python package exposing a public API surface",
+        )
+        result = derive_domain_from_ledger(ledger)
+        assert TaskClass.CLI not in result.classes, (
+            f"exclusion-phrased goal must not match cli: goal={goal!r}, result={result}"
+        )

--- a/tests/unit/auto/test_domain_inference.py
+++ b/tests/unit/auto/test_domain_inference.py
@@ -648,6 +648,34 @@ def test_cli_does_not_match_on_non_prefix_negation() -> None:
         )
 
 
+def test_cli_does_not_match_on_participle_negation() -> None:
+    """Bot's round-7 reproductions: descriptive participles between the
+    negation cue and the CLI token. With the connector whitelist
+    replaced by a distance-bounded path + affirmative-flip blocker,
+    arbitrary participles ("intended", "meant", "designed", "exposed",
+    "for") no longer need to be enumerated."""
+    for goal in (
+        "Build a Python library that is not intended to be a CLI",
+        "Build a Python library that is not meant to be a CLI",
+        "Build a Python library that is not designed to be a CLI",
+        "Build a Python library that is not exposed as a CLI",
+        "Build a Python library, not for CLI use",
+        # Multi-word phrase variants.
+        "Build a Python library that is not intended to be a command-line tool",
+        "Build a Python library that is not designed to be a command line tool",
+    ):
+        ledger = _bare_ledger(goal)
+        _seed_section(
+            ledger,
+            "outputs",
+            value="An importable Python package exposing a public API surface",
+        )
+        result = derive_domain_from_ledger(ledger)
+        assert TaskClass.CLI not in result.classes, (
+            f"participle-negated goal must not match cli: goal={goal!r}, result={result}"
+        )
+
+
 def test_cli_token_unaffected_by_non_prefix_in_other_words() -> None:
     """Positive lock for the `non-` prefix regex: words like
     `non-client`, `non-clinic`, `nonprofit` must not be falsely

--- a/tests/unit/auto/test_domain_inference.py
+++ b/tests/unit/auto/test_domain_inference.py
@@ -243,3 +243,111 @@ def test_domain_inference_dataclass_properties() -> None:
     )
     assert unmatched.is_unmatched
     assert unmatched.single is TaskClass.LIBRARY
+
+
+# ---------------------------------------------------------------------------
+# #1170 R2 regression locks (PR-ζ-A)
+#
+# The PR-β ledger_only closure path produces ledgers whose `outputs` and
+# `runtime_context` are filled by conservative defaults that do NOT
+# contain cli-specific vocabulary (stdout / exit code / shell / …).
+# Before PR-ζ-A, ``_matches_cli`` made ``goal_signal`` structurally
+# redundant — only runtime/output vocabulary could classify cli — which
+# left cli-todo terminating BLOCKED with ``active_task_class='library'``.
+# The cases below lock the goal-signal sufficiency in, and tighten
+# ``_matches_library`` so the generic word "module" no longer shadows
+# other classes.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_matches_on_goal_signal_alone() -> None:
+    """A ledger whose `goal` says CLI but whose `outputs` lacks cli
+    vocabulary should still classify as CLI as long as the
+    ledger-evidence gate is satisfied (outputs OR runtime is non-empty)."""
+    ledger = _bare_ledger("Build a habit-tracker CLI for end users")
+    # Generic non-cli output vocabulary — what a ledger_only closure
+    # would typically write.
+    _seed_section(ledger, "outputs", value="JSON file stored in the working directory")
+    result = derive_domain_from_ledger(ledger)
+    assert result.is_single
+    assert result.single is TaskClass.CLI
+
+
+def test_cli_matches_on_conservative_default_ledger() -> None:
+    """R2 evidence reproduction: conservative-default-heavy ledger whose
+    goal explicitly says "CLI" must classify as CLI, not fall back to
+    LIBRARY. Locks #1170 R2 root cause RC-A."""
+    ledger = _bare_ledger(
+        "Build a small habit-tracker CLI that lets the user add, list, "
+        "and check off habits, persisting them as JSON in the working "
+        "directory."
+    )
+    # Mimic CONSERVATIVE_DEFAULT entries seen in R2-cli-todo evidence:
+    # vocabulary chosen by the standardizer's safe defaults rather than
+    # by user confirmation, so cli-specific tokens are absent.
+    _seed_section(
+        ledger,
+        "outputs",
+        value="Persistent JSON state file in the working directory",
+        source=LedgerSource.CONSERVATIVE_DEFAULT,
+    )
+    _seed_section(
+        ledger,
+        "runtime_context",
+        value="Local Python 3.x environment",
+        source=LedgerSource.CONSERVATIVE_DEFAULT,
+    )
+    result = derive_domain_from_ledger(ledger)
+    assert result.is_single, f"expected single match, got {result}"
+    assert result.single is TaskClass.CLI
+
+
+def test_cli_and_library_no_longer_dual_match_on_module_keyword() -> None:
+    """Before PR-ζ-A, an output saying "Python module" caused
+    ``_matches_library`` to fire on the generic Python-module sense
+    (any code unit), shadowing cli/web-service classification. After
+    removing "module" from the library keyword set, this should NOT
+    fire library."""
+    ledger = _bare_ledger("Build a habit-tracker CLI")
+    _seed_section(
+        ledger,
+        "outputs",
+        value="A small Python module that prints habit list to stdout",
+    )
+    result = derive_domain_from_ledger(ledger)
+    assert TaskClass.LIBRARY not in result.classes
+    # Positive: cli should still fire from goal_signal + output_signal
+    # (stdout is a cli token).
+    assert result.is_single
+    assert result.single is TaskClass.CLI
+
+
+def test_library_still_matches_on_explicit_surface_keywords() -> None:
+    """Positive regression lock — removing "module" must not weaken
+    the library predicate on its actual distinctive keywords."""
+    for surface in (
+        "An importable Python package",
+        "Public API surface for downstream consumers",
+        "An SDK for the foo service",
+        "A reusable library exposing helpers",
+    ):
+        ledger = _bare_ledger("Publish a foo helper")
+        _seed_section(ledger, "outputs", value=surface)
+        result = derive_domain_from_ledger(ledger)
+        assert TaskClass.LIBRARY in result.classes, (
+            f"library should still match on surface={surface!r}"
+        )
+
+
+def test_cli_does_not_fire_without_any_ledger_evidence() -> None:
+    """The ledger-evidence gate must remain in force: a goal that says
+    "cli" but with empty outputs AND empty runtime_context must NOT
+    classify as cli. This preserves the SSOT #1157 L1 invariant that
+    classification is ledger-derived, not goal-text-derived alone."""
+    ledger = _bare_ledger("Build a CLI tool")
+    # Deliberately seed only non-output/non-runtime sections so the gate
+    # fails. (The gate requires outputs OR runtime_context to be
+    # non-empty before any signal contributes.)
+    _seed_section(ledger, "actors", value="Single end user")
+    result = derive_domain_from_ledger(ledger)
+    assert TaskClass.CLI not in result.classes

--- a/tests/unit/auto/test_domain_inference.py
+++ b/tests/unit/auto/test_domain_inference.py
@@ -627,6 +627,48 @@ def test_cli_still_matches_on_affirmative_not_just_or_not_only_expansion() -> No
         )
 
 
+def test_cli_does_not_match_on_non_prefix_negation() -> None:
+    """Bot's round-6 reproduction: "non-CLI" / "non CLI" prefix forms.
+    These must be treated as exclusion, not as positive CLI evidence."""
+    for goal in (
+        "Build a non-CLI Python library",
+        "Build a non CLI Python library",
+        "Build a non-command-line Python library",
+        "Build a non-command line Python library",
+    ):
+        ledger = _bare_ledger(goal)
+        _seed_section(
+            ledger,
+            "outputs",
+            value="An importable Python package exposing a public API surface",
+        )
+        result = derive_domain_from_ledger(ledger)
+        assert TaskClass.CLI not in result.classes, (
+            f"non-prefix goal must not match cli: goal={goal!r}, result={result}"
+        )
+
+
+def test_cli_token_unaffected_by_non_prefix_in_other_words() -> None:
+    """Positive lock for the `non-` prefix regex: words like
+    `non-client`, `non-clinic`, `nonprofit` must not be falsely
+    stripped or affect the CLI signal."""
+    # No CLI signal in any of these; the test ensures the strip regex
+    # does not bleed into adjacent legitimate words that happen to
+    # contain "non" + cl-prefixed letters.
+    for goal in (
+        "Build a non-client analytics dashboard",
+        "Build a non-clinic appointment scheduler",
+        "Build a nonprofit donation tracker",
+    ):
+        ledger = _bare_ledger(goal)
+        _seed_section(ledger, "outputs", value="Persistent JSON state file")
+        result = derive_domain_from_ledger(ledger)
+        # No CLI signal here — neither positive nor false-stripped.
+        assert TaskClass.CLI not in result.classes, (
+            f"unrelated `non-` word must not affect cli matcher: goal={goal!r}, result={result}"
+        )
+
+
 def test_cli_does_not_match_on_exclusion_phrasing() -> None:
     """Bot's named scenario (`Build a Python library, without a CLI`) +
     the other common exclusion shapes — each must drop CLI from the

--- a/tests/unit/auto/test_domain_inference.py
+++ b/tests/unit/auto/test_domain_inference.py
@@ -351,3 +351,95 @@ def test_cli_does_not_fire_without_any_ledger_evidence() -> None:
     _seed_section(ledger, "actors", value="Single end user")
     result = derive_domain_from_ledger(ledger)
     assert TaskClass.CLI not in result.classes
+
+
+# ---------------------------------------------------------------------------
+# PR-ζ-A review-feedback regression locks (#1264 word-boundary blocker).
+#
+# ouroboros-agent[bot] flagged that promoting `goal_signal` to be
+# independently sufficient (above) exposed the underlying *substring*
+# matcher: a goal like "Build a Python client library for the Foo API"
+# would have CLI fire because "client" contains "cli", producing an
+# ambiguous {CLI, LIBRARY} match. Ambiguous classifications skip default
+# AC injection (pipeline.py:732-740), so legitimate client-library tasks
+# would lose their library contract.
+#
+# The fix tightens the goal-side "cli" check to a token-bounded regex
+# (`\bcli\b`) so substrings inside other words no longer trigger.
+# Multi-word phrases ("command line", "command-line") still match as
+# literal substrings — they are not vulnerable to this class of false
+# positive.
+# ---------------------------------------------------------------------------
+
+
+def test_cli_does_not_false_match_on_client_library_goal() -> None:
+    """Goal: "Build a Python client library for the Foo API" with library
+    outputs must NOT trigger CLI via substring "cli" inside "client".
+    Locks the PR #1264 reviewer's blocker scenario."""
+    ledger = _bare_ledger("Build a Python client library for the Foo API")
+    _seed_section(
+        ledger,
+        "outputs",
+        value="An importable Python package exposing a public API surface",
+    )
+    result = derive_domain_from_ledger(ledger)
+    assert TaskClass.CLI not in result.classes, (
+        f"cli must not false-match on 'client library' goal, got {result}"
+    )
+    assert result.is_single
+    assert result.single is TaskClass.LIBRARY
+
+
+def test_cli_token_does_not_false_match_on_click_clinic_etc() -> None:
+    """Token-boundary regression lock for other words containing the
+    letters c-l-i: click (CLI framework name, but inside a noun), clinic,
+    cliché, etc. None of these should fire CLI from goal alone."""
+    for false_friend in (
+        "Build a click-tracking analytics dashboard",
+        "Build a clinic appointment scheduler",
+        "Build a clipboard manager",
+        "Build a clipper service for short URLs",
+    ):
+        ledger = _bare_ledger(false_friend)
+        # Provide neutral outputs so the gate is satisfied but no other
+        # signal fires CLI from outputs/runtime.
+        _seed_section(ledger, "outputs", value="Persistent JSON state file")
+        result = derive_domain_from_ledger(ledger)
+        assert TaskClass.CLI not in result.classes, (
+            f"cli must not match goal={false_friend!r}; got {result}"
+        )
+
+
+def test_cli_still_matches_on_standalone_cli_token() -> None:
+    """Positive regression lock: standalone "cli" as a word (with
+    surrounding whitespace, punctuation, or end-of-string) must still
+    fire the goal-signal CLI path after the regex tightening."""
+    for goal in (
+        "Build a CLI for habits",
+        "Make a small cli.",
+        "habit-tracker cli, persisting JSON",
+        "build cli",
+    ):
+        ledger = _bare_ledger(goal)
+        # Gate-satisfying neutral output.
+        _seed_section(ledger, "outputs", value="Persistent JSON state file")
+        result = derive_domain_from_ledger(ledger)
+        assert result.is_single, f"expected single match for goal={goal!r}, got {result}"
+        assert result.single is TaskClass.CLI, (
+            f"goal={goal!r} should classify as cli, got {result.single}"
+        )
+
+
+def test_cli_still_matches_on_command_line_phrase() -> None:
+    """The multi-word "command line" / "command-line" goal phrases are
+    not vulnerable to the substring false-positive class and remain
+    plain substring matches."""
+    for goal in (
+        "Build a command line habit tracker",
+        "Build a command-line habit tracker",
+    ):
+        ledger = _bare_ledger(goal)
+        _seed_section(ledger, "outputs", value="Persistent JSON state file")
+        result = derive_domain_from_ledger(ledger)
+        assert result.is_single
+        assert result.single is TaskClass.CLI

--- a/tests/unit/auto/test_domain_inference.py
+++ b/tests/unit/auto/test_domain_inference.py
@@ -443,3 +443,89 @@ def test_cli_still_matches_on_command_line_phrase() -> None:
         result = derive_domain_from_ledger(ledger)
         assert result.is_single
         assert result.single is TaskClass.CLI
+
+
+# ---------------------------------------------------------------------------
+# PR-ζ-A second-round review-feedback regression locks (#1264 negation
+# blocker).
+#
+# After tightening the goal-side `cli` substring to a word-boundary
+# token (above), ouroboros-agent[bot] flagged a follow-up false-positive
+# class: explicitly *negated* CLI mentions. A goal like "Build a Python
+# client library for the Foo API, not a CLI" still matches `\bcli\b`
+# against the literal "CLI" inside "not a CLI", so the inference
+# returned {CLI, LIBRARY} — ambiguous. Ambiguous classifications skip
+# default AC injection (pipeline.py:732-740), so a goal that *explicitly*
+# excludes CLI would silently lose its library contract.
+#
+# The fix adds a small negation-context regex
+# (`_NEGATED_CLI_GOAL_RE`) and re-checks the goal text with the
+# negated mentions stripped. The tests below lock the named scenarios
+# from the bot's review plus a positive case (mixed negation + positive
+# assertion).
+# ---------------------------------------------------------------------------
+
+
+def test_cli_does_not_match_on_explicitly_negated_goal() -> None:
+    """Reviewer's exact named scenario: "Build a Python client library
+    for the Foo API, not a CLI" with library outputs must return a
+    single LIBRARY classification, not ambiguous {CLI, LIBRARY}."""
+    ledger = _bare_ledger("Build a Python client library for the Foo API, not a CLI")
+    _seed_section(
+        ledger,
+        "outputs",
+        value="An importable Python package exposing a public API surface",
+    )
+    result = derive_domain_from_ledger(ledger)
+    assert TaskClass.CLI not in result.classes, f"cli must not match negated goal; got {result}"
+    assert result.is_single
+    assert result.single is TaskClass.LIBRARY
+
+
+def test_cli_does_not_match_on_various_negation_forms() -> None:
+    """Cover the common natural-language negation shapes the matcher
+    must reject — "not a CLI", "no CLI", "isn't a CLI", "never a CLI",
+    and the same shapes wrapping the "command line" / "command-line"
+    multi-word phrase."""
+    for goal in (
+        "Build a Python library, not a CLI",
+        "Build a Python library — no CLI here",
+        "Publish an SDK; isn't a CLI",
+        "Ship a package; never a CLI",
+        "Build a Python library, not a command line tool",
+        "Build a Python library, not a command-line tool",
+    ):
+        ledger = _bare_ledger(goal)
+        _seed_section(
+            ledger,
+            "outputs",
+            value="An importable Python package exposing a public API surface",
+        )
+        result = derive_domain_from_ledger(ledger)
+        assert TaskClass.CLI not in result.classes, (
+            f"negated goal must not match cli: goal={goal!r}, result={result}"
+        )
+
+
+def test_cli_still_matches_when_negation_is_about_other_class() -> None:
+    """Positive lock: when the negation clause is about a *different*
+    class (e.g. "not a webhook"), the CLI signal from the rest of the
+    goal must still fire."""
+    ledger = _bare_ledger("Build a CLI for habit tracking, not a webhook receiver")
+    _seed_section(ledger, "outputs", value="Persistent JSON state file")
+    result = derive_domain_from_ledger(ledger)
+    assert TaskClass.CLI in result.classes
+    # Webhook should not fire because outputs lacks the side-effect
+    # signals; CLI is the sole match.
+    assert result.is_single
+    assert result.single is TaskClass.CLI
+
+
+def test_cli_still_matches_when_negated_mention_appears_alongside_positive_one() -> None:
+    """Edge case: a goal that contains both a positive CLI assertion AND
+    a negated CLI mention (e.g. "CLI, not a CLI library") must still
+    classify as CLI — the positive mention survives the strip."""
+    ledger = _bare_ledger("Build a CLI for habits — not a CLI testing library")
+    _seed_section(ledger, "outputs", value="Persistent JSON state file")
+    result = derive_domain_from_ledger(ledger)
+    assert TaskClass.CLI in result.classes

--- a/tests/unit/auto/test_domain_inference.py
+++ b/tests/unit/auto/test_domain_inference.py
@@ -604,6 +604,29 @@ def test_cli_still_matches_on_positive_modal_goal() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_cli_still_matches_on_affirmative_not_just_or_not_only_expansion() -> None:
+    """Bot's round-5 reproduction: `not just a CLI` / `not only a CLI`
+    are AFFIRMATIVE expansions ("a CLI and also something else"), not
+    denials. The negation stripper must NOT collapse them, so the CLI
+    signal survives and goal_signal fires."""
+    for goal in (
+        "Build not just a CLI for habits",
+        "Build not only a CLI for habits",
+        "Build a tool that is not only a CLI but also a library",
+        "Build a tool that is not just a CLI but also a library",
+        "Build a tool that should not just be a CLI but also a library",
+    ):
+        ledger = _bare_ledger(goal)
+        # Neutral output so the gate is satisfied but no output/runtime
+        # signal contributes — the test isolates the goal-signal path.
+        _seed_section(ledger, "outputs", value="Persistent JSON state file")
+        result = derive_domain_from_ledger(ledger)
+        assert TaskClass.CLI in result.classes, (
+            f"affirmative 'not just/only a CLI' must still match cli: "
+            f"goal={goal!r}, result={result}"
+        )
+
+
 def test_cli_does_not_match_on_exclusion_phrasing() -> None:
     """Bot's named scenario (`Build a Python library, without a CLI`) +
     the other common exclusion shapes — each must drop CLI from the


### PR DESCRIPTION
## Summary

- `domain_inference._matches_cli` had a logical dead-code path that made `goal_signal` structurally unreachable, blocking cli classification under the new `ledger_only` closure flow.
- `_matches_library` matched the generic keyword "module" and shadowed cli/web_service under conservative-default-heavy ledgers.
- Adds 5 regression-lock unit tests covering the goal-signal sufficiency path and the library tightening.

## Why now

This is the first half of the cli-todo R2 (#1170) acceptance failure.

#1170 R2 (2026-05-27, HEAD 2f6247c6 = PR-γ) terminated `BLOCKED` with `active_task_class='library'`, `grade=C`, `runtime_probe_evidence=[]`. Raw evidence: `.ooo-observability/R2-cli-todo-20260527T071708Z.json`.

Root cause RC-A:
```python
# domain_inference.py:141 (before)
return runtime_signal or (output_signal and (goal_signal or outputs))
```
`outputs` is already guaranteed non-empty past the line-132 gate, so `(goal_signal or outputs)` is always True and the expression collapses to `runtime_signal or output_signal`. `goal_signal` is dead.

PR-β (#1252) promoted ledger_only closure to the in-loop primary check, so canonical scenarios now reach seed generation with conservative-default-heavy ledgers. Those ledgers do not emit cli vocabulary (`stdout`, `exit code`, `shell`, `terminal`), so the broken predicate fell to the LIBRARY fallback → cli-todo R2 terminal BLOCKED.

The SSOT #1157 L1 invariant ("ledger-derive, not goal-only") is preserved by the gate (`outputs OR runtime_context` must be non-empty); the change only removes the dead-code redundancy inside the return expression.

## Changes

- `src/ouroboros/auto/domain_inference.py`
  - `_matches_cli`: return `runtime_signal or goal_signal or output_signal` (gate unchanged).
  - `_matches_library`: remove `"module"` from keyword set.
- `tests/unit/auto/test_domain_inference.py`
  - 5 new regression locks (cli-on-goal-alone, R2-conservative-default reproduction, library/cli no-dual-match on "module", library positive surface keywords, cli gate invariant).

## Test plan

- [x] `uv run pytest tests/unit/auto/test_domain_inference.py -v` → 18/18 pass (13 prior + 5 new).
- [x] `uv run pytest tests/unit/auto/ -x -q` → 991/991 pass (no regressions in the wider auto suite).
- [ ] After merge + PR-ζ-B, rerun cli-todo R2 → expect `active_task_class='cli'` (RC-A confirmed solved), grade may still block on ambiguity until PR-ζ-B lands (RC-B).

## Merge sequencing

PR-ζ-A is independent and can land alone. The cli-todo acceptance gate also requires PR-ζ-B (closure-mode-aware grading) to actually reach PRODUCT_COMPLETE; ζ-A solves the task-class half, ζ-B solves the grading-policy half.

Refs: #1170, #1157, #1171.

🤖 Generated with [Claude Code](https://claude.com/claude-code)