### PR TITLE
fix(auto): close backend-ready fallback resumes

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -1548,7 +1548,9 @@ class AutoInterviewDriver:
             tool_name="interview_driver",
         )
         self._save(state)
-        return AutoInterviewResult("seed_ready", state.interview_session_id, ledger, state.current_round)
+        return AutoInterviewResult(
+            "seed_ready", state.interview_session_id, ledger, state.current_round
+        )
 
     async def _with_timeout(
         self, awaitable: Awaitable[InterviewTurn], state: AutoPipelineState, *, tool_name: str

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -1095,6 +1095,8 @@ class AutoInterviewDriver:
                 active_profile=getattr(self.answerer, "active_profile", None),
             )
             if finalization is None or not finalization.completed or not ledger.is_seed_ready():
+                if finalization is not None:
+                    _revert_safe_default_entries(ledger, finalization.defaulted_sections)
                 return None
             closure_mode = "safe_default_no_backend"
 

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -117,6 +117,7 @@ _EVENT_STORE_EMIT_TIMEOUT_SECONDS = 1.0
 # structlog warning.
 
 INTERVIEW_SAFE_DEFAULT_SYNTHESIS_STOP_REASON_CODE = "interview_safe_default_synthesis_incomplete"
+BACKEND_READY_AMBIGUITY_THRESHOLD = 0.20
 
 # Issue #1248 — L5 ladder typed terminal for a safe-default lateral escalation
 # that exhausted every available persona without resolving the matcher fire.
@@ -532,6 +533,10 @@ class AutoInterviewDriver:
                 self._save(state)
         except TimeoutError as exc:
             self._record_evidence_based_session_id(state, exc, preassigned_id)
+            if interview_tool_name == "interview.start":
+                fallback = self._try_close_after_backend_start_failure(state, ledger, exc)
+                if fallback is not None:
+                    return fallback
             message = str(exc)
             state.mark_blocked(message, tool_name=interview_tool_name)
             record_authoring_backend(state)
@@ -631,6 +636,14 @@ class AutoInterviewDriver:
             self._save(state)
 
             if backend_done and not ledger_done:
+                backend_ready_defaults = await self._try_close_backend_ready_safe_defaults(
+                    state,
+                    ledger,
+                    turn,
+                )
+                if backend_ready_defaults is not None:
+                    return backend_ready_defaults
+
                 # Backend said done but ledger isn't — pick the first detected
                 # gap and answer it. This drives the backend to reopen with
                 # substantive new content; we never accept closure unilaterally.
@@ -1419,6 +1432,122 @@ class AutoInterviewDriver:
 
         return finalization
 
