### PR TITLE
fix(opencode): cover Windows cleanup review blockers

### DIFF
--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -1125,6 +1125,7 @@ class OpenCodeRuntime:
         process: Any | None = None
         process_finished = False
         process_terminated = False
+        windows_child_cleanup_done = False
         control_state: dict[str, Any] | None = None
         stderr_task: asyncio.Task[list[str]] | None = None
 
@@ -1254,6 +1255,8 @@ class OpenCodeRuntime:
         except TimeoutError as e:
             if process is not None and control_state is not None:
                 await self._terminate_process(process)
+                self._cleanup_windows_child_processes(process)
+                windows_child_cleanup_done = True
                 control_state["terminated"] = True
             process_terminated = True
             if stderr_task is not None:
@@ -1287,6 +1290,8 @@ class OpenCodeRuntime:
                 process=process,
                 control_state=control_state,
             )
+            self._cleanup_windows_child_processes(process)
+            windows_child_cleanup_done = True
             stderr_lines = await stderr_task
 
             if yielded_final:
@@ -1328,7 +1333,8 @@ class OpenCodeRuntime:
                 ):
                     await self._terminate_process(process)
                     process_terminated = True
-                self._cleanup_windows_child_processes(process)
+                if not windows_child_cleanup_done:
+                    self._cleanup_windows_child_processes(process)
             if stderr_task is not None and not stderr_task.done():
                 stderr_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -1304,8 +1304,7 @@ class OpenCodeRuntime:
                     if pid is not None:
                         with contextlib.suppress(Exception):
                             subprocess.run(
-                                ["wmic", "process", "where",
-                                 f"(ParentProcessId={pid})", "delete"],
+                                ["wmic", "process", "where", f"(ParentProcessId={pid})", "delete"],
                                 capture_output=True,
                                 timeout=5,
                             )

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -1321,13 +1321,14 @@ class OpenCodeRuntime:
             )
         finally:
             if process is not None:
-                self._cleanup_windows_child_processes(process)
                 if (
                     not process_finished
                     and not process_terminated
                     and getattr(process, "returncode", None) is None
                 ):
                     await self._terminate_process(process)
+                    process_terminated = True
+                self._cleanup_windows_child_processes(process)
             if stderr_task is not None and not stderr_task.done():
                 stderr_task.cancel()
                 with contextlib.suppress(asyncio.CancelledError):

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -29,6 +29,7 @@ import os
 from pathlib import Path
 import re
 import shutil
+import subprocess
 from typing import Any
 
 from ouroboros.config import get_opencode_cli_path
@@ -1293,6 +1294,21 @@ class OpenCodeRuntime:
             )
         finally:
             if process is not None:
