### PR TITLE
feat(auto): partial_seed_from_evidence substrate (PR-A; #1257)

### DIFF
--- a/src/ouroboros/auto/ledger_seed.py
+++ b/src/ouroboros/auto/ledger_seed.py
@@ -25,6 +25,31 @@ _INACTIVE_STATUSES: frozenset[LedgerStatus] = frozenset(
     }
 )
 
+PARTIAL_SEED_GENERATION_MODE = "partial_seed_from_evidence"
+"""``SeedMetadata.generation_mode`` value for degraded-recovery Seeds.
+
+Single source of truth shared by :func:`partial_seed_from_evidence` and the
+grade/run gates that suppress high-ambiguity-only blockers for degraded seeds
+(#1257 PR-C).
+"""
+
+_PARTIAL_DEFAULT_ACCEPTANCE = (
+    "Synthesized Seed runs without raising and the recorded goal is "
+    "surfaced in execution output (conservative smoke).",
+)
+
+_PARTIAL_DEFAULT_VERIFICATION = (
+    "Execute the smallest available smoke check for the goal; capture "
+    "stdout/stderr and exit code; confirm no unhandled exception."
+)
+
+_PARTIAL_DEFAULT_FAILURE_MODES = (
+    "Unresolved ledger slots may produce incomplete or surprising behavior; "
+    "treat as next-step requirements rather than terminal blockers."
+)
+
+_PARTIAL_PLACEHOLDER_FIELD = "(unresolved at deadline; see unresolved_slots)"
+
 
 def synthesize_seed_from_ledger(
     ledger: SeedDraftLedger,
@@ -110,6 +135,176 @@ def synthesize_seed_from_ledger(
             seed_id=f"seed_{uuid4().hex[:12]}",
             ambiguity_score=max(0.05, deterministic_floor(ledger)),
             interview_id=interview_id,
+        ),
+    )
+
+
+def partial_seed_from_evidence(
+    ledger: SeedDraftLedger,
+    *,
+    reason: str,
+    interview_id: str | None = None,
+) -> Seed:
+    """Synthesize a degraded but executable Seed from an incomplete ledger.
+
+    The primary use case is the interview-deadline closure ladder (#1257 PR-B):
+    when ``ledger.is_seed_ready()`` is False but the deadline has fired, we
+    still want to produce *some* product surface rather than terminating in
+    ``interview_phase_deadline`` BLOCKED. The resulting Seed:
+
+    * is a valid Pydantic :class:`~ouroboros.core.seed.Seed`,
+    * preserves every active ledger entry (so partial work is not discarded),
+    * records the unresolved sections in
+      :attr:`~ouroboros.core.seed.SeedMetadata.unresolved_slots` for downstream
+      gates to convert into next-step hints,
+    * fills missing acceptance/verification slots with conservative smoke
+      defaults, and
+    * lists the unresolved slots in ``constraints`` so executors cannot
+      silently overrun the deadline-driven recovery contract.
+
+    ``goal`` remains a hard prerequisite: a missing goal is a structural
+    failure (no product can exist without one) and raises ``ValueError``. This
+    is the only divergence from "fail-soft": if even the goal is unresolved,
+    the deadline has nothing to recover into.
+
+    The function performs no model or external IO; it is safe to call from
+    deadline handlers without re-introducing latency that was the original
+    timeout source.
+
+    Args:
+        ledger: The incomplete (or complete) ledger to build a Seed from.
+        reason: Free-form provenance string recorded on
+            :attr:`~ouroboros.core.seed.SeedMetadata.recovery_reason` (e.g.
+            ``"interview_phase_deadline"``).
+        interview_id: Reference to the source interview, mirrored on
+            :attr:`~ouroboros.core.seed.SeedMetadata.interview_id`.
+
+    Returns:
+        A valid degraded :class:`~ouroboros.core.seed.Seed`.
+
+    Raises:
+        ValueError: If the ledger has no active goal entry.
+    """
+    if not reason or not reason.strip():
+        msg = "partial_seed_from_evidence requires a non-empty reason"
+        raise ValueError(msg)
+
+    try:
+        goal = _latest_value(ledger, "goal")
+    except ValueError as exc:
+        msg = (
+            "cannot synthesize partial Seed without an active goal entry; "
+            "goal missing is a structural defect, not a deadline recovery case"
+        )
+        raise ValueError(msg) from exc
+
+    open_gaps = tuple(ledger.open_gaps())
+    unresolved_slots = tuple(slot for slot in open_gaps if slot != "goal")
+    degraded = bool(unresolved_slots) or "goal" in open_gaps
+
+    constraints = list(_lines_from_section(ledger, "constraints"))
+    non_goals = _lines_from_section(ledger, "non_goals")
+    for item in non_goals:
+        constraints.append(f"Non-goal: {item}")
+    for slot in unresolved_slots:
+        constraints.append(
+            f"Known unresolved slot ({slot}): treat as next-step requirement, not implicit success."
+        )
+
+    acceptance = _lines_from_section(ledger, "acceptance_criteria")
+    if not acceptance:
+        acceptance = _PARTIAL_DEFAULT_ACCEPTANCE
+
+    verification_plan = (
+        _joined_section(ledger, "verification_plan") or _PARTIAL_DEFAULT_VERIFICATION
+    )
+    failure_modes = _joined_section(ledger, "failure_modes") or _PARTIAL_DEFAULT_FAILURE_MODES
+
+    ontology_schema = OntologySchema(
+        name=_ontology_name(goal),
+        description=(
+            "Partial ontology synthesized from incomplete Seed Draft Ledger "
+            f"under degraded-recovery reason: {reason}."
+        ),
+        fields=(
+            OntologyField(
+                name="actors",
+                field_type="string",
+                description=_joined_section(ledger, "actors") or _PARTIAL_PLACEHOLDER_FIELD,
+            ),
+            OntologyField(
+                name="inputs",
+                field_type="string",
+                description=_joined_section(ledger, "inputs") or _PARTIAL_PLACEHOLDER_FIELD,
+            ),
+            OntologyField(
+                name="outputs",
+                field_type="string",
+                description=_joined_section(ledger, "outputs") or _PARTIAL_PLACEHOLDER_FIELD,
+            ),
+            OntologyField(
+                name="runtime_context",
+                field_type="string",
+                description=_joined_section(ledger, "runtime_context")
+                or _PARTIAL_PLACEHOLDER_FIELD,
+            ),
+        ),
+    )
+
+    # Degraded seeds carry a deliberately elevated ambiguity floor so that
+    # downstream grading observers can see the deadline-driven uncertainty
+    # without us having to special-case the gate logic here. The grade gate
+    # (PR-C) decides whether to suppress the high_ambiguity_score blocker
+    # based on ``metadata.degraded`` / ``generation_mode`` — it does not
+    # re-derive uncertainty from the score itself.
+    floor = deterministic_floor(ledger)
+    ambiguity_score = max(0.05, floor)
+    if degraded:
+        ambiguity_score = max(ambiguity_score, 0.6)
+
+    return Seed(
+        goal=goal,
+        constraints=tuple(dict.fromkeys(constraints)),
+        acceptance_criteria=acceptance,
+        ontology_schema=ontology_schema,
+        evaluation_principles=(
+            EvaluationPrinciple(
+                name="partial_recovery_evidence",
+                description=(
+                    "Degraded Seed preserves ledger evidence collected before the "
+                    "deadline; unresolved slots are surfaced as next-step hints."
+                ),
+                weight=0.5,
+            ),
+            EvaluationPrinciple(
+                name="observable_verification",
+                description=verification_plan,
+                weight=0.5,
+            ),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="partial_acceptance_smoke",
+                description=(
+                    "Conservative smoke verification passes for the recorded goal "
+                    "without raising or violating known constraints."
+                ),
+                evaluation_criteria=verification_plan,
+            ),
+            ExitCondition(
+                name="failure_modes_absent",
+                description=f"Known failure modes are absent: {failure_modes}",
+                evaluation_criteria="No listed failure mode is observed in verification evidence.",
+            ),
+        ),
+        metadata=SeedMetadata(
+            seed_id=f"seed_{uuid4().hex[:12]}",
+            ambiguity_score=ambiguity_score,
+            interview_id=interview_id,
+            generation_mode=PARTIAL_SEED_GENERATION_MODE,
+            degraded=degraded,
+            unresolved_slots=unresolved_slots,
+            recovery_reason=reason,
         ),
     )
 

