### PR TITLE
feat(auto): isolate coding sessions with checkpoint commits

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -221,15 +221,26 @@ class HandlerSeedGenerator:
 class HandlerRunStarter:
     """Callable run starter backed by ``ouroboros_start_execute_seed``."""
 
-    def __init__(self, handler: StartExecuteSeedHandler, *, cwd: str) -> None:
+    def __init__(
+        self,
+        handler: StartExecuteSeedHandler,
+        *,
+        cwd: str,
+        use_worktree: bool = True,
+    ) -> None:
         self.handler = handler
         self.cwd = cwd
+        self.use_worktree = use_worktree
 
     async def __call__(self, seed: Seed, *, idempotency_key: str = "") -> dict[str, object]:
         seed_yaml = yaml.dump(
             seed.to_dict(), default_flow_style=False, allow_unicode=True, sort_keys=False
         )
-        arguments: dict[str, object] = {"seed_content": seed_yaml, "cwd": self.cwd}
+        arguments: dict[str, object] = {
+            "seed_content": seed_yaml,
+            "cwd": self.cwd,
+            "use_worktree": self.use_worktree,
+        }
         if idempotency_key:
             arguments["idempotency_key"] = idempotency_key
         result = _unwrap(
@@ -411,6 +422,11 @@ class HandlerRalphStarter:
         reattach_terminal: bool = True,
         reuse_existing: bool = True,
         return_after_dispatch: bool = True,
+        commit_policy: str | None = None,
+        auto_session_id: str | None = None,
+        execution_id: str | None = None,
+        checkpoint_commits: list[dict[str, Any]] | None = None,
+        checkpoint_attempted_ac_ids: list[str] | None = None,
     ) -> dict[str, Any]:
         """Dispatch the Ralph loop and optionally wait for terminal completion.
 
@@ -468,6 +484,16 @@ class HandlerRalphStarter:
         }
         if self.project_dir is not None:
             arguments["project_dir"] = self.project_dir
+        if commit_policy is not None:
+            arguments["commit_policy"] = commit_policy
+        if auto_session_id is not None:
+            arguments["auto_session_id"] = auto_session_id
+        if execution_id is not None:
+            arguments["execution_id"] = execution_id
+        if checkpoint_commits is not None:
+            arguments["checkpoint_commits"] = checkpoint_commits
+        if checkpoint_attempted_ac_ids is not None:
+            arguments["checkpoint_attempted_ac_ids"] = checkpoint_attempted_ac_ids
         if max_total_seconds is not None:
             arguments["max_total_seconds"] = max_total_seconds
         if per_iteration_timeout_seconds is not None:

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -467,13 +467,15 @@ class HandlerRalphStarter:
             )
             terminal_status = _optional_str(terminal_meta.get("status")) or "failed"
             stop_reason = _optional_str(terminal_meta.get("stop_reason"))
-            return {
+            reattach_result: dict[str, Any] = {
                 "job_id": existing_job_id,
                 "lineage_id": lineage_id,
                 "dispatch_mode": "job",
                 "terminal_status": terminal_status,
                 "stop_reason": stop_reason,
             }
+            _forward_checkpoint_meta(reattach_result, terminal_meta)
+            return reattach_result
 
         seed_yaml = yaml.dump(
             seed.to_dict(), default_flow_style=False, allow_unicode=True, sort_keys=False
@@ -606,6 +608,7 @@ class HandlerRalphStarter:
             # ``_optional_str`` would collapse the empty string to None and
             # silently skip EVALUATE.
             terminal_result["result_text"] = artifact_text
+        _forward_checkpoint_meta(terminal_result, terminal_meta)
         return terminal_result
 
 
@@ -670,6 +673,7 @@ class HandlerRalphPoller:
             # VALID graded artifact, so use ``_artifact_text`` rather than
             # ``_optional_str``.
             result["result_text"] = artifact_text
+        _forward_checkpoint_meta(result, terminal_meta)
         return result
 
 
@@ -1163,6 +1167,34 @@ def _current_generation_from_meta(meta: dict[str, Any]) -> int | None:
     if generations_generation is not None:
         return generations_generation
     return _optional_int(meta.get("iterations"))
+
+
+def _forward_checkpoint_meta(target: dict[str, Any], terminal_meta: dict[str, Any]) -> None:
+    """Copy AC checkpoint metadata from a terminal Ralph job snapshot.
+
+    ``RalphLoopResult.to_tool_result`` surfaces ``checkpoint_commits`` /
+    ``checkpoint_attempted_ac_ids`` in the job ``result_meta`` that
+    :func:`_wait_for_job_terminal` returns. The job-mode adapters rebuild a
+    *structured* terminal dict (rather than passing ``terminal_meta`` through
+    verbatim) and so must explicitly preserve these two lists, otherwise
+    :meth:`AutoPipeline._handoff_to_ralph` — which reads them off the returned
+    ``ralph_meta`` — never persists the durable commit list or the
+    retry-idempotency attempt set onto ``AutoPipelineState``. Dropping them
+    diverges the auto state from git side effects already performed inside the
+    managed worktree and makes a later resume re-attempt already-committed ACs
+    (Q00/ouroboros#1281 review ``req_1780029496_276``).
+
+    Only forwards a key when the snapshot actually carries a list for it, so
+    callers whose terminal metadata has no checkpoint fields keep their exact
+    prior shape. Entries are type-filtered to mirror the ``AutoPipelineState``
+    invariants (commits are objects, attempted AC ids are strings).
+    """
+    commits = terminal_meta.get("checkpoint_commits")
+    if isinstance(commits, list):
+        target["checkpoint_commits"] = [item for item in commits if isinstance(item, dict)]
+    attempts = terminal_meta.get("checkpoint_attempted_ac_ids")
+    if isinstance(attempts, list):
+        target["checkpoint_attempted_ac_ids"] = [item for item in attempts if isinstance(item, str)]
 
 
 def _artifact_text(value: object) -> str | None:

--- a/src/ouroboros/auto/checkpoint_commits.py
+++ b/src/ouroboros/auto/checkpoint_commits.py
@@ -1,0 +1,185 @@
+"""Git checkpoint commits for verified auto acceptance criteria."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+
+from ouroboros.auto.state import AutoCommitPolicy, AutoPipelineState
+
+_SECRET_PATH_RE = re.compile(r"(^|/)(\.env(?:\.|$)|.*secret.*|.*credential.*)", re.IGNORECASE)
+
+
+@dataclass(frozen=True, slots=True)
+class CheckpointCommitResult:
+    """Outcome of a checkpoint commit attempt."""
+
+    status: str
+    commit: str | None = None
+    reason: str | None = None
+
+
+def checkpoint_passed_ac(
+    state: AutoPipelineState,
+    *,
+    repo_cwd: str | Path,
+    ac_id: str,
+    ac_text: str,
+) -> CheckpointCommitResult:
+    """Commit current git changes for a newly passed acceptance criterion."""
+    if state.commit_policy is not AutoCommitPolicy.AC_CHECKPOINT:
+        return CheckpointCommitResult(status="skipped", reason="commit_policy")
+    if any(entry.get("ac_id") == ac_id for entry in state.checkpoint_commits):
+        return CheckpointCommitResult(status="skipped", reason="already_committed")
+    if ac_id in state.checkpoint_attempted_ac_ids:
+        return CheckpointCommitResult(status="skipped", reason="already_attempted")
+    state.checkpoint_attempted_ac_ids.append(ac_id)
+
+    repo = Path(repo_cwd).expanduser().resolve()
+    if not _is_git_repo(repo):
+        return CheckpointCommitResult(status="skipped", reason="not_git_repo")
+
+    paths = _changed_paths(repo)
+    safe_paths = [path for path in paths if not _SECRET_PATH_RE.search(path)]
+    if not safe_paths:
+        return CheckpointCommitResult(status="skipped", reason="no_safe_changes")
+
+    _git(repo, "add", "--", *safe_paths)
+    if not _staged_changes(repo, safe_paths):
+        return CheckpointCommitResult(status="skipped", reason="no_staged_changes")
+
+    subject = f"ooo: satisfy {ac_id} {_summarize_ac(ac_text)}".strip()
+    message = "\n".join(
+        [
+            subject[:72],
+            "",
+            f"Auto-Session: {state.auto_session_id}",
+            f"Execution-Id: {state.execution_id or 'none'}",
+            f"Acceptance-Criterion: {ac_id}",
+        ]
+    )
+    _git(repo, "commit", "-m", message, "--", *safe_paths)
+    commit = _git(repo, "rev-parse", "--short", "HEAD")
+    state.checkpoint_commits.append(
+        {
+            "ac_id": ac_id,
+            "ac_text": ac_text,
+            "commit": commit,
+            "execution_id": state.execution_id,
+            "policy": state.commit_policy.value,
+        }
+    )
+    return CheckpointCommitResult(status="committed", commit=commit)
+
+
+def checkpoint_final_auto(
+    state: AutoPipelineState,
+    *,
+    repo_cwd: str | Path,
+    summary: str = "final verified auto result",
+) -> CheckpointCommitResult:
+    """Commit final git changes once when final-only policy is selected."""
+    if state.commit_policy is not AutoCommitPolicy.FINAL_ONLY:
+        return CheckpointCommitResult(status="skipped", reason="commit_policy")
+    if state.final_checkpoint_attempted:
+        return CheckpointCommitResult(status="skipped", reason="already_attempted")
+
+    state.final_checkpoint_attempted = True
+    repo = Path(repo_cwd).expanduser().resolve()
+    if not _is_git_repo(repo):
+        return CheckpointCommitResult(status="skipped", reason="not_git_repo")
+
+    paths = _changed_paths(repo)
+    safe_paths = [path for path in paths if not _SECRET_PATH_RE.search(path)]
+    if not safe_paths:
+        return CheckpointCommitResult(status="skipped", reason="no_safe_changes")
+
+    _git(repo, "add", "--", *safe_paths)
+    if not _staged_changes(repo, safe_paths):
+        return CheckpointCommitResult(status="skipped", reason="no_staged_changes")
+
+    message = "\n".join(
+        [
+            f"ooo: complete auto session {_summarize_ac(summary)}"[:72],
+            "",
+            f"Auto-Session: {state.auto_session_id}",
+            f"Execution-Id: {state.execution_id or 'none'}",
+            "Commit-Policy: final_only",
+        ]
+    )
+    _git(repo, "commit", "-m", message, "--", *safe_paths)
+    commit = _git(repo, "rev-parse", "--short", "HEAD")
+    state.checkpoint_commits.append(
+        {
+            "ac_id": "FINAL",
+            "ac_text": summary,
+            "commit": commit,
+            "execution_id": state.execution_id,
+            "policy": state.commit_policy.value,
+        }
+    )
+    return CheckpointCommitResult(status="committed", commit=commit)
+
+
+def _is_git_repo(repo: Path) -> bool:
+    try:
+        _git(repo, "rev-parse", "--is-inside-work-tree")
+    except RuntimeError:
+        return False
+    return True
+
+
+def _changed_paths(repo: Path) -> list[str]:
+    output = _git(repo, "status", "--porcelain=v1", "-z", "--untracked-files=all")
+    paths: list[str] = []
+    entries = output.split("\0")
+    index = 0
+    while index < len(entries):
+        entry = entries[index]
+        index += 1
+        if not entry:
+            continue
+        status = entry[:2]
+        path = entry[3:]
+        if path:
+            paths.append(path)
+        if status[0] in {"R", "C"} or status[1] in {"R", "C"}:
+            index += 1
+    return paths
+
+
+def _staged_changes(repo: Path, paths: list[str]) -> bool:
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--quiet", "--", *paths],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    return result.returncode == 1
+
+
+def _summarize_ac(ac_text: str) -> str:
+    summary = " ".join(ac_text.split())
+    if len(summary) > 48:
+        summary = summary[:45].rstrip() + "..."
+    return summary
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed: {result.stderr.strip() or result.stdout.strip()}"
+        )
+    return result.stdout.strip()

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -17,6 +17,7 @@ import structlog
 from ouroboros.auto.adapters import EvaluateResult, LateralResult
 from ouroboros.auto.answerer import AutoAnswerer
 from ouroboros.auto.blocker_attribution import record_authoring_backend
+from ouroboros.auto.checkpoint_commits import checkpoint_final_auto
 from ouroboros.auto.domain_inference import derive_domain_from_ledger
 from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
 from ouroboros.auto.execution_acceptance import normalize_execution_acceptance
