### PR TITLE
fix(auto): gate runs on low-ambiguity seed QA

### DIFF
--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -788,6 +788,65 @@ class HandlerEvaluator:
         )
 
 
+class HandlerSeedQAEvaluator:
+    """Callable Seed QA evaluator backed by ``ouroboros_qa``."""
+
+    def __init__(self, qa_handler: QAHandler) -> None:
+        self.qa_handler = qa_handler
+
+    async def __call__(self, seed: Seed, ledger: Any) -> EvaluateResult:
+        seed_yaml = yaml.dump(
+            seed.to_dict(), default_flow_style=False, allow_unicode=True, sort_keys=False
+        )
+        ledger_reference = yaml.dump(
+            ledger.to_dict() if hasattr(ledger, "to_dict") else ledger,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
+        )
+        quality_bar = (
+            "The Seed must be ready for autonomous execution before run starts. "
+            "It must preserve the interview/ledger intent, have ambiguity_score <= 0.20, "
+            "contain concrete acceptance criteria, include constraints/non-goals/runtime "
+            "context, and avoid unsupported assumptions or missing requirements."
+        )
+        result = await self.qa_handler.handle(
+            {
+                "artifact": seed_yaml,
+                "artifact_type": "document",
+                "quality_bar": quality_bar,
+                "reference": ledger_reference,
+                "seed_content": seed_yaml,
+                "pass_threshold": 0.80,
+            }
+        )
+        if result.is_err:
+            return EvaluateResult(
+                passed=False,
+                score=0.0,
+                verdict="fail",
+                error=str(result.error),
+            )
+        meta = result.value.meta or {}
+        if str(meta.get("status", "")) == "delegated_to_subagent":
+            return EvaluateResult(
+                passed=False,
+                score=0.0,
+                verdict="fail",
+                error=(
+                    "QAHandler returned a plugin-delegation envelope; the auto pipeline "
+                    "cannot grade Seed QA via out-of-band subagent dispatch"
+                ),
+            )
+        return EvaluateResult(
+            passed=bool(meta.get("passed", False)),
+            score=float(meta.get("score", 0.0)),
+            verdict=str(meta.get("verdict", "fail")),
+            differences=tuple(meta.get("differences", ()) or ()),
+            suggestions=tuple(meta.get("suggestions", ()) or ()),
+        )
+
+
 @dataclass(frozen=True, slots=True)
 class LateralResult:
     """Structured result returned by :class:`HandlerLateralThinker`.

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -167,7 +167,12 @@ def _lateral_response_authorizes_demotion(text: str | None) -> bool:
 
 
 def _backend_confirmed_seed_ready(turn: InterviewTurn) -> bool:
-    """Return True when the backend closed the interview below the ambiguity gate."""
+    """Return True when the backend closed the interview within the ambiguity gate.
+
+    Backends that do not yet report ``ambiguity_score`` remain compatible:
+    ``seed_ready`` / ``completed`` without a score is accepted as a backend
+    confirmation.
+    """
     if not (turn.seed_ready or turn.completed):
         return False
     if turn.ambiguity_score is None:
@@ -192,10 +197,10 @@ class InterviewTurn:
     session_id: str
     seed_ready: bool = False
     completed: bool = False
-    # Optional diagnostic surface — backend's own ambiguity reading for the
-    # current turn. The driver never gates on this; it is only used to build
-    # informative blocker messages when the mutual-agreement closure gate
-    # exhausts its budget without both parties converging.
+    # Optional backend ambiguity reading for the current turn. When present,
+    # the driver uses it for the low-ambiguity backend closure gate and for
+    # blocker/status messages; when absent, legacy ``seed_ready`` /
+    # ``completed`` confirmations remain accepted.
     ambiguity_score: float | None = None
 
 

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -166,6 +166,15 @@ def _lateral_response_authorizes_demotion(text: str | None) -> bool:
     return bool(_LATERAL_CLEARANCE_MARKER_RE.search(text))
 
 
+def _backend_confirmed_seed_ready(turn: InterviewTurn) -> bool:
+    """Return True when the backend closed the interview below the ambiguity gate."""
+    if not (turn.seed_ready or turn.completed):
+        return False
+    if turn.ambiguity_score is None:
+        return True
+    return float(turn.ambiguity_score) <= BACKEND_READY_AMBIGUITY_THRESHOLD
+
+
 # Structural alias for the production lateral-thinker callable. Mirrors the
 # alias declared on ``ouroboros.auto.pipeline``; duplicated locally because
 # ``adapters.LateralResult`` cannot be imported at module load time without
@@ -617,37 +626,22 @@ class AutoInterviewDriver:
                 "blocked", state.interview_session_id, ledger, state.current_round, blocker
             )
 
-        # Closure gate (ledger-primary, backend-advisory per SSOT #1157
-        # *Closure Policy* section, 2026-05-27): an interview closes the
-        # moment ``ledger.is_seed_ready()`` returns True, regardless of
-        # backend ``seed_ready`` state. Backend signals remain useful as
-        # advisory metadata but no longer gate closure on their own.
-        # Disagreement is reframed as the next answer instead of a terminal
-        # block:
+        # Closure gate: the ledger must be structurally complete and the
+        # backend must acknowledge Seed readiness at or below the ambiguity
+        # threshold. Disagreement is reframed as the next answer until the
+        # bounded interview budget is exhausted:
         #
         # * backend signals completion but the ledger has open gaps → answer
         #   the first open gap so the backend re-scores against substantive
         #   new content; the loop refuses backend-only closure (the
         #   premature-closure invariant preserved below).
-        # * backend keeps asking but the ledger is structurally full → close
-        #   immediately as ``ledger_only``; do NOT let the backend extend the
-        #   dialogue past structural completeness, because an LLM evaluator
-        #   never saturates and waiting for its agreement stalls indefinitely
-        #   (the #1170 R2-diag failure mode).
+        # * backend keeps asking, or reports completion with ambiguity > 0.20,
+        #   while the ledger is structurally full → keep answering until the
+        #   backend score converges or max_rounds blocks the session.
         #
-        # ``max_rounds`` is the budget for ledger-filling rounds. The interview
-        # closes the moment ``ledger.is_seed_ready()`` returns True
-        # (ledger-primary closure policy per SSOT #1157 "Closure Policy"
-        # section, formalized 2026-05-27 after #1170 R2-diag confirmed the
-        # legacy AND-gate stalls the simplest canonical case). Backend
-        # ``seed_ready`` / ``completed`` / ``ambiguity_score`` is recorded as
-        # advisory signal on ``state.interview_closure_mode`` but no longer
-        # gates closure — an LLM evaluator never saturates, so requiring its
-        # agreement makes every populated ledger wait indefinitely for an
-        # acknowledgement that never comes. PR-B1 (#1148) shipped a
-        # ``ledger_only`` escape hatch at ``max_rounds`` but kept the AND-gate
-        # as the primary path; this PR promotes ``ledger_only`` to the
-        # primary in-loop closure mode (see SSOT freshness sync 2026-05-27).
+        # ``max_rounds`` is the budget for ledger-filling and backend
+        # convergence rounds. This intentionally prevents a high-ambiguity
+        # backend result from moving directly into Seed generation.
         #
         # Premature-closure invariant preserved below: when the backend
         # reports ``seed_ready`` / ``completed`` but the ledger has open
@@ -655,23 +649,10 @@ class AutoInterviewDriver:
         # the next answer toward filling the next detected gap.
         for round_number in range(state.current_round + 1, self.max_rounds + 1):
             backend_done = turn.seed_ready or turn.completed
+            backend_confirmed = _backend_confirmed_seed_ready(turn)
             ledger_done = ledger.is_seed_ready()
-            if ledger_done:
-                closure_mode = "mutual_agreement" if backend_done else "ledger_only"
-                # Observability parity with the previous max_rounds-only
-                # ledger_only path: emit the same ``auto.interview.ledger_only_closure``
-                # event so existing log-grep consumers and #1170 R2 evidence
-                # captures continue to work. ``mutual_agreement`` is not given
-                # a dedicated event because it was not previously emitted in
-                # the in-loop close path.
-                if not backend_done:
-                    log.info(
-                        "auto.interview.ledger_only_closure",
-                        auto_session_id=state.auto_session_id,
-                        round_number=round_number,
-                        ambiguity_score=turn.ambiguity_score,
-                        interview_session_id=state.interview_session_id,
-                    )
+            if ledger_done and backend_confirmed:
+                closure_mode = "mutual_agreement"
                 state.pending_question = None
                 state.interview_completed = True
                 state.interview_closure_mode = closure_mode
@@ -851,7 +832,7 @@ class AutoInterviewDriver:
                     round_number=round_number + 1,
                 )
 
-        # max_rounds exhausted — one final ledger-primary closure check, then
+        # max_rounds exhausted — one final backend-confirmed closure check, then
         # safe-default finalization for autonomous ``ooo auto``.  The manual
         # ``ooo interview`` path remains strict/fail-closed in its own driver;
         # this auto driver is allowed to close missing/weak required sections
@@ -860,21 +841,13 @@ class AutoInterviewDriver:
         # interview loop: explicit/backend-provided answers always win first,
         # and defaults are only the final escape from a benign stalled dialog.
         #
-        # The final ledger-primary check catches the case where the last
-        # round's apply / backend exchange filled the ledger after the
-        # top-of-loop ledger check fired False for round ``max_rounds``.
+        # The final check catches the case where the last round's apply /
+        # backend exchange both filled the ledger and lowered ambiguity.
         backend_done = turn.seed_ready or turn.completed
+        backend_confirmed = _backend_confirmed_seed_ready(turn)
         ledger_done = ledger.is_seed_ready()
-        if ledger_done:
-            closure_mode = "mutual_agreement" if backend_done else "ledger_only"
-            if not backend_done:
-                log.info(
-                    "auto.interview.ledger_only_closure",
-                    auto_session_id=state.auto_session_id,
-                    round_number=self.max_rounds,
-                    ambiguity_score=turn.ambiguity_score,
-                    interview_session_id=state.interview_session_id,
-                )
+        if ledger_done and backend_confirmed:
+            closure_mode = "mutual_agreement"
             state.pending_question = None
             state.interview_completed = True
             state.interview_closure_mode = closure_mode
@@ -1047,13 +1020,8 @@ class AutoInterviewDriver:
             ambiguity_part = "ambiguity_score=unknown"
         open_gaps = ledger.open_gaps()
         gaps_part = f"open_gaps={open_gaps}" if open_gaps else "open_gaps=[]"
-        # NOTE: PR-B1 (#1148) previously placed a ``ledger_only`` fallback
-        # here for the ``ledger_done and not backend_done`` case at
-        # max_rounds. That fallback is now unreachable — the ledger-primary
-        # check at the top of this max_rounds block (and at the top of each
-        # in-loop iteration) closes any ``ledger_done`` case before we get
-        # here, regardless of backend state. See SSOT #1157 "Closure Policy"
-        # section (formalized 2026-05-27) for the design rationale.
+        # A complete ledger without a low-ambiguity backend close lands here
+        # and blocks instead of forcing Seed generation from stale ambiguity.
         # PR-B2 / #821: partial safe-default closure — some required gaps were
         # safely defaultable, but at least one remained unsafe at max_rounds.
         # Distinguish from the generic "nothing was defaultable" path with a
@@ -1107,13 +1075,12 @@ class AutoInterviewDriver:
                 "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
             )
 
-        # Defensive last resort: ledger is not done, safe-default could not
-        # close, no unsafe-gap partial-rollback fired. Under the ledger-primary
-        # policy this means every required section was probed and the
-        # ``finalize_safe_defaultable_gaps`` policy found nothing safe to fill.
+        # Defensive last resort: the interview did not reach a low-ambiguity
+        # backend-confirmed close, safe-default could not close, and no
+        # unsafe-gap partial-rollback fired.
         # Surface as a typed BLOCKED so callers can resume / sharpen the goal.
-        # ``ledger_done`` is guaranteed False here (otherwise the top
-        # max_rounds check above would have returned ``seed_ready``).
+        # ``ledger_done`` may be true here; that means backend ambiguity never
+        # fell below the closure threshold.
         blocker = (
             f"auto interview reached max_rounds={self.max_rounds} without closure: "
             f"backend_done={backend_done} ({ambiguity_part}), "

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -970,11 +970,18 @@ class AutoInterviewDriver:
                     )
                 state.interview_session_id = synthesis_turn.session_id
                 state.pending_question = synthesis_turn.question
-                if not (synthesis_turn.seed_ready or synthesis_turn.completed):
+                if not _backend_confirmed_seed_ready(synthesis_turn):
                     _revert_safe_default_entries(ledger, finalization.defaulted_sections)
+                    ambiguity_part = (
+                        f"ambiguity_score={synthesis_turn.ambiguity_score:.2f}"
+                        if synthesis_turn.ambiguity_score is not None
+                        else "ambiguity_score=unknown"
+                    )
                     blocker = (
-                        "safe-default synthesis did not close the persisted interview: "
-                        "backend_done=False, ledger defaults rolled back"
+                        "safe-default synthesis did not close the persisted interview "
+                        "within the backend ambiguity gate: "
+                        f"backend_done={bool(synthesis_turn.seed_ready or synthesis_turn.completed)}, "
+                        f"{ambiguity_part}, ledger defaults rolled back"
                     )
                     log.warning(
                         "auto.interview.safe_default_synthesis_nonclosure",
@@ -983,6 +990,7 @@ class AutoInterviewDriver:
                         defaulted_sections=finalization.defaulted_sections,
                         backend_seed_ready=bool(synthesis_turn.seed_ready),
                         backend_completed=bool(synthesis_turn.completed),
+                        backend_ambiguity=synthesis_turn.ambiguity_score,
                         synthesis_pushed=synthesis_pushed,
                     )
                     state.ledger = ledger.to_dict()
@@ -1557,11 +1565,18 @@ class AutoInterviewDriver:
                 )
             state.interview_session_id = synthesis_turn.session_id
             state.pending_question = synthesis_turn.question
-            if not (synthesis_turn.seed_ready or synthesis_turn.completed):
+            if not _backend_confirmed_seed_ready(synthesis_turn):
                 _revert_safe_default_entries(ledger, finalization.defaulted_sections)
+                ambiguity_part = (
+                    f"ambiguity_score={synthesis_turn.ambiguity_score:.2f}"
+                    if synthesis_turn.ambiguity_score is not None
+                    else "ambiguity_score=unknown"
+                )
                 blocker = (
-                    "backend-ready safe-default synthesis did not close the persisted interview: "
-                    "ledger defaults rolled back"
+                    "backend-ready safe-default synthesis did not close the persisted interview "
+                    "within the backend ambiguity gate: "
+                    f"backend_done={bool(synthesis_turn.seed_ready or synthesis_turn.completed)}, "
+                    f"{ambiguity_part}, ledger defaults rolled back"
                 )
                 state.ledger = ledger.to_dict()
                 state.mark_blocked(

--- a/src/ouroboros/auto/ledger_seed.py
+++ b/src/ouroboros/auto/ledger_seed.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 from uuid import uuid4
 
 from ouroboros.auto.grading import deterministic_floor
@@ -33,6 +34,18 @@ grade/run gates that suppress high-ambiguity-only blockers for degraded seeds
 (#1257 PR-C).
 """
 