+    async def _try_close_backend_ready_safe_defaults(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        turn: InterviewTurn,
+    ) -> AutoInterviewResult | None:
+        """Close benign remaining gaps after a low-ambiguity backend completion.
+
+        Backend completion alone is not enough to close auto interviews: the
+        ledger still owns structural readiness. When the backend also reports a
+        concrete ambiguity score at the seed threshold, any remaining
+        missing/weak sections are safe to route through the same audited
+        safe-default finalizer used at max_rounds. Unsafe/conflicting gaps keep
+        the existing gap-reopen path.
+        """
+        if turn.ambiguity_score is None or turn.ambiguity_score > BACKEND_READY_AMBIGUITY_THRESHOLD:
+            return None
+        if ledger.is_seed_ready():
+            return None
+
+        finalization = finalize_safe_defaultable_gaps(
+            ledger,
+            goal=state.goal,
+            provenance=(
+                "backend readiness "
+                f"ambiguity_score={turn.ambiguity_score:.2f} "
+                f"round={state.current_round}"
+            ),
+            pending_question=turn.question,
+            active_profile=getattr(self.answerer, "active_profile", None),
+        )
+        if not finalization.completed or not ledger.is_seed_ready():
+            _revert_safe_default_entries(ledger, finalization.defaulted_sections)
+            log.info(
+                "auto.interview.backend_ready_safe_default.skipped",
+                auto_session_id=state.auto_session_id,
+                ambiguity_score=turn.ambiguity_score,
+                defaulted_sections=finalization.defaulted_sections,
+                unsafe_gaps=finalization.unsafe_gaps,
+                open_gaps=ledger.open_gaps(),
+            )
+            return None
+
+        synthesis = build_safe_default_synthesis(finalization)
+        if synthesis and state.interview_session_id:
+            try:
+                synthesis_turn = _validate_turn(
+                    await self._with_timeout(
+                        self.backend.answer(
+                            state.interview_session_id,
+                            synthesis,
+                            last_question=(
+                                "[driver safe-default finalization: "
+                                f"backend_ambiguity={turn.ambiguity_score:.2f}]"
+                            ),
+                        ),
+                        state,
+                        tool_name="interview.backend_ready_safe_default_synthesis",
+                    )
+                )
+            except Exception as exc:  # noqa: BLE001 - keep ledger/transcript in sync
+                _revert_safe_default_entries(ledger, finalization.defaulted_sections)
+                blocker = (
+                    "backend-ready safe-default synthesis transcript sync failed; "
+                    f"rolled back defaulted sections: {', '.join(finalization.defaulted_sections)}; "
+                    f"error={exc}"
+                )
+                state.ledger = ledger.to_dict()
+                state.mark_blocked(
+                    blocker,
+                    tool_name="interview.backend_ready_safe_default_synthesis",
+                    error_code=INTERVIEW_SAFE_DEFAULT_SYNTHESIS_STOP_REASON_CODE,
+                )
+                record_authoring_backend(state)
+                self._save(state)
+                return AutoInterviewResult(
+                    "blocked", state.interview_session_id, ledger, state.current_round, blocker
+                )
+            state.interview_session_id = synthesis_turn.session_id
+            state.pending_question = synthesis_turn.question
+            if not (synthesis_turn.seed_ready or synthesis_turn.completed):
+                _revert_safe_default_entries(ledger, finalization.defaulted_sections)
+                blocker = (
+                    "backend-ready safe-default synthesis did not close the persisted interview: "
+                    "ledger defaults rolled back"
+                )
+                state.ledger = ledger.to_dict()
+                state.mark_blocked(
+                    blocker,
+                    tool_name="interview.backend_ready_safe_default_synthesis",
+                    error_code=INTERVIEW_SAFE_DEFAULT_SYNTHESIS_STOP_REASON_CODE,
+                )
+                record_authoring_backend(state)
+                self._save(state)
+                return AutoInterviewResult(
+                    "blocked", state.interview_session_id, ledger, state.current_round, blocker
+                )
+
+        log.info(
+            "auto.interview.backend_ready_safe_default.closed",
+            auto_session_id=state.auto_session_id,
+            ambiguity_score=turn.ambiguity_score,
+            defaulted_sections=finalization.defaulted_sections,
+        )
+        state.ledger = ledger.to_dict()
+        state.pending_question = None
+        state.interview_completed = True
+        state.interview_closure_mode = "safe_default"
+        state.mark_progress(
+            "backend-ready safe-default finalization closed interview gaps: "
+            + ", ".join(finalization.defaulted_sections),
+            tool_name="interview_driver",
+        )
+        self._save(state)
+        return AutoInterviewResult("seed_ready", state.interview_session_id, ledger, state.current_round)
+
     async def _with_timeout(
         self, awaitable: Awaitable[InterviewTurn], state: AutoPipelineState, *, tool_name: str
     ) -> InterviewTurn:
@@ -1660,6 +1789,8 @@ def _is_authoring_backend_unavailable(exc: Exception) -> bool:
         "profile",
         "codex",
         "provider",