@@ -52,6 +53,7 @@ from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import (
     DEFAULT_TIMEOUT_SECONDS_BY_PHASE,
     MAX_EVALUATE_ROUNDS,
+    AutoCommitPolicy,
     AutoPhase,
     AutoPipelineState,
     AutoResumeCapability,
@@ -341,6 +343,7 @@ class AutoPipelineResult:
     # is returned, so this field is both surface evidence and a completion
     # grade input rather than a passive annotation.
     runtime_probe_evidence: tuple[RuntimeEvidence, ...] = ()
+    checkpoint_commits: tuple[dict[str, Any], ...] = ()
     # #1257 PR-C — degraded-recovery terminal surface.
     #
     # When the interview-phase deadline rerouted into PR-A's
@@ -2179,6 +2182,16 @@ class AutoPipeline:
             starter_kwargs["reattach_terminal"] = reattach_terminal
         if _accepts_keyword(self.ralph_starter, "reuse_existing"):
             starter_kwargs["reuse_existing"] = reuse_existing
+        if _accepts_keyword(self.ralph_starter, "commit_policy"):
+            starter_kwargs["commit_policy"] = state.commit_policy.value
+        if _accepts_keyword(self.ralph_starter, "auto_session_id"):
+            starter_kwargs["auto_session_id"] = state.auto_session_id
+        if _accepts_keyword(self.ralph_starter, "execution_id"):
+            starter_kwargs["execution_id"] = state.execution_id
+        if _accepts_keyword(self.ralph_starter, "checkpoint_commits"):
+            starter_kwargs["checkpoint_commits"] = state.checkpoint_commits
+        if _accepts_keyword(self.ralph_starter, "checkpoint_attempted_ac_ids"):
+            starter_kwargs["checkpoint_attempted_ac_ids"] = state.checkpoint_attempted_ac_ids
         try:
             ralph_call = self.ralph_starter(seed, **starter_kwargs)
             if state.deadline_at is None:
@@ -2225,6 +2238,16 @@ class AutoPipeline:
                 state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
             )
         state.ralph_job_id = _optional_str(ralph_meta.get("job_id"))
+        ralph_checkpoint_commits = ralph_meta.get("checkpoint_commits")
+        if isinstance(ralph_checkpoint_commits, list):
+            state.checkpoint_commits = [
+                item for item in ralph_checkpoint_commits if isinstance(item, dict)
+            ]
+        ralph_checkpoint_attempts = ralph_meta.get("checkpoint_attempted_ac_ids")
+        if isinstance(ralph_checkpoint_attempts, list):
+            state.checkpoint_attempted_ac_ids = [
+                item for item in ralph_checkpoint_attempts if isinstance(item, str)
+            ]
         state.ralph_dispatch_mode = _optional_str(ralph_meta.get("dispatch_mode"))
         terminal_status = _optional_str(ralph_meta.get("terminal_status"))
         stop_reason = _optional_str(ralph_meta.get("stop_reason"))
@@ -3683,6 +3706,8 @@ class AutoPipeline:
         run_subagent: dict[str, Any] | None = None,
         status_override: str | None = None,
     ) -> AutoPipelineResult:
+        if state.phase == AutoPhase.COMPLETE:
+            self._checkpoint_final_commit(state)
         summary = ledger.summary()
         ledger_provenance = {
             source: tuple(sections) for source, sections in summary.get("provenance", {}).items()
@@ -3759,10 +3784,33 @@ class AutoPipeline:
             assumption_only_sections=tuple(summary.get("assumption_only_sections", ())),
             runtime_probe_evidence=self._last_probe_evidence
             or _runtime_probe_evidence_from_state(state),
+            checkpoint_commits=tuple(state.checkpoint_commits),
             partial_product=partial_product,
             partial_product_reason=partial_product_reason,
             partial_unresolved_slots=partial_unresolved_slots,
         )
+
+    def _checkpoint_final_commit(self, state: AutoPipelineState) -> None:
+        """Attempt the one-shot final-only checkpoint at product completion."""
+        if state.commit_policy is not AutoCommitPolicy.FINAL_ONLY:
+            return
+        if state.final_checkpoint_attempted:
+            return
+        try:
+            checkpoint_final_auto(
+                state,
+                repo_cwd=state.cwd,
+                summary=state.last_progress_message or "final verified auto result",
+            )
+        except RuntimeError as exc:
+            log.warning(
+                "auto_final_checkpoint_commit_failed",
+                auto_session_id=state.auto_session_id,
+                cwd=state.cwd,
+                error=str(exc),
+            )
+            state.final_checkpoint_attempted = True
+        self._save(state)
 
     def _attach_run_if_requested(self, state: AutoPipelineState) -> bool | None:
         handle = _first_nonempty(

--- a/src/ouroboros/auto/policies.py
+++ b/src/ouroboros/auto/policies.py
@@ -1,0 +1,26 @@
+"""Auto-mode execution policy defaults."""
+
+from __future__ import annotations
+
+from ouroboros.auto.state import AutoCommitPolicy, AutoPipelineState, AutoWorktreePolicy
+
+
+def apply_domain_policy_defaults(state: AutoPipelineState) -> None:
+    """Apply domain-specific policy defaults to a newly profiled session.
+
+    The defaults are intentionally written into :class:`AutoPipelineState` so
+    resume keeps the same isolation/commit behavior even if profile detection
+    would later change.
+    """
+    if state.active_domain_profile_name == "coding":
+        from ouroboros.auto.profiles.coding import (
+            DEFAULT_COMMIT_POLICY,
+            DEFAULT_WORKTREE_POLICY,
+        )
+
+        state.commit_policy = DEFAULT_COMMIT_POLICY
+        state.worktree_policy = DEFAULT_WORKTREE_POLICY
+        return
+
+    state.commit_policy = AutoCommitPolicy.FINAL_ONLY
+    state.worktree_policy = AutoWorktreePolicy.CURRENT

--- a/src/ouroboros/auto/policies.py
+++ b/src/ouroboros/auto/policies.py
@@ -22,5 +22,9 @@ def apply_domain_policy_defaults(state: AutoPipelineState) -> None:
         state.worktree_policy = DEFAULT_WORKTREE_POLICY
         return
 
-    state.commit_policy = AutoCommitPolicy.FINAL_ONLY
+    # Non-coding / unknown domains never auto-commit or relocate the caller's
+    # checkout by default. Final-only commits on the current checkout are an
+    # explicit operator opt-in (``--commit-policy final_only``) rather than a
+    # silent side effect of completing a research/documentation/skip_run flow.
+    state.commit_policy = AutoCommitPolicy.NONE
     state.worktree_policy = AutoWorktreePolicy.CURRENT

--- a/src/ouroboros/auto/profiles/coding.py
+++ b/src/ouroboros/auto/profiles/coding.py
@@ -15,6 +15,10 @@ from types import MappingProxyType
 from typing import Any
 
 from ouroboros.auto.domain_profile import DomainProfile
+from ouroboros.auto.state import AutoCommitPolicy, AutoWorktreePolicy
+
+DEFAULT_COMMIT_POLICY = AutoCommitPolicy.AC_CHECKPOINT
+DEFAULT_WORKTREE_POLICY = AutoWorktreePolicy.AUTO
 
 # Keep these lightweight constants local so importing/registering the built-in
 # coding profile does not import ``ouroboros.auto.grading`` and its pydantic

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -491,9 +491,13 @@ class AutoPipelineState:
     # verified acceptance boundaries become git checkpoint commits.
     # ``worktree_policy`` controls whether mutating execution should happen
     # in an isolated managed worktree rather than the caller's checkout.
-    # Defaults are conservative for legacy/non-coding sessions; coding profile
-    # activation raises these to AC checkpoint commits + automatic worktrees.
-    commit_policy: AutoCommitPolicy = AutoCommitPolicy.FINAL_ONLY
+    # Defaults are conservative for legacy/non-coding sessions: NO git commits
+    # and the caller's current checkout, so a non-coding/research/skip_run flow
+    # (or a legacy resumed session) never mutates the operator's working tree by
+    # default. Coding profile activation raises these to AC checkpoint commits +
+    # automatic worktrees; final-only commits on the current checkout remain an
+    # explicit operator opt-in (``--commit-policy final_only``).
+    commit_policy: AutoCommitPolicy = AutoCommitPolicy.NONE
     worktree_policy: AutoWorktreePolicy = AutoWorktreePolicy.CURRENT
     managed_worktree: dict[str, Any] | None = None
     checkpoint_commits: list[dict[str, Any]] = field(default_factory=list)
@@ -928,7 +932,7 @@ class AutoPipelineState:
         payload.setdefault("last_lateral_text", None)
         payload.setdefault("lateral_input_hash", None)
         payload.setdefault("active_domain_profile_name", None)
-        payload.setdefault("commit_policy", AutoCommitPolicy.FINAL_ONLY.value)
+        payload.setdefault("commit_policy", AutoCommitPolicy.NONE.value)
         payload.setdefault("worktree_policy", AutoWorktreePolicy.CURRENT.value)
         payload.setdefault("managed_worktree", None)
         payload.setdefault("checkpoint_commits", [])

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -62,6 +62,23 @@ class AutoPolicy(StrEnum):
     BALANCED = "balanced"
 
 
+class AutoCommitPolicy(StrEnum):
+    """When auto-mode should create git checkpoint commits."""
+
+    AC_CHECKPOINT = "ac_checkpoint"
+    FINAL_ONLY = "final_only"
+    NONE = "none"
+
+
+class AutoWorktreePolicy(StrEnum):
+    """How auto-mode should isolate mutating coding work."""
+
+    AUTO = "auto"
+    ALWAYS = "always"
+    CURRENT = "current"
+    NONE = "none"
+
+
 class SeedOrigin(StrEnum):
     """Provenance of the persisted Seed for an auto session.
 
@@ -470,6 +487,18 @@ class AutoPipelineState:
     # fallback. None means no profile was activated, so legacy state files load
     # unchanged.
     active_domain_profile_name: str | None = None
+    # Coding-domain isolation defaults. ``commit_policy`` controls whether
+    # verified acceptance boundaries become git checkpoint commits.
+    # ``worktree_policy`` controls whether mutating execution should happen
+    # in an isolated managed worktree rather than the caller's checkout.
+    # Defaults are conservative for legacy/non-coding sessions; coding profile
+    # activation raises these to AC checkpoint commits + automatic worktrees.
+    commit_policy: AutoCommitPolicy = AutoCommitPolicy.FINAL_ONLY
+    worktree_policy: AutoWorktreePolicy = AutoWorktreePolicy.CURRENT
+    managed_worktree: dict[str, Any] | None = None
+    checkpoint_commits: list[dict[str, Any]] = field(default_factory=list)
+    checkpoint_attempted_ac_ids: list[str] = field(default_factory=list)
+    final_checkpoint_attempted: bool = False
     # L1-d / #1171: active TaskClass (cli / webhook / game_2d / …) derived
     # from the standardized ledger after seed generation. Distinct from
     # ``active_domain_profile_name`` (which is a meta-domain concept —
@@ -842,6 +871,8 @@ class AutoPipelineState:
         data["phase"] = self.phase.value
         data["policy"] = self.policy.value
         data["seed_origin"] = self.seed_origin.value
+        data["commit_policy"] = self.commit_policy.value
+        data["worktree_policy"] = self.worktree_policy.value
         # ``deadline_at`` is a *monotonic*-clock value scoped to the writing
         # process; it is meaningless to a future loader. Persist only the
         # epoch companion and recompute ``deadline_at`` from it on load. The
@@ -897,6 +928,12 @@ class AutoPipelineState:
         payload.setdefault("last_lateral_text", None)
         payload.setdefault("lateral_input_hash", None)
         payload.setdefault("active_domain_profile_name", None)
+        payload.setdefault("commit_policy", AutoCommitPolicy.FINAL_ONLY.value)
+        payload.setdefault("worktree_policy", AutoWorktreePolicy.CURRENT.value)
+        payload.setdefault("managed_worktree", None)
+        payload.setdefault("checkpoint_commits", [])
+        payload.setdefault("checkpoint_attempted_ac_ids", [])
+        payload.setdefault("final_checkpoint_attempted", False)
         payload.setdefault("active_task_class", None)
         payload.setdefault("last_error_code", None)
         payload.setdefault("interview_closure_mode", None)
@@ -936,6 +973,16 @@ class AutoPipelineState:
             raise ValueError(msg)
         payload["phase"] = AutoPhase(payload["phase"])
         payload["policy"] = AutoPolicy(payload["policy"])
+        try:
+            payload["commit_policy"] = AutoCommitPolicy(payload["commit_policy"])
+        except ValueError as exc:
+            msg = f"commit_policy must be one of {[item.value for item in AutoCommitPolicy]}"
+            raise ValueError(msg) from exc
+        try:
+            payload["worktree_policy"] = AutoWorktreePolicy(payload["worktree_policy"])
+        except ValueError as exc:
+            msg = f"worktree_policy must be one of {[item.value for item in AutoWorktreePolicy]}"
+            raise ValueError(msg) from exc
         try:
             payload["seed_origin"] = SeedOrigin(payload["seed_origin"])
         except ValueError as exc:
@@ -1072,6 +1119,22 @@ class AutoPipelineState:
             raise ValueError(msg)
         if not isinstance(self.user_preferences, dict):
             msg = "user_preferences must be an object"
+            raise ValueError(msg)
+        if self.managed_worktree is not None and not isinstance(self.managed_worktree, dict):
+            msg = "managed_worktree must be an object or null"
+            raise ValueError(msg)
+        if not isinstance(self.checkpoint_commits, list) or any(
+            not isinstance(item, dict) for item in self.checkpoint_commits
+        ):
+            msg = "checkpoint_commits must be a list of objects"
+            raise ValueError(msg)
+        if not isinstance(self.checkpoint_attempted_ac_ids, list) or any(
+            not isinstance(item, str) for item in self.checkpoint_attempted_ac_ids
+        ):
+            msg = "checkpoint_attempted_ac_ids must be a list of strings"
+            raise ValueError(msg)
+        if not isinstance(self.final_checkpoint_attempted, bool):
+            msg = "final_checkpoint_attempted must be a boolean"
             raise ValueError(msg)
         for pref_key, pref_value in self.user_preferences.items():
             if not isinstance(pref_key, str) or not pref_key.strip():

--- a/src/ouroboros/auto/worktree.py
+++ b/src/ouroboros/auto/worktree.py
@@ -1,0 +1,51 @@
+"""Managed worktree support for auto coding sessions."""
+
+from __future__ import annotations
+
+from ouroboros.auto.state import AutoPipelineState, AutoWorktreePolicy
+from ouroboros.core.worktree import (
+    TaskWorkspace,
+    WorktreeError,
+    is_git_repo,
+    release_lock,
+    restore_task_workspace,
+)
+
+
+def ensure_auto_worktree(state: AutoPipelineState) -> TaskWorkspace | None:
+    """Create or restore the auto session worktree when policy requires it.
+
+    ``AUTO`` is intentionally coding-only: non-coding sessions can still opt in
+    with ``ALWAYS``, but the default remains the caller's current directory.
+    """
+    if state.worktree_policy in {AutoWorktreePolicy.NONE, AutoWorktreePolicy.CURRENT}:
+        return None
+    if (
+        state.worktree_policy is AutoWorktreePolicy.AUTO
+        and state.active_domain_profile_name != "coding"
+    ):
+        return None
+    if not is_git_repo(state.cwd):
+        if state.worktree_policy is AutoWorktreePolicy.ALWAYS:
+            raise WorktreeError(
+                "Auto worktree policy requires a git repository",
+                details={"cwd": state.cwd},
+            )
+        return None
+
+    persisted = TaskWorkspace.from_progress_dict(state.managed_worktree)
+    workspace = restore_task_workspace(
+        state.auto_session_id,
+        persisted,
+        fallback_source_cwd=state.cwd,
+        allow_dirty=True,
+    )
+    state.managed_worktree = workspace.to_progress_dict()
+    state.cwd = workspace.effective_cwd
+    return workspace
+
+
+def release_auto_worktree(workspace: TaskWorkspace | None) -> None:
+    """Release the auto worktree lock if this process owns one."""
+    if workspace is not None:
+        release_lock(workspace.lock_path)

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -26,6 +26,7 @@ from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
 from ouroboros.auto.handoff_contract import RUN_HANDOFF_STARTED_STATUS
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
+from ouroboros.auto.policies import apply_domain_policy_defaults
 
 # Import the built-in profile package once so CLI domain activation sees
 # production registrations, not just profiles manually loaded by tests.
@@ -38,10 +39,13 @@ from ouroboros.auto.state import (
     DEFAULT_PIPELINE_TIMEOUT_SECONDS,
     MAX_PIPELINE_TIMEOUT_SECONDS,
     MIN_PIPELINE_TIMEOUT_SECONDS,
+    AutoCommitPolicy,
     AutoPhase,
     AutoPipelineState,
     AutoStore,
+    AutoWorktreePolicy,
 )
+from ouroboros.auto.worktree import ensure_auto_worktree, release_auto_worktree
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success
 from ouroboros.config import get_opencode_mode
@@ -225,6 +229,22 @@ def auto_command(
             ),
         ),
     ] = None,
+    commit_policy: Annotated[
+        str | None,
+        typer.Option(
+            "--commit-policy",
+            hidden=True,
+            help="Checkpoint policy: ac_checkpoint, final_only, or none.",
+        ),
+    ] = None,
+    worktree_policy: Annotated[
+        str | None,
+        typer.Option(
+            "--worktree-policy",
+            hidden=True,
+            help="Worktree isolation policy: auto, always, current, or none.",
+        ),
+    ] = None,
 ) -> None:
     """Run an A-grade-gated auto pipeline.
 
@@ -271,6 +291,8 @@ def auto_command(
                 pipeline_timeout_seconds=timeout,
                 complete_product=complete_product,
                 domain=domain,
+                commit_policy=commit_policy,
+                worktree_policy=worktree_policy,
                 progress_callback=_make_progress_renderer(quiet=quiet),
             )
         )
