### PR TITLE
Relay auto interview questions in progress output

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -410,6 +410,59 @@ class AutoInterviewDriver:
         except Exception:
             pass
 
+    def _emit_interview_question(
+        self,
+        state: AutoPipelineState,
+        *,
+        question: str,
+        round_number: int | None,
+    ) -> None:
+        if self.progress_callback is None:
+            return
+        label = (
+            f"question round {round_number}/{self.max_rounds}"
+            if round_number is not None
+            else "question"
+        )
+        event = AutoProgressEvent(
+            auto_session_id=state.auto_session_id,
+            phase=state.phase.value,
+            kind="question",
+            message=label,
+            round=round_number,
+            question=question,
+        )
+        try:
+            self.progress_callback(event)
+        except Exception:
+            pass
+
+    def _emit_auto_answer(
+        self,
+        state: AutoPipelineState,
+        *,
+        round_number: int,
+        source: str,
+        question: str,
+        answer: str,
+    ) -> None:
+        if self.progress_callback is None:
+            return
+        event = AutoProgressEvent(
+            auto_session_id=state.auto_session_id,
+            phase=state.phase.value,
+            kind="answer",
+            message=f"answered round {round_number}/{self.max_rounds} from {source}",
+            round=round_number,
+            question=question,
+            answer=answer,
+            answer_source=source,
+        )
+        try:
+            self.progress_callback(event)
+        except Exception:
+            pass
+
     async def run(self, state: AutoPipelineState, ledger: SeedDraftLedger) -> AutoInterviewResult:
         """Run bounded auto interview until Seed-ready or blocked.
 
@@ -531,6 +584,11 @@ class AutoInterviewDriver:
                 state.interview_session_id = turn.session_id
                 state.pending_question = turn.question
                 self._save(state)
+            self._emit_interview_question(
+                state,
+                question=turn.question,
+                round_number=state.current_round + 1 if not turn.completed else None,
+            )
         except TimeoutError as exc:
             self._record_evidence_based_session_id(state, exc, preassigned_id)
             if interview_tool_name == "interview.start":
@@ -779,6 +837,19 @@ class AutoInterviewDriver:
                 tool_name="auto_answerer",
             )
             self._save(state)
+            self._emit_auto_answer(
+                state,
+                round_number=round_number,
+                source=answer.source.value,
+                question=question_for_record,
+                answer=answer.text,
+            )
+            if turn.question and not turn.completed:
+                self._emit_interview_question(
+                    state,
+                    question=turn.question,
+                    round_number=round_number + 1,
+                )
 
         # max_rounds exhausted — one final ledger-primary closure check, then
         # safe-default finalization for autonomous ``ooo auto``.  The manual

--- a/src/ouroboros/auto/progress.py
+++ b/src/ouroboros/auto/progress.py
@@ -14,7 +14,7 @@ from typing import Literal
 
 from ouroboros.auto.state import utc_now_iso
 
-AutoProgressKind = Literal["phase", "grade", "repair"]
+AutoProgressKind = Literal["phase", "grade", "repair", "question", "answer"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -36,6 +36,8 @@ class AutoProgressEvent:
       observation.
     - ``repair``: the repair round counter advanced since the last
       observation.
+    - ``question``: the auto interview produced or resumed a question.
+    - ``answer``: the auto answerer submitted a source-tagged answer.
     """
 
     auto_session_id: str
@@ -44,6 +46,9 @@ class AutoProgressEvent:
     message: str
     round: int | None = None
     grade: str | None = None
+    question: str | None = None
+    answer: str | None = None
+    answer_source: str | None = None
     timestamp: str = field(default_factory=utc_now_iso)
 
 

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -587,6 +587,20 @@ def _make_progress_renderer(*, quiet: bool) -> AutoProgressCallback | None:
         return None
 
     def render(event: AutoProgressEvent) -> None:
+        if event.kind == "question":
+            label = f"question round {event.round}" if event.round is not None else "question"
+            text = _rich_escape((event.question or event.message).strip())
+            console.print(rf"[dim]\[auto][/] {label} — {text}")
+            return
+        if event.kind == "answer":
+            label = f"answer round {event.round}" if event.round is not None else "answer"
+            source = rf" \[{_rich_escape(event.answer_source)}]" if event.answer_source else ""
+            question = _rich_escape((event.question or "").strip())
+            answer = _rich_escape((event.answer or event.message).strip())
+            if question:
+                console.print(rf"[dim]\[auto][/] {label}{source} Q — {question}")
+            console.print(rf"[dim]\[auto][/] {label}{source} A — {answer}")
+            return
         if event.kind == "grade":
             label = f"grade {event.grade}" if event.grade else "grade"
         elif event.kind == "repair":
@@ -621,10 +635,9 @@ def _print_status(state: AutoPipelineState) -> None:
         console.print(f"Interview session: {state.interview_session_id}")
     console.print(f"Current interview round: {state.current_round}")
     if state.pending_question:
