### PR TITLE
feat(orchestrator): plan delivery fan-out within backend concurrency limits

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -199,7 +199,7 @@ orchestrator:
 | `runtime_backend` | `"claude"` \| `"codex"` \| `"opencode"` \| `"hermes"` \| `"gemini"` \| `"kiro"` \| `"copilot"` \| `"pi"` | `"claude"` | The agent runtime backend used for workflow execution. Overridable via `OUROBOROS_AGENT_RUNTIME`. See [runtime capability matrix](runtime-capability-matrix.md). |
 | `permission_mode` | `"default"` \| `"acceptEdits"` \| `"bypassPermissions"` | `"acceptEdits"` | Permission mode for Claude and Codex runtimes. Overridable via `OUROBOROS_AGENT_PERMISSION_MODE`. |
 | `opencode_permission_mode` | `"default"` \| `"acceptEdits"` \| `"bypassPermissions"` | `"bypassPermissions"` | Permission mode when using the OpenCode runtime. Overridable via `OUROBOROS_OPENCODE_PERMISSION_MODE`. |
-| `max_parallel_workers` | `int >= 1` | `3` | Maximum concurrent Acceptance Criteria workers for parallel execution. Overridable via `OUROBOROS_MAX_PARALLEL_WORKERS`. Invalid explicit values fail instead of falling back to the default. |
+| `max_parallel_workers` | `int >= 1` | `3` | Requested maximum concurrent Acceptance Criteria workers for parallel execution. Overridable via `OUROBOROS_MAX_PARALLEL_WORKERS`. Invalid explicit values fail instead of falling back to the default. **Note:** the effective fan-out is additionally capped to the connected backend's known concurrency limit — the native Claude backend is governed by its RPM/TPM rate bucket, while CLI runtimes whose underlying LLM limits are unknown (`hermes`, `codex`, `gemini`, `opencode`, ...) are **serialized to 1 by default** to avoid stampeding the provider's rate/quota window. Raise that cap with `OUROBOROS_MAX_CONCURRENCY`. |
 | `cli_path` | `string \| null` | `null` | Absolute path to the Claude CLI binary (`~` is expanded). When `null`, the SDK-bundled CLI is used. Overridable via `OUROBOROS_CLI_PATH`. |
 | `codex_cli_path` | `string \| null` | `null` | Absolute path to the Codex CLI binary (`~` is expanded). When `null`, resolved from `PATH` at runtime. Overridable via `OUROBOROS_CODEX_CLI_PATH`. |
 | `opencode_cli_path` | `string \| null` | `null` | Absolute path to the OpenCode CLI binary (`~` is expanded). When `null`, resolved from `PATH` at runtime. Overridable via `OUROBOROS_OPENCODE_CLI_PATH`. |