@@ -317,6 +339,8 @@ async def _run_auto(
     pipeline_timeout_seconds: float | None = None,
     complete_product: bool = False,
     domain: str | None = None,
+    commit_policy: str | None = None,
+    worktree_policy: str | None = None,
     progress_callback: AutoProgressCallback | None = None,
 ) -> AutoPipelineResult:
     store = AutoStore()
@@ -413,13 +437,19 @@ async def _run_auto(
             )
             raise typer.Exit(1)
         state.active_domain_profile_name = active_profile.name
+        apply_domain_policy_defaults(state)
     elif not resume:
         active_profile = DEFAULT_REGISTRY.detect_best(Path(state.cwd))
         state.active_domain_profile_name = active_profile.name if active_profile else None
+        apply_domain_policy_defaults(state)
     else:
         # Resume preserves the session-start profile unless the operator
         # explicitly passes --domain to intentionally retarget it.
         pass
+    if commit_policy is not None:
+        state.commit_policy = AutoCommitPolicy(commit_policy)
+    if worktree_policy is not None:
+        state.worktree_policy = AutoWorktreePolicy(worktree_policy)
 
     if runtime == "opencode":
         # Q00/ouroboros#782 review-7 BLOCKING #3 + review-8 BLOCKING #1: keep
@@ -461,6 +491,8 @@ async def _run_auto(
             )
             raise ValueError(msg)
         state.provenance = incoming_provenance
+
+    auto_workspace = ensure_auto_worktree(state)
 
     authoring_opencode_mode = "subprocess" if opencode_mode == "plugin" else opencode_mode
     interview = InterviewHandler(
@@ -515,7 +547,11 @@ async def _run_auto(
         run_starter=(
             HandlerSynchronousRunStarter(execute_seed, cwd=state.cwd)
             if complete_product
-            else HandlerRunStarter(start_execute, cwd=state.cwd)
+            else HandlerRunStarter(
+                start_execute,
+                cwd=state.cwd,
+                use_worktree=auto_workspace is None,
+            )
         ),
         store=store,
         repairer=SeedRepairer(max_repair_rounds=max_repair_rounds),
@@ -538,6 +574,7 @@ async def _run_auto(
     try:
         result = await pipeline.run(state)
     finally:
+        release_auto_worktree(auto_workspace)
         await watchdog_event_store.close()
     return result
 
@@ -805,6 +842,10 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
         console.print(f"Run reconciled at: {result.run_reconciled_at}")
     if result.status == "detached":
         _print_detached_guidance(result)
+    if result.checkpoint_commits:
+        console.print("Checkpoint commits:")
+        for entry in result.checkpoint_commits:
+            console.print(f"  {entry.get('ac_id')}: {entry.get('commit')}")
     if show_ledger:
         if result.assumptions:
             console.print("Assumptions:")

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -30,6 +30,7 @@ from ouroboros.auto.answerer import (
     AutoAnswerContext,
     risky_user_preference_blocker_for,
 )
+from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
 from ouroboros.auto.execution_acceptance import (
     has_auto_wrapper_context,
     is_auto_reporting_acceptance_criterion,
@@ -45,6 +46,7 @@ from ouroboros.auto.ledger import (
     SeedDraftLedger,
 )
 from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
+from ouroboros.auto.policies import apply_domain_policy_defaults
 from ouroboros.auto.repo_context import repo_auto_answer_context
 from ouroboros.auto.resume_render import render_resume_lines
 from ouroboros.auto.seed_repairer import SeedRepairer
@@ -53,11 +55,14 @@ from ouroboros.auto.state import (
     MAX_PIPELINE_TIMEOUT_SECONDS,
     MIN_PIPELINE_TIMEOUT_SECONDS,
     TERMINAL_PHASES,
+    AutoCommitPolicy,
     AutoPhase,
     AutoPipelineState,
     AutoResumeCapability,
     AutoStore,
+    AutoWorktreePolicy,
 )
+from ouroboros.auto.worktree import ensure_auto_worktree, release_auto_worktree
 from ouroboros.config import get_opencode_mode
 from ouroboros.core.file_lock import file_lock
 from ouroboros.core.types import Result
@@ -222,6 +227,24 @@ class AutoHandler:
                     required=False,
                     default=False,
                 ),
+                MCPToolParameter(
+                    "domain",
+                    ToolInputType.STRING,
+                    "Optional domain profile name (for example, coding)",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    "commit_policy",
+                    ToolInputType.STRING,
+                    "Checkpoint commit policy: ac_checkpoint, final_only, or none",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    "worktree_policy",
+                    ToolInputType.STRING,
+                    "Worktree isolation policy: auto, always, current, or none",
+                    required=False,
+                ),
             ),
         )
 
@@ -245,6 +268,10 @@ class AutoHandler:
         elif auto_session_id is not None:
             try:
                 state = store.load(auto_session_id)
+            except ValueError as exc:
+                return Result.err(MCPToolError(str(exc), tool_name="ouroboros_auto"))
+            try:
+                _apply_requested_domain_and_policies(state, arguments, detect_profile=False)
             except ValueError as exc:
                 return Result.err(MCPToolError(str(exc), tool_name="ouroboros_auto"))
             start_lease_token, lease_error = _reserve_start_lease(
@@ -313,6 +340,7 @@ class AutoHandler:
         supplied_user_preferences: dict[str, str | None] = {}
         if isinstance(resume, str) and resume:
             state = store.load(resume)
+            _apply_requested_domain_and_policies(state, arguments, detect_profile=False)
             cwd = state.cwd
             runtime_backend = state.runtime_backend or self.agent_runtime_backend
             if runtime_backend is None and state.opencode_mode is not None:
@@ -368,6 +396,7 @@ class AutoHandler:
             skip_run = requested_skip_run
             goal_text = goal.strip()
             state = AutoPipelineState(goal=goal_text, cwd=cwd)
+            _apply_requested_domain_and_policies(state, arguments)
             state.user_preferences = _merge_goal_user_preferences(
                 goal_text, supplied_user_preferences
             )
@@ -388,6 +417,8 @@ class AutoHandler:
         if opencode_mode is not None:
             state.ralph_opencode_mode = state.ralph_opencode_mode or opencode_mode
         state.skip_run = skip_run
+
+        auto_workspace = ensure_auto_worktree(state)
 
         authoring_opencode_mode = "subprocess" if opencode_mode == "plugin" else opencode_mode
         interview_handler = _authoring_interview_handler(
@@ -430,7 +461,7 @@ class AutoHandler:
             lateral_thinker = HandlerLateralThinker(lateral_handler)
 
         driver = AutoInterviewDriver(
-            HandlerInterviewBackend(interview_handler, cwd=cwd),
+            HandlerInterviewBackend(interview_handler, cwd=state.cwd),
             store=store,
             max_rounds=max_interview_rounds,
             timeout_seconds=state.phase_timeout_seconds(AutoPhase.INTERVIEW),
@@ -455,7 +486,11 @@ class AutoHandler:
                     opencode_mode=ralph_opencode_mode,
                 )
             )
-        ralph_starter = HandlerRalphStarter(ralph_handler) if ralph_handler is not None else None
+        ralph_starter = (
+            HandlerRalphStarter(ralph_handler, project_dir=state.cwd)
+            if ralph_handler is not None
+            else None
+        )
         # Q00/ouroboros#773 (review-5 finding 1): wire a poller backed by the
         # same ``RalphHandler`` so MCP-side resumes of an interrupted
         # ``RALPH_HANDOFF`` checkpoint actually reconcile the persisted job
@@ -502,7 +537,11 @@ class AutoHandler:
         pipeline = AutoPipeline(
             driver,
             HandlerSeedGenerator(generate_seed_handler),
-            run_starter=HandlerRunStarter(start_execute, cwd=cwd),
+            run_starter=HandlerRunStarter(
+                start_execute,
+                cwd=state.cwd,
+                use_worktree=auto_workspace is None,
+            ),
             store=store,
             repairer=SeedRepairer(max_repair_rounds=max_repair_rounds),
             seed_saver=save_seed,
@@ -525,6 +564,7 @@ class AutoHandler:
         try:
             return await pipeline.run(state)
         finally:
+            release_auto_worktree(auto_workspace)
             if self.event_store is None:
                 await watchdog_event_store.close()
 
@@ -813,6 +853,7 @@ class StartAutoHandler:
         """Persist a new auto session before the background job starts."""
         cwd = str(_resolve_cwd(arguments.get("cwd")))
         state = AutoPipelineState(goal=goal, cwd=cwd)
+        _apply_requested_domain_and_policies(state, arguments)
         state.max_interview_rounds = _positive_int_arg(arguments, "max_interview_rounds", 12)
         state.max_repair_rounds = _positive_int_arg(arguments, "max_repair_rounds", 5)
         state.skip_run = bool(arguments.get("skip_run", False))
@@ -950,6 +991,34 @@ class StartAutoHandler:
             ),
             False,
         )
+
+
+def _apply_requested_domain_and_policies(
+    state: AutoPipelineState,
+    arguments: dict[str, Any],
+    *,
+    detect_profile: bool = True,
+) -> None:
+    """Apply fresh/resume domain and execution-policy arguments to state."""
+    domain = _optional_text_arg(arguments, "domain")
+    if domain is not None:
+        profile = DEFAULT_REGISTRY.get(domain)
+        if profile is None:
+            raise ValueError(f"Unknown domain profile: {domain!r}")
+        state.active_domain_profile_name = profile.name
+        apply_domain_policy_defaults(state)
+    elif detect_profile and state.active_domain_profile_name is None:
+        profile = DEFAULT_REGISTRY.detect_best(Path(state.cwd))
+        state.active_domain_profile_name = profile.name if profile else None
+        apply_domain_policy_defaults(state)
+
+    commit_policy = _optional_text_arg(arguments, "commit_policy")
+    if commit_policy is not None:
+        state.commit_policy = AutoCommitPolicy(commit_policy)
+
+    worktree_policy = _optional_text_arg(arguments, "worktree_policy")
+    if worktree_policy is not None:
+        state.worktree_policy = AutoWorktreePolicy(worktree_policy)
 
 
 def _build_auto_subagent(
@@ -1294,6 +1363,8 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         meta["ralph_lineage_id"] = result.ralph_lineage_id
     if result.ralph_dispatch_mode:
         meta["ralph_dispatch_mode"] = result.ralph_dispatch_mode
+    if result.checkpoint_commits:
+        meta["checkpoint_commits"] = [dict(item) for item in result.checkpoint_commits]
     if (
         result.status == "complete"
         and result.ralph_dispatch_mode == "plugin"
@@ -2006,6 +2077,10 @@ def _format_result(result: AutoPipelineResult) -> str:
             lines.append(f"  job_id: {result.ralph_job_id}")
         if result.ralph_lineage_id:
             lines.append(f"  lineage_id: {result.ralph_lineage_id}")
+    if result.checkpoint_commits:
+        lines.append("Checkpoint commits:")
+        for entry in result.checkpoint_commits:
+            lines.append(f"- {entry.get('ac_id')}: {entry.get('commit')}")
     # RFC #809 Phase 2.1 — render the EVALUATE verdict when present so resume
     # surfaces tell the user whether the session converged on AC verification
     # or stalled with QA findings the operator must act on.

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -16,6 +16,8 @@ from uuid import uuid4
 import structlog
 import yaml
 
+from ouroboros.auto.checkpoint_commits import checkpoint_passed_ac
+from ouroboros.auto.state import AutoCommitPolicy, AutoPipelineState
 from ouroboros.config import get_runtime_controls_config
 from ouroboros.core.project_paths import resolve_path_against_base, resolve_seed_project_path
 from ouroboros.core.seed import Seed
@@ -217,6 +219,36 @@ class EvolveStepHandler(BridgeAwareMixin):
                     ),
                     required=False,
                 ),
+                MCPToolParameter(
+                    name="commit_policy",
+                    type=ToolInputType.STRING,
+                    description="Optional checkpoint commit policy for passed ACs.",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    name="auto_session_id",
+                    type=ToolInputType.STRING,
+                    description="Optional auto session id for checkpoint commit metadata.",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    name="execution_id",
+                    type=ToolInputType.STRING,
+                    description="Optional execution id for checkpoint commit metadata.",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    name="checkpoint_commits",
+                    type=ToolInputType.ARRAY,
+                    description="Existing checkpoint commit records for idempotency.",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    name="checkpoint_attempted_ac_ids",
+                    type=ToolInputType.ARRAY,
+                    description="Acceptance criteria already considered for checkpoint commits.",
+                    required=False,
+                ),
             ),
         )
 
