### PR TITLE
fix(auto): require terminal run evidence before Ralph

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1119,18 +1119,11 @@ class AutoPipeline:
                             return self._result(
                                 state, ledger, review=review, blocker=state.last_error
                             )
-                        # ``_wait_owned_run_job_terminal`` returns ``None``
-                        # when the configured run starter does not expose
-                        # ``handler._job_manager.get_snapshot``. The bot
-                        # review explicitly flags this as "treats an
-                        # unverified persisted run handle as enough to
-                        # start Ralph" — a persisted ``job_id`` proves
-                        # *dispatch*, not terminal success. Without a
-                        # reconciliation channel the resume cannot prove
-                        # the run finished successfully, so refuse the
-                        # Ralph handoff just as the jobless-synchronous
-                        # branch below does for ``execution_id``-only
-                        # handles.
+                        # If no snapshot channel is available, a persisted
+                        # ``job_id`` remains dispatch evidence only. Resume
+                        # cannot prove terminal success, so refuse Ralph
+                        # handoff just as the jobless-synchronous branch
+                        # below does for ``execution_id``-only handles.
                         if terminal_run_meta is None:
                             state.mark_blocked(
                                 "Cannot resume complete-product Ralph handoff: "

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -3758,7 +3758,10 @@ async def _wait_owned_run_job_terminal(
     loop = asyncio.get_running_loop()
     deadline = loop.time() + max(0.0, timeout_seconds)
     while True:
-        snapshot = await get_snapshot(job_id)
+        try:
+            snapshot = await get_snapshot(job_id)
+        except Exception:
+            return None
         if getattr(snapshot, "is_terminal", False):
             meta = dict(getattr(snapshot, "result_meta", None) or {})
             status = getattr(getattr(snapshot, "status", None), "value", None)

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1098,6 +1098,183 @@ class AutoPipeline:
                         )
                         self._save(state)
                         return self._result(state, ledger, review=review, blocker=state.last_error)
+                    # Persisted run handles prove the execute_seed job was
+                    # *dispatched*, not that it reached terminal success.
+                    # The fresh-path RUN → RALPH_HANDOFF contract
+                    # (lines ~1242-1340) refuses to hand off to Ralph until
+                    # the owned run job has finished successfully — paused
+                    # and queued/running/cancel_requested both BLOCK with
+                    # ``tool_name="run_starter"``, which
+                    # ``_recoverable_phase_for_tool`` maps back to ``RUN``.
+                    # Without re-polling here, a resume after one of those
+                    # blockers would walk past the gate and start Ralph
+                    # against a still-pending product run. Mirror the
+                    # fresh-path snapshot poll + status gate so resume and
+                    # fresh dispatch share the same terminal-success
+                    # contract.
+                    if state.job_id:
+                        terminal_run_meta = await _wait_owned_run_job_terminal(
+                            self.run_starter,
+                            state.job_id,
+                            timeout_seconds=self._deadline_capped_timeout(
+                                state, state.phase_timeout_seconds(AutoPhase.RUN)
+                            ),
+                        )
+                        if self._enforce_deadline(state):
+                            return self._result(
+                                state, ledger, review=review, blocker=state.last_error
+                            )
+                        # ``_wait_owned_run_job_terminal`` returns ``None``
+                        # when the configured run starter does not expose
+                        # ``handler._job_manager.get_snapshot``. The bot
+                        # review explicitly flags this as "treats an
+                        # unverified persisted run handle as enough to
+                        # start Ralph" — a persisted ``job_id`` proves
+                        # *dispatch*, not terminal success. Without a
+                        # reconciliation channel the resume cannot prove
+                        # the run finished successfully, so refuse the
+                        # Ralph handoff just as the jobless-synchronous
+                        # branch below does for ``execution_id``-only
+                        # handles.
+                        if terminal_run_meta is None:
+                            state.mark_blocked(
+                                "Cannot resume complete-product Ralph handoff: "
+                                "the owned run job snapshot is unavailable "
+                                f"(job_id={state.job_id!r}) so the persisted run "
+                                "handle cannot be confirmed as terminal-success. "
+                                "Resolve the run job to a terminal state, or clear "
+                                "the persisted handle before retrying.",
+                                tool_name="run_starter",
+                            )
+                            self._save(state)
+                            return self._result(
+                                state,
+                                ledger,
+                                review=review,
+                                blocker=state.last_error,
+                                run_subagent=None,
+                            )
+                        run_status_resume = _optional_str(terminal_run_meta.get("status"))
+                        run_success_resume = terminal_run_meta.get("success")
+                        failed_run_statuses = {"failed", "cancelled", "interrupted"}
+                        if run_success_resume is False or (
+                            run_status_resume in failed_run_statuses
+                        ):
+                            resolved_status = run_status_resume or "failed"
+                            state.mark_blocked(
+                                "resumed run execution finished unsuccessfully "
+                                f"before Ralph handoff: {resolved_status}",
+                                tool_name="run_starter",
+                            )
+                            self._save(state)
+                            return self._result(
+                                state,
+                                ledger,
+                                review=review,
+                                blocker=state.last_error,
+                                run_subagent=None,
+                            )
+                        incomplete_run_statuses = {
+                            "queued",
+                            "running",
+                            "cancel_requested",
+                        }
+                        if run_status_resume in incomplete_run_statuses:
+                            state.mark_blocked(
+                                "resumed run execution did not finish "
+                                f"before Ralph handoff: {run_status_resume}",
+                                tool_name="run_starter",
+                            )
+                            self._save(state)
+                            return self._result(
+                                state,
+                                ledger,
+                                review=review,
+                                blocker=state.last_error,
+                                run_subagent=None,
+                            )
+                        if run_status_resume == "paused":
+                            state.mark_blocked(
+                                "resumed run execution paused before Ralph handoff; "
+                                "resume the paused run before continuing",
+                                tool_name="run_starter",
+                            )
+                            self._save(state)
+                            return self._result(
+                                state,
+                                ledger,
+                                review=review,
+                                blocker=state.last_error,
+                                run_subagent=None,
+                            )
+                        # Allowlist-style terminal-success check: a poll
+                        # that returned terminal metadata but does not
+                        # advertise an explicit success signal (e.g. the
+                        # snapshot's ``result_meta`` is empty or carries
+                        # an unknown status) is NOT evidence the product
+                        # run reached terminal success. Refuse the
+                        # handoff just like the unreconcilable cases
+                        # above so a malformed or unfamiliar snapshot
+                        # cannot pass the gate by omission.
+                        if run_success_resume is not True and run_status_resume != "completed":
+                            state.mark_blocked(
+                                "Cannot resume complete-product Ralph handoff: "
+                                "owned run job snapshot did not confirm terminal "
+                                f"success (status={run_status_resume!r}, "
+                                f"success={run_success_resume!r}). Resolve the run "
+                                "to terminal-success or clear the persisted handle "
+                                "before retrying.",
+                                tool_name="run_starter",
+                            )
+                            self._save(state)
+                            return self._result(
+                                state,
+                                ledger,
+                                review=review,
+                                blocker=state.last_error,
+                                run_subagent=None,
+                            )
+                    else:
+                        # Synchronous starters
+                        # (``HandlerSynchronousRunStarter``) return
+                        # ``job_id=None`` while still persisting
+                        # ``execution_id`` / ``run_session_id``, so the
+                        # fresh-path terminal-success validation relies on
+                        # the starter's returned dict — there is no
+                        # job-manager snapshot to reconcile against on
+                        # resume. A resume that reaches this branch with no
+                        # persisted ``job_id`` is therefore unreconcilable:
+                        # the most common cause is a fresh-path BLOCK on
+                        # paused/failed/non-terminal synchronous
+                        # execution, after which
+                        # ``_recoverable_phase_for_tool("run_starter")``
+                        # returns ``AutoPhase.RUN`` and re-enters the
+                        # persisted-handle branch. Dispatching Ralph from
+                        # ``execution_id``/``run_session_id`` alone would
+                        # advertise a non-terminal product run as ready
+                        # for the persistence loop, breaking the same
+                        # contract the fresh-path paused guard enforces.
+                        # Block with actionable guidance instead — the
+                        # operator must resolve the synchronous run
+                        # itself (resume it, or wipe the persisted handle)
+                        # before complete-product can continue.
+                        state.mark_blocked(
+                            "Cannot resume complete-product Ralph handoff for "
+                            "jobless synchronous execution: no job-manager "
+                            "snapshot is available to verify the persisted "
+                            "execution_id/run_session_id reached terminal "
+                            "success. Resume the synchronous run to completion "
+                            "or clear the persisted handle before retrying.",
+                            tool_name="run_starter",
+                        )
+                        self._save(state)
+                        return self._result(
+                            state,
+                            ledger,
+                            review=review,
+                            blocker=state.last_error,
+                            run_subagent=None,
+                        )
                     return await self._handoff_to_ralph(
                         state, ledger, seed, review, run_subagent=None
                     )
@@ -3565,6 +3742,33 @@ async def _cancel_ralph_status_mirror(task: asyncio.Task[None] | None) -> None:
     task.cancel()
     with suppress(asyncio.CancelledError):
         await task
+
+
+async def _wait_owned_run_job_terminal(
+    adapter: object | None,
+    job_id: str,
+    *,
+    timeout_seconds: float,
+) -> dict[str, Any] | None:
+    handler = getattr(adapter, "handler", None)
+    job_manager = getattr(handler, "_job_manager", None)
+    get_snapshot = getattr(job_manager, "get_snapshot", None)
+    if get_snapshot is None:
+        return None
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + max(0.0, timeout_seconds)
+    while True:
+        snapshot = await get_snapshot(job_id)
+        if getattr(snapshot, "is_terminal", False):
+            meta = dict(getattr(snapshot, "result_meta", None) or {})
+            status = getattr(getattr(snapshot, "status", None), "value", None)
+            if isinstance(status, str):
+                meta.setdefault("status", status)
+            return meta
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            return {"status": "running"}
+        await asyncio.sleep(min(0.1, remaining))
 
 
 def _artifact_text(value: object) -> str | None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1100,18 +1100,13 @@ class AutoPipeline:
                         return self._result(state, ledger, review=review, blocker=state.last_error)
                     # Persisted run handles prove the execute_seed job was
                     # *dispatched*, not that it reached terminal success.
-                    # The fresh-path RUN → RALPH_HANDOFF contract
-                    # (lines ~1242-1340) refuses to hand off to Ralph until
-                    # the owned run job has finished successfully — paused
-                    # and queued/running/cancel_requested both BLOCK with
-                    # ``tool_name="run_starter"``, which
-                    # ``_recoverable_phase_for_tool`` maps back to ``RUN``.
-                    # Without re-polling here, a resume after one of those
-                    # blockers would walk past the gate and start Ralph
-                    # against a still-pending product run. Mirror the
-                    # fresh-path snapshot poll + status gate so resume and
-                    # fresh dispatch share the same terminal-success
-                    # contract.
+                    # On resume, persisted handles are dispatch evidence
+                    # only. A previous run may have blocked while the owned
+                    # job was paused, queued, running, cancel-requested, or
+                    # otherwise unreconcilable. Without re-polling here,
+                    # that resume would walk past the RUN gate and start
+                    # Ralph against a still-pending product run. Require
+                    # terminal-success evidence before resuming Ralph.
                     if state.job_id:
                         terminal_run_meta = await _wait_owned_run_job_terminal(
                             self.run_starter,

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -1405,6 +1405,7 @@ async def test_run_resume_with_persisted_handle_blocks_when_owned_job_still_runn
     state.run_handoff_status = "started"
     state.job_id = "job_run_pending_resume"
     state.complete_product = True
+    state.timeout_seconds_by_phase = {AutoPhase.RUN: 0.01}
 
     class _RunSnapshot:
         is_terminal = False
@@ -1442,6 +1443,52 @@ async def test_run_resume_with_persisted_handle_blocks_when_owned_job_still_runn
     assert state.phase is AutoPhase.BLOCKED
     assert state.last_tool_name == "run_starter"
     assert "did not finish" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
+async def test_run_resume_with_stale_persisted_job_id_blocks_instead_of_crashing(
+    tmp_path,
+) -> None:
+    """Missing job snapshots are persistence-boundary blockers, not process crashes."""
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_stale"
+    state.execution_id = "execution_stale"
+    state.complete_product = True
+
+    class _RunJobManager:
+        async def get_snapshot(self, _job_id: str) -> object:
+            raise ValueError("Job not found: job_run_stale")
+
+    class _RunHandler:
+        _job_manager = _RunJobManager()
+
+    class StaleSnapshotStarter:
+        handler = _RunHandler()
+
+        async def __call__(self, _seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not start a duplicate run")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("ralph_starter must not run with a stale run job")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=StaleSnapshotStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "snapshot is unavailable" in (state.last_error or "")
     assert state.ralph_job_id is None
 
 

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -43,6 +43,7 @@ from ouroboros.core.seed import (
     SeedMetadata,
 )
 from ouroboros.events.base import BaseEvent
+from ouroboros.mcp.job_manager import JobStatus
 
 
 def _build_seed(seed_id: str = "seed_test_001") -> Seed:
@@ -1245,12 +1246,54 @@ async def test_ralph_handoff_resume_falls_back_to_guidance_without_resumer(tmp_p
 # ---------------------------------------------------------------------------
 
 
+def _terminal_success_run_starter(job_id: str = "job_run_existing") -> Any:
+    """Build a run_starter adapter whose owned-job snapshot reports terminal success.
+
+    Mirrors the production ``HandlerRunStarter`` / ``HandlerSynchronousRunStarter``
+    shape: ``adapter.handler._job_manager.get_snapshot(job_id)`` returns a
+    snapshot whose ``is_terminal`` is True and ``result_meta`` advertises
+    ``status="completed"`` / ``success=True``. The starter callable itself
+    raises so the test proves resume does NOT redispatch the run job; the
+    only signal feeding the resume gate is the persisted run handle plus
+    the snapshot poll.
+    """
+
+    class _RunSnapshot:
+        is_terminal = True
+        status = JobStatus.COMPLETED
+        result_meta = {"status": "completed", "success": True}
+
+    class _RunJobManager:
+        async def get_snapshot(self, snapshot_job_id: str) -> _RunSnapshot:
+            assert snapshot_job_id == job_id
+            return _RunSnapshot()
+
+    class _RunHandler:
+        _job_manager = _RunJobManager()
+
+    class TerminalSuccessStarter:
+        handler = _RunHandler()
+
+        async def __call__(self, _seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not start a duplicate run")
+
+    return TerminalSuccessStarter()
+
+
 @pytest.mark.asyncio
 async def test_run_resume_with_persisted_handle_and_complete_product_dispatches_ralph(
     tmp_path,
 ) -> None:
     """RUN resume with persisted run handles MUST honor ``complete_product``
-    and continue to RALPH_HANDOFF, not short-circuit to COMPLETE."""
+    and continue to RALPH_HANDOFF, not short-circuit to COMPLETE.
+
+    The resume gate now mirrors the fresh-path contract by polling the
+    owned-job snapshot for terminal success before invoking Ralph; this
+    test wires a snapshot that reports ``status="completed"`` /
+    ``success=True`` so the handoff proceeds and proves the happy path
+    still works.
+    """
+
     state = _state_at_run_phase(tmp_path)
     state.run_start_attempted = True
     state.run_handoff_status = "started"
@@ -1272,13 +1315,10 @@ async def test_run_resume_with_persisted_handle_and_complete_product_dispatches_
             "stop_reason": "qa passed",
         }
 
-    async def run_starter(_seed: Seed, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
-        raise AssertionError("resume must not start a duplicate run")
-
     pipeline = AutoPipeline(
         _StubInterviewDriver(),
         _seed_generator_unused,
-        run_starter=run_starter,
+        run_starter=_terminal_success_run_starter("job_run_existing"),
         reviewer=_PassReviewer(),
         ralph_starter=ralph_starter,
         complete_product=True,
@@ -1290,6 +1330,349 @@ async def test_run_resume_with_persisted_handle_and_complete_product_dispatches_
     assert result.status == "complete"
     assert state.phase is AutoPhase.COMPLETE
     assert state.ralph_job_id == "job_ralph_resumed"
+
+
+@pytest.mark.asyncio
+async def test_run_resume_with_persisted_handle_blocks_when_owned_job_paused(
+    tmp_path,
+) -> None:
+    """Resume MUST NOT hand off to Ralph when the owned run job is paused.
+
+    Mirrors the fresh-path paused guard. A paused complete-product run
+    means the operator must resume the run itself before Ralph can take
+    over.
+    """
+
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_paused_resume"
+    state.execution_id = "execution_paused_resume"
+    state.complete_product = True
+
+    class _RunSnapshot:
+        is_terminal = True
+        status = JobStatus.COMPLETED  # status enum value irrelevant; result_meta wins
+        result_meta = {"status": "paused", "success": None}
+
+    class _RunJobManager:
+        async def get_snapshot(self, _job_id: str) -> _RunSnapshot:
+            return _RunSnapshot()
+
+    class _RunHandler:
+        _job_manager = _RunJobManager()
+
+    class PausedSnapshotStarter:
+        handler = _RunHandler()
+
+        async def __call__(self, _seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not start a duplicate run")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("ralph_starter must not run while resumed execution is paused")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=PausedSnapshotStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "paused" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
+async def test_run_resume_with_persisted_handle_blocks_when_owned_job_still_running(
+    tmp_path,
+) -> None:
+    """Resume MUST block when the owned run job is still queued/running.
+
+    The snapshot returns ``status="running"`` to model a poll that did not
+    observe terminal completion within the per-phase budget — the fresh
+    path treats this identically and we mirror that contract.
+    """
+
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_pending_resume"
+    state.complete_product = True
+
+    class _RunSnapshot:
+        is_terminal = False
+        status = JobStatus.RUNNING
+        result_meta: dict[str, Any] = {}
+
+    class _RunJobManager:
+        async def get_snapshot(self, _job_id: str) -> _RunSnapshot:
+            return _RunSnapshot()
+
+    class _RunHandler:
+        _job_manager = _RunJobManager()
+
+    class RunningSnapshotStarter:
+        handler = _RunHandler()
+
+        async def __call__(self, _seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not start a duplicate run")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("ralph_starter must not run while resumed execution is still pending")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=RunningSnapshotStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "did not finish" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
+async def test_run_resume_with_persisted_job_id_blocks_when_starter_has_no_snapshot_api(
+    tmp_path,
+) -> None:
+    """Persisted ``job_id`` without a job-manager snapshot must not satisfy the resume gate.
+
+    A persisted ``job_id`` proves the execute_seed job was dispatched,
+    not that it reached terminal success. When the configured run
+    starter does not expose ``handler._job_manager.get_snapshot``,
+    ``_wait_owned_run_job_terminal`` returns ``None`` and the resume
+    branch cannot reconcile the owned-job lifecycle. Without an
+    explicit guard the previous resume path would walk past the
+    terminal check and start Ralph on dispatch evidence alone; the new
+    contract refuses the handoff in that case, mirroring the
+    jobless-synchronous branch.
+    """
+
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_unpollable"
+    state.execution_id = "execution_unpollable"
+    state.run_session_id = "session_unpollable"
+    state.complete_product = True
+
+    class UnpollableStarter:
+        # No ``handler`` attribute => ``_wait_owned_run_job_terminal``
+        # returns None because ``get_snapshot`` cannot be resolved.
+
+        async def __call__(self, _seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not redispatch the run job")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError(
+            "ralph_starter must not run when the owned job cannot be reconciled"
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=UnpollableStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "snapshot is unavailable" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
+async def test_run_resume_blocks_when_snapshot_does_not_confirm_terminal_success(
+    tmp_path,
+) -> None:
+    """An ambiguous terminal snapshot (no ``success=True`` / no ``status=completed``) must NOT pass the gate.
+
+    ``_wait_owned_run_job_terminal`` may return ``result_meta`` that is
+    empty or carries an unfamiliar status (e.g. an adapter that flips
+    ``is_terminal`` but does not populate the success/status keys auto
+    consumes). Such a payload is not evidence of terminal success and
+    must be treated as unreconcilable, not silently fall through to the
+    Ralph handoff. This guards the resume gate against snapshot shapes
+    that bypass the failed/paused/queued allowlist by omission.
+    """
+
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_ambiguous"
+    state.complete_product = True
+
+    class _RunSnapshot:
+        is_terminal = True
+        # status enum unset and result_meta empty: ``_wait_owned_run_job_terminal``
+        # produces ``{}`` because the snapshot has nothing to ``setdefault`` from,
+        # and the resume gate sees neither ``success=True`` nor
+        # ``status="completed"``.
+        status = None
+        result_meta: dict[str, Any] = {}
+
+    class _RunJobManager:
+        async def get_snapshot(self, _job_id: str) -> _RunSnapshot:
+            return _RunSnapshot()
+
+    class _RunHandler:
+        _job_manager = _RunJobManager()
+
+    class AmbiguousSnapshotStarter:
+        handler = _RunHandler()
+
+        async def __call__(self, _seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not redispatch the run job")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError(
+            "ralph_starter must not run when the snapshot does not confirm terminal success"
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=AmbiguousSnapshotStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "did not confirm terminal success" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
+async def test_run_resume_with_jobless_sync_handle_blocks_complete_product_ralph(
+    tmp_path,
+) -> None:
+    """Jobless synchronous executions cannot be reconciled on resume.
+
+    ``HandlerSynchronousRunStarter`` always returns ``job_id=None`` and
+    relies on the starter's returned dict for terminal-success
+    validation. On resume that dict is gone, so persisted
+    ``execution_id``/``run_session_id`` alone are not evidence of
+    terminal success — they only prove an execution session existed.
+    Most often this branch is reached after the fresh-path paused/failed
+    guard blocked the synchronous run; ``_recoverable_phase_for_tool``
+    sends the resume back into RUN, where without an explicit guard
+    Ralph would launch against the still-pending product session.
+    Resume must block until the operator resolves the synchronous run
+    itself.
+    """
+
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = None
+    state.execution_id = "execution_paused_sync"
+    state.run_session_id = "session_paused_sync"
+    state.complete_product = True
+
+    class JoblessSyncStarter:
+        synchronous_execution = True
+
+        async def __call__(
+            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+        ) -> dict[str, Any]:
+            raise AssertionError("resume must not redispatch a synchronous run")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError(
+            "ralph_starter must not run while jobless sync execution is unreconcilable"
+        )
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=JoblessSyncStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "jobless synchronous execution" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
+async def test_run_resume_with_persisted_handle_blocks_when_owned_job_failed(
+    tmp_path,
+) -> None:
+    """Resume MUST surface a failed owned run job instead of starting Ralph."""
+
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_failed_resume"
+    state.complete_product = True
+
+    class _RunSnapshot:
+        is_terminal = True
+        status = JobStatus.FAILED
+        result_meta = {"status": "failed", "success": False}
+
+    class _RunJobManager:
+        async def get_snapshot(self, _job_id: str) -> _RunSnapshot:
+            return _RunSnapshot()
+
+    class _RunHandler:
+        _job_manager = _RunJobManager()
+
+    class FailedSnapshotStarter:
+        handler = _RunHandler()
+
+        async def __call__(self, _seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not start a duplicate run")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("ralph_starter must not run after a failed resumed execution")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=FailedSnapshotStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == "run_starter"
+    assert "finished unsuccessfully" in (state.last_error or "")
+    assert state.ralph_job_id is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -1525,9 +1525,7 @@ async def test_run_resume_with_persisted_job_id_blocks_when_starter_has_no_snaps
             raise AssertionError("resume must not redispatch the run job")
 
     async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
-        raise AssertionError(
-            "ralph_starter must not run when the owned job cannot be reconciled"
-        )
+        raise AssertionError("ralph_starter must not run when the owned job cannot be reconciled")
 
     pipeline = AutoPipeline(
         _StubInterviewDriver(),
@@ -1644,7 +1642,10 @@ async def test_run_resume_with_jobless_sync_handle_blocks_complete_product_ralph
         synchronous_execution = True
 
         async def __call__(
-            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+            self,
+            _seed: Seed,
+            *,
+            idempotency_key: str = "",  # noqa: ARG002
         ) -> dict[str, Any]:
             raise AssertionError("resume must not redispatch a synchronous run")
 

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -1405,7 +1405,7 @@ async def test_run_resume_with_persisted_handle_blocks_when_owned_job_still_runn
     state.run_handoff_status = "started"
     state.job_id = "job_run_pending_resume"
     state.complete_product = True
-    state.timeout_seconds_by_phase = {AutoPhase.RUN: 0.01}
+    state.timeout_seconds_by_phase = {**state.timeout_seconds_by_phase, AutoPhase.RUN.value: 1}
 
     class _RunSnapshot:
         is_terminal = False


### PR DESCRIPTION
## Summary
- Reopens the Ralph handoff slice from approved #1262 against `main` after the old base branch was deleted.
- On complete-product RUN resume, treat persisted `job_id`/`execution_id`/`run_session_id` as dispatch evidence only, not terminal-success evidence.
- Poll owned run job snapshots before resuming Ralph handoff; block paused, running/queued, failed, unpollable, ambiguous, and jobless synchronous handles.
- Keep the happy path intact when the owned job snapshot explicitly reports terminal success.

## Split Context
This is PR 2 of 3 split from #1262. It is intentionally independent of PR 1 and targets `main` directly.

## Verification
- `uv run ruff check src/ouroboros/auto/pipeline.py tests/unit/auto/test_pipeline_ralph_handoff.py`
- `uv run ruff format --check src/ouroboros/auto/pipeline.py tests/unit/auto/test_pipeline_ralph_handoff.py`
- `uv run pytest tests/unit/auto/test_pipeline_ralph_handoff.py -q` (`48 passed`)

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A - not an R-run benchmark PR | N/A - Ralph resume guard only | n/a |
| Per-round wall-clock (s/round) | N/A - not an R-run benchmark PR | N/A - no canonical R-run captured | n/a |
| Terminal reason                | N/A - not an R-run benchmark PR | N/A - targeted resume/handoff coverage only | n/a |
| EventStore event count         | N/A - not an R-run benchmark PR | N/A - no canonical R-run captured | n/a |

Budget compliance: [x] N/A (Ralph resume guard changes; no canonical R-run comparison captured)

## Related issues
- Split follow-up for #1262