### PR TITLE
feat(pi): install ooo bridge for interactive Pi sessions

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -243,6 +243,10 @@ ouroboros setup [OPTIONS]
 | `--non-interactive` | Skip interactive prompts (for scripted installs) |
 | `--mcp-mode TEXT` | Codex MCP config mode: `auto` (default), `preserve`, or `stdio` |
 
+For Pi, setup also installs `~/.pi/agent/extensions/ouroboros-ooo-bridge.ts`.
+Restart Pi or run `/reload` and interactive Pi/roach-pi sessions can dispatch
+`ooo ...` commands into Ouroboros through the shared skill router.
+
 **Examples:**
 
 ```bash

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -766,7 +766,7 @@ llm:
   backend: pi
 ```
 
-Pi is available as an agent runtime backend and, when the Pi LLM adapter is installed, an LLM-only backend for interview, ambiguity scoring, seed-extraction, and structured JSON flows. The Pi LLM adapter supports structured `response_format` requests through prompt-level JSON/schema instructions plus adapter-side extraction and validation; Pi does not expose a Codex-style native `--output-schema` hard-enforcement flag. The runtime uses documented JSON mode (`pi --mode json <prompt>`) and preserves Pi native session IDs for targeted resume.
+Pi is available as an agent runtime backend and, when the Pi LLM adapter is installed, an LLM-only backend for interview, ambiguity scoring, seed-extraction, and structured JSON flows. `ouroboros setup --runtime pi` records the Pi executable and installs a managed Pi extension at `~/.pi/agent/extensions/ouroboros-ooo-bridge.ts`, so interactive Pi/roach-pi sessions can route exact-prefix `ooo ...` input back into Ouroboros after Pi restart or `/reload`. The Pi LLM adapter supports structured `response_format` requests through prompt-level JSON/schema instructions plus adapter-side extraction and validation; Pi does not expose a Codex-style native `--output-schema` hard-enforcement flag. The runtime uses documented JSON mode (`pi --mode json <prompt>`) and preserves Pi native session IDs for targeted resume.
 
 ### Full Config Skeleton
 

--- a/docs/runtime-guides/pi.md
+++ b/docs/runtime-guides/pi.md
@@ -31,7 +31,8 @@ Pi model turn and JSONL events
 
 So "Pi is an Ouroboros runtime" means step 2b exists and is selectable. It
 does not mean Pi packages are imported into Ouroboros, and it does not mean
-Pi's interactive command UI becomes part of the Ouroboros command router.
+Pi's interactive command UI becomes part of the Ouroboros command router
+unless the managed Pi bridge extension is installed by setup.
 
 ## Prerequisites
 
@@ -53,11 +54,14 @@ npm install -g --ignore-scripts @earendil-works/pi-coding-agent
 pi
 # In the interactive Pi session, run /login and select openai-codex.
 
-# 2. Point Ouroboros at Pi
+# 2. Point Ouroboros at Pi and install the Pi-side ooo bridge
 ouroboros setup --runtime pi
 
 # 3. Run a workflow through the configured runtime
 ouroboros run workflow seed.yaml