@@ -398,6 +430,17 @@ class EvolveStepHandler(BridgeAwareMixin):
                     status = "PASS" if ac.passed else "FAIL"
                     text_lines.append(f"- AC {ac.ac_index + 1}: [{status}] {ac.ac_content[:80]}")
 
+        checkpoint_commits, checkpoint_attempted_ac_ids = _checkpoint_passed_generation_acs(
+            arguments,
+            gen.evaluation_summary,
+            resolved_verification_working_dir,
+        )
+        if checkpoint_commits:
+            text_lines.append("")
+            text_lines.append("### Checkpoint commits")
+            for entry in checkpoint_commits:
+                text_lines.append(f"- {entry.get('ac_id')}: {entry.get('commit')}")
+
         if gen.wonder_output:
             text_lines.append("")
             text_lines.append("### Wonder questions")
@@ -472,6 +515,8 @@ class EvolveStepHandler(BridgeAwareMixin):
             "next_generation": step.next_generation,
             "executed": execute,
             "has_execution_output": gen.execution_output is not None,
+            "checkpoint_commits": checkpoint_commits,
+            "checkpoint_attempted_ac_ids": checkpoint_attempted_ac_ids,
         }
         if workspace is not None:
             meta["worktree_path"] = workspace.worktree_path
@@ -486,6 +531,52 @@ class EvolveStepHandler(BridgeAwareMixin):
                 meta=meta,
             )
         )
+
+
+def _checkpoint_passed_generation_acs(
+    arguments: dict[str, Any],
+    evaluation_summary: Any,
+    repo_cwd: Path,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Create checkpoint commits for passed ACs when requested."""
+    existing = [
+        item for item in arguments.get("checkpoint_commits", []) if isinstance(item, dict)
+    ]
+    attempted = [
+        item for item in arguments.get("checkpoint_attempted_ac_ids", []) if isinstance(item, str)
+    ]
+    if evaluation_summary is None or not getattr(evaluation_summary, "ac_results", None):
+        return existing, attempted
+    raw_policy = arguments.get("commit_policy")
+    if not isinstance(raw_policy, str) or not raw_policy.strip():
+        return existing, attempted
+    auto_session_id = arguments.get("auto_session_id")
+    if not isinstance(auto_session_id, str) or not auto_session_id.strip():
+        return existing, attempted
+
+    try:
+        commit_policy = AutoCommitPolicy(raw_policy)
+    except ValueError:
+        return existing, attempted
+
+    state = AutoPipelineState(goal="Ralph checkpoint", cwd=str(repo_cwd))
+    state.auto_session_id = auto_session_id
+    execution_id = arguments.get("execution_id")
+    if isinstance(execution_id, str) and execution_id.strip():
+        state.execution_id = execution_id
+    state.commit_policy = commit_policy
+    state.checkpoint_commits = list(existing)
+    state.checkpoint_attempted_ac_ids = list(attempted)
+    for ac in evaluation_summary.ac_results:
+        if not getattr(ac, "passed", False):
+            continue
+        ac_id = f"AC-{int(getattr(ac, 'ac_index', 0)) + 1}"
+        ac_text = str(getattr(ac, "ac_content", ac_id))
+        try:
+            checkpoint_passed_ac(state, repo_cwd=repo_cwd, ac_id=ac_id, ac_text=ac_text)
+        except RuntimeError as exc:
+            log.warning("mcp.tool.evolve_step.checkpoint_commit_failed", error=str(exc))
+    return state.checkpoint_commits, state.checkpoint_attempted_ac_ids
 
 
 @dataclass

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -539,9 +539,7 @@ def _checkpoint_passed_generation_acs(
     repo_cwd: Path,
 ) -> tuple[list[dict[str, Any]], list[str]]:
     """Create checkpoint commits for passed ACs when requested."""
-    existing = [
-        item for item in arguments.get("checkpoint_commits", []) if isinstance(item, dict)
-    ]
+    existing = [item for item in arguments.get("checkpoint_commits", []) if isinstance(item, dict)]
     attempted = [
         item for item in arguments.get("checkpoint_attempted_ac_ids", []) if isinstance(item, str)
     ]

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -123,6 +123,26 @@ def _resolve_evolve_verification_working_dir(
     return stable_base
 
 
+def _resolve_checkpoint_working_dir(
+    workspace: TaskWorkspace | None,
+    resolved_verification_working_dir: Path,
+) -> Path:
+    """Resolve the directory AC checkpoint commits must target.
+
+    Checkpoint commits have to be created in the same filesystem root that the
+    generation actually mutated. When ``maybe_restore_task_workspace`` created a
+    managed lineage worktree, execution ran in ``workspace.effective_cwd`` — not
+    the caller's original ``project_dir`` that
+    ``_resolve_evolve_verification_working_dir`` prefers. Committing the parent
+    project dir there records the AC as *attempted* with ``no_safe_changes`` (no
+    diff outside the worktree), so the passed AC is never checkpointed. Prefer
+    the effective worktree whenever one is active.
+    """
+    if workspace is not None:
+        return Path(workspace.effective_cwd)
+    return resolved_verification_working_dir
+
+
 @dataclass
 class EvolveStepHandler(BridgeAwareMixin):
     """Handler for the ouroboros_evolve_step tool.
@@ -433,7 +453,7 @@ class EvolveStepHandler(BridgeAwareMixin):
         checkpoint_commits, checkpoint_attempted_ac_ids = _checkpoint_passed_generation_acs(
             arguments,
             gen.evaluation_summary,
-            resolved_verification_working_dir,
+            _resolve_checkpoint_working_dir(workspace, resolved_verification_working_dir),
         )
         if checkpoint_commits:
             text_lines.append("")

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -495,7 +495,9 @@ class ExecuteSeedHandler(BridgeAwareMixin):
             console = Console(stderr=True)
             session_repo = SessionRepository(event_store)
             workspace: TaskWorkspace | None = None
+            tracker = None
             launched = False
+            use_worktree = bool(arguments.get("use_worktree", True))
 
             try:
                 if is_resume and session_id:
@@ -522,22 +524,25 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                                 tool_name="ouroboros_execute_seed",
                             )
                         )
