### PR TITLE
fix(h7): prefer verifier retry admission policy

### DIFF
--- a/src/ouroboros/orchestrator/failure_taxonomy.py
+++ b/src/ouroboros/orchestrator/failure_taxonomy.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import StrEnum
 
-from ouroboros.orchestrator.verifier import Attempt
+from ouroboros.orchestrator.verifier import Attempt, RetryAdmission
 
 
 class FailureClass(StrEnum):
@@ -126,6 +126,59 @@ def policy_for(failure: FailureClass) -> RecoveryPolicy:
         raise ValueError(msg) from exc
 
 
+def policy_for_attempt(attempt: Attempt) -> RecoveryPolicy | None:
+    """Return the recovery policy for an Attempt.
+
+    Prefer explicit verifier ``retry_admission`` when present. ``failure_class``
+    remains a useful taxonomy label, but deliver-gate routes can intentionally
+    diverge from the old class-to-policy table (for example fabricated evidence
+    that should redispatch before model escalation). Callers that need an action
+    should use this helper rather than classifying and then calling
+    :func:`policy_for` themselves.
+    """
+    if attempt.accepted:
+        return None
+    if attempt.verdict is not None:
+        policy = _policy_for_retry_admission(attempt.verdict.retry_admission)
+        if policy is not None:
+            return policy
+    failure = classify(attempt)
+    return policy_for(failure) if failure is not None else None
+
+
+def _policy_for_retry_admission(
+    retry_admission: RetryAdmission,
+) -> RecoveryPolicy | None:
+    if retry_admission is RetryAdmission.ACCEPT:
+        return None
+    if retry_admission is RetryAdmission.RETRY:
+        return RecoveryPolicy(
+            action=RecoveryAction.RETRY,
+            rationale="Verifier retry_admission explicitly requested same-leaf retry.",
+        )
+    if retry_admission is RetryAdmission.REDISPATCH:
+        return RecoveryPolicy(
+            action=RecoveryAction.REDISPATCH,
+            rationale="Verifier retry_admission explicitly requested redispatch.",
+        )
+    if retry_admission is RetryAdmission.ESCALATE_MODEL:
+        return RecoveryPolicy(
+            action=RecoveryAction.ESCALATE_MODEL,
+            rationale="Verifier retry_admission explicitly requested model escalation.",
+        )
+    if retry_admission is RetryAdmission.ESCALATE_HUMAN:
+        return RecoveryPolicy(
+            action=RecoveryAction.ESCALATE_HUMAN,
+            rationale="Verifier retry_admission explicitly requested human escalation.",
+        )
+    if retry_admission is RetryAdmission.BLOCK:
+        return RecoveryPolicy(
+            action=RecoveryAction.ESCALATE_HUMAN,
+            rationale="Verifier retry_admission reported a hard block.",
+        )
+    return None
+
+
 def classify(attempt: Attempt) -> FailureClass | None:
     """Classify a single Attempt from the verifier loop.
 
@@ -169,4 +222,5 @@ __all__ = [
     "RecoveryPolicy",
     "classify",
     "policy_for",
+    "policy_for_attempt",
 ]

--- a/tests/unit/orchestrator/test_failure_taxonomy.py
+++ b/tests/unit/orchestrator/test_failure_taxonomy.py
@@ -15,8 +15,9 @@ from ouroboros.orchestrator.failure_taxonomy import (
     RecoveryAction,
     classify,
     policy_for,
+    policy_for_attempt,
 )
-from ouroboros.orchestrator.verifier import Attempt, VerifierVerdict
+from ouroboros.orchestrator.verifier import Attempt, RetryAdmission, VerifierVerdict
 
 
 def _accepted_attempt() -> Attempt:
@@ -149,3 +150,64 @@ class TestPolicyTable:
 
     def test_blocked_escalates_to_human(self) -> None:
         assert policy_for(FailureClass.BLOCKED).action == RecoveryAction.ESCALATE_HUMAN
+
+
+class TestPolicyForAttempt:
+    def test_accepted_attempt_has_no_recovery_policy(self) -> None:
+        assert policy_for_attempt(_accepted_attempt()) is None
+
+    def test_retry_admission_wins_over_failure_class_policy(self) -> None:
+        attempt = _attempt(
+            validation=ValidationResult(ok=True),
+            verdict=VerifierVerdict(
+                passed=False,
+                reasons=("unsupported_fact_id: fact_fake is not present",),
+                failure_class="FABRICATION_SUSPECTED",
+                retry_admission=RetryAdmission.REDISPATCH,
+            ),
+        )
+
+        assert classify(attempt) == FailureClass.FABRICATION_SUSPECTED
+        assert policy_for(FailureClass.FABRICATION_SUSPECTED).action == (
+            RecoveryAction.ESCALATE_MODEL
+        )
+        policy = policy_for_attempt(attempt)
+        assert policy is not None
+        assert policy.action is RecoveryAction.REDISPATCH
+        assert "retry_admission" in policy.rationale
+
+    @pytest.mark.parametrize(
+        ("admission", "action"),
+        [
+            (RetryAdmission.RETRY, RecoveryAction.RETRY),
+            (RetryAdmission.REDISPATCH, RecoveryAction.REDISPATCH),
+            (RetryAdmission.ESCALATE_MODEL, RecoveryAction.ESCALATE_MODEL),
+            (RetryAdmission.ESCALATE_HUMAN, RecoveryAction.ESCALATE_HUMAN),
+            (RetryAdmission.BLOCK, RecoveryAction.ESCALATE_HUMAN),
+        ],
+    )
+    def test_retry_admission_maps_to_recovery_policy(
+        self,
+        admission: RetryAdmission,
+        action: RecoveryAction,
+    ) -> None:
+        attempt = _attempt(
+            validation=ValidationResult(ok=True),
+            verdict=VerifierVerdict(
+                passed=False,
+                reasons=("route me",),
+                retry_admission=admission,
+            ),
+        )
+
+        policy = policy_for_attempt(attempt)
+        assert policy is not None
+        assert policy.action is action
+
+    def test_falls_back_to_classification_when_no_verdict(self) -> None:
+        attempt = _attempt(evidence_error="not json")
+
+        policy = policy_for_attempt(attempt)
+
+        assert policy is not None
+        assert policy.action is RecoveryAction.RETRY


### PR DESCRIPTION
## Summary
- Add policy_for_attempt() as the H7 recovery-policy entrypoint for verifier attempts.
- Prefer VerifierVerdict.retry_admission over failure_class-derived policy when an explicit admission is present.
- Preserve fallback classify() + policy_for() behavior for attempts without verifier verdicts.

## Context
Follow-up from #1330 review: deliver-gate verdicts can intentionally diverge between failure_class and retry_admission, e.g. failure_class=FABRICATION_SUSPECTED with retry_admission=REDISPATCH. Future H7 consumers should prefer retry_admission instead of inferring policy from failure_class alone.

## Tests
- uv run pytest tests/unit/orchestrator/test_failure_taxonomy.py tests/unit/harness/test_deliver_routing.py -q
- uv run pytest tests/unit/orchestrator/test_failure_taxonomy.py tests/unit/orchestrator/test_verifier.py tests/unit/harness/test_deliver_routing.py tests/unit/orchestrator/test_rfc_v2_integration.py -q
- uv run ruff check src/ouroboros/orchestrator/failure_taxonomy.py tests/unit/orchestrator/test_failure_taxonomy.py
- uv run ruff format --check src/ouroboros/orchestrator/failure_taxonomy.py tests/unit/orchestrator/test_failure_taxonomy.py
- uv run mypy src/ouroboros/orchestrator/failure_taxonomy.py

Follow-up to #1330