### PR TITLE
Follow up #1285 linked stream residue

### DIFF
--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -246,73 +246,87 @@ async def _query_linked_stream_events(
 ) -> tuple[list[BaseEvent], int, bool]:
     """Fetch a bounded page of new events from the job's linked streams.
 
-    Each linked stream (job/execution/session/lineage) is read with a per-stream
-    ``limit`` so that a stale or first ``stream="linked"`` poll over a
-    long-running auto/session cannot materialize an unbounded event-store query
-    or MCP response. The returned cursor advances only as far as every saturated
-    stream was actually drained — i.e. to the lowest "more may remain" boundary —
-    so the follow-up poll resumes the remainder without skipping events.
-    ``has_more`` is True when at least one stream still has events past this page.
+    Linked streams (job/execution/session/lineage) share one rowid cursor, so
+    the page is delivered as a single global rowid window ``(cursor, boundary]``:
 
-    The materialized page is therefore bounded by ``links × limit`` events
-    regardless of how far behind the caller cursor is.
+    1. Peek each stream with a rowid-ordered ``limit`` (bounded reads, so a stale
+       or first ``stream="linked"`` poll over a long-running auto/session cannot
+       materialize an unbounded query/response). A stream that returns a full
+       page may have more rows past it.
+    2. Clamp ``boundary`` to the lowest saturated stream cursor — the highest
+       rowid below which *every* stream's knowledge is complete — then re-read
+       each stream only up to ``boundary``.
+
+    Because rowid order is the cursor dimension, ``boundary`` is skip-safe even
+    when timestamp order diverges from insertion order, and no event past
+    ``boundary`` is returned, so the follow-up poll (cursor=boundary) never
+    re-delivers or skips an event. ``has_more`` is True when a stream still has
+    rows beyond ``boundary``. The page is bounded by ``links × limit`` events.
     """
-    collected: dict[str, BaseEvent] = {}
-    # Streams that returned a full page may have more rows past their cursor;
-    # streams that returned fewer are fully drained up to their cursor.
-    saturated_cursors: list[int] = []
-    drained_cursors: list[int] = []
 
-    def collect(events: list[BaseEvent], new_cursor: int) -> None:
-        for event in events:
-            collected[event.id] = event
-        if len(events) >= limit:
-            saturated_cursors.append(new_cursor)
-        else:
-            drained_cursors.append(new_cursor)
+    async def gather(
+        page_limit: int | None, max_row_id: int | None
+    ) -> list[tuple[list[BaseEvent], int]]:
+        """Read every linked stream with a shared (limit, max_row_id) contract."""
+        results: list[tuple[list[BaseEvent], int]] = [
+            await event_store.get_events_after(
+                "job", snapshot.job_id, cursor, limit=page_limit, max_row_id=max_row_id
+            )
+        ]
+        if snapshot.links.execution_id:
+            results.append(
+                await event_store.get_events_after(
+                    "execution",
+                    snapshot.links.execution_id,
+                    cursor,
+                    limit=page_limit,
+                    max_row_id=max_row_id,
+                )
+            )
+        if snapshot.links.session_id:
+            results.append(
+                await event_store.query_session_related_events_after(
+                    session_id=snapshot.links.session_id,
+                    execution_id=snapshot.links.execution_id,
+                    last_row_id=cursor,
+                    limit=page_limit,
+                    max_row_id=max_row_id,
+                )
+            )
+        if snapshot.links.lineage_id:
+            results.append(
+                await event_store.get_events_after(
+                    "lineage",
+                    snapshot.links.lineage_id,
+                    cursor,
+                    limit=page_limit,
+                    max_row_id=max_row_id,
+                )
+            )
+        return results
 
-    job_events, job_cursor = await event_store.get_events_after(
-        "job", snapshot.job_id, cursor, limit=limit
-    )
-    collect(job_events, job_cursor)
+    def merge(results: list[tuple[list[BaseEvent], int]]) -> list[BaseEvent]:
+        collected: dict[str, BaseEvent] = {}
+        for events, _new_cursor in results:
+            for event in events:
+                collected[event.id] = event
+        return sorted(collected.values(), key=lambda event: (event.timestamp, event.id))
 
-    if snapshot.links.execution_id:
-        execution_events, execution_cursor = await event_store.get_events_after(
-            "execution",
-            snapshot.links.execution_id,
-            cursor,
-            limit=limit,
-        )
-        collect(execution_events, execution_cursor)
+    # Pass 1: bounded rowid-ordered peek to discover the global page boundary.
+    peeked = await gather(limit, None)
+    saturated = [new_cursor for events, new_cursor in peeked if len(events) >= limit]
 
-    if snapshot.links.session_id:
-        session_events, session_cursor = await event_store.query_session_related_events_after(
-            session_id=snapshot.links.session_id,
-            execution_id=snapshot.links.execution_id,
-            last_row_id=cursor,
-            limit=limit,
-        )
-        collect(session_events, session_cursor)
+    if not saturated:
+        # Every stream is fully drained to the global head; the peek is complete.
+        next_cursor = max([cursor, *(new_cursor for _events, new_cursor in peeked)])
+        return merge(peeked), next_cursor, False
 
