### PR TITLE
fix(cli): add pi backend switching and quiet dispatch logs

### DIFF
--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -265,6 +265,7 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         supports_runtime=True,
         supports_llm=True,
         supports_interview_driver=True,
+        switchable_runtime=True,
         cli_name="pi",
         cli_config_key="pi_cli_path",
         supports_tool_envelope=False,

--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -156,7 +156,7 @@ def show(
 def backend(
     new_backend: Annotated[
         str | None,
-        typer.Argument(help="Backend to switch to (claude, codex, hermes, gemini, goose)."),
+        typer.Argument(help="Backend to switch to (claude, codex, hermes, gemini, goose, pi)."),
     ] = None,
 ) -> None:
     """Show or switch the runtime backend.
@@ -173,6 +173,7 @@ def backend(
     [dim]    ouroboros config backend hermes    # switch to Hermes[/dim]
     [dim]    ouroboros config backend gemini    # switch to Gemini CLI[/dim]
     [dim]    ouroboros config backend goose     # switch to Goose[/dim]
+    [dim]    ouroboros config backend pi        # switch to Pi CLI[/dim]
     """
     data, config_path = _load_config()
     current = data.get("orchestrator", {}).get("runtime_backend", "unknown")
@@ -184,7 +185,8 @@ def backend(
         if cli_path:
             console.print(f"[bold]CLI path:[/bold]        [dim]{cli_path}[/dim]")
         console.print(
-            "\n[dim]Switch with: ouroboros config backend <claude|codex|hermes|gemini|goose>[/dim]\n"
+            "\n[dim]Switch with: ouroboros config backend "
+            "<claude|codex|hermes|gemini|goose|pi>[/dim]\n"
         )
         return
 
@@ -216,6 +218,10 @@ def backend(
         from ouroboros.config import get_goose_cli_path
 
         cli_path = get_goose_cli_path()
+    elif new_backend == "pi":
+        from ouroboros.config import get_pi_cli_path
+
+        cli_path = get_pi_cli_path()
     if not cli_path:
         cli_path = shutil.which(cli_name)
     if not cli_path:
@@ -230,6 +236,12 @@ def backend(
                 "goose CLI not found.\n"
                 "Set OUROBOROS_GOOSE_CLI_PATH, configure orchestrator.goose_cli_path "
                 "in config.yaml, or install goose on PATH and retry."
+            )
+        elif new_backend == "pi":
+            print_error(
+                "pi CLI not found.\n"
+                "Set OUROBOROS_PI_CLI_PATH, configure orchestrator.pi_cli_path "
+                "in config.yaml, or install pi on PATH and retry."
             )
         else:
             print_error(f"{cli_name} CLI not found in PATH.\nInstall it first, then retry.")
@@ -247,6 +259,7 @@ def backend(
         _setup_gemini,
         _setup_goose,
         _setup_hermes,
+        _setup_pi,
     )
 
     _setup_had_errors = False
@@ -272,6 +285,8 @@ def backend(
             _setup_gemini(cli_path)
         elif new_backend == "goose":
             _setup_goose(cli_path)
+        elif new_backend == "pi":
+            _setup_pi(cli_path)
     except Exception as exc:
         setup_failed = True
         console.quiet = prev_quiet

--- a/src/ouroboros/cli/commands/dispatch.py
+++ b/src/ouroboros/cli/commands/dispatch.py
@@ -38,6 +38,32 @@ def _env_positive_int(name: str, default: int) -> int:
     return value if value > 0 else default
 
 
+def _env_flag(name: str) -> bool:
+    """Return True when an environment variable carries a truthy value."""
+    raw = os.environ.get(name)
+    if raw is None:
+        return False
+    return raw.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _silence_bridge_console_logs() -> None:
+    """Suppress structlog console output on the deterministic dispatch path.
+
+    External frontdoors (e.g. the Pi ``ooo`` bridge) capture this process'
+    stderr and surface it alongside the user-facing stdout result, so the
+    normal diagnostic stream (``mcp.server.tool_registered`` and friends)
+    leaks into the rendered output. Silence console logging here while
+    keeping file logging (``~/.ouroboros/logs/``) intact for debugging.
+    Genuine tracebacks still reach stderr. Opt back in with
+    ``OUROBOROS_DISPATCH_VERBOSE=1``.
+    """
+    if _env_flag("OUROBOROS_DISPATCH_VERBOSE"):
+        return
+    from ouroboros.observability.logging import set_console_logging
+
+    set_console_logging(False)
+
+
 def _print_tool_result(result: MCPToolResult) -> None:
     text = result.text_content.strip()
     if text:
@@ -204,6 +230,7 @@ def dispatch_command(
     frontdoors such as Pi extensions a deterministic bridge into the same
     shared skill router used by subprocess runtimes.
     """
+    _silence_bridge_console_logs()
     prompt = _join_prompt(prompt_parts)
     if not prompt:
         print_error("Usage: ouroboros dispatch 'ooo <command> [args...]'")

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -385,11 +385,20 @@ async def _run_mcp_server(
     stop_task = asyncio.create_task(stop.wait(), name="ouroboros-mcp-stop")
     watchdog_task = asyncio.create_task(_orphan_watchdog(), name="ouroboros-mcp-watchdog")
 
+    serve_exc: BaseException | None = None
     try:
         await asyncio.wait(
             {serve_task, stop_task},
             return_when=asyncio.FIRST_COMPLETED,
         )
+        # When the serve loop itself is what finished (rather than a stop
+        # signal), preserve any failure it raised. asyncio.wait() leaves the
+        # exception parked on the task, so a bind/listen/runtime error from
+        # server.serve() would otherwise be discarded by the suppressing
+        # cleanup below and reported as a clean shutdown. A normal serve return
+        # or a stop-driven shutdown leaves serve_exc None.
+        if serve_task.done() and not serve_task.cancelled():
+            serve_exc = serve_task.exception()
     finally:
         # Runs for SIGTERM, orphan-exit and KeyboardInterrupt too, so
         # EventStore.close() always gets to collapse the WAL. Cancel the serve
@@ -426,6 +435,13 @@ async def _run_mcp_server(
             serve_exc = serve_task.exception()
             if serve_exc is not None:
                 raise serve_exc
+
+    # Surface a serve-loop failure only after cleanup has collapsed the WAL and
+    # released the stores. This restores the error-propagation contract of the
+    # prior ``await server.serve(...)`` so ``ouroboros mcp serve`` exits non-zero
+    # on startup/runtime failures instead of reporting a clean stop.
+    if serve_exc is not None:
+        raise serve_exc
 
 
 @app.command()

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -190,6 +190,31 @@ class TestConfigBackend:
         assert result.exit_code == 0
         mock_setup.assert_called_once_with("/opt/goose/bin/goose")
 
+    def test_switch_to_pi_honors_configured_cli_path(self, config_dir: Path) -> None:
+        """config backend pi should honor explicit env/config path helpers."""
+        with (
+            patch("ouroboros.config.models.get_config_dir", return_value=config_dir),
+            patch("ouroboros.config.get_pi_cli_path", return_value="/opt/pi/bin/pi"),
+            patch("shutil.which", return_value=None),
+            patch("ouroboros.cli.commands.setup._setup_pi") as mock_setup,
+        ):
+            result = runner.invoke(app, ["backend", "pi"])
+
+        assert result.exit_code == 0
+        mock_setup.assert_called_once_with("/opt/pi/bin/pi")
+
+    def test_switch_to_pi_reports_missing_cli_path(self, config_dir: Path) -> None:
+        """config backend pi should surface pi-specific guidance when no CLI is found."""
+        with (
+            patch("ouroboros.config.models.get_config_dir", return_value=config_dir),
+            patch("ouroboros.config.get_pi_cli_path", return_value=None),
+            patch("shutil.which", return_value=None),
+        ):
+            result = runner.invoke(app, ["backend", "pi"])
+
+        assert result.exit_code == 1
+        assert "OUROBOROS_PI_CLI_PATH" in result.output
+
     def test_switch_warns_on_setup_print_error(self, config_dir: Path) -> None:
         """config backend should warn when setup emits print_error (non-exception failure)."""
         from ouroboros.cli.commands import setup as setup_mod

--- a/tests/unit/cli/test_mcp_startup_cleanup.py
+++ b/tests/unit/cli/test_mcp_startup_cleanup.py
@@ -357,6 +357,38 @@ class TestMCPStartupAutoCleanup:
         mock_server.serve.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_serve_failure_propagates_after_cleanup(self) -> None:
+        """A serve-loop failure (e.g. bind/listen error) must surface to the CLI
+        instead of being swallowed as a clean shutdown, while persistent stores
+        are still released. Regression for the lifecycle wrapper that awaited the
+        serve task under ``contextlib.suppress(Exception)``."""
+        mock_es, mock_repo, mock_server = self._create_patches(cancelled_sessions=[])
+        mock_server.serve = AsyncMock(side_effect=OSError("address already in use"))
+
+        with (
+            patch(
+                "ouroboros.persistence.event_store.EventStore",
+                return_value=mock_es,
+            ),
+            patch(
+                "ouroboros.orchestrator.session.SessionRepository",
+                return_value=mock_repo,
+            ),
+            patch(
+                "ouroboros.mcp.server.adapter.create_ouroboros_server",
+                return_value=mock_server,
+            ),
+        ):
+            from ouroboros.cli.commands.mcp import _run_mcp_server
+
+            with pytest.raises(OSError, match="address already in use"):
+                await _run_mcp_server("localhost", 8080, "stdio")
+
+        # Cleanup still ran despite the failure: adapter shutdown owns store
+        # closure, so the WAL checkpoint path is reached even when serve fails.
+        mock_server.shutdown.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_event_store_init_failure_aborts_startup(self) -> None:
         """Persistent-store init failures must surface — the server cannot
         safely run with a half-initialized store, so the failure propagates

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -1433,3 +1433,61 @@ class TestReplayWorkflowLifecycleResilience:
             [record.getMessage(), *(str(value) for value in vars(record).values())]
         )
         assert sentinel_secret not in captured_log_text
+
+
+class TestEventStoreCloseWalCheckpoint:
+    """Test EventStore.close() WAL checkpoint behavior.
+
+    A writable store must collapse the WAL with an explicit TRUNCATE checkpoint
+    on close so the -wal file does not grow unbounded across many concurrent
+    sessions; a read-only store must skip that write entirely (it would trip
+    SQLite's read-only guard).
+    """
+
+    @staticmethod
+    def _attach_sql_capture(store: EventStore) -> list[str]:
+        """Record raw SQL executed by ``store`` until it is closed."""
+        from sqlalchemy import event as sa_event
+
+        assert store._engine is not None  # type: ignore[attr-defined]
+        executed: list[str] = []
+
+        def _capture(_conn, _cursor, statement, _params, _context, _many) -> None:
+            executed.append(statement)
+
+        sa_event.listen(
+            store._engine.sync_engine,  # type: ignore[attr-defined]
+            "before_cursor_execute",
+            _capture,
+        )
+        return executed
+
+    async def test_close_truncates_wal_for_writable_store(self, tmp_path) -> None:
+        """Writable close() issues PRAGMA wal_checkpoint(TRUNCATE)."""
+        db_path = tmp_path / "writable.db"
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+
+        executed = self._attach_sql_capture(store)
+        await store.close()
+
+        assert any("wal_checkpoint(truncate)" in sql.lower() for sql in executed)
+        assert store._engine is None  # type: ignore[attr-defined]
+
+    async def test_close_skips_wal_checkpoint_for_readonly_store(self, tmp_path) -> None:
+        """Read-only close() must not attempt the WAL checkpoint write."""
+        db_path = tmp_path / "readonly.db"
+        # Create the on-disk schema with a writable store first so the read-only
+        # store has an existing database file to open.
+        writable = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await writable.initialize()
+        await writable.close()
+
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}", read_only=True)
+        await store.initialize()
+
+        executed = self._attach_sql_capture(store)
+        await store.close()
+
+        assert not any("wal_checkpoint" in sql.lower() for sql in executed)
+        assert store._engine is None  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

- Add Pi to the `ouroboros config backend` switch path so local users can select the Pi runtime from the same CLI surface as other backends.
- Silence bridge console logging on deterministic dispatch calls so Pi frontdoors do not show MCP registration noise in user-facing output.
- Harden MCP server shutdown and EventStore closing so orphaned local servers and growing SQLite WAL files are cleaned up reliably.

## Changes

- Mark Pi as a switchable runtime backend and wire `config backend pi` through configured path lookup, PATH fallback, setup delegation, and Pi-specific error guidance.
- Add dispatch-time console log suppression with `OUROBOROS_DISPATCH_VERBOSE=1` as an opt-in escape hatch.
- Add signal/orphan handling around MCP server serve loops and close persistent stores on shutdown.
- Add a best-effort SQLite WAL truncate checkpoint when closing writable event stores.
- Cover Pi backend switching behavior in CLI config tests.

## Notes

Verification run:

- `uv run pytest tests/unit/cli/test_config.py -q`
- `uv run ruff check src/ouroboros/backends/capabilities.py src/ouroboros/cli/commands/config.py src/ouroboros/cli/commands/dispatch.py src/ouroboros/cli/commands/mcp.py src/ouroboros/persistence/event_store.py tests/unit/cli/test_config.py`
- `git diff --cached --check`