@@ -598,7 +598,8 @@ All environment variables have higher priority than the corresponding `config.ya
 | `OUROBOROS_AGENT_RUNTIME` | `orchestrator.runtime_backend` | Active runtime backend (`claude`, `codex`, `opencode`, `hermes`, `gemini`, `kiro`, `copilot`, `pi`). |
 | `OUROBOROS_AGENT_PERMISSION_MODE` | `orchestrator.permission_mode` | Permission mode for non-OpenCode runtimes. |
 | `OUROBOROS_OPENCODE_PERMISSION_MODE` | `orchestrator.opencode_permission_mode` | Permission mode when using OpenCode runtime. |
-| `OUROBOROS_MAX_PARALLEL_WORKERS` | `orchestrator.max_parallel_workers` | Maximum concurrent Acceptance Criteria workers for parallel execution. Must be a positive integer. |
+| `OUROBOROS_MAX_PARALLEL_WORKERS` | `orchestrator.max_parallel_workers` | Requested maximum concurrent Acceptance Criteria workers for parallel execution. Must be a positive integer. |
+| `OUROBOROS_MAX_CONCURRENCY` | _(fan-out cap)_ | Caps the effective delivery fan-out for the connected backend, overriding Ouroboros' backend-aware default. Use it to raise CLI runtimes (`hermes`, `codex`, ...) above their serialized-by-default ceiling of 1. Must be a positive integer; blank/invalid values are ignored so the safety cap is never silently disabled. |
 | `OUROBOROS_CLI_PATH` | `orchestrator.cli_path` | Path to the Claude CLI binary. |
 | `OUROBOROS_CODEX_CLI_PATH` | `orchestrator.codex_cli_path` | Path to the Codex CLI binary. |
 | `OUROBOROS_OPENCODE_CLI_PATH` | `orchestrator.opencode_cli_path` | Path to the OpenCode CLI binary. |

--- a/src/ouroboros/orchestrator/adapter.py
+++ b/src/ouroboros/orchestrator/adapter.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.types import Result
 from ouroboros.observability.logging import get_logger
+from ouroboros.orchestrator.backend_limits import resolve_backend_limits
 from ouroboros.orchestrator.rate_limit import (
     DEFAULT_ANTHROPIC_RPM_CEILING,
     DEFAULT_ANTHROPIC_TPM_CEILING,
@@ -954,16 +955,26 @@ class ClaudeAgentAdapter:
         return parsed
 
     def _build_rate_limit_bucket(self) -> SharedRateLimitBucket:
-        """Create the shared Anthropic rate-limit bucket for orchestrator workers."""
+        """Create the shared rate-limit bucket for orchestrator workers.
+
+        RPM/TPM defaults are sourced from the backend-limits registry (the
+        single source of truth for per-backend constraints) and may be
+        overridden per deployment via the ``OUROBOROS_ANTHROPIC_*`` env knobs
+        (``0`` disables that limit). For the native Claude backend this resolves
+        to the same Anthropic ceilings as before.
+        """
+        limits = resolve_backend_limits(self._runtime_backend)
+        rpm_default = limits.requests_per_minute or DEFAULT_ANTHROPIC_RPM_CEILING
+        tpm_default = limits.tokens_per_minute or DEFAULT_ANTHROPIC_TPM_CEILING
         return SharedRateLimitBucket(
             runtime_backend=self._runtime_backend,
             request_limit=self._parse_optional_positive_int(
                 "OUROBOROS_ANTHROPIC_RPM_CEILING",
-                default=DEFAULT_ANTHROPIC_RPM_CEILING,
+                default=rpm_default,
             ),
             token_limit=self._parse_optional_positive_int(
                 "OUROBOROS_ANTHROPIC_TPM_CEILING",
-                default=DEFAULT_ANTHROPIC_TPM_CEILING,
+                default=tpm_default,
             ),
         )
 

--- a/src/ouroboros/orchestrator/backend_limits.py
+++ b/src/ouroboros/orchestrator/backend_limits.py
@@ -1,0 +1,141 @@
+"""Backend-aware fan-out concurrency planning.
+
+Ouroboros plans delivery (the parallel execution of acceptance criteria) and is
+responsible for keeping that fan-out within the concurrency and rate-limit
+constraints of the connected LLM backend — it must not rely on the agent
+runtime to throttle itself. See ``docs/rca-june-2026.md`` (R3): a hermes→Z.AI
+run fanned out 14 acceptance criteria at once and stampeded an already-exhausted
+quota because nothing on the Ouroboros side bounded concurrency for that
+runtime (only the native Claude adapter carries a shared rate-limit bucket).
+
+Policy: backends whose underlying LLM limits Ouroboros cannot know — every CLI
+runtime (hermes, codex, gemini, opencode, ...) — are **serialized by default**
+(one acceptance criterion at a time) and raised only by explicit operator
+override via ``OUROBOROS_MAX_CONCURRENCY``. The native Claude backend is left
+uncapped here because it is already governed by its RPM/TPM bucket
+(``SharedRateLimitBucket``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+import os
+
+from ouroboros.orchestrator.rate_limit import (
+    DEFAULT_ANTHROPIC_RPM_CEILING,
+    DEFAULT_ANTHROPIC_TPM_CEILING,
+)
+
+#: Default fan-out cap for backends with no Ouroboros-known LLM limits.
+DEFAULT_UNKNOWN_MAX_CONCURRENCY = 1
+
+#: Operator override for the resolved concurrency cap (applies to any backend).
+MAX_CONCURRENCY_ENV = "OUROBOROS_MAX_CONCURRENCY"
+
+
+@dataclass(frozen=True, slots=True)
+class BackendConcurrencyLimits:
+    """Concurrency/rate constraints Ouroboros applies when planning fan-out.
+
+    Attributes:
+        backend: Canonical backend identifier the limits were resolved for.
+        max_concurrency: Maximum acceptance criteria to dispatch in parallel.
+            ``None`` means Ouroboros imposes no fan-out cap (the backend is
+            governed elsewhere, e.g. the native Claude RPM/TPM bucket).
+        requests_per_minute: Known request ceiling, if any (advisory; consumed
+            by the native Claude rate-limit bucket).
+        tokens_per_minute: Known token ceiling, if any (advisory).
+    """
+
+    backend: str
+    max_concurrency: int | None
+    requests_per_minute: int | None = None
+    tokens_per_minute: int | None = None
+
+
+# Canonical aliases for backend identifiers seen on adapters / config.
+_BACKEND_ALIASES = {
+    "anthropic": "claude",
+    "claude_code": "claude",
+}
+
+# Backends with Ouroboros-known governance. Only the native Claude adapter is
+# uncapped here (its shared RPM/TPM bucket paces it); everything else falls
+# through to the conservative default below.
+_KNOWN_BACKENDS: dict[str, BackendConcurrencyLimits] = {
+    "claude": BackendConcurrencyLimits(
+        backend="claude",
+        max_concurrency=None,
+        requests_per_minute=DEFAULT_ANTHROPIC_RPM_CEILING,
+        tokens_per_minute=DEFAULT_ANTHROPIC_TPM_CEILING,
+    ),
+}
+
+
+def _normalize_backend(backend: str | None) -> str:
+    """Lower-case, trim, and canonicalize a backend identifier."""
+    name = (backend or "").strip().lower()
+    return _BACKEND_ALIASES.get(name, name)
+
+
+def _read_max_concurrency_override() -> int | None:
+    """Return a positive ``OUROBOROS_MAX_CONCURRENCY`` override, else ``None``.
+
+    Blank, non-integer, and non-positive values are ignored so a malformed
+    override never silently disables the safety cap.
+    """
+    raw = os.environ.get(MAX_CONCURRENCY_ENV, "").strip()
+    if not raw:
+        return None
+    try:
+        parsed = int(raw)
+    except ValueError:
+        return None
+    return parsed if parsed > 0 else None
+
+
+def resolve_backend_limits(backend: str | None) -> BackendConcurrencyLimits:
+    """Resolve concurrency/rate limits for ``backend``.
+
+    Known backends use their registry entry; everything else (CLI runtimes,
+    unknown, or missing) is serialized to :data:`DEFAULT_UNKNOWN_MAX_CONCURRENCY`.
+    A positive ``OUROBOROS_MAX_CONCURRENCY`` env override replaces the resolved
+    ``max_concurrency`` for any backend.
+    """
+    canonical = _normalize_backend(backend)
+    base = _KNOWN_BACKENDS.get(canonical)
+    if base is None:
+        base = BackendConcurrencyLimits(
+            backend=canonical or "unknown",
+            max_concurrency=DEFAULT_UNKNOWN_MAX_CONCURRENCY,
+        )
+
+    override = _read_max_concurrency_override()
+    if override is not None:
+        base = replace(base, max_concurrency=override)
+
+    return base
+
+
+def plan_fan_out_concurrency(
+    requested_workers: int,
+    limits: BackendConcurrencyLimits,
+) -> int:
+    """Return the effective parallel-worker count for delivery fan-out.
+
+    The result is the requested worker count, clamped to at least 1 and capped
+    by ``limits.max_concurrency`` when the backend declares one.
+    """
+    requested = max(1, requested_workers)
+    if limits.max_concurrency is None:
+        return requested
+    return max(1, min(requested, limits.max_concurrency))
+
+
+__all__ = [
+    "DEFAULT_UNKNOWN_MAX_CONCURRENCY",
+    "MAX_CONCURRENCY_ENV",
+    "BackendConcurrencyLimits",
+    "plan_fan_out_concurrency",
+    "resolve_backend_limits",
+]

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -50,6 +50,10 @@ from ouroboros.orchestrator.adapter import (
     AgentRuntime,
     RuntimeHandle,
 )
+from ouroboros.orchestrator.backend_limits import (
+    plan_fan_out_concurrency,
+    resolve_backend_limits,
+)
 from ouroboros.orchestrator.capabilities import (
     CapabilityGraph,
     build_capability_graph,
@@ -480,6 +484,18 @@ class OrchestratorRunner:
         self._fat_harness_mode = fat_harness_mode
         # Track active session for external cancellation by execution_id
         self._active_sessions: dict[str, str] = {}  # execution_id -> session_id
+
+    def _plan_parallel_workers(self) -> int:
+        """Return the effective fan-out worker count for the connected backend.
+
+        Ouroboros caps delivery fan-out to the connected backend's known
+        concurrency limit so it does not stampede the LLM's rate/quota window
+        (R3). Backends whose underlying LLM limits are unknown — the CLI
+        runtimes — serialize by default and are raised only via
+        ``OUROBOROS_MAX_CONCURRENCY``.
+        """
+        limits = resolve_backend_limits(self._adapter.runtime_backend)
+        return plan_fan_out_concurrency(self._max_parallel_workers, limits)
 
     @property
     def mcp_manager(self) -> MCPClientManager | None:
@@ -2764,13 +2780,29 @@ class OrchestratorRunner:
 
         execution_profile = _execution_profile_for_seed(seed)
 
+        # Cap fan-out to the connected backend's concurrency constraints so a
+        # parallel dispatch never stampedes the LLM's rate/quota window (R3).
+        effective_workers = self._plan_parallel_workers()
+        if effective_workers < self._max_parallel_workers:
+            self._console.print(
+                f"[yellow]Fan-out capped to {effective_workers} worker(s) for backend "
+                f"'{self._adapter.runtime_backend}' (requested {self._max_parallel_workers}). "
+                f"Override with OUROBOROS_MAX_CONCURRENCY.[/yellow]"
+            )
+            log.info(
+                "orchestrator.runner.fan_out_capped",
+                runtime_backend=self._adapter.runtime_backend,
+                requested_workers=self._max_parallel_workers,
+                effective_workers=effective_workers,
+            )
+
         # Execute in parallel
         parallel_executor = ParallelACExecutor(
             adapter=self._adapter,
             event_store=self._event_store,
             console=self._console,
             enable_decomposition=self._enable_decomposition,
-            max_concurrent=self._max_parallel_workers,
+            max_concurrent=effective_workers,
             max_decomposition_depth=self._max_decomposition_depth,
             inherited_runtime_handle=self._inherited_runtime_handle,
             task_cwd=self._effective_cwd(),
@@ -2845,6 +2877,7 @@ class OrchestratorRunner:
             "total_levels": execution_plan.total_stages,
             "max_decomposition_depth": self._max_decomposition_depth,
             "max_parallel_workers": self._max_parallel_workers,
+            "effective_parallel_workers": effective_workers,
             "verification_report": verification_report,
             **self._task_summary(),
         }

--- a/tests/unit/orchestrator/test_backend_limits.py
+++ b/tests/unit/orchestrator/test_backend_limits.py
@@ -1,0 +1,100 @@
+"""Unit tests for backend-aware fan-out concurrency planning.
+
+Ouroboros must plan delivery fan-out to comply with the connected backend's
+concurrency/rate constraints rather than relying on the agent runtime to manage
+it. Backends whose underlying LLM limits Ouroboros cannot know (the CLI
+runtimes — hermes, codex, gemini, ...) are serialized by default and raised
+only by explicit override. See ``docs`` RCA (P1 / R3).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.backend_limits import (
+    DEFAULT_UNKNOWN_MAX_CONCURRENCY,
+    MAX_CONCURRENCY_ENV,
+    BackendConcurrencyLimits,
+    plan_fan_out_concurrency,
+    resolve_backend_limits,
+)
+
+
+class TestResolveBackendLimits:
+    """Resolution of per-backend limits from the registry and overrides."""
+
+    def test_native_claude_is_not_concurrency_capped(self) -> None:
+        # The native Claude adapter has its own shared RPM/TPM bucket, so it is
+        # governed there rather than by a fan-out concurrency cap.
+        limits = resolve_backend_limits("claude")
+
+        assert limits.max_concurrency is None
+        assert limits.requests_per_minute == 40
+        assert limits.tokens_per_minute == 32_000
+
+    def test_anthropic_alias_resolves_to_claude(self) -> None:
+        assert resolve_backend_limits("anthropic").max_concurrency is None
+
+    @pytest.mark.parametrize(
+        "backend",
+        ["hermes_cli", "hermes", "codex_cli", "gemini_cli", "opencode", "goose", "pi", "copilot"],
+    )
+    def test_cli_backends_are_serialized_by_default(self, backend: str) -> None:
+        limits = resolve_backend_limits(backend)
+
+        assert limits.max_concurrency == DEFAULT_UNKNOWN_MAX_CONCURRENCY == 1
+
+    def test_unknown_or_missing_backend_is_serialized(self) -> None:
+        assert resolve_backend_limits(None).max_concurrency == 1
+        assert resolve_backend_limits("").max_concurrency == 1
+        assert resolve_backend_limits("totally-made-up").max_concurrency == 1
+
+    def test_backend_name_is_normalized(self) -> None:
+        assert resolve_backend_limits("  Hermes_CLI ").max_concurrency == 1
+        assert resolve_backend_limits("CLAUDE").max_concurrency is None
+
+    def test_env_override_raises_cli_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(MAX_CONCURRENCY_ENV, "4")
+
+        assert resolve_backend_limits("hermes_cli").max_concurrency == 4
+
+    def test_env_override_applies_to_known_backend_too(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(MAX_CONCURRENCY_ENV, "2")
+
+        assert resolve_backend_limits("claude").max_concurrency == 2
+
+    @pytest.mark.parametrize("value", ["0", "-3", "not-a-number", ""])
+    def test_invalid_env_override_is_ignored(
+        self, value: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv(MAX_CONCURRENCY_ENV, value)
+
+        # Falls back to the registry default (serialize for a CLI backend).
+        assert resolve_backend_limits("hermes_cli").max_concurrency == 1
+
+
+class TestPlanFanOutConcurrency:
+    """The pure planning function that caps requested workers."""
+
+    def test_caps_requested_to_backend_max(self) -> None:
+        limits = BackendConcurrencyLimits(backend="hermes", max_concurrency=1)
+
+        assert plan_fan_out_concurrency(3, limits) == 1
+
+    def test_uncapped_backend_respects_requested(self) -> None:
+        limits = BackendConcurrencyLimits(backend="claude", max_concurrency=None)
+
+        assert plan_fan_out_concurrency(3, limits) == 3
+
+    def test_requested_below_cap_is_unchanged(self) -> None:
+        limits = BackendConcurrencyLimits(backend="x", max_concurrency=8)
+
+        assert plan_fan_out_concurrency(1, limits) == 1
+
+    def test_never_returns_below_one(self) -> None:
+        limits = BackendConcurrencyLimits(backend="x", max_concurrency=1)
+
+        assert plan_fan_out_concurrency(0, limits) == 1
+        assert plan_fan_out_concurrency(-5, limits) == 1

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -2710,6 +2710,61 @@ class TestOrchestratorRunner:
             allowed_tools=[],
         )
 
+    def test_plan_parallel_workers_serializes_cli_backend(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+    ) -> None:
+        """A CLI backend (no known LLM limits) is serialized regardless of the
+        configured worker count (R3 stampede guard)."""
+        mock_adapter.runtime_backend = "hermes_cli"
+        runner = OrchestratorRunner(
+            mock_adapter,
+            mock_event_store,
+            mock_console,
+            max_parallel_workers=3,
+        )
+
+        assert runner._plan_parallel_workers() == 1
+
+    def test_plan_parallel_workers_respects_native_claude(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+    ) -> None:
+        """The native Claude backend is governed by its rate bucket, so fan-out
+        is not concurrency-capped here."""
+        mock_adapter.runtime_backend = "claude"
+        runner = OrchestratorRunner(
+            mock_adapter,
+            mock_event_store,
+            mock_console,
+            max_parallel_workers=3,
+        )
+
+        assert runner._plan_parallel_workers() == 3
+
+    def test_plan_parallel_workers_honors_env_override(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Operators can raise the cap for a CLI backend via env override."""
+        monkeypatch.setenv("OUROBOROS_MAX_CONCURRENCY", "2")
+        mock_adapter.runtime_backend = "hermes_cli"
+        runner = OrchestratorRunner(
+            mock_adapter,
+            mock_event_store,
+            mock_console,
+            max_parallel_workers=5,
+        )
+
+        assert runner._plan_parallel_workers() == 2
+
     def test_build_dependency_analyzer_catches_expected_exceptions(
         self,
         mock_adapter: MagicMock,


### PR DESCRIPTION
## Problem

Ouroboros fans out parallel acceptance-criteria (AC) workers using only the configured `max_parallel_workers`, with **no awareness of the connected LLM backend's concurrency/rate constraints**. Only the native Claude adapter carries a shared RPM/TPM bucket (`SharedRateLimitBucket`); every CLI runtime — `hermes`, `codex`, `gemini`, `opencode`, ... — has **zero Ouroboros-side rate governance**.

A real `hermes → Z.AI/GLM` run consequently fanned out **14 ACs at once** into an already-exhausted 5-hour quota and hard-failed instantly (RCA R3). Ouroboros relied on the runtime to throttle itself — which it did not.

## Approach

Ouroboros now **plans its own fan-out** to comply with the backend's constraints, rather than delegating that to the runtime.

- **`orchestrator/backend_limits.py`** (new) — a per-backend concurrency/rate registry plus two pure helpers:
  - `resolve_backend_limits(backend)` — registry lookup + normalization + `OUROBOROS_MAX_CONCURRENCY` override.
  - `plan_fan_out_concurrency(requested, limits)` — clamps requested workers to `[1, max_concurrency]`.
- **Policy** (selected deliberately, safe-by-default): the native Claude backend is left to its RPM/TPM bucket (uncapped here, behavior unchanged); backends whose underlying LLM limits Ouroboros cannot know are **serialized (cap = 1) by default** and raised only via the explicit `OUROBOROS_MAX_CONCURRENCY` operator override.
- **`OrchestratorRunner._plan_parallel_workers()`** resolves the connected backend's limit and caps the effective `max_concurrent` passed to the parallel executor, with a console notice + structured log when the cap reduces fan-out. `max_parallel_workers` stays the *requested* value in the execution summary; a new `effective_parallel_workers` records what actually ran.
- **`ClaudeAgentAdapter._build_rate_limit_bucket()`** now sources its RPM/TPM defaults from the same registry (single source of truth), removing the previously hardcoded Anthropic ceilings. Claude behavior is byte-for-byte unchanged (same defaults, same `OUROBOROS_ANTHROPIC_*` overrides).

> Runtimes should still manage their own rate limits — but Ouroboros no longer *depends* on them doing so. Generalizing a full shared rate bucket into the non-Claude runtimes is a natural follow-up (it needs budget-wait plumbing in each runtime); this PR delivers the runtime-agnostic concurrency lever that prevents the stampede today.

## Behavior change

CLI-runtime users who relied on the implicit default of 3 parallel workers will now run serialized unless they set `OUROBOROS_MAX_CONCURRENCY`. This is intentional (safe-by-default) and is surfaced both in the console output and in `docs/config-reference.md`.

## Tests

- `tests/unit/orchestrator/test_backend_limits.py` — resolution, alias normalization, CLI serialization, override precedence/validation, clamping (never < 1).
- `tests/unit/orchestrator/test_runner.py` — CLI backend serialized to 1; native Claude uncapped; env override raises the cap.

Full unit + integration suites pass locally (**10353 passed, 4 skipped**); `ruff` + `mypy` clean on changed files.

## Relationship to other work

Independent of the P0 typed-error PR (#1360); they touch disjoint files and can merge in any order. Both come from the same verified RCA (P0 = R4 typed error contract; this = R3 fan-out governance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)