### PR TITLE
feat(auto): interview deadline → closure ladder, not terminal BLOCKED (PR-B; #1257)

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -34,7 +34,11 @@ from ouroboros.auto.handoff_contract import (
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.lateral_routing import select_persona_for_qa_failure
 from ouroboros.auto.ledger import AssumptionRecord, SeedDraftLedger
-from ouroboros.auto.ledger_seed import synthesize_seed_from_ledger
+from ouroboros.auto.ledger_seed import (
+    PARTIAL_SEED_GENERATION_MODE,
+    partial_seed_from_evidence,
+    synthesize_seed_from_ledger,
+)
 from ouroboros.auto.listeners import RALPH_CANCEL_BLOCKER_REASON, mirror_ralph_job_events
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.recovery_plan import (
@@ -651,13 +655,20 @@ class AutoPipeline:
                     except TimeoutError:
                         if self._enforce_deadline(state):
                             return self._result(state, ledger, blocker=state.last_error)
-                        state.mark_blocked(
-                            f"interview phase exceeded {interview_phase_timeout:.0f}s",
-                            tool_name="interview_driver",
-                            error_code="interview_phase_deadline",
+                        # PR-B / #1257 closure ladder: the per-phase interview
+                        # deadline is no longer a terminal BLOCKED. Instead, the
+                        # ledger evidence collected so far is converted into a
+                        # Seed (complete → ``synthesize_seed_from_ledger``,
+                        # incomplete → ``partial_seed_from_evidence``) and the
+                        # pipeline transitions into REVIEW so a partial product
+                        # can still surface. ``_enforce_deadline`` above keeps
+                        # the global pipeline-deadline contract untouched: only
+                        # the per-phase ``interview_phase_deadline`` is rerouted.
+                        return await self._handle_interview_deadline(
+                            state,
+                            ledger,
+                            timeout_seconds=interview_phase_timeout,
                         )
-                        self._save(state)
-                        return self._result(state, ledger, blocker=state.last_error)
                 finally:
                     # RFC #1256 §I4 — composition-root drain on EVERY
                     # exit path: clean completion, ``TimeoutError``
@@ -1499,6 +1510,166 @@ class AutoPipeline:
                     state.deadline_at += elapsed
                 if state.deadline_at_epoch is not None:
                     state.deadline_at_epoch += elapsed
+
+    async def _emit_runtime_deadline_interview_fired(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        *,
+        timeout_seconds: float,
+        closure_route: str,
+    ) -> None:
+        """Persist a ``runtime.deadline.interview.fired`` event, fail-open.
+
+        Reuses the interview driver's ``event_store`` (the only EventStore
+        the pipeline holds a handle to today, wired in #1260) so the
+        deadline event lands in the same aggregate stream that
+        ``ouroboros_query_events(auto_session_id)`` already consumes for
+        ``auto.interview.*`` lifecycle records. The event itself is a
+        runtime-class event (``runtime.deadline.*``) so the aggregate
+        type uses ``auto_session`` rather than the interview-specific
+        ``auto_interview``; this matches the pattern used by
+        :class:`Watchdog` for ``runtime.watchdog.*`` events.
+
+        Errors and timeouts are downgraded to typed structlog warnings —
+        observability must never convert the deadline-recovery path back
+        into a terminal BLOCKED. The append is dispatched as a fire-and-
+        forget ``asyncio.create_task`` so it cannot consume the post-
+        deadline budget; the existing ``_drain_interview_observer_events``
+        ran *before* this helper, so we have no in-flight observer tasks
+        to coordinate with here.
+        """
+        event_store = getattr(self.interview_driver, "event_store", None)
+        if event_store is None:
+            return
+        from ouroboros.events.base import (
+            BaseEvent,  # local import: keeps top-level dep graph stable
+        )
+
+        payload: dict[str, Any] = {
+            "auto_session_id": state.auto_session_id,
+            "phase": AutoPhase.INTERVIEW.value,
+            "timeout_seconds": float(timeout_seconds),
+            "ledger_ready": ledger.is_seed_ready(),
+            "open_gaps": list(ledger.open_gaps()),
+            "rounds_completed": int(state.current_round or 0),
+            "closure_route": closure_route,
+        }
+
+        async def _append() -> None:
+            try:
+                await asyncio.wait_for(
+                    event_store.append(
+                        BaseEvent(
+                            type="runtime.deadline.interview.fired",
+                            aggregate_type="auto_session",
+                            aggregate_id=state.auto_session_id,
+                            data=payload,
+                        )
+                    ),
+                    timeout=_INTERVIEW_OBSERVER_DRAIN_TIMEOUT_SECONDS,
+                )
+            except TimeoutError:
+                log.warning(
+                    "runtime.deadline.interview.fired.timed_out",
+                    auto_session_id=state.auto_session_id,
+                    timeout_seconds=_INTERVIEW_OBSERVER_DRAIN_TIMEOUT_SECONDS,
+                )
+            except Exception as exc:  # noqa: BLE001 — observer must not break the loop
+                log.warning(
+                    "runtime.deadline.interview.fired.failed",
+                    auto_session_id=state.auto_session_id,
+                    error=str(exc),
+                )
+
+        try:
+            asyncio.create_task(_append())  # noqa: RUF006 — fire-and-forget per docstring
+        except RuntimeError:
+            # No running loop (e.g. some test stubs invoke deadline
+            # routing outside an ``asyncio.run`` context). Fail-open.
+            log.warning(
+                "runtime.deadline.interview.fired.no_running_loop",
+                auto_session_id=state.auto_session_id,
+            )
+
+    async def _handle_interview_deadline(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        *,
+        timeout_seconds: float,
+    ) -> AutoPipelineResult:
+        """Convert an interview-phase deadline into a Seed-generation entry.
+
+        Implements the #1257 PR-B closure ladder:
+
+        1. Emit ``runtime.deadline.interview.fired`` so post-hoc evidence
+           inspection can see *why* the recovery path was taken.
+        2. If the ledger is Seed-ready, synthesize a normal Seed via
+           :func:`synthesize_seed_from_ledger`; otherwise fall back to
+           :func:`partial_seed_from_evidence` with
+           ``reason="interview_phase_deadline"`` so unresolved sections
+           become next-step hints on the resulting degraded Seed (PR-A).
+        3. Persist the Seed via :meth:`_record_generated_seed`, mark
+           ``interview_completed = True``, and transition to ``REVIEW`` so
+           the rest of the pipeline (grading, run handoff) can still
+           surface a partial product. PR-C teaches the grade gate to
+           respect ``metadata.degraded`` so the degraded Seed is not
+           re-blocked at REVIEW solely on high-ambiguity grounds.
+
+        The global ``pipeline_timeout_seconds`` deadline is unaffected:
+        callers gate on :meth:`_enforce_deadline` *before* invoking this
+        helper, so this method only fires when the per-phase deadline
+        tripped while the top-level budget still has time.
+        """
+        ledger_ready = ledger.is_seed_ready()
+        closure_route = "ledger_seed" if ledger_ready else PARTIAL_SEED_GENERATION_MODE
+        await self._emit_runtime_deadline_interview_fired(
+            state,
+            ledger,
+            timeout_seconds=timeout_seconds,
+            closure_route=closure_route,
+        )
+
+        if ledger_ready:
+            seed = synthesize_seed_from_ledger(ledger, interview_id=state.interview_session_id)
+            progress_message = (
+                "Interview phase deadline fired; closed via complete-ledger Seed synthesis"
+            )
+        else:
+            seed = partial_seed_from_evidence(
+                ledger,
+                reason="interview_phase_deadline",
+                interview_id=state.interview_session_id,
+            )
+            progress_message = (
+                "Interview phase deadline fired; closed via partial_seed_from_evidence (degraded)"
+            )
+
+        seed = self._record_generated_seed(state, ledger, seed)
+        state.interview_completed = True
+        state.mark_progress(
+            progress_message,
+            tool_name="interview_deadline_recovery",
+        )
+        self._save(state)
+        # State machine requires INTERVIEW → SEED_GENERATION → REVIEW; the
+        # SEED_GENERATION transition is informational since the Seed is already
+        # in ``state.seed_artifact`` from ``_record_generated_seed``, mirroring
+        # the non-deadline ``synthesize_seed_from_ledger`` paths in this file
+        # (e.g. the ledger-only-no-backend branch around the
+        # ``interview_closure_mode in {ledger_only_no_backend, ...}`` block).
+        state.transition(
+            AutoPhase.SEED_GENERATION,
+            f"interview-deadline closure via {closure_route}",
+        )
+        self._save(state)
+        state.transition(
+            AutoPhase.REVIEW,
+            f"reviewing Seed after interview-deadline closure via {closure_route}",
+        )
+        self._save(state)
+        return await self.run(state)
 
     async def _handoff_to_ralph(
         self,

--- a/tests/unit/auto/test_pipeline_interview_deadline_closure.py
+++ b/tests/unit/auto/test_pipeline_interview_deadline_closure.py
@@ -1,0 +1,230 @@
+"""Tests for the interview-deadline closure ladder (#1257 PR-B).
+
+The per-phase ``INTERVIEW`` deadline used to terminate as
+``interview_phase_deadline`` BLOCKED. PR-B reroutes it through Seed
+synthesis (complete ledger → :func:`synthesize_seed_from_ledger`,
+incomplete ledger → :func:`partial_seed_from_evidence`) so a partial
+product can still surface downstream. These tests pin:
+
+1. ``runtime.deadline.interview.fired`` is appended to the wired
+   EventStore with the contract payload.
+2. An incomplete ledger reaches the degraded substrate path and the
+   persisted Seed metadata advertises the recovery.
+3. A complete ledger reaches the normal substrate path and the
+   persisted Seed metadata stays at the ``"normal"`` default.
+4. The pipeline does not re-mark ``interview_phase_deadline`` BLOCKED
+   on the deadline path.
+
+The downstream grade/run gates are deliberately out of scope for PR-B —
+this test file asserts *routing*, not terminal outcome. PR-C tightens
+the grade-gate side so degraded seeds can reach the partial-product
+terminal in PR-D's canonical regression.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+from ouroboros.auto.ledger import (
+    LedgerEntry,
+    LedgerSource,
+    LedgerStatus,
+    SeedDraftLedger,
+)
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.state import (
+    AutoPhase,
+    AutoPipelineState,
+    AutoStore,
+)
+from ouroboros.events.base import BaseEvent
+
+
+class _RecordingEventStore:
+    """In-memory EventStore stub, modeled on ``test_interview_driver_event_store_wiring``."""
+
+    def __init__(self) -> None:
+        self.appended: list[BaseEvent] = []
+
+    async def append(self, event: BaseEvent, **_: Any) -> None:
+        self.appended.append(event)
+
+
+class _DeadlineDriver:
+    """Interview driver stub that sleeps past the per-phase deadline.
+
+    Mirrors the ``_pending_emit_tasks`` / ``event_store`` / ``wait_for_pending_emits``
+    surface the production driver exposes so the pipeline's deadline
+    handler can locate the EventStore via ``self.interview_driver.event_store``.
+    """
+
+    progress_callback = None
+
+    def __init__(self, event_store: _RecordingEventStore | None = None) -> None:
+        self.event_store = event_store
+        self._pending_emit_tasks: set[asyncio.Task[None]] = set()
+
+    async def wait_for_pending_emits(self) -> None:
+        return None
+
+    async def run(self, _state, _ledger):  # noqa: ARG002
+        await asyncio.sleep(3600)
+        raise AssertionError("must be cancelled by phase timeout")
+
+
+async def _no_seed_generator(_session_id: str):  # pragma: no cover - unused under deadline path
+    raise AssertionError("seed generator must not be called on the deadline path")
+
+
+def _build_deadline_state(tmp_path, *, goal: str = "Build a CLI") -> AutoPipelineState:
+    state = AutoPipelineState(goal=goal, cwd=str(tmp_path))
+    state.timeout_seconds_by_phase[AutoPhase.INTERVIEW.value] = 1
+    # Keep the top-level deadline far in the future so ``_enforce_deadline``
+    # does NOT short-circuit and hijack the routing.
+    state.deadline_at = time.monotonic() + 3600
+    state.deadline_at_epoch = time.time() + 3600
+    state.transition(AutoPhase.INTERVIEW, "starting interview")
+    return state
+
+
+@pytest.mark.asyncio
+async def test_deadline_emits_runtime_event_and_routes_through_partial_seed(tmp_path) -> None:
+    """Incomplete ledger + interview deadline → degraded seed + runtime event."""
+    event_store = _RecordingEventStore()
+    driver = _DeadlineDriver(event_store=event_store)
+    state = _build_deadline_state(tmp_path)
+    store = AutoStore(tmp_path)
+    pipeline = AutoPipeline(driver, _no_seed_generator, store=store)
+
+    await pipeline.run(state)
+    # Give the fire-and-forget event-append task a tick to flush.
+    await asyncio.sleep(0)
+
+    # 1. The runtime deadline event must have been appended.
+    deadline_events = [
+        event for event in event_store.appended if event.type == "runtime.deadline.interview.fired"
+    ]
+    assert len(deadline_events) == 1, (
+        f"expected exactly one runtime.deadline.interview.fired event; "
+        f"got {[e.type for e in event_store.appended]}"
+    )
+    event = deadline_events[0]
+    assert event.aggregate_type == "auto_session"
+    assert event.aggregate_id == state.auto_session_id
+    payload = event.data
+    assert payload["auto_session_id"] == state.auto_session_id
+    assert payload["phase"] == AutoPhase.INTERVIEW.value
+    assert payload["timeout_seconds"] == pytest.approx(1.0)
+    assert payload["ledger_ready"] is False
+    assert payload["closure_route"] == "partial_seed_from_evidence"
+    assert "actors" in payload["open_gaps"], "incomplete ledger must list open gaps"
+
+    # 2. The persisted Seed must come from the degraded substrate.
+    assert state.seed_artifact is not None
+    metadata = state.seed_artifact["metadata"]
+    assert metadata["generation_mode"] == "partial_seed_from_evidence"
+    assert metadata["degraded"] is True
+    assert metadata["recovery_reason"] == "interview_phase_deadline"
+    assert metadata["unresolved_slots"]
+
+    # 3. The pipeline must NOT mark interview_phase_deadline BLOCKED.
+    assert state.last_error_code != "interview_phase_deadline"
+
+
+@pytest.mark.asyncio
+async def test_deadline_with_complete_ledger_routes_through_normal_seed(tmp_path) -> None:
+    """Complete ledger + interview deadline → normal seed via legacy synthesizer."""
+    # Pre-populate every required section so ``ledger.is_seed_ready()`` is True
+    # when the deadline fires. The driver still sleeps past the phase timeout
+    # so the closure ladder is exercised; the difference is the *route*.
+    event_store = _RecordingEventStore()
+    state = _build_deadline_state(tmp_path, goal="Build a CLI")
+    store = AutoStore(tmp_path)
+
+    # The pipeline builds the ledger from ``state.goal`` on entry. Hydrate
+    # every required section from inside the driver — that's the same in-
+    # memory ledger the deadline handler will inspect when the per-phase
+    # timeout fires.
+    class _LedgerSeedingDeadlineDriver(_DeadlineDriver):
+        async def run(self, _state, ledger: SeedDraftLedger):  # noqa: ARG002
+            # Populate every required section before the deadline fires so the
+            # closure ladder routes through the complete-ledger branch.
+            for section, value in {
+                "actors": "End user.",
+                "inputs": "CLI argument.",
+                "outputs": "stdout greeting.",
+                "constraints": "Pure Python.",
+                "non_goals": "Long-running daemon.",
+                "acceptance_criteria": "Exit code 0 and prints greeting.",
+                "verification_plan": "Run with sample arg; assert stdout/exit.",
+                "failure_modes": "Missing argument raises typed error.",
+                "runtime_context": "Local developer shell on POSIX.",
+            }.items():
+                ledger.add_entry(
+                    section,
+                    LedgerEntry(
+                        key=f"{section}.deadline_test",
+                        value=value,
+                        source=LedgerSource.USER_GOAL,
+                        confidence=0.9,
+                        status=LedgerStatus.CONFIRMED,
+                    ),
+                )
+            await asyncio.sleep(3600)
+            raise AssertionError("must be cancelled by phase timeout")
+
+    driver = _LedgerSeedingDeadlineDriver(event_store=event_store)
+    pipeline = AutoPipeline(driver, _no_seed_generator, store=store)
+
+    await pipeline.run(state)
+    await asyncio.sleep(0)
+
+    # The runtime event must report the ledger-seed route, not partial-seed.
+    deadline_events = [
+        event for event in event_store.appended if event.type == "runtime.deadline.interview.fired"
+    ]
+    assert len(deadline_events) == 1
+    payload = deadline_events[0].data
+    assert payload["ledger_ready"] is True
+    assert payload["closure_route"] == "ledger_seed"
+    assert payload["open_gaps"] == []
+
+    # And the persisted Seed metadata stays at the ``"normal"`` default
+    # because complete-ledger synthesis does not flip the recovery fields.
+    assert state.seed_artifact is not None
+    metadata = state.seed_artifact["metadata"]
+    assert metadata["generation_mode"] == "normal"
+    assert metadata["degraded"] is False
+    assert metadata["recovery_reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_deadline_path_marks_interview_completed(tmp_path) -> None:
+    """The deadline closure ladder must mark the interview phase done so
+    downstream consumers do not interpret the partial product as "interview
+    still open"."""
+    state = _build_deadline_state(tmp_path)
+    driver = _DeadlineDriver()
+    pipeline = AutoPipeline(driver, _no_seed_generator, store=AutoStore(tmp_path))
+
+    await pipeline.run(state)
+
+    assert state.interview_completed is True
+
+
+@pytest.mark.asyncio
+async def test_deadline_path_without_event_store_does_not_raise(tmp_path) -> None:
+    """Back-compat: drivers wired without an EventStore must still survive the
+    deadline path. The recovery routing must not depend on observability."""
+    state = _build_deadline_state(tmp_path)
+    driver = _DeadlineDriver(event_store=None)
+    pipeline = AutoPipeline(driver, _no_seed_generator, store=AutoStore(tmp_path))
+
+    # Must not raise; should still produce a degraded seed artifact.
+    await pipeline.run(state)
+    assert state.seed_artifact is not None
+    assert state.seed_artifact["metadata"]["generation_mode"] == "partial_seed_from_evidence"

--- a/tests/unit/auto/test_stop_reason_code.py
+++ b/tests/unit/auto/test_stop_reason_code.py
@@ -74,18 +74,25 @@ async def test_interview_max_rounds_exhausted_sets_stop_reason_code(tmp_path) ->
 
 
 # ---------------------------------------------------------------------------
-# Test 2 — interview_phase_deadline
+# Test 2 — interview_phase_deadline no longer terminal (#1257 PR-B)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_interview_phase_deadline_sets_stop_reason_code(tmp_path) -> None:
-    """AutoPipeline result carries ``interview_phase_deadline`` when the interview
-    phase exceeds its configured per-phase timeout.
+async def test_interview_phase_deadline_routes_into_closure_ladder(tmp_path) -> None:
+    """#1257 PR-B: the per-phase interview deadline must NOT terminate as
+    ``interview_phase_deadline`` BLOCKED anymore.
+
+    Instead, the pipeline emits a degraded Seed via
+    :func:`partial_seed_from_evidence` and transitions through
+    SEED_GENERATION → REVIEW. The deadline may still surface a downstream
+    blocker (e.g. a grade-gate C result before PR-C teaches the gate to
+    respect ``metadata.degraded``), but the stop_reason_code MUST be
+    something other than ``interview_phase_deadline`` and the persisted
+    Seed MUST carry the degraded-recovery metadata.
     """
 
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
-        # Sleep longer than the phase timeout so asyncio.wait_for trips.
         await asyncio.sleep(3600)
         raise AssertionError("interview.start should have been cancelled by phase timeout")
 
@@ -93,22 +100,16 @@ async def test_interview_phase_deadline_sets_stop_reason_code(tmp_path) -> None:
         raise AssertionError("answer should never be called")
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
-    # Set a tiny per-phase timeout for INTERVIEW so the wait_for fires quickly.
     state.timeout_seconds_by_phase[AutoPhase.INTERVIEW.value] = 1
-    # Arm the top-level deadline far in the future so it does NOT fire first
-    # and hijack the blocker attribution.
     import time
 
     state.deadline_at = time.monotonic() + 3600
     state.deadline_at_epoch = time.time() + 3600
-    # Put the state into INTERVIEW phase so the pipeline enters interview logic.
     state.transition(AutoPhase.INTERVIEW, "starting interview")
 
     store = AutoStore(tmp_path)
 
     class _SlowDriver:
-        """Interview driver that wraps a FunctionBackend but sleeps in run()."""
-
         progress_callback = None
 
         async def run(self, _state, _ledger):  # noqa: ARG002
@@ -119,11 +120,22 @@ async def test_interview_phase_deadline_sets_stop_reason_code(tmp_path) -> None:
 
     result = await pipeline.run(state)
 
-    assert result.status == "blocked"
-    assert result.stop_reason_code == "interview_phase_deadline"
-    assert state.last_error_code == "interview_phase_deadline"
-    assert result.blocker is not None
-    assert "interview phase exceeded" in result.blocker
+    # The per-phase deadline must no longer be the terminal stop reason.
+    assert result.stop_reason_code != "interview_phase_deadline"
+    assert state.last_error_code != "interview_phase_deadline"
+
+    # A degraded Seed artifact must have been persisted by the closure ladder.
+    assert state.seed_artifact is not None
+    metadata = state.seed_artifact.get("metadata", {})
+    assert metadata.get("generation_mode") == "partial_seed_from_evidence"
+    assert metadata.get("degraded") is True
+    assert metadata.get("recovery_reason") == "interview_phase_deadline"
+    # The unresolved gaps must be surfaced verbatim so PR-C / PR-D can convert
+    # them into next-step hints.
+    assert metadata.get("unresolved_slots"), (
+        "degraded seed must list unresolved ledger sections so downstream "
+        "gates can convert them into next-step hints"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
> **Stacked PR — depends on #1269 (PR-A).** Cumulative diff includes PR-A; please merge #1269 first and rebase this branch onto main so the diff reduces to the PR-B-only changes.

## Summary
- The per-phase `INTERVIEW` deadline in `AutoPipeline._run_inner` no longer terminates as `interview_phase_deadline` BLOCKED.
- New `AutoPipeline._handle_interview_deadline` routes through PR-A's substrate: complete ledger → `synthesize_seed_from_ledger`, incomplete ledger → `partial_seed_from_evidence(reason="interview_phase_deadline")`, then INTERVIEW → SEED_GENERATION → REVIEW so the pipeline can still surface a partial product.
- Emits `runtime.deadline.interview.fired` with the contract payload (`auto_session_id`, `phase`, `timeout_seconds`, `ledger_ready`, `open_gaps`, `rounds_completed`, `closure_route`) via the interview driver's `EventStore`, fail-open.
- The global `pipeline_timeout_seconds` deadline is **unchanged** — `_enforce_deadline` still short-circuits BEFORE the new helper runs.

## Why narrow
PR-B is intentionally limited to *routing*. The grade/review gate may still BLOCKED on a degraded seed in this PR (e.g. via `high_ambiguity_score`); PR-C teaches the gate to respect `metadata.degraded` so the partial-product terminal becomes reachable.

## Stacking
- #1269 (PR-A) — substrate
- **PR-B (this PR)** — routing
- PR-C — degraded seed survives grade/review, `auto.product.partial_emitted` terminal
- PR-D — canonical regression evidence

## Non-goals
- No grade/review policy changes.
- No removal of unrelated `mark_blocked` sites (that is #1256-scope).
- No LLM auto-fill (#1263).

## Test plan
- [x] New `tests/unit/auto/test_pipeline_interview_deadline_closure.py` pins:
  - `runtime.deadline.interview.fired` payload (4 fields + `closure_route`),
  - partial-seed routing for incomplete ledger,
  - normal-seed routing for complete ledger,
  - `state.interview_completed = True` on the deadline path,
  - back-compat when no EventStore is wired.
- [x] Rewrote `tests/unit/auto/test_stop_reason_code.py::test_interview_phase_deadline_*` so it pins the new contract ("deadline is no longer terminal; degraded seed persisted") instead of the deleted BLOCKED behavior.
- [x] `uv run pytest tests/unit/auto/` — full auto suite passes (exit 0).
- [x] `uv run ruff check` + `uv run ruff format --check` clean on touched files.

## R-run comparison

This PR is **routing-only on a deadline-conditional branch**: `AutoPipeline._handle_interview_deadline` only fires when `asyncio.wait_for(self.interview_driver.run(...), timeout=interview_phase_timeout)` raises `TimeoutError`. The canonical `cli-todo` R-run completes its interview phase well under the per-phase deadline, so the new helper is never entered in baseline conditions and the per-round wall-clock is byte-equivalent to PR-A's substrate baseline.

The previously-terminal `interview_phase_deadline` BLOCKED path (zero post-INTERVIEW work) is replaced with `synthesize_seed_from_ledger` / `partial_seed_from_evidence` + a transition through `SEED_GENERATION` → `REVIEW` — this only runs on the deadline-fired path; on that path the prior behavior was to do nothing further, so a "1.5× per-round" ratio does not apply. Under §I5 the row is "no per-round comparison reachable from the canonical R-run", matching the template's substrate-only `N/A | N/A | n/a` provision.

| Metric                         | Baseline (sha) | This PR (sha) | Ratio |
|--------------------------------|----------------|---------------|-------|
| Rounds completed in 600 s      | N/A            | N/A           | n/a   |
| Per-round wall-clock (s/round) | N/A            | N/A           | n/a   |
| Terminal reason                | N/A            | N/A           | n/a   |
| EventStore event count         | N/A            | N/A           | n/a   |

Budget compliance: [x] N/A (routing-only on a deadline-conditional path that the canonical `cli-todo` R-run does not enter; baseline per-round wall-clock is unchanged. PR-D (#1272) carries the canonical-with-timeout regression that will exercise the new path end-to-end.)

## Related issues
Refs #1257, #1269, RFC #1256 §I4/§I5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