-    if snapshot.links.lineage_id:
-        lineage_events, lineage_cursor = await event_store.get_events_after(
-            "lineage",
-            snapshot.links.lineage_id,
-            cursor,
-            limit=limit,
-        )
-        collect(lineage_events, lineage_cursor)
-
-    events = sorted(collected.values(), key=lambda event: (event.timestamp, event.id))
-
-    has_more = bool(saturated_cursors)
-    if has_more:
-        # Clamp to the lowest saturated boundary so no saturated stream is
-        # advanced past its returned page; the next poll re-reads from there.
-        next_cursor = min(saturated_cursors)
-    else:
-        next_cursor = max([cursor, *drained_cursors])
-    return events, next_cursor, has_more
+    # Pass 2: clamp to the lowest saturated boundary and re-read each stream only
+    # up to it, yielding a contiguous rowid window with no skips and no rows past
+    # the cursor handed back. boundary > cursor (page rowids are all > cursor), so
+    # the next poll strictly advances.
+    boundary = min(saturated)
+    return merge(await gather(None, boundary)), boundary, True
 
 
 @dataclass

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -216,6 +216,17 @@ def _event_stream_item(event: BaseEvent) -> dict[str, Any]:
     }
 
 
+def _compact_stream_suffix(stream_items: list[dict[str, Any]], cursor: int) -> str:
+    """One-line linked-stream summary appended to compact/summary job views.
+
+    Empty when no linked events were streamed, so callers can unconditionally
+    concatenate the result without re-checking ``stream_items``.
+    """
+    if not stream_items:
+        return ""
+    return f"\nstream_events {len(stream_items)} cursor={cursor}"
+
+
 async def _query_linked_stream_events(
     event_store: EventStore,
     snapshot: JobSnapshot,
@@ -1016,8 +1027,7 @@ class JobWaitHandler:
                     progress,
                     include_message=view == "summary",
                 )
-                if stream_items:
-                    text += f"\nstream_events {len(stream_items)} cursor={snapshot.cursor}"
+                text += _compact_stream_suffix(stream_items, snapshot.cursor)
             elif view in {"compact", "summary"}:
                 if stream_items:
                     summaries = ", ".join(item["type"] for item in stream_items[-3:])
@@ -1034,12 +1044,10 @@ class JobWaitHandler:
                 text += "\n\nNo new job-level events during this wait window."
         elif view == "compact":
             text = _render_compact_job_snapshot(snapshot, progress, include_message=False)
-            if stream_items:
-                text += f"\nstream_events {len(stream_items)} cursor={snapshot.cursor}"
+            text += _compact_stream_suffix(stream_items, snapshot.cursor)
         elif view == "summary":
             text = _render_compact_job_snapshot(snapshot, progress, include_message=True)
-            if stream_items:
-                text += f"\nstream_events {len(stream_items)} cursor={snapshot.cursor}"
+            text += _compact_stream_suffix(stream_items, snapshot.cursor)
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text=text),),

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -216,61 +216,103 @@ def _event_stream_item(event: BaseEvent) -> dict[str, Any]:
     }
 
 
-def _compact_stream_suffix(stream_items: list[dict[str, Any]], cursor: int) -> str:
+def _compact_stream_suffix(
+    stream_items: list[dict[str, Any]],
+    cursor: int,
+    *,
+    has_more: bool = False,
+) -> str:
     """One-line linked-stream summary appended to compact/summary job views.
 
     Empty when no linked events were streamed, so callers can unconditionally
-    concatenate the result without re-checking ``stream_items``.
+    concatenate the result without re-checking ``stream_items``. ``has_more``
+    appends a ``more=1`` marker signalling the caller should poll again with the
+    returned cursor to drain the rest of a bounded linked-stream page.
     """
     if not stream_items:
         return ""
-    return f"\nstream_events {len(stream_items)} cursor={cursor}"
+    suffix = f"\nstream_events {len(stream_items)} cursor={cursor}"
+    if has_more:
+        suffix += " more=1"
+    return suffix
 
 
 async def _query_linked_stream_events(
     event_store: EventStore,
     snapshot: JobSnapshot,
     cursor: int,
-) -> tuple[list[BaseEvent], int]:
-    """Fetch new events from the job's linked execution/session/lineage streams."""
-    collected: dict[str, BaseEvent] = {}
-    max_cursor = cursor
+    *,
+    limit: int = _JOB_STREAM_EVENT_LIMIT,
+) -> tuple[list[BaseEvent], int, bool]:
+    """Fetch a bounded page of new events from the job's linked streams.
 
-    async def collect(events: list[BaseEvent], new_cursor: int) -> None:
-        nonlocal max_cursor
-        max_cursor = max(max_cursor, new_cursor)
+    Each linked stream (job/execution/session/lineage) is read with a per-stream
+    ``limit`` so that a stale or first ``stream="linked"`` poll over a
+    long-running auto/session cannot materialize an unbounded event-store query
+    or MCP response. The returned cursor advances only as far as every saturated
+    stream was actually drained — i.e. to the lowest "more may remain" boundary —
+    so the follow-up poll resumes the remainder without skipping events.
+    ``has_more`` is True when at least one stream still has events past this page.
+
+    The materialized page is therefore bounded by ``links × limit`` events
+    regardless of how far behind the caller cursor is.
+    """
+    collected: dict[str, BaseEvent] = {}
+    # Streams that returned a full page may have more rows past their cursor;
+    # streams that returned fewer are fully drained up to their cursor.
+    saturated_cursors: list[int] = []
+    drained_cursors: list[int] = []
+
+    def collect(events: list[BaseEvent], new_cursor: int) -> None:
         for event in events:
             collected[event.id] = event
+        if len(events) >= limit:
+            saturated_cursors.append(new_cursor)
+        else:
+            drained_cursors.append(new_cursor)
 
-    job_events, job_cursor = await event_store.get_events_after("job", snapshot.job_id, cursor)
-    await collect(job_events, job_cursor)
+    job_events, job_cursor = await event_store.get_events_after(
+        "job", snapshot.job_id, cursor, limit=limit
+    )
+    collect(job_events, job_cursor)
 
     if snapshot.links.execution_id:
         execution_events, execution_cursor = await event_store.get_events_after(
             "execution",
             snapshot.links.execution_id,
             cursor,
+            limit=limit,
         )
