### PR TITLE
Improve detached auto job tracking UX

### DIFF
--- a/.claude-plugin/skills/auto/SKILL.md
+++ b/.claude-plugin/skills/auto/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auto
 description: "Automatically converge from goal to A-grade Seed and execute it"
-mcp_tool: ouroboros_auto
+mcp_tool: ouroboros_start_auto
 mcp_args:
   goal: "$goal"
   resume: "$resume"
@@ -19,14 +19,14 @@ Run the full-quality auto pipeline from a single task description.
 
 ## Dispatch requirement
 
-This skill must be executed by invoking MCP tool `ouroboros_auto`. Do not
+This skill must be executed by invoking MCP tool `ouroboros_start_auto`. Do not
 manually inspect repositories, run shell commands, query GitHub, edit files, or
 otherwise emulate the auto pipeline as a substitute.
 
-If `ouroboros_auto` is unavailable, stop and report that the required MCP tool
+If `ouroboros_start_auto` is unavailable, stop and report that the required MCP tool
 is unavailable. A manual fallback is not an `ooo auto` run.
 
-If `ouroboros_auto` is invoked successfully but returns `blocked`, `failed`, or
+If `ouroboros_start_auto` is invoked successfully but returns `blocked`, `failed`, or
 another terminal auto-session status, report that auto-session status and the
 tool's blocker. Do not label that outcome as MCP dispatch failure; dispatch
 failure means the MCP tool could not be invoked.
@@ -43,7 +43,7 @@ ooo auto "Build a local-first habit tracker CLI" --complete-product
 
 ## CLI flag → MCP arg translation
 
-When the user types `ooo auto` with CLI-style flags inside chat, translate to MCP arguments before invoking `ouroboros_auto`:
+When the user types `ooo auto` with CLI-style flags inside chat, translate to MCP arguments before invoking `ouroboros_start_auto`:
 
 | CLI flag | MCP arg | Type |
 |----------|---------|------|

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,9 @@
+[mcp_servers.ouroboros]
+command = "uvx"
+args = [
+    "--from",
+    "ouroboros-ai[mcp,claude]",
+    "ouroboros",
+    "mcp",
+    "serve",
+]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ROOT=\"${CLAUDE_PLUGIN_ROOT:-$PWD}\"; python3 \"$ROOT/scripts/drift-monitor.py\" || python \"$ROOT/scripts/drift-monitor.py\"",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "ROOT=\"${CLAUDE_PLUGIN_ROOT:-$PWD}\"; python3 \"$ROOT/scripts/keyword-detector.py\" || python \"$ROOT/scripts/keyword-detector.py\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Each command loads its agent/MCP on-demand. Details in each skill file.
 | Command | Loads |
 |---------|-------|
 | `ooo` | — |
-| `ooo auto` | MCP: `ouroboros_auto` |
+| `ooo auto` | MCP: `ouroboros_start_auto` |
 | `ooo interview` | `ouroboros:socratic-interviewer` |
 | `ooo seed` | `ouroboros:seed-architect` |
 | `ooo run` | MCP required |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,95 @@
+# Ouroboros - Development Environment
+
+> This AGENTS.md is for **local development only**. End users install via:
+> ```
+> Codex plugin marketplace add Q00/ouroboros
+> Codex plugin install ouroboros@ouroboros
+> ```
+> Once installed as a plugin, skills/hooks/agents work natively without this file.
+
+## ooo Commands (Dev Mode)
+
+When the user types any of these commands, read the corresponding SKILL.md file and follow its instructions exactly:
+
+| Input | Action |
+|-------|--------|
+| `ooo` (bare, no subcommand) | Read `skills/welcome/SKILL.md` and follow it |
+| `ooo auto ...` | Read `skills/auto/SKILL.md` and follow it |
+| `ooo interview ...` | Read `skills/interview/SKILL.md` and follow it |
+| `ooo seed` | Read `skills/seed/SKILL.md` and follow it |
+| `ooo run` | Read `skills/run/SKILL.md` and follow it |
+| `ooo evaluate` or `ooo eval` | Read `skills/evaluate/SKILL.md` and follow it |
+| `ooo evolve ...` | Read `skills/evolve/SKILL.md` and follow it |
+| `ooo unstuck` or `ooo stuck` or `ooo lateral` | Read `skills/unstuck/SKILL.md` and follow it |
+| `ooo status` or `ooo drift` | Read `skills/status/SKILL.md` and follow it |
+| `ooo ralph` | Read `skills/ralph/SKILL.md` and follow it |
+| `ooo tutorial` | Read `skills/tutorial/SKILL.md` and follow it |
+| `ooo setup` | Read `skills/setup/SKILL.md` and follow it |
+| `ooo welcome` | Read `skills/welcome/SKILL.md` and follow it |
+| `ooo cancel` | Read `skills/cancel/SKILL.md` and follow it |
+| `ooo qa` or `ooo qa ...` | Read `skills/qa/SKILL.md` and follow it |
+| `ooo help` | Read `skills/help/SKILL.md` and follow it |
+| `ooo update` | Read `skills/update/SKILL.md` and follow it |
+| `ooo pm` or `ooo pm ...` | Read `skills/pm/SKILL.md` and follow it |
+| `ooo brownfield` or `ooo brownfield ...` | Read `skills/brownfield/SKILL.md` and follow it |
+| `ooo publish` or `ooo publish ...` | Read `skills/publish/SKILL.md` and follow it |
+| `ooo resume-session` | Read `skills/resume-session/SKILL.md` and follow it |
+
+**Important**: Do NOT use the Skill tool. Read the file with the Read tool and execute its instructions directly.
+
+## Agents
+
+Bundled agents live in `src/ouroboros/agents/`. When a skill references an agent (e.g., `ouroboros:socratic-interviewer`), read its definition from `src/ouroboros/agents/{name}.md` and adopt that role. Use `OUROBOROS_AGENTS_DIR` or `.Codex-plugin/agents/` only for explicit custom overrides.
+
+<!-- ooo:START -->
+<!-- ooo:VERSION:0.26.0 -->
+# Ouroboros — Specification-First AI Development
+
+> Before telling AI what to build, define what should be built.
+> As Socrates asked 2,500 years ago — "What do you truly know?"
+> Ouroboros turns that question into an evolutionary AI workflow engine.
+
+Most AI coding fails at the input, not the output. Ouroboros fixes this by
+**exposing hidden assumptions before any code is written**.
+
+1. **Socratic Clarity** — Question until ambiguity ≤ 0.2
+2. **Ontological Precision** — Solve the root problem, not symptoms
+3. **Evolutionary Loops** — Each evaluation cycle feeds back into better specs
+
+```
+Interview → Seed → Execute → Evaluate
+    ↑                           ↓
+    └─── Evolutionary Loop ─────┘
+```
+
+## ooo Commands
+
+Each command loads its agent/MCP on-demand. Details in each skill file.
+
+| Command | Loads |
+|---------|-------|
+| `ooo` | — |
+| `ooo auto` | MCP: `ouroboros_auto` |
+| `ooo interview` | `ouroboros:socratic-interviewer` |
+| `ooo seed` | `ouroboros:seed-architect` |
+| `ooo run` | MCP required |
+| `ooo evolve` | MCP: `evolve_step` |
+| `ooo evaluate` | `ouroboros:evaluator` |
+| `ooo qa` | `ouroboros:qa-judge` |
+| `ooo unstuck` | `ouroboros:{persona}` |
+| `ooo status` | MCP: `session_status` |
+| `ooo ralph` | Persistent loop until verified |
+| `ooo tutorial` | Interactive hands-on learning |
+| `ooo setup` | — |
+| `ooo help` | — |
+| `ooo update` | PyPI version check + upgrade |
+| `ooo publish` | `gh` CLI — Seed to GitHub Issues |
+| `ooo resume-session` | Restore previous Codex session context |
+
+## Agents
+
+Loaded on-demand — not preloaded.
+
+**Core**: socratic-interviewer, ontologist, seed-architect, evaluator, qa-judge, contrarian
+**Support**: hacker, simplifier, researcher, architect
+<!-- ooo:END -->

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -261,6 +261,126 @@ Ouroboros exposes workflow tools as ordinary MCP handlers. The MCP server does
 not parse `ooo` syntax and does not receive channel-specific identifiers for
 skill routing.
 
+### Detached `auto` Jobs
+
+`ouroboros_start_auto` starts detached `auto` work as non-terminal tracked
+background work. A successful start response returns a `job_id` immediately;
+that handle identifies tracked background work, not a completed workflow result.
+The job remains observable through its lifecycle status until it reaches a
+terminal state such as `completed`, `failed`, `cancelled`, or `expired`.
+
+MCP clients wait for and retrieve detached `auto` results with the standard job
+tools:
+
+```text
+ouroboros_job_status(job_id="JOB_ID")
+ouroboros_job_wait(job_id="JOB_ID")
+ouroboros_job_result(job_id="JOB_ID")
+```
+
+Treat `running` or other non-terminal status output as progress only. A
+`running` lifecycle status is non-terminal tracked background work, not a final
+`auto` result. Wait with `ouroboros_job_wait`, then fetch the completed result
+with `ouroboros_job_result` after the job reaches a terminal lifecycle status.
+When MCP status reports `completed`, `ouroboros_job_result(job_id="JOB_ID")`
+retrieves the stable completed `auto` result for that job handle. Unknown,
+expired, or otherwise unavailable handles return an MCP error response.
+When MCP status cannot resolve the supplied handle, treat the detached work as
+`invalid` or unavailable rather than as running or completed. The stable
+observable status is the MCP error response for that handle, not a detached
+`auto` result. Next steps are to check the copied `job_id`, inspect any
+surfaced auto session, execution, or lineage handle, then restart the detached
+auto flow when no valid handle can be recovered.
+
+The minimal stable invalid-handle error contract marks the handle as terminally
+unavailable and resultless:
+
+```text
+ouroboros_job_result(job_id="missing_detached_auto")
+
+error.message = "Job handle not found: missing_detached_auto. Result unavailable."
+error.error_code = "job_handle_not_found"
+error.details.job_id = "missing_detached_auto"
+error.details.lifecycle_status = "invalid"
+error.details.is_terminal = true
+error.details.result_available = false
+error.details.reason = "not_found"
+```
+
+A completed detached `auto` result may include text content, metadata, and an
+artifact resource reference. The minimal stable retrieval contract is the job
+handle, terminal lifecycle status, terminal marker, and returned content:
+
+```text
+ouroboros_job_result(job_id="job_auto_docs_done")
+
+content[0].text = "detached auto result artifact: seed.yaml"
+content[1].uri = "file:///tmp/detached-auto-result.json"
+meta.job_id = "job_auto_docs_done"
+meta.status = "completed"
+meta.is_terminal = true
+```
+
+When MCP status reports `failed`, the job is terminal and still observable;
+`ouroboros_job_result(job_id="JOB_ID")` returns the stable failure output or
+error details for that job handle with `is_error=true`, not a successful `auto`
+result. Next steps are to inspect `ouroboros_job_status(job_id="JOB_ID")` and
+`ouroboros_job_result(job_id="JOB_ID")`, then resume or retry from the surfaced
+auto session, execution, or lineage handle when one is present.
+
+```text
+ouroboros_job_result(job_id="job_auto_docs_failed")
+
+is_error = true
+content[0].text = "detached auto failed: seed repair budget exhausted"
+meta.job_id = "job_auto_docs_failed"
+meta.status = "failed"
+meta.is_terminal = true
+meta.error = "seed repair budget exhausted"
+```
+
+When MCP status reports `cancelled`, the job is terminal and still observable;
+`ouroboros_job_result(job_id="JOB_ID")` returns stable cancellation output or
+error details for that job handle with `is_error=true` and the cancellation
+reason when one is available, not a successful `auto` result. Next steps are to
+inspect `ouroboros_job_status(job_id="JOB_ID")` and
+`ouroboros_job_result(job_id="JOB_ID")`, then restart the detached auto flow or
+resume from the surfaced auto session, execution, or lineage handle when one is
+present.
+
+```text
+ouroboros_job_result(job_id="job_auto_docs_cancelled")
+
+is_error = true
+content[0].text = "detached auto cancelled: user requested cancellation"
+meta.job_id = "job_auto_docs_cancelled"
+meta.status = "cancelled"
+meta.lifecycle_status = "cancelled"
+meta.is_terminal = true
+meta.error = "user requested cancellation"
+```
+
+When MCP status reports `expired`, the job is terminal tracked background work
+whose retained result is no longer available through that job handle. The stable
+observable status is `expired` with `is_error=true`, not `running` or
+`completed`, and `ouroboros_job_result(job_id="JOB_ID")` returns stable
+expiration error details for that handle rather than a detached `auto` result.
+Next steps are to inspect any surfaced auto session, execution, or lineage
+handle, then resume from that handle or restart the detached auto flow when no
+recoverable handle is present.
+
+```text
+ouroboros_job_result(job_id="job_auto_docs_expired")
+
+error.message = "Job handle expired: job_auto_docs_expired. Result unavailable."
+error.error_code = "job_handle_expired"
+error.details.job_id = "job_auto_docs_expired"
+error.details.lifecycle_status = "expired"
+error.details.is_terminal = true
+error.details.result_available = false
+error.details.reason = "expired"
+```
+
 ### `ouroboros_brownfield` Scan Boundaries
 
 The brownfield MCP tool registers existing codebases for PM/interview context.

--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -267,7 +267,9 @@ skill routing.
 background work. A successful start response returns a `job_id` immediately;
 that handle identifies tracked background work, not a completed workflow result.
 The job remains observable through its lifecycle status until it reaches a
-terminal state such as `completed`, `failed`, `cancelled`, or `expired`.
+terminal state such as `completed`, `failed`, or `cancelled`. Expired retention
+is reported by `ouroboros_job_result` when the stored terminal result is no
+longer available.
 
 MCP clients wait for and retrieve detached `auto` results with the standard job
 tools:
@@ -360,14 +362,13 @@ meta.is_terminal = true
 meta.error = "user requested cancellation"
 ```
 
-When MCP status reports `expired`, the job is terminal tracked background work
-whose retained result is no longer available through that job handle. The stable
-observable status is `expired` with `is_error=true`, not `running` or
-`completed`, and `ouroboros_job_result(job_id="JOB_ID")` returns stable
-expiration error details for that handle rather than a detached `auto` result.
-Next steps are to inspect any surfaced auto session, execution, or lineage
-handle, then resume from that handle or restart the detached auto flow when no
-recoverable handle is present.
+When `ouroboros_job_result(job_id="JOB_ID")` reports `expired`, the job is
+terminal tracked background work whose retained result is no longer available
+through that job handle. `ouroboros_job_status` still reports the stored
+terminal lifecycle status, while result retrieval returns stable expiration
+error details rather than a detached `auto` result. Next steps are to inspect
+any surfaced auto session, execution, or lineage handle, then resume from that
+handle or restart the detached auto flow when no recoverable handle is present.
 
 ```text
 ouroboros_job_result(job_id="job_auto_docs_expired")

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -81,7 +81,9 @@ Auto mode starts execution only after the generated Seed reaches A-grade. If a p
 Detached `auto` work is non-terminal tracked background work. Starting it does
 not mean the workflow has completed; the returned `job_id` is a handle for a
 tracked job whose lifecycle remains observable until it reaches a terminal
-state such as `completed`, `failed`, `cancelled`, or `expired`.
+state such as `completed`, `failed`, or `cancelled`. Expired retention is
+reported by `ouroboros job result` when the stored terminal result is no longer
+available.
 
 CLI users wait and retrieve with the standard job surfaces:
 
@@ -107,6 +109,9 @@ terminal lifecycle status. When CLI status reports `completed`,
 that job handle. When CLI status reports `failed`, the job is terminal and
 still observable; `ouroboros job result JOB_ID` returns the stable failure
 output or error details for that job handle, not a successful `auto` result.
+Next steps are to inspect `ouroboros job status JOB_ID` and
+`ouroboros job result JOB_ID`, then resume or retry from the surfaced auto
+session, execution, or lineage handle when one is present.
 When CLI status reports `cancelled`, the job is terminal and still observable;
 `ouroboros job result JOB_ID` returns stable cancellation output or error
 details for that job handle with the cancellation reason when one is available,
@@ -115,18 +120,15 @@ not a successful `auto` result. Next steps are to inspect
 the detached auto flow or resume from the surfaced auto session, execution, or
 lineage handle when one is present. The CLI prints the stable cancellation
 output and exits non-zero because the terminal result is an error result.
-When CLI status reports `expired`, the job is terminal tracked background work
-whose retained result is no longer available through that job handle. The stable
-observable status is `expired`, not `running` or `completed`, and
-`ouroboros job result JOB_ID` returns the stable expiration error details for
-that handle rather than a detached `auto` result. Next steps are to inspect any
+When `ouroboros job result JOB_ID` reports `expired`, the job is terminal
+tracked background work whose retained result is no longer available through
+that job handle. `ouroboros job status JOB_ID` still reports the stored terminal
+lifecycle status, while result retrieval returns stable expiration error
+details rather than a detached `auto` result. Next steps are to inspect any
 surfaced auto session, execution, or lineage handle, then resume from that
 handle or restart the detached auto flow when no recoverable handle is present.
-Next steps are to inspect `ouroboros job status JOB_ID` and
-`ouroboros job result JOB_ID`, then resume or retry from the surfaced auto
-session, execution, or lineage handle when one is present. Unknown, expired, or
-otherwise unavailable handles fail through the CLI with a non-zero status and
-through MCP with an error response.
+Unknown, expired, or otherwise unavailable handles fail through the CLI with a
+non-zero status and through MCP with an error response.
 When CLI status cannot resolve the supplied handle, treat the detached work as
 `invalid` or unavailable rather than as running or completed. The stable
 observable status is the non-zero CLI exit plus the human-readable error for

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -76,6 +76,92 @@ ouroboros auto "Build a local-first habit tracker CLI"
 
 Auto mode starts execution only after the generated Seed reaches A-grade. If a phase times out or hits a hard blocker, the command prints the auto session id and a resume command instead of hanging indefinitely.
 
+### Detached `auto` wait and retrieve
+
+Detached `auto` work is non-terminal tracked background work. Starting it does
+not mean the workflow has completed; the returned `job_id` is a handle for a
+tracked job whose lifecycle remains observable until it reaches a terminal
+state such as `completed`, `failed`, `cancelled`, or `expired`.
+
+CLI users wait and retrieve with the standard job surfaces:
+
+```bash
+ouroboros job status JOB_ID
+ouroboros job wait JOB_ID
+ouroboros job result JOB_ID
+```
+
+MCP clients use the matching job tools:
+
+```text
+ouroboros_job_status(job_id="JOB_ID")
+ouroboros_job_wait(job_id="JOB_ID")
+ouroboros_job_result(job_id="JOB_ID")
+```
+
+While a detached job is still running, its `running` lifecycle status is
+non-terminal tracked background work. Treat status output as progress, not as
+the final `auto` result. Retrieve the result only after the job reaches a
+terminal lifecycle status. When CLI status reports `completed`,
+`ouroboros job result JOB_ID` retrieves the stable completed `auto` result for
+that job handle. When CLI status reports `failed`, the job is terminal and
+still observable; `ouroboros job result JOB_ID` returns the stable failure
+output or error details for that job handle, not a successful `auto` result.
+When CLI status reports `cancelled`, the job is terminal and still observable;
+`ouroboros job result JOB_ID` returns stable cancellation output or error
+details for that job handle with the cancellation reason when one is available,
+not a successful `auto` result. Next steps are to inspect
+`ouroboros job status JOB_ID` and `ouroboros job result JOB_ID`, then restart
+the detached auto flow or resume from the surfaced auto session, execution, or
+lineage handle when one is present. The CLI prints the stable cancellation
+output and exits non-zero because the terminal result is an error result.
+When CLI status reports `expired`, the job is terminal tracked background work
+whose retained result is no longer available through that job handle. The stable
+observable status is `expired`, not `running` or `completed`, and
+`ouroboros job result JOB_ID` returns the stable expiration error details for
+that handle rather than a detached `auto` result. Next steps are to inspect any
+surfaced auto session, execution, or lineage handle, then resume from that
+handle or restart the detached auto flow when no recoverable handle is present.
+Next steps are to inspect `ouroboros job status JOB_ID` and
+`ouroboros job result JOB_ID`, then resume or retry from the surfaced auto
+session, execution, or lineage handle when one is present. Unknown, expired, or
+otherwise unavailable handles fail through the CLI with a non-zero status and
+through MCP with an error response.
+When CLI status cannot resolve the supplied handle, treat the detached work as
+`invalid` or unavailable rather than as running or completed. The stable
+observable status is the non-zero CLI exit plus the human-readable error for
+that handle. Next steps are to check the copied `job_id`, inspect any surfaced
+auto session, execution, or lineage handle, then restart the detached auto flow
+when no valid handle can be recovered.
+
+Example invalid CLI retrieval output:
+
+```bash
+$ ouroboros job result missing_detached_auto
+Job handle not found: missing_detached_auto. Result unavailable.
+```
+
+Example completed CLI retrieval output:
+
+```bash
+$ ouroboros job result job_auto_docs_done
+detached auto result artifact: seed.yaml
+```
+
+Example cancelled CLI retrieval output:
+
+```bash
+$ ouroboros job result job_auto_docs_cancelled
+detached auto cancelled: user requested cancellation
+```
+
+Example expired CLI retrieval output:
+
+```bash
+$ ouroboros job result job_auto_docs_expired
+Job handle expired: job_auto_docs_expired. Result unavailable.
+```
+
 > **`ooo auto` does not accept `--opencode-mode`.** OpenCode mode is
 > selected once at install time via `ouroboros setup --opencode-mode
 > <plugin|subprocess>` (recorded in `~/.ouroboros/config.yaml`); the auto

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -31,6 +31,13 @@ another terminal auto-session status, report that auto-session status and the
 tool's blocker. Do not label that outcome as MCP dispatch failure; dispatch
 failure means the MCP tool could not be invoked.
 
+If the active runtime routes `ooo auto` through a background starter such as
+`ouroboros_start_auto`, do not stop after returning the `job_id`. Keep ownership
+of the conversational UX: retain the returned `job_id`, `auto_session_id`, and
+cursor, then monitor the job with `ouroboros_job_wait` / `ouroboros_job_status`
+until a terminal job status is reached or the user explicitly asks you to stop.
+The user should not have to poll the job manually.
+
 ## Usage
 
 ```text
@@ -66,6 +73,36 @@ When the user types `ooo auto` with CLI-style flags inside chat, translate to MC
 4. Reviews and repairs until A-grade or blocked.
 5. Starts execution only after A-grade.
 6. When `complete_product=true`, chains RUN → RALPH_HANDOFF after a successful run handoff and waits for a terminal Ralph status so a single invocation iterates Ralph until QA passes, convergence, or a budget bound trips. A QA-pass on the executed product completes the auto session; recognized failure modes (`iteration_timeout`, `wall_clock_exhausted`, `oscillation_detected`, `grade_regressing`, `max_generations reached`) block the auto session with the matching `stop_reason` in `last_error` so operators can resume after the cause is addressed.
+
+## Background monitoring UX
+
+When an auto start response includes `response.meta.job_id`:
+
+1. Briefly acknowledge that auto started and keep the handles in local state:
+   `job_id`, `auto_session_id` / `session_id`, and `cursor` from `response.meta`
+   if present.
+2. Immediately enter a low-noise monitor loop with:
+   - `ouroboros_job_wait(job_id=<job_id>, cursor=<cursor>, timeout_seconds=120, view="summary")`
+   - update `cursor = response.meta.cursor` after every wait/status response
+   - treat `response.meta` as the source of truth; use response text only as a
+     human-readable hint
+3. Relay only meaningful changes: status changes, phase changes, new
+   execution/session/lineage handles, progress counters, blocker/error text, or
+   a terminal state. If `response.meta.changed is false`, continue silently
+   unless the user asked for heartbeat updates.
+4. If the job status is non-terminal (`queued`, `running`, or another active
+   status), keep waiting. Do not tell the user to call job tools themselves.
+5. When the job reaches a terminal status, call `ouroboros_job_result(job_id)`
+   and summarize the final auto-session outcome. If the final auto result is
+   `detached`, keep tracking the surfaced downstream job/Ralph handles when
+   available instead of presenting `detached` as completion.
+6. If `response.meta.status == "delegated_to_plugin"` and
+   `response.meta.job_id is None`, report that OpenCode plugin mode delegated
+   the work to the child Task/session. Do not call job wait/result without a
+   real job id; follow the host Task widget/session lifecycle.
+
+Use short progress relays; the goal is “I am still watching this for you,” not a
+wall of logs.
 
 ### Canonical stop_reason_code taxonomy
 

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auto
 description: "Automatically converge from goal to A-grade Seed and execute it"
-mcp_tool: ouroboros_auto
+mcp_tool: ouroboros_start_auto
 mcp_args:
   goal: "$goal"
   resume: "$resume"
@@ -19,14 +19,14 @@ Run the full-quality auto pipeline from a single task description.
 
 ## Dispatch requirement
 
-This skill must be executed by invoking MCP tool `ouroboros_auto`. Do not
+This skill must be executed by invoking MCP tool `ouroboros_start_auto`. Do not
 manually inspect repositories, run shell commands, query GitHub, edit files, or
 otherwise emulate the auto pipeline as a substitute.
 
-If `ouroboros_auto` is unavailable, stop and report that the required MCP tool
+If `ouroboros_start_auto` is unavailable, stop and report that the required MCP tool
 is unavailable. A manual fallback is not an `ooo auto` run.
 
-If `ouroboros_auto` is invoked successfully but returns `blocked`, `failed`, or
+If `ouroboros_start_auto` is invoked successfully but returns `blocked`, `failed`, or
 another terminal auto-session status, report that auto-session status and the
 tool's blocker. Do not label that outcome as MCP dispatch failure; dispatch
 failure means the MCP tool could not be invoked.
@@ -50,7 +50,7 @@ ooo auto "Build a local-first habit tracker CLI" --complete-product
 
 ## CLI flag → MCP arg translation
 
-When the user types `ooo auto` with CLI-style flags inside chat, translate to MCP arguments before invoking `ouroboros_auto`:
+When the user types `ooo auto` with CLI-style flags inside chat, translate to MCP arguments before invoking `ouroboros_start_auto`:
 
 | CLI flag | MCP arg | Type |
 |----------|---------|------|

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -380,13 +380,12 @@ class HandlerRalphStarter:
     """Callable Ralph starter backed by ``ouroboros_ralph``.
 
     Bridges :class:`AutoPipeline`'s RUN → RALPH_HANDOFF transition to the
-    runtime-owned Ralph loop introduced in Q00/ouroboros#528. Awaits the
-    background job to a terminal state in non-plugin runtimes so the auto
-    pipeline can produce a final ``COMPLETE`` / ``BLOCKED`` / ``FAILED``
-    auto phase from the same ``AutoPipeline.run()`` call. In plugin mode
-    the handler returns ``delegated_to_plugin`` immediately and the
-    pipeline records ``ralph_dispatch_mode="plugin"`` without invoking
-    job tools.
+    runtime-owned Ralph loop introduced in Q00/ouroboros#528. By default it
+    returns as soon as the background job is durably dispatched; waiting for a
+    terminal Ralph verdict is opt-in via ``return_after_dispatch=False`` so MCP
+    clients do not get pinned to long-running work. In plugin mode the handler
+    returns ``delegated_to_plugin`` immediately and the pipeline records
+    ``ralph_dispatch_mode="plugin"`` without invoking job tools.
     """
 
     def __init__(self, handler: RalphHandler, *, project_dir: str | None = None) -> None:
@@ -411,8 +410,9 @@ class HandlerRalphStarter:
         on_started: Callable[[dict[str, Any]], None] | None = None,
         reattach_terminal: bool = True,
         reuse_existing: bool = True,
+        return_after_dispatch: bool = True,
     ) -> dict[str, Any]:
-        """Dispatch the Ralph loop and wait for terminal completion.
+        """Dispatch the Ralph loop and optionally wait for terminal completion.
 
         ``on_dispatched`` is invoked with the dispatch envelope *before*
         the wait-for-terminal poll begins, so callers (notably
@@ -523,9 +523,11 @@ class HandlerRalphStarter:
             if dispatch_callback is not None:
                 dispatch_callback(envelope)
             return envelope
-        # Job mode: wait for the background job to terminate, then map the
-        # final job snapshot back into the structured terminal status the
-        # pipeline maps onto an auto phase.
+        # Job mode: return the tracking handle immediately by default. Callers
+        # that explicitly pass ``return_after_dispatch=False`` can still wait
+        # for the background job to terminate and map the final snapshot back
+        # into the structured terminal status the pipeline maps onto an auto
+        # phase.
         job_id = _optional_str(meta.get("job_id"))
         if not job_id:
             raise HandlerError("ouroboros_ralph did not return a job_id")
@@ -541,6 +543,14 @@ class HandlerRalphStarter:
                     "dispatch_mode": "job",
                 }
             )
+        if return_after_dispatch:
+            return {
+                "job_id": job_id,
+                "lineage_id": _optional_str(meta.get("lineage_id")) or lineage_id,
+                "dispatch_mode": "job",
+                "terminal_status": "running_async",
+                "stop_reason": "foreground_timeout_elapsed",
+            }
         if max_total_seconds is None:
             terminal_meta = await _wait_for_job_terminal(job_manager, job_id)
         else:
@@ -602,12 +612,18 @@ class HandlerRalphPoller:
     ) -> dict[str, Any]:
         job_manager = self.handler._job_manager  # noqa: SLF001
         if max_total_seconds is None:
-            terminal_meta = await _wait_for_job_terminal(job_manager, job_id)
+            terminal_meta = await _wait_for_job_terminal(
+                job_manager,
+                job_id,
+                timeout_seconds=0,
+                detach_on_timeout=True,
+            )
         else:
             terminal_meta = await _wait_for_job_terminal_with_cancel_cleanup(
                 job_manager,
                 job_id,
                 timeout_seconds=max_total_seconds,
+                detach_on_timeout=True,
             )
         terminal_status = _optional_str(terminal_meta.get("status")) or "failed"
         stop_reason = _optional_str(terminal_meta.get("stop_reason"))
@@ -877,6 +893,7 @@ async def _wait_for_job_terminal(
     poll_interval: float = 0.05,
     timeout_seconds: float | None = None,
     cancel_on_timeout: bool = False,
+    detach_on_timeout: bool = False,
 ) -> dict[str, Any]:
     """Poll the job manager until ``job_id`` reaches a terminal state.
 
@@ -908,6 +925,12 @@ async def _wait_for_job_terminal(
         if deadline is not None:
             remaining = deadline - loop.time()
             if remaining <= 0:
+                if detach_on_timeout:
+                    return {
+                        "job_id": job_id,
+                        "status": "running_async",
+                        "stop_reason": "foreground_timeout_elapsed",
+                    }
                 if cancel_on_timeout:
                     await _cancel_job_after_terminal_wait_timeout(job_manager, job_id)
                 return {
@@ -925,13 +948,15 @@ async def _wait_for_job_terminal_with_cancel_cleanup(
     job_id: str,
     *,
     timeout_seconds: float,
+    detach_on_timeout: bool = False,
 ) -> dict[str, Any]:
     try:
         return await _wait_for_job_terminal(
             job_manager,
             job_id,
             timeout_seconds=timeout_seconds,
-            cancel_on_timeout=True,
+            cancel_on_timeout=not detach_on_timeout,
+            detach_on_timeout=detach_on_timeout,
         )
     except asyncio.CancelledError:
         await _cancel_job_after_terminal_wait_timeout(job_manager, job_id)

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -2296,6 +2296,19 @@ class AutoPipeline:
             return self._result(
                 state, ledger, review=review, blocker=state.last_error, run_subagent=run_subagent
             )
+        if terminal_status == "running_async":
+            state.mark_progress(
+                "background Ralph job is still tracked",
+                tool_name=PIPELINE_DEADLINE_TOOL_NAME,
+            )
+            self._save(state)
+            return self._result(
+                state,
+                ledger,
+                review=review,
+                run_subagent=run_subagent,
+                status_override=DETACHED_STATUS,
+            )
         # Any other failure (terminal failure action, exception bubbled up,
         # or an unrecognized status) is a hard FAILED.
         message = (

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -205,6 +205,7 @@ _RALPH_BLOCKED_STOP_REASONS: frozenset[str] = frozenset(
 # recovery decisions and surfaces can detect "deadline-expired" vs ordinary
 # per-tool blockers without scanning the error message.
 PIPELINE_DEADLINE_TOOL_NAME = "pipeline_deadline"
+DETACHED_STATUS = "detached"
 _RESUME_EXPIRED_MESSAGE = "pipeline_timeout (deadline expired before resume)"
 # Mirrors RalphHandler.MIN_MAX_TOTAL_SECONDS. The auto layer checks this before
 # dispatch so an insufficient top-level pipeline budget remains a pipeline
@@ -3391,6 +3392,13 @@ class AutoPipeline:
                 ralph_result_text=_artifact_text(ralph_meta.get("result_text")),
                 resumed=True,
             )
+        if terminal_status == "running_async":
+            state.mark_progress(
+                "background Ralph job is still tracked",
+                tool_name=PIPELINE_DEADLINE_TOOL_NAME,
+            )
+            self._save(state)
+            return self._result(state, ledger, review=review, status_override=DETACHED_STATUS)
         # Q00/ouroboros#782 review-10 BLOCKING #2: ``terminal_status ==
         # "cancelled"`` must map to BLOCKED with the pinned
         # ``RALPH_CANCEL_BLOCKER_REASON`` — same as the live ``_handoff_to_ralph``

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -706,12 +706,34 @@ def _is_external_ralph_plugin_completion(result: AutoPipelineResult) -> bool:
     return result.status == "complete" and result.ralph_dispatch_mode == "plugin"
 
 
+def _print_detached_guidance(result: AutoPipelineResult) -> None:
+    """Print stable handles and wait/retrieve commands for detached auto work."""
+    console.print("Detached result handles:")
+    console.print(f"  Auto session ID: {result.auto_session_id}")
+    if result.job_id:
+        console.print(f"  Execution job ID: {result.job_id}")
+    if result.ralph_job_id:
+        console.print(f"  Ralph job ID: {result.ralph_job_id}")
+    if result.ralph_lineage_id:
+        console.print(f"  Ralph lineage ID: {result.ralph_lineage_id}")
+
+    console.print(f"Wait: ooo auto --resume {result.auto_session_id}")
+    console.print(f"Retrieve: ooo auto --status --resume {result.auto_session_id}")
+    if result.ralph_job_id:
+        console.print(f"Wait job (CLI): ouroboros job wait {result.ralph_job_id}")
+        console.print(f"Retrieve job (CLI): ouroboros job result {result.ralph_job_id}")
+        console.print(f'Wait job (MCP): ouroboros_job_wait(job_id="{result.ralph_job_id}")')
+        console.print(f'Retrieve job (MCP): ouroboros_job_result(job_id="{result.ralph_job_id}")')
+
+
 def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
     handoff_only = _is_run_handoff_only_completion(result)
     completed_ralph_product = _is_completed_ralph_product(result)
     external_ralph_plugin = _is_external_ralph_plugin_completion(result)
     if handoff_only:
         print_info("Auto run handoff started")
+    elif result.status == "detached":
+        print_info("Auto pipeline detached")
     elif result.status == "complete":
         print_success("Auto pipeline completed")
     elif result.status in {"blocked", "failed"}:
@@ -724,6 +746,10 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
     if handoff_only:
         console.print(
             "Product status: [yellow]not verified complete; execution is still external/pending[/]"
+        )
+    elif result.status == "detached":
+        console.print(
+            "Product status: [yellow]not verified complete; background work is still running[/]"
         )
     elif completed_ralph_product:
         console.print("Product status: [green]completed by Ralph loop[/]")
@@ -764,6 +790,8 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
         console.print(f"Run reconciliation status: {result.run_reconciliation_status}")
         console.print(f"Run reconciliation source: {result.run_reconciliation_source}")
         console.print(f"Run reconciled at: {result.run_reconciled_at}")
+    if result.status == "detached":
+        _print_detached_guidance(result)
     if show_ledger:
         if result.assumptions:
             console.print("Assumptions:")

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -105,7 +105,7 @@ def doctor(
     print_success(
         "Codex ooo auto dispatch: OK\n"
         "- rule maps `ooo auto` to `ouroboros_start_auto`\n"
-        "- auto skill declares MCP dispatch through `ouroboros_auto`\n"
+        "- auto skill declares MCP dispatch through `ouroboros_start_auto`\n"
         "- Codex config contains an `ouroboros` MCP server entry"
         + ("\n- live stdio initialize/list_tools exposes required auto tools" if live_mcp else ""),
         title="Codex Doctor",
@@ -133,8 +133,8 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
         failures.append(f"missing auto skill file: {skill_path}")
     else:
         skill = _read_codex_text(skill_path, "auto skill", failures)
-        if skill is not None and "mcp_tool: ouroboros_auto" not in skill:
-            failures.append("auto skill does not declare `mcp_tool: ouroboros_auto`")
+        if skill is not None and "mcp_tool: ouroboros_start_auto" not in skill:
+            failures.append("auto skill does not declare `mcp_tool: ouroboros_start_auto`")
         if skill is not None and (
             "manual" not in skill.lower() or "unavailable" not in skill.lower()
         ):

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -104,7 +104,7 @@ def doctor(
 
     print_success(
         "Codex ooo auto dispatch: OK\n"
-        "- rule maps `ooo auto` to `ouroboros_auto`\n"
+        "- rule maps `ooo auto` to `ouroboros_start_auto`\n"
         "- auto skill declares MCP dispatch through `ouroboros_auto`\n"
         "- Codex config contains an `ouroboros` MCP server entry"
         + ("\n- live stdio initialize/list_tools exposes required auto tools" if live_mcp else ""),
@@ -121,8 +121,8 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
         failures.append(f"missing Codex rules file: {rules_path}")
     else:
         rules = _read_codex_text(rules_path, "Codex rules", failures)
-        if rules is not None and ("`ooo auto" not in rules or "ouroboros_auto" not in rules):
-            failures.append("Codex rules do not map `ooo auto` to `ouroboros_auto`")
+        if rules is not None and ("`ooo auto" not in rules or "ouroboros_start_auto" not in rules):
+            failures.append("Codex rules do not map `ooo auto` to `ouroboros_start_auto`")
         if rules is not None and (
             "manual" not in rules.lower() or "unavailable" not in rules.lower()
         ):

