### PR TITLE
fix(auto): clean up synchronous complete-product runs

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -4,11 +4,13 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable
+import contextlib
 from dataclasses import dataclass
 import hashlib
 import os
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
 import yaml
 
@@ -22,12 +24,14 @@ from ouroboros.mcp.tools.authoring_handlers import (
     InterviewHandler,
 )
 from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
-from ouroboros.mcp.tools.execution_handlers import StartExecuteSeedHandler
+from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler
 from ouroboros.mcp.tools.qa import QAHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.tools.subagent import should_dispatch_via_plugin
 from ouroboros.mcp.types import MCPToolResult
 from ouroboros.orchestrator.runtime_evidence import HeadlessRunProbe, RuntimeEvidence
+from ouroboros.orchestrator.session import SessionRepository, SessionStatus
+from ouroboros.persistence.event_store import EventStore
 from ouroboros.resilience.lateral import ThinkingPersona
 
 _SAFE_SEED_ID_FILENAME_CHARS = frozenset(
@@ -237,10 +241,141 @@ class HandlerRunStarter:
             "job_id": _optional_str(meta.get("job_id")),
             "session_id": _optional_str(meta.get("session_id")),
             "execution_id": _optional_str(meta.get("execution_id")),
+            "status": _optional_str(meta.get("status")),
         }
+        if isinstance(meta.get("success"), bool):
+            run_meta["success"] = meta["success"]
         if isinstance(meta.get("_subagent"), dict):
             run_meta["_subagent"] = meta["_subagent"]
         return run_meta
+
+
+class HandlerSynchronousRunStarter:
+    """Callable run starter backed by inline ``ouroboros_execute_seed`` execution."""
+
+    synchronous_execution = True
+
+    def __init__(
+        self,
+        handler: ExecuteSeedHandler,
+        *,
+        cwd: str,
+        skip_qa: bool = True,
+        terminal_poll_interval_seconds: float = 2.0,
+    ) -> None:
+        self.handler = handler
+        self.cwd = cwd
+        self.skip_qa = skip_qa
+        self.terminal_poll_interval_seconds = terminal_poll_interval_seconds
+        self._latest_run_meta: dict[str, object] | None = None
+
+    async def __call__(self, seed: Seed, *, idempotency_key: str = "") -> dict[str, object]:  # noqa: ARG002
+        seed_yaml = yaml.dump(
+            seed.to_dict(), default_flow_style=False, allow_unicode=True, sort_keys=False
+        )
+        session_id = f"orch_{uuid4().hex[:12]}"
+        execution_id = f"exec_{uuid4().hex[:12]}"
+        self._latest_run_meta = {
+            "job_id": None,
+            "session_id": session_id,
+            "execution_id": execution_id,
+            "status": "running",
+            "_allow_deadline_completion_grace": True,
+        }
+        task = asyncio.create_task(
+            self.handler.handle(
+                {"seed_content": seed_yaml, "cwd": self.cwd, "skip_qa": self.skip_qa},
+                execution_id=execution_id,
+                session_id_override=session_id,
+                synchronous=True,
+            )
+        )
+        task.add_done_callback(_consume_background_result)
+        try:
+            while True:
+                done, _pending = await asyncio.wait(
+                    {task},
+                    timeout=max(0.1, self.terminal_poll_interval_seconds),
+                )
+                if done:
+                    result = _unwrap(await task, tool_name="ouroboros_execute_seed")
+                    break
+                recovered = await self.recover_timed_out_run()
+                if recovered is not None:
+                    return recovered
+        except asyncio.CancelledError:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            if self._latest_run_meta is not None:
+                self._latest_run_meta = {
+                    **self._latest_run_meta,
+                    "status": "cancelled",
+                    "success": False,
+                }
+            raise
+        meta = result.meta or {}
+        run_meta: dict[str, object] = {
+            "job_id": None,
+            "session_id": _optional_str(meta.get("session_id")),
+            "execution_id": _optional_str(meta.get("execution_id")),
+            "status": _optional_str(meta.get("status")),
+            "_allow_deadline_completion_grace": True,
+        }
+        if isinstance(meta.get("success"), bool):
+            run_meta["success"] = meta["success"]
+        if isinstance(meta.get("_subagent"), dict):
+            run_meta["_subagent"] = meta["_subagent"]
+        self._latest_run_meta = dict(run_meta)
+        return run_meta
+
+    async def recover_timed_out_run(self) -> dict[str, object] | None:
+        """Recover terminal metadata if inline execution finished during handler teardown."""
+        latest = self._latest_run_meta
+        if not latest:
+            return None
+        session_id = _optional_str(latest.get("session_id"))
+        execution_id = _optional_str(latest.get("execution_id"))
+        if not session_id:
+            return None
+
+        event_store = EventStore()
+        try:
+            await event_store.initialize()
+            result = await SessionRepository(event_store).reconstruct_session(session_id)
+        finally:
+            close_result = event_store.close()
+            if asyncio.iscoroutine(close_result):
+                await close_result
+        if result.is_err:
+            return None
+
+        tracker = result.value
+        if tracker.status == SessionStatus.RUNNING:
+            return None
+        status = tracker.status.value
+        recovered: dict[str, object] = {
+            "job_id": None,
+            "session_id": tracker.session_id,
+            "execution_id": execution_id or tracker.execution_id,
+            "status": status,
+            "_allow_deadline_completion_grace": True,
+        }
+        if tracker.status == SessionStatus.COMPLETED:
+            recovered["success"] = True
+        elif tracker.status in (SessionStatus.FAILED, SessionStatus.CANCELLED):
+            recovered["success"] = False
+        self._latest_run_meta = dict(recovered)
+        return recovered
+
+
+def _consume_background_result(task: asyncio.Task[Any]) -> None:
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        return
+    except Exception:
+        return
 
 
 class HandlerRalphStarter:
@@ -311,7 +446,7 @@ class HandlerRalphStarter:
                         "status": "reattaching",
                     }
                 )
