### PR TITLE
fix(orchestrator): preserve typed error metadata on hermes failures (usage-limit pause regression)

### DIFF
--- a/src/ouroboros/orchestrator/hermes_runtime.py
+++ b/src/ouroboros/orchestrator/hermes_runtime.py
@@ -31,6 +31,7 @@ from ouroboros.orchestrator.adapter import (
     SkillDispatchHandler,
     TaskResult,
 )
+from ouroboros.orchestrator.runtime_error import classify_subprocess_failure
 from ouroboros.router import (
     InvalidInputReason,
     InvalidSkill,
@@ -523,7 +524,7 @@ class HermesCliRuntime(AgentRuntime):
             yield AgentMessage(
                 type="result",
                 content=f"Hermes execution failed:\n{failure_content}",
-                data={"subtype": "error", "exit_code": returncode},
+                data=classify_subprocess_failure(failure_content, exit_code=returncode),
                 resume_handle=handle,
             )
             return

--- a/src/ouroboros/orchestrator/runtime_error.py
+++ b/src/ouroboros/orchestrator/runtime_error.py
@@ -1,0 +1,86 @@
+"""Typed classification of runtime subprocess failures.
+
+CLI-backed runtimes (hermes, gemini-cli, ...) surface upstream failures as a
+non-zero process exit plus free-form stdout/stderr text. Collapsing that to
+``{"subtype": "error", "exit_code": N}`` discards the provider's typed signal —
+the HTTP status and quota/usage-limit phrasing — that the orchestrator's
+recoverable-failure classifier keys on. The consequence (see
+``docs/rca-june-2026.md``, issue 1.1) is that a provider usage-limit window
+hard-fails the whole run instead of pausing it gracefully.
+
+``classify_subprocess_failure`` re-derives those typed fields from the failure
+text so they can be attached to the runtime ``AgentMessage`` metadata. The
+returned keys are a subset of those recognized by
+``OrchestratorRunner._metadata_has_runtime_error_shape`` — in particular
+``error_type`` is always present, which is what marks a failure as
+runtime-owned and lets the existing (conservative) usage-limit text classifier
+run at all.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+#: Generic runtime failure when no more specific class is detected.
+RUNTIME_EXECUTION_ERROR = "RuntimeExecutionError"
+#: Rate-limit / usage-limit / quota failure (HTTP 429 or matching phrasing).
+RATE_LIMIT_ERROR = "RateLimitError"
+
+# Match an HTTP 4xx/5xx status only when anchored to a status-like keyword, so
+# durations ("5 hour") and timestamps ("21:41:18") are never read as codes.
+_HTTP_STATUS_PATTERN = re.compile(
+    r"(?:http|status(?:\s*code)?|code|error)\b\W{0,4}(?P<status>[45]\d\d)\b",
+    re.IGNORECASE,
+)
+
+# Phrases that indicate a rate-limit / usage-limit / quota condition.
+_RATE_LIMIT_PATTERN = re.compile(
+    r"\b(?:rate[\s_-]*limit"
+    r"|usage[\s_-]*limit"
+    r"|quota"
+    r"|too\s+many\s+requests"
+    r"|limit\s+reached)\b",
+    re.IGNORECASE,
+)
+
+
+def _extract_http_status(text: str) -> int | None:
+    """Return the first anchored HTTP 4xx/5xx status code in ``text``."""
+    match = _HTTP_STATUS_PATTERN.search(text)
+    if match is None:
+        return None
+    return int(match.group("status"))
+
+
+def classify_subprocess_failure(text: str, *, exit_code: int) -> dict[str, Any]:
+    """Build typed error metadata for a non-zero runtime subprocess exit.
+
+    Args:
+        text: Combined stderr/stdout (or a synthesized message) describing the
+            failure.
+        exit_code: The process exit code.
+
+    Returns:
+        A metadata dict suitable for ``AgentMessage.data``. Always carries
+        ``subtype="error"``, the ``exit_code``, and a typed ``error_type``;
+        adds ``http_status`` when a status code can be identified.
+    """
+    failure_text = text or ""
+    metadata: dict[str, Any] = {"subtype": "error", "exit_code": exit_code}
+
+    http_status = _extract_http_status(failure_text)
+    if http_status is not None:
+        metadata["http_status"] = http_status
+
+    is_rate_limited = http_status == 429 or _RATE_LIMIT_PATTERN.search(failure_text) is not None
+    metadata["error_type"] = RATE_LIMIT_ERROR if is_rate_limited else RUNTIME_EXECUTION_ERROR
+
+    return metadata
+
+
+__all__ = [
+    "RATE_LIMIT_ERROR",
+    "RUNTIME_EXECUTION_ERROR",
+    "classify_subprocess_failure",
+]

--- a/tests/unit/orchestrator/test_hermes_runtime.py
+++ b/tests/unit/orchestrator/test_hermes_runtime.py
@@ -568,6 +568,50 @@ class TestHermesCliRuntime:
         assert messages[-1].content == "Hermes fallback completed"
 
     @pytest.mark.asyncio
+    async def test_execute_task_nonzero_exit_emits_typed_error_metadata(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A non-zero hermes exit carrying a provider 429 must surface typed
+        error metadata (issue 1.1 regression). Without it the failure lacks
+        runtime-error shape and the run hard-fails instead of pausing."""
+        self._write_skill(
+            tmp_path,
+            "run",
+            [
+                "name: run",
+                "mcp_tool: ouroboros_execute_seed",
+                "mcp_args:",
+                '  seed_path: "$1"',
+            ],
+        )
+        runtime = HermesCliRuntime(
+            cli_path="hermes",
+            cwd="/tmp/project",
+            skills_dir=tmp_path,
+        )
+        process = _FakeProcess(
+            stdout="",
+            stderr="HTTP 429: Usage limit reached for 5 hour.",
+            returncode=1,
+        )
+
+        with patch(
+            "ouroboros.orchestrator.hermes_runtime.asyncio.create_subprocess_exec",
+            return_value=process,
+        ):
+            messages = [
+                message async for message in runtime.execute_task("please ooo run seed.yaml")
+            ]
+
+        final = messages[-1]
+        assert final.is_error
+        assert final.data["subtype"] == "error"
+        assert final.data["exit_code"] == 1
+        assert final.data["error_type"] == "RateLimitError"
+        assert final.data["http_status"] == 429
+
+    @pytest.mark.asyncio
     async def test_execute_task_maps_interview_argument_to_initial_context(
         self,
         tmp_path: Path,

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -37,6 +37,7 @@ from ouroboros.orchestrator.runner import (
     build_system_prompt,
     build_task_prompt,
 )
+from ouroboros.orchestrator.runtime_error import classify_subprocess_failure
 from ouroboros.orchestrator.session import SessionStatus, SessionTracker
 
 
@@ -1476,6 +1477,54 @@ class TestOrchestratorRunner:
         assert pause.pause_kind == "usage_limit"
         assert pause.pause_seconds == 18000
         assert pause.resume_after == now + timedelta(hours=5)
+
+    def test_recoverable_failure_detects_hermes_usage_limit_exit(
+        self,
+        runner: OrchestratorRunner,
+    ) -> None:
+        """Regression for issue 1.1: a hermes non-zero exit carrying a Z.AI/GLM
+        usage-limit 429 must pause, not hard-fail. Before the typed-error
+        contract the hermes path emitted only ``{"subtype","exit_code"}``, which
+        the classifier rejected for lacking runtime-error shape."""
+        now = datetime(2026, 1, 1, tzinfo=UTC)
+        failure_text = (
+            "API call failed after 3 retries:\n"
+            "HTTP 429: Usage limit reached for 5 hour.\n"
+            "Your limit will reset at 2026-06-07 21:41:18"
+        )
+        message = AgentMessage(
+            type="result",
+            content=f"Hermes execution failed:\n{failure_text}",
+            data=classify_subprocess_failure(failure_text, exit_code=1),
+        )
+
+        pause = runner._recoverable_failure_pause(message, now=now)
+
+        assert pause is not None
+        assert pause.pause_kind == "usage_limit"
+        assert pause.pause_seconds == 18000
+        assert pause.resume_after == now + timedelta(hours=5)
+
+    def test_recoverable_failure_ignores_ordinary_hermes_exit(
+        self,
+        runner: OrchestratorRunner,
+    ) -> None:
+        """A typed-but-ordinary hermes failure must not trigger a usage pause."""
+        message = AgentMessage(
+            type="result",
+            content="Hermes execution failed:\nTraceback: ValueError: bad config",
+            data=classify_subprocess_failure(
+                "Traceback: ValueError: bad config",
+                exit_code=1,
+            ),
+        )
+
+        pause = runner._recoverable_failure_pause(
+            message,
+            now=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+
+        assert pause is None
 
     def test_recoverable_failure_sums_compound_retry_window(
         self,

--- a/tests/unit/orchestrator/test_runtime_error.py
+++ b/tests/unit/orchestrator/test_runtime_error.py
@@ -1,0 +1,94 @@
+"""Unit tests for runtime subprocess-failure classification.
+
+These cover the typed-error contract that lets the orchestrator's recoverable-
+failure classifier recognize provider usage-limit windows surfaced by CLI
+runtimes (hermes, gemini-cli, ...) as a non-zero process exit plus free-form
+text. See ``docs/rca-june-2026.md`` (P0).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.runtime_error import classify_subprocess_failure
+
+# The exact failure text that hard-failed the June 2026 run (issue 1.1).
+_ZAI_429_TEXT = (
+    "API call failed after 3 retries:\n"
+    "HTTP 429: Usage limit reached for 5 hour.\n"
+    "Your limit will reset at 2026-06-07 21:41:18"
+)
+
+
+class TestClassifySubprocessFailure:
+    """Behaviour of ``classify_subprocess_failure``."""
+
+    def test_preserves_subtype_and_exit_code(self) -> None:
+        # Arrange / Act
+        metadata = classify_subprocess_failure("boom", exit_code=2)
+
+        # Assert
+        assert metadata["subtype"] == "error"
+        assert metadata["exit_code"] == 2
+
+    def test_zai_usage_limit_429_is_typed_as_rate_limit(self) -> None:
+        # Act
+        metadata = classify_subprocess_failure(_ZAI_429_TEXT, exit_code=1)
+
+        # Assert
+        assert metadata["error_type"] == "RateLimitError"
+        assert metadata["http_status"] == 429
+
+    def test_always_sets_error_type_so_failure_has_runtime_shape(self) -> None:
+        # A plain failure must still carry a typed error_type so the
+        # orchestrator recognizes it as runtime-owned (the bug was the
+        # absence of any shape key).
+        metadata = classify_subprocess_failure(
+            "Hermes exited with code 1",
+            exit_code=1,
+        )
+
+        assert metadata["error_type"] == "RuntimeExecutionError"
+
+    def test_non_rate_limit_failure_has_no_http_status(self) -> None:
+        metadata = classify_subprocess_failure(
+            "Traceback: ValueError: bad config",
+            exit_code=1,
+        )
+
+        assert "http_status" not in metadata
+        assert metadata["error_type"] == "RuntimeExecutionError"
+
+    def test_detects_rate_limit_phrase_without_status_code(self) -> None:
+        metadata = classify_subprocess_failure(
+            "Error: rate limit exceeded, slow down",
+            exit_code=1,
+        )
+
+        assert metadata["error_type"] == "RateLimitError"
+
+    def test_extracts_http_500(self) -> None:
+        metadata = classify_subprocess_failure(
+            "HTTP 500: internal server error",
+            exit_code=1,
+        )
+
+        assert metadata["http_status"] == 500
+        assert metadata["error_type"] == "RuntimeExecutionError"
+
+    def test_does_not_mistake_timestamps_or_durations_for_status(self) -> None:
+        # "5 hour" and "21:41:18" must not be read as HTTP status codes.
+        metadata = classify_subprocess_failure(
+            "Please try again in 5 hour, around 21:41:18",
+            exit_code=1,
+        )
+
+        assert "http_status" not in metadata
+
+    @pytest.mark.parametrize("text", ["", "   ", "\n"])
+    def test_empty_text_still_yields_typed_metadata(self, text: str) -> None:
+        metadata = classify_subprocess_failure(text, exit_code=137)
+
+        assert metadata["subtype"] == "error"
+        assert metadata["exit_code"] == 137
+        assert metadata["error_type"] == "RuntimeExecutionError"


### PR DESCRIPTION
## Problem

When the **hermes** CLI runtime exits non-zero — e.g. a Z.AI/GLM `HTTP 429: Usage limit reached` surfaced after hermes' own retries — it emitted only:

```python
data={"subtype": "error", "exit_code": returncode}
```

The orchestrator's recoverable-failure classifier (`OrchestratorRunner._is_usage_limit_text`) short-circuits unless the message carries a **runtime-error shape** — one of `error_type`, `http_status`, `status`, `provider`, … (`_metadata_has_runtime_error_shape`). Neither `subtype` nor `exit_code` qualifies, so the classifier returned `False` **before** its usage-limit text/duration regex ever ran.

Result: the `usage_limit_pause` mechanism never fired, and a single provider quota window **hard-failed the entire run** (every acceptance criterion failed instantly, zero tokens consumed) instead of pausing for graceful resume.

This was the most disruptive issue in a real run (Claude Code plugin → hermes → Z.AI/GLM via litellm). Note the inconsistency this fixes: hermes' *timeout* path already sets `error_type="TimeoutError"` and is recognized; only the generic non-zero-exit path (where 429s land) was opaque. The Codex runtime works for the same reason — it sets `error_type`.

## Fix

A small, pure, well-tested classifier — `orchestrator/runtime_error.py::classify_subprocess_failure` — re-derives typed fields from the failure text:

- **always** sets `error_type` (so the failure is recognized as runtime-owned),
- adds `http_status` when an HTTP status is anchored to a status keyword (so `5 hour` / `21:41:18` are never misread as codes),
- types it as `RateLimitError` on a 429 or rate/usage/quota signal, else `RuntimeExecutionError`.

It's wired into the hermes non-zero-exit path. The metadata stays **backward compatible** (`subtype` and `exit_code` preserved) — the change is purely additive. The existing, conservative usage-limit text/duration logic now runs and correctly distinguishes a multi-hour usage window (→ pause) from an ordinary 429 with no long window (→ no pause).

## Why this approach

The classifier already keys on exactly these fields, so populating them at the source is sufficient and minimal — no change to the matcher's logic, no new false-positive surface (the regex remains the discriminator). This is the P0 of a broader RCA; follow-ups (parameter-level capability negotiation, provider-aware quota tracking, authoritative job reconciliation) are intentionally out of scope here.

## Tests

- `tests/unit/orchestrator/test_runtime_error.py` — classifier unit tests: status extraction, rate-limit typing, no false positives on timestamps/durations, empty input.
- `test_hermes_runtime.py::test_execute_task_nonzero_exit_emits_typed_error_metadata` — a non-zero hermes exit carrying a 429 emits `error_type=RateLimitError` + `http_status=429`.
- `test_runner.py::test_recoverable_failure_detects_hermes_usage_limit_exit` — **regression**: a hermes-shaped 429 now yields an 18000s `usage_limit` pause.
- `test_runner.py::test_recoverable_failure_ignores_ordinary_hermes_exit` — an ordinary typed hermes failure still does **not** pause.

Full orchestrator unit suite passes locally (1777 passed, 1 skipped); `ruff` and `mypy` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)