-        question = state.pending_question.replace("\n", " ").strip()
-        if len(question) > 160:
-            question = f"{question[:157]}..."
-        console.print(f"Pending question: {question}")
+        question = _rich_escape(state.pending_question.strip())
+        console.print("Pending question:")
+        console.print(f"  {question}")
     if state.seed_path:
         console.print(f"Seed: {state.seed_path}")
     console.print(f"Seed origin: {state.seed_origin.value}")

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -55,6 +55,20 @@ def _format_auto_status(state) -> str:
     }
     lines.append(f"Terminal: {is_terminal}")
     lines.append(f"Last progress: {state.last_progress_message}")
+    if state.pending_question:
+        lines.append("Pending question:")
+        for line in str(state.pending_question).strip().splitlines() or [""]:
+            lines.append(f"  {line}")
+    if state.auto_answer_log:
+        recent = state.auto_answer_log[-3:]
+        lines.append(f"Recent auto answers (last {len(recent)}):")
+        for entry in recent:
+            round_value = entry.get("round", "?")
+            source = entry.get("source", "?")
+            question = str(entry.get("question", "")).strip()
+            answer = str(entry.get("answer", "")).strip()
+            lines.append(f"  round {round_value} [{source}] Q: {question}")
+            lines.append(f"    A: {answer}")
 
     is_gap_window = (
         state.phase is AutoPhase.RALPH_HANDOFF

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1947,6 +1947,9 @@ def _format_result(result: AutoPipelineResult) -> str:
         lines.append(f"Seed grade: {result.grade}")
     if result.interview_session_id:
         lines.append(f"Interview session: {result.interview_session_id}")
+    if result.pending_question:
+        lines.append("Pending question:")
+        lines.extend(f"  {line}" for line in result.pending_question.strip().splitlines())
     if result.seed_path:
         lines.append(f"Seed: {result.seed_path}")
     lines.append(f"Seed origin: {result.seed_origin}")

--- a/src/ouroboros/mcp/tools/query_handlers.py
+++ b/src/ouroboros/mcp/tools/query_handlers.py
@@ -173,6 +173,20 @@ class SessionStatusHandler:
             f"Terminal: {is_terminal}",
             f"Last progress: {state.last_progress_message}",
         ]
+        if state.pending_question:
+            lines.append("Pending question:")
+            for line in str(state.pending_question).strip().splitlines() or [""]:
+                lines.append(f"  {line}")
+        recent_auto_answers = state.auto_answer_log[-3:]
+        if recent_auto_answers:
+            lines.append(f"Recent auto answers (last {len(recent_auto_answers)}):")
+            for entry in recent_auto_answers:
+                round_value = entry.get("round", "?")
+                source = entry.get("source", "?")
+                question = str(entry.get("question", "")).strip()
+                answer = str(entry.get("answer", "")).strip()
+                lines.append(f"  round {round_value} [{source}] Q: {question}")
+                lines.append(f"    A: {answer}")
         if state.last_grade:
             lines.append(f"Seed grade: {state.last_grade}")
         if is_gap_window:
@@ -202,6 +216,10 @@ class SessionStatusHandler:
             "last_progress_message": state.last_progress_message,
             "last_progress_at": state.last_progress_at,
         }
+        if state.pending_question:
+            meta["pending_question"] = state.pending_question
+        if recent_auto_answers:
+            meta["auto_answer_log"] = recent_auto_answers
         if state.last_error:
             meta["blocker"] = state.last_error
         if is_gap_window:

--- a/tests/integration/auto/test_status_unified.py
+++ b/tests/integration/auto/test_status_unified.py
@@ -147,6 +147,42 @@ def test_happy_path_qa_passed_completes_auto(tmp_path) -> None:
     assert ralph["lineage_id"] == state.ralph_lineage_id
 
 
+def test_mcp_auto_status_surfaces_pending_question_and_recent_answers(tmp_path) -> None:
+    """MCP session status mirrors CLI interview progress context."""
+    state = _state_at_run(tmp_path)
+    state.pending_question = "Which runtime should handle this?\nAny credentials?"
+    state.auto_answer_log = [
+        {
+            "round": 1,
+            "source": "user",
+            "question": "What is the goal?",
+            "answer": "Build the CLI.",
+        },
+        {
+            "round": 2,
+            "source": "auto",
+            "question": "Which runtime should handle this?",
+            "answer": "Codex runtime.",
+        },
+    ]
+    AutoStore(tmp_path).save(state)
+
+    handler = SessionStatusHandler(auto_store=AutoStore(tmp_path))
+    result = asyncio.run(handler.handle({"session_id": state.auto_session_id}))
+
+    assert result.is_ok
+    meta = result.value.meta
+    assert meta["pending_question"] == "Which runtime should handle this?\nAny credentials?"
+    assert meta["auto_answer_log"] == state.auto_answer_log
+    text = result.value.content[0].text
+    assert "Pending question:" in text
+    assert "  Which runtime should handle this?" in text
+    assert "  Any credentials?" in text
+    assert "Recent auto answers (last 2):" in text
+    assert "  round 2 [auto] Q: Which runtime should handle this?" in text
+    assert "    A: Codex runtime." in text
+
+
 def test_listener_prefers_terminal_generations_over_iterations(tmp_path) -> None:
     """Terminal metadata must mirror lineage generation, not loop iteration count."""
     state = _state_at_ralph_handoff(tmp_path)

