### PR TITLE
fix(installer): prefer freshly installed ouroboros for setup

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -488,21 +488,44 @@ else
   fi
 fi
 
-# Ensure ouroboros binary is in PATH (uv tool install may add to ~/.local/bin)
-if ! command -v ouroboros &>/dev/null; then
-  for p in "$HOME/.local/bin" "$HOME/.cargo/bin" "$HOME/bin"; do
-    if [ -x "$p/ouroboros" ]; then
-      export PATH="$p:$PATH"
-      break
+# Ensure setup runs the freshly-installed uv tool binary rather than a stale
+# command already on PATH. uv can install into UV_TOOL_BIN_DIR or its configured
+# tool bin directory without updating the current shell's PATH, so remember the
+# fresh executable and invoke that exact path below. For pipx/pip installs,
+# preserve the existing PATH command unless no ouroboros command is visible.
+OUROBOROS_BIN=""
+_prepend_path_if_ouroboros() {
+  local candidate="$1"
+  if [ -n "$candidate" ] && [ -x "$candidate/ouroboros" ]; then
+    export PATH="$candidate:$PATH"
+    if [ -z "$OUROBOROS_BIN" ]; then
+      OUROBOROS_BIN="$candidate/ouroboros"
     fi
+    return 0
+  fi
+  return 1
+}
+
+if [ "$INSTALL_METHOD" = "uv" ]; then
+  _prepend_path_if_ouroboros "${UV_TOOL_BIN_DIR:-}" || true
+  if command -v uv &>/dev/null; then
+    UV_TOOL_BIN="$(uv tool dir --bin 2>/dev/null || true)"
+    _prepend_path_if_ouroboros "$UV_TOOL_BIN" || true
+  fi
+fi
+
+if [ -z "$OUROBOROS_BIN" ] && ! command -v ouroboros &>/dev/null; then
+  for p in "$HOME/.local/bin" "$HOME/.cargo/bin" "$HOME/bin"; do
+    _prepend_path_if_ouroboros "$p" || true
   done
 fi
 
 # 4. Setup (ouroboros CLI configures runtime-specific integration)
 _step "4/4  Wiring local integrations" "Creates config and runtime-specific files when a backend was selected."
