### PR TITLE
feat(harness): promote TraceGuard verdict admission

### DIFF
--- a/docs/agentos/traceguard-vs-legacy-benchmark.md
+++ b/docs/agentos/traceguard-vs-legacy-benchmark.md
@@ -74,9 +74,19 @@ Fat-harness baseline report — profile=traceguard_plus_claim_term_guard_fixture
 - Claim-term guard semantic-miss incidents per 100 ACs: -12.5000
 - Claim-term guard median chars ratio: 1.4054
 
+## H1 retry admission
+
+| Fixture | Accepted | Failure class | Retry admission | Evidence refs |
+| --- | --- | --- | --- | ---: |
+| fixture:h1/traceguard/accepted | true |  | ACCEPT | 1 |
+| fixture:h1/traceguard/missing-evidence | false | EVIDENCE_MISSING | RETRY | 0 |
+| fixture:h1/claim-term/semantic-miss | false | SCOPE_CREEP | REDISPATCH | 1 |
+| fixture:h1/traceguard/repeated-fabrication | false | FABRICATION_SUSPECTED | ESCALATE_MODEL | 0 |
+
 ## Gate interpretation
 
 - TraceGuard reduces fixture fabrication incidents to 0 per 100 ACs.
 - The deterministic claim-term guard rejects the fixture semantic miss without reintroducing fabrication.
 - One-shot pass rate drops because unsupported legacy self-reports are rejected instead of counted as accepted.
 - Median chars stay within the <= 1.5x C.4 budget guardrail.
+- H1 admission is typed for accepted, retryable, redispatch, and model-escalation verdicts.

--- a/docs/rfc/verdict-envelope-v1.md
+++ b/docs/rfc/verdict-envelope-v1.md
@@ -1,0 +1,96 @@
+# Verdict Envelope v1
+
+Issue: #814
+
+Status: schema-first design RFC. This document fixes the multi-persona verdict
+output shape before subsystem adoption.
+
+## Problem
+
+Ouroboros already has a dispatch-side `_subagent` / `_subagents` envelope, but
+the result side is fragmented:
+
+- `ConsensusResult` in `src/ouroboros/evaluation/models.py` stores votes,
+  approval, majority ratio, and disagreements.
+- Stage 3 events in `src/ouroboros/events/evaluation.py` emit `approved`,
+  `votes`, `majority_ratio`, `disagreements`, and count fields.
+- MCP-facing tools in `src/ouroboros/mcp/tools/definitions.py` return
+  tool-specific text/meta shapes.
+
+That fragmentation makes callers infer verdict semantics from prose or
+subsystem-specific fields. The output contract should instead expose one typed
+envelope.
+
+## Schema
+
+The canonical envelope is JSON-serializable and may be represented by Pydantic
+or dataclass models in implementation PRs.
+
+```json
+{
+  "schema_version": "verdict_envelope.v1",
+  "verdict": "string or null",
+  "status": "PASS | FAIL | BLOCKED | DEFERRED",
+  "members": ["hacker", "architect"],
+  "dissent": [
+    {
+      "persona_a": "hacker",
+      "persona_b": "architect",
+      "topic": "scope risk",
+      "summary": "short disagreement summary"
+    }
+  ],
+  "evidence_used": ["evt_123", "artifact_456"],
+  "transcript_ref": "evt_transcript_789",
+  "follow_up_issue_refs": ["#1306"],
+  "metadata": {
+    "source": "evaluation.stage3"
+  }
+}
+```
+
+Field rules:
+
+- `schema_version` is required and must be `verdict_envelope.v1`.
+- `verdict` is a one-line synthesized conclusion, or `null` when synthesis is
+  deliberately deferred to the user.
+- `status` is required. `DEFERRED` is the default for user-owned decisions such
+  as lateral multi-persona debate.
+- `members` is the ordered set of participating personas/models/roles.
+- `dissent` is optional and contains pairwise or topic-level disagreement.
+- `evidence_used` contains stable event IDs, artifact IDs, fact IDs, or handles
+  that substantiate the verdict.
+- `transcript_ref` is optional until #819 provides durable transcript storage.
+- `follow_up_issue_refs` lists implementation issues opened from this design.
+- `metadata` is for subsystem-specific values that must not define verdict
+  semantics.
+
+## Migration Map
+
+| Existing shape | Envelope mapping | Gap |
+| --- | --- | --- |
+| `ConsensusResult.approved` | `status=PASS` when true, `status=FAIL` when false | No explicit deferred state. |
+| `ConsensusResult.disagreements` | `dissent[].summary` | Lacks structured persona pairs/topics. |
+| `ConsensusResult.votes[].model` | `members[]` | Models are not always personas. |
+| Stage 3 `approved` event field | `status` | Event has no `schema_version`. |
+| Stage 3 `votes` event field | `members` plus `metadata.votes` | Vote details remain subsystem metadata. |
+| Stage 3 `disagreements` event field | `dissent` | Needs structured dissent records. |
+| MCP tool text outputs | `verdict` plus `metadata.rendered_text` | Text must stop being the semantic source of truth. |
+| MCP tool meta outputs | `metadata` | Existing meta can be preserved under namespaced keys. |
+
+## Follow-up Implementation Issues
+
+- #814 follow-up A: add a shared `VerdictEnvelopeV1` model and JSON schema.
+- #814 follow-up B: adapt `ConsensusResult` / deliberative evaluation outputs
+  to expose `VerdictEnvelopeV1`.
+- #814 follow-up C: emit `verdict_envelope` from Stage 3 evaluation events.
+- #814 follow-up D: add MCP tool result metadata for `verdict_envelope` while
+  preserving current rendered text for compatibility.
+- #1306: use typed verifier output and retry admission for TraceGuard-backed H1
+  deliver verdicts.
+
+## Non-goals
+
+- Do not require every user-facing response to auto-synthesize a verdict.
+- Do not replace subsystem-specific detailed result models.
+- Do not make transcript storage mandatory before #819.

--- a/src/ouroboros/harness/deliver_routing.py
+++ b/src/ouroboros/harness/deliver_routing.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 
 from ouroboros.harness.deliver_gate import DeliverGateVerdict
 from ouroboros.orchestrator.failure_taxonomy import RecoveryAction
