### PR TITLE
feat(runtime): add managed instruction artifact installers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@ Thank you for your interest in contributing to Ouroboros! This guide covers ever
 - [Documentation Coverage](#documentation-coverage)
   - [CLI Commands → Doc Mapping](#cli-commands--doc-mapping)
   - [Orchestrator → Doc Mapping](#orchestrator--doc-mapping)
+  - [Capability Graph → Doc Mapping](#capability-graph--doc-mapping)
   - [Configuration → Doc Mapping](#configuration--doc-mapping)
   - [Evaluation Pipeline → Doc Mapping](#evaluation-pipeline--doc-mapping)
   - [TUI Source → Doc Mapping](#tui-source--doc-mapping)
@@ -600,7 +601,24 @@ Changes under `src/ouroboros/orchestrator/` affect runtime behavior documentatio
 | `command_dispatcher.py` | `docs/architecture.md` — command dispatch model |
 | `level_context.py` | `docs/architecture.md` — level context description |
 
-**Runtime availability rule**: If `create_agent_runtime()` raises `NotImplementedError` for a backend, that backend **must not** appear in docs as a working option. All three backends (`claude`, `codex`, `opencode`) are fully implemented and documented.
+**Runtime availability rule**: If `create_agent_runtime()` raises `NotImplementedError` for a backend, that backend **must not** appear in docs as a working option. Runtime backend availability is registry-owned; when `runtime_backend_choices()` or setup support changes, update the runtime capability matrix, setup docs, and per-runtime guide/gap documentation together.
+
+---
+
+### Capability Graph → Doc Mapping
+
+Changes that add, remove, rename, or reinterpret a skill execution capability
+must keep the capability graph and generated runtime instructions in sync.
+
+| Source path | Must update |
+|-------------|-------------|
+| `skills/*/SKILL.md` | `docs/runtime-guides/skill-capability-guides.md` if `required_capabilities` changes or the skill depends on a new abstract runtime action |
+| `src/ouroboros/backends/capabilities.py` | `docs/runtime-guides/skill-capability-guides.md`; renderer/package snapshot tests for Codex, Hermes, Claude, and setup-owned runtime artifacts |
+| `src/ouroboros/runtime_instruction_artifacts.py` | `docs/runtime-guides/skill-capability-guides.md`; `docs/cli-reference.md` setup section if install paths or managed surfaces change |
+| Packaged guide snapshots such as `.claude-plugin/SKILL_CAPABILITY_GUIDE.md` | Update when `render_backend_skill_capability_guide(<backend>)` output changes |
+
+Before submitting a capability graph PR, run the checklist in
+[`docs/runtime-guides/skill-capability-guides.md`](./docs/runtime-guides/skill-capability-guides.md#contributor-checklist-for-capability-changes).
 
 ---
 
@@ -668,7 +686,7 @@ Changes under `skills/` (YAML skill definitions used by Claude and Codex) or `sr
 | Source path | Must update |
 |-------------|-------------|
 | `skills/codex.md` | `docs/runtime-guides/codex.md` — if skill instructions change |
-| `skills/*.yaml` or `src/ouroboros/agents/*.md` | `docs/` guide that describes the affected skill/agent behaviour |
+| `skills/*.yaml`, `skills/*/SKILL.md`, or `src/ouroboros/agents/*.md` | `docs/` guide that describes the affected skill/agent behaviour; `docs/runtime-guides/skill-capability-guides.md` if required capabilities change |
 | `src/ouroboros/plugin/skills/executor.py` | `docs/architecture.md` — skill execution model |
 | `src/ouroboros/plugin/agents/registry.py` | `docs/architecture.md` — agent registry; `docs/runtime-capability-matrix.md` if supported agents change per runtime |
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -226,7 +226,7 @@ truth table describes the gate function alone, not the auto flow:
 Detect available runtime backends and configure Ouroboros for your environment.
 
 Ouroboros supports multiple runtime backends via a pluggable `AgentRuntime` protocol. The `setup` command auto-detects
-which runtimes are available in your PATH (currently: Claude Code, Codex CLI, OpenCode) and
+which runtimes are available in your PATH (currently: Claude Code, Codex CLI, OpenCode, Hermes, Gemini, Kiro, Copilot, and Goose) and
 configures `orchestrator.runtime_backend` accordingly. Additional runtimes can be registered
 by implementing the protocol — see [Architecture](architecture.md#how-to-add-a-new-runtime-adapter).
 
@@ -238,7 +238,7 @@ ouroboros setup [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `-r, --runtime TEXT` | Runtime backend to configure. Shipped values: `claude`, `codex`, `opencode`, `hermes`, `gemini`, `kiro`. Auto-detected if omitted |
+| `-r, --runtime TEXT` | Runtime backend to configure. Shipped values: `claude`, `codex`, `opencode`, `hermes`, `gemini`, `kiro`, `copilot`, `goose`. Auto-detected if omitted |
 | `--opencode-mode TEXT` | OpenCode integration mode: `plugin` (default, recommended — bridge plugin for interactive sessions) or `subprocess` (headless/CI). Mutually exclusive — see [OpenCode runtime guide](runtime-guides/opencode.md#configuration) |
 | `--non-interactive` | Skip interactive prompts (for scripted installs) |
 | `--mcp-mode TEXT` | Codex MCP config mode: `auto` (default), `preserve`, or `stdio` |
@@ -264,7 +264,7 @@ ouroboros setup --non-interactive
 
 **What setup does:**
 
-- Scans PATH for `claude`, `codex`, `opencode`, `hermes`, `gemini`, and `kiro-cli` CLI binaries
+- Scans PATH for `claude`, `codex`, `opencode`, `hermes`, `gemini`, `kiro-cli`, `copilot`, and `goose` CLI binaries
 - Prompts you to select a runtime if multiple are found (or auto-selects if only one)
 - Writes `orchestrator.runtime_backend` to `~/.ouroboros/config.yaml`
 - For Claude Code: registers the MCP server in `~/.claude/mcp.json`
@@ -275,7 +275,11 @@ ouroboros setup --non-interactive
 - For Codex CLI: installs managed `~/.codex/ouroboros-*.config.toml` profile-v2 anchors on current Codex releases, or legacy `[profiles.ouroboros-*]` anchors when the detected CLI still requires them
 - For OpenCode: registers the Ouroboros MCP server in OpenCode's configuration
 - For OpenCode (plugin mode): installs the bridge plugin into `<opencode_config_dir>/plugins/ouroboros-bridge/`
+- For OpenCode: installs the runtime skill capability guide into global `AGENTS.md` in the active OpenCode config directory
+- For Gemini CLI: installs the runtime skill capability guide into `~/.gemini/GEMINI.md`
 - For Kiro CLI: sets `orchestrator.kiro_cli_path` and `llm.backend: kiro` in `~/.ouroboros/config.yaml`, and registers the Ouroboros MCP server in `~/.kiro/settings/mcp.json` with `OUROBOROS_RUNTIME=kiro` / `OUROBOROS_LLM_BACKEND=kiro` baked into the entry's `env` so `ooo <skill>` shortcuts route to the Kiro adapter on the very next `kiro-cli chat`. The detector prefers the resolved `ouroboros` binary over `uvx` to stay within Kiro's MCP init timeout
+- For Kiro CLI: installs the runtime skill capability guide into `~/.kiro/steering/ouroboros-skill-capability-guide.md`
+- For Copilot CLI: installs the runtime skill capability guide into `~/.copilot/ouroboros-instructions/AGENTS.md` and configures Ouroboros-launched Copilot child sessions to read it via `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`
 
 > **Codex config split:** put persistent Ouroboros per-role model overrides in `~/.ouroboros/config.yaml` (`clarification.default_model`, `llm.qa_model`, `evaluation.semantic_model`, `consensus.models`, `consensus.advocate_model`, `consensus.devil_model`, `consensus.judge_model`). `~/.codex/config.toml` is only the Codex MCP/env hookup file used by setup on current Codex releases; profile anchors live in `~/.codex/<profile>.config.toml`. If you run a long-lived URL-based Ouroboros MCP server, setup preserves that user-managed entry in the default `--mcp-mode auto`; use `--mcp-mode stdio` only when you intentionally want setup to replace it.
 

--- a/docs/contributing/key-patterns.md
+++ b/docs/contributing/key-patterns.md
@@ -223,6 +223,30 @@ seed.goal = "Different goal"  # ValidationError: frozen
 - The ontology can evolve with consensus, but direction fields cannot
 - Use `seed.to_dict()` / `Seed.from_dict()` for serialization
 
+## 8. Capability Graph for Skill Execution
+
+Skills declare abstract runtime needs; runtime adapters translate those needs
+through the capability graph.
+
+**Location**: `src/ouroboros/backends/capabilities.py`
+
+```python
+SkillExecutionCapability(
+    name="run_lateral_review",
+    guidance=(
+        "When an interview response marks `lateral_review_required=true`, "
+        "call `ouroboros_lateral_think` with the supplied tool args before "
+        "routing the next interview turn."
+    ),
+)
+```
+
+**Rules**:
+- Keep `SKILL.md` capability names runtime-neutral
+- Put runtime-specific tool names and prompt wording inside `SkillExecutionCapability.guidance`
+- Regenerate or update setup-owned instruction artifacts when rendered guide output changes
+- Follow `docs/runtime-guides/skill-capability-guides.md` before merging capability changes
+
 ## Summary Table
 
 | Pattern | When to Use | Key File |
@@ -234,3 +258,4 @@ seed.goal = "Different goal"  # ValidationError: frozen
 | Three-stage eval | Artifact verification | `evaluation/pipeline.py` |
 | TUI SSOT | UI state management | `tui/app.py`, `tui/events.py` |
 | Seed immutability | Workflow specification | `core/seed.py` |
+| Capability graph | Runtime-specific skill execution | `backends/capabilities.py` |

--- a/docs/runtime-guides/copilot.md
+++ b/docs/runtime-guides/copilot.md
@@ -45,6 +45,7 @@ ouroboros setup --runtime copilot
 #   - calls https://api.githubcopilot.com/models with your gh token
 #   - prints the live model list and lets you pick a default
 #   - writes ~/.ouroboros/config.yaml + ~/.copilot/mcp-config.json
+#   - installs ~/.copilot/ouroboros-instructions/AGENTS.md for Ouroboros runs
 
 # 4. Restart your Copilot session, then use ooo skills
 copilot
@@ -63,6 +64,11 @@ The runtime looks for the binary in this order:
 This means non-PATH installs (for example, a winget or scoop install on
 Windows that lands the binary outside `$PATH`) work without modifying
 shell init.
+
+Ouroboros-launched Copilot child sessions append the setup-owned
+`~/.copilot/ouroboros-instructions` directory to
+`COPILOT_CUSTOM_INSTRUCTIONS_DIRS` using Copilot CLI's comma-separated list
+format. Existing custom instruction directories are preserved.
 
 ## Live model discovery
 

--- a/docs/runtime-guides/skill-capability-guides.md
+++ b/docs/runtime-guides/skill-capability-guides.md
@@ -4,6 +4,30 @@ Issue #1008 moves runtime-specific skill execution guidance out of individual
 `SKILL.md` files and into the backend capability registry. Runtime adapters then
 consume the rendered guide through the instruction surface they actually own.
 
+## Capability graph contract
+
+The capability graph is the source of truth that maps abstract skill needs to
+runtime-specific tool names, prompt instructions, and unsupported behavior.
+
+```
+SKILL.md required capabilities
+    -> src/ouroboros/backends/capabilities.py
+    -> render_backend_skill_capability_guide(<backend>)
+    -> runtime-owned instruction artifact
+    -> runtime session behavior
+```
+
+`SKILL.md` files should describe what a skill needs in runtime-neutral terms
+such as `run_lateral_review`. They should not name a specific runtime's prompt
+file, CLI flag, or tool spelling unless the skill is explicitly runtime-scoped.
+Backend-specific wording belongs in `SkillExecutionCapability` entries in
+`src/ouroboros/backends/capabilities.py`.
+
+When the graph changes, contributors must update every generated or
+setup-owned surface that exposes the graph. A capability added only to a
+`SKILL.md` is not shipped until a maintained runtime can discover it through
+its rendered guide or a documented fallback.
+
 ## Current coverage
 
 | Runtime | Generated artifact surface | Status |
@@ -11,10 +35,12 @@ consume the rendered guide through the instruction surface they actually own.
 | Codex | Managed rule under `~/.codex/rules/ouroboros.md` | Installed during Codex setup/update via the generated guide renderer. |
 | Hermes | `~/.hermes/skills/autonomous-ai-agents/ouroboros/SKILL_CAPABILITY_GUIDE.md` | Installed with the Hermes skill bundle. |
 | Claude | `.claude-plugin/SKILL_CAPABILITY_GUIDE.md` | Shipped with the Claude plugin package and checked against the renderer. |
-| OpenCode | `AGENTS.md` in the OpenCode config directory | Installer helper is available and writes a managed marked section; setup integration lands in the follow-up OpenCode PR. |
-| Gemini | `~/.gemini/GEMINI.md` | Installer helper is available and writes a managed marked section; setup integration is still pending. |
-| Kiro | `~/.kiro/steering/ouroboros-skill-capability-guide.md` | Installer helper is available and writes a managed marked section; setup integration is still pending. |
-| Copilot | `~/.copilot/ouroboros-instructions/AGENTS.md` | Installer helper is available and writes a managed marked section; setup integration is still pending. |
+| OpenCode | Global `AGENTS.md` in the active OpenCode config directory | Installed by OpenCode setup for plugin and subprocess modes. |
+| Gemini | `~/.gemini/GEMINI.md` | Installed by Gemini setup as a managed section in the global Gemini memory file. |
+| Kiro | `~/.kiro/steering/ouroboros-skill-capability-guide.md` | Installed by Kiro setup as a global steering file. |
+| Copilot | `~/.copilot/ouroboros-instructions/AGENTS.md` | Installed by Copilot setup; Ouroboros Copilot runtime also injects that directory through `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`. |
+| Goose | No setup-owned capability artifact yet | Known gap: setup can select Goose as a runtime, but no durable Goose instruction surface or Goose-specific `SkillExecutionCapability` entries are registered yet. Keep skill requirements runtime-neutral and rely on runtime-local operator guidance until a Goose artifact installer exists. |
+| Pi | No setup-owned capability artifact yet | Known gap: Pi has generic rendered capability guidance in the registry, but setup does not yet install it into a durable Pi-owned instruction artifact. Use `render_backend_skill_capability_guide("pi")` when building Pi prompts until a stable artifact surface exists. |
 
 ## Seed generation client-gate enforcement
 
@@ -26,14 +52,15 @@ existing clients. Set `OUROBOROS_REQUIRE_CLIENT_GATES=1` to promote missing
 gates to a hard MCP precondition while migrating maintained clients to pass the
 `client_gates` acknowledgements.
 
-## Fallback behavior before setup integration
+## Fallback behavior for new runtimes without generated artifacts
 
-Until a runtime installer is wired into `ouroboros setup`, clients should render
+When adding a new runtime that does not yet have a durable instruction surface
+owned by `ouroboros setup`, clients should render
 `render_backend_skill_capability_guide(<backend>)` when building prompts or
 user-facing setup guidance, but must not copy long adapter sections into
 individual `SKILL.md` files.
 
-The fallback is intentionally conservative:
+The fallback for new runtimes should stay conservative:
 
 1. Keep `SKILL.md` files runtime-neutral.
 2. Keep backend-specific execution wording in `src/ouroboros/backends/capabilities.py`.
@@ -41,6 +68,35 @@ The fallback is intentionally conservative:
    surface that setup can refresh idempotently.
 4. If no such surface exists, document the gap here and rely on the generic
    backend guide until the runtime integration grows one.
+
+## Contributor checklist for capability changes
+
+Use this checklist when a PR adds, removes, renames, or materially changes an
+abstract capability used by any skill.
+
+1. Update the relevant `SKILL.md` `required_capabilities` or instructions using
+   runtime-neutral capability names.
+2. Update `src/ouroboros/backends/capabilities.py` with the matching
+   `SkillExecutionCapability` entries for every maintained backend.
+3. Update any setup-owned or packaged instruction artifacts that are checked in,
+   such as `.claude-plugin/SKILL_CAPABILITY_GUIDE.md`, when renderer output
+   changes.
+4. Update this document when a runtime's generated artifact surface changes or a
+   backend has a known gap.
+5. Add or update tests that prove the rendered guide and installed artifacts
+   contain the capability.
+
+Recommended targeted checks:
+
+```bash
+uv run pytest -q \
+  tests/unit/backends/test_capabilities.py \
+  tests/unit/test_runtime_skill_capability_docs.py \
+  tests/unit/test_runtime_instruction_artifacts.py \
+  tests/unit/test_claude_plugin_skill_guide.py \
+  tests/unit/test_codex_artifacts.py::TestInstallCodexRules::test_packaged_rules_include_rendered_skill_capability_guide \
+  tests/unit/hermes/test_artifacts.py
+```
 
 ## Adding a new runtime artifact
 

--- a/docs/runtime-guides/skill-capability-guides.md
+++ b/docs/runtime-guides/skill-capability-guides.md
@@ -11,10 +11,10 @@ consume the rendered guide through the instruction surface they actually own.
 | Codex | Managed rule under `~/.codex/rules/ouroboros.md` | Installed during Codex setup/update via the generated guide renderer. |
 | Hermes | `~/.hermes/skills/autonomous-ai-agents/ouroboros/SKILL_CAPABILITY_GUIDE.md` | Installed with the Hermes skill bundle. |
 | Claude | `.claude-plugin/SKILL_CAPABILITY_GUIDE.md` | Shipped with the Claude plugin package and checked against the renderer. |
-| OpenCode | Not yet a stable prompt/rule artifact in setup | Fallback: use the generic guide from `backends.capabilities` and keep bridge-plugin behavior unchanged until OpenCode exposes a durable instruction surface. |
-| Gemini | Not yet a setup-owned prompt/rule artifact | Fallback: use the generic guide from `backends.capabilities`; setup only switches Ouroboros runtime/backend config today. |
-| Kiro | Not yet a setup-owned prompt/rule artifact | Fallback: use the generic guide from `backends.capabilities`; setup currently registers MCP and backend config only. |
-| Copilot | Not yet a setup-owned prompt/rule artifact | Fallback: use the generic guide from `backends.capabilities`; setup currently registers MCP and model/runtime config only. |
+| OpenCode | `AGENTS.md` in the OpenCode config directory | Installer helper is available and writes a managed marked section; setup integration lands in the follow-up OpenCode PR. |
+| Gemini | `~/.gemini/GEMINI.md` | Installer helper is available and writes a managed marked section; setup integration is still pending. |
+| Kiro | `~/.kiro/steering/ouroboros-skill-capability-guide.md` | Installer helper is available and writes a managed marked section; setup integration is still pending. |
+| Copilot | `~/.copilot/ouroboros-instructions/AGENTS.md` | Installer helper is available and writes a managed marked section; setup integration is still pending. |
 
 ## Seed generation client-gate enforcement
 
@@ -26,12 +26,12 @@ existing clients. Set `OUROBOROS_REQUIRE_CLIENT_GATES=1` to promote missing
 gates to a hard MCP precondition while migrating maintained clients to pass the
 `client_gates` acknowledgements.
 
-## Fallback behavior for runtimes without generated artifacts
+## Fallback behavior before setup integration
 
-Until a runtime has a durable instruction surface owned by `ouroboros setup`,
-clients should render `render_backend_skill_capability_guide(<backend>)` when
-building prompts or user-facing setup guidance, but must not copy long adapter
-sections into individual `SKILL.md` files.
+Until a runtime installer is wired into `ouroboros setup`, clients should render
+`render_backend_skill_capability_guide(<backend>)` when building prompts or
+user-facing setup guidance, but must not copy long adapter sections into
+individual `SKILL.md` files.
 
 The fallback is intentionally conservative:
 

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -1223,6 +1223,32 @@ def _install_hermes_artifacts() -> None:
         print_error("Could not locate packaged skills for Hermes.")
 
 
+def _install_runtime_instruction_artifact(backend: str, **kwargs: object) -> None:
+    """Install a setup-owned runtime instruction artifact when supported."""
+    from ouroboros.runtime_instruction_artifacts import (
+        install_copilot_instruction_artifact,
+        install_gemini_instruction_artifact,
+        install_kiro_instruction_artifact,
+        install_opencode_instruction_artifact,
+    )
+
+    installers = {
+        "opencode": install_opencode_instruction_artifact,
+        "gemini": install_gemini_instruction_artifact,
+        "kiro": install_kiro_instruction_artifact,
+        "copilot": install_copilot_instruction_artifact,
+    }
+    installer = installers.get(backend)
+    if installer is None:
+        return
+    try:
+        artifact = installer(**kwargs)
+    except OSError as exc:
+        print_warning(f"Could not install {backend} instruction artifact: {exc}")
+        return
+    print_success(f"Installed {backend.title()} instruction guide → {artifact.path}")
+
+
 def _register_hermes_mcp_server() -> None:
     """Register the Ouroboros MCP hookup in ~/.hermes/config.yaml."""
     hermes_config = Path.home() / ".hermes" / "config.yaml"
@@ -1498,6 +1524,7 @@ def _setup_kiro(kiro_path: str) -> None:
     print_info(f"Config saved to: {config_path}")
 
     _register_kiro_mcp_server()
+    _install_runtime_instruction_artifact("kiro")
 
 
 def _register_copilot_mcp_server() -> None:
@@ -1767,6 +1794,7 @@ def _setup_copilot(copilot_path: str, *, non_interactive: bool = False) -> None:
     print_info(f"Config saved to: {config_path}")
 
     _register_copilot_mcp_server()
+    _install_runtime_instruction_artifact("copilot")
 
 
 def _setup_gemini(gemini_path: str) -> None:
@@ -1812,6 +1840,7 @@ def _setup_gemini(gemini_path: str) -> None:
 
     print_success(f"Configured Gemini runtime (CLI: {gemini_path})")
     print_info(f"Config saved to: {config_path}")
+    _install_runtime_instruction_artifact("gemini")
 
 
 def _setup_goose(goose_path: str) -> None:
@@ -2366,6 +2395,7 @@ def _setup_opencode(opencode_path: str, mode: str = "plugin") -> bool:
         # paths are not active simultaneously (duplicate dispatch).
         with _temporary_opencode_cli_path(opencode_path):
             _cleanup_plugin_artifacts()
+            _install_runtime_instruction_artifact("opencode", config_dir=opencode_config_dir())
 
         print_success(f"Configured OpenCode subprocess runtime (CLI: {opencode_path})")
         print_info(f"Config saved to: {config_path}")
@@ -2394,6 +2424,9 @@ def _setup_opencode(opencode_path: str, mode: str = "plugin") -> bool:
             "after fixing the issues above."
         )
         return False
+
+    with _temporary_opencode_cli_path(opencode_path):
+        _install_runtime_instruction_artifact("opencode", config_dir=opencode_config_dir())
 
     # All installs succeeded — now safe to persist config.
     # Plugin mode still needs runtime_backend=opencode so the MCP server's
@@ -2591,7 +2624,7 @@ def setup(
         typer.Option(
             "--runtime",
             "-r",
-            help="Runtime backend to configure (claude, codex, opencode, hermes, gemini, kiro, copilot).",
+            help="Runtime backend to configure (claude, codex, opencode, hermes, gemini, kiro, copilot, goose).",
         ),
     ] = None,
     non_interactive: Annotated[

--- a/src/ouroboros/copilot/cli_policy.py
+++ b/src/ouroboros/copilot/cli_policy.py
@@ -153,6 +153,7 @@ def build_copilot_child_env(
     # agent runtime and refuse to start or hang.
     env.pop("CLAUDECODE", None)
     env.pop("CODEX_THREAD_ID", None)
+    _add_ouroboros_copilot_instruction_dir(env)
 
     try:
         depth = int(env.get("_OUROBOROS_DEPTH", "0")) + 1
@@ -164,6 +165,19 @@ def build_copilot_child_env(
 
     env["_OUROBOROS_DEPTH"] = str(depth)
     return env
+
+
+def _add_ouroboros_copilot_instruction_dir(env: dict[str, str]) -> None:
+    """Ensure Copilot CLI sees the setup-owned Ouroboros AGENTS.md directory."""
+    from ouroboros.runtime_instruction_artifacts import copilot_instruction_dir
+
+    instruction_dir = str(copilot_instruction_dir())
+    key = "COPILOT_CUSTOM_INSTRUCTIONS_DIRS"
+    existing = env.get(key, "")
+    parts = [part.strip() for part in existing.split(",") if part.strip()]
+    if instruction_dir not in parts:
+        parts.append(instruction_dir)
+    env[key] = ",".join(parts)
 
 
 def _which(name: str) -> str | None:

--- a/src/ouroboros/runtime_instruction_artifacts.py
+++ b/src/ouroboros/runtime_instruction_artifacts.py
@@ -1,0 +1,140 @@
+"""Install runtime-owned instruction artifacts for skill capability guides."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from ouroboros.backends.capabilities import render_backend_skill_capability_guide
+
+GUIDE_FILENAME = "ouroboros-skill-capability-guide.md"
+COPILOT_INSTRUCTIONS_DIRNAME = "ouroboros-instructions"
+COPILOT_AGENTS_FILENAME = "AGENTS.md"
+_SECTION_START = "<!-- ouroboros:skill-capability-guide:start -->"
+_SECTION_END = "<!-- ouroboros:skill-capability-guide:end -->"
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeInstructionArtifact:
+    """One installed runtime instruction artifact."""
+
+    backend: str
+    path: Path
+
+
+def _render_section(backend: str) -> str:
+    guide = render_backend_skill_capability_guide(backend).rstrip()
+    return f"{_SECTION_START}\n{guide}\n{_SECTION_END}\n"
+
+
+def _upsert_marked_section(existing: str, section: str) -> str:
+    """Insert or replace the managed capability-guide section."""
+    start = existing.find(_SECTION_START)
+    end = existing.find(_SECTION_END)
+    if start != -1 and end != -1 and end > start:
+        end += len(_SECTION_END)
+        return f"{existing[:start].rstrip()}\n\n{section}{existing[end:].lstrip()}".rstrip() + "\n"
+
+    base = existing.rstrip()
+    if not base:
+        return section
+    return f"{base}\n\n{section}"
+
+
+def _write_managed_section(path: Path, backend: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = path.read_text(encoding="utf-8") if path.exists() else ""
+    path.write_text(
+        _upsert_marked_section(existing, _render_section(backend)),
+        encoding="utf-8",
+    )
+    return path
+
+
+def opencode_instruction_path(config_dir: str | Path) -> Path:
+    """Return OpenCode's global instruction artifact path."""
+    return Path(config_dir).expanduser() / "AGENTS.md"
+
+
+def gemini_instruction_path(home: str | Path | None = None) -> Path:
+    """Return Gemini CLI's global memory/instruction artifact path."""
+    root = Path(home).expanduser() if home is not None else Path.home()
+    return root / ".gemini" / "GEMINI.md"
+
+
+def kiro_instruction_path(home: str | Path | None = None) -> Path:
+    """Return Kiro's global steering artifact path."""
+    root = Path(home).expanduser() if home is not None else Path.home()
+    return root / ".kiro" / "steering" / GUIDE_FILENAME
+
+
+def copilot_instruction_dir(home: str | Path | None = None) -> Path:
+    """Return the setup-owned Copilot custom-instructions directory."""
+    root = Path(home).expanduser() if home is not None else Path.home()
+    return root / ".copilot" / COPILOT_INSTRUCTIONS_DIRNAME
+
+
+def copilot_instruction_path(home: str | Path | None = None) -> Path:
+    """Return the setup-owned Copilot AGENTS.md instruction artifact path."""
+    return copilot_instruction_dir(home) / COPILOT_AGENTS_FILENAME
+
+
+def install_opencode_instruction_artifact(
+    *,
+    config_dir: str | Path,
+) -> RuntimeInstructionArtifact:
+    """Install OpenCode's setup-owned global AGENTS.md guidance section."""
+    return RuntimeInstructionArtifact(
+        backend="opencode",
+        path=_write_managed_section(opencode_instruction_path(config_dir), "opencode"),
+    )
+
+
+def install_gemini_instruction_artifact(
+    *,
+    home: str | Path | None = None,
+) -> RuntimeInstructionArtifact:
+    """Install Gemini CLI's setup-owned global GEMINI.md guidance section."""
+    return RuntimeInstructionArtifact(
+        backend="gemini",
+        path=_write_managed_section(gemini_instruction_path(home), "gemini"),
+    )
+
+
+def install_kiro_instruction_artifact(
+    *,
+    home: str | Path | None = None,
+) -> RuntimeInstructionArtifact:
+    """Install Kiro's setup-owned global steering guidance file."""
+    return RuntimeInstructionArtifact(
+        backend="kiro",
+        path=_write_managed_section(kiro_instruction_path(home), "kiro"),
+    )
+
+
+def install_copilot_instruction_artifact(
+    *,
+    home: str | Path | None = None,
+) -> RuntimeInstructionArtifact:
+    """Install Copilot CLI's setup-owned AGENTS.md guidance file."""
+    return RuntimeInstructionArtifact(
+        backend="copilot",
+        path=_write_managed_section(copilot_instruction_path(home), "copilot"),
+    )
+
+
+__all__ = [
+    "COPILOT_AGENTS_FILENAME",
+    "COPILOT_INSTRUCTIONS_DIRNAME",
+    "GUIDE_FILENAME",
+    "RuntimeInstructionArtifact",
+    "copilot_instruction_dir",
+    "copilot_instruction_path",
+    "gemini_instruction_path",
+    "install_copilot_instruction_artifact",
+    "install_gemini_instruction_artifact",
+    "install_kiro_instruction_artifact",
+    "install_opencode_instruction_artifact",
+    "kiro_instruction_path",
+    "opencode_instruction_path",
+]

--- a/src/ouroboros/runtime_instruction_artifacts.py
+++ b/src/ouroboros/runtime_instruction_artifacts.py
@@ -44,6 +44,12 @@ def _upsert_marked_section(existing: str, section: str) -> str:
             chunks.append(existing[cursor:])
             break
 
+        nested_start = existing.find(_SECTION_START, start + len(_SECTION_START), end)
+        if nested_start != -1:
+            chunks.append(existing[cursor:nested_start])
+            cursor = nested_start
+            continue
+
         chunks.append(existing[cursor:start])
         if not replaced:
             chunks.append(section)

--- a/src/ouroboros/runtime_instruction_artifacts.py
+++ b/src/ouroboros/runtime_instruction_artifacts.py
@@ -28,12 +28,30 @@ def _render_section(backend: str) -> str:
 
 
 def _upsert_marked_section(existing: str, section: str) -> str:
-    """Insert or replace the managed capability-guide section."""
-    start = existing.find(_SECTION_START)
-    end = existing.rfind(_SECTION_END)
-    if start != -1 and end != -1 and end > start:
-        end += len(_SECTION_END)
-        return f"{existing[:start].rstrip()}\n\n{section}{existing[end:].lstrip()}".rstrip() + "\n"
+    """Insert or replace managed guide sections without dropping user text."""
+    chunks: list[str] = []
+    replaced = False
+    cursor = 0
+
+    while True:
+        start = existing.find(_SECTION_START, cursor)
+        if start == -1:
+            chunks.append(existing[cursor:])
+            break
+
+        end = existing.find(_SECTION_END, start + len(_SECTION_START))
+        if end == -1:
+            chunks.append(existing[cursor:])
+            break
+
+        chunks.append(existing[cursor:start])
+        if not replaced:
+            chunks.append(section)
+            replaced = True
+        cursor = end + len(_SECTION_END)
+
+    if replaced:
+        return "".join(chunks).rstrip() + "\n"
 
     base = existing.rstrip()
     if not base:

--- a/src/ouroboros/runtime_instruction_artifacts.py
+++ b/src/ouroboros/runtime_instruction_artifacts.py
@@ -30,7 +30,7 @@ def _render_section(backend: str) -> str:
 def _upsert_marked_section(existing: str, section: str) -> str:
     """Insert or replace the managed capability-guide section."""
     start = existing.find(_SECTION_START)
-    end = existing.find(_SECTION_END)
+    end = existing.rfind(_SECTION_END)
     if start != -1 and end != -1 and end > start:
         end += len(_SECTION_END)
         return f"{existing[:start].rstrip()}\n\n{section}{existing[end:].lstrip()}".rstrip() + "\n"

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -2596,6 +2596,7 @@ class TestOpenCodeSetupConfigYaml:
             patch("ouroboros.cli.commands.setup._ensure_opencode_mcp_entry"),
             patch("ouroboros.cli.commands.setup._ensure_claude_mcp_entry"),
             patch("ouroboros.cli.commands.setup._cleanup_plugin_artifacts"),
+            patch("ouroboros.cli.commands.setup._install_runtime_instruction_artifact"),
         ):
             from ouroboros.cli.commands.setup import _setup_opencode
 
@@ -2605,6 +2606,53 @@ class TestOpenCodeSetupConfigYaml:
         assert isinstance(result, dict)
         assert result["orchestrator"]["runtime_backend"] == "opencode"
         assert result["llm"]["backend"] == "opencode"
+
+    def test_subprocess_setup_installs_instruction_artifact(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("{}", encoding="utf-8")
+        opencode_dir = tmp_path / "opencode-config"
+
+        with (
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup._cleanup_plugin_artifacts"),
+            patch("ouroboros.cli.commands.setup.opencode_config_dir", return_value=opencode_dir),
+        ):
+            from ouroboros.cli.commands.setup import _setup_opencode
+
+            _setup_opencode("/usr/bin/opencode", mode="subprocess")
+
+        guide_path = opencode_dir / "AGENTS.md"
+        assert guide_path.is_file()
+        assert "## Ouroboros Skill Capability Guide: Opencode" in guide_path.read_text(
+            encoding="utf-8"
+        )
+
+    def test_plugin_setup_installs_instruction_artifact_after_success(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("{}", encoding="utf-8")
+        opencode_dir = tmp_path / "opencode-config"
+
+        with (
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup._install_opencode_bridge_plugin", return_value=True),
+            patch("ouroboros.cli.commands.setup._ensure_opencode_mcp_entry", return_value=True),
+            patch("ouroboros.cli.commands.setup._ensure_opencode_plugin_entry", return_value=True),
+            patch("ouroboros.cli.commands.setup.opencode_config_dir", return_value=opencode_dir),
+        ):
+            from ouroboros.cli.commands.setup import _setup_opencode
+
+            assert _setup_opencode("/usr/bin/opencode", mode="plugin") is True
+
+        guide_path = opencode_dir / "AGENTS.md"
+        assert guide_path.is_file()
+        assert "## Ouroboros Skill Capability Guide: Opencode" in guide_path.read_text(
+            encoding="utf-8"
+        )
 
     def test_orchestrator_as_list_repaired(self, tmp_path: Path) -> None:
         """If orchestrator is a list, _setup_opencode replaces with dict."""
@@ -2621,6 +2669,7 @@ class TestOpenCodeSetupConfigYaml:
             patch("ouroboros.cli.commands.setup._ensure_opencode_mcp_entry"),
             patch("ouroboros.cli.commands.setup._ensure_claude_mcp_entry"),
             patch("ouroboros.cli.commands.setup._cleanup_plugin_artifacts"),
+            patch("ouroboros.cli.commands.setup._install_runtime_instruction_artifact"),
         ):
             from ouroboros.cli.commands.setup import _setup_opencode
 
@@ -2645,6 +2694,7 @@ class TestOpenCodeSetupConfigYaml:
             patch("ouroboros.cli.commands.setup._ensure_opencode_plugin_entry"),
             patch("ouroboros.cli.commands.setup._install_opencode_bridge_plugin"),
             patch("ouroboros.cli.commands.setup._ensure_claude_mcp_entry") as mock_claude,
+            patch("ouroboros.cli.commands.setup._install_runtime_instruction_artifact"),
         ):
             from ouroboros.cli.commands.setup import _setup_opencode
 
@@ -2666,7 +2716,7 @@ class TestOpenCodeSetupConfigYaml:
         observed: list[str | None] = []
         monkeypatch.delenv("OUROBOROS_OPENCODE_CLI_PATH", raising=False)
 
-        def record_cli_path() -> bool:
+        def record_cli_path(*_args: object, **_kwargs: object) -> bool:
             observed.append(os.environ.get("OUROBOROS_OPENCODE_CLI_PATH"))
             return True
 
@@ -2684,12 +2734,16 @@ class TestOpenCodeSetupConfigYaml:
                 "ouroboros.cli.commands.setup._ensure_opencode_plugin_entry",
                 side_effect=record_cli_path,
             ),
+            patch(
+                "ouroboros.cli.commands.setup._install_runtime_instruction_artifact",
+                side_effect=record_cli_path,
+            ),
         ):
             from ouroboros.cli.commands.setup import _setup_opencode
 
             assert _setup_opencode(cli_path, mode="plugin") is True
 
-        assert observed == [cli_path, cli_path, cli_path]
+        assert observed == [cli_path, cli_path, cli_path, cli_path]
         assert os.environ.get("OUROBOROS_OPENCODE_CLI_PATH") is None
 
     def test_plugin_setup_failure_returns_false_without_persisting_config(
@@ -2701,6 +2755,7 @@ class TestOpenCodeSetupConfigYaml:
         config_dir.mkdir()
         config_path = config_dir / "config.yaml"
         config_path.write_text("{}", encoding="utf-8")
+        opencode_dir = tmp_path / "opencode-config"
 
         with (
             patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
@@ -2709,12 +2764,14 @@ class TestOpenCodeSetupConfigYaml:
             ),
             patch("ouroboros.cli.commands.setup._ensure_opencode_mcp_entry", return_value=True),
             patch("ouroboros.cli.commands.setup._ensure_opencode_plugin_entry", return_value=True),
+            patch("ouroboros.cli.commands.setup.opencode_config_dir", return_value=opencode_dir),
         ):
             from ouroboros.cli.commands.setup import _setup_opencode
 
             assert _setup_opencode("/usr/bin/opencode", mode="plugin") is False
 
         assert yaml.safe_load(config_path.read_text(encoding="utf-8")) == {}
+        assert not (opencode_dir / "AGENTS.md").exists()
 
     def test_plugin_setup_failure_exits_before_success_banner(self, tmp_path: Path) -> None:
         """Top-level setup must propagate plugin setup failure to exit status."""
@@ -2764,6 +2821,7 @@ class TestOpenCodeModePersisted:
             patch("ouroboros.cli.commands.setup._install_opencode_bridge_plugin"),
             patch("ouroboros.cli.commands.setup._ensure_claude_mcp_entry"),
             patch("ouroboros.cli.commands.setup._cleanup_plugin_artifacts"),
+            patch("ouroboros.cli.commands.setup._install_runtime_instruction_artifact"),
         ):
             from ouroboros.cli.commands.setup import _setup_opencode
 
@@ -2930,8 +2988,47 @@ class TestGooseSetup:
         assert chosen["path"] == "/custom/goose"
 
 
+class TestGeminiSetup:
+    """Tests for Gemini-specific setup behavior."""
+
+    def test_setup_gemini_installs_instruction_artifact(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("{}", encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+        ):
+            setup_cmd._setup_gemini("/opt/bin/gemini")
+
+        guide_path = tmp_path / ".gemini" / "GEMINI.md"
+        assert guide_path.is_file()
+        assert "## Ouroboros Skill Capability Guide: Gemini" in guide_path.read_text(
+            encoding="utf-8"
+        )
+
+
 class TestKiroSetup:
     """Tests for Kiro-specific setup behavior."""
+
+    def test_setup_kiro_installs_instruction_artifact(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("{}", encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch("ouroboros.cli.commands.setup._register_kiro_mcp_server"),
+        ):
+            setup_cmd._setup_kiro("/opt/bin/kiro-cli")
+
+        guide_path = tmp_path / ".kiro" / "steering" / "ouroboros-skill-capability-guide.md"
+        assert guide_path.is_file()
+        assert "### When a skill requires `run_lateral_review`" in guide_path.read_text(
+            encoding="utf-8"
+        )
 
     def test_detect_runtimes_includes_kiro(self, tmp_path: Path) -> None:
         """_detect_runtimes should surface kiro when kiro-cli is on PATH.
@@ -3307,6 +3404,11 @@ class TestCopilotSetup:
         assert config["clarification"]["default_model"] == "claude-opus-4.6"
         # Explicit user overrides are preserved.
         assert config["llm"]["qa_model"] == "x"
+        guide_path = tmp_path / ".copilot" / "ouroboros-instructions" / "AGENTS.md"
+        assert guide_path.is_file()
+        assert "### When a skill requires `run_lateral_review`" in guide_path.read_text(
+            encoding="utf-8"
+        )
         mock_register.assert_called_once_with()
 
     def test_setup_copilot_replaces_shipped_default_model_fields(self, tmp_path: Path) -> None:

--- a/tests/unit/copilot/test_cli_policy.py
+++ b/tests/unit/copilot/test_cli_policy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import sys
 
@@ -134,6 +135,35 @@ class TestBuildCopilotChildEnv:
         # GH_TOKEN / GITHUB_TOKEN must survive — child needs them to authenticate.
         assert env["GH_TOKEN"] == "ghp_secret"
         assert env["GITHUB_TOKEN"] == "ghp_other"
+        parts = env["COPILOT_CUSTOM_INSTRUCTIONS_DIRS"].split(",")
+        assert parts[-1].endswith(os.path.join(".copilot", "ouroboros-instructions"))
+
+    def test_preserves_existing_custom_instruction_dirs(self, tmp_path: Path) -> None:
+        existing = str(tmp_path / "existing")
+        env = build_copilot_child_env(
+            base_env={"COPILOT_CUSTOM_INSTRUCTIONS_DIRS": existing},
+            depth_error_factory=lambda depth, max_depth: RuntimeError(f"depth {depth}/{max_depth}"),
+        )
+
+        parts = env["COPILOT_CUSTOM_INSTRUCTIONS_DIRS"].split(",")
+        assert parts[0] == existing
+        assert parts[-1].endswith(os.path.join(".copilot", "ouroboros-instructions"))
+
+    def test_preserves_existing_comma_separated_custom_instruction_dirs(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        first = str(tmp_path / "first")
+        second = str(tmp_path / "second")
+        env = build_copilot_child_env(
+            base_env={"COPILOT_CUSTOM_INSTRUCTIONS_DIRS": f"{first},{second}"},
+            depth_error_factory=lambda depth, max_depth: RuntimeError(f"depth {depth}/{max_depth}"),
+        )
+
+        parts = env["COPILOT_CUSTOM_INSTRUCTIONS_DIRS"].split(",")
+        assert parts[0] == first
+        assert parts[1] == second
+        assert parts[-1].endswith(os.path.join(".copilot", "ouroboros-instructions"))
 
     def test_uses_supplied_error_factory_for_depth_guard(self) -> None:
         class DepthExceededError(RuntimeError):

--- a/tests/unit/test_runtime_instruction_artifacts.py
+++ b/tests/unit/test_runtime_instruction_artifacts.py
@@ -1,0 +1,67 @@
+"""Tests for setup-owned runtime instruction artifacts."""
+
+from pathlib import Path
+
+from ouroboros.runtime_instruction_artifacts import (
+    COPILOT_AGENTS_FILENAME,
+    COPILOT_INSTRUCTIONS_DIRNAME,
+    GUIDE_FILENAME,
+    install_copilot_instruction_artifact,
+    install_gemini_instruction_artifact,
+    install_kiro_instruction_artifact,
+    install_opencode_instruction_artifact,
+)
+
+
+def test_opencode_installs_global_agents_section(tmp_path: Path) -> None:
+    artifact = install_opencode_instruction_artifact(config_dir=tmp_path / "opencode")
+
+    assert artifact.backend == "opencode"
+    assert artifact.path == tmp_path / "opencode" / "AGENTS.md"
+    content = artifact.path.read_text(encoding="utf-8")
+    assert "## Ouroboros Skill Capability Guide: Opencode" in content
+    assert "### When a skill requires `run_lateral_review`" in content
+
+
+def test_gemini_installs_global_gemini_memory_section(tmp_path: Path) -> None:
+    artifact = install_gemini_instruction_artifact(home=tmp_path)
+
+    assert artifact.path == tmp_path / ".gemini" / "GEMINI.md"
+    content = artifact.path.read_text(encoding="utf-8")
+    assert "## Ouroboros Skill Capability Guide: Gemini" in content
+    assert "lateral_review_required=true" in content
+
+
+def test_kiro_installs_global_steering_file(tmp_path: Path) -> None:
+    artifact = install_kiro_instruction_artifact(home=tmp_path)
+
+    assert artifact.path == tmp_path / ".kiro" / "steering" / GUIDE_FILENAME
+    content = artifact.path.read_text(encoding="utf-8")
+    assert "## Ouroboros Skill Capability Guide: Kiro" in content
+    assert "### When a skill requires `run_lateral_review`" in content
+
+
+def test_copilot_installs_custom_agents_file(tmp_path: Path) -> None:
+    artifact = install_copilot_instruction_artifact(home=tmp_path)
+
+    assert artifact.path == (
+        tmp_path / ".copilot" / COPILOT_INSTRUCTIONS_DIRNAME / COPILOT_AGENTS_FILENAME
+    )
+    content = artifact.path.read_text(encoding="utf-8")
+    assert "## Ouroboros Skill Capability Guide: Copilot" in content
+    assert "### When a skill requires `run_lateral_review`" in content
+
+
+def test_marked_section_refresh_is_idempotent(tmp_path: Path) -> None:
+    path = tmp_path / "opencode" / "AGENTS.md"
+    path.parent.mkdir(parents=True)
+    path.write_text("# User instructions\n\nKeep this line.\n", encoding="utf-8")
+
+    first = install_opencode_instruction_artifact(config_dir=tmp_path / "opencode")
+    second = install_opencode_instruction_artifact(config_dir=tmp_path / "opencode")
+
+    assert first.path == second.path
+    content = path.read_text(encoding="utf-8")
+    assert content.count("<!-- ouroboros:skill-capability-guide:start -->") == 1
+    assert content.startswith("# User instructions")
+    assert "Keep this line." in content

--- a/tests/unit/test_runtime_instruction_artifacts.py
+++ b/tests/unit/test_runtime_instruction_artifacts.py
@@ -65,3 +65,26 @@ def test_marked_section_refresh_is_idempotent(tmp_path: Path) -> None:
     assert content.count("<!-- ouroboros:skill-capability-guide:start -->") == 1
     assert content.startswith("# User instructions")
     assert "Keep this line." in content
+
+
+def test_marked_section_refresh_collapses_duplicate_managed_sections(tmp_path: Path) -> None:
+    path = tmp_path / "opencode" / "AGENTS.md"
+    path.parent.mkdir(parents=True)
+    duplicate_section = (
+        "<!-- ouroboros:skill-capability-guide:start -->\n"
+        "stale guide\n"
+        "<!-- ouroboros:skill-capability-guide:end -->\n"
+    )
+    path.write_text(
+        f"# User instructions\n\n{duplicate_section}\n{duplicate_section}\nKeep this line.\n",
+        encoding="utf-8",
+    )
+
+    install_opencode_instruction_artifact(config_dir=tmp_path / "opencode")
+
+    content = path.read_text(encoding="utf-8")
+    assert content.count("<!-- ouroboros:skill-capability-guide:start -->") == 1
+    assert content.count("<!-- ouroboros:skill-capability-guide:end -->") == 1
+    assert "stale guide" not in content
+    assert content.startswith("# User instructions")
+    assert "Keep this line." in content

--- a/tests/unit/test_runtime_instruction_artifacts.py
+++ b/tests/unit/test_runtime_instruction_artifacts.py
@@ -76,7 +76,7 @@ def test_marked_section_refresh_collapses_duplicate_managed_sections(tmp_path: P
         "<!-- ouroboros:skill-capability-guide:end -->\n"
     )
     path.write_text(
-        f"# User instructions\n\n{duplicate_section}\n{duplicate_section}\nKeep this line.\n",
+        f"# User instructions\n\n{duplicate_section}\nUSER CUSTOM LINE BETWEEN DUPLICATES\n\n{duplicate_section}\nKeep this line.\n",
         encoding="utf-8",
     )
 
@@ -86,5 +86,6 @@ def test_marked_section_refresh_collapses_duplicate_managed_sections(tmp_path: P
     assert content.count("<!-- ouroboros:skill-capability-guide:start -->") == 1
     assert content.count("<!-- ouroboros:skill-capability-guide:end -->") == 1
     assert "stale guide" not in content
+    assert "USER CUSTOM LINE BETWEEN DUPLICATES" in content
     assert content.startswith("# User instructions")
     assert "Keep this line." in content

--- a/tests/unit/test_runtime_instruction_artifacts.py
+++ b/tests/unit/test_runtime_instruction_artifacts.py
@@ -89,3 +89,31 @@ def test_marked_section_refresh_collapses_duplicate_managed_sections(tmp_path: P
     assert "USER CUSTOM LINE BETWEEN DUPLICATES" in content
     assert content.startswith("# User instructions")
     assert "Keep this line." in content
+
+
+def test_marked_section_refresh_preserves_text_after_stray_start_marker(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "opencode" / "AGENTS.md"
+    path.parent.mkdir(parents=True)
+    valid_section = (
+        "<!-- ouroboros:skill-capability-guide:start -->\n"
+        "stale guide\n"
+        "<!-- ouroboros:skill-capability-guide:end -->\n"
+    )
+    path.write_text(
+        "# User instructions\n\n"
+        "<!-- ouroboros:skill-capability-guide:start -->\n"
+        "USER CUSTOM LINE THAT MUST SURVIVE\n\n"
+        f"{valid_section}"
+        "Keep this line.\n",
+        encoding="utf-8",
+    )
+
+    install_opencode_instruction_artifact(config_dir=tmp_path / "opencode")
+
+    content = path.read_text(encoding="utf-8")
+    assert "USER CUSTOM LINE THAT MUST SURVIVE" in content
+    assert "stale guide" not in content
+    assert "Keep this line." in content
+    assert "## Ouroboros Skill Capability Guide: Opencode" in content

--- a/tests/unit/test_runtime_skill_capability_docs.py
+++ b/tests/unit/test_runtime_skill_capability_docs.py
@@ -2,13 +2,38 @@
 
 from pathlib import Path
 
+from ouroboros.backends.capabilities import runtime_backend_choices
+
 
 def test_runtime_skill_capability_guide_docs_cover_all_runtime_backends() -> None:
     docs = Path("docs/runtime-guides/skill-capability-guides.md").read_text(encoding="utf-8")
 
-    for backend in ("Codex", "Hermes", "Claude", "OpenCode", "Gemini", "Kiro", "Copilot"):
-        assert f"| {backend} |" in docs
+    coverage_section = docs.split("## Current coverage", 1)[1].split("## Seed generation", 1)[0]
+    documented_runtime_names = {
+        row.split("|")[1].strip().lower()
+        for row in coverage_section.splitlines()
+        if row.startswith("|") and not row.startswith("| ---") and "Generated artifact surface" not in row
+    }
+    assert set(runtime_backend_choices()) <= documented_runtime_names
 
+    assert "Global `AGENTS.md`" in docs
+    assert "`~/.gemini/GEMINI.md`" in docs
+    assert "`~/.kiro/steering/ouroboros-skill-capability-guide.md`" in docs
+    assert "`~/.copilot/ouroboros-instructions/AGENTS.md`" in docs
+    assert "| Goose | No setup-owned capability artifact yet |" in docs
+    assert "| Pi | No setup-owned capability artifact yet |" in docs
     assert "render_backend_skill_capability_guide(<backend>)" in docs
+    assert "## Capability graph contract" in docs
+    assert "## Contributor checklist for capability changes" in docs
+    assert "`src/ouroboros/backends/capabilities.py`" in docs
+    assert "SkillExecutionCapability" in docs
     compact = " ".join(docs.split())
     assert "must not copy long adapter sections into individual `SKILL.md` files" in compact
+
+
+def test_cli_reference_setup_runtime_list_includes_supported_runtime_backends() -> None:
+    docs = Path("docs/cli-reference.md").read_text(encoding="utf-8")
+
+    assert "`claude`, `codex`, `opencode`, `hermes`, `gemini`, `kiro`, `copilot`, `goose`" in docs
+    assert "Claude Code, Codex CLI, OpenCode, Hermes, Gemini, Kiro, Copilot, and Goose" in docs
+    assert "`kiro-cli`, `copilot`, and `goose` CLI binaries" in docs


### PR DESCRIPTION
## Summary
- add shared runtime instruction artifact installer helpers
- render backend skill capability guides into managed marked sections
- cover OpenCode, Gemini, Kiro, and Copilot artifact paths plus idempotent refresh

## Stack
Base: #1334

## Tests
- `uv run pytest -q tests/unit/backends/test_capabilities.py tests/unit/cli/test_setup.py tests/unit/copilot/test_cli_policy.py tests/unit/hermes/test_artifacts.py tests/unit/mcp/tools/test_interview_lateral_review_advisory.py tests/unit/test_claude_plugin_skill_guide.py tests/unit/test_codex_artifacts.py tests/unit/test_runtime_instruction_artifacts.py tests/unit/test_runtime_skill_capability_docs.py`
- `uv run ruff check src/ouroboros/backends/capabilities.py src/ouroboros/runtime_instruction_artifacts.py src/ouroboros/cli/commands/setup.py src/ouroboros/copilot/cli_policy.py src/ouroboros/mcp/tools/authoring_handlers.py tests/unit/backends/test_capabilities.py tests/unit/cli/test_setup.py tests/unit/copilot/test_cli_policy.py tests/unit/hermes/test_artifacts.py tests/unit/mcp/tools/test_interview_lateral_review_advisory.py tests/unit/test_codex_artifacts.py tests/unit/test_runtime_instruction_artifacts.py tests/unit/test_runtime_skill_capability_docs.py`
- `uv run pytest tests/unit/ -q`