### PR TITLE
feat(plugin): v0.4 schema + tool-call hook type promotion (#939 PR F-1)

### DIFF
--- a/src/ouroboros/plugin/hooks.py
+++ b/src/ouroboros/plugin/hooks.py
@@ -73,6 +73,24 @@ class HookKind(StrEnum):
     #: separate ``plugin:lifecycle:cleanup`` permission to be defined.
     ON_CANCEL = "on_cancel"
 
+    #: Tool-call observation / intercept hook promoted out of
+    #: :class:`DeferredHookKind` by #939 PR F-1. Manifests at
+    #: ``schema_version >= "0.4"`` may declare it. Payload, permission
+    #: scopes, failure policy, and audit event names are locked in
+    #: ``docs/rfc/plugin-tool-call-hook-contract.md``. **Runtime
+    #: dispatch is not enabled by PR F-1**: declaring this hook in a
+    #: v0.4 manifest is currently a no-op at runtime, and the firewall
+    #: will not invoke it until PR F-2 ships the dispatch wiring.
+    BEFORE_TOOL_CALL = "before_tool_call"
+
+    #: Tool-call after-call observation hook promoted out of
+    #: :class:`DeferredHookKind` by #939 PR F-1. See
+    #: :data:`BEFORE_TOOL_CALL` for the dispatch caveat. The schema
+    #: pins this hook to ``failure_policy='fail_open'`` because the
+    #: after-call payload describes a tool result that has already
+    #: been observed by the caller.
+    AFTER_TOOL_CALL = "after_tool_call"
+
 
 class DeferredHookKind(StrEnum):
     """Hook names deferred to follow-up RFC slices.
@@ -91,8 +109,6 @@ class DeferredHookKind(StrEnum):
     diff in review.
     """
 
-    BEFORE_TOOL_CALL = "before_tool_call"
-    AFTER_TOOL_CALL = "after_tool_call"
     BEFORE_ARTIFACT_WRITE = "before_artifact_write"
     AFTER_ARTIFACT_WRITE = "after_artifact_write"
 
@@ -201,6 +217,60 @@ HOOK_LIFECYCLE_SCOPES: Final[frozenset[str]] = frozenset(
 )
 
 
+#: Frozen subset of :class:`HookKind` that observes plugin-mediated
+#: tool calls. Promoted out of :class:`DeferredHookKind` by #939 PR F-1.
+#: Manifests at ``schema_version >= "0.4"`` may declare these names.
+#: Runtime dispatch wiring is deferred to PR F-2; until that ships,
+#: declaring a tool-call hook is accepted by the schema and the
+#: manifest validator but never invoked by the firewall.
+TOOL_CALL_HOOK_KINDS: Final[frozenset[HookKind]] = frozenset(
+    {HookKind.BEFORE_TOOL_CALL, HookKind.AFTER_TOOL_CALL}
+)
+
+TOOL_CALL_HOOK_NAMES: Final[frozenset[str]] = frozenset(hook.value for hook in TOOL_CALL_HOOK_KINDS)
+"""String names for v0.4 tool-call hooks."""
+
+#: Hook permission scope required for tool-call hooks that may *block*
+#: a plugin-mediated tool invocation through ``fail_closed`` (or
+#: explicitly veto via the dispatch return value). Holders of this
+#: scope MUST also hold the tool-specific permission declared in the
+#: manifest's ``commands[].permissions`` / ``tools.allowed`` surface;
+#: that enforcement remains the firewall's responsibility and is
+#: tracked under PR F-2.
+HOOK_TOOL_INTERCEPT_SCOPE: Final[str] = "plugin:tool:intercept"
+
+#: Hook permission scope reserved for observation-only tool-call
+#: hooks. Holders may never veto a tool call; the v0.4 schema constrains
+#: them to ``failure_policy='fail_open'`` and PR F-2's dispatcher will
+#: reject any blocked return value coming from an observe-only hook.
+HOOK_TOOL_OBSERVE_SCOPE: Final[str] = "plugin:tool:observe"
+
+#: Frozen set of v0.4 tool-call permission scopes. Validators reference
+#: this set rather than the bare strings so new scopes cannot sneak
+#: past the routing path without an explicit code change here.
+HOOK_TOOL_CALL_SCOPES: Final[frozenset[str]] = frozenset(
+    {HOOK_TOOL_INTERCEPT_SCOPE, HOOK_TOOL_OBSERVE_SCOPE}
+)
+
+#: Reserved audit event names for the tool-call hook family.
+#: Locked in ``docs/rfc/plugin-tool-call-hook-contract.md`` § 6 and
+#: vendored in the v0.4 JSON Schema's ``audit.events`` enum.
+#: **PR F-1 does not emit any of these events**; emission is owned by
+#: PR F-2's firewall dispatcher.
+HOOK_TOOL_INTERCEPT_REQUESTED_EVENT: Final[str] = "plugin.tool.intercept.requested"
+HOOK_TOOL_INTERCEPT_COMPLETED_EVENT: Final[str] = "plugin.tool.intercept.completed"
+HOOK_TOOL_INTERCEPT_BLOCKED_EVENT: Final[str] = "plugin.tool.intercept.blocked"
+HOOK_TOOL_OBSERVE_RECORDED_EVENT: Final[str] = "plugin.tool.observe.recorded"
+HOOK_TOOL_CALL_AUDIT_EVENTS: Final[frozenset[str]] = frozenset(
+    {
+        HOOK_TOOL_INTERCEPT_REQUESTED_EVENT,
+        HOOK_TOOL_INTERCEPT_COMPLETED_EVENT,
+        HOOK_TOOL_INTERCEPT_BLOCKED_EVENT,
+        HOOK_TOOL_OBSERVE_RECORDED_EVENT,
+    }
+)
+
+
 def is_v1_hook_kind(value: str) -> bool:
     """Return True iff ``value`` names a hook included in v1.
 
@@ -262,6 +332,27 @@ def is_hook_lifecycle_scope(value: str) -> bool:
     return value in HOOK_LIFECYCLE_SCOPES
 
 
+def is_tool_call_hook_kind(value: str) -> bool:
+    """Return True iff ``value`` names a v0.4 tool-call hook.
+
+    Use this in manifest validators and runtime dispatchers so the
+    boundary between lifecycle and tool-call hooks stays explicit. The
+    v0.4 schema accepts these names but PR F-1 does not yet wire them
+    into the firewall's dispatch path; PR F-2 will use this helper to
+    select tool-call hooks at the tool-call boundary.
+    """
+    return value in TOOL_CALL_HOOK_NAMES
+
+
+def is_hook_tool_call_scope(value: str) -> bool:
+    """Return True iff ``value`` names a v0.4 tool-call permission scope.
+
+    Mirrors :func:`is_hook_lifecycle_scope` for the
+    ``plugin:tool:intercept`` / ``plugin:tool:observe`` scope pair.
+    """
+    return value in HOOK_TOOL_CALL_SCOPES
+
+
 __all__ = [
     "HOOK_AUDIT_EVENTS",
     "HOOK_BLOCKED_EVENT",
@@ -274,16 +365,28 @@ __all__ = [
     "HOOK_LIFECYCLE_SCOPES",
     "HOOK_OUTCOME_AUDIT_EVENTS",
     "HOOK_RUNTIME_AUDIT_EVENTS",
+    "HOOK_TOOL_CALL_AUDIT_EVENTS",
+    "HOOK_TOOL_CALL_SCOPES",
+    "HOOK_TOOL_INTERCEPT_BLOCKED_EVENT",
+    "HOOK_TOOL_INTERCEPT_COMPLETED_EVENT",
+    "HOOK_TOOL_INTERCEPT_REQUESTED_EVENT",
+    "HOOK_TOOL_INTERCEPT_SCOPE",
+    "HOOK_TOOL_OBSERVE_RECORDED_EVENT",
+    "HOOK_TOOL_OBSERVE_SCOPE",
     "TERMINAL_DEFERRED_HOOK_KINDS",
     "TERMINAL_DEFERRED_HOOK_NAMES",
     "TERMINAL_OBSERVABILITY_HOOK_KINDS",
     "TERMINAL_OBSERVABILITY_HOOK_NAMES",
+    "TOOL_CALL_HOOK_KINDS",
+    "TOOL_CALL_HOOK_NAMES",
     "DeferredHookKind",
     "ExcludedHookKind",
     "HookFailurePolicy",
     "HookKind",
     "is_deferred_hook_kind",
     "is_excluded_hook_kind",
+    "is_hook_tool_call_scope",
+    "is_tool_call_hook_kind",
     "is_hook_lifecycle_scope",
     "is_terminal_deferred_hook_kind",
     "is_terminal_observability_hook_kind",

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -40,15 +40,19 @@ from ouroboros.plugin.hooks import (
     HOOK_LIFECYCLE_POLICY_SCOPE,
     HOOK_LIFECYCLE_READ_SCOPE,
     HOOK_LIFECYCLE_SCOPES,
+    HOOK_TOOL_CALL_AUDIT_EVENTS,
+    HOOK_TOOL_CALL_SCOPES,
     HOOK_TOOL_INTERCEPT_BLOCKED_EVENT,
     HOOK_TOOL_INTERCEPT_COMPLETED_EVENT,
     HOOK_TOOL_INTERCEPT_REQUESTED_EVENT,
+    HOOK_TOOL_INTERCEPT_SCOPE,
     HOOK_TOOL_OBSERVE_RECORDED_EVENT,
     TERMINAL_OBSERVABILITY_HOOK_NAMES,
     HookFailurePolicy,
     HookKind,
     is_deferred_hook_kind,
     is_excluded_hook_kind,
+    is_tool_call_hook_kind,
     is_v1_failure_policy,
     is_v1_hook_kind,
 )
@@ -650,21 +654,44 @@ def _validate_hook_lifecycle_permission(
     manifest_path: str | Path,
     schema_version: str,
 ) -> None:
-    """Require v0.3 lifecycle hooks to declare a v1 lifecycle permission.
+    """Require v0.3 / v0.4 lifecycle and tool-call hooks to declare required permissions.
 
     ``plugin:lifecycle:read`` remains the permission boundary for
     observability hooks, and it must be a required top-level permission
-    before the firewall can dispatch those hooks. Hooks that can veto
-    command execution through ``fail_closed`` must declare the stronger
-    ``plugin:lifecycle:policy`` scope and that scope must also be a
-    required top-level permission, because the firewall trust gate authorizes
-    required top-level permissions before hook dispatch. Enforce this only
-    for the tightened v0.3 hook contract so supported v0.2 manifests keep
-    their compatibility behavior until that schema version is retired
-    deliberately.
+    before the firewall can dispatch those hooks. Lifecycle hooks that
+    can veto command execution through ``fail_closed`` must declare the
+    stronger ``plugin:lifecycle:policy`` scope and that scope must also
+    be a required top-level permission, because the firewall trust gate
+    authorizes required top-level permissions before hook dispatch.
+
+    v0.4 promotes the tool-call hook family (``before_tool_call`` /
+    ``after_tool_call``) into the v1 dispatch vocabulary. The same
+    "required top-level permission" rule applies: tool-call hooks must
+    declare either ``plugin:tool:intercept`` or ``plugin:tool:observe``
+    in ``hooks[].permissions`` *and* the matching scope must also be a
+    required top-level permission. ``before_tool_call`` with
+    ``fail_closed`` additionally requires ``plugin:tool:intercept``
+    specifically — observe-only scope cannot grant veto authority. The
+    schema layer already constrains the per-hook permission list, but
+    only the loader can enforce the ``required=true`` half of the
+    contract; JSON Schema cannot express that condition on a
+    cross-referenced top-level array entry.
+
+    Enforce this only for the tightened v0.3 / v0.4 hook contract so
+    supported v0.2 manifests keep their compatibility behavior until
+    that schema version is retired deliberately.
     """
 
-    if schema_version != "0.3" or not is_v1_hook_kind(raw["name"]):
+    if schema_version not in {"0.3", "0.4"} or not is_v1_hook_kind(raw["name"]):
+        return
+    if is_tool_call_hook_kind(raw["name"]):
+        _validate_tool_call_hook_permission(
+            raw,
+            declared_required_permission_scopes=declared_required_permission_scopes,
+            hook_index=hook_index,
+            manifest_path=manifest_path,
+            schema_version=schema_version,
+        )
         return
     permissions = raw.get("permissions", ())
     if raw["name"] in TERMINAL_OBSERVABILITY_HOOK_NAMES:
@@ -730,6 +757,83 @@ def _validate_hook_lifecycle_permission(
     )
 
 
+def _validate_tool_call_hook_permission(
+    raw: dict[str, Any],
+    *,
+    declared_required_permission_scopes: frozenset[str],
+    hook_index: int,
+    manifest_path: str | Path,
+    schema_version: str,
+) -> None:
+    """Enforce v0.4 tool-call hook trust-boundary permissions at load time.
+
+    The JSON Schema already enforces the per-hook permission list (a
+    ``before_tool_call`` with ``fail_closed`` must carry
+    ``plugin:tool:intercept`` in ``hooks[].permissions``); this loader
+    check is the orthogonal half that JSON Schema cannot express:
+    whichever tool-call scope the hook declares, the same scope must be
+    a top-level *required* permission. Without this, PR F-2's firewall
+    dispatcher — which only inspects required top-level permissions —
+    would invoke a tool-call hook whose authority was granted at
+    install-time as merely optional, bypassing the trust grant
+    boundary.
+
+    Fail-closed tool-call hooks specifically must hold
+    ``plugin:tool:intercept`` as a required top-level permission;
+    ``plugin:tool:observe`` cannot grant veto authority even though it
+    is sufficient for fail-open observation.
+    """
+
+    if schema_version != "0.4":
+        return
+    permissions = raw.get("permissions", ())
+    declared_tool_scopes = HOOK_TOOL_CALL_SCOPES.intersection(permissions)
+    if not declared_tool_scopes:
+        raise PluginManifestError(
+            "v0.4 tool-call hook must declare a tool-call permission",
+            path=str(manifest_path),
+            json_pointer=f"/hooks/{hook_index}/permissions",
+            expected=f"one of {sorted(HOOK_TOOL_CALL_SCOPES)!r} in hooks[].permissions",
+            got=permissions,
+        )
+    if not declared_tool_scopes.intersection(declared_required_permission_scopes):
+        raise PluginManifestError(
+            "v0.4 tool-call hook permission must be required",
+            path=str(manifest_path),
+            json_pointer="/permissions",
+            expected=(
+                "top-level tool-call permission with required=true for one of "
+                f"{sorted(declared_tool_scopes)!r}"
+            ),
+            got=f"required permissions {sorted(declared_required_permission_scopes)!r}",
+        )
+    if raw["failure_policy"] != HookFailurePolicy.FAIL_CLOSED.value:
+        return
+    # fail_closed tool-call hooks must specifically hold
+    # plugin:tool:intercept as a required top-level permission. The
+    # schema already enforces that the per-hook permission list contains
+    # plugin:tool:intercept when fail_closed is used; this enforces the
+    # required=true half so the firewall trust grant cannot be bypassed
+    # by marking the intercept scope optional.
+    if HOOK_TOOL_INTERCEPT_SCOPE not in permissions:
+        raise PluginManifestError(
+            "v0.4 fail_closed tool-call hook must declare plugin:tool:intercept",
+            path=str(manifest_path),
+            json_pointer=f"/hooks/{hook_index}/permissions",
+            expected=f"{HOOK_TOOL_INTERCEPT_SCOPE!r} in hooks[].permissions",
+            got=permissions,
+        )
+    if HOOK_TOOL_INTERCEPT_SCOPE in declared_required_permission_scopes:
+        return
+    raise PluginManifestError(
+        "v0.4 fail_closed tool-call hook intercept permission must be required",
+        path=str(manifest_path),
+        json_pointer="/permissions",
+        expected=f"top-level {HOOK_TOOL_INTERCEPT_SCOPE!r} permission with required=true",
+        got=f"required permissions {sorted(declared_required_permission_scopes)!r}",
+    )
+
+
 def _validate_hook_name(
     name: Any,
     *,
@@ -742,7 +846,10 @@ def _validate_hook_name(
     v0.2 remains a supported manifest schema and its JSON Schema already
     defines the accepted hook-name enum for that version. Preserve that
     compatibility boundary here: v0.2 manifests keep their schema-level
-    contract, while v0.3 gets the tightened v1-only Python guard.
+    contract, while v0.3 / v0.4 get the tightened v1-only Python guard.
+    v0.4 admits the tool-call hook family into the v1 vocabulary, so
+    ``is_v1_hook_kind`` returns True for those names; deferred and
+    excluded names still reject identically.
     """
     json_pointer = f"/hooks/{hook_index}/name"
     if not isinstance(name, str) or not name:
@@ -754,7 +861,7 @@ def _validate_hook_name(
             got=repr(name),
         )
 
-    if schema_version != "0.3" or is_v1_hook_kind(name):
+    if schema_version not in {"0.3", "0.4"} or is_v1_hook_kind(name):
         return
 
     if is_deferred_hook_kind(name):
@@ -802,8 +909,12 @@ def _validate_failure_policy(
     )
 
 
-_OBSERVATION_ONLY_V03_HOOK_NAMES: frozenset[str] = frozenset(
-    {HookKind.AFTER_INVOCATION.value, *TERMINAL_OBSERVABILITY_HOOK_NAMES}
+_OBSERVATION_ONLY_HOOK_NAMES: frozenset[str] = frozenset(
+    {
+        HookKind.AFTER_INVOCATION.value,
+        HookKind.AFTER_TOOL_CALL.value,
+        *TERMINAL_OBSERVABILITY_HOOK_NAMES,
+    }
 )
 
 
@@ -815,27 +926,31 @@ def _validate_after_invocation_policy(
     manifest_path: str | Path,
     schema_version: str,
 ) -> None:
-    """Keep v0.3 observation-only hooks from acquiring veto authority.
+    """Keep v0.3 / v0.4 observation-only hooks from acquiring veto authority.
 
     v0.3 lifecycle permissions are read-only, so terminal observability
     hooks (``after_invocation`` plus the additive ``on_error`` /
     ``on_cancel`` hooks from PR #1131) may observe the completed outcome
     but must not be able to veto or rewrite it through a fail-closed
-    policy. v0.2 compatibility is left unchanged; those hooks load but
-    runtime dispatch remains disabled.
+    policy. v0.4 adds ``after_tool_call`` to the observation-only set:
+    the after-call payload describes a tool result the caller has
+    already observed, so it must be ``fail_open`` (the v0.4 JSON Schema
+    enforces this too; this loader check is defense-in-depth). v0.2
+    compatibility is left unchanged; those hooks load but runtime
+    dispatch remains disabled.
     """
 
     if (
-        schema_version != "0.3"
-        or hook_name not in _OBSERVATION_ONLY_V03_HOOK_NAMES
+        schema_version not in {"0.3", "0.4"}
+        or hook_name not in _OBSERVATION_ONLY_HOOK_NAMES
         or failure_policy != HookFailurePolicy.FAIL_CLOSED.value
     ):
         return
     raise PluginManifestError(
-        f"v0.3 {hook_name} hooks must use fail_open",
+        f"{hook_name} hooks must use fail_open",
         path=str(manifest_path),
         json_pointer=f"/hooks/{hook_index}/failure_policy",
-        expected=f"'fail_open' for v0.3 {hook_name} hooks",
+        expected=f"'fail_open' for {hook_name} hooks",
         got=failure_policy,
     )
 
@@ -860,16 +975,24 @@ def _validate_hook_audit_events(
     complete v0.3 lifecycle vocabulary.
     """
 
-    if schema_version != "0.3" or not audit_was_explicit:
+    if schema_version not in {"0.3", "0.4"} or not audit_was_explicit:
         return
     required_events = set(AuditSpec.standard_four_events().events)
     if hooks:
         required_events.update(HOOK_EVENT_TYPES)
+    # v0.4 additionally reserves the four plugin.tool.* audit event names
+    # whenever a tool-call hook is declared, mirroring
+    # AuditSpec.standard_events_for_schema("0.4"). PR F-1 only reserves
+    # the names; PR F-2 owns emission. Requiring them in an explicit
+    # audit.events block keeps the narrowed runtime contract honest once
+    # dispatch lands, exactly as the v0.3 lifecycle invariant does.
+    if schema_version == "0.4" and any(is_tool_call_hook_kind(hook.name) for hook in hooks):
+        required_events.update(HOOK_TOOL_CALL_AUDIT_EVENTS)
     missing_events = required_events.difference(audit.events)
     if not missing_events:
         return
     raise PluginManifestError(
-        "v0.3 explicit audit.events must include every runtime-emitted event",
+        "explicit audit.events must include every runtime-emitted event",
         path=str(manifest_path),
         json_pointer="/audit/events",
         expected=f"events including {sorted(required_events)!r}",

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -40,6 +40,10 @@ from ouroboros.plugin.hooks import (
     HOOK_LIFECYCLE_POLICY_SCOPE,
     HOOK_LIFECYCLE_READ_SCOPE,
     HOOK_LIFECYCLE_SCOPES,
+    HOOK_TOOL_INTERCEPT_BLOCKED_EVENT,
+    HOOK_TOOL_INTERCEPT_COMPLETED_EVENT,
+    HOOK_TOOL_INTERCEPT_REQUESTED_EVENT,
+    HOOK_TOOL_OBSERVE_RECORDED_EVENT,
     TERMINAL_OBSERVABILITY_HOOK_NAMES,
     HookFailurePolicy,
     HookKind,
@@ -60,8 +64,13 @@ except ImportError as exc:  # pragma: no cover
 # Support window per Q00/ouroboros-plugins#11 lock: current MAJOR + previous MAJOR.
 # v0.1 is the archived base manifest contract; v0.2 is the local extension
 # that adds optional hook declarations; v0.3 narrows hooks[].name to the
-# v1 ``HookKind`` vocabulary at the JSON Schema layer.
-SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("0.1", "0.2", "0.3")
+# v1 ``HookKind`` vocabulary at the JSON Schema layer; v0.4 promotes the
+# tool-call hook family (``before_tool_call`` / ``after_tool_call``) into
+# the same JSON Schema enum and reserves the matching ``plugin.tool.*``
+# audit event names. Runtime dispatch of tool-call hooks is still
+# deferred to #939 PR F-2; v0.4 manifests may declare them but the
+# firewall will not invoke them until that follow-up ships.
+SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("0.1", "0.2", "0.3", "0.4")
 
 # Source types whose `path` must be a sandboxed relative slug — no absolute
 # paths and no parent-directory traversal. `local_path` resolves relative to
@@ -191,6 +200,24 @@ class AuditSpec:
                     HOOK_COMPLETED_EVENT,
                     HOOK_BLOCKED_EVENT,
                     HOOK_FAILED_EVENT,
+                )
+            )
+        if schema_version == "0.4":
+            # v0.4 keeps the v0.3 hook event family and additively
+            # reserves the four ``plugin.tool.*`` event names locked
+            # in ``docs/rfc/plugin-tool-call-hook-contract.md`` § 6.
+            # PR F-1 only reserves the names; PR F-2 owns emission.
+            return AuditSpec(
+                events=(
+                    *AuditSpec.standard_four_events().events,
+                    HOOK_INVOKED_EVENT,
+                    HOOK_COMPLETED_EVENT,
+                    HOOK_BLOCKED_EVENT,
+                    HOOK_FAILED_EVENT,
+                    HOOK_TOOL_INTERCEPT_REQUESTED_EVENT,
+                    HOOK_TOOL_INTERCEPT_COMPLETED_EVENT,
+                    HOOK_TOOL_INTERCEPT_BLOCKED_EVENT,
+                    HOOK_TOOL_OBSERVE_RECORDED_EVENT,
                 )
             )
         return AuditSpec.standard_four_events()

--- a/src/ouroboros/plugin/schemas/0.4/_source.json
+++ b/src/ouroboros/plugin/schemas/0.4/_source.json
@@ -1,0 +1,20 @@
+{
+  "source": "Q00/ouroboros",
+  "purpose": "Local plugin manifest schema v0.4: promotes the tool-call hook family (`before_tool_call` / `after_tool_call`) from the v0.3 deferred bucket into the v1 dispatch vocabulary so plugins can declare them in a manifest. This is the contract-only half of #939 PR F (PR F-1); runtime dispatch wiring lands in a follow-up slice (PR F-2).",
+  "note": "Iterates on local 0.3 by adding the two tool-call hook names to hooks[].name; adding plugin:tool:intercept / plugin:tool:observe to hooks[].permissions; constraining after_tool_call to failure_policy='fail_open' (mirrors after_invocation / on_error / on_cancel); allowing before_tool_call to declare fail_closed only when permissions contain plugin:tool:intercept (mirrors the lifecycle:policy gate); and expanding audit.events with the four reserved plugin.tool.* event names from docs/rfc/plugin-tool-call-hook-contract.md §6. v0.3 manifests are unaffected. Tool-call hook dispatch is NOT enabled by this schema bump — declaring a tool-call hook in a v0.4 manifest is currently a no-op at runtime, and the firewall will not invoke it until PR F-2 ships. Deferred artifact/state hook names (before_artifact_write, after_artifact_write, before_state_commit, after_state_commit) and the excluded `on_event` / `on_rewind` family remain rejected at the v0.4 schema layer; their contract lives in docs/rfc/plugin-artifact-state-hook-contract.md and they will land under a future schema version owned by PR G.",
+  "local_extensions": {
+    "plugin.schema.json": [
+      "Bumped $id/title/schema_version const from 0.3 to 0.4.",
+      "Expanded hooks[].name enum to include 'before_tool_call' and 'after_tool_call' from src/ouroboros/plugin/hooks.py HookKind (promoted out of DeferredHookKind by the same PR F-1 slice).",
+      "Expanded hooks[].permissions enum to include 'plugin:tool:intercept' and 'plugin:tool:observe', and broadened the anyOf clause so a manifest hook permission list may contain any non-empty subset of lifecycle/tool scopes appropriate to its hook name.",
+      "Added an if/then rule constraining 'after_tool_call' hooks to failure_policy='fail_open' at the schema layer, matching the §5 contract: observation-only after_tool_call hooks must not mask the underlying tool result.",
+      "Refined the fail_closed gate: fail_closed lifecycle hooks must still declare plugin:lifecycle:policy; fail_closed tool-call hooks must declare plugin:tool:intercept. This is encoded as two parallel if/then clauses keyed on the hook name family so the v0.3 lifecycle invariant is preserved verbatim.",
+      "Added the four reserved tool-call audit event names (plugin.tool.intercept.requested, plugin.tool.intercept.completed, plugin.tool.intercept.blocked, plugin.tool.observe.recorded) to audit.events. The runtime emission of these events is deferred to PR F-2; manifests may declare them in v0.4 but no dispatcher emits them yet.",
+      "Preserved every other v0.3 invariant verbatim: source/path sandboxing, command shape, capabilities/permissions structure, entrypoint contract, command-level AgentOS metadata, and x-* extension property pattern.",
+      "Deferred artifact/state hook names (before_artifact_write, after_artifact_write, before_state_commit, after_state_commit) and excluded names (on_event, on_rewind, before_runtime_start, after_runtime_start, before_state_commit, after_state_commit) remain rejected by the schema enum; see docs/rfc/plugin-artifact-state-hook-contract.md for the future PR G contract."
+    ],
+    "audit-event.schema.json": [
+      "Vendored audit-event.schema.json with local 0.4 $id/title/schema_version alignment and the four additive tool-call event names: plugin.tool.intercept.requested, plugin.tool.intercept.completed, plugin.tool.intercept.blocked, plugin.tool.observe.recorded. These are reserved names — emission lands in PR F-2's dispatcher."
+    ]
+  }
+}

--- a/src/ouroboros/plugin/schemas/0.4/audit-event.schema.json
+++ b/src/ouroboros/plugin/schemas/0.4/audit-event.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Q00/ouroboros/schemas/local/0.4/audit-event.schema.json",
+  "title": "Ouroboros Plugin Audit Event (v0.4)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_type",
+    "occurred_at",
+    "plugin",
+    "command",
+    "trust_state",
+    "capabilities_used",
+    "permissions_used",
+    "result"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.4"
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "plugin.discovered",
+        "plugin.installed",
+        "plugin.trusted",
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.completed",
+        "plugin.failed",
+        "plugin.hook.invoked",
+        "plugin.hook.completed",
+        "plugin.hook.blocked",
+        "plugin.hook.failed",
+        "plugin.tool.intercept.requested",
+        "plugin.tool.intercept.completed",
+        "plugin.tool.intercept.blocked",
+        "plugin.tool.observe.recorded"
+      ]
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "plugin": {
+      "type": "object",
+      "required": ["name", "version", "source_type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "source_type": {
+          "type": "string",
+          "enum": ["local_path", "plugin_home", "first_party"]
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "required": ["namespace", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "namespace": { "type": "string" },
+        "name": { "type": "string" },
+        "argv": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "argv_summary": {
+          "type": "object",
+          "description": "Bounded fingerprint of argv added in step 1 of the audit-fidelity plan. Lets operators size the actual distribution before any cap is chosen and lets consumers correlate identical invocations by sha without dragging the full payload through the index. The argv field itself is unchanged in this step.",
+          "required": ["argc", "byte_length", "sha256"],
+          "additionalProperties": false,
+          "properties": {
+            "argc": { "type": "integer", "minimum": 0 },
+            "byte_length": { "type": "integer", "minimum": 0 },
+            "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+          }
+        }
+      }
+    },
+    "trust_state": {
+      "type": "string",
+      "enum": ["discovered", "installed", "trusted", "disabled", "blocked", "first_party"]
+    },
+    "capabilities_used": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "permissions_used": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "result": {
+      "type": "object",
+      "required": ["status"],
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["success", "blocked", "failed", "trust_subject_changed"]
+        },
+        "message": { "type": "string" }
+      }
+    }
+  }
+}

--- a/src/ouroboros/plugin/schemas/0.4/plugin.schema.json
+++ b/src/ouroboros/plugin/schemas/0.4/plugin.schema.json
@@ -1,0 +1,513 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Q00/ouroboros/schemas/local/0.4/plugin.schema.json",
+  "title": "Ouroboros Plugin Manifest (v0.4)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "name",
+    "version",
+    "source",
+    "commands",
+    "capabilities",
+    "permissions",
+    "entrypoint"
+  ],
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[a-z0-9][a-z0-9-]*$": {
+      "type": "object",
+      "description": "Namespaced extension metadata accepted for forward-compatible loaders."
+    }
+  },
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.4"
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "description": {
+      "type": "string",
+      "default": ""
+    },
+    "source": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["local_path", "plugin_home", "first_party"]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {"type": {"const": "local_path"}},
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["type", "path"]
+          }
+        },
+        {
+          "if": {
+            "properties": {"type": {"const": "plugin_home"}},
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["type", "path"]
+          }
+        }
+      ]
+    },
+    "commands": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["namespace", "name", "summary", "usage", "risk"],
+        "additionalProperties": false,
+        "patternProperties": {
+          "^x-[a-z0-9][a-z0-9-]*$": {
+            "type": "object",
+            "description": "Namespaced command extension metadata accepted for forward-compatible loaders."
+          }
+        },
+        "properties": {
+          "namespace": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$"
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "usage": {
+            "type": "string",
+            "minLength": 1
+          },
+          "risk": {
+            "type": "string",
+            "enum": ["read_only", "write", "destructive"]
+          },
+          "requires_confirmation": {
+            "type": "boolean",
+            "default": false
+          },
+          "arguments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name", "type", "required"],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "pattern": "^[a-z][a-z0-9_-]*$"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": ["string", "boolean", "integer", "path", "url"]
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "permissions": {
+            "type": "array",
+            "description": "Command-specific permission scopes. Every scope must also be declared in top-level permissions[].scope so the core trust boundary remains authoritative.",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9:-]*$"
+            },
+            "uniqueItems": true
+          },
+          "upstream": {
+            "type": "object",
+            "description": "Opaque upstream capability/source metadata for AgentOS assimilation. Preserved by loaders but not trusted for execution policy.",
+            "additionalProperties": true
+          },
+          "artifacts": {
+            "type": "object",
+            "description": "Opaque artifact contract hints for AgentOS assimilation. Preserved by loaders but not trusted for path authorization.",
+            "additionalProperties": true
+          },
+          "handoff": {
+            "type": "object",
+            "description": "Opaque handoff contract hints for AgentOS continuation. Preserved by loaders but not trusted for dispatch.",
+            "additionalProperties": true
+          },
+          "timeout_seconds": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 86400,
+            "description": "Command timeout hint in seconds; dispatchers may apply a stricter runtime cap."
+          },
+          "result_states": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["completed", "blocked", "failed", "cancelled"]
+            },
+            "uniqueItems": true,
+            "minItems": 1,
+            "description": "Declared terminal states the command adapter may emit."
+          },
+          "redaction": {
+            "type": "object",
+            "description": "Opaque redaction policy hints for produced artifacts/provenance.",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "access"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "seed",
+              "ledger",
+              "state",
+              "provenance",
+              "runtime",
+              "mcp",
+              "handoff",
+              "progress"
+            ]
+          },
+          "access": {
+            "type": "string",
+            "enum": ["read", "write", "execute", "attach"]
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "permissions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["scope", "risk", "required"],
+        "additionalProperties": false,
+        "properties": {
+          "scope": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_-]*(?::[a-z][a-z0-9_-]*){0,3}$"
+          },
+          "risk": {
+            "type": "string",
+            "enum": ["read_only", "write", "destructive"]
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "entrypoint": {
+      "type": "object",
+      "required": ["type", "command"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "command"
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "required": ["events"],
+      "additionalProperties": false,
+      "default": {
+        "events": [
+          "plugin.invoked",
+          "plugin.permission_used",
+          "plugin.completed",
+          "plugin.failed",
+          "plugin.hook.invoked",
+          "plugin.hook.completed",
+          "plugin.hook.blocked",
+          "plugin.hook.failed",
+          "plugin.tool.intercept.requested",
+          "plugin.tool.intercept.completed",
+          "plugin.tool.intercept.blocked",
+          "plugin.tool.observe.recorded"
+        ]
+      },
+      "properties": {
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "plugin.discovered",
+              "plugin.installed",
+              "plugin.trusted",
+              "plugin.invoked",
+              "plugin.permission_used",
+              "plugin.completed",
+              "plugin.failed",
+              "plugin.hook.invoked",
+              "plugin.hook.completed",
+              "plugin.hook.blocked",
+              "plugin.hook.failed",
+              "plugin.tool.intercept.requested",
+              "plugin.tool.intercept.completed",
+              "plugin.tool.intercept.blocked",
+              "plugin.tool.observe.recorded"
+            ]
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "hooks": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "required": ["name", "entrypoint", "failure_policy", "permissions"],
+        "additionalProperties": false,
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "name": {
+                  "const": "after_invocation"
+                }
+              },
+              "required": ["name"]
+            },
+            "then": {
+              "properties": {
+                "failure_policy": {
+                  "const": "fail_open"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "name": {
+                  "const": "on_error"
+                }
+              },
+              "required": ["name"]
+            },
+            "then": {
+              "properties": {
+                "failure_policy": {
+                  "const": "fail_open"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "name": {
+                  "const": "on_cancel"
+                }
+              },
+              "required": ["name"]
+            },
+            "then": {
+              "properties": {
+                "failure_policy": {
+                  "const": "fail_open"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "name": {
+                  "const": "after_tool_call"
+                }
+              },
+              "required": ["name"]
+            },
+            "then": {
+              "properties": {
+                "failure_policy": {
+                  "const": "fail_open"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "name": {
+                  "enum": [
+                    "before_invocation",
+                    "after_invocation",
+                    "on_error",
+                    "on_cancel"
+                  ]
+                },
+                "failure_policy": {
+                  "const": "fail_closed"
+                }
+              },
+              "required": ["name", "failure_policy"]
+            },
+            "then": {
+              "properties": {
+                "permissions": {
+                  "contains": {
+                    "const": "plugin:lifecycle:policy"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "name": {
+                  "const": "before_tool_call"
+                },
+                "failure_policy": {
+                  "const": "fail_closed"
+                }
+              },
+              "required": ["name", "failure_policy"]
+            },
+            "then": {
+              "properties": {
+                "permissions": {
+                  "contains": {
+                    "const": "plugin:tool:intercept"
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "before_invocation",
+              "after_invocation",
+              "on_error",
+              "on_cancel",
+              "before_tool_call",
+              "after_tool_call"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "entrypoint": {
+            "type": "object",
+            "required": ["type", "command"],
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "command"
+              },
+              "command": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "plugin:lifecycle:read",
+                "plugin:lifecycle:policy",
+                "plugin:tool:intercept",
+                "plugin:tool:observe"
+              ]
+            },
+            "anyOf": [
+              {
+                "contains": {
+                  "const": "plugin:lifecycle:read"
+                }
+              },
+              {
+                "contains": {
+                  "const": "plugin:lifecycle:policy"
+                }
+              },
+              {
+                "contains": {
+                  "const": "plugin:tool:intercept"
+                }
+              },
+              {
+                "contains": {
+                  "const": "plugin:tool:observe"
+                }
+              }
+            ],
+            "uniqueItems": true,
+            "default": []
+          },
+          "timeout_seconds": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 300
+          },
+          "failure_policy": {
+            "type": "string",
+            "enum": ["fail_open", "fail_closed"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/unit/plugin/test_hooks_contract.py
+++ b/tests/unit/plugin/test_hooks_contract.py
@@ -44,13 +44,18 @@ from ouroboros.plugin.hooks import (
 
 class TestHookKindEnumeration:
     def test_v1_hook_set_is_exact(self) -> None:
-        # PR #1131 promotes the terminal observability hooks into v1 so
-        # ``HookKind`` now lists exactly four "Included" hooks.
+        # PR #1131 promoted the terminal observability hooks into v1, and
+        # #939 PR F-1 additionally promoted the tool-call hook family
+        # (before_tool_call / after_tool_call) so ``HookKind`` now lists
+        # exactly six "Included" hooks for v0.4 manifests. Runtime
+        # dispatch of the tool-call hooks is still deferred to PR F-2.
         assert {kind.value for kind in HookKind} == {
             "before_invocation",
             "after_invocation",
             "on_error",
             "on_cancel",
+            "before_tool_call",
+            "after_tool_call",
         }
 
     def test_terminal_observability_hook_set_is_exact(self) -> None:
@@ -69,10 +74,11 @@ class TestHookKindEnumeration:
 
     def test_deferred_hook_set_is_exact(self) -> None:
         # ``on_error`` / ``on_cancel`` were lifted out of the deferred
-        # bucket by PR #1131; the remaining names stay deferred.
+        # bucket by PR #1131, and ``before_tool_call`` / ``after_tool_call``
+        # by #939 PR F-1. The remaining artifact-write names stay
+        # deferred under #939 PR G (gated on the write-side substrate
+        # from #946 / #956).
         assert {kind.value for kind in DeferredHookKind} == {
-            "before_tool_call",
-            "after_tool_call",
             "before_artifact_write",
             "after_artifact_write",
         }
@@ -133,8 +139,11 @@ class TestRoutingHelpers:
         # Terminal observability hooks were promoted into v1 by PR #1131.
         assert is_v1_hook_kind("on_error")
         assert is_v1_hook_kind("on_cancel")
-        assert not is_v1_hook_kind("before_tool_call")
+        # Tool-call hooks were promoted into v1 by #939 PR F-1.
+        assert is_v1_hook_kind("before_tool_call")
+        assert is_v1_hook_kind("after_tool_call")
         assert not is_v1_hook_kind("on_event")
+        assert not is_v1_hook_kind("before_artifact_write")
         assert not is_v1_hook_kind("unknown_hook")
 
     def test_terminal_deferred_hook_kind_router_is_empty(self) -> None:
@@ -154,13 +163,17 @@ class TestRoutingHelpers:
         assert not is_terminal_observability_hook_kind("unknown_hook")
 
     def test_deferred_hook_kind_router(self) -> None:
-        assert is_deferred_hook_kind("before_tool_call")
+        assert is_deferred_hook_kind("before_artifact_write")
         assert is_deferred_hook_kind("after_artifact_write")
         assert not is_deferred_hook_kind("before_invocation")
         assert not is_deferred_hook_kind("on_event")
         # on_error / on_cancel are no longer deferred.
         assert not is_deferred_hook_kind("on_error")
         assert not is_deferred_hook_kind("on_cancel")
+        # before_tool_call / after_tool_call were promoted into v1 by
+        # #939 PR F-1 and are no longer deferred.
+        assert not is_deferred_hook_kind("before_tool_call")
+        assert not is_deferred_hook_kind("after_tool_call")
 
     def test_excluded_hook_kind_router(self) -> None:
         assert is_excluded_hook_kind("before_runtime_start")

--- a/tests/unit/plugin/test_manifest_schema_0_4.py
+++ b/tests/unit/plugin/test_manifest_schema_0_4.py
@@ -402,3 +402,144 @@ class TestV04AuditEventDefaultForLoader:
         default_events = tuple(schema["properties"]["audit"]["default"]["events"])
         loader_events = AuditSpec.standard_events_for_schema("0.4").events
         assert default_events == loader_events
+
+
+def _set_permission_required(payload: dict, scope: str, required: bool) -> None:
+    """Flip the ``required`` flag on a top-level permission entry in place."""
+    for permission in payload["permissions"]:
+        if permission["scope"] == scope:
+            permission["required"] = required
+            return
+    raise AssertionError(f"scope {scope!r} not present in manifest permissions")
+
+
+class TestV04LoaderRequiredPermissions:
+    """Loader-level trust-boundary checks the JSON Schema cannot express.
+
+    The v0.4 JSON Schema enforces *which* permission scope a hook must
+    list in ``hooks[].permissions``, but only the loader can enforce
+    that the same scope is declared ``required=true`` at the top level.
+    PR F-2's firewall dispatcher authorizes required top-level
+    permissions before invoking a hook, so a hook whose authority is
+    granted as merely optional would bypass the trust grant boundary
+    once dispatch lands. These tests lock that enforcement now, at the
+    contract-only stage, so F-2 ships against a frozen invariant.
+    """
+
+    def test_v04_lifecycle_fail_closed_requires_required_policy_permission(
+        self, tmp_path: Path
+    ) -> None:
+        # v0.3 invariant must hold for v0.4: a fail_closed lifecycle hook
+        # whose plugin:lifecycle:policy scope is optional is rejected.
+        payload = _v04_manifest()
+        payload["hooks"] = [_lifecycle_hook(name="before_invocation", failure_policy="fail_closed")]
+        _set_permission_required(payload, HOOK_LIFECYCLE_POLICY_SCOPE, False)
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        assert exc_info.value.json_pointer == "/permissions"
+
+    def test_v04_before_tool_call_fail_closed_requires_required_intercept(
+        self, tmp_path: Path
+    ) -> None:
+        payload = _v04_manifest()
+        payload["hooks"] = [_tool_call_hook(name="before_tool_call", failure_policy="fail_closed")]
+        _set_permission_required(payload, HOOK_TOOL_INTERCEPT_SCOPE, False)
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        assert exc_info.value.json_pointer == "/permissions"
+
+    def test_v04_observe_tool_call_requires_required_observe(self, tmp_path: Path) -> None:
+        # An observe-only after_tool_call hook still needs its
+        # plugin:tool:observe scope to be a required top-level permission.
+        payload = _v04_manifest()
+        payload["hooks"] = [
+            _tool_call_hook(
+                name="after_tool_call",
+                failure_policy="fail_open",
+                scope=HOOK_TOOL_OBSERVE_SCOPE,
+            )
+        ]
+        _set_permission_required(payload, HOOK_TOOL_OBSERVE_SCOPE, False)
+        _set_permission_required(payload, HOOK_TOOL_INTERCEPT_SCOPE, False)
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        assert exc_info.value.json_pointer == "/permissions"
+
+    def test_v04_tool_call_required_permission_accepted(self, tmp_path: Path) -> None:
+        # Positive control: with the intercept scope required (the
+        # _v04_manifest default), a fail_closed tool-call hook loads.
+        payload = _v04_manifest()
+        payload["hooks"] = [_tool_call_hook(name="before_tool_call", failure_policy="fail_closed")]
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.hooks[0].name == HookKind.BEFORE_TOOL_CALL.value
+
+
+class TestV04ExplicitAuditEventsLoader:
+    """v0.4 explicit audit.events must stay aligned with runtime-emitted events.
+
+    Mirrors the v0.3 invariant: when a manifest narrows ``audit.events``
+    explicitly, the list becomes the runtime contract and must include
+    every event the firewall would emit for the declared hooks. v0.4
+    additionally requires the four reserved ``plugin.tool.*`` names when
+    a tool-call hook is declared.
+    """
+
+    def test_v04_lifecycle_hook_partial_audit_events_rejected(self, tmp_path: Path) -> None:
+        payload = _v04_manifest()
+        payload["hooks"] = [_lifecycle_hook(name="before_invocation", failure_policy="fail_closed")]
+        # Core events only — omits the plugin.hook.* family the firewall
+        # emits for a declared lifecycle hook.
+        payload["audit"] = {
+            "events": [
+                "plugin.invoked",
+                "plugin.permission_used",
+                "plugin.completed",
+                "plugin.failed",
+            ]
+        }
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        assert exc_info.value.json_pointer == "/audit/events"
+
+    def test_v04_tool_call_hook_partial_audit_events_rejected(self, tmp_path: Path) -> None:
+        payload = _v04_manifest()
+        payload["hooks"] = [_tool_call_hook(name="before_tool_call", failure_policy="fail_closed")]
+        # Has the lifecycle hook events but omits the reserved
+        # plugin.tool.* names required when a tool-call hook is declared.
+        payload["audit"] = {
+            "events": [
+                "plugin.invoked",
+                "plugin.permission_used",
+                "plugin.completed",
+                "plugin.failed",
+                "plugin.hook.invoked",
+                "plugin.hook.completed",
+                "plugin.hook.blocked",
+                "plugin.hook.failed",
+            ]
+        }
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        assert exc_info.value.json_pointer == "/audit/events"
+
+    def test_v04_tool_call_hook_complete_audit_events_accepted(self, tmp_path: Path) -> None:
+        payload = _v04_manifest()
+        payload["hooks"] = [_tool_call_hook(name="before_tool_call", failure_policy="fail_closed")]
+        payload["audit"] = {
+            "events": [
+                "plugin.invoked",
+                "plugin.permission_used",
+                "plugin.completed",
+                "plugin.failed",
+                "plugin.hook.invoked",
+                "plugin.hook.completed",
+                "plugin.hook.blocked",
+                "plugin.hook.failed",
+                HOOK_TOOL_INTERCEPT_REQUESTED_EVENT,
+                HOOK_TOOL_INTERCEPT_COMPLETED_EVENT,
+                HOOK_TOOL_INTERCEPT_BLOCKED_EVENT,
+                HOOK_TOOL_OBSERVE_RECORDED_EVENT,
+            ]
+        }
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert HOOK_TOOL_INTERCEPT_REQUESTED_EVENT in manifest.audit.events

--- a/tests/unit/plugin/test_manifest_schema_0_4.py
+++ b/tests/unit/plugin/test_manifest_schema_0_4.py
@@ -1,0 +1,404 @@
+"""Schema-layer tests for the v0.4 plugin manifest (#939 PR F-1).
+
+v0.4 promotes the tool-call hook family
+(``before_tool_call`` / ``after_tool_call``) into the v1 ``HookKind``
+vocabulary and adds the matching permission scopes
+(``plugin:tool:intercept`` / ``plugin:tool:observe``) plus the four
+reserved ``plugin.tool.*`` audit event names locked in
+``docs/rfc/plugin-tool-call-hook-contract.md``.
+
+What this test file covers:
+
+* v0.4 manifests with lifecycle hooks still load (backward compatible).
+* v0.4 manifests with tool-call hooks load when permission / failure
+  policy combinations match the schema rules.
+* v0.4 manifests with tool-call hooks fail at the schema layer when
+  permission / failure policy combinations violate the rules.
+* v0.4 schema still rejects deferred artifact/state and excluded
+  hook names at ``/hooks/0/name``.
+* v0.3 manifests continue to reject tool-call hook names — PR F-1
+  does not retroactively relax v0.3 behavior.
+* ``standard_events_for_schema("0.4")`` returns the expanded event
+  tuple that includes the four ``plugin.tool.*`` reserved names.
+
+Runtime dispatch wiring lands in PR F-2; these tests only assert the
+manifest-layer contract.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.hooks import (
+    HOOK_LIFECYCLE_POLICY_SCOPE,
+    HOOK_LIFECYCLE_READ_SCOPE,
+    HOOK_TOOL_CALL_AUDIT_EVENTS,
+    HOOK_TOOL_INTERCEPT_BLOCKED_EVENT,
+    HOOK_TOOL_INTERCEPT_COMPLETED_EVENT,
+    HOOK_TOOL_INTERCEPT_REQUESTED_EVENT,
+    HOOK_TOOL_INTERCEPT_SCOPE,
+    HOOK_TOOL_OBSERVE_RECORDED_EVENT,
+    HOOK_TOOL_OBSERVE_SCOPE,
+    HookKind,
+)
+from ouroboros.plugin.manifest import (
+    SUPPORTED_SCHEMA_VERSIONS,
+    AuditSpec,
+    PluginManifestError,
+    load_manifest,
+)
+from tests.unit.plugin.test_manifest import REFERENCE_MANIFEST
+
+
+def _v04_manifest() -> dict:
+    payload = deepcopy(REFERENCE_MANIFEST)
+    payload["schema_version"] = "0.4"
+    payload["permissions"].append(
+        {
+            "scope": HOOK_LIFECYCLE_READ_SCOPE,
+            "risk": "read_only",
+            "required": True,
+            "reason": "Allow v1 lifecycle hook observation.",
+        }
+    )
+    payload["permissions"].append(
+        {
+            "scope": HOOK_LIFECYCLE_POLICY_SCOPE,
+            "risk": "read_only",
+            "required": True,
+            "reason": "Allow v1 lifecycle hook policy decisions.",
+        }
+    )
+    # PR F-1: tool-call hook permission scopes must also be declared as
+    # top-level permissions so the firewall trust boundary remains
+    # authoritative once PR F-2 wires runtime dispatch.
+    payload["permissions"].append(
+        {
+            "scope": HOOK_TOOL_INTERCEPT_SCOPE,
+            "risk": "write",
+            "required": True,
+            "reason": "Allow tool-call interception by lifecycle hooks.",
+        }
+    )
+    payload["permissions"].append(
+        {
+            "scope": HOOK_TOOL_OBSERVE_SCOPE,
+            "risk": "read_only",
+            "required": True,
+            "reason": "Allow tool-call observation by lifecycle hooks.",
+        }
+    )
+    return payload
+
+
+def _v03_manifest_for_negative_test() -> dict:
+    """v0.3 manifest for regression tests that v0.3 still rejects tool-call names."""
+
+    payload = deepcopy(REFERENCE_MANIFEST)
+    payload["schema_version"] = "0.3"
+    payload["permissions"].append(
+        {
+            "scope": HOOK_LIFECYCLE_READ_SCOPE,
+            "risk": "read_only",
+            "required": True,
+            "reason": "Allow v1 lifecycle hook observation.",
+        }
+    )
+    payload["permissions"].append(
+        {
+            "scope": HOOK_LIFECYCLE_POLICY_SCOPE,
+            "risk": "read_only",
+            "required": True,
+            "reason": "Allow v1 lifecycle hook policy decisions.",
+        }
+    )
+    return payload
+
+
+def _write(tmp_path: Path, payload: dict) -> Path:
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_text(json.dumps(payload))
+    return target
+
+
+def _lifecycle_hook(name: str = "before_invocation", failure_policy: str = "fail_closed") -> dict:
+    return {
+        "name": name,
+        "description": "Inspect invocation metadata.",
+        "entrypoint": {
+            "type": "command",
+            "command": "python -m plugin_hooks before",
+        },
+        "permissions": [
+            HOOK_LIFECYCLE_POLICY_SCOPE
+            if failure_policy == "fail_closed"
+            else HOOK_LIFECYCLE_READ_SCOPE
+        ],
+        "failure_policy": failure_policy,
+        "timeout_seconds": 5,
+    }
+
+
+def _tool_call_hook(
+    name: str = "before_tool_call",
+    failure_policy: str = "fail_closed",
+    scope: str | None = None,
+) -> dict:
+    if scope is None:
+        scope = (
+            HOOK_TOOL_INTERCEPT_SCOPE
+            if failure_policy == "fail_closed"
+            else HOOK_TOOL_OBSERVE_SCOPE
+        )
+    return {
+        "name": name,
+        "description": "Observe (or gate) a plugin-mediated tool call.",
+        "entrypoint": {
+            "type": "command",
+            "command": "python -m plugin_hooks tool_call",
+        },
+        "permissions": [scope],
+        "failure_policy": failure_policy,
+        "timeout_seconds": 5,
+    }
+
+
+class TestSupportedSchemaVersions:
+    def test_0_4_included_in_support_window(self) -> None:
+        assert "0.4" in SUPPORTED_SCHEMA_VERSIONS
+
+    def test_0_3_remains_supported(self) -> None:
+        # v0.3 must stay supported during the transition.
+        assert "0.3" in SUPPORTED_SCHEMA_VERSIONS
+
+
+class TestV04LifecycleBackwardCompatibility:
+    """v0.4 manifests must still accept the v0.3 lifecycle hook contract."""
+
+    def test_before_invocation_accepted(self, tmp_path: Path) -> None:
+        payload = _v04_manifest()
+        payload["hooks"] = [_lifecycle_hook(name="before_invocation")]
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.schema_version == "0.4"
+        assert manifest.hooks[0].name == "before_invocation"
+
+    def test_after_invocation_fail_open_accepted(self, tmp_path: Path) -> None:
+        payload = _v04_manifest()
+        payload["hooks"] = [_lifecycle_hook(name="after_invocation", failure_policy="fail_open")]
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.hooks[0].name == "after_invocation"
+
+    def test_on_error_fail_open_accepted(self, tmp_path: Path) -> None:
+        payload = _v04_manifest()
+        payload["hooks"] = [_lifecycle_hook(name="on_error", failure_policy="fail_open")]
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.hooks[0].name == "on_error"
+
+
+class TestV04ToolCallHookEnum:
+    """v0.4 manifests accept the tool-call hook names at the schema layer."""
+
+    def test_before_tool_call_intercept_fail_closed_accepted(self, tmp_path: Path) -> None:
+        payload = _v04_manifest()
+        payload["hooks"] = [_tool_call_hook(name="before_tool_call", failure_policy="fail_closed")]
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.schema_version == "0.4"
+        assert manifest.hooks[0].name == HookKind.BEFORE_TOOL_CALL.value
+        assert manifest.hooks[0].failure_policy == "fail_closed"
+        assert HOOK_TOOL_INTERCEPT_SCOPE in manifest.hooks[0].permissions
+
+    def test_before_tool_call_intercept_fail_open_accepted(self, tmp_path: Path) -> None:
+        # `plugin:tool:intercept` may opt down to `fail_open` per §5 of the contract.
+        payload = _v04_manifest()
+        payload["hooks"] = [
+            _tool_call_hook(
+                name="before_tool_call",
+                failure_policy="fail_open",
+                scope=HOOK_TOOL_INTERCEPT_SCOPE,
+            )
+        ]
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.hooks[0].failure_policy == "fail_open"
+
+    def test_before_tool_call_observe_only_fail_open_accepted(self, tmp_path: Path) -> None:
+        payload = _v04_manifest()
+        payload["hooks"] = [
+            _tool_call_hook(
+                name="before_tool_call",
+                failure_policy="fail_open",
+                scope=HOOK_TOOL_OBSERVE_SCOPE,
+            )
+        ]
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.hooks[0].permissions == (HOOK_TOOL_OBSERVE_SCOPE,)
+
+    def test_after_tool_call_observe_fail_open_accepted(self, tmp_path: Path) -> None:
+        payload = _v04_manifest()
+        payload["hooks"] = [
+            _tool_call_hook(
+                name="after_tool_call",
+                failure_policy="fail_open",
+                scope=HOOK_TOOL_OBSERVE_SCOPE,
+            )
+        ]
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert manifest.hooks[0].name == HookKind.AFTER_TOOL_CALL.value
+
+
+class TestV04ToolCallSchemaRules:
+    """v0.4 schema constraints on failure_policy and permissions."""
+
+    def test_after_tool_call_fail_closed_rejected(self, tmp_path: Path) -> None:
+        # after_tool_call is observation-only — fail_closed is rejected.
+        payload = _v04_manifest()
+        payload["hooks"] = [
+            _tool_call_hook(
+                name="after_tool_call",
+                failure_policy="fail_closed",
+                scope=HOOK_TOOL_INTERCEPT_SCOPE,
+            )
+        ]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        assert exc_info.value.json_pointer == "/hooks/0/failure_policy"
+
+    def test_before_tool_call_fail_closed_without_intercept_rejected(self, tmp_path: Path) -> None:
+        # fail_closed before_tool_call must declare plugin:tool:intercept.
+        payload = _v04_manifest()
+        payload["hooks"] = [
+            _tool_call_hook(
+                name="before_tool_call",
+                failure_policy="fail_closed",
+                scope=HOOK_TOOL_OBSERVE_SCOPE,
+            )
+        ]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        assert exc_info.value.json_pointer == "/hooks/0/permissions"
+
+    def test_lifecycle_fail_closed_still_requires_lifecycle_policy(self, tmp_path: Path) -> None:
+        # The v0.3 invariant must remain — a lifecycle fail_closed hook
+        # cannot satisfy the gate with a tool-call permission scope.
+        payload = _v04_manifest()
+        payload["hooks"] = [_lifecycle_hook(name="before_invocation", failure_policy="fail_closed")]
+        payload["hooks"][0]["permissions"] = [HOOK_TOOL_INTERCEPT_SCOPE]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        assert exc_info.value.json_pointer == "/hooks/0/permissions"
+
+
+class TestV04DeferredAndExcludedHookNames:
+    """v0.4 still rejects deferred artifact/state and excluded hook names."""
+
+    @pytest.mark.parametrize(
+        "deferred_name",
+        ["before_artifact_write", "after_artifact_write"],
+    )
+    def test_artifact_state_names_rejected_at_schema_layer(
+        self, tmp_path: Path, deferred_name: str
+    ) -> None:
+        payload = _v04_manifest()
+        payload["hooks"] = [_lifecycle_hook(name=deferred_name)]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        assert exc_info.value.json_pointer == "/hooks/0/name"
+
+    @pytest.mark.parametrize(
+        "excluded_name",
+        [
+            "before_runtime_start",
+            "after_runtime_start",
+            "before_state_commit",
+            "after_state_commit",
+            "on_event",
+            "on_rewind",
+        ],
+    )
+    def test_excluded_name_rejected_at_schema_layer(
+        self, tmp_path: Path, excluded_name: str
+    ) -> None:
+        payload = _v04_manifest()
+        payload["hooks"] = [_lifecycle_hook(name=excluded_name)]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        assert exc_info.value.json_pointer == "/hooks/0/name"
+
+
+class TestV03DoesNotInheritToolCall:
+    """v0.3 manifests must still reject tool-call hook names at the schema layer.
+
+    PR F-1 moves the names from ``DeferredHookKind`` into ``HookKind`` but
+    must not relax the v0.3 JSON Schema enum; v0.3 plugins relying on
+    that boundary continue to fail closed.
+    """
+
+    @pytest.mark.parametrize(
+        "tool_call_name",
+        ["before_tool_call", "after_tool_call"],
+    )
+    def test_v03_rejects_tool_call_name(self, tmp_path: Path, tool_call_name: str) -> None:
+        payload = _v03_manifest_for_negative_test()
+        payload["hooks"] = [_tool_call_hook(name=tool_call_name, failure_policy="fail_open")]
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+        assert exc_info.value.json_pointer == "/hooks/0/name"
+
+
+class TestV04AuditEvents:
+    def test_standard_events_for_schema_v04_includes_tool_call_events(self) -> None:
+        spec = AuditSpec.standard_events_for_schema("0.4")
+        assert HOOK_TOOL_INTERCEPT_REQUESTED_EVENT in spec.events
+        assert HOOK_TOOL_INTERCEPT_COMPLETED_EVENT in spec.events
+        assert HOOK_TOOL_INTERCEPT_BLOCKED_EVENT in spec.events
+        assert HOOK_TOOL_OBSERVE_RECORDED_EVENT in spec.events
+
+    def test_v04_audit_default_in_schema_includes_tool_call_events(self) -> None:
+        schema_path = (
+            Path(__file__).resolve().parents[3]
+            / "src/ouroboros/plugin/schemas/0.4/plugin.schema.json"
+        )
+        schema = json.loads(schema_path.read_text())
+        default_events = set(schema["properties"]["audit"]["default"]["events"])
+        assert default_events >= HOOK_TOOL_CALL_AUDIT_EVENTS
+
+    def test_v04_audit_enum_accepts_tool_call_events(self, tmp_path: Path) -> None:
+        payload = _v04_manifest()
+        payload["hooks"] = [
+            _tool_call_hook(name="before_tool_call", failure_policy="fail_closed"),
+        ]
+        payload["audit"] = {
+            "events": [
+                "plugin.invoked",
+                "plugin.permission_used",
+                "plugin.completed",
+                "plugin.failed",
+                "plugin.hook.invoked",
+                "plugin.hook.completed",
+                "plugin.hook.blocked",
+                "plugin.hook.failed",
+                HOOK_TOOL_INTERCEPT_REQUESTED_EVENT,
+                HOOK_TOOL_INTERCEPT_COMPLETED_EVENT,
+                HOOK_TOOL_INTERCEPT_BLOCKED_EVENT,
+                HOOK_TOOL_OBSERVE_RECORDED_EVENT,
+            ]
+        }
+        manifest = load_manifest(_write(tmp_path, payload))
+        assert HOOK_TOOL_INTERCEPT_REQUESTED_EVENT in manifest.audit.events
+
+
+class TestV04AuditEventDefaultForLoader:
+    """Confirm the manifest loader's standard_events_for_schema match the JSON Schema default for v0.4."""
+
+    def test_loader_and_schema_default_match(self) -> None:
+        schema_path = (
+            Path(__file__).resolve().parents[3]
+            / "src/ouroboros/plugin/schemas/0.4/plugin.schema.json"
+        )
+        schema = json.loads(schema_path.read_text())
+        default_events = tuple(schema["properties"]["audit"]["default"]["events"])
+        loader_events = AuditSpec.standard_events_for_schema("0.4").events
+        assert default_events == loader_events


### PR DESCRIPTION
## Summary

PR F-1 from the [#939 scope-decision plan](https://github.com/Q00/ouroboros/issues/939#issuecomment-4477726327). Locks the **manifest-layer half** of the tool-call hook family so PR F-2 can ship the firewall dispatch wiring against a frozen contract.

- Promotes `before_tool_call` / `after_tool_call` from `DeferredHookKind` into the v1 `HookKind` vocabulary.
- Vendors `src/ouroboros/plugin/schemas/0.4/` (manifest + audit-event schemas + `_source.json`).
- Reserves the four `plugin.tool.*` audit event names locked in [`docs/rfc/plugin-tool-call-hook-contract.md`](https://github.com/Q00/ouroboros/blob/main/docs/rfc/plugin-tool-call-hook-contract.md).
- Adds the matching permission scope constants (`plugin:tool:intercept`, `plugin:tool:observe`) and the routing helpers `is_tool_call_hook_kind` / `is_hook_tool_call_scope`.

**Runtime dispatch is NOT in this PR.** Declaring a tool-call hook in a v0.4 manifest is currently a no-op at runtime; the firewall will not invoke `before_tool_call` / `after_tool_call` until **PR F-2** ships the dispatch wiring at the MCP/tool-call boundary.

## Schema-layer rules now enforced

| Rule | Where |
|---|---|
| `hooks[].name` enum gains `before_tool_call` / `after_tool_call` | `0.4/plugin.schema.json` |
| `after_tool_call` must be `failure_policy=fail_open` | `allOf` if/then |
| `before_tool_call` with `fail_closed` must contain `plugin:tool:intercept` | `allOf` if/then |
| Lifecycle `fail_closed` (before_invocation/etc) still requires `plugin:lifecycle:policy` | `allOf` if/then (regression-protected) |
| Deferred artifact/state hook names still rejected | `hooks[].name` enum |
| Excluded names (`on_event`, `on_rewind`, …) still rejected | `hooks[].name` enum |
| v0.3 manifests still reject tool-call hook names | v0.3 enum unchanged |

## Why F-1 is safe to ship without F-2

- The v0.3 JSON Schema enum is untouched — existing v0.3 plugins keep their tighter contract.
- v0.4 manifests can declare the new hooks but the firewall never invokes them. There is no behavior change at the trust boundary.
- `_validate_lifecycle_permission` and `_validate_after_invocation_policy` continue to gate v0.3 specifically; v0.4 relies on JSON Schema rules, which the new test file exercises directly.
- The change shrinks the diff PR F-2 has to make: PR F-2 only needs to add the firewall dispatch wiring and integration tests, with the contract surface already locked.

## Test plan

- [x] `PYTHONPATH=src python -m pytest tests/unit/plugin/ -q` → **499 passed, 1 skipped**.
- [x] `ruff check` and `ruff format` clean on changed files.
- [x] New `tests/unit/plugin/test_manifest_schema_0_4.py` covers 26 cases:
  - schema acceptance for lifecycle hooks (backward compat),
  - schema acceptance for tool-call hooks across `intercept`+`fail_closed`, `intercept`+`fail_open`, `observe`+`fail_open`, `after_tool_call`+`observe`,
  - schema rejection for `after_tool_call`+`fail_closed`, `before_tool_call`+`fail_closed` without intercept, lifecycle `fail_closed` with only tool-call scope,
  - schema rejection for deferred artifact/state names + excluded names,
  - v0.3 manifests still rejecting tool-call hook names,
  - audit event default parity between schema and loader.
- [x] `tests/unit/plugin/test_hooks_contract.py` updated to reflect the new six-hook v1 vocabulary and two-hook deferred bucket.

## What's still gated

| Item | Owner | Gate |
|---|---|---|
| Tool-call hook firewall dispatch | **PR F-2** | this PR + the MCP/tool-call boundary integration |
| `plugin.tool.*` audit event emission | **PR F-2** | this PR (reserved names land here) |
| `on_event` observability dispatch | PR H | deferred — see #939 defer comment |
| `on_rewind` | PR I | deferred — needs rewind primitive RFC |
| Artifact/state hook contract docs | merged earlier as [#1276 PR D-docs](https://github.com/Q00/ouroboros/pull/1276) | PR G dispatch needs #946 v2 write-side |

Refs #939 #961