### PR TITLE
test(auto): canonical regression for #1257 closure ladder (PR-D)

### DIFF
--- a/tests/canonical/README.md
+++ b/tests/canonical/README.md
@@ -178,3 +178,25 @@ Any `interview_max_rounds_exhausted` blocker on a canonical scenario
 is treated as a hard failure — it indicates either the legacy
 AND-gate is back in production or PR-β has not been deployed
 (release cut needed via PR-δ).
+
+## Interview-deadline closure ladder (PR-D / #1257)
+
+`interview_phase_deadline` BLOCKED is also a hard failure on canonical
+scenarios. PR-A/B/C/D of #1257 replace that terminal with a typed
+closure ladder:
+
+- the deadline emits `runtime.deadline.interview.fired`,
+- the pipeline synthesizes a `Seed` (complete ledger →
+  `synthesize_seed_from_ledger`, incomplete → `partial_seed_from_evidence`),
+- and the partial Seed reaches `AutoPhase.COMPLETE` with
+  `auto.product.partial_emitted` + `partial_product=True` /
+  `partial_unresolved_slots` on the result envelope.
+
+The hermetic regression for that contract lives in
+`tests/integration/auto/test_interview_deadline_partial_product_regression.py`
+and runs in plain CI alongside this hermetic harness (no
+`OUROBOROS_RUN_CANONICAL=1` needed because the deadline simulator is
+deterministic and incurs no LLM cost). The live-run path here MUST
+also surface `partial_product=True` and the deadline/partial-emitted
+event pair when the deadline branch is taken — paraphrased absence of
+those fields is treated as evidence the closure ladder has regressed.

