### PR TITLE
fix(auto): stop blocking language/runtime/greenfield interview questions

### DIFF
--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -2143,9 +2143,51 @@ def _risky_fallback_blocker_for(question: str, lowered: str) -> AutoBlocker | No
     return None
 
 
+def _is_safe_implementation_choice_question(lowered: str) -> bool:
+    """True for questions about implementation substrate or project placement.
+
+    Choosing a programming language / runtime / framework, or deciding between a
+    greenfield project and an existing repository (where the code should "live"),
+    are safe-defaultable engineering decisions — never external-authority actions
+    — so they must not trip the deployment / credential blocker patterns.
+
+    Motivating false positive (#1170 canonical cli-todo R3): the question
+    "What programming language and runtime should this CLI be built in ... and is
+    there an existing project or repository this tool should live inside, or will
+    it be a standalone greenfield project?" matched the deployment pattern because
+    the verb "live" ("where should it live") collided with the deployment-sense
+    "live" token and "project" matched the deployment-target noun group. The
+    session terminated as BLOCKED("deployment target requires human authority")
+    instead of safe-defaulting to greenfield, breaking the product-or-die path.
+    """
+    # Genuine external-authority signals → defer to normal classification so a
+    # real deployment / credential / payment question is still blocked.
+    if re.search(
+        r"\b(deploy|deployment|release|publish|production|hosting|"
+        r"credential|secret|api key|access token|password|payment|billing)\b",
+        lowered,
+    ):
+        return False
+    return _matches_any(
+        lowered,
+        (
+            r"\b(which|what)\b.+\b(programming language|language|runtime|"
+            r"framework|frameworks|libraries|library|tech stack|stack)\b",
+            r"\b(greenfield|standalone)\b.+\bproject\b",
+            r"\b(existing|new)\b.+\b(project|repo|repository|codebase)\b.+"
+            r"\b(live|reside|inside|within|build|built|placed|located)\b",
+            r"\bwhere\b.+\b(should|will|does|to)\b.+\b(live|reside|placed|located)\b",
+        ),
+    )
+
+
 def _blocker_for(question: str) -> AutoBlocker | None:
     lowered = question.lower()