+                # On Windows, opencode (Node.js) spawns child processes such as
+                # a session server that outlive the parent subprocess. Windows
+                # preserves the original PPID on orphaned processes, so we can
+                # find and terminate them by PPID even after the parent has
+                # already exited (issue #1314).
+                if os.name == "nt":
+                    pid = getattr(process, "pid", None)
+                    if pid is not None:
+                        with contextlib.suppress(Exception):
+                            subprocess.run(
+                                ["wmic", "process", "where",
+                                 f"(ParentProcessId={pid})", "delete"],
+                                capture_output=True,
+                                timeout=5,
+                            )
                 if (
                     not process_finished
                     and not process_terminated

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -567,6 +567,33 @@ class OpenCodeRuntime:
 
     # -- Process management ------------------------------------------------
 
+    def _cleanup_windows_child_processes(self, process: Any) -> None:
+        """Best-effort cleanup for Windows children orphaned by Node CLIs.
+
+        OpenCode may leave session-server children behind after the parent
+        subprocess exits normally. Windows preserves the original parent PID
+        on those orphaned children, so a PPID-targeted cleanup can run even
+        after ``process.wait()`` has completed.
+        """
+        if os.name != "nt":
+            return
+        pid = getattr(process, "pid", None)
+        if pid is None:
+            return
+        try:
+            subprocess.run(
+                ["wmic", "process", "where", f"(ParentProcessId={pid})", "delete"],
+                capture_output=True,
+                timeout=5,
+                check=False,
+            )
+        except Exception as exc:
+            log.warning(
+                f"{self._log_namespace}.windows_child_cleanup_failed",
+                pid=pid,
+                error=str(exc),
+            )
+
     async def _terminate_process(self, process: Any) -> None:
         """Best-effort subprocess shutdown.
 
@@ -1294,20 +1321,7 @@ class OpenCodeRuntime:
             )
         finally:
             if process is not None:
-                # On Windows, opencode (Node.js) spawns child processes such as
-                # a session server that outlive the parent subprocess. Windows
-                # preserves the original PPID on orphaned processes, so we can
-                # find and terminate them by PPID even after the parent has
-                # already exited (issue #1314).
-                if os.name == "nt":
-                    pid = getattr(process, "pid", None)
-                    if pid is not None:
-                        with contextlib.suppress(Exception):
-                            subprocess.run(
-                                ["wmic", "process", "where", f"(ParentProcessId={pid})", "delete"],
-                                capture_output=True,
-                                timeout=5,
-                            )
+                self._cleanup_windows_child_processes(process)
                 if (
                     not process_finished
                     and not process_terminated

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -567,7 +567,7 @@ class OpenCodeRuntime:
 
     # -- Process management ------------------------------------------------
 
-    def _cleanup_windows_child_processes(self, process: Any) -> None:
+    def _cleanup_windows_child_processes(self, process: Any) -> bool:
         """Best-effort cleanup for Windows children orphaned by Node CLIs.
 
         OpenCode may leave session-server children behind after the parent
@@ -576,10 +576,10 @@ class OpenCodeRuntime:
         after ``process.wait()`` has completed.
         """
         if os.name != "nt":
-            return
+            return True
         pid = getattr(process, "pid", None)
         if pid is None:
-            return
+            return True
         try:
             subprocess.run(
                 ["wmic", "process", "where", f"(ParentProcessId={pid})", "delete"],
@@ -587,12 +587,36 @@ class OpenCodeRuntime:
                 timeout=5,
                 check=False,
             )
+            return True
         except Exception as exc:
             log.warning(
                 f"{self._log_namespace}.windows_child_cleanup_failed",
                 pid=pid,
                 error=str(exc),
             )
+            return False
+
+    async def _collect_stderr_after_windows_cleanup(
+        self,
+        stderr_task: asyncio.Task[list[str]] | None,
+        *,
+        cleanup_succeeded: bool,
+    ) -> list[str]:
+        """Drain stderr, but do not hang forever after failed Windows cleanup.
+
+        Windows child cleanup is best-effort. If it fails while an orphaned
+        child still owns the inherited stderr pipe, waiting for EOF can block
+        normal result emission. In that failure mode, cancel the stderr drain
+        and let the caller return the best available result/error message.
+        """
+        if stderr_task is None:
+            return []
+        if cleanup_succeeded or stderr_task.done():
+            return await stderr_task
+        stderr_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await stderr_task
+        return []
 
     async def _terminate_process(self, process: Any) -> None:
         """Best-effort subprocess shutdown.
@@ -1126,6 +1150,7 @@ class OpenCodeRuntime:
         process_finished = False
         process_terminated = False
         windows_child_cleanup_done = False
+        windows_child_cleanup_succeeded = True
         control_state: dict[str, Any] | None = None
         stderr_task: asyncio.Task[list[str]] | None = None
 
@@ -1255,12 +1280,15 @@ class OpenCodeRuntime:
         except TimeoutError as e:
             if process is not None and control_state is not None:
                 await self._terminate_process(process)
-                self._cleanup_windows_child_processes(process)
+                windows_child_cleanup_succeeded = self._cleanup_windows_child_processes(process)
                 windows_child_cleanup_done = True
                 control_state["terminated"] = True
             process_terminated = True
             if stderr_task is not None:
-                stderr_lines = await stderr_task
+                stderr_lines = await self._collect_stderr_after_windows_cleanup(
+                    stderr_task,
+                    cleanup_succeeded=windows_child_cleanup_succeeded,
+                )
             final_message = "\n".join(stderr_lines).strip()
             if not final_message:
                 final_message = f"{self._display_name} became unresponsive and was terminated: {e}"
@@ -1290,9 +1318,12 @@ class OpenCodeRuntime:
                 process=process,
                 control_state=control_state,
             )
