### PR TITLE
fix(pi): report malformed runtime events

### DIFF
--- a/src/ouroboros/orchestrator/pi_runtime.py
+++ b/src/ouroboros/orchestrator/pi_runtime.py
@@ -262,6 +262,12 @@ class PiRuntime:
             return None
         return event if isinstance(event, dict) else None
 
+    def _malformed_event_message(self, line: str) -> str:
+        preview = line.strip()
+        if len(preview) > 240:
+            preview = f"{preview[:237]}..."
+        return f"Malformed {self._display_name} JSON event: {preview}"
+
     def _extract_session_id(self, event: dict[str, Any]) -> str | None:
         """Extract session ID from the pi session header event."""
         if event.get("type") == "session":
@@ -504,7 +510,19 @@ class PiRuntime:
                         continue
                     event = self._parse_event(line)
                     if event is None:
-                        continue
+                        if process is not None:
+                            await self._terminate_process(process)
+                        process_terminated = True
+                        yield AgentMessage(
+                            type="result",
+                            content=self._malformed_event_message(line),
+                            data={
+                                "subtype": "error",
+                                "error_type": "MalformedPiEvent",
+                            },
+                            resume_handle=current_handle,
+                        )
+                        return
 
                     # Session header — extract ID
                     sid = self._extract_session_id(event)

--- a/tests/unit/orchestrator/test_pi_runtime.py
+++ b/tests/unit/orchestrator/test_pi_runtime.py
@@ -257,6 +257,50 @@ async def test_agent_end_does_not_mask_nonzero_exit() -> None:
     assert result.data["error_type"] == "PiError"
 
 
+
+@pytest.mark.asyncio
+async def test_execute_task_reports_malformed_json_event() -> None:
+    process = _FakeProcess(
+        stdout_lines=[
+            _jsonl_event({"type": "session", "id": "session-1"}),
+            "not-json",
+        ],
+        stderr_lines=[],
+        returncode=0,
+    )
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+
+    with patch("asyncio.create_subprocess_exec", return_value=process):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    result = [m for m in messages if m.type == "result"][-1]
+    assert result.is_error
+    assert result.content == "Malformed Pi JSON event: not-json"
+    assert result.data == {
+        "subtype": "error",
+        "error_type": "MalformedPiEvent",
+    }
+    assert result.resume_handle is not None
+    assert result.resume_handle.native_session_id == "session-1"
+    assert process.terminated
+
+
+@pytest.mark.asyncio
+async def test_execute_task_to_result_maps_malformed_event_to_provider_error() -> None:
+    process = _FakeProcess(stdout_lines=["[bad-json]"], stderr_lines=[], returncode=0)
+    runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+
+    with patch("asyncio.create_subprocess_exec", return_value=process):
+        result = await runtime.execute_task_to_result("Do it")
+
+    assert result.is_err
+    error = result.error
+    assert error is not None
+    assert error.provider == "pi"
+    assert error.message == "Malformed Pi JSON event: [bad-json]"
+    assert error.details == {"messages": ["Malformed Pi JSON event: [bad-json]"]}
+    assert process.terminated
+
 def test_runtime_factory_constructs_pi_runtime() -> None:
     from ouroboros.orchestrator.runtime_factory import create_agent_runtime
 

--- a/tests/unit/orchestrator/test_pi_runtime.py
+++ b/tests/unit/orchestrator/test_pi_runtime.py
@@ -257,7 +257,6 @@ async def test_agent_end_does_not_mask_nonzero_exit() -> None:
     assert result.data["error_type"] == "PiError"
 
 
-
 @pytest.mark.asyncio
 async def test_execute_task_reports_malformed_json_event() -> None:
     process = _FakeProcess(
@@ -300,6 +299,7 @@ async def test_execute_task_to_result_maps_malformed_event_to_provider_error() -
     assert error.message == "Malformed Pi JSON event: [bad-json]"
     assert error.details == {"messages": ["Malformed Pi JSON event: [bad-json]"]}
     assert process.terminated
+
 
 def test_runtime_factory_constructs_pi_runtime() -> None:
     from ouroboros.orchestrator.runtime_factory import create_agent_runtime


### PR DESCRIPTION
## Summary

- Treat malformed Pi JSONL output as a terminal runtime error instead of silently skipping it.
- Preserve any session handle already discovered before the malformed event.
- Cover both streaming `execute_task()` and `execute_task_to_result()` error mapping.

## Test plan

- `uv run pytest tests/unit/orchestrator/test_pi_runtime.py`
- `uv run ruff check src/ouroboros/orchestrator/pi_runtime.py tests/unit/orchestrator/test_pi_runtime.py`

Refs #1310