-        await collect(execution_events, execution_cursor)
+        collect(execution_events, execution_cursor)
 
     if snapshot.links.session_id:
         session_events, session_cursor = await event_store.query_session_related_events_after(
             session_id=snapshot.links.session_id,
             execution_id=snapshot.links.execution_id,
             last_row_id=cursor,
+            limit=limit,
         )
-        await collect(session_events, session_cursor)
+        collect(session_events, session_cursor)
 
     if snapshot.links.lineage_id:
         lineage_events, lineage_cursor = await event_store.get_events_after(
             "lineage",
             snapshot.links.lineage_id,
             cursor,
+            limit=limit,
         )
-        await collect(lineage_events, lineage_cursor)
+        collect(lineage_events, lineage_cursor)
 
     events = sorted(collected.values(), key=lambda event: (event.timestamp, event.id))
-    return events, max_cursor
+
+    has_more = bool(saturated_cursors)
+    if has_more:
+        # Clamp to the lowest saturated boundary so no saturated stream is
+        # advanced past its returned page; the next poll re-reads from there.
+        next_cursor = min(saturated_cursors)
+    else:
+        next_cursor = max([cursor, *drained_cursors])
+    return events, next_cursor, has_more
 
 
 @dataclass
@@ -948,6 +990,7 @@ class JobWaitHandler:
                     changed,
                     stream_events,
                     stream_cursor,
+                    stream_has_more,
                 ) = await self._wait_for_linked_change(
                     job_id,
                     cursor=cursor,
@@ -961,6 +1004,7 @@ class JobWaitHandler:
                 )
                 stream_events = []
                 stream_cursor = cursor
+                stream_has_more = False
         except ValueError as exc:
             return Result.err(
                 MCPToolError(
@@ -1004,6 +1048,8 @@ class JobWaitHandler:
             for item in stream_items[-_JOB_STREAM_EVENT_LIMIT:]:
                 detail = f" -- {item['detail']}" if item["detail"] else ""
                 text += f"\n- `{item['type']}` [{item['scope']}]{detail}"
+            if stream_has_more:
+                text += f"\n\nMore linked events pending; poll again with cursor={snapshot.cursor}."
         has_live_execution_progress = snapshot.links.execution_id is not None and any(
             progress.get(key) is not None
             for key in (
@@ -1027,12 +1073,16 @@ class JobWaitHandler:
                     progress,
                     include_message=view == "summary",
                 )
-                text += _compact_stream_suffix(stream_items, snapshot.cursor)
+                text += _compact_stream_suffix(
+                    stream_items, snapshot.cursor, has_more=stream_has_more
+                )
             elif view in {"compact", "summary"}:
                 if stream_items:
                     summaries = ", ".join(item["type"] for item in stream_items[-3:])
+                    more = " more=1" if stream_has_more else ""
                     text = (
-                        f"stream_events {len(stream_items)} cursor={snapshot.cursor}: {summaries}"
+                        f"stream_events {len(stream_items)} "
+                        f"cursor={snapshot.cursor}{more}: {summaries}"
                     )
                 else:
                     text = f"unchanged cursor={snapshot.cursor}"
@@ -1044,10 +1094,10 @@ class JobWaitHandler:
                 text += "\n\nNo new job-level events during this wait window."
         elif view == "compact":
             text = _render_compact_job_snapshot(snapshot, progress, include_message=False)
-            text += _compact_stream_suffix(stream_items, snapshot.cursor)
+            text += _compact_stream_suffix(stream_items, snapshot.cursor, has_more=stream_has_more)
         elif view == "summary":
             text = _render_compact_job_snapshot(snapshot, progress, include_message=True)
-            text += _compact_stream_suffix(stream_items, snapshot.cursor)
+            text += _compact_stream_suffix(stream_items, snapshot.cursor, has_more=stream_has_more)
         return Result.ok(
             MCPToolResult(
                 content=(MCPContentItem(type=ContentType.TEXT, text=text),),
@@ -1058,6 +1108,7 @@ class JobWaitHandler:
                     "view": view,
                     "stream": stream,
                     "stream_events": stream_items,
+                    "stream_has_more": stream_has_more,
                     **progress,
                 },
             )
@@ -1069,7 +1120,7 @@ class JobWaitHandler:
         *,
         cursor: int,
         timeout_seconds: int,
-    ) -> tuple[JobSnapshot, bool, list[BaseEvent], int]:
+    ) -> tuple[JobSnapshot, bool, list[BaseEvent], int, bool]:
         """Long-poll job plus linked child/session event streams."""
         deadline = asyncio.get_running_loop().time() + timeout_seconds
         while True:
@@ -1078,7 +1129,7 @@ class JobWaitHandler:
                 cursor=cursor,
                 timeout_seconds=0,
             )