-            terminal_meta = await _wait_for_job_terminal(
+            terminal_meta = await _wait_for_job_terminal_with_cancel_cleanup(
                 job_manager,
                 existing_job_id,
                 timeout_seconds=max_total_seconds,
@@ -411,7 +546,7 @@ class HandlerRalphStarter:
         if max_total_seconds is None:
             terminal_meta = await _wait_for_job_terminal(job_manager, job_id)
         else:
-            terminal_meta = await _wait_for_job_terminal(
+            terminal_meta = await _wait_for_job_terminal_with_cancel_cleanup(
                 job_manager,
                 job_id,
                 timeout_seconds=max_total_seconds,
@@ -471,7 +606,7 @@ class HandlerRalphPoller:
         if max_total_seconds is None:
             terminal_meta = await _wait_for_job_terminal(job_manager, job_id)
         else:
-            terminal_meta = await _wait_for_job_terminal(
+            terminal_meta = await _wait_for_job_terminal_with_cancel_cleanup(
                 job_manager,
                 job_id,
                 timeout_seconds=max_total_seconds,
@@ -743,6 +878,7 @@ async def _wait_for_job_terminal(
     *,
     poll_interval: float = 0.05,
     timeout_seconds: float | None = None,
+    cancel_on_timeout: bool = False,
 ) -> dict[str, Any]:
     """Poll the job manager until ``job_id`` reaches a terminal state.
 
@@ -774,6 +910,8 @@ async def _wait_for_job_terminal(
         if deadline is not None:
             remaining = deadline - loop.time()
             if remaining <= 0:
+                if cancel_on_timeout:
+                    await _cancel_job_after_terminal_wait_timeout(job_manager, job_id)
                 return {
                     "job_id": job_id,
                     "status": "failed",
@@ -782,6 +920,35 @@ async def _wait_for_job_terminal(
             await asyncio.sleep(min(poll_interval, remaining))
             continue
         await asyncio.sleep(poll_interval)
+
+
+async def _wait_for_job_terminal_with_cancel_cleanup(
+    job_manager: JobManager,
+    job_id: str,
+    *,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    try:
+        return await _wait_for_job_terminal(
+            job_manager,
+            job_id,
+            timeout_seconds=timeout_seconds,
+            cancel_on_timeout=True,
+        )
+    except asyncio.CancelledError:
+        await _cancel_job_after_terminal_wait_timeout(job_manager, job_id)
+        raise
+
+
+async def _cancel_job_after_terminal_wait_timeout(job_manager: JobManager, job_id: str) -> None:
+    """Best-effort cleanup for jobs that outlive the auto pipeline deadline."""
+    cancel_job = getattr(job_manager, "cancel_job", None)
+    if cancel_job is None:
+        return
+    try:
+        await cancel_job(job_id)
+    except Exception:
+        return
 
 
 def _terminal_job_status(status: JobStatus) -> str:

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -280,7 +280,6 @@ class HandlerSynchronousRunStarter:
             "session_id": session_id,
             "execution_id": execution_id,
             "status": "running",
-            "_allow_deadline_completion_grace": True,
         }
         task = asyncio.create_task(
             self.handler.handle(
@@ -320,7 +319,6 @@ class HandlerSynchronousRunStarter:
             "session_id": _optional_str(meta.get("session_id")),
             "execution_id": _optional_str(meta.get("execution_id")),
             "status": _optional_str(meta.get("status")),
-            "_allow_deadline_completion_grace": True,
         }
         if isinstance(meta.get("success"), bool):
             run_meta["success"] = meta["success"]

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -124,10 +124,11 @@ def normalize_execution_acceptance(seed: Seed) -> Seed:
     context.
     """
     criteria = tuple(ac for ac in seed.acceptance_criteria if ac and ac.strip())
+    direction_context = "\n".join((seed.goal, *seed.constraints))
     if not criteria or not _has_auto_wrapper_context(seed.goal, criteria):
         return seed
 
-    filtered = normalize_observation_execution_criteria(criteria, context_text=seed.goal)
+    filtered = normalize_observation_execution_criteria(criteria, context_text=direction_context)
     if not filtered or filtered == criteria:
         return seed
     return seed.model_copy(update={"acceptance_criteria": filtered})
@@ -221,8 +222,8 @@ def _canonical_hello_auto_observation_ac(context_text: str, criteria: tuple[str,
 def _extract_hello_auto_return_value(text: str) -> str:
     for pattern in (
         r"hello_auto\(\)(?:\s*->\s*str)?\s+returns?\s+exactly\s+[`'\"]([^`'\"]+)[`'\"]",
-        r"returning\s+exactly\s+[`'\"]([^`'\"]+)[`'\"]",
         r"must\s+return\s+exactly\s+[`'\"]([^`'\"]+)[`'\"]",
+        r"returning\s+exactly\s+[`'\"]([^`'\"]+)[`'\"]",
     ):
         match = re.search(pattern, text, flags=re.IGNORECASE)
         if match:

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 from ouroboros.core.seed import Seed
 
 _AUTO_WRAPPER_CRITERIA = frozenset(
@@ -59,7 +61,7 @@ _OBSERVATION_CONTEXT_ALTERNATES = (
 
 _CANONICAL_HELLO_AUTO_OBSERVATION_AC = (
     "Create `hello_auto.py` and `tests/test_hello_auto.py` so "
-    "`hello_auto() -> str` returns exactly `hello from ooo auto`, "
+    "`hello_auto() -> str` returns exactly `{return_value}`, "
     "the test imports `hello_auto` and asserts that exact value, and "
     "the exact command `uv run pytest tests/test_hello_auto.py` passes."
 )
@@ -162,7 +164,8 @@ def normalize_observation_execution_criteria(
         passthrough = [
             line for line in execution_lines if not _is_hello_auto_observation_unit_line(line)
         ]
-        return tuple(dict.fromkeys((_CANONICAL_HELLO_AUTO_OBSERVATION_AC, *passthrough)))
+        canonical = _canonical_hello_auto_observation_ac(context_text, tuple(execution_lines))
+        return tuple(dict.fromkeys((canonical, *passthrough)))
 
     normalized = [_normalize_known_observation_execution_line(line) for line in execution_lines]
     return tuple(dict.fromkeys(normalized))
@@ -208,6 +211,23 @@ def _normalize_known_observation_execution_line(criterion: str) -> str:
     if key in _HELLO_AUTO_PYTEST_EQUIVALENTS:
         return "The exact command `uv run pytest tests/test_hello_auto.py` passes."
     return criterion
+
+
+def _canonical_hello_auto_observation_ac(context_text: str, criteria: tuple[str, ...]) -> str:
+    return_value = _extract_hello_auto_return_value("\n".join((context_text, *criteria)))
+    return _CANONICAL_HELLO_AUTO_OBSERVATION_AC.format(return_value=return_value)
+
+
+def _extract_hello_auto_return_value(text: str) -> str:
+    for pattern in (
+        r"hello_auto\(\)(?:\s*->\s*str)?\s+returns?\s+exactly\s+[`'\"]([^`'\"]+)[`'\"]",
+        r"returning\s+exactly\s+[`'\"]([^`'\"]+)[`'\"]",
+        r"must\s+return\s+exactly\s+[`'\"]([^`'\"]+)[`'\"]",
+    ):
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match:
+            return match.group(1).strip()
+    return "hello from ooo auto"
 
 
 def _is_observation_report_only_line(criterion: str) -> bool:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1469,7 +1469,7 @@ class AutoPipeline:
         ):
             remaining = self._remaining_deadline_seconds(state)
             if remaining is not None:
-                return remaining + _SYNCHRONOUS_RUN_COMPLETION_GRACE_SECONDS
+                return remaining
             return float(state.phase_timeout_seconds(AutoPhase.RUN))
         return self._deadline_capped_timeout(state, self.run_start_timeout_seconds)
 
@@ -3510,7 +3510,9 @@ def _arm_legacy_missing_deadline(state: AutoPipelineState) -> bool:
 
 
 def _allows_synchronous_completion_grace(run_meta: dict[str, Any]) -> bool:
-    return bool(run_meta.get("_allow_deadline_completion_grace"))
+    return bool(run_meta.get("_allow_deadline_completion_grace")) and bool(
+        run_meta.get("_recovered_after_timeout")
+    )
 
 
 def _within_synchronous_completion_grace(state: AutoPipelineState) -> bool:
@@ -3531,7 +3533,9 @@ async def _recover_timed_out_synchronous_run(
         recovered = await asyncio.wait_for(recover(), timeout=timeout_seconds)
     except Exception:
         return None
-    return recovered if isinstance(recovered, dict) else None
+    if not isinstance(recovered, dict):
+        return None
+    return {**recovered, "_recovered_after_timeout": True}
 
 
 def _has_reconciliable_ralph_resume_checkpoint(state: AutoPipelineState) -> bool:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -225,6 +225,7 @@ _DEFAULT_RALPH_PER_ITERATION_SECONDS = 1800.0
 # never run without this floor — silently demoting a legitimately completed
 # Ralph loop to a false ``pipeline_timeout`` BLOCKED.
 _RALPH_RESUME_PEEK_SECONDS = 1.0
+_SYNCHRONOUS_RUN_COMPLETION_GRACE_SECONDS = 300.0
 
 # RFC #1256 §I4 — bounded composition-root drain budget for typed
 # ``auto.interview.*`` lifecycle events scheduled by
@@ -1219,7 +1220,7 @@ class AutoPipeline:
             state.run_start_attempted = True
             self._save(state)
             run_meta: dict[str, Any] | None = None
-            run_start_timeout = self._deadline_capped_timeout(state, self.run_start_timeout_seconds)
+            run_start_timeout = self._run_start_timeout(state)
             try:
                 run_kwargs: dict[str, Any] = {}
                 if _accepts_keyword(self.run_starter, IDEMPOTENCY_KWARG_NAME):
@@ -1231,27 +1232,30 @@ class AutoPipeline:
                 if not isinstance(run_meta, dict):
                     msg = f"run starter returned {type(run_meta).__name__}, expected dict"
                     raise TypeError(msg)
-            except TimeoutError as exc:
-                if self._enforce_deadline(state):
-                    return self._result(state, ledger, review=review, blocker=state.last_error)
-                _mark_unknown_run_handoff(state, status=UNKNOWN_TIMEOUT_STATUS)
-                if retried:
+            except TimeoutError:
+                if state.is_deadline_expired():
+                    recovered_run_meta = await _recover_timed_out_synchronous_run(
+                        self.run_starter,
+                        timeout_seconds=5.0,
+                    )
+                    if recovered_run_meta is not None:
+                        run_meta = recovered_run_meta
+                    elif self._enforce_deadline(state):
+                        return self._result(state, ledger, review=review, blocker=state.last_error)
+                if run_meta is None:
+                    _mark_unknown_run_handoff(state, status=UNKNOWN_TIMEOUT_STATUS)
+                if run_meta is None and retried:
                     state.run_handoff_guidance = (
                         f"{state.run_handoff_guidance or ''} "
                         f"{RETRY_GUIDANCE_PHRASE} {idempotency_key}"
                     ).strip()
                     state.mark_blocked(
-                        f"run start timed out after {self.run_start_timeout_seconds:.0f}s; "
+                        f"run start timed out after {run_start_timeout:.0f}s; "
                         f"{RETRY_GUIDANCE_PHRASE} {idempotency_key}",
                         tool_name="run_starter",
                     )
                     self._save(state)
-                    return self._result(
-                        state,
-                        ledger,
-                        review=review,
-                        blocker=state.last_error or str(exc),
-                    )
+                    return self._result(state, ledger, review=review, blocker=state.last_error)
             except Exception as exc:
                 if retried:
                     # Retry attempt itself raised — bound is exhausted. The
@@ -1300,6 +1304,37 @@ class AutoPipeline:
                 if any((state.job_id, state.execution_id, state.run_session_id)):
                     state.run_handoff_status = RUN_HANDOFF_STARTED_STATUS
                     state.run_handoff_guidance = None
+                    run_success = run_meta.get("success")
+                    if (
+                        self.complete_product
+                        and bool(getattr(self.run_starter, "synchronous_execution", False))
+                        and run_success is True
+                    ):
+                        if state.is_deadline_expired() and not (
+                            _allows_synchronous_completion_grace(run_meta)
+                            and _within_synchronous_completion_grace(state)
+                        ):
+                            if self._enforce_deadline(state):
+                                return self._result(
+                                    state,
+                                    ledger,
+                                    review=review,
+                                    blocker=state.last_error,
+                                    run_subagent=run_subagent,
+                                )
+                        state.run_handoff_status = "completed"
+                        state.run_handoff_guidance = None
+                        state.transition(
+                            AutoPhase.COMPLETE,
+                            "synchronous execution completed for complete-product run",
+                        )
+                        self._save(state)
+                        return self._result(
+                            state,
+                            ledger,
+                            review=review,
+                            run_subagent=run_subagent,
+                        )
                     # Q00/ouroboros#773: when ``--complete-product`` is set
                     # and a ralph starter is configured, chain RUN →
                     # RALPH_HANDOFF instead of going straight to COMPLETE.
@@ -1420,6 +1455,23 @@ class AutoPipeline:
         if remaining <= 0:
             return 0.0
         return float(min(float(phase_timeout), remaining))
+
+    def _run_start_timeout(self, state: AutoPipelineState) -> float:
+        """Return the timeout budget for the run starter invocation.
+
+        Async run starters only enqueue work, so they keep the short
+        ``run_start_timeout_seconds`` budget. The CLI complete-product path can
+        use a synchronous starter that owns the actual execution; treat that as
+        RUN phase work and let the top-level pipeline deadline bound it.
+        """
+        if self.complete_product and bool(
+            getattr(self.run_starter, "synchronous_execution", False)
+        ):
+            remaining = self._remaining_deadline_seconds(state)
+            if remaining is not None:
+                return remaining + _SYNCHRONOUS_RUN_COMPLETION_GRACE_SECONDS
+            return float(state.phase_timeout_seconds(AutoPhase.RUN))
+        return self._deadline_capped_timeout(state, self.run_start_timeout_seconds)
 
     async def _drain_interview_observer_events(
         self, state: AutoPipelineState | None = None
@@ -3455,6 +3507,31 @@ def _arm_legacy_missing_deadline(state: AutoPipelineState) -> bool:
         return False
     state.arm_deadline()
     return True
+
+
+def _allows_synchronous_completion_grace(run_meta: dict[str, Any]) -> bool:
+    return bool(run_meta.get("_allow_deadline_completion_grace"))
+
+
+def _within_synchronous_completion_grace(state: AutoPipelineState) -> bool:
+    if state.deadline_at is None:
+        return True
+    return (time.monotonic() - state.deadline_at) <= _SYNCHRONOUS_RUN_COMPLETION_GRACE_SECONDS
+
+
+async def _recover_timed_out_synchronous_run(
+    adapter: object | None,
+    *,
+    timeout_seconds: float,
+) -> dict[str, Any] | None:
+    recover = getattr(adapter, "recover_timed_out_run", None)
+    if recover is None:
+        return None
+    try:
+        recovered = await asyncio.wait_for(recover(), timeout=timeout_seconds)
+    except Exception:
+        return None
+    return recovered if isinstance(recovered, dict) else None
 
 
 def _has_reconciliable_ralph_resume_checkpoint(state: AutoPipelineState) -> bool:

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -18,6 +18,7 @@ from ouroboros.auto.adapters import (
     HandlerRalphStarter,
     HandlerRunStarter,
     HandlerSeedGenerator,
+    HandlerSynchronousRunStarter,
     load_seed,
     save_seed,
 )
@@ -511,7 +512,11 @@ async def _run_auto(
     pipeline = AutoPipeline(
         driver,
         HandlerSeedGenerator(generate_seed),
-        run_starter=HandlerRunStarter(start_execute, cwd=state.cwd),
+        run_starter=(
+            HandlerSynchronousRunStarter(execute_seed, cwd=state.cwd)
+            if complete_product
+            else HandlerRunStarter(start_execute, cwd=state.cwd)
+        ),
         store=store,
         repairer=SeedRepairer(max_repair_rounds=max_repair_rounds),
         seed_saver=save_seed,

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -867,6 +867,7 @@ class EventStore:
         resolved_execution_id = execution_id or await self._resolve_execution_id_for_session(
             session_id,
         )
+        session_started_at = await self._resolve_session_started_at(session_id)
 
         conditions = _session_related_event_conditions(session_id, resolved_execution_id)
 
@@ -877,6 +878,8 @@ class EventStore:
                     .where(or_(*conditions))
                     .order_by(events_table.c.timestamp.desc())
                 )
+                if session_started_at is not None:
+                    query = query.where(events_table.c.timestamp >= session_started_at)
 
                 if event_type:
                     query = query.where(events_table.c.event_type == event_type)
@@ -1047,6 +1050,27 @@ class EventStore:
                 if isinstance(execution_id, str) and execution_id:
                     return execution_id
             return None
+
+    async def _resolve_session_started_at(self, session_id: str) -> Any | None:
+        """Return the persisted start timestamp for a session, if available."""
+        if self._engine is None:
+            raise PersistenceError(
+                "EventStore not initialized. Call initialize() first.",
+                operation="resolve_session_started_at",
+            )
+
+        async with self._engine.begin() as conn:
+            query = (
+                select(events_table.c.timestamp)
+                .where(events_table.c.aggregate_type == "session")
+                .where(events_table.c.aggregate_id == session_id)
+                .where(events_table.c.event_type == "orchestrator.session.started")
+                .order_by(events_table.c.timestamp.asc())
+                .limit(1)
+            )
+            result = await conn.execute(query)
+            row = result.first()
+            return row[0] if row is not None else None
 
     async def get_all_lineages(self) -> list[BaseEvent]:
         """Get all lineage creation events.

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -987,6 +987,7 @@ class EventStore:
         resolved_execution_id = execution_id or await self._resolve_execution_id_for_session(
             session_id,
         )
+        session_started_at = await self._resolve_session_started_at(session_id)
         conditions = _session_related_event_conditions(session_id, resolved_execution_id)
 
         try:
@@ -998,6 +999,8 @@ class EventStore:
                     .where(text("rowid > :last_id").bindparams(last_id=last_row_id))
                     .order_by(events_table.c.timestamp, events_table.c.id)
                 )
+                if session_started_at is not None:
+                    query = query.where(events_table.c.timestamp >= session_started_at)
 
                 if event_type:
                     query = query.where(events_table.c.event_type == event_type)

--- a/tests/unit/auto/test_adapters_client_gates.py
+++ b/tests/unit/auto/test_adapters_client_gates.py
@@ -2,14 +2,25 @@
 
 from __future__ import annotations
 
+import asyncio
 from unittest.mock import AsyncMock
 
 import pytest
 
-from ouroboros.auto.adapters import HandlerError, HandlerInterviewBackend, HandlerSeedGenerator
+from ouroboros.auto.adapters import (
+    HandlerError,
+    HandlerInterviewBackend,
+    HandlerSeedGenerator,
+    HandlerSynchronousRunStarter,
+)
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPToolError
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+
+
+class _FakeSeed:
+    def to_dict(self) -> dict[str, object]:
+        return {"goal": "Create hello_auto.py", "acceptance_criteria": ()}
 
 
 @pytest.mark.asyncio
@@ -44,6 +55,107 @@ async def test_auto_interview_backend_ignores_seed_ready_client_gate_metadata(tm
 
     assert turn.session_id == "interview_auto"
     assert turn.seed_ready is True
+
+
+@pytest.mark.asyncio
+async def test_synchronous_run_starter_skips_execute_seed_qa(tmp_path) -> None:
+    """Auto complete-product uses exact execution evidence, not execute_seed QA teardown."""
+    handler = AsyncMock()
+    handler.handle = AsyncMock(
+        return_value=Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="done"),),
+                is_error=False,
+                meta={
+                    "session_id": "orch_sync",
+                    "execution_id": "exec_sync",
+                    "status": "completed",
+                    "success": True,
+                },
+            )
+        )
+    )
+    starter = HandlerSynchronousRunStarter(handler, cwd=str(tmp_path))
+
+    result = await starter(_FakeSeed())  # type: ignore[arg-type]
+
+    arguments = handler.handle.await_args.args[0]
+    assert arguments["skip_qa"] is True
+    assert result["status"] == "completed"
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_synchronous_run_starter_returns_persisted_terminal_meta_before_teardown(
+    tmp_path,
+) -> None:
+    """Auto does not wait for execute_seed teardown after the session is terminal."""
+    handler = AsyncMock()
+
+    async def slow_handle(*_args: object, **_kwargs: object) -> object:
+        await asyncio.sleep(60)
+        raise AssertionError("terminal recovery should return first")
+
+    handler.handle = AsyncMock(side_effect=slow_handle)
+
+    class RecoveringStarter(HandlerSynchronousRunStarter):
+        async def recover_timed_out_run(self) -> dict[str, object] | None:
+            return {
+                "job_id": None,
+                "session_id": "orch_recovered",
+                "execution_id": "exec_recovered",
+                "status": "completed",
+                "success": True,
+                "_allow_deadline_completion_grace": True,
+            }
+
+    starter = RecoveringStarter(
+        handler,
+        cwd=str(tmp_path),
+        terminal_poll_interval_seconds=0.1,
+    )
+
+    result = await starter(_FakeSeed())  # type: ignore[arg-type]
+
+    assert result["session_id"] == "orch_recovered"
+    assert result["execution_id"] == "exec_recovered"
+    assert result["success"] is True
+
+
+@pytest.mark.asyncio
+async def test_synchronous_run_starter_cancels_inner_execute_seed_on_outer_cancel(
+    tmp_path,
+) -> None:
+    """A timed-out auto pipeline must not leave inline execution running."""
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+    handler = AsyncMock()
+
+    async def hanging_handle(*_args: object, **_kwargs: object) -> object:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    handler.handle = AsyncMock(side_effect=hanging_handle)
+    starter = HandlerSynchronousRunStarter(
+        handler,
+        cwd=str(tmp_path),
+        terminal_poll_interval_seconds=60,
+    )
+
+    call_task = asyncio.create_task(starter(_FakeSeed()))  # type: ignore[arg-type]
+    await asyncio.wait_for(started.wait(), timeout=1)
+
+    call_task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await call_task
+    await asyncio.wait_for(cancelled.wait(), timeout=1)
+    assert starter._latest_run_meta is not None
+    assert starter._latest_run_meta["status"] == "cancelled"
+    assert starter._latest_run_meta["success"] is False
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -76,6 +76,35 @@ def test_normalize_execution_acceptance_preserves_requested_hello_auto_value() -
             ),
             "constraints": (
                 "hello_auto() must return exactly 'hello from ooo auto fresh'",
+                "Only edit hello_auto.py and tests/test_hello_auto.py",
+            ),
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == (
+        "Create `hello_auto.py` and `tests/test_hello_auto.py` so "
+        "`hello_auto() -> str` returns exactly `hello from ooo auto fresh`, "
+        "the test imports `hello_auto` and asserts that exact value, and "
+        "the exact command `uv run pytest tests/test_hello_auto.py` passes.",
+    )
+
+
+def test_normalize_execution_acceptance_reads_requested_value_from_constraints() -> None:
+    seed = _seed(
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+    ).model_copy(
+        update={
+            "goal": (
+                "Observation run: verify latest main Ouroboros ooo auto with "
+                "hello_auto.py and tests/test_hello_auto.py via ouroboros_auto."
+            ),
+            "constraints": (
+                "hello_auto() must return exactly 'hello from ooo auto fresh'",
+                "Only edit hello_auto.py and tests/test_hello_auto.py",
             ),
         }
     )

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -61,6 +61,35 @@ def test_normalize_execution_acceptance_drops_auto_report_criteria() -> None:
     assert normalized.acceptance_criteria == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
 
 
+def test_normalize_execution_acceptance_preserves_requested_hello_auto_value() -> None:
+    seed = _seed(
+        "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
+        "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
+        "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+    ).model_copy(
+        update={
+            "goal": (
+                "Create hello_auto.py with hello_auto() returning exactly "
+                "'hello from ooo auto fresh'. Create tests/test_hello_auto.py "
+                "importing hello_auto and asserting that exact value. Verification "
+                "command is uv run pytest tests/test_hello_auto.py."
+            ),
+            "constraints": (
+                "hello_auto() must return exactly 'hello from ooo auto fresh'",
+            ),
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == (
+        "Create `hello_auto.py` and `tests/test_hello_auto.py` so "
+        "`hello_auto() -> str` returns exactly `hello from ooo auto fresh`, "
+        "the test imports `hello_auto` and asserts that exact value, and "
+        "the exact command `uv run pytest tests/test_hello_auto.py` passes.",
+    )
+
+
 def test_normalize_execution_acceptance_drops_observation_report_metadata() -> None:
     seed = _seed(
         "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -631,7 +631,10 @@ async def test_complete_product_synchronous_run_uses_pipeline_deadline_not_hando
         synchronous_execution = True
 
         async def __call__(
-            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+            self,
+            _seed: Seed,
+            *,
+            idempotency_key: str = "",  # noqa: ARG002
         ) -> dict[str, Any]:
             await asyncio.sleep(0.02)
             return {
@@ -697,7 +700,10 @@ async def test_complete_product_synchronous_success_after_deadline_blocks_as_tim
         synchronous_execution = True
 
         async def __call__(
-            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+            self,
+            _seed: Seed,
+            *,
+            idempotency_key: str = "",  # noqa: ARG002
         ) -> dict[str, Any]:
             state.deadline_at = time.monotonic() - 1.0
             state.deadline_at_epoch = time.time() - 1.0
@@ -740,7 +746,10 @@ async def test_first_party_synchronous_success_within_grace_completes(tmp_path) 
         synchronous_execution = True
 
         async def __call__(
-            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+            self,
+            _seed: Seed,
+            *,
+            idempotency_key: str = "",  # noqa: ARG002
         ) -> dict[str, Any]:
             state.deadline_at = time.monotonic() - 1.0
             state.deadline_at_epoch = time.time() - 1.0
@@ -789,7 +798,10 @@ async def test_first_party_synchronous_timeout_recovers_completed_session(
         synchronous_execution = True
 
         async def __call__(
-            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+            self,
+            _seed: Seed,
+            *,
+            idempotency_key: str = "",  # noqa: ARG002
         ) -> dict[str, Any]:
             await asyncio.sleep(1.0)
             raise AssertionError("wait_for should time out first")

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -669,8 +669,8 @@ async def test_complete_product_synchronous_run_uses_pipeline_deadline_not_hando
     assert state.last_tool_name != "run_starter"
 
 
-def test_complete_product_synchronous_run_timeout_has_completion_grace(tmp_path) -> None:
-    """Synchronous run teardown gets a small grace beyond the strict deadline."""
+def test_complete_product_synchronous_run_timeout_is_capped_by_deadline(tmp_path) -> None:
+    """Synchronous RUN work is bounded by the strict pipeline deadline."""
     state = _state_at_run_phase(tmp_path)
     state.deadline_at = time.monotonic() + 5.0
 
@@ -686,7 +686,7 @@ def test_complete_product_synchronous_run_timeout_has_completion_grace(tmp_path)
         run_start_timeout_seconds=0.001,
     )
 
-    assert pipeline._run_start_timeout(state) > 5.0
+    assert 0.0 < pipeline._run_start_timeout(state) <= 5.0
 
 
 @pytest.mark.asyncio
@@ -738,8 +738,10 @@ async def test_complete_product_synchronous_success_after_deadline_blocks_as_tim
 
 
 @pytest.mark.asyncio
-async def test_first_party_synchronous_success_within_grace_completes(tmp_path) -> None:
-    """First-party inline execution may return terminal metadata during teardown grace."""
+async def test_first_party_synchronous_success_after_deadline_blocks_even_with_grace_flag(
+    tmp_path,
+) -> None:
+    """Grace applies only to timeout recovery, not over-deadline RUN work."""
     state = _state_at_run_phase(tmp_path)
 
     class FirstPartySyncStarter:
@@ -776,10 +778,10 @@ async def test_first_party_synchronous_success_within_grace_completes(tmp_path) 
 
     result = await pipeline.run(state)
 
-    assert result.status == "complete"
-    assert result.run_handoff_status == "completed"
-    assert state.phase is AutoPhase.COMPLETE
-    assert state.last_tool_name != PIPELINE_DEADLINE_TOOL_NAME
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.last_tool_name == PIPELINE_DEADLINE_TOOL_NAME
+    assert "pipeline_timeout" in (state.last_error or "")
     assert state.ralph_job_id is None
 
 

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -619,6 +619,218 @@ async def test_ralph_handoff_resume_does_not_dispatch_duplicate_work(tmp_path) -
 
 
 @pytest.mark.asyncio
+async def test_complete_product_synchronous_run_uses_pipeline_deadline_not_handoff_timeout(
+    tmp_path,
+) -> None:
+    """Inline complete-product execution is terminal RUN work, not quick enqueue work."""
+    state = _state_at_run_phase(tmp_path)
+    state.pipeline_timeout_seconds = 120.0
+    state.arm_deadline()
+
+    class SlowSynchronousRunStarter:
+        synchronous_execution = True
+
+        async def __call__(
+            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+        ) -> dict[str, Any]:
+            await asyncio.sleep(0.02)
+            return {
+                "job_id": None,
+                "session_id": "sync_session",
+                "execution_id": "sync_exec",
+                "status": "completed",
+                "success": True,
+            }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("successful synchronous run must not dispatch Ralph")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=SlowSynchronousRunStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+        run_start_timeout_seconds=0.001,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.run_handoff_status == "completed"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.execution_id == "sync_exec"
+    assert state.run_handoff_status == "completed"
+    assert state.ralph_job_id is None
+    assert state.last_tool_name != "run_starter"
+
+
+def test_complete_product_synchronous_run_timeout_has_completion_grace(tmp_path) -> None:
+    """Synchronous run teardown gets a small grace beyond the strict deadline."""
+    state = _state_at_run_phase(tmp_path)
+    state.deadline_at = time.monotonic() + 5.0
+
+    class SynchronousRunStarter:
+        synchronous_execution = True
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=SynchronousRunStarter(),
+        reviewer=_PassReviewer(),
+        complete_product=True,
+        run_start_timeout_seconds=0.001,
+    )
+
+    assert pipeline._run_start_timeout(state) > 5.0
+
+
+@pytest.mark.asyncio
+async def test_complete_product_synchronous_success_after_deadline_blocks_as_timeout(
+    tmp_path,
+) -> None:
+    """Sync completion grace must not turn into extra execution budget."""
+    state = _state_at_run_phase(tmp_path)
+
+    class OverBudgetSyncStarter:
+        synchronous_execution = True
+
+        async def __call__(
+            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+        ) -> dict[str, Any]:
+            state.deadline_at = time.monotonic() - 1.0
+            state.deadline_at_epoch = time.time() - 1.0
+            return {
+                "job_id": None,
+                "session_id": "sync_over_budget",
+                "execution_id": "sync_over_budget_exec",
+                "status": "completed",
+                "success": True,
+            }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("ralph_starter must not run when sync execution is over deadline")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=OverBudgetSyncStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.is_deadline_expired()
+    assert state.last_tool_name == PIPELINE_DEADLINE_TOOL_NAME
+    assert "pipeline_timeout" in (state.last_error or "")
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
+async def test_first_party_synchronous_success_within_grace_completes(tmp_path) -> None:
+    """First-party inline execution may return terminal metadata during teardown grace."""
+    state = _state_at_run_phase(tmp_path)
+
+    class FirstPartySyncStarter:
+        synchronous_execution = True
+
+        async def __call__(
+            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+        ) -> dict[str, Any]:
+            state.deadline_at = time.monotonic() - 1.0
+            state.deadline_at_epoch = time.time() - 1.0
+            return {
+                "job_id": None,
+                "session_id": "sync_grace",
+                "execution_id": "sync_grace_exec",
+                "status": "completed",
+                "success": True,
+                "_allow_deadline_completion_grace": True,
+            }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("successful first-party sync execution must not dispatch Ralph")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=FirstPartySyncStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.run_handoff_status == "completed"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.last_tool_name != PIPELINE_DEADLINE_TOOL_NAME
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
+async def test_first_party_synchronous_timeout_recovers_completed_session(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If inline handler teardown times out, recover terminal session metadata."""
+    monkeypatch.setattr(pipeline_module, "_SYNCHRONOUS_RUN_COMPLETION_GRACE_SECONDS", 0.05)
+    state = _state_at_run_phase(tmp_path)
+    state.deadline_at = time.monotonic() + 0.2
+    state.deadline_at_epoch = time.time() + 0.2
+
+    class TimeoutAfterCompletionStarter:
+        synchronous_execution = True
+
+        async def __call__(
+            self, _seed: Seed, *, idempotency_key: str = ""  # noqa: ARG002
+        ) -> dict[str, Any]:
+            await asyncio.sleep(1.0)
+            raise AssertionError("wait_for should time out first")
+
+        async def recover_timed_out_run(self) -> dict[str, Any]:
+            state.deadline_at = time.monotonic() - 0.01
+            state.deadline_at_epoch = time.time() - 0.01
+            return {
+                "job_id": None,
+                "session_id": "sync_recovered",
+                "execution_id": "sync_recovered_exec",
+                "status": "completed",
+                "success": True,
+                "_allow_deadline_completion_grace": True,
+            }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("successful recovered sync execution must not dispatch Ralph")
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=TimeoutAfterCompletionStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+        run_start_timeout_seconds=0.001,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.run_handoff_status == "completed"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.execution_id == "sync_recovered_exec"
+    assert state.run_session_id == "sync_recovered"
+    assert state.last_tool_name != PIPELINE_DEADLINE_TOOL_NAME
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
 async def test_insufficient_ralph_deadline_budget_blocks_as_pipeline_timeout(tmp_path) -> None:
     state = _state_at_run_phase(tmp_path)
     state.deadline_at = time.monotonic() + 0.25

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -962,6 +962,51 @@ class TestSessionRelatedEvents:
         assert [event.type for event in second_batch] == ["execution.ac.heartbeat"]
         assert next_cursor > cursor
 
+    async def test_session_related_events_after_are_bounded_by_session_start(
+        self,
+        event_store: EventStore,
+    ) -> None:
+        """Incremental session polling must ignore stale pre-start payload matches."""
+        session_id = "sess-bounded-related-after"
+        execution_id = "exec-bounded-related-after"
+        session_started_at = datetime.now(UTC)
+        await event_store.append(
+            BaseEvent(
+                type="execution.ac.heartbeat",
+                timestamp=session_started_at - timedelta(days=1),
+                aggregate_type="execution",
+                aggregate_id="old-runtime-scope",
+                data={"session_id": session_id, "message_count": 1},
+            )
+        )
+        await event_store.append(
+            BaseEvent(
+                type="orchestrator.session.started",
+                timestamp=session_started_at,
+                aggregate_type="session",
+                aggregate_id=session_id,
+                data={"execution_id": execution_id, "seed_id": "seed-bounded-related-after"},
+            )
+        )
+        await event_store.append(
+            BaseEvent(
+                type="execution.ac.heartbeat",
+                timestamp=session_started_at + timedelta(seconds=1),
+                aggregate_type="execution",
+                aggregate_id="new-runtime-scope",
+                data={"session_id": session_id, "message_count": 1},
+            )
+        )
+
+        events, cursor = await event_store.query_session_related_events_after(
+            session_id,
+            execution_id=execution_id,
+            last_row_id=0,
+        )
+
+        assert [event.aggregate_id for event in events] == [session_id, "new-runtime-scope"]
+        assert cursor > 0
+
     async def test_session_related_events_after_includes_exact_parent_execution_children(
         self,
         event_store: EventStore,

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -1,6 +1,7 @@
 """Unit tests for ouroboros.persistence.event_store module."""
 
 import asyncio
+from datetime import UTC, datetime, timedelta
 import logging
 
 import pytest
@@ -784,6 +785,53 @@ class TestSessionRelatedEvents:
         assert f"{execution_scope}_level_1_coordinator_reconciliation" in aggregate_ids
         assert f"{execution_scope}_child_0" in aggregate_ids
         assert "other_evolve_ac_0" not in aggregate_ids
+
+    async def test_session_related_events_are_bounded_by_session_start(
+        self,
+        event_store: EventStore,
+    ) -> None:
+        """Historical payload matches should not force full-history session scans."""
+        session_id = "sess-bounded-related"
+        execution_id = "exec-bounded-related"
+        session_started_at = datetime.now(UTC)
+        await event_store.append(
+            BaseEvent(
+                type="execution.ac.heartbeat",
+                timestamp=session_started_at - timedelta(days=1),
+                aggregate_type="execution",
+                aggregate_id="old-runtime-scope",
+                data={"session_id": session_id, "message_count": 1},
+            )
+        )
+        await event_store.append(
+            BaseEvent(
+                type="orchestrator.session.started",
+                timestamp=session_started_at,
+                aggregate_type="session",
+                aggregate_id=session_id,
+                data={"execution_id": execution_id, "seed_id": "seed-bounded-related"},
+            )
+        )
+        await event_store.append(
+            BaseEvent(
+                type="execution.ac.heartbeat",
+                timestamp=session_started_at + timedelta(seconds=1),
+                aggregate_type="execution",
+                aggregate_id="new-runtime-scope",
+                data={"session_id": session_id, "message_count": 1},
+            )
+        )
+
+        result = await event_store.query_session_related_events(
+            session_id,
+            execution_id=execution_id,
+            limit=None,
+        )
+        aggregate_ids = {event.aggregate_id for event in result}
+
+        assert "new-runtime-scope" in aggregate_ids
+        assert session_id in aggregate_ids
+        assert "old-runtime-scope" not in aggregate_ids
 
     async def test_execution_related_events_include_child_scopes(
         self,


### PR DESCRIPTION
## Summary
- Reopens the synchronous complete-product cleanup slice from approved #1262 against `main` after the old base branch was deleted.
- Add `HandlerSynchronousRunStarter` so CLI `--complete-product` can run inline `execute_seed`, recover terminal session metadata during handler teardown, and cancel the inner execution task when the outer auto pipeline is cancelled.
- Treat synchronous complete-product execution as RUN phase work bounded by the pipeline deadline/grace contract, and recover terminal metadata before reporting timeout.
- Bound session-related event recovery to events at or after the session start timestamp.
- Preserve the exact requested `hello_auto()` return value when canonicalizing smoke acceptance criteria, including constraints-only direction.

## Split Context
This is PR 3 of 3 split from #1262. It is independent of PR 1 and PR 2 and targets `main` directly. If PR 2 merges first, this branch may need a small rebase around `pipeline.py`/`test_pipeline_ralph_handoff.py`.

## Verification
- `uv run ruff check src/ouroboros/auto/adapters.py src/ouroboros/auto/execution_acceptance.py src/ouroboros/auto/pipeline.py src/ouroboros/cli/commands/auto.py src/ouroboros/persistence/event_store.py tests/unit/auto/test_adapters_client_gates.py tests/unit/auto/test_execution_acceptance.py tests/unit/auto/test_pipeline_ralph_handoff.py tests/unit/persistence/test_event_store.py`
- `uv run ruff format --check src/ouroboros/auto/adapters.py src/ouroboros/auto/execution_acceptance.py src/ouroboros/auto/pipeline.py src/ouroboros/cli/commands/auto.py src/ouroboros/persistence/event_store.py tests/unit/auto/test_adapters_client_gates.py tests/unit/auto/test_execution_acceptance.py tests/unit/auto/test_pipeline_ralph_handoff.py tests/unit/persistence/test_event_store.py`
- `uv run pytest tests/unit/auto/test_adapters_client_gates.py tests/unit/auto/test_execution_acceptance.py tests/unit/auto/test_pipeline_ralph_handoff.py tests/unit/persistence/test_event_store.py -q` (`114 passed`)

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A - not an R-run benchmark PR | N/A - synchronous complete-product cleanup only | n/a |
| Per-round wall-clock (s/round) | N/A - not an R-run benchmark PR | N/A - no canonical R-run captured | n/a |
| Terminal reason                | N/A - not an R-run benchmark PR | N/A - targeted sync cleanup/recovery coverage only | n/a |
| EventStore event count         | N/A - not an R-run benchmark PR | N/A - no canonical R-run captured | n/a |

Budget compliance: [x] N/A (synchronous complete-product cleanup; no canonical R-run comparison captured)

## Related issues
- Split follow-up for #1262