-                    persisted = TaskWorkspace.from_progress_dict(tracker.progress.get("workspace"))
-                    try:
-                        workspace = maybe_restore_task_workspace(
-                            session_id,
-                            persisted,
-                            fallback_source_cwd=resolved_cwd,
-                            allow_dirty=inherited_runtime_handle is not None,
+                    if use_worktree:
+                        persisted = TaskWorkspace.from_progress_dict(
+                            tracker.progress.get("workspace")
                         )
-                    except WorktreeError as e:
-                        return Result.err(
-                            MCPToolError(
-                                f"Task workspace error: {e.message}",
-                                tool_name="ouroboros_execute_seed",
+                        try:
+                            workspace = maybe_restore_task_workspace(
+                                session_id,
+                                persisted,
+                                fallback_source_cwd=resolved_cwd,
+                                allow_dirty=inherited_runtime_handle is not None,
                             )
-                        )
-                else:
+                        except WorktreeError as e:
+                            return Result.err(
+                                MCPToolError(
+                                    f"Task workspace error: {e.message}",
+                                    tool_name="ouroboros_execute_seed",
+                                )
+                            )
+                elif use_worktree:
                     try:
                         workspace = maybe_prepare_task_workspace(
                             resolved_cwd,

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -402,9 +402,7 @@ class RalphHandler:
             auto_session_id=arguments.get("auto_session_id"),
             execution_id=arguments.get("execution_id"),
             checkpoint_commits=tuple(
-                item
-                for item in arguments.get("checkpoint_commits", [])
-                if isinstance(item, dict)
+                item for item in arguments.get("checkpoint_commits", []) if isinstance(item, dict)
             ),
             checkpoint_attempted_ac_ids=tuple(
                 item

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -430,6 +430,11 @@ class RalphHandler:
                 max_total_seconds=config.max_total_seconds,
                 oscillation_window=config.oscillation_window,
                 grade_regression_window=config.grade_regression_window,
+                commit_policy=config.commit_policy,
+                auto_session_id=config.auto_session_id,
+                execution_id=config.execution_id,
+                checkpoint_commits=config.checkpoint_commits,
+                checkpoint_attempted_ac_ids=config.checkpoint_attempted_ac_ids,
             )
             await self._event_store.initialize()
             await emit_subagent_dispatched_event(

--- a/src/ouroboros/mcp/tools/ralph_handlers.py
+++ b/src/ouroboros/mcp/tools/ralph_handlers.py
@@ -128,6 +128,36 @@ class RalphHandler:
                     required=False,
                 ),
                 MCPToolParameter(
+                    name="commit_policy",
+                    type=ToolInputType.STRING,
+                    description="Optional checkpoint commit policy forwarded to evolve_step.",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    name="auto_session_id",
+                    type=ToolInputType.STRING,
+                    description="Optional auto session id used for checkpoint commit metadata.",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    name="execution_id",
+                    type=ToolInputType.STRING,
+                    description="Optional execution id used for checkpoint commit metadata.",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    name="checkpoint_commits",
+                    type=ToolInputType.ARRAY,
+                    description="Existing checkpoint commit records forwarded to evolve_step.",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    name="checkpoint_attempted_ac_ids",
+                    type=ToolInputType.ARRAY,
+                    description="Acceptance criteria already considered for checkpoint commits.",
+                    required=False,
+                ),
+                MCPToolParameter(
                     name="max_generations",
                     type=ToolInputType.INTEGER,
                     description="Maximum generations to run before stopping. Default: 10. Range: 1-10.",
@@ -368,6 +398,19 @@ class RalphHandler:
             max_total_seconds=max_total_seconds,
             oscillation_window=oscillation_window,
             grade_regression_window=grade_regression_window,
+            commit_policy=arguments.get("commit_policy"),
+            auto_session_id=arguments.get("auto_session_id"),
+            execution_id=arguments.get("execution_id"),
+            checkpoint_commits=tuple(
+                item
+                for item in arguments.get("checkpoint_commits", [])
+                if isinstance(item, dict)
+            ),
+            checkpoint_attempted_ac_ids=tuple(
+                item
+                for item in arguments.get("checkpoint_attempted_ac_ids", [])
+                if isinstance(item, str)
+            ),
         )
 
         if should_dispatch_via_plugin(self.agent_runtime_backend, self.opencode_mode):

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -1256,6 +1256,11 @@ def build_ralph_subagent(
     max_total_seconds: float | None = None,
     oscillation_window: int | None = None,
     grade_regression_window: int | None = None,
+    commit_policy: str | None = None,
+    auto_session_id: str | None = None,
+    execution_id: str | None = None,
+    checkpoint_commits: tuple[dict[str, Any], ...] = (),
+    checkpoint_attempted_ac_ids: tuple[str, ...] = (),
     delegation_depth: int = 1,
     allow_nested_ouroboros_ralph: bool = False,
 ) -> SubagentPayload:
@@ -1396,6 +1401,22 @@ def build_ralph_subagent(
             "`stop_reason=wall_clock_exhausted`.\n"
         )
 
+    checkpoint_note = ""
+    if commit_policy and commit_policy != "none" and auto_session_id:
+        checkpoint_note = (
+            "\n## Checkpoint Commits\n"
+            f"commit_policy: {commit_policy}\n"
+            f"auto_session_id: {auto_session_id}\n"
+            f"execution_id: {execution_id or 'none'}\n"
+            "When you run each `evolve_step`, forward `commit_policy`, "
+            "`auto_session_id`, `execution_id`, `checkpoint_commits`, and "
+            "`checkpoint_attempted_ac_ids` so verified acceptance criteria are "
+            "checkpoint-committed in the execution worktree. Carry the updated "
+            "`checkpoint_commits` / `checkpoint_attempted_ac_ids` returned by one "
+            "`evolve_step` into the next so commits stay idempotent across "
+            "iterations.\n"
+        )
+
     prompt = f"""## Your Task
 
 Run a Ralph loop for the given lineage inside this OpenCode child session.
@@ -1427,7 +1448,7 @@ Repeat one evolutionary generation at a time until one stop condition is met:
 - allow_nested_ouroboros_ralph: {str(allow_nested_ouroboros_ralph).lower()}
 - Do not call ouroboros_ralph from this child session. Run the loop directly
   by executing/evaluating one generation at a time.
-{seed_note}{mode_note}{parallel_note}{project_dir_note}{qa_note}{total_timeout_note}{timeout_note}{progress_note}{budget_note}
+{seed_note}{mode_note}{parallel_note}{project_dir_note}{qa_note}{total_timeout_note}{timeout_note}{progress_note}{budget_note}{checkpoint_note}
 For generation 1, use the seed content when present. For later generations,
 reconstruct state from the lineage and continue without resending seed_content.
 
@@ -1455,6 +1476,17 @@ do not enqueue another background Ralph job."""
         context["oscillation_window"] = oscillation_window
     if grade_regression_window is not None:
         context["grade_regression_window"] = grade_regression_window
+    # Forward the checkpoint contract so plugin-mode Ralph reaches the same AC
+    # checkpoint behavior as the in-process RalphLoopRunner. Only attach the
+    # fields when a committing policy is actually configured, so legacy callers
+    # that never set commit_policy keep the prior context shape.
+    if commit_policy and commit_policy != "none" and auto_session_id:
+        context["commit_policy"] = commit_policy
+        context["auto_session_id"] = auto_session_id
+        if execution_id:
+            context["execution_id"] = execution_id
+        context["checkpoint_commits"] = [dict(item) for item in checkpoint_commits]
+        context["checkpoint_attempted_ac_ids"] = list(checkpoint_attempted_ac_ids)
 
     return build_subagent_payload(
         tool_name="ouroboros_ralph",

--- a/src/ouroboros/ralph_loop.py
+++ b/src/ouroboros/ralph_loop.py
@@ -55,6 +55,11 @@ class RalphLoopConfig:
     max_total_seconds: float | None = None
     oscillation_window: int = DEFAULT_OSCILLATION_WINDOW
     grade_regression_window: int = DEFAULT_GRADE_REGRESSION_WINDOW
+    commit_policy: str | None = None
+    auto_session_id: str | None = None
+    execution_id: str | None = None
+    checkpoint_commits: tuple[dict[str, Any], ...] = ()
+    checkpoint_attempted_ac_ids: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True, slots=True)
@@ -139,6 +144,8 @@ class RalphLoopRunner:
         stop_reason = "max_generations reached"
         status = "completed"
         loop_start_monotonic = time.monotonic()
+        checkpoint_commits = list(config.checkpoint_commits)
+        checkpoint_attempted_ac_ids = list(config.checkpoint_attempted_ac_ids)
 
         for iteration_index in range(1, config.max_generations + 1):
             if (
@@ -182,6 +189,16 @@ class RalphLoopRunner:
                 arguments["seed_content"] = seed_content
             if config.project_dir:
                 arguments["project_dir"] = config.project_dir
+            if config.commit_policy:
+                arguments["commit_policy"] = config.commit_policy
+            if config.auto_session_id:
+                arguments["auto_session_id"] = config.auto_session_id
+            if config.execution_id:
+                arguments["execution_id"] = config.execution_id
+            if checkpoint_commits:
+                arguments["checkpoint_commits"] = checkpoint_commits
+            if checkpoint_attempted_ac_ids:
+                arguments["checkpoint_attempted_ac_ids"] = checkpoint_attempted_ac_ids
 
             iteration_timed_out = False
             try:
@@ -239,6 +256,16 @@ class RalphLoopRunner:
                 raise RuntimeError(str(result.error))
 
             final_result = result.value
+            result_checkpoint_commits = final_result.meta.get("checkpoint_commits")
+            if isinstance(result_checkpoint_commits, list):
+                checkpoint_commits = [
+                    item for item in result_checkpoint_commits if isinstance(item, dict)
+                ]
+            result_checkpoint_attempts = final_result.meta.get("checkpoint_attempted_ac_ids")
+            if isinstance(result_checkpoint_attempts, list):
+                checkpoint_attempted_ac_ids = [
+                    item for item in result_checkpoint_attempts if isinstance(item, str)
+                ]
             action = str(final_result.meta.get("action", "unknown"))
             generation = _coerce_int(final_result.meta.get("generation"))
             qa_verdict = _extract_qa_verdict(final_result.meta)

--- a/tests/unit/auto/test_adapters_ralph_poller.py
+++ b/tests/unit/auto/test_adapters_ralph_poller.py
@@ -204,6 +204,7 @@ async def test_handler_ralph_starter_forwards_checkpoint_meta_via_real_job_manag
             lineage_id="lineage-ckpt",
             reuse_existing=False,
             max_total_seconds=5.0,
+            return_after_dispatch=False,
         )
 
         assert result["terminal_status"] == "completed"

--- a/tests/unit/auto/test_adapters_ralph_poller.py
+++ b/tests/unit/auto/test_adapters_ralph_poller.py
@@ -2,12 +2,18 @@
 
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 from ouroboros.auto import adapters
-from ouroboros.auto.adapters import HandlerRalphPoller
+from ouroboros.auto.adapters import HandlerRalphPoller, HandlerRalphStarter
+from ouroboros.core.types import Result
+from ouroboros.mcp.job_manager import JobManager
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.persistence.event_store import EventStore
 
 
 class _FakeJobManager:
@@ -75,3 +81,133 @@ async def test_handler_ralph_poller_prefers_generations_over_iterations(
     result = await poller(job_id="job_ralph_existing")
 
     assert result["current_generation"] == 10
+
+
+# ---------------------------------------------------------------------------
+# Full Ralph job-manager adapter path: checkpoint metadata propagation
+# (Q00/ouroboros#1281 review req_1780029496_276 BLOCKING).
+#
+# These exercise the *real* JobManager terminal-snapshot boundary — not a
+# monkeypatched ``_wait_for_job_terminal`` and not ``RalphLoopRunner`` directly
+# — so a regression that drops ``checkpoint_commits`` /
+# ``checkpoint_attempted_ac_ids`` when the job-mode adapters rebuild their
+# structured terminal dict is caught. Without forwarding, an in-process
+# complete-product coding session can create AC git commits inside
+# ``evolve_step`` while the auto state/result never persists or surfaces them,
+# so a later resume re-attempts already-committed ACs.
+# ---------------------------------------------------------------------------
+
+_CHECKPOINT_COMMITS = [
+    {"ac_id": "AC-1", "sha": "abc1230", "subject": "feat: satisfy AC-1"},
+    {"ac_id": "AC-2", "sha": "def4560", "subject": "feat: satisfy AC-2"},
+]
+_CHECKPOINT_ATTEMPTS = ["AC-1", "AC-2", "AC-3"]
+
+
+async def _cancel_manager_tasks(manager: JobManager) -> None:
+    tasks = [
+        *manager._tasks.values(),  # noqa: SLF001
+        *manager._runner_tasks.values(),  # noqa: SLF001
+        *manager._monitors.values(),  # noqa: SLF001
+    ]
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def _ralph_terminal_result(lineage_id: str) -> MCPToolResult:
+    """Mirror the meta shape ``RalphLoopResult.to_tool_result`` surfaces."""
+    return MCPToolResult(
+        content=(MCPContentItem(type=ContentType.TEXT, text="ralph done"),),
+        is_error=False,
+        meta={
+            "status": "completed",
+            "stop_reason": "qa passed",
+            "lineage_id": lineage_id,
+            "iterations": 3,
+            "checkpoint_commits": _CHECKPOINT_COMMITS,
+            "checkpoint_attempted_ac_ids": _CHECKPOINT_ATTEMPTS,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_handler_ralph_poller_forwards_checkpoint_meta_via_real_job_manager(
+    tmp_path,
+) -> None:
+    """Resume path must carry the durable commit list back into auto state."""
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(store)
+    try:
+
+        async def _runner() -> MCPToolResult:
+            return _ralph_terminal_result("lineage-ckpt")
+
+        started = await manager.start_job(
+            job_type="ralph", initial_message="queued", runner=_runner()
+        )
+        handler = SimpleNamespace(_job_manager=manager)
+        poller = HandlerRalphPoller(handler)  # type: ignore[arg-type]
+
+        result = await poller(job_id=started.job_id, max_total_seconds=5.0)
+
+        assert result["terminal_status"] == "completed"
+        assert result["checkpoint_commits"] == _CHECKPOINT_COMMITS
+        assert result["checkpoint_attempted_ac_ids"] == _CHECKPOINT_ATTEMPTS
+    finally:
+        await _cancel_manager_tasks(manager)
+
+
+@pytest.mark.asyncio
+async def test_handler_ralph_starter_forwards_checkpoint_meta_via_real_job_manager(
+    tmp_path,
+) -> None:
+    """Job-mode starter must carry checkpoint metadata back into auto state."""
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(store)
+
+    class _StarterHandler:
+        # Absent runtime-backend attrs => job mode (not plugin dispatch).
+        agent_runtime_backend = None
+        opencode_mode = None
+
+        def __init__(self, job_manager: JobManager) -> None:
+            self._job_manager = job_manager
+
+        async def handle(self, arguments: dict[str, Any]) -> Result[MCPToolResult, Any]:
+            lineage_id = arguments.get("lineage_id", "lineage-ckpt")
+
+            async def _runner() -> MCPToolResult:
+                return _ralph_terminal_result(lineage_id)
+
+            started = await self._job_manager.start_job(
+                job_type="ralph", initial_message="queued", runner=_runner()
+            )
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="dispatched"),),
+                    is_error=False,
+                    meta={"dispatch_mode": "job", "job_id": started.job_id},
+                )
+            )
+
+    try:
+        handler = _StarterHandler(manager)
+        starter = HandlerRalphStarter(handler)  # type: ignore[arg-type]
+        # ``to_dict`` is the only Seed surface the job-mode starter touches.
+        seed = SimpleNamespace(to_dict=lambda: {"goal": "x", "acceptance_criteria": ["a"]})
+
+        result = await starter(
+            seed,  # type: ignore[arg-type]
+            lineage_id="lineage-ckpt",
+            reuse_existing=False,
+            max_total_seconds=5.0,
+        )
+
+        assert result["terminal_status"] == "completed"
+        assert result["checkpoint_commits"] == _CHECKPOINT_COMMITS
+        assert result["checkpoint_attempted_ac_ids"] == _CHECKPOINT_ATTEMPTS
+    finally:
+        await _cancel_manager_tasks(manager)

--- a/tests/unit/auto/test_auto_policies.py
+++ b/tests/unit/auto/test_auto_policies.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from ouroboros.auto.policies import apply_domain_policy_defaults
+from ouroboros.auto.profiles.coding import DEFAULT_COMMIT_POLICY, DEFAULT_WORKTREE_POLICY
+from ouroboros.auto.state import AutoCommitPolicy, AutoPipelineState, AutoWorktreePolicy
+
+
+def test_coding_profile_defaults_to_ac_checkpoints_and_auto_worktree() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.active_domain_profile_name = "coding"
+
+    apply_domain_policy_defaults(state)
+
+    assert state.commit_policy is DEFAULT_COMMIT_POLICY
+    assert state.worktree_policy is DEFAULT_WORKTREE_POLICY
+    assert state.commit_policy is AutoCommitPolicy.AC_CHECKPOINT
+    assert state.worktree_policy is AutoWorktreePolicy.AUTO
+
+
+def test_non_coding_profile_defaults_to_conservative_policies() -> None:
+    state = AutoPipelineState(goal="Summarize papers", cwd="/tmp/project")
+    state.active_domain_profile_name = "research"
+
+    apply_domain_policy_defaults(state)
+
+    assert state.commit_policy is AutoCommitPolicy.FINAL_ONLY
+    assert state.worktree_policy is AutoWorktreePolicy.CURRENT

--- a/tests/unit/auto/test_auto_policies.py
+++ b/tests/unit/auto/test_auto_policies.py
@@ -23,5 +23,7 @@ def test_non_coding_profile_defaults_to_conservative_policies() -> None:
 
     apply_domain_policy_defaults(state)
 
-    assert state.commit_policy is AutoCommitPolicy.FINAL_ONLY
+    # Non-coding domains must not auto-commit the caller's checkout by default;
+    # final-only commits stay an explicit operator opt-in.
+    assert state.commit_policy is AutoCommitPolicy.NONE
     assert state.worktree_policy is AutoWorktreePolicy.CURRENT

--- a/tests/unit/auto/test_auto_worktree.py
+++ b/tests/unit/auto/test_auto_worktree.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import subprocess
+
+from ouroboros.auto.state import AutoPipelineState, AutoWorktreePolicy
+from ouroboros.auto.worktree import ensure_auto_worktree, release_auto_worktree
+
+
+def _git(repo, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(path) -> None:
+    path.mkdir()
+    _git(path, "init", "-b", "main")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test User")
+    (path / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+    _git(path, "add", "pyproject.toml")
+    _git(path, "commit", "-m", "initial")
+
+
+def test_coding_auto_policy_creates_managed_worktree_and_updates_cwd(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "dirty.txt").write_text("uncommitted caller work\n", encoding="utf-8")
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(repo))
+    state.active_domain_profile_name = "coding"
+    state.worktree_policy = AutoWorktreePolicy.AUTO
+
+    workspace = ensure_auto_worktree(state)
+    try:
+        assert workspace is not None
+        assert state.managed_worktree is not None
+        assert state.cwd == workspace.effective_cwd
+        assert workspace.worktree_path != str(repo)
+        assert workspace.branch == f"ooo/{state.auto_session_id}"
+        assert not (repo / "dirty.txt").exists() or (repo / "dirty.txt").read_text() == (
+            "uncommitted caller work\n"
+        )
+    finally:
+        release_auto_worktree(workspace)
+
+
+def test_coding_auto_policy_reuses_persisted_managed_worktree(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(repo))
+    state.active_domain_profile_name = "coding"
+    state.worktree_policy = AutoWorktreePolicy.AUTO
+
+    first = ensure_auto_worktree(state)
+    release_auto_worktree(first)
+
+    second = ensure_auto_worktree(state)
+    try:
+        assert first is not None
+        assert second is not None
+        assert second.worktree_path == first.worktree_path
+        assert second.branch == first.branch
+        assert state.managed_worktree is not None
+    finally:
+        release_auto_worktree(second)
+
+
+def test_auto_policy_gracefully_skips_non_repo(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("HOME", str(tmp_path / "home"))
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.active_domain_profile_name = "coding"
+    state.worktree_policy = AutoWorktreePolicy.AUTO
+
+    assert ensure_auto_worktree(state) is None
+    assert state.managed_worktree is None
+    assert state.cwd == str(tmp_path)

--- a/tests/unit/auto/test_checkpoint_commits.py
+++ b/tests/unit/auto/test_checkpoint_commits.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import subprocess
+
+from ouroboros.auto.checkpoint_commits import checkpoint_final_auto, checkpoint_passed_ac
+from ouroboros.auto.ledger import SeedDraftLedger
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.state import AutoCommitPolicy, AutoPhase, AutoPipelineState
+
+
+def _git(repo, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(path) -> None:
+    path.mkdir()
+    _git(path, "init", "-b", "main")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test User")
+    (path / "README.md").write_text("demo\n", encoding="utf-8")
+    _git(path, "add", "README.md")
+    _git(path, "commit", "-m", "initial")
+
+
+def test_checkpoint_passed_ac_commits_once_with_metadata(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "feature.py").write_text("print('ok')\n", encoding="utf-8")
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(repo))
+    state.commit_policy = AutoCommitPolicy.AC_CHECKPOINT
+    state.execution_id = "exec_123"
+
+    result = checkpoint_passed_ac(
+        state,
+        repo_cwd=repo,
+        ac_id="AC-1",
+        ac_text="Command prints stable output",
+    )
+    duplicate = checkpoint_passed_ac(
+        state,
+        repo_cwd=repo,
+        ac_id="AC-1",
+        ac_text="Command prints stable output",
+    )
+
+    assert result.status == "committed"
+    assert result.commit
+    assert duplicate.status == "skipped"
+    assert duplicate.reason == "already_committed"
+    assert state.checkpoint_attempted_ac_ids == ["AC-1"]
+    assert state.checkpoint_commits == [
+        {
+            "ac_id": "AC-1",
+            "ac_text": "Command prints stable output",
+            "commit": result.commit,
+            "execution_id": "exec_123",
+            "policy": "ac_checkpoint",
+        }
+    ]
+    log = _git(repo, "log", "-1", "--pretty=%B")
+    assert "ooo: satisfy AC-1 Command prints stable output" in log
+    assert f"Auto-Session: {state.auto_session_id}" in log
+    assert "Execution-Id: exec_123" in log
+    assert "Acceptance-Criterion: AC-1" in log
+
+
+def test_checkpoint_passed_ac_skips_dirty_secret_only_changes(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / ".env").write_text("TOKEN=secret\n", encoding="utf-8")
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(repo))
+    state.commit_policy = AutoCommitPolicy.AC_CHECKPOINT
+
+    result = checkpoint_passed_ac(
+        state,
+        repo_cwd=repo,
+        ac_id="AC-2",
+        ac_text="Does not commit secrets",
+    )
+
+    assert result.status == "skipped"
+    assert result.reason == "no_safe_changes"
+    assert state.checkpoint_commits == []
+    assert state.checkpoint_attempted_ac_ids == ["AC-2"]
+    assert _git(repo, "log", "--oneline").count("\n") == 0
+
+
+def test_checkpoint_passed_ac_does_not_commit_pre_staged_secret(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / ".env").write_text("TOKEN=secret\n", encoding="utf-8")
+    _git(repo, "add", ".env")
+    (repo / "feature.py").write_text("print('ok')\n", encoding="utf-8")
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(repo))
+    state.commit_policy = AutoCommitPolicy.AC_CHECKPOINT
+
+    result = checkpoint_passed_ac(
+        state,
+        repo_cwd=repo,
+        ac_id="AC-2",
+        ac_text="Command prints stable output",
+    )
+
+    assert result.status == "committed"
+    assert _git(repo, "show", "--name-only", "--pretty=", "HEAD") == "feature.py"
+    assert ".env" in _git(repo, "diff", "--cached", "--name-only")
+
+
+def test_checkpoint_passed_ac_does_not_retry_attempted_pass_transition(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(repo))
+    state.commit_policy = AutoCommitPolicy.AC_CHECKPOINT
+
+    first = checkpoint_passed_ac(
+        state,
+        repo_cwd=repo,
+        ac_id="AC-6",
+        ac_text="Command prints stable output",
+    )
+    (repo / "feature.py").write_text("print('later')\n", encoding="utf-8")
+    second = checkpoint_passed_ac(
+        state,
+        repo_cwd=repo,
+        ac_id="AC-6",
+        ac_text="Command prints stable output",
+    )
+
+    assert first.status == "skipped"
+    assert first.reason == "no_safe_changes"
+    assert second.status == "skipped"
+    assert second.reason == "already_attempted"
+    assert _git(repo, "rev-list", "--count", "HEAD") == "1"
+
+
+def test_checkpoint_passed_ac_respects_disabled_policy(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "feature.py").write_text("print('ok')\n", encoding="utf-8")
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(repo))
+    state.commit_policy = AutoCommitPolicy.NONE
+
+    result = checkpoint_passed_ac(
+        state,
+        repo_cwd=repo,
+        ac_id="AC-3",
+        ac_text="Command prints stable output",
+    )
+
+    assert result.status == "skipped"
+    assert result.reason == "commit_policy"
+    assert state.checkpoint_commits == []
+
+
+def test_checkpoint_passed_ac_skips_for_final_only_policy(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "feature.py").write_text("print('ok')\n", encoding="utf-8")
+    state = AutoPipelineState(goal="Write docs", cwd=str(repo))
+    state.commit_policy = AutoCommitPolicy.FINAL_ONLY
+
+    result = checkpoint_passed_ac(
+        state,
+        repo_cwd=repo,
+        ac_id="AC-4",
+        ac_text="Documentation is complete",
+    )
+
+    assert result.status == "skipped"
+    assert result.reason == "commit_policy"
+    assert _git(repo, "rev-list", "--count", "HEAD") == "1"
+
+
+def test_checkpoint_passed_ac_gracefully_skips_non_repo(tmp_path) -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.commit_policy = AutoCommitPolicy.AC_CHECKPOINT
+
+    result = checkpoint_passed_ac(
+        state,
+        repo_cwd=tmp_path,
+        ac_id="AC-5",
+        ac_text="Command prints stable output",
+    )
+
+    assert result.status == "skipped"
+    assert result.reason == "not_git_repo"
+    assert state.checkpoint_commits == []
+
+
+def test_checkpoint_final_auto_commits_once_for_final_only_policy(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "feature.py").write_text("print('done')\n", encoding="utf-8")
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(repo))
+    state.commit_policy = AutoCommitPolicy.FINAL_ONLY
+    state.execution_id = "exec_123"
+
+    result = checkpoint_final_auto(
+        state,
+        repo_cwd=repo,
+        summary="all acceptance criteria passed",
+    )
+    duplicate = checkpoint_final_auto(
+        state,
+        repo_cwd=repo,
+        summary="all acceptance criteria passed",
+    )
+
+    assert result.status == "committed"
+    assert duplicate.status == "skipped"
+    assert duplicate.reason == "already_attempted"
+    assert state.final_checkpoint_attempted is True
+    assert state.checkpoint_commits == [
+        {
+            "ac_id": "FINAL",
+            "ac_text": "all acceptance criteria passed",
+            "commit": result.commit,
+            "execution_id": "exec_123",
+            "policy": "final_only",
+        }
+    ]
+    log = _git(repo, "log", "-1", "--pretty=%B")
+    assert "ooo: complete auto session all acceptance criteria passed" in log
+    assert f"Auto-Session: {state.auto_session_id}" in log
+    assert "Execution-Id: exec_123" in log
+    assert "Commit-Policy: final_only" in log
+
+
+def test_pipeline_result_attempts_final_only_commit_on_complete(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "feature.py").write_text("print('done')\n", encoding="utf-8")
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(repo))
+    state.commit_policy = AutoCommitPolicy.FINAL_ONLY
+    state.phase = AutoPhase.COMPLETE
+    state.last_progress_message = "all acceptance criteria passed"
+    pipeline = AutoPipeline(
+        interview_driver=None,  # type: ignore[arg-type]
+        seed_generator=None,  # type: ignore[arg-type]
+    )
+
+    result = pipeline._result(state, SeedDraftLedger.from_goal(state.goal))
+    replay = pipeline._result(state, SeedDraftLedger.from_goal(state.goal))
+
+    assert result.status == "complete"
+    assert len(result.checkpoint_commits) == 1
+    assert replay.checkpoint_commits == result.checkpoint_commits
+    assert state.final_checkpoint_attempted is True
+    assert _git(repo, "rev-list", "--count", "HEAD") == "2"

