### PR TITLE
fix(evaluation): exclude local artifacts from collection

### DIFF
--- a/src/ouroboros/evaluation/artifact_collector.py
+++ b/src/ouroboros/evaluation/artifact_collector.py
@@ -89,6 +89,25 @@ _SKIP_DIRS: frozenset[str] = frozenset(
         ".tox",
         "coverage",
         ".nyc_output",
+        "docs",
+        "examples",
+        "fixtures",
+        "output",
+        "test",
+        "tests",
+    }
+)
+
+# Explicit development/evaluation configuration files are useful for local
+# setup, but they are not production source evidence and may contain
+# workstation-specific bridge paths.
+_SKIP_FILENAMES: frozenset[str] = frozenset(
+    {
+        ".ouroboros_eval_artifact.md",
+        "config.yaml",
+        "config.yml",
+        "mcp.yaml",
+        "mcp.yml",
     }
 )
 
@@ -166,6 +185,11 @@ def _is_sensitive_file(fname: str) -> bool:
         return True
     # Catch unlisted dotenv variants (e.g. .env.ci, .env.foo).
     return lowered.startswith(".env.")
+
+
+def _is_skipped_source_file(fname: str) -> bool:
+    """Return True when ``fname`` is not production source evidence."""
+    return fname.lower() in _SKIP_FILENAMES
 
 
 class ArtifactCollector:
@@ -302,6 +326,8 @@ class ArtifactCollector:
             for fname in files:
                 ext = os.path.splitext(fname)[1].lower()
                 if ext in _SKIP_EXTENSIONS:
+                    continue
+                if _is_skipped_source_file(fname):
                     continue
                 if _is_sensitive_file(fname):
                     continue

--- a/tests/unit/test_artifact_collector.py
+++ b/tests/unit/test_artifact_collector.py
@@ -72,6 +72,32 @@ class TestArtifactCollector:
         assert len(bundle.files) >= 1
         assert bundle.text_summary == output
 
+    def test_directory_scan_collects_production_adapter_sources_only(self) -> None:
+        tmpdir = self._create_project(
+            {
+                "src/ouroboros/orchestrator/pi_runtime.py": "class PiRuntime:\n    pass\n",
+                "src/ouroboros/orchestrator/runtime_factory.py": "def create_agent_runtime():\n    pass\n",
+                "tests/unit/orchestrator/test_pi_runtime.py": "def test_pi_runtime():\n    pass\n",
+                "tests/fixtures/pi_bridge_fixture.py": "print('fixture bridge')\n",
+                "docs/pi-runtime.md": "# pi runtime docs\n",
+                ".ouroboros_eval_artifact.md": "temporary evaluation artifact\n",
+                "config.yaml": "pi_bridge_command: /Users/jaegyu.lee/Project/pi/bridge\n",
+            }
+        )
+
+        collector = ArtifactCollector()
+        bundle = collector.collect("No file operations here.", project_dir=tmpdir)
+        real_tmpdir = os.path.realpath(tmpdir)
+        relative_paths = {os.path.relpath(file.file_path, real_tmpdir) for file in bundle.files}
+
+        assert "src/ouroboros/orchestrator/pi_runtime.py" in relative_paths
+        assert "src/ouroboros/orchestrator/runtime_factory.py" in relative_paths
+        assert "tests/unit/orchestrator/test_pi_runtime.py" not in relative_paths
+        assert "tests/fixtures/pi_bridge_fixture.py" not in relative_paths
+        assert "docs/pi-runtime.md" not in relative_paths
+        assert ".ouroboros_eval_artifact.md" not in relative_paths
+        assert "config.yaml" not in relative_paths
+
     def test_total_chars_tracked(self) -> None:
         tmpdir = self._create_project(
             {


### PR DESCRIPTION
## Summary

- Prevents fallback artifact scans from collecting development-only files and local execution artifacts.
- Keeps semantic evaluation evidence focused on production source files.
- Adds a regression covering Pi adapter source files beside ignored tests, fixtures, docs, output, and local config artifacts.

## Changes

- Add skipped directory names for broad fallback scans: `docs`, `examples`, `fixtures`, `output`, `test`, and `tests`.
- Add explicit skipped filenames for local/evaluation config artifacts such as `.ouroboros_eval_artifact.md`, `config.yaml`, and `mcp.yaml`.
- Cover the behavior in `tests/unit/test_artifact_collector.py`.

## Notes

This is independent from #1326/#1327 and can merge directly to `main`.

Verification:
- `uv run pytest tests/unit/test_artifact_collector.py -q`
- `uv run ruff check src/ouroboros/evaluation/artifact_collector.py tests/unit/test_artifact_collector.py`
- `uv run ruff format --check src/ouroboros/evaluation/artifact_collector.py tests/unit/test_artifact_collector.py`