### PR TITLE
Add opt-in linked job event streaming

### DIFF
--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -154,6 +154,17 @@ def _event_stream_item(event: BaseEvent) -> dict[str, Any]:
     }
 
 
+def _compact_stream_suffix(stream_items: list[dict[str, Any]], cursor: int) -> str:
+    """One-line linked-stream summary appended to compact/summary job views.
+
+    Empty when no linked events were streamed, so callers can unconditionally
+    concatenate the result without re-checking ``stream_items``.
+    """
+    if not stream_items:
+        return ""
+    return f"\nstream_events {len(stream_items)} cursor={cursor}"
+
+
 async def _query_linked_stream_events(
     event_store: EventStore,
     snapshot: JobSnapshot,
@@ -849,8 +860,7 @@ class JobWaitHandler:
                     progress,
                     include_message=view == "summary",
                 )
-                if stream_items:
-                    text += f"\nstream_events {len(stream_items)} cursor={snapshot.cursor}"
+                text += _compact_stream_suffix(stream_items, snapshot.cursor)
             elif view in {"compact", "summary"}:
                 if stream_items:
                     summaries = ", ".join(item["type"] for item in stream_items[-3:])
@@ -867,12 +877,10 @@ class JobWaitHandler:
                 text += "\n\nNo new job-level events during this wait window."
         elif view == "compact":
             text = _render_compact_job_snapshot(snapshot, progress, include_message=False)
-            if stream_items:
-                text += f"\nstream_events {len(stream_items)} cursor={snapshot.cursor}"
+            text += _compact_stream_suffix(stream_items, snapshot.cursor)
         elif view == "summary":
             text = _render_compact_job_snapshot(snapshot, progress, include_message=True)
-            if stream_items:
-                text += f"\nstream_events {len(stream_items)} cursor={snapshot.cursor}"
+            text += _compact_stream_suffix(stream_items, snapshot.cursor)
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text=text),),

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -8,12 +8,14 @@ Contains handlers for background job operations and execution cancellation:
 - CancelJobHandler: Cancel a background job
 """
 
+import asyncio
 from dataclasses import dataclass, field, replace
 from typing import Any
 
 import structlog
 
 from ouroboros.core.types import Result
+from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.job_manager import JobManager, JobSnapshot, JobStatus
 from ouroboros.mcp.tools.ac_tree_hud_handler import (
@@ -51,6 +53,17 @@ _JOB_VIEW_ALIASES = {
     "tree": "full",
     "verbose": "full",
 }
+_JOB_STREAM_ALIASES = {
+    "default": "progress",
+    "progress": "progress",
+    "execution": "progress",
+    "linked": "linked",
+    "events": "linked",
+    "all": "linked",
+    "children": "linked",
+    "subagents": "linked",
+}
+_JOB_STREAM_EVENT_LIMIT = 10
 
 
 def _normalize_job_view(value: object) -> str:
@@ -60,6 +73,15 @@ def _normalize_job_view(value: object) -> str:
         if stripped:
             return _JOB_VIEW_ALIASES.get(stripped, _DEFAULT_JOB_VIEW)
     return _DEFAULT_JOB_VIEW
+
+
+def _normalize_job_stream(value: object) -> str:
+    """Normalize requested job wait stream scope."""
+    if isinstance(value, str):
+        stripped = value.strip().lower()
+        if stripped:
+            return _JOB_STREAM_ALIASES.get(stripped, "progress")
+    return "progress"
 
 
 async def _query_all_execution_subtask_events(
@@ -87,6 +109,95 @@ async def _query_latest_workflow_event(event_store: EventStore, execution_id: st
         limit=1,
     )
     return events[0] if events else None
+
+
+def _event_scope(event: BaseEvent) -> str:
+    return f"{event.aggregate_type}:{event.aggregate_id}"
+
+
+def _compact_event_detail(event: BaseEvent) -> str:
+    data = event.data
+    for key in (
+        "message",
+        "activity_detail",
+        "activity",
+        "title",
+        "content",
+        "phase",
+        "status",
+        "reason",
+        "tool_name",
+    ):
+        value = data.get(key)
+        if value not in (None, ""):
+            return str(value).replace("\n", " ")[:240]
+    if data:
+        pairs = []
+        for key, value in list(data.items())[:4]:
+            if value in (None, "", [], {}):
+                continue
+            pairs.append(f"{key}={str(value).replace(chr(10), ' ')[:80]}")
+        if pairs:
+            return ", ".join(pairs)[:240]
+    return ""
+
+
+def _event_stream_item(event: BaseEvent) -> dict[str, Any]:
+    return {
+        "id": event.id,
+        "type": event.type,
+        "timestamp": event.timestamp.isoformat(),
+        "aggregate_type": event.aggregate_type,
+        "aggregate_id": event.aggregate_id,
+        "scope": _event_scope(event),
+        "detail": _compact_event_detail(event),
+    }
+
+
+async def _query_linked_stream_events(
+    event_store: EventStore,
+    snapshot: JobSnapshot,
+    cursor: int,
+) -> tuple[list[BaseEvent], int]:
+    """Fetch new events from the job's linked execution/session/lineage streams."""
+    collected: dict[str, BaseEvent] = {}
+    max_cursor = cursor
+
+    async def collect(events: list[BaseEvent], new_cursor: int) -> None:
+        nonlocal max_cursor
+        max_cursor = max(max_cursor, new_cursor)
+        for event in events:
+            collected[event.id] = event
+
+    job_events, job_cursor = await event_store.get_events_after("job", snapshot.job_id, cursor)
+    await collect(job_events, job_cursor)
+
+    if snapshot.links.execution_id:
+        execution_events, execution_cursor = await event_store.get_events_after(
+            "execution",
+            snapshot.links.execution_id,
+            cursor,
+        )
+        await collect(execution_events, execution_cursor)
+
+    if snapshot.links.session_id:
+        session_events, session_cursor = await event_store.query_session_related_events_after(
+            session_id=snapshot.links.session_id,
+            execution_id=snapshot.links.execution_id,
+            last_row_id=cursor,
+        )
+        await collect(session_events, session_cursor)
+
+    if snapshot.links.lineage_id:
+        lineage_events, lineage_cursor = await event_store.get_events_after(
+            "lineage",
+            snapshot.links.lineage_id,
+            cursor,
+        )
+        await collect(lineage_events, lineage_cursor)
+
+    events = sorted(collected.values(), key=lambda event: (event.timestamp, event.id))
+    return events, max_cursor
 
 
 @dataclass
