### PR TITLE
fix(run): guard home dir in _detect_project_root_from_seed_path

### DIFF
--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -189,7 +189,15 @@ def _detect_project_root_from_seed_path(seed_file: Path, *, max_levels: int = 6)
     current = seed_file.parent.resolve()
     for _ in range(max_levels):
         if current.name == "seeds" and current.parent.name == ".ouroboros":
-            return current.parent.parent
+            candidate = current.parent.parent
+            # Do not treat the home directory as a project root.
+            # ~/.ouroboros/seeds/ is the global Ouroboros seed store and
+            # matches the central-seed pattern structurally, but ~ is not a
+            # project root. Returning it as one causes opencode to start with
+            # cwd=$HOME for every globally-stored seed (issue #1312).
+            if candidate.resolve() == Path.home().resolve():
+                return None
+            return candidate
         parent = current.parent
         if parent == current:
             break

--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -183,8 +183,9 @@ def _detect_project_root_from_seed_path(seed_file: Path, *, max_levels: int = 6)
     files at the repository root rather than next to the seed.
 
     Returns ``None`` when no ``.ouroboros/seeds`` ancestry is found within
-    ``max_levels`` parents; the caller falls back to ``seed_file.parent``
-    in that case.
+    ``max_levels`` parents, or when the matching ancestry is the global
+    ``~/.ouroboros/seeds`` store rather than a project-local seed store;
+    the caller falls back to ``seed_file.parent`` in that case.
     """
     current = seed_file.parent.resolve()
     for _ in range(max_levels):

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -1304,8 +1304,7 @@ class OpenCodeRuntime:
                     if pid is not None:
                         with contextlib.suppress(Exception):
                             subprocess.run(
-                                ["wmic", "process", "where",
-                                 f"(ParentProcessId={pid})", "delete"],
+                                ["wmic", "process", "where", f"(ParentProcessId={pid})", "delete"],
                                 capture_output=True,
                                 timeout=5,
                             )

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -29,7 +29,6 @@ import os
 from pathlib import Path
 import re
 import shutil
-import subprocess
 from typing import Any
 
 from ouroboros.config import get_opencode_cli_path
@@ -1294,20 +1293,6 @@ class OpenCodeRuntime:
             )
         finally:
             if process is not None:
-                # On Windows, opencode (Node.js) spawns child processes such as
-                # a session server that outlive the parent subprocess. Windows
-                # preserves the original PPID on orphaned processes, so we can
-                # find and terminate them by PPID even after the parent has
-                # already exited (issue #1314).
-                if os.name == "nt":
-                    pid = getattr(process, "pid", None)
-                    if pid is not None:
-                        with contextlib.suppress(Exception):
-                            subprocess.run(
-                                ["wmic", "process", "where", f"(ParentProcessId={pid})", "delete"],
-                                capture_output=True,
-                                timeout=5,
-                            )
                 if (
                     not process_finished
                     and not process_terminated

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -29,6 +29,7 @@ import os
 from pathlib import Path
 import re
 import shutil
+import subprocess
 from typing import Any
 
 from ouroboros.config import get_opencode_cli_path
@@ -1293,6 +1294,21 @@ class OpenCodeRuntime:
             )
         finally:
             if process is not None:
+                # On Windows, opencode (Node.js) spawns child processes such as
+                # a session server that outlive the parent subprocess. Windows
+                # preserves the original PPID on orphaned processes, so we can
+                # find and terminate them by PPID even after the parent has
+                # already exited (issue #1314).
+                if os.name == "nt":
+                    pid = getattr(process, "pid", None)
+                    if pid is not None:
+                        with contextlib.suppress(Exception):
+                            subprocess.run(
+                                ["wmic", "process", "where",
+                                 f"(ParentProcessId={pid})", "delete"],
+                                capture_output=True,
+                                timeout=5,
+                            )
                 if (
                     not process_finished
                     and not process_terminated

--- a/tests/unit/cli/test_run_qa.py
+++ b/tests/unit/cli/test_run_qa.py
@@ -216,6 +216,100 @@ def test_resolve_cli_project_dir_uses_parent_when_context_reference_is_file(
     )
 
 
+def test_resolve_cli_project_dir_global_seed_store_without_hints_does_not_return_home(
+    tmp_path: Path,
+) -> None:
+    """A global seed store path must not become the runtime project cwd (#1312)."""
+    fake_home = tmp_path / "home"
+    global_seed_dir = fake_home / ".ouroboros" / "seeds" / "demo"
+    global_seed_dir.mkdir(parents=True)
+    seed_file = global_seed_dir / "seed.yaml"
+    seed_file.write_text("goal: ignored\n", encoding="utf-8")
+    seed = Seed.from_dict(VALID_SEED_DATA)
+
+    with patch.object(Path, "home", return_value=fake_home):
+        resolved = _resolve_cli_project_dir(seed, seed_file, seed_data=VALID_SEED_DATA)
+
+    assert resolved == global_seed_dir.resolve()
+    assert resolved != fake_home.resolve()
+
+
+def test_resolve_cli_project_dir_global_seed_store_still_prefers_explicit_project_dir(
+    tmp_path: Path,
+) -> None:
+    """--project-dir remains the highest-priority boundary for global seeds."""
+    fake_home = tmp_path / "home"
+    global_seed_dir = fake_home / ".ouroboros" / "seeds" / "demo"
+    global_seed_dir.mkdir(parents=True)
+    seed_file = global_seed_dir / "seed.yaml"
+    seed_file.write_text("goal: ignored\n", encoding="utf-8")
+    explicit_project = tmp_path / "actual-project"
+    explicit_project.mkdir()
+    seed = Seed.from_dict(VALID_SEED_DATA)
+
+    with patch.object(Path, "home", return_value=fake_home):
+        resolved = _resolve_cli_project_dir(
+            seed,
+            seed_file,
+            seed_data=VALID_SEED_DATA,
+            project_dir=explicit_project,
+        )
+
+    assert resolved == explicit_project.resolve()
+
+
+def test_resolve_cli_project_dir_global_seed_store_still_uses_raw_metadata_project_dir(
+    tmp_path: Path,
+) -> None:
+    """Raw metadata project_dir keeps #1160/#1161 precedence for global seeds."""
+    fake_home = tmp_path / "home"
+    global_seed_dir = fake_home / ".ouroboros" / "seeds" / "demo"
+    repo_root = global_seed_dir / "repo-root"
+    repo_root.mkdir(parents=True)
+    seed_file = global_seed_dir / "seed.yaml"
+    seed_file.write_text("goal: ignored\n", encoding="utf-8")
+    seed_data = {
+        **VALID_SEED_DATA,
+        "metadata": {**VALID_SEED_DATA["metadata"], "project_dir": "repo-root"},
+    }
+    seed = Seed.from_dict(seed_data)
+
+    with patch.object(Path, "home", return_value=fake_home):
+        resolved = _resolve_cli_project_dir(seed, seed_file, seed_data=seed_data)
+
+    assert resolved == repo_root.resolve()
+
+
+def test_resolve_cli_project_dir_global_seed_store_still_uses_brownfield_target_dir(
+    tmp_path: Path,
+) -> None:
+    """brownfield_context.target_dir remains preferred over global seed fallback."""
+    fake_home = tmp_path / "home"
+    global_seed_dir = fake_home / ".ouroboros" / "seeds" / "demo"
+    global_seed_dir.mkdir(parents=True)
+    seed_file = global_seed_dir / "seed.yaml"
+    seed_file.write_text("goal: ignored\n", encoding="utf-8")
+    target_dir = tmp_path / "actual-project"
+    target_dir.mkdir()
+    seed_data = {
+        **VALID_SEED_DATA,
+        "brownfield_context": {
+            "project_type": "brownfield",
+            "target_dir": str(target_dir),
+            "context_references": [
+                {"path": "main.py", "role": "primary", "summary": "target file"},
+            ],
+        },
+    }
+    (target_dir / "main.py").write_text("print('hi')\n", encoding="utf-8")
+    seed = Seed.from_dict(seed_data)
+
+    with patch.object(Path, "home", return_value=fake_home):
+        resolved = _resolve_cli_project_dir(seed, seed_file, seed_data=seed_data)
+
+    assert resolved == target_dir.resolve()
+
+
 def test_resolve_fat_harness_mode_defaults_to_disabled() -> None:
     """Fresh runs use the default runner unless the seed opts into fat-harness."""
     assert _resolve_fat_harness_mode(VALID_SEED_DATA) is False

--- a/tests/unit/cli/test_run_qa.py
+++ b/tests/unit/cli/test_run_qa.py
@@ -694,6 +694,24 @@ async def test_run_orchestrator_falls_back_when_artifact_generation_fails(tmp_pa
 class TestDetectProjectRootFromSeedPath:
     """Tests for ouroboros.cli.commands.run._detect_project_root_from_seed_path."""
 
+    def test_returns_none_when_candidate_is_home_dir(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Seeds in ~/.ouroboros/seeds/ must not yield home dir as project root (issue #1312)."""
+        from ouroboros.cli.commands.run import _detect_project_root_from_seed_path
+
+        fake_home = tmp_path / "home"
+        global_seeds = fake_home / ".ouroboros" / "seeds" / "myfeat"
+        global_seeds.mkdir(parents=True)
+        seed_file = global_seeds / "seed.yaml"
+        seed_file.write_text("goal: x")
+
+        with patch.object(Path, "home", return_value=fake_home):
+            result = _detect_project_root_from_seed_path(seed_file)
+
+        assert result is None
+
     def test_returns_root_when_seed_lives_under_dot_ouroboros_seeds(
         self,
         tmp_path: Path,


### PR DESCRIPTION
Fixes #1312.

This PR narrows the #1312 fix to the confirmed cwd-resolution bug:

- `~/.ouroboros/seeds/...` structurally matches the project-local `<project>/.ouroboros/seeds/...` pattern.
- `_detect_project_root_from_seed_path()` could therefore return `Path.home()` as a false project root.
- `_resolve_cli_project_dir()` could then pass `$HOME` as the runtime cwd for globally stored seeds.

## Fix

Treat the global seed store as **not** being a project-local central seed store:

```python
candidate = current.parent.parent
if candidate.resolve() == Path.home().resolve():
    return None
```

The caller then uses the existing resolution chain instead of accepting `$HOME` as the project root.

## Scope boundaries

This PR intentionally does **not** implement DB-registered brownfield default repo cwd semantics. The accepted run-path precedence remains:

1. explicit `--project-dir`;
2. raw `metadata.project_dir` / `metadata.working_directory`;
3. `brownfield_context.target_dir`;
4. project-local central seed root detection;
5. seed parent fallback.

The unrelated OpenCode Windows child-process cleanup was removed from this PR; that belongs to #1314 or another dedicated runtime-process PR.

## Tests

```bash
uv run pytest tests/unit/cli/test_run_qa.py -q
# 39 passed

uv run ruff check src/ouroboros/cli/commands/run.py tests/unit/cli/test_run_qa.py src/ouroboros/orchestrator/opencode_runtime.py
# All checks passed

uv run ruff format --check src/ouroboros/cli/commands/run.py tests/unit/cli/test_run_qa.py src/ouroboros/orchestrator/opencode_runtime.py
# 3 files already formatted
```