-            events, stream_cursor = await _query_linked_stream_events(
+            events, stream_cursor, has_more = await _query_linked_stream_events(
                 self._event_store,
                 snapshot,
                 cursor,
@@ -1091,7 +1142,7 @@ class JobWaitHandler:
             ):
                 if stream_cursor != snapshot.cursor:
                     snapshot = replace(snapshot, cursor=max(snapshot.cursor, stream_cursor))
-                return snapshot, changed, events, stream_cursor
+                return snapshot, changed, events, stream_cursor, has_more
             await asyncio.sleep(0.5)
 
 

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -259,7 +259,7 @@ async def _query_linked_stream_events(
         await collect(lineage_events, lineage_cursor)
 
     events = sorted(collected.values(), key=lambda event: (event.timestamp, event.id))
-    return events[-_JOB_STREAM_EVENT_LIMIT:], max_cursor
+    return events, max_cursor
 
 
 @dataclass

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -1041,8 +1041,18 @@ class JobWaitHandler:
             )
 
         execution_progress_changed = False
-        response_cursor = max(snapshot.cursor, stream_cursor, cursor)
-        if snapshot.links.execution_id:
+        if stream == "linked":
+            # Execution events are already part of the bounded linked page, and
+            # `_wait_for_linked_change` pinned the cursor to that page boundary.
+            # Derive the progress signal from the page itself and never advance
+            # the public cursor past the boundary here: a separate execution scan
+            # could otherwise publish a rowid above a held-back lower-rowid stream
+            # event, skipping it on the next poll.
+            execution_progress_changed = any(
+                event.type in _JOB_PROGRESS_EVENT_TYPES for event in stream_events
+            )
+        elif snapshot.links.execution_id:
+            response_cursor = max(snapshot.cursor, stream_cursor, cursor)
             execution_events, execution_cursor = await self._event_store.get_events_after(
                 "execution",
                 snapshot.links.execution_id,
@@ -1154,8 +1164,12 @@ class JobWaitHandler:
                 or snapshot.is_terminal
                 or asyncio.get_running_loop().time() >= deadline
             ):
-                if stream_cursor != snapshot.cursor:
-                    snapshot = replace(snapshot, cursor=max(snapshot.cursor, stream_cursor))
+                # Pin the public cursor to the linked page boundary (not max with
+                # the job-manager cursor): the boundary uniformly bounds every
+                # linked stream including job, so a higher job cursor would skip
+                # held-back lower-rowid events from a clamped sibling stream.
+                if snapshot.cursor != stream_cursor:
+                    snapshot = replace(snapshot, cursor=stream_cursor)
                 return snapshot, changed, events, stream_cursor, has_more
             await asyncio.sleep(0.5)
 

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -470,6 +470,8 @@ class EventStore:
         aggregate_type: str,
         aggregate_id: str,
         last_row_id: int = 0,
+        *,
+        limit: int | None = None,
     ) -> tuple[list[BaseEvent], int]:
         """Get events for an aggregate after a given row ID.
 
@@ -481,6 +483,11 @@ class EventStore:
             aggregate_id: The unique identifier of the aggregate.
             last_row_id: The SQLite rowid of the last event processed.
                          Pass 0 to get all events from the beginning.
+            limit: Optional maximum number of events to materialize. When set,
+                   only the first ``limit`` events after the cursor are loaded
+                   (bounded fetch) and the returned cursor advances to the last
+                   row in that page, so a follow-up poll resumes the remainder
+                   without skipping events. ``None`` keeps the unbounded fetch.
 
         Returns:
             Tuple of (list of new events, max rowid seen).
@@ -500,13 +507,16 @@ class EventStore:
                 # Use SQLite's implicit rowid for efficient cursor-based pagination.
                 # This avoids deserializing all prior events just to slice the tail.
                 rowid_col = text("rowid")
-                result = await conn.execute(
+                query = (
                     select(events_table, rowid_col)
                     .where(events_table.c.aggregate_type == aggregate_type)
                     .where(events_table.c.aggregate_id == aggregate_id)
                     .where(text("rowid > :last_id").bindparams(last_id=last_row_id))
                     .order_by(events_table.c.timestamp, events_table.c.id)
                 )
+                if limit is not None:
+                    query = query.limit(limit)
+                result = await conn.execute(query)
                 rows = result.mappings().all()
                 if not rows:
                     return [], last_row_id
@@ -971,12 +981,20 @@ class EventStore:
         execution_id: str | None = None,
         event_type: str | None = None,
         last_row_id: int = 0,
+        *,
+        limit: int | None = None,
     ) -> tuple[list[BaseEvent], int]:
         """Incrementally query events across a session and related execution scopes.
 
         This is the multi-aggregate equivalent of ``get_events_after``. It uses
         the same exact session/execution payload predicates as
         ``query_session_related_events`` while advancing a single rowid cursor.
+
+        When ``limit`` is set, only the first ``limit`` events after the cursor
+        are materialized and the returned cursor advances to the last row in
+        that page, so a stale or first-time poll over a long-running session
+        cannot load an unbounded result set; a follow-up poll resumes the
+        remainder without skipping events. ``None`` keeps the unbounded fetch.
         """
         if self._engine is None:
             raise PersistenceError(
@@ -1004,6 +1022,9 @@ class EventStore:
 
                 if event_type:
                     query = query.where(events_table.c.event_type == event_type)
+
+                if limit is not None:
+                    query = query.limit(limit)
 
                 result = await conn.execute(query)
                 rows = result.mappings().all()

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -472,6 +472,7 @@ class EventStore:
         last_row_id: int = 0,
         *,
         limit: int | None = None,
+        max_row_id: int | None = None,
     ) -> tuple[list[BaseEvent], int]:
         """Get events for an aggregate after a given row ID.
 
@@ -484,10 +485,14 @@ class EventStore:
             last_row_id: The SQLite rowid of the last event processed.
                          Pass 0 to get all events from the beginning.
             limit: Optional maximum number of events to materialize. When set,
-                   only the first ``limit`` events after the cursor are loaded
-                   (bounded fetch) and the returned cursor advances to the last
-                   row in that page, so a follow-up poll resumes the remainder
-                   without skipping events. ``None`` keeps the unbounded fetch.
+                   the page is ordered by ``rowid`` (the cursor dimension) and
+                   capped, so the returned ``max(rowid)`` is a true boundary and
+                   a follow-up poll resumes the remainder without skipping rows
+                   appended out of timestamp order. ``None`` keeps the unbounded
+                   timestamp-ordered fetch other callers rely on.
+            max_row_id: Optional inclusive upper bound on rowid. Lets a caller
+                   that has already chosen a global page boundary re-read exactly
+                   the rows at or before that boundary (``rowid <= max_row_id``).
 
         Returns:
             Tuple of (list of new events, max rowid seen).