@@ -639,6 +750,16 @@ class JobWaitHandler:
                     required=False,
                     default=_DEFAULT_JOB_VIEW,
                 ),
+                MCPToolParameter(
+                    name="stream",
+                    type=ToolInputType.STRING,
+                    description=(
+                        "'progress' (default) watches job/execution progress; "
+                        "'linked' also streams linked session, lineage, and subagent events."
+                    ),
+                    required=False,
+                    default="progress",
+                ),
             ),
         )
 
@@ -658,18 +779,33 @@ class JobWaitHandler:
         cursor = int(arguments.get("cursor", 0))
         timeout_seconds = int(arguments.get("timeout_seconds", 30))
         view = _normalize_job_view(arguments.get("view"))
+        stream = _normalize_job_stream(arguments.get("stream"))
 
         try:
-            snapshot, changed = await self._job_manager.wait_for_change(
-                job_id,
-                cursor=cursor,
-                timeout_seconds=timeout_seconds,
-            )
+            if stream == "linked":
+                (
+                    snapshot,
+                    changed,
+                    stream_events,
+                    stream_cursor,
+                ) = await self._wait_for_linked_change(
+                    job_id,
+                    cursor=cursor,
+                    timeout_seconds=timeout_seconds,
+                )
+            else:
+                snapshot, changed = await self._job_manager.wait_for_change(
+                    job_id,
+                    cursor=cursor,
+                    timeout_seconds=timeout_seconds,
+                )
+                stream_events = []
+                stream_cursor = cursor
         except ValueError as exc:
             return Result.err(MCPToolError(str(exc), tool_name="ouroboros_job_wait"))
 
         execution_progress_changed = False
