### PR TITLE
feat(auto): auto_fill_remaining substrate for non-converging interviews (#1263 PR-1)

### DIFF
--- a/src/ouroboros/auto/auto_fill.py
+++ b/src/ouroboros/auto/auto_fill.py
@@ -1,0 +1,105 @@
+"""Aggressive LLM auto-fill substrate for non-converging interviews.
+
+RFC #1256 §I3 (#1263 PR-1). When the interview cannot converge — max rounds
+reached, ambiguity oscillating, phase deadline approaching — the engine must
+aggressively fill the remaining open ledger slots through inference rather than
+declaring non-convergence as a terminal cause. The user's absence of an answer
+is never a sufficient reason to halt: every ``ooo auto`` session should be able
+to reach a seed-ready ledger.
+
+This module is the **pure substrate primitive only** and is intentionally NOT
+wired into the interview driver loop yet (that is #1263 PR-2). It takes an
+injected ``fill_slot`` callable (the LLM call) so it performs no IO itself and
+is therefore safe to unit test and to run inside the bounded interview loop
+without risking a hang.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from ouroboros.auto.ledger import (
+    LedgerEntry,
+    LedgerSource,
+    LedgerStatus,
+    SeedDraftLedger,
+)
+
+# Documented confidence floor for an auto-filled slot whose proposal carries no
+# usable confidence of its own (RFC #1256 §I3).
+_DEFAULT_AUTO_FILL_CONFIDENCE = 0.5
+
+
+@dataclass(frozen=True, slots=True)
+class AutoFillProposal:
+    """One inference-proposed fill for a single open ledger section.
+
+    ``value`` is the best-guess content for the section. ``confidence`` is
+    carried onto the ledger entry; a non-positive value is replaced by the
+    documented 0.5 floor so a model that declines to score still produces an
+    audited, low-confidence default. ``rationale`` is optional provenance text.
+    """
+
+    value: str
+    confidence: float = _DEFAULT_AUTO_FILL_CONFIDENCE
+    rationale: str = ""
+
+
+# ``fill_slot(section_name, ledger)`` returns a proposal for the named open
+# section, or ``None`` to decline (the caller's next closure-ladder rung — RFC
+# #1256 §I2 ``partial_seed_from_evidence`` — then handles the still-open gap).
+FillSlot = Callable[[str, SeedDraftLedger], "AutoFillProposal | None"]
+
+
+def auto_fill_remaining(ledger: SeedDraftLedger, *, fill_slot: FillSlot) -> list[str]:
+    """Fill open ledger gaps via injected inference so a non-converging interview
+    can still reach a seed-ready ledger.
+
+    Iterates the ledger's currently-open required sections (a snapshot taken
+    before any mutation, so each originally-open gap is attempted exactly once)
+    and asks ``fill_slot`` for a best-guess value. Each accepted proposal is
+    appended as a single :class:`LedgerEntry` with
+    ``source = LedgerSource.AUTO_FILL_INFERENCE`` and
+    ``status = LedgerStatus.DEFAULTED``; its confidence is carried from the
+    proposal (clamped by ``LedgerEntry`` to ``[0, 1]``, floored at 0.5 when the
+    proposal omits it).
+
+    The ledger is mutated in place. Returns the section names that were actually
+    *resolved* by the fill (a proposal that does not clear the gap — e.g. the
+    section is still BLOCKED/CONFLICTING — is not reported). Sections the filler
+    declines (``None`` or blank value) are left open for the caller's next rung.
+
+    This function performs no IO and makes no model calls of its own; all
+    inference is delegated to ``fill_slot``.
+    """
+    filled: list[str] = []
+    for section_name in ledger.open_gaps():
+        proposal = fill_slot(section_name, ledger)
+        if proposal is None:
+            continue
+        value = proposal.value.strip()
+        if not value:
+            continue
+        confidence = proposal.confidence
+        if confidence <= 0.0:
+            confidence = _DEFAULT_AUTO_FILL_CONFIDENCE
+        ledger.add_entry(
+            section_name,
+            LedgerEntry(
+                key=f"{section_name}.auto_fill_inference",
+                value=value,
+                source=LedgerSource.AUTO_FILL_INFERENCE,
+                confidence=confidence,
+                status=LedgerStatus.DEFAULTED,
+                reversible=True,
+                rationale=(
+                    proposal.rationale
+                    or "Auto-filled by inference (RFC #1256 §I3) because the "
+                    "interview did not converge before its deadline."
+                ),
+            ),
+        )
+        if section_name not in ledger.open_gaps():
+            filled.append(section_name)
+    return filled

--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -512,6 +512,16 @@ def deterministic_floor(ledger: SeedDraftLedger) -> float:
     return min(1.0, max(0.0, floor))
 
 
+# Assumption-class sources whose unreviewed best-guess content must still be
+# screened for high-risk terms before a seed can grade as runnable.
+# ``AUTO_FILL_INFERENCE`` (RFC #1256 §I3) joins ``ASSUMPTION`` here: an
+# auto-filled slot can close a required section with no user signal at all, so a
+# risky inferred value must block grading exactly as a risky human-style
+# assumption does — otherwise the §I3 closure path becomes a way to smuggle
+# unreviewed credential/production/payment content past this safety gate.
+_HIGH_RISK_GATED_SOURCES = frozenset({LedgerSource.ASSUMPTION, LedgerSource.AUTO_FILL_INFERENCE})
+
+
 def _high_risk_assumption_count(ledger: SeedDraftLedger) -> int:
     risky_terms = ("credential", "api key", "production", "payment", "legal", "medical")
     inactive_statuses = {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
@@ -519,7 +529,7 @@ def _high_risk_assumption_count(ledger: SeedDraftLedger) -> int:
         1
         for section in ledger.sections.values()
         for entry in section.entries
-        if entry.source == LedgerSource.ASSUMPTION
+        if entry.source in _HIGH_RISK_GATED_SOURCES
         and section.name != "non_goals"
         and entry.status not in inactive_statuses
         and any(term in entry.value.lower() for term in risky_terms)

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -19,6 +19,10 @@ class LedgerSource(StrEnum):
     ASSUMPTION = "assumption"
     NON_GOAL = "non_goal"
     INFERENCE = "inference"
+    # Aggressive LLM auto-fill for a non-converging interview (RFC #1256 §I3,
+    # #1263). Assumption-class, not evidence-backed: a model best-guess emitted
+    # only when the interview cannot otherwise close a required section.
+    AUTO_FILL_INFERENCE = "auto_fill_inference"
     BLOCKER = "blocker"
 
 
@@ -43,6 +47,7 @@ SOURCE_PRIORITY: tuple[LedgerSource, ...] = (
     LedgerSource.CONSERVATIVE_DEFAULT,
     LedgerSource.INFERENCE,
     LedgerSource.ASSUMPTION,
+    LedgerSource.AUTO_FILL_INFERENCE,
     LedgerSource.BLOCKER,
 )
 """Deterministic conflict priority for same-key ledger contradictions.
