### PR TITLE
feat(auto): propagate closure_mode to seed grading (PR-ζ-B; #1157 closure policy grading-half)

### DIFF
--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -144,8 +144,27 @@ class GradeGate:
         }
         return self._result(scores=scores, findings=findings, blockers=blockers)
 
-    def grade_seed(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> GradeResult:
-        """Grade a generated Seed deterministically."""
+    def grade_seed(
+        self,
+        seed: Seed,
+        *,
+        ledger: SeedDraftLedger | None = None,
+        closure_mode: str | None = None,
+    ) -> GradeResult:
+        """Grade a generated Seed deterministically.
+
+        ``closure_mode`` carries the interview's terminal closure mode
+        from :class:`AutoPipelineState` so the grader can honor SSOT
+        #1157 *Closure Policy*: when the interview closed on ledger
+        evidence (``ledger_only`` / ``safe_default``), the LLM-derived
+        ``ambiguity_score`` is acknowledged-stale by design — the
+        ledger's structural completeness IS the ambiguity invariant
+        and the standalone ``high_ambiguity_score`` blocker is
+        suppressed. Other grading axes (coverage / testability /
+        open_gap / blocker count / risk) remain unchanged. When
+        ``closure_mode`` is None (legacy callers, tests, non-pipeline
+        usage) the strict pre-#1157 behavior is retained.
+        """
         findings: list[GradeFinding] = []
         blockers: list[GradeFinding] = []
 
@@ -161,7 +180,15 @@ class GradeGate:
                     "Regenerate or repair the Seed so its goal matches the auto interview ledger goal.",
                 )
             )