--- a/src/ouroboros/cli/commands/job.py
+++ b/src/ouroboros/cli/commands/job.py
@@ -1,0 +1,104 @@
+"""CLI wrappers for MCP background job monitoring."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Annotated
+
+import typer
+
+from ouroboros.cli.formatters.panels import print_error
+from ouroboros.mcp.tools.job_handlers import JobResultHandler, JobStatusHandler, JobWaitHandler
+from ouroboros.mcp.types import MCPToolResult
+
+app = typer.Typer(
+    name="job",
+    help="Inspect background Ouroboros jobs.",
+    no_args_is_help=True,
+)
+
+
+def _emit_result(result: MCPToolResult) -> None:
+    """Print stable text output from a job handler."""
+    text = result.text_content
+    if text:
+        typer.echo(text)
+
+
+def _run_job_handler(handler, arguments: dict[str, object]) -> None:
+    """Run an async MCP job handler and map errors to CLI exit status."""
+    result = asyncio.run(handler.handle(arguments))
+    if result.is_err:
+        print_error(result.error.message)
+        raise typer.Exit(1)
+    _emit_result(result.value)
+    if result.value.is_error:
+        raise typer.Exit(1)
+
+
+@app.command(name="status")
+def status(
+    job_id: Annotated[str, typer.Argument(help="Job ID returned by a start tool.")],
+    view: Annotated[
+        str,
+        typer.Option(
+            "--view",
+            help="'full' (default), 'summary', or 'compact'.",
+        ),
+    ] = "full",
+) -> None:
+    """Print the latest status for a background job."""
+    _run_job_handler(JobStatusHandler(), {"job_id": job_id, "view": view})
+
+
+@app.command(name="wait")
+def wait(
+    job_id: Annotated[str, typer.Argument(help="Job ID returned by a start tool.")],
+    cursor: Annotated[
+        int,
+        typer.Option("--cursor", help="Previous cursor from job status or job wait."),
+    ] = 0,
+    timeout_seconds: Annotated[
+        int,
+        typer.Option(
+            "--timeout-seconds",
+            help="Maximum seconds to wait for a change; defaults to an immediate snapshot.",
+        ),
+    ] = 0,
+    view: Annotated[
+        str,
+        typer.Option(
+            "--view",
+            help="'full' (default), 'summary', or 'compact'.",
+        ),
+    ] = "full",
+    stream: Annotated[
+        str,
+        typer.Option(
+            "--stream",
+            help="'progress' (default) or 'linked'.",
+        ),
+    ] = "progress",
+) -> None:
+    """Wait briefly for a background job update."""
+    _run_job_handler(
+        JobWaitHandler(),
+        {
+            "job_id": job_id,
+            "cursor": cursor,
+            "timeout_seconds": timeout_seconds,
+            "view": view,
+            "stream": stream,
+        },
+    )
+
+
+@app.command(name="result")
+def result(
+    job_id: Annotated[str, typer.Argument(help="Job ID returned by a start tool.")],
+) -> None:
+    """Print the terminal result for a completed background job."""
+    _run_job_handler(JobResultHandler(), {"job_id": job_id})
+
+
+__all__ = ["app"]

--- a/src/ouroboros/cli/main.py
+++ b/src/ouroboros/cli/main.py
@@ -28,6 +28,7 @@ from ouroboros.cli.commands import (
     config,
     detect,
     init,
+    job,
     mcp,
     plugin,
     pm,
@@ -79,9 +80,20 @@ app = typer.Typer(
 )
 
 # Register direct commands and command groups
-app.command(name="auto", help="Run bounded full-quality ooo auto pipeline.")(auto.auto_command)
+app.command(
+    name="auto",
+    help=(
+        "Run bounded full-quality ooo auto pipeline.\n\n"
+        "Detached auto background work is non-terminal tracked work. "
+        "Wait for completion with:\n\n"
+        "  ouroboros job wait JOB_ID\n\n"
+        "Retrieve completed results with:\n\n"
+        "  ouroboros job result JOB_ID"
+    ),
+)(auto.auto_command)
 app.add_typer(init.app, name="init")
 app.add_typer(run.app, name="run")
+app.add_typer(job.app, name="job")
 app.add_typer(config.app, name="config")
 app.add_typer(status.app, name="status")
 app.add_typer(cancel.app, name="cancel")

--- a/src/ouroboros/codex/ouroboros.md
+++ b/src/ouroboros/codex/ouroboros.md
@@ -13,15 +13,15 @@ Do NOT interpret `ooo` commands as natural language. ALWAYS route to the MCP too
 | `ooo interview "<answer>"` (follow-up) | `ouroboros_interview` with `answer` and `session_id` |
 | `ooo seed [session_id]` | `ouroboros_generate_seed` |
 | `ooo run <seed.yaml>` | `ouroboros_execute_seed` with `seed_path` |
-| `ooo auto ...` | `ouroboros_auto` with the resolved `goal` / `resume` / option arguments |
+| `ooo auto ...` | `ouroboros_start_auto` with the resolved `goal` / `resume` / option arguments |
 | `ooo status [session_id]` | `ouroboros_session_status` |
 | `ooo evaluate <session_id>` | `ouroboros_evaluate` |
 | `ooo evolve ...` | `ouroboros_evolve_step` |
 | `ooo cancel [execution_id]` | `ouroboros_cancel_execution` |
 | `ooo unstuck` / `ooo lateral` | `ouroboros_lateral_think` |
-| `ooo auto ...` | `ouroboros_auto` |
+| `ooo auto ...` | `ouroboros_start_auto` |
 
-If `ouroboros_auto` is unavailable, stop and report that the MCP dispatch surface is broken. Do not manually emulate `ooo auto` with ordinary shell, GitHub, or coding work.
+If `ouroboros_start_auto` is unavailable, stop and report that the MCP dispatch surface is broken. Do not manually emulate `ooo auto` with ordinary shell, GitHub, or coding work.
 
 ## Natural Language Mapping
 
@@ -38,15 +38,27 @@ For natural-language requests, map to the corresponding MCP tool:
 A-grade review/repair, and execution handoff. Do not emulate it with manual
 shell, repository, or GitHub work.
 
-If a user input starts with `ooo auto`, call `ouroboros_auto`. If that MCP tool
-is unavailable, stop and report that `ouroboros_auto` is unavailable instead of
-continuing as a normal Codex task.
+If a user input starts with `ooo auto`, call `ouroboros_start_auto`. Full auto
+runs routinely exceed interactive MCP tool-call timeouts, so the background
+starter is the supported default. It returns `job_id` and `auto_session_id`
+quickly; report both briefly, retain the `job_id` plus latest cursor, and keep
+monitoring the job yourself with `ouroboros_job_wait` / `ouroboros_job_status`.
+Do not hand the user polling instructions as the final UX. For normal
+conversational tracking, call `ouroboros_job_wait` with a positive
+`timeout_seconds` value (for example 120) and `view="summary"`, update the cursor
+from `response.meta.cursor`, relay only meaningful changes, and continue until a
+terminal job status is reached or the user explicitly asks you to stop. If that
+MCP tool is unavailable, stop and report that `ouroboros_start_auto` is
+unavailable instead of continuing as a normal Codex task.
 
 If `ouroboros_auto` is invoked and returns an auto-session outcome such as
 `blocked`, `failed`, or `complete`, report that outcome as the auto session
-result. Do not call a `blocked` or `failed` auto-session result a dispatch
-failure; dispatch failure is reserved for cases where the MCP tool could not be
-invoked.
+result. `detached` is non-terminal tracked background work; surface the job or
+Ralph handles and keep polling without blocking the foreground tool call. After
+the auto job reaches a terminal job status, call `ouroboros_job_result(job_id)`
+and summarize the final auto result. Do not call a `blocked` or `failed`
+auto-session result a dispatch failure; dispatch failure is reserved for cases
+where the MCP tool could not be invoked.
 
 ## Setup & Update
 

--- a/src/ouroboros/codex/ouroboros.md
+++ b/src/ouroboros/codex/ouroboros.md
@@ -19,7 +19,6 @@ Do NOT interpret `ooo` commands as natural language. ALWAYS route to the MCP too
 | `ooo evolve ...` | `ouroboros_evolve_step` |
 | `ooo cancel [execution_id]` | `ouroboros_cancel_execution` |
 | `ooo unstuck` / `ooo lateral` | `ouroboros_lateral_think` |
-| `ooo auto ...` | `ouroboros_start_auto` |
 
 If `ouroboros_start_auto` is unavailable, stop and report that the MCP dispatch surface is broken. Do not manually emulate `ooo auto` with ordinary shell, GitHub, or coding work.
 

--- a/src/ouroboros/codex/ouroboros.md
+++ b/src/ouroboros/codex/ouroboros.md
@@ -50,7 +50,7 @@ terminal job status is reached or the user explicitly asks you to stop. If that
 MCP tool is unavailable, stop and report that `ouroboros_start_auto` is
 unavailable instead of continuing as a normal Codex task.
 
-If `ouroboros_auto` is invoked and returns an auto-session outcome such as
+If `ouroboros_start_auto` is invoked and returns an auto-session outcome such as
 `blocked`, `failed`, or `complete`, report that outcome as the auto session
 result. `detached` is non-terminal tracked background work; surface the job or
 Ralph handles and keep polling without blocking the foreground tool call. After

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -57,6 +57,7 @@ class JobSnapshot:
     links: JobLinks = field(default_factory=JobLinks)
     result_text: str | None = None
     result_meta: dict[str, Any] = field(default_factory=dict)
+    result_payload: dict[str, Any] | None = None
     error: str | None = None
 
     @property
@@ -80,11 +81,49 @@ def _safe_meta(value: Any) -> Any:
     return str(value)
 
 
+def _safe_result_payload(result: Any) -> dict[str, Any]:
+    """Return a JSON-safe representation of an MCP tool result."""
+    content = []
+    for item in getattr(result, "content", ()) or ():
+        content.append(
+            {
+                "type": str(getattr(item, "type", "")),
+                "text": getattr(item, "text", None),
+                "data": getattr(item, "data", None),
+                "mime_type": getattr(item, "mime_type", None),
+                "uri": getattr(item, "uri", None),
+            }
+        )
+    return {
+        "content": _safe_meta(content),
+        "is_error": bool(getattr(result, "is_error", False)),
+        "meta": _safe_meta(getattr(result, "meta", {})),
+        "text_content": getattr(result, "text_content", str(result)),
+    }
+
+
 _JOB_TTL = timedelta(hours=1)
 _COMPLETED_EXECUTION_CANCEL_GRACE_SECONDS = 5.0
 _RECOVERED_COMPLETION_EVENT_ID_PREFIX = "mcp-job-recovered-completed-"
 _RECOVERED_FAILURE_EVENT_ID_PREFIX = "mcp-job-recovered-failed-"
 logger = logging.getLogger(__name__)
+
+
+def is_terminal_job_expired(
+    snapshot: JobSnapshot,
+    *,
+    now: datetime | None = None,
+    ttl: timedelta | None = None,
+) -> bool:
+    """Return true when a terminal job handle is past the retrieval TTL."""
+    if not snapshot.is_terminal:
+        return False
+    ttl = ttl or _JOB_TTL
+    current = now or datetime.now(UTC)
+    updated = snapshot.updated_at
+    if updated.tzinfo is None:
+        updated = updated.replace(tzinfo=UTC)
+    return updated < current - ttl
 
 
 def _consume_task_result(task: asyncio.Task[Any]) -> None:
@@ -182,6 +221,11 @@ def _snapshot_with_terminal_event(
         cursor=cursor,
         result_text=data.get("result_text", snapshot.result_text),
         result_meta=data.get("result_meta") if isinstance(data.get("result_meta"), dict) else {},
+        result_payload=(
+            data.get("result_payload")
+            if isinstance(data.get("result_payload"), dict)
+            else snapshot.result_payload
+        ),
         error=data.get("error"),
     )
 
@@ -381,6 +425,7 @@ class JobManager:
                     }.get(terminal_status, "Job complete"),
                     "result_text": getattr(result, "text_content", str(result))[:20_000],
                     "result_meta": _safe_meta(getattr(result, "meta", {})),
+                    "result_payload": _safe_result_payload(result),
                     "is_error": bool(getattr(result, "is_error", False)),
                 },
             )
@@ -797,6 +842,7 @@ class JobManager:
         )
         result_text: str | None = None
         result_meta: dict[str, Any] = {}
+        result_payload: dict[str, Any] | None = None
         error: str | None = None
 
         for event in events[1:]:
@@ -816,6 +862,8 @@ class JobManager:
                 result_text = data["result_text"]
             if "result_meta" in data and isinstance(data["result_meta"], dict):
                 result_meta = data["result_meta"]
+            if "result_payload" in data and isinstance(data["result_payload"], dict):
+                result_payload = data["result_payload"]
             if "error" in data:
                 error = data["error"]
 
@@ -830,6 +878,7 @@ class JobManager:
             links=links,
             result_text=result_text,
             result_meta=result_meta,
+            result_payload=result_payload,
             error=error,
         )
         return await self._recover_linked_execution_terminal_snapshot(snapshot)

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1351,6 +1351,13 @@ async def _reconcile_execution_job_snapshot(result: AutoPipelineResult) -> AutoP
     """Project the linked execution job lifecycle onto the auto resume result."""
     if not result.job_id:
         return result
+    if (
+        result.status == "detached"
+        or result.phase == AutoPhase.RALPH_HANDOFF.value
+        or result.ralph_job_id
+        or result.ralph_lineage_id
+    ):
+        return result
     try:
         snapshot = await JobManager().get_snapshot(result.job_id)
     except Exception:

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -780,9 +780,11 @@ class StartAutoHandler:
             )
 
         text = (
-            f"Started background auto session. job_id={snapshot.job_id}\n\n"
-            f"Auto session ID: {auto_session_id}\n\n"
-            "Poll with ouroboros_job_status / ouroboros_job_wait."
+            "Started background auto session.\n\n"
+            "Status: queued\n\n"
+            "Track with ouroboros_job_wait / ouroboros_job_status until terminal, "
+            "then fetch ouroboros_job_result. Use response metadata for job_id "
+            "and auto_session_id."
         )
         return Result.ok(
             MCPToolResult(
@@ -794,6 +796,9 @@ class StartAutoHandler:
                     "session_id": auto_session_id,
                     "status": "queued",
                     "dispatch_mode": "job",
+                    "status_tool": "ouroboros_job_status",
+                    "wait_tool": "ouroboros_job_wait",
+                    "result_tool": "ouroboros_job_result",
                 },
             )
         )
@@ -1372,10 +1377,12 @@ async def _reconcile_execution_job_snapshot(result: AutoPipelineResult) -> AutoP
         resume_capability = AutoResumeCapability.NONE
     elif snapshot.status is JobStatus.COMPLETED:
         status = "complete"
+        blocker = None
         resume_capability = AutoResumeCapability.NONE
     return replace(
         result,
         status=status,
+        phase="complete" if status == "complete" else result.phase,
         blocker=blocker,
         resume_capability=resume_capability,
         execution_job_status=snapshot.status.value,

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -722,6 +722,21 @@ def _job_status_category(snapshot: JobSnapshot) -> str:
     return "terminal" if snapshot.is_terminal else "non_terminal"
 
 
+# Terminal job statuses whose outcome must surface as an error. INTERRUPTED is
+# terminal (see ``JobSnapshot.is_terminal``) and is persisted when a child tool
+# returns ``meta.status="interrupted"`` with ``is_error=True``, so result/status
+# surfaces must treat it as a failed outcome rather than a successful result.
+_TERMINAL_ERROR_STATUSES = frozenset({JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.INTERRUPTED})
+
+
+def _job_is_error(snapshot: JobSnapshot) -> bool:
+    """Return true when a job's terminal outcome must be presented as an error."""
+    if snapshot.status in _TERMINAL_ERROR_STATUSES:
+        return True
+    payload = snapshot.result_payload
+    return bool(payload.get("is_error")) if isinstance(payload, dict) else False
+
+
 def _job_snapshot_meta(snapshot: JobSnapshot) -> dict[str, Any]:
     """Return stable structured metadata shared by job status APIs."""
     links = {
@@ -807,7 +822,7 @@ class JobStatusHandler:
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text=text),),
-                is_error=snapshot.status in {JobStatus.FAILED, JobStatus.CANCELLED},
+                is_error=_job_is_error(snapshot),
                 meta={
                     **_job_snapshot_meta(snapshot),
                     "view": view,
@@ -1028,7 +1043,7 @@ class JobWaitHandler:
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text=text),),
-                is_error=snapshot.status in {JobStatus.FAILED, JobStatus.CANCELLED},
+                is_error=_job_is_error(snapshot),
                 meta={
                     **_job_snapshot_meta(snapshot),
                     "changed": response_changed,
@@ -1174,7 +1189,7 @@ class JobResultHandler:
         return Result.ok(
             MCPToolResult(
                 content=content,
-                is_error=snapshot.status in {JobStatus.FAILED, JobStatus.CANCELLED},
+                is_error=_job_is_error(snapshot),
                 meta={
                     **_job_snapshot_meta(snapshot),
                     **result_payload_meta,

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -8,14 +8,21 @@ Contains handlers for background job operations and execution cancellation:
 - CancelJobHandler: Cancel a background job
 """
 
+import asyncio
 from dataclasses import dataclass, field, replace
 from typing import Any
 
 import structlog
 
 from ouroboros.core.types import Result
+from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
-from ouroboros.mcp.job_manager import JobManager, JobSnapshot, JobStatus
+from ouroboros.mcp.job_manager import (
+    JobManager,
+    JobSnapshot,
+    JobStatus,
+    is_terminal_job_expired,
+)
 from ouroboros.mcp.tools.ac_tree_hud_handler import (
     format_subtask_progress_summary,
     summarize_subtask_events,
@@ -51,6 +58,17 @@ _JOB_VIEW_ALIASES = {
     "tree": "full",
     "verbose": "full",
 }
+_JOB_STREAM_ALIASES = {
+    "default": "progress",
+    "progress": "progress",
+    "execution": "progress",
+    "linked": "linked",
+    "events": "linked",
+    "all": "linked",
+    "children": "linked",
+    "subagents": "linked",
+}
+_JOB_STREAM_EVENT_LIMIT = 10
 
 
 def _normalize_job_view(value: object) -> str:
@@ -60,6 +78,72 @@ def _normalize_job_view(value: object) -> str:
         if stripped:
             return _JOB_VIEW_ALIASES.get(stripped, _DEFAULT_JOB_VIEW)
     return _DEFAULT_JOB_VIEW
+
+
+def _normalize_job_stream(value: object) -> str:
+    """Normalize requested job wait stream scope."""
+    if isinstance(value, str):
+        stripped = value.strip().lower()
+        if stripped:
+            return _JOB_STREAM_ALIASES.get(stripped, "progress")
+    return "progress"
+
+
+def _content_items_from_result_payload(
+    payload: dict[str, Any] | None,
+) -> tuple[MCPContentItem, ...]:
+    """Rebuild MCP content items from a persisted terminal result payload."""
+    if not isinstance(payload, dict):
+        return ()
+    raw_content = payload.get("content")
+    if not isinstance(raw_content, list):
+        return ()
+
+    items: list[MCPContentItem] = []
+    for raw_item in raw_content:
+        if not isinstance(raw_item, dict):
+            continue
+        raw_type = raw_item.get("type")
+        try:
+            content_type = ContentType(raw_type)
+        except ValueError:
+            continue
+        items.append(
+            MCPContentItem(
+                type=content_type,
+                text=raw_item.get("text") if isinstance(raw_item.get("text"), str) else None,
+                data=raw_item.get("data") if isinstance(raw_item.get("data"), str) else None,
+                mime_type=(
+                    raw_item.get("mime_type")
+                    if isinstance(raw_item.get("mime_type"), str)
+                    else None
+                ),
+                uri=raw_item.get("uri") if isinstance(raw_item.get("uri"), str) else None,
+            )
+        )
+    return tuple(items)
+
+
+def _parse_non_negative_int_argument(
+    arguments: dict[str, Any],
+    name: str,
+    *,
+    default: int,
+    tool_name: str,
+) -> Result[int, MCPServerError]:
+    """Parse a non-negative integer tool argument into a stable MCP error."""
+    raw = arguments.get(name, default)
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return Result.err(
+            MCPToolError(f"{name} must be a non-negative integer", tool_name=tool_name)
+        )
+    if value < 0:
+        return Result.err(
+            MCPToolError(f"{name} must be a non-negative integer", tool_name=tool_name)
+        )
+    return Result.ok(value)
 
 
 async def _query_all_execution_subtask_events(
@@ -87,6 +171,95 @@ async def _query_latest_workflow_event(event_store: EventStore, execution_id: st
         limit=1,
     )
     return events[0] if events else None
+
+
+def _event_scope(event: BaseEvent) -> str:
+    return f"{event.aggregate_type}:{event.aggregate_id}"
+
+
+def _compact_event_detail(event: BaseEvent) -> str:
+    data = event.data
+    for key in (
+        "message",
+        "activity_detail",
+        "activity",
+        "title",
+        "content",
+        "phase",
+        "status",
+        "reason",
+        "tool_name",
+    ):
+        value = data.get(key)
+        if value not in (None, ""):
+            return str(value).replace("\n", " ")[:240]
+    if data:
+        pairs = []
+        for key, value in list(data.items())[:4]:
+            if value in (None, "", [], {}):
+                continue
+            pairs.append(f"{key}={str(value).replace(chr(10), ' ')[:80]}")
+        if pairs:
+            return ", ".join(pairs)[:240]
+    return ""
+
+
+def _event_stream_item(event: BaseEvent) -> dict[str, Any]:
+    return {
+        "id": event.id,
+        "type": event.type,
+        "timestamp": event.timestamp.isoformat(),
+        "aggregate_type": event.aggregate_type,
+        "aggregate_id": event.aggregate_id,
+        "scope": _event_scope(event),
+        "detail": _compact_event_detail(event),
+    }
+
+
+async def _query_linked_stream_events(
+    event_store: EventStore,
+    snapshot: JobSnapshot,
+    cursor: int,
+) -> tuple[list[BaseEvent], int]:
+    """Fetch new events from the job's linked execution/session/lineage streams."""
+    collected: dict[str, BaseEvent] = {}
+    max_cursor = cursor
+
+    async def collect(events: list[BaseEvent], new_cursor: int) -> None:
+        nonlocal max_cursor
+        max_cursor = max(max_cursor, new_cursor)
+        for event in events:
+            collected[event.id] = event
+
+    job_events, job_cursor = await event_store.get_events_after("job", snapshot.job_id, cursor)
+    await collect(job_events, job_cursor)
+
+    if snapshot.links.execution_id:
+        execution_events, execution_cursor = await event_store.get_events_after(
+            "execution",
+            snapshot.links.execution_id,
+            cursor,
+        )
+        await collect(execution_events, execution_cursor)
+
+    if snapshot.links.session_id:
+        session_events, session_cursor = await event_store.query_session_related_events_after(
+            session_id=snapshot.links.session_id,
+            execution_id=snapshot.links.execution_id,
+            last_row_id=cursor,
+        )
+        await collect(session_events, session_cursor)
+
+    if snapshot.links.lineage_id:
+        lineage_events, lineage_cursor = await event_store.get_events_after(
+            "lineage",
+            snapshot.links.lineage_id,
+            cursor,
+        )
+        await collect(lineage_events, lineage_cursor)
+
+    events = sorted(collected.values(), key=lambda event: (event.timestamp, event.id))
+    return events[-_JOB_STREAM_EVENT_LIMIT:], max_cursor
 
 
 @dataclass
@@ -348,16 +521,24 @@ async def _render_job_snapshot_inner(
 ) -> tuple[str, dict[str, Any]]:
     """Inner render without caching.  Returns (text, progress_dict)."""
     progress = dict(_EMPTY_PROGRESS)
+    status_category = _job_status_category(snapshot)
     lines = [
         f"## Job: {snapshot.job_id}",
         "",
         f"**Type**: {snapshot.job_type}",
         f"**Status**: {snapshot.status.value}",
+        f"**Terminal**: {str(snapshot.is_terminal).lower()}",
+        f"**Status Category**: {status_category}",
         f"**Message**: {snapshot.message}",
-        f"**Created**: {snapshot.created_at.isoformat()}",
-        f"**Updated**: {snapshot.updated_at.isoformat()}",
         f"**Cursor**: {snapshot.cursor}",
     ]
+    if snapshot.job_type != "auto":
+        lines[7:7] = [
+            f"**Created**: {snapshot.created_at.isoformat()}",
+            f"**Updated**: {snapshot.updated_at.isoformat()}",
+        ]
+    if snapshot.job_type == "auto" and not snapshot.is_terminal:
+        lines.insert(6, "**Tracking**: detached auto tracked background work")
 
     link_lines = _render_job_link_lines(snapshot)
     if link_lines:
@@ -516,6 +697,55 @@ def _render_job_link_lines(snapshot: JobSnapshot) -> list[str]:
     return lines
 
 
+def _render_non_terminal_result_unavailable(snapshot: JobSnapshot) -> str:
+    """Return stable guidance when result retrieval is requested too early."""
+    lines = [
+        f"Job result not ready: {snapshot.job_id}",
+        f"status={snapshot.status.value}",
+        f"terminal={str(snapshot.is_terminal).lower()}",
+    ]
+    if snapshot.job_type == "auto":
+        lines.append("detached auto job is still tracked background work")
+    lines.extend(
+        [
+            f"wait: ouroboros job wait {snapshot.job_id}",
+            f"retrieve after terminal status: ouroboros job result {snapshot.job_id}",
+            f'mcp_wait: ouroboros_job_wait(job_id="{snapshot.job_id}")',
+            f'mcp_result: ouroboros_job_result(job_id="{snapshot.job_id}")',
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _job_status_category(snapshot: JobSnapshot) -> str:
+    """Return the stable category for status consumers."""
+    return "terminal" if snapshot.is_terminal else "non_terminal"
+
+
+def _job_snapshot_meta(snapshot: JobSnapshot) -> dict[str, Any]:
+    """Return stable structured metadata shared by job status APIs."""
+    links = {
+        "session_id": snapshot.links.session_id,
+        "execution_id": snapshot.links.execution_id,
+        "lineage_id": snapshot.links.lineage_id,
+    }
+    return {
+        "job_id": snapshot.job_id,
+        "job_type": snapshot.job_type,
+        "status": snapshot.status.value,
+        "lifecycle_status": snapshot.status.value,
+        "status_category": _job_status_category(snapshot),
+        "is_terminal": snapshot.is_terminal,
+        "result_available": snapshot.is_terminal,
+        "error": snapshot.error,
+        "cursor": snapshot.cursor,
+        "links": links,
+        "session_id": snapshot.links.session_id,
+        "execution_id": snapshot.links.execution_id,
+        "lineage_id": snapshot.links.lineage_id,
+    }
+
+
 @dataclass
 class JobStatusHandler:
     """Return a human-readable status summary for a background job."""
@@ -579,12 +809,7 @@ class JobStatusHandler:
                 content=(MCPContentItem(type=ContentType.TEXT, text=text),),
                 is_error=snapshot.status in {JobStatus.FAILED, JobStatus.CANCELLED},
                 meta={
-                    "job_id": snapshot.job_id,
-                    "status": snapshot.status.value,
-                    "cursor": snapshot.cursor,
-                    "session_id": snapshot.links.session_id,
-                    "execution_id": snapshot.links.execution_id,
-                    "lineage_id": snapshot.links.lineage_id,
+                    **_job_snapshot_meta(snapshot),
                     "view": view,
                     **progress,
                 },
@@ -628,9 +853,13 @@ class JobWaitHandler:
                 MCPToolParameter(
                     name="timeout_seconds",
                     type=ToolInputType.INTEGER,
-                    description="Maximum seconds to wait for a change (longer = fewer round-trips)",
+                    description=(
+                        "Maximum seconds to wait for a change. Defaults to 0 so the "
+                        "tool returns an immediate snapshot and never holds the MCP "
+                        "client open unless the caller explicitly asks for long-polling."
+                    ),
                     required=False,
-                    default=30,
+                    default=0,
                 ),
                 MCPToolParameter(
                     name="view",
@@ -638,6 +867,16 @@ class JobWaitHandler:
                     description="'full' (default), 'summary', or 'compact'.",
                     required=False,
                     default=_DEFAULT_JOB_VIEW,
+                ),
+                MCPToolParameter(
+                    name="stream",
+                    type=ToolInputType.STRING,
+                    description=(
+                        "'progress' (default) watches job/execution progress; "
+                        "'linked' also streams linked session, lineage, and subagent events."
+                    ),
+                    required=False,
+                    default="progress",
                 ),
             ),
         )
@@ -655,21 +894,70 @@ class JobWaitHandler:
                 )
             )
 
-        cursor = int(arguments.get("cursor", 0))
-        timeout_seconds = int(arguments.get("timeout_seconds", 30))
+        cursor_result = _parse_non_negative_int_argument(
+            arguments,
+            "cursor",
+            default=0,
+            tool_name="ouroboros_job_wait",
+        )
+        if cursor_result.is_err:
+            return Result.err(cursor_result.error)
+        timeout_result = _parse_non_negative_int_argument(
+            arguments,
+            "timeout_seconds",
+            default=0,
+            tool_name="ouroboros_job_wait",
+        )
+        if timeout_result.is_err:
+            return Result.err(timeout_result.error)
+        cursor = cursor_result.value
+        timeout_seconds = timeout_result.value
         view = _normalize_job_view(arguments.get("view"))
+        stream = _normalize_job_stream(arguments.get("stream"))
 
         try:
-            snapshot, changed = await self._job_manager.wait_for_change(
-                job_id,
-                cursor=cursor,
-                timeout_seconds=timeout_seconds,
-            )
+            if stream == "linked":
+                (
+                    snapshot,
+                    changed,
+                    stream_events,
+                    stream_cursor,
+                ) = await self._wait_for_linked_change(
+                    job_id,
+                    cursor=cursor,
+                    timeout_seconds=timeout_seconds,
+                )
+            else:
+                snapshot, changed = await self._job_manager.wait_for_change(
+                    job_id,
+                    cursor=cursor,
+                    timeout_seconds=timeout_seconds,
+                )
+                stream_events = []
+                stream_cursor = cursor
         except ValueError as exc:
-            return Result.err(MCPToolError(str(exc), tool_name="ouroboros_job_wait"))
+            return Result.err(
+                MCPToolError(
+                    (
+                        f"Job not found: {job_id}. Wait unavailable. "
+                        "Check the job handle returned by detached auto start, "
+                        f"then retry `ouroboros job wait {job_id}`."
+                    ),
+                    tool_name="ouroboros_job_wait",
+                    error_code="job_handle_not_found",
+                    details={
+                        "job_id": job_id,
+                        "lifecycle_status": "invalid",
+                        "is_terminal": False,
+                        "result_available": False,
+                        "reason": "not_found",
+                        "source_error": str(exc),
+                    },
+                )
+            )
 
         execution_progress_changed = False
-        response_cursor = max(snapshot.cursor, cursor)
+        response_cursor = max(snapshot.cursor, stream_cursor, cursor)
         if snapshot.links.execution_id:
             execution_events, execution_cursor = await self._event_store.get_events_after(
                 "execution",
@@ -684,6 +972,12 @@ class JobWaitHandler:
                 snapshot = replace(snapshot, cursor=response_cursor)
 
         text, progress = await _render_job_snapshot(snapshot, self._event_store)
+        stream_items = [_event_stream_item(event) for event in stream_events]
+        if stream_items:
+            text += "\n\n### Stream Events"
+            for item in stream_items[-_JOB_STREAM_EVENT_LIMIT:]:
+                detail = f" -- {item['detail']}" if item["detail"] else ""
+                text += f"\n- `{item['type']}` [{item['scope']}]{detail}"
         has_live_execution_progress = snapshot.links.execution_id is not None and any(
             progress.get(key) is not None
             for key in (
@@ -694,45 +988,88 @@ class JobWaitHandler:
                 "sub_ac_total",
             )
         )
-        response_changed = changed or execution_progress_changed
+        stream_changed = bool(stream_items)
+        response_changed = changed or execution_progress_changed or stream_changed
         if not changed:
             if (
                 view in {"compact", "summary"}
                 and has_live_execution_progress
-                and execution_progress_changed
+                and (execution_progress_changed or stream_changed)
             ):
                 text = _render_compact_job_snapshot(
                     snapshot,
                     progress,
                     include_message=view == "summary",
                 )
+                if stream_items:
+                    text += f"\nstream_events {len(stream_items)} cursor={snapshot.cursor}"
             elif view in {"compact", "summary"}:
-                text = f"unchanged cursor={snapshot.cursor}"
+                if stream_items:
+                    summaries = ", ".join(item["type"] for item in stream_items[-3:])
+                    text = (
+                        f"stream_events {len(stream_items)} cursor={snapshot.cursor}: {summaries}"
+                    )
+                else:
+                    text = f"unchanged cursor={snapshot.cursor}"
             elif execution_progress_changed:
                 text += "\n\nExecution progress updated during this wait window."
+            elif stream_changed:
+                text += "\n\nLinked stream events updated during this wait window."
             else:
                 text += "\n\nNo new job-level events during this wait window."
         elif view == "compact":
             text = _render_compact_job_snapshot(snapshot, progress, include_message=False)
+            if stream_items:
+                text += f"\nstream_events {len(stream_items)} cursor={snapshot.cursor}"
         elif view == "summary":
             text = _render_compact_job_snapshot(snapshot, progress, include_message=True)
+            if stream_items:
+                text += f"\nstream_events {len(stream_items)} cursor={snapshot.cursor}"
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text=text),),
                 is_error=snapshot.status in {JobStatus.FAILED, JobStatus.CANCELLED},
                 meta={
-                    "job_id": snapshot.job_id,
-                    "status": snapshot.status.value,
-                    "cursor": snapshot.cursor,
+                    **_job_snapshot_meta(snapshot),
                     "changed": response_changed,
-                    "session_id": snapshot.links.session_id,
-                    "execution_id": snapshot.links.execution_id,
-                    "lineage_id": snapshot.links.lineage_id,
                     "view": view,
+                    "stream": stream,
+                    "stream_events": stream_items,
                     **progress,
                 },
             )
         )
