### PR TITLE
fix(installer): include click runtime dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.12"
 dependencies = [
     "aiosqlite>=0.20.0,<1.0.0",
     "anyio>=4.0.0,<5.0.0",
+    "click>=8.1.0,<9.0.0",
     "jsonschema>=4.21.0,<5.0.0",
     "pydantic>=2.0.0,<3.0.0",
     "prompt-toolkit>=3.0.0,<4.0.0",

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -12,6 +12,7 @@
 set -euo pipefail
 
 PACKAGE_NAME="ouroboros-ai"
+CLICK_SPEC="click>=8.1.0,<9.0.0"
 MIN_PYTHON="3.12"
 IS_LOCAL=false
 RECONFIGURE="${OUROBOROS_INSTALL_RECONFIGURE:-}"
@@ -333,7 +334,9 @@ echo "Installing ${INSTALL_SPEC} ..."
 INSTALL_METHOD=""
 if [ "$HAS_UV" = true ]; then
   INSTALL_METHOD="uv"
-  UV_ARGS=(tool install --upgrade --python ">=3.12" "$PACKAGE_NAME")
+  # `click` is also declared in pyproject, but keep this explicit so the
+  # installer can repair already-published wheels whose metadata missed it.
+  UV_ARGS=(tool install --upgrade --python ">=3.12" "$PACKAGE_NAME" --with "$CLICK_SPEC")
   if [ -n "$PRE_FLAG" ]; then
     UV_ARGS+=(--prerelease=allow)
   fi
@@ -375,12 +378,14 @@ elif [ "$HAS_PIPX" = true ]; then
   else
     pipx install --force --python "$PYTHON" "$INSTALL_SPEC"
   fi
+  # The venv name is the distribution name even when installing from a local path.
+  pipx inject "ouroboros-ai" "$CLICK_SPEC"
 else
   INSTALL_METHOD="pip"
   if [ -n "$PRE_FLAG" ]; then
-    $PYTHON -m pip install --user --upgrade --pre "$INSTALL_SPEC"
+    $PYTHON -m pip install --user --upgrade --pre "$INSTALL_SPEC" "$CLICK_SPEC"
   else
-    $PYTHON -m pip install --user --upgrade "$INSTALL_SPEC"
+    $PYTHON -m pip install --user --upgrade "$INSTALL_SPEC" "$CLICK_SPEC"
   fi
 fi
 

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -98,7 +98,7 @@ def test_preserves_opencode_backend_from_existing_config(tmp_path: Path) -> None
     assert "Runtime: opencode (preserved from" in result.stdout
     assert "Installing . ..." in result.stdout
     assert (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines() == [
-        "uv tool install --upgrade --python >=3.12 .",
+        "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0",
         "ouroboros setup --runtime opencode --non-interactive",
     ]
 
@@ -114,7 +114,7 @@ def test_explicit_claude_installs_mcp_and_claude_extras(tmp_path: Path) -> None:
     calls = (tmp_path / "calls.log").read_text(encoding="utf-8")
     assert "Runtime: claude (from --runtime / OUROBOROS_INSTALL_RUNTIME)" in result.stdout
     assert (
-        "uv tool install --upgrade --python >=3.12 . --with mcp>=1.26.0,<2.0.0 --with claude-agent-sdk>=0.1.0,<1.0.0 --with anthropic>=0.52.0,<1.0.0"
+        "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0 --with mcp>=1.26.0,<2.0.0 --with claude-agent-sdk>=0.1.0,<1.0.0 --with anthropic>=0.52.0,<1.0.0"
         in calls
     )
     assert "ouroboros setup --runtime claude --non-interactive" in calls
@@ -130,7 +130,10 @@ def test_pypi_lookup_failure_stays_stable_only_for_remote_install(tmp_path: Path
 
     assert result.returncode == 0, result.stderr
     calls = (tmp_path / "calls.log").read_text(encoding="utf-8")
-    assert "uv tool install --upgrade --python >=3.12 ouroboros-ai" in calls
+    assert (
+        "uv tool install --upgrade --python >=3.12 ouroboros-ai --with click>=8.1.0,<9.0.0"
+        in calls
+    )
     assert "--prerelease=allow" not in calls
 
 

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -131,8 +131,7 @@ def test_pypi_lookup_failure_stays_stable_only_for_remote_install(tmp_path: Path
     assert result.returncode == 0, result.stderr
     calls = (tmp_path / "calls.log").read_text(encoding="utf-8")
     assert (
-        "uv tool install --upgrade --python >=3.12 ouroboros-ai --with click>=8.1.0,<9.0.0"
-        in calls
+        "uv tool install --upgrade --python >=3.12 ouroboros-ai --with click>=8.1.0,<9.0.0" in calls
     )
     assert "--prerelease=allow" not in calls
 

--- a/uv.lock
+++ b/uv.lock
@@ -1494,6 +1494,7 @@ source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
     { name = "anyio" },
+    { name = "click" },
     { name = "jsonschema" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
@@ -1555,6 +1556,7 @@ requires-dist = [
     { name = "anyio", specifier = ">=4.0.0,<5.0.0" },
     { name = "claude-agent-sdk", marker = "extra == 'all'", specifier = ">=0.1.0,<1.0.0" },
     { name = "claude-agent-sdk", marker = "extra == 'claude'", specifier = ">=0.1.0,<1.0.0" },
+    { name = "click", specifier = ">=8.1.0,<9.0.0" },
     { name = "jsonschema", specifier = ">=4.21.0,<5.0.0" },
     { name = "litellm", marker = "extra == 'all'", specifier = ">=1.80.0,<=1.82.6" },
     { name = "litellm", marker = "extra == 'litellm'", specifier = ">=1.80.0,<=1.82.6" },


### PR DESCRIPTION
## Summary

- Declare `click` as a direct runtime dependency because the CLI imports it directly.
- Make `install.sh` inject `click` across `uv`, `pipx`, and `pip` installs so already-published wheels with missing metadata can be repaired without waiting for a version bump.

## Changes

- Added `click>=8.1.0,<9.0.0` to `pyproject.toml` and refreshed `uv.lock`.
- Added explicit installer-side `click` installation for `uv tool install`, `pipx inject`, and `pip install --user` paths.
- Updated installer regression tests for the new `uv --with click` behavior.

## Verification

- `bash -n scripts/install.sh`
- `uv run pytest tests/unit/scripts/test_install_runtime_selection.py tests/unit/cli/test_plugin_dispatch.py`
- `uv run python -c "import click; from ouroboros.cli.main import app; print('ok')"`
- `uv build --wheel`