### PR TITLE
feat(auto): emit auto.product.emitted on ralph success terminal (#1254 §I4 slice)

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1572,6 +1572,21 @@ class AutoPipeline:
                                 )
                         state.run_handoff_status = "completed"
                         state.run_handoff_guidance = None
+                        # RFC #1256 §I4 (#1254): emit the typed
+                        # ``auto.product.emitted`` terminal for the synchronous
+                        # complete-product success path — the branch
+                        # ``cli/commands/auto.py`` wires via
+                        # ``HandlerSynchronousRunStarter``, which completes
+                        # inline at RUN without RALPH_HANDOFF/EVALUATE. Without
+                        # this, a successful synchronous CLI run left no
+                        # queryable terminal event (ouroboros-agent[bot]
+                        # req_1780072861_321 blocker). There is no ralph/QA
+                        # stop_reason on this path, so ``stop_reason=None``.
+                        await self._emit_product_emitted_terminal(
+                            state,
+                            review=review,
+                            stop_reason=None,
+                        )
                         state.transition(
                             AutoPhase.COMPLETE,
                             "synchronous execution completed for complete-product run",
@@ -1992,21 +2007,32 @@ class AutoPipeline:
 
         RFC #1256 §I4 (#1254). Symmetric to
         :meth:`_emit_partial_product_terminal`'s ``auto.product.partial_emitted``
-        on the degraded path. Shared by *both* complete-product success
-        terminals so a successful run always leaves at least one queryable
-        terminal event under ``ouroboros_query_events(auto_session_id)``
+        on the degraded path. Shared by *every* in-process complete-product
+        success terminal so a successful run always leaves at least one
+        queryable terminal event under ``ouroboros_query_events(auto_session_id)``
         instead of the auto session aggregate being empty on success:
 
         * the direct ralph-completed path in :meth:`_evaluate_or_complete`
-          (no evaluator wired, or plugin mode), and
+          (no evaluator wired),
         * the evaluator-pass path in :meth:`_finalize_evaluate` — the branch
-          MCP wires for normal non-plugin complete-product runs, which
-          previously transitioned to COMPLETE with no terminal event.
+          MCP wires for normal non-plugin complete-product runs,
+        * the synchronous CLI run-success path (``HandlerSynchronousRunStarter``,
+          which completes inline at RUN), and
+        * the ralph re-attach success path in :meth:`_reattach_ralph_job`.
+
+        These terminals are mutually exclusive for a single run, so a
+        complete-product success emits **exactly one** ``auto.product.emitted``.
+
+        Deliberately *not* emitted on the OpenCode **plugin-delegation**
+        terminals ("ralph loop delegated…" / "resumed … plugin Ralph delegation
+        checkpoint"): in plugin mode the loop and its product are owned by the
+        spawned child session, so this process has not produced a product to
+        announce — emitting here would be a false terminal.
 
         Awaited inline via the same fail-open :meth:`_emit_runtime_event`, so a
         slow/absent EventStore never converts a successful COMPLETE into a
-        BLOCKED. The two terminals are mutually exclusive for a single run, so
-        a complete-product success emits exactly one ``auto.product.emitted``.
+        BLOCKED. ``review`` may be ``None`` (re-attach observer has no
+        in-scope grade), in which case ``grade`` resolves to ``None``.
         """
         await self._emit_runtime_event(
             "auto.product.emitted",
@@ -3628,6 +3654,19 @@ class AutoPipeline:
         if current_generation is not None:
             state.ralph_current_generation = current_generation
         if terminal_status == "completed":
+            # RFC #1256 §I4 (#1254): emit the typed ``auto.product.emitted``
+            # terminal for the ralph re-attach success path — resume after a
+            # crash between persisting ``ralph_job_id`` and the original wait
+            # finishing. This observes an already-dispatched job's terminal and
+            # transitions straight to COMPLETE (no ``_evaluate_or_complete``),
+            # so without this a re-attached successful run left no queryable
+            # terminal event. ``review`` is not in scope on the re-attach
+            # observer, so ``grade`` resolves to ``None``.
+            await self._emit_product_emitted_terminal(
+                state,
+                review=None,
+                stop_reason=stop_reason,
+            )
             state.transition(
                 AutoPhase.COMPLETE,
                 f"ralph loop completed on re-attach ({stop_reason or 'qa passed'})",

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1980,6 +1980,46 @@ class AutoPipeline:
         self._save(state)
         return self._result(state, ledger, review=review)
 
+    async def _emit_product_emitted_terminal(
+        self,
+        state: AutoPipelineState,
+        *,
+        review: SeedReview | None,
+        stop_reason: str | None,
+        resumed: bool = False,
+    ) -> None:
+        """Emit a typed ``auto.product.emitted`` at a complete-product success terminal.
+
+        RFC #1256 §I4 (#1254). Symmetric to
+        :meth:`_emit_partial_product_terminal`'s ``auto.product.partial_emitted``
+        on the degraded path. Shared by *both* complete-product success
+        terminals so a successful run always leaves at least one queryable
+        terminal event under ``ouroboros_query_events(auto_session_id)``
+        instead of the auto session aggregate being empty on success:
+
+        * the direct ralph-completed path in :meth:`_evaluate_or_complete`
+          (no evaluator wired, or plugin mode), and
+        * the evaluator-pass path in :meth:`_finalize_evaluate` — the branch
+          MCP wires for normal non-plugin complete-product runs, which
+          previously transitioned to COMPLETE with no terminal event.
+
+        Awaited inline via the same fail-open :meth:`_emit_runtime_event`, so a
+        slow/absent EventStore never converts a successful COMPLETE into a
+        BLOCKED. The two terminals are mutually exclusive for a single run, so
+        a complete-product success emits exactly one ``auto.product.emitted``.
+        """
+        await self._emit_runtime_event(
+            "auto.product.emitted",
+            state.auto_session_id,
+            {
+                "auto_session_id": state.auto_session_id,
+                "seed_id": state.seed_id,
+                "grade": (review.grade_result.grade.value if review is not None else None),
+                "stop_reason": stop_reason,
+                "resumed": resumed,
+            },
+        )
+
     async def _emit_runtime_event(
         self,
         event_type: str,
@@ -2388,24 +2428,16 @@ class AutoPipeline:
                 state, ledger, review=review, blocker=probe_blocker, run_subagent=run_subagent
             )
         message_prefix = "resumed ralph loop completed" if resumed else "ralph loop completed"
-        # RFC #1256 §I4 (#1254, first success-terminal slice): emit a typed
-        # ``auto.product.emitted`` keyed to the auto session — symmetric to the
-        # existing ``auto.product.partial_emitted`` on the degraded path — so a
-        # successful complete-product run leaves at least one queryable terminal
-        # event under ``ouroboros_query_events(auto_session_id)`` instead of the
-        # auto session aggregate being empty on success. Awaited inline via the
-        # same fail-open path, so a slow/absent EventStore never converts a
-        # successful COMPLETE into a BLOCKED.
-        await self._emit_runtime_event(
-            "auto.product.emitted",
-            state.auto_session_id,
-            {
-                "auto_session_id": state.auto_session_id,
-                "seed_id": seed.metadata.seed_id,
-                "grade": (review.grade_result.grade.value if review is not None else None),
-                "stop_reason": stop_reason,
-                "resumed": resumed,
-            },
+        # RFC #1256 §I4 (#1254): emit the typed ``auto.product.emitted`` terminal
+        # for the direct ralph-completed success path (no evaluator wired, or
+        # plugin mode). The evaluator-pass path emits the same event from
+        # :meth:`_finalize_evaluate`; both share
+        # :meth:`_emit_product_emitted_terminal`.
+        await self._emit_product_emitted_terminal(
+            state,
+            review=review,
+            stop_reason=stop_reason,
+            resumed=resumed,
         )
         state.transition(
             AutoPhase.COMPLETE,
@@ -2807,6 +2839,16 @@ class AutoPipeline:
                 return self._result(
                     state, ledger, review=review, blocker=probe_blocker, run_subagent=run_subagent
                 )
+            # RFC #1256 §I4 (#1254): emit the typed ``auto.product.emitted``
+            # terminal for the evaluator-pass success path — the branch MCP
+            # wires for normal non-plugin complete-product runs. Without this,
+            # the production path transitioned to COMPLETE with no queryable
+            # terminal event (ouroboros-agent[bot] req_1780070213_316 blocker).
+            await self._emit_product_emitted_terminal(
+                state,
+                review=review,
+                stop_reason=stop_reason,
+            )
             state.transition(
                 AutoPhase.COMPLETE,
                 f"evaluator passed: {verdict} (score {score:.2f}){cache_suffix}"

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -2388,6 +2388,25 @@ class AutoPipeline:
                 state, ledger, review=review, blocker=probe_blocker, run_subagent=run_subagent
             )
         message_prefix = "resumed ralph loop completed" if resumed else "ralph loop completed"
+        # RFC #1256 §I4 (#1254, first success-terminal slice): emit a typed
+        # ``auto.product.emitted`` keyed to the auto session — symmetric to the
+        # existing ``auto.product.partial_emitted`` on the degraded path — so a
+        # successful complete-product run leaves at least one queryable terminal
+        # event under ``ouroboros_query_events(auto_session_id)`` instead of the
+        # auto session aggregate being empty on success. Awaited inline via the
+        # same fail-open path, so a slow/absent EventStore never converts a
+        # successful COMPLETE into a BLOCKED.
+        await self._emit_runtime_event(
+            "auto.product.emitted",
+            state.auto_session_id,
+            {
+                "auto_session_id": state.auto_session_id,
+                "seed_id": seed.metadata.seed_id,
+                "grade": (review.grade_result.grade.value if review is not None else None),
+                "stop_reason": stop_reason,
+                "resumed": resumed,
+            },
+        )
         state.transition(
             AutoPhase.COMPLETE,
             f"{message_prefix} ({stop_reason or 'qa passed'})",

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -20,6 +20,7 @@ from ouroboros.auto import pipeline as pipeline_module
 from ouroboros.auto.adapters import EvaluateResult
 from ouroboros.auto.grading import GradeResult, SeedGrade
 from ouroboros.auto.interview_driver import AutoInterviewResult
+from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.pipeline import (
     _RALPH_BLOCKED_STOP_REASONS,
     PIPELINE_DEADLINE_TOOL_NAME,
@@ -488,6 +489,71 @@ async def test_evaluator_pass_emits_auto_product_emitted_event(tmp_path) -> None
 
     assert result.status == "complete"
     assert state.phase is AutoPhase.COMPLETE
+    emitted = [event for event in event_store.appended if event.type == "auto.product.emitted"]
+    assert len(emitted) == 1
+    event = emitted[0]
+    assert event.aggregate_type == "auto_session"
+    assert event.aggregate_id == state.auto_session_id
+    assert event.data["auto_session_id"] == state.auto_session_id
+    assert event.data["seed_id"] == state.seed_id
+
+
+@pytest.mark.asyncio
+async def test_synchronous_complete_product_success_emits_auto_product_emitted_event(
+    tmp_path,
+) -> None:
+    """The synchronous CLI complete-product success terminal also emits
+    ``auto.product.emitted`` (RFC #1256 §I4 / #1254; ouroboros-agent[bot]
+    req_1780072861_321 blocker).
+
+    ``cli/commands/auto.py`` wires ``HandlerSynchronousRunStarter``
+    (``synchronous_execution = True``) for complete-product runs, so a
+    ``run_success is True`` completes inline at RUN and transitions straight to
+    COMPLETE without RALPH_HANDOFF or EVALUATE. This third success terminal
+    previously left the auto session aggregate empty on success. All three
+    complete-product success terminals now share
+    ``_emit_product_emitted_terminal`` and are mutually exclusive, so a
+    successful run emits exactly one event.
+    """
+    state = _state_at_run_phase(tmp_path)
+    event_store = _RecordingEventStore()
+    driver = _StubInterviewDriver()
+    driver.event_store = event_store
+
+    class SynchronousRunStarter:
+        synchronous_execution = True
+
+        async def __call__(
+            self,
+            _seed: Seed,
+            *,
+            idempotency_key: str = "",  # noqa: ARG002
+        ) -> dict[str, Any]:
+            return {
+                "job_id": None,
+                "session_id": "sync_session",
+                "execution_id": "sync_exec",
+                "status": "completed",
+                "success": True,
+            }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise AssertionError("successful synchronous run must not dispatch Ralph")
+
+    pipeline = AutoPipeline(
+        driver,
+        _seed_generator_unused,
+        run_starter=SynchronousRunStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    assert state.run_handoff_status == "completed"
     emitted = [event for event in event_store.appended if event.type == "auto.product.emitted"]
     assert len(emitted) == 1
     event = emitted[0]
@@ -1290,6 +1356,56 @@ def _state_in_ralph_handoff(tmp_path) -> AutoPipelineState:
     state.ralph_dispatch_mode = "job"
     state.transition(AutoPhase.RALPH_HANDOFF, "persisted ralph checkpoint")
     return state
+
+
+@pytest.mark.asyncio
+async def test_ralph_reattach_success_emits_auto_product_emitted_event(tmp_path) -> None:
+    """The ralph re-attach success terminal also emits ``auto.product.emitted``
+    (RFC #1256 §I4 / #1254).
+
+    ``_reattach_ralph_job`` resumes after a crash between persisting
+    ``ralph_job_id`` and the original wait finishing: it observes the
+    already-dispatched job's terminal and transitions straight to COMPLETE
+    without ``_evaluate_or_complete``. Without an emit on this branch a
+    re-attached successful complete-product run left the auto session aggregate
+    empty. ``review`` is not in scope on the re-attach observer, so ``grade``
+    resolves to ``None`` while the event still keys to the auto session.
+    """
+    state = _state_in_ralph_handoff(tmp_path)
+    event_store = _RecordingEventStore()
+    driver = _StubInterviewDriver()
+    driver.event_store = event_store
+
+    async def ralph_starter(_seed: Seed | None, **kwargs: Any) -> dict[str, Any]:
+        assert kwargs.get("attach_job_id") == state.ralph_job_id
+        return {
+            "job_id": kwargs["attach_job_id"],
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    pipeline = AutoPipeline(
+        driver,
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline._reattach_ralph_job(state, ledger=SeedDraftLedger.from_goal(state.goal))
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
+    emitted = [event for event in event_store.appended if event.type == "auto.product.emitted"]
+    assert len(emitted) == 1
+    event = emitted[0]
+    assert event.aggregate_type == "auto_session"
+    assert event.aggregate_id == state.auto_session_id
+    assert event.data["auto_session_id"] == state.auto_session_id
+    assert event.data["grade"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -17,6 +17,7 @@ from typing import Any
 import pytest
 
 from ouroboros.auto import pipeline as pipeline_module
+from ouroboros.auto.adapters import EvaluateResult
 from ouroboros.auto.grading import GradeResult, SeedGrade
 from ouroboros.auto.interview_driver import AutoInterviewResult
 from ouroboros.auto.pipeline import (
@@ -430,6 +431,63 @@ async def test_ralph_completed_emits_auto_product_emitted_event(tmp_path) -> Non
     result = await pipeline.run(state)
 
     assert result.status == "complete"
+    emitted = [event for event in event_store.appended if event.type == "auto.product.emitted"]
+    assert len(emitted) == 1
+    event = emitted[0]
+    assert event.aggregate_type == "auto_session"
+    assert event.aggregate_id == state.auto_session_id
+    assert event.data["auto_session_id"] == state.auto_session_id
+    assert event.data["seed_id"] == state.seed_id
+
+
+@pytest.mark.asyncio
+async def test_evaluator_pass_emits_auto_product_emitted_event(tmp_path) -> None:
+    """The evaluator-pass success terminal also emits ``auto.product.emitted``
+    (RFC #1256 §I4 / #1254; ouroboros-agent[bot] req_1780070213_316 blocker).
+
+    MCP wires ``HandlerEvaluator`` for normal non-plugin complete-product runs,
+    so Ralph's ``result_text`` routes ``_evaluate_or_complete`` through
+    ``_run_evaluate`` → ``_finalize_evaluate`` rather than the direct
+    ralph-completed terminal. This production success branch previously
+    transitioned to COMPLETE with no queryable terminal event, leaving the auto
+    session aggregate empty on success — the exact gap this PR closes. Both
+    success terminals share ``_emit_product_emitted_terminal`` and are mutually
+    exclusive, so a complete-product success emits exactly one event.
+    """
+    state = _state_at_run_phase(tmp_path)
+    event_store = _RecordingEventStore()
+    driver = _StubInterviewDriver()
+    driver.event_store = event_store
+
+    async def ralph_starter(_seed: Seed, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "job_id": "job_ralph_eval_emit",
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+            # result_text present → routes through the evaluator path, not the
+            # direct ralph-completed terminal.
+            "result_text": "stdout: ok\nexit_code: 0",
+        }
+
+    async def evaluator(_seed: Seed, _artifact: str) -> EvaluateResult:
+        return EvaluateResult(passed=True, score=0.95, verdict="pass")
+
+    pipeline = AutoPipeline(
+        driver,
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+        evaluator=evaluator,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert state.phase is AutoPhase.COMPLETE
     emitted = [event for event in event_store.appended if event.type == "auto.product.emitted"]
     assert len(emitted) == 1
     event = emitted[0]

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -382,6 +382,63 @@ async def test_ralph_qa_passed_completes_auto(tmp_path) -> None:
     assert captured["kwargs"]["lineage_id"] == state.ralph_lineage_id
 
 
+class _RecordingEventStore:
+    """Minimal EventStore stub capturing appended events for assertions."""
+
+    def __init__(self) -> None:
+        self.appended: list[BaseEvent] = []
+
+    async def append(self, event: BaseEvent, **_: Any) -> None:
+        self.appended.append(event)
+
+
+@pytest.mark.asyncio
+async def test_ralph_completed_emits_auto_product_emitted_event(tmp_path) -> None:
+    """A successful ralph completion emits a typed ``auto.product.emitted`` event
+    keyed to the auto session (RFC #1256 §I4 / #1254, first success-terminal slice).
+
+    Symmetric to the existing ``auto.product.partial_emitted`` on the degraded
+    path: a successful complete-product run must leave at least one queryable
+    terminal event under ``ouroboros_query_events(auto_session_id)`` instead of
+    the auto session aggregate being empty on success.
+    """
+    state = _state_at_run_phase(tmp_path)
+    event_store = _RecordingEventStore()
+    driver = _StubInterviewDriver()
+    # The pipeline reads the EventStore off the interview driver
+    # (``getattr(self.interview_driver, "event_store", None)``).
+    driver.event_store = event_store
+
+    async def ralph_starter(_seed: Seed, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "job_id": "job_ralph_emit",
+            "lineage_id": kwargs["lineage_id"],
+            "dispatch_mode": "job",
+            "terminal_status": "completed",
+            "stop_reason": "qa passed",
+        }
+
+    pipeline = AutoPipeline(
+        driver,
+        _seed_generator_unused,
+        run_starter=_run_starter_ok,
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    emitted = [event for event in event_store.appended if event.type == "auto.product.emitted"]
+    assert len(emitted) == 1
+    event = emitted[0]
+    assert event.aggregate_type == "auto_session"
+    assert event.aggregate_id == state.auto_session_id
+    assert event.data["auto_session_id"] == state.auto_session_id
+    assert event.data["seed_id"] == state.seed_id
+
+
 @pytest.mark.asyncio
 async def test_ralph_job_id_persisted_while_starter_waits_for_terminal(tmp_path) -> None:
     state = _state_at_run_phase(tmp_path)

--- a/tests/unit/test_detached_auto_docs.py
+++ b/tests/unit/test_detached_auto_docs.py
@@ -15,6 +15,21 @@ from ouroboros.persistence.event_store import EventStore
 runner = CliRunner()
 
 
+def _recent_event_timestamp(minutes_ago: int = 5) -> datetime:
+    """Anchor persisted job event timestamps within ``_JOB_TTL`` (1 hour).
+
+    ``is_terminal_job_expired`` compares a job's terminal event timestamp
+    against ``datetime.now(UTC)``, so a hardcoded calendar date is a silent
+    time-bomb: once wall-clock drifts past ``timestamp + _JOB_TTL`` the job is
+    reported as expired and these result-retrieval docs/API checks flake (they
+    pass only on the same day they were authored). Deriving the anchor from
+    ``now`` keeps the "freshly terminal" fixtures stable regardless of when CI
+    runs. The dedicated expiry test (below) keeps using an explicit
+    ``now - 2h`` anchor to assert the expired path.
+    """
+    return datetime.now(UTC) - timedelta(minutes=minutes_ago)
+
+
 def test_cli_docs_describe_detached_auto_as_tracked_non_terminal_background_work() -> None:
     docs = Path("docs/cli-reference.md").read_text(encoding="utf-8")
     compact = " ".join(docs.split())
@@ -130,7 +145,7 @@ def test_cli_docs_api_check_verifies_completed_detached_auto_result_output(
     job_id = "job_auto_docs_done"
     auto_session_id = "auto_docs_done"
     result_text = "detached auto result artifact: seed.yaml"
-    timestamp = datetime(2026, 5, 29, 12, 0, tzinfo=UTC)
+    timestamp = _recent_event_timestamp()
 
     async def _persist_completed_auto_job() -> None:
         store = EventStore(db_url)
@@ -238,7 +253,7 @@ def test_mcp_docs_api_check_verifies_completed_detached_auto_result_response(
     auto_session_id = "auto_docs_done"
     result_text = "detached auto result artifact: seed.yaml"
     artifact_uri = "file:///tmp/detached-auto-result.json"
-    timestamp = datetime(2026, 5, 29, 12, 0, tzinfo=UTC)
+    timestamp = _recent_event_timestamp()
 
     async def _persist_completed_auto_job_and_fetch_result():
         store = EventStore(db_url)
@@ -475,7 +490,7 @@ def test_mcp_docs_api_check_verifies_failed_detached_auto_result_response(
     failure_text = "detached auto failed: seed repair budget exhausted"
     success_text = "detached auto result artifact: seed.yaml"
     source_error = "seed repair budget exhausted"
-    timestamp = datetime(2026, 5, 29, 12, 30, tzinfo=UTC)
+    timestamp = _recent_event_timestamp()
 
     async def _persist_failed_auto_job_and_fetch_result():
         store = EventStore(db_url)
@@ -638,7 +653,7 @@ def test_mcp_docs_api_check_verifies_cancelled_detached_auto_result_response(
     cancellation_text = "detached auto cancelled: user requested cancellation"
     success_text = "detached auto result artifact: seed.yaml"
     source_error = "user requested cancellation"
-    timestamp = datetime(2026, 5, 29, 13, 0, tzinfo=UTC)
+    timestamp = _recent_event_timestamp()
 
     async def _persist_cancelled_auto_job_and_fetch_result():
         store = EventStore(db_url)


### PR DESCRIPTION
## Summary

A successful complete-product run left the auto-session EventStore aggregate empty: only
the degraded path emitted `auto.product.partial_emitted`, so `ouroboros_query_events(auto_session_id)`
returned nothing for a run that actually produced a verified product (observed in #1170
canonical cli-todo).

This PR (RFC #1256 §I4 / #1254) emits a typed `auto.product.emitted` event keyed to the auto
session at **every in-process complete-product success terminal**, symmetric to the existing
`auto.product.partial_emitted` on the degraded path. All terminals share one
`_emit_product_emitted_terminal` helper and are mutually exclusive for a given run, so a
complete-product success emits **exactly one** event:

| # | Terminal | Path | Wired by |
|---|----------|------|----------|
| 1 | Direct ralph-completed | `_evaluate_or_complete` | no evaluator |
| 2 | Evaluator-pass | `_finalize_evaluate` | MCP non-plugin complete-product |
| 3 | Synchronous CLI run-success | inline RUN completion | `cli/commands/auto.py` → `HandlerSynchronousRunStarter` |
| 4 | Ralph re-attach success | `_reattach_ralph_job` | resume-after-crash observer |

**Deliberately not emitted** on the OpenCode **plugin-delegation** terminals ("ralph loop
delegated…" / "resumed … plugin Ralph delegation checkpoint"): in plugin mode the spawned child
session owns the loop and its product, so this process has produced nothing to announce — emitting
would be a false terminal. The helper rides the same awaited-inline fail-open `_emit_runtime_event`
path, so a slow/absent EventStore never converts a successful COMPLETE into a BLOCKED.

> This evolved across review rounds with ouroboros-agent[bot]: `req_1780070213_316` flagged the
> evaluator-pass gap (fixed), and `req_1780072861_321` flagged the synchronous CLI gap (fixed). The
> re-attach terminal was covered proactively in the same pass so the contract holds at every boundary.

**Scope / not in this PR:** full §I4 lifecycle coverage (seed-generation / run / closure events and
dispatched-job background-flush timing) remains tracked under #1254. This PR covers the
complete-product **success** terminals only.

## Test plan

- `test_ralph_completed_emits_auto_product_emitted_event` — direct ralph path.
- `test_evaluator_pass_emits_auto_product_emitted_event` — evaluator-pass path.
- `test_synchronous_complete_product_success_emits_auto_product_emitted_event` — synchronous CLI path.
- `test_ralph_reattach_success_emits_auto_product_emitted_event` — re-attach path.
  (all assert exactly one `auto.product.emitted`, `aggregate_type=auto_session`,
  `aggregate_id=auto_session_id`, via an event-store stub.)
- `tests/unit/auto/` (1113) green; `mypy src/ouroboros/auto/pipeline.py` clean; ruff + format clean.

### CI de-flake (separate commit, unrelated to the feature change)
`tests/unit/test_detached_auto_docs.py` had four "freshly terminal" job fixtures anchored to a
hardcoded `datetime(2026, 5, 29, …)`. Result retrieval gates on `is_terminal_job_expired`
(compares the terminal event timestamp against `datetime.now(UTC)` with `_JOB_TTL = 1h`), so once
wall-clock drifts past that date + 1h the jobs report `Job handle expired` and the four checks fail —
a pre-existing time-bomb on `main` (its Tests run was green only on 2026-05-29). Replaced the anchors
with `_recent_event_timestamp()` (now − 5m); same test-only timestamp-de-flake pattern as #1292.

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha) | This PR (sha) | Ratio |
|--------------------------------|----------------|---------------|-------|
| Rounds completed in 600 s      | N/A            | N/A           | n/a   |
| Per-round wall-clock (s/round) | N/A            | N/A           | n/a   |
| Terminal reason                | N/A            | N/A           | n/a   |
| EventStore event count         | N/A            | N/A           | n/a   |

One additional awaited event append on the success terminal only; not in any per-round path
(terminals are mutually exclusive, so still exactly one append per successful run).

Budget compliance: [x] within 1.5×

## Related issues

Refs #1254 (§I4), #1256, #1170.