@@ -455,6 +460,7 @@ class SeedDraftLedger:
             LedgerSource.ASSUMPTION,
             LedgerSource.INFERENCE,
             LedgerSource.CONSERVATIVE_DEFAULT,
+            LedgerSource.AUTO_FILL_INFERENCE,
         }
         resolved: dict[tuple[str, str], AssumptionRecord] = {}
         for section in self.sections.values():

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -119,8 +119,9 @@ class AssumptionRecord:
 
     ``source`` is the string form of one of the assumption-class
     :class:`LedgerSource` values — ``assumption`` (auto-answerer
-    fallback), ``inference`` (model reasoning), or
-    ``conservative_default`` (safe-default policy). These three are
+    fallback), ``inference`` (model reasoning), ``conservative_default``
+    (safe-default policy), or ``auto_fill_inference`` (RFC #1256 §I3
+    aggressive auto-fill for a non-converging interview). These are
     precisely the sources that, per :data:`_EVIDENCE_BACKED_SOURCES`,
     are not evidence-backed and therefore contribute to
     ``assumption_only_sections`` in :meth:`SeedDraftLedger.summary`.

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -444,9 +444,10 @@ class SeedDraftLedger:
         PR-C2 / #1157: auditable companion to :meth:`assumptions` (which
         returns plain ``list[str]`` for backwards-compatible callers). The
         returned records cover every active entry whose source is one of
