### PR TITLE
Follow up #1283 auto dispatch residue

### DIFF
--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -21,15 +21,21 @@ Run the full-quality auto pipeline from a single task description.
 
 This skill must be executed by invoking MCP tool `ouroboros_start_auto`. Do not
 manually inspect repositories, run shell commands, query GitHub, edit files, or
-otherwise emulate the auto pipeline as a substitute.
+otherwise emulate the auto pipeline as a substitute. Full auto runs routinely
+exceed interactive MCP tool-call timeouts, so the background starter is the
+supported default: it returns `job_id` and `auto_session_id` quickly. Retain
+both, poll progress with `ouroboros_job_wait` / `ouroboros_job_status`, and read
+terminal results with `ouroboros_job_result`.
 
-If `ouroboros_start_auto` is unavailable, stop and report that the required MCP tool
-is unavailable. A manual fallback is not an `ooo auto` run.
+If `ouroboros_start_auto` is unavailable, or if any required job polling/result
+MCP tool is unavailable, stop and report that the required MCP tool is
+unavailable. A manual fallback is not an `ooo auto` run.
 
-If `ouroboros_start_auto` is invoked successfully but returns `blocked`, `failed`, or
-another terminal auto-session status, report that auto-session status and the
-tool's blocker. Do not label that outcome as MCP dispatch failure; dispatch
-failure means the MCP tool could not be invoked.
+If a started auto job later returns `detached`, `blocked`, `failed`, or another
+auto-session status, report that auto-session status and the tool's blocker.
+`detached` is non-terminal tracked background work; surface the job/Ralph
+handles and keep polling. Do not label a `blocked` or `failed` outcome as MCP
+dispatch failure; dispatch failure means the MCP tool could not be invoked.
 
 If the active runtime routes `ooo auto` through a background starter such as
 `ouroboros_start_auto`, do not stop after returning the `job_id`. Keep ownership

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -27,6 +27,9 @@ _REQUIRED_CODEX_AUTO_TOOLS = frozenset(
     {
         "ouroboros_auto",
         "ouroboros_start_auto",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
         "ouroboros_interview",
         "ouroboros_generate_seed",
     }
@@ -106,6 +109,7 @@ def doctor(
         "Codex ooo auto dispatch: OK\n"
         "- rule maps `ooo auto` to `ouroboros_start_auto`\n"
         "- auto skill declares MCP dispatch through `ouroboros_start_auto`\n"
+        "- live MCP auto workflow includes job status/wait/result tools when probed\n"
         "- Codex config contains an `ouroboros` MCP server entry"
         + ("\n- live stdio initialize/list_tools exposes required auto tools" if live_mcp else ""),
         title="Codex Doctor",

--- a/src/ouroboros/codex/ouroboros.md
+++ b/src/ouroboros/codex/ouroboros.md
@@ -47,8 +47,9 @@ conversational tracking, call `ouroboros_job_wait` with a positive
 `timeout_seconds` value (for example 120) and `view="summary"`, update the cursor
 from `response.meta.cursor`, relay only meaningful changes, and continue until a
 terminal job status is reached or the user explicitly asks you to stop. If that
-MCP tool is unavailable, stop and report that `ouroboros_start_auto` is
-unavailable instead of continuing as a normal Codex task.
+MCP tool is unavailable, or if any required job polling/result MCP tool is
+unavailable, stop and report that the MCP dispatch surface is incomplete instead
+of continuing as a normal Codex task.
 
 If `ouroboros_start_auto` is invoked and returns an auto-session outcome such as
 `blocked`, `failed`, or `complete`, report that outcome as the auto session

--- a/tests/integration/auto/test_dispatch_to_seed_e2e.py
+++ b/tests/integration/auto/test_dispatch_to_seed_e2e.py
@@ -1,8 +1,12 @@
 """End-to-end ``ooo auto`` dispatch regression tests.
 
 Closes the last open acceptance bullet of issue #637: prove that ``ooo auto ...``
-reaches the ``ouroboros_start_auto`` MCP pipeline and produces a Seed (or fails closed
-with the documented unavailable-tool contract). The tests stay laser-focused on
+reaches the auto MCP pipeline and produces a Seed (or fails closed with the
+documented unavailable-tool contract). Per #1283 the deterministic dispatch
+surface now routes typed ``ooo auto`` to the async background starter
+``ouroboros_start_auto`` (parity with the Codex rules/doctor), so the tool name
+asserted on the dispatch boundary is ``ouroboros_start_auto``. The tests stay
+laser-focused on
 this acceptance bullet — they do not exercise progress UI, answer grounding, or
 CLI help text. All side-effects are confined to ``tmp_path``: no network, no
 real LLM, no real home directory.
@@ -20,8 +24,8 @@ Cases:
    boundary) — it covers the ledger-hydration + seed-generator wiring landed in
    PR #652. Case 1 already covers the dispatch boundary itself.
 3. The deterministic ``ooo auto`` dispatch surface fails closed with the
-   user-visible "ouroboros_start_auto is unavailable" contract message and does not
-   create any persisted auto session state when the MCP tool is unregistered.
+   user-visible "ouroboros_start_auto is unavailable" contract message and does
+   not create any persisted auto session state when the MCP tool is unregistered.
 """
 
 from __future__ import annotations

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -25,6 +25,9 @@ runner = CliRunner()
 _REQUIRED_CODEX_AUTO_TOOLS_FOR_TEST = {
     "ouroboros_auto",
     "ouroboros_start_auto",
+    "ouroboros_job_status",
+    "ouroboros_job_wait",
+    "ouroboros_job_result",
     "ouroboros_interview",
     "ouroboros_generate_seed",
 }
@@ -237,6 +240,9 @@ class TestCodexDoctor:
             return_value={
                 "ouroboros_auto",
                 "ouroboros_start_auto",
+                "ouroboros_job_status",
+                "ouroboros_job_wait",
+                "ouroboros_job_result",
                 "ouroboros_interview",
                 "ouroboros_generate_seed",
             }
@@ -307,6 +313,9 @@ class TestCodexDoctor:
                         "tools": [
                             {"name": "ouroboros_auto", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_start_auto", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_status", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_wait", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_result", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_interview", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_generate_seed", "inputSchema": {"type": "object"}},
                         ]
@@ -378,6 +387,9 @@ class TestCodexDoctor:
                         "tools": [
                             {"name": "ouroboros_auto", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_start_auto", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_status", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_wait", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_result", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_interview", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_generate_seed", "inputSchema": {"type": "object"}},
                         ]
@@ -444,6 +456,9 @@ class TestCodexDoctor:
                         "tools": [
                             {"name": "ouroboros_auto", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_start_auto", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_status", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_wait", "inputSchema": {"type": "object"}},
+                            {"name": "ouroboros_job_result", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_interview", "inputSchema": {"type": "object"}},
                             {"name": "ouroboros_generate_seed", "inputSchema": {"type": "object"}},
                         ]
@@ -572,6 +587,30 @@ class TestCodexDoctor:
 
         assert any("missing required auto tools" in failure for failure in failures)
         assert any("ouroboros_auto" in failure for failure in failures)
+
+    def test_check_auto_dispatch_surface_live_mcp_reports_missing_job_polling_tools(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+
+        with patch(
+            "ouroboros.cli.commands.codex._list_stdio_mcp_tool_names",
+            AsyncMock(
+                return_value={
+                    "ouroboros_auto",
+                    "ouroboros_start_auto",
+                    "ouroboros_interview",
+                    "ouroboros_generate_seed",
+                }
+            ),
+        ):
+            failures = _check_auto_dispatch_surface(codex_dir, live_mcp=True)
+
+        assert any("missing required auto tools" in failure for failure in failures)
+        assert any("ouroboros_job_wait" in failure for failure in failures)
+        assert any("ouroboros_job_result" in failure for failure in failures)
 
     def test_check_auto_dispatch_surface_live_mcp_reports_handshake_failure(
         self,

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -1780,7 +1780,7 @@ class TestCodexCliRuntime:
             [
                 "name: auto",
                 'description: "Automatically converge from goal to A-grade Seed and execute it"',
-                "mcp_tool: ouroboros_auto",
+                "mcp_tool: ouroboros_start_auto",
                 "mcp_args:",
                 '  goal: "$goal"',
                 '  cwd: "$CWD"',
@@ -1808,14 +1808,14 @@ class TestCodexCliRuntime:
         assert len(messages) == 1
         assert messages[0].is_error is True
         assert messages[0].content.startswith("Cannot run ooo auto")
-        assert "`ouroboros_auto` is unavailable" in messages[0].content
+        assert "`ouroboros_start_auto` is unavailable" in messages[0].content
         assert "ouroboros mcp doctor" in messages[0].content
         assert mock_warning.call_args.kwargs["fallback"] == "terminal_error"
         assert messages[0].data == {
             "subtype": "error",
             "error_type": "SkillDispatchUnavailable",
             "skill_name": "auto",
-            "tool_name": "ouroboros_auto",
+            "tool_name": "ouroboros_start_auto",
             "command_prefix": "ooo auto",
             "dispatch_error_type": "LookupError",
             "dispatch_error": "No local handler registered",
@@ -1834,7 +1834,7 @@ class TestCodexCliRuntime:
             [
                 "name: auto",
                 'description: "Automatically converge from goal to A-grade Seed and execute it"',
-                "mcp_tool: ouroboros_auto",
+                "mcp_tool: ouroboros_start_auto",
                 "mcp_args:",
                 '  goal: "$goal"',
                 '  cwd: "$CWD"',
@@ -1842,7 +1842,7 @@ class TestCodexCliRuntime:
         )
         dispatcher = AsyncMock(
             return_value=(
-                AgentMessage(type="assistant", content="Calling tool: ouroboros_auto"),
+                AgentMessage(type="assistant", content="Calling tool: ouroboros_start_auto"),
                 AgentMessage(
                     type="result",
                     content="Auto MCP server unavailable",
@@ -1876,7 +1876,7 @@ class TestCodexCliRuntime:
         assert mock_warning.call_args.kwargs["error_type"] == "MCPConnectionError"
         mock_exec.assert_not_called()
         assert [message.content for message in messages] == [
-            "Calling tool: ouroboros_auto",
+            "Calling tool: ouroboros_start_auto",
             "Auto MCP server unavailable",
         ]
         assert messages[-1].data["error_type"] == "MCPConnectionError"
@@ -1894,7 +1894,7 @@ class TestCodexCliRuntime:
             [
                 "name: auto",
                 'description: "Automatically converge from goal to A-grade Seed and execute it"',
-                "mcp_tool: ouroboros_auto",
+                "mcp_tool: ouroboros_start_auto",
                 "mcp_args:",
                 '  goal: "$goal"',
                 '  cwd: "$CWD"',
@@ -1902,10 +1902,10 @@ class TestCodexCliRuntime:
         )
         dispatcher = AsyncMock(
             return_value=(
-                AgentMessage(type="assistant", content="Calling tool: ouroboros_auto"),
+                AgentMessage(type="assistant", content="Calling tool: ouroboros_start_auto"),
                 AgentMessage(
                     type="result",
-                    content="Tool ouroboros_auto not found",
+                    content="Tool ouroboros_start_auto not found",
                     data={
                         "subtype": "error",
                         "recoverable": True,
@@ -1935,7 +1935,7 @@ class TestCodexCliRuntime:
         assert len(messages) == 1
         assert messages[0].data["error_type"] == "SkillDispatchUnavailable"
         assert messages[0].data["dispatch_error_type"] == "MCPResourceNotFoundError"
-        assert messages[0].data["dispatch_error"] == "Tool ouroboros_auto not found"
+        assert messages[0].data["dispatch_error"] == "Tool ouroboros_start_auto not found"
         assert messages[0].data["dispatch_error_category"] == "mcp_registration_missing"
 
     @pytest.mark.asyncio
@@ -1950,7 +1950,7 @@ class TestCodexCliRuntime:
             [
                 "name: auto",
                 'description: "Automatically converge from goal to A-grade Seed and execute it"',
-                "mcp_tool: ouroboros_auto",
+                "mcp_tool: ouroboros_start_auto",
                 "mcp_args:",
                 '  goal: "$goal"',
                 '  cwd: "$CWD"',
@@ -1958,7 +1958,7 @@ class TestCodexCliRuntime:
         )
         dispatcher = AsyncMock(
             return_value=(
-                AgentMessage(type="assistant", content="Calling tool: ouroboros_auto"),
+                AgentMessage(type="assistant", content="Calling tool: ouroboros_start_auto"),
                 AgentMessage(
                     type="result",
                     content="MCPClientError: Transport closed",
@@ -2008,7 +2008,7 @@ class TestCodexCliRuntime:
             [
                 "name: auto",
                 'description: "Automatically converge from goal to A-grade Seed and execute it"',
-                "mcp_tool: ouroboros_auto",
+                "mcp_tool: ouroboros_start_auto",
                 "mcp_args:",
                 '  goal: "$goal"',
                 '  cwd: "$CWD"',
@@ -2016,7 +2016,7 @@ class TestCodexCliRuntime:
         )
         dispatcher = AsyncMock(
             return_value=(
-                AgentMessage(type="assistant", content="Calling tool: ouroboros_auto"),
+                AgentMessage(type="assistant", content="Calling tool: ouroboros_start_auto"),
                 AgentMessage(
                     type="result",
                     content="Auto pipeline failed: model provider crashed",
@@ -2050,7 +2050,7 @@ class TestCodexCliRuntime:
         assert mock_warning.call_args.kwargs["error_type"] == "MCPToolError"
         mock_exec.assert_not_called()
         assert [message.content for message in messages] == [
-            "Calling tool: ouroboros_auto",
+            "Calling tool: ouroboros_start_auto",
             "Auto pipeline failed: model provider crashed",
         ]
         assert messages[-1].data["error_type"] == "MCPToolError"
@@ -2068,7 +2068,7 @@ class TestCodexCliRuntime:
             [
                 "name: auto",
                 'description: "Automatically converge from goal to A-grade Seed and execute it"',
-                "mcp_tool: ouroboros_auto",
+                "mcp_tool: ouroboros_start_auto",
                 "mcp_args:",
                 '  goal: "$goal"',
                 '  cwd: "$CWD"',
@@ -2118,7 +2118,7 @@ class TestCodexCliRuntime:
             [
                 "name: auto",
                 'description: "Automatically converge from goal to A-grade Seed and execute it"',
-                "mcp_tool: ouroboros_auto",
+                "mcp_tool: ouroboros_start_auto",
                 "mcp_args:",
                 '  goal: "$goal"',
                 '  cwd: "$CWD"',

--- a/tests/unit/router/test_packaged_auto_dispatch.py
+++ b/tests/unit/router/test_packaged_auto_dispatch.py
@@ -6,7 +6,13 @@ from ouroboros.router import Resolved, resolve_skill_dispatch
 
 
 def test_packaged_auto_skill_dispatches_to_ouroboros_start_auto(tmp_path: Path) -> None:
-    """Lock the packaged ``ooo auto`` dispatch metadata used by Codex runtimes."""
+    """Lock the packaged ``ooo auto`` dispatch metadata used by Codex/Hermes runtimes.
+
+    Regression for #1283: the deterministic skill/router path must resolve typed
+    ``ooo auto`` to the async background starter ``ouroboros_start_auto`` so it
+    stays in parity with the Codex rules and doctor surface. A full synchronous
+    ``ouroboros_auto`` call exceeds interactive MCP tool-call timeouts.
+    """
     prompt = 'ooo auto "Audit the open PRs" --skip-run'
 
     result = resolve_skill_dispatch(prompt, cwd=tmp_path)

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -262,11 +262,12 @@ class TestLoadPackagedCodexSkills:
         """The auto skill body must not allow silent manual emulation."""
         skill = load_packaged_codex_skill("auto")
 
-        assert "must be executed by invoking MCP tool `ouroboros_start_auto`" in skill
-        assert "manual fallback is not an `ooo auto` run" in skill
-        assert "Do not label that outcome as MCP dispatch failure" in skill
-        assert "The user should not have to poll the job manually" in skill
-        assert "ouroboros_job_result(job_id)" in skill
+        compact = " ".join(skill.split())
+        assert "must be executed by invoking MCP tool `ouroboros_start_auto`" in compact
+        assert "manual fallback is not an `ooo auto` run" in compact
+        assert "Do not label a `blocked` or `failed` outcome as MCP dispatch failure" in compact
+        assert "The user should not have to poll the job manually" in compact
+        assert "ouroboros_job_result" in compact
 
     def test_packaged_interview_skill_uses_runtime_capability_terms(self) -> None:
         """Runtime skill instructions should not hardcode Claude-only tool surfaces."""


### PR DESCRIPTION
## Summary
- Carry forward the remaining #1283 Codex/packaged auto dispatch parity residue after #1286 superseded the main feature path.
- Tighten packaged auto skill and Codex rule guidance around `ouroboros_start_auto`, job polling/result tools, and fail-closed behavior.
- Preserve the additional dispatch boundary tests that were left behind when #1283 was closed unmerged.

## Verification
- `uv run pytest tests/unit/cli/test_codex_command.py tests/unit/test_codex_artifacts.py tests/unit/router/test_packaged_auto_dispatch.py tests/integration/auto/test_dispatch_to_seed_e2e.py tests/unit/orchestrator/test_codex_cli_runtime.py` -> 120 passed

Superseded source: #1283.