--- a/tests/unit/auto/test_checkpoint_commits.py
+++ b/tests/unit/auto/test_checkpoint_commits.py
@@ -254,3 +254,38 @@ def test_pipeline_result_attempts_final_only_commit_on_complete(tmp_path) -> Non
     assert replay.checkpoint_commits == result.checkpoint_commits
     assert state.final_checkpoint_attempted is True
     assert _git(repo, "rev-list", "--count", "HEAD") == "2"
+
+
+def test_pipeline_result_does_not_commit_dirty_current_checkout_by_default(tmp_path) -> None:
+    """#1281 review blocker: a default (non-coding / legacy) session must never
+    commit the caller's pre-existing dirty checkout when it completes.
+
+    Regression for ouroboros-agent[bot] ``req_1780010936_238``. The prior default
+    of ``FINAL_ONLY`` + ``CURRENT`` turned every ``COMPLETE`` result into a git
+    commit of the operator's working tree, even for research/documentation/
+    ``skip_run`` flows that performed no managed coding work. The conservative
+    default is now ``NONE``; final-only commits on the current checkout require
+    an explicit operator opt-in.
+    """
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    # Operator's own uncommitted edits, unrelated to the auto session.
+    (repo / "operator_wip.py").write_text("print('local wip')\n", encoding="utf-8")
+    state = AutoPipelineState(goal="Summarize research papers", cwd=str(repo))
+    # No explicit policy is set: the conservative defaults must apply.
+    assert state.commit_policy is AutoCommitPolicy.NONE
+    state.phase = AutoPhase.COMPLETE
+    state.last_progress_message = "research summary complete"
+    pipeline = AutoPipeline(
+        interview_driver=None,  # type: ignore[arg-type]
+        seed_generator=None,  # type: ignore[arg-type]
+    )
+
+    result = pipeline._result(state, SeedDraftLedger.from_goal(state.goal))
+
+    assert result.status == "complete"
+    assert result.checkpoint_commits == ()
+    assert state.final_checkpoint_attempted is False
+    # No commit was created and the operator's WIP stays uncommitted.
+    assert _git(repo, "rev-list", "--count", "HEAD") == "1"
+    assert "operator_wip.py" in _git(repo, "status", "--porcelain")

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -83,7 +83,9 @@ def test_legacy_state_defaults_to_non_coding_policy() -> None:
 
     restored = AutoPipelineState.from_dict(payload)
 
