### PR TITLE
Route Codex auto through background starter

### DIFF
--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auto
 description: "Automatically converge from goal to A-grade Seed and execute it"
-mcp_tool: ouroboros_auto
+mcp_tool: ouroboros_start_auto
 mcp_args:
   goal: "$goal"
   resume: "$resume"
@@ -19,17 +19,23 @@ Run the full-quality auto pipeline from a single task description.
 
 ## Dispatch requirement
 
-This skill must be executed by invoking MCP tool `ouroboros_auto`. Do not
+This skill must be executed by invoking MCP tool `ouroboros_start_auto`. Do not
 manually inspect repositories, run shell commands, query GitHub, edit files, or
-otherwise emulate the auto pipeline as a substitute.
+otherwise emulate the auto pipeline as a substitute. Full auto runs routinely
+exceed interactive MCP tool-call timeouts, so the background starter is the
+supported default: it returns `job_id` and `auto_session_id` quickly. Retain
+both, poll progress with `ouroboros_job_wait` / `ouroboros_job_status`, and read
+terminal results with `ouroboros_job_result`.
 
-If `ouroboros_auto` is unavailable, stop and report that the required MCP tool
-is unavailable. A manual fallback is not an `ooo auto` run.
+If `ouroboros_start_auto` is unavailable, or if any required job polling/result
+MCP tool is unavailable, stop and report that the required MCP tool is
+unavailable. A manual fallback is not an `ooo auto` run.
 
-If `ouroboros_auto` is invoked successfully but returns `blocked`, `failed`, or
-another terminal auto-session status, report that auto-session status and the
-tool's blocker. Do not label that outcome as MCP dispatch failure; dispatch
-failure means the MCP tool could not be invoked.
+If a started auto job later returns `detached`, `blocked`, `failed`, or another
+auto-session status, report that auto-session status and the tool's blocker.
+`detached` is non-terminal tracked background work; surface the job/Ralph
+handles and keep polling. Do not label a `blocked` or `failed` outcome as MCP
+dispatch failure; dispatch failure means the MCP tool could not be invoked.
 
 ## Usage
 
@@ -43,7 +49,7 @@ ooo auto "Build a local-first habit tracker CLI" --complete-product
 
 ## CLI flag → MCP arg translation
 