@@ -512,10 +517,16 @@ class EventStore:
                     .where(events_table.c.aggregate_type == aggregate_type)
                     .where(events_table.c.aggregate_id == aggregate_id)
                     .where(text("rowid > :last_id").bindparams(last_id=last_row_id))
-                    .order_by(events_table.c.timestamp, events_table.c.id)
                 )
+                if max_row_id is not None:
+                    query = query.where(text("rowid <= :max_id").bindparams(max_id=max_row_id))
                 if limit is not None:
-                    query = query.limit(limit)
+                    # Page by rowid so max(rowid) is a contiguous boundary; ordering
+                    # a limited page by timestamp could advance the cursor past a
+                    # lower-rowid row appended out of order, skipping it forever.
+                    query = query.order_by(rowid_col).limit(limit)
+                else:
+                    query = query.order_by(events_table.c.timestamp, events_table.c.id)
                 result = await conn.execute(query)
                 rows = result.mappings().all()
                 if not rows:
@@ -983,6 +994,7 @@ class EventStore:
         last_row_id: int = 0,
         *,
         limit: int | None = None,
+        max_row_id: int | None = None,
     ) -> tuple[list[BaseEvent], int]:
         """Incrementally query events across a session and related execution scopes.
 
@@ -990,11 +1002,13 @@ class EventStore:
         the same exact session/execution payload predicates as
         ``query_session_related_events`` while advancing a single rowid cursor.
 
-        When ``limit`` is set, only the first ``limit`` events after the cursor
-        are materialized and the returned cursor advances to the last row in
-        that page, so a stale or first-time poll over a long-running session
-        cannot load an unbounded result set; a follow-up poll resumes the
-        remainder without skipping events. ``None`` keeps the unbounded fetch.
+        When ``limit`` is set the page is ordered by ``rowid`` and capped, so a
+        stale or first-time poll over a long-running session cannot load an
+        unbounded result set and the returned ``max(rowid)`` is a true boundary
+        a follow-up poll resumes from without skipping rows appended out of
+        timestamp order. ``max_row_id`` bounds the read to ``rowid <= max_row_id``
+        for callers that have already chosen a global page boundary. ``None``
+        for both keeps the unbounded timestamp-ordered fetch.
         """
         if self._engine is None:
             raise PersistenceError(
@@ -1015,8 +1029,9 @@ class EventStore:
                     select(events_table, rowid_col)
                     .where(or_(*conditions))
                     .where(text("rowid > :last_id").bindparams(last_id=last_row_id))
-                    .order_by(events_table.c.timestamp, events_table.c.id)
                 )
+                if max_row_id is not None:
+                    query = query.where(text("rowid <= :max_id").bindparams(max_id=max_row_id))
                 if session_started_at is not None:
                     query = query.where(events_table.c.timestamp >= session_started_at)
 
@@ -1024,7 +1039,11 @@ class EventStore:
                     query = query.where(events_table.c.event_type == event_type)
 
                 if limit is not None:
-                    query = query.limit(limit)
+                    # Page by rowid (see get_events_after) so the cursor boundary
+                    # is skip-safe even when timestamp order diverges from rowid.
+                    query = query.order_by(rowid_col).limit(limit)
+                else:
+                    query = query.order_by(events_table.c.timestamp, events_table.c.id)
 
                 result = await conn.execute(query)
                 rows = result.mappings().all()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -3635,6 +3635,94 @@ class TestJobManager:
         # Single session stream → contiguous delivery with no duplicates or gaps.
         assert delivered == [f"event {index:02d}" for index in range(total_events)]
 