-            self._cleanup_windows_child_processes(process)
+            windows_child_cleanup_succeeded = self._cleanup_windows_child_processes(process)
             windows_child_cleanup_done = True
-            stderr_lines = await stderr_task
+            stderr_lines = await self._collect_stderr_after_windows_cleanup(
+                stderr_task,
+                cleanup_succeeded=windows_child_cleanup_succeeded,
+            )
 
             if yielded_final:
                 return

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -581,12 +581,20 @@ class OpenCodeRuntime:
         if pid is None:
             return True
         try:
-            subprocess.run(
+            result = subprocess.run(
                 ["wmic", "process", "where", f"(ParentProcessId={pid})", "delete"],
                 capture_output=True,
                 timeout=5,
                 check=False,
             )
+            returncode = getattr(result, "returncode", 0)
+            if isinstance(returncode, int) and returncode != 0:
+                log.warning(
+                    f"{self._log_namespace}.windows_child_cleanup_failed",
+                    pid=pid,
+                    returncode=returncode,
+                )
+                return False
             return True
         except Exception as exc:
             log.warning(

--- a/tests/unit/orchestrator/test_opencode_runtime.py
+++ b/tests/unit/orchestrator/test_opencode_runtime.py
@@ -1351,6 +1351,42 @@ class TestOpenCodeRuntimeExecuteTask:
         assert any(msg.type == "result" for msg in messages)
 
     @pytest.mark.asyncio
+    async def test_execute_task_windows_cleanup_failure_does_not_block_on_stderr(
+        self,
+    ) -> None:
+        text_event = json.dumps(
+            {
+                "type": "text",
+                "sessionID": "sess-windows-stderr-cleanup-fails",
+                "part": {"type": "text", "text": "Done"},
+            }
+        )
+        cleanup_started = asyncio.Event()
+        process = _FakeProcess(stdout_lines=[text_event], stderr_lines=[], returncode=0)
+        process.stderr = _WaitForCleanupStream(cleanup_started)
+        process.pid = 9753
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        def cleanup_children(*_args: object, **_kwargs: object) -> None:
+            cleanup_started.set()
+            raise TimeoutError("wmic hung")
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=process),
+            patch.object(opencode_runtime_module.os, "name", "nt"),
+            patch.object(opencode_runtime_module.subprocess, "run", side_effect=cleanup_children),
+            patch.object(opencode_runtime_module.log, "warning") as mock_warning,
+        ):
+            messages = await asyncio.wait_for(
+                _collect_async(runtime.execute_task("Hello")),
+                timeout=1,
+            )
+
+        assert cleanup_started.is_set()
+        assert any(msg.type == "result" for msg in messages)
+        assert mock_warning.call_args.args[0] == "opencode_runtime.windows_child_cleanup_failed"
+
+    @pytest.mark.asyncio
     async def test_execute_task_windows_child_cleanup_runs_after_aclose_termination(
         self,
     ) -> None:

--- a/tests/unit/orchestrator/test_opencode_runtime.py
+++ b/tests/unit/orchestrator/test_opencode_runtime.py
@@ -1300,6 +1300,43 @@ class TestOpenCodeRuntimeExecuteTask:
         )
 
     @pytest.mark.asyncio
