### PR TITLE
fix(opencode): kill orphaned child processes on Windows after AC completion

### DIFF
--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -1304,8 +1304,7 @@ class OpenCodeRuntime:
                     if pid is not None:
                         with contextlib.suppress(Exception):
                             subprocess.run(
-                                ["wmic", "process", "where",
-                                 f"(ParentProcessId={pid})", "delete"],
+                                ["wmic", "process", "where", f"(ParentProcessId={pid})", "delete"],
                                 capture_output=True,
                                 timeout=5,
                             )

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -29,6 +29,7 @@ import os
 from pathlib import Path
 import re
 import shutil
+import subprocess
 from typing import Any
 
 from ouroboros.config import get_opencode_cli_path
@@ -1293,6 +1294,21 @@ class OpenCodeRuntime:
             )
         finally:
             if process is not None:
+                # On Windows, opencode (Node.js) spawns child processes such as
+                # a session server that outlive the parent subprocess. Windows
+                # preserves the original PPID on orphaned processes, so we can
+                # find and terminate them by PPID even after the parent has
+                # already exited (issue #1314).
+                if os.name == "nt":
+                    pid = getattr(process, "pid", None)
+                    if pid is not None:
+                        with contextlib.suppress(Exception):
+                            subprocess.run(
+                                ["wmic", "process", "where",
+                                 f"(ParentProcessId={pid})", "delete"],
+                                capture_output=True,
+                                timeout=5,
+                            )
                 if (
                     not process_finished
                     and not process_terminated


### PR DESCRIPTION
## Summary

On Windows, `opencode` (Node.js) spawns child processes — such as a session server — that outlive the `opencode run` subprocess. When `execute_task` completes normally, `process_finished=True` causes the `finally` block to skip `_terminate_process`, leaving children as zombies. With N ACs, N orphaned `opencode` processes accumulate.

**Root cause** — normal-completion path skips cleanup:
```python
finally:
    if process is not None:
        if (
            not process_finished   # ← True on success, skips terminate
            and not process_terminated
            and getattr(process, "returncode", None) is None
        ):
            await self._terminate_process(process)
```

**Key insight**: Windows preserves the original `PPID` on orphaned processes (unlike Linux which re-parents to `init`). Even after the parent exits, children still carry the dead parent's PID as `ParentProcessId`. This means we can find and terminate them by `PPID` after the fact.

**Fix** — Windows-only `wmic` call in `finally`, runs on both success and error paths:
```python
if os.name == "nt":
    pid = getattr(process, "pid", None)
    if pid is not None:
        with contextlib.suppress(Exception):
            subprocess.run(
                ["wmic", "process", "where",
                 f"(ParentProcessId={pid})", "delete"],
                capture_output=True,
                timeout=5,
            )
```

- **Windows-only** (`os.name == "nt"`) — POSIX unaffected
- **Both paths** — runs before the existing conditional, covers success and error
- **Safe** — `contextlib.suppress(Exception)` + 5s timeout; failure is silent
- **No new dependencies** — `subprocess` is stdlib
- `wmic` available on all supported Windows versions; `wmic` correctly traverses stale PPID entries

## Test plan

- [x] 51 existing `test_opencode_runtime.py` tests pass (6 pre-existing Windows path-separator failures are unrelated to this change)
- [x] No new failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)