+DEADLINE_LEDGER_SEED_GENERATION_MODE = "interview_deadline_complete_ledger"
+"""``SeedMetadata.generation_mode`` for a *complete* ledger that reached closure
+via the interview-phase deadline recovery path (#1302).
+
+Distinct from :data:`PARTIAL_SEED_GENERATION_MODE`: the ledger is fully resolved
+(no ``unresolved_slots``), but the per-phase interview deadline cut the Socratic
+loop short before the backend could confirm low ambiguity (``<= 0.20``). The
+Seed therefore carries the full ledger content yet is flagged ``degraded`` so
+the grade/run gates surface it as a typed partial-product terminal instead of
+auto-running a Seed whose low ambiguity was never backend-confirmed.
+"""
+
 _PARTIAL_DEFAULT_ACCEPTANCE = (
     "Synthesized Seed runs without raising and the recorded goal is "
     "surfaced in execution output (conservative smoke).",
@@ -55,6 +68,7 @@ def synthesize_seed_from_ledger(
     ledger: SeedDraftLedger,
     *,
     interview_id: str | None = None,
+    recovery_reason: str | None = None,
 ) -> Seed:
     """Build a valid Seed directly from a complete auto ledger.
 
@@ -62,6 +76,18 @@ def synthesize_seed_from_ledger(
     unavailable after the deterministic ledger has enough evidence to proceed.
     The ledger remains the source of truth; this function performs no model or
     external IO.
+
+    Args:
+        ledger: The complete ledger to synthesize from.
+        interview_id: Reference to the source interview, mirrored on
+            :attr:`~ouroboros.core.seed.SeedMetadata.interview_id`.
+        recovery_reason: When set (e.g. ``"interview_phase_deadline"``), the
+            ledger is complete but closure was reached via a recovery path that
+            never obtained backend-confirmed low ambiguity (#1302). The Seed
+            keeps its full ledger content but is stamped ``degraded`` with
+            :data:`DEADLINE_LEDGER_SEED_GENERATION_MODE` so the grade/run gates
+            route it to the typed partial-product terminal instead of auto-RUN.
+            ``None`` (default) yields the legacy fully-runnable ``"normal"`` Seed.
     """
     if not ledger.is_seed_ready():
         msg = f"cannot synthesize Seed from incomplete ledger: {', '.join(ledger.open_gaps())}"
@@ -132,11 +158,33 @@ def synthesize_seed_from_ledger(
             ),
         ),
         metadata=SeedMetadata(
-            seed_id=f"seed_{uuid4().hex[:12]}",
-            ambiguity_score=max(0.05, deterministic_floor(ledger)),
-            interview_id=interview_id,
+            **_synthesized_metadata_kwargs(ledger, interview_id, recovery_reason)
         ),
     )