+    async def test_execute_task_windows_child_cleanup_runs_after_aclose_termination(
+        self,
+    ) -> None:
+        text_event = json.dumps(
+            {
+                "type": "text",
+                "sessionID": "sess-windows-aclose",
+                "part": {"type": "text", "text": "Partial"},
+            }
+        )
+        process = _FakeProcess(stdout_lines=[text_event], stderr_lines=[], returncode=0)
+        process.pid = 2468
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        call_order: list[str] = []
+
+        async def terminate_process(proc: _FakeProcess) -> None:
+            call_order.append("terminate")
+            proc.terminate()
+
+        def cleanup_children(*_args: object, **_kwargs: object) -> None:
+            call_order.append("cleanup")
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=process),
+            patch.object(opencode_runtime_module.os, "name", "nt"),
+            patch.object(runtime, "_terminate_process", side_effect=terminate_process),
+            patch.object(opencode_runtime_module.subprocess, "run", side_effect=cleanup_children),
+        ):
+            stream = runtime.execute_task("Hello")
+            first_message = await stream.__anext__()
+            await stream.aclose()
+
+        assert first_message.type == "assistant"
+        assert process.terminated
+        assert call_order == ["terminate", "cleanup"]
+
+    @pytest.mark.asyncio
     async def test_execute_task_with_session_tracking(self) -> None:
         """Session ID from events is captured into the runtime handle."""
         text_event = json.dumps(

--- a/tests/unit/orchestrator/test_opencode_runtime.py
+++ b/tests/unit/orchestrator/test_opencode_runtime.py
@@ -6,6 +6,7 @@ import asyncio
 import inspect
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -1385,6 +1386,43 @@ class TestOpenCodeRuntimeExecuteTask:
         assert cleanup_started.is_set()
         assert any(msg.type == "result" for msg in messages)
         assert mock_warning.call_args.args[0] == "opencode_runtime.windows_child_cleanup_failed"
+
+    @pytest.mark.asyncio
+    async def test_execute_task_windows_cleanup_nonzero_exit_does_not_block_on_stderr(
+        self,
+    ) -> None:
+        text_event = json.dumps(
+            {
+                "type": "text",
+                "sessionID": "sess-windows-stderr-cleanup-nonzero",
+                "part": {"type": "text", "text": "Done"},
+            }
+        )
+        cleanup_started = asyncio.Event()
+        process = _FakeProcess(stdout_lines=[text_event], stderr_lines=[], returncode=0)
+        process.stderr = _WaitForCleanupStream(cleanup_started)
+        process.pid = 8642
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        def cleanup_children(*_args: object, **_kwargs: object) -> SimpleNamespace:
+            cleanup_started.set()
+            return SimpleNamespace(returncode=1)
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=process),
+            patch.object(opencode_runtime_module.os, "name", "nt"),
+            patch.object(opencode_runtime_module.subprocess, "run", side_effect=cleanup_children),
+            patch.object(opencode_runtime_module.log, "warning") as mock_warning,
+        ):
+            messages = await asyncio.wait_for(
+                _collect_async(runtime.execute_task("Hello")),
+                timeout=1,
+            )
+
+        assert cleanup_started.is_set()
+        assert any(msg.type == "result" for msg in messages)
+        assert mock_warning.call_args.args[0] == "opencode_runtime.windows_child_cleanup_failed"
+        assert mock_warning.call_args.kwargs["returncode"] == 1
 
     @pytest.mark.asyncio
     async def test_execute_task_windows_child_cleanup_runs_after_aclose_termination(

--- a/tests/unit/orchestrator/test_opencode_runtime.py
+++ b/tests/unit/orchestrator/test_opencode_runtime.py
@@ -1225,7 +1225,6 @@ class TestOpenCodeRuntimeExecuteTask:
         assert len(text_msgs) >= 1
         assert "Task completed" in text_msgs[0].content
 
-
     def test_windows_child_cleanup_invokes_wmic_for_parent_pid(self) -> None:
         runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
         process = _FakeProcess(stdout_lines=[], stderr_lines=[], returncode=0)
@@ -1262,7 +1261,9 @@ class TestOpenCodeRuntimeExecuteTask:
 
         with (
             patch.object(opencode_runtime_module.os, "name", "nt"),
-            patch.object(opencode_runtime_module.subprocess, "run", side_effect=TimeoutError("slow")),
+            patch.object(
+                opencode_runtime_module.subprocess, "run", side_effect=TimeoutError("slow")
+            ),
             patch.object(opencode_runtime_module.log, "warning") as mock_warning,
         ):
             runtime._cleanup_windows_child_processes(process)

--- a/tests/unit/orchestrator/test_opencode_runtime.py
+++ b/tests/unit/orchestrator/test_opencode_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import inspect
 import json
 from pathlib import Path
@@ -16,6 +17,10 @@ import ouroboros.orchestrator.opencode_runtime as opencode_runtime_module
 from ouroboros.orchestrator.opencode_runtime import OpenCodeRuntime
 from ouroboros.router import Resolved, ResolveRequest
 from ouroboros.router import resolve_skill_dispatch as shared_resolve_skill_dispatch
+
+
+async def _collect_async(iterator):
+    return [item async for item in iterator]
 
 
 class _FakeStream:
@@ -33,6 +38,19 @@ class _FakeStream:
         data = bytes(self._buffer[:n])
         del self._buffer[:n]
         return data
+
+
+class _WaitForCleanupStream:
+    def __init__(self, cleanup_started: asyncio.Event) -> None:
+        self._cleanup_started = cleanup_started
+        self._closed = False
+
+    async def read(self, _n: int = -1) -> bytes:
+        if self._closed:
+            return b""
+        await self._cleanup_started.wait()
+        self._closed = True
+        return b""
 
 
 class _FakeStdin:
@@ -1298,6 +1316,39 @@ class TestOpenCodeRuntimeExecuteTask:
             timeout=5,
             check=False,
         )