-When the user types `ooo auto` with CLI-style flags inside chat, translate to MCP arguments before invoking `ouroboros_auto`:
+When the user types `ooo auto` with CLI-style flags inside chat, translate to MCP arguments before invoking `ouroboros_start_auto`:
 
 | CLI flag | MCP arg | Type |
 |----------|---------|------|

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -27,6 +27,9 @@ _REQUIRED_CODEX_AUTO_TOOLS = frozenset(
     {
         "ouroboros_auto",
         "ouroboros_start_auto",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
         "ouroboros_interview",
         "ouroboros_generate_seed",
     }
@@ -104,8 +107,9 @@ def doctor(
 
     print_success(
         "Codex ooo auto dispatch: OK\n"
-        "- rule maps `ooo auto` to `ouroboros_auto`\n"
+        "- rule maps `ooo auto` to `ouroboros_start_auto`\n"
         "- auto skill declares MCP dispatch through `ouroboros_auto`\n"
+        "- live MCP auto workflow includes job status/wait/result tools when probed\n"
         "- Codex config contains an `ouroboros` MCP server entry"
         + ("\n- live stdio initialize/list_tools exposes required auto tools" if live_mcp else ""),
         title="Codex Doctor",
@@ -121,8 +125,8 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
         failures.append(f"missing Codex rules file: {rules_path}")
     else:
         rules = _read_codex_text(rules_path, "Codex rules", failures)
-        if rules is not None and ("`ooo auto" not in rules or "ouroboros_auto" not in rules):
-            failures.append("Codex rules do not map `ooo auto` to `ouroboros_auto`")
+        if rules is not None and ("`ooo auto" not in rules or "ouroboros_start_auto" not in rules):
+            failures.append("Codex rules do not map `ooo auto` to `ouroboros_start_auto`")
         if rules is not None and (
             "manual" not in rules.lower() or "unavailable" not in rules.lower()
         ):

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -108,7 +108,7 @@ def doctor(
     print_success(
         "Codex ooo auto dispatch: OK\n"
         "- rule maps `ooo auto` to `ouroboros_start_auto`\n"
-        "- auto skill declares MCP dispatch through `ouroboros_auto`\n"
+        "- auto skill declares MCP dispatch through `ouroboros_start_auto`\n"
         "- live MCP auto workflow includes job status/wait/result tools when probed\n"
         "- Codex config contains an `ouroboros` MCP server entry"
         + ("\n- live stdio initialize/list_tools exposes required auto tools" if live_mcp else ""),
@@ -137,8 +137,8 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
         failures.append(f"missing auto skill file: {skill_path}")
     else:
         skill = _read_codex_text(skill_path, "auto skill", failures)
-        if skill is not None and "mcp_tool: ouroboros_auto" not in skill:
-            failures.append("auto skill does not declare `mcp_tool: ouroboros_auto`")
+        if skill is not None and "mcp_tool: ouroboros_start_auto" not in skill:
+            failures.append("auto skill does not declare `mcp_tool: ouroboros_start_auto`")
         if skill is not None and (
             "manual" not in skill.lower() or "unavailable" not in skill.lower()
         ):

--- a/src/ouroboros/codex/ouroboros.md
+++ b/src/ouroboros/codex/ouroboros.md
@@ -13,15 +13,14 @@ Do NOT interpret `ooo` commands as natural language. ALWAYS route to the MCP too
 | `ooo interview "<answer>"` (follow-up) | `ouroboros_interview` with `answer` and `session_id` |
 | `ooo seed [session_id]` | `ouroboros_generate_seed` |
 | `ooo run <seed.yaml>` | `ouroboros_execute_seed` with `seed_path` |
-| `ooo auto ...` | `ouroboros_auto` with the resolved `goal` / `resume` / option arguments |
+| `ooo auto ...` | `ouroboros_start_auto` with the resolved `goal` / `resume` / option arguments |
 | `ooo status [session_id]` | `ouroboros_session_status` |
 | `ooo evaluate <session_id>` | `ouroboros_evaluate` |
 | `ooo evolve ...` | `ouroboros_evolve_step` |
 | `ooo cancel [execution_id]` | `ouroboros_cancel_execution` |
 | `ooo unstuck` / `ooo lateral` | `ouroboros_lateral_think` |
-| `ooo auto ...` | `ouroboros_auto` |
 
-If `ouroboros_auto` is unavailable, stop and report that the MCP dispatch surface is broken. Do not manually emulate `ooo auto` with ordinary shell, GitHub, or coding work.
+If `ouroboros_start_auto` is unavailable, stop and report that the MCP dispatch surface is broken. Do not manually emulate `ooo auto` with ordinary shell, GitHub, or coding work.
 
 ## Natural Language Mapping
 
@@ -38,15 +37,21 @@ For natural-language requests, map to the corresponding MCP tool:
 A-grade review/repair, and execution handoff. Do not emulate it with manual
 shell, repository, or GitHub work.
 
-If a user input starts with `ooo auto`, call `ouroboros_auto`. If that MCP tool
-is unavailable, stop and report that `ouroboros_auto` is unavailable instead of
-continuing as a normal Codex task.
+If a user input starts with `ooo auto`, call `ouroboros_start_auto`. Full auto
+runs routinely exceed interactive MCP tool-call timeouts, so the background
+starter is the supported default. It returns `job_id` and `auto_session_id`
+quickly; report both, retain the latest cursor, and monitor progress with
+`ouroboros_job_wait` / `ouroboros_job_status`. Read terminal results with
+`ouroboros_job_result`. If that MCP tool is unavailable, or if any required job
+polling/result MCP tool is unavailable, stop and report that the MCP dispatch
+surface is incomplete instead of continuing as a normal Codex task.
 
-If `ouroboros_auto` is invoked and returns an auto-session outcome such as
+If a started auto job later returns an auto-session outcome such as `detached`,
 `blocked`, `failed`, or `complete`, report that outcome as the auto session
-result. Do not call a `blocked` or `failed` auto-session result a dispatch
-failure; dispatch failure is reserved for cases where the MCP tool could not be
-invoked.
+result. `detached` is non-terminal tracked background work; surface the job or
+Ralph handles and keep polling. Do not call a `blocked` or `failed`
+auto-session result a dispatch failure; dispatch failure is reserved for cases
+where the MCP tool could not be invoked.
 
 ## Setup & Update
 

--- a/tests/integration/auto/test_dispatch_to_seed_e2e.py
+++ b/tests/integration/auto/test_dispatch_to_seed_e2e.py
@@ -1,8 +1,12 @@
 """End-to-end ``ooo auto`` dispatch regression tests.
 
 Closes the last open acceptance bullet of issue #637: prove that ``ooo auto ...``
-reaches the ``ouroboros_auto`` MCP pipeline and produces a Seed (or fails closed
-with the documented unavailable-tool contract). The tests stay laser-focused on
+reaches the auto MCP pipeline and produces a Seed (or fails closed with the
+documented unavailable-tool contract). Per #1283 the deterministic dispatch
+surface now routes typed ``ooo auto`` to the async background starter
+``ouroboros_start_auto`` (parity with the Codex rules/doctor), so the tool name
+asserted on the dispatch boundary is ``ouroboros_start_auto``. The tests stay
+laser-focused on
 this acceptance bullet — they do not exercise progress UI, answer grounding, or
 CLI help text. All side-effects are confined to ``tmp_path``: no network, no
 real LLM, no real home directory.
@@ -20,8 +24,8 @@ Cases:
    boundary) — it covers the ledger-hydration + seed-generator wiring landed in
    PR #652. Case 1 already covers the dispatch boundary itself.
 3. The deterministic ``ooo auto`` dispatch surface fails closed with the
-   user-visible "ouroboros_auto is unavailable" contract message and does not
-   create any persisted auto session state when the MCP tool is unregistered.
+   user-visible "ouroboros_start_auto is unavailable" contract message and does
+   not create any persisted auto session state when the MCP tool is unregistered.
 """
 
 from __future__ import annotations
@@ -423,7 +427,7 @@ async def test_ooo_auto_dispatch_reaches_seed_via_runtime(
     assert intercepts, "skill_dispatcher must be awaited for ooo auto"
     intercept = intercepts[0]
     assert intercept.skill_name == "auto"
-    assert intercept.mcp_tool == "ouroboros_auto"
+    assert intercept.mcp_tool == "ouroboros_start_auto"
     assert intercept.command_prefix == "ooo auto"
 
     # The runtime contract requires documented packaged auto placeholders to be
@@ -464,7 +468,7 @@ async def test_ooo_auto_dispatch_reaches_seed_via_runtime(
     final = messages[0]
     assert final.is_final
     assert not final.is_error, f"dispatch should succeed, got {final!r}"
-    assert final.data.get("tool_name") == "ouroboros_auto"
+    assert final.data.get("tool_name") == "ouroboros_start_auto"
     assert final.data.get("seed_path") == str(seed_path)
     assert final.data.get("status") == "complete"
     assert final.data.get("grade") == "A"
@@ -707,7 +711,7 @@ async def test_sparse_goal_reaches_seed_via_interview_fill(tmp_path: Path) -> No
 
 
 async def test_dispatch_fails_closed_when_ouroboros_auto_unregistered(tmp_path: Path) -> None:
-    """``ooo auto`` must fail closed when the ``ouroboros_auto`` MCP tool is unregistered.
+    """``ooo auto`` must fail closed when the ``ouroboros_start_auto`` MCP tool is unregistered.
 
     The dispatch surface returns a fail-closed ``AgentMessage``; no
     ``AutoHandler`` or ``AutoStore`` is constructed downstream because the
@@ -731,7 +735,7 @@ async def test_dispatch_fails_closed_when_ouroboros_auto_unregistered(tmp_path: 
     cwd.mkdir()
 
     dispatcher = AsyncMock(
-        side_effect=LookupError("No local handler registered for tool: ouroboros_auto")
+        side_effect=LookupError("No local handler registered for tool: ouroboros_start_auto")
     )
     runtime = CodexCliRuntime(
         cli_path="codex",
@@ -757,12 +761,13 @@ async def test_dispatch_fails_closed_when_ouroboros_auto_unregistered(tmp_path: 
     failure = messages[0]
     assert failure.is_error is True
 
-    # The Issue #637 acceptance phrase is "ouroboros_auto MCP tool is unavailable;
-    # cannot run ooo auto". The actual codebase contract phrasing combines both
-    # halves into a single sentence — assert each half is present so the contract
-    # cannot silently regress in either direction.
+    # The Issue #637 acceptance phrase is "the auto MCP tool is unavailable;
+    # cannot run ooo auto"; post-#1283 the dispatched tool is ouroboros_start_auto.
+    # The actual codebase contract phrasing combines both halves into a single
+    # sentence — assert each half is present so the contract cannot silently
+    # regress in either direction.
     assert "Cannot run ooo auto" in failure.content
-    assert "`ouroboros_auto` is unavailable" in failure.content
+    assert "`ouroboros_start_auto` is unavailable" in failure.content
     assert failure.data["error_type"] == "SkillDispatchUnavailable"
-    assert failure.data["tool_name"] == "ouroboros_auto"
+    assert failure.data["tool_name"] == "ouroboros_start_auto"
     assert failure.data["command_prefix"] == "ooo auto"

--- a/tests/integration/test_codex_cli_passthrough_smoke.py
+++ b/tests/integration/test_codex_cli_passthrough_smoke.py
@@ -145,11 +145,11 @@ async def test_packaged_ooo_auto_missing_mcp_tool_fails_closed_without_codex_fal
     assert runtime._skill_dispatcher is not None
     with resolve_packaged_codex_skill_path("auto", skills_dir=runtime._skills_dir) as skill_md_path:
         content = skill_md_path.read_text(encoding="utf-8")
-    assert "mcp_tool: ouroboros_auto" in content
+    assert "mcp_tool: ouroboros_start_auto" in content
 
     fake_server = AsyncMock()
     fake_server.call_tool = AsyncMock(
-        side_effect=LookupError("No local handler registered for tool: ouroboros_auto")
+        side_effect=LookupError("No local handler registered for tool: ouroboros_start_auto")
     )
 
     with (
@@ -162,13 +162,13 @@ async def test_packaged_ooo_auto_missing_mcp_tool_fails_closed_without_codex_fal
         messages = [message async for message in runtime.execute_task("ooo auto Build a CLI")]
 
     fake_server.call_tool.assert_awaited_once()
-    assert fake_server.call_tool.await_args.args[0] == "ouroboros_auto"
+    assert fake_server.call_tool.await_args.args[0] == "ouroboros_start_auto"
     mock_exec.assert_not_called()
     mock_warning.assert_called_once()
     assert mock_warning.call_args.kwargs["fallback"] == "terminal_error"
     assert len(messages) == 1
     assert messages[0].is_error is True
     assert messages[0].content.startswith("Cannot run ooo auto")
-    assert "`ouroboros_auto` is unavailable" in messages[0].content
+    assert "`ouroboros_start_auto` is unavailable" in messages[0].content
     assert messages[0].data["error_type"] == "SkillDispatchUnavailable"
-    assert messages[0].data["tool_name"] == "ouroboros_auto"
+    assert messages[0].data["tool_name"] == "ouroboros_start_auto"

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -105,7 +105,7 @@ def test_auto_skill_frontmatter_dispatches_to_mcp_tool() -> None:
     content = skill.read_text(encoding="utf-8")
 
     assert "name: auto" in content
-    assert "mcp_tool: ouroboros_auto" in content
+    assert "mcp_tool: ouroboros_start_auto" in content
     assert 'goal: "$goal"' in content
     assert 'resume: "$resume"' in content
     assert 'skip_run: "$skip_run"' in content

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -78,7 +78,7 @@ class TestCodexDoctor:
         skill_path.write_text(
             "---\n"
             "name: auto\n"
-            "mcp_tool: ouroboros_auto\n"
+            "mcp_tool: ouroboros_start_auto\n"
             "---\n"
             "Manual fallback is not allowed when the tool is unavailable.\n",
             encoding="utf-8",
@@ -661,7 +661,7 @@ class TestCodexDoctor:
         failures = _check_auto_dispatch_surface(codex_dir)
 
         assert "Codex rules do not map `ooo auto` to `ouroboros_start_auto`" in failures
-        assert "auto skill does not declare `mcp_tool: ouroboros_auto`" in failures
+        assert "auto skill does not declare `mcp_tool: ouroboros_start_auto`" in failures
         assert "Codex config does not contain [mcp_servers.ouroboros]" in failures
 
     def test_doctor_command_exits_nonzero_when_dispatch_surface_is_broken(

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -25,6 +25,9 @@ runner = CliRunner()
 _REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST = {
     "ouroboros_auto",
     "ouroboros_start_auto",
+    "ouroboros_job_status",
+    "ouroboros_job_wait",
+    "ouroboros_job_result",
     "ouroboros_interview",
     "ouroboros_generate_seed",
 }
@@ -65,7 +68,7 @@ class TestCodexDoctor:
         rules_path = codex_dir / "rules" / "ouroboros.md"
         rules_path.parent.mkdir(parents=True, exist_ok=True)
         rules_path.write_text(
-            "| `ooo auto ...` | `ouroboros_auto` |\n"
+            "| `ooo auto ...` | `ouroboros_start_auto` |\n"
             "Do not emulate it with manual work. If unavailable, stop.\n",
             encoding="utf-8",
         )
@@ -237,6 +240,9 @@ class TestCodexDoctor:
             return_value={
                 "ouroboros_auto",
                 "ouroboros_start_auto",
+                "ouroboros_job_status",
+                "ouroboros_job_wait",
+                "ouroboros_job_result",
                 "ouroboros_interview",
                 "ouroboros_generate_seed",
             }
@@ -307,6 +313,9 @@ class TestCodexDoctor:
                         "tools": [
                             {"name": "ouroboros_auto", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_start_auto", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_status", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_wait", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_result", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_interview", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_generate_seed", "inputSchema": {"type": "object"}},
                         ]
@@ -378,6 +387,9 @@ class TestCodexDoctor:
                         "tools": [
                             {"name": "ouroboros_auto", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_start_auto", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_status", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_wait", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_result", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_interview", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_generate_seed", "inputSchema": {"type": "object"}},
                         ]
@@ -444,6 +456,9 @@ class TestCodexDoctor:
                         "tools": [
                             {"name": "ouroboros_auto", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_start_auto", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_status", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_wait", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_result", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_interview", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_generate_seed", "inputSchema": {"type": "object"}},
                         ]
@@ -573,6 +588,30 @@ class TestCodexDoctor:
         assert any("missing required auto tools" in failure for failure in failures)
         assert any("ouroboros_auto" in failure for failure in failures)
 
+    def test_check_auto_dispatch_surface_live_mcp_reports_missing_job_polling_tools(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+
+        with patch(
+            "ouroboros.cli.commands.codex._list_stdio_mcp_tool_names",
+            AsyncMock(
+                return_value={
+                    "ouroboros_auto",
+                    "ouroboros_start_auto",
+                    "ouroboros_interview",
+                    "ouroboros_generate_seed",
+                }
+            ),
+        ):
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=True)
+
+        assert any("missing required auto tools" in failure for failure in failures)
+        assert any("ouroboros_job_wait" in failure for failure in failures)
+        assert any("ouroboros_job_result" in failure for failure in failures)
+
     def test_check_auto_dispatch_surface_live_mcp_reports_handshake_failure(
         self,
         tmp_path: Path,
@@ -621,7 +660,7 @@ class TestCodexDoctor:
 
         failures = _check_auto_dispatch_surface(codex_dir)
 
-        assert "Codex rules do not map `ooo auto` to `ouroboros_auto`" in failures
+        assert "Codex rules do not map `ooo auto` to `ouroboros_start_auto`" in failures
         assert "auto skill does not declare `mcp_tool: ouroboros_auto`" in failures
         assert "Codex config does not contain [mcp_servers.ouroboros]" in failures
 

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -1780,7 +1780,7 @@ class TestCodexCliRuntime:
             [
                 "name: auto",
                 'description: "Automatically converge from goal to A-grade Seed and execute it"',
-                "mcp_tool: ouroboros_auto",
+                "mcp_tool: ouroboros_start_auto",
                 "mcp_args:",
                 '  goal: "$goal"',
                 '  cwd: "$CWD"',
@@ -1808,14 +1808,14 @@ class TestCodexCliRuntime:
         assert len(messages) == 1
         assert messages[0].is_error is True
         assert messages[0].content.startswith("Cannot run ooo auto")
-        assert "`ouroboros_auto` is unavailable" in messages[0].content
+        assert "`ouroboros_start_auto` is unavailable" in messages[0].content
         assert "ouroboros mcp doctor" in messages[0].content
         assert mock_warning.call_args.kwargs["fallback"] == "terminal_error"
         assert messages[0].data == {
             "subtype": "error",
             "error_type": "SkillDispatchUnavailable",
             "skill_name": "auto",
-            "tool_name": "ouroboros_auto",
+            "tool_name": "ouroboros_start_auto",
             "command_prefix": "ooo auto",
             "dispatch_error_type": "LookupError",
             "dispatch_error": "No local handler registered",
@@ -1834,7 +1834,7 @@ class TestCodexCliRuntime:
             [
                 "name: auto",
                 'description: "Automatically converge from goal to A-grade Seed and execute it"',
-                "mcp_tool: ouroboros_auto",
+                "mcp_tool: ouroboros_start_auto",
                 "mcp_args:",
                 '  goal: "$goal"',
                 '  cwd: "$CWD"',
@@ -1842,7 +1842,7 @@ class TestCodexCliRuntime:
         )
         dispatcher = AsyncMock(
             return_value=(
-                AgentMessage(type="assistant", content="Calling tool: ouroboros_auto"),
+                AgentMessage(type="assistant", content="Calling tool: ouroboros_start_auto"),
                 AgentMessage(
                     type="result",
                     content="Auto MCP server unavailable",
@@ -1876,7 +1876,7 @@ class TestCodexCliRuntime:
         assert mock_warning.call_args.kwargs["error_type"] == "MCPConnectionError"
         mock_exec.assert_not_called()
         assert [message.content for message in messages] == [
-            "Calling tool: ouroboros_auto",
+            "Calling tool: ouroboros_start_auto",
             "Auto MCP server unavailable",
         ]
         assert messages[-1].data["error_type"] == "MCPConnectionError"
@@ -1894,7 +1894,7 @@ class TestCodexCliRuntime:
             [
                 "name: auto",
                 'description: "Automatically converge from goal to A-grade Seed and execute it"',
-                "mcp_tool: ouroboros_auto",
+                "mcp_tool: ouroboros_start_auto",
                 "mcp_args:",
                 '  goal: "$goal"',
                 '  cwd: "$CWD"',
@@ -1902,10 +1902,10 @@ class TestCodexCliRuntime:
         )
         dispatcher = AsyncMock(
             return_value=(
-                AgentMessage(type="assistant", content="Calling tool: ouroboros_auto"),
+                AgentMessage(type="assistant", content="Calling tool: ouroboros_start_auto"),
                 AgentMessage(
                     type="result",
-                    content="Tool ouroboros_auto not found",
+                    content="Tool ouroboros_start_auto not found",
                     data={
                         "subtype": "error",
                         "recoverable": True,
@@ -1935,7 +1935,7 @@ class TestCodexCliRuntime:
         assert len(messages) == 1
         assert messages[0].data["error_type"] == "SkillDispatchUnavailable"
         assert messages[0].data["dispatch_error_type"] == "MCPResourceNotFoundError"
-        assert messages[0].data["dispatch_error"] == "Tool ouroboros_auto not found"
+        assert messages[0].data["dispatch_error"] == "Tool ouroboros_start_auto not found"
         assert messages[0].data["dispatch_error_category"] == "mcp_registration_missing"
 
     @pytest.mark.asyncio
@@ -1950,7 +1950,7 @@ class TestCodexCliRuntime:
             [
                 "name: auto",
                 'description: "Automatically converge from goal to A-grade Seed and execute it"',
-                "mcp_tool: ouroboros_auto",
+                "mcp_tool: ouroboros_start_auto",
                 "mcp_args:",
                 '  goal: "$goal"',
                 '  cwd: "$CWD"',
@@ -1958,7 +1958,7 @@ class TestCodexCliRuntime:
         )
         dispatcher = AsyncMock(
             return_value=(
-                AgentMessage(type="assistant", content="Calling tool: ouroboros_auto"),
+                AgentMessage(type="assistant", content="Calling tool: ouroboros_start_auto"),
                 AgentMessage(
                     type="result",
                     content="MCPClientError: Transport closed",
@@ -2008,7 +2008,7 @@ class TestCodexCliRuntime:
             [
                 "name: auto",
                 'description: "Automatically converge from goal to A-grade Seed and execute it"',
-                "mcp_tool: ouroboros_auto",
+                "mcp_tool: ouroboros_start_auto",
                 "mcp_args:",
                 '  goal: "$goal"',
                 '  cwd: "$CWD"',
@@ -2016,7 +2016,7 @@ class TestCodexCliRuntime:
         )
         dispatcher = AsyncMock(
             return_value=(
-                AgentMessage(type="assistant", content="Calling tool: ouroboros_auto"),
+                AgentMessage(type="assistant", content="Calling tool: ouroboros_start_auto"),
                 AgentMessage(
                     type="result",
                     content="Auto pipeline failed: model provider crashed",
@@ -2050,7 +2050,7 @@ class TestCodexCliRuntime:
         assert mock_warning.call_args.kwargs["error_type"] == "MCPToolError"
         mock_exec.assert_not_called()
         assert [message.content for message in messages] == [
-            "Calling tool: ouroboros_auto",
+            "Calling tool: ouroboros_start_auto",
             "Auto pipeline failed: model provider crashed",
         ]
         assert messages[-1].data["error_type"] == "MCPToolError"
@@ -2068,7 +2068,7 @@ class TestCodexCliRuntime:
             [
                 "name: auto",
                 'description: "Automatically converge from goal to A-grade Seed and execute it"',
-                "mcp_tool: ouroboros_auto",
+                "mcp_tool: ouroboros_start_auto",
                 "mcp_args:",
                 '  goal: "$goal"',
                 '  cwd: "$CWD"',
@@ -2118,7 +2118,7 @@ class TestCodexCliRuntime:
             [
                 "name: auto",
                 'description: "Automatically converge from goal to A-grade Seed and execute it"',
-                "mcp_tool: ouroboros_auto",
+                "mcp_tool: ouroboros_start_auto",
                 "mcp_args:",
                 '  goal: "$goal"',
                 '  cwd: "$CWD"',

--- a/tests/unit/router/test_dispatch.py
+++ b/tests/unit/router/test_dispatch.py
@@ -532,7 +532,7 @@ def test_packaged_auto_resolves_documented_chat_dispatch_flags(tmp_path: Path) -
 
     assert isinstance(result, Resolved)
     assert result.skill_name == "auto"
-    assert result.mcp_tool == "ouroboros_auto"
+    assert result.mcp_tool == "ouroboros_start_auto"
     assert result.mcp_args["goal"] == "Build a hello CLI"
     assert result.mcp_args["cwd"] == str(runtime_cwd)
     assert result.mcp_args["complete_product"] is True

--- a/tests/unit/router/test_packaged_auto_dispatch.py
+++ b/tests/unit/router/test_packaged_auto_dispatch.py
@@ -5,15 +5,21 @@ from pathlib import Path
 from ouroboros.router import Resolved, resolve_skill_dispatch
 
 
-def test_packaged_auto_skill_dispatches_to_ouroboros_auto(tmp_path: Path) -> None:
-    """Lock the packaged ``ooo auto`` dispatch metadata used by Codex runtimes."""
+def test_packaged_auto_skill_dispatches_to_ouroboros_start_auto(tmp_path: Path) -> None:
+    """Lock the packaged ``ooo auto`` dispatch metadata used by Codex/Hermes runtimes.
+
+    Regression for #1283: the deterministic skill/router path must resolve typed
+    ``ooo auto`` to the async background starter ``ouroboros_start_auto`` so it
+    stays in parity with the Codex rules and doctor surface. A full synchronous
+    ``ouroboros_auto`` call exceeds interactive MCP tool-call timeouts.
+    """
     prompt = 'ooo auto "Audit the open PRs" --skip-run'
 
     result = resolve_skill_dispatch(prompt, cwd=tmp_path)
 
     assert isinstance(result, Resolved)
     assert result.command_prefix == "ooo auto"
-    assert result.mcp_tool == "ouroboros_auto"
+    assert result.mcp_tool == "ouroboros_start_auto"
     assert result.mcp_args == {
         "goal": "Audit the open PRs",
         "resume": "",

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -253,9 +253,10 @@ class TestLoadPackagedCodexSkills:
         """The auto skill body must not allow silent manual emulation."""
         skill = load_packaged_codex_skill("auto")
 
-        assert "must be executed by invoking MCP tool `ouroboros_auto`" in skill
-        assert "manual fallback is not an `ooo auto` run" in skill
-        assert "Do not label that outcome as MCP dispatch failure" in skill
+        compact = " ".join(skill.split())
+        assert "must be executed by invoking MCP tool `ouroboros_start_auto`" in compact
+        assert "manual fallback is not an `ooo auto` run" in compact
+        assert "Do not label a `blocked` or `failed` outcome as MCP dispatch failure" in compact
 
     def test_packaged_interview_skill_uses_runtime_capability_terms(self) -> None:
         """Runtime skill instructions should not hardcode Claude-only tool surfaces."""

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -183,11 +183,12 @@ class TestInstallCodexRules:
     def test_packaged_rules_fail_closed_for_ooo_auto(self) -> None:
         """Codex rules must route ``ooo auto`` to the real MCP tool, not manual work."""
         rules = load_packaged_codex_rules()
+        compact = " ".join(rules.split())
 
-        assert "| `ooo auto ...` | `ouroboros_auto`" in rules
+        assert "| `ooo auto ...` | `ouroboros_start_auto`" in rules
         assert "Do not emulate it with manual" in rules
-        assert "If that MCP tool\nis unavailable" in rules
-        assert "Do not call a `blocked` or `failed` auto-session result a dispatch" in rules
+        assert "If that MCP tool is unavailable" in compact
+        assert "Do not call a `blocked` or `failed` auto-session result a dispatch" in compact
 
     def test_packaged_rules_include_rendered_skill_capability_guide(self) -> None:
         """Codex rules should include the generated runtime skill capability guide."""


### PR DESCRIPTION
## Summary
- Route Codex `ooo auto` rules to `ouroboros_start_auto` instead of the blocking auto tool
- Update Codex doctor checks and packaged rule tests to validate the background starter route

## Tests
- uv run pytest tests/unit/cli/test_codex_command.py tests/unit/test_codex_artifacts.py