-    if _is_safe_product_branch_question(lowered) or _is_safe_product_sensitive_question(lowered):
+    if (
+        _is_safe_product_branch_question(lowered)
+        or _is_safe_product_sensitive_question(lowered)
+        or _is_safe_implementation_choice_question(lowered)
+    ):
         return None
 
     external_action_patterns = (

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -2143,13 +2143,15 @@ def _risky_fallback_blocker_for(question: str, lowered: str) -> AutoBlocker | No
     return None
 
 
+_DEPLOYMENT_AUTHORITY_REASON = "deployment target requires human authority"
+
+
 def _is_safe_implementation_choice_question(lowered: str) -> bool:
     """True for questions about implementation substrate or project placement.
 
     Choosing a programming language / runtime / framework, or deciding between a
     greenfield project and an existing repository (where the code should "live"),
-    are safe-defaultable engineering decisions — never external-authority actions
-    — so they must not trip the deployment / credential blocker patterns.
+    are safe-defaultable engineering decisions — never external-authority actions.
 
     Motivating false positive (#1170 canonical cli-todo R3): the question
     "What programming language and runtime should this CLI be built in ... and is
@@ -2159,26 +2161,18 @@ def _is_safe_implementation_choice_question(lowered: str) -> bool:
     "live" token and "project" matched the deployment-target noun group. The
     session terminated as BLOCKED("deployment target requires human authority")
     instead of safe-defaulting to greenfield, breaking the product-or-die path.
+
+    This predicate intentionally governs **only** suppression of the deployment
+    false positive (see `_blocker_for`): it can never shadow credential, payment,
+    legal, medical, or destructive blockers, so it does not need to mirror their
+    vocabularies. The single negative check below keeps a *genuine* deployment
+    question (which also names a language/runtime) blocked.
     """
-    # Genuine external-authority signals → defer to normal classification so any
-    # real external action is still inspected by `_blocker_for`. Deferring is
-    # safe-by-construction: it only re-runs normal classification, which blocks
-    # *iff* a genuine `external_action_patterns` entry matches — it never blocks a
-    # benign substrate/placement question. The vocabulary below therefore mirrors
-    # every external-action category (deployment, credential, payment, legal,
-    # medical, and destructive operations) so an implementation-choice phrasing can
-    # never short-circuit an unrelated authority blocker. (#1295 review: the prior
-    # negative check excluded only deployment/credential/payment, so a destructive
-    # prompt such as "what language should the cleanup script use to remove the
-    # database?" bypassed the destructive-operation blocker.)
+    # A genuine deployment-sense signal means this is a real deployment-target
+    # question, not the benign "where should the code live" collision → do not
+    # suppress the deployment blocker.
     if re.search(
-        r"\b(deploy|deployment|release|publish|production|prod|hosting|host|"
-        r"credential|credentials|secret|api key|access token|auth token|"
-        r"private key|password|payment|billing|paid service|credit card|"
-        r"bank account|invoice|charge|purchase|subscribe|"
-        r"legal|compliance|license|contract|"
-        r"medical|clinical|diagnosis|treatment|health|"
-        r"delete|drop|erase|wipe|remove|destroy|truncate)\b",
+        r"\b(deploy|deployment|release|publish|production|prod|hosting|host)\b",
         lowered,
     ):
         return False
@@ -2197,11 +2191,7 @@ def _is_safe_implementation_choice_question(lowered: str) -> bool:
 
 def _blocker_for(question: str) -> AutoBlocker | None:
     lowered = question.lower()
-    if (
-        _is_safe_product_branch_question(lowered)
-        or _is_safe_product_sensitive_question(lowered)
-        or _is_safe_implementation_choice_question(lowered)
-    ):
+    if _is_safe_product_branch_question(lowered) or _is_safe_product_sensitive_question(lowered):
         return None
 
     external_action_patterns = (
@@ -2255,15 +2245,15 @@ def _blocker_for(question: str) -> AutoBlocker | None:
         ),
         (
             r"\b(should|can|may|will|do we|should we)\b.+\b(deploy|release|publish)\b.+\b(to|against|on)\s+\b(production|prod|live|external)\b",
-            "deployment target requires human authority",
+            _DEPLOYMENT_AUTHORITY_REASON,
         ),
         (
             r"\b(which|what|choose|select|use|configure|set)\b.+\b(production|prod|live|external)\b.+\b(environment|target|account|project|cluster|region)\b",
-            "deployment target requires human authority",
+            _DEPLOYMENT_AUTHORITY_REASON,
         ),
         (
             r"\b(which|what|choose|select|use|configure|set)\b.+\b(environment|target|account|project|cluster|region)\b.+\b(deploy|release|publish)\b.+\b(production|prod|live|external)\b",
-            "deployment target requires human authority",
+            _DEPLOYMENT_AUTHORITY_REASON,
         ),
         (
             r"\b(provide|enter|paste|supply|use|configure|set)\b.+\b(production|prod|live|external)\b.+\b(credential|secret|api key)\b",
@@ -2282,7 +2272,16 @@ def _blocker_for(question: str) -> AutoBlocker | None:
             "credential or secret value required",
         ),
     )
+    safe_implementation_choice = _is_safe_implementation_choice_question(lowered)
     for pattern, reason in external_action_patterns:
         if re.search(pattern, lowered):
+            # The implementation-choice guard may suppress ONLY the deployment
+            # false positive (the verb-"live" / "project" collision, #1170 R3).
+            # It is structurally incapable of shadowing credential, payment,
+            # legal, medical, or destructive blockers, so it never needs to mirror
+            # their vocabularies (#1295 review: a parallel negative list was
+            # brittle and missed plural credential forms).
+            if safe_implementation_choice and reason == _DEPLOYMENT_AUTHORITY_REASON:
+                continue
             return AutoBlocker(reason=reason, question=question)
     return None