-        the three assumption-class :class:`LedgerSource` values —
-        ``ASSUMPTION``, ``INFERENCE``, ``CONSERVATIVE_DEFAULT`` — i.e. the
-        sources that produce ``assumption_only_sections`` in
+        the four assumption-class :class:`LedgerSource` values —
+        ``ASSUMPTION``, ``INFERENCE``, ``CONSERVATIVE_DEFAULT``, and
+        ``AUTO_FILL_INFERENCE`` — i.e. the sources that produce
+        ``assumption_only_sections`` in
         :meth:`summary`. Entries whose status is in
         :data:`_INACTIVE_STATUSES` (WEAK / CONFLICTING / BLOCKED) are
         excluded, matching the active-set semantics used by

--- a/tests/unit/auto/test_auto_fill.py
+++ b/tests/unit/auto/test_auto_fill.py
@@ -1,0 +1,135 @@
+"""Unit tests for the §I3 aggressive auto-fill substrate (#1263 PR-1).
+
+These exercise ``auto_fill_remaining`` in isolation with an injected stub filler;
+the driver wiring (#1263 PR-2) and seed ``auto_filled_slots`` metadata (PR-3) are
+out of scope here.
+"""
+
+from __future__ import annotations
+
+from ouroboros.auto.auto_fill import AutoFillProposal, auto_fill_remaining
+from ouroboros.auto.ledger import (
+    LedgerEntry,
+    LedgerSource,
+    LedgerStatus,
+    SeedDraftLedger,
+)
+
+
+def _ledger_with_open_gaps() -> SeedDraftLedger:
+    # ``from_goal`` resolves "goal" (plus any explicitly hydrated sections); the
+    # remaining required sections start MISSING and therefore show as open gaps.
+    ledger = SeedDraftLedger.from_goal("Build a habit-tracker CLI")
+    assert not ledger.is_seed_ready()
+    assert ledger.open_gaps()
+    return ledger
+
+
+def test_auto_fill_fills_open_gaps_and_makes_ledger_seed_ready() -> None:
+    ledger = _ledger_with_open_gaps()
+    gaps_before = set(ledger.open_gaps())
+
+    def fill_slot(section: str, _ledger: SeedDraftLedger) -> AutoFillProposal:
+        return AutoFillProposal(value=f"auto value for {section}", confidence=0.7)
+
+    filled = auto_fill_remaining(ledger, fill_slot=fill_slot)
+
+    assert set(filled) == gaps_before
+    assert ledger.is_seed_ready()
+    for section in filled:
+        auto_entries = [
+            e
+            for e in ledger.sections[section].entries
+            if e.source == LedgerSource.AUTO_FILL_INFERENCE
+        ]
+        assert len(auto_entries) == 1
+        assert auto_entries[0].status == LedgerStatus.DEFAULTED
+        assert auto_entries[0].confidence == 0.7
+        assert auto_entries[0].key == f"{section}.auto_fill_inference"
+
+
+def test_auto_fill_declined_slot_stays_open() -> None:
+    ledger = _ledger_with_open_gaps()
+    target = ledger.open_gaps()[0]
+
+    def fill_slot(section: str, _ledger: SeedDraftLedger) -> AutoFillProposal | None:
+        return None if section == target else AutoFillProposal(value=f"value {section}")
+
+    filled = auto_fill_remaining(ledger, fill_slot=fill_slot)
+
+    assert target not in filled
+    assert target in ledger.open_gaps()
+    assert not ledger.is_seed_ready()
+
+
+def test_auto_fill_blank_value_is_skipped() -> None:
+    ledger = _ledger_with_open_gaps()
+
+    def fill_slot(section: str, _ledger: SeedDraftLedger) -> AutoFillProposal:
+        return AutoFillProposal(value="   ")  # whitespace-only is not content
+
+    filled = auto_fill_remaining(ledger, fill_slot=fill_slot)
+
+    assert filled == []
+    assert not ledger.is_seed_ready()
+
+
+def test_auto_fill_confidence_floor_when_unscored() -> None:
+    ledger = _ledger_with_open_gaps()
+
+    def fill_slot(section: str, _ledger: SeedDraftLedger) -> AutoFillProposal:
+        return AutoFillProposal(value=f"value {section}", confidence=0.0)
+
+    auto_fill_remaining(ledger, fill_slot=fill_slot)
+
+    auto_entries = [
+        e
+        for section in ledger.sections.values()
+        for e in section.entries
+        if e.source == LedgerSource.AUTO_FILL_INFERENCE
+    ]
+    assert auto_entries
+    assert all(e.confidence == 0.5 for e in auto_entries)
+
+
+def test_auto_fill_entries_surface_as_assumption_sources() -> None:
+    ledger = _ledger_with_open_gaps()
+
+    def fill_slot(section: str, _ledger: SeedDraftLedger) -> AutoFillProposal:
+        return AutoFillProposal(value=f"value {section}", confidence=0.6)
+
+    auto_fill_remaining(ledger, fill_slot=fill_slot)
+
+    records = ledger.assumption_sources()
+    assert any(r.source == LedgerSource.AUTO_FILL_INFERENCE.value for r in records)
+
+
+def test_auto_fill_leaves_already_resolved_sections_untouched() -> None:
+    ledger = _ledger_with_open_gaps()
+    target = ledger.open_gaps()[0]
+    ledger.add_entry(
+        target,
+        LedgerEntry(
+            key=f"{target}.user",
+            value="user provided",
+            source=LedgerSource.USER_PREFERENCE,
+            confidence=0.9,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+    assert target not in ledger.open_gaps()
+
+    offered: list[str] = []
+
+    def fill_slot(section: str, _ledger: SeedDraftLedger) -> AutoFillProposal:
+        offered.append(section)
+        return AutoFillProposal(value=f"value {section}")
+
+    auto_fill_remaining(ledger, fill_slot=fill_slot)
+
+    # A section that is already resolved is never offered to the filler, and no
+    # auto-fill entry is appended to it.
+    assert target not in offered
+    assert all(
+        e.source != LedgerSource.AUTO_FILL_INFERENCE for e in ledger.sections[target].entries
+    )

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1403,7 +1403,9 @@ async def test_pipeline_result_surfaces_assumption_sources_with_provenance(tmp_p
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
     ledger = SeedDraftLedger.from_goal(state.goal)
     _fill_ready(ledger)
-    # Add one entry from each of the three assumption-class sources. The
+    # Add explicit ASSUMPTION and INFERENCE entries (conservative-default
+    # entries already come from ``_fill_ready``); each assumption-class source
+    # must surface through ``assumption_sources`` with its tag intact. The
     # ASSUMPTION entry has unique text so the legacy ``assumptions`` field
     # still surfaces it.
     ledger.add_entry(

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -2363,11 +2363,11 @@ def test_auto_answerer_allows_qualified_compliance_policy_features() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_assumption_sources_returns_records_for_all_three_assumption_class_sources() -> None:
+def test_assumption_sources_returns_records_for_all_assumption_class_sources() -> None:
     """``assumption_sources()`` must surface ``ASSUMPTION``, ``INFERENCE``,
-    and ``CONSERVATIVE_DEFAULT`` entries with their source tag intact.
-    ``assumptions()`` continues to return only the ``ASSUMPTION`` subset
-    (backwards-compatibility guard)."""
+    ``CONSERVATIVE_DEFAULT``, and ``AUTO_FILL_INFERENCE`` entries with their
+    source tag intact. ``assumptions()`` continues to return only the
+    ``ASSUMPTION`` subset (backwards-compatibility guard)."""
     from ouroboros.auto.ledger import AssumptionRecord
 
     ledger = SeedDraftLedger.from_goal("Build a tiny local CLI")
@@ -2401,6 +2401,16 @@ def test_assumption_sources_returns_records_for_all_three_assumption_class_sourc
             status=LedgerStatus.DEFAULTED,
         ),
     )
+    ledger.add_entry(
+        "inputs",
+        LedgerEntry(
+            key="inputs.auto_fill_inference",
+            value="Inputs are positional command arguments",
+            source=LedgerSource.AUTO_FILL_INFERENCE,
+            confidence=0.5,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
 
     records = ledger.assumption_sources()
     assert all(isinstance(rec, AssumptionRecord) for rec in records)
@@ -2409,11 +2419,13 @@ def test_assumption_sources_returns_records_for_all_three_assumption_class_sourc
     assert by_text["Primary actor is a single local developer"].source == "assumption"
     assert by_text["Outputs are stdout-only"].source == "inference"
     assert by_text["Use existing project patterns"].source == "conservative_default"
+    assert by_text["Inputs are positional command arguments"].source == "auto_fill_inference"
 
     # confidence is preserved verbatim per entry.
     assert by_text["Primary actor is a single local developer"].confidence == 0.7
     assert by_text["Outputs are stdout-only"].confidence == 0.6
     assert by_text["Use existing project patterns"].confidence == 0.85
+    assert by_text["Inputs are positional command arguments"].confidence == 0.5
 
     # Backwards-compat guard: ``assumptions()`` is unchanged in scope —
     # only the ASSUMPTION-source entry appears there.

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -1296,6 +1296,34 @@ def test_grade_gate_ignores_inactive_high_risk_assumptions() -> None:
     assert not any(blocker.code == "high_risk_assumptions" for blocker in result.blockers)
 
 
+def test_grade_gate_blocks_high_risk_auto_fill_inference() -> None:
+    # RFC #1256 §I3 safety boundary: an AUTO_FILL_INFERENCE entry can close a
+    # required section with no user signal, so risky inferred content must trip
+    # the same high-risk gate as a risky ASSUMPTION — otherwise §I3 auto-fill
+    # would be a path to smuggle unreviewed production/credential content into a
+    # runnable seed.
+    ledger = SeedDraftLedger.from_goal("Build a local task app")
+    _fill_minimal_ready_ledger(ledger)
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.auto_fill_inference",
+            value="Use production credential for deployment",
+            source=LedgerSource.AUTO_FILL_INFERENCE,
+            confidence=0.5,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+
+    result = GradeGate().grade_seed(
+        _seed(ac=("`task list` prints stable stdout",), goal="Build a local task app"),
+        ledger=ledger,
+    )
+
+    assert any(blocker.code == "high_risk_assumptions" for blocker in result.blockers)
+    assert not result.may_run
+
+
 def test_grade_gate_blocks_high_ambiguity_seed() -> None:
     ledger = SeedDraftLedger.from_goal("Build a CLI")
     _fill_minimal_ready_ledger(ledger)

--- a/tests/unit/test_detached_auto_docs.py
+++ b/tests/unit/test_detached_auto_docs.py
@@ -130,7 +130,11 @@ def test_cli_docs_api_check_verifies_completed_detached_auto_result_output(
     job_id = "job_auto_docs_done"
     auto_session_id = "auto_docs_done"
     result_text = "detached auto result artifact: seed.yaml"
-    timestamp = datetime(2026, 5, 29, 12, 0, tzinfo=UTC)
+    # Anchor to wall-clock now so the terminal handle stays inside the 1h
+    # retrieval TTL (``_JOB_TTL``); a hardcoded absolute date silently expires
+    # once real time advances past it. Mirrors the relative-time pattern used
+    # by the expired-state test below.
+    timestamp = datetime.now(UTC) - timedelta(minutes=3)
 
     async def _persist_completed_auto_job() -> None:
         store = EventStore(db_url)
@@ -238,7 +242,10 @@ def test_mcp_docs_api_check_verifies_completed_detached_auto_result_response(
     auto_session_id = "auto_docs_done"
     result_text = "detached auto result artifact: seed.yaml"
     artifact_uri = "file:///tmp/detached-auto-result.json"
-    timestamp = datetime(2026, 5, 29, 12, 0, tzinfo=UTC)
+    # Relative to now: keeps the completed handle inside the 1h retrieval TTL
+    # regardless of wall-clock date (see the expired-state test for the
+    # complementary past-TTL case).
+    timestamp = datetime.now(UTC) - timedelta(minutes=3)
 
     async def _persist_completed_auto_job_and_fetch_result():
         store = EventStore(db_url)
@@ -475,7 +482,8 @@ def test_mcp_docs_api_check_verifies_failed_detached_auto_result_response(
     failure_text = "detached auto failed: seed repair budget exhausted"
     success_text = "detached auto result artifact: seed.yaml"
     source_error = "seed repair budget exhausted"
-    timestamp = datetime(2026, 5, 29, 12, 30, tzinfo=UTC)
+    # Relative to now so the failed handle stays inside the 1h retrieval TTL.
+    timestamp = datetime.now(UTC) - timedelta(minutes=2)
 
     async def _persist_failed_auto_job_and_fetch_result():
         store = EventStore(db_url)
@@ -638,7 +646,8 @@ def test_mcp_docs_api_check_verifies_cancelled_detached_auto_result_response(
     cancellation_text = "detached auto cancelled: user requested cancellation"
     success_text = "detached auto result artifact: seed.yaml"
     source_error = "user requested cancellation"
-    timestamp = datetime(2026, 5, 29, 13, 0, tzinfo=UTC)
+    # Relative to now so the cancelled handle stays inside the 1h retrieval TTL.
+    timestamp = datetime.now(UTC) - timedelta(minutes=1)
 
     async def _persist_cancelled_auto_job_and_fetch_result():
         store = EventStore(db_url)


### PR DESCRIPTION
## Summary

RFC #1256 §I3 (#1263 **PR-1**): when the interview cannot converge before its deadline,
the engine must aggressively fill remaining open ledger slots through inference rather than
terminating BLOCKED. Observed live in #1170 canonical cli-todo R3, where a single unresolved
slot ended the session with no seed and no product.

This is the **pure substrate slice only**: `auto_fill.py::auto_fill_remaining(ledger, *,
fill_slot=...)` takes an injected filler (the model call) so it performs no IO and is safe
to unit test and to run inside the bounded interview loop. Each accepted proposal is appended
as one `LedgerEntry` with `source=AUTO_FILL_INFERENCE` / `status=DEFAULTED`, confidence carried
(floored at 0.5); declined/blank slots stay open for the §I2 `partial_seed_from_evidence` rung.
Adds `LedgerSource.AUTO_FILL_INFERENCE` (assumption-class; in `SOURCE_PRIORITY` and the
`assumption_sources()` provenance set).

**Not** wired into the driver loop (PR-2) and does **not** yet annotate the seed with
`auto_filled_slots` (PR-3) — those land as follow-ups so this PR stays additive and
behavior-unchanged.

## Test plan

- New `tests/unit/auto/test_auto_fill.py` (6): fill→seed-ready, decline→open, blank skip,
  confidence floor, surfaces in `assumption_sources()`, resolved sections untouched.
- Full `tests/unit/auto/` green (1115); ruff clean.

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha) | This PR (sha) | Ratio |
|--------------------------------|----------------|---------------|-------|
| Rounds completed in 600 s      | N/A            | N/A           | n/a   |
| Per-round wall-clock (s/round) | N/A            | N/A           | n/a   |
| Terminal reason                | N/A            | N/A           | n/a   |
| EventStore event count         | N/A            | N/A           | n/a   |

Additive, unwired substrate (new module + enum member); not in any per-round path.

Budget compliance: [x] within 1.5×

## Related issues

Refs #1256 (§I3), #1263 (PR-1), #1170.