+from ouroboros.orchestrator.verifier import RetryAdmission, VerifierStatus, VerifierVerdict
 
 
 @dataclass(frozen=True, slots=True)
@@ -133,11 +134,89 @@ def route_deliver_gate_verdict(
     )
 
 
+def deliver_gate_verifier_verdict(
+    verdict: DeliverGateVerdict,
+    *,
+    rejection_count: int = 1,
+    model_escalation_threshold: int = 2,
+) -> VerifierVerdict:
+    """Promote a TraceGuard deliver verdict into the H1 verifier contract.
+
+    This is the #1306 behavior-change bridge: callers can pass the returned
+    ``VerifierVerdict`` through the existing H1 acceptance boundary instead of
+    treating ``DeliverGateVerdict`` as read-only observation.
+    """
+    route = route_deliver_gate_verdict(
+        verdict,
+        rejection_count=rejection_count,
+        model_escalation_threshold=model_escalation_threshold,
+    )
+    if route.accepted:
+        return VerifierVerdict(
+            passed=True,
+            status=VerifierStatus.PASS,
+            evidence_used=verdict.evidence_event_ids,
+            retry_admission=RetryAdmission.ACCEPT,
+        )
+
+    failure_class = _failure_class_for_route(route)
+    status = VerifierStatus.BLOCKED if failure_class == "BLOCKED" else VerifierStatus.FAIL
+    return VerifierVerdict(
+        passed=False,
+        reasons=(
+            f"{route.reason}: " + "; ".join(route.source_reasons)
+            if route.source_reasons
+            else route.reason,
+        ),
+        failure_class=failure_class,
+        status=status,
+        evidence_used=verdict.evidence_event_ids,
+        retry_admission=_retry_admission_for_route(route),
+    )
+
+
+def _retry_admission_for_route(route: DeliverGateRoute) -> RetryAdmission:
+    if route.action is RecoveryAction.RETRY:
+        return RetryAdmission.RETRY
+    if route.action is RecoveryAction.REDISPATCH:
+        return RetryAdmission.REDISPATCH
+    if route.action is RecoveryAction.ESCALATE_MODEL:
+        return RetryAdmission.ESCALATE_MODEL
+    if route.action is RecoveryAction.ESCALATE_HUMAN:
+        return RetryAdmission.ESCALATE_HUMAN
+    return RetryAdmission.BLOCK
+
+
+def _failure_class_for_route(route: DeliverGateRoute) -> str:
+    reason_codes = tuple(_reason_code(reason) for reason in route.source_reasons)
+    if route.action is RecoveryAction.ESCALATE_HUMAN:
+        return "BLOCKED"
+    if any(reason in _RETRY_REASONS for reason in reason_codes):
+        return "EVIDENCE_MISSING"
+    if any(reason == "semantic_miss" for reason in reason_codes):
+        return "SCOPE_CREEP"
+    if any(
+        reason in {"evidence_handle_mismatch", "chunk_handle_without_fact"}
+        for reason in reason_codes
+    ):
+        return "EVIDENCE_FORM_MISMATCH"
+    if any(
+        reason in {"unsupported_fact_id", "malformed_evidence_claim"} for reason in reason_codes
+    ):
+        return "FABRICATION_SUSPECTED"
+    if route.action is RecoveryAction.ESCALATE_MODEL:
+        return "FABRICATION_SUSPECTED"
+    if route.action is RecoveryAction.REDISPATCH:
+        return "STALL"
+    return "BLOCKED"
+
+
 def _reason_code(reason: str) -> str:
     return reason.split(":", maxsplit=1)[0].strip()
 
 
 __all__ = [
     "DeliverGateRoute",
+    "deliver_gate_verifier_verdict",
     "route_deliver_gate_verdict",
 ]

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -5634,6 +5634,17 @@ Files present:
                     verifier_failure_class=(
                         verifier_verdict.failure_class if verifier_verdict is not None else None
                     ),
