### PR TITLE
fix(auto): size Ralph per-iteration timeout to pipeline budget, not 1800s default

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -213,15 +213,28 @@ _RESUME_EXPIRED_MESSAGE = "pipeline_timeout (deadline expired before resume)"
 # dispatch so an insufficient top-level pipeline budget remains a pipeline
 # timeout, not a Ralph argument-validation failure.
 _MIN_RALPH_MAX_TOTAL_SECONDS = 1.0
-# Mirrors RalphHandler.MIN_PER_ITERATION_TIMEOUT_SECONDS / DEFAULT_PER_ITERATION_TIMEOUT_SECONDS.
-# When the remaining pipeline budget is shorter than the Ralph default
-# per-iteration timeout, the auto layer caps ``per_iteration_timeout_seconds``
-# so a single ``evolve_step`` cannot block past ``deadline_at``. RalphLoopRunner
-# only checks ``max_total_seconds`` at iteration boundaries, so without this cap
-# the first iteration could still run for the full default 1800s — violating
-# the top-level pipeline deadline contract pinned by Q00/ouroboros#779.
+# Mirrors RalphHandler per-iteration bounds
+# (MIN_/MAX_PER_ITERATION_TIMEOUT_SECONDS). The auto layer sizes
+# ``per_iteration_timeout_seconds`` to the *remaining pipeline budget* so a
+# single ``evolve_step`` cannot block past ``deadline_at`` (Q00/ouroboros#779)
+# — RalphLoopRunner only checks ``max_total_seconds`` at iteration boundaries,
+# so without an upper bound the iteration could overshoot the deadline.
+#
+# It must NOT, however, cap below that budget. A ``complete_product`` gen-1
+# iteration legitimately runs both the implementation pass and the evolve
+# verification pass in one ``evolve_step``; the standalone Ralph default
+# (1800s) is far too small for that and was observed killing a
+# still-progressing iteration with ~5400s of pipeline budget left (cli-todo
+# live R2: 14/14 ACs complete, then cancelled at 1800s -> failed/iteration_timeout
+# despite the working product on disk). The ceiling is therefore the
+# Ralph-supported maximum, not the standalone default; ``max_total_seconds``
+# still bounds the whole loop.
 _MIN_RALPH_PER_ITERATION_SECONDS = 30.0
+# Standalone Ralph default — kept for parity with RalphHandler, but NOT used as
+# the auto-path per-iteration ceiling (see ``_MAX_RALPH_PER_ITERATION_SECONDS``).
 _DEFAULT_RALPH_PER_ITERATION_SECONDS = 1800.0
+# Mirrors RalphHandler.MAX_PER_ITERATION_TIMEOUT_SECONDS.
+_MAX_RALPH_PER_ITERATION_SECONDS = 7200.0
 
 # Q00/ouroboros#782 review-12 BLOCKING #1: when the top-level deadline has
 # already expired but a persisted Ralph job awaits reconciliation, give the
@@ -2108,21 +2121,25 @@ class AutoPipeline:
                     run_subagent=run_subagent,
                 )
             max_total_seconds = remaining
-            # Cap per-iteration so a single ``evolve_step`` cannot block past
-            # the remaining deadline. ``RalphLoopRunner`` checks
-            # ``max_total_seconds`` only at the top of each iteration, so
-            # without this cap the first iteration could still run for the
-            # full default 1800s after the deadline expired. Floored at the
+            # Size per-iteration to the remaining pipeline budget so a single
+            # ``evolve_step`` cannot block past ``deadline_at`` while ALSO not
+            # being capped below that budget. ``RalphLoopRunner`` checks
+            # ``max_total_seconds`` only at iteration boundaries, so the upper
+            # bound here is what stops a single iteration from overshooting the
+            # deadline. The ceiling is the Ralph-supported maximum (7200s), NOT
+            # the standalone default (1800s): a ``complete_product`` gen-1
+            # iteration does implementation + evolve verification in one step
+            # and the 1800s default was killing it mid-verification with
+            # pipeline budget still remaining (cli-todo live R2). Floored at the
             # Ralph minimum (30s) — when the remaining budget is itself below