+        "timed out",
+        "timeout",
         "api key",
         "authentication",
         "rate limit",

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1010,6 +1010,47 @@ async def test_interview_driver_closes_with_safe_defaults_when_start_times_out(
 
 
 @pytest.mark.asyncio
+async def test_interview_driver_rolls_back_partial_defaults_when_start_timeout_stays_blocked(
+    tmp_path,
+) -> None:
+    async def start(goal: str, cwd: str, *, interview_id: str | None = None) -> InterviewTurn:  # noqa: ARG001
+        await asyncio.sleep(0.05)
+        return InterviewTurn("What should we verify?", interview_id or "interview_timeout")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("answer must not run when start times out")
+
+    state = AutoPipelineState(goal="Build a small local CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.contradiction",
+            value="Two recorded answers disagree on whether to allow new deps.",
+            source=LedgerSource.USER_PREFERENCE,
+            confidence=1.0,
+            status=LedgerStatus.CONFLICTING,
+        ),
+    )
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer, is_session_persisted=lambda _id: False),
+        store=AutoStore(tmp_path),
+        timeout_seconds=0.001,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.interview_closure_mode is None
+    assert not any(
+        entry.key.endswith(".safe_default_finalization")
+        for section in ledger.sections.values()
+        for entry in section.entries
+    ), "partial safe-default rollback must remove all defaulted entries"
+    assert state.ledger == {}
+
+
+@pytest.mark.asyncio
 async def test_interview_driver_supplies_bounded_repo_facts_to_answerer(tmp_path) -> None:
     (tmp_path / "pyproject.toml").write_text(
         "\n".join(

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -3932,9 +3932,7 @@ async def test_backend_ready_low_ambiguity_closes_safe_defaultable_gaps(tmp_path
     assert result.status == "seed_ready"
     assert state.interview_closure_mode == "safe_default"
     assert ledger.is_seed_ready()
-    assert observed_last_questions == [
-        "[driver safe-default finalization: backend_ambiguity=0.16]"
-    ]
+    assert observed_last_questions == ["[driver safe-default finalization: backend_ambiguity=0.16]"]
     assert observed_answers and "[safe-default-synthesis]" in observed_answers[0]
 
 

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -939,7 +939,7 @@ async def test_interview_driver_blocks_on_backend_timeout(tmp_path) -> None:
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("done", session_id, seed_ready=True)
 
-    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state = AutoPipelineState(goal="Deploy to production", cwd=str(tmp_path))
     ledger = SeedDraftLedger.from_goal(state.goal)
     driver = AutoInterviewDriver(
         FunctionInterviewBackend(start, answer),
@@ -964,7 +964,7 @@ async def test_interview_driver_timeout_message_records_state_policy_source(tmp_
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("done", session_id, seed_ready=True)
 
-    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state = AutoPipelineState(goal="Deploy to production", cwd=str(tmp_path))
     ledger = SeedDraftLedger.from_goal(state.goal)
     driver = AutoInterviewDriver(
         FunctionInterviewBackend(start, answer),
@@ -978,6 +978,35 @@ async def test_interview_driver_timeout_message_records_state_policy_source(tmp_
     assert "interview.start timed out after 0s" in blocker
     assert "policy: state.timeout_seconds_by_phase[interview]" in blocker
     assert state.last_error == blocker
+
+
+@pytest.mark.asyncio
+async def test_interview_driver_closes_with_safe_defaults_when_start_times_out(
+    tmp_path,
+) -> None:
+    async def start(goal: str, cwd: str, *, interview_id: str | None = None) -> InterviewTurn:  # noqa: ARG001
+        await asyncio.sleep(0.05)
+        return InterviewTurn("What should we verify?", interview_id or "interview_timeout")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("answer must not run when start times out")
+
+    state = AutoPipelineState(goal="Build a small local CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    store = AutoStore(tmp_path)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer, is_session_persisted=lambda _id: False),
+        store=store,
+        timeout_seconds=0.001,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert result.blocker is None
+    assert state.interview_session_id is None
+    assert state.interview_closure_mode == "safe_default_no_backend"
+    assert ledger.is_seed_ready()
 
 
 @pytest.mark.asyncio
@@ -2776,6 +2805,76 @@ async def test_pipeline_seed_generation_without_interview_session_synthesizes_co
 
 
 @pytest.mark.asyncio
+async def test_pipeline_resumes_no_backend_interview_closure_without_session_id(
+    tmp_path,
+) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("resume should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        raise AssertionError("no-backend resume should synthesize without handler seed generation")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_completed = True
+    state.interview_closure_mode = "safe_default_no_backend"
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(driver, generate_seed, store=AutoStore(tmp_path), skip_run=True)
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase == AutoPhase.COMPLETE
+    assert result.interview_session_id is None
+    assert state.seed_artifact is not None
+
+
+@pytest.mark.asyncio
+async def test_pipeline_seed_generation_timeout_falls_back_to_completed_ledger(
+    tmp_path,
+) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("seed phase should not restart interview")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("seed phase should not answer interview")
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        await asyncio.sleep(0.05)
+        return _seed()
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.interview_session_id = "interview_timeout_seed"
+    state.interview_completed = True
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(FunctionInterviewBackend(start, answer), store=AutoStore(tmp_path))
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        skip_run=True,
+        seed_timeout_seconds=0.001,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.grade == "A"
+    assert state.last_tool_name == "ledger_seed_generator"
+    assert state.seed_artifact is not None
+
+
+@pytest.mark.asyncio
 async def test_pipeline_retry_after_blocked_run_start_replay_from_seed_path(tmp_path) -> None:
     """Resuming a blocked run-start session retries the run starter once."""
 
@@ -3747,6 +3846,58 @@ async def test_interview_driver_supplies_last_question_for_seed_ready_gap_reopen
 
 
 @pytest.mark.asyncio
+async def test_backend_ready_low_ambiguity_closes_safe_defaultable_gaps(tmp_path) -> None:
+    """Low-ambiguity backend completion should not reopen on benign safe gaps."""
+    observed_last_questions: list[str | None] = []
+    observed_answers: list[str] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "ready",
+            "interview_backend_ready_defaults",
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.16,
+        )
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        observed_last_questions.append(last_question)
+        observed_answers.append(text)
+        return InterviewTurn(
+            "done",
+            session_id,
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.16,
+        )
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    ledger.sections["non_goals"].entries.clear()
+    ledger.sections["failure_modes"].entries.clear()
+    ledger.sections["runtime_context"].entries.clear()
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=3,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "seed_ready"
+    assert state.interview_closure_mode == "safe_default"
+    assert ledger.is_seed_ready()
+    assert observed_last_questions == [
+        "[driver safe-default finalization: backend_ambiguity=0.16]"
+    ]
+    assert observed_answers and "[safe-default-synthesis]" in observed_answers[0]
+
+
+@pytest.mark.asyncio
 async def test_interview_driver_does_not_replace_specific_verification_answer_with_gap_prompt(
     tmp_path,
 ) -> None:
@@ -4454,8 +4605,9 @@ async def test_interview_driver_keeps_session_id_when_probe_confirms_persistence
 
     result = await driver.run(state, ledger)
 
-    assert result.status == "blocked"
+    assert result.status == "seed_ready"
     assert state.interview_session_id, "probe-confirmed id must be saved on auto state"
+    assert state.interview_closure_mode == "safe_default_no_backend"
     assert received_ids == [state.interview_session_id], (
         "backend.start must receive the pre-allocated interview_id so the "
         "persisted interview file matches auto state"
@@ -4594,7 +4746,7 @@ async def test_interview_driver_persists_partial_session_id_on_start_failure(tmp
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("answer must not be called when start fails")
 
-    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state = AutoPipelineState(goal="Deploy to production", cwd=str(tmp_path))
     ledger = SeedDraftLedger.from_goal(state.goal)
     store = AutoStore(tmp_path)
     driver = AutoInterviewDriver(


### PR DESCRIPTION
## Summary
- Reopens the timeout fallback/resume slice from approved #1262 against `main` after the old base branch was deleted.
- Close deterministic safe-default interviews when backend start is unavailable and the ledger can be made seed-ready without advertising an unsynchronized backend session id.
- Close backend-complete, low-ambiguity interviews by synchronizing safe-default synthesis back to the backend transcript before marking the ledger complete.
- Add regression coverage for start timeout fallback, seed-generation timeout ledger fallback, and backend-ready safe-default closure.

## Split Context
This is PR 1 of 3 split from #1262. #1261's `ledger_seed.py`/base synthesis is already on `main`; this PR keeps only the timeout fallback/resume contract deltas.

## Verification
- `uv run ruff check src/ouroboros/auto/interview_driver.py tests/unit/auto/test_interview_pipeline.py`
- `uv run ruff format --check src/ouroboros/auto/interview_driver.py tests/unit/auto/test_interview_pipeline.py`
- `uv run pytest tests/unit/auto/test_interview_pipeline.py -q` (`158 passed`)

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A - not an R-run benchmark PR | N/A - timeout fallback/resume contract only | n/a |
| Per-round wall-clock (s/round) | N/A - not an R-run benchmark PR | N/A - no canonical R-run captured | n/a |
| Terminal reason                | N/A - not an R-run benchmark PR | N/A - targeted unit/regression coverage only | n/a |
| EventStore event count         | N/A - not an R-run benchmark PR | N/A - no canonical R-run captured | n/a |

Budget compliance: [x] N/A (control-flow/resume fallback changes; no canonical R-run comparison captured)

## Related issues
- Split follow-up for #1262