+
+# 4. In Pi or roach-pi/custom Pi, restart Pi or run /reload, then:
+ooo auto build a small CLI
 ```
 
 If Pi is installed outside `PATH`, set:
@@ -100,6 +104,11 @@ process return code.
 
 ## What `ooo` Means With Pi
 
+There are two supported entry paths.
+
+### Ouroboros Launches Pi
+
+When Ouroboros is already in control and `runtime_backend: pi` is selected,
 `ooo <skill>` is handled by Ouroboros before the Pi subprocess starts.
 
 The Pi runtime calls the shared `SkillInterceptor` at the top of
@@ -113,9 +122,51 @@ This means:
 - `ooo interview` in an Ouroboros-controlled Pi runtime means "Ouroboros
   handles the interview command, using the configured LLM backend for
   authoring."
-- It does not mean Pi has learned a new native `ooo` slash command.
-- It does not mean typing `ooo interview` inside an unrelated interactive Pi
-  terminal session will invoke Ouroboros.
+- Pi only runs normal Seed execution prompts after the command dispatch path
+  has decided the input is not an `ooo` shortcut.
+
+### Pi Or roach-pi Launches Ouroboros
+
+`ouroboros setup --runtime pi` also installs a managed global Pi extension:
+
+```text
+~/.pi/agent/extensions/ouroboros-ooo-bridge.ts
+```
+
+Pi auto-loads extensions from that directory. After restarting Pi or running
+`/reload`, interactive Pi sessions, including customized Pi setups such as
+roach-pi, can type:
+
+```text
+ooo auto build a small CLI
+ooo interview clarify this feature
+/ooo status auto --resume auto_...
+```
+
+The extension intercepts exact-prefix `ooo ...` input and runs:
+
+```text
+ouroboros dispatch --runtime pi --cwd <pi-session-cwd> "ooo ..."
+```
+
+That hidden `dispatch` entrypoint uses the same shared skill resolver and MCP
+handler composition as the runtime adapters. This is intentionally not a
+roach-pi-specific adapter: roach-pi remains Pi customization loaded by Pi, and
+Ouroboros owns only the bridge that forwards `ooo` commands into Ouroboros.
+
+The bridge only consumes commands that the hidden dispatcher can execute through
+MCP-backed skill frontmatter. Commands that are first-party shortcuts but do not
+declare an MCP dispatch target, such as `ooo help` or bare `ooo`, are returned
+to Pi with a deterministic unsupported-dispatch exit code so the normal Pi
+session can continue handling the input instead of receiving a hard bridge
+failure.
+
+For `ooo auto`, the dispatcher owns the background job lifecycle. After
+`ouroboros_start_auto` returns a `job_id`, the dispatch process polls
+`ouroboros_job_wait` and fetches `ouroboros_job_result` when the job reaches a
+terminal state. This keeps interactive Pi sessions aligned with the normal
+`ooo auto` contract: users do not have to manually poll the background job just
+because the command entered through Pi.
 
 ## `ooo auto --runtime pi`
 
@@ -160,12 +211,15 @@ That is different from saying `roach-pi` is the Ouroboros runtime adapter.
 | Ouroboros launches `pi --mode json` | Supported Pi runtime path |
 | Pi loads installed packages/extensions during that process | Allowed by Pi; visible to the Pi run |
 | A package adds headless-compatible tools/hooks used by Pi's model turn | May work, because it runs inside Pi |
-| A package adds interactive slash commands or UI prompts | Not guaranteed by the Ouroboros Pi runtime |
+| A package adds interactive slash commands or UI prompts | Works in normal interactive Pi; not guaranteed in Ouroboros-launched JSON mode |
+| Interactive Pi/roach-pi user types `ooo ...` after setup bridge install | Supported through the managed Pi extension |
 | `roach-pi` becomes a selectable Ouroboros runtime backend by itself | No; that would require a dedicated adapter or bridge |
 
 In short: `runtime_backend: pi` selects the Pi CLI as the execution engine.
 A customized Pi distribution can affect what happens inside that Pi process,
-but Ouroboros only depends on Pi's JSON-mode subprocess contract.
+but Ouroboros only depends on Pi's JSON-mode subprocess contract for runtime
+execution and on Pi's documented global extension loader for the interactive
+`ooo` bridge.
 
 ## Pi As LLM Backend
 
@@ -200,7 +254,7 @@ JSON extraction and validation rather than provider-native schema enforcement.
 | Structured event stream | Yes, JSONL parsed by `PiRuntime` |
 | Structured schema responses as LLM backend | Soft-enforced and validated |
 | Pi extension loading | Pi-owned; works when compatible with headless JSON mode |
-| Interactive Pi slash UI under Ouroboros | Not part of the runtime contract |
+| Interactive Pi `ooo` frontdoor | Yes, via managed setup-installed extension |
 
 ## Troubleshooting
 
@@ -217,3 +271,7 @@ The command may depend on Pi's interactive UI context. Ouroboros runs Pi in
 one-shot JSON mode, so interactive slash-command UX is not guaranteed. Prefer
 normal Seed execution prompts or headless-compatible Pi extensions for
 Ouroboros workflows.
+
+**`ooo ...` is sent to the model as ordinary chat inside Pi**
+Run `ouroboros setup --runtime pi`, then restart Pi or run `/reload`. Confirm
+that `~/.pi/agent/extensions/ouroboros-ooo-bridge.ts` exists.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -4,7 +4,7 @@
 #
 # Runtime selection (first match wins):
 #   1. OUROBOROS_INSTALL_RUNTIME env var
-#      (claude|codex|opencode|hermes|gemini|kiro|copilot|all)
+#      (claude|codex|opencode|hermes|gemini|kiro|copilot|pi|all)
 #   2. Existing ~/.ouroboros/config.yaml runtime — preserved on upgrade
 #      unless OUROBOROS_INSTALL_RECONFIGURE=1 (or --reconfigure flag) is set.
 #   3. Interactive prompt when stdin is a TTY.
@@ -153,6 +153,7 @@ HAS_OPENCODE=false
 HAS_GEMINI=false
 HAS_KIRO=false
 HAS_COPILOT=false
+HAS_PI=false
 if command -v codex &>/dev/null; then
   echo "  Codex:  $(which codex)"
   HAS_CODEX=true
@@ -181,6 +182,10 @@ if command -v copilot &>/dev/null; then
   echo "  Copilot: $(which copilot)"
   HAS_COPILOT=true
 fi
+if command -v pi &>/dev/null; then
+  echo "  Pi:      $(which pi)"
+  HAS_PI=true
+fi
 
 RUNTIME_COUNT=0
 [ "$HAS_CLAUDE" = true ] && RUNTIME_COUNT=$((RUNTIME_COUNT + 1))
@@ -190,6 +195,7 @@ RUNTIME_COUNT=0
 [ "$HAS_GEMINI" = true ] && RUNTIME_COUNT=$((RUNTIME_COUNT + 1))
 [ "$HAS_KIRO" = true ] && RUNTIME_COUNT=$((RUNTIME_COUNT + 1))
 [ "$HAS_COPILOT" = true ] && RUNTIME_COUNT=$((RUNTIME_COUNT + 1))
+[ "$HAS_PI" = true ] && RUNTIME_COUNT=$((RUNTIME_COUNT + 1))
 
 # Map a runtime name to (EXTRAS, RUNTIME) pair.
 # Used after explicit/preserved runtime resolution to derive install extras.
@@ -202,10 +208,11 @@ _runtime_to_extras() {
     gemini)  EXTRAS=""; RUNTIME="gemini" ;;
     kiro)    EXTRAS=""; RUNTIME="kiro" ;;
     copilot) EXTRAS=""; RUNTIME="copilot" ;;
+    pi)      EXTRAS=""; RUNTIME="pi" ;;
     all)     EXTRAS="[all]"; RUNTIME="" ;;
     "")      EXTRAS=""; RUNTIME="" ;;
     *)
-      echo "Error: unsupported runtime '$1' (expected: claude, codex, opencode, hermes, gemini, kiro, copilot, all)"
+      echo "Error: unsupported runtime '$1' (expected: claude, codex, opencode, hermes, gemini, kiro, copilot, pi, all)"
       exit 1
       ;;
   esac
@@ -218,7 +225,7 @@ EXISTING_CONFIG="$HOME/.ouroboros/config.yaml"
 if [ -z "$EXPLICIT_RUNTIME" ] && [ -z "$RECONFIGURE" ] && [ -f "$EXISTING_CONFIG" ] && command -v python3 &>/dev/null; then
   EXISTING_RUNTIME=$(EXISTING_CONFIG="$EXISTING_CONFIG" python3 -c "
 import os, re
-supported = {'claude', 'codex', 'opencode', 'hermes', 'gemini', 'kiro', 'copilot'}
+supported = {'claude', 'codex', 'opencode', 'hermes', 'gemini', 'kiro', 'copilot', 'pi'}
 try:
     lines = open(os.environ['EXISTING_CONFIG']).read().splitlines()
     in_orchestrator = False
@@ -258,7 +265,8 @@ elif [ "$RUNTIME_COUNT" -gt 1 ]; then
     echo "  [5] Gemini   (pip install ${PACKAGE_NAME})"
     echo "  [6] Kiro     (pip install ${PACKAGE_NAME})"
     echo "  [7] Copilot  (pip install ${PACKAGE_NAME})"
-    echo "  [8] All      (pip install ${PACKAGE_NAME}[all])"
+    echo "  [8] Pi       (pip install ${PACKAGE_NAME})"
+    echo "  [9] All      (pip install ${PACKAGE_NAME}[all])"
     read -rp "Select [1]: " choice
     case "${choice:-1}" in
       2) _runtime_to_extras "codex" ;;
@@ -267,7 +275,8 @@ elif [ "$RUNTIME_COUNT" -gt 1 ]; then
       5) _runtime_to_extras "gemini" ;;
       6) _runtime_to_extras "kiro" ;;
       7) _runtime_to_extras "copilot" ;;
-      8) _runtime_to_extras "all" ;;
+      8) _runtime_to_extras "pi" ;;
+      9) _runtime_to_extras "all" ;;
       *) _runtime_to_extras "claude" ;;
     esac
   else
@@ -288,6 +297,8 @@ elif [ "$HAS_KIRO" = true ] && [ "$RUNTIME_COUNT" -eq 1 ]; then
   _runtime_to_extras "kiro"
 elif [ "$HAS_COPILOT" = true ] && [ "$RUNTIME_COUNT" -eq 1 ]; then
   _runtime_to_extras "copilot"
+elif [ "$HAS_PI" = true ] && [ "$RUNTIME_COUNT" -eq 1 ]; then
+  _runtime_to_extras "pi"
 else
   # No runtime CLI on PATH yet — first install. Always prompt when interactive
   # so the user picks deliberately rather than silently defaulting to claude.
@@ -301,7 +312,8 @@ else
     echo "  [5] Gemini   (pip install ${PACKAGE_NAME})"
     echo "  [6] Kiro     (pip install ${PACKAGE_NAME})"
     echo "  [7] Copilot  (pip install ${PACKAGE_NAME})"
-    echo "  [8] All      (pip install ${PACKAGE_NAME}[all])"
+    echo "  [8] Pi       (pip install ${PACKAGE_NAME})"
+    echo "  [9] All      (pip install ${PACKAGE_NAME}[all])"
     echo "  [0] None     (install base package only — pick a backend later)"
     read -rp "Select [1]: " choice
     case "${choice:-1}" in
@@ -312,14 +324,15 @@ else
       5) _runtime_to_extras "gemini" ;;
       6) _runtime_to_extras "kiro" ;;
       7) _runtime_to_extras "copilot" ;;
-      8) _runtime_to_extras "all" ;;
+      8) _runtime_to_extras "pi" ;;
+      9) _runtime_to_extras "all" ;;
       *) _runtime_to_extras "claude" ;;
     esac
   else
     # Pipe mode (curl | bash): install base package, skip runtime-specific setup.
     echo
     echo "  No runtime detected (non-interactive: installing base package)"
-    echo "  Pick a backend afterwards with: ouroboros setup --runtime <claude|codex|opencode|hermes|gemini|kiro|copilot>"
+    echo "  Pick a backend afterwards with: ouroboros setup --runtime <claude|codex|opencode|hermes|gemini|kiro|copilot|pi>"
     _runtime_to_extras ""
   fi
 fi
@@ -501,4 +514,4 @@ echo
 if [ -n "$RUNTIME" ]; then
   echo "  Current backend: $RUNTIME"
 fi
-echo "  Switch backend later: ouroboros setup --runtime <claude|codex|opencode|hermes|gemini|kiro|copilot>"
+echo "  Switch backend later: ouroboros setup --runtime <claude|codex|opencode|hermes|gemini|kiro|copilot|pi>"

--- a/src/ouroboros/cli/commands/dispatch.py
+++ b/src/ouroboros/cli/commands/dispatch.py
@@ -1,0 +1,224 @@
+"""Hidden CLI entrypoint for external frontdoors that need ``ooo`` dispatch."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+import time
+from typing import Annotated
+
+import typer
+
+from ouroboros.cli.formatters import console
+from ouroboros.cli.formatters.panels import print_error
+from ouroboros.mcp.tools.job_handlers import JobResultHandler, JobWaitHandler
+from ouroboros.mcp.types import MCPToolResult
+from ouroboros.orchestrator.adapter import AgentMessage
+from ouroboros.orchestrator.command_dispatcher import create_codex_command_dispatcher
+from ouroboros.router import InvalidSkill, NotHandled, ResolveRequest, resolve_skill_dispatch
+
+_UNSUPPORTED_DISPATCH_EXIT_CODE = 78
+_AUTO_MONITOR_DEFAULT_TIMEOUT_SECONDS = 6 * 60 * 60
+_AUTO_MONITOR_WAIT_SECONDS = 120
+
+
+def _join_prompt(prompt_parts: list[str]) -> str:
+    return " ".join(part for part in prompt_parts if part is not None).strip()
+
+
+def _env_positive_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value > 0 else default
+
+
+def _print_tool_result(result: MCPToolResult) -> None:
+    text = result.text_content.strip()
+    if text:
+        console.print(text)
+
+
+def _result_message(messages: tuple[AgentMessage, ...]) -> AgentMessage | None:
+    return next((message for message in messages if message.type == "result"), None)
+
+
+def _coerce_cursor(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return max(value, 0)
+    if isinstance(value, str):
+        try:
+            return max(int(value), 0)
+        except ValueError:
+            return 0
+    return 0
+
+
+async def _monitor_auto_job(
+    job_id: str,
+    *,
+    cursor: int = 0,
+    max_seconds: int | None = None,
+) -> int:
+    """Own the foreground UX for ``ooo auto`` background jobs."""
+    wait_handler = JobWaitHandler()
+    result_handler = JobResultHandler()
+    deadline = time.monotonic() + (
+        max_seconds
+        if max_seconds is not None
+        else _env_positive_int(
+            "OUROBOROS_DISPATCH_AUTO_MONITOR_TIMEOUT_SECONDS",
+            _AUTO_MONITOR_DEFAULT_TIMEOUT_SECONDS,
+        )
+    )
+
+    console.print(f"Monitoring auto job: {job_id}")
+    last_printed = ""
+    while True:
+        remaining = max(0, int(deadline - time.monotonic()))
+        if remaining <= 0:
+            print_error(
+                f"Auto job monitor timed out before terminal status: {job_id}. "
+                f"Resume with `ouroboros job wait {job_id}`."
+            )
+            return 1
+
+        wait_result = await wait_handler.handle(
+            {
+                "job_id": job_id,
+                "cursor": cursor,
+                "timeout_seconds": min(_AUTO_MONITOR_WAIT_SECONDS, remaining),
+                "view": "summary",
+                "stream": "linked",
+            }
+        )
+        if wait_result.is_err:
+            print_error(wait_result.error.message)
+            return 1
+
+        snapshot = wait_result.value
+        meta = snapshot.meta
+        cursor = _coerce_cursor(meta.get("cursor"))
+        text = snapshot.text_content.strip()
+        is_terminal = bool(meta.get("is_terminal"))
+        changed = bool(meta.get("changed")) or is_terminal
+        if text and changed and text != last_printed:
+            console.print(text)
+            last_printed = text
+
+        if not is_terminal:
+            continue
+
+        terminal_result = await result_handler.handle({"job_id": job_id})
+        if terminal_result.is_err:
+            print_error(terminal_result.error.message)
+            return 1
+        _print_tool_result(terminal_result.value)
+        return 1 if snapshot.is_error or terminal_result.value.is_error else 0
+
+
+async def _dispatch_prompt(
+    prompt: str,
+    *,
+    runtime: str,
+    llm_backend: str | None,
+    cwd: Path,
+) -> int:
+    resolved = resolve_skill_dispatch(ResolveRequest(prompt=prompt, cwd=cwd))
+    if isinstance(resolved, NotHandled):
+        return _UNSUPPORTED_DISPATCH_EXIT_CODE
+    if isinstance(resolved, InvalidSkill):
+        if resolved.reason.startswith("missing required frontmatter key:"):
+            return _UNSUPPORTED_DISPATCH_EXIT_CODE
+        print_error(f"Invalid Ouroboros skill command: {resolved.reason} ({resolved.skill_path})")
+        return 2
+
+    dispatcher = create_codex_command_dispatcher(
+        cwd=cwd,
+        runtime_backend=runtime,
+        llm_backend=llm_backend,
+    )
+    messages = await dispatcher(resolved, None)
+    if not messages:
+        print_error(f"Ouroboros dispatch produced no output for: {resolved.command_prefix}")
+        return 1
+
+    result_message = _result_message(messages)
+    exit_code = 0
+    for message in messages:
+        if message.type == "result":
+            if message.content:
+                console.print(message.content)
+            if message.data.get("tool_error") or message.data.get("subtype") == "error":
+                exit_code = 1
+    if (
+        exit_code == 0
+        and resolved.mcp_tool == "ouroboros_start_auto"
+        and result_message is not None
+        and isinstance(result_message.data.get("job_id"), str)
+    ):
+        exit_code = await _monitor_auto_job(
+            result_message.data["job_id"],
+            cursor=_coerce_cursor(result_message.data.get("cursor")),
+        )
+    return exit_code
+
+
+def dispatch_command(
+    prompt_parts: Annotated[
+        list[str],
+        typer.Argument(help="The full ooo command to dispatch."),
+    ],
+    runtime: Annotated[
+        str,
+        typer.Option(
+            "--runtime",
+            help="Runtime backend to bind the MCP dispatch server to.",
+        ),
+    ] = "pi",
+    llm_backend: Annotated[
+        str | None,
+        typer.Option(
+            "--llm-backend",
+            help="Optional LLM backend override for authoring/evaluation handlers.",
+        ),
+    ] = None,
+    cwd: Annotated[
+        Path | None,
+        typer.Option(
+            "--cwd",
+            help="Working directory to resolve skill dispatch and handler context from.",
+        ),
+    ] = None,
+) -> None:
+    """Dispatch an exact-prefix ``ooo`` command through Ouroboros MCP handlers.
+
+    This command is intentionally hidden from normal help. It gives external
+    frontdoors such as Pi extensions a deterministic bridge into the same
+    shared skill router used by subprocess runtimes.
+    """
+    prompt = _join_prompt(prompt_parts)
+    if not prompt:
+        print_error("Usage: ouroboros dispatch 'ooo <command> [args...]'")
+        raise typer.Exit(2)
+
+    exit_code = asyncio.run(
+        _dispatch_prompt(
+            prompt,
+            runtime=runtime,
+            llm_backend=llm_backend,
+            cwd=(cwd or Path.cwd()).resolve(),
+        )
+    )
+    if exit_code:
+        raise typer.Exit(exit_code)
+
+
+__all__ = ["dispatch_command"]

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -1778,6 +1778,138 @@ def _setup_copilot(copilot_path: str, *, non_interactive: bool = False) -> None:
     _register_copilot_mcp_server()
 
 
+_PI_OOO_BRIDGE_FILENAME = "ouroboros-ooo-bridge.ts"
+
+
+def _detect_pi_bridge_dispatch_entry() -> tuple[str, list[str]]:
+    """Return the launcher a managed Pi bridge should use for this install."""
+    if _is_source_tree_ouroboros_build():
+        return sys.executable, ["-m", "ouroboros"]
+    try:
+        version = importlib_metadata.version("ouroboros-ai")
+    except importlib_metadata.PackageNotFoundError:
+        return sys.executable, ["-m", "ouroboros"]
+    if ".dev" in version:
+        return sys.executable, ["-m", "ouroboros"]
+    return shutil.which("ouroboros") or "ouroboros", []
+
+
+def _pi_ooo_bridge_source_text() -> str:
+    """Return the managed Pi extension source for ``ooo`` frontdoor dispatch."""
+    command, args = _detect_pi_bridge_dispatch_entry()
+    default_command = json.dumps(command)
+    default_args = json.dumps(args)
+    return f'''/**
+ * Ouroboros ooo bridge for Pi.
+ *
+ * Managed by `ouroboros setup --runtime pi`.
+ * Routes exact-prefix `ooo ...` inputs from interactive Pi into Ouroboros'
+ * shared skill dispatcher instead of sending them to the model as chat.
+ */
+import type {{ ExtensionAPI, ExtensionContext }} from "@earendil-works/pi-coding-agent";
+
+const COMMAND_RE = /^\\s*ooo(?:\\s+|$)/i;
+const UNSUPPORTED_DISPATCH_EXIT_CODE = 78;
+const TIMEOUT_MS = Number(process.env.OUROBOROS_PI_BRIDGE_TIMEOUT_MS || 6 * 60 * 60 * 1000);
+const DEFAULT_COMMAND = {default_command};
+const DEFAULT_ARGS = {default_args};
+
+function ouroborosEntry(): {{ command: string; args: string[] }} {{
+  if (process.env.OUROBOROS_CLI) return {{ command: process.env.OUROBOROS_CLI, args: [] }};
+  return {{ command: DEFAULT_COMMAND, args: DEFAULT_ARGS }};
+}}
+
+function outputText(stdout: string, stderr: string): string {{
+  const out = stdout.trim();
+  const err = stderr.trim();
+  if (out && err) return `${{out}}\\n\\n${{err}}`;
+  return out || err || "(no output)";
+}}
+
+async function dispatch(pi: ExtensionAPI, text: string, ctx: ExtensionContext): Promise<boolean> {{
+  ctx.ui.notify(`Ouroboros dispatch: ${{text}}`, "info");
+  const entry = ouroborosEntry();
+  const result = await pi.exec(
+    entry.command,
+    [...entry.args, "dispatch", "--runtime", "pi", "--cwd", ctx.cwd, text],
+    {{ cwd: ctx.cwd, timeout: TIMEOUT_MS }},
+  );
+  if (result.code === UNSUPPORTED_DISPATCH_EXIT_CODE) {{
+    ctx.ui.notify(`Ouroboros did not claim command; continuing in Pi`, "info");
+    return false;
+  }}
+  const body = outputText(result.stdout || "", result.stderr || "");
+  pi.sendMessage({{
+    customType: "ouroboros",
+    content: body,
+    display: true,
+    details: {{ command: text, exitCode: result.code }},
+  }});
+  if (result.code !== 0) {{
+    ctx.ui.notify(`Ouroboros dispatch failed (${{result.code ?? "unknown"}})`, "error");
+  }}
+  return true;
+}}
+
+export default function ouroborosBridge(pi: ExtensionAPI) {{
+  pi.registerCommand("ooo", {{
+    description: "Dispatch an Ouroboros ooo command",
+    handler: async (args, ctx) => {{
+      const text = `ooo ${{args}}`.trim();
+      await dispatch(pi, text, ctx);
+    }},
+  }});
+
+  pi.on("input", async (event, ctx) => {{
+    if (event.source === "extension") {{
+      return {{ action: "continue" }};
+    }}
+    if (!COMMAND_RE.test(event.text)) {{
+      return {{ action: "continue" }};
+    }}
+    const handled = await dispatch(pi, event.text.trim(), ctx);
+    return {{ action: handled ? "handled" : "continue" }};
+  }});
+}}
+'''
+
+
+def _install_pi_ooo_bridge() -> bool:
+    """Install the managed Pi extension that routes interactive ``ooo`` input.
+
+    Pi auto-discovers global extensions in ``~/.pi/agent/extensions/*.ts``.
+    Writing a single managed file there avoids modifying Pi itself or any
+    third-party package such as roach-pi, while making the bridge available to
+    every Pi-based/customized session after ``/reload`` or restart.
+    """
+    import hashlib
+
+    dest = Path.home() / ".pi" / "agent" / "extensions" / _PI_OOO_BRIDGE_FILENAME
+    content = _pi_ooo_bridge_source_text()
+    new_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+    existing_hash: str | None = None
+    if dest.exists():
+        try:
+            existing_hash = hashlib.sha256(dest.read_bytes()).hexdigest()
+        except OSError:
+            existing_hash = None
+
+    if existing_hash == new_hash:
+        print_info(f"Pi ooo bridge already up to date: {dest}")
+        return True
+
+    try:
+        _atomic_write_text(dest, content)
+    except OSError as exc:
+        print_warning(f"Could not install Pi ooo bridge at {dest}: {exc}")
+        return False
+
+    print_success(f"{'Updated' if existing_hash is not None else 'Installed'} Pi ooo bridge: {dest}")
+    print_info("Restart Pi or run /reload in an existing Pi session to load the bridge.")
+    return True
+
+
 def _setup_gemini(gemini_path: str) -> None:
     """Configure Ouroboros for the Gemini CLI runtime.
 
@@ -1827,11 +1959,12 @@ def _setup_pi(pi_path: str) -> None:
     """Configure Ouroboros for the Pi CLI runtime.
 
     Pi is a base-package agent runtime: setup records the executable path and
-    runtime backend, while skill/MCP dispatch is handled by the adapter at
-    execution time before spawning the Pi subprocess. The Pi LLM adapter remains
-    opt-in so setup does not unexpectedly move authoring/evaluation traffic to a
-    different provider; when selected explicitly, structured response_format
-    requests are enforced cooperatively by that adapter.
+    runtime backend, and installs a managed Pi extension so interactive Pi
+    sessions can route ``ooo ...`` inputs into Ouroboros' shared skill
+    dispatcher. The Pi LLM adapter remains opt-in so setup does not
+    unexpectedly move authoring/evaluation traffic to a different provider;
+    when selected explicitly, structured response_format requests are enforced
+    cooperatively by that adapter.
     """
     from ouroboros.config.loader import create_default_config, ensure_config_dir
 
@@ -1860,6 +1993,7 @@ def _setup_pi(pi_path: str) -> None:
 
     print_success(f"Configured Pi runtime (CLI: {pi_path})")
     print_info(f"Config saved to: {config_path}")
+    _install_pi_ooo_bridge()
 
 
 def _setup_goose(goose_path: str) -> None:

--- a/src/ouroboros/cli/main.py
+++ b/src/ouroboros/cli/main.py
@@ -27,6 +27,7 @@ from ouroboros.cli.commands import (
     codex,
     config,
     detect,
+    dispatch,
     init,
     job,
     mcp,
@@ -108,6 +109,7 @@ app.add_typer(plugin.app, name="plugin")
 app.add_typer(resume.app, name="resume")
 app.add_typer(uninstall.app, name="uninstall")
 app.add_typer(workflow_ir.app, name="workflow-ir")
+app.command(name="dispatch", hidden=True)(dispatch.dispatch_command)
 
 
 # Top-level convenience aliases

--- a/tests/unit/cli/test_dispatch_command.py
+++ b/tests/unit/cli/test_dispatch_command.py
@@ -1,0 +1,194 @@
+"""Tests for the hidden external-frontdoor dispatch CLI."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+from ouroboros.cli.commands import dispatch as dispatch_cmd
+from ouroboros.core.types import Result
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.orchestrator.adapter import AgentMessage
+from ouroboros.router.types import InvalidSkill, NotHandled, Resolved
+
+
+def test_dispatch_prompt_routes_resolved_ooo_command(capsys) -> None:
+    resolved = Resolved(
+        skill_name="auto",
+        command_prefix="ooo auto",
+        prompt="ooo auto build it",
+        skill_path=Path("skills/auto/SKILL.md"),
+        mcp_tool="ouroboros_start_auto",
+        mcp_args={"goal": "build it"},
+        first_argument="build it",
+    )
+    captured: dict[str, object] = {}
+
+    async def fake_dispatch(intercept, current_handle):
+        captured["intercept"] = intercept
+        captured["current_handle"] = current_handle
+        return (
+            AgentMessage(type="assistant", content="Calling tool: ouroboros_start_auto"),
+            AgentMessage(type="result", content="queued auto", data={"subtype": "success"}),
+        )
+
+    with (
+        patch("ouroboros.cli.commands.dispatch.resolve_skill_dispatch", return_value=resolved),
+        patch(
+            "ouroboros.cli.commands.dispatch.create_codex_command_dispatcher",
+            return_value=fake_dispatch,
+        ) as make_dispatcher,
+    ):
+        exit_code = asyncio.run(
+            dispatch_cmd._dispatch_prompt(
+                "ooo auto build it",
+                runtime="pi",
+                llm_backend=None,
+                cwd=Path("/tmp/project"),
+            )
+        )
+
+    assert exit_code == 0
+    assert captured["intercept"] is resolved
+    assert captured["current_handle"] is None
+    make_dispatcher.assert_called_once_with(
+        cwd=Path("/tmp/project"),
+        runtime_backend="pi",
+        llm_backend=None,
+    )
+    assert "queued auto" in capsys.readouterr().out
+
+
+def test_dispatch_prompt_returns_unsupported_for_non_mcp_skill(capsys) -> None:
+    invalid = InvalidSkill(
+        reason="missing required frontmatter key: mcp_tool",
+        skill_path=Path("skills/help/SKILL.md"),
+    )
+
+    with patch("ouroboros.cli.commands.dispatch.resolve_skill_dispatch", return_value=invalid):
+        exit_code = asyncio.run(
+            dispatch_cmd._dispatch_prompt(
+                "ooo help",
+                runtime="pi",
+                llm_backend=None,
+                cwd=Path("/tmp/project"),
+            )
+        )
+
+    assert exit_code == dispatch_cmd._UNSUPPORTED_DISPATCH_EXIT_CODE
+    assert capsys.readouterr().out == ""
+
+
+def test_dispatch_prompt_returns_unsupported_for_unhandled_prompt(capsys) -> None:
+    with patch(
+        "ouroboros.cli.commands.dispatch.resolve_skill_dispatch",
+        return_value=NotHandled(reason="skill not found"),
+    ):
+        exit_code = asyncio.run(
+            dispatch_cmd._dispatch_prompt(
+                "ooo no-such-skill",
+                runtime="pi",
+                llm_backend=None,
+                cwd=Path("/tmp/project"),
+            )
+        )
+
+    assert exit_code == dispatch_cmd._UNSUPPORTED_DISPATCH_EXIT_CODE
+    assert capsys.readouterr().out == ""
+
+
+def test_dispatch_prompt_reports_malformed_skill_without_traceback(capsys) -> None:
+    invalid = InvalidSkill(
+        reason="mcp_tool must be a non-empty string",
+        skill_path=Path("skills/help/SKILL.md"),
+    )
+
+    with patch("ouroboros.cli.commands.dispatch.resolve_skill_dispatch", return_value=invalid):
+        exit_code = asyncio.run(
+            dispatch_cmd._dispatch_prompt(
+                "ooo help",
+                runtime="pi",
+                llm_backend=None,
+                cwd=Path("/tmp/project"),
+            )
+        )
+
+    assert exit_code == 2
+    output = capsys.readouterr().out
+    assert "Invalid Ouroboros skill command: mcp_tool must be a non-empty string" in output
+    assert "skills/help/SKILL.md" in output
+
+
+def test_dispatch_prompt_monitors_auto_job_until_result(capsys) -> None:
+    resolved = Resolved(
+        skill_name="auto",
+        command_prefix="ooo auto",
+        prompt="ooo auto build it",
+        skill_path=Path("skills/auto/SKILL.md"),
+        mcp_tool="ouroboros_start_auto",
+        mcp_args={"goal": "build it"},
+        first_argument="build it",
+    )
+
+    async def fake_dispatch(intercept, current_handle):
+        return (
+            AgentMessage(type="assistant", content="Calling tool: ouroboros_start_auto"),
+            AgentMessage(
+                type="result",
+                content="started auto",
+                data={"subtype": "success", "job_id": "job_auto_123", "cursor": 1},
+            ),
+        )
+
+    class FakeWaitHandler:
+        async def handle(self, arguments):
+            assert arguments["job_id"] == "job_auto_123"
+            assert arguments["cursor"] == 1
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="job completed"),),
+                    meta={
+                        "job_id": "job_auto_123",
+                        "cursor": 2,
+                        "changed": True,
+                        "is_terminal": True,
+                        "status": "completed",
+                    },
+                )
+            )
+
+    class FakeResultHandler:
+        async def handle(self, arguments):
+            assert arguments == {"job_id": "job_auto_123"}
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="final auto result"),),
+                    meta={"job_id": "job_auto_123", "is_terminal": True},
+                )
+            )
+
+    with (
+        patch("ouroboros.cli.commands.dispatch.resolve_skill_dispatch", return_value=resolved),
+        patch(
+            "ouroboros.cli.commands.dispatch.create_codex_command_dispatcher",
+            return_value=fake_dispatch,
+        ),
+        patch("ouroboros.cli.commands.dispatch.JobWaitHandler", return_value=FakeWaitHandler()),
+        patch("ouroboros.cli.commands.dispatch.JobResultHandler", return_value=FakeResultHandler()),
+    ):
+        exit_code = asyncio.run(
+            dispatch_cmd._dispatch_prompt(
+                "ooo auto build it",
+                runtime="pi",
+                llm_backend=None,
+                cwd=Path("/tmp/project"),
+            )
+        )
+
+    assert exit_code == 0
+    output = capsys.readouterr().out
+    assert "started auto" in output
+    assert "Monitoring auto job: job_auto_123" in output
+    assert "job completed" in output
+    assert "final auto result" in output

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -3856,10 +3856,29 @@ class TestCopilotSetup:
 
         config_path = tmp_path / ".ouroboros" / "config.yaml"
         config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        bridge_path = tmp_path / ".pi" / "agent" / "extensions" / "ouroboros-ooo-bridge.ts"
 
         assert config["orchestrator"]["runtime_backend"] == "pi"
         assert config["orchestrator"]["pi_cli_path"] == "/opt/bin/pi"
         assert config["llm"]["backend"] == "codex"
+        assert bridge_path.exists()
+        bridge_source = bridge_path.read_text(encoding="utf-8")
+        assert 'pi.registerCommand("ooo"' in bridge_source
+        assert 'pi.on("input"' in bridge_source
+        assert '[...entry.args, "dispatch", "--runtime", "pi", "--cwd", ctx.cwd, text]' in bridge_source
+        assert "UNSUPPORTED_DISPATCH_EXIT_CODE = 78" in bridge_source
+        assert 'return { action: handled ? "handled" : "continue" }' in bridge_source
+
+    def test_install_pi_ooo_bridge_is_idempotent(self, tmp_path: Path) -> None:
+        """The managed Pi bridge should not rewrite an already-current extension."""
+        bridge_path = tmp_path / ".pi" / "agent" / "extensions" / "ouroboros-ooo-bridge.ts"
+
+        with patch("pathlib.Path.home", return_value=tmp_path):
+            assert setup_cmd._install_pi_ooo_bridge() is True
+            first_mtime = bridge_path.stat().st_mtime_ns
+            assert setup_cmd._install_pi_ooo_bridge() is True
+
+        assert bridge_path.stat().st_mtime_ns == first_mtime
 
     def test_setup_cli_with_runtime_pi_flag(self, tmp_path: Path) -> None:
         """`ouroboros setup --runtime pi --non-interactive` runs the Pi setup path."""

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -120,6 +120,37 @@ def test_explicit_claude_installs_mcp_and_claude_extras(tmp_path: Path) -> None:
     assert "ouroboros setup --runtime claude --non-interactive" in calls
 
 
+def test_explicit_pi_installs_base_and_runs_pi_setup(tmp_path: Path) -> None:
+    result = _run_installer(
+        tmp_path,
+        env={"OUROBOROS_INSTALL_RUNTIME": "pi"},
+        fake_commands={"pi": "#!/bin/sh\nexit 0\n"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    calls = (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines()
+    assert "Runtime: pi (from --runtime / OUROBOROS_INSTALL_RUNTIME)" in result.stdout
+    assert calls == [
+        "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0",
+        "ouroboros setup --runtime pi --non-interactive",
+    ]
+
+
+def test_detects_pi_as_single_runtime_and_runs_pi_setup(tmp_path: Path) -> None:
+    result = _run_installer(
+        tmp_path,
+        fake_commands={"pi": "#!/bin/sh\nexit 0\n"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    calls = (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines()
+    assert "Pi:" in result.stdout
+    assert calls == [
+        "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0",
+        "ouroboros setup --runtime pi --non-interactive",
+    ]
+
+
 def test_pypi_lookup_failure_stays_stable_only_for_remote_install(tmp_path: Path) -> None:
     result = _run_installer(
         tmp_path,


### PR DESCRIPTION
## Summary

- Adds a Pi frontdoor bridge so Pi and custom Pi distributions can intercept `ooo ...` input and route it through Ouroboros instead of sending it to the model.
- Installs the managed bridge from `ouroboros setup --runtime pi`, and teaches `scripts/install.sh` to detect/select Pi like the other supported runtimes.
- Adds a hidden `ouroboros dispatch` command so external frontdoors can reuse the existing skill dispatch/MCP execution path without changing the AgentRuntime abstraction.

## Changes

- Runtime setup
  - Writes the managed Pi extension to `~/.pi/agent/extensions/ouroboros-ooo-bridge.ts`.
  - Keeps Pi runtime config generation intact while adding the frontdoor bridge installation step.
  - Supports source/dev installs by embedding the current Python module launcher, with `OUROBOROS_CLI` as an override.

- Installer
  - Detects `pi` on PATH.
  - Supports `OUROBOROS_INSTALL_RUNTIME=pi` and `--runtime pi`.
  - Includes Pi in interactive runtime selection, single-runtime auto-detection, and setup guidance.

- Dispatch/docs/tests
  - Adds hidden `ouroboros dispatch --runtime pi --cwd <cwd> "ooo ..."` for bridge callers.
  - Documents both Pi integration paths: Ouroboros launching Pi as a runtime, and Pi launching Ouroboros from an interactive session.
  - Covers dispatch, setup, and installer behavior with focused unit tests.

## Verification

- `uv run pytest tests/unit/scripts/test_install_runtime_selection.py tests/unit/cli/test_dispatch_command.py tests/unit/cli/test_setup.py -k 'pi or dispatch or install_script_syntax'`
- `bash -n scripts/install.sh`
- `uv run ruff check src/ouroboros/cli/commands/dispatch.py src/ouroboros/cli/commands/setup.py tests/unit/cli/test_dispatch_command.py tests/unit/cli/test_setup.py tests/unit/scripts/test_install_runtime_selection.py`
- `uv run ouroboros setup --runtime pi --non-interactive`
- `pi --extension ~/.pi/agent/extensions/ouroboros-ooo-bridge.ts --mode json 'ooo help'`

## Notes

This is stacked on #1333. It does not modify `/Users/jaegyu.lee/Project/pi`, roach-pi, the existing AgentRuntime interface, or Codex/Goose/Kiro runtime behavior.