--- a/tests/unit/auto/test_cli_progress.py
+++ b/tests/unit/auto/test_cli_progress.py
@@ -59,6 +59,41 @@ def test_make_progress_renderer_emits_phase_grade_repair_lines(capsys) -> None:
     assert "[auto] repair round 1 — repair round 1" in output
 
 
+def test_make_progress_renderer_relays_interview_questions_and_answers(capsys) -> None:
+    render = _make_progress_renderer(quiet=False)
+    assert render is not None
+
+    render(
+        AutoProgressEvent(
+            auto_session_id="auto_x",
+            phase="interview",
+            kind="question",
+            message="question round 2/12",
+            round=2,
+            question="Which repo docs should be updated?",
+        )
+    )
+    render(
+        AutoProgressEvent(
+            auto_session_id="auto_x",
+            phase="interview",
+            kind="answer",
+            message="answered round 2/12 from repo_fact",
+            round=2,
+            question="Which repo docs should be updated?",
+            answer="Update docs/agentos/release-readiness.md and docs/README.md.",
+            answer_source="repo_fact",
+        )
+    )
+
+    output = _strip_ansi(capsys.readouterr().out)
+    assert "[auto] question round 2 — Which repo docs should be updated?" in output
+    assert "[auto] answer round 2 [repo_fact] Q — Which repo docs should be updated?" in output
+    assert "[auto] answer round 2 [repo_fact] A — Update" in output
+    assert "docs/agentos/release-readiness.md" in output
+    assert "and docs/README.md." in output
+
+
 def test_cli_auto_help_documents_quiet_flag() -> None:
     result = CliRunner().invoke(app, ["auto", "--help"])
     output = _strip_ansi(result.output)
@@ -156,6 +191,31 @@ def test_auto_interview_driver_emits_progress_via_callback() -> None:
     ]
     assert all(event.kind == "phase" for event in captured)
     assert all(event.phase == "interview" for event in captured)
+
+
+def test_auto_interview_driver_can_emit_question_and_answer_payloads() -> None:
+    from ouroboros.auto.interview_driver import AutoInterviewDriver
+    from ouroboros.auto.state import AutoPhase, AutoPipelineState
+
+    captured: list[AutoProgressEvent] = []
+    driver = AutoInterviewDriver(object(), progress_callback=captured.append)  # type: ignore[arg-type]
+    state = AutoPipelineState(goal="Build a CLI", cwd="/tmp")
+    state.transition(AutoPhase.INTERVIEW, "interview")
+
+    driver._emit_interview_question(state, question="What should it print?", round_number=1)
+    driver._emit_auto_answer(
+        state,
+        round_number=1,
+        source="conservative_default",
+        question="What should it print?",
+        answer="It should print hello.",
+    )
+
+    assert [event.kind for event in captured] == ["question", "answer"]
+    assert captured[0].question == "What should it print?"
+    assert captured[1].question == "What should it print?"
+    assert captured[1].answer == "It should print hello."
+    assert captured[1].answer_source == "conservative_default"
 
 
 def test_auto_interview_driver_swallows_callback_errors() -> None:

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -537,6 +537,23 @@ def test_print_status_resume_capability_resume() -> None:
     assert "Start fresh" not in output
 
 
+def test_print_status_renders_full_pending_question_without_truncation() -> None:
+    state = _state_in_phase(AutoPhase.INTERVIEW)
+    state.pending_question = (
+        "This is a deliberately long pending question that should remain visible "
+        "because operators need to understand what the autonomous interview is "
+        "asking before the answerer responds, even when the question is longer "
+        "than the old compact one-line preview limit."
+    )
+
+    output = _capture_status(state)
+
+    assert "Pending question:" in output
+    assert "old" in output
+    assert "compact one-line preview limit." in output
+    assert "..." not in output
+
+
 def test_print_result_show_ledger_renders_assumption_sources() -> None:
     from ouroboros.auto.ledger import AssumptionRecord
 


### PR DESCRIPTION
## Summary
- Surface hidden auto interview questions through CLI/MCP progress output
- Add recent auto-answer/status rendering so long-running auto is less black-box

## Tests
- uv run pytest tests/unit/cli/test_auto_command.py tests/unit/mcp/tools/test_start_auto.py

Note: the broader `tests/unit/cli/test_status.py` health-output tests currently truncate long paths under this local Rich terminal width; I did not change that unrelated behavior in this PR.

## R-run comparison

| Metric                         | Baseline (sha) | This PR (sha) | Ratio |
|--------------------------------|----------------|---------------|-------|
| Rounds completed in 600 s      | N/A            | N/A           | n/a   |
| Per-round wall-clock (s/round) | N/A            | N/A           | n/a   |
| Terminal reason                | N/A            | N/A           | n/a   |
| EventStore event count         | N/A            | N/A           | n/a   |

Budget compliance: [x] N/A (progress rendering only; no canonical R-run path changed)