### PR TITLE
fix(mcp): stop orphaned servers and reclaim WAL; speed up session list

### DIFF
--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -6,10 +6,12 @@ Start and manage the MCP (Model Context Protocol) server.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from enum import Enum
 import json
 import os
 from pathlib import Path
+import signal
 import subprocess
 import sys
 from typing import Annotated
@@ -322,17 +324,102 @@ async def _run_mcp_server(
 
     _write_pid_file()
 
-    # Start serving
+    # Start serving with graceful shutdown + orphan reaping.
+    #
+    # asyncio.run() only translates SIGINT into KeyboardInterrupt; an unhandled
+    # SIGTERM would terminate the process immediately and skip the finally block
+    # below — leaking the PID file and, more importantly, skipping the
+    # EventStore.close() WAL TRUNCATE checkpoint (the -wal file then grows
+    # unbounded across many concurrent sessions). Install explicit handlers and
+    # race the serve task against a stop Event so every shutdown path is clean.
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+
+    def _request_stop(signame: str) -> None:
+        _console_out.print(f"[blue]Received {signame}, shutting down...[/blue]")
+        stop.set()
+
+    # Resolve signals by name: SIGHUP is POSIX-only, so referencing
+    # ``signal.SIGHUP`` directly would raise AttributeError while *building* the
+    # loop iterable on Windows — before the suppress() below could catch it.
+    # getattr keeps SIGHUP on POSIX and skips it where the constant is absent.
+    for _signame in ("SIGTERM", "SIGINT", "SIGHUP"):
+        _sig = getattr(signal, _signame, None)
+        if _sig is None:
+            continue
+        # add_signal_handler is unavailable on some event loops (e.g. the
+        # Windows Proactor loop); fall back silently — KeyboardInterrupt still
+        # covers SIGINT there.
+        with contextlib.suppress(NotImplementedError, ValueError, RuntimeError):
+            loop.add_signal_handler(_sig, _request_stop, _sig.name)
+
+    # Parent-death watchdog: when the MCP client that spawned us dies, this
+    # process is reparented away from its original parent so a vanished client
+    # never leaves an orphaned server pinning the SQLite database (the
+    # streamable-http case in particular has no stdin EOF to rely on). macOS
+    # lacks Linux's PR_SET_PDEATHSIG, so we poll getppid() — a POSIX best-effort
+    # backstop. We compare against the *original* ppid rather than testing
+    # ``== 1`` so detection still fires under a child-subreaper (systemd --user,
+    # tini, some container runtimes) where the orphan reparents to the subreaper
+    # rather than to pid 1. Skipped when launched already-detached on purpose
+    # (orig_ppid is already 1, e.g. a real launchd/systemd service). Not
+    # effective on Windows (no reparent-on-death model); SIGINT/stdin EOF cover
+    # the common cases there.
+    orig_ppid = os.getppid()
+
+    async def _orphan_watchdog() -> None:
+        if orig_ppid == 1:
+            return
+        while not stop.is_set():
+            if os.getppid() != orig_ppid:
+                _console_out.print("[yellow]Parent client gone — orphan exit[/yellow]")
+                stop.set()
+                return
+            with contextlib.suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(stop.wait(), timeout=5.0)
+
+    serve_task = asyncio.create_task(
+        server.serve(transport=transport, host=host, port=port),
+        name="ouroboros-mcp-serve",
+    )
+    stop_task = asyncio.create_task(stop.wait(), name="ouroboros-mcp-stop")
+    watchdog_task = asyncio.create_task(_orphan_watchdog(), name="ouroboros-mcp-watchdog")
+
     try:
-        await server.serve(transport=transport, host=host, port=port)
+        await asyncio.wait(
+            {serve_task, stop_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
     finally:
+        # Runs for SIGTERM, orphan-exit and KeyboardInterrupt too, so
+        # EventStore.close() always gets to collapse the WAL. Cancel the serve
+        # loop and helpers, then release the persistent stores in reverse init
+        # order. Draining under suppress() guarantees cleanup is never skipped;
+        # the genuine serve-loop outcome is re-inspected afterwards.
+        for _task in (serve_task, watchdog_task, stop_task):
+            if not _task.done():
+                _task.cancel()
+        for _task in (serve_task, watchdog_task, stop_task):
+            with contextlib.suppress(BaseException):
+                await _task
         if cleanup_task is not None and not cleanup_task.done():
             cleanup_task.cancel()
-            try:
+            with contextlib.suppress(asyncio.CancelledError):
                 await cleanup_task
-            except asyncio.CancelledError:
-                pass
+        with contextlib.suppress(Exception):
+            await brownfield_store.close()
+        with contextlib.suppress(Exception):
+            await event_store.close()
         _cleanup_pid_file()
+        # Surface an abnormal serve-loop termination. A cancellation is the
+        # intended shutdown path (SIGTERM/orphan-exit/stdin EOF), but any other
+        # exception means the transport loop itself crashed — re-raise it after
+        # cleanup so the command exits non-zero with a trace instead of a silent
+        # exit 0 that would hide exactly the failure class this server must report.
+        if not serve_task.cancelled():
+            serve_exc = serve_task.exception()
+            if serve_exc is not None:
+                raise serve_exc
 
 
 @app.command()

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -406,10 +406,16 @@ async def _run_mcp_server(
             cleanup_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await cleanup_task
+        # Route teardown through the adapter so its owned resources close in the
+        # documented order: the ControlBus reactive surface is drained first
+        # (cancelling subscriber tasks), then the EventStore (whose close()
+        # collapses the WAL) and BrownfieldStore, then the MCP bridge. Closing
+        # the stores directly here would bypass that contract and leave
+        # control-bus tasks and upstream bridge connections dangling. Best
+        # effort — a drain/close failure is already logged inside shutdown();
+        # never let it escape the cleanup path.
         with contextlib.suppress(Exception):
-            await brownfield_store.close()
-        with contextlib.suppress(Exception):
-            await event_store.close()
+            await server.shutdown()
         _cleanup_pid_file()
         # Surface an abnormal serve-loop termination. A cancellation is the
         # intended shutdown path (SIGTERM/orphan-exit/stdin EOF), but any other

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
+import contextlib
 from dataclasses import dataclass
 import logging
 from pathlib import Path
@@ -629,10 +630,28 @@ class EventStore:
 
         try:
             async with self._engine.begin() as conn:
+                # SQLite's planner mis-selects ix_events_timestamp here: to
+                # satisfy ORDER BY timestamp it scans *every* event row and
+                # applies the LIKE filter inline, turning this into a 30s+
+                # query on large stores (the session events are a tiny subset).
+                # SQLAlchemy/SQLite ignores with_hint(), so pin the selective
+                # ix_events_event_type index explicitly via raw SQL. The
+                # 'orchestrator.session.%' prefix is index-friendly; the small
+                # matched set is then ordered in a temp b-tree.
+                # ``.columns(*events_table.c)`` re-attaches the ORM column
+                # types so SQLAlchemy applies the same result processing as a
+                # ``select(events_table)`` would (notably JSON payload
+                # deserialization and timestamp coercion); without it the raw
+                # text result yields the payload as a JSON *string* and
+                # BaseEvent.from_db_row rejects it.
                 query = (
-                    select(events_table)
-                    .where(events_table.c.event_type.like("orchestrator.session.%"))
-                    .order_by(events_table.c.timestamp.asc())
+                    text(
+                        "SELECT * FROM events INDEXED BY ix_events_event_type "
+                        "WHERE event_type LIKE :pattern "
+                        "ORDER BY timestamp ASC"
+                    )
+                    .bindparams(pattern="orchestrator.session.%")
+                    .columns(*events_table.c)
                 )
 
                 result = await conn.execute(query)
@@ -1278,6 +1297,25 @@ class EventStore:
     async def close(self) -> None:
         """Close the database connection."""
         if self._engine is not None:
+            # Collapse the WAL back into the main DB before disposing. Without
+            # an explicit TRUNCATE checkpoint, long-lived multi-connection
+            # setups (many concurrent MCP/TUI sessions) let the -wal file grow
+            # unbounded: passive autocheckpoints cannot truncate while any
+            # other reader is active, so the file only ever appends. Best
+            # effort — ignore failures (read-only stores, lock contention).
+            #
+            # Use a short per-connection busy_timeout instead of the 30s default
+            # (set in initialize()): the checkpoint needs the write lock, and a
+            # peer process mid-write could otherwise stall this shutdown path for
+            # up to 30s. A missed checkpoint is harmless — the next clean close
+            # retries — so we cap the wait at ~2s. ``connect()`` (not ``begin()``)
+            # avoids an upfront BEGIN IMMEDIATE; the checkpoint acquires its own
+            # lock under the bounded timeout.
+            if not self._read_only:
+                with contextlib.suppress(Exception):
+                    async with self._engine.connect() as conn:
+                        await conn.exec_driver_sql("PRAGMA busy_timeout=2000")
+                        await conn.exec_driver_sql("PRAGMA wal_checkpoint(TRUNCATE)")
             await self._engine.dispose()
             self._engine = None
 

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import and_, event, func, or_, select, text
+from sqlalchemy.exc import OperationalError
 
 if TYPE_CHECKING:
     from ouroboros.orchestrator.workflow_lifecycle import WorkflowLifecycleEvent
@@ -628,35 +629,45 @@ class EventStore:
                 operation="get_all_sessions",
             )
 
+        # Pin the selective ix_events_event_type index. SQLite's planner
+        # otherwise satisfies ORDER BY timestamp by scanning *every* event row
+        # via ix_events_timestamp and filtering inline — a 30s+ query on large
+        # stores, even though session events are a tiny subset. SQLAlchemy/SQLite
+        # ignores with_hint(), so the hint is pinned via raw SQL.
+        # ``.columns(*events_table.c)`` re-attaches the ORM column types so the
+        # raw result gets the same processing as ``select(events_table)`` (notably
+        # JSON payload deserialization); without it from_db_row rejects the
+        # payload string.
+        indexed_query = (
+            text(
+                "SELECT * FROM events INDEXED BY ix_events_event_type "
+                "WHERE event_type LIKE :pattern "
+                "ORDER BY timestamp ASC"
+            )
+            .bindparams(pattern="orchestrator.session.%")
+            .columns(*events_table.c)
+        )
+        fallback_query = (
+            select(events_table)
+            .where(events_table.c.event_type.like("orchestrator.session.%"))
+            .order_by(events_table.c.timestamp.asc())
+        )
         try:
-            async with self._engine.begin() as conn:
-                # SQLite's planner mis-selects ix_events_timestamp here: to
-                # satisfy ORDER BY timestamp it scans *every* event row and
-                # applies the LIKE filter inline, turning this into a 30s+
-                # query on large stores (the session events are a tiny subset).
-                # SQLAlchemy/SQLite ignores with_hint(), so pin the selective
-                # ix_events_event_type index explicitly via raw SQL. The
-                # 'orchestrator.session.%' prefix is index-friendly; the small
-                # matched set is then ordered in a temp b-tree.
-                # ``.columns(*events_table.c)`` re-attaches the ORM column
-                # types so SQLAlchemy applies the same result processing as a
-                # ``select(events_table)`` would (notably JSON payload
-                # deserialization and timestamp coercion); without it the raw
-                # text result yields the payload as a JSON *string* and
-                # BaseEvent.from_db_row rejects it.
-                query = (
-                    text(
-                        "SELECT * FROM events INDEXED BY ix_events_event_type "
-                        "WHERE event_type LIKE :pattern "
-                        "ORDER BY timestamp ASC"
-                    )
-                    .bindparams(pattern="orchestrator.session.%")
-                    .columns(*events_table.c)
-                )
-
-                result = await conn.execute(query)
-                rows = result.mappings().all()
-                return [BaseEvent.from_db_row(dict(row)) for row in rows]
+            try:
+                async with self._engine.begin() as conn:
+                    result = await conn.execute(indexed_query)
+                    rows = result.mappings().all()
+                    return [BaseEvent.from_db_row(dict(row)) for row in rows]
+            except OperationalError:
+                # ``INDEXED BY`` makes ix_events_event_type mandatory; SQLite
+                # errors if it is absent (e.g. a store created outside the
+                # bundled schema/migrations). Fall back to the planner's choice
+                # on a fresh transaction so correctness never depends on a
+                # specific index name.
+                async with self._engine.begin() as conn:
+                    result = await conn.execute(fallback_query)
+                    rows = result.mappings().all()
+                    return [BaseEvent.from_db_row(dict(row)) for row in rows]
         except Exception as e:
             raise PersistenceError(
                 f"Failed to get all sessions: {e}",

--- a/tests/unit/cli/test_mcp_startup_cleanup.py
+++ b/tests/unit/cli/test_mcp_startup_cleanup.py
@@ -91,6 +91,7 @@ class TestMCPStartupAutoCleanup:
         mock_server = MagicMock()
         mock_server.info.tools = []
         mock_server.serve = AsyncMock()
+        mock_server.shutdown = AsyncMock()
 
         return mock_event_store, mock_repo, mock_server
 
@@ -125,6 +126,39 @@ class TestMCPStartupAutoCleanup:
         mock_repo.cancel_orphaned_sessions.assert_called_once()
         mock_es.initialize.assert_awaited_once()
         mock_server.serve.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_routes_through_server_shutdown(self) -> None:
+        """Teardown must drain adapter-owned resources via ``server.shutdown()``
+        (ControlBus → stores → bridge), not close the stores directly — so
+        control-bus subscriber tasks are drained and the bridge is closed in
+        the documented order."""
+        mock_es, mock_repo, mock_server = self._create_patches(cancelled_sessions=[])
+
+        async def serve_side_effect(*args, **kwargs) -> None:
+            await asyncio.sleep(0)
+
+        mock_server.serve.side_effect = serve_side_effect
+
+        with (
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=mock_es,
+            ),
+            patch(
+                "ouroboros.orchestrator.session.SessionRepository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "ouroboros.mcp.server.adapter.create_ouroboros_server",
+                return_value=mock_server,
+            ),
+        ):
+            from ouroboros.cli.commands.mcp import _run_mcp_server
+
+            await _run_mcp_server("localhost", 8080, "stdio")
+
+        mock_server.shutdown.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_startup_does_not_wait_for_background_cleanup(self) -> None:

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -1177,6 +1177,89 @@ class TestGetAllSessions:
         with pytest.raises(PersistenceError):
             await store.get_all_sessions()
 
+    async def test_falls_back_when_forced_index_missing(self, event_store: EventStore) -> None:
+        """``INDEXED BY ix_events_event_type`` makes the index mandatory; if a
+        store lacks it, get_all_sessions must fall back to the planner's choice
+        and still return correct, ordered results instead of erroring."""
+        for suffix in ("started", "completed"):
+            await event_store.append(
+                BaseEvent(
+                    type=f"orchestrator.session.{suffix}",
+                    aggregate_type="session",
+                    aggregate_id="sess-fallback",
+                    data={"seed_goal": "g"},
+                )
+            )
+
+        # Drop the index the fast path pins so a raw INDEXED BY would error.
+        async with event_store._engine.begin() as conn:  # type: ignore[union-attr]
+            await conn.exec_driver_sql("DROP INDEX IF EXISTS ix_events_event_type")
+
+        result = await event_store.get_all_sessions()
+        sess = [e for e in result if e.aggregate_id == "sess-fallback"]
+        assert len(sess) == 2
+        assert sess[0].type == "orchestrator.session.started"
+        assert sess[1].type == "orchestrator.session.completed"
+        # Payload is still deserialized into a dict (column types preserved).
+        assert sess[0].data.get("seed_goal") == "g"
+
+
+class TestEventStoreClose:
+    """Close-time behavior: WAL checkpoint, idempotency, read-only safety."""
+
+    async def test_close_collapses_wal(self, tmp_path) -> None:
+        """close() runs a TRUNCATE checkpoint so the ``-wal`` file is collapsed
+        instead of growing unbounded across long-lived multi-connection use."""
+        db_path = tmp_path / "wal_close.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+        for i in range(200):
+            await store.append(
+                BaseEvent(
+                    type="orchestrator.session.started",
+                    aggregate_type="session",
+                    aggregate_id=f"s{i}",
+                    data={"blob": "x" * 1000},
+                )
+            )
+
+        wal = db_path.with_name(db_path.name + "-wal")
+        assert wal.exists() and wal.stat().st_size > 0
+
+        await store.close()
+
+        # TRUNCATE checkpoint shrinks the WAL to empty (or SQLite removes it on
+        # the final connection close).
+        assert (not wal.exists()) or wal.stat().st_size == 0
+
+    async def test_close_is_idempotent(self, tmp_path) -> None:
+        """Calling close() twice must be safe (engine already disposed)."""
+        db_path = tmp_path / "wal_idem.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+        await store.close()
+        await store.close()  # must not raise
+
+    async def test_close_read_only_skips_write_checkpoint(self, tmp_path) -> None:
+        """A read-only store must not attempt the (writing) WAL checkpoint —
+        doing so would raise 'attempt to write a readonly database'."""
+        db_path = tmp_path / "ro.db"
+        writer = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await writer.initialize()
+        await writer.append(
+            BaseEvent(
+                type="orchestrator.session.started",
+                aggregate_type="session",
+                aggregate_id="s1",
+                data={},
+            )
+        )
+        await writer.close()
+
+        ro = EventStore(f"sqlite+aiosqlite:///{db_path}", read_only=True)
+        await ro.initialize()
+        await ro.close()  # must not raise
+
 
 class TestEventStoreTransactions:
     """Test transaction handling per AC7."""


### PR DESCRIPTION
## Problem

The TUI/MCP became very slow and the on-disk store ballooned — on one machine **13GB `ouroboros.db` + 17GB `-wal`**, of which only ~53MB was live data. Three compounding causes:

1. **`get_all_sessions()` took ~33s.** SQLite's planner satisfied `ORDER BY timestamp` by scanning all ~850k event rows via `ix_events_timestamp` and filtering inline, instead of using the selective `ix_events_event_type` (session events are a tiny subset). This is the first query the TUI session list runs, so the UI hung for ~33s on open.
2. **The `-wal` file grew unbounded.** With many concurrent MCP/TUI connections a reader was always pinning the WAL, so passive autocheckpoints could never truncate it, and nothing ran an explicit `TRUNCATE` checkpoint.
3. **`ouroboros mcp serve` had no shutdown hooks.** An unhandled `SIGTERM` bypassed the cleanup `finally`; a dead client left the server (especially `streamable-http`, which has no stdin EOF) orphaned and holding the DB open → process + connection accumulation.

## Changes

**`persistence/event_store.py`**
- `get_all_sessions()`: pin `INDEXED BY ix_events_event_type` via raw `text()` + `.columns(*events_table.c)` (to keep ORM result processing / JSON payload deserialization). SQLAlchemy/SQLite ignores `with_hint()`. **33.7s → 1.3s**, identical 453-row result.
- `close()`: explicit `wal_checkpoint(TRUNCATE)`, bounded by a short 2s `busy_timeout` connection so a peer write-lock cannot stall shutdown for the 30s default.

**`cli/commands/mcp.py`** (`_run_mcp_server`)
- Graceful `SIGTERM`/`SIGINT`/`SIGHUP` handlers → the cleanup `finally` (WAL collapse + PID cleanup) always runs.
- Parent-death watchdog: self-terminates when reparented away from its original ppid (covers child-subreaper hosts like `systemd --user`, not just pid 1).
- Re-raises a genuine serve-loop crash after cleanup instead of exiting 0 silently.

## Adversarial review

This change went through a multi-agent adversarial review (4 dimensions × verify), which surfaced and fixed 4 issues in the first draft:
- `signal.SIGHUP` crashed `mcp serve` on Windows at startup (tuple built before the `suppress`) → resolved via `getattr`.
- A serve-loop crash was swallowed by the `finally` `suppress(Exception)` (silent exit 0, a regression) → the serve task's exception is now re-raised.
- `close()` WAL `TRUNCATE` could block shutdown up to 30s under write-lock contention → short `busy_timeout`.
- Orphan watchdog `getppid()==1` never fired under `systemd --user` (subreaper) → compare `!= orig_ppid`.

## Verification
- `ruff` / `ruff format` / `mypy` clean
- 325 targeted tests pass
- Integration tested on a live server: SIGTERM graceful shutdown, orphan self-termination (parent SIGKILL → reparent → exit), and WAL truncate-on-close (4MB → 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