+
+    @pytest.mark.asyncio
+    async def test_execute_task_windows_child_cleanup_runs_before_success_stderr_drain(
+        self,
+    ) -> None:
+        text_event = json.dumps(
+            {
+                "type": "text",
+                "sessionID": "sess-windows-stderr-held",
+                "part": {"type": "text", "text": "Done"},
+            }
+        )
+        cleanup_started = asyncio.Event()
+        process = _FakeProcess(stdout_lines=[text_event], stderr_lines=[], returncode=0)
+        process.stderr = _WaitForCleanupStream(cleanup_started)
+        process.pid = 1357
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        def cleanup_children(*_args: object, **_kwargs: object) -> None:
+            cleanup_started.set()
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=process),
+            patch.object(opencode_runtime_module.os, "name", "nt"),
+            patch.object(opencode_runtime_module.subprocess, "run", side_effect=cleanup_children),
+        ):
+            messages = await asyncio.wait_for(
+                _collect_async(runtime.execute_task("Hello")),
+                timeout=1,
+            )
+
+        assert cleanup_started.is_set()
+        assert any(msg.type == "result" for msg in messages)
 
     @pytest.mark.asyncio
     async def test_execute_task_windows_child_cleanup_runs_after_aclose_termination(

--- a/tests/unit/orchestrator/test_opencode_runtime.py
+++ b/tests/unit/orchestrator/test_opencode_runtime.py
@@ -1225,6 +1225,79 @@ class TestOpenCodeRuntimeExecuteTask:
         assert len(text_msgs) >= 1
         assert "Task completed" in text_msgs[0].content
 
+
+    def test_windows_child_cleanup_invokes_wmic_for_parent_pid(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        process = _FakeProcess(stdout_lines=[], stderr_lines=[], returncode=0)
+        process.pid = 4242
+
+        with (
+            patch.object(opencode_runtime_module.os, "name", "nt"),
+            patch.object(opencode_runtime_module.subprocess, "run") as mock_run,
+        ):
+            runtime._cleanup_windows_child_processes(process)
+
+        mock_run.assert_called_once_with(
+            ["wmic", "process", "where", "(ParentProcessId=4242)", "delete"],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+
+    def test_windows_child_cleanup_skips_non_windows(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        process = _FakeProcess(stdout_lines=[], stderr_lines=[], returncode=0)
+
+        with (
+            patch.object(opencode_runtime_module.os, "name", "posix"),
+            patch.object(opencode_runtime_module.subprocess, "run") as mock_run,
+        ):
+            runtime._cleanup_windows_child_processes(process)
+
+        mock_run.assert_not_called()
+
+    def test_windows_child_cleanup_logs_failures(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+        process = _FakeProcess(stdout_lines=[], stderr_lines=[], returncode=0)
+
+        with (
+            patch.object(opencode_runtime_module.os, "name", "nt"),
+            patch.object(opencode_runtime_module.subprocess, "run", side_effect=TimeoutError("slow")),
+            patch.object(opencode_runtime_module.log, "warning") as mock_warning,
+        ):
+            runtime._cleanup_windows_child_processes(process)
+
+        mock_warning.assert_called_once()
+        assert mock_warning.call_args.args[0] == "opencode_runtime.windows_child_cleanup_failed"
+
+    @pytest.mark.asyncio
+    async def test_execute_task_windows_child_cleanup_runs_after_success(self) -> None:
+        text_event = json.dumps(
+            {
+                "type": "text",
+                "sessionID": "sess-windows-cleanup",
+                "part": {"type": "text", "text": "Done"},
+            }
+        )
+        process = _FakeProcess(stdout_lines=[text_event], stderr_lines=[], returncode=0)
+        process.pid = 6789
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        with (
+            patch("asyncio.create_subprocess_exec", return_value=process),
+            patch.object(opencode_runtime_module.os, "name", "nt"),
+            patch.object(opencode_runtime_module.subprocess, "run") as mock_run,
+        ):
+            messages = [msg async for msg in runtime.execute_task("Hello")]
+
+        assert any(msg.type == "result" for msg in messages)
+        mock_run.assert_called_once_with(
+            ["wmic", "process", "where", "(ParentProcessId=6789)", "delete"],
+            capture_output=True,
+            timeout=5,
+            check=False,
+        )
+
     @pytest.mark.asyncio
     async def test_execute_task_with_session_tracking(self) -> None:
         """Session ID from events is captured into the runtime handle."""


### PR DESCRIPTION
## Summary

Maintainer follow-up for #1314. The original PR branch lives on `kenlin-open/ouroboros`; although GitHub reports `maintainerCanModify=true`, this maintainer account has no push permission to that fork. This upstream branch carries the same #1314 implementation plus the review-blocker fixes.

## What changed after #1314 HEAD

- Extracted Windows child-process cleanup into a testable `_cleanup_windows_child_processes()` helper.
- Kept the cleanup Windows-only and PPID-scoped.
- Added a warning log when the best-effort cleanup command fails or times out.
- Added focused tests proving:
  - `wmic process where (ParentProcessId=PID) delete` is invoked on Windows;
  - non-Windows platforms do not invoke cleanup;
  - failures are logged instead of silently swallowed;
  - normal successful `execute_task()` teardown still runs the Windows child cleanup path.

## Alignment

This remains aligned with #961 and the current `ooo auto` direction because it is a narrow runtime-boundary durability fix. It does not change AgentOS persistence, replay, verifier, or Track C contracts.

## Verification

- `uv run pytest tests/unit/orchestrator/test_opencode_runtime.py -q` → 61 passed
- `uv run ruff check src/ouroboros/orchestrator/opencode_runtime.py tests/unit/orchestrator/test_opencode_runtime.py` → passed

## Notes

If the original contributor branch becomes writable, this commit can be cherry-picked back onto #1314. Otherwise this PR can serve as the mergeable maintainer-owned replacement.