-            # that floor we still cap at 30s rather than rejecting at the
-            # auto layer, since the pre-dispatch ``MIN_RALPH_MAX_TOTAL_SECONDS``
-            # check already protects against a sub-second budget. The
-            # ``max_total_seconds`` cap then aborts the loop before any
-            # follow-up iteration starts, so the worst-case overshoot is one
-            # iteration of up to 30 seconds.
+            # that floor we still cap at 30s rather than rejecting at the auto
+            # layer, since the pre-dispatch ``MIN_RALPH_MAX_TOTAL_SECONDS`` check
+            # already protects against a sub-second budget; ``max_total_seconds``
+            # then aborts the loop before any follow-up iteration starts, so the
+            # worst-case overshoot is one iteration of up to 30 seconds.
             per_iteration_timeout_seconds = max(
                 _MIN_RALPH_PER_ITERATION_SECONDS,
-                min(_DEFAULT_RALPH_PER_ITERATION_SECONDS, remaining),
+                min(_MAX_RALPH_PER_ITERATION_SECONDS, remaining),
             )
 
         ralph_mirror_task: asyncio.Task[None] | None = None

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -383,6 +383,71 @@ async def test_ralph_qa_passed_completes_auto(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("remaining_budget", "expected_per_iteration"),
+    [
+        # Budget far above the standalone 1800s default must NOT be capped at
+        # 1800 — this is the cli-todo live R2 regression: gen-1 ran
+        # implementation + evolve verification in one ``evolve_step`` and was
+        # cancelled at 1800s with ~5400s of pipeline budget still left.
+        (6000.0, 6000.0),
+        # Budget above the Ralph-supported maximum is ceilinged at the max.
+        (9000.0, 7200.0),
+        # Budget below the standalone default tracks the budget unchanged
+        # (the original lower-bound behaviour the cap was introduced for).
+        (600.0, 600.0),
+    ],
+)
+async def test_ralph_per_iteration_timeout_tracks_pipeline_budget(
+    tmp_path, remaining_budget: float, expected_per_iteration: float
+) -> None:
+    """``complete_product`` Ralph handoff sizes ``per_iteration_timeout_seconds``
+    to the remaining pipeline budget (capped at the Ralph max, floored at the
+    Ralph min), not the standalone 1800s default. ``max_total_seconds`` still
+    bounds the whole loop, so a single long gen-1 iteration is no longer killed
+    while pipeline budget remains.
+    """
+    state = _state_at_run_phase(tmp_path)
+    # Override the armed deadline so ``remaining`` is deterministic. ``deadline_at``
+    # is a monotonic-clock value (see ``AutoPipelineState.arm_deadline``).
+    state.deadline_at = time.monotonic() + remaining_budget
+
+    captured: dict[str, Any] = {}
+
+    async def ralph_starter(_seed: Seed, **kwargs: Any) -> dict[str, Any]:
+        captured["kwargs"] = kwargs
+        return {
+            "job_id": "job_ralph_budget",
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    pipeline = AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    per_iteration = captured["kwargs"]["per_iteration_timeout_seconds"]
+    max_total = captured["kwargs"]["max_total_seconds"]
+    # A few milliseconds elapse between arming the deadline above and the
+    # pipeline reading ``remaining``, so allow a small tolerance.
+    assert per_iteration == pytest.approx(expected_per_iteration, abs=5.0)
+    # Never above the Ralph-supported maximum, and never above the whole-loop
+    # budget that ``max_total_seconds`` enforces.
+    assert per_iteration <= pipeline_module._MAX_RALPH_PER_ITERATION_SECONDS
+    assert per_iteration <= max_total + 5.0
+
+
+@pytest.mark.asyncio
 async def test_ralph_job_id_persisted_while_starter_waits_for_terminal(tmp_path) -> None:
     state = _state_at_run_phase(tmp_path)
     store = AutoStore(tmp_path)
@@ -972,17 +1037,21 @@ async def test_ralph_handoff_caps_per_iteration_at_remaining_budget(tmp_path) ->
 
 
 @pytest.mark.asyncio
-async def test_ralph_handoff_uses_default_per_iteration_with_ample_budget(tmp_path) -> None:
-    """When remaining budget exceeds the Ralph default, no tighter cap is forwarded.
+async def test_ralph_handoff_per_iteration_tracks_budget_with_ample_budget(tmp_path) -> None:
+    """With ample budget the per-iteration timeout tracks the budget, NOT the 1800s default.
 
-    Pinning the upper bound prevents accidental over-tightening for the
-    common case (2h default deadline, RUN reached early with hours of
-    budget left): the bot's contract is to honor the deadline, not to
-    aggressively shrink the per-iteration budget below the established
-    1800s default.
+    Historical note: an earlier revision pinned this at the standalone 1800s
+    default (``== 1800.0``) on the theory that the per-iteration budget should
+    not exceed the established default. The cli-todo live R2 run disproved that
+    for the ``complete_product`` path — gen-1 runs implementation + evolve
+    verification in a single ``evolve_step`` and was cancelled at 1800s with
+    ~5400s of pipeline budget still remaining (``failed/iteration_timeout``
+    despite a working product on disk). The corrected contract: size
+    per-iteration to the remaining budget, ceilinged at the Ralph-supported
+    maximum (7200s), with ``max_total_seconds`` bounding the whole loop.
     """
     state = _state_at_run_phase(tmp_path)
-    # Two hours remaining — well above the 1800s default.
+    # Two hours remaining — well above the 1800s standalone default.
     state.deadline_at = time.monotonic() + 7200.0
     state.deadline_at_epoch = time.time() + 7200.0
 
@@ -1010,9 +1079,15 @@ async def test_ralph_handoff_uses_default_per_iteration_with_ample_budget(tmp_pa
     await pipeline.run(state)
 
     forwarded = captured["kwargs"]
-    # Remaining is much greater than 1800s, so the cap saturates at the
-    # Ralph default — never above it.
-    assert forwarded["per_iteration_timeout_seconds"] == 1800.0
+    # The fix: the per-iteration budget is NOT shrunk to the standalone 1800s
+    # default; it tracks the remaining budget (≈7200s here), ceilinged at the
+    # Ralph-supported maximum.
+    assert forwarded["per_iteration_timeout_seconds"] > 1800.0
+    assert forwarded["per_iteration_timeout_seconds"] == pytest.approx(7200.0, abs=5.0)
+    assert (
+        forwarded["per_iteration_timeout_seconds"]
+        <= pipeline_module._MAX_RALPH_PER_ITERATION_SECONDS
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_detached_auto_docs.py
+++ b/tests/unit/test_detached_auto_docs.py
@@ -130,7 +130,11 @@ def test_cli_docs_api_check_verifies_completed_detached_auto_result_output(
     job_id = "job_auto_docs_done"
     auto_session_id = "auto_docs_done"
     result_text = "detached auto result artifact: seed.yaml"
-    timestamp = datetime(2026, 5, 29, 12, 0, tzinfo=UTC)
+    # Anchor the persisted job within the 1h terminal-retention TTL relative to
+    # "now" rather than a fixed calendar date: a hardcoded timestamp silently
+    # crosses the TTL once the wall clock advances past it + ``_JOB_TTL``,
+    # turning a fresh completed handle into a spurious "Job handle expired".
+    timestamp = datetime.now(UTC) - timedelta(minutes=1)
 
     async def _persist_completed_auto_job() -> None:
         store = EventStore(db_url)
@@ -238,7 +242,9 @@ def test_mcp_docs_api_check_verifies_completed_detached_auto_result_response(
     auto_session_id = "auto_docs_done"
     result_text = "detached auto result artifact: seed.yaml"
     artifact_uri = "file:///tmp/detached-auto-result.json"
-    timestamp = datetime(2026, 5, 29, 12, 0, tzinfo=UTC)
+    # Relative to "now" so the handle stays inside the 1h retention TTL on any
+    # run date (see the completed-CLI variant above).
+    timestamp = datetime.now(UTC) - timedelta(minutes=1)
 
     async def _persist_completed_auto_job_and_fetch_result():
         store = EventStore(db_url)
@@ -475,7 +481,9 @@ def test_mcp_docs_api_check_verifies_failed_detached_auto_result_response(
     failure_text = "detached auto failed: seed repair budget exhausted"
     success_text = "detached auto result artifact: seed.yaml"
     source_error = "seed repair budget exhausted"
-    timestamp = datetime(2026, 5, 29, 12, 30, tzinfo=UTC)
+    # Relative to "now" so the failed handle stays inside the 1h retention TTL
+    # on any run date (a fixed date silently expires once now > date + _JOB_TTL).
+    timestamp = datetime.now(UTC) - timedelta(minutes=1)
 
     async def _persist_failed_auto_job_and_fetch_result():
         store = EventStore(db_url)
@@ -638,7 +646,9 @@ def test_mcp_docs_api_check_verifies_cancelled_detached_auto_result_response(
     cancellation_text = "detached auto cancelled: user requested cancellation"
     success_text = "detached auto result artifact: seed.yaml"
     source_error = "user requested cancellation"
-    timestamp = datetime(2026, 5, 29, 13, 0, tzinfo=UTC)
+    # Relative to "now" so the cancelled handle stays inside the 1h retention
+    # TTL on any run date (a fixed date silently expires once now > date + TTL).
+    timestamp = datetime.now(UTC) - timedelta(minutes=1)
 
     async def _persist_cancelled_auto_job_and_fetch_result():
         store = EventStore(db_url)


### PR DESCRIPTION
## Summary

The `complete_product` Ralph handoff capped `per_iteration_timeout_seconds` at the
standalone Ralph default (1800s) even when the pipeline deadline had hours of budget
left: `min(_DEFAULT_RALPH_PER_ITERATION_SECONDS, remaining)` saturates at 1800 once
`remaining > 1800`. A gen-1 `evolve_step` runs implementation + evolve verification in
one iteration, so the canonical cli-todo live run produced a working product (14/14 ACs,
407 tests passing) then was cancelled at 1800s with ~5400s of pipeline budget remaining —
surfacing as `failed/iteration_timeout` despite the working product on disk.

Fix: size the per-iteration timeout to the remaining budget, ceilinged at the
Ralph-supported maximum (7200s, mirrors `RalphHandler.MAX_PER_ITERATION_TIMEOUT_SECONDS`)
instead of the 1800s standalone default. `max_total_seconds` still bounds the whole loop,
so the deadline contract (#779/#782) is preserved and behaviour for budgets below 1800s
is unchanged.

## Test plan

- New parametrized regression `test_ralph_per_iteration_timeout_tracks_pipeline_budget`
  (6000→~6000, 9000→7200 cap, 600→~600 unchanged).
- Rewrote `test_ralph_handoff_..._with_ample_budget` to assert the corrected contract.
- `tests/unit/auto/test_pipeline_ralph_handoff.py` (57) + full `tests/unit/auto/` green; ruff clean.

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha) | This PR (sha) | Ratio |
|--------------------------------|----------------|---------------|-------|
| Rounds completed in 600 s      | N/A            | N/A           | n/a   |
| Per-round wall-clock (s/round) | N/A            | N/A           | n/a   |
| Terminal reason                | N/A            | N/A           | n/a   |
| EventStore event count         | N/A            | N/A           | n/a   |

This change only raises the Ralph **per-iteration** timeout ceiling; it does not touch the
interview per-round loop, so it adds no per-round wall-clock cost.

Budget compliance: [x] within 1.5×

## Related issues

Refs #1256 (§I1/§I6), #1170, #1258.