-        response_cursor = max(snapshot.cursor, cursor)
+        response_cursor = max(snapshot.cursor, stream_cursor, cursor)
         if snapshot.links.execution_id:
             execution_events, execution_cursor = await self._event_store.get_events_after(
                 "execution",
@@ -684,6 +820,12 @@ class JobWaitHandler:
                 snapshot = replace(snapshot, cursor=response_cursor)
 
         text, progress = await _render_job_snapshot(snapshot, self._event_store)
+        stream_items = [_event_stream_item(event) for event in stream_events]
+        if stream_items:
+            text += "\n\n### Stream Events"
+            for item in stream_items[-_JOB_STREAM_EVENT_LIMIT:]:
+                detail = f" -- {item['detail']}" if item["detail"] else ""
+                text += f"\n- `{item['type']}` [{item['scope']}]{detail}"
         has_live_execution_progress = snapshot.links.execution_id is not None and any(
             progress.get(key) is not None
             for key in (
@@ -694,28 +836,43 @@ class JobWaitHandler:
                 "sub_ac_total",
             )
         )
-        response_changed = changed or execution_progress_changed
+        stream_changed = bool(stream_items)
+        response_changed = changed or execution_progress_changed or stream_changed
         if not changed:
             if (
                 view in {"compact", "summary"}
                 and has_live_execution_progress
-                and execution_progress_changed
+                and (execution_progress_changed or stream_changed)
             ):
                 text = _render_compact_job_snapshot(
                     snapshot,
                     progress,
                     include_message=view == "summary",
                 )
+                if stream_items:
+                    text += f"\nstream_events {len(stream_items)} cursor={snapshot.cursor}"
             elif view in {"compact", "summary"}:
-                text = f"unchanged cursor={snapshot.cursor}"
+                if stream_items:
+                    summaries = ", ".join(item["type"] for item in stream_items[-3:])
+                    text = (
+                        f"stream_events {len(stream_items)} cursor={snapshot.cursor}: {summaries}"
+                    )
+                else:
+                    text = f"unchanged cursor={snapshot.cursor}"
             elif execution_progress_changed:
                 text += "\n\nExecution progress updated during this wait window."
+            elif stream_changed:
+                text += "\n\nLinked stream events updated during this wait window."
             else:
                 text += "\n\nNo new job-level events during this wait window."
         elif view == "compact":
             text = _render_compact_job_snapshot(snapshot, progress, include_message=False)
+            if stream_items:
+                text += f"\nstream_events {len(stream_items)} cursor={snapshot.cursor}"
         elif view == "summary":
             text = _render_compact_job_snapshot(snapshot, progress, include_message=True)
+            if stream_items:
+                text += f"\nstream_events {len(stream_items)} cursor={snapshot.cursor}"
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text=text),),
@@ -729,10 +886,43 @@ class JobWaitHandler:
                     "execution_id": snapshot.links.execution_id,
                     "lineage_id": snapshot.links.lineage_id,
                     "view": view,
+                    "stream": stream,
+                    "stream_events": stream_items,
                     **progress,
                 },
             )
         )
+
+    async def _wait_for_linked_change(
+        self,
+        job_id: str,
+        *,
+        cursor: int,
+        timeout_seconds: int,
+    ) -> tuple[JobSnapshot, bool, list[BaseEvent], int]:
+        """Long-poll job plus linked child/session event streams."""
+        deadline = asyncio.get_running_loop().time() + timeout_seconds
+        while True:
+            snapshot, changed = await self._job_manager.wait_for_change(
+                job_id,
+                cursor=cursor,
+                timeout_seconds=0,
+            )
+            events, stream_cursor = await _query_linked_stream_events(
+                self._event_store,
+                snapshot,
+                cursor,
+            )
+            if (
+                changed
+                or events
+                or snapshot.is_terminal
+                or asyncio.get_running_loop().time() >= deadline
+            ):
+                if stream_cursor != snapshot.cursor:
+                    snapshot = replace(snapshot, cursor=max(snapshot.cursor, stream_cursor))
+                return snapshot, changed, events, stream_cursor
+            await asyncio.sleep(0.5)
 
 
 @dataclass

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
@@ -3037,6 +3038,191 @@ class TestJobManager:
         assert result.value.meta["session_id"] == "orch_wait_links"
         assert result.value.meta["execution_id"] == "exec_wait_links"
         assert result.value.meta["lineage_id"] == "lin_wait_links"