+
+
+def _synthesized_metadata_kwargs(
+    ledger: SeedDraftLedger,
+    interview_id: str | None,
+    recovery_reason: str | None,
+) -> dict[str, Any]:
+    """Build the ``SeedMetadata`` kwargs for :func:`synthesize_seed_from_ledger`.
+
+    A plain ``recovery_reason is None`` keeps the legacy ``"normal"`` provenance.
+    When a recovery reason is supplied the complete-ledger Seed is flagged
+    ``degraded`` (with no ``unresolved_slots`` — the ledger is fully resolved)
+    so the deadline-recovery contract (#1302) routes it away from auto-RUN.
+    """
+    kwargs: dict[str, Any] = {
+        "seed_id": f"seed_{uuid4().hex[:12]}",
+        "ambiguity_score": max(0.05, deterministic_floor(ledger)),
+        "interview_id": interview_id,
+    }
+    if recovery_reason is not None:
+        kwargs["generation_mode"] = DEADLINE_LEDGER_SEED_GENERATION_MODE
+        kwargs["degraded"] = True
+        kwargs["recovery_reason"] = recovery_reason
+    return kwargs
 
 
 def partial_seed_from_evidence(

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1897,17 +1897,25 @@ class AutoPipeline:
 
         1. Emit ``runtime.deadline.interview.fired`` so post-hoc evidence
            inspection can see *why* the recovery path was taken.
-        2. If the ledger is Seed-ready, synthesize a normal Seed via
-           :func:`synthesize_seed_from_ledger`; otherwise fall back to
-           :func:`partial_seed_from_evidence` with
-           ``reason="interview_phase_deadline"`` so unresolved sections
-           become next-step hints on the resulting degraded Seed (PR-A).
+        2. Synthesize a Seed from the evidence collected so far. Either
+           branch yields a **degraded** Seed, because a deadline closure
+           never obtained backend-confirmed low ambiguity (#1302):
+
+           * complete ledger → :func:`synthesize_seed_from_ledger` with
+             ``recovery_reason="interview_phase_deadline"`` (full ledger
+             content, no ``unresolved_slots``, but ``degraded=True``);
+           * incomplete ledger → :func:`partial_seed_from_evidence` with
+             ``reason="interview_phase_deadline"`` so unresolved sections
+             become next-step hints on the degraded Seed (PR-A).
         3. Persist the Seed via :meth:`_record_generated_seed`, mark
            ``interview_completed = True``, and transition to ``REVIEW`` so
-           the rest of the pipeline (grading, run handoff) can still
-           surface a partial product. PR-C teaches the grade gate to
-           respect ``metadata.degraded`` so the degraded Seed is not
-           re-blocked at REVIEW solely on high-ambiguity grounds.
+           the rest of the pipeline can surface a typed partial product
+           via :meth:`_emit_partial_product_terminal`. PR-C teaches the
+           grade gate to respect ``metadata.degraded`` so a deadline Seed
+           is routed to the partial-product terminal (not auto-RUN) and is
+           not re-blocked solely on high-ambiguity grounds. Hard safety
+           blockers (``missing_goal`` / ``seed_goal_mismatch`` /
+           ``high_risk_assumptions``) still terminate.
 
         The global ``pipeline_timeout_seconds`` deadline is unaffected:
         callers gate on :meth:`_enforce_deadline` *before* invoking this
@@ -1924,9 +1932,23 @@ class AutoPipeline:
         )
 
         if ledger_ready:
-            seed = synthesize_seed_from_ledger(ledger, interview_id=state.interview_session_id)
+            # #1302 ambiguity-before-execution: a per-phase interview deadline
+            # cut the Socratic loop short before the backend could confirm low
+            # ambiguity (<= 0.20). A structurally complete ledger is NOT a
+            # substitute for that confirmation, so this Seed must NOT auto-RUN.
+            # Synthesize the full ledger content but stamp it as a degraded
+            # deadline-recovery terminal (``recovery_reason`` set), so REVIEW
+            # routes it to :meth:`_emit_partial_product_terminal` exactly like
+            # the incomplete-ledger branch below instead of proceeding through
+            # the grade / Seed QA / RUN gates on unconfirmed-ambiguity evidence.
+            seed = synthesize_seed_from_ledger(
+                ledger,
+                interview_id=state.interview_session_id,
+                recovery_reason="interview_phase_deadline",
+            )
             progress_message = (
-                "Interview phase deadline fired; closed via complete-ledger Seed synthesis"
+                "Interview phase deadline fired; closed via complete-ledger Seed synthesis "
+                "(degraded recovery: backend low ambiguity was never confirmed)"
             )
         else:
             seed = partial_seed_from_evidence(

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -6,11 +6,12 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from dataclasses import asdict, dataclass, field
-from datetime import datetime
+from datetime import UTC, datetime
 import inspect
 import threading
 import time
 from typing import Any, Protocol
+from uuid import uuid4
 
 import structlog
 
@@ -182,6 +183,7 @@ SeedLoader = Callable[[str], Seed]
 # JobSnapshot.result_text from Ralph's terminal snapshot), returns a typed
 # EvaluateResult. See HandlerEvaluator for the production implementation.
 Evaluator = Callable[[Seed, str], Awaitable[EvaluateResult]]
+SeedQAEvaluator = Callable[[Seed, SeedDraftLedger], Awaitable[EvaluateResult]]
 # LateralThinker contract: invoked as keyword-only call with the persona +
 # QA-failure shape + run artifact, returns a typed LateralResult. See
 # HandlerLateralThinker for the production implementation.
@@ -431,6 +433,10 @@ class AutoPipeline:
     # to BLOCKED with the QA differences/suggestions in ``last_error``.
     # See :class:`HandlerEvaluator` in adapters.py for the production wiring.
     evaluator: Evaluator | None = None
+    # Optional pre-run Seed QA gate backed by ``ouroboros_qa``. Deterministic
+    # grading still owns cheap structural repair; this gate prevents a Seed
+    # that fails the same QA contract users run manually from reaching RUN.
+    seed_qa_evaluator: SeedQAEvaluator | None = None
     # RFC #809 Phase 2.2 — when set AND ``complete_product`` is True AND the
     # evaluator reports ``passed=False``, the pipeline inserts an
     # UNSTUCK_LATERAL phase between EVALUATE and the BLOCKED transition.
@@ -1151,6 +1157,12 @@ class AutoPipeline:
                 state.mark_blocked(blocker, tool_name="grade_gate")
                 self._save(state)
                 return self._result(state, ledger, review=review, blocker=blocker)
+
+            seed_qa, seed, review = await self._run_seed_qa_gate(
+                state, ledger, seed, review=review
+            )
+            if seed_qa is not None:
+                return seed_qa
 
             if self.skip_run or state.skip_run:
                 state.transition(
@@ -2520,6 +2532,132 @@ class AutoPipeline:
         state.mark_blocked(msg, tool_name="probe_runner")
         self._save(state)
         return msg
+
+    async def _run_seed_qa_gate(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        seed: Seed,
+        *,
+        review: SeedReview | None,
+    ) -> tuple[AutoPipelineResult | None, Seed, SeedReview | None]:
+        """Run the optional ``ooo qa`` Seed gate before skip-run completion or RUN."""
+        if self.seed_qa_evaluator is None:
+            return None, seed, review
+
+        current_seed = seed
+        current_review = review
+        max_attempts = max(1, int(state.max_repair_rounds or 1))
+        for attempt in range(1, max_attempts + 1):
+            timeout = self._deadline_capped_timeout(
+                state, state.phase_timeout_seconds(AutoPhase.EVALUATE)
+            )
+            try:
+                qa_result = await asyncio.wait_for(
+                    self.seed_qa_evaluator(current_seed, ledger), timeout=timeout
+                )
+            except TimeoutError:
+                if self._enforce_deadline(state):
+                    return (
+                        self._result(state, ledger, review=current_review, blocker=state.last_error),
+                        current_seed,
+                        current_review,
+                    )
+                state.mark_blocked(
+                    f"Seed QA timed out after {timeout:.0f}s",
+                    tool_name="seed_qa",
+                )
+                self._save(state)
+                return (
+                    self._result(state, ledger, review=current_review, blocker=state.last_error),
+                    current_seed,
+                    current_review,
+                )
+            except Exception as exc:
+                state.mark_blocked(f"Seed QA raised: {exc}", tool_name="seed_qa")
+                self._save(state)
+                return (
+                    self._result(state, ledger, review=current_review, blocker=state.last_error),
+                    current_seed,
+                    current_review,
+                )
+
+            if qa_result.error:
+                state.mark_blocked(
+                    f"Seed QA reported transient error: {qa_result.error}",
+                    tool_name="seed_qa",
+                )
+                self._save(state)
+                return (
+                    self._result(state, ledger, review=current_review, blocker=state.last_error),
+                    current_seed,
+                    current_review,
+                )
+
+            state.last_qa_score = float(qa_result.score)
+            state.last_qa_verdict = str(qa_result.verdict)
+            state.last_qa_passed = bool(qa_result.passed)
+            state.last_qa_differences = list(qa_result.differences)
+            state.last_qa_suggestions = list(qa_result.suggestions)
+            if qa_result.passed:
+                state.mark_progress(
+                    f"Seed QA passed: {qa_result.verdict} (score {qa_result.score:.2f})",
+                    tool_name="seed_qa",
+                )
+                self._save(state)
+                return None, current_seed, current_review
+
+            if attempt < max_attempts:
+                current_seed = normalize_execution_acceptance(
+                    _seed_with_seed_qa_feedback(current_seed, qa_result, attempt=attempt)
+                )
+                current_review = SeedReviewer(self.grade_gate).review(
+                    current_seed,
+                    ledger=ledger,
+                    closure_mode=state.interview_closure_mode,
+                    degraded=bool(getattr(current_seed.metadata, "degraded", False)),
+                )
+                state.seed_artifact = current_seed.to_dict()
+                state.seed_id = current_seed.metadata.seed_id
+                state.last_grade = current_review.grade_result.grade.value
+                state.findings = [asdict(finding) for finding in current_review.findings]
+                if self.seed_saver is not None:
+                    try:
+                        state.seed_path = self.seed_saver(current_seed)
+                    except Exception as exc:
+                        state.mark_failed(f"seed save failed: {exc}", tool_name="seed_saver")
+                        self._save(state)
+                        return (
+                            self._result(
+                                state, ledger, review=current_review, blocker=state.last_error
+                            ),
+                            current_seed,
+                            current_review,
+                        )
+                state.mark_progress(
+                    f"Seed QA repair attempt {attempt}/{max_attempts - 1} applied",
+                    tool_name="seed_qa",
+                )
+                self._save(state)
+                continue
+
+            details = [
+                f"Seed QA did not pass after {attempt} attempt(s): "
+                f"{qa_result.verdict} (score {qa_result.score:.2f})"
+            ]
+            if qa_result.differences:
+                details.append("differences: " + "; ".join(qa_result.differences[:3]))
+            if qa_result.suggestions:
+                details.append("suggestions: " + "; ".join(qa_result.suggestions[:3]))
+            state.mark_blocked("; ".join(details), tool_name="seed_qa")
+            self._save(state)
+            return (
+                self._result(state, ledger, review=current_review, blocker=state.last_error),
+                current_seed,
+                current_review,
+            )
+
+        return None, current_seed, current_review
 
     async def _run_evaluate(
         self,
@@ -4160,7 +4298,7 @@ def _recoverable_phase_for_tool(tool_name: str | None) -> AutoPhase | None:
         return AutoPhase.INTERVIEW
     if tool_name == "seed_generator":
         return AutoPhase.SEED_GENERATION
-    if tool_name in {"seed_saver", "grade_gate", "seed_loader", "seed_repairer"}:
+    if tool_name in {"seed_saver", "grade_gate", "seed_loader", "seed_repairer", "seed_qa"}:
         # ``seed_repairer`` joins this set so a repair-phase timeout (the
         # outer ``asyncio.wait_for`` around ``repairer.converge`` inside
         # AutoPipeline.run) is recoverable on ``--resume``: the only sensible
@@ -4280,6 +4418,30 @@ def _seed_with_recovery_constraint(seed: Seed, plan: AutoRecoveryPlan) -> Seed:
         f"relaxing the goal or acceptance criteria: {instruction}"
     )
     return seed.model_copy(update={"constraints": (*seed.constraints, constraint)})
+
+
+def _seed_with_seed_qa_feedback(seed: Seed, qa_result: EvaluateResult, *, attempt: int) -> Seed:
+    """Return a Seed revised with bounded pre-run Seed QA feedback."""
+    feedback = [*qa_result.differences[:3], *qa_result.suggestions[:3]]
+    normalized_feedback = tuple(dict.fromkeys(item.strip() for item in feedback if item.strip()))
+    if not normalized_feedback:
+        normalized_feedback = ("Seed QA failed without actionable differences or suggestions.",)
+    constraint = (
+        f"[seed qa repair attempt {attempt}] Resolve before execution: "
+        + " | ".join(normalized_feedback)
+    )
+    return seed.model_copy(
+        update={
+            "constraints": tuple(dict.fromkeys((*seed.constraints, constraint))),
+            "metadata": seed.metadata.model_copy(
+                update={
+                    "seed_id": f"seed_{uuid4().hex[:12]}",
+                    "created_at": datetime.now(UTC),
+                    "parent_seed_id": seed.metadata.seed_id,
+                }
+            ),
+        }
+    )
 
 
 def _first_nonempty(*values: str | None) -> str | None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1158,9 +1158,7 @@ class AutoPipeline:
                 self._save(state)
                 return self._result(state, ledger, review=review, blocker=blocker)
 
-            seed_qa, seed, review = await self._run_seed_qa_gate(
-                state, ledger, seed, review=review
-            )
+            seed_qa, seed, review = await self._run_seed_qa_gate(state, ledger, seed, review=review)
             if seed_qa is not None:
                 return seed_qa
 
@@ -2559,7 +2557,9 @@ class AutoPipeline:
             except TimeoutError:
                 if self._enforce_deadline(state):
                     return (
-                        self._result(state, ledger, review=current_review, blocker=state.last_error),
+                        self._result(
+                            state, ledger, review=current_review, blocker=state.last_error
+                        ),
                         current_seed,
                         current_review,
                     )
@@ -4426,9 +4426,8 @@ def _seed_with_seed_qa_feedback(seed: Seed, qa_result: EvaluateResult, *, attemp
     normalized_feedback = tuple(dict.fromkeys(item.strip() for item in feedback if item.strip()))
     if not normalized_feedback:
         normalized_feedback = ("Seed QA failed without actionable differences or suggestions.",)
-    constraint = (
-        f"[seed qa repair attempt {attempt}] Resolve before execution: "
-        + " | ".join(normalized_feedback)
+    constraint = f"[seed qa repair attempt {attempt}] Resolve before execution: " + " | ".join(
+        normalized_feedback
     )
     return seed.model_copy(
         update={

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -2600,6 +2600,15 @@ class AutoPipeline:
             state.last_qa_differences = list(qa_result.differences)
             state.last_qa_suggestions = list(qa_result.suggestions)
             if qa_result.passed:
+                review_blocker = self._seed_review_gate_blocker(state, current_review)
+                if review_blocker is not None:
+                    state.mark_blocked(review_blocker, tool_name="grade_gate")
+                    self._save(state)
+                    return (
+                        self._result(state, ledger, review=current_review, blocker=review_blocker),
+                        current_seed,
+                        current_review,
+                    )
                 state.mark_progress(
                     f"Seed QA passed: {qa_result.verdict} (score {qa_result.score:.2f})",
                     tool_name="seed_qa",
@@ -2658,6 +2667,21 @@ class AutoPipeline:
             )
 
         return None, current_seed, current_review
+
+    def _seed_review_gate_blocker(
+        self, state: AutoPipelineState, review: SeedReview | None
+    ) -> str | None:
+        """Return the deterministic review blocker that must still gate Seed QA pass paths."""
+        if review is None:
+            return None
+        if not _grade_meets_required(review.grade_result.grade.value, state.required_grade):
+            return (
+                f"Seed grade {review.grade_result.grade.value} did not meet "
+                f"required grade {state.required_grade}"
+            )
+        if not review.may_run and not (self.skip_run or state.skip_run):
+            return "Seed review did not clear the Seed for execution"
+        return None
 
     async def _run_evaluate(
         self,

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -18,6 +18,7 @@ from ouroboros.auto.adapters import (
     HandlerRalphStarter,
     HandlerRunStarter,
     HandlerSeedGenerator,
+    HandlerSeedQAEvaluator,
     HandlerSynchronousRunStarter,
     load_seed,
     save_seed,
@@ -51,6 +52,7 @@ from ouroboros.cli.formatters.panels import print_error, print_info, print_succe
 from ouroboros.config import get_opencode_mode
 from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler
+from ouroboros.mcp.tools.qa import QAHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.orchestrator import resolve_agent_runtime_backend
 from ouroboros.persistence.event_store import EventStore
@@ -505,6 +507,7 @@ async def _run_auto(
     start_execute = StartExecuteSeedHandler(
         execute_handler=execute_seed, agent_runtime_backend=runtime, opencode_mode=opencode_mode
     )
+    seed_qa = QAHandler(agent_runtime_backend=runtime, opencode_mode=authoring_opencode_mode)
     driver = AutoInterviewDriver(
         HandlerInterviewBackend(interview, cwd=state.cwd),
         store=store,
@@ -567,6 +570,7 @@ async def _run_auto(
         ralph_starter=ralph_starter,
         ralph_resumer=ralph_resumer,
         complete_product=complete_product,
+        seed_qa_evaluator=HandlerSeedQAEvaluator(seed_qa),
         progress_callback=progress_callback,
         watchdog=watchdog,
         probe_runner=EnvRuntimeProbeRunner() if complete_product else None,

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -148,13 +148,20 @@ class SeedMetadata(BaseModel, frozen=True):
             paths (e.g. ``"partial_seed_from_evidence"``) MUST set this so
             grading/run gates can distinguish a fully-resolved Seed from one
             built under deadline pressure (#1257).
-        degraded: ``True`` when the Seed was synthesized from an incomplete
-            ledger and carries unresolved slots. Always pairs with a non-default
-            ``generation_mode`` and at least one entry in ``unresolved_slots``.
+        degraded: ``True`` when the Seed was synthesized under a recovery path
+            rather than a clean low-ambiguity closure, so grade/run gates route
+            it to a typed partial-product terminal instead of auto-RUN. Always
+            pairs with a non-default ``generation_mode``. Two cases:
+            (a) incomplete ledger (``partial_seed_from_evidence``) — carries at
+            least one entry in ``unresolved_slots``; (b) complete ledger closed
+            via the interview-phase deadline (#1302) — ``unresolved_slots`` is
+            empty because the ledger is fully resolved, but no backend-confirmed
+            low ambiguity exists.
         unresolved_slots: Ledger sections that were still
             MISSING/WEAK/CONFLICTING/BLOCKED at synthesis time. Empty for normal
-            seeds. Surfaced verbatim so downstream gates can transform them into
-            ``next_step`` hints instead of terminal blockers.
+            seeds and for complete-ledger deadline-recovery seeds. Surfaced
+            verbatim so downstream gates can transform them into ``next_step``
+            hints instead of terminal blockers.
         recovery_reason: Free-form description of why the degraded path was
             taken (e.g. ``"interview_phase_deadline"``). ``None`` for normal
             seeds.

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -23,6 +23,7 @@ from ouroboros.auto.adapters import (
     HandlerRalphStarter,
     HandlerRunStarter,
     HandlerSeedGenerator,
+    HandlerSeedQAEvaluator,
     load_seed,
     save_seed,
 )
@@ -521,6 +522,7 @@ class AutoHandler:
         # for that callsite without re-instantiating ``lateral_thinker``
         # here.
         evaluator = None
+        seed_qa_evaluator = None
         if complete_product and not opencode_plugin_mode:
             qa_handler = QAHandler(
                 llm_backend=self.llm_backend,
@@ -528,6 +530,14 @@ class AutoHandler:
                 opencode_mode=opencode_mode,
             )
             evaluator = HandlerEvaluator(qa_handler)
+            seed_qa_evaluator = HandlerSeedQAEvaluator(qa_handler)
+        elif not opencode_plugin_mode:
+            seed_qa_handler = QAHandler(
+                llm_backend=self.llm_backend,
+                agent_runtime_backend=runtime_backend,
+                opencode_mode=opencode_mode,
+            )
+            seed_qa_evaluator = HandlerSeedQAEvaluator(seed_qa_handler)
         watchdog_event_store = self.event_store or EventStore()
         await watchdog_event_store.initialize()
         watchdog = Watchdog(
@@ -557,6 +567,7 @@ class AutoHandler:
             ralph_resumer=ralph_resumer,
             complete_product=complete_product,
             evaluator=evaluator,
+            seed_qa_evaluator=seed_qa_evaluator,
             lateral_thinker=lateral_thinker,
             watchdog=watchdog,
             probe_runner=EnvRuntimeProbeRunner() if complete_product else None,

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -500,19 +500,14 @@ class AutoHandler:
         # ``EventStore``) — without that share the poller would query a
         # fresh, empty job table.
         ralph_resumer = HandlerRalphPoller(ralph_handler) if ralph_handler is not None else None
-        # RFC #809 Phase 2.1 — wire the QA-backed evaluator only when the
-        # session is in complete-product mode. Outside that mode the chain
-        # is RUN → COMPLETE (async run handoff) so there is no synchronous
-        # artifact to grade; instantiating QAHandler would be wasted setup.
-        #
-        # Plugin-mode skip: ``QAHandler`` dispatches to OpenCode Task panes
-        # when ``opencode_mode == "plugin"``. The auto pipeline's Phase
-        # 2.1/2.2 advisory layer is synchronous and cannot consume
-        # out-of-band subagent output, so the evaluator stays unwired in
-        # plugin mode. The chain then falls back to the pre-Phase-2.1
-        # behaviour (RUN → RALPH_HANDOFF → COMPLETE) — the existing Ralph
-        # plugin delegation continues to drive complete-product sessions
-        # in OpenCode Task panes as before.
+        # RFC #809 Phase 2.1 — wire Seed QA on every MCP auto surface before
+        # RUN/skip-run transitions. For OpenCode plugin sessions, use the same
+        # demoted authoring mode as Interview/GenerateSeed so QA executes
+        # inline instead of emitting an out-of-band ``_subagent`` envelope that
+        # the synchronous pipeline cannot consume. Keep the optional
+        # complete-product execution evaluator plugin-skipped: that later
+        # EVALUATE-stage advisory path still grades post-run artifacts and
+        # cannot consume plugin Task-pane output.
         #
         # Issue #1248 — ``lateral_thinker`` is constructed above (before
         # the driver) so it is available to both the driver's
@@ -522,22 +517,14 @@ class AutoHandler:
         # for that callsite without re-instantiating ``lateral_thinker``
         # here.
         evaluator = None
-        seed_qa_evaluator = None
+        seed_qa_handler = QAHandler(
+            llm_backend=self.llm_backend,
+            agent_runtime_backend=runtime_backend,
+            opencode_mode=authoring_opencode_mode,
+        )
+        seed_qa_evaluator = HandlerSeedQAEvaluator(seed_qa_handler)
         if complete_product and not opencode_plugin_mode:
-            qa_handler = QAHandler(
-                llm_backend=self.llm_backend,
-                agent_runtime_backend=runtime_backend,
-                opencode_mode=opencode_mode,
-            )
-            evaluator = HandlerEvaluator(qa_handler)
-            seed_qa_evaluator = HandlerSeedQAEvaluator(qa_handler)
-        elif not opencode_plugin_mode:
-            seed_qa_handler = QAHandler(
-                llm_backend=self.llm_backend,
-                agent_runtime_backend=runtime_backend,
-                opencode_mode=opencode_mode,
-            )
-            seed_qa_evaluator = HandlerSeedQAEvaluator(seed_qa_handler)
+            evaluator = HandlerEvaluator(seed_qa_handler)
         watchdog_event_store = self.event_store or EventStore()
         await watchdog_event_store.initialize()
         watchdog = Watchdog(

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -749,6 +749,51 @@ async def test_interview_driver_finalizes_safe_defaults_after_benign_max_rounds(
 
 
 @pytest.mark.asyncio
+async def test_interview_driver_rolls_back_safe_defaults_when_synthesis_is_high_ambiguity(
+    tmp_path,
+) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What else should we know?", "interview_defaults")
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        if "[safe-default-synthesis]" in text:
+            return InterviewTurn(
+                "done",
+                session_id,
+                seed_ready=True,
+                completed=True,
+                ambiguity_score=0.42,
+            )
+        return InterviewTurn("What else should we know?", session_id, seed_ready=False)
+
+    state = AutoPipelineState(goal="Build a tiny local CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.interview_completed is False
+    assert state.interview_closure_mode is None
+    assert "ambiguity_score=0.42" in (result.blocker or "")
+    assert "ledger defaults rolled back" in (result.blocker or "")
+    assert state.last_error_code == "interview_safe_default_synthesis_incomplete"
+    assert ledger.open_gaps()
+    assert not any(
+        entry.key == f"{section_name}.safe_default_finalization"
+        for section_name, section in ledger.sections.items()
+        for entry in section.entries
+    )
+
+
+@pytest.mark.asyncio
 async def test_interview_driver_blocks_with_unsafe_gaps_when_partially_defaultable(
     tmp_path,
 ) -> None:
@@ -4256,6 +4301,59 @@ async def test_backend_ready_low_ambiguity_closes_safe_defaultable_gaps(tmp_path
     assert ledger.is_seed_ready()
     assert observed_last_questions == ["[driver safe-default finalization: backend_ambiguity=0.16]"]
     assert observed_answers and "[safe-default-synthesis]" in observed_answers[0]
+
+
+@pytest.mark.asyncio
+async def test_backend_ready_safe_default_rolls_back_when_synthesis_is_high_ambiguity(
+    tmp_path,
+) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "ready",
+            "interview_backend_ready_high_ambiguity_defaults",
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.16,
+        )
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done",
+            session_id,
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.42,
+        )
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    ledger.sections["non_goals"].entries.clear()
+    ledger.sections["failure_modes"].entries.clear()
+    ledger.sections["runtime_context"].entries.clear()
+
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=3,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert state.interview_completed is False
+    assert state.interview_closure_mode is None
+    assert "ambiguity_score=0.42" in (result.blocker or "")
+    assert "ledger defaults rolled back" in (result.blocker or "")
+    assert state.last_error_code == "interview_safe_default_synthesis_incomplete"
+    assert ledger.open_gaps()
+    assert not any(
+        entry.key == f"{section_name}.safe_default_finalization"
+        for section_name, section in ledger.sections.items()
+        for entry in section.entries
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -4,7 +4,7 @@ import asyncio
 
 import pytest
 
-from ouroboros.auto.adapters import PartialInterviewStartError
+from ouroboros.auto.adapters import EvaluateResult, PartialInterviewStartError
 from ouroboros.auto.grading import GradeResult, SeedGrade
 from ouroboros.auto.interview_driver import (
     AutoInterviewDriver,
@@ -1383,6 +1383,231 @@ async def test_pipeline_skip_run_stops_after_a_grade_seed(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_auto_interview_requires_backend_ambiguity_below_threshold(tmp_path) -> None:
+    ledger = SeedDraftLedger.from_goal("Build a local CLI")
+    _fill_ready(ledger)
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "Still ambiguous",
+            "interview_high_ambiguity",
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.42,
+        )
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "Still ambiguous",
+            session_id,
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.42,
+        )
+
+    state = AutoPipelineState(goal="Build a local CLI", cwd=str(tmp_path))
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+    )
+
+    result = await driver.run(state, ledger)
+
+    assert result.status == "blocked"
+    assert "ambiguity_score=0.42" in (result.blocker or "")
+    assert state.interview_completed is False
+
+
+@pytest.mark.asyncio
+async def test_pipeline_blocks_run_when_seed_qa_does_not_pass(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done",
+            "interview_seed_qa",
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.12,
+        )
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done",
+            session_id,
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.12,
+        )
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        raise AssertionError("run must not start before Seed QA passes")
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(
+            passed=False,
+            score=0.58,
+            verdict="revise",
+            differences=("missing interview nuance",),
+            suggestions=("carry forward the unresolved decision",),
+        )
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        seed_qa_evaluator=seed_qa,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert result.blocker is not None
+    assert "Seed QA did not pass" in result.blocker
+    assert state.last_tool_name == "seed_qa"
+    assert state.last_qa_score == 0.58
+
+
+@pytest.mark.asyncio
+async def test_pipeline_runs_after_seed_qa_passes(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done",
+            "interview_seed_qa_pass",
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.12,
+        )
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done",
+            session_id,
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.12,
+        )
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        return {"job_id": "job_seed_qa_pass"}
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        return EvaluateResult(passed=True, score=0.92, verdict="pass")
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        seed_qa_evaluator=seed_qa,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.job_id == "job_seed_qa_pass"
+    assert state.last_qa_score == 0.92
+
+
+@pytest.mark.asyncio
+async def test_pipeline_repairs_seed_qa_feedback_before_run(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done",
+            "interview_seed_qa_repair",
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.12,
+        )
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done",
+            session_id,
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.12,
+        )
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    qa_calls = 0
+    captured_run_seed: Seed | None = None
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        nonlocal qa_calls
+        qa_calls += 1
+        if qa_calls == 1:
+            return EvaluateResult(
+                passed=False,
+                score=0.58,
+                verdict="revise",
+                differences=("missing explicit no-op scope",),
+                suggestions=("add no-op scope constraint",),
+            )
+        assert any("missing explicit no-op scope" in item for item in seed.constraints)
+        return EvaluateResult(passed=True, score=0.88, verdict="pass")
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        nonlocal captured_run_seed
+        captured_run_seed = seed
+        return {"job_id": "job_seed_qa_repaired"}
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.max_repair_rounds = 2
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        seed_qa_evaluator=seed_qa,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    assert result.job_id == "job_seed_qa_repaired"
+    assert qa_calls == 2
+    assert captured_run_seed is not None
+    assert any("missing explicit no-op scope" in item for item in captured_run_seed.constraints)
+
+
+@pytest.mark.asyncio
 async def test_pipeline_result_surfaces_assumption_sources_with_provenance(tmp_path) -> None:
     """PR-C2 / #1157: ``AutoPipelineResult.assumption_sources`` carries the
     ledger's assumption-class entries with the source tag intact. The legacy
@@ -1577,19 +1802,10 @@ async def test_pipeline_syncs_state_seed_id_after_repair_changes_identity(tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_interview_resume_with_complete_ledger_closes_via_ledger_only(tmp_path) -> None:
-    """Resume with a fully-populated ledger closes immediately as ``ledger_only``
-    without calling the backend with the persisted pending_question.
-
-    PR-β / SSOT #1157 "Closure Policy" (2026-05-27): the ledger-primary
-    policy says a complete ledger is sufficient evidence to proceed; calling
-    the backend to acknowledge what the ledger already contains is wasted
-    work. The original test asserted backend re-engagement on resume, which
-    was a consequence of the AND-gate (backend approval required regardless
-    of ledger state). Under ledger-primary, skipping the backend call is the
-    correct behavior — the persisted ``pending_question`` is informational
-    only when resume happens with the ledger already structurally complete.
-    """
+async def test_interview_resume_with_complete_ledger_requires_low_ambiguity_ack(
+    tmp_path,
+) -> None:
+    """Resume with a complete ledger still waits for backend low-ambiguity closure."""
     calls: list[str] = []
 
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
@@ -1597,7 +1813,9 @@ async def test_interview_resume_with_complete_ledger_closes_via_ledger_only(tmp_
 
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
         calls.append(text)
-        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+        return InterviewTurn(
+            "done", session_id, seed_ready=True, completed=True, ambiguity_score=0.12
+        )
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
     state.transition(AutoPhase.INTERVIEW, "resume interview")
@@ -1612,9 +1830,8 @@ async def test_interview_resume_with_complete_ledger_closes_via_ledger_only(tmp_
     result = await driver.run(state, ledger)
 
     assert result.status == "seed_ready"
-    assert state.interview_closure_mode == "ledger_only"
-    # PR-β: complete ledger ⇒ no backend call needed on resume.
-    assert calls == []
+    assert state.interview_closure_mode == "mutual_agreement"
+    assert calls
 
 
 @pytest.mark.asyncio
@@ -1793,11 +2010,10 @@ async def test_interview_driver_blocks_when_backend_never_marks_ready(tmp_path) 
 
     result = await driver.run(state, ledger)
 
-    # PR-B1 / #821: ledger pre-filled + backend never closes → ledger-only closure, not blocked.
-    assert result.status == "seed_ready"
-    assert state.interview_completed is True
-    assert state.interview_closure_mode == "ledger_only"
-    assert state.phase != AutoPhase.BLOCKED
+    assert result.status == "blocked"
+    assert state.interview_completed is False
+    assert state.interview_closure_mode is None
+    assert state.phase == AutoPhase.BLOCKED
 
 
 @pytest.mark.asyncio
@@ -2548,10 +2764,9 @@ async def test_interview_driver_clears_pending_question_before_backend_answer(tm
         return InterviewTurn("What should we verify?", "interview_1")
 
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
-        persisted = store.load(state.auto_session_id)
-        assert persisted.pending_question is None
-        assert persisted.last_tool_name == "auto_answerer"
-        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+        return InterviewTurn(
+            "done", session_id, seed_ready=True, completed=True, ambiguity_score=0.12
+        )
 
     state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
     ledger = SeedDraftLedger.from_goal(state.goal)
@@ -2972,15 +3187,8 @@ async def test_pipeline_retry_after_blocked_run_start_replay_from_seed_path(tmp_
 @pytest.mark.asyncio
 async def test_pipeline_recovers_auto_answerer_block_to_interview(tmp_path) -> None:
     """Resume after an auto_answerer block closes immediately when the ledger
-    is already complete — backend call is skipped (PR-β ledger-primary policy).
-
-    The original test asserted backend re-engagement (``calls`` non-empty).
-    Under SSOT #1157 "Closure Policy" (2026-05-27), recovering from a prior
-    block when the persisted ledger is already structurally complete should
-    close as ``ledger_only`` and proceed to Seed generation without
-    re-consuming the persisted ``pending_question``. The recovery contract
-    (transition from BLOCKED to INTERVIEW phase, then to seed_ready) is
-    still exercised; only the backend-call expectation is removed.
+    is already complete. The backend must still acknowledge low ambiguity
+    before Seed generation.
     """
     calls: list[str] = []
 
@@ -2989,7 +3197,9 @@ async def test_pipeline_recovers_auto_answerer_block_to_interview(tmp_path) -> N
 
     async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
         calls.append(text)
-        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+        return InterviewTurn(
+            "done", session_id, seed_ready=True, completed=True, ambiguity_score=0.12
+        )
 
     async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
         return _seed()
@@ -3010,9 +3220,8 @@ async def test_pipeline_recovers_auto_answerer_block_to_interview(tmp_path) -> N
     result = await pipeline.run(state)
 
     assert result.status == "complete"
-    assert state.interview_closure_mode == "ledger_only"
-    # PR-β: complete ledger ⇒ no backend re-engagement needed on recovery.
-    assert calls == []
+    assert state.interview_closure_mode == "mutual_agreement"
+    assert calls
 
 
 @pytest.mark.asyncio
@@ -3295,12 +3504,10 @@ async def test_ledger_primary_closes_as_ledger_only_when_backend_never_converges
 
     result = await driver.run(state, ledger)
 
-    assert result.status == "seed_ready"
-    assert state.interview_closure_mode == "ledger_only"
-    assert result.rounds == 0  # closed immediately, no rounds consumed
-    # Critical: no backend.answer() calls — the persistent saturation backend
-    # would have looped indefinitely under the legacy AND-gate.
-    assert backend_calls == 0
+    assert result.status == "blocked"
+    assert state.interview_closure_mode is None
+    assert result.rounds == 12
+    assert backend_calls == 12
 
 
 @pytest.mark.asyncio
@@ -3422,7 +3629,13 @@ async def test_pipeline_forwards_force_to_seed_generator_on_ledger_only_closure(
     async def answer(
         session_id: str, text: str, *, last_question: str | None = None
     ) -> InterviewTurn:  # noqa: ARG001
-        raise AssertionError("complete ledger should close on round 0 without answering")
+        return InterviewTurn(
+            "What else should we know?",
+            session_id,
+            seed_ready=False,
+            completed=False,
+            ambiguity_score=0.40,
+        )
 
     async def generate_seed(session_id: str, *, force: bool = False) -> Seed:
         seed_calls.append({"session_id": session_id, "force": force})
@@ -3449,20 +3662,10 @@ async def test_pipeline_forwards_force_to_seed_generator_on_ledger_only_closure(
 
     result = await pipeline.run(state)
 
-    # Interview closes as ledger_only at round 0 (no backend touches).
-    assert state.interview_closure_mode == "ledger_only"
-    # Seed generation actually runs and ``force=True`` is forwarded —
-    # this is the contract that closes the bot review #1 blocker.
-    assert len(seed_calls) == 1
-    assert seed_calls[0]["force"] is True
-    # End-to-end: the pipeline reaches RUN (or beyond) — i.e. the
-    # SEED_GENERATION boundary did NOT re-block ledger-only sessions.
-    assert result.status in ("complete", "blocked", "seed_ready")
-    if result.status == "blocked":
-        # Whatever blocked must NOT be the ambiguity-gate ValidationError
-        # the bot called out — that would mean ``force`` was not honored.
-        assert "Ambiguity score" not in (result.blocker or "")
-        assert "ambiguity_score" not in (result.blocker or "")
+    assert result.status == "blocked"
+    assert state.interview_closure_mode is None
+    assert seed_calls == []
+    assert "ambiguity_score=0.40" in (result.blocker or "")
 
 
 @pytest.mark.asyncio
@@ -3487,7 +3690,13 @@ async def test_pipeline_synthesizes_seed_when_completed_ledger_generator_times_o
         )
 
     async def answer(session_id, text, *, last_question=None):  # noqa: ARG001
-        raise AssertionError("complete ledger should close on round 0 without answering")
+        return InterviewTurn(
+            "What else should we know?",
+            session_id,
+            seed_ready=False,
+            completed=False,
+            ambiguity_score=0.40,
+        )
 
     async def generate_seed(session_id: str, *, force: bool = False) -> Seed:  # noqa: ARG001
         await asyncio.sleep(1)
@@ -3515,10 +3724,9 @@ async def test_pipeline_synthesizes_seed_when_completed_ledger_generator_times_o
 
     result = await pipeline.run(state)
 
-    assert state.interview_closure_mode == "ledger_only"
-    assert state.seed_origin == "auto_pipeline"
-    assert state.seed_artifact is not None
-    assert result.status in ("complete", "blocked", "seed_ready")
+    assert state.interview_closure_mode is None
+    assert not state.seed_artifact
+    assert result.status == "blocked"
     assert "seed generation timed out" not in (result.blocker or "")
 
 
@@ -4212,16 +4420,8 @@ async def test_resume_after_interview_max_rounds_can_continue_when_bound_raised(
 
     assert result.status == "complete", f"resume blocked: {result.blocker!r}"
     assert state.phase == AutoPhase.COMPLETE
-    # PR-β / SSOT #1157 "Closure Policy" (2026-05-27): the resume scenario
-    # carries a complete ledger (``_fill_ready`` populated all required
-    # sections before persistence), so the ledger-primary in-loop check
-    # closes immediately as ``ledger_only`` without re-engaging the backend.
-    # The test's purpose — verifying that a max_rounds-blocked session can
-    # resume cleanly when ``max_interview_rounds`` is raised — is satisfied
-    # by ``result.status == "complete"``; the previous backend-re-engagement
-    # assertion was a consequence of the AND-gate, not a contract of resume.
-    assert state.interview_closure_mode == "ledger_only"
-    assert answer_calls == [], "complete ledger ⇒ no backend re-engagement on resume"
+    assert state.interview_closure_mode == "mutual_agreement"
+    assert answer_calls
 
 
 @pytest.mark.asyncio
@@ -5075,10 +5275,10 @@ async def test_max_rounds_ledger_only_consensus_closes_interview(tmp_path) -> No
 
     result = await driver.run(state, ledger)
 
-    assert result.status == "seed_ready"
-    assert state.interview_completed is True
-    assert state.interview_closure_mode == "ledger_only"
-    assert state.phase != AutoPhase.BLOCKED
+    assert result.status == "blocked"
+    assert state.interview_completed is False
+    assert state.interview_closure_mode is None
+    assert state.phase == AutoPhase.BLOCKED
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -5,7 +5,7 @@ import asyncio
 import pytest
 
 from ouroboros.auto.adapters import EvaluateResult, PartialInterviewStartError
-from ouroboros.auto.grading import GradeResult, SeedGrade
+from ouroboros.auto.grading import GradeFinding, GradeGate, GradeResult, SeedGrade
 from ouroboros.auto.interview_driver import (
     AutoInterviewDriver,
     FunctionInterviewBackend,
@@ -1605,6 +1605,118 @@ async def test_pipeline_repairs_seed_qa_feedback_before_run(tmp_path) -> None:
     assert qa_calls == 2
     assert captured_run_seed is not None
     assert any("missing explicit no-op scope" in item for item in captured_run_seed.constraints)
+
+
+@pytest.mark.asyncio
+async def test_pipeline_blocks_qa_repaired_seed_when_review_no_longer_may_run(tmp_path) -> None:
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done",
+            "interview_seed_qa_repair_rejected",
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.12,
+        )
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn(
+            "done",
+            session_id,
+            seed_ready=True,
+            completed=True,
+            ambiguity_score=0.12,
+        )
+
+    async def generate_seed(session_id: str) -> Seed:  # noqa: ARG001
+        return _seed()
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        raise AssertionError("QA-passing but review-blocked repaired Seed must not run")
+
+    qa_calls = 0
+
+    async def seed_qa(seed: Seed, ledger: SeedDraftLedger) -> EvaluateResult:  # noqa: ARG001
+        nonlocal qa_calls
+        qa_calls += 1
+        if qa_calls == 1:
+            return EvaluateResult(
+                passed=False,
+                score=0.58,
+                verdict="revise",
+                suggestions=("introduce review-blocking post-QA constraint",),
+            )
+        assert any("review-blocking" in item for item in seed.constraints)
+        return EvaluateResult(passed=True, score=0.91, verdict="pass")
+
+    class ConstraintBlockingGate(GradeGate):
+        def grade_seed(
+            self,
+            seed: Seed,
+            *,
+            ledger: SeedDraftLedger | None = None,  # noqa: ARG002
+            closure_mode: str | None = None,  # noqa: ARG002
+            degraded: bool | None = None,  # noqa: ARG002
+        ) -> GradeResult:
+            if any("review-blocking" in constraint for constraint in seed.constraints):
+                blocker = GradeFinding(
+                    "post_qa_review_blocker",
+                    "high",
+                    "QA repair introduced a deterministic blocker",
+                    "constraints",
+                    "Remove the post-QA blocker before execution.",
+                )
+                return GradeResult(
+                    grade=SeedGrade.C,
+                    scores={
+                        "coverage": 0.5,
+                        "ambiguity": 0.5,
+                        "testability": 0.5,
+                        "execution_feasibility": 0.4,
+                        "risk": 0.4,
+                    },
+                    blockers=[blocker],
+                    may_run=False,
+                )
+            return GradeResult(
+                grade=SeedGrade.A,
+                scores={
+                    "coverage": 0.95,
+                    "ambiguity": 0.05,
+                    "testability": 0.95,
+                    "execution_feasibility": 0.95,
+                    "risk": 0.05,
+                },
+                may_run=True,
+            )
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.max_repair_rounds = 2
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        grade_gate=ConstraintBlockingGate(),
+        seed_qa_evaluator=seed_qa,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert result.blocker is not None
+    assert "Seed grade C did not meet required grade A" in result.blocker
+    assert qa_calls == 2
+    assert state.last_tool_name == "grade_gate"
+    assert state.last_qa_passed is True
+    assert state.last_grade == "C"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_pipeline_interview_deadline_closure.py
+++ b/tests/unit/auto/test_pipeline_interview_deadline_closure.py
@@ -10,15 +10,20 @@ product can still surface downstream. These tests pin:
    EventStore with the contract payload.
 2. An incomplete ledger reaches the degraded substrate path and the
    persisted Seed metadata advertises the recovery.
-3. A complete ledger reaches the normal substrate path and the
-   persisted Seed metadata stays at the ``"normal"`` default.
+3. A complete ledger ALSO reaches a degraded recovery terminal (#1302):
+   a per-phase interview deadline never obtained backend-confirmed low
+   ambiguity, so even a structurally complete ledger is stamped
+   ``degraded`` with ``recovery_reason="interview_phase_deadline"`` and
+   the new :data:`DEADLINE_LEDGER_SEED_GENERATION_MODE` so it cannot
+   auto-RUN on unconfirmed-ambiguity evidence.
 4. The pipeline does not re-mark ``interview_phase_deadline`` BLOCKED
    on the deadline path.
+5. The complete-ledger deadline path never reaches RUN / Seed QA even
+   when both are wired (#1302 ambiguity-before-execution gate).
 
-The downstream grade/run gates are deliberately out of scope for PR-B —
-this test file asserts *routing*, not terminal outcome. PR-C tightens
-the grade-gate side so degraded seeds can reach the partial-product
-terminal in PR-D's canonical regression.
+PR-C tightens the grade-gate side so degraded seeds reach the
+partial-product terminal; #1302 extends that to the complete-ledger
+deadline closure.
 """
 
 from __future__ import annotations
@@ -135,24 +140,18 @@ async def test_deadline_emits_runtime_event_and_routes_through_partial_seed(tmp_
     assert state.last_error_code != "interview_phase_deadline"
 
 
-@pytest.mark.asyncio
-async def test_deadline_with_complete_ledger_routes_through_normal_seed(tmp_path) -> None:
-    """Complete ledger + interview deadline → normal seed via legacy synthesizer."""
-    # Pre-populate every required section so ``ledger.is_seed_ready()`` is True
-    # when the deadline fires. The driver still sleeps past the phase timeout
-    # so the closure ladder is exercised; the difference is the *route*.
-    event_store = _RecordingEventStore()
-    state = _build_deadline_state(tmp_path, goal="Build a CLI")
-    store = AutoStore(tmp_path)
+def _complete_ledger_deadline_driver():
+    """Driver subclass that hydrates a complete ledger before the deadline.
 
-    # The pipeline builds the ledger from ``state.goal`` on entry. Hydrate
-    # every required section from inside the driver — that's the same in-
-    # memory ledger the deadline handler will inspect when the per-phase
-    # timeout fires.
+    The pipeline builds the ledger from ``state.goal`` on entry; this driver
+    fills every required section from inside ``run`` — the same in-memory
+    ledger the deadline handler inspects when the per-phase timeout fires —
+    then sleeps past the deadline so the closure ladder routes through the
+    complete-ledger branch.
+    """
+
     class _LedgerSeedingDeadlineDriver(_DeadlineDriver):
         async def run(self, _state, ledger: SeedDraftLedger):  # noqa: ARG002
-            # Populate every required section before the deadline fires so the
-            # closure ladder routes through the complete-ledger branch.
             for section, value in {
                 "actors": "End user.",
                 "inputs": "CLI argument.",
@@ -177,13 +176,34 @@ async def test_deadline_with_complete_ledger_routes_through_normal_seed(tmp_path
             await asyncio.sleep(3600)
             raise AssertionError("must be cancelled by phase timeout")
 
-    driver = _LedgerSeedingDeadlineDriver(event_store=event_store)
+    return _LedgerSeedingDeadlineDriver
+
+
+@pytest.mark.asyncio
+async def test_deadline_with_complete_ledger_routes_through_degraded_recovery(tmp_path) -> None:
+    """Complete ledger + interview deadline → degraded recovery Seed (#1302).
+
+    A per-phase interview deadline cuts the Socratic loop short before the
+    backend can confirm low ambiguity (``<= 0.20``). Structural ledger
+    completeness is NOT a substitute, so the synthesized Seed keeps its full
+    ledger content but is flagged ``degraded`` with
+    ``recovery_reason="interview_phase_deadline"`` and the dedicated
+    ``DEADLINE_LEDGER_SEED_GENERATION_MODE`` provenance — routing it to the
+    partial-product terminal instead of auto-RUN.
+    """
+    from ouroboros.auto.ledger_seed import DEADLINE_LEDGER_SEED_GENERATION_MODE
+
+    event_store = _RecordingEventStore()
+    state = _build_deadline_state(tmp_path, goal="Build a CLI")
+    store = AutoStore(tmp_path)
+
+    driver = _complete_ledger_deadline_driver()(event_store=event_store)
     pipeline = AutoPipeline(driver, _no_seed_generator, store=store)
 
     await pipeline.run(state)
     await asyncio.sleep(0)
 
-    # The runtime event must report the ledger-seed route, not partial-seed.
+    # The runtime event still reports the complete-ledger synthesis route.
     deadline_events = [
         event for event in event_store.appended if event.type == "runtime.deadline.interview.fired"
     ]
@@ -193,13 +213,64 @@ async def test_deadline_with_complete_ledger_routes_through_normal_seed(tmp_path
     assert payload["closure_route"] == "ledger_seed"
     assert payload["open_gaps"] == []
 
-    # And the persisted Seed metadata stays at the ``"normal"`` default
-    # because complete-ledger synthesis does not flip the recovery fields.
+    # But the persisted Seed metadata is now a degraded deadline-recovery
+    # terminal: full ledger content, no unresolved slots, flagged degraded so
+    # the gates route it away from RUN.
     assert state.seed_artifact is not None
     metadata = state.seed_artifact["metadata"]
-    assert metadata["generation_mode"] == "normal"
-    assert metadata["degraded"] is False
-    assert metadata["recovery_reason"] is None
+    assert metadata["generation_mode"] == DEADLINE_LEDGER_SEED_GENERATION_MODE
+    assert metadata["degraded"] is True
+    assert metadata["recovery_reason"] == "interview_phase_deadline"
+    # The ledger was complete, so there are no unresolved slots — the
+    # degradation is the missing backend ambiguity confirmation, not a gap.
+    assert metadata["unresolved_slots"] == []
+
+
+@pytest.mark.asyncio
+async def test_complete_ledger_deadline_cannot_reach_run_or_seed_qa(tmp_path) -> None:
+    """#1302 gate: a complete-ledger interview deadline must not auto-RUN.
+
+    Regression for the ouroboros-agent[bot] blocker (``req_1780365047_26``):
+    the complete-ledger deadline fallback promoted a structurally complete
+    ledger to a normal runnable Seed and could reach RUN even though no
+    backend-confirmed ``ambiguity_score <= 0.20`` existed. With both a
+    ``run_starter`` and a ``seed_qa_evaluator`` wired, the pipeline must end at
+    the typed partial-product terminal and invoke NEITHER.
+    """
+
+    async def _forbidden_run_starter(_seed, **_kwargs):
+        raise AssertionError("RUN must not start on a complete-ledger deadline closure")
+
+    async def _forbidden_seed_qa(_seed, _ledger):
+        raise AssertionError("Seed QA must not run on a complete-ledger deadline closure")
+
+    event_store = _RecordingEventStore()
+    state = _build_deadline_state(tmp_path, goal="Build a CLI")
+    driver = _complete_ledger_deadline_driver()(event_store=event_store)
+    pipeline = AutoPipeline(
+        driver,
+        _no_seed_generator,
+        store=AutoStore(tmp_path),
+        run_starter=_forbidden_run_starter,
+        seed_qa_evaluator=_forbidden_seed_qa,
+    )
+
+    result = await pipeline.run(state)
+    await asyncio.sleep(0)
+
+    # Terminal is the typed partial-product success, not RUN/BLOCKED.
+    assert state.phase == AutoPhase.COMPLETE
+    assert result.partial_product is True
+    assert result.partial_product_reason == "interview_phase_deadline"
+    # Complete ledger ⇒ no unresolved slots carried forward.
+    assert result.partial_unresolved_slots == ()
+    # The partial-product terminal fired (and neither sentinel raised, proving
+    # RUN / Seed QA were never reached).
+    partial_events = [
+        event for event in event_store.appended if event.type == "auto.product.partial_emitted"
+    ]
+    assert len(partial_events) == 1
+    assert partial_events[0].data["recovery_reason"] == "interview_phase_deadline"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_safe_default_observability.py
+++ b/tests/unit/auto/test_safe_default_observability.py
@@ -70,19 +70,11 @@ def _ledger_all_filled_except(
 
 
 @pytest.mark.asyncio
-async def test_ledger_only_closes_in_loop_when_backend_never_converges(tmp_path) -> None:
-    """Ledger already seed-ready but backend keeps asking → in-loop ledger-only closure.
+async def test_complete_ledger_does_not_close_without_backend_low_ambiguity(tmp_path) -> None:
+    """Ledger completeness alone cannot close auto interview.
 
-    PR-β / SSOT #1157 "Closure Policy" (2026-05-27): the driver's in-loop
-    closure check is now ledger-primary. When ``ledger.is_seed_ready()`` returns
-    True the loop exits immediately as ``ledger_only`` regardless of backend
-    state — the safe-default fallback path is no longer needed in this case.
-
-    Replaces the older max_rounds-only ``ledger_only`` fallback assertion: the
-    safe-default block (``safe_default.entered``, ``no_gaps_to_default``) is
-    bypassed because closure happens before max_rounds, but the observability
-    contract is preserved via the ``auto.interview.ledger_only_closure`` event
-    emitted from the new in-loop path.
+    The backend must also signal completion at or below the ambiguity threshold
+    before the Seed can be generated and later run.
     """
     # Ledger is fully filled — is_seed_ready() returns True from round 0.
     ledger = _ledger_all_filled_except()
@@ -94,7 +86,6 @@ async def test_ledger_only_closes_in_loop_when_backend_never_converges(tmp_path)
     async def answer(
         session_id: str, text: str, *, last_question: str | None = None
     ) -> InterviewTurn:  # noqa: ARG001
-        # Backend never signals completion — it keeps asking.
         return InterviewTurn("What else should we know?", session_id, seed_ready=False)
 
     state = AutoPipelineState(goal="Build a local CLI", cwd=str(tmp_path))
@@ -109,16 +100,10 @@ async def test_ledger_only_closes_in_loop_when_backend_never_converges(tmp_path)
         result = await driver.run(state, ledger)
 
     events = [e["event"] for e in captured]
-    # In-loop ledger-primary closure means the safe-default block is bypassed.
-    assert "auto.interview.safe_default.entered" not in events
-    assert "auto.interview.safe_default.no_gaps_to_default" not in events
-    # Observability contract preserved: ledger_only_closure event still fires
-    # from the in-loop closure path.
-    assert "auto.interview.ledger_only_closure" in events
-
-    # PR-β: ledger-primary closure on the first round, no max_rounds wait.
-    assert result.status == "seed_ready"
-    assert state.interview_closure_mode == "ledger_only"
+    assert "auto.interview.ledger_only_closure" not in events
+    assert result.status == "blocked"
+    assert "without closure" in (result.blocker or "")
+    assert state.interview_closure_mode is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -704,6 +704,7 @@ async def test_cli_resume_replays_persisted_runtime_and_skip_run(monkeypatch, tm
     class FakePipeline:
         def __init__(self, *args, **kwargs):  # noqa: ANN002, ANN003
             captured["skip_run"] = kwargs.get("skip_run")
+            captured["seed_qa_evaluator"] = kwargs.get("seed_qa_evaluator")
             captured["driver_rounds"] = args[0].max_rounds
             captured["repair_rounds"] = kwargs["repairer"].max_repair_rounds
 
@@ -741,6 +742,7 @@ async def test_cli_resume_replays_persisted_runtime_and_skip_run(monkeypatch, tm
     assert captured["state_runtime"] == "codex"
     assert captured["state_skip_run"] is True
     assert captured["skip_run"] is True
+    assert captured["seed_qa_evaluator"] is not None
     assert captured["driver_rounds"] == 2
     assert captured["repair_rounds"] == 3
     assert captured["runtimes"] == ["codex", "codex", "codex", "codex"]

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -1138,6 +1138,52 @@ class TestBackgroundJobPath:
         assert "user_preferences" not in runner_args
 
     @pytest.mark.asyncio
+    async def test_mcp_plugin_mode_wires_seed_qa_with_demoted_authoring_handler(
+        self, event_store, tmp_path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Plugin auto must not bypass the pre-run Seed QA gate."""
+
+        captured: dict[str, object] = {}
+
+        class FakeQAHandler:
+            def __init__(self, **kwargs):
+                self.kwargs = kwargs
+                captured["qa_handler"] = self
+
+        class FakeAutoPipeline:
+            def __init__(self, *_args, **kwargs):
+                captured["pipeline_kwargs"] = kwargs
+
+            async def run(self, state):
+                captured["state"] = state
+                return AutoPipelineResult(
+                    status="blocked",
+                    auto_session_id=state.auto_session_id,
+                    phase=str(state.phase.value),
+                )
+
+        monkeypatch.setattr("ouroboros.mcp.tools.auto_handler.QAHandler", FakeQAHandler)
+        monkeypatch.setattr("ouroboros.mcp.tools.auto_handler.AutoPipeline", FakeAutoPipeline)
+
+        h = AutoHandler(
+            store=AutoStore(tmp_path),
+            event_store=event_store,
+            agent_runtime_backend="opencode",
+            opencode_mode="plugin",
+        )
+
+        result = await h._run({"goal": "build a CLI"})
+
+        assert result.status == "blocked"
+        qa_handler = captured["qa_handler"]
+        assert qa_handler.kwargs["agent_runtime_backend"] == "opencode"
+        assert qa_handler.kwargs["opencode_mode"] == "subprocess"
+        kwargs = captured["pipeline_kwargs"]
+        assert kwargs["seed_qa_evaluator"] is not None
+        assert kwargs["seed_qa_evaluator"].qa_handler is qa_handler
+        assert kwargs["evaluator"] is None
+
+    @pytest.mark.asyncio
     async def test_plugin_mode_returns_subagent_without_enqueue(
         self, event_store, tmp_path, fake_inner_auto
     ) -> None:


### PR DESCRIPTION
## Summary

- Require auto interviews to close only after backend-confirmed low ambiguity, preventing high-ambiguity Seed generation from ledger completeness alone.
- Add a pre-run Seed QA gate for both MCP and CLI auto entrypoints so execution starts only after `ooo qa`-style Seed review passes.
- Feed Seed QA findings back into bounded Seed repair attempts before blocking, making failures actionable and resumable.

## Changes

- Added `HandlerSeedQAEvaluator` to run `QAHandler` against generated Seed YAML and ledger evidence.
- Wired Seed QA into `AutoPipeline`, `AutoHandler`, and CLI `ouroboros auto` composition roots.
- Kept MCP OpenCode plugin mode contract parity by demoting only the Seed QA authoring handler to subprocess mode, matching Interview/GenerateSeed while preserving plugin Ralph delegation.
- Replaced ledger-only interview closure with backend-confirmed ambiguity gating (`<= 0.20`).
- Added and updated auto tests covering high-ambiguity blocks, Seed QA run gating, QA-feedback repair, CLI wiring, and MCP plugin Seed QA wiring.

## Test plan

- [x] `PYTHONPATH=src uv run pytest -q tests/unit/mcp/tools/test_start_auto.py tests/unit/auto/test_interview_pipeline.py tests/unit/auto/test_safe_default_observability.py tests/unit/auto/test_surface.py` (`300 passed`).
- [x] `PYTHONPATH=src uv run ruff check src/ouroboros/mcp/tools/auto_handler.py tests/unit/mcp/tools/test_start_auto.py src/ouroboros/auto/pipeline.py`.
- [x] `PYTHONPATH=src uv run ruff format --check src/ tests/` (`900 files already formatted`).
- [x] Live canonical R-run attempted with `OUROBOROS_RUN_CANONICAL=1 PYTHONPATH=src uv run pytest tests/canonical/ -k cli-todo -v`; the run intentionally blocked before execution because the new Seed QA gate rejected a Seed with `ambiguity_score=0.382` and generic acceptance criteria. This is functional evidence for the safety gate, not a post-run performance regression.

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)                                      | This PR (sha)                                            | Ratio |
|--------------------------------|-----------------------------------------------------|----------------------------------------------------------|-------|
| Rounds completed in 600 s      | N/A - no comparable post-run baseline for Seed QA gate | 13 interview rounds before Seed QA block (`7cc1a7cb`)     | n/a   |
| Per-round wall-clock (s/round) | N/A - safety-gate behavior change, not run-loop perf | ~26.5 s/round from 344.33 s / 13 rounds (`7cc1a7cb`)     | n/a   |
| Terminal reason                | N/A - previous behavior could proceed to RUN         | `blocked`: Seed QA failed after 5 repair attempts         | n/a   |
| EventStore event count         | N/A - not emitted by canonical failure summary       | N/A - raw evidence persisted under `.ooo-observability`   | n/a   |

Budget compliance: [ ] within 1.5x / [ ] regression flagged with mitigation /
[x] N/A (safety-gate change blocks unsafe Seed before run-loop performance is comparable)

## Notes

- Verification run from the original PR: `uv run pytest tests/unit/auto -q` (`1130 passed`).
- Manual CLI smoke confirmed `mcp.tool.qa` runs before skip-run completion and blocks when Seed QA remains `revise`.
