### PR TITLE
fix(tests): make Hermes runtime cwd assertions cross-platform

### DIFF
--- a/tests/unit/orchestrator/test_hermes_runtime.py
+++ b/tests/unit/orchestrator/test_hermes_runtime.py
@@ -18,6 +18,8 @@ import ouroboros.orchestrator.hermes_runtime as hermes_runtime_module
 from ouroboros.orchestrator.hermes_runtime import HermesCliRuntime, _parse_quiet_output
 from ouroboros.router import Resolved, ResolveRequest, SkillDispatchRouter
 
+_EXPECTED_CWD = str(Path("/tmp/project"))
+
 
 class _FakeStream:
     def __init__(self, text: str) -> None:
@@ -119,7 +121,7 @@ class TestHermesCliRuntime:
     def test_runtime_properties(self) -> None:
         runtime = HermesCliRuntime(cli_path="hermes", cwd="/tmp/project")
         assert runtime.runtime_backend == "hermes_cli"
-        assert runtime.working_directory == "/tmp/project"
+        assert runtime.working_directory == _EXPECTED_CWD
         assert runtime.permission_mode == "default"
 
     def test_constructor_accepts_llm_backend(self) -> None:
@@ -360,7 +362,7 @@ class TestHermesCliRuntime:
         resolve_request = observed_requests[0]
         assert isinstance(resolve_request, ResolveRequest)
         assert resolve_request.prompt == prompt
-        assert resolve_request.cwd == "/tmp/project"
+        assert resolve_request.cwd == _EXPECTED_CWD
         assert resolve_request.skills_dir == tmp_path
         dispatcher.assert_awaited_once()
         mock_exec.assert_not_called()
@@ -372,9 +374,9 @@ class TestHermesCliRuntime:
         assert intercept.first_argument == expected_argument
         assert intercept.mcp_args == {
             "seed_path": expected_argument,
-            "cwd": "/tmp/project",
-            "label": f"cwd=/tmp/project seed={expected_argument}",
-            "nested": {"values": [expected_argument, "/tmp/project"]},
+            "cwd": _EXPECTED_CWD,
+            "label": f"cwd={_EXPECTED_CWD} seed={expected_argument}",
+            "nested": {"values": [expected_argument, _EXPECTED_CWD]},
         }
         assert messages[-1].content == "Intercepted"
 
@@ -431,7 +433,7 @@ class TestHermesCliRuntime:
         request = mock_resolve.call_args.args[0]
         assert isinstance(request, ResolveRequest)
         assert request.prompt == "ooo run seed.yaml"
-        assert request.cwd == "/tmp/project"
+        assert request.cwd == _EXPECTED_CWD
         assert request.skills_dir == tmp_path
         dispatcher.assert_awaited_once()
         assert dispatcher.await_args.args[0] is resolved
@@ -493,7 +495,7 @@ class TestHermesCliRuntime:
         request = mock_resolve.call_args.args[0]
         assert isinstance(request, ResolveRequest)
         assert request.prompt == "ooo run prompt-derived.yaml"
-        assert request.cwd == "/tmp/project"
+        assert request.cwd == _EXPECTED_CWD
         assert request.skills_dir == tmp_path
         mock_lookup.assert_called_once_with("router_only_tool")
         fake_handler.handle.assert_awaited_once_with(
@@ -603,7 +605,7 @@ class TestHermesCliRuntime:
         assert intercept.mcp_tool == "ouroboros_interview"
         assert intercept.mcp_args == {
             "initial_context": "Build a REST API",
-            "cwd": "/tmp/project",
+            "cwd": _EXPECTED_CWD,
         }
         assert messages[-1].content == "Intercepted"
 


### PR DESCRIPTION
## Summary

On Windows, `Path("/tmp/project")` normalizes to `\tmp\project`. The Hermes runtime unit tests hardcoded the POSIX path `/tmp/project` in several assertions, causing 5 test failures on Windows:

- `test_runtime_properties`
- `test_execute_task_uses_shared_router_for_normalized_ooo_dispatch`
- `test_execute_task_passes_resolved_router_result_and_handle_to_dispatcher`
- `test_execute_task_builtin_dispatcher_emits_router_payload_fields`
- `test_execute_task_maps_interview_argument_to_initial_context`

This PR introduces `_EXPECTED_CWD = str(Path("/tmp/project"))` at the top of `test_hermes_runtime.py` and uses it in all `cwd` assertions. This matches the pattern already used in the Codex CLI runtime tests (`test_codex_cli_runtime.py`), which defines `_EXPECTED_PROJECT_CWD` the same way.

## Test plan

- [x] `uv run pytest tests/unit/orchestrator/test_hermes_runtime.py -q` passes (48 passed, 0 failed)
- [x] `uv run ruff check tests/unit/orchestrator/test_hermes_runtime.py` clean
- [x] `uv run ruff format --check tests/unit/orchestrator/test_hermes_runtime.py` clean

## R-run comparison

Not applicable — this PR only modifies test assertions in `tests/unit/orchestrator/test_hermes_runtime.py`, with no changes to `src/ouroboros/auto/`.