--- a/src/ouroboros/auto/ledger_seed.py
+++ b/src/ouroboros/auto/ledger_seed.py
@@ -162,10 +162,15 @@ def partial_seed_from_evidence(
     * lists the unresolved slots in ``constraints`` so executors cannot
       silently overrun the deadline-driven recovery contract.
 
-    ``goal`` remains a hard prerequisite: a missing goal is a structural
-    failure (no product can exist without one) and raises ``ValueError``. This
-    is the only divergence from "fail-soft": if even the goal is unresolved,
-    the deadline has nothing to recover into.
+    ``goal`` remains a hard prerequisite: a *missing* goal (no active value at
+    all) is a structural failure — no product can exist without one — and
+    raises ``ValueError``. This is the only divergence from "fail-soft": if
+    even the goal is unresolved, the deadline has nothing to recover into. A
+    goal that is present but only WEAK / CONFLICTING / BLOCKED at the
+    aggregate level (e.g. a confirmed goal followed by a later blocked or
+    conflicting goal entry) is NOT a structural failure — the active value is
+    used, but ``"goal"`` is surfaced in ``unresolved_slots`` and
+    ``constraints`` so downstream gates see the contested provenance.
 
     The function performs no model or external IO; it is safe to call from
     deadline handlers without re-introducing latency that was the original
@@ -198,9 +203,17 @@ def partial_seed_from_evidence(
         )
         raise ValueError(msg) from exc
 
-    open_gaps = tuple(ledger.open_gaps())
-    unresolved_slots = tuple(slot for slot in open_gaps if slot != "goal")
-    degraded = bool(unresolved_slots) or "goal" in open_gaps
+    # ``_latest_value`` above guarantees the ledger has at least one active goal
+    # value, but the aggregate goal-section status can still be WEAK /
+    # CONFLICTING / BLOCKED (e.g. a confirmed goal followed by a blocked or
+    # conflicting later entry), in which case ``open_gaps`` still includes
+    # ``"goal"``. The recovery contract requires us to surface that fact
+    # verbatim in both ``unresolved_slots`` and ``constraints`` so PR-C gates
+    # can convert it into a next-step hint instead of treating the degraded
+    # Seed as goal-resolved. We therefore preserve every open gap — including
+    # ``goal`` — in the provenance surface.
+    unresolved_slots = tuple(ledger.open_gaps())
+    degraded = bool(unresolved_slots)
 
     constraints = list(_lines_from_section(ledger, "constraints"))
     non_goals = _lines_from_section(ledger, "non_goals")

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -143,6 +143,21 @@ class SeedMetadata(BaseModel, frozen=True):
         created_at: When this seed was generated.
         ambiguity_score: The ambiguity score at generation time.
         interview_id: Reference to the source interview.
+        generation_mode: Provenance label for how the Seed was synthesized.
+            ``"normal"`` is the legacy ledger-complete path; degraded recovery
+            paths (e.g. ``"partial_seed_from_evidence"``) MUST set this so
+            grading/run gates can distinguish a fully-resolved Seed from one
+            built under deadline pressure (#1257).
+        degraded: ``True`` when the Seed was synthesized from an incomplete
+            ledger and carries unresolved slots. Always pairs with a non-default
+            ``generation_mode`` and at least one entry in ``unresolved_slots``.
+        unresolved_slots: Ledger sections that were still
+            MISSING/WEAK/CONFLICTING/BLOCKED at synthesis time. Empty for normal
+            seeds. Surfaced verbatim so downstream gates can transform them into
+            ``next_step`` hints instead of terminal blockers.
+        recovery_reason: Free-form description of why the degraded path was
+            taken (e.g. ``"interview_phase_deadline"``). ``None`` for normal
+            seeds.
     """
 
     seed_id: str = Field(default_factory=lambda: f"seed_{uuid4().hex[:12]}")
@@ -151,6 +166,10 @@ class SeedMetadata(BaseModel, frozen=True):
     ambiguity_score: float = Field(default=0.15, ge=0.0, le=1.0)
     interview_id: str | None = Field(default=None)
     parent_seed_id: str | None = Field(default=None)
+    generation_mode: str = Field(default="normal", min_length=1)
+    degraded: bool = Field(default=False)
+    unresolved_slots: tuple[str, ...] = Field(default_factory=tuple)
+    recovery_reason: str | None = Field(default=None)
 
 
 class Seed(BaseModel, frozen=True):

--- a/tests/unit/auto/test_ledger_seed.py
+++ b/tests/unit/auto/test_ledger_seed.py
@@ -1,0 +1,186 @@
+"""Tests for :mod:`ouroboros.auto.ledger_seed`.
+
+Covers the legacy ``synthesize_seed_from_ledger`` path and the new
+``partial_seed_from_evidence`` degraded-recovery substrate added for #1257
+PR-A. The substrate must:
+
+* preserve the strict legacy contract (no behavior change when the ledger is
+  complete),
+* produce a *valid* Seed from an incomplete ledger,
+* surface unresolved sections through ``SeedMetadata.unresolved_slots`` and the
+  constraints list so downstream gates can convert them into next-step hints,
+* refuse to synthesize when goal itself is missing (structural defect, not a
+  deadline-recovery case), and
+* perform no model/external IO (implicitly: only deterministic operations).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.ledger import (
+    LedgerEntry,
+    LedgerSource,
+    LedgerStatus,
+    SeedDraftLedger,
+)
+from ouroboros.auto.ledger_seed import (
+    PARTIAL_SEED_GENERATION_MODE,
+    partial_seed_from_evidence,
+    synthesize_seed_from_ledger,
+)
+from ouroboros.core.seed import Seed
+
+
+def _populate_complete_ledger(goal: str = "Build a CLI tool that prints hello.") -> SeedDraftLedger:
+    """Build a ledger where every required section has a CONFIRMED entry."""
+    ledger = SeedDraftLedger.from_goal(goal)
+    fillers = {
+        "actors": "End user invoking the CLI.",
+        "inputs": "A single positional argument provided on the command line.",
+        "outputs": "stdout text greeting the user.",
+        "constraints": "Pure Python; no external network calls.",
+        "non_goals": "Long-running daemon mode.",
+        "acceptance_criteria": "CLI exits with code 0 and prints the greeting.",
+        "verification_plan": "Run the CLI with a sample arg and assert stdout/exit code.",
+        "failure_modes": "Missing argument raises a typed error.",
+        "runtime_context": "Local developer shell on POSIX.",
+    }
+    for section, value in fillers.items():
+        ledger.add_entry(
+            section,
+            LedgerEntry(
+                key=f"{section}.test",
+                value=value,
+                source=LedgerSource.USER_GOAL,
+                confidence=0.9,
+                status=LedgerStatus.CONFIRMED,
+            ),
+        )
+    return ledger
+
+
+class TestSynthesizeSeedFromLedgerUnchanged:
+    """PR-A is additive: the strict legacy path must remain bit-for-bit equivalent."""
+
+    def test_complete_ledger_still_produces_normal_seed(self) -> None:
+        ledger = _populate_complete_ledger()
+        seed = synthesize_seed_from_ledger(ledger, interview_id="iv-1")
+
+        assert isinstance(seed, Seed)
+        assert seed.goal.startswith("Build a CLI tool")
+        # New SeedMetadata fields keep their defaults — no regression for callers
+        # that never touched ``generation_mode`` / ``degraded`` / etc.
+        assert seed.metadata.generation_mode == "normal"
+        assert seed.metadata.degraded is False
+        assert seed.metadata.unresolved_slots == ()
+        assert seed.metadata.recovery_reason is None
+        assert seed.metadata.interview_id == "iv-1"
+
+    def test_incomplete_ledger_still_raises_on_strict_path(self) -> None:
+        # Goal-only ledger is intentionally not Seed-ready; legacy contract is
+        # to refuse rather than fabricate.
+        ledger = SeedDraftLedger.from_goal("Some goal.")
+        with pytest.raises(ValueError, match="incomplete ledger"):
+            synthesize_seed_from_ledger(ledger)
+
+
+class TestPartialSeedFromEvidence:
+    """Substrate for #1257 PR-B's interview-deadline closure ladder."""
+
+    def test_returns_valid_seed_when_ledger_incomplete(self) -> None:
+        ledger = SeedDraftLedger.from_goal("Goal that survived the deadline.")
+        seed = partial_seed_from_evidence(
+            ledger,
+            reason="interview_phase_deadline",
+            interview_id="iv-partial",
+        )
+
+        # Pydantic validity is implicit in successful construction, but assert
+        # the contract surface explicitly.
+        assert isinstance(seed, Seed)
+        assert seed.goal == "Goal that survived the deadline."
+        assert seed.metadata.generation_mode == PARTIAL_SEED_GENERATION_MODE
+        assert seed.metadata.degraded is True
+        assert seed.metadata.recovery_reason == "interview_phase_deadline"
+        assert seed.metadata.interview_id == "iv-partial"
+
+    def test_unresolved_slots_match_open_gaps_excluding_goal(self) -> None:
+        ledger = SeedDraftLedger.from_goal("A bare goal.")
+        # ``from_goal`` only resolves the goal section; every other required
+        # section is MISSING and therefore an open gap.
+        open_gaps = set(ledger.open_gaps())
+        # Goal itself is resolved by ``from_goal``.
+        assert "goal" not in open_gaps
+
+        seed = partial_seed_from_evidence(ledger, reason="interview_phase_deadline")
+
+        assert set(seed.metadata.unresolved_slots) == open_gaps
+        # And every unresolved slot is surfaced through constraints so the
+        # executor cannot silently assume completeness.
+        for slot in seed.metadata.unresolved_slots:
+            assert any(
+                slot in constraint and "Known unresolved slot" in constraint
+                for constraint in seed.constraints
+            ), f"missing unresolved-slot constraint for {slot}"
+
+    def test_complete_ledger_marks_seed_non_degraded(self) -> None:
+        ledger = _populate_complete_ledger()
+        seed = partial_seed_from_evidence(ledger, reason="forced_review")
+
+        assert seed.metadata.degraded is False
+        assert seed.metadata.unresolved_slots == ()
+        # Still tagged with the partial generation_mode so audit can tell this
+        # Seed came from the recovery path even though no gap existed.
+        assert seed.metadata.generation_mode == PARTIAL_SEED_GENERATION_MODE
+        assert seed.metadata.recovery_reason == "forced_review"
+
+    def test_missing_goal_raises_structural_error(self) -> None:
+        # An empty goal short-circuits ``from_goal`` and leaves the goal
+        # section in WEAK state without an active value.
+        ledger = SeedDraftLedger.from_goal("")
+        with pytest.raises(ValueError, match="structural defect"):
+            partial_seed_from_evidence(ledger, reason="interview_phase_deadline")
+
+    def test_blank_reason_rejected(self) -> None:
+        ledger = SeedDraftLedger.from_goal("Goal.")
+        with pytest.raises(ValueError, match="non-empty reason"):
+            partial_seed_from_evidence(ledger, reason="   ")
+
+    def test_defaults_fill_missing_acceptance_and_verification(self) -> None:
+        ledger = SeedDraftLedger.from_goal("Goal only.")
+        seed = partial_seed_from_evidence(ledger, reason="interview_phase_deadline")
+
+        assert seed.acceptance_criteria, "acceptance must be populated from defaults"
+        assert len(seed.exit_conditions) >= 1
+        verification = seed.exit_conditions[0].evaluation_criteria
+        assert "smoke" in verification.lower()
+
+    def test_ambiguity_score_elevated_for_degraded_seed(self) -> None:
+        ledger = SeedDraftLedger.from_goal("Goal only.")
+        seed = partial_seed_from_evidence(ledger, reason="interview_phase_deadline")
+        assert seed.metadata.ambiguity_score >= 0.6, (
+            "degraded seed must carry an elevated ambiguity floor so downstream "
+            "observers can see the deadline-driven uncertainty without inspecting "
+            "the recovery_reason field"
+        )
+
+    def test_existing_ledger_evidence_preserved(self) -> None:
+        ledger = SeedDraftLedger.from_goal("Goal with partial evidence.")
+        ledger.add_entry(
+            "constraints",
+            LedgerEntry(
+                key="constraints.partial",
+                value="Must run offline.",
+                source=LedgerSource.USER_GOAL,
+                confidence=0.9,
+                status=LedgerStatus.CONFIRMED,
+            ),
+        )
+
+        seed = partial_seed_from_evidence(ledger, reason="interview_phase_deadline")
+
+        # ``_lines_from_section`` strips trailing punctuation as part of the
+        # legacy normalization shared with ``synthesize_seed_from_ledger`` —
+        # match that contract instead of the raw entry value.
+        assert "Must run offline" in seed.constraints

--- a/tests/unit/auto/test_ledger_seed.py
+++ b/tests/unit/auto/test_ledger_seed.py
@@ -105,7 +105,7 @@ class TestPartialSeedFromEvidence:
         assert seed.metadata.recovery_reason == "interview_phase_deadline"
         assert seed.metadata.interview_id == "iv-partial"
 
-    def test_unresolved_slots_match_open_gaps_excluding_goal(self) -> None:
+    def test_unresolved_slots_match_open_gaps(self) -> None:
         ledger = SeedDraftLedger.from_goal("A bare goal.")
         # ``from_goal`` only resolves the goal section; every other required
         # section is MISSING and therefore an open gap.
@@ -115,6 +115,9 @@ class TestPartialSeedFromEvidence:
 
         seed = partial_seed_from_evidence(ledger, reason="interview_phase_deadline")
 
+        # Every open gap is surfaced verbatim — including ``goal`` when the
+        # aggregate goal status itself is unresolved (see
+        # ``test_blocked_goal_entry_surfaced_in_unresolved_slots``).
         assert set(seed.metadata.unresolved_slots) == open_gaps
         # And every unresolved slot is surfaced through constraints so the
         # executor cannot silently assume completeness.
@@ -123,6 +126,78 @@ class TestPartialSeedFromEvidence:
                 slot in constraint and "Known unresolved slot" in constraint
                 for constraint in seed.constraints
             ), f"missing unresolved-slot constraint for {slot}"
+
+    def test_blocked_goal_entry_surfaced_in_unresolved_slots(self) -> None:
+        """A CONFIRMED-then-BLOCKED goal section is degraded with goal provenance.
+
+        Regression for the #1269 review blocker: ``open_gaps()`` reports
+        ``"goal"`` whenever the aggregate goal-section status is
+        MISSING / WEAK / CONFLICTING / BLOCKED, but ``_latest_value`` still
+        returns the active CONFIRMED value. Earlier revisions filtered
+        ``goal`` out of ``unresolved_slots`` unconditionally, leaving
+        ``degraded=True`` with ``unresolved_slots=()`` and no
+        ``"Known unresolved slot (goal)"`` constraint — a silent provenance
+        loss that PR-C gates would have mistaken for a fully resolved goal.
+        """
+        ledger = SeedDraftLedger.from_goal("Original goal that survived.")
+        # A later same-section different-key BLOCKED entry tips the aggregate
+        # status to BLOCKED without invalidating the CONFIRMED active value.
+        ledger.add_entry(
+            "goal",
+            LedgerEntry(
+                key="goal.review_blocker",
+                value="Reviewer raised a blocker on the goal interpretation.",
+                source=LedgerSource.USER_GOAL,
+                confidence=0.9,
+                status=LedgerStatus.BLOCKED,
+            ),
+        )
+
+        # Active goal value is still available — the deadline can still
+        # recover into *something* — but ``goal`` is in ``open_gaps``.
+        assert "goal" in set(ledger.open_gaps())
+
+        seed = partial_seed_from_evidence(ledger, reason="interview_phase_deadline")
+
+        assert seed.goal == "Original goal that survived."
+        assert seed.metadata.degraded is True
+        assert "goal" in seed.metadata.unresolved_slots, (
+            "BLOCKED goal aggregate must be surfaced as unresolved provenance, not silently dropped"
+        )
+        assert any(
+            "Known unresolved slot (goal)" in constraint for constraint in seed.constraints
+        ), "constraints must carry the goal-unresolved next-step hint"
+
+    def test_conflicting_goal_entry_surfaced_in_unresolved_slots(self) -> None:
+        """A CONFIRMED-plus-CONFLICTING goal section is degraded with goal provenance.
+
+        Sibling regression to the BLOCKED case: ``LedgerSection.status()``
+        returns CONFLICTING when no entry is BLOCKED but at least one is
+        CONFLICTING. ``_latest_value`` still returns the latest non-inactive
+        (CONFIRMED) goal, so the deadline has something to recover into —
+        but the aggregate goal status is contested and the recovery contract
+        must surface that.
+        """
+        ledger = SeedDraftLedger.from_goal("Primary goal still in scope.")
+        ledger.add_entry(
+            "goal",
+            LedgerEntry(
+                key="goal.alt_interpretation",
+                value="An alternate goal phrasing the interview never resolved.",
+                source=LedgerSource.USER_GOAL,
+                confidence=0.7,
+                status=LedgerStatus.CONFLICTING,
+            ),
+        )
+
+        assert "goal" in set(ledger.open_gaps())
+
+        seed = partial_seed_from_evidence(ledger, reason="interview_phase_deadline")
+
+        assert seed.goal == "Primary goal still in scope."
+        assert seed.metadata.degraded is True
+        assert "goal" in seed.metadata.unresolved_slots
+        assert any("Known unresolved slot (goal)" in constraint for constraint in seed.constraints)
 
     def test_complete_ledger_marks_seed_non_degraded(self) -> None:
         ledger = _populate_complete_ledger()


### PR DESCRIPTION
## Summary
- Adds the deterministic substrate for the #1257 closure ladder: a degraded but valid `Seed` synthesized from an incomplete ledger, so an interview-phase deadline no longer terminates in `interview_phase_deadline` BLOCKED.
- `SeedMetadata` gains four additive fields (`generation_mode`, `degraded`, `unresolved_slots`, `recovery_reason`) so downstream grade/run gates can recognize a degraded seed without re-deriving uncertainty.
- New `partial_seed_from_evidence(ledger, *, reason, interview_id=None)` preserves active ledger entries, lists open gaps in `metadata.unresolved_slots` *and* `constraints` (as next-step requirements), and falls back to conservative smoke defaults for missing acceptance/verification.
- Missing `goal` stays a hard structural error — the deadline cannot recover into "nothing". A goal that is present but only WEAK/CONFLICTING/BLOCKED at the aggregate level (e.g. a confirmed goal followed by a later blocked or conflicting entry) is **not** treated as missing; the active value is used and `"goal"` is surfaced verbatim in `unresolved_slots` and `constraints` so PR-C gates see the contested provenance.

## Why this is substrate-only
PR-A intentionally **does not** change pipeline timeout routing or any grading gate. Its job is to let PR-B replace the `mark_blocked(interview_phase_deadline)` call site with a real recovery path, and to let PR-C teach `grade/review` to respect the new metadata. Splitting the substrate keeps PR-B narrow enough to review as a routing change rather than a behavioral overhaul.

## Stacking
This is the first of four PRs targeting #1257:
- **PR-A (this PR)** — substrate
- PR-B — `pipeline.py` TimeoutError → seed synthesis → REVIEW/RUN
- PR-C — degraded seed survives grade/review, surfaces `auto.product.partial_emitted`
- PR-D — canonical/integration regression evidence

## Non-goals
- No pipeline routing changes.
- No grade-gate policy changes.
- No LLM auto-fill (that is #1263, after PR-C).
- No removal of other `mark_blocked` sites — broader #1256 scope.

## Test plan
- [x] `uv run pytest tests/unit/auto/test_ledger_seed.py` — 12/12 pass (10 original + 2 new regressions for CONFIRMED+BLOCKED and CONFIRMED+CONFLICTING goal aggregates).
- [x] `uv run pytest tests/unit/core tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_seed_repairer_bounded.py tests/unit/auto/test_interview_pipeline.py tests/unit/auto/test_pipeline_deadline.py` — 750/750 pass (no regression from the additive `SeedMetadata` fields).
- [x] `uv run ruff check` + `uv run ruff format --check` clean on touched files.

## R-run comparison

This PR is **substrate-only**: it adds `partial_seed_from_evidence` and four additive `SeedMetadata` fields, with **no pipeline routing wiring and no grading-gate policy change** (see "Why this is substrate-only" above and the explicit non-goals section). No code in `src/ouroboros/auto/pipeline.py` calls the new substrate; the new `SeedMetadata` fields have defaults that leave existing **runtime behavior** byte-identical (the four new fields do appear in `Seed.model_dump()` / `Seed.to_dict()` output with their default values, so the *serialized* form is additively extended — older readers ignore the extra keys, and a Seed round-trips through `to_dict() → from_dict()` unchanged). Consequently, no per-round wall-clock change is reachable from the canonical `cli-todo` R-run, and an R-run comparison is `N/A` per the §I5 template ("substrate-only PRs that genuinely have no per-round comparison, fill every cell explicitly (`N/A | N/A | n/a`) so the intent is auditable").

| Metric                         | Baseline (sha) | This PR (sha) | Ratio |
|--------------------------------|----------------|---------------|-------|
| Rounds completed in 600 s      | N/A            | N/A           | n/a   |
| Per-round wall-clock (s/round) | N/A            | N/A           | n/a   |
| Terminal reason                | N/A            | N/A           | n/a   |
| EventStore event count         | N/A            | N/A           | n/a   |

Budget compliance: [x] N/A (substrate-only; PR adds no runtime call site and no grading-gate behavior change — every `src/ouroboros/auto/` line added is either an additive `SeedMetadata` field with a default, a new function not called from existing code, or its tests. The §I5 baseline guards the per-round wall-clock; this PR cannot move that number.)

PR-B (#1270) is the first PR in this stack that introduces a new pipeline call site (the timeout recovery path). Real per-round R-run numbers will land there once a canonical-with-timeout regression is wired in PR-D (#1272).

## Related issues
Refs #1257, RFC #1256 §I4/§I5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