--- a/tests/integration/auto/test_interview_deadline_partial_product_regression.py
+++ b/tests/integration/auto/test_interview_deadline_partial_product_regression.py
@@ -1,0 +1,264 @@
+"""Integration regression for the #1257 interview-deadline closure ladder.
+
+This file is **PR-D**: the canonical regression evidence layer for the
+#1257 work. It binds every contract surface PR-A/B/C added to a single
+end-to-end assertion so future refactors cannot silently revert any
+piece of the closure ladder. The scenarios are deliberately deterministic
+and hermetic — no live LLM, no `OUROBOROS_RUN_CANONICAL=1` opt-in — so
+they run in plain CI alongside the existing unit suites.
+
+Coverage:
+
+1. **R4-equivalent timeout fixture.** A pre-armed interview-phase
+   deadline against a sleeping driver must:
+     - NOT terminate as ``interview_phase_deadline`` BLOCKED,
+     - persist a degraded ``Seed`` artifact with the PR-A metadata,
+     - append ``runtime.deadline.interview.fired`` (PR-B) and
+       ``auto.product.partial_emitted`` (PR-C) to the EventStore,
+     - surface the PR-C ``partial_product*`` fields on the result envelope.
+
+2. **Partial product fixture.** A successful deadline run reaches
+   ``AutoPhase.COMPLETE`` with ``partial_product=True``, the recovery
+   reason mirrored from the Seed, and unresolved slots carried forward
+   verbatim as next-step hints.
+
+3. **Raw evidence file.** The integration test writes a JSON evidence
+   blob to the pytest tmp path so reviewers can audit the full
+   seed/product/event trail without re-running the test.
+
+Per the #1257 spec, #1170 closure remains out of scope; this file only
+binds the #1257 regression contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+import time
+from typing import Any
+
+import pytest
+
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.state import (
+    AutoPhase,
+    AutoPipelineState,
+    AutoStore,
+)
+from ouroboros.events.base import BaseEvent
+
+
+class _RecordingEventStore:
+    """In-memory EventStore stub. Mirrors the production append surface."""
+
+    def __init__(self) -> None:
+        self.appended: list[BaseEvent] = []
+
+    async def append(self, event: BaseEvent, **_: Any) -> None:
+        self.appended.append(event)
+
+
+class _DeadlineDriver:
+    """Interview driver stub that sleeps past the per-phase deadline.
+
+    Exposes the same observability surface the production driver does
+    (``event_store``, ``_pending_emit_tasks``, ``wait_for_pending_emits``)
+    so the pipeline's deadline handler can locate the EventStore via
+    ``self.interview_driver.event_store``.
+    """
+
+    progress_callback = None
+
+    def __init__(self, event_store: _RecordingEventStore | None = None) -> None:
+        self.event_store = event_store
+        self._pending_emit_tasks: set[asyncio.Task[None]] = set()
+
+    async def wait_for_pending_emits(self) -> None:
+        return None
+
+    async def run(self, _state, _ledger):  # noqa: ARG002
+        await asyncio.sleep(3600)
+        raise AssertionError("must be cancelled by per-phase deadline")
+
+
+async def _unused_seed_generator(_session_id: str):  # pragma: no cover - unused
+    raise AssertionError("seed generator must not run on the deadline path")
+
+
+def _arm_interview_deadline(state: AutoPipelineState, *, phase_seconds: int = 1) -> None:
+    """Set up the interview-phase deadline and a far-future top-level deadline.
+
+    The top-level (`pipeline_timeout_seconds`) deadline is kept far in the
+    future so `_enforce_deadline` does NOT short-circuit and hijack the
+    routing — we want the PER-PHASE deadline to be the trigger.
+    """
+    state.timeout_seconds_by_phase[AutoPhase.INTERVIEW.value] = phase_seconds
+    state.deadline_at = time.monotonic() + 3600
+    state.deadline_at_epoch = time.time() + 3600
+    state.transition(AutoPhase.INTERVIEW, "starting interview")
+
+
+def _write_evidence_blob(
+    path: Path,
+    *,
+    state: AutoPipelineState,
+    result: Any,
+    event_store: _RecordingEventStore,
+) -> Path:
+    """Persist a JSON evidence blob mirroring the spec's PR-D contract.
+
+    The blob captures everything a reviewer needs to verify the #1257
+    regression without re-running the test: the persisted Seed artifact,
+    the closure-ladder result envelope, and the full ordered event list.
+    """
+    blob = {
+        "auto_session_id": state.auto_session_id,
+        "phase": state.phase.value,
+        "last_error_code": state.last_error_code,
+        "seed_artifact": state.seed_artifact,
+        "result": {
+            "status": result.status,
+            "phase": result.phase,
+            "stop_reason_code": result.stop_reason_code,
+            "blocker": result.blocker,
+            "partial_product": result.partial_product,
+            "partial_product_reason": result.partial_product_reason,
+            "partial_unresolved_slots": list(result.partial_unresolved_slots),
+        },
+        "events": [
+            {
+                "type": event.type,
+                "aggregate_type": event.aggregate_type,
+                "aggregate_id": event.aggregate_id,
+                "data": dict(event.data),
+            }
+            for event in event_store.appended
+        ],
+    }
+    path.write_text(json.dumps(blob, indent=2, sort_keys=True), encoding="utf-8")
+    return path
+
+
+@pytest.mark.asyncio
+async def test_r4_equivalent_interview_deadline_regression(tmp_path: Path) -> None:
+    """Full regression for #1257: interview deadline → partial product terminal.
+
+    Binds PR-A's substrate, PR-B's routing, and PR-C's terminal into a
+    single end-to-end contract assertion. Also writes a raw evidence file
+    so future reviewers can audit the closure ladder without re-running
+    the test.
+    """
+    event_store = _RecordingEventStore()
+    driver = _DeadlineDriver(event_store=event_store)
+    state = AutoPipelineState(goal="Build a tiny CLI tool.", cwd=str(tmp_path))
+    _arm_interview_deadline(state)
+
+    pipeline = AutoPipeline(driver, _unused_seed_generator, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+    # Flush fire-and-forget event-append tasks.
+    await asyncio.sleep(0)
+
+    # ----- Terminal must NOT be the deleted ``interview_phase_deadline`` BLOCKED.
+    assert result.stop_reason_code != "interview_phase_deadline"
+    assert state.last_error_code != "interview_phase_deadline"
+
+    # ----- PR-C terminal: the pipeline must reach COMPLETE with partial_product.
+    assert state.phase == AutoPhase.COMPLETE
+    assert result.status == "complete"
+    assert result.blocker is None
+    assert result.partial_product is True
+    assert result.partial_product_reason == "interview_phase_deadline"
+    assert result.partial_unresolved_slots, (
+        "unresolved slots must be surfaced verbatim so MCP/CLI consumers "
+        "can convert them into next-step hints"
+    )
+
+    # ----- PR-A substrate: persisted Seed carries the degraded metadata.
+    assert state.seed_artifact is not None
+    seed_meta = state.seed_artifact["metadata"]
+    assert seed_meta["generation_mode"] == "partial_seed_from_evidence"
+    assert seed_meta["degraded"] is True
+    assert seed_meta["recovery_reason"] == "interview_phase_deadline"
+    assert seed_meta["unresolved_slots"], "seed metadata must list unresolved slots"
+    # ``constraints`` mirrors each unresolved slot so the run path cannot
+    # silently overrun the deadline-driven recovery contract.
+    constraint_blob = " ".join(state.seed_artifact["constraints"])
+    for slot in seed_meta["unresolved_slots"]:
+        assert slot in constraint_blob, (
+            f"unresolved slot {slot} must appear in constraints as a next-step "
+            f"requirement; got: {constraint_blob!r}"
+        )
+
+    # ----- PR-B routing: runtime.deadline.interview.fired event landed.
+    deadline_events = [
+        event for event in event_store.appended if event.type == "runtime.deadline.interview.fired"
+    ]
+    assert len(deadline_events) == 1
+    deadline_payload = deadline_events[0].data
+    assert deadline_payload["auto_session_id"] == state.auto_session_id
+    assert deadline_payload["phase"] == AutoPhase.INTERVIEW.value
+    assert deadline_payload["closure_route"] == "partial_seed_from_evidence"
+    assert deadline_payload["ledger_ready"] is False
+    assert deadline_payload["open_gaps"], "deadline event must list open gaps"
+
+    # ----- PR-C terminal: auto.product.partial_emitted event landed.
+    partial_events = [
+        event for event in event_store.appended if event.type == "auto.product.partial_emitted"
+    ]
+    assert len(partial_events) == 1
+    partial_payload = partial_events[0].data
+    assert partial_payload["auto_session_id"] == state.auto_session_id
+    assert partial_payload["seed_id"] == state.seed_id
+    assert partial_payload["recovery_reason"] == "interview_phase_deadline"
+    assert partial_payload["unresolved_slots"], (
+        "partial-emitted payload must list unresolved slots verbatim"
+    )
+
+    # ----- Event ordering: deadline event MUST precede partial-emitted event.
+    deadline_index = event_store.appended.index(deadline_events[0])
+    partial_index = event_store.appended.index(partial_events[0])
+    assert deadline_index < partial_index, (
+        "runtime.deadline.interview.fired must be emitted before "
+        "auto.product.partial_emitted so post-hoc audit can trace the "
+        "closure ladder in order"
+    )
+
+    # ----- Raw evidence file for reviewer audit (PR-D contract).
+    evidence_path = _write_evidence_blob(
+        tmp_path / "issue_1257_pr_d_evidence.json",
+        state=state,
+        result=result,
+        event_store=event_store,
+    )
+    assert evidence_path.exists()
+    # Sanity-check the round-trip so the file isn't silently corrupted.
+    loaded = json.loads(evidence_path.read_text(encoding="utf-8"))
+    assert loaded["result"]["partial_product"] is True
+    assert any(event["type"] == "runtime.deadline.interview.fired" for event in loaded["events"])
+    assert any(event["type"] == "auto.product.partial_emitted" for event in loaded["events"])
+
+
+@pytest.mark.asyncio
+async def test_interview_deadline_regression_without_event_store(tmp_path: Path) -> None:
+    """Back-compat: the closure ladder must succeed even without observability.
+
+    A driver wired without an EventStore is the legacy/test default. The
+    #1257 closure ladder must not depend on observability for correctness —
+    the partial product terminal still has to fire and the result envelope
+    still has to carry the PR-C surface fields.
+    """
+    driver = _DeadlineDriver(event_store=None)
+    state = AutoPipelineState(goal="Build a tiny CLI tool.", cwd=str(tmp_path))
+    _arm_interview_deadline(state)
+    pipeline = AutoPipeline(driver, _unused_seed_generator, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+
+    assert state.phase == AutoPhase.COMPLETE
+    assert result.partial_product is True
+    assert result.partial_product_reason == "interview_phase_deadline"
+    assert result.partial_unresolved_slots
+    assert state.seed_artifact is not None
+    assert state.seed_artifact["metadata"]["degraded"] is True

--- a/tests/integration/auto/test_interview_deadline_partial_product_regression.py
+++ b/tests/integration/auto/test_interview_deadline_partial_product_regression.py
@@ -262,3 +262,96 @@ async def test_interview_deadline_regression_without_event_store(tmp_path: Path)
     assert result.partial_unresolved_slots
     assert state.seed_artifact is not None
     assert state.seed_artifact["metadata"]["degraded"] is True
+
+
+class _SelectivelyDelayingEventStore(_RecordingEventStore):
+    """EventStore stub whose append for a chosen event type is artificially slow.
+
+    Designed to reproduce the race that ouroboros-agent[bot]
+    ``supersede-requeue-pr:1272-ce273bf`` flagged: when
+    ``runtime.deadline.interview.fired`` is slow but
+    ``auto.product.partial_emitted`` is fast, a fire-and-forget
+    implementation persists them in the wrong order even though the
+    pipeline invokes them sequentially. Awaiting the appends inline
+    (PR-C follow-up 2) eliminates that race and this test pins the
+    contract.
+    """
+
+    def __init__(self, slow_event_type: str, slow_delay_seconds: float) -> None:
+        super().__init__()
+        self._slow_event_type = slow_event_type
+        self._slow_delay_seconds = slow_delay_seconds
+
+    async def append(self, event: BaseEvent, **kw: Any) -> None:
+        if event.type == self._slow_event_type:
+            await asyncio.sleep(self._slow_delay_seconds)
+        await super().append(event, **kw)
+
+
+@pytest.mark.asyncio
+async def test_deadline_event_ordering_holds_when_first_append_is_slow(
+    tmp_path: Path,
+) -> None:
+    """Regression for ouroboros-agent[bot] ``supersede-requeue-pr:1272-ce273bf``.
+
+    The canonical evidence contract requires
+    ``runtime.deadline.interview.fired`` (PR-B) to precede
+    ``auto.product.partial_emitted`` (PR-C) in the persisted EventStore
+    stream. The prior fire-and-forget implementation in
+    ``_emit_runtime_event`` failed this under realistic append latency:
+    if the first append was slow while the second was fast, the
+    persisted stream contained ``auto.product.partial_emitted`` first,
+    contradicting the lifecycle even when the result envelope said
+    ``partial_product=True``.
+
+    This test deliberately delays the deadline event append while
+    keeping the partial-emitted append fast. With the PR-C follow-up
+    that awaits appends inline, ordering MUST still hold; with the
+    prior implementation the assertion below would fail.
+    """
+    # 250 ms is enough to be detectable but well inside the
+    # ``_INTERVIEW_OBSERVER_DRAIN_TIMEOUT_SECONDS`` bound.
+    event_store = _SelectivelyDelayingEventStore(
+        slow_event_type="runtime.deadline.interview.fired",
+        slow_delay_seconds=0.25,
+    )
+    driver = _DeadlineDriver(event_store=event_store)
+    state = AutoPipelineState(goal="Build a tiny CLI tool.", cwd=str(tmp_path))
+    _arm_interview_deadline(state)
+    pipeline = AutoPipeline(driver, _unused_seed_generator, store=AutoStore(tmp_path))
+
+    result = await pipeline.run(state)
+    # Give any (incorrectly) outstanding fire-and-forget tasks ample time
+    # to land — if ordering is correct this is a no-op; if the prior
+    # race resurfaces, this is when the misordered tail would arrive.
+    for _ in range(8):
+        await asyncio.sleep(0)
+    await asyncio.sleep(0.3)
+
+    # Functional surface unchanged.
+    assert result.partial_product is True
+    assert result.partial_product_reason == "interview_phase_deadline"
+    assert state.phase == AutoPhase.COMPLETE
+
+    # Ordering contract: deadline event MUST precede partial-emitted
+    # event in the persisted stream, even though its append was slower.
+    types_in_order = [event.type for event in event_store.appended]
+    deadline_indices = [
+        idx for idx, t in enumerate(types_in_order) if t == "runtime.deadline.interview.fired"
+    ]
+    partial_indices = [
+        idx for idx, t in enumerate(types_in_order) if t == "auto.product.partial_emitted"
+    ]
+    assert deadline_indices, (
+        "deadline event must land in the persisted stream even under append latency"
+    )
+    assert partial_indices, (
+        "partial-emitted event must land in the persisted stream even under append latency"
+    )
+    assert deadline_indices[0] < partial_indices[0], (
+        "runtime.deadline.interview.fired must persist BEFORE auto.product.partial_emitted "
+        "regardless of relative append latency — fire-and-forget scheduling broke this; "
+        "the PR-C follow-up awaits appends inline to preserve the canonical ordering "
+        "contract. Observed order: "
+        f"{types_in_order}"
+    )


### PR DESCRIPTION
> **Stacked PR — final of four. Depends on #1269 (PR-A), #1270 (PR-B), #1271 (PR-C).** Cumulative diff includes all three; please merge in order (#1269 → #1270 → #1271 → this PR).

## Summary
Final layer of the #1257 stack: a hermetic integration regression that binds every contract surface PR-A/B/C added into a single end-to-end assertion, plus a canonical README note pinning the new contract for future maintainers.

## Coverage
`tests/integration/auto/test_interview_deadline_partial_product_regression.py`:

1. **R4-equivalent timeout fixture** — pre-arms an interview-phase deadline against a sleeping driver and asserts the full ladder:
   - terminal is NOT `interview_phase_deadline` BLOCKED,
   - persisted Seed metadata: `generation_mode == "partial_seed_from_evidence"`, `degraded == True`, `recovery_reason == "interview_phase_deadline"`, non-empty `unresolved_slots` (PR-A),
   - `runtime.deadline.interview.fired` event landed with the full payload (PR-B),
   - `auto.product.partial_emitted` event landed with `recovery_reason` / `unresolved_slots` (PR-C),
   - event ordering: deadline event precedes partial-emitted event,
   - result envelope: `partial_product=True`, `partial_product_reason`, `partial_unresolved_slots`,
   - constraint mirroring: every `unresolved_slot` appears in the seed's `constraints` as a next-step requirement.

2. **Partial product fixture without event store** — back-compat assertion that the closure ladder still produces a partial product terminal when the driver is wired without an EventStore. Observability is fail-open by design and must never become a correctness dependency.

3. **Raw evidence file** — the regression writes a JSON evidence blob (`issue_1257_pr_d_evidence.json`) to the pytest tmp path so reviewers can audit the full seed / product / event trail without re-running the test. Mirrors the canonical raw-passthrough contract.

`tests/canonical/README.md`:
- new "Interview-deadline closure ladder (PR-D / #1257)" section pins `interview_phase_deadline` BLOCKED as a hard failure on canonical scenarios (parallel to the existing PR-β `interview_max_rounds_exhausted` rule), and points reviewers at the integration regression.

## Picked up from PR-C follow-up (now in the cumulative diff)
The cumulative diff also carries the PR-C follow-up commit `8a93db65` (rebased onto pr-1257-d):
- `LedgerStatus.BLOCKED` ledger gaps remain hard `ledger_blocked_gap` blockers on the degraded path (closes ouroboros-agent[bot] `req_1779969257_174`).
- `_result_meta` / `_format_result` surface `partial_product*` on the MCP wire + CLI text (closes ouroboros-agent[bot] `req_1779969483_175` Medium follow-up).
- Five new tests (3 unit + 2 MCP surface) pin both fixes.

## Non-goals (per #1257 spec)
- Full #1170 close / 3-task matrix.
- #1256 close.
- Performance numerical enforcement.

## Hermetic by design
Both regressions run in plain CI alongside the existing unit suites — no `OUROBOROS_RUN_CANONICAL=1` opt-in needed, because the deadline simulator is deterministic and incurs no LLM cost.

## Test plan
- [x] `uv run pytest tests/integration/auto/test_interview_deadline_partial_product_regression.py` — 2 / 2 pass.
- [x] `uv run pytest tests/unit/auto/ tests/integration/auto/ tests/unit/mcp/tools/test_auto_interview_construction.py` — 1137 passed (the +5 PR-C follow-up tests are included).
- [x] `uv run ruff check` + `uv run ruff format --check` clean on touched files.

## R-run comparison (required for `src/ouroboros/auto/` changes)

PR-D is **tests-only** at the `src/ouroboros/auto/` boundary — the cumulative diff inherits PR-C's grade-gate-policy / result-envelope code changes, but PR-D itself adds no source code under `src/ouroboros/auto/`. The integration regression simulates a deadline against a sleeping driver and exercises the typed-terminal contract; it does not exercise (or change) the per-interview-round wall-clock loop that §I5 protects.

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [x] N/A (PR-D is tests-only at the `src/ouroboros/auto/` boundary; cumulative changes inherited from PR-C are gated on the deadline already firing and add no per-round-loop work)

## Stacking
- #1269 (PR-A) — substrate
- #1270 (PR-B) — routing
- #1271 (PR-C) — partial product terminal
- **PR-D (this PR)** — canonical regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)