+
+    async def _wait_for_linked_change(
+        self,
+        job_id: str,
+        *,
+        cursor: int,
+        timeout_seconds: int,
+    ) -> tuple[JobSnapshot, bool, list[BaseEvent], int]:
+        """Long-poll job plus linked child/session event streams."""
+        deadline = asyncio.get_running_loop().time() + timeout_seconds
+        while True:
+            snapshot, changed = await self._job_manager.wait_for_change(
+                job_id,
+                cursor=cursor,
+                timeout_seconds=0,
+            )
+            events, stream_cursor = await _query_linked_stream_events(
+                self._event_store,
+                snapshot,
+                cursor,
+            )
+            if (
+                changed
+                or events
+                or snapshot.is_terminal
+                or asyncio.get_running_loop().time() >= deadline
+            ):
+                if stream_cursor != snapshot.cursor:
+                    snapshot = replace(snapshot, cursor=max(snapshot.cursor, stream_cursor))
+                return snapshot, changed, events, stream_cursor
+            await asyncio.sleep(0.5)
 
 
 @dataclass
@@ -777,27 +1114,70 @@ class JobResultHandler:
         try:
             snapshot = await self._job_manager.get_snapshot(job_id)
         except ValueError as exc:
-            return Result.err(MCPToolError(str(exc), tool_name="ouroboros_job_result"))
-
-        if not snapshot.is_terminal:
             return Result.err(
                 MCPToolError(
-                    f"Job still running: {snapshot.status.value}",
+                    f"Job handle not found: {job_id}. Result unavailable.",
                     tool_name="ouroboros_job_result",
+                    error_code="job_handle_not_found",
+                    details={
+                        "job_id": job_id,
+                        "lifecycle_status": "invalid",
+                        "is_terminal": True,
+                        "result_available": False,
+                        "reason": "not_found",
+                        "source_error": str(exc),
+                    },
                 )
             )
 
+        if is_terminal_job_expired(snapshot):
+            return Result.err(
+                MCPToolError(
+                    f"Job handle expired: {snapshot.job_id}. Result unavailable.",
+                    tool_name="ouroboros_job_result",
+                    error_code="job_handle_expired",
+                    details={
+                        "job_id": snapshot.job_id,
+                        "lifecycle_status": "expired",
+                        "is_terminal": snapshot.is_terminal,
+                        "result_available": False,
+                        "reason": "expired",
+                    },
+                )
+            )
+
+        if not snapshot.is_terminal:
+            return Result.ok(
+                MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text=_render_non_terminal_result_unavailable(snapshot),
+                        ),
+                    ),
+                    is_error=False,
+                    meta={
+                        **_job_snapshot_meta(snapshot),
+                        "result_available": False,
+                    },
+                )
+            )
+
+        stored_content = _content_items_from_result_payload(snapshot.result_payload)
         result_text = snapshot.result_text or snapshot.error or snapshot.message
+        content = stored_content or (MCPContentItem(type=ContentType.TEXT, text=result_text),)
+        result_payload_meta = (
+            {"result_payload": snapshot.result_payload}
+            if snapshot.result_payload is not None
+            else {}
+        )
         return Result.ok(
             MCPToolResult(
-                content=(MCPContentItem(type=ContentType.TEXT, text=result_text),),
+                content=content,
                 is_error=snapshot.status in {JobStatus.FAILED, JobStatus.CANCELLED},
                 meta={
-                    "job_id": snapshot.job_id,
-                    "status": snapshot.status.value,
-                    "session_id": snapshot.links.session_id,
-                    "execution_id": snapshot.links.execution_id,
-                    "lineage_id": snapshot.links.lineage_id,
+                    **_job_snapshot_meta(snapshot),
+                    **result_payload_meta,
                     **snapshot.result_meta,
                 },
             )

--- a/src/ouroboros/mcp/tools/query_handlers.py
+++ b/src/ouroboros/mcp/tools/query_handlers.py
@@ -126,8 +126,14 @@ class SessionStatusHandler:
         return None
 
     async def _reconcile_auto_state_from_execution_job(self, state: Any) -> None:
-        """Project a completed linked execution job onto auto status displays."""
+        """Project a completed run job onto non-complete-product status displays."""
         if not state.job_id:
+            return
+        if (
+            state.phase is AutoPhase.RALPH_HANDOFF
+            or state.ralph_job_id is not None
+            or state.ralph_lineage_id is not None
+        ):
             return
         try:
             snapshot = await JobManager().get_snapshot(state.job_id)
@@ -208,6 +214,8 @@ class SessionStatusHandler:
             ):
                 if key in ralph_block:
                     lines.append(f"  {key}: {ralph_block[key]}")
+        if state.last_error:
+            lines.append(f"Blocker: {state.last_error}")
         status_text = "\n".join(lines) + "\n"
 
         meta: dict[str, Any] = {

--- a/src/ouroboros/mcp/tools/query_handlers.py
+++ b/src/ouroboros/mcp/tools/query_handlers.py
@@ -14,6 +14,7 @@ import structlog
 from ouroboros.auto.state import AutoPhase, AutoStore
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
+from ouroboros.mcp.job_manager import JobManager, JobStatus
 from ouroboros.mcp.tools.ac_tree_hud_handler import (
     format_subtask_progress_summary,
     summarize_subtask_events,
@@ -124,7 +125,23 @@ class SessionStatusHandler:
             }
         return None
 
-    def _handle_auto_session(
+    async def _reconcile_auto_state_from_execution_job(self, state: Any) -> None:
+        """Project a completed linked execution job onto auto status displays."""
+        if not state.job_id:
+            return
+        try:
+            snapshot = await JobManager().get_snapshot(state.job_id)
+        except Exception:
+            return
+        if snapshot.status is JobStatus.COMPLETED:
+            state.phase = AutoPhase.COMPLETE
+            state.last_error = None
+            state.last_error_code = None
+            state.last_progress_message = "execution job completed"
+            state.ralph_job_status = "completed"
+            state.ralph_stop_reason = None
+
+    async def _handle_auto_session(
         self,
         session_id: str,
     ) -> Result[MCPToolResult, MCPServerError]:
@@ -144,6 +161,7 @@ class SessionStatusHandler:
                     tool_name="ouroboros_session_status",
                 )
             )
+        await self._reconcile_auto_state_from_execution_job(state)
 
         # Gap window per the issue contract: between RUN's run_handoff_status
         # transitioning to "started" and the RALPH_HANDOFF entry persisting a
@@ -248,7 +266,7 @@ class SessionStatusHandler:
         # linked or is being prepared.
         if isinstance(session_id, str) and session_id.startswith("auto_"):
             try:
-                return self._handle_auto_session(session_id)
+                return await self._handle_auto_session(session_id)
             except Exception as e:  # pragma: no cover - defensive
                 log.error("mcp.tool.session_status.auto_error", error=str(e))
                 return Result.err(

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -55,6 +55,12 @@ _INTERVIEW_SUBAGENT_MAX_TRANSCRIPT_QUESTION_CHARS = 900
 _INTERVIEW_SUBAGENT_MAX_TRANSCRIPT_ANSWER_CHARS = 220
 _INTERVIEW_SUBAGENT_MAX_ANSWER_CHARS = 300
 
+
+def _canonical_response_json(body: dict[str, Any]) -> str:
+    """Render structured MCP dispatch content with deterministic key order."""
+    return json.dumps(body, sort_keys=True, separators=(",", ":"))
+
+
 # ---------------------------------------------------------------------------
 # SubagentPayload dataclass
 # ---------------------------------------------------------------------------
@@ -224,7 +230,7 @@ def build_subagent_result(
 
     return Result.ok(
         MCPToolResult(
-            content=(MCPContentItem(type=ContentType.TEXT, text=json.dumps(body)),),
+            content=(MCPContentItem(type=ContentType.TEXT, text=_canonical_response_json(body)),),
             is_error=False,
             meta=dict(body),
         )
@@ -1023,7 +1029,7 @@ def build_multi_subagent_result(
 
     return Result.ok(
         MCPToolResult(
-            content=(MCPContentItem(type=ContentType.TEXT, text=json.dumps(body)),),
+            content=(MCPContentItem(type=ContentType.TEXT, text=_canonical_response_json(body)),),
             is_error=False,
             meta=dict(body),
         )

--- a/tests/integration/auto/test_dispatch_to_seed_e2e.py
+++ b/tests/integration/auto/test_dispatch_to_seed_e2e.py
@@ -1,7 +1,7 @@
 """End-to-end ``ooo auto`` dispatch regression tests.
 
 Closes the last open acceptance bullet of issue #637: prove that ``ooo auto ...``
-reaches the ``ouroboros_auto`` MCP pipeline and produces a Seed (or fails closed
+reaches the ``ouroboros_start_auto`` MCP pipeline and produces a Seed (or fails closed
 with the documented unavailable-tool contract). The tests stay laser-focused on
 this acceptance bullet — they do not exercise progress UI, answer grounding, or
 CLI help text. All side-effects are confined to ``tmp_path``: no network, no
@@ -20,7 +20,7 @@ Cases:
    boundary) — it covers the ledger-hydration + seed-generator wiring landed in
    PR #652. Case 1 already covers the dispatch boundary itself.
 3. The deterministic ``ooo auto`` dispatch surface fails closed with the
-   user-visible "ouroboros_auto is unavailable" contract message and does not
+   user-visible "ouroboros_start_auto is unavailable" contract message and does not
    create any persisted auto session state when the MCP tool is unregistered.
 """
 
@@ -423,7 +423,7 @@ async def test_ooo_auto_dispatch_reaches_seed_via_runtime(
     assert intercepts, "skill_dispatcher must be awaited for ooo auto"
     intercept = intercepts[0]
     assert intercept.skill_name == "auto"
-    assert intercept.mcp_tool == "ouroboros_auto"
+    assert intercept.mcp_tool == "ouroboros_start_auto"
     assert intercept.command_prefix == "ooo auto"
 
     # The runtime contract requires documented packaged auto placeholders to be
@@ -464,7 +464,7 @@ async def test_ooo_auto_dispatch_reaches_seed_via_runtime(
     final = messages[0]
     assert final.is_final
     assert not final.is_error, f"dispatch should succeed, got {final!r}"
-    assert final.data.get("tool_name") == "ouroboros_auto"
+    assert final.data.get("tool_name") == "ouroboros_start_auto"
     assert final.data.get("seed_path") == str(seed_path)
     assert final.data.get("status") == "complete"
     assert final.data.get("grade") == "A"
@@ -706,8 +706,8 @@ async def test_sparse_goal_reaches_seed_via_interview_fill(tmp_path: Path) -> No
 # ---------------------------------------------------------------------------
 
 
-async def test_dispatch_fails_closed_when_ouroboros_auto_unregistered(tmp_path: Path) -> None:
-    """``ooo auto`` must fail closed when the ``ouroboros_auto`` MCP tool is unregistered.
+async def test_dispatch_fails_closed_when_ouroboros_start_auto_unregistered(tmp_path: Path) -> None:
+    """``ooo auto`` must fail closed when the ``ouroboros_start_auto`` MCP tool is unregistered.
 
     The dispatch surface returns a fail-closed ``AgentMessage``; no
     ``AutoHandler`` or ``AutoStore`` is constructed downstream because the
@@ -731,7 +731,7 @@ async def test_dispatch_fails_closed_when_ouroboros_auto_unregistered(tmp_path: 
     cwd.mkdir()
 
     dispatcher = AsyncMock(
-        side_effect=LookupError("No local handler registered for tool: ouroboros_auto")
+        side_effect=LookupError("No local handler registered for tool: ouroboros_start_auto")
     )
     runtime = CodexCliRuntime(
         cli_path="codex",
@@ -757,12 +757,12 @@ async def test_dispatch_fails_closed_when_ouroboros_auto_unregistered(tmp_path: 
     failure = messages[0]
     assert failure.is_error is True
 
-    # The Issue #637 acceptance phrase is "ouroboros_auto MCP tool is unavailable;
+    # The Issue #637 acceptance phrase is "ouroboros_start_auto MCP tool is unavailable;
     # cannot run ooo auto". The actual codebase contract phrasing combines both
     # halves into a single sentence — assert each half is present so the contract
     # cannot silently regress in either direction.
     assert "Cannot run ooo auto" in failure.content
-    assert "`ouroboros_auto` is unavailable" in failure.content
+    assert "`ouroboros_start_auto` is unavailable" in failure.content
     assert failure.data["error_type"] == "SkillDispatchUnavailable"
-    assert failure.data["tool_name"] == "ouroboros_auto"
+    assert failure.data["tool_name"] == "ouroboros_start_auto"
     assert failure.data["command_prefix"] == "ooo auto"

--- a/tests/integration/auto/test_status_unified.py
+++ b/tests/integration/auto/test_status_unified.py
@@ -35,7 +35,7 @@ from ouroboros.auto.state import (
     AutoStore,
 )
 from ouroboros.events.base import BaseEvent
-from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
+from ouroboros.mcp.job_manager import JobLinks, JobManager, JobSnapshot, JobStatus
 from ouroboros.mcp.tools.query_handlers import SessionStatusHandler
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.persistence.event_store import EventStore
@@ -414,6 +414,52 @@ def test_terminal_lineage_without_job_id_is_not_gap_window(tmp_path, phase: Auto
     assert "pending" not in meta
     assert "ralph" not in meta
     assert "Pending: starting ralph" not in result.value.content[0].text
+
+
+def test_mcp_auto_status_reconciles_completed_execution_over_ralph_timeout(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """A completed linked execution job must not keep showing a Ralph timeout blocker."""
+    state = _state_at_ralph_handoff(tmp_path, with_job_id=True)
+    state.job_id = "job_execution_done"
+    state.execution_id = "exec_done"
+    state.run_session_id = "orch_done"
+    state.mark_blocked("iteration_timeout", tool_name="ralph_starter")
+    state.ralph_job_status = "failed"
+    state.ralph_stop_reason = "iteration_timeout"
+    AutoStore(tmp_path).save(state)
+
+    class FakeJobManager:
+        async def get_snapshot(self, job_id: str) -> JobSnapshot:
+            assert job_id == state.job_id
+            now = datetime.now(UTC)
+            return JobSnapshot(
+                job_id=job_id,
+                job_type="execute_seed",
+                status=JobStatus.COMPLETED,
+                message="Execution complete: 15/15 ACs completed",
+                created_at=now,
+                updated_at=now,
+                links=JobLinks(session_id=state.run_session_id, execution_id=state.execution_id),
+            )
+
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.query_handlers.JobManager",
+        lambda: FakeJobManager(),
+    )
+
+    handler = SessionStatusHandler(auto_store=AutoStore(tmp_path))
+    result = asyncio.run(handler.handle({"session_id": state.auto_session_id}))
+
+    assert result.is_ok
+    assert result.value.meta["phase"] == "complete"
+    assert result.value.meta["is_terminal"] is True
+    assert "blocker" not in result.value.meta
+    text = result.value.text_content
+    assert "Phase: complete" in text
+    assert "Blocker:" not in text
+    assert "iteration_timeout" not in text
 
 
 @pytest.mark.parametrize("phase", (AutoPhase.BLOCKED, AutoPhase.FAILED))

--- a/tests/integration/auto/test_status_unified.py
+++ b/tests/integration/auto/test_status_unified.py
@@ -416,11 +416,11 @@ def test_terminal_lineage_without_job_id_is_not_gap_window(tmp_path, phase: Auto
     assert "Pending: starting ralph" not in result.value.content[0].text
 
 
-def test_mcp_auto_status_reconciles_completed_execution_over_ralph_timeout(
+def test_mcp_auto_status_does_not_complete_from_execution_job_during_ralph_handoff(
     tmp_path,
     monkeypatch,
 ) -> None:
-    """A completed linked execution job must not keep showing a Ralph timeout blocker."""
+    """Execution job completion is not complete-product proof during Ralph."""
     state = _state_at_ralph_handoff(tmp_path, with_job_id=True)
     state.job_id = "job_execution_done"
     state.execution_id = "exec_done"
@@ -428,6 +428,50 @@ def test_mcp_auto_status_reconciles_completed_execution_over_ralph_timeout(
     state.mark_blocked("iteration_timeout", tool_name="ralph_starter")
     state.ralph_job_status = "failed"
     state.ralph_stop_reason = "iteration_timeout"
+    AutoStore(tmp_path).save(state)
+
+    class FakeJobManager:
+        async def get_snapshot(self, job_id: str) -> JobSnapshot:
+            assert job_id == state.job_id
+            now = datetime.now(UTC)
+            return JobSnapshot(
+                job_id=job_id,
+                job_type="execute_seed",
+                status=JobStatus.COMPLETED,
+                message="Execution complete: 15/15 ACs completed",
+                created_at=now,
+                updated_at=now,
+                links=JobLinks(session_id=state.run_session_id, execution_id=state.execution_id),
+            )
+
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.query_handlers.JobManager",
+        lambda: FakeJobManager(),
+    )
+
+    handler = SessionStatusHandler(auto_store=AutoStore(tmp_path))
+    result = asyncio.run(handler.handle({"session_id": state.auto_session_id}))
+
+    assert result.is_ok
+    assert result.value.meta["phase"] == "blocked"
+    assert result.value.meta["is_terminal"] is True
+    assert result.value.meta["blocker"] == "iteration_timeout"
+    assert result.value.meta["ralph"]["status"] == "failed"
+    assert result.value.meta["ralph"]["stop_reason"] == "iteration_timeout"
+    text = result.value.text_content
+    assert "Phase: blocked" in text
+    assert "Blocker: iteration_timeout" in text
+
+
+def test_mcp_auto_status_reconciles_completed_execution_without_ralph_handoff(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    """Legacy run-only auto sessions may complete from the linked run job."""
+    state = _state_at_run(tmp_path)
+    state.job_id = "job_execution_done"
+    state.execution_id = "exec_done"
+    state.run_session_id = "orch_done"
     AutoStore(tmp_path).save(state)
 
     class FakeJobManager:

--- a/tests/integration/test_codex_cli_passthrough_smoke.py
+++ b/tests/integration/test_codex_cli_passthrough_smoke.py
@@ -145,11 +145,11 @@ async def test_packaged_ooo_auto_missing_mcp_tool_fails_closed_without_codex_fal
     assert runtime._skill_dispatcher is not None
     with resolve_packaged_codex_skill_path("auto", skills_dir=runtime._skills_dir) as skill_md_path:
         content = skill_md_path.read_text(encoding="utf-8")
-    assert "mcp_tool: ouroboros_auto" in content
+    assert "mcp_tool: ouroboros_start_auto" in content
 
     fake_server = AsyncMock()
     fake_server.call_tool = AsyncMock(
-        side_effect=LookupError("No local handler registered for tool: ouroboros_auto")
+        side_effect=LookupError("No local handler registered for tool: ouroboros_start_auto")
     )
 
     with (
@@ -162,13 +162,13 @@ async def test_packaged_ooo_auto_missing_mcp_tool_fails_closed_without_codex_fal
         messages = [message async for message in runtime.execute_task("ooo auto Build a CLI")]
 
     fake_server.call_tool.assert_awaited_once()
-    assert fake_server.call_tool.await_args.args[0] == "ouroboros_auto"
+    assert fake_server.call_tool.await_args.args[0] == "ouroboros_start_auto"
     mock_exec.assert_not_called()
     mock_warning.assert_called_once()
     assert mock_warning.call_args.kwargs["fallback"] == "terminal_error"
     assert len(messages) == 1
     assert messages[0].is_error is True
     assert messages[0].content.startswith("Cannot run ooo auto")
-    assert "`ouroboros_auto` is unavailable" in messages[0].content
+    assert "`ouroboros_start_auto` is unavailable" in messages[0].content
     assert messages[0].data["error_type"] == "SkillDispatchUnavailable"
-    assert messages[0].data["tool_name"] == "ouroboros_auto"
+    assert messages[0].data["tool_name"] == "ouroboros_start_auto"

--- a/tests/unit/auto/test_adapters_ralph_poller.py
+++ b/tests/unit/auto/test_adapters_ralph_poller.py
@@ -28,7 +28,7 @@ async def test_handler_ralph_poller_propagates_terminal_generation_metadata(
     handler = _FakeRalphHandler()
     poller = HandlerRalphPoller(handler)  # type: ignore[arg-type]
 
-    async def wait_for_terminal(_job_manager: Any, job_id: str) -> dict[str, Any]:
+    async def wait_for_terminal(_job_manager: Any, job_id: str, **_kwargs: Any) -> dict[str, Any]:
         assert job_id == "job_ralph_existing"
         return {
             "status": "completed",
@@ -60,7 +60,7 @@ async def test_handler_ralph_poller_prefers_generations_over_iterations(
     handler = _FakeRalphHandler()
     poller = HandlerRalphPoller(handler)  # type: ignore[arg-type]
 
-    async def wait_for_terminal(_job_manager: Any, job_id: str) -> dict[str, Any]:
+    async def wait_for_terminal(_job_manager: Any, job_id: str, **_kwargs: Any) -> dict[str, Any]:
         assert job_id == "job_ralph_existing"
         return {
             "status": "completed",

--- a/tests/unit/auto/test_pipeline_evaluate.py
+++ b/tests/unit/auto/test_pipeline_evaluate.py
@@ -728,10 +728,52 @@ async def test_handler_ralph_starter_returns_result_text() -> None:
     starter = HandlerRalphStarter(  # type: ignore[arg-type]
         _StubRalphHandler(), project_dir="/tmp/auto-project"
     )
-    result = await starter(_build_seed(), lineage_id="lineage_X")
+    result = await starter(
+        _build_seed(),
+        lineage_id="lineage_X",
+        return_after_dispatch=False,
+    )
     assert result["result_text"] == "ralph artifact text"
     assert result["terminal_status"] == "completed"
     assert captured_arguments["project_dir"] == "/tmp/auto-project"
+
+
+@pytest.mark.asyncio
+async def test_handler_ralph_starter_detaches_by_default() -> None:
+    """Production Ralph handoff must not wait for terminal job completion unless
+    a caller explicitly opts into the old blocking behavior."""
+    from ouroboros.auto.adapters import HandlerRalphStarter
+
+    class _StubJobManager:
+        async def get_snapshot(self, _job_id: str):  # pragma: no cover
+            raise AssertionError("default Ralph starter must not poll terminal status")
+
+    class _StubRalphHandler:
+        _job_manager = _StubJobManager()
+
+        async def handle(self, _arguments: dict[str, Any]):  # noqa: ANN201
+            from ouroboros.core.types import Result
+            from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="dispatched"),),
+                    is_error=False,
+                    meta={
+                        "job_id": "job_ralph_async",
+                        "lineage_id": "lineage_async",
+                        "dispatch_mode": "job",
+                        "status": "running",
+                    },
+                )
+            )
+
+    starter = HandlerRalphStarter(_StubRalphHandler())  # type: ignore[arg-type]
+    result = await starter(_build_seed(), lineage_id="lineage_async")
+
+    assert result["job_id"] == "job_ralph_async"
+    assert result["terminal_status"] == "running_async"
+    assert result["stop_reason"] == "foreground_timeout_elapsed"
 
 
 # ---------------------------------------------------------------------------
@@ -1114,7 +1156,11 @@ async def test_handler_ralph_starter_preserves_empty_result_text() -> None:
             )
 
     starter = HandlerRalphStarter(_StubRalphHandler())  # type: ignore[arg-type]
-    result = await starter(_build_seed(), lineage_id="lineage_empty")
+    result = await starter(
+        _build_seed(),
+        lineage_id="lineage_empty",
+        return_after_dispatch=False,
+    )
     # Critical: result_text must be ``""`` (a string), NOT None.
     assert result["result_text"] == ""
     assert isinstance(result["result_text"], str)

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -1015,6 +1015,39 @@ async def test_ralph_handoff_uses_default_per_iteration_with_ample_budget(tmp_pa
     assert forwarded["per_iteration_timeout_seconds"] == 1800.0
 
 
+@pytest.mark.asyncio
+async def test_fresh_ralph_handoff_running_async_returns_detached(tmp_path) -> None:
+    """Fresh production Ralph dispatch may return a tracked non-terminal job."""
+    state = _state_at_run_phase(tmp_path)
+
+    async def ralph_starter(_seed: Seed, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "job_id": "job_ralph_async",
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "running_async",
+            "stop_reason": "foreground_timeout_elapsed",
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "detached"
+    assert state.phase is AutoPhase.RALPH_HANDOFF
+    assert state.ralph_job_id == "job_ralph_async"
+    assert state.ralph_job_status == "running_async"
+    assert state.ralph_stop_reason == "foreground_timeout_elapsed"
+    assert state.last_error is None
+
+
 # ---------------------------------------------------------------------------
 # Persisted complete_product intent (review-3 finding 2).
 # ---------------------------------------------------------------------------

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -105,7 +105,7 @@ def test_auto_skill_frontmatter_dispatches_to_mcp_tool() -> None:
     content = skill.read_text(encoding="utf-8")
 
     assert "name: auto" in content
-    assert "mcp_tool: ouroboros_auto" in content
+    assert "mcp_tool: ouroboros_start_auto" in content
     assert 'goal: "$goal"' in content
     assert 'resume: "$resume"' in content
     assert 'skip_run: "$skip_run"' in content

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -30,6 +30,17 @@ def test_auto_help_uses_direct_goal_command_shape() -> None:
     assert "Goal/task for ooo auto" in output
 
 
+def test_auto_help_documents_detached_wait_and_retrieve_commands() -> None:
+    result = runner.invoke(app, ["auto", "--help"])
+
+    assert result.exit_code == 0
+    output = _plain(result.output)
+    assert "Detached auto background work is non-terminal tracked work" in output
+    assert "ouroboros job wait JOB_ID" in output
+    assert "Retrieve completed results with:" in output
+    assert "ouroboros job result JOB_ID" in output
+
+
 def test_auto_goal_skip_run_does_not_require_subcommand() -> None:
     result_value = AutoPipelineResult(
         status="complete",
@@ -51,6 +62,122 @@ def test_auto_goal_skip_run_does_not_require_subcommand() -> None:
     assert run_auto.called
     assert "Auto session:" in result.output
     assert "auto_test" in result.output
+
+
+def test_auto_detached_start_output_includes_handles_and_wait_retrieve_guidance() -> None:
+    def result_value() -> AutoPipelineResult:
+        return AutoPipelineResult(
+            status="detached",
+            auto_session_id="auto_detached_123",
+            phase=AutoPhase.RALPH_HANDOFF.value,
+            grade="A",
+            seed_path="/tmp/seed.yaml",
+            job_id="job_execute_123",
+            execution_id="exec_detached_123",
+            run_session_id="orch_detached_123",
+            run_handoff_status="started",
+            ralph_job_id="job_ralph_456",
+            ralph_lineage_id="lineage_ralph_789",
+            ralph_dispatch_mode="job",
+        )
+
+    def consume(coro):
+        coro.close()
+        return result_value()
+
+    with patch("ouroboros.cli.commands.auto.asyncio.run", side_effect=consume):
+        first = runner.invoke(app, ["auto", "safe detached goal", "--complete-product"])
+        second = runner.invoke(app, ["auto", "safe detached goal", "--complete-product"])
+
+    assert first.exit_code == 0
+    assert second.exit_code == 0
+    output = _plain(first.output)
+    assert output == _plain(second.output)
+    assert not re.search(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]", output)
+    assert "Last progress at:" not in output
+    assert "Attached at:" not in output
+    assert "Run reconciled at:" not in output
+    assert output == (
+        "╭───────── Info ─────────╮\n"
+        "│ Auto pipeline detached │\n"
+        "╰────────────────────────╯\n"
+        "Auto session: auto_detached_123\n"
+        "Status: detached\n"
+        "Product status: not verified complete; background work is still running\n"
+        "Authoring backend: in-process (unspecified)\n"
+        "Run backend: unspecified\n"
+        "Seed grade: A\n"
+        "Seed: /tmp/seed.yaml\n"
+        "Seed origin: none\n"
+        "Execution started:\n"
+        "  Job ID: job_execute_123\n"
+        "  Execution ID: exec_detached_123\n"
+        "  Session ID: orch_detached_123\n"
+        "Run handoff status: started\n"
+        "Detached result handles:\n"
+        "  Auto session ID: auto_detached_123\n"
+        "  Execution job ID: job_execute_123\n"
+        "  Ralph job ID: job_ralph_456\n"
+        "  Ralph lineage ID: lineage_ralph_789\n"
+        "Wait: ooo auto --resume auto_detached_123\n"
+        "Retrieve: ooo auto --status --resume auto_detached_123\n"
+        "Wait job (CLI): ouroboros job wait job_ralph_456\n"
+        "Retrieve job (CLI): ouroboros job result job_ralph_456\n"
+        'Wait job (MCP): ouroboros_job_wait(job_id="job_ralph_456")\n'
+        'Retrieve job (MCP): ouroboros_job_result(job_id="job_ralph_456")\n'
+        "Resume: ooo auto --resume auto_detached_123\n"
+    )
+    assert "Auto pipeline detached" in output
+    assert "Status: detached" in output
+    assert "Product status: not verified complete; background work is still running" in output
+    assert "Auto pipeline completed" not in output
+    assert "Auto session: auto_detached_123" in output
+    assert "Execution started:" in output
+    assert "Job ID: job_execute_123" in output
+    assert "Execution ID: exec_detached_123" in output
+    assert "Session ID: orch_detached_123" in output
+    assert "Run handoff status: started" in output
+    assert "Detached result handles:" in output
+    assert "Auto session ID: auto_detached_123" in output
+    assert "Execution job ID: job_execute_123" in output
+    assert "Ralph job ID: job_ralph_456" in output
+    assert "Ralph lineage ID: lineage_ralph_789" in output
+    assert "Wait: ooo auto --resume auto_detached_123" in output
+    assert "Retrieve: ooo auto --status --resume auto_detached_123" in output
+    assert "Wait job (CLI): ouroboros job wait job_ralph_456" in output
+    assert "Retrieve job (CLI): ouroboros job result job_ralph_456" in output
+    assert 'Wait job (MCP): ouroboros_job_wait(job_id="job_ralph_456")' in output
+    assert 'Retrieve job (MCP): ouroboros_job_result(job_id="job_ralph_456")' in output
+
+
+def test_auto_detached_start_output_includes_pollable_cli_job_handle() -> None:
+    """Runnable CLI check for the detached auto job handle printed at start."""
+    result_value = AutoPipelineResult(
+        status="detached",
+        auto_session_id="auto_pollable_start",
+        phase=AutoPhase.RALPH_HANDOFF.value,
+        grade="A",
+        seed_path="/tmp/seed.yaml",
+        job_id="job_execute_pollable",
+        ralph_job_id="job_ralph_pollable",
+        ralph_lineage_id="lineage_pollable",
+        ralph_dispatch_mode="job",
+    )
+
+    def consume(coro):
+        coro.close()
+        return result_value
+
+    with patch("ouroboros.cli.commands.auto.asyncio.run", side_effect=consume):
+        result = runner.invoke(app, ["auto", "safe detached goal", "--complete-product"])
+
+    output = _plain(result.output)
+    assert result.exit_code == 0
+    assert "Status: detached" in output
+    assert "Detached result handles:" in output
+    assert "Ralph job ID: job_ralph_pollable" in output
+    assert "Wait job (CLI): ouroboros job wait job_ralph_pollable" in output
+    assert "Retrieve job (CLI): ouroboros job result job_ralph_pollable" in output
 
 
 def _persisted_state_with_bounds(tmp_path, *, max_interview_rounds: int, max_repair_rounds: int):

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -65,7 +65,7 @@ class TestCodexDoctor:
         rules_path = codex_dir / "rules" / "ouroboros.md"
         rules_path.parent.mkdir(parents=True, exist_ok=True)
         rules_path.write_text(
-            "| `ooo auto ...` | `ouroboros_auto` |\n"
+            "| `ooo auto ...` | `ouroboros_start_auto` |\n"
             "Do not emulate it with manual work. If unavailable, stop.\n",
             encoding="utf-8",
         )
@@ -621,7 +621,7 @@ class TestCodexDoctor:
 
         failures = _check_auto_dispatch_surface(codex_dir)
 
-        assert "Codex rules do not map `ooo auto` to `ouroboros_auto`" in failures
+        assert "Codex rules do not map `ooo auto` to `ouroboros_start_auto`" in failures
         assert "auto skill does not declare `mcp_tool: ouroboros_auto`" in failures
         assert "Codex config does not contain [mcp_servers.ouroboros]" in failures
 

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -75,7 +75,7 @@ class TestCodexDoctor:
         skill_path.write_text(
             "---\n"
             "name: auto\n"
-            "mcp_tool: ouroboros_auto\n"
+            "mcp_tool: ouroboros_start_auto\n"
             "---\n"
             "Manual fallback is not allowed when the tool is unavailable.\n",
             encoding="utf-8",
@@ -622,7 +622,7 @@ class TestCodexDoctor:
         failures = _check_auto_dispatch_surface(codex_dir)
 
         assert "Codex rules do not map `ooo auto` to `ouroboros_start_auto`" in failures
-        assert "auto skill does not declare `mcp_tool: ouroboros_auto`" in failures
+        assert "auto skill does not declare `mcp_tool: ouroboros_start_auto`" in failures
         assert "Codex config does not contain [mcp_servers.ouroboros]" in failures
 
     def test_doctor_command_exits_nonzero_when_dispatch_surface_is_broken(

--- a/tests/unit/cli/test_detached_auto_wait_command.py
+++ b/tests/unit/cli/test_detached_auto_wait_command.py
@@ -1,0 +1,433 @@
+"""Focused tests for detached auto wait CLI observability."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+import json
+import re
+
+from typer.testing import CliRunner
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
+from ouroboros.mcp.tools.job_handlers import JobResultHandler, JobWaitHandler
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.persistence.event_store import EventStore
+
+runner = CliRunner()
+
+
+def test_cli_detached_auto_wait_reports_in_progress_background_work(monkeypatch, tmp_path) -> None:
+    """Verify the wait command gives stable status for running detached auto work."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'detached-auto-wait.db'}"
+    job_id = "job_auto_wait_running_focus"
+    session_id = "auto_session_wait_running_focus"
+    timestamp = datetime(2026, 5, 29, 12, 0, tzinfo=UTC)
+
+    async def _persist_running_detached_auto_job() -> None:
+        store = EventStore(db_url)
+        await store.initialize()
+        try:
+            await store.append(
+                BaseEvent(
+                    id="evt_auto_wait_created",
+                    type="mcp.job.created",
+                    timestamp=timestamp,
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "job_type": "auto",
+                        "status": JobStatus.QUEUED.value,
+                        "message": "Queued detached auto",
+                        "links": {
+                            "session_id": session_id,
+                            "execution_id": None,
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    id="evt_auto_wait_running",
+                    type="mcp.job.updated",
+                    timestamp=timestamp,
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "status": JobStatus.RUNNING.value,
+                        "message": "Running auto",
+                        "links": {
+                            "session_id": session_id,
+                            "execution_id": None,
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+        finally:
+            await store.close()
+
+    asyncio.run(_persist_running_detached_auto_job())
+
+    monkeypatch.setattr(
+        job_command,
+        "JobWaitHandler",
+        lambda: JobWaitHandler(event_store=EventStore(db_url)),
+    )
+
+    command = ["job", "wait", job_id, "--cursor", "2", "--timeout-seconds", "0"]
+    result = runner.invoke(app, command)
+    repeated = runner.invoke(app, command)
+
+    expected_output = (
+        f"## Job: {job_id}\n"
+        "\n"
+        "**Type**: auto\n"
+        "**Status**: running\n"
+        "**Terminal**: false\n"
+        "**Status Category**: non_terminal\n"
+        "**Tracking**: detached auto tracked background work\n"
+        "**Message**: Running auto\n"
+        "**Cursor**: 2\n"
+        "\n"
+        "### Links\n"
+        f"**Session ID**: {session_id}\n"
+        "\n"
+        "No new job-level events during this wait window.\n"
+    )
+
+    assert result.exit_code == 0
+    assert repeated.exit_code == 0
+    assert result.output == expected_output
+    assert repeated.output == expected_output
+    assert "Use `ouroboros_job_result` to fetch the full terminal output." not in result.output
+    assert not re.search(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]", result.output)
+
+
+def test_cli_detached_auto_wait_invalid_handle_fails_with_actionable_error(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify wait fails stably for an unknown detached auto handle."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'missing-detached-auto-wait.db'}"
+    invalid_job_id = "missing_detached_auto_wait"
+
+    monkeypatch.setattr(
+        job_command,
+        "JobWaitHandler",
+        lambda: JobWaitHandler(event_store=EventStore(db_url)),
+    )
+
+    command = ["job", "wait", invalid_job_id, "--timeout-seconds", "0"]
+    result = runner.invoke(app, command)
+    repeated = runner.invoke(app, command)
+
+    assert result.exit_code == 1
+    assert repeated.exit_code == 1
+    assert repeated.output == result.output
+    assert f"Job not found: {invalid_job_id}. Wait unavailable." in result.output
+    assert "Check the job" in result.output
+    assert "handle returned by detached auto start" in result.output
+    assert "ouroboros job wait" in result.output
+    assert invalid_job_id in result.output
+    assert "**Status**: completed" not in result.output
+    assert "**Terminal**: true" not in result.output
+    assert "Use `ouroboros_job_result` to fetch the full terminal output." not in result.output
+    assert not re.search(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]", result.output)
+
+
+def test_cli_detached_auto_wait_failed_job_exits_nonzero_with_stable_error(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify a failed detached auto wait command is observable and non-zero."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'failed-detached-auto-wait.db'}"
+
+    async def _failed_auto_runner() -> MCPToolResult:
+        return MCPToolResult(
+            content=(
+                MCPContentItem(
+                    type=ContentType.TEXT,
+                    text="detached auto failed\nstatus=failed\nterminal=true",
+                ),
+            ),
+            is_error=True,
+            meta={
+                "auto_session_id": "auto_session_failed_wait_focus",
+                "status": "failed",
+                "error_code": "seed_gate_failed",
+            },
+        )
+
+    async def _persist_failed_detached_auto_job() -> str:
+        store = EventStore(db_url)
+        manager = JobManager(store)
+        try:
+            started = await manager.start_job(
+                job_type="auto",
+                initial_message="Queued detached auto",
+                runner=_failed_auto_runner(),
+                links=JobLinks(session_id="auto_session_failed_wait_focus"),
+            )
+            deadline = asyncio.get_running_loop().time() + 1
+            snapshot = await manager.get_snapshot(started.job_id)
+            while snapshot.status is not JobStatus.FAILED:
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise AssertionError(
+                        f"job {started.job_id} did not fail; last={snapshot.status}"
+                    )
+                await asyncio.sleep(0.01)
+                snapshot = await manager.get_snapshot(started.job_id)
+            return started.job_id
+        finally:
+            await store.close()
+
+    job_id = asyncio.run(_persist_failed_detached_auto_job())
+
+    monkeypatch.setattr(
+        job_command,
+        "JobWaitHandler",
+        lambda: JobWaitHandler(event_store=EventStore(db_url)),
+    )
+
+    command = ["job", "wait", job_id, "--timeout-seconds", "0"]
+    result = runner.invoke(app, command)
+    repeated = runner.invoke(app, command)
+
+    assert result.exit_code == 1
+    assert repeated.exit_code == 1
+    assert repeated.output == result.output
+    assert f"## Job: {job_id}" in result.output
+    assert "**Type**: auto" in result.output
+    assert "**Status**: failed" in result.output
+    assert "**Terminal**: true" in result.output
+    assert "**Status Category**: terminal" in result.output
+    assert "**Message**: Job failed" in result.output
+    assert "**Session ID**: auto_session_failed_wait_focus" in result.output
+    assert "Use `ouroboros_job_result` to fetch the full terminal output." in result.output
+    assert "detached auto tracked background work" not in result.output
+    assert "status=completed" not in result.output
+    assert not re.search(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]", result.output)
+
+
+def test_cli_detached_auto_result_invalid_handle_fails_stably(monkeypatch, tmp_path) -> None:
+    """Verify result retrieval fails deterministically for an invalid auto handle."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'missing-detached-auto-result.db'}"
+    invalid_job_id = "missing_detached_auto"
+
+    monkeypatch.setattr(
+        job_command,
+        "JobResultHandler",
+        lambda: JobResultHandler(event_store=EventStore(db_url)),
+    )
+
+    command = ["job", "result", invalid_job_id]
+    result = runner.invoke(app, command)
+    repeated = runner.invoke(app, command)
+
+    expected_message = f"Job handle not found: {invalid_job_id}. Result unavailable."
+
+    assert result.exit_code == 1
+    assert repeated.exit_code == 1
+    assert repeated.output == result.output
+    assert expected_message in result.output
+    assert not re.search(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]", result.output)
+
+
+def test_cli_detached_auto_result_missing_run_is_actionable_not_terminal_success(
+    monkeypatch, tmp_path
+) -> None:
+    """Independently verify missing detached result retrieval fails usefully."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'unknown-detached-auto-result.db'}"
+    unknown_job_id = "unknown_detached_auto_result"
+
+    monkeypatch.setattr(
+        job_command,
+        "JobResultHandler",
+        lambda: JobResultHandler(event_store=EventStore(db_url)),
+    )
+
+    command = ["job", "result", unknown_job_id]
+    first = runner.invoke(app, command)
+    second = runner.invoke(app, command)
+
+    expected_message = f"Job handle not found: {unknown_job_id}. Result unavailable."
+
+    assert first.exit_code == 1
+    assert second.exit_code == 1
+    assert second.output == first.output
+    assert expected_message in first.output
+    assert "Job handle" in first.output
+    assert "Result unavailable" in first.output
+    assert unknown_job_id in first.output
+    assert "**Status**: completed" not in first.output
+    assert "**Terminal**: true" not in first.output
+    assert "status=completed" not in first.output
+    assert "terminal=true" not in first.output
+    assert "Use `ouroboros_job_result` to fetch the full terminal output." not in first.output
+    assert not re.search(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]", first.output)
+
+
+def test_cli_detached_auto_result_returns_completed_artifact(monkeypatch, tmp_path) -> None:
+    """Verify the focused CLI result command retrieves completed detached auto output."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'completed-detached-auto-result.db'}"
+
+    async def _completed_auto_runner() -> MCPToolResult:
+        return MCPToolResult(
+            content=(
+                MCPContentItem(
+                    type=ContentType.TEXT,
+                    text=(
+                        "detached auto completed result\n"
+                        "status=completed\n"
+                        "terminal=true\n"
+                        "artifact=seed.yaml"
+                    ),
+                ),
+            ),
+            meta={"auto_session_id": "auto_session_result_focus"},
+        )
+
+    async def _persist_completed_detached_auto_job() -> str:
+        store = EventStore(db_url)
+        manager = JobManager(store)
+        try:
+            started = await manager.start_job(
+                job_type="auto",
+                initial_message="Queued detached auto",
+                runner=_completed_auto_runner(),
+                links=JobLinks(session_id="auto_session_result_focus"),
+            )
+            deadline = asyncio.get_running_loop().time() + 1
+            snapshot = await manager.get_snapshot(started.job_id)
+            while snapshot.status is not JobStatus.COMPLETED:
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise AssertionError(
+                        f"job {started.job_id} did not complete; last={snapshot.status}"
+                    )
+                await asyncio.sleep(0.01)
+                snapshot = await manager.get_snapshot(started.job_id)
+            return started.job_id
+        finally:
+            await store.close()
+
+    job_id = asyncio.run(_persist_completed_detached_auto_job())
+
+    monkeypatch.setattr(
+        job_command,
+        "JobResultHandler",
+        lambda: JobResultHandler(event_store=EventStore(db_url)),
+    )
+
+    command = ["job", "result", job_id]
+    result = runner.invoke(app, command)
+    repeated = runner.invoke(app, command)
+
+    expected_output = (
+        "detached auto completed result\nstatus=completed\nterminal=true\nartifact=seed.yaml\n"
+    )
+
+    assert result.exit_code == 0
+    assert repeated.exit_code == 0
+    assert result.output == expected_output
+    assert repeated.output == expected_output
+    assert not re.search(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]", result.output)
+
+
+def test_cli_detached_auto_result_returns_stable_failure_error_payload(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify completed failure retrieval exposes a stable minimal error payload."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'failed-detached-auto-result.db'}"
+    error_payload = {
+        "status": "failed",
+        "terminal": True,
+        "error": {
+            "code": "seed_gate_failed",
+            "message": "Seed gate failed",
+        },
+    }
+
+    async def _failed_auto_runner() -> MCPToolResult:
+        return MCPToolResult(
+            content=(
+                MCPContentItem(
+                    type=ContentType.TEXT,
+                    text=json.dumps(error_payload, sort_keys=True),
+                ),
+            ),
+            is_error=True,
+            meta={
+                "auto_session_id": "auto_session_failed_result_focus",
+                "status": "failed",
+                "error_code": "seed_gate_failed",
+            },
+        )
+
+    async def _persist_failed_detached_auto_job() -> str:
+        store = EventStore(db_url)
+        manager = JobManager(store)
+        try:
+            started = await manager.start_job(
+                job_type="auto",
+                initial_message="Queued detached auto",
+                runner=_failed_auto_runner(),
+                links=JobLinks(session_id="auto_session_failed_result_focus"),
+            )
+            deadline = asyncio.get_running_loop().time() + 1
+            snapshot = await manager.get_snapshot(started.job_id)
+            while snapshot.status is not JobStatus.FAILED:
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise AssertionError(
+                        f"job {started.job_id} did not fail; last={snapshot.status}"
+                    )
+                await asyncio.sleep(0.01)
+                snapshot = await manager.get_snapshot(started.job_id)
+            return started.job_id
+        finally:
+            await store.close()
+
+    job_id = asyncio.run(_persist_failed_detached_auto_job())
+
+    monkeypatch.setattr(
+        job_command,
+        "JobResultHandler",
+        lambda: JobResultHandler(event_store=EventStore(db_url)),
+    )
+
+    command = ["job", "result", job_id]
+    result = runner.invoke(app, command)
+    repeated = runner.invoke(app, command)
+
+    assert result.exit_code == 1
+    assert repeated.exit_code == 1
+    assert repeated.output == result.output
+    assert json.loads(result.output) == error_payload
+    assert set(json.loads(result.output)) == {"status", "terminal", "error"}
+    assert set(json.loads(result.output)["error"]) == {"code", "message"}
+    assert "seed_gate_failed" in result.output
+    assert "Seed gate failed" in result.output
+    assert "status=completed" not in result.output
+    assert "artifact=seed.yaml" not in result.output
+    assert not re.search(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]", result.output)

--- a/tests/unit/cli/test_job_command.py
+++ b/tests/unit/cli/test_job_command.py
@@ -1,0 +1,813 @@
+"""Tests for the documented background job CLI surface."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+import re
+
+from typer.testing import CliRunner
+
+from ouroboros.core.types import Result
+from ouroboros.events.base import BaseEvent
+from ouroboros.mcp.errors import MCPToolError
+from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
+from ouroboros.mcp.tools.job_handlers import JobResultHandler, JobStatusHandler, JobWaitHandler
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.persistence.event_store import EventStore
+
+runner = CliRunner()
+
+
+class _OkStatusHandler:
+    async def handle(self, arguments):
+        assert arguments == {"job_id": "job_123", "view": "compact"}
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="job_123 | running"),),
+                meta={"job_id": "job_123", "status": "running"},
+            )
+        )
+
+
+class _OkWaitHandler:
+    async def handle(self, arguments):
+        assert arguments == {
+            "job_id": "job_123",
+            "cursor": 7,
+            "timeout_seconds": 0,
+            "view": "summary",
+            "stream": "progress",
+        }
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="unchanged cursor=7"),),
+                meta={"job_id": "job_123", "status": "running", "cursor": 7},
+            )
+        )
+
+
+class _CompletedAutoWaitHandler:
+    async def handle(self, arguments):
+        assert arguments == {
+            "job_id": "job_auto_done",
+            "cursor": 0,
+            "timeout_seconds": 0,
+            "view": "full",
+            "stream": "progress",
+        }
+        return Result.ok(
+            MCPToolResult(
+                content=(
+                    MCPContentItem(
+                        type=ContentType.TEXT,
+                        text=(
+                            "## Job: job_auto_done\n\n"
+                            "**Type**: auto\n"
+                            "**Status**: completed\n"
+                            "**Message**: Job complete\n"
+                            "**Cursor**: 42\n"
+                            "\n### Result\n"
+                            "Use `ouroboros_job_result` to fetch the full terminal output."
+                        ),
+                    ),
+                ),
+                meta={
+                    "job_id": "job_auto_done",
+                    "status": "completed",
+                    "cursor": 42,
+                    "changed": True,
+                    "session_id": "auto_session_done",
+                },
+            )
+        )
+
+
+class _RunningAutoWaitHandler:
+    async def handle(self, arguments):
+        assert arguments == {
+            "job_id": "job_auto_running",
+            "cursor": 0,
+            "timeout_seconds": 0,
+            "view": "full",
+            "stream": "progress",
+        }
+        return Result.ok(
+            MCPToolResult(
+                content=(
+                    MCPContentItem(
+                        type=ContentType.TEXT,
+                        text=(
+                            "## Job: job_auto_running\n\n"
+                            "**Type**: auto\n"
+                            "**Status**: running\n"
+                            "**Terminal**: false\n"
+                            "**Message**: Auto pipeline still running\n"
+                            "**Cursor**: 11\n"
+                            "\nNo new job-level events during this wait window."
+                        ),
+                    ),
+                ),
+                meta={
+                    "job_id": "job_auto_running",
+                    "status": "running",
+                    "cursor": 11,
+                    "changed": False,
+                    "session_id": "auto_session_running",
+                },
+            )
+        )
+
+
+class _OkResultHandler:
+    async def handle(self, arguments):
+        assert arguments == {"job_id": "job_123"}
+        return Result.ok(
+            MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="final auto result"),),
+                meta={"job_id": "job_123", "status": "completed"},
+            )
+        )
+
+
+class _MissingJobHandler:
+    async def handle(self, arguments):
+        assert arguments == {"job_id": "missing", "view": "full"}
+        return Result.err(MCPToolError("Job not found: missing", tool_name="ouroboros_job_status"))
+
+
+class _InvalidWaitHandler:
+    async def handle(self, arguments):
+        assert arguments == {
+            "job_id": "job_123",
+            "cursor": 0,
+            "timeout_seconds": -1,
+            "view": "full",
+            "stream": "progress",
+        }
+        return Result.err(
+            MCPToolError(
+                "timeout_seconds must be a non-negative integer",
+                tool_name="ouroboros_job_wait",
+            )
+        )
+
+
+def test_documented_job_status_command_exits_zero(monkeypatch) -> None:
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    monkeypatch.setattr(job_command, "JobStatusHandler", _OkStatusHandler)
+
+    result = runner.invoke(app, ["job", "status", "job_123", "--view", "compact"])
+
+    assert result.exit_code == 0
+    assert "job_123 | running" in result.output
+
+
+def test_documented_job_wait_command_exits_zero(monkeypatch) -> None:
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    monkeypatch.setattr(job_command, "JobWaitHandler", _OkWaitHandler)
+
+    result = runner.invoke(
+        app,
+        ["job", "wait", "job_123", "--cursor", "7", "--view", "summary"],
+    )
+
+    assert result.exit_code == 0
+    assert "unchanged cursor=7" in result.output
+
+
+def test_detached_auto_job_wait_command_reports_completed_status(monkeypatch) -> None:
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    monkeypatch.setattr(job_command, "JobWaitHandler", _CompletedAutoWaitHandler)
+
+    result = runner.invoke(app, ["job", "wait", "job_auto_done"])
+
+    assert result.exit_code == 0
+    assert "## Job: job_auto_done" in result.output
+    assert "**Type**: auto" in result.output
+    assert "**Status**: completed" in result.output
+    assert "**Cursor**: 42" in result.output
+    assert "Use `ouroboros_job_result` to fetch the full terminal output." in result.output
+
+
+def test_detached_auto_job_wait_command_reports_running_non_terminal_status(
+    monkeypatch,
+) -> None:
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    monkeypatch.setattr(job_command, "JobWaitHandler", _RunningAutoWaitHandler)
+
+    result = runner.invoke(app, ["job", "wait", "job_auto_running"])
+
+    assert result.exit_code == 0
+    assert "## Job: job_auto_running" in result.output
+    assert "**Type**: auto" in result.output
+    assert "**Status**: running" in result.output
+    assert "**Terminal**: false" in result.output
+    assert "**Message**: Auto pipeline still running" in result.output
+    assert "**Cursor**: 11" in result.output
+    assert "No new job-level events during this wait window." in result.output
+    assert "Use `ouroboros_job_result` to fetch the full terminal output." not in result.output
+
+
+def test_detached_auto_job_status_command_reports_tracked_running_work(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify CLI status reconstructs non-terminal detached auto background work."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'running-detached-auto-jobs.db'}"
+    job_id = "job_auto_running_status"
+    auto_session_id = "auto_cli_running_status"
+
+    async def _persist_running_auto_job() -> None:
+        store = EventStore(db_url)
+        await store.initialize()
+        try:
+            await store.append(
+                BaseEvent(
+                    type="mcp.job.created",
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "job_type": "auto",
+                        "status": JobStatus.QUEUED.value,
+                        "message": "Queued detached auto",
+                        "links": {
+                            "session_id": auto_session_id,
+                            "execution_id": None,
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="mcp.job.updated",
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "status": JobStatus.RUNNING.value,
+                        "message": "Running auto",
+                        "links": {
+                            "session_id": auto_session_id,
+                            "execution_id": None,
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+        finally:
+            await store.close()
+
+    asyncio.run(_persist_running_auto_job())
+
+    monkeypatch.setattr(
+        job_command,
+        "JobStatusHandler",
+        lambda: JobStatusHandler(event_store=EventStore(db_url)),
+    )
+
+    result = runner.invoke(app, ["job", "status", job_id])
+
+    assert result.exit_code == 0
+    assert f"## Job: {job_id}" in result.output
+    assert "**Type**: auto" in result.output
+    assert "**Status**: running" in result.output
+    assert "**Terminal**: false" in result.output
+    assert "**Status Category**: non_terminal" in result.output
+    assert "**Tracking**: detached auto tracked background work" in result.output
+    assert "**Message**: Running auto" in result.output
+    assert f"**Session ID**: {auto_session_id}" in result.output
+    assert "Use `ouroboros_job_result` to fetch the full terminal output." not in result.output
+
+
+def test_detached_auto_job_wait_stdout_is_deterministic_for_identical_inputs(
+    monkeypatch, tmp_path
+) -> None:
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'detached-auto-stable.db'}"
+    job_id = "job_auto_stable"
+    auto_session_id = "auto_cli_stable"
+    timestamp = datetime(2026, 5, 29, 12, 0, tzinfo=UTC)
+
+    async def _persist_running_auto_job() -> None:
+        store = EventStore(db_url)
+        await store.initialize()
+        try:
+            await store.append(
+                BaseEvent(
+                    id="evt_auto_stable_created",
+                    type="mcp.job.created",
+                    timestamp=timestamp,
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "job_type": "auto",
+                        "status": JobStatus.QUEUED.value,
+                        "message": "Queued detached auto",
+                        "links": {
+                            "session_id": auto_session_id,
+                            "execution_id": None,
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    id="evt_auto_stable_running",
+                    type="mcp.job.updated",
+                    timestamp=timestamp,
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "status": JobStatus.RUNNING.value,
+                        "message": "Running auto",
+                        "links": {
+                            "session_id": auto_session_id,
+                            "execution_id": None,
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+        finally:
+            await store.close()
+
+    asyncio.run(_persist_running_auto_job())
+
+    monkeypatch.setattr(
+        job_command,
+        "JobWaitHandler",
+        lambda: JobWaitHandler(event_store=EventStore(db_url)),
+    )
+
+    command = ["job", "wait", job_id, "--timeout-seconds", "0"]
+    first = runner.invoke(app, command)
+    second = runner.invoke(app, command)
+
+    assert first.exit_code == 0
+    assert second.exit_code == 0
+    assert first.output == second.output
+    assert not re.search(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]", first.output)
+    assert "**Created**:" not in first.output
+    assert "**Updated**:" not in first.output
+    assert first.output == (
+        f"## Job: {job_id}\n"
+        "\n"
+        "**Type**: auto\n"
+        "**Status**: running\n"
+        "**Terminal**: false\n"
+        "**Status Category**: non_terminal\n"
+        "**Tracking**: detached auto tracked background work\n"
+        "**Message**: Running auto\n"
+        "**Cursor**: 2\n"
+        "\n"
+        "### Links\n"
+        f"**Session ID**: {auto_session_id}\n"
+    )
+    assert f"## Job: {job_id}" in first.output
+    assert "**Status**: running" in first.output
+    assert "**Terminal**: false" in first.output
+    assert "**Status Category**: non_terminal" in first.output
+    assert "No new job-level events during this wait window." not in first.output
+
+
+def test_documented_job_result_command_exits_zero(monkeypatch) -> None:
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    monkeypatch.setattr(job_command, "JobResultHandler", _OkResultHandler)
+
+    result = runner.invoke(app, ["job", "result", "job_123"])
+
+    assert result.exit_code == 0
+    assert "final auto result" in result.output
+
+
+def test_cli_retrieves_previously_tracked_detached_auto_result(monkeypatch, tmp_path) -> None:
+    """Verify CLI result retrieval reconstructs a completed detached auto job."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'detached-auto-jobs.db'}"
+
+    async def _detached_auto_runner() -> MCPToolResult:
+        await asyncio.sleep(0.01)
+        return MCPToolResult(
+            content=(
+                MCPContentItem(
+                    type=ContentType.TEXT,
+                    text=(
+                        "detached auto completed result\n"
+                        "status=completed\n"
+                        "terminal=true\n"
+                        "artifact=seed.yaml"
+                    ),
+                ),
+            ),
+            meta={
+                "auto_session_id": "auto_cli_later",
+                "completed_at": "2026-05-29T12:00:00+00:00",
+            },
+        )
+
+    async def _persist_completed_auto_job() -> str:
+        store = EventStore(db_url)
+        manager = JobManager(store)
+        try:
+            started = await manager.start_job(
+                job_type="auto",
+                initial_message="Queued auto",
+                runner=_detached_auto_runner(),
+                links=JobLinks(session_id="auto_cli_later"),
+            )
+            deadline = asyncio.get_running_loop().time() + 1
+            snapshot = await manager.get_snapshot(started.job_id)
+            while snapshot.status is not JobStatus.COMPLETED:
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise AssertionError(
+                        f"job {started.job_id} did not complete; last={snapshot.status}"
+                    )
+                await asyncio.sleep(0.01)
+                snapshot = await manager.get_snapshot(started.job_id)
+            return started.job_id
+        finally:
+            await store.close()
+
+    job_id = asyncio.run(_persist_completed_auto_job())
+
+    monkeypatch.setattr(
+        job_command,
+        "JobResultHandler",
+        lambda: JobResultHandler(event_store=EventStore(db_url)),
+    )
+
+    result = runner.invoke(app, ["job", "result", job_id])
+    repeated = runner.invoke(app, ["job", "result", job_id])
+
+    assert result.exit_code == 0
+    assert repeated.exit_code == 0
+    assert repeated.output == result.output
+    assert result.output == (
+        "detached auto completed result\nstatus=completed\nterminal=true\nartifact=seed.yaml\n"
+    )
+    assert not re.search(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]", result.output)
+    assert "**Created**:" not in result.output
+    assert "**Updated**:" not in result.output
+
+
+def test_cli_retrieves_failed_detached_auto_result_distinct_from_success(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify documented CLI wait/result surfaces failed detached auto distinctly."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'failed-detached-auto-jobs.db'}"
+
+    async def _successful_auto_runner() -> MCPToolResult:
+        return MCPToolResult(
+            content=(
+                MCPContentItem(
+                    type=ContentType.TEXT,
+                    text=(
+                        "detached auto completed result\n"
+                        "status=completed\n"
+                        "terminal=true\n"
+                        "artifact=seed.yaml"
+                    ),
+                ),
+            ),
+            meta={"auto_session_id": "auto_cli_success", "status": "completed"},
+        )
+
+    async def _failed_auto_runner() -> MCPToolResult:
+        return MCPToolResult(
+            content=(
+                MCPContentItem(
+                    type=ContentType.TEXT,
+                    text=(
+                        "detached auto failed result\n"
+                        "status=failed\n"
+                        "terminal=true\n"
+                        "error=seed gate failed"
+                    ),
+                ),
+            ),
+            is_error=True,
+            meta={
+                "auto_session_id": "auto_cli_failed",
+                "status": "failed",
+                "error_code": "seed_gate_failed",
+            },
+        )
+
+    async def _wait_for_status(manager: JobManager, job_id: str, status: JobStatus) -> None:
+        deadline = asyncio.get_running_loop().time() + 1
+        snapshot = await manager.get_snapshot(job_id)
+        while snapshot.status is not status:
+            if asyncio.get_running_loop().time() >= deadline:
+                raise AssertionError(
+                    f"job {job_id} did not become {status}; last={snapshot.status}"
+                )
+            await asyncio.sleep(0.01)
+            snapshot = await manager.get_snapshot(job_id)
+
+    async def _persist_terminal_auto_jobs() -> tuple[str, str]:
+        store = EventStore(db_url)
+        manager = JobManager(store)
+        try:
+            successful = await manager.start_job(
+                job_type="auto",
+                initial_message="Queued successful auto",
+                runner=_successful_auto_runner(),
+                links=JobLinks(session_id="auto_cli_success"),
+            )
+            failed = await manager.start_job(
+                job_type="auto",
+                initial_message="Queued failed auto",
+                runner=_failed_auto_runner(),
+                links=JobLinks(session_id="auto_cli_failed"),
+            )
+            await _wait_for_status(manager, successful.job_id, JobStatus.COMPLETED)
+            await _wait_for_status(manager, failed.job_id, JobStatus.FAILED)
+            return successful.job_id, failed.job_id
+        finally:
+            await store.close()
+
+    success_job_id, failed_job_id = asyncio.run(_persist_terminal_auto_jobs())
+
+    monkeypatch.setattr(
+        job_command,
+        "JobWaitHandler",
+        lambda: JobWaitHandler(event_store=EventStore(db_url)),
+    )
+    monkeypatch.setattr(
+        job_command,
+        "JobResultHandler",
+        lambda: JobResultHandler(event_store=EventStore(db_url)),
+    )
+
+    failed_wait = runner.invoke(app, ["job", "wait", failed_job_id])
+    success_result = runner.invoke(app, ["job", "result", success_job_id])
+    failed_result = runner.invoke(app, ["job", "result", failed_job_id])
+    repeated_failed_result = runner.invoke(app, ["job", "result", failed_job_id])
+
+    assert failed_wait.exit_code == 1
+    assert f"## Job: {failed_job_id}" in failed_wait.output
+    assert "**Type**: auto" in failed_wait.output
+    assert "**Status**: failed" in failed_wait.output
+    assert "**Terminal**: true" in failed_wait.output
+    assert "Use `ouroboros_job_result` to fetch the full terminal output." in failed_wait.output
+
+    assert success_result.exit_code == 0
+    assert success_result.output == (
+        "detached auto completed result\nstatus=completed\nterminal=true\nartifact=seed.yaml\n"
+    )
+
+    assert failed_result.exit_code == 1
+    assert repeated_failed_result.exit_code == 1
+    assert repeated_failed_result.output == failed_result.output
+    assert failed_result.output == (
+        "detached auto failed result\nstatus=failed\nterminal=true\nerror=seed gate failed\n"
+    )
+    assert failed_result.output != success_result.output
+    assert "status=completed" not in failed_result.output
+    assert "artifact=seed.yaml" not in failed_result.output
+    assert not re.search(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]", failed_result.output)
+
+
+def test_cli_detached_auto_result_for_running_job_reports_not_ready(monkeypatch, tmp_path) -> None:
+    """Verify premature CLI result retrieval emits stable pending guidance."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'running-detached-auto-result.db'}"
+    job_id = "job_auto_result_running"
+    auto_session_id = "auto_cli_result_running"
+
+    async def _persist_running_auto_job() -> None:
+        store = EventStore(db_url)
+        await store.initialize()
+        try:
+            await store.append(
+                BaseEvent(
+                    type="mcp.job.created",
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "job_type": "auto",
+                        "status": JobStatus.QUEUED.value,
+                        "message": "Queued detached auto",
+                        "links": {
+                            "session_id": auto_session_id,
+                            "execution_id": None,
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    type="mcp.job.updated",
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "status": JobStatus.RUNNING.value,
+                        "message": "Running auto",
+                        "links": {
+                            "session_id": auto_session_id,
+                            "execution_id": None,
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+        finally:
+            await store.close()
+
+    asyncio.run(_persist_running_auto_job())
+
+    monkeypatch.setattr(
+        job_command,
+        "JobResultHandler",
+        lambda: JobResultHandler(event_store=EventStore(db_url)),
+    )
+
+    result = runner.invoke(app, ["job", "result", job_id])
+    repeated = runner.invoke(app, ["job", "result", job_id])
+
+    assert result.exit_code == 0
+    assert repeated.exit_code == 0
+    assert repeated.output == result.output
+    assert f"Job result not ready: {job_id}" in result.output
+    assert "status=running" in result.output
+    assert "terminal=false" in result.output
+    assert "detached auto job is still tracked background work" in result.output
+    assert f"wait: ouroboros job wait {job_id}" in result.output
+    assert f"retrieve after terminal status: ouroboros job result {job_id}" in result.output
+    assert f'mcp_wait: ouroboros_job_wait(job_id="{job_id}")' in result.output
+    assert f'mcp_result: ouroboros_job_result(job_id="{job_id}")' in result.output
+
+
+def test_cli_detached_auto_result_with_invalid_job_handle_exits_nonzero(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify CLI result retrieval fails clearly for an unknown detached job handle."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'missing-detached-auto-result.db'}"
+
+    monkeypatch.setattr(
+        job_command,
+        "JobResultHandler",
+        lambda: JobResultHandler(event_store=EventStore(db_url)),
+    )
+
+    result = runner.invoke(app, ["job", "result", "missing_detached_auto"])
+
+    assert result.exit_code == 1
+    assert "Job handle not found: missing_detached_auto. Result unavailable." in result.output
+
+
+def test_cli_detached_auto_result_with_expired_job_handle_exits_nonzero(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify CLI result retrieval fails clearly for an expired detached job handle."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'expired-detached-auto-result.db'}"
+    job_id = "job_auto_result_expired"
+    expired_at = datetime.now(UTC) - timedelta(hours=2)
+
+    async def _persist_expired_auto_job() -> None:
+        store = EventStore(db_url)
+        await store.initialize()
+        try:
+            await store.append(
+                BaseEvent(
+                    id="evt_expired_auto_created",
+                    type="mcp.job.created",
+                    timestamp=expired_at,
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "job_type": "auto",
+                        "status": JobStatus.QUEUED.value,
+                        "message": "Queued detached auto",
+                        "links": {
+                            "session_id": "auto_cli_result_expired",
+                            "execution_id": None,
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    id="evt_expired_auto_completed",
+                    type="mcp.job.completed",
+                    timestamp=expired_at + timedelta(seconds=1),
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "status": JobStatus.COMPLETED.value,
+                        "message": "Job complete",
+                        "result_text": "stale detached auto result",
+                        "result_meta": {"auto_session_id": "auto_cli_result_expired"},
+                        "is_error": False,
+                    },
+                )
+            )
+        finally:
+            await store.close()
+
+    asyncio.run(_persist_expired_auto_job())
+
+    monkeypatch.setattr(
+        job_command,
+        "JobResultHandler",
+        lambda: JobResultHandler(event_store=EventStore(db_url)),
+    )
+
+    result = runner.invoke(app, ["job", "result", job_id])
+
+    assert result.exit_code == 1
+    assert f"Job handle expired: {job_id}" in result.output
+    assert "Result unavailable." in result.output
+
+
+def test_cli_wait_and_status_with_invalid_detached_auto_handle_fail_stably(
+    monkeypatch, tmp_path
+) -> None:
+    """Verify CLI wait/status fail clearly for an unknown detached auto handle."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'missing-detached-auto-status.db'}"
+    invalid_job_id = "missing_detached_auto"
+
+    monkeypatch.setattr(
+        job_command,
+        "JobStatusHandler",
+        lambda: JobStatusHandler(event_store=EventStore(db_url)),
+    )
+    monkeypatch.setattr(
+        job_command,
+        "JobWaitHandler",
+        lambda: JobWaitHandler(event_store=EventStore(db_url)),
+    )
+
+    first_status = runner.invoke(app, ["job", "status", invalid_job_id])
+    second_status = runner.invoke(app, ["job", "status", invalid_job_id])
+    first_wait = runner.invoke(app, ["job", "wait", invalid_job_id, "--timeout-seconds", "0"])
+    second_wait = runner.invoke(app, ["job", "wait", invalid_job_id, "--timeout-seconds", "0"])
+
+    assert first_status.exit_code == 1
+    assert second_status.exit_code == 1
+    assert first_wait.exit_code == 1
+    assert second_wait.exit_code == 1
+    assert second_status.output == first_status.output
+    assert second_wait.output == first_wait.output
+    assert f"Job not found: {invalid_job_id}" in first_status.output
+    assert f"Job not found: {invalid_job_id}" in first_wait.output
+    assert not re.search(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]", first_status.output)
+    assert not re.search(r"\b\d{4}-\d{2}-\d{2}[T ][0-9:.+-]", first_wait.output)
+
+
+def test_invalid_job_handle_exits_nonzero(monkeypatch) -> None:
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    monkeypatch.setattr(job_command, "JobStatusHandler", _MissingJobHandler)
+
+    result = runner.invoke(app, ["job", "status", "missing"])
+
+    assert result.exit_code == 1
+    assert "Job not found: missing" in result.output
+
+
+def test_invalid_job_wait_argument_exits_nonzero(monkeypatch) -> None:
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    monkeypatch.setattr(job_command, "JobWaitHandler", _InvalidWaitHandler)
+
+    result = runner.invoke(app, ["job", "wait", "job_123", "--timeout-seconds", "-1"])
+
+    assert result.exit_code == 1
+    assert "timeout_seconds must be a non-negative integer" in result.output

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 import yaml
 
 from ouroboros.cli.commands.status import app
+from ouroboros.cli.formatters import console
 
 runner = CliRunner(env={"COLUMNS": "240"})
 
@@ -30,6 +32,20 @@ API_ENV_KEYS = [
     "OUROBOROS_OPENCODE_CLI_PATH",
     "CODEX_HOME",
 ]
+
+
+@pytest.fixture(autouse=True)
+def _wide_rich_console() -> None:
+    """Keep Rich health tables from truncating asserted status details."""
+    previous_width = console._width  # noqa: SLF001
+    previous_height = console._height  # noqa: SLF001
+    console._width = 240  # noqa: SLF001
+    console._height = 80  # noqa: SLF001
+    try:
+        yield
+    finally:
+        console._width = previous_width  # noqa: SLF001
+        console._height = previous_height  # noqa: SLF001
 
 
 def _clear_auth_env(monkeypatch) -> None:

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -72,6 +72,13 @@ def _write_credentials(config_dir: Path, api_key: str = "sk-present") -> None:
     )
 
 
+def test_status_auto_invalid_session_id_exits_nonzero() -> None:
+    result = runner.invoke(app, ["auto", "missing"])
+
+    assert result.exit_code == 1
+    assert "auto_session_id must start with auto_" in result.output
+
+
 def test_health_reports_all_ok(monkeypatch, tmp_path: Path) -> None:
     config_dir = tmp_path / "config"
     data_dir = config_dir / "data"

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -12,6 +12,7 @@ from ouroboros.events.lineage import lineage_generation_watchdog_decision
 from ouroboros.mcp import job_manager as job_manager_module
 from ouroboros.mcp.job_manager import JobLinks, JobManager, JobSnapshot, JobStatus
 from ouroboros.mcp.tools.job_handlers import (
+    JobResultHandler,
     JobStatusHandler,
     JobWaitHandler,
     _render_compact_job_snapshot,
@@ -1707,6 +1708,58 @@ class TestJobManager:
         finally:
             await store.close()
 
+    async def test_job_result_handler_returns_persisted_success_payload(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+
+        try:
+
+            async def _runner() -> MCPToolResult:
+                await asyncio.sleep(0.01)
+                return MCPToolResult(
+                    content=(
+                        MCPContentItem(type=ContentType.TEXT, text="auto result summary"),
+                        MCPContentItem(
+                            type=ContentType.RESOURCE,
+                            uri="file:///tmp/detached-auto-result.json",
+                        ),
+                    ),
+                    is_error=False,
+                    meta={
+                        "auto_session_id": "auto_payload_success",
+                        "result": {"artifact": "detached-auto-result.json", "ok": True},
+                    },
+                )
+
+            started = await manager.start_job(
+                job_type="auto",
+                initial_message="queued",
+                runner=_runner(),
+                links=JobLinks(session_id="auto_payload_success"),
+            )
+            await _wait_for_job_status(manager, started.job_id, JobStatus.COMPLETED)
+
+            result = await JobResultHandler(event_store=store).handle({"job_id": started.job_id})
+
+            assert result.is_ok
+            assert result.value.content == (
+                MCPContentItem(type=ContentType.TEXT, text="auto result summary"),
+                MCPContentItem(
+                    type=ContentType.RESOURCE,
+                    uri="file:///tmp/detached-auto-result.json",
+                ),
+            )
+            assert result.value.meta["auto_session_id"] == "auto_payload_success"
+            assert result.value.meta["result"] == {
+                "artifact": "detached-auto-result.json",
+                "ok": True,
+            }
+            assert result.value.meta["result_payload"]["content"][1]["uri"] == (
+                "file:///tmp/detached-auto-result.json"
+            )
+        finally:
+            await store.close()
+
     async def test_start_job_default_allocates_job_id(self, tmp_path) -> None:
         store = _build_store(tmp_path)
         manager = JobManager(store)
@@ -2993,6 +3046,303 @@ class TestJobManager:
         assert "No new job-level events during this wait window." in result.value.text_content
         assert result.value.text_content != "unchanged cursor=12"
 
+    async def test_job_wait_omitted_timeout_returns_immediate_snapshot(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        snapshot = JobSnapshot(
+            job_id="job_wait_default_timeout",
+            job_type="execute_seed",
+            status=JobStatus.RUNNING,
+            message="Running execute_seed",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=5,
+            links=JobLinks(),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                assert cursor == 5
+                assert timeout_seconds == 0
+                return snapshot, False
+
+        handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+        result = await handler.handle({"job_id": "job_wait_default_timeout", "cursor": 5})
+
+        assert result.is_ok
+        assert result.value.meta["changed"] is False
+        assert result.value.meta["cursor"] == 5
+
+    async def test_job_wait_rejects_invalid_cursor_argument(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        handler = JobWaitHandler(event_store=store)
+
+        result = await handler.handle({"job_id": "job_wait_bad_cursor", "cursor": "later"})
+
+        assert result.is_err
+        assert "cursor must be a non-negative integer" in str(result.error)
+
+    async def test_job_wait_rejects_negative_timeout_argument(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        handler = JobWaitHandler(event_store=store)
+
+        result = await handler.handle({"job_id": "job_wait_bad_timeout", "timeout_seconds": -1})
+
+        assert result.is_err
+        assert "timeout_seconds must be a non-negative integer" in str(result.error)
+
+    async def test_job_result_invalid_handle_returns_mcp_error(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        await store.initialize()
+        try:
+            handler = JobResultHandler(event_store=store)
+            result = await handler.handle({"job_id": "job_missing_detached_auto"})
+        finally:
+            await store.close()
+
+        assert result.is_err
+        assert "not found" in str(result.error).lower()
+
+    async def test_detached_auto_status_retrieval_tracks_running_then_terminal_result(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        auto_session_id = "auto_detached_status"
+        stop = asyncio.Event()
+
+        async def _runner() -> MCPToolResult:
+            await stop.wait()
+            return MCPToolResult(
+                content=(
+                    MCPContentItem(
+                        type=ContentType.TEXT,
+                        text="detached auto completed artifact",
+                    ),
+                    MCPContentItem(
+                        type=ContentType.RESOURCE,
+                        uri="file:///tmp/auto-detached-status-result.json",
+                    ),
+                ),
+                is_error=False,
+                meta={
+                    "auto_session_id": auto_session_id,
+                    "status": "completed",
+                    "result": {
+                        "artifact": "auto-detached-status-result.json",
+                        "ok": True,
+                    },
+                },
+            )
+
+        try:
+            started = await manager.start_job(
+                job_type="auto",
+                initial_message="Queued detached auto",
+                runner=_runner(),
+                links=JobLinks(session_id=auto_session_id),
+            )
+            await _wait_for_job_status(manager, started.job_id, JobStatus.RUNNING)
+
+            status_handler = JobStatusHandler(event_store=store, job_manager=manager)
+            running_status = await status_handler.handle({"job_id": started.job_id, "view": "full"})
+
+            assert running_status.is_ok
+            running_text = running_status.value.content[0].text
+            assert f"## Job: {started.job_id}" in running_text
+            assert "**Type**: auto" in running_text
+            assert "**Status**: running" in running_text
+            assert "**Terminal**: false" in running_text
+            assert "**Status Category**: non_terminal" in running_text
+            assert f"**Session ID**: {auto_session_id}" in running_text
+            assert running_status.value.meta["job_id"] == started.job_id
+            assert running_status.value.meta["job_type"] == "auto"
+            assert running_status.value.meta["status"] == "running"
+            assert running_status.value.meta["lifecycle_status"] == "running"
+            assert running_status.value.meta["status_category"] == "non_terminal"
+            assert running_status.value.meta["is_terminal"] is False
+            assert running_status.value.meta["result_available"] is False
+            assert running_status.value.meta["error"] is None
+            assert running_status.value.meta["status"] not in {
+                "completed",
+                "failed",
+                "cancelled",
+            }
+            assert running_status.value.is_error is False
+            assert running_status.value.meta["session_id"] == auto_session_id
+            assert running_status.value.meta["links"] == {
+                "session_id": auto_session_id,
+                "execution_id": None,
+                "lineage_id": None,
+            }
+            assert {
+                "job_id",
+                "job_type",
+                "status",
+                "lifecycle_status",
+                "status_category",
+                "is_terminal",
+                "result_available",
+                "error",
+                "cursor",
+                "links",
+                "session_id",
+                "execution_id",
+                "lineage_id",
+                "view",
+            }.issubset(running_status.value.meta)
+
+            wait_handler = JobWaitHandler(event_store=store, job_manager=manager)
+            running_wait = await wait_handler.handle(
+                {"job_id": started.job_id, "cursor": 0, "timeout_seconds": 0, "view": "summary"}
+            )
+            assert running_wait.is_ok
+            assert started.job_id in running_wait.value.content[0].text
+            assert "running" in running_wait.value.content[0].text
+            assert running_wait.value.meta["job_id"] == started.job_id
+            assert running_wait.value.meta["job_type"] == "auto"
+            assert running_wait.value.meta["status"] == "running"
+            assert running_wait.value.meta["lifecycle_status"] == "running"
+            assert running_wait.value.meta["status_category"] == "non_terminal"
+            assert running_wait.value.meta["is_terminal"] is False
+            assert running_wait.value.meta["result_available"] is False
+            assert running_wait.value.meta["error"] is None
+            assert running_wait.value.meta["session_id"] == auto_session_id
+            assert running_wait.value.meta["links"] == {
+                "session_id": auto_session_id,
+                "execution_id": None,
+                "lineage_id": None,
+            }
+
+            result_handler = JobResultHandler(event_store=store, job_manager=manager)
+            premature_result = await result_handler.handle({"job_id": started.job_id})
+            assert premature_result.is_ok
+            assert premature_result.value.is_error is False
+            premature_text = premature_result.value.content[0].text
+            assert f"Job result not ready: {started.job_id}" in premature_text
+            assert "status=running" in premature_text
+            assert "terminal=false" in premature_text
+            assert "detached auto job is still tracked background work" in premature_text
+            assert f"wait: ouroboros job wait {started.job_id}" in premature_text
+            assert (
+                f"retrieve after terminal status: ouroboros job result {started.job_id}"
+                in premature_text
+            )
+            assert premature_result.value.meta["job_id"] == started.job_id
+            assert premature_result.value.meta["status"] == "running"
+            assert premature_result.value.meta["is_terminal"] is False
+            assert premature_result.value.meta["result_available"] is False
+            assert premature_result.value.meta["session_id"] == auto_session_id
+
+            still_running = await manager.get_snapshot(started.job_id)
+            assert still_running.status is JobStatus.RUNNING
+            assert still_running.is_terminal is False
+
+            stop.set()
+            await _wait_for_job_status(manager, started.job_id, JobStatus.COMPLETED)
+
+            terminal_status = await status_handler.handle(
+                {"job_id": started.job_id, "view": "summary"}
+            )
+            assert terminal_status.is_ok
+            assert started.job_id in terminal_status.value.content[0].text
+            assert "completed" in terminal_status.value.content[0].text
+            assert terminal_status.value.meta["status"] == "completed"
+            assert terminal_status.value.meta["is_terminal"] is True
+            assert terminal_status.value.meta["session_id"] == auto_session_id
+
+            final_result = await result_handler.handle({"job_id": started.job_id})
+            assert final_result.is_ok
+            assert final_result.value.content == (
+                MCPContentItem(
+                    type=ContentType.TEXT,
+                    text="detached auto completed artifact",
+                ),
+                MCPContentItem(
+                    type=ContentType.RESOURCE,
+                    uri="file:///tmp/auto-detached-status-result.json",
+                ),
+            )
+            assert final_result.value.meta["status"] == "completed"
+            assert final_result.value.meta["lifecycle_status"] == "completed"
+            assert final_result.value.meta["is_terminal"] is True
+            assert final_result.value.meta["result_available"] is True
+            assert final_result.value.meta["session_id"] == auto_session_id
+            assert final_result.value.meta["auto_session_id"] == auto_session_id
+            assert final_result.value.meta["result"] == {
+                "artifact": "auto-detached-status-result.json",
+                "ok": True,
+            }
+            assert final_result.value.meta["result_payload"]["is_error"] is False
+            assert final_result.value.meta["result_payload"]["content"][0]["text"] == (
+                "detached auto completed artifact"
+            )
+            assert final_result.value.meta["result_payload"]["content"][1]["uri"] == (
+                "file:///tmp/auto-detached-status-result.json"
+            )
+        finally:
+            stop.set()
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_job_wait_completed_detached_auto_returns_success_status(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        auto_session_id = "auto_wait_completed"
+
+        async def _runner() -> MCPToolResult:
+            return MCPToolResult(
+                content=(
+                    MCPContentItem(
+                        type=ContentType.TEXT,
+                        text="detached auto completed through wait",
+                    ),
+                ),
+                is_error=False,
+                meta={
+                    "auto_session_id": auto_session_id,
+                    "status": "completed",
+                },
+            )
+
+        try:
+            started = await manager.start_job(
+                job_type="auto",
+                initial_message="Queued detached auto",
+                runner=_runner(),
+                links=JobLinks(session_id=auto_session_id),
+            )
+            await _wait_for_job_status(manager, started.job_id, JobStatus.COMPLETED)
+
+            handler = JobWaitHandler(event_store=store, job_manager=manager)
+            result = await handler.handle(
+                {
+                    "job_id": started.job_id,
+                    "cursor": 0,
+                    "timeout_seconds": 0,
+                    "view": "summary",
+                }
+            )
+
+            assert result.is_ok
+            assert result.value.is_error is False
+            assert result.value.meta["job_id"] == started.job_id
+            assert result.value.meta["status"] == "completed"
+            assert result.value.meta["is_terminal"] is True
+            assert result.value.meta["changed"] is True
+            assert result.value.meta["session_id"] == auto_session_id
+            assert started.job_id in result.value.text_content
+            assert "completed" in result.value.text_content
+        finally:
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_job_wait_meta_includes_polling_links_for_clients(self, tmp_path) -> None:
         store = _build_store(tmp_path)
         snapshot = JobSnapshot(
@@ -3356,6 +3706,46 @@ class TestJobManager:
             assert terminal_recovered is not None
             assert terminal_recovered.job_id == started.job_id
             assert terminal_recovered.status == JobStatus.COMPLETED
+        finally:
+            gate.set()
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_detached_auto_status_output_includes_stable_status_category(
+        self, tmp_path
+    ) -> None:
+        """Runnable API check for stable detached status category output."""
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+        gate: asyncio.Event = asyncio.Event()
+
+        try:
+
+            async def _slow_runner() -> MCPToolResult:
+                await gate.wait()
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="auto done"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="auto",
+                initial_message="queued",
+                runner=_slow_runner(),
+                links=JobLinks(session_id="auto_status_category"),
+            )
+            await _wait_for_job_status(manager, started.job_id, JobStatus.RUNNING)
+
+            status_handler = JobStatusHandler(event_store=store, job_manager=manager)
+            status = await status_handler.handle({"job_id": started.job_id, "view": "full"})
+
+            assert status.is_ok
+            assert "**Status Category**: non_terminal" in status.value.text_content
+            assert status.value.meta["status"] == "running"
+            assert status.value.meta["lifecycle_status"] == "running"
+            assert status.value.meta["status_category"] == "non_terminal"
+            assert status.value.meta["is_terminal"] is False
         finally:
             gate.set()
             await _cancel_manager_tasks(manager)

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -209,17 +209,20 @@ def test_execution_job_completed_keeps_auto_complete(monkeypatch) -> None:
         lambda: FakeJobManager(),
     )
     result = AutoPipelineResult(
-        status="running",
+        status="blocked",
         auto_session_id="auto_1",
-        phase="complete",
+        phase="blocked",
         job_id="job_done",
         run_handoff_status="started",
+        blocker="iteration_timeout",
         resume_capability=AutoResumeCapability.RESUME,
     )
 
     reconciled = asyncio.run(_reconcile_execution_job_snapshot(result))
 
     assert reconciled.status == "complete"
+    assert reconciled.phase == "complete"
+    assert reconciled.blocker is None
     assert reconciled.execution_job_status == "completed"
     assert reconciled.resume_capability is AutoResumeCapability.NONE
     meta = _result_meta(reconciled)
@@ -228,6 +231,9 @@ def test_execution_job_completed_keeps_auto_complete(monkeypatch) -> None:
     assert "presentation_status" not in meta
     assert "product_status" not in meta
     assert "Status: complete" in text
+    assert "Phase: complete" in text
+    assert "Blocker:" not in text
+    assert "iteration_timeout" not in text
     assert "Status: run_handoff_started" not in text
     assert "Product status: not verified complete" not in text
 

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1863,8 +1863,10 @@ class TestAsyncJobHandlers:
         handler = JobWaitHandler()
         params = {p.name: p for p in handler.definition.parameters}
         param_names = set(params)
-        assert param_names == {"job_id", "cursor", "timeout_seconds", "view"}
+        assert param_names == {"job_id", "cursor", "timeout_seconds", "view", "stream"}
         assert params["view"].default == "full"
+        assert params["stream"].default == "progress"
+        assert params["timeout_seconds"].default == 0
 
     def test_job_result_definition_name(self) -> None:
         handler = JobResultHandler()

--- a/tests/unit/mcp/tools/test_job_invalid_arguments.py
+++ b/tests/unit/mcp/tools/test_job_invalid_arguments.py
@@ -1,0 +1,136 @@
+"""Invalid argument coverage for async job MCP tools."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.mcp.job_manager import JobStatus
+from ouroboros.mcp.tools.job_handlers import (
+    JobResultHandler,
+    JobStatusHandler,
+    JobWaitHandler,
+)
+from ouroboros.persistence.event_store import EventStore
+
+
+@pytest.fixture
+async def event_store():
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    yield store
+    await store.close()
+
+
+@pytest.mark.asyncio
+async def test_job_wait_rejects_non_integer_cursor(event_store) -> None:
+    handler = JobWaitHandler(event_store=event_store)
+
+    result = await handler.handle({"job_id": "job_missing", "cursor": "abc"})
+
+    assert result.is_err
+    assert result.error.tool_name == "ouroboros_job_wait"
+    assert result.error.message == "cursor must be a non-negative integer"
+
+
+@pytest.mark.asyncio
+async def test_job_wait_rejects_negative_timeout(event_store) -> None:
+    handler = JobWaitHandler(event_store=event_store)
+
+    result = await handler.handle({"job_id": "job_missing", "timeout_seconds": -1})
+
+    assert result.is_err
+    assert result.error.tool_name == "ouroboros_job_wait"
+    assert result.error.message == "timeout_seconds must be a non-negative integer"
+
+
+@pytest.mark.asyncio
+async def test_detached_auto_status_invalid_handle_returns_stable_failure(event_store) -> None:
+    job_id = "job_missing_detached_auto"
+    handler = JobStatusHandler(event_store=event_store)
+
+    first = await handler.handle({"job_id": job_id, "view": "full"})
+    second = await handler.handle({"job_id": job_id, "view": "summary"})
+
+    assert first.is_err
+    assert second.is_err
+    assert first.error.tool_name == "ouroboros_job_status"
+    assert second.error.tool_name == "ouroboros_job_status"
+    assert first.error.message == f"Job not found: {job_id}"
+    assert second.error.message == f"Job not found: {job_id}"
+    assert first.error.error_code is None
+    assert second.error.error_code is None
+    assert first.error.details == {}
+    assert second.error.details == {}
+
+
+@pytest.mark.asyncio
+async def test_job_result_invalid_handle_returns_structured_error(event_store) -> None:
+    job_id = "job_missing_detached_auto"
+    handler = JobResultHandler(event_store=event_store)
+
+    result = await handler.handle({"job_id": job_id})
+
+    assert result.is_err
+    assert result.error.tool_name == "ouroboros_job_result"
+    assert result.error.error_code == "job_handle_not_found"
+    assert result.error.message == f"Job handle not found: {job_id}. Result unavailable."
+    assert result.error.details == {
+        "job_id": job_id,
+        "lifecycle_status": "invalid",
+        "is_terminal": True,
+        "result_available": False,
+        "reason": "not_found",
+        "source_error": f"Job not found: {job_id}",
+    }
+
+
+@pytest.mark.asyncio
+async def test_job_result_rejects_expired_terminal_handle(event_store) -> None:
+    job_id = "job_expired_result"
+    expired_at = datetime.now(UTC) - timedelta(hours=2)
+    await event_store.append(
+        BaseEvent(
+            id="evt_expired_result_created",
+            type="mcp.job.created",
+            timestamp=expired_at,
+            aggregate_type="job",
+            aggregate_id=job_id,
+            data={
+                "job_type": "auto",
+                "status": JobStatus.QUEUED.value,
+                "message": "Queued detached auto",
+            },
+        )
+    )
+    await event_store.append(
+        BaseEvent(
+            id="evt_expired_result_completed",
+            type="mcp.job.completed",
+            timestamp=expired_at + timedelta(seconds=1),
+            aggregate_type="job",
+            aggregate_id=job_id,
+            data={
+                "status": JobStatus.COMPLETED.value,
+                "message": "Job complete",
+                "result_text": "stale result",
+            },
+        )
+    )
+    handler = JobResultHandler(event_store=event_store)
+
+    result = await handler.handle({"job_id": job_id})
+
+    assert result.is_err
+    assert result.error.tool_name == "ouroboros_job_result"
+    assert result.error.error_code == "job_handle_expired"
+    assert result.error.message == f"Job handle expired: {job_id}. Result unavailable."
+    assert result.error.details == {
+        "job_id": job_id,
+        "lifecycle_status": "expired",
+        "is_terminal": True,
+        "result_available": False,
+        "reason": "expired",
+    }

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -14,6 +14,7 @@ from datetime import UTC, datetime, timedelta
 import inspect
 import json
 import os
+import re
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -22,7 +23,9 @@ from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipelineResult
 from ouroboros.auto.state import AutoPipelineState, AutoStore
 from ouroboros.core.types import Result
+from ouroboros.mcp.job_manager import JobManager, JobStatus
 from ouroboros.mcp.tools.auto_handler import AutoHandler, StartAutoHandler
+from ouroboros.mcp.tools.job_handlers import JobResultHandler, JobStatusHandler, JobWaitHandler
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.persistence.event_store import EventStore
 
@@ -66,6 +69,63 @@ Success criteria:
 Important dispatch rule:
 If `ouroboros_auto` is unavailable or interpreted as normal text, stop and report failure.
 """
+
+
+_AUTO_ID_RE = re.compile(r"auto_[0-9a-f]+")
+_UUID_HEX_RE = re.compile(r"\b[0-9a-f]{32}\b")
+
+
+def _normalize_detached_auto_response(value):
+    """Scrub generated handles while preserving rendered response structure."""
+    if isinstance(value, dict):
+        return {key: _normalize_detached_auto_response(item) for key, item in sorted(value.items())}
+    if isinstance(value, (list, tuple)):
+        return [_normalize_detached_auto_response(item) for item in value]
+    if isinstance(value, str):
+        value = _AUTO_ID_RE.sub("auto_<id>", value)
+        value = _UUID_HEX_RE.sub("<uuid>", value)
+        return value
+    return value
+
+
+def _serializable_tool_result(result: MCPToolResult) -> dict[str, object]:
+    return {
+        "content": [
+            {
+                "type": item.type.value,
+                "text": item.text,
+                "data": item.data,
+                "mime_type": item.mime_type,
+                "uri": item.uri,
+            }
+            for item in result.content
+        ],
+        "is_error": result.is_error,
+        "meta": result.meta,
+    }
+
+
+def _assert_detached_start_text_has_guidance_without_handles(
+    result: MCPToolResult,
+    *,
+    job_id: str,
+    auto_session_id: str,
+) -> None:
+    text = result.text_content
+    assert text == (
+        "Started background auto session.\n\n"
+        "Status: queued\n\n"
+        "Track with ouroboros_job_wait / ouroboros_job_status until terminal, "
+        "then fetch ouroboros_job_result. Use response metadata for job_id "
+        "and auto_session_id."
+    )
+    assert "ouroboros_job_wait" in text
+    assert "ouroboros_job_status" in text
+    assert "ouroboros_job_result" in text
+    assert job_id not in text
+    assert auto_session_id not in text
+    assert not _AUTO_ID_RE.search(text)
+    assert not _UUID_HEX_RE.search(text)
 
 
 @pytest.fixture
@@ -213,19 +273,601 @@ class TestBackgroundJobPath:
         auto_session_id = result.value.meta["auto_session_id"]
         assert isinstance(auto_session_id, str)
         assert auto_session_id.startswith("auto_")
-        assert result.value.content[0].text == (
-            "Started background auto session. job_id=job_auto_001\n\n"
-            f"Auto session ID: {auto_session_id}\n\n"
-            "Poll with ouroboros_job_status / ouroboros_job_wait."
+        _assert_detached_start_text_has_guidance_without_handles(
+            result.value,
+            job_id="job_auto_001",
+            auto_session_id=auto_session_id,
         )
         assert result.value.meta["job_id"] == "job_auto_001"
         assert result.value.meta["session_id"] == auto_session_id
         assert result.value.meta["dispatch_mode"] == "job"
+        assert result.value.meta["status_tool"] == "ouroboros_job_status"
+        assert result.value.meta["wait_tool"] == "ouroboros_job_wait"
+        assert result.value.meta["result_tool"] == "ouroboros_job_result"
         assert captured["links"].session_id == auto_session_id
         assert store.path_for(auto_session_id).exists()
         # The inner AutoHandler must NOT have run synchronously — the runner is
         # enqueued on the JobManager only.
         fake_inner_auto.handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mcp_start_auto_detached_response_text_is_deterministic_for_identical_input(
+        self, event_store, fake_inner_auto, tmp_path
+    ) -> None:
+        async def _invoke(store_path, job_id: str) -> MCPToolResult:
+            job_manager = MagicMock()
+            snapshot = MagicMock()
+            snapshot.job_id = job_id
+
+            async def _start_job(*, runner, **_):
+                if inspect.iscoroutine(runner):
+                    runner.close()
+                return snapshot
+
+            job_manager.start_job = AsyncMock(side_effect=_start_job)
+            handler = StartAutoHandler(
+                event_store=event_store,
+                job_manager=job_manager,
+                store=AutoStore(store_path),
+            )
+            handler._inner_auto = fake_inner_auto
+
+            result = await handler.handle({"goal": "document detached auto polling"})
+            assert result.is_ok
+            return result.value
+
+        first = await _invoke(tmp_path / "first", "job_auto_001")
+        second = await _invoke(tmp_path / "second", "job_auto_002")
+
+        assert first.text_content == second.text_content
+        assert first.meta["job_id"] != second.meta["job_id"]
+        assert first.meta["auto_session_id"] != second.meta["auto_session_id"]
+        _assert_detached_start_text_has_guidance_without_handles(
+            first,
+            job_id=first.meta["job_id"],
+            auto_session_id=first.meta["auto_session_id"],
+        )
+        _assert_detached_start_text_has_guidance_without_handles(
+            second,
+            job_id=second.meta["job_id"],
+            auto_session_id=second.meta["auto_session_id"],
+        )
+        assert first.meta["status"] == second.meta["status"] == "queued"
+        assert first.meta["dispatch_mode"] == second.meta["dispatch_mode"] == "job"
+        assert first.meta["wait_tool"] == second.meta["wait_tool"] == "ouroboros_job_wait"
+        fake_inner_auto.handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_mcp_start_auto_response_job_handle_can_poll_and_fetch_result(
+        self, event_store, tmp_path
+    ) -> None:
+        """Runnable API check for the detached start handle contract."""
+        job_manager = JobManager(event_store)
+        store = AutoStore(tmp_path)
+        inner_started = asyncio.Event()
+        release_inner = asyncio.Event()
+
+        async def _pollable_auto(arguments):
+            inner_started.set()
+            await release_inner.wait()
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="detached result"),),
+                    is_error=False,
+                    meta={
+                        "auto_session_id": arguments["resume"],
+                        "status": "completed",
+                        "artifact": "detached-auto-result",
+                    },
+                )
+            )
+
+        inner = MagicMock(spec=AutoHandler)
+        inner.handle = AsyncMock(side_effect=_pollable_auto)
+        handler = StartAutoHandler(
+            event_store=event_store,
+            job_manager=job_manager,
+            store=store,
+        )
+        handler._inner_auto = inner
+
+        started = await handler.handle({"goal": "return a stable detached auto handle"})
+
+        try:
+            assert started.is_ok
+            job_id = started.value.meta["job_id"]
+            auto_session_id = started.value.meta["auto_session_id"]
+            assert re.fullmatch(r"job_[0-9a-f]{12}", job_id)
+            assert isinstance(auto_session_id, str)
+            assert auto_session_id.startswith("auto_")
+            assert started.value.meta == {
+                "job_id": job_id,
+                "auto_session_id": auto_session_id,
+                "session_id": auto_session_id,
+                "status": "queued",
+                "dispatch_mode": "job",
+                "status_tool": "ouroboros_job_status",
+                "wait_tool": "ouroboros_job_wait",
+                "result_tool": "ouroboros_job_result",
+            }
+
+            await asyncio.wait_for(inner_started.wait(), timeout=1.0)
+
+            status_handler = JobStatusHandler(event_store=event_store, job_manager=job_manager)
+            status = await status_handler.handle({"job_id": job_id, "view": "summary"})
+
+            assert status.is_ok
+            assert status.value.meta["job_id"] == job_id
+            assert status.value.meta["session_id"] == auto_session_id
+            assert status.value.meta["status"] in {"queued", "running"}
+            assert status.value.meta["is_terminal"] is False
+
+            release_inner.set()
+            wait_handler = JobWaitHandler(event_store=event_store, job_manager=job_manager)
+            terminal = None
+            for _ in range(50):
+                waited = await wait_handler.handle(
+                    {"job_id": job_id, "cursor": 0, "timeout_seconds": 0, "view": "summary"}
+                )
+                assert waited.is_ok
+                if waited.value.meta["is_terminal"]:
+                    terminal = waited.value
+                    break
+                await asyncio.sleep(0.01)
+
+            assert terminal is not None
+            assert terminal.meta["job_id"] == job_id
+            assert terminal.meta["session_id"] == auto_session_id
+            assert terminal.meta["status"] == "completed"
+
+            result_handler = JobResultHandler(event_store=event_store, job_manager=job_manager)
+            fetched = await result_handler.handle({"job_id": job_id})
+
+            assert fetched.is_ok
+            assert fetched.value.text_content == "detached result"
+            assert fetched.value.meta["job_id"] == job_id
+            assert fetched.value.meta["session_id"] == auto_session_id
+            assert fetched.value.meta["auto_session_id"] == auto_session_id
+            assert fetched.value.meta["status"] == "completed"
+            assert fetched.value.meta["is_terminal"] is True
+            assert fetched.value.meta["artifact"] == "detached-auto-result"
+        finally:
+            release_inner.set()
+
+    @pytest.mark.asyncio
+    async def test_mcp_start_auto_status_reports_running_detached_background_work(
+        self, event_store, tmp_path
+    ) -> None:
+        job_manager = JobManager(event_store)
+        store = AutoStore(tmp_path)
+        inner_started = asyncio.Event()
+        release_inner = asyncio.Event()
+
+        async def _blocking_auto(_arguments):
+            inner_started.set()
+            await release_inner.wait()
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="detached auto done"),),
+                    is_error=False,
+                    meta={"auto_session_id": "auto_running_status"},
+                )
+            )
+
+        inner = MagicMock(spec=AutoHandler)
+        inner.handle = AsyncMock(side_effect=_blocking_auto)
+        handler = StartAutoHandler(
+            event_store=event_store,
+            job_manager=job_manager,
+            store=store,
+        )
+        handler._inner_auto = inner
+
+        started = await handler.handle({"goal": "keep detached auto observable"})
+
+        try:
+            assert started.is_ok
+            job_id = started.value.meta["job_id"]
+            auto_session_id = started.value.meta["auto_session_id"]
+            await asyncio.wait_for(inner_started.wait(), timeout=1.0)
+
+            deadline = asyncio.get_running_loop().time() + 1.0
+            snapshot = await job_manager.get_snapshot(job_id)
+            while snapshot.status is not JobStatus.RUNNING:
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise AssertionError(
+                        f"job {job_id} did not become running; last={snapshot.status}"
+                    )
+                await asyncio.sleep(0.01)
+                snapshot = await job_manager.get_snapshot(job_id)
+
+            status_handler = JobStatusHandler(event_store=event_store, job_manager=job_manager)
+            status = await status_handler.handle({"job_id": job_id, "view": "full"})
+
+            assert status.is_ok
+            assert status.value.is_error is False
+            assert status.value.meta["job_id"] == job_id
+            assert status.value.meta["status"] == "running"
+            assert status.value.meta["status"] not in {"completed", "failed", "cancelled"}
+            assert status.value.meta["is_terminal"] is False
+            assert status.value.meta["result_available"] is False
+            assert status.value.meta["session_id"] == auto_session_id
+            assert status.value.meta["view"] == "full"
+            assert f"## Job: {job_id}" in status.value.text_content
+            assert "**Type**: auto" in status.value.text_content
+            assert "**Status**: running" in status.value.text_content
+            assert "**Terminal**: false" in status.value.text_content
+            assert "**Status**: completed" not in status.value.text_content
+            assert "**Status**: failed" not in status.value.text_content
+            assert "**Status**: cancelled" not in status.value.text_content
+            assert (
+                "**Tracking**: detached auto tracked background work" in status.value.text_content
+            )
+            assert f"**Session ID**: {auto_session_id}" in status.value.text_content
+            assert "Use `ouroboros_job_result` to fetch the full terminal output." not in (
+                status.value.text_content
+            )
+        finally:
+            release_inner.set()
+            if started.is_ok:
+                job_id = started.value.meta["job_id"]
+                deadline = asyncio.get_running_loop().time() + 1.0
+                snapshot = await job_manager.get_snapshot(job_id)
+                while snapshot.status is not JobStatus.COMPLETED:
+                    if asyncio.get_running_loop().time() >= deadline:
+                        break
+                    await asyncio.sleep(0.01)
+                    snapshot = await job_manager.get_snapshot(job_id)
+
+    @pytest.mark.asyncio
+    async def test_mcp_start_auto_wait_reports_stable_running_detached_output(
+        self, event_store, tmp_path
+    ) -> None:
+        """Runnable API check for observable wait output while auto is still running."""
+        job_manager = JobManager(event_store)
+        store = AutoStore(tmp_path)
+        inner_started = asyncio.Event()
+        release_inner = asyncio.Event()
+
+        async def _blocking_auto(_arguments):
+            inner_started.set()
+            await release_inner.wait()
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="detached auto done"),),
+                    is_error=False,
+                    meta={"auto_session_id": "auto_running_wait"},
+                )
+            )
+
+        inner = MagicMock(spec=AutoHandler)
+        inner.handle = AsyncMock(side_effect=_blocking_auto)
+        handler = StartAutoHandler(
+            event_store=event_store,
+            job_manager=job_manager,
+            store=store,
+        )
+        handler._inner_auto = inner
+
+        started = await handler.handle({"goal": "keep detached auto wait observable"})
+
+        try:
+            assert started.is_ok
+            job_id = started.value.meta["job_id"]
+            auto_session_id = started.value.meta["auto_session_id"]
+            await asyncio.wait_for(inner_started.wait(), timeout=1.0)
+
+            deadline = asyncio.get_running_loop().time() + 1.0
+            snapshot = await job_manager.get_snapshot(job_id)
+            while snapshot.status is not JobStatus.RUNNING:
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise AssertionError(
+                        f"job {job_id} did not become running; last={snapshot.status}"
+                    )
+                await asyncio.sleep(0.01)
+                snapshot = await job_manager.get_snapshot(job_id)
+
+            wait_handler = JobWaitHandler(event_store=event_store, job_manager=job_manager)
+            arguments = {
+                "job_id": job_id,
+                "cursor": snapshot.cursor,
+                "timeout_seconds": 0,
+                "view": "full",
+            }
+
+            first = await wait_handler.handle(arguments)
+            second = await wait_handler.handle(arguments)
+
+            assert first.is_ok
+            assert second.is_ok
+            assert first.value.text_content == second.value.text_content
+            assert first.value.meta == second.value.meta
+            assert first.value.meta["job_id"] == job_id
+            assert first.value.meta["status"] == "running"
+            assert first.value.meta["is_terminal"] is False
+            assert first.value.meta["changed"] is False
+            assert first.value.meta["session_id"] == auto_session_id
+            assert f"## Job: {job_id}" in first.value.text_content
+            assert "**Type**: auto" in first.value.text_content
+            assert "**Status**: running" in first.value.text_content
+            assert "**Terminal**: false" in first.value.text_content
+            assert "**Tracking**: detached auto tracked background work" in first.value.text_content
+            assert f"**Session ID**: {auto_session_id}" in first.value.text_content
+            assert "No new job-level events during this wait window." in first.value.text_content
+            assert "Use `ouroboros_job_result` to fetch the full terminal output." not in (
+                first.value.text_content
+            )
+        finally:
+            release_inner.set()
+            if started.is_ok:
+                deadline = asyncio.get_running_loop().time() + 1.0
+                snapshot = await job_manager.get_snapshot(started.value.meta["job_id"])
+                while snapshot.status is not JobStatus.COMPLETED:
+                    if asyncio.get_running_loop().time() >= deadline:
+                        break
+                    await asyncio.sleep(0.01)
+                    snapshot = await job_manager.get_snapshot(started.value.meta["job_id"])
+
+    @pytest.mark.asyncio
+    async def test_mcp_start_auto_wait_then_result_returns_completed_artifact(
+        self, event_store, tmp_path
+    ) -> None:
+        job_manager = JobManager(event_store)
+        store = AutoStore(tmp_path)
+        inner = MagicMock(spec=AutoHandler)
+        inner.handle = AsyncMock(
+            return_value=Result.ok(
+                MCPToolResult(
+                    content=(
+                        MCPContentItem(type=ContentType.TEXT, text="detached auto finished"),
+                        MCPContentItem(
+                            type=ContentType.RESOURCE,
+                            uri="file:///tmp/detached-auto-result.json",
+                        ),
+                    ),
+                    is_error=False,
+                    meta={
+                        "auto_session_id": "auto_completed_result",
+                        "status": "completed",
+                        "result": {
+                            "artifact": "detached-auto-result.json",
+                            "ok": True,
+                        },
+                    },
+                )
+            )
+        )
+        handler = StartAutoHandler(
+            event_store=event_store,
+            job_manager=job_manager,
+            store=store,
+        )
+        handler._inner_auto = inner
+
+        started = await handler.handle({"goal": "produce a detached auto artifact"})
+
+        assert started.is_ok
+        job_id = started.value.meta["job_id"]
+        auto_session_id = started.value.meta["auto_session_id"]
+        wait_handler = JobWaitHandler(event_store=event_store, job_manager=job_manager)
+        result_handler = JobResultHandler(event_store=event_store, job_manager=job_manager)
+
+        terminal_wait = None
+        for _ in range(50):
+            wait_result = await wait_handler.handle(
+                {"job_id": job_id, "cursor": 0, "timeout_seconds": 0, "view": "summary"}
+            )
+            assert wait_result.is_ok
+            if wait_result.value.meta["is_terminal"]:
+                terminal_wait = wait_result.value
+                break
+            await asyncio.sleep(0.01)
+
+        assert terminal_wait is not None
+        assert terminal_wait.meta["status"] == "completed"
+        assert terminal_wait.meta["session_id"] == auto_session_id
+        assert job_id in terminal_wait.text_content
+
+        completed = await result_handler.handle({"job_id": job_id})
+
+        assert completed.is_ok
+        assert completed.value.is_error is False
+        assert completed.value.content == (
+            MCPContentItem(type=ContentType.TEXT, text="detached auto finished"),
+            MCPContentItem(
+                type=ContentType.RESOURCE,
+                uri="file:///tmp/detached-auto-result.json",
+            ),
+        )
+        assert completed.value.meta["job_id"] == job_id
+        assert completed.value.meta["status"] == "completed"
+        assert completed.value.meta["is_terminal"] is True
+        assert completed.value.meta["session_id"] == auto_session_id
+        assert completed.value.meta["auto_session_id"] == "auto_completed_result"
+        assert completed.value.meta["result"] == {
+            "artifact": "detached-auto-result.json",
+            "ok": True,
+        }
+        assert completed.value.meta["result_payload"] == {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "detached auto finished",
+                    "data": None,
+                    "mime_type": None,
+                    "uri": None,
+                },
+                {
+                    "type": "resource",
+                    "text": None,
+                    "data": None,
+                    "mime_type": None,
+                    "uri": "file:///tmp/detached-auto-result.json",
+                },
+            ],
+            "is_error": False,
+            "meta": {
+                "auto_session_id": "auto_completed_result",
+                "status": "completed",
+                "result": {
+                    "artifact": "detached-auto-result.json",
+                    "ok": True,
+                },
+            },
+            "text_content": "detached auto finished",
+        }
+        assert completed.value.text_content == "detached auto finished"
+
+        repeated = await result_handler.handle({"job_id": job_id})
+
+        assert repeated.is_ok
+        assert repeated.value.content == completed.value.content
+        assert repeated.value.meta == completed.value.meta
+        assert repeated.value.text_content == completed.value.text_content
+        inner.handle.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_mcp_detached_auto_failed_result_returns_stable_error_output(
+        self, event_store, tmp_path
+    ) -> None:
+        """Runnable API check for failed detached auto result retrieval."""
+        job_manager = JobManager(event_store)
+        store = AutoStore(tmp_path)
+        inner = MagicMock(spec=AutoHandler)
+        inner.handle = AsyncMock(
+            return_value=Result.ok(
+                MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text="detached auto failed: seed repair did not converge",
+                        ),
+                    ),
+                    is_error=True,
+                    meta={
+                        "auto_session_id": "auto_failed_result",
+                        "status": "failed",
+                        "error": {
+                            "code": "seed_repair_exhausted",
+                            "message": "Seed repair did not converge",
+                        },
+                    },
+                )
+            )
+        )
+        handler = StartAutoHandler(
+            event_store=event_store,
+            job_manager=job_manager,
+            store=store,
+        )
+        handler._inner_auto = inner
+
+        started = await handler.handle({"goal": "surface detached auto failure"})
+
+        assert started.is_ok
+        job_id = started.value.meta["job_id"]
+        auto_session_id = started.value.meta["auto_session_id"]
+        wait_handler = JobWaitHandler(event_store=event_store, job_manager=job_manager)
+        result_handler = JobResultHandler(event_store=event_store, job_manager=job_manager)
+
+        terminal_wait = None
+        for _ in range(50):
+            wait_result = await wait_handler.handle(
+                {"job_id": job_id, "cursor": 0, "timeout_seconds": 0, "view": "summary"}
+            )
+            assert wait_result.is_ok
+            if wait_result.value.meta["is_terminal"]:
+                terminal_wait = wait_result.value
+                break
+            await asyncio.sleep(0.01)
+
+        assert terminal_wait is not None
+        assert terminal_wait.is_error is True
+        assert terminal_wait.meta["job_id"] == job_id
+        assert terminal_wait.meta["session_id"] == auto_session_id
+        assert terminal_wait.meta["status"] == "failed"
+        assert terminal_wait.meta["lifecycle_status"] == "failed"
+        assert terminal_wait.meta["status_category"] == "terminal"
+        assert terminal_wait.meta["is_terminal"] is True
+        assert terminal_wait.meta["result_available"] is True
+
+        first = await result_handler.handle({"job_id": job_id})
+        second = await result_handler.handle({"job_id": job_id})
+
+        assert first.is_ok
+        assert second.is_ok
+        assert first.value.is_error is True
+        assert second.value.is_error is True
+        assert _serializable_tool_result(first.value) == _serializable_tool_result(second.value)
+        assert first.value.content == (
+            MCPContentItem(
+                type=ContentType.TEXT,
+                text="detached auto failed: seed repair did not converge",
+            ),
+        )
+        assert first.value.text_content == "detached auto failed: seed repair did not converge"
+        assert first.value.meta["job_id"] == job_id
+        assert first.value.meta["session_id"] == auto_session_id
+        assert first.value.meta["auto_session_id"] == "auto_failed_result"
+        assert first.value.meta["status"] == "failed"
+        assert first.value.meta["lifecycle_status"] == "failed"
+        assert first.value.meta["status_category"] == "terminal"
+        assert first.value.meta["is_terminal"] is True
+        assert first.value.meta["result_available"] is True
+        assert first.value.meta["error"] == {
+            "code": "seed_repair_exhausted",
+            "message": "Seed repair did not converge",
+        }
+        assert first.value.meta["result_payload"] == {
+            "content": [
+                {
+                    "type": "text",
+                    "text": "detached auto failed: seed repair did not converge",
+                    "data": None,
+                    "mime_type": None,
+                    "uri": None,
+                },
+            ],
+            "is_error": True,
+            "meta": {
+                "auto_session_id": "auto_failed_result",
+                "status": "failed",
+                "error": {
+                    "code": "seed_repair_exhausted",
+                    "message": "Seed repair did not converge",
+                },
+            },
+            "text_content": "detached auto failed: seed repair did not converge",
+        }
+        inner.handle.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_mcp_detached_auto_result_invalid_handle_returns_stable_failure(
+        self, event_store
+    ) -> None:
+        job_id = "job_missing_detached_auto"
+        handler = JobResultHandler(event_store=event_store)
+
+        first = await handler.handle({"job_id": job_id})
+        second = await handler.handle({"job_id": job_id})
+
+        assert first.is_err
+        assert second.is_err
+        assert first.error.tool_name == "ouroboros_job_result"
+        assert first.error.error_code == "job_handle_not_found"
+        assert first.error.message == f"Job handle not found: {job_id}. Result unavailable."
+        assert first.error.details == {
+            "job_id": job_id,
+            "lifecycle_status": "invalid",
+            "is_terminal": True,
+            "result_available": False,
+            "reason": "not_found",
+            "source_error": f"Job not found: {job_id}",
+        }
+        assert second.error.tool_name == first.error.tool_name
+        assert second.error.error_code == first.error.error_code
+        assert second.error.message == first.error.message
+        assert second.error.details == first.error.details
 
     @pytest.mark.asyncio
     async def test_new_structured_goal_preallocates_seed_ready_ledger(
@@ -334,6 +976,49 @@ class TestBackgroundJobPath:
         body = json.loads(result.value.content[0].text)
         assert body["auto_session_id"] == meta["auto_session_id"]
         job_manager.start_job.assert_not_called()
+        fake_inner_auto.handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_plugin_detached_auto_response_is_deterministic_after_scrubbing_handles(
+        self, event_store, tmp_path, fake_inner_auto
+    ) -> None:
+        async def _invoke(store_path):
+            job_manager = MagicMock()
+            job_manager.start_job = AsyncMock()
+            handler = StartAutoHandler(
+                event_store=event_store,
+                job_manager=job_manager,
+                store=AutoStore(store_path),
+                agent_runtime_backend="opencode",
+                opencode_mode="plugin",
+            )
+            handler._inner_auto = fake_inner_auto
+
+            result = await handler.handle(
+                {
+                    "goal": "document detached auto polling",
+                    "skip_run": True,
+                    "user_preferences": {
+                        "constraints": "Keep the UX contract stable.",
+                        "non_goals": ["No nested auto execution."],
+                    },
+                }
+            )
+
+            assert result.is_ok
+            body = json.loads(result.value.text_content)
+            assert result.value.text_content == json.dumps(
+                body,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            job_manager.start_job.assert_not_called()
+            return _normalize_detached_auto_response(_serializable_tool_result(result.value))
+
+        first = await _invoke(tmp_path / "first")
+        second = await _invoke(tmp_path / "second")
+
+        assert first == second
         fake_inner_auto.handle.assert_not_called()
 
     @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -24,7 +24,11 @@ from ouroboros.auto.pipeline import AutoPipelineResult
 from ouroboros.auto.state import AutoPipelineState, AutoStore
 from ouroboros.core.types import Result
 from ouroboros.mcp.job_manager import JobManager, JobStatus
-from ouroboros.mcp.tools.auto_handler import AutoHandler, StartAutoHandler
+from ouroboros.mcp.tools.auto_handler import (
+    AutoHandler,
+    StartAutoHandler,
+    _reconcile_execution_job_snapshot,
+)
 from ouroboros.mcp.tools.job_handlers import JobResultHandler, JobStatusHandler, JobWaitHandler
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.persistence.event_store import EventStore
@@ -126,6 +130,41 @@ def _assert_detached_start_text_has_guidance_without_handles(
     assert auto_session_id not in text
     assert not _AUTO_ID_RE.search(text)
     assert not _UUID_HEX_RE.search(text)
+
+
+@pytest.mark.asyncio
+async def test_reconcile_execution_job_does_not_complete_detached_ralph_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Execution completion must not override active Ralph detached evidence."""
+
+    class FakeJobManager:
+        async def get_snapshot(self, job_id: str):  # pragma: no cover
+            raise AssertionError(f"should not inspect execution job for {job_id}")
+
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.auto_handler.JobManager",
+        lambda: FakeJobManager(),
+    )
+    result = AutoPipelineResult(
+        status="detached",
+        auto_session_id="auto_detached",
+        phase="ralph_handoff",
+        job_id="job_execution_done",
+        execution_id="exec_done",
+        run_session_id="orch_done",
+        ralph_job_id="job_ralph_running",
+        ralph_lineage_id="lin_ralph_running",
+        ralph_dispatch_mode="job",
+        execution_job_status=JobStatus.COMPLETED.value,
+    )
+
+    reconciled = await _reconcile_execution_job_snapshot(result)
+
+    assert reconciled is result
+    assert reconciled.status == "detached"
+    assert reconciled.phase == "ralph_handoff"
+    assert reconciled.ralph_job_id == "job_ralph_running"
 
 
 @pytest.fixture

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -692,15 +692,20 @@ class TestBackgroundJobPath:
         result_handler = JobResultHandler(event_store=event_store, job_manager=job_manager)
 
         terminal_wait = None
-        for _ in range(50):
+        cursor = 0
+        # Advance the cursor and use a blocking per-wait timeout under a generous
+        # wall-clock deadline so the background runner reaches terminal even on a
+        # slow/loaded CI runner. A fixed tiny busy-poll budget races the dispatch.
+        deadline = asyncio.get_running_loop().time() + 10.0
+        while asyncio.get_running_loop().time() < deadline:
             wait_result = await wait_handler.handle(
-                {"job_id": job_id, "cursor": 0, "timeout_seconds": 0, "view": "summary"}
+                {"job_id": job_id, "cursor": cursor, "timeout_seconds": 2, "view": "summary"}
             )
             assert wait_result.is_ok
+            cursor = wait_result.value.meta["cursor"]
             if wait_result.value.meta["is_terminal"]:
                 terminal_wait = wait_result.value
                 break
-            await asyncio.sleep(0.01)
 
         assert terminal_wait is not None
         assert terminal_wait.meta["status"] == "completed"
@@ -810,15 +815,20 @@ class TestBackgroundJobPath:
         result_handler = JobResultHandler(event_store=event_store, job_manager=job_manager)
 
         terminal_wait = None
-        for _ in range(50):
+        cursor = 0
+        # Advance the cursor and use a blocking per-wait timeout under a generous
+        # wall-clock deadline so the background runner reaches terminal even on a
+        # slow/loaded CI runner. A fixed tiny busy-poll budget races the dispatch.
+        deadline = asyncio.get_running_loop().time() + 10.0
+        while asyncio.get_running_loop().time() < deadline:
             wait_result = await wait_handler.handle(
-                {"job_id": job_id, "cursor": 0, "timeout_seconds": 0, "view": "summary"}
+                {"job_id": job_id, "cursor": cursor, "timeout_seconds": 2, "view": "summary"}
             )
             assert wait_result.is_ok
+            cursor = wait_result.value.meta["cursor"]
             if wait_result.value.meta["is_terminal"]:
                 terminal_wait = wait_result.value
                 break
-            await asyncio.sleep(0.01)
 
         assert terminal_wait is not None
         assert terminal_wait.is_error is True

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -891,6 +891,83 @@ class TestBackgroundJobPath:
         inner.handle.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_mcp_detached_auto_interrupted_result_surfaces_as_error(
+        self, event_store, tmp_path
+    ) -> None:
+        """Interrupted is terminal-and-error; result/status must not report success."""
+        job_manager = JobManager(event_store)
+        store = AutoStore(tmp_path)
+        inner = MagicMock(spec=AutoHandler)
+        inner.handle = AsyncMock(
+            return_value=Result.ok(
+                MCPToolResult(
+                    content=(
+                        MCPContentItem(
+                            type=ContentType.TEXT,
+                            text="detached auto interrupted: budget exhausted mid-run",
+                        ),
+                    ),
+                    is_error=True,
+                    meta={
+                        "auto_session_id": "auto_interrupted_result",
+                        "status": "interrupted",
+                        "error": {
+                            "code": "wall_clock_exhausted",
+                            "message": "Interrupted before terminal verdict",
+                        },
+                    },
+                )
+            )
+        )
+        handler = StartAutoHandler(
+            event_store=event_store,
+            job_manager=job_manager,
+            store=store,
+        )
+        handler._inner_auto = inner
+
+        started = await handler.handle({"goal": "surface detached auto interruption"})
+
+        assert started.is_ok
+        job_id = started.value.meta["job_id"]
+        wait_handler = JobWaitHandler(event_store=event_store, job_manager=job_manager)
+        status_handler = JobStatusHandler(event_store=event_store, job_manager=job_manager)
+        result_handler = JobResultHandler(event_store=event_store, job_manager=job_manager)
+
+        terminal_wait = None
+        cursor = 0
+        deadline = asyncio.get_running_loop().time() + 10.0
+        while asyncio.get_running_loop().time() < deadline:
+            wait_result = await wait_handler.handle(
+                {"job_id": job_id, "cursor": cursor, "timeout_seconds": 2, "view": "summary"}
+            )
+            assert wait_result.is_ok
+            cursor = wait_result.value.meta["cursor"]
+            if wait_result.value.meta["is_terminal"]:
+                terminal_wait = wait_result.value
+                break
+
+        assert terminal_wait is not None
+        # The regression: an interrupted terminal job must not be reported as success.
+        assert terminal_wait.is_error is True
+        assert terminal_wait.meta["status"] == "interrupted"
+        assert terminal_wait.meta["lifecycle_status"] == "interrupted"
+        assert terminal_wait.meta["status_category"] == "terminal"
+
+        status = await status_handler.handle({"job_id": job_id})
+        assert status.is_ok
+        assert status.value.is_error is True
+        assert status.value.meta["status"] == "interrupted"
+
+        result = await result_handler.handle({"job_id": job_id})
+        assert result.is_ok
+        assert result.value.is_error is True
+        assert result.value.meta["status"] == "interrupted"
+        assert result.value.meta["is_terminal"] is True
+        assert result.value.meta["result_payload"]["is_error"] is True
+        inner.handle.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_mcp_detached_auto_result_invalid_handle_returns_stable_failure(
         self, event_store
     ) -> None:

--- a/tests/unit/router/test_dispatch.py
+++ b/tests/unit/router/test_dispatch.py
@@ -532,7 +532,7 @@ def test_packaged_auto_resolves_documented_chat_dispatch_flags(tmp_path: Path) -
 
     assert isinstance(result, Resolved)
     assert result.skill_name == "auto"
-    assert result.mcp_tool == "ouroboros_auto"
+    assert result.mcp_tool == "ouroboros_start_auto"
     assert result.mcp_args["goal"] == "Build a hello CLI"
     assert result.mcp_args["cwd"] == str(runtime_cwd)
     assert result.mcp_args["complete_product"] is True

--- a/tests/unit/router/test_packaged_auto_dispatch.py
+++ b/tests/unit/router/test_packaged_auto_dispatch.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from ouroboros.router import Resolved, resolve_skill_dispatch
 
 
-def test_packaged_auto_skill_dispatches_to_ouroboros_auto(tmp_path: Path) -> None:
+def test_packaged_auto_skill_dispatches_to_ouroboros_start_auto(tmp_path: Path) -> None:
     """Lock the packaged ``ooo auto`` dispatch metadata used by Codex runtimes."""
     prompt = 'ooo auto "Audit the open PRs" --skip-run'
 
@@ -13,7 +13,7 @@ def test_packaged_auto_skill_dispatches_to_ouroboros_auto(tmp_path: Path) -> Non
 
     assert isinstance(result, Resolved)
     assert result.command_prefix == "ooo auto"
-    assert result.mcp_tool == "ouroboros_auto"
+    assert result.mcp_tool == "ouroboros_start_auto"
     assert result.mcp_args == {
         "goal": "Audit the open PRs",
         "resume": "",

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -262,7 +262,7 @@ class TestLoadPackagedCodexSkills:
         """The auto skill body must not allow silent manual emulation."""
         skill = load_packaged_codex_skill("auto")
 
-        assert "must be executed by invoking MCP tool `ouroboros_auto`" in skill
+        assert "must be executed by invoking MCP tool `ouroboros_start_auto`" in skill
         assert "manual fallback is not an `ooo auto` run" in skill
         assert "Do not label that outcome as MCP dispatch failure" in skill
         assert "The user should not have to poll the job manually" in skill

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -65,6 +65,15 @@ class TestInstallCodexRules:
         assert secondary_target_path.read_text(encoding="utf-8") == "# status rules\n"
         assert not rules_dir.joinpath("team.md").exists()
 
+    def test_packaged_rules_make_auto_monitoring_agent_owned(self) -> None:
+        """Codex rules should keep background auto polling in the agent UX."""
+        rules = load_packaged_codex_rules()
+        compact = " ".join(rules.split())
+
+        assert "keep monitoring the job yourself" in compact
+        assert "Do not hand the user polling instructions as the final UX" in compact
+        assert "ouroboros_job_result(job_id)" in compact
+
     def test_refresh_does_not_prune_stale_namespaced_rules_by_default(self, tmp_path: Path) -> None:
         """Setup refresh should leave removed Ouroboros rules untouched unless update-mode prune is requested."""
         codex_dir = tmp_path / ".codex"
@@ -183,11 +192,12 @@ class TestInstallCodexRules:
     def test_packaged_rules_fail_closed_for_ooo_auto(self) -> None:
         """Codex rules must route ``ooo auto`` to the real MCP tool, not manual work."""
         rules = load_packaged_codex_rules()
+        compact = " ".join(rules.split())
 
-        assert "| `ooo auto ...` | `ouroboros_auto`" in rules
+        assert "| `ooo auto ...` | `ouroboros_start_auto`" in rules
         assert "Do not emulate it with manual" in rules
-        assert "If that MCP tool\nis unavailable" in rules
-        assert "Do not call a `blocked` or `failed` auto-session result a dispatch" in rules
+        assert "If that MCP tool is unavailable" in compact
+        assert "Do not call a `blocked` or `failed` auto-session result a dispatch" in compact
 
     def test_packaged_rules_include_rendered_skill_capability_guide(self) -> None:
         """Codex rules should include the generated runtime skill capability guide."""
@@ -255,6 +265,8 @@ class TestLoadPackagedCodexSkills:
         assert "must be executed by invoking MCP tool `ouroboros_auto`" in skill
         assert "manual fallback is not an `ooo auto` run" in skill
         assert "Do not label that outcome as MCP dispatch failure" in skill
+        assert "The user should not have to poll the job manually" in skill
+        assert "ouroboros_job_result(job_id)" in skill
 
     def test_packaged_interview_skill_uses_runtime_capability_terms(self) -> None:
         """Runtime skill instructions should not hardcode Claude-only tool surfaces."""

--- a/tests/unit/test_detached_auto_docs.py
+++ b/tests/unit/test_detached_auto_docs.py
@@ -1,0 +1,994 @@
+"""Tests for detached auto user-facing documentation."""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
+from ouroboros.mcp.tools.job_handlers import JobResultHandler
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.persistence.event_store import EventStore
+
+runner = CliRunner()
+
+
+def test_cli_docs_describe_detached_auto_as_tracked_non_terminal_background_work() -> None:
+    docs = Path("docs/cli-reference.md").read_text(encoding="utf-8")
+    compact = " ".join(docs.split())
+
+    assert "Detached `auto` wait and retrieve" in docs
+    assert "Detached `auto` work is non-terminal tracked background work" in compact
+    assert "Starting it does not mean the workflow has completed" in compact
+    assert "returned `job_id` is a handle for a tracked job" in compact
+    assert "reaches a terminal lifecycle status" in compact
+
+    for cli_command in (
+        "ouroboros job status JOB_ID",
+        "ouroboros job wait JOB_ID",
+        "ouroboros job result JOB_ID",
+    ):
+        assert cli_command in docs
+
+    for mcp_tool in (
+        'ouroboros_job_status(job_id="JOB_ID")',
+        'ouroboros_job_wait(job_id="JOB_ID")',
+        'ouroboros_job_result(job_id="JOB_ID")',
+    ):
+        assert mcp_tool in docs
+
+    assert "non-zero status" in compact
+    assert "error response" in compact
+
+
+def test_mcp_docs_describe_detached_auto_as_tracked_non_terminal_background_work() -> None:
+    """Runnable artifact check for MCP detached auto wait/retrieve docs."""
+    docs = Path("docs/api/mcp.md").read_text(encoding="utf-8")
+    compact = " ".join(docs.split())
+
+    assert "Detached `auto` Jobs" in docs
+    assert (
+        "`ouroboros_start_auto` starts detached `auto` work as non-terminal tracked background work"
+        in compact
+    )
+    assert (
+        "that handle identifies tracked background work, not a completed workflow result" in compact
+    )
+    assert "terminal state such as `completed`, `failed`, `cancelled`, or `expired`" in compact
+
+    for mcp_tool in (
+        'ouroboros_job_status(job_id="JOB_ID")',
+        'ouroboros_job_wait(job_id="JOB_ID")',
+        'ouroboros_job_result(job_id="JOB_ID")',
+    ):
+        assert mcp_tool in docs
+
+    assert "Treat `running` or other non-terminal status output as progress only" in compact
+    assert "Wait with `ouroboros_job_wait`, then fetch the completed result" in compact
+    assert "MCP error response" in compact
+
+
+def test_docs_verify_running_state_includes_stable_wait_and_retrieve_guidance() -> None:
+    """Docs artifact check for detached running-state wait/retrieve guidance."""
+    cli_docs = Path("docs/cli-reference.md").read_text(encoding="utf-8")
+    mcp_docs = Path("docs/api/mcp.md").read_text(encoding="utf-8")
+
+    cli_compact = " ".join(cli_docs.split())
+    mcp_compact = " ".join(mcp_docs.split())
+
+    assert "its `running` lifecycle status is non-terminal tracked background work" in cli_compact
+    assert "Treat status output as progress, not as the final `auto` result" in cli_compact
+    assert (
+        "Retrieve the result only after the job reaches a terminal lifecycle status" in cli_compact
+    )
+
+    assert "`running` lifecycle status is non-terminal tracked background work" in mcp_compact
+    assert "Treat `running` or other non-terminal status output as progress only" in mcp_compact
+    assert "Wait with `ouroboros_job_wait`, then fetch the completed result" in mcp_compact
+
+    for cli_command in (
+        "ouroboros job status JOB_ID",
+        "ouroboros job wait JOB_ID",
+        "ouroboros job result JOB_ID",
+    ):
+        assert cli_command in cli_docs
+
+    for mcp_tool in (
+        'ouroboros_job_status(job_id="JOB_ID")',
+        'ouroboros_job_wait(job_id="JOB_ID")',
+        'ouroboros_job_result(job_id="JOB_ID")',
+    ):
+        assert mcp_tool in mcp_docs
+
+
+def test_cli_docs_verify_completed_state_has_stable_result_retrieval_semantics() -> None:
+    """Docs artifact check for completed detached auto CLI result retrieval."""
+    docs = Path("docs/cli-reference.md").read_text(encoding="utf-8")
+    compact = " ".join(docs.split())
+
+    assert "Detached `auto` wait and retrieve" in docs
+    assert "ouroboros job status JOB_ID" in docs
+    assert "ouroboros job wait JOB_ID" in docs
+    assert "ouroboros job result JOB_ID" in docs
+    assert "When CLI status reports `completed`" in compact
+    assert "`ouroboros job result JOB_ID` retrieves the stable completed `auto` result" in compact
+    assert "that job handle" in compact
+
+
+def test_cli_docs_api_check_verifies_completed_detached_auto_result_output(
+    monkeypatch, tmp_path
+) -> None:
+    """Runnable docs/API check for completed detached auto CLI result retrieval."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    docs = Path("docs/cli-reference.md").read_text(encoding="utf-8")
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'detached-auto-docs-check.db'}"
+    job_id = "job_auto_docs_done"
+    auto_session_id = "auto_docs_done"
+    result_text = "detached auto result artifact: seed.yaml"
+    timestamp = datetime(2026, 5, 29, 12, 0, tzinfo=UTC)
+
+    async def _persist_completed_auto_job() -> None:
+        store = EventStore(db_url)
+        await store.initialize()
+        try:
+            await store.append(
+                BaseEvent(
+                    id="evt_auto_docs_created",
+                    type="mcp.job.created",
+                    timestamp=timestamp,
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "job_type": "auto",
+                        "status": JobStatus.QUEUED.value,
+                        "message": "Queued detached auto",
+                        "links": {
+                            "session_id": auto_session_id,
+                            "execution_id": None,
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    id="evt_auto_docs_completed",
+                    type="mcp.job.completed",
+                    timestamp=timestamp + timedelta(seconds=1),
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "status": JobStatus.COMPLETED.value,
+                        "message": "Job complete",
+                        "result_text": result_text,
+                        "result_meta": {"auto_session_id": auto_session_id},
+                        "result_payload": {
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": result_text,
+                                    "data": None,
+                                    "mime_type": None,
+                                    "uri": None,
+                                }
+                            ],
+                            "is_error": False,
+                            "meta": {"auto_session_id": auto_session_id},
+                            "text_content": result_text,
+                        },
+                        "is_error": False,
+                    },
+                )
+            )
+        finally:
+            await store.close()
+
+    asyncio.run(_persist_completed_auto_job())
+
+    monkeypatch.setattr(
+        job_command,
+        "JobResultHandler",
+        lambda: JobResultHandler(event_store=EventStore(db_url)),
+    )
+
+    result = runner.invoke(app, ["job", "result", job_id])
+    repeated = runner.invoke(app, ["job", "result", job_id])
+
+    assert result.exit_code == 0
+    assert repeated.exit_code == 0
+    assert result.output == repeated.output == f"{result_text}\n"
+    assert f"$ ouroboros job result {job_id}" in docs
+    assert result_text in docs
+
+
+def test_mcp_docs_verify_completed_state_has_stable_result_retrieval_semantics() -> None:
+    """Docs artifact check for completed detached auto MCP result retrieval."""
+    docs = Path("docs/api/mcp.md").read_text(encoding="utf-8")
+    compact = " ".join(docs.split())
+
+    assert "Detached `auto` Jobs" in docs
+    assert 'ouroboros_job_status(job_id="JOB_ID")' in docs
+    assert 'ouroboros_job_wait(job_id="JOB_ID")' in docs
+    assert 'ouroboros_job_result(job_id="JOB_ID")' in docs
+    assert "When MCP status reports `completed`" in compact
+    assert (
+        '`ouroboros_job_result(job_id="JOB_ID")` retrieves the stable completed `auto` result'
+        in compact
+    )
+    assert "that job handle" in compact
+    assert 'ouroboros_job_result(job_id="job_auto_docs_done")' in docs
+    assert 'content[0].text = "detached auto result artifact: seed.yaml"' in docs
+    assert 'content[1].uri = "file:///tmp/detached-auto-result.json"' in docs
+    assert 'meta.status = "completed"' in docs
+    assert "meta.is_terminal = true" in docs
+
+
+def test_mcp_docs_api_check_verifies_completed_detached_auto_result_response(
+    tmp_path,
+) -> None:
+    """Runnable docs/API check for completed detached auto MCP result retrieval."""
+    docs = Path("docs/api/mcp.md").read_text(encoding="utf-8")
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'detached-auto-mcp-docs-check.db'}"
+    job_id = "job_auto_docs_done"
+    auto_session_id = "auto_docs_done"
+    result_text = "detached auto result artifact: seed.yaml"
+    artifact_uri = "file:///tmp/detached-auto-result.json"
+    timestamp = datetime(2026, 5, 29, 12, 0, tzinfo=UTC)
+
+    async def _persist_completed_auto_job_and_fetch_result():
+        store = EventStore(db_url)
+        await store.initialize()
+        try:
+            await store.append(
+                BaseEvent(
+                    id="evt_auto_mcp_docs_created",
+                    type="mcp.job.created",
+                    timestamp=timestamp,
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "job_type": "auto",
+                        "status": JobStatus.QUEUED.value,
+                        "message": "Queued detached auto",
+                        "links": {
+                            "session_id": auto_session_id,
+                            "execution_id": None,
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    id="evt_auto_mcp_docs_completed",
+                    type="mcp.job.completed",
+                    timestamp=timestamp + timedelta(seconds=1),
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "status": JobStatus.COMPLETED.value,
+                        "message": "Job complete",
+                        "result_text": result_text,
+                        "result_meta": {
+                            "auto_session_id": auto_session_id,
+                            "result": {
+                                "artifact": "detached-auto-result.json",
+                                "ok": True,
+                            },
+                        },
+                        "result_payload": {
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": result_text,
+                                    "data": None,
+                                    "mime_type": None,
+                                    "uri": None,
+                                },
+                                {
+                                    "type": "resource",
+                                    "text": None,
+                                    "data": None,
+                                    "mime_type": None,
+                                    "uri": artifact_uri,
+                                },
+                            ],
+                            "is_error": False,
+                            "meta": {
+                                "auto_session_id": auto_session_id,
+                                "result": {
+                                    "artifact": "detached-auto-result.json",
+                                    "ok": True,
+                                },
+                            },
+                            "text_content": result_text,
+                        },
+                        "is_error": False,
+                    },
+                )
+            )
+
+            handler = JobResultHandler(event_store=store)
+            first = await handler.handle({"job_id": job_id})
+            second = await handler.handle({"job_id": job_id})
+            return first, second
+        finally:
+            await store.close()
+
+    first, second = asyncio.run(_persist_completed_auto_job_and_fetch_result())
+
+    assert first.is_ok
+    assert second.is_ok
+    assert first.value.is_error is False
+    assert second.value.is_error is False
+    assert (
+        first.value.content
+        == second.value.content
+        == (
+            MCPContentItem(type=ContentType.TEXT, text=result_text),
+            MCPContentItem(type=ContentType.RESOURCE, uri=artifact_uri),
+        )
+    )
+    assert first.value.meta == second.value.meta
+    assert first.value.meta["job_id"] == job_id
+    assert first.value.meta["status"] == "completed"
+    assert first.value.meta["is_terminal"] is True
+    assert first.value.meta["session_id"] == auto_session_id
+    assert first.value.meta["auto_session_id"] == auto_session_id
+    assert first.value.meta["result"] == {
+        "artifact": "detached-auto-result.json",
+        "ok": True,
+    }
+    assert first.value.meta["result_payload"]["content"][1]["uri"] == artifact_uri
+
+    assert f'ouroboros_job_result(job_id="{job_id}")' in docs
+    assert f'content[0].text = "{result_text}"' in docs
+    assert f'content[1].uri = "{artifact_uri}"' in docs
+    assert 'meta.status = "completed"' in docs
+    assert "meta.is_terminal = true" in docs
+
+
+def test_completed_detached_auto_result_retrieval_leaves_inspectable_event_trace(
+    tmp_path,
+) -> None:
+    """Runnable artifact/log check for completed detached auto retrieval."""
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'detached-auto-artifact-trace.db'}"
+    result_text = "detached auto result artifact: seed.yaml"
+    artifact_uri = f"file://{tmp_path / 'seed.yaml'}"
+
+    async def _run_completed_job_and_verify_trace() -> None:
+        store = EventStore(db_url)
+        manager = JobManager(store)
+        try:
+
+            async def _detached_auto_runner() -> MCPToolResult:
+                return MCPToolResult(
+                    content=(
+                        MCPContentItem(type=ContentType.TEXT, text=result_text),
+                        MCPContentItem(type=ContentType.RESOURCE, uri=artifact_uri),
+                    ),
+                    meta={
+                        "auto_session_id": "auto_artifact_trace",
+                        "result": {"artifact": "seed.yaml", "ok": True},
+                    },
+                )
+
+            started = await manager.start_job(
+                job_type="auto",
+                initial_message="Queued auto",
+                runner=_detached_auto_runner(),
+                links=JobLinks(session_id="auto_artifact_trace"),
+            )
+
+            deadline = asyncio.get_running_loop().time() + 1
+            snapshot = await manager.get_snapshot(started.job_id)
+            while snapshot.status is not JobStatus.COMPLETED:
+                if asyncio.get_running_loop().time() >= deadline:
+                    raise AssertionError(
+                        f"job {started.job_id} did not complete; last={snapshot.status}"
+                    )
+                await asyncio.sleep(0.01)
+                snapshot = await manager.get_snapshot(started.job_id)
+
+            handler = JobResultHandler(event_store=store, job_manager=manager)
+            retrieved = await handler.handle({"job_id": started.job_id})
+            assert retrieved.is_ok
+            assert retrieved.value.content == (
+                MCPContentItem(type=ContentType.TEXT, text=result_text),
+                MCPContentItem(type=ContentType.RESOURCE, uri=artifact_uri),
+            )
+            assert retrieved.value.meta["result"]["artifact"] == "seed.yaml"
+
+            events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
+            completed_events = [event for event in events if event.type == "mcp.job.completed"]
+            assert len(completed_events) == 1
+            trace = completed_events[0].data
+            assert trace["status"] == JobStatus.COMPLETED.value
+            assert trace["result_text"] == result_text
+            assert trace["result_payload"]["content"][0]["text"] == result_text
+            assert trace["result_payload"]["content"][1]["uri"] == artifact_uri
+            assert trace["result_meta"]["result"] == {"artifact": "seed.yaml", "ok": True}
+        finally:
+            await store.close()
+
+    asyncio.run(_run_completed_job_and_verify_trace())
+
+
+def test_docs_verify_failed_state_has_stable_status_semantics_and_next_steps() -> None:
+    """Docs artifact check for failed detached auto status/result guidance."""
+    cli_docs = Path("docs/cli-reference.md").read_text(encoding="utf-8")
+    mcp_docs = Path("docs/api/mcp.md").read_text(encoding="utf-8")
+
+    cli_compact = " ".join(cli_docs.split())
+    mcp_compact = " ".join(mcp_docs.split())
+
+    assert (
+        "When CLI status reports `failed`, the job is terminal and still observable" in cli_compact
+    )
+    assert (
+        "`ouroboros job result JOB_ID` returns the stable failure output or error details"
+        in cli_compact
+    )
+    assert "not a successful `auto` result" in cli_compact
+    assert "Next steps are to inspect `ouroboros job status JOB_ID`" in cli_compact
+    assert "`ouroboros job result JOB_ID`" in cli_compact
+    assert (
+        "resume or retry from the surfaced auto session, execution, or lineage handle"
+        in cli_compact
+    )
+
+    assert (
+        "When MCP status reports `failed`, the job is terminal and still observable" in mcp_compact
+    )
+    assert (
+        '`ouroboros_job_result(job_id="JOB_ID")` returns the stable failure output or error details'
+        in mcp_compact
+    )
+    assert "`is_error=true`" in mcp_compact
+    assert "not a successful `auto` result" in mcp_compact
+    assert 'Next steps are to inspect `ouroboros_job_status(job_id="JOB_ID")`' in mcp_compact
+    assert 'ouroboros_job_result(job_id="JOB_ID")' in mcp_compact
+    assert (
+        "resume or retry from the surfaced auto session, execution, or lineage handle"
+        in mcp_compact
+    )
+    assert 'ouroboros_job_result(job_id="job_auto_docs_failed")' in mcp_docs
+    assert "is_error = true" in mcp_docs
+    assert 'content[0].text = "detached auto failed: seed repair budget exhausted"' in mcp_docs
+    assert 'meta.status = "failed"' in mcp_docs
+    assert 'meta.error = "seed repair budget exhausted"' in mcp_docs
+
+
+def test_mcp_docs_api_check_verifies_failed_detached_auto_result_response(
+    tmp_path,
+) -> None:
+    """Runnable MCP docs/API check for failed detached auto result retrieval."""
+    docs = Path("docs/api/mcp.md").read_text(encoding="utf-8")
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'detached-auto-mcp-failed-docs-check.db'}"
+    job_id = "job_auto_docs_failed"
+    auto_session_id = "auto_docs_failed"
+    failure_text = "detached auto failed: seed repair budget exhausted"
+    success_text = "detached auto result artifact: seed.yaml"
+    source_error = "seed repair budget exhausted"
+    timestamp = datetime(2026, 5, 29, 12, 30, tzinfo=UTC)
+
+    async def _persist_failed_auto_job_and_fetch_result():
+        store = EventStore(db_url)
+        await store.initialize()
+        try:
+            await store.append(
+                BaseEvent(
+                    id="evt_auto_mcp_failed_docs_created",
+                    type="mcp.job.created",
+                    timestamp=timestamp,
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "job_type": "auto",
+                        "status": JobStatus.QUEUED.value,
+                        "message": "Queued detached auto",
+                        "links": {
+                            "session_id": auto_session_id,
+                            "execution_id": None,
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    id="evt_auto_mcp_failed_docs_terminal",
+                    type="mcp.job.failed",
+                    timestamp=timestamp + timedelta(seconds=1),
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "status": JobStatus.FAILED.value,
+                        "message": "Job failed",
+                        "error": source_error,
+                        "result_text": failure_text,
+                        "result_meta": {
+                            "auto_session_id": auto_session_id,
+                            "failure_kind": "seed_repair_budget",
+                        },
+                        "result_payload": {
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": failure_text,
+                                    "data": None,
+                                    "mime_type": None,
+                                    "uri": None,
+                                },
+                            ],
+                            "is_error": True,
+                            "meta": {
+                                "auto_session_id": auto_session_id,
+                                "failure_kind": "seed_repair_budget",
+                            },
+                            "text_content": failure_text,
+                        },
+                        "is_error": True,
+                    },
+                )
+            )
+
+            handler = JobResultHandler(event_store=store)
+            first = await handler.handle({"job_id": job_id})
+            second = await handler.handle({"job_id": job_id})
+            return first, second
+        finally:
+            await store.close()
+
+    first, second = asyncio.run(_persist_failed_auto_job_and_fetch_result())
+
+    assert first.is_ok
+    assert second.is_ok
+    assert first.value.is_error is True
+    assert second.value.is_error is True
+    assert (
+        first.value.content
+        == second.value.content
+        == (MCPContentItem(type=ContentType.TEXT, text=failure_text),)
+    )
+    assert first.value.text_content == failure_text
+    assert success_text not in first.value.text_content
+    assert first.value.meta == second.value.meta
+    assert first.value.meta["job_id"] == job_id
+    assert first.value.meta["status"] == "failed"
+    assert first.value.meta["lifecycle_status"] == "failed"
+    assert first.value.meta["is_terminal"] is True
+    assert first.value.meta["result_available"] is True
+    assert first.value.meta["error"] == source_error
+    assert first.value.meta["session_id"] == auto_session_id
+    assert first.value.meta["auto_session_id"] == auto_session_id
+    assert first.value.meta["failure_kind"] == "seed_repair_budget"
+    assert first.value.meta["result_payload"]["is_error"] is True
+    assert first.value.meta["result_payload"]["content"][0]["text"] == failure_text
+
+    assert f'ouroboros_job_result(job_id="{job_id}")' in docs
+    assert f'content[0].text = "{failure_text}"' in docs
+    assert "is_error = true" in docs
+    assert 'meta.status = "failed"' in docs
+    assert "meta.is_terminal = true" in docs
+    assert f'meta.error = "{source_error}"' in docs
+
+
+def test_docs_verify_cancelled_state_has_stable_status_semantics_and_next_steps() -> None:
+    """Docs artifact check for cancelled detached auto status/result guidance."""
+    cli_docs = Path("docs/cli-reference.md").read_text(encoding="utf-8")
+    mcp_docs = Path("docs/api/mcp.md").read_text(encoding="utf-8")
+
+    cli_compact = " ".join(cli_docs.split())
+    mcp_compact = " ".join(mcp_docs.split())
+
+    assert (
+        "When CLI status reports `cancelled`, the job is terminal and still observable"
+        in cli_compact
+    )
+    assert (
+        "`ouroboros job result JOB_ID` returns stable cancellation output or error details"
+        in cli_compact
+    )
+    assert "cancellation reason when one is available" in cli_compact
+    assert "not a successful `auto` result" in cli_compact
+    assert "Next steps are to inspect `ouroboros job status JOB_ID`" in cli_compact
+    assert "`ouroboros job result JOB_ID`" in cli_compact
+    assert "restart the detached auto flow or resume from the surfaced auto session" in cli_compact
+    assert "exits non-zero because the terminal result is an error result" in cli_compact
+    assert "ouroboros job result job_auto_docs_cancelled" in cli_docs
+    assert "detached auto cancelled: user requested cancellation" in cli_docs
+
+    assert (
+        "When MCP status reports `cancelled`, the job is terminal and still observable"
+        in mcp_compact
+    )
+    assert (
+        '`ouroboros_job_result(job_id="JOB_ID")` returns stable cancellation '
+        "output or error details" in mcp_compact
+    )
+    assert "`is_error=true`" in mcp_compact
+    assert "cancellation reason when one is available" in mcp_compact
+    assert "not a successful `auto` result" in mcp_compact
+    assert 'Next steps are to inspect `ouroboros_job_status(job_id="JOB_ID")`' in mcp_compact
+    assert 'ouroboros_job_result(job_id="JOB_ID")' in mcp_compact
+    assert "restart the detached auto flow or resume from the surfaced auto session" in mcp_compact
+    assert 'ouroboros_job_result(job_id="job_auto_docs_cancelled")' in mcp_docs
+    assert "is_error = true" in mcp_docs
+    assert 'content[0].text = "detached auto cancelled: user requested cancellation"' in mcp_docs
+    assert 'meta.status = "cancelled"' in mcp_docs
+    assert 'meta.lifecycle_status = "cancelled"' in mcp_docs
+    assert "meta.is_terminal = true" in mcp_docs
+    assert 'meta.error = "user requested cancellation"' in mcp_docs
+
+
+def test_mcp_docs_api_check_verifies_cancelled_detached_auto_result_response(
+    tmp_path,
+) -> None:
+    """Runnable MCP docs/API check for cancelled detached auto result retrieval."""
+    docs = Path("docs/api/mcp.md").read_text(encoding="utf-8")
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'detached-auto-mcp-cancelled-docs-check.db'}"
+    job_id = "job_auto_docs_cancelled"
+    auto_session_id = "auto_docs_cancelled"
+    cancellation_text = "detached auto cancelled: user requested cancellation"
+    success_text = "detached auto result artifact: seed.yaml"
+    source_error = "user requested cancellation"
+    timestamp = datetime(2026, 5, 29, 13, 0, tzinfo=UTC)
+
+    async def _persist_cancelled_auto_job_and_fetch_result():
+        store = EventStore(db_url)
+        await store.initialize()
+        try:
+            await store.append(
+                BaseEvent(
+                    id="evt_auto_mcp_cancelled_docs_created",
+                    type="mcp.job.created",
+                    timestamp=timestamp,
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "job_type": "auto",
+                        "status": JobStatus.QUEUED.value,
+                        "message": "Queued detached auto",
+                        "links": {
+                            "session_id": auto_session_id,
+                            "execution_id": None,
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    id="evt_auto_mcp_cancelled_docs_terminal",
+                    type="mcp.job.cancelled",
+                    timestamp=timestamp + timedelta(seconds=1),
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "status": JobStatus.CANCELLED.value,
+                        "message": "Job cancelled",
+                        "error": source_error,
+                        "result_text": cancellation_text,
+                        "result_meta": {
+                            "auto_session_id": auto_session_id,
+                            "cancellation_reason": source_error,
+                        },
+                        "result_payload": {
+                            "content": [
+                                {
+                                    "type": "text",
+                                    "text": cancellation_text,
+                                    "data": None,
+                                    "mime_type": None,
+                                    "uri": None,
+                                },
+                            ],
+                            "is_error": True,
+                            "meta": {
+                                "auto_session_id": auto_session_id,
+                                "cancellation_reason": source_error,
+                            },
+                            "text_content": cancellation_text,
+                        },
+                        "is_error": True,
+                    },
+                )
+            )
+
+            handler = JobResultHandler(event_store=store)
+            first = await handler.handle({"job_id": job_id})
+            second = await handler.handle({"job_id": job_id})
+            return first, second
+        finally:
+            await store.close()
+
+    first, second = asyncio.run(_persist_cancelled_auto_job_and_fetch_result())
+
+    assert first.is_ok
+    assert second.is_ok
+    assert first.value.is_error is True
+    assert second.value.is_error is True
+    assert (
+        first.value.content
+        == second.value.content
+        == (MCPContentItem(type=ContentType.TEXT, text=cancellation_text),)
+    )
+    assert first.value.text_content == cancellation_text
+    assert success_text not in first.value.text_content
+    assert first.value.meta == second.value.meta
+    assert first.value.meta["job_id"] == job_id
+    assert first.value.meta["status"] == "cancelled"
+    assert first.value.meta["lifecycle_status"] == "cancelled"
+    assert first.value.meta["is_terminal"] is True
+    assert first.value.meta["result_available"] is True
+    assert first.value.meta["error"] == source_error
+    assert first.value.meta["session_id"] == auto_session_id
+    assert first.value.meta["auto_session_id"] == auto_session_id
+    assert first.value.meta["cancellation_reason"] == source_error
+    assert first.value.meta["result_payload"]["is_error"] is True
+    assert first.value.meta["result_payload"]["content"][0]["text"] == cancellation_text
+
+    assert f'ouroboros_job_result(job_id="{job_id}")' in docs
+    assert f'content[0].text = "{cancellation_text}"' in docs
+    assert "is_error = true" in docs
+    assert 'meta.status = "cancelled"' in docs
+    assert 'meta.lifecycle_status = "cancelled"' in docs
+    assert "meta.is_terminal = true" in docs
+    assert f'meta.error = "{source_error}"' in docs
+
+
+def test_docs_verify_expired_state_has_stable_status_semantics_and_next_steps() -> None:
+    """Docs artifact check for expired detached auto status/result guidance."""
+    cli_docs = Path("docs/cli-reference.md").read_text(encoding="utf-8")
+    mcp_docs = Path("docs/api/mcp.md").read_text(encoding="utf-8")
+
+    cli_compact = " ".join(cli_docs.split())
+    mcp_compact = " ".join(mcp_docs.split())
+
+    assert (
+        "When CLI status reports `expired`, the job is terminal tracked background work"
+        in cli_compact
+    )
+    assert "retained result is no longer available through that job handle" in cli_compact
+    assert "stable observable status is `expired`, not `running` or `completed`" in cli_compact
+    assert (
+        "`ouroboros job result JOB_ID` returns the stable expiration error details" in cli_compact
+    )
+    assert "rather than a detached `auto` result" in cli_compact
+    assert "Next steps are to inspect any surfaced auto session" in cli_compact
+    assert "resume from that handle or restart the detached auto flow" in cli_compact
+    assert "when no recoverable handle is present" in cli_compact
+
+    assert (
+        "When MCP status reports `expired`, the job is terminal tracked background work"
+        in mcp_compact
+    )
+    assert "retained result is no longer available through that job handle" in mcp_compact
+    assert (
+        "stable observable status is `expired` with `is_error=true`, not `running` or "
+        "`completed`" in mcp_compact
+    )
+    assert (
+        '`ouroboros_job_result(job_id="JOB_ID")` returns stable expiration error details'
+        in mcp_compact
+    )
+    assert "rather than a detached `auto` result" in mcp_compact
+    assert "Next steps are to inspect any surfaced auto session" in mcp_compact
+    assert "resume from that handle or restart the detached auto flow" in mcp_compact
+    assert "when no recoverable handle is present" in mcp_compact
+    assert "ouroboros job result job_auto_docs_expired" in cli_docs
+    assert "Job handle expired: job_auto_docs_expired. Result unavailable." in cli_docs
+    assert 'ouroboros_job_result(job_id="job_auto_docs_expired")' in mcp_docs
+    assert (
+        'error.message = "Job handle expired: job_auto_docs_expired. Result unavailable."'
+        in mcp_docs
+    )
+    assert 'error.error_code = "job_handle_expired"' in mcp_docs
+    assert 'error.details.lifecycle_status = "expired"' in mcp_docs
+    assert "error.details.is_terminal = true" in mcp_docs
+    assert "error.details.result_available = false" in mcp_docs
+    assert 'error.details.reason = "expired"' in mcp_docs
+
+
+def test_docs_api_check_verifies_expired_detached_work_observable_contract(
+    monkeypatch, tmp_path
+) -> None:
+    """Runnable docs/API check for expired detached auto handles."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    cli_docs = Path("docs/cli-reference.md").read_text(encoding="utf-8")
+    mcp_docs = Path("docs/api/mcp.md").read_text(encoding="utf-8")
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'expired-detached-auto-docs-check.db'}"
+    job_id = "job_auto_docs_expired"
+    auto_session_id = "auto_docs_expired"
+    expired_at = datetime.now(UTC) - timedelta(hours=2)
+
+    async def _persist_expired_auto_job_and_fetch_result():
+        store = EventStore(db_url)
+        await store.initialize()
+        try:
+            await store.append(
+                BaseEvent(
+                    id="evt_auto_expired_docs_created",
+                    type="mcp.job.created",
+                    timestamp=expired_at,
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "job_type": "auto",
+                        "status": JobStatus.QUEUED.value,
+                        "message": "Queued detached auto",
+                        "links": {
+                            "session_id": auto_session_id,
+                            "execution_id": None,
+                            "lineage_id": None,
+                        },
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    id="evt_auto_expired_docs_completed",
+                    type="mcp.job.completed",
+                    timestamp=expired_at + timedelta(seconds=1),
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "status": JobStatus.COMPLETED.value,
+                        "message": "Job complete",
+                        "result_text": "detached auto result artifact: expired seed.yaml",
+                        "result_meta": {"auto_session_id": auto_session_id},
+                        "is_error": False,
+                    },
+                )
+            )
+
+            handler = JobResultHandler(event_store=store)
+            return await handler.handle({"job_id": job_id})
+        finally:
+            await store.close()
+
+    api_result = asyncio.run(_persist_expired_auto_job_and_fetch_result())
+
+    assert api_result.is_err
+    assert api_result.error.tool_name == "ouroboros_job_result"
+    assert api_result.error.error_code == "job_handle_expired"
+    assert api_result.error.message == (
+        "Job handle expired: job_auto_docs_expired. Result unavailable."
+    )
+    assert api_result.error.details == {
+        "job_id": job_id,
+        "lifecycle_status": "expired",
+        "is_terminal": True,
+        "result_available": False,
+        "reason": "expired",
+    }
+
+    monkeypatch.setattr(
+        job_command,
+        "JobResultHandler",
+        lambda: JobResultHandler(event_store=EventStore(db_url)),
+    )
+    cli_result = runner.invoke(app, ["job", "result", job_id])
+
+    assert cli_result.exit_code == 1
+    assert api_result.error.message in cli_result.output
+    assert f"$ ouroboros job result {job_id}" in cli_docs
+    assert api_result.error.message in cli_docs
+    assert f'ouroboros_job_result(job_id="{job_id}")' in mcp_docs
+    assert f'error.message = "{api_result.error.message}"' in mcp_docs
+    assert f'error.error_code = "{api_result.error.error_code}"' in mcp_docs
+    assert 'error.details.lifecycle_status = "expired"' in mcp_docs
+    assert "error.details.is_terminal = true" in mcp_docs
+    assert "error.details.result_available = false" in mcp_docs
+    assert 'error.details.reason = "expired"' in mcp_docs
+
+
+def test_docs_verify_invalid_detached_work_has_stable_status_semantics_and_next_steps() -> None:
+    """Docs artifact check for invalid detached auto handles."""
+    cli_docs = Path("docs/cli-reference.md").read_text(encoding="utf-8")
+    mcp_docs = Path("docs/api/mcp.md").read_text(encoding="utf-8")
+
+    cli_compact = " ".join(cli_docs.split())
+    mcp_compact = " ".join(mcp_docs.split())
+
+    assert "Unknown, expired, or otherwise unavailable handles fail" in cli_compact
+    assert (
+        "When CLI status cannot resolve the supplied handle, treat the detached work "
+        "as `invalid` or unavailable rather than as running or completed" in cli_compact
+    )
+    assert "stable observable status is the non-zero CLI exit" in cli_compact
+    assert "human-readable error for that handle" in cli_compact
+    assert "Next steps are to check the copied `job_id`" in cli_compact
+    assert "inspect any surfaced auto session, execution, or lineage handle" in cli_compact
+    assert "restart the detached auto flow when no valid handle can be recovered" in cli_compact
+
+    assert (
+        "Unknown, expired, or otherwise unavailable handles return an MCP error response"
+        in mcp_compact
+    )
+    assert (
+        "When MCP status cannot resolve the supplied handle, treat the detached work "
+        "as `invalid` or unavailable rather than as running or completed" in mcp_compact
+    )
+    assert "stable observable status is the MCP error response for that handle" in mcp_compact
+    assert "not a detached `auto` result" in mcp_compact
+    assert "Next steps are to check the copied `job_id`" in mcp_compact
+    assert "inspect any surfaced auto session, execution, or lineage handle" in mcp_compact
+    assert "restart the detached auto flow when no valid handle can be recovered" in mcp_compact
+    assert 'ouroboros_job_result(job_id="missing_detached_auto")' in mcp_docs
+    assert (
+        'error.message = "Job handle not found: missing_detached_auto. Result unavailable."'
+        in mcp_docs
+    )
+    assert 'error.error_code = "job_handle_not_found"' in mcp_docs
+    assert 'error.details.lifecycle_status = "invalid"' in mcp_docs
+    assert "error.details.is_terminal = true" in mcp_docs
+    assert "error.details.result_available = false" in mcp_docs
+    assert 'error.details.reason = "not_found"' in mcp_docs
+
+    assert "$ ouroboros job result missing_detached_auto" in cli_docs
+    assert "Job handle not found: missing_detached_auto. Result unavailable." in cli_docs
+
+
+def test_docs_api_check_verifies_invalid_detached_work_observable_contract(
+    monkeypatch, tmp_path
+) -> None:
+    """Runnable docs/API check for invalid detached auto handles."""
+    from ouroboros.cli.commands import job as job_command
+    from ouroboros.cli.main import app
+
+    cli_docs = Path("docs/cli-reference.md").read_text(encoding="utf-8")
+    mcp_docs = Path("docs/api/mcp.md").read_text(encoding="utf-8")
+    db_url = f"sqlite+aiosqlite:///{tmp_path / 'invalid-detached-auto-docs-check.db'}"
+    job_id = "missing_detached_auto"
+
+    async def _fetch_invalid_result():
+        store = EventStore(db_url)
+        await store.initialize()
+        try:
+            handler = JobResultHandler(event_store=store)
+            return await handler.handle({"job_id": job_id})
+        finally:
+            await store.close()
+
+    api_result = asyncio.run(_fetch_invalid_result())
+
+    assert api_result.is_err
+    assert api_result.error.tool_name == "ouroboros_job_result"
+    assert api_result.error.error_code == "job_handle_not_found"
+    assert api_result.error.message == (
+        "Job handle not found: missing_detached_auto. Result unavailable."
+    )
+    assert api_result.error.details == {
+        "job_id": job_id,
+        "lifecycle_status": "invalid",
+        "is_terminal": True,
+        "result_available": False,
+        "reason": "not_found",
+        "source_error": f"Job not found: {job_id}",
+    }
+
+    monkeypatch.setattr(
+        job_command,
+        "JobResultHandler",
+        lambda: JobResultHandler(event_store=EventStore(db_url)),
+    )
+    cli_result = runner.invoke(app, ["job", "result", job_id])
+
+    assert cli_result.exit_code == 1
+    assert api_result.error.message in cli_result.output
+    assert f"$ ouroboros job result {job_id}" in cli_docs
+    assert api_result.error.message in cli_docs
+    assert f'ouroboros_job_result(job_id="{job_id}")' in mcp_docs
+    assert f'error.message = "{api_result.error.message}"' in mcp_docs
+    assert f'error.error_code = "{api_result.error.error_code}"' in mcp_docs
+    assert 'error.details.lifecycle_status = "invalid"' in mcp_docs
+    assert "error.details.is_terminal = true" in mcp_docs
+    assert "error.details.result_available = false" in mcp_docs

--- a/tests/unit/test_detached_auto_docs.py
+++ b/tests/unit/test_detached_auto_docs.py
@@ -56,7 +56,8 @@ def test_mcp_docs_describe_detached_auto_as_tracked_non_terminal_background_work
     assert (
         "that handle identifies tracked background work, not a completed workflow result" in compact
     )
-    assert "terminal state such as `completed`, `failed`, `cancelled`, or `expired`" in compact
+    assert "terminal state such as `completed`, `failed`, or `cancelled`" in compact
+    assert "Expired retention is reported by `ouroboros_job_result`" in compact
 
     for mcp_tool in (
         'ouroboros_job_status(job_id="JOB_ID")',
@@ -750,33 +751,19 @@ def test_docs_verify_expired_state_has_stable_status_semantics_and_next_steps() 
     cli_compact = " ".join(cli_docs.split())
     mcp_compact = " ".join(mcp_docs.split())
 
-    assert (
-        "When CLI status reports `expired`, the job is terminal tracked background work"
-        in cli_compact
-    )
+    assert "When `ouroboros job result JOB_ID` reports `expired`" in cli_compact
     assert "retained result is no longer available through that job handle" in cli_compact
-    assert "stable observable status is `expired`, not `running` or `completed`" in cli_compact
-    assert (
-        "`ouroboros job result JOB_ID` returns the stable expiration error details" in cli_compact
-    )
+    assert "`ouroboros job status JOB_ID` still reports the stored terminal" in cli_compact
+    assert "result retrieval returns stable expiration error details" in cli_compact
     assert "rather than a detached `auto` result" in cli_compact
     assert "Next steps are to inspect any surfaced auto session" in cli_compact
     assert "resume from that handle or restart the detached auto flow" in cli_compact
     assert "when no recoverable handle is present" in cli_compact
 
-    assert (
-        "When MCP status reports `expired`, the job is terminal tracked background work"
-        in mcp_compact
-    )
+    assert 'When `ouroboros_job_result(job_id="JOB_ID")` reports `expired`' in mcp_compact
     assert "retained result is no longer available through that job handle" in mcp_compact
-    assert (
-        "stable observable status is `expired` with `is_error=true`, not `running` or "
-        "`completed`" in mcp_compact
-    )
-    assert (
-        '`ouroboros_job_result(job_id="JOB_ID")` returns stable expiration error details'
-        in mcp_compact
-    )
+    assert "`ouroboros_job_status` still reports the stored terminal" in mcp_compact
+    assert "result retrieval returns stable expiration error details" in mcp_compact
     assert "rather than a detached `auto` result" in mcp_compact
     assert "Next steps are to inspect any surfaced auto session" in mcp_compact
     assert "resume from that handle or restart the detached auto flow" in mcp_compact


### PR DESCRIPTION
## Summary
- Add detached auto job wait/result CLI and MCP UX for stable status/result retrieval
- Document detached auto as non-terminal tracked background work in repo docs and skills
- Reconcile completed execution jobs over stale Ralph timeout blockers in auto result/status surfaces

## Tests
- uv run pytest tests/integration/auto/test_status_unified.py::test_mcp_auto_status_reconciles_completed_execution_over_ralph_timeout tests/unit/mcp/tools/test_auto_interview_construction.py::test_execution_job_completed_keeps_auto_complete tests/unit/mcp/tools/test_start_auto.py tests/unit/mcp/test_job_manager.py tests/unit/mcp/tools/test_definitions.py tests/unit/auto/test_pipeline_evaluate.py tests/unit/auto/test_pipeline_ralph_handoff.py tests/unit/cli/test_job_command.py tests/unit/cli/test_detached_auto_wait_command.py tests/unit/mcp/tools/test_job_invalid_arguments.py tests/unit/test_detached_auto_docs.py

## R-run comparison

| Metric                         | Baseline (sha) | This PR (sha) | Ratio |
|--------------------------------|----------------|---------------|-------|
| Rounds completed in 600 s      | N/A            | N/A           | n/a   |
| Per-round wall-clock (s/round) | N/A            | N/A           | n/a   |
| Terminal reason                | N/A            | N/A           | n/a   |
| EventStore event count         | N/A            | N/A           | n/a   |

Budget compliance: [x] N/A (detached job UX/docs/status retrieval; no canonical R-run path changed)