+                    verifier_status=(
+                        verifier_verdict.status.value if verifier_verdict is not None else None
+                    ),
+                    retry_admission=(
+                        verifier_verdict.retry_admission.value
+                        if verifier_verdict is not None
+                        else None
+                    ),
+                    verifier_evidence_used=(
+                        list(verifier_verdict.evidence_used) if verifier_verdict is not None else []
+                    ),
                 )
                 result_final_message = (
                     f"{fat_harness_error}\n\nRuntime final message:\n{final_message}"
@@ -6036,6 +6047,9 @@ Files present:
         if verifier_verdict is not None:
             data["verifier_reasons"] = list(verifier_verdict.reasons)
             data["verifier_failure_class"] = verifier_verdict.failure_class
+            data["verifier_status"] = verifier_verdict.status.value
+            data["retry_admission"] = verifier_verdict.retry_admission.value
+            data["verifier_evidence_used"] = list(verifier_verdict.evidence_used)
         if typed_evidence is not None:
             data["typed_evidence_fields"] = sorted(typed_evidence.data)
             data["ignored_out_of_scope_evidence_fields"] = list(

--- a/src/ouroboros/orchestrator/traceguard_benchmark_capture.py
+++ b/src/ouroboros/orchestrator/traceguard_benchmark_capture.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from ouroboros.harness.deliver_gate import DeliverGateVerdict
+from ouroboros.harness.deliver_routing import deliver_gate_verifier_verdict
 from ouroboros.orchestrator.baseline_metrics import (
     DEFAULT_MAX_RETRIES,
     FatHarnessMetricsReport,
@@ -26,6 +28,26 @@ from ouroboros.orchestrator.baseline_metrics_format import render_baseline_repor
 BENCHMARK_PROFILE_LEGACY = "legacy_self_report_fixture"
 BENCHMARK_PROFILE_TRACEGUARD = "traceguard_deliver_gate_fixture"
 BENCHMARK_PROFILE_TRACEGUARD_CLAIM_TERM_GUARD = "traceguard_plus_claim_term_guard_fixture"
+
+
+@dataclass(frozen=True)
+class H1RetryAdmissionFixtureRow:
+    """Recorded H1 admission outcome for a deliver-gate verdict fixture."""
+
+    fixture: str
+    accepted: bool
+    failure_class: str | None
+    retry_admission: str
+    evidence_used_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "fixture": self.fixture,
+            "accepted": self.accepted,
+            "failure_class": self.failure_class,
+            "retry_admission": self.retry_admission,
+            "evidence_used_count": self.evidence_used_count,
+        }
 
 
 LEGACY_SELF_REPORT_ROWS: tuple[BaselineMetricFixtureRow, ...] = (
@@ -118,6 +140,7 @@ class TraceGuardBenchmarkCapture:
     legacy_rows: tuple[BaselineMetricFixtureRow, ...]
     traceguard_rows: tuple[BaselineMetricFixtureRow, ...]
     claim_term_guard_rows: tuple[BaselineMetricFixtureRow, ...]
+    h1_retry_admission_rows: tuple[H1RetryAdmissionFixtureRow, ...]
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -132,6 +155,14 @@ class TraceGuardBenchmarkCapture:
             "claim_term_guard": {
                 "report": self.claim_term_guard_report.to_dict(),
                 "rows": [row.to_dict() for row in self.claim_term_guard_rows],
+            },
+            "h1_retry_admission": {
+                "rows": [row.to_dict() for row in self.h1_retry_admission_rows],
+                "all_typed": all(row.retry_admission for row in self.h1_retry_admission_rows),
+                "accepted_count": sum(1 for row in self.h1_retry_admission_rows if row.accepted),
+                "routed_count": sum(
+                    1 for row in self.h1_retry_admission_rows if row.retry_admission != "ACCEPT"
+                ),
             },
             "delta": {
                 "fabrication_incidents_per_100_acs": (
@@ -182,6 +213,7 @@ def build_traceguard_benchmark_capture() -> TraceGuardBenchmarkCapture:
         legacy_rows=LEGACY_SELF_REPORT_ROWS,
         traceguard_rows=traceguard_rows,
         claim_term_guard_rows=claim_term_guard_rows,
+        h1_retry_admission_rows=_h1_retry_admission_rows(),
     )
 
 
@@ -212,12 +244,66 @@ def _claim_term_guard_rows(
     return tuple(guarded)
 
 
+def _h1_retry_admission_rows() -> tuple[H1RetryAdmissionFixtureRow, ...]:
+    fixtures = {
+        "fixture:h1/traceguard/accepted": DeliverGateVerdict(
+            ac_id="AC-1",
+            accepted=True,
+            unsupported_claim_rate=0.0,
+            accepted_fact_ids=("fact_1",),
+            evidence_event_ids=("evt_accept",),
+        ),
+        "fixture:h1/traceguard/missing-evidence": DeliverGateVerdict(
+            ac_id="AC-2",
+            accepted=False,
+            unsupported_claim_rate=1.0,
+            rejected_fact_ids=("fact_missing",),
+            rejected_reasons=("missing_evidence_handle: ev_missing is not present in manifest",),
+        ),
+        "fixture:h1/claim-term/semantic-miss": DeliverGateVerdict(
+            ac_id="AC-3",
+            accepted=False,
+            unsupported_claim_rate=1.0,
+            rejected_fact_ids=("fact_semantic",),
+            rejected_reasons=("semantic_miss: evidence text lacks behavior=admin_delete_denied",),
+            evidence_event_ids=("evt_semantic",),
+        ),
+        "fixture:h1/traceguard/repeated-fabrication": DeliverGateVerdict(
+            ac_id="AC-4",
+            accepted=False,
+            unsupported_claim_rate=1.0,
+            rejected_fact_ids=("fact_fake",),
+            rejected_reasons=("unsupported_fact_id: fact_fake is not present",),
+        ),
+    }
+    rows: list[H1RetryAdmissionFixtureRow] = []
+    for fixture, verdict in fixtures.items():
+        rejection_count = 2 if fixture.endswith("repeated-fabrication") else 1
+        verifier_verdict = deliver_gate_verifier_verdict(
+            verdict,
+            rejection_count=rejection_count,
+            model_escalation_threshold=2,
+        )
+        rows.append(
+            H1RetryAdmissionFixtureRow(
+                fixture=fixture,
+                accepted=verifier_verdict.passed,
+                failure_class=verifier_verdict.failure_class,
+                retry_admission=verifier_verdict.retry_admission.value,
+                evidence_used_count=len(verifier_verdict.evidence_used),
+            )
+        )
+    return tuple(rows)
+
+
 def render_traceguard_benchmark_markdown(
     capture: TraceGuardBenchmarkCapture | None = None,
 ) -> str:
     """Render the benchmark artifact for maintainer review."""
     capture = build_traceguard_benchmark_capture() if capture is None else capture
-    data = capture.to_dict()["delta"]
+    capture_data = capture.to_dict()
+    data = capture_data["delta"]
+    h1_rows = capture_data["h1_retry_admission"]["rows"]
     lines = [
         "# #978 P4 TraceGuard vs legacy baseline benchmark",
         "",
@@ -251,12 +337,29 @@ def render_traceguard_benchmark_markdown(
         f"{data['claim_term_guard_semantic_miss_incidents_per_100_acs']:.4f}",
         f"- Claim-term guard median chars ratio: {data['claim_term_guard_median_chars_ratio']:.4f}",
         "",
+        "## H1 retry admission",
+        "",
+        "| Fixture | Accepted | Failure class | Retry admission | Evidence refs |",
+        "| --- | --- | --- | --- | ---: |",
+        *(
+            "| {fixture} | {accepted} | {failure_class} | {retry_admission} | "
+            "{evidence_used_count} |".format(
+                fixture=row["fixture"],
+                accepted=str(row["accepted"]).lower(),
+                failure_class=row["failure_class"] or "",
+                retry_admission=row["retry_admission"],
+                evidence_used_count=row["evidence_used_count"],
+            )
+            for row in h1_rows
+        ),
+        "",
         "## Gate interpretation",
         "",
         "- TraceGuard reduces fixture fabrication incidents to 0 per 100 ACs.",
         "- The deterministic claim-term guard rejects the fixture semantic miss without reintroducing fabrication.",
         "- One-shot pass rate drops because unsupported legacy self-reports are rejected instead of counted as accepted.",
         "- Median chars stay within the <= 1.5x C.4 budget guardrail.",
+        "- H1 admission is typed for accepted, retryable, redispatch, and model-escalation verdicts.",
     ]
     return "\n".join(lines) + "\n"
 
@@ -274,6 +377,7 @@ __all__ = [
     "BENCHMARK_PROFILE_TRACEGUARD",
     "BENCHMARK_PROFILE_TRACEGUARD_CLAIM_TERM_GUARD",
     "LEGACY_SELF_REPORT_ROWS",
+    "H1RetryAdmissionFixtureRow",
     "TraceGuardBenchmarkCapture",
     "build_traceguard_benchmark_capture",
     "render_traceguard_benchmark_markdown",

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -296,6 +296,7 @@ def verifier_operational_failure_verdict(exc: BaseException) -> VerifierVerdict:
             passed=False,
             reasons=(f"verifier raised {type(exc).__name__}: {exc}",),
             failure_class="STALL",
+            retry_admission=RetryAdmission.RETRY,
         )
     raise exc
 
@@ -520,6 +521,11 @@ def run_with_verifier(
         if attempt.accepted:
             return LoopResult(accepted=True, attempts=tuple(attempts))
         if attempt.blocked:
+            return LoopResult(accepted=False, attempts=tuple(attempts))
+        if (
+            attempt.verdict is not None
+            and attempt.verdict.retry_admission is not RetryAdmission.RETRY
+        ):
             return LoopResult(accepted=False, attempts=tuple(attempts))
 
         feedback = _failure_reasons(attempt)

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -21,9 +21,11 @@ Loop semantics:
        BLOCKED without verifier invocation. Other validation failures
        short-circuit the verifier and retry (the leaf would never satisfy
        the contract even if the verifier said PASS).
-    4. Otherwise the verifier is invoked. PASS → return. FAIL → retry,
-       feeding the verdict reasons back to the executor.
-    5. After `max_retries` exhausted FAILs, return the last attempt with
+    4. Otherwise the verifier is invoked. PASS → return. FAIL with
+       retry_admission=RETRY → retry, feeding the verdict reasons back to the
+       executor. Other retry admissions return immediately so the caller can
+       redispatch, escalate, or block without burning the same-leaf retry budget.
+    5. After `max_retries` exhausted retryable FAILs, return the last attempt with
        accepted=False so the outer orchestrator can escalate.
 
 The retry budget defaults to K=2 per shaun0927's H1 sketch in #830.
@@ -261,7 +263,9 @@ def _default_retry_admission_for_failure_class(
         return RetryAdmission.REDISPATCH
     if failure_class == "BLOCKED":
         return RetryAdmission.BLOCK
-    return RetryAdmission.RETRY
+    if failure_class in {"EVIDENCE_MISSING", "EVIDENCE_FORM_MISMATCH"}:
+        return RetryAdmission.RETRY
+    return RetryAdmission.REDISPATCH
 
 
 class Verifier(Protocol):

--- a/src/ouroboros/orchestrator/verifier.py
+++ b/src/ouroboros/orchestrator/verifier.py
@@ -32,6 +32,7 @@ The retry budget defaults to K=2 per shaun0927's H1 sketch in #830.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import StrEnum
 import subprocess
 from typing import Protocol
 
@@ -94,6 +95,25 @@ _VALID_FAILURE_CLASSES: frozenset[str] = frozenset(
 )
 
 
+class VerifierStatus(StrEnum):
+    """Machine-readable verifier outcome for H1 retry admission."""
+
+    PASS = "PASS"
+    FAIL = "FAIL"
+    BLOCKED = "BLOCKED"
+
+
+class RetryAdmission(StrEnum):
+    """Harness-owned next-action admission after a verifier verdict."""
+
+    ACCEPT = "ACCEPT"
+    RETRY = "RETRY"
+    REDISPATCH = "REDISPATCH"
+    ESCALATE_MODEL = "ESCALATE_MODEL"
+    ESCALATE_HUMAN = "ESCALATE_HUMAN"
+    BLOCK = "BLOCK"
+
+
 @dataclass(frozen=True)
 class VerifierVerdict:
     """Outcome of a single verifier pass.
@@ -109,13 +129,31 @@ class VerifierVerdict:
             "EVIDENCE_MISSING", "EVIDENCE_FORM_MISMATCH",
             "FABRICATION_SUSPECTED", "SCOPE_CREEP", "STALL",
             "BLOCKED", or None for an unclassified failure.
+        status: Typed verifier status. Defaults from ``passed`` and
+            ``failure_class`` for backward compatibility.
+        evidence_used: Stable evidence refs used by the verifier.
+        retry_admission: Machine-readable next-action admission. Defaults to
+            ACCEPT for passes and the H7 recovery policy for failures.
     """
 
     passed: bool
     reasons: tuple[str, ...] = ()
     failure_class: str | None = None
+    status: VerifierStatus | str | None = None
+    evidence_used: tuple[str, ...] = ()
+    retry_admission: RetryAdmission | str | None = None
 
     def __post_init__(self) -> None:
+        status = _normalize_verifier_status(
+            self.status,
+            passed=self.passed,
+            failure_class=self.failure_class,
+        )
+        retry_admission = _normalize_retry_admission(
+            self.retry_admission,
+            passed=self.passed,
+            failure_class=self.failure_class,
+        )
         if self.passed and self.reasons:
             msg = "VerifierVerdict(passed=True) must not carry reasons"
             raise VerifierContractError(msg)
@@ -144,6 +182,86 @@ class VerifierVerdict:
                 f"not a recognized taxonomy value. Valid: {valid}, or None."
             )
             raise VerifierContractError(msg)
+        if self.passed and status is not VerifierStatus.PASS:
+            msg = "VerifierVerdict(passed=True) must have status PASS"
+            raise VerifierContractError(msg)
+        if self.passed and retry_admission is not RetryAdmission.ACCEPT:
+            msg = "VerifierVerdict(passed=True) must have retry_admission ACCEPT"
+            raise VerifierContractError(msg)
+        if not self.passed and status is VerifierStatus.PASS:
+            msg = "VerifierVerdict(passed=False) cannot have status PASS"
+            raise VerifierContractError(msg)
+        if not self.passed and retry_admission is RetryAdmission.ACCEPT:
+            msg = "VerifierVerdict(passed=False) cannot have retry_admission ACCEPT"
+            raise VerifierContractError(msg)
+        object.__setattr__(self, "status", status)
+        object.__setattr__(self, "retry_admission", retry_admission)
+        object.__setattr__(self, "evidence_used", _normalize_evidence_used(self.evidence_used))
+
+
+def _normalize_verifier_status(
+    status: VerifierStatus | str | None,
+    *,
+    passed: bool,
+    failure_class: str | None,
+) -> VerifierStatus:
+    if status is None:
+        return (
+            VerifierStatus.PASS
+            if passed
+            else (VerifierStatus.BLOCKED if failure_class == "BLOCKED" else VerifierStatus.FAIL)
+        )
+    try:
+        return VerifierStatus(status)
+    except ValueError as exc:
+        valid = ", ".join(item.value for item in VerifierStatus)
+        msg = f"VerifierVerdict.status={status!r} is not valid. Valid: {valid}."
+        raise VerifierContractError(msg) from exc
+
+
+def _normalize_retry_admission(
+    retry_admission: RetryAdmission | str | None,
+    *,
+    passed: bool,
+    failure_class: str | None,
+) -> RetryAdmission:
+    if retry_admission is None:
+        if passed:
+            return RetryAdmission.ACCEPT
+        return _default_retry_admission_for_failure_class(failure_class)
+    try:
+        return RetryAdmission(retry_admission)
+    except ValueError as exc:
+        valid = ", ".join(item.value for item in RetryAdmission)
+        msg = f"VerifierVerdict.retry_admission={retry_admission!r} is not valid. Valid: {valid}."
+        raise VerifierContractError(msg) from exc
+
+
+def _normalize_evidence_used(evidence_used: tuple[str, ...]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+    for item in evidence_used:
+        if not isinstance(item, str):
+            msg = "VerifierVerdict.evidence_used must contain strings"
+            raise VerifierContractError(msg)
+        stripped = item.strip()
+        if not stripped or stripped in seen:
+            continue
+        seen.add(stripped)
+        normalized.append(stripped)
+    return tuple(normalized)
+
+
+def _default_retry_admission_for_failure_class(
+    failure_class: str | None,
+) -> RetryAdmission:
+    if failure_class == "FABRICATION_SUSPECTED":
+        return RetryAdmission.ESCALATE_MODEL
+    if failure_class in {"SCOPE_CREEP", "STALL"}:
+        return RetryAdmission.REDISPATCH
+    if failure_class == "BLOCKED":
+        return RetryAdmission.BLOCK
+    return RetryAdmission.RETRY
 
 
 class Verifier(Protocol):
@@ -416,6 +534,8 @@ __all__ = [
     "LoopResult",
     "Verifier",
     "VerifierContractError",
+    "RetryAdmission",
+    "VerifierStatus",
     "VerifierVerdict",
     "run_with_verifier",
     "structural_atomic_verifier",

--- a/tests/unit/harness/test_deliver_routing.py
+++ b/tests/unit/harness/test_deliver_routing.py
@@ -12,9 +12,13 @@ from ouroboros.harness.deliver_gate import (
     DeliverGateVerdict,
     evaluate_deliver_claim,
 )
-from ouroboros.harness.deliver_routing import route_deliver_gate_verdict
+from ouroboros.harness.deliver_routing import (
+    deliver_gate_verifier_verdict,
+    route_deliver_gate_verdict,
+)
 from ouroboros.harness.journal import EvidenceEntry, EvidenceKind, EvidenceManifest
 from ouroboros.orchestrator.failure_taxonomy import RecoveryAction
+from ouroboros.orchestrator.verifier import RetryAdmission, VerifierStatus
 
 
 def _verdict(*, accepted: bool, reasons: tuple[str, ...] = ()) -> DeliverGateVerdict:
@@ -35,6 +39,23 @@ def test_accepted_verdict_has_no_recovery_action() -> None:
     assert route.reason == "deliver_gate_accepted"
 
 
+def test_accepted_verdict_promotes_to_h1_accept_verifier_output() -> None:
+    verdict = DeliverGateVerdict(
+        ac_id="AC-1",
+        accepted=True,
+        unsupported_claim_rate=0.0,
+        accepted_fact_ids=("fact_1",),
+        evidence_event_ids=("evt_1", "evt_1", "evt_2"),
+    )
+
+    verifier_verdict = deliver_gate_verifier_verdict(verdict)
+
+    assert verifier_verdict.passed is True
+    assert verifier_verdict.status is VerifierStatus.PASS
+    assert verifier_verdict.retry_admission is RetryAdmission.ACCEPT
+    assert verifier_verdict.evidence_used == ("evt_1", "evt_2")
+
+
 def test_missing_evidence_routes_to_retry() -> None:
     route = route_deliver_gate_verdict(
         _verdict(accepted=False, reasons=("missing_evidence_handle: ev_1 was not found",))
@@ -42,6 +63,13 @@ def test_missing_evidence_routes_to_retry() -> None:
 
     assert route.action is RecoveryAction.RETRY
     assert route.reason == "deliver_gate_retryable_evidence_gap"
+
+    verifier_verdict = deliver_gate_verifier_verdict(
+        _verdict(accepted=False, reasons=("missing_evidence_handle: ev_1 was not found",))
+    )
+    assert verifier_verdict.status is VerifierStatus.FAIL
+    assert verifier_verdict.failure_class == "EVIDENCE_MISSING"
+    assert verifier_verdict.retry_admission is RetryAdmission.RETRY
 
 
 def test_missing_claim_handle_from_real_verdict_producer_routes_to_retry() -> None:
@@ -116,6 +144,17 @@ def test_semantic_miss_routes_to_redispatch_before_escalation_threshold() -> Non
     assert route.action is RecoveryAction.REDISPATCH
     assert route.reason == "deliver_gate_redispatch_required"
 
+    verifier_verdict = deliver_gate_verifier_verdict(
+        _verdict(
+            accepted=False,
+            reasons=("semantic_miss: evidence text lacks behavior=admin_delete_denied",),
+        ),
+        rejection_count=1,
+        model_escalation_threshold=2,
+    )
+    assert verifier_verdict.failure_class == "SCOPE_CREEP"
+    assert verifier_verdict.retry_admission is RetryAdmission.REDISPATCH
+
 
 def test_repeated_traceguard_rejections_route_to_model_escalation() -> None:
     route = route_deliver_gate_verdict(
@@ -127,6 +166,14 @@ def test_repeated_traceguard_rejections_route_to_model_escalation() -> None:
     assert route.action is RecoveryAction.ESCALATE_MODEL
     assert route.reason == "deliver_gate_repeated_rejection"
 
+    verifier_verdict = deliver_gate_verifier_verdict(
+        _verdict(accepted=False, reasons=("unsupported_fact_id: fact_1 is not present",)),
+        rejection_count=2,
+        model_escalation_threshold=2,
+    )
+    assert verifier_verdict.failure_class == "FABRICATION_SUSPECTED"
+    assert verifier_verdict.retry_admission is RetryAdmission.ESCALATE_MODEL
+
 
 def test_external_dependency_routes_to_hitl() -> None:
     route = route_deliver_gate_verdict(
@@ -135,6 +182,13 @@ def test_external_dependency_routes_to_hitl() -> None:
 
     assert route.action is RecoveryAction.ESCALATE_HUMAN
     assert route.reason == "deliver_gate_requires_human"
+
+    verifier_verdict = deliver_gate_verifier_verdict(
+        _verdict(accepted=False, reasons=("external_dependency_missing: API key missing",))
+    )
+    assert verifier_verdict.status is VerifierStatus.BLOCKED
+    assert verifier_verdict.failure_class == "BLOCKED"
+    assert verifier_verdict.retry_admission is RetryAdmission.ESCALATE_HUMAN
 
 
 def test_rejects_invalid_routing_counters() -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -6374,6 +6374,9 @@ class TestParallelACExecutor:
             verifier_passed=False,
             verifier_reasons=["claimed test command did not support the AC"],
             verifier_failure_class="FABRICATION_SUSPECTED",
+            verifier_status="FAIL",
+            retry_admission="ESCALATE_MODEL",
+            verifier_evidence_used=[],
         )
 
         assert result.success is False
@@ -6392,6 +6395,9 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_ran"] is True
         assert evidence_event.data["verifier_passed"] is False
         assert evidence_event.data["verifier_failure_class"] == "FABRICATION_SUSPECTED"
+        assert evidence_event.data["verifier_status"] == "FAIL"
+        assert evidence_event.data["retry_admission"] == "ESCALATE_MODEL"
+        assert evidence_event.data["verifier_evidence_used"] == []
         assert evidence_event.data["verifier_reasons"] == [
             "claimed test command did not support the AC"
         ]

--- a/tests/unit/orchestrator/test_traceguard_benchmark_capture.py
+++ b/tests/unit/orchestrator/test_traceguard_benchmark_capture.py
@@ -73,6 +73,19 @@ def test_traceguard_benchmark_delta_is_json_serializable() -> None:
     json.dumps(payload)
 
 
+def test_traceguard_benchmark_records_h1_retry_admission_outcomes() -> None:
+    payload = build_traceguard_benchmark_capture().to_dict()
+    rows = {row["fixture"]: row for row in payload["h1_retry_admission"]["rows"]}
+
+    assert payload["h1_retry_admission"]["all_typed"] is True
+    assert rows["fixture:h1/traceguard/accepted"]["retry_admission"] == "ACCEPT"
+    assert rows["fixture:h1/traceguard/missing-evidence"]["failure_class"] == "EVIDENCE_MISSING"
+    assert rows["fixture:h1/traceguard/missing-evidence"]["retry_admission"] == "RETRY"
+    assert rows["fixture:h1/claim-term/semantic-miss"]["failure_class"] == "SCOPE_CREEP"
+    assert rows["fixture:h1/claim-term/semantic-miss"]["retry_admission"] == "REDISPATCH"
+    assert rows["fixture:h1/traceguard/repeated-fabrication"]["retry_admission"] == "ESCALATE_MODEL"
+
+
 def test_traceguard_benchmark_markdown_artifact_matches_renderer() -> None:
     expected = render_traceguard_benchmark_markdown()
     artifact = Path("docs/agentos/traceguard-vs-legacy-benchmark.md").read_text()
@@ -81,3 +94,4 @@ def test_traceguard_benchmark_markdown_artifact_matches_renderer() -> None:
     assert "Fabrication incidents per 100 ACs" in artifact
     assert "Semantic-miss incidents per 100 ACs" in artifact
     assert "TraceGuard + claim-term guard" in artifact
+    assert "H1 retry admission" in artifact

--- a/tests/unit/orchestrator/test_verifier.py
+++ b/tests/unit/orchestrator/test_verifier.py
@@ -415,7 +415,8 @@ class TestRetryWithFeedback:
     def test_exhaust_retries_returns_unaccepted(self, code_profile: ExecutionProfile) -> None:
         outputs = [_code_evidence() for _ in range(3)]
         verdicts = [
-            VerifierVerdict(passed=False, reasons=("bad",), failure_class="STALL") for _ in range(3)
+            VerifierVerdict(passed=False, reasons=("bad",), failure_class="EVIDENCE_MISSING")
+            for _ in range(3)
         ]
         executor = ScriptedExecutor(outputs=outputs)
         verifier = ScriptedVerifier(verdicts=verdicts)
@@ -433,12 +434,12 @@ class TestRetryWithFeedback:
         assert verifier.calls == 3
         # Final attempt is not accepted but verdict is recorded.
         assert result.final.verdict is not None
-        assert result.final.verdict.failure_class == "STALL"
+        assert result.final.verdict.retry_admission is RetryAdmission.RETRY
 
     def test_default_max_retries_is_two(self) -> None:
         assert DEFAULT_MAX_RETRIES == 2
 
-    def test_h1_consumes_traceguard_deliver_verdict_for_retry_admission(
+    def test_h1_stops_same_leaf_retry_for_traceguard_redispatch_admission(
         self, code_profile: ExecutionProfile
     ) -> None:
         executor = ScriptedExecutor(outputs=[_code_evidence(), _code_evidence()])
@@ -451,27 +452,16 @@ class TestRetryWithFeedback:
             record: EvidenceRecord,
         ) -> VerifierVerdict:
             del profile, ac, leaf_output, record
-            if not getattr(traceguard_backed_verifier, "fired", False):
-                traceguard_backed_verifier.fired = True  # type: ignore[attr-defined]
-                return deliver_gate_verifier_verdict(
-                    DeliverGateVerdict(
-                        ac_id="AC-1",
-                        accepted=False,
-                        unsupported_claim_rate=1.0,
-                        rejected_fact_ids=("fact_1",),
-                        rejected_reasons=(
-                            "semantic_miss: evidence text lacks behavior=admin_delete_denied",
-                        ),
-                        evidence_event_ids=("evt_semantic_miss",),
-                    )
-                )
             return deliver_gate_verifier_verdict(
                 DeliverGateVerdict(
                     ac_id="AC-1",
-                    accepted=True,
-                    unsupported_claim_rate=0.0,
-                    accepted_fact_ids=("fact_1",),
-                    evidence_event_ids=("evt_fixed",),
+                    accepted=False,
+                    unsupported_claim_rate=1.0,
+                    rejected_fact_ids=("fact_1",),
+                    rejected_reasons=(
+                        "semantic_miss: evidence text lacks behavior=admin_delete_denied",
+                    ),
+                    evidence_event_ids=("evt_semantic_miss",),
                 )
             )
 
@@ -483,15 +473,68 @@ class TestRetryWithFeedback:
             max_retries=1,
         )
 
-        assert result.accepted is True
+        assert result.accepted is False
+        assert len(result.attempts) == 1
         first = result.attempts[0]
         assert first.verdict is not None
         assert first.verdict.failure_class == "SCOPE_CREEP"
         assert first.verdict.retry_admission is RetryAdmission.REDISPATCH
         assert first.verdict.evidence_used == ("evt_semantic_miss",)
-        assert "semantic_miss" in executor.feedbacks[1][0]
+        assert executor.feedbacks == [()]
+
+    @pytest.mark.parametrize(
+        ("verdict", "expected_admission"),
+        [
+            (
+                VerifierVerdict(
+                    passed=False,
+                    reasons=("fabricated",),
+                    failure_class="FABRICATION_SUSPECTED",
+                ),
+                RetryAdmission.ESCALATE_MODEL,
+            ),
+            (
+                VerifierVerdict(
+                    passed=False,
+                    reasons=("blocked",),
+                    failure_class="BLOCKED",
+                ),
+                RetryAdmission.BLOCK,
+            ),
+            (
+                VerifierVerdict(
+                    passed=False,
+                    reasons=("human needed",),
+                    failure_class="BLOCKED",
+                    retry_admission=RetryAdmission.ESCALATE_HUMAN,
+                ),
+                RetryAdmission.ESCALATE_HUMAN,
+            ),
+        ],
+    )
+    def test_h1_stops_same_leaf_retry_for_non_retry_admissions(
+        self,
+        code_profile: ExecutionProfile,
+        verdict: VerifierVerdict,
+        expected_admission: RetryAdmission,
+    ) -> None:
+        executor = ScriptedExecutor(outputs=[_code_evidence(), _code_evidence()])
+        verifier = ScriptedVerifier(verdicts=[verdict, VerifierVerdict(passed=True)])
+
+        result = run_with_verifier(
+            executor=executor,
+            verifier=verifier,
+            profile=code_profile,
+            ac="x",
+            max_retries=1,
+        )
+
+        assert result.accepted is False
+        assert len(result.attempts) == 1
+        assert verifier.calls == 1
+        assert executor.feedbacks == [()]
         assert result.final.verdict is not None
-        assert result.final.verdict.retry_admission is RetryAdmission.ACCEPT
+        assert result.final.verdict.retry_admission is expected_admission
 
 
 class TestEvidenceShortCircuit:

--- a/tests/unit/orchestrator/test_verifier.py
+++ b/tests/unit/orchestrator/test_verifier.py
@@ -7,12 +7,16 @@ import json
 
 import pytest
 
+from ouroboros.harness.deliver_gate import DeliverGateVerdict
+from ouroboros.harness.deliver_routing import deliver_gate_verifier_verdict
 from ouroboros.orchestrator.evidence_schema import EvidenceRecord, ProfileEvidenceConfigError
 from ouroboros.orchestrator.profile_loader import EvidenceSchema, ExecutionProfile, load_profile
 from ouroboros.orchestrator.verifier import (
     DEFAULT_MAX_RETRIES,
     LoopResult,
+    RetryAdmission,
     VerifierContractError,
+    VerifierStatus,
     VerifierVerdict,
     run_with_verifier,
 )
@@ -81,6 +85,25 @@ class TestVerifierVerdict:
             passed=False, reasons=("missing test",), failure_class="EVIDENCE_MISSING"
         )
         assert verdict.passed is False
+        assert verdict.status is VerifierStatus.FAIL
+        assert verdict.retry_admission is RetryAdmission.RETRY
+
+    def test_pass_defaults_to_typed_acceptance(self) -> None:
+        verdict = VerifierVerdict(passed=True, evidence_used=(" evt_1 ", "evt_1", "evt_2"))
+
+        assert verdict.status is VerifierStatus.PASS
+        assert verdict.retry_admission is RetryAdmission.ACCEPT
+        assert verdict.evidence_used == ("evt_1", "evt_2")
+
+    def test_blocked_failure_defaults_to_block_status_and_admission(self) -> None:
+        verdict = VerifierVerdict(
+            passed=False,
+            reasons=("blocked",),
+            failure_class="BLOCKED",
+        )
+
+        assert verdict.status is VerifierStatus.BLOCKED
+        assert verdict.retry_admission is RetryAdmission.BLOCK
 
     def test_fail_without_reasons_rejected(self) -> None:
         # A bare FAIL produces no feedback for the retry executor and no
@@ -105,6 +128,18 @@ class TestVerifierVerdict:
         # verifier impl that typo'd the tag. Reject at construction.
         with pytest.raises(ValueError, match="not a recognized taxonomy"):
             VerifierVerdict(passed=False, reasons=("bad",), failure_class="MYSTERY")
+
+    def test_pass_cannot_use_non_accept_retry_admission(self) -> None:
+        with pytest.raises(ValueError, match="retry_admission ACCEPT"):
+            VerifierVerdict(passed=True, retry_admission="RETRY")
+
+    def test_fail_cannot_use_accept_retry_admission(self) -> None:
+        with pytest.raises(ValueError, match="cannot have retry_admission ACCEPT"):
+            VerifierVerdict(
+                passed=False,
+                reasons=("bad",),
+                retry_admission="ACCEPT",
+            )
 
     @pytest.mark.parametrize(
         "klass",
@@ -402,6 +437,61 @@ class TestRetryWithFeedback:
 
     def test_default_max_retries_is_two(self) -> None:
         assert DEFAULT_MAX_RETRIES == 2
+
+    def test_h1_consumes_traceguard_deliver_verdict_for_retry_admission(
+        self, code_profile: ExecutionProfile
+    ) -> None:
+        executor = ScriptedExecutor(outputs=[_code_evidence(), _code_evidence()])
+
+        def traceguard_backed_verifier(
+            *,
+            profile: ExecutionProfile,
+            ac: str,
+            leaf_output: str,
+            record: EvidenceRecord,
+        ) -> VerifierVerdict:
+            del profile, ac, leaf_output, record
+            if not getattr(traceguard_backed_verifier, "fired", False):
+                traceguard_backed_verifier.fired = True  # type: ignore[attr-defined]
+                return deliver_gate_verifier_verdict(
+                    DeliverGateVerdict(
+                        ac_id="AC-1",
+                        accepted=False,
+                        unsupported_claim_rate=1.0,
+                        rejected_fact_ids=("fact_1",),
+                        rejected_reasons=(
+                            "semantic_miss: evidence text lacks behavior=admin_delete_denied",
+                        ),
+                        evidence_event_ids=("evt_semantic_miss",),
+                    )
+                )
+            return deliver_gate_verifier_verdict(
+                DeliverGateVerdict(
+                    ac_id="AC-1",
+                    accepted=True,
+                    unsupported_claim_rate=0.0,
+                    accepted_fact_ids=("fact_1",),
+                    evidence_event_ids=("evt_fixed",),
+                )
+            )
+
+        result = run_with_verifier(
+            executor=executor,
+            verifier=traceguard_backed_verifier,
+            profile=code_profile,
+            ac="deny admin delete",
+            max_retries=1,
+        )
+
+        assert result.accepted is True
+        first = result.attempts[0]
+        assert first.verdict is not None
+        assert first.verdict.failure_class == "SCOPE_CREEP"
+        assert first.verdict.retry_admission is RetryAdmission.REDISPATCH
+        assert first.verdict.evidence_used == ("evt_semantic_miss",)
+        assert "semantic_miss" in executor.feedbacks[1][0]
+        assert result.final.verdict is not None
+        assert result.final.verdict.retry_admission is RetryAdmission.ACCEPT
 
 
 class TestEvidenceShortCircuit:

--- a/tests/unit/orchestrator/test_verifier.py
+++ b/tests/unit/orchestrator/test_verifier.py
@@ -105,6 +105,13 @@ class TestVerifierVerdict:
         assert verdict.status is VerifierStatus.BLOCKED
         assert verdict.retry_admission is RetryAdmission.BLOCK
 
+    def test_unclassified_failure_defaults_to_stall_redispatch_policy(self) -> None:
+        verdict = VerifierVerdict(passed=False, reasons=("ambiguous verifier failure",))
+
+        assert verdict.status is VerifierStatus.FAIL
+        assert verdict.failure_class is None
+        assert verdict.retry_admission is RetryAdmission.REDISPATCH
+
     def test_fail_without_reasons_rejected(self) -> None:
         # A bare FAIL produces no feedback for the retry executor and no
         # explanation on budget exhaustion — rejected at construction
@@ -397,7 +404,11 @@ class TestRetryWithFeedback:
         executor = ScriptedExecutor(outputs=[_code_evidence(), _code_evidence()])
         verifier = ScriptedVerifier(
             verdicts=[
-                VerifierVerdict(passed=False, reasons=("tests look fake",)),
+                VerifierVerdict(
+                    passed=False,
+                    reasons=("tests look fake",),
+                    retry_admission=RetryAdmission.RETRY,
+                ),
                 VerifierVerdict(passed=True),
             ]
         )


### PR DESCRIPTION
## Summary
- Add #814 Verdict Envelope v1 RFC to fix the output schema direction before adoption.
- Extend H1 verifier output with typed status, evidence refs, and retry_admission.
- Promote TraceGuard DeliverGateVerdict through deliver_routing into VerifierVerdict so accepted/retry/redispatch/escalation decisions are typed and auditable.
- Persist verifier_status, retry_admission, and verifier_evidence_used on atomic typed-evidence events.
- Extend the TraceGuard benchmark artifact with H1 retry admission fixture outcomes.

## Review fixes
- H1 run_with_verifier now only retries the same leaf when retry_admission is RETRY.
- REDISPATCH, ESCALATE_MODEL, ESCALATE_HUMAN, and BLOCK return immediately with the typed verdict for upstream routing.
- Operational verifier failures explicitly keep transient retry semantics with retry_admission=RETRY.
- Unclassified verifier failures now follow the H7 STALL policy and default to REDISPATCH.

## Manual benchmark
uv run python -m ouroboros.orchestrator.traceguard_benchmark_capture

Observed H1 admission fixtures:
- accepted -> ACCEPT
- missing evidence -> EVIDENCE_MISSING / RETRY
- claim-term semantic miss -> SCOPE_CREEP / REDISPATCH
- repeated fabrication -> FABRICATION_SUSPECTED / ESCALATE_MODEL

## Tests
- uv run ruff check src/ tests/
- uv run ruff format --check src/ tests/
- uv run pytest tests/unit/harness tests/unit/orchestrator/test_verifier.py tests/unit/orchestrator/test_failure_taxonomy.py tests/unit/orchestrator/test_traceguard_benchmark_capture.py tests/unit/orchestrator/test_parallel_executor.py::TestParallelACExecutor::test_fat_harness_mode_rejects_verifier_fail -q
- uv run mypy src/ouroboros/orchestrator/verifier.py src/ouroboros/harness/deliver_routing.py src/ouroboros/orchestrator/traceguard_benchmark_capture.py
- uv run pytest tests/unit -q -> first run had one async polling flake in test_mcp_start_auto_response_job_handle_can_poll_and_fetch_result; rerunning that exact test passed.
- uv run pytest tests/unit/mcp/tools/test_start_auto.py::TestBackgroundJobPath::test_mcp_start_auto_response_job_handle_can_poll_and_fetch_result -q

Refs #814, #1306