-        if seed.metadata.ambiguity_score > 0.20:
+        # SSOT #1157 *Closure Policy* (grading half — PR-ζ-B follow-up to PR-β):
+        # when the interview closed on ledger evidence, the LLM-derived
+        # ambiguity_score is stale by design (the ledger's structural
+        # completeness IS the acceptance signal). Suppress the standalone
+        # ambiguity blocker; other grading axes still constrain quality.
+        # See #1170 R2 (2026-05-27): cli-todo terminated BLOCKED at this
+        # very gate with ambiguity_score=0.467 despite ledger_only closure.
+        ledger_primary_closure = closure_mode in {"ledger_only", "safe_default"}
+        if not ledger_primary_closure and seed.metadata.ambiguity_score > 0.20:
             blockers.append(
                 GradeFinding(
                     "high_ambiguity_score",

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -895,6 +895,13 @@ class AutoPipeline:
             # ``SeedRepairer.converge`` does declare it.
             if _accepts_keyword(repairer.converge, "cancel_event"):
                 converge_kwargs["cancel_event"] = cancel_event
+            # SSOT #1157 *Closure Policy* (PR-ζ-B): propagate the
+            # interview's closure mode so the grading-half of the policy
+            # (suppress standalone ambiguity blocker under
+            # ledger_only / safe_default) applies inside the repair loop.
+            # Same stub-tolerant gate as cancel_event above.
+            if _accepts_keyword(repairer.converge, "closure_mode"):
+                converge_kwargs["closure_mode"] = state.interview_closure_mode
             bounded_repair_timeout = self._deadline_capped_timeout(state, repair_timeout)
             try:
                 seed, review, repairs = await asyncio.wait_for(
@@ -1002,9 +1009,17 @@ class AutoPipeline:
                 review_timeout = self._deadline_capped_timeout(
                     state, state.phase_timeout_seconds(AutoPhase.REVIEW)
                 )
+                # SSOT #1157 *Closure Policy* (PR-ζ-B): same stub-tolerant
+                # closure_mode propagation as the REVIEW-phase converge
+                # call above. Direct ``reviewer.review`` callers (test
+                # stubs, alternative reviewer implementations) may not
+                # accept the kwarg yet.
+                review_kwargs: dict[str, Any] = {"ledger": ledger}
+                if _accepts_keyword(reviewer.review, "closure_mode"):
+                    review_kwargs["closure_mode"] = state.interview_closure_mode
                 try:
                     review = await asyncio.wait_for(
-                        asyncio.to_thread(reviewer.review, seed, ledger=ledger),
+                        asyncio.to_thread(reviewer.review, seed, **review_kwargs),
                         timeout=review_timeout,
                     )
                 except TimeoutError:

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -2,16 +2,41 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+import inspect
 import re
 import threading
+from typing import Any
 from uuid import uuid4
 
 from ouroboros.auto.grading import VAGUE_TERMS, SeedGrade
 from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
 from ouroboros.core.seed import Seed
+
+
+def _review_accepts_closure_mode(review_callable: Callable[..., Any]) -> bool:
+    """Return True iff ``review_callable`` declares ``closure_mode``.
+
+    Older test stubs / external reviewer implementations declared
+    ``review(self, seed, *, ledger=None)`` without ``closure_mode``.
+    PR-ζ-B added the kwarg to :class:`SeedReviewer`; the repair loop
+    must keep working against those stubs by *omitting* the kwarg
+    when the callable does not accept it. Mirrors
+    ``pipeline._accepts_keyword``.
+    """
+    try:
+        sig = inspect.signature(review_callable)
+    except (TypeError, ValueError):
+        return False
+    for param in sig.parameters.values():
+        if param.name == "closure_mode":
+            return True
+        if param.kind is inspect.Parameter.VAR_KEYWORD:
+            return True
+    return False
 
 
 class RepairCancelled(Exception):
@@ -172,6 +197,7 @@ class SeedRepairer:
         *,
         ledger: SeedDraftLedger | None = None,
         cancel_event: threading.Event | None = None,
+        closure_mode: str | None = None,
     ) -> tuple[Seed, SeedReview, list[RepairResult]]:
         """Review/repair until A-grade or bounded stop.
 
@@ -209,8 +235,16 @@ class SeedRepairer:
                     "repair phase cancelled by pipeline timeout before next reviewer call"
                 )
 
+        # SSOT #1157 *Closure Policy* (PR-ζ-B): forward closure_mode to the
+        # reviewer only when its ``review`` method declares the kwarg.
+        # Legacy test stubs / external reviewers that only accept
+        # ``(seed, *, ledger)`` continue to work unchanged.
+        review_kwargs: dict[str, Any] = {"ledger": ledger}
+        if _review_accepts_closure_mode(self.reviewer.review):
+            review_kwargs["closure_mode"] = closure_mode
+
         _check_cancelled()
-        review = self.reviewer.review(current, ledger=ledger)
+        review = self.reviewer.review(current, **review_kwargs)
         for _ in range(self.max_iterations):
             _check_cancelled()
             if review.grade_result.grade == SeedGrade.A and review.may_run:
@@ -228,15 +262,15 @@ class SeedRepairer:
                 # still describes the previous (pre-repair) seed. Re-review
                 # ``current`` once so the returned pair is consistent.
                 _check_cancelled()
-                review = self.reviewer.review(current, ledger=ledger)
+                review = self.reviewer.review(current, **review_kwargs)
                 return current, review, history
             if high and high == previous_high_fingerprints:
                 _check_cancelled()
-                review = self.reviewer.review(current, ledger=ledger)
+                review = self.reviewer.review(current, **review_kwargs)
                 return current, review, history
             previous_high_fingerprints = high
             _check_cancelled()
-            review = self.reviewer.review(current, ledger=ledger)
+            review = self.reviewer.review(current, **review_kwargs)
         return current, review, history
 
 

--- a/src/ouroboros/auto/seed_reviewer.py
+++ b/src/ouroboros/auto/seed_reviewer.py
@@ -54,9 +54,23 @@ class SeedReviewer:
     def __init__(self, grade_gate: GradeGate | None = None) -> None:
         self.grade_gate = grade_gate or GradeGate()
 
-    def review(self, seed: Seed, *, ledger: SeedDraftLedger | None = None) -> SeedReview:
-        """Return structured review findings for ``seed``."""
-        grade = self.grade_gate.grade_seed(seed, ledger=ledger)
+    def review(
+        self,
+        seed: Seed,
+        *,
+        ledger: SeedDraftLedger | None = None,
+        closure_mode: str | None = None,
+    ) -> SeedReview:
+        """Return structured review findings for ``seed``.
+
+        ``closure_mode`` is passed through to :meth:`GradeGate.grade_seed`
+        so the SSOT #1157 closure policy (PR-ζ-B) applies uniformly
+        whether the pipeline calls ``review`` directly or via
+        :class:`SeedRepairer`. When ``None`` (legacy callers and tests
+        without pipeline context) the strict pre-policy behavior is
+        retained.
+        """
+        grade = self.grade_gate.grade_seed(seed, ledger=ledger, closure_mode=closure_mode)
         findings = tuple(
             ReviewFinding.from_parts(
                 code=finding.code,

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -2497,9 +2497,7 @@ def _high_ambiguity_seed(*, ambiguity: float = 0.50) -> Seed:
     return Seed(
         goal="Build a habit tracker",
         constraints=("Use existing project patterns",),
-        acceptance_criteria=(
-            "`habit list` prints stable stdout containing created habits",
-        ),
+        acceptance_criteria=("`habit list` prints stable stdout containing created habits",),
         ontology_schema=OntologySchema(
             name="CliTask",
             description="CLI task ontology",
@@ -2614,9 +2612,7 @@ def test_seed_reviewer_propagates_closure_mode_to_grade_gate() -> None:
 
     assert review.grade_result.grade == SeedGrade.A
     assert review.may_run
-    assert "high_ambiguity_score" not in {
-        finding.code for finding in review.grade_result.blockers
-    }
+    assert "high_ambiguity_score" not in {finding.code for finding in review.grade_result.blockers}
 
 
 def test_seed_repairer_converge_propagates_closure_mode() -> None:

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -2477,3 +2477,194 @@ def test_assumption_sources_dedupes_same_text_across_sections() -> None:
     records = ledger.assumption_sources()
     assert len(records) == 1
     assert records[0].text == "Single local CLI user"
+
+
+# ---------------------------------------------------------------------------
+# PR-ζ-B · closure_mode-aware ambiguity grading
+#
+# SSOT #1157 *Closure Policy* (grading half — back-fill of PR-β).
+# When the interview closed on ledger evidence (`ledger_only` /
+# `safe_default`), the standalone `high_ambiguity_score` blocker is
+# suppressed because the ledger's structural completeness IS the
+# acceptance signal. Other grading axes remain in force. Locks
+# #1170 R2 (2026-05-27) root cause RC-B.
+# ---------------------------------------------------------------------------
+
+
+def _high_ambiguity_seed(*, ambiguity: float = 0.50) -> Seed:
+    """Build the same minimal observable Seed as ``_seed`` but with
+    ``ambiguity_score`` deliberately above the 0.20 LLM threshold."""
+    return Seed(
+        goal="Build a habit tracker",
+        constraints=("Use existing project patterns",),
+        acceptance_criteria=(
+            "`habit list` prints stable stdout containing created habits",
+        ),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior", weight=1.0),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=ambiguity),
+    )
+
+
+def test_grade_gate_ledger_only_suppresses_high_ambiguity_blocker() -> None:
+    """Closure mode = `ledger_only` → standalone ambiguity blocker
+    suppressed. Other axes unchanged. Reproduces the cli-todo R2 fix
+    path."""
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _high_ambiguity_seed(ambiguity=0.50)
+
+    result = GradeGate().grade_seed(seed, ledger=ledger, closure_mode="ledger_only")
+
+    assert "high_ambiguity_score" not in {b.code for b in result.blockers}
+    assert result.grade == SeedGrade.A
+    assert result.may_run
+
+
+def test_grade_gate_safe_default_also_suppresses_high_ambiguity_blocker() -> None:
+    """`safe_default` is the same closure-policy tier as `ledger_only`
+    (see #1157 Closure Policy hierarchy) — the ambiguity blocker is
+    suppressed there too."""
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _high_ambiguity_seed(ambiguity=0.50)
+
+    result = GradeGate().grade_seed(seed, ledger=ledger, closure_mode="safe_default")
+
+    assert "high_ambiguity_score" not in {b.code for b in result.blockers}
+    assert result.grade == SeedGrade.A
+
+
+def test_grade_gate_mutual_agreement_keeps_ambiguity_blocker() -> None:
+    """`mutual_agreement` closure means backend signal aligned with
+    ledger — the LLM-derived ambiguity_score is treated as
+    authoritative, so the > 0.20 blocker still fires."""
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _high_ambiguity_seed(ambiguity=0.50)
+
+    result = GradeGate().grade_seed(seed, ledger=ledger, closure_mode="mutual_agreement")
+
+    assert "high_ambiguity_score" in {b.code for b in result.blockers}
+    assert result.grade == SeedGrade.C
+    assert not result.may_run
+
+
+def test_grade_gate_closure_mode_none_uses_strict_default() -> None:
+    """Backwards compatibility: callers that do not pass closure_mode
+    (legacy paths, isolated unit tests) keep the strict pre-PR-ζ-B
+    behavior. The ambiguity blocker still fires."""
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _high_ambiguity_seed(ambiguity=0.50)
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)  # closure_mode omitted
+
+    assert "high_ambiguity_score" in {b.code for b in result.blockers}
+    assert result.grade == SeedGrade.C
+
+
+def test_grade_gate_ledger_only_still_blocks_when_other_blockers_exist() -> None:
+    """The PR-ζ-B relaxation is narrow: ONLY the standalone ambiguity
+    blocker is suppressed. Other grading axes (open_gaps, goal
+    mismatch, missing AC, etc.) continue to produce blockers and
+    grade C under `ledger_only` exactly as under any other closure."""
+    # Use an empty ledger so `ledger_open_gap` blockers fire for every
+    # required section even though closure_mode says ledger_only.
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    seed = _high_ambiguity_seed(ambiguity=0.50)
+
+    result = GradeGate().grade_seed(seed, ledger=ledger, closure_mode="ledger_only")
+
+    blocker_codes = {b.code for b in result.blockers}
+    # Ambiguity blocker IS suppressed.
+    assert "high_ambiguity_score" not in blocker_codes
+    # But ledger_open_gap blockers continue to fire for the unresolved
+    # required sections.
+    assert "ledger_open_gap" in blocker_codes
+    assert result.grade == SeedGrade.C
+    assert not result.may_run
+
+
+def test_seed_reviewer_propagates_closure_mode_to_grade_gate() -> None:
+    """The SeedReviewer must forward ``closure_mode`` to GradeGate so
+    the ledger-primary policy applies whether the pipeline calls the
+    reviewer directly or through SeedRepairer.converge."""
+    from ouroboros.auto.seed_reviewer import SeedReviewer
+
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _high_ambiguity_seed(ambiguity=0.50)
+
+    reviewer = SeedReviewer(GradeGate())
+    review = reviewer.review(seed, ledger=ledger, closure_mode="ledger_only")
+
+    assert review.grade_result.grade == SeedGrade.A
+    assert review.may_run
+    assert "high_ambiguity_score" not in {
+        finding.code for finding in review.grade_result.blockers
+    }
+
+
+def test_seed_repairer_converge_propagates_closure_mode() -> None:
+    """SeedRepairer.converge must forward ``closure_mode`` through every
+    reviewer.review call inside the repair loop. Without this, a
+    high-ambiguity seed would survive the direct review path but get
+    repeatedly re-graded as C inside the repair loop."""
+    from ouroboros.auto.seed_repairer import SeedRepairer
+    from ouroboros.auto.seed_reviewer import SeedReviewer
+
+    ledger = SeedDraftLedger.from_goal("Build a habit tracker")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _high_ambiguity_seed(ambiguity=0.50)
+
+    repairer = SeedRepairer(reviewer=SeedReviewer(GradeGate()))
+    converged_seed, review, history = repairer.converge(
+        seed, ledger=ledger, closure_mode="ledger_only"
+    )
+
+    # First-iteration review under ledger_only should already be grade
+    # A — no repair attempts needed.
+    assert review.grade_result.grade == SeedGrade.A
+    assert review.may_run
+    assert history == []
+    # Seed unchanged because already-A seeds skip repair.
+    assert converged_seed.metadata.ambiguity_score == 0.50
+
+
+def test_pipeline_accepts_keyword_sees_closure_mode_on_production_signatures() -> None:
+    """Locks the pipeline-side propagation contract: pipeline.py uses
+    ``_accepts_keyword(callable, "closure_mode")`` to decide whether to
+    forward ``state.interview_closure_mode`` into ``repairer.converge``
+    and ``reviewer.review`` (see pipeline.py REVIEW-phase plumbing).
+    Both production callables MUST declare ``closure_mode`` so the gate
+    fires and the kwarg is actually forwarded; otherwise PR-ζ-B is
+    silently inert in production while unit tests pass."""
+    from ouroboros.auto.pipeline import _accepts_keyword
+    from ouroboros.auto.seed_repairer import SeedRepairer
+    from ouroboros.auto.seed_reviewer import SeedReviewer
+
+    reviewer = SeedReviewer(GradeGate())
+    repairer = SeedRepairer(reviewer=reviewer)
+
+    assert _accepts_keyword(reviewer.review, "closure_mode"), (
+        "SeedReviewer.review must declare closure_mode so the "
+        "pipeline REVIEW-phase forwarder activates"
+    )
+    assert _accepts_keyword(repairer.converge, "closure_mode"), (
+        "SeedRepairer.converge must declare closure_mode so the "
+        "pipeline REPAIR-phase forwarder activates"
+    )


### PR DESCRIPTION
## Summary

- Implements the **grading-half** of SSOT #1157 *Closure Policy* that PR-β (#1252) left missing.
- When the interview closed on ledger evidence (`ledger_only` / `safe_default`), the LLM-derived `ambiguity_score` is acknowledged-stale by design — the ledger's structural completeness IS the acceptance signal. The standalone `high_ambiguity_score` blocker is suppressed under those closure modes; all other grading axes (coverage, testability, `ledger_open_gap`, blocker count, risk, goal mismatch) remain in force.
- Propagates `state.interview_closure_mode` through the existing `SeedReviewer` → `GradeGate` and `SeedRepairer.converge` → `reviewer.review` chains, behind the same stub-tolerant `_accepts_keyword` gates the pipeline already uses for `cancel_event`.
- Adds 8 unit tests locking the policy and the propagation contract.

## Why now

#1170 R2 (2026-05-27, HEAD `2f6247c6` = PR-γ) terminated `BLOCKED` at A-grade despite `closure_mode='ledger_only'` and a structurally-complete ledger. Raw evidence: `.ooo-observability/R2-cli-todo-20260527T071708Z.json`.

Trace:
```
PR-β: interview closes at round 7, closure_mode='ledger_only'   ✅
pipeline.py:710-718  deterministic_floor(ledger) = 0.467         ◀ measurement
grading.py:164       ambiguity_score(=0.467) > 0.20 → blocker    ◀ stale policy
grading.py:277       blocker present → grade = C
pipeline.py:932-935  required_grade=A vs actual=C → BLOCKED
```

`pipeline.py:674-687` comment explicitly acknowledges the policy *for seed generation*:
> *"the persisted backend ambiguity_score is acknowledged-stale by design — the ledger's structural completeness IS the acceptance signal..."*

But that policy was never propagated to grading. PR-ζ-B closes the gap.

SSOT #1157 Closure Policy is explicit:
> *"A fully-populated ledger IS ambiguity ≤ 0.2 by construction."*

Reframed measurement axis (ledger structural completeness), not abandoned principle.

## Changes

- `src/ouroboros/auto/grading.py`
  - `grade_seed(..., closure_mode: str | None = None)`; gate the `high_ambiguity_score` blocker behind `closure_mode not in {ledger_only, safe_default}`.
  - `deterministic_floor` unchanged — measurement is preserved; only the policy is closure-mode aware.
- `src/ouroboros/auto/seed_reviewer.py`
  - `SeedReviewer.review` passes `closure_mode` to `grade_seed`.
- `src/ouroboros/auto/seed_repairer.py`
  - `SeedRepairer.converge` accepts `closure_mode`; new `_review_accepts_closure_mode` helper keeps legacy reviewer stubs (`review(self, seed, *, ledger=None)`) working unchanged.
- `src/ouroboros/auto/pipeline.py`
  - REVIEW-phase `converge` and direct `reviewer.review` call sites both forward `state.interview_closure_mode` behind the existing `_accepts_keyword` gate (same pattern as `cancel_event`).
- `tests/unit/auto/test_ledger_grading_answerer.py`
  - 8 new tests (see below).

## Backwards compatibility

- `closure_mode=None` (default) → strict pre-policy behavior preserved. Legacy callers, isolated unit tests, and third-party `GradeGate` consumers are unaffected.
- Test stubs that don't accept `closure_mode` continue to work because both production callables guard the kwarg behind `_accepts_keyword` / `_review_accepts_closure_mode`.

## Test plan

- [x] `uv run pytest tests/unit/auto/ -x -q` → 994/994 pass (986 prior + 8 new).
- [x] `uv run pytest tests/unit/ -q` → 9697/9697 pass + 2 skipped. No regressions in the wider unit suite.
- [ ] After merge alongside PR-ζ-A (#1264), rerun cli-todo R2 → expect `terminal=PRODUCT_COMPLETE`, `closure_mode=ledger_only`, `active_task_class=cli` (from ζ-A), `grade=A`, `runtime_probe_evidence ⊇ {headless_run, stdout_golden}`.

## New unit tests

| Test | Locks |
|---|---|
| `ledger_only_suppresses_high_ambiguity_blocker` | Core PR-ζ-B behavior on `ledger_only` |
| `safe_default_also_suppresses_high_ambiguity_blocker` | Same policy tier per #1157 hierarchy |
| `mutual_agreement_keeps_ambiguity_blocker` | No relaxation when backend agreed |
| `closure_mode_none_uses_strict_default` | Backwards compatibility |
| `ledger_only_still_blocks_when_other_blockers_exist` | Relaxation is narrow — other axes intact |
| `seed_reviewer_propagates_closure_mode_to_grade_gate` | Reviewer → GradeGate forwarding |
| `seed_repairer_converge_propagates_closure_mode` | Repair-loop forwarding |
| `pipeline_accepts_keyword_sees_closure_mode_on_production_signatures` | Pipeline-side `_accepts_keyword` gate fires (prevents silent inertness in production) |

## Merge sequencing

Logically independent of PR-ζ-A (#1264). The cli-todo acceptance gate (#1170 R2/R3) requires **both** — ζ-A fixes RC-A (task-class mis-inference), ζ-B fixes RC-B (grading policy gap). Either merge order works for the code; conventional sequence is ζ-A first so R2 retry between them produces an interpretable diagnostic (`active_task_class='cli'`, grade still C from ambiguity → confirms ζ-A standalone correctness before ζ-B lands).

PR-δ (0.39.2 release cut) should wait until R2/R3 PASS on `main` after both PRs land.

Refs: #1170, #1157, #1252 (PR-β).

🤖 Generated with [Claude Code](https://claude.com/claude-code)