--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -2160,11 +2160,25 @@ def _is_safe_implementation_choice_question(lowered: str) -> bool:
     session terminated as BLOCKED("deployment target requires human authority")
     instead of safe-defaulting to greenfield, breaking the product-or-die path.
     """
-    # Genuine external-authority signals → defer to normal classification so a
-    # real deployment / credential / payment question is still blocked.
+    # Genuine external-authority signals → defer to normal classification so any
+    # real external action is still inspected by `_blocker_for`. Deferring is
+    # safe-by-construction: it only re-runs normal classification, which blocks
+    # *iff* a genuine `external_action_patterns` entry matches — it never blocks a
+    # benign substrate/placement question. The vocabulary below therefore mirrors
+    # every external-action category (deployment, credential, payment, legal,
+    # medical, and destructive operations) so an implementation-choice phrasing can
+    # never short-circuit an unrelated authority blocker. (#1295 review: the prior
+    # negative check excluded only deployment/credential/payment, so a destructive
+    # prompt such as "what language should the cleanup script use to remove the
+    # database?" bypassed the destructive-operation blocker.)
     if re.search(
-        r"\b(deploy|deployment|release|publish|production|hosting|"
-        r"credential|secret|api key|access token|password|payment|billing)\b",
+        r"\b(deploy|deployment|release|publish|production|prod|hosting|host|"
+        r"credential|credentials|secret|api key|access token|auth token|"
+        r"private key|password|payment|billing|paid service|credit card|"
+        r"bank account|invoice|charge|purchase|subscribe|"
+        r"legal|compliance|license|contract|"
+        r"medical|clinical|diagnosis|treatment|health|"
+        r"delete|drop|erase|wipe|remove|destroy|truncate)\b",
         lowered,
     ):
         return False

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -609,6 +609,34 @@ def test_implementation_choice_guard_does_not_weaken_deployment_blocking() -> No
         assert answer.source == AutoAnswerSource.BLOCKER
 
 
+def test_implementation_choice_guard_defers_to_other_authority_blockers() -> None:
+    """The implementation-choice guard must not short-circuit *any* genuine
+    external-authority blocker when the prompt merely also carries
+    language/runtime/framework wording.
+
+    Regression for the #1295 review blocker: the guard's negative-signal check
+    originally excluded only deployment/credential/payment terms, so a destructive
+    operation phrased as an implementation choice — e.g. "what language should the
+    cleanup script use to remove the database?" — bypassed the destructive-operation
+    blocker and returned a conservative default with no blocker. The guard now
+    defers whenever any external-action signal (destructive / credential / payment /
+    legal / medical) is present, so these still block."""
+    answerer = AutoAnswerer()
+    blocking_questions = (
+        # Destructive operation wrapped in a language/runtime/framework choice.
+        "What language should the cleanup script use to remove the database?",
+        "What runtime should the tool use to delete the prod branch?",
+        "Which framework should we use to wipe the production database?",
+        "Which programming language should the migration use to drop the db?",
+        # Other authority categories that share the same allowlist short-circuit.
+        "Which language should we use to enter the production api key value?",
+    )
+    for question in blocking_questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a CLI"))
+        assert answer.blocker is not None, f"expected blocker for: {question!r}"
+        assert answer.source == AutoAnswerSource.BLOCKER
+
+
 def test_blank_goal_remains_open_gap() -> None:
     ledger = SeedDraftLedger.from_goal("   ")
     _fill_minimal_ready_ledger(ledger)

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -564,6 +564,51 @@ def test_auto_answerer_blocks_contextual_human_authority_questions() -> None:
         assert answer.source == AutoAnswerSource.BLOCKER
 
 
+def test_auto_answerer_allows_implementation_choice_questions() -> None:
+    """Language / runtime / framework choice and greenfield-vs-existing-repo
+    placement are safe-defaultable engineering decisions and must not block.
+
+    Regression for #1170 canonical cli-todo R3: the auto interview terminated as
+    BLOCKED("deployment target requires human authority") because the verb "live"
+    in "...this tool should live inside..." collided with the deployment-sense
+    "live" token (and "project" matched the deployment-target noun group),
+    halting the product-or-die path instead of safe-defaulting to greenfield.
+    """
+    answerer = AutoAnswerer()
+    safe_questions = (
+        # The exact R3 question, verbatim (em dashes included).
+        (
+            "What programming language and runtime should this CLI be built in — "
+            "for example, Python with the standard library, Node.js, or something "
+            "else — and is there an existing project or repository this tool should "
+            "live inside, or will it be a standalone greenfield project?"
+        ),
+        "What programming language should this tool be built in?",
+        "Which framework and runtime should we use?",
+        "Should this be a standalone greenfield project or live inside an existing repo?",
+        "Where should the new module live in the codebase?",
+    )
+    for question in safe_questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a habit-tracker CLI"))
+        assert answer.blocker is None, f"unexpected blocker for: {question!r}"
+        assert answer.source != AutoAnswerSource.BLOCKER
+
+
+def test_implementation_choice_guard_does_not_weaken_deployment_blocking() -> None:
+    """The implementation-choice guard must keep genuine deployment / production
+    authority questions blocked (the verb-"live" fix is deliberately narrow)."""
+    answerer = AutoAnswerer()
+    blocking_questions = (
+        "Which production environment should we deploy the CLI to?",
+        "Which production cluster and region should we deploy to?",
+        "Should we deploy to production or live?",
+    )
+    for question in blocking_questions:
+        answer = answerer.answer(question, SeedDraftLedger.from_goal("Deploy a service"))
+        assert answer.blocker is not None, f"expected blocker for: {question!r}"
+        assert answer.source == AutoAnswerSource.BLOCKER
+
+
 def test_blank_goal_remains_open_gap() -> None:
     ledger = SeedDraftLedger.from_goal("   ")
     _fill_minimal_ready_ledger(ledger)

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -628,8 +628,12 @@ def test_implementation_choice_guard_defers_to_other_authority_blockers() -> Non
         "What runtime should the tool use to delete the prod branch?",
         "Which framework should we use to wipe the production database?",
         "Which programming language should the migration use to drop the db?",
-        # Other authority categories that share the same allowlist short-circuit.
+        # Credential authority — singular and plural forms, with CI/workflow/env
+        # context — must all stay blocked even when phrased as a language choice.
         "Which language should we use to enter the production api key value?",
+        "Which language should we use to configure API keys value?",
+        "Which framework should we use to configure passwords in CI?",
+        "What runtime should we use to set the api keys in the workflow?",
     )
     for question in blocking_questions:
         answer = answerer.answer(question, SeedDraftLedger.from_goal("Build a CLI"))

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -602,6 +602,12 @@ def test_implementation_choice_guard_does_not_weaken_deployment_blocking() -> No
         "Which production environment should we deploy the CLI to?",
         "Which production cluster and region should we deploy to?",
         "Should we deploy to production or live?",
+        # The deployment-sense negative check must stay load-bearing: a genuine
+        # deployment question that *also* names a language/runtime (so it matches a
+        # positive implementation-choice pattern) must still block — otherwise the
+        # guard would suppress the deployment authority gate.
+        "Which language should we use, and which production cluster should we deploy to?",
+        "What runtime and which production environment should we deploy to?",
     )
     for question in blocking_questions:
         answer = answerer.answer(question, SeedDraftLedger.from_goal("Deploy a service"))

--- a/tests/unit/test_detached_auto_docs.py
+++ b/tests/unit/test_detached_auto_docs.py
@@ -130,7 +130,10 @@ def test_cli_docs_api_check_verifies_completed_detached_auto_result_output(
     job_id = "job_auto_docs_done"
     auto_session_id = "auto_docs_done"
     result_text = "detached auto result artifact: seed.yaml"
-    timestamp = datetime(2026, 5, 29, 12, 0, tzinfo=UTC)
+    # Anchor to wall-clock now (within the 1h _JOB_TTL) so the terminal job
+    # handle stays retrievable regardless of when CI runs. A fixed past date
+    # would expire once real time advances >1h past it (job_handle_expired).
+    timestamp = datetime.now(UTC) - timedelta(minutes=5)
 
     async def _persist_completed_auto_job() -> None:
         store = EventStore(db_url)
@@ -238,7 +241,10 @@ def test_mcp_docs_api_check_verifies_completed_detached_auto_result_response(
     auto_session_id = "auto_docs_done"
     result_text = "detached auto result artifact: seed.yaml"
     artifact_uri = "file:///tmp/detached-auto-result.json"
-    timestamp = datetime(2026, 5, 29, 12, 0, tzinfo=UTC)
+    # Anchor to wall-clock now (within the 1h _JOB_TTL) so the terminal job
+    # handle stays retrievable regardless of when CI runs. A fixed past date
+    # would expire once real time advances >1h past it (job_handle_expired).
+    timestamp = datetime.now(UTC) - timedelta(minutes=5)
 
     async def _persist_completed_auto_job_and_fetch_result():
         store = EventStore(db_url)
@@ -475,7 +481,8 @@ def test_mcp_docs_api_check_verifies_failed_detached_auto_result_response(
     failure_text = "detached auto failed: seed repair budget exhausted"
     success_text = "detached auto result artifact: seed.yaml"
     source_error = "seed repair budget exhausted"
-    timestamp = datetime(2026, 5, 29, 12, 30, tzinfo=UTC)
+    # Anchor to wall-clock now (within the 1h _JOB_TTL); see note above.
+    timestamp = datetime.now(UTC) - timedelta(minutes=5)
 
     async def _persist_failed_auto_job_and_fetch_result():
         store = EventStore(db_url)
@@ -638,7 +645,8 @@ def test_mcp_docs_api_check_verifies_cancelled_detached_auto_result_response(
     cancellation_text = "detached auto cancelled: user requested cancellation"
     success_text = "detached auto result artifact: seed.yaml"
     source_error = "user requested cancellation"
-    timestamp = datetime(2026, 5, 29, 13, 0, tzinfo=UTC)
+    # Anchor to wall-clock now (within the 1h _JOB_TTL); see note above.
+    timestamp = datetime.now(UTC) - timedelta(minutes=5)
 
     async def _persist_cancelled_auto_job_and_fetch_result():
         store = EventStore(db_url)


### PR DESCRIPTION
## Summary

The interview blocker classifier escalated a benign implementation-choice question to
`BLOCKED("deployment target requires human authority")`. The deployment patterns' `live`
token matched the English verb "live" ("...is there an existing project or repository this
tool should live inside...") while "project" matched the deployment-target noun group, so
the canonical cli-todo R3 run halted at interview round 4 with no seed and no product — a
product-or-die (RFC #1256 §I1) violation and a reproducibility break versus R2 where the
same class of question was auto-answered.

Fix: add `_is_safe_implementation_choice_question`, a short-circuit guard checked alongside
the existing safe-product guards. It returns no blocker for language / runtime / framework
choice and greenfield-vs-existing-repo placement questions (safe conservative defaults),
while deferring to normal classification whenever a genuine deploy / production /
credential / payment signal is present. The risky deployment/credential regexes are
untouched, so real production-authority questions still block.

## Test plan

- `test_auto_answerer_allows_implementation_choice_questions` (exact R3 question verbatim + variants → no blocker).
- `test_implementation_choice_guard_does_not_weaken_deployment_blocking` (real deploy/prod questions still block).
- `tests/unit/auto/test_ledger_grading_answerer.py` + full `tests/unit/auto/` green; ruff clean.

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha) | This PR (sha) | Ratio |
|--------------------------------|----------------|---------------|-------|
| Rounds completed in 600 s      | N/A            | N/A           | n/a   |
| Per-round wall-clock (s/round) | N/A            | N/A           | n/a   |
| Terminal reason                | N/A            | N/A           | n/a   |
| EventStore event count         | N/A            | N/A           | n/a   |

Pure classifier guard (one added regex short-circuit); no per-round wall-clock cost.

Budget compliance: [x] within 1.5×

## Related issues

Refs #1170, #1256 (§I1/§I3).
