### PR TITLE
fix(goose): keep LLM completion calls profile-free

### DIFF
--- a/src/ouroboros/providers/goose_cli_adapter.py
+++ b/src/ouroboros/providers/goose_cli_adapter.py
@@ -232,7 +232,14 @@ class GooseCliLLMAdapter(CodexCliLLMAdapter):
     ) -> list[str]:
         """Build the ``goose run`` command; prompt is fed via stdin."""
         del output_last_message_path, output_schema_path, profile
-        command = [self._cli_path, "run", "--output-format", "stream-json"]
+        command = [
+            self._cli_path,
+            "run",
+            "--output-format",
+            "stream-json",
+            "--no-profile",
+            "--quiet",
+        ]
         if self._ephemeral:
             command.append("--no-session")
         else:

--- a/tests/unit/orchestrator/test_goose_runtime.py
+++ b/tests/unit/orchestrator/test_goose_runtime.py
@@ -86,6 +86,8 @@ def test_goose_command_uses_run_stream_json_and_stdin() -> None:
 
     assert command[:4] == ["/tmp/goose", "run", "--output-format", "stream-json"]
     assert "--resume" in command
+    assert "--no-profile" not in command
+    assert "--quiet" not in command
     assert command[-2:] == ["-i", "-"]
     assert "session-1" in command
 

--- a/tests/unit/providers/test_goose_cli_adapter.py
+++ b/tests/unit/providers/test_goose_cli_adapter.py
@@ -76,6 +76,8 @@ class TestGooseCliLLMAdapter:
         )
 
         assert command[:4] == ["/tmp/goose", "run", "--output-format", "stream-json"]
+        assert "--no-profile" in command
+        assert "--quiet" in command
         assert "--no-session" in command
         assert "--max-turns" in command
         assert "3" in command


### PR DESCRIPTION
## Summary

Keep Goose-backed LLM-only completion calls profile-free by adding `--no-profile --quiet` to `GooseCliLLMAdapter` command construction.

## Why

`GooseCliLLMAdapter` is used for completion-style calls such as structured JSON/schema responses, seed/decomposition/evaluation flows, and other LLM-only operations. These calls should not load the user's default Goose tool profile.

When the default Goose profile is loaded, the model can emit tool requests instead of returning the requested JSON. In headless subprocess mode this can fail with approval/tool-call errors and makes schema extraction unreliable.

This change is scoped to `GooseCliLLMAdapter` only. `GooseCliRuntime` remains profile-enabled for normal AC worker execution.

## Verification

- `uv run pytest tests/unit/providers/test_goose_cli_adapter.py -q`
- Local Goose structured JSON smoke: `gou-test-goose-json --trials 1` → 4/4 pass
- Local Goose runtime smoke: `gou-test-runtime-smoke --keep` → passed; expected file was created in linked git worktree

## Notes

This is separate from the Goose CLI/provider fix for `response.completed` events that omit `response.output`; that issue is fixed in newer Goose (`1.36.0` locally tested). This PR only addresses the Ouroboros adapter behavior for LLM completion calls.