+
+    async def test_job_wait_linked_stream_surfaces_subagent_events(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        await store.initialize()
+        await store.append(
+            BaseEvent(
+                type="subagent.dispatched",
+                aggregate_type="subagent",
+                aggregate_id="orch_stream_links",
+                data={
+                    "session_id": "orch_stream_links",
+                    "tool_name": "ouroboros_qa",
+                    "title": "QA Review",
+                },
+            )
+        )
+        snapshot = JobSnapshot(
+            job_id="job_wait_linked_stream",
+            job_type="auto",
+            status=JobStatus.RUNNING,
+            message="Running auto",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=0,
+            links=JobLinks(session_id="orch_stream_links"),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                assert cursor == 0
+                assert timeout_seconds == 0
+                return snapshot, False
+
+        try:
+            handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+            result = await handler.handle(
+                {
+                    "job_id": "job_wait_linked_stream",
+                    "cursor": 0,
+                    "timeout_seconds": 0,
+                    "stream": "linked",
+                }
+            )
+        finally:
+            await store.close()
+
+        assert result.is_ok
+        assert result.value.meta["changed"] is True
+        assert result.value.meta["stream"] == "linked"
+        assert result.value.meta["cursor"] > 0
+        assert result.value.meta["stream_events"][0]["type"] == "subagent.dispatched"
+        assert result.value.meta["stream_events"][0]["scope"] == "subagent:orch_stream_links"
+        assert "### Stream Events" in result.value.text_content
+        assert "`subagent.dispatched` [subagent:orch_stream_links] -- QA Review" in (
+            result.value.text_content
+        )
+
+    async def test_job_wait_linked_stream_does_not_advance_past_omitted_events(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        await store.initialize()
+        for index in range(12):
+            await store.append(
+                BaseEvent(
+                    type="subagent.output",
+                    aggregate_type="subagent",
+                    aggregate_id=f"orch_stream_burst_{index}",
+                    data={
+                        "session_id": "orch_stream_burst",
+                        "message": f"burst {index}",
+                    },
+                )
+            )
+        snapshot = JobSnapshot(
+            job_id="job_wait_linked_burst",
+            job_type="auto",
+            status=JobStatus.RUNNING,
+            message="Running auto",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=0,
+            links=JobLinks(session_id="orch_stream_burst"),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                assert timeout_seconds == 0
+                return replace(snapshot, cursor=cursor), False
+
+        try:
+            handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+            result = await handler.handle(
+                {
+                    "job_id": "job_wait_linked_burst",
+                    "cursor": 0,
+                    "timeout_seconds": 0,
+                    "stream": "linked",
+                }
+            )
+            assert result.is_ok
+            first_cursor = result.value.meta["cursor"]
+            assert len(result.value.meta["stream_events"]) == 12
+            assert [item["detail"] for item in result.value.meta["stream_events"]] == [
+                f"burst {index}" for index in range(12)
+            ]
+
+            unchanged = await handler.handle(
+                {
+                    "job_id": "job_wait_linked_burst",
+                    "cursor": first_cursor,
+                    "timeout_seconds": 0,
+                    "stream": "linked",
+                }
+            )
+        finally:
+            await store.close()
+
+        assert unchanged.is_ok
+        assert unchanged.value.meta["stream_events"] == []
+        assert unchanged.value.meta["cursor"] == first_cursor
+        assert "No new job-level events during this wait window." in unchanged.value.text_content
+
+    async def test_job_wait_default_stream_does_not_surface_subagent_events(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        await store.initialize()
+        await store.append(
+            BaseEvent(
+                type="subagent.dispatched",
+                aggregate_type="subagent",
+                aggregate_id="orch_default_stream",
+                data={"session_id": "orch_default_stream", "title": "Hidden unless opted in"},
+            )
+        )
+        snapshot = JobSnapshot(
+            job_id="job_wait_default_stream",
+            job_type="auto",
+            status=JobStatus.RUNNING,
+            message="Running auto",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=0,
+            links=JobLinks(session_id="orch_default_stream"),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                assert cursor == 0
+                assert timeout_seconds == 0
+                return snapshot, False
+
+        try:
+            handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+            result = await handler.handle(
+                {"job_id": "job_wait_default_stream", "cursor": 0, "timeout_seconds": 0}
+            )
+        finally:
+            await store.close()
+
+        assert result.is_ok
+        assert result.value.meta["changed"] is False
+        assert result.value.meta["stream"] == "progress"
+        assert result.value.meta["stream_events"] == []
+        assert "Hidden unless opted in" not in result.value.text_content
 
     async def test_job_wait_summary_view_returns_compact_unchanged_line(self, tmp_path) -> None:
         store = _build_store(tmp_path)

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1863,8 +1863,9 @@ class TestAsyncJobHandlers:
         handler = JobWaitHandler()
         params = {p.name: p for p in handler.definition.parameters}
         param_names = set(params)
-        assert param_names == {"job_id", "cursor", "timeout_seconds", "view"}
+        assert param_names == {"job_id", "cursor", "timeout_seconds", "view", "stream"}
         assert params["view"].default == "full"
+        assert params["stream"].default == "progress"
 
     def test_job_result_definition_name(self) -> None:
         handler = JobResultHandler()


### PR DESCRIPTION
## Summary
- Add `stream` support to `ouroboros_job_wait` for linked session/execution/lineage events
- Include compact stream event summaries and metadata for subscribers that opt in
- Cover linked stream behavior through job manager and MCP handler tests

## Tests
- uv run pytest tests/unit/mcp/test_job_manager.py tests/unit/mcp/tools/test_start_auto.py