-    assert restored.commit_policy is AutoCommitPolicy.FINAL_ONLY
+    # Legacy state files predate the commit/worktree policy keys; they must
+    # resume with NO auto-commit so an existing dirty checkout is never mutated.
+    assert restored.commit_policy is AutoCommitPolicy.NONE
     assert restored.worktree_policy is AutoWorktreePolicy.CURRENT
     assert restored.managed_worktree is None
     assert restored.checkpoint_commits == []

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -6,10 +6,12 @@ import pytest
 
 from ouroboros.auto.state import (
     DEFAULT_TIMEOUT_SECONDS_BY_PHASE,
+    AutoCommitPolicy,
     AutoPhase,
     AutoPipelineState,
     AutoResumeCapability,
     AutoStore,
+    AutoWorktreePolicy,
 )
 
 
@@ -46,6 +48,47 @@ def test_store_roundtrip_and_corrupt_state(tmp_path) -> None:
     path.write_text("not json", encoding="utf-8")
     with pytest.raises(ValueError, match="corrupt"):
         store.load(state.auto_session_id)
+
+
+def test_commit_and_worktree_policy_roundtrip() -> None:
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
+    state.commit_policy = AutoCommitPolicy.AC_CHECKPOINT
+    state.worktree_policy = AutoWorktreePolicy.AUTO
+    state.managed_worktree = {"worktree_path": "/tmp/wt", "branch": "codex/ooo-auto-abc"}
+    state.checkpoint_commits = [{"ac_id": "AC-1", "commit": "abc123"}]
+    state.checkpoint_attempted_ac_ids = ["AC-1", "AC-2"]
+    state.final_checkpoint_attempted = True
+
+    payload = state.to_dict()
+    restored = AutoPipelineState.from_dict(payload)
+
+    assert payload["commit_policy"] == "ac_checkpoint"
+    assert payload["worktree_policy"] == "auto"
+    assert restored.commit_policy is AutoCommitPolicy.AC_CHECKPOINT
+    assert restored.worktree_policy is AutoWorktreePolicy.AUTO
+    assert restored.managed_worktree == state.managed_worktree
+    assert restored.checkpoint_commits == state.checkpoint_commits
+    assert restored.checkpoint_attempted_ac_ids == state.checkpoint_attempted_ac_ids
+    assert restored.final_checkpoint_attempted is True
+
+
+def test_legacy_state_defaults_to_non_coding_policy() -> None:
+    payload = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project").to_dict()
+    payload.pop("commit_policy")
+    payload.pop("worktree_policy")
+    payload.pop("managed_worktree")
+    payload.pop("checkpoint_commits")
+    payload.pop("checkpoint_attempted_ac_ids")
+    payload.pop("final_checkpoint_attempted")
+
+    restored = AutoPipelineState.from_dict(payload)
+
+    assert restored.commit_policy is AutoCommitPolicy.FINAL_ONLY
+    assert restored.worktree_policy is AutoWorktreePolicy.CURRENT
+    assert restored.managed_worktree is None
+    assert restored.checkpoint_commits == []
+    assert restored.checkpoint_attempted_ac_ids == []
+    assert restored.final_checkpoint_attempted is False
 
 
 def test_terminal_state_is_not_stale() -> None:

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -369,6 +369,47 @@ def test_run_auto_uses_default_state_interview_timeout_for_new_sessions() -> Non
     assert captured["driver_timeout_seconds"] == 600.0
 
 
+def test_run_auto_policy_args_override_detected_coding_defaults(tmp_path, monkeypatch) -> None:
+    import asyncio
+
+    from ouroboros.auto.state import AutoCommitPolicy, AutoWorktreePolicy
+    from ouroboros.cli.commands.auto import _run_auto
+
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    async def fake_pipeline_run(self, run_state):  # noqa: ARG001
+        captured["domain"] = run_state.active_domain_profile_name
+        captured["commit_policy"] = run_state.commit_policy
+        captured["worktree_policy"] = run_state.worktree_policy
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=run_state.auto_session_id,
+            phase="complete",
+            grade="A",
+        )
+
+    with patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=fake_pipeline_run):
+        result = asyncio.run(
+            _run_auto(
+                goal="Build a CLI",
+                resume=None,
+                runtime="claude",
+                max_interview_rounds=None,
+                max_repair_rounds=None,
+                skip_run=True,
+                commit_policy="none",
+                worktree_policy="current",
+            )
+        )
+
+    assert result.status == "complete"
+    assert captured["domain"] == "coding"
+    assert captured["commit_policy"] is AutoCommitPolicy.NONE
+    assert captured["worktree_policy"] is AutoWorktreePolicy.CURRENT
+
+
 def test_resume_rejects_lower_bound_override(tmp_path) -> None:
     """Tightening a bound on resume must be refused — never trap a session further."""
     import asyncio

--- a/tests/unit/mcp/tools/test_evolve_checkpoint_commits.py
+++ b/tests/unit/mcp/tools/test_evolve_checkpoint_commits.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import subprocess
+
+from ouroboros.core.lineage import ACResult, EvaluationSummary
+from ouroboros.mcp.tools.evolution_handlers import _checkpoint_passed_generation_acs
+
+
+def _git(repo, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(path) -> None:
+    path.mkdir()
+    _git(path, "init", "-b", "main")
+    _git(path, "config", "user.email", "test@example.com")
+    _git(path, "config", "user.name", "Test User")
+    (path / "README.md").write_text("demo\n", encoding="utf-8")
+    _git(path, "add", "README.md")
+    _git(path, "commit", "-m", "initial")
+
+
+def test_evolve_checkpoint_commits_only_newly_passed_acs(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    (repo / "feature.py").write_text("print('ok')\n", encoding="utf-8")
+    summary = EvaluationSummary(
+        final_approved=False,
+        highest_stage_passed=3,
+        ac_results=(
+            ACResult(ac_index=0, ac_content="Command prints stable output", passed=True),
+            ACResult(ac_index=1, ac_content="Docs are updated", passed=False),
+        ),
+    )
+
+    commits, attempts = _checkpoint_passed_generation_acs(
+        {
+            "commit_policy": "ac_checkpoint",
+            "auto_session_id": "auto_test123",
+            "execution_id": "exec_123",
+        },
+        summary,
+        repo,
+    )
+    repeated_commits, repeated_attempts = _checkpoint_passed_generation_acs(
+        {
+            "commit_policy": "ac_checkpoint",
+            "auto_session_id": "auto_test123",
+            "checkpoint_commits": commits,
+            "checkpoint_attempted_ac_ids": attempts,
+        },
+        summary,
+        repo,
+    )
+
+    assert len(commits) == 1
+    assert commits[0]["ac_id"] == "AC-1"
+    assert attempts == ["AC-1"]
+    assert repeated_commits == commits
+    assert repeated_attempts == attempts
+    log = _git(repo, "log", "-1", "--pretty=%B")
+    assert "Acceptance-Criterion: AC-1" in log
+    assert "Execution-Id: exec_123" in log
+
+
+def test_evolve_checkpoint_does_not_retry_attempted_pass_without_diff(tmp_path) -> None:
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    summary = EvaluationSummary(
+        final_approved=True,
+        highest_stage_passed=3,
+        ac_results=(
+            ACResult(ac_index=0, ac_content="Command prints stable output", passed=True),
+        ),
+    )
+
+    commits, attempts = _checkpoint_passed_generation_acs(
+        {
+            "commit_policy": "ac_checkpoint",
+            "auto_session_id": "auto_test123",
+        },
+        summary,
+        repo,
+    )
+    (repo / "feature.py").write_text("print('later')\n", encoding="utf-8")
+    repeated_commits, repeated_attempts = _checkpoint_passed_generation_acs(
+        {
+            "commit_policy": "ac_checkpoint",
+            "auto_session_id": "auto_test123",
+            "checkpoint_commits": commits,
+            "checkpoint_attempted_ac_ids": attempts,
+        },
+        summary,
+        repo,
+    )
+
+    assert commits == []
+    assert attempts == ["AC-1"]
+    assert repeated_commits == []
+    assert repeated_attempts == ["AC-1"]
+    assert _git(repo, "rev-list", "--count", "HEAD") == "1"

--- a/tests/unit/mcp/tools/test_evolve_checkpoint_commits.py
+++ b/tests/unit/mcp/tools/test_evolve_checkpoint_commits.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
+from pathlib import Path
 import subprocess
 
 from ouroboros.core.lineage import ACResult, EvaluationSummary
-from ouroboros.mcp.tools.evolution_handlers import _checkpoint_passed_generation_acs
+from ouroboros.mcp.tools.evolution_handlers import (
+    _checkpoint_passed_generation_acs,
+    _resolve_checkpoint_working_dir,
+)
+
+
+@dataclass
+class _FakeWorkspace:
+    effective_cwd: str
 
 
 def _git(repo, *args: str) -> str:
@@ -104,3 +114,53 @@ def test_evolve_checkpoint_does_not_retry_attempted_pass_without_diff(tmp_path) 
     assert repeated_commits == []
     assert repeated_attempts == ["AC-1"]
     assert _git(repo, "rev-list", "--count", "HEAD") == "1"
+
+
+def test_resolve_checkpoint_working_dir_prefers_effective_worktree(tmp_path) -> None:
+    """#1281 review blocker 1: when a managed lineage worktree is active, the
+    checkpoint must target the worktree that execution mutated — not the
+    original project_dir preferred by verification-dir resolution.
+    """
+    project_dir = tmp_path / "project"
+    worktree = tmp_path / "worktree"
+
+    assert _resolve_checkpoint_working_dir(None, project_dir) == project_dir
+    assert (
+        _resolve_checkpoint_working_dir(_FakeWorkspace(effective_cwd=str(worktree)), project_dir)
+        == worktree
+    )
+
+
+def test_evolve_checkpoint_commits_target_worktree_not_parent_project(tmp_path) -> None:
+    """The passed AC's diff lives in the lineage worktree; committing the parent
+    project_dir (no diff) would burn the attempt as ``no_safe_changes`` and lose
+    the checkpoint. Resolving to the effective worktree commits it correctly and
+    leaves the parent checkout untouched.
+    """
+    project_dir = tmp_path / "project"
+    _init_repo(project_dir)
+    worktree = tmp_path / "worktree"
+    _init_repo(worktree)
+    # The generation's mutation only exists in the worktree.
+    (worktree / "feature.py").write_text("print('ok')\n", encoding="utf-8")
+    summary = EvaluationSummary(
+        final_approved=True,
+        highest_stage_passed=3,
+        ac_results=(ACResult(ac_index=0, ac_content="Command prints stable output", passed=True),),
+    )
+
+    checkpoint_dir = _resolve_checkpoint_working_dir(
+        _FakeWorkspace(effective_cwd=str(worktree)),
+        Path(project_dir),
+    )
+    commits, attempts = _checkpoint_passed_generation_acs(
+        {"commit_policy": "ac_checkpoint", "auto_session_id": "auto_test123"},
+        summary,
+        checkpoint_dir,
+    )
+
+    assert len(commits) == 1
+    assert commits[0]["ac_id"] == "AC-1"
+    # Commit landed in the worktree, not the parent project checkout.
+    assert _git(worktree, "rev-list", "--count", "HEAD") == "2"
+    assert _git(project_dir, "rev-list", "--count", "HEAD") == "1"

--- a/tests/unit/mcp/tools/test_evolve_checkpoint_commits.py
+++ b/tests/unit/mcp/tools/test_evolve_checkpoint_commits.py
@@ -76,9 +76,7 @@ def test_evolve_checkpoint_does_not_retry_attempted_pass_without_diff(tmp_path) 
     summary = EvaluationSummary(
         final_approved=True,
         highest_stage_passed=3,
-        ac_results=(
-            ACResult(ac_index=0, ac_content="Command prints stable output", passed=True),
-        ),
+        ac_results=(ACResult(ac_index=0, ac_content="Command prints stable output", passed=True),),
     )
 
     commits, attempts = _checkpoint_passed_generation_acs(

--- a/tests/unit/mcp/tools/test_ralph_handler.py
+++ b/tests/unit/mcp/tools/test_ralph_handler.py
@@ -95,6 +95,52 @@ async def test_ralph_loop_runs_multiple_generations_until_converged() -> None:
 
 
 @pytest.mark.asyncio
+async def test_ralph_loop_forwards_checkpoint_commit_state() -> None:
+    evolve = _FakeEvolveHandler(["continue", "converged"])
+
+    async def handle(arguments: dict[str, Any]):
+        evolve.calls.append(dict(arguments))
+        attempts = list(arguments.get("checkpoint_attempted_ac_ids", []))
+        if len(evolve.calls) == 1:
+            attempts.append("AC-2")
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="ok"),),
+                is_error=False,
+                meta={
+                    "lineage_id": arguments["lineage_id"],
+                    "generation": len(evolve.calls),
+                    "action": "converged" if len(evolve.calls) == 2 else "continue",
+                    "checkpoint_commits": arguments.get("checkpoint_commits", []),
+                    "checkpoint_attempted_ac_ids": attempts,
+                },
+            )
+        )
+
+    evolve.handle = handle  # type: ignore[method-assign]
+    runner = RalphLoopRunner(evolve)
+
+    result = await runner.run(
+        RalphLoopConfig(
+            lineage_id="lin_checkpoint",
+            seed_content="goal: test",
+            max_generations=3,
+            commit_policy="ac_checkpoint",
+            auto_session_id="auto_123",
+            execution_id="exec_123",
+            checkpoint_commits=({"ac_id": "AC-1", "commit": "abc123"},),
+            checkpoint_attempted_ac_ids=("AC-1",),
+        )
+    )
+
+    assert result.status == "completed"
+    assert evolve.calls[0]["execution_id"] == "exec_123"
+    assert evolve.calls[0]["checkpoint_attempted_ac_ids"] == ["AC-1"]
+    assert evolve.calls[1]["checkpoint_attempted_ac_ids"] == ["AC-1", "AC-2"]
+    assert evolve.calls[1]["checkpoint_commits"] == [{"ac_id": "AC-1", "commit": "abc123"}]
+
+
+@pytest.mark.asyncio
 async def test_ralph_loop_stops_at_max_generations() -> None:
     evolve = _FakeEvolveHandler(["continue"])
     runner = RalphLoopRunner(evolve)