-if [ -n "$RUNTIME" ] && command -v ouroboros &>/dev/null; then
-  _info "Running: ouroboros setup --runtime $RUNTIME --non-interactive"
-  ouroboros setup --runtime "$RUNTIME" --non-interactive || true
+if [ -n "$RUNTIME" ] && { [ -n "$OUROBOROS_BIN" ] || command -v ouroboros &>/dev/null; }; then
+  OUROBOROS_SETUP_CMD="${OUROBOROS_BIN:-ouroboros}"
+  _info "Running: $OUROBOROS_SETUP_CMD setup --runtime $RUNTIME --non-interactive"
+  "$OUROBOROS_SETUP_CMD" setup --runtime "$RUNTIME" --non-interactive || true
 elif [ -n "$RUNTIME" ]; then
   _warn "ouroboros command is not on PATH yet; run setup after your shell sees the installed binary."
 else

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -18,25 +18,41 @@ def _write_executable(path: Path, content: str) -> None:
 def _run_installer(
     tmp_path: Path,
     *,
+    include_uv: bool = True,
     local_repo: bool = True,
     env: dict[str, str] | None = None,
     fake_commands: dict[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
+    tool_bin_dir = tmp_path / "uv-tool-bin"
+    tool_bin_dir.mkdir()
     calls = tmp_path / "calls.log"
 
-    _write_executable(
-        bin_dir / "uv",
-        f"""#!/bin/sh
+    if include_uv:
+        _write_executable(
+            bin_dir / "uv",
+            f"""#!/bin/sh
 if [ "$1" = "--version" ]; then
   echo "uv 0.0.0-test"
   exit 0
 fi
+if [ "$1" = "tool" ] && [ "$2" = "dir" ] && [ "$3" = "--bin" ]; then
+  echo "{tool_bin_dir!s}"
+  exit 0
+fi
+if [ "$1" = "tool" ] && [ "$2" = "install" ]; then
+  cat > "{tool_bin_dir!s}/ouroboros" <<'SH'
+#!/bin/sh
+printf 'ouroboros %s\\n' "$*" >> "{calls!s}"
+exit 0
+SH
+  chmod 755 "{tool_bin_dir!s}/ouroboros"
+fi
 printf 'uv %s\\n' "$*" >> {calls!s}
 exit 0
 """,
-    )
+        )
     _write_executable(
         bin_dir / "ouroboros",
         f"""#!/bin/sh
@@ -134,6 +150,74 @@ def test_explicit_pi_installs_base_and_runs_pi_setup(tmp_path: Path) -> None:
         "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0",
         "ouroboros setup --runtime pi --non-interactive",
     ]
+
+
+def test_uv_install_setup_prefers_fresh_tool_bin_over_stale_path_command(tmp_path: Path) -> None:
+    result = _run_installer(
+        tmp_path,
+        env={"OUROBOROS_INSTALL_RUNTIME": "pi"},
+        fake_commands={
+            "pi": "#!/bin/sh\nexit 0\n",
+            "ouroboros": f"#!/bin/sh\nprintf 'stale-ouroboros %s\\n' \"$*\" >> {tmp_path / 'calls.log'}\nexit 0\n",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    calls = (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines()
+    assert "ouroboros setup --runtime pi --non-interactive" in calls
+    assert not any(call.startswith("stale-ouroboros setup") for call in calls)
+
+
+def test_uv_install_setup_prefers_fresh_tool_bin_over_stale_home_local_bin(
+    tmp_path: Path,
+) -> None:
+    home_local_bin = tmp_path / "home" / ".local" / "bin"
+    home_local_bin.mkdir(parents=True)
+    _write_executable(
+        home_local_bin / "ouroboros",
+        f"#!/bin/sh\nprintf 'stale-local-ouroboros %s\\n' \"$*\" >> {tmp_path / 'calls.log'}\nexit 0\n",
+    )
+
+    result = _run_installer(
+        tmp_path,
+        env={"OUROBOROS_INSTALL_RUNTIME": "pi"},
+        fake_commands={"pi": "#!/bin/sh\nexit 0\n"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    calls = (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines()
+    assert "ouroboros setup --runtime pi --non-interactive" in calls
+    assert not any(call.startswith("stale-local-ouroboros setup") for call in calls)
+
+
+def test_pipx_install_setup_prefers_existing_path_command_over_stale_home_local_bin(
+    tmp_path: Path,
+) -> None:
+    home_local_bin = tmp_path / "home" / ".local" / "bin"
+    home_local_bin.mkdir(parents=True)
+    _write_executable(
+        home_local_bin / "ouroboros",
+        f"#!/bin/sh\nprintf 'stale-home-ouroboros %s\\n' \"$*\" >> {tmp_path / 'calls.log'}\nexit 0\n",
+    )
+
+    python = '#!/bin/sh\nif [ "$1" = "-c" ]; then echo 3.12; exit 0; fi\necho \'Python 3.12.0\'\n'
+    result = _run_installer(
+        tmp_path,
+        include_uv=False,
+        env={"OUROBOROS_INSTALL_RUNTIME": "pi"},
+        fake_commands={
+            "pipx": '#!/bin/sh\nif [ "$1" = "--version" ]; then echo \'pipx 0.0.0-test\'; exit 0; fi\nprintf \'pipx %s\\n\' "$*" >> __CALLS__\nexit 0\n'.replace(
+                "__CALLS__", str(tmp_path / "calls.log")
+            ),
+            "python3.12": python,
+            "pi": "#!/bin/sh\nexit 0\n",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    calls = (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines()
+    assert "ouroboros setup --runtime pi --non-interactive" in calls
+    assert not any(call.startswith("stale-home-ouroboros setup") for call in calls)
 
 
 def test_detects_pi_as_single_runtime_and_runs_pi_setup(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Prefer the freshly installed uv tool-bin `ouroboros` before any stale executable already on PATH.
- Invoke the remembered fresh uv executable path directly for setup, so later fallback PATH probing cannot reorder it behind stale legacy bins.
- Preserve pipx/pip behavior by only scanning fallback home bins when no `ouroboros` command is visible.
- Add regression tests for stale PATH commands, stale `$HOME/.local/bin/ouroboros` under uv, and stale `$HOME/.local/bin/ouroboros` under pipx.

## Why
While doing the release smoke after `v0.40.1`, an isolated Pi install completed with exit 0 but ran setup through an older global `ouroboros`, producing `Unsupported runtime: pi`. That can make installer output look successful while runtime-specific setup was skipped or misconfigured.

## Review Response
- Addressed first requested change: `$HOME/.local/bin` fallback probing can no longer overtake the fresh uv tool bin, because step 4 executes the remembered fresh uv executable path directly.
- Addressed second requested change: the home-bin fallback is no longer unconditional for pipx/pip. It only runs when no `ouroboros` command is already visible, preserving the existing PATH command for non-uv install paths.
- Added focused regressions for both stale-home-bin cases.

## Verification
- `bash -n scripts/install.sh`
- `uv run --python 3.12 ruff check .`
- `uv run --python 3.12 python -m pytest tests/unit/scripts/test_install_runtime_selection.py tests/unit/cli/test_setup.py -q` -> 165 passed
- Isolated uv installer smoke with stale `$HOME/.local/bin/ouroboros`, custom `HOME`, `UV_TOOL_DIR`, `UV_TOOL_BIN_DIR`, and `OUROBOROS_INSTALL_RUNTIME=pi`: setup runs the fresh `UV_TOOL_BIN_DIR/ouroboros`, reaches `Configured Pi runtime`, and writes `.pi/agent/extensions/ouroboros-ooo-bridge.ts`.
- Isolated pipx installer smoke with fresh PATH `ouroboros` and stale `$HOME/.local/bin/ouroboros`: setup runs the PATH command and does not execute the stale home-bin command.

## Note
The real Pi native response smoke still fails in this local environment because the configured OpenAI key is rejected with 401; that is credential/auth state, not this installer path bug.