+    async def test_job_wait_linked_stream_mixed_streams_no_duplicate_delivery(
+        self, tmp_path
+    ) -> None:
+        """A saturated stream must not drag higher-rowid sibling events into a page.
+
+        Regression for cross-stream duplicate delivery: with a full job page and
+        one higher-rowid session event, the page boundary is clamped to the job
+        stream's cursor, so the session event is held back rather than returned
+        above the cursor (which would re-deliver it on the next poll). It must
+        surface exactly once, on the following poll.
+        """
+        store = _build_store(tmp_path)
+        await store.initialize()
+        for index in range(10):
+            await store.append(
+                BaseEvent(
+                    type="job.progress",
+                    aggregate_type="job",
+                    aggregate_id="job_mixed_streams",
+                    data={"message": f"job {index}"},
+                )
+            )
+        # Appended last, so this carries the highest rowid of the linked set.
+        await store.append(
+            BaseEvent(
+                type="subagent.dispatched",
+                aggregate_type="subagent",
+                aggregate_id="orch_mixed",
+                data={"session_id": "orch_mixed", "title": "late subagent"},
+            )
+        )
+        snapshot = JobSnapshot(
+            job_id="job_mixed_streams",
+            job_type="auto",
+            status=JobStatus.RUNNING,
+            message="Running auto",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=0,
+            links=JobLinks(session_id="orch_mixed"),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                assert timeout_seconds == 0
+                return replace(snapshot, cursor=cursor), False
+
+        try:
+            handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+            first = await handler.handle(
+                {
+                    "job_id": "job_mixed_streams",
+                    "cursor": 0,
+                    "timeout_seconds": 0,
+                    "stream": "linked",
+                }
+            )
+            assert first.is_ok
+            first_types = [item["type"] for item in first.value.meta["stream_events"]]
+            # The session event (higher rowid) is held back behind the boundary.
+            assert first_types == ["job.progress"] * 10
+            assert "subagent.dispatched" not in first_types
+            assert first.value.meta["stream_has_more"] is True
+            first_cursor = first.value.meta["cursor"]
+
+            second = await handler.handle(
+                {
+                    "job_id": "job_mixed_streams",
+                    "cursor": first_cursor,
+                    "timeout_seconds": 0,
+                    "stream": "linked",
+                }
+            )
+            assert second.is_ok
+            second_types = [item["type"] for item in second.value.meta["stream_events"]]
+            # Delivered now, exactly once, with no job events repeated.
+            assert second_types == ["subagent.dispatched"]
+            assert second.value.meta["cursor"] > first_cursor
+        finally:
+            await store.close()
+
     async def test_job_wait_default_stream_does_not_surface_subagent_events(self, tmp_path) -> None:
         store = _build_store(tmp_path)
         await store.initialize()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -3723,6 +3723,104 @@ class TestJobManager:
         finally:
             await store.close()
 
+    async def test_job_wait_linked_stream_execution_scan_does_not_skip_held_events(
+        self, tmp_path
+    ) -> None:
+        """The published cursor must not advance past held-back linked events.
+
+        Regression: the handler separately scans execution events and folds their
+        cursor into the response. With a saturated job page, a held session event,
+        and a later execution progress event, that scan could publish a cursor
+        above the held session event's rowid, skipping it forever. The linked
+        cursor must stay pinned to the bounded page boundary so the held event
+        surfaces on the next poll.
+        """
+        store = _build_store(tmp_path)
+        await store.initialize()
+        for index in range(10):
+            await store.append(
+                BaseEvent(
+                    type="job.progress",
+                    aggregate_type="job",
+                    aggregate_id="job_skip",
+                    data={"message": f"job {index}"},
+                )
+            )
+        await store.append(
+            BaseEvent(
+                type="subagent.dispatched",
+                aggregate_type="subagent",
+                aggregate_id="orch_skip",
+                data={"session_id": "orch_skip", "title": "held subagent"},
+            )
+        )
+        # Highest rowid: a later execution progress event whose cursor must not
+        # be allowed to leapfrog the held subagent event above.
+        await store.append(
+            BaseEvent(
+                type="execution.node.updated",
+                aggregate_type="execution",
+                aggregate_id="exec_skip",
+                data={"execution_id": "exec_skip", "node": "n1"},
+            )
+        )
+        snapshot = JobSnapshot(
+            job_id="job_skip",
+            job_type="auto",
+            status=JobStatus.RUNNING,
+            message="Running auto",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=0,
+            links=JobLinks(session_id="orch_skip", execution_id="exec_skip"),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                assert timeout_seconds == 0
+                return replace(snapshot, cursor=cursor), False
+
+        try:
+            handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+            first = await handler.handle(
+                {
+                    "job_id": "job_skip",
+                    "cursor": 0,
+                    "timeout_seconds": 0,
+                    "stream": "linked",
+                }
+            )
+            assert first.is_ok
+            first_types = [item["type"] for item in first.value.meta["stream_events"]]
+            assert first_types == ["job.progress"] * 10
+            assert first.value.meta["stream_has_more"] is True
+            first_cursor = first.value.meta["cursor"]
+
+            second = await handler.handle(
+                {
+                    "job_id": "job_skip",
+                    "cursor": first_cursor,
+                    "timeout_seconds": 0,
+                    "stream": "linked",
+                }
+            )
+            assert second.is_ok
+            second_types = [item["type"] for item in second.value.meta["stream_events"]]
+            # The held subagent event is NOT skipped by the execution cursor; it
+            # surfaces alongside the execution event on the next poll.
+            assert "subagent.dispatched" in second_types
+            assert "execution.node.updated" in second_types
+            assert second.value.meta["cursor"] > first_cursor
+        finally:
+            await store.close()
+
     async def test_job_wait_default_stream_does_not_surface_subagent_events(self, tmp_path) -> None:
         store = _build_store(tmp_path)
         await store.initialize()

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -3494,6 +3494,9 @@ class TestJobManager:
 
         try:
             handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+            # First poll over a stale cursor returns a bounded page (the per-stream
+            # limit is 10), not all 12 events, so the MCP response stays bounded
+            # regardless of how far behind the caller cursor is.
             result = await handler.handle(
                 {
                     "job_id": "job_wait_linked_burst",
@@ -3504,15 +3507,38 @@ class TestJobManager:
             )
             assert result.is_ok
             first_cursor = result.value.meta["cursor"]
-            assert len(result.value.meta["stream_events"]) == 12
-            assert [item["detail"] for item in result.value.meta["stream_events"]] == [
-                f"burst {index}" for index in range(12)
-            ]
+            first_page = [item["detail"] for item in result.value.meta["stream_events"]]
+            assert first_page == [f"burst {index}" for index in range(10)]
+            assert result.value.meta["stream_has_more"] is True
+            assert "more=1" in result.value.text_content or "More linked events pending" in (
+                result.value.text_content
+            )
+
+            # The cursor advanced only to the page boundary, so the follow-up poll
+            # drains the remainder without skipping the omitted events.
+            second = await handler.handle(
+                {
+                    "job_id": "job_wait_linked_burst",
+                    "cursor": first_cursor,
+                    "timeout_seconds": 0,
+                    "stream": "linked",
+                }
+            )
+            assert second.is_ok
+            second_cursor = second.value.meta["cursor"]
+            second_page = [item["detail"] for item in second.value.meta["stream_events"]]
+            assert second_page == [f"burst {index}" for index in range(10, 12)]
+            assert second.value.meta["stream_has_more"] is False
+            assert second_cursor > first_cursor
+
+            # Every burst event is delivered exactly once across the two pages,
+            # with none skipped past the advancing cursor.
+            assert first_page + second_page == [f"burst {index}" for index in range(12)]
 
             unchanged = await handler.handle(
                 {
                     "job_id": "job_wait_linked_burst",
-                    "cursor": first_cursor,
+                    "cursor": second_cursor,
                     "timeout_seconds": 0,
                     "stream": "linked",
                 }
@@ -3522,8 +3548,92 @@ class TestJobManager:
 
         assert unchanged.is_ok
         assert unchanged.value.meta["stream_events"] == []
-        assert unchanged.value.meta["cursor"] == first_cursor
+        assert unchanged.value.meta["stream_has_more"] is False
+        assert unchanged.value.meta["cursor"] == second_cursor
         assert "No new job-level events during this wait window." in unchanged.value.text_content
+
+    async def test_job_wait_linked_stream_drains_stale_cursor_in_bounded_pages(
+        self, tmp_path
+    ) -> None:
+        """A stale cursor over a large backlog is drained in bounded pages.
+
+        Regression guard for the unbounded-response risk: removing the old
+        suffix truncation must not let a first/stale ``stream="linked"`` poll
+        materialize the entire backlog. Each page stays within the per-stream
+        limit, the cursor advances monotonically, and every event is delivered
+        exactly once with none skipped past the advancing cursor.
+        """
+        store = _build_store(tmp_path)
+        await store.initialize()
+        total_events = 25
+        for index in range(total_events):
+            await store.append(
+                BaseEvent(
+                    type="subagent.output",
+                    aggregate_type="subagent",
+                    aggregate_id=f"orch_backlog_{index}",
+                    data={
+                        "session_id": "orch_backlog",
+                        "message": f"event {index:02d}",
+                    },
+                )
+            )
+        snapshot = JobSnapshot(
+            job_id="job_wait_linked_backlog",
+            job_type="auto",
+            status=JobStatus.RUNNING,
+            message="Running auto",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=0,
+            links=JobLinks(session_id="orch_backlog"),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                assert timeout_seconds == 0
+                return replace(snapshot, cursor=cursor), False
+
+        delivered: list[str] = []
+        cursor = 0
+        try:
+            handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+            for _ in range(total_events + 1):  # bounded loop; must converge well before
+                result = await handler.handle(
+                    {
+                        "job_id": "job_wait_linked_backlog",
+                        "cursor": cursor,
+                        "timeout_seconds": 0,
+                        "stream": "linked",
+                    }
+                )
+                assert result.is_ok
+                page = [item["detail"] for item in result.value.meta["stream_events"]]
+                # Every page is bounded by the per-stream limit (single session stream).
+                assert len(page) <= 10
+                next_cursor = result.value.meta["cursor"]
+                if not page:
+                    assert result.value.meta["stream_has_more"] is False
+                    break
+                # Cursor advances strictly while events remain, guaranteeing progress.
+                assert next_cursor > cursor
+                cursor = next_cursor
+                delivered.extend(page)
+                if not result.value.meta["stream_has_more"]:
+                    # A final empty poll confirms the backlog is fully drained.
+                    continue
+        finally:
+            await store.close()
+
+        # Single session stream → contiguous delivery with no duplicates or gaps.
+        assert delivered == [f"event {index:02d}" for index in range(total_events)]
 
     async def test_job_wait_default_stream_does_not_surface_subagent_events(self, tmp_path) -> None:
         store = _build_store(tmp_path)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, patch
 
@@ -3387,6 +3388,191 @@ class TestJobManager:
         assert result.value.meta["session_id"] == "orch_wait_links"
         assert result.value.meta["execution_id"] == "exec_wait_links"
         assert result.value.meta["lineage_id"] == "lin_wait_links"
+
+    async def test_job_wait_linked_stream_surfaces_subagent_events(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        await store.initialize()
+        await store.append(
+            BaseEvent(
+                type="subagent.dispatched",
+                aggregate_type="subagent",
+                aggregate_id="orch_stream_links",
+                data={
+                    "session_id": "orch_stream_links",
+                    "tool_name": "ouroboros_qa",
+                    "title": "QA Review",
+                },
+            )
+        )
+        snapshot = JobSnapshot(
+            job_id="job_wait_linked_stream",
+            job_type="auto",
+            status=JobStatus.RUNNING,
+            message="Running auto",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=0,
+            links=JobLinks(session_id="orch_stream_links"),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                assert cursor == 0
+                assert timeout_seconds == 0
+                return snapshot, False
+
+        try:
+            handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+            result = await handler.handle(
+                {
+                    "job_id": "job_wait_linked_stream",
+                    "cursor": 0,
+                    "timeout_seconds": 0,
+                    "stream": "linked",
+                }
+            )
+        finally:
+            await store.close()
+
+        assert result.is_ok
+        assert result.value.meta["changed"] is True
+        assert result.value.meta["stream"] == "linked"
+        assert result.value.meta["cursor"] > 0
+        assert result.value.meta["stream_events"][0]["type"] == "subagent.dispatched"
+        assert result.value.meta["stream_events"][0]["scope"] == "subagent:orch_stream_links"
+        assert "### Stream Events" in result.value.text_content
+        assert "`subagent.dispatched` [subagent:orch_stream_links] -- QA Review" in (
+            result.value.text_content
+        )
+
+    async def test_job_wait_linked_stream_does_not_advance_past_omitted_events(
+        self, tmp_path
+    ) -> None:
+        store = _build_store(tmp_path)
+        await store.initialize()
+        for index in range(12):
+            await store.append(
+                BaseEvent(
+                    type="subagent.output",
+                    aggregate_type="subagent",
+                    aggregate_id=f"orch_stream_burst_{index}",
+                    data={
+                        "session_id": "orch_stream_burst",
+                        "message": f"burst {index}",
+                    },
+                )
+            )
+        snapshot = JobSnapshot(
+            job_id="job_wait_linked_burst",
+            job_type="auto",
+            status=JobStatus.RUNNING,
+            message="Running auto",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=0,
+            links=JobLinks(session_id="orch_stream_burst"),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                assert timeout_seconds == 0
+                return replace(snapshot, cursor=cursor), False
+
+        try:
+            handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+            result = await handler.handle(
+                {
+                    "job_id": "job_wait_linked_burst",
+                    "cursor": 0,
+                    "timeout_seconds": 0,
+                    "stream": "linked",
+                }
+            )
+            assert result.is_ok
+            first_cursor = result.value.meta["cursor"]
+            assert len(result.value.meta["stream_events"]) == 12
+            assert [item["detail"] for item in result.value.meta["stream_events"]] == [
+                f"burst {index}" for index in range(12)
+            ]
+
+            unchanged = await handler.handle(
+                {
+                    "job_id": "job_wait_linked_burst",
+                    "cursor": first_cursor,
+                    "timeout_seconds": 0,
+                    "stream": "linked",
+                }
+            )
+        finally:
+            await store.close()
+
+        assert unchanged.is_ok
+        assert unchanged.value.meta["stream_events"] == []
+        assert unchanged.value.meta["cursor"] == first_cursor
+        assert "No new job-level events during this wait window." in unchanged.value.text_content
+
+    async def test_job_wait_default_stream_does_not_surface_subagent_events(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        await store.initialize()
+        await store.append(
+            BaseEvent(
+                type="subagent.dispatched",
+                aggregate_type="subagent",
+                aggregate_id="orch_default_stream",
+                data={"session_id": "orch_default_stream", "title": "Hidden unless opted in"},
+            )
+        )
+        snapshot = JobSnapshot(
+            job_id="job_wait_default_stream",
+            job_type="auto",
+            status=JobStatus.RUNNING,
+            message="Running auto",
+            created_at=datetime(2026, 4, 22, tzinfo=UTC),
+            updated_at=datetime(2026, 4, 22, tzinfo=UTC),
+            cursor=0,
+            links=JobLinks(session_id="orch_default_stream"),
+        )
+
+        class StaticJobManager:
+            async def wait_for_change(
+                self,
+                job_id: str,
+                *,
+                cursor: int,
+                timeout_seconds: int,
+            ) -> tuple[JobSnapshot, bool]:
+                assert job_id == snapshot.job_id
+                assert cursor == 0
+                assert timeout_seconds == 0
+                return snapshot, False
+
+        try:
+            handler = JobWaitHandler(event_store=store, job_manager=StaticJobManager())
+            result = await handler.handle(
+                {"job_id": "job_wait_default_stream", "cursor": 0, "timeout_seconds": 0}
+            )
+        finally:
+            await store.close()
+
+        assert result.is_ok
+        assert result.value.meta["changed"] is False
+        assert result.value.meta["stream"] == "progress"
+        assert result.value.meta["stream_events"] == []
+        assert "Hidden unless opted in" not in result.value.text_content
 
     async def test_job_wait_summary_view_returns_compact_unchanged_line(self, tmp_path) -> None:
         store = _build_store(tmp_path)

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -492,6 +492,54 @@ class TestEventStoreGetEventsAfter:
         assert all(e.data["batch"] == 2 for e in new_events)
         assert new_row_id > last_row_id
 
+    async def test_get_events_after_limit_does_not_skip_out_of_order_timestamps(
+        self, event_store: EventStore
+    ) -> None:
+        """A limited page must page by rowid, not timestamp, to stay skip-safe.
+
+        Regression: if a row is appended with an earlier timestamp than an
+        existing row, a limited page ordered by timestamp would return the
+        higher rowid first and advance the cursor past the lower-rowid row,
+        skipping it forever. Paging by rowid keeps every row reachable.
+        """
+        from datetime import UTC, datetime
+
+        # rowid 1 carries the LATER timestamp; rowid 2 the earlier one.
+        await event_store.append(
+            BaseEvent(
+                type="test.event.created",
+                aggregate_type="execution",
+                aggregate_id="exec-ooo",
+                timestamp=datetime(2026, 4, 22, 0, 0, 10, tzinfo=UTC),
+                data={"label": "rowid1-late-ts"},
+            )
+        )
+        await event_store.append(
+            BaseEvent(
+                type="test.event.created",
+                aggregate_type="execution",
+                aggregate_id="exec-ooo",
+                timestamp=datetime(2026, 4, 22, 0, 0, 0, tzinfo=UTC),
+                data={"label": "rowid2-early-ts"},
+            )
+        )
+
+        seen: list[str] = []
+        cursor = 0
+        for _ in range(4):  # bounded; must converge in 2 real pages + 1 empty
+            page, next_cursor = await event_store.get_events_after(
+                "execution", "exec-ooo", cursor, limit=1
+            )
+            if not page:
+                break
+            assert len(page) == 1
+            assert next_cursor > cursor  # cursor strictly advances, no stall
+            cursor = next_cursor
+            seen.append(page[0].data["label"])
+
+        # Both rows delivered exactly once, lowest rowid first, none skipped.
+        assert seen == ["rowid1-late-ts", "rowid2-early-ts"]
+
     async def test_get_events_after_returns_empty_when_no_new_events(
         self, event_store: EventStore
     ) -> None:


### PR DESCRIPTION
## Summary
- Carry forward the remaining #1285 linked-stream residue after #1286 superseded the broader detached job UX track.
- Preserve burst-safe linked stream metadata coverage for `ouroboros_job_wait(stream="linked")`.
- Keep the compact linked-stream suffix helper refactor that avoids duplicated text formatting.

## Verification
- `uv run pytest tests/unit/mcp/test_job_manager.py tests/unit/mcp/tools/test_definitions.py` -> 203 passed

Superseded source: #1285.