--- a/tests/unit/mcp/tools/test_ralph_handler.py
+++ b/tests/unit/mcp/tools/test_ralph_handler.py
@@ -324,6 +324,81 @@ async def test_ralph_handler_plugin_mode_delegates_without_local_job() -> None:
 
 
 @pytest.mark.asyncio
+async def test_ralph_handler_plugin_mode_forwards_checkpoint_contract() -> None:
+    """#1281 review blocker: plugin-mode Ralph must carry the AC checkpoint
+    contract the in-process RalphLoopRunner receives, otherwise coding
+    complete-product sessions silently run Ralph without checkpoint policy/state.
+    """
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    job_manager = JobManager(store)
+    evolve = _FakeEvolveHandler(["converged"])
+    handler = RalphHandler(
+        evolve_handler=evolve,  # type: ignore[arg-type]
+        event_store=store,
+        job_manager=job_manager,
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    try:
+        result = await handler.handle(
+            {
+                "lineage_id": "lin_ckpt",
+                "seed_content": "goal: plugin",
+                "max_generations": 3,
+                "commit_policy": "ac_checkpoint",
+                "auto_session_id": "auto_ckpt123",
+                "execution_id": "exec_ckpt123",
+                "checkpoint_commits": [{"ac_id": "AC-1", "commit": "abc1234"}],
+                "checkpoint_attempted_ac_ids": ["AC-1"],
+            }
+        )
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert meta["status"] == "delegated_to_plugin"
+        ctx = meta["_subagent"]["context"]
+        assert ctx["commit_policy"] == "ac_checkpoint"
+        assert ctx["auto_session_id"] == "auto_ckpt123"
+        assert ctx["execution_id"] == "exec_ckpt123"
+        assert ctx["checkpoint_commits"] == [{"ac_id": "AC-1", "commit": "abc1234"}]
+        assert ctx["checkpoint_attempted_ac_ids"] == ["AC-1"]
+        # The prompt advertises the checkpoint obligation to the child session.
+        assert "Checkpoint Commits" in meta["_subagent"]["prompt"]
+        assert evolve.calls == []
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_ralph_handler_plugin_mode_omits_checkpoint_when_unset() -> None:
+    """Legacy callers that never set commit_policy keep the prior context shape."""
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    job_manager = JobManager(store)
+    evolve = _FakeEvolveHandler(["converged"])
+    handler = RalphHandler(
+        evolve_handler=evolve,  # type: ignore[arg-type]
+        event_store=store,
+        job_manager=job_manager,
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    try:
+        result = await handler.handle(
+            {"lineage_id": "lin_plain", "seed_content": "goal: plugin", "max_generations": 3}
+        )
+
+        assert result.is_ok
+        ctx = result.value.meta["_subagent"]["context"]
+        assert "commit_policy" not in ctx
+        assert "checkpoint_commits" not in ctx
+        assert "Checkpoint Commits" not in result.value.meta["_subagent"]["prompt"]
+    finally:
+        await store.close()
+
+
+@pytest.mark.asyncio
 async def test_start_ralph_handler_plugin_mode_delegates_without_local_job() -> None:
     store = EventStore("sqlite+aiosqlite:///:memory:")
     job_manager = JobManager(store)

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -21,7 +21,12 @@ import pytest
 
 from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipelineResult
-from ouroboros.auto.state import AutoPipelineState, AutoStore
+from ouroboros.auto.state import (
+    AutoCommitPolicy,
+    AutoPipelineState,
+    AutoStore,
+    AutoWorktreePolicy,
+)
 from ouroboros.core.types import Result
 from ouroboros.mcp.job_manager import JobManager, JobStatus
 from ouroboros.mcp.tools.auto_handler import (
@@ -1022,6 +1027,67 @@ class TestBackgroundJobPath:
         assert "failure_modes" in state.user_preferences
         assert SeedDraftLedger.from_dict(state.ledger).open_gaps() == []
         fake_inner_auto.handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_new_coding_goal_preallocates_coding_policy_defaults(
+        self, event_store, tmp_path, fake_inner_auto
+    ) -> None:
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+        job_manager = MagicMock()
+        snapshot = MagicMock()
+        snapshot.job_id = "job_auto_coding_defaults"
+
+        async def _start_job(*, runner, **_):
+            if inspect.iscoroutine(runner):
+                runner.close()
+            return snapshot
+
+        job_manager.start_job = AsyncMock(side_effect=_start_job)
+        store = AutoStore(tmp_path / "store")
+        h = StartAutoHandler(event_store=event_store, job_manager=job_manager, store=store)
+        h._inner_auto = fake_inner_auto
+
+        result = await h.handle({"goal": "build a CLI", "cwd": str(tmp_path)})
+
+        assert result.is_ok
+        state = store.load(result.value.meta["auto_session_id"])
+        assert state.active_domain_profile_name == "coding"
+        assert state.commit_policy is AutoCommitPolicy.AC_CHECKPOINT
+        assert state.worktree_policy is AutoWorktreePolicy.AUTO
+
+    @pytest.mark.asyncio
+    async def test_new_auto_policy_args_override_profile_defaults(
+        self, event_store, tmp_path, fake_inner_auto
+    ) -> None:
+        (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+        job_manager = MagicMock()
+        snapshot = MagicMock()
+        snapshot.job_id = "job_auto_policy_override"
+
+        async def _start_job(*, runner, **_):
+            if inspect.iscoroutine(runner):
+                runner.close()
+            return snapshot
+
+        job_manager.start_job = AsyncMock(side_effect=_start_job)
+        store = AutoStore(tmp_path / "store")
+        h = StartAutoHandler(event_store=event_store, job_manager=job_manager, store=store)
+        h._inner_auto = fake_inner_auto
+
+        result = await h.handle(
+            {
+                "goal": "build a CLI",
+                "cwd": str(tmp_path),
+                "commit_policy": "none",
+                "worktree_policy": "current",
+            }
+        )
+
+        assert result.is_ok
+        state = store.load(result.value.meta["auto_session_id"])
+        assert state.active_domain_profile_name == "coding"
+        assert state.commit_policy is AutoCommitPolicy.NONE
+        assert state.worktree_policy is AutoWorktreePolicy.CURRENT
 
     @pytest.mark.asyncio
     async def test_fresh_structured_goal_runner_resumes_without_preference_override(


### PR DESCRIPTION
## Summary
- add auto commit/worktree policies persisted on AutoPipelineState with coding-profile defaults
- run coding auto sessions in a managed worktree and pass that cwd through run/ralph/evolve
- add AC checkpoint commits, final-only commits, secret-ish path filtering, checkpoint attempt idempotency, and result summaries

## Update — review fix (ouroboros-agent[bot] `req_1780010936_238`)
The bot's BLOCKING finding was that the default `FINAL_ONLY` + `CURRENT` policy
made **every** `COMPLETE` result commit the caller's current checkout — including
non-coding / research / documentation / `skip_run` flows and legacy-resumed
sessions that performed no managed coding work. That could commit an operator's
pre-existing dirty working tree unexpectedly.

Fix: the conservative default is now `commit_policy = NONE` in the dataclass, the
`from_dict` legacy loader, and the non-coding profile branch. Coding sessions are
unchanged (`AC_CHECKPOINT` inside an isolated managed worktree). Final-only
commits on the caller's current checkout are now an explicit operator opt-in
(`--commit-policy final_only`). A regression test exercises the dirty
current-checkout default-completion path and asserts no commit is created.
Also rebased onto `main` (resolved the `cli/commands/auto.py` conflict with the
`complete_product` synchronous run-starter) and applied `ruff format`.

## Tests
- uv run pytest tests/unit/core/test_worktree.py tests/unit/auto/test_checkpoint_commits.py tests/unit/mcp/tools/test_evolve_checkpoint_commits.py tests/unit/auto/test_auto_worktree.py tests/unit/auto/test_state.py tests/unit/auto/test_auto_policies.py tests/unit/mcp/tools/test_start_auto.py tests/unit/cli/test_auto_command.py tests/unit/mcp/tools/test_auto_handler_ralph_runtime.py tests/unit/mcp/tools/test_definitions.py tests/unit/auto/test_adapters_ralph_poller.py tests/unit/mcp/tools/test_ralph_handler.py -q
- uv run ruff check + ruff format --check src/ tests/
- uv run mypy src/ouroboros/auto/state.py src/ouroboros/auto/policies.py src/ouroboros/auto/checkpoint_commits.py
- git diff --check

## R-run comparison (required for `src/ouroboros/auto/` changes)

This PR adds worktree-isolation + checkpoint-commit machinery; it does **not**
change the per-interview-round wall-clock loop that RFC #1256 §I5 protects.
Checkpoint commits run only at AC-pass / completion for coding sessions and add
a small bounded `git add`/`git commit` cost; the default path is now `NONE`
(no commit, no added work). No canonical R-run is meaningful for this change.

| Metric                         | Baseline (sha)                  | This PR (sha)                                   | Ratio |
|--------------------------------|---------------------------------|-------------------------------------------------|-------|
| Rounds completed in 600 s      | N/A - not an R-run benchmark PR | N/A - worktree/checkpoint isolation only        | n/a   |
| Per-round wall-clock (s/round) | N/A - not an R-run benchmark PR | N/A - per-round loop unchanged                  | n/a   |
| Terminal reason                | N/A - not an R-run benchmark PR | N/A - terminal contract unchanged               | n/a   |
| EventStore event count         | N/A - not an R-run benchmark PR | N/A - no per-round events added                 | n/a   |

Budget compliance: [x] N/A (per-round interview/run loop unchanged; checkpoint commits are AC/terminal-scoped and the default policy adds no work)

## Related issues
- Track B (`ooo auto` self-healing) follow-up; refs #961
