### PR TITLE
fix(deps): pin typer before vendored click

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "rich>=13.0.0,<15.0.0",
     "sqlalchemy[asyncio]>=2.0.0,<3.0.0",
     "structlog>=24.0.0,<26.0.0",
-    "typer>=0.12.0,<1.0.0",
+    "typer>=0.12.0,<0.26.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1577,7 +1577,7 @@ requires-dist = [
     { name = "structlog", specifier = ">=24.0.0,<26.0.0" },
     { name = "textual", marker = "extra == 'all'", specifier = ">=1.0.0,<9.0.0" },
     { name = "textual", marker = "extra == 'tui'", specifier = ">=1.0.0,<9.0.0" },
-    { name = "typer", specifier = ">=0.12.0,<1.0.0" },
+    { name = "typer", specifier = ">=0.12.0,<0.26.0" },
 ]
 provides-extras = ["all", "claude", "copilot", "dashboard", "litellm", "mcp", "tui"]
 


### PR DESCRIPTION
## Summary

- Cap `typer` below `0.26.0` so the current Typer/Click integration boundary stays on the externally installed Click line while the CLI still mixes Typer and direct Click extension points.
- Keep the direct `click>=8.1.0,<9.0.0` runtime dependency that is now present on `main`; Ouroboros imports external Click APIs directly, so this PR is a complementary Typer-boundary guard rather than an attempt to avoid Click as a direct dependency.

## Changes

- Changed the runtime dependency from `typer>=0.12.0,<1.0.0` to `typer>=0.12.0,<0.26.0`.
- Refreshed `uv.lock` project metadata to match the narrowed Typer range.

## Notes

Typer `0.26.x` moves to a private vendored Click implementation. Ouroboros currently imports and uses external Click APIs directly in the CLI/plugin-dispatch layer while also extending Typer internals such as `TyperGroup`, so the safe boundary is to keep Typer on the pre-0.26 line until that integration layer is refactored or explicitly validated against the new vendored boundary.

This is intentionally a narrow dependency/runtime compatibility PR. It does not change AgentOS tier gates, `ooo auto` behavior, persistence/replay, MCP, plugin state, or artifact-location semantics.

## Verification

Current head: `44a748ac7661feee28d379c6028bd3cee015dcfc`

- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv lock --check`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run python - <<'PY' ... from ouroboros.cli.main import app ... print click/typer versions ... PY`
  - resolved `click 8.3.1`, `typer 0.24.1`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run pytest -q tests/unit/cli/test_main.py tests/unit/test_main_entry_point.py tests/unit/cli/test_doc_commands.py tests/unit/cli/test_plugin_dispatch.py tests/unit/scripts/test_install_runtime_selection.py`
  - `74 passed, 1 warning`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run ruff check pyproject.toml tests/unit/cli/test_main.py tests/unit/test_main_entry_point.py tests/unit/cli/test_doc_commands.py tests/unit/cli/test_plugin_dispatch.py tests/unit/scripts/test_install_runtime_selection.py`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run ruff format --check tests/unit/cli/test_main.py tests/unit/test_main_entry_point.py tests/unit/cli/test_doc_commands.py tests/unit/cli/test_plugin_dispatch.py tests/unit/scripts/test_install_runtime_selection.py`
- `SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv build --wheel`
- `uv pip check --python .venv/bin/python`
- GitHub checks on the current head are green.
