### PR TITLE
Harden ooo auto policy aliases and timeout preflight

### DIFF
--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -79,6 +79,72 @@ class AutoWorktreePolicy(StrEnum):
     NONE = "none"
 
 
+WORKTREE_POLICY_ALIASES: dict[str, str] = {
+    # Natural-language / older gateway spellings for mandatory isolation.
+    "create_isolated_worktree": AutoWorktreePolicy.ALWAYS.value,
+    "isolated": AutoWorktreePolicy.ALWAYS.value,
+    "isolate": AutoWorktreePolicy.ALWAYS.value,
+    "required": AutoWorktreePolicy.ALWAYS.value,
+    "use_isolated_worktree": AutoWorktreePolicy.ALWAYS.value,
+    "always_create": AutoWorktreePolicy.ALWAYS.value,
+    # Explicit current-worktree spellings.
+    "current_worktree": AutoWorktreePolicy.CURRENT.value,
+    "reuse_current": AutoWorktreePolicy.CURRENT.value,
+    "use_current_worktree": AutoWorktreePolicy.CURRENT.value,
+    # Explicit opt-out spellings.
+    "no_worktree": AutoWorktreePolicy.NONE.value,
+    "disable_worktree": AutoWorktreePolicy.NONE.value,
+}
+
+
+def parse_auto_worktree_policy(value: str) -> AutoWorktreePolicy:
+    """Parse a worktree isolation policy, accepting stable aliases.
+
+    External callers often express the intent as ``create_isolated_worktree``
+    or ``required`` even though the durable enum is intentionally compact.
+    Normalizing those spellings at the boundary keeps the persisted state
+    canonical while making the MCP/CLI surface resilient to natural policy
+    names emitted by agents and gateways.
+    """
+    raw = value.strip()
+    normalized = raw.lower().replace("-", "_").replace(" ", "_")
+    canonical = WORKTREE_POLICY_ALIASES.get(normalized, normalized)
+    try:
+        return AutoWorktreePolicy(canonical)
+    except ValueError as exc:
+        valid = ", ".join(item.value for item in AutoWorktreePolicy)
+        alias_hint = "create_isolated_worktree → always"
+        msg = (
+            f"worktree_policy must be one of: {valid}. "
+            f"Accepted aliases include {alias_hint}. Got {raw!r}."
+        )
+        raise ValueError(msg) from exc
+
+
+COMPLETE_PRODUCT_MIN_PIPELINE_TIMEOUT_SECONDS: float = 1800.0
+
+
+def validate_complete_product_timeout(
+    *,
+    complete_product: bool,
+    pipeline_timeout_seconds: float | None,
+    option_name: str = "pipeline_timeout_seconds",
+) -> None:
+    """Fail fast when complete-product auto is given an impractical deadline."""
+    if (
+        complete_product
+        and pipeline_timeout_seconds is not None
+        and pipeline_timeout_seconds < COMPLETE_PRODUCT_MIN_PIPELINE_TIMEOUT_SECONDS
+    ):
+        msg = (
+            f"complete_product=true requires {option_name} >= "
+            f"{COMPLETE_PRODUCT_MIN_PIPELINE_TIMEOUT_SECONDS:g} seconds. "
+            f"Omit {option_name} to use the default 7200s long-running auto budget, "
+            "or pass a larger value for interview, Seed, run, and Ralph/QA phases."
+        )
+        raise ValueError(msg)
+
+
 class SeedOrigin(StrEnum):
     """Provenance of the persisted Seed for an auto session.
 
@@ -983,10 +1049,9 @@ class AutoPipelineState:
             msg = f"commit_policy must be one of {[item.value for item in AutoCommitPolicy]}"
             raise ValueError(msg) from exc
         try:
-            payload["worktree_policy"] = AutoWorktreePolicy(payload["worktree_policy"])
+            payload["worktree_policy"] = parse_auto_worktree_policy(payload["worktree_policy"])
         except ValueError as exc:
-            msg = f"worktree_policy must be one of {[item.value for item in AutoWorktreePolicy]}"
-            raise ValueError(msg) from exc
+            raise ValueError(str(exc)) from exc
         try:
             payload["seed_origin"] = SeedOrigin(payload["seed_origin"])
         except ValueError as exc:

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -43,7 +43,8 @@ from ouroboros.auto.state import (
     AutoPhase,
     AutoPipelineState,
     AutoStore,
-    AutoWorktreePolicy,
+    parse_auto_worktree_policy,
+    validate_complete_product_timeout,
 )
 from ouroboros.auto.worktree import ensure_auto_worktree, release_auto_worktree
 from ouroboros.cli.formatters import console
@@ -353,6 +354,11 @@ async def _run_auto(
         raise ValueError("--attach-execution/--attach-job/--attach-session require --resume")
     if reconcile_run and not resume:
         raise ValueError("--reconcile-run requires --resume")
+    validate_complete_product_timeout(
+        complete_product=complete_product and not bool(resume),
+        pipeline_timeout_seconds=pipeline_timeout_seconds,
+        option_name="--timeout",
+    )
     if resume:
         if pipeline_timeout_seconds is not None:
             raise ValueError(
@@ -449,7 +455,7 @@ async def _run_auto(
     if commit_policy is not None:
         state.commit_policy = AutoCommitPolicy(commit_policy)
     if worktree_policy is not None:
-        state.worktree_policy = AutoWorktreePolicy(worktree_policy)
+        state.worktree_policy = parse_auto_worktree_policy(worktree_policy)
 
     if runtime == "opencode":
         # Q00/ouroboros#782 review-7 BLOCKING #3 + review-8 BLOCKING #1: keep

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -60,7 +60,8 @@ from ouroboros.auto.state import (
     AutoPipelineState,
     AutoResumeCapability,
     AutoStore,
-    AutoWorktreePolicy,
+    parse_auto_worktree_policy,
+    validate_complete_product_timeout,
 )
 from ouroboros.auto.worktree import ensure_auto_worktree, release_auto_worktree
 from ouroboros.config import get_opencode_mode
@@ -330,6 +331,10 @@ class AutoHandler:
                 "pipeline_timeout_seconds cannot be changed on resume; the "
                 "original deadline is preserved across process restarts"
             )
+        validate_complete_product_timeout(
+            complete_product=complete_product and not (isinstance(resume, str) and resume),
+            pipeline_timeout_seconds=pipeline_timeout_seconds,
+        )
         # Distinguish "caller did not pass user_preferences" from "caller
         # passed an empty mapping". Only validate/parse when the caller
         # actually supplied the arg so a resume call can defer to persisted
@@ -663,6 +668,10 @@ class StartAutoHandler:
                 for field_name in ("attach_execution", "attach_job", "attach_session")
             )
             requested_pipeline_timeout = _optional_pipeline_timeout(arguments)
+            validate_complete_product_timeout(
+                complete_product=bool(arguments.get("complete_product", False)) and not has_resume,
+                pipeline_timeout_seconds=requested_pipeline_timeout,
+            )
         except ValueError as exc:
             return Result.err(MCPToolError(str(exc), tool_name="ouroboros_start_auto"))
         if attach_requested and not has_resume:
@@ -1018,7 +1027,7 @@ def _apply_requested_domain_and_policies(
 
     worktree_policy = _optional_text_arg(arguments, "worktree_policy")
     if worktree_policy is not None:
-        state.worktree_policy = AutoWorktreePolicy(worktree_policy)
+        state.worktree_policy = parse_auto_worktree_policy(worktree_policy)
 
 
 def _build_auto_subagent(

--- a/tests/integration/auto/test_dispatch_to_seed_e2e.py
+++ b/tests/integration/auto/test_dispatch_to_seed_e2e.py
@@ -415,7 +415,7 @@ async def test_ooo_auto_dispatch_reaches_seed_via_runtime(
         messages = [
             message
             async for message in runtime.execute_task(
-                f'ooo auto "{user_goal}" --complete-product --pipeline-timeout-seconds 600.5'
+                f'ooo auto "{user_goal}" --complete-product --pipeline-timeout-seconds 1800.5'
             )
         ]
 
@@ -449,7 +449,7 @@ async def test_ooo_auto_dispatch_reaches_seed_via_runtime(
         f"resolve_skill_dispatch must inject runtime cwd via $CWD; got {args!r}"
     )
     assert args["complete_product"] is True
-    assert args["pipeline_timeout_seconds"] == 600.5
+    assert args["pipeline_timeout_seconds"] == 1800.5
     assert isinstance(args["pipeline_timeout_seconds"], float)
 
     # AutoHandler._run actually executed: stub AutoPipeline observed the state.
@@ -461,7 +461,7 @@ async def test_ooo_auto_dispatch_reaches_seed_via_runtime(
     )
     assert captured.get("complete_product") is True
     assert captured.get("state_complete_product") is True
-    assert captured.get("state_pipeline_timeout_seconds") == 600.5
+    assert captured.get("state_pipeline_timeout_seconds") == 1800.5
 
     # The runtime must yield a single final result message carrying the Seed.
     assert len(messages) == 1, f"expected single dispatch result, got {messages!r}"

--- a/tests/unit/auto/test_pipeline_deadline.py
+++ b/tests/unit/auto/test_pipeline_deadline.py
@@ -458,6 +458,24 @@ async def test_mcp_handler_rejects_timeout_below_floor() -> None:
 
 
 @pytest.mark.asyncio
+async def test_mcp_handler_rejects_complete_product_short_timeout_before_pipeline() -> None:
+    """Complete-product auto should fail fast when the explicit deadline is too short."""
+    from ouroboros.mcp.tools.auto_handler import AutoHandler
+
+    handler = AutoHandler()
+    outcome = await handler.handle(
+        {
+            "goal": "Build a product",
+            "complete_product": True,
+            "pipeline_timeout_seconds": 100,
+        }
+    )
+
+    assert outcome.is_err
+    assert "complete_product=true requires pipeline_timeout_seconds >= 1800" in str(outcome.error)
+
+
+@pytest.mark.asyncio
 async def test_mcp_handler_rejects_timeout_above_ceiling() -> None:
     """The MCP handler rejects ``pipeline_timeout_seconds`` above the 86400s ceiling."""
     from ouroboros.mcp.tools.auto_handler import AutoHandler

--- a/tests/unit/auto/test_state.py
+++ b/tests/unit/auto/test_state.py
@@ -93,6 +93,31 @@ def test_legacy_state_defaults_to_non_coding_policy() -> None:
     assert restored.final_checkpoint_attempted is False
 
 
+def test_worktree_policy_aliases_parse_to_canonical_values() -> None:
+    from ouroboros.auto.state import parse_auto_worktree_policy
+
+    assert parse_auto_worktree_policy("create_isolated_worktree") is AutoWorktreePolicy.ALWAYS
+    assert parse_auto_worktree_policy("required") is AutoWorktreePolicy.ALWAYS
+    assert parse_auto_worktree_policy("reuse-current") is AutoWorktreePolicy.CURRENT
+    assert parse_auto_worktree_policy("no worktree") is AutoWorktreePolicy.NONE
+
+
+def test_worktree_policy_aliases_load_from_state_payload() -> None:
+    payload = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project").to_dict()
+    payload["worktree_policy"] = "create_isolated_worktree"
+
+    restored = AutoPipelineState.from_dict(payload)
+
+    assert restored.worktree_policy is AutoWorktreePolicy.ALWAYS
+
+
+def test_invalid_worktree_policy_names_suggest_alias() -> None:
+    from ouroboros.auto.state import parse_auto_worktree_policy
+
+    with pytest.raises(ValueError, match="create_isolated_worktree .* always"):
+        parse_auto_worktree_policy("make_new_tree")
+
+
 def test_terminal_state_is_not_stale() -> None:
     state = AutoPipelineState(goal="Build a CLI", cwd="/tmp/project")
     state.transition(AutoPhase.INTERVIEW, "starting")

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -410,6 +410,65 @@ def test_run_auto_policy_args_override_detected_coding_defaults(tmp_path, monkey
     assert captured["worktree_policy"] is AutoWorktreePolicy.CURRENT
 
 
+def test_run_auto_accepts_current_worktree_policy_alias(tmp_path, monkeypatch) -> None:
+    import asyncio
+
+    from ouroboros.auto.state import AutoWorktreePolicy
+    from ouroboros.cli.commands.auto import _run_auto
+
+    monkeypatch.chdir(tmp_path)
+    captured: dict[str, object] = {}
+
+    async def fake_pipeline_run(self, run_state):  # noqa: ARG001
+        captured["worktree_policy"] = run_state.worktree_policy
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=run_state.auto_session_id,
+            phase="complete",
+            grade="A",
+        )
+
+    with patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=fake_pipeline_run):
+        result = asyncio.run(
+            _run_auto(
+                goal="Build a CLI",
+                resume=None,
+                runtime="claude",
+                max_interview_rounds=None,
+                max_repair_rounds=None,
+                skip_run=True,
+                worktree_policy="reuse_current",
+            )
+        )
+
+    assert result.status == "complete"
+    assert captured["worktree_policy"] is AutoWorktreePolicy.CURRENT
+
+
+def test_run_auto_rejects_complete_product_short_timeout(tmp_path, monkeypatch) -> None:
+    import asyncio
+
+    import pytest
+
+    from ouroboros.cli.commands.auto import _run_auto
+
+    monkeypatch.chdir(tmp_path)
+
+    with pytest.raises(ValueError, match="complete_product=true requires --timeout >= 1800"):
+        asyncio.run(
+            _run_auto(
+                goal="Build a product",
+                resume=None,
+                runtime="claude",
+                max_interview_rounds=None,
+                max_repair_rounds=None,
+                skip_run=False,
+                complete_product=True,
+                pipeline_timeout_seconds=100,
+            )
+        )
+
+
 def test_resume_rejects_lower_bound_override(tmp_path) -> None:
     """Tightening a bound on resume must be refused — never trap a session further."""
     import asyncio

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -1090,6 +1090,61 @@ class TestBackgroundJobPath:
         assert state.worktree_policy is AutoWorktreePolicy.CURRENT
 
     @pytest.mark.asyncio
+    async def test_new_auto_policy_args_accept_worktree_aliases(
+        self, event_store, tmp_path, fake_inner_auto
+    ) -> None:
+        job_manager = MagicMock()
+        snapshot = MagicMock()
+        snapshot.job_id = "job_auto_policy_alias"
+
+        async def _start_job(*, runner, **_):
+            if inspect.iscoroutine(runner):
+                runner.close()
+            return snapshot
+
+        job_manager.start_job = AsyncMock(side_effect=_start_job)
+        store = AutoStore(tmp_path / "store")
+        h = StartAutoHandler(event_store=event_store, job_manager=job_manager, store=store)
+        h._inner_auto = fake_inner_auto
+
+        result = await h.handle(
+            {
+                "goal": "build a CLI",
+                "cwd": str(tmp_path),
+                "worktree_policy": "create_isolated_worktree",
+            }
+        )
+
+        assert result.is_ok
+        state = store.load(result.value.meta["auto_session_id"])
+        assert state.worktree_policy is AutoWorktreePolicy.ALWAYS
+
+    @pytest.mark.asyncio
+    async def test_complete_product_with_short_timeout_fails_fast(
+        self, event_store, tmp_path, fake_inner_auto
+    ) -> None:
+        job_manager = MagicMock()
+        store = AutoStore(tmp_path / "store")
+        h = StartAutoHandler(event_store=event_store, job_manager=job_manager, store=store)
+        h._inner_auto = fake_inner_auto
+
+        result = await h.handle(
+            {
+                "goal": "build a product",
+                "cwd": str(tmp_path),
+                "complete_product": True,
+                "pipeline_timeout_seconds": 100,
+            }
+        )
+
+        assert result.is_err
+        assert "complete_product=true requires pipeline_timeout_seconds >= 1800" in str(
+            result.error
+        )
+        job_manager.start_job.assert_not_called()
+        fake_inner_auto.handle.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_fresh_structured_goal_runner_resumes_without_preference_override(
         self, event_store, tmp_path
     ) -> None:


### PR DESCRIPTION
## Summary

Fixes #1304.

This PR hardens the `ooo auto` boundary for two failure modes seen in Codex/OMX dispatches before implementation begins:

- natural worktree isolation policy names such as `create_isolated_worktree` now normalize to canonical durable enum values;
- `complete_product=true` with an explicitly too-short pipeline timeout now fails fast with actionable guidance instead of spending the budget in interview and blocking as `pipeline_timeout`. The floor is a guardrail, not a completion guarantee; omitted timeouts still use the existing 7200s default.

## Changes

- Added `parse_auto_worktree_policy()` with stable aliases:
  - `create_isolated_worktree`, `isolated`, `isolate`, `required`, `use_isolated_worktree`, `always_create` → `always`
  - `current_worktree`, `reuse_current`, `use_current_worktree` → `current`
  - `no_worktree`, `disable_worktree` → `none`
- Reused that parser for:
  - MCP auto policy args,
  - CLI `--worktree-policy`,
  - persisted state loading.
- Added `validate_complete_product_timeout()` to reject explicit `complete_product=true` deadlines below 1800 seconds.
- Kept omitted timeout behavior unchanged so complete-product sessions still use the existing long default budget.
- Added unit coverage for state parsing, MCP start-auto, synchronous auto handler preflight, and CLI `_run_auto`.

## Tests

```bash
uv run pytest tests/unit/auto/test_state.py \
  tests/unit/mcp/tools/test_start_auto.py::TestBackgroundJobPath::test_new_auto_policy_args_accept_worktree_aliases \
  tests/unit/mcp/tools/test_start_auto.py::TestBackgroundJobPath::test_complete_product_with_short_timeout_fails_fast \
  tests/unit/auto/test_pipeline_deadline.py::test_mcp_handler_rejects_complete_product_short_timeout_before_pipeline \
  tests/unit/cli/test_auto_command.py::test_run_auto_accepts_current_worktree_policy_alias \
  tests/unit/cli/test_auto_command.py::test_run_auto_rejects_complete_product_short_timeout
```

```bash
uv run pytest tests/unit/mcp/tools/test_start_auto.py \
  tests/unit/cli/test_auto_command.py \
  tests/unit/auto/test_pipeline_deadline.py \
  tests/unit/cli/test_codex_command.py::TestCodexDoctor
```

Both passed locally.

## Notes

This intentionally does not remove or redesign `ouroboros_auto`. The upstream skill already routes normal `ooo auto` through `ouroboros_start_auto`; this PR only makes policy parsing and explicit short-budget handling safer.

## R-run comparison

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation / [x] N/A (boundary parsing/preflight only; PR does not alter per-round auto/R-run execution loops)
