### PR TITLE
feat(orchestrator): add explicit ouroboros tool capabilities

### DIFF
--- a/src/ouroboros/backends/__init__.py
+++ b/src/ouroboros/backends/__init__.py
@@ -2,8 +2,10 @@
 
 from ouroboros.backends.capabilities import (
     BackendCapability,
+    RuntimeSubagentOrchestrationContract,
     SkillExecutionCapability,
     backend_supports_tool_envelope,
+    build_runtime_subagent_orchestration_contract,
     get_backend_capability,
     interview_driver_backend_choices,
     llm_backend_choices,
@@ -18,8 +20,10 @@ from ouroboros.backends.capabilities import (
 
 __all__ = [
     "BackendCapability",
+    "RuntimeSubagentOrchestrationContract",
     "SkillExecutionCapability",
     "backend_supports_tool_envelope",
+    "build_runtime_subagent_orchestration_contract",
     "get_backend_capability",
     "interview_driver_backend_choices",
     "llm_backend_choices",

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -8,7 +8,9 @@ sets.
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,12 +35,40 @@ class BackendCapability:
     cli_config_key: str | None = None
     soft_tool_enforcement: bool = False
     supports_tool_envelope: bool = True
+    supports_native_parallel_subagents: bool = False
     skill_execution_capabilities: tuple[SkillExecutionCapability, ...] = ()
 
     @property
     def names(self) -> tuple[str, ...]:
         """Canonical name plus accepted aliases."""
         return (self.name, *self.aliases)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeSubagentOrchestrationContract:
+    """Runtime handling contract for MCP subagent directive metadata."""
+
+    backend_name: str
+    supports_native_parallel_subagents: bool
+    dispatch_mode: str
+    mcp_directive_keys: tuple[str, ...]
+    sequential_fallback: Mapping[str, Any]
+    runtime_instruction_handling: str
+    callable_mcp_tool_capabilities: tuple[Mapping[str, Any], ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the contract for runtime envelopes and tests."""
+        return {
+            "backend_name": self.backend_name,
+            "supports_native_parallel_subagents": self.supports_native_parallel_subagents,
+            "dispatch_mode": self.dispatch_mode,
+            "mcp_directive_keys": list(self.mcp_directive_keys),
+            "sequential_fallback": dict(self.sequential_fallback),
+            "runtime_instruction_handling": self.runtime_instruction_handling,
+            "callable_mcp_tool_capabilities": [
+                dict(capability) for capability in self.callable_mcp_tool_capabilities
+            ],
+        }
 
 
 _CODEX_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
@@ -170,6 +200,19 @@ _GENERIC_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
     ),
 )
 
+_OPENCODE_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
+    *_GENERIC_SKILL_EXECUTION_CAPABILITIES,
+    SkillExecutionCapability(
+        name="orchestrate_subagents",
+        guidance=(
+            "Use OpenCode's native task/subagent primitive for parallel-capable "
+            "Ouroboros subagent fan-out, including `_subagent` and `_subagents` "
+            "MCP directive payloads. Preserve the sequential fallback described "
+            "by the MCP capability metadata when native parallel dispatch is unavailable."
+        ),
+    ),
+)
+
 _CAPABILITIES: tuple[BackendCapability, ...] = (
     BackendCapability(
         name="claude",
@@ -245,8 +288,9 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         supports_interview_driver=True,
         cli_name="opencode",
         cli_config_key="opencode_cli_path",
-        skill_execution_capabilities=_GENERIC_SKILL_EXECUTION_CAPABILITIES,
+        skill_execution_capabilities=_OPENCODE_SKILL_EXECUTION_CAPABILITIES,
         soft_tool_enforcement=True,
+        supports_native_parallel_subagents=True,
     ),
     BackendCapability(
         name="goose",
@@ -304,6 +348,57 @@ def render_backend_skill_capability_guide(name: str) -> str:
             )
         )
     return "\n".join(lines).rstrip() + "\n"
+
+
+def build_runtime_subagent_orchestration_contract(
+    name: str,
+    *,
+    directive_metadata: Mapping[str, Any],
+    callable_mcp_tool_capabilities: Sequence[Mapping[str, Any]] = (),
+) -> RuntimeSubagentOrchestrationContract:
+    """Build runtime-specific handling metadata for MCP subagent directives.
+
+    ``directive_metadata`` is the explicit MCP-side orchestration metadata from
+    owned Ouroboros tools, such as the lateral panel contract. Runtime support
+    determines whether native parallel subagent dispatch can be used or whether
+    the declared sequential fallback must be followed.
+    """
+    capability = get_backend_capability(name)
+    if capability is None:
+        msg = f"Unsupported backend: {name.strip().lower()}"
+        raise ValueError(msg)
+
+    sequential_fallback = directive_metadata.get("sequential_fallback", {})
+    if not isinstance(sequential_fallback, Mapping):
+        sequential_fallback = {}
+
+    if capability.supports_native_parallel_subagents:
+        dispatch_mode = "native_parallel_subagents"
+        runtime_instruction_handling = (
+            "Consume MCP `_subagent` or `_subagents` directive payloads with the "
+            "runtime's native parallel subagent primitive. Keep the MCP-declared "
+            "sequential fallback available for downgraded runtime surfaces."
+        )
+    else:
+        dispatch_mode = "sequential_fallback"
+        runtime_instruction_handling = (
+            "This runtime has no native parallel subagent primitive. Follow the "
+            "MCP `sequential_fallback` contract and process each structured "
+            "subagent payload sequentially, preserving the response correlation "
+            "keys declared by the directive metadata."
+        )
+
+    return RuntimeSubagentOrchestrationContract(
+        backend_name=capability.name,
+        supports_native_parallel_subagents=capability.supports_native_parallel_subagents,
+        dispatch_mode=dispatch_mode,
+        mcp_directive_keys=("_subagent", "_subagents"),
+        sequential_fallback=dict(sequential_fallback),
+        runtime_instruction_handling=runtime_instruction_handling,
+        callable_mcp_tool_capabilities=tuple(
+            dict(capability) for capability in callable_mcp_tool_capabilities
+        ),
+    )
 
 
 def get_backend_capability(name: str) -> BackendCapability | None:
@@ -385,8 +480,10 @@ def backend_supports_tool_envelope(name: str | None) -> bool:
 
 __all__ = [
     "BackendCapability",
+    "RuntimeSubagentOrchestrationContract",
     "SkillExecutionCapability",
     "backend_supports_tool_envelope",
+    "build_runtime_subagent_orchestration_contract",
     "get_backend_capability",
     "interview_driver_backend_choices",
     "llm_backend_choices",

--- a/src/ouroboros/evaluation/mechanical.py
+++ b/src/ouroboros/evaluation/mechanical.py
@@ -12,6 +12,7 @@ The MechanicalVerifier is stateless and produces immutable results.
 
 import asyncio
 from dataclasses import dataclass
+import os
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,26 @@ from ouroboros.events.evaluation import (
     create_stage1_completed_event,
     create_stage1_started_event,
 )
+
+_COMMAND_OUTPUT_PREVIEW_CHARS = 500
+
+
+def _output_preview(text: str) -> str:
+    """Return a compact output preview preserving the diagnostically useful tail."""
+    if not text:
+        return ""
+    if len(text) <= _COMMAND_OUTPUT_PREVIEW_CHARS:
+        return text
+    return text[:_COMMAND_OUTPUT_PREVIEW_CHARS]
+
+
+def _output_tail(text: str) -> str:
+    """Return the tail of command output where test failures usually appear."""
+    if not text:
+        return ""
+    if len(text) <= _COMMAND_OUTPUT_PREVIEW_CHARS:
+        return text
+    return text[-_COMMAND_OUTPUT_PREVIEW_CHARS:]
 
 
 @dataclass(frozen=True, slots=True)
@@ -81,12 +102,18 @@ async def run_command(
     Returns:
         CommandResult with output and status
     """
+    env = os.environ.copy()
+    # The MCP server sets this sentinel to prevent recursive server spawning.
+    # Mechanical verification must test the repository as a fresh process would;
+    # leaking the sentinel makes CLI tests take the nested-server early exit.
+    env.pop("_OUROBOROS_NESTED", None)
     try:
         process = await asyncio.create_subprocess_exec(
             *command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=working_dir,
+            env=env,
         )
 
         try:
@@ -287,9 +314,13 @@ class MechanicalVerifier:
 
         passed = cmd_result.return_code == 0
         details: dict[str, Any] = {
+            "command": list(command),
+            "working_dir": str(self.config.working_dir) if self.config.working_dir else None,
             "return_code": cmd_result.return_code,
-            "stdout_preview": cmd_result.stdout[:500] if cmd_result.stdout else "",
-            "stderr_preview": cmd_result.stderr[:500] if cmd_result.stderr else "",
+            "stdout_preview": _output_preview(cmd_result.stdout),
+            "stderr_preview": _output_preview(cmd_result.stderr),
+            "stdout_tail": _output_tail(cmd_result.stdout),
+            "stderr_tail": _output_tail(cmd_result.stderr),
         }
 
         # Extract coverage if this was a coverage check

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -46,6 +46,7 @@ from ouroboros.mcp.tools.subagent import (
     build_interview_subagent,
     build_subagent_result,
     emit_subagent_dispatched_event,
+    lateral_persona_panel_metadata_from_capability_definitions,
     should_dispatch_via_plugin,
 )
 from ouroboros.mcp.types import (
@@ -55,6 +56,11 @@ from ouroboros.mcp.types import (
     MCPToolParameter,
     MCPToolResult,
     ToolInputType,
+)
+from ouroboros.orchestrator.capabilities import (
+    interview_code_investigation_answer_contract,
+    ouroboros_tool_capability_metadata,
+    stable_code_investigation_question_identity,
 )
 from ouroboros.orchestrator.policy import (
     PolicyContext,
@@ -197,6 +203,18 @@ _INTERVIEW_COMPLETION_NEGATIONS = (
     "do not close",
     "dont close",
     "don't close",
+)
+
+_INTERVIEW_LATERAL_REVIEW_PROSE_FALLBACK_INSTRUCTION = (
+    "Follow skills/interview/SKILL.md milestone lateral-review dispatch: "
+    "call ouroboros_lateral_think with meta.lateral_review_tool_args when "
+    "present. If only legacy advisory fields are present, call it with "
+    'personas=["researcher","contrarian","simplifier"], a problem context '
+    "containing the current interview session, milestone, and question, and a "
+    "current approach describing the next interview-routing decision. Fold only "
+    "concrete, user-safe findings into the next answer or question; if lateral "
+    "tooling is unavailable, continue the interview and say the review could "
+    "not be run."
 )
 
 
@@ -431,6 +449,77 @@ def _build_interview_lateral_review_tool_args(
     }
 
 
+def _build_interview_lateral_review_orchestration(
+    *,
+    tool_args: dict[str, Any],
+) -> dict[str, Any]:
+    """Build runtime handling metadata for interview lateral-review panels."""
+    panel = lateral_persona_panel_metadata_from_capability_definitions()
+    if not panel:
+        return {
+            "kind": "mcp_directive",
+            "directive": "run_lateral_persona_panel",
+            "mcp_tool": "ouroboros_lateral_think",
+            "tool_args": dict(tool_args),
+            "structured_lateral_panel_metadata_available": False,
+            "fallback": "skill_prose_instructions",
+            "prose_instruction_source": "skills/interview/SKILL.md",
+            "prose_instruction": _INTERVIEW_LATERAL_REVIEW_PROSE_FALLBACK_INSTRUCTION,
+            "runtime_handling": {
+                "call_mcp_tool_first": True,
+                "result_correlation_key": None,
+                "requires_prose_parsing": True,
+                "synthesize_before_interview_continuation": True,
+            },
+        }
+    requested_personas = [str(item) for item in tool_args.get("personas", [])]
+    panel_persona_by_id = {
+        str(persona.get("persona_id")): dict(persona)
+        for persona in panel.get("personas", [])
+        if isinstance(persona, dict) and persona.get("persona_id")
+    }
+    panel_personas = [
+        panel_persona_by_id[persona_id]
+        for persona_id in requested_personas
+        if persona_id in panel_persona_by_id
+    ]
+    response_refs = dict(panel.get("response_payload_refs", {}))
+    sequential_fallback = dict(panel.get("sequential_fallback", {}))
+    sequential_mode = str(
+        sequential_fallback.get("mode") or "sequential_persona_payload_dispatch"
+    )
+    mcp_tool = str(panel.get("mcp_tool") or "ouroboros_lateral_think")
+
+    return {
+        "kind": "mcp_directive",
+        "directive": "run_lateral_persona_panel",
+        "mcp_tool": mcp_tool,
+        "tool_args": dict(tool_args),
+        "panel": {
+            "panel_id": str(panel.get("panel_id") or "lateral_persona_panel.v1"),
+            "mcp_tool": mcp_tool,
+            "dispatch_modes": list(panel.get("dispatch_modes", [])),
+            "parallel_preference": str(
+                panel.get("parallel_preference")
+                or "parallel_when_runtime_supports_subagents"
+            ),
+            "sequential_fallback": sequential_fallback,
+            "personas": panel_personas,
+            "response_payload_refs": response_refs,
+            "runtime_instruction": str(panel.get("runtime_instruction") or ""),
+        },
+        "runtime_handling": {
+            "call_mcp_tool_first": True,
+            "parallel_capable_execution_mode": "parallel_subagent_panel",
+            "sequential_fallback_mode": sequential_mode,
+            "sequential_fallback_trigger": sequential_fallback.get("trigger"),
+            "result_correlation_key": response_refs.get("result_correlation_key"),
+            "requires_prose_parsing": bool(response_refs.get("requires_prose_parsing")),
+            "synthesize_before_interview_continuation": True,
+        },
+    }
+
+
 def _with_lateral_review_dispatch(
     state: InterviewState,
     *,
@@ -441,17 +530,23 @@ def _with_lateral_review_dispatch(
     """Attach runnable lateral-think dispatch metadata to an advisory."""
     if lateral_review_meta is None:
         return None
+    tool_args = _build_interview_lateral_review_tool_args(
+        state,
+        next_question=next_question,
+        score=score,
+        lateral_review_meta=lateral_review_meta,
+    )
     enriched = dict(lateral_review_meta)
     enriched.update(
         {
             "lateral_review_required": True,
             "lateral_review_tool": "ouroboros_lateral_think",
             "lateral_review_personas": list(_INTERVIEW_LATERAL_PERSONAS),
-            "lateral_review_tool_args": _build_interview_lateral_review_tool_args(
-                state,
-                next_question=next_question,
-                score=score,
-                lateral_review_meta=lateral_review_meta,
+            "lateral_review_tool_args": tool_args,
+            "lateral_review_orchestration": (
+                _build_interview_lateral_review_orchestration(
+                    tool_args=tool_args,
+                )
             ),
         }
     )
@@ -498,6 +593,60 @@ def _format_question_with_ambiguity(question: str, score: AmbiguityScore | None)
     if score is None:
         return question
     return f"(ambiguity: {score.overall_score:.2f}) {question}"
+
+
+def _build_code_investigation_request(
+    *,
+    session_id: str,
+    question: str,
+    last_question: str | None = None,
+) -> dict[str, Any]:
+    """Build stable metadata for caller-side code-fact investigation.
+
+    The interview MCP tool is only the question generator; repo inspection runs
+    in the parent runtime. This metadata gives that runtime a concrete request
+    envelope keyed to the exact question text, so investigation results can be
+    correlated even when the user-facing display has an ambiguity prefix.
+    """
+    mcp_tool_capability = ouroboros_tool_capability_metadata("ouroboros_interview")
+    code_investigation = mcp_tool_capability["orchestration"]["code_investigation"]
+    request: dict[str, Any] = {
+        "session_id": session_id,
+        "question_identity": stable_code_investigation_question_identity(question),
+        "question": question,
+        "investigation_goal": "describe_current_state_from_code",
+        "investigation_targets": [{"target_type": "workspace", "scope": "active"}],
+        "fact_categories": [
+            "tech_stack",
+            "frameworks",
+            "dependencies",
+            "current_patterns",
+            "architecture",
+            "file_structure",
+            "configuration",
+        ],
+        "allowed_capabilities": ["inspect_code"],
+        "repo_inspection_tool_capabilities": list(
+            code_investigation["repo_inspection_tool_capabilities"]
+        ),
+        "confidence_policy": {
+            "auto_confirm_when": ["exact manifest or config match with a single clear answer"],
+            "confirmation_required_when": [
+                "multiple code paths or configuration sources disagree",
+                "the answer implies a product or architecture decision",
+            ],
+            "human_judgment_when": [
+                "desired future behavior",
+                "priority, scope, ownership, rollout, or acceptance criteria",
+            ],
+        },
+        "answer_prefixes": ["[from-code]", "[from-code][auto-confirmed]"],
+        "answer_contract": interview_code_investigation_answer_contract(),
+        "mcp_tool_capability": mcp_tool_capability,
+    }
+    if last_question:
+        request["last_question"] = last_question
+    return request
 
 
 def _is_initial_context_length_guard_question(question: str) -> bool:
@@ -2198,6 +2347,13 @@ class InterviewHandler:
                     # axis must not flip or ``HandlerInterviewBackend.start``
                     # would raise on every oversized ``initial_context``.
                     start_meta.update(_length_guard_meta_fields())
+                else:
+                    start_meta["code_investigation_request"] = (
+                        _build_code_investigation_request(
+                            session_id=state.interview_id,
+                            question=question,
+                        )
+                    )
 
                 start_response_text = (
                     f"Interview started. Session ID: {state.interview_id}\n\n{display_question}"
@@ -2282,6 +2438,13 @@ class InterviewHandler:
                         # ``False`` so the auto driver does not treat the
                         # summarize prompt as a hard failure.
                         resume_meta.update(_length_guard_meta_fields())
+                    else:
+                        resume_meta["code_investigation_request"] = (
+                            _build_code_investigation_request(
+                                session_id=session_id,
+                                question=pending_question,
+                            )
+                        )
 
                     resume_response_text = f"Session {session_id}\n\n{display_question}"
                     # Q00/ouroboros#831 (diagnostics): response-shape event for
@@ -2806,6 +2969,13 @@ class InterviewHandler:
                     # guard meta-directive.  ``is_error`` stays ``False`` so
                     # the auto driver's ``answer()`` path is not raised on.
                     answer_meta.update(_length_guard_meta_fields())
+                else:
+                    answer_meta["code_investigation_request"] = (
+                        _build_code_investigation_request(
+                            session_id=session_id,
+                            question=question,
+                        )
+                    )
 
                 if lateral_review_dispatch_meta is not None:
                     answer_meta.update(lateral_review_dispatch_meta)

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -909,6 +909,22 @@ class EvaluateHandler:
             for check in s1.checks:
                 status = "PASS" if check.passed else "FAIL"
                 lines.append(f"  [{status}] {check.check_type}: {check.message}")
+                if not check.passed:
+                    details = check.details
+                    command = details.get("command")
+                    if isinstance(command, list) and command:
+                        lines.append(f"    command: {' '.join(str(part) for part in command)}")
+                    working_dir = details.get("working_dir")
+                    if working_dir:
+                        lines.append(f"    cwd: {working_dir}")
+                    stdout_tail = str(details.get("stdout_tail") or "").strip()
+                    stderr_tail = str(details.get("stderr_tail") or "").strip()
+                    if stdout_tail:
+                        lines.append("    stdout tail:")
+                        lines.extend(f"      {line}" for line in stdout_tail.splitlines())
+                    if stderr_tail:
+                        lines.append("    stderr tail:")
+                        lines.extend(f"      {line}" for line in stderr_tail.splitlines())
             lines.append("")
 
         # Stage 2 results

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -32,7 +32,10 @@ Payload structure:
 
 from __future__ import annotations
 
+import base64
+from collections.abc import Mapping
 from dataclasses import dataclass, field
+from functools import lru_cache
 import json
 import re
 from typing import Any
@@ -49,16 +52,421 @@ from ouroboros.mcp.types import (
 
 log = structlog.get_logger(__name__)
 
+_LATERAL_INLINE_DISPATCH_OPEN = "<!-- ouroboros-lateral-inline-dispatch-v1 base64\n"
+_LATERAL_INLINE_DISPATCH_CLOSE = "\n-->"
 _INTERVIEW_SUBAGENT_MAX_CONTEXT_CHARS = 600
 _INTERVIEW_SUBAGENT_MAX_PREVIOUS_TRANSCRIPT_CHARS = 200
 _INTERVIEW_SUBAGENT_MAX_TRANSCRIPT_QUESTION_CHARS = 900
 _INTERVIEW_SUBAGENT_MAX_TRANSCRIPT_ANSWER_CHARS = 220
 _INTERVIEW_SUBAGENT_MAX_ANSWER_CHARS = 300
+_LATERAL_PANEL_FALLBACK_ID = "lateral_persona_panel.v1"
+_LATERAL_PANEL_FALLBACK_TOOL = "ouroboros_lateral_think"
+_LATERAL_PANEL_FALLBACK_SEQUENTIAL_MODE = "sequential_persona_payload_dispatch"
+_LATERAL_PANEL_FALLBACK_PARALLEL_MODE = "parallel_subagent_panel"
 
 
 def _canonical_response_json(body: dict[str, Any]) -> str:
     """Render structured MCP dispatch content with deterministic key order."""
     return json.dumps(body, sort_keys=True, separators=(",", ":"))
+
+
+def _payload_persona(payload: Mapping[str, Any]) -> str:
+    context = payload.get("context")
+    if isinstance(context, Mapping):
+        persona = context.get("persona")
+        if persona:
+            return str(persona)
+    title = str(payload.get("title") or "")
+    match = re.search(r"\(([^)]+)\)", title)
+    if match:
+        return match.group(1)
+    return "unknown"
+
+
+def _response_text_json_payload(result: MCPToolResult) -> dict[str, Any] | None:
+    text = result.text_content.strip()
+    if not text or not text.startswith("{"):
+        return None
+    try:
+        decoded = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
+def _inline_lateral_dispatch_payload(result: MCPToolResult) -> dict[str, Any] | None:
+    text = result.text_content
+    open_idx = text.rfind(_LATERAL_INLINE_DISPATCH_OPEN)
+    if open_idx == -1:
+        return None
+    close_idx = text.rfind(_LATERAL_INLINE_DISPATCH_CLOSE)
+    if close_idx <= open_idx:
+        return None
+    encoded = text[open_idx + len(_LATERAL_INLINE_DISPATCH_OPEN) : close_idx]
+    try:
+        decoded = base64.b64decode(encoded.encode("ascii")).decode("utf-8")
+        payload = json.loads(decoded)
+    except (ValueError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _lateral_payload_container(result: MCPToolResult) -> tuple[dict[str, Any], str]:
+    """Return the first structured lateral dispatch container and its source."""
+    if isinstance(result.meta, dict):
+        if "_subagents" in result.meta or "_subagent" in result.meta:
+            return result.meta, "meta"
+        if "payloads" in result.meta:
+            return result.meta, "inline_meta"
+
+    content_payload = _response_text_json_payload(result)
+    if content_payload and ("_subagents" in content_payload or "_subagent" in content_payload):
+        return content_payload, "content_json"
+
+    inline_payload = _inline_lateral_dispatch_payload(result)
+    if inline_payload and "payloads" in inline_payload:
+        return inline_payload, "inline_content"
+
+    return {}, "none"
+
+
+@lru_cache(maxsize=1)
+def lateral_persona_panel_metadata_from_capability_definitions() -> dict[str, Any]:
+    """Read lateral persona panel metadata from Ouroboros tool capabilities.
+
+    The interview orchestration reader intentionally consumes the same
+    capability graph exposed to runtimes, rather than duplicating the
+    ``ouroboros_lateral_think`` panel contract in this response-normalization
+    layer.
+    """
+    from ouroboros.mcp.tools.definitions import get_ouroboros_tools
+    from ouroboros.orchestrator.capabilities import build_capability_graph
+    from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools())
+    graph = build_capability_graph(assemble_session_tool_catalog(attached_tools=owned_tools))
+    for descriptor in graph.capabilities:
+        if descriptor.name != _LATERAL_PANEL_FALLBACK_TOOL or descriptor.metadata is None:
+            continue
+        panel = descriptor.metadata.orchestration.get("lateral_panel")
+        if isinstance(panel, Mapping):
+            return dict(panel)
+    return {}
+
+
+def _lateral_panel_capability_metadata(
+    lateral_panel_metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Normalize caller-supplied or capability-derived lateral panel metadata."""
+    raw = (
+        lateral_panel_metadata
+        if lateral_panel_metadata is not None
+        else lateral_persona_panel_metadata_from_capability_definitions()
+    )
+    return dict(raw) if isinstance(raw, Mapping) else {}
+
+
+def _lateral_panel_persona_roles(
+    lateral_panel_metadata: Mapping[str, Any],
+) -> dict[str, str]:
+    raw_personas = lateral_panel_metadata.get("personas")
+    if not isinstance(raw_personas, list | tuple):
+        return {}
+    roles: dict[str, str] = {}
+    for persona in raw_personas:
+        if not isinstance(persona, Mapping):
+            continue
+        persona_id = persona.get("persona_id")
+        role = persona.get("role")
+        if persona_id and role:
+            roles[str(persona_id)] = str(role)
+    return roles
+
+
+def _lateral_panel_id(lateral_panel_metadata: Mapping[str, Any]) -> str:
+    return str(lateral_panel_metadata.get("panel_id") or _LATERAL_PANEL_FALLBACK_ID)
+
+
+def _lateral_panel_tool(lateral_panel_metadata: Mapping[str, Any]) -> str:
+    return str(lateral_panel_metadata.get("mcp_tool") or _LATERAL_PANEL_FALLBACK_TOOL)
+
+
+def _lateral_panel_requires_prose_parsing(
+    lateral_panel_metadata: Mapping[str, Any],
+) -> bool:
+    refs = lateral_panel_metadata.get("response_payload_refs")
+    if isinstance(refs, Mapping) and "requires_prose_parsing" in refs:
+        return bool(refs["requires_prose_parsing"])
+    return False
+
+
+def _lateral_panel_sequential_mode(lateral_panel_metadata: Mapping[str, Any]) -> str:
+    fallback = lateral_panel_metadata.get("sequential_fallback")
+    if isinstance(fallback, Mapping) and fallback.get("mode"):
+        return str(fallback["mode"])
+    return _LATERAL_PANEL_FALLBACK_SEQUENTIAL_MODE
+
+
+def lateral_review_response_to_interview_orchestration_entries(
+    result: MCPToolResult,
+    *,
+    session_id: str | None = None,
+    runtime_supports_parallel_subagents: bool = True,
+    lateral_panel_metadata: Mapping[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Convert a lateral-review MCP response into interview persona-panel entries.
+
+    ``ouroboros_lateral_think`` can return plugin-native ``_subagents``, a
+    single ``_subagent``, inline-fallback ``meta.payloads``, or a content-only
+    base64 dispatch block when a transport drops ``meta``. This helper
+    normalizes every supported shape into deterministic interview orchestration
+    metadata entries so the interview runtime can dispatch persona panels
+    without prose parsing.
+    """
+    container, source = _lateral_payload_container(result)
+    if not container:
+        return []
+
+    dispatch_mode = str(container.get("dispatch_mode") or "plugin")
+    raw_payloads: Any
+    if isinstance(container.get("_subagents"), list):
+        raw_payloads = container["_subagents"]
+    elif isinstance(container.get("payloads"), list):
+        raw_payloads = container["payloads"]
+    elif isinstance(container.get("_subagent"), Mapping):
+        raw_payloads = [container["_subagent"]]
+    else:
+        return []
+
+    payloads = [payload for payload in raw_payloads if isinstance(payload, Mapping)]
+    if not payloads:
+        return []
+
+    panel_metadata = _lateral_panel_capability_metadata(lateral_panel_metadata)
+    panel_id = _lateral_panel_id(panel_metadata)
+    mcp_tool = _lateral_panel_tool(panel_metadata)
+    sequential_mode = _lateral_panel_sequential_mode(panel_metadata)
+    requires_prose_parsing = _lateral_panel_requires_prose_parsing(panel_metadata)
+    persona_roles = _lateral_panel_persona_roles(panel_metadata)
+    execution_mode = (
+        _LATERAL_PANEL_FALLBACK_PARALLEL_MODE
+        if len(payloads) > 1 and runtime_supports_parallel_subagents
+        else sequential_mode
+    )
+    parallel_group = (
+        f"{session_id}:{panel_id}" if session_id else panel_id
+    )
+
+    entries: list[dict[str, Any]] = []
+    for index, payload in enumerate(payloads, start=1):
+        context = payload.get("context") if isinstance(payload.get("context"), Mapping) else {}
+        persona = _payload_persona(payload)
+        entries.append(
+            {
+                "kind": "interview_orchestration_metadata",
+                "panel_id": panel_id,
+                "panel_role": "persona",
+                "persona_id": persona,
+                "persona_role": persona_roles.get(persona, ""),
+                "session_id": session_id,
+                "mcp_tool": mcp_tool,
+                "tool_name": str(payload.get("tool_name") or mcp_tool),
+                "title": str(payload.get("title") or f"Lateral ({persona})"),
+                "agent": str(payload.get("agent") or "general"),
+                "model": payload.get("model"),
+                "prompt": str(payload.get("prompt") or ""),
+                "context": dict(context),
+                "dispatch_mode": dispatch_mode,
+                "response_payload_source": source,
+                "execution_mode": execution_mode,
+                "parallel_group": parallel_group,
+                "execution_order": index,
+                "requires_prose_parsing": requires_prose_parsing,
+                "sequential_fallback_used": execution_mode == sequential_mode,
+            }
+        )
+    return entries
+
+
+def lateral_review_response_to_interview_orchestration_metadata(
+    result: MCPToolResult,
+    *,
+    session_id: str | None = None,
+    runtime_supports_parallel_subagents: bool = True,
+    lateral_panel_metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the interview metadata envelope for a lateral persona-panel result."""
+    panel_metadata = _lateral_panel_capability_metadata(lateral_panel_metadata)
+    panel_id = _lateral_panel_id(panel_metadata)
+    mcp_tool = _lateral_panel_tool(panel_metadata)
+    sequential_mode = _lateral_panel_sequential_mode(panel_metadata)
+    requires_prose_parsing = _lateral_panel_requires_prose_parsing(panel_metadata)
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        result,
+        session_id=session_id,
+        runtime_supports_parallel_subagents=runtime_supports_parallel_subagents,
+        lateral_panel_metadata=panel_metadata,
+    )
+    return {
+        "lateral_panel": {
+            "panel_id": panel_id,
+            "mcp_tool": mcp_tool,
+            "entry_count": len(entries),
+            "execution_mode": (
+                entries[0]["execution_mode"] if entries else sequential_mode
+            ),
+            "requires_prose_parsing": requires_prose_parsing,
+            "entries": entries,
+        }
+    }
+
+
+def synthesize_lateral_persona_panel_when_complete(
+    entries: list[Mapping[str, Any]],
+    persona_outputs: Mapping[str, Any],
+    synthesizer: Any,
+) -> dict[str, Any]:
+    """Aggregate lateral persona outputs and synthesize only when complete.
+
+    Parent runtimes receive one orchestration entry per persona and may get
+    child results in any order. This helper preserves dispatch order, checks
+    completion by ``persona_id``, and calls ``synthesizer`` only after every
+    dispatched persona has a corresponding output.
+    """
+    expected_personas = [
+        str(entry["persona_id"])
+        for entry in sorted(
+            entries,
+            key=lambda item: int(item.get("execution_order") or 0),
+        )
+        if entry.get("persona_id")
+    ]
+    outputs_by_persona = {
+        str(persona): output
+        for persona, output in persona_outputs.items()
+        if str(persona) in expected_personas
+    }
+    missing_personas = [
+        persona for persona in expected_personas if persona not in outputs_by_persona
+    ]
+    aggregated_outputs = [
+        {
+            "persona_id": persona,
+            "output": outputs_by_persona[persona],
+        }
+        for persona in expected_personas
+        if persona in outputs_by_persona
+    ]
+    if missing_personas:
+        return {
+            "ready_for_synthesis": False,
+            "expected_personas": expected_personas,
+            "missing_personas": missing_personas,
+            "aggregated_outputs": aggregated_outputs,
+            "synthesis": None,
+        }
+    return {
+        "ready_for_synthesis": True,
+        "expected_personas": expected_personas,
+        "missing_personas": [],
+        "aggregated_outputs": aggregated_outputs,
+        "synthesis": synthesizer(aggregated_outputs),
+    }
+
+
+def continue_interview_after_lateral_persona_synthesis(
+    entries: list[Mapping[str, Any]],
+    persona_outputs: Mapping[str, Any],
+    synthesizer: Any,
+    interview_continuation: Any,
+) -> dict[str, Any]:
+    """Run interview continuation only after lateral panel synthesis is ready.
+
+    Runtimes may collect persona panel outputs out of order. This helper keeps
+    the runtime handoff deterministic: it returns the incomplete synthesis
+    state without calling the continuation, and calls the continuation only
+    after ``synthesize_lateral_persona_panel_when_complete`` has produced a
+    synthesized lateral result.
+    """
+    synthesis_state = synthesize_lateral_persona_panel_when_complete(
+        entries,
+        persona_outputs,
+        synthesizer,
+    )
+    if not synthesis_state["ready_for_synthesis"]:
+        return {
+            **synthesis_state,
+            "continued_interview": False,
+            "interview_continuation": None,
+        }
+    return {
+        **synthesis_state,
+        "continued_interview": True,
+        "interview_continuation": interview_continuation(synthesis_state["synthesis"]),
+    }
+
+
+def synthesize_code_investigation_when_complete(
+    request: Mapping[str, Any],
+    investigation_results: Mapping[str, Any],
+    synthesizer: Any,
+) -> dict[str, Any]:
+    """Collect code-fact investigation outputs before interview synthesis.
+
+    Parent runtimes may dispatch one or more repo-inspection subagents for a
+    single interview question. This helper filters child outputs to the
+    originating request and calls ``synthesizer`` only when every required result
+    is present, so interview continuation receives factual code context rather
+    than partially collected child state.
+    """
+    session_id = str(request.get("session_id") or "")
+    question_identity = str(request.get("question_identity") or "")
+    required_ids = request.get("required_result_ids")
+    if isinstance(required_ids, (list, tuple)) and required_ids:
+        expected_result_ids = [str(item) for item in required_ids]
+    else:
+        expected_result_ids = ["code_facts"]
+
+    outputs_by_result_id: dict[str, Any] = {}
+    for result_id, output in investigation_results.items():
+        if str(result_id) not in expected_result_ids:
+            continue
+        if not isinstance(output, Mapping):
+            continue
+        if str(output.get("session_id") or "") != session_id:
+            continue
+        if str(output.get("question_identity") or "") != question_identity:
+            continue
+        outputs_by_result_id[str(result_id)] = output
+
+    missing_result_ids = [
+        result_id
+        for result_id in expected_result_ids
+        if result_id not in outputs_by_result_id
+    ]
+    aggregated_outputs = [
+        {
+            "result_id": result_id,
+            "output": outputs_by_result_id[result_id],
+        }
+        for result_id in expected_result_ids
+        if result_id in outputs_by_result_id
+    ]
+    if missing_result_ids:
+        return {
+            "ready_for_synthesis": False,
+            "expected_result_ids": expected_result_ids,
+            "missing_result_ids": missing_result_ids,
+            "aggregated_outputs": aggregated_outputs,
+            "synthesis": None,
+        }
+    return {
+        "ready_for_synthesis": True,
+        "expected_result_ids": expected_result_ids,
+        "missing_result_ids": [],
+        "aggregated_outputs": aggregated_outputs,
+        "synthesis": synthesizer(aggregated_outputs),
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1145,6 +1553,7 @@ def build_lateral_multi_subagent(
             build_subagent_payload(
                 tool_name="ouroboros_lateral_think",
                 title=f"Lateral ({persona.value})",
+                agent=persona.value,
                 prompt=prompt,
                 context=context,
             )

--- a/src/ouroboros/orchestrator/capabilities.py
+++ b/src/ouroboros/orchestrator/capabilities.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from enum import StrEnum
+from functools import lru_cache
+import hashlib
 import os
 from pathlib import Path
 import stat
 from typing import Any
+import unicodedata
 
 import yaml
 
@@ -19,6 +22,7 @@ from ouroboros.orchestrator.mcp_tools import (
     SessionToolCatalogEntry,
     ToolCatalogSourceMetadata,
 )
+from ouroboros.orchestrator.skill_tool_mapping import get_packaged_skill_context_keys
 
 log = get_logger(__name__)
 
@@ -87,6 +91,85 @@ class CapabilitySemantics:
 
 
 @dataclass(frozen=True, slots=True)
+class CapabilityToolMetadata:
+    """Tool-specific capability metadata used by runtime orchestration."""
+
+    input_schema: Mapping[str, Any]
+    mutation_class: str
+    execution_mode: str
+    companions: tuple[str, ...]
+    required_context_keys: tuple[str, ...]
+    mutation_targets: tuple[str, ...]
+    state_mutations: tuple[Mapping[str, Any], ...]
+    side_effects: tuple[str, ...]
+    retry: Mapping[str, Any]
+    interrupt: Mapping[str, Any]
+    cancel: Mapping[str, Any]
+    fallback_used: bool = False
+    orchestration: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class _OuroborosToolCapabilitySpec:
+    """Explicit capability metadata spec for one Ouroboros-owned MCP tool."""
+
+    execution_mode: str
+    companions: tuple[str, ...]
+    side_effects: tuple[str, ...]
+    retry: Mapping[str, Any]
+    interrupt: Mapping[str, Any]
+    mutation_class: CapabilityMutationClass | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class LateralPersonaMetadata:
+    """Structured metadata for one lateral persona subagent lane."""
+
+    persona_id: str
+    role: str
+    prompt: Mapping[str, Any]
+    response_payload_ref: Mapping[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-safe capability metadata."""
+        return {
+            "persona_id": self.persona_id,
+            "role": self.role,
+            "prompt": dict(self.prompt),
+            "response_payload_ref": dict(self.response_payload_ref),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LateralPersonaPanelMetadata:
+    """Structured metadata for lateral multi-persona orchestration."""
+
+    panel_id: str
+    mcp_tool: str
+    dispatch_modes: tuple[str, ...]
+    parallel_preference: str
+    sequential_fallback: Mapping[str, Any]
+    personas: tuple[LateralPersonaMetadata, ...]
+    request_model_schema: Mapping[str, Any]
+    response_payload_refs: Mapping[str, Any]
+    runtime_instruction: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to JSON-safe capability metadata."""
+        return {
+            "panel_id": self.panel_id,
+            "mcp_tool": self.mcp_tool,
+            "dispatch_modes": list(self.dispatch_modes),
+            "parallel_preference": self.parallel_preference,
+            "sequential_fallback": dict(self.sequential_fallback),
+            "personas": [persona.to_dict() for persona in self.personas],
+            "request_model_schema": dict(self.request_model_schema),
+            "response_payload_refs": dict(self.response_payload_refs),
+            "runtime_instruction": self.runtime_instruction,
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class CapabilityDescriptor:
     """Capability wrapper around a normalized tool definition."""
 
@@ -98,6 +181,7 @@ class CapabilityDescriptor:
     source_kind: str
     source_name: str
     semantics: CapabilitySemantics
+    metadata: CapabilityToolMetadata | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -109,6 +193,17 @@ class CapabilityGraph:
     def names(self) -> tuple[str, ...]:
         """Return capability names in graph order."""
         return tuple(descriptor.name for descriptor in self.capabilities)
+
+    def by_name(self) -> Mapping[str, CapabilityDescriptor]:
+        """Return capability descriptors keyed by normalized tool name."""
+        return {descriptor.name: descriptor for descriptor in self.capabilities}
+
+
+def stable_code_investigation_question_identity(question: str) -> str:
+    """Return a deterministic identity for an interview-originating question."""
+    normalized = " ".join(unicodedata.normalize("NFKC", question).strip().split())
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+    return f"interview-question:{digest}"
 
 
 _BUILTIN_SEMANTICS: dict[str, CapabilitySemantics] = {
@@ -199,8 +294,2863 @@ _DEFAULT_ATTACHED_SEMANTICS = CapabilitySemantics(
     scope=CapabilityScope.ATTACHMENT,
 )
 
+_OUROBOROS_COMPANION_FAMILIES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    (
+        "auto",
+        (
+            "ouroboros_auto",
+            "ouroboros_start_auto",
+        ),
+    ),
+    (
+        "execute",
+        (
+            "ouroboros_execute_seed",
+            "ouroboros_start_execute_seed",
+            "ouroboros_cancel_execution",
+        ),
+    ),
+    (
+        "job",
+        (
+            "ouroboros_start_auto",
+            "ouroboros_start_execute_seed",
+            "ouroboros_start_evaluate",
+            "ouroboros_start_evolve_step",
+            "ouroboros_start_ralph",
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+            "ouroboros_cancel_job",
+        ),
+    ),
+    (
+        "session",
+        (
+            "ouroboros_session_status",
+            "ouroboros_query_events",
+            "ouroboros_query_projection",
+            "ouroboros_ac_tree_hud",
+        ),
+    ),
+    (
+        "authoring",
+        (
+            "ouroboros_interview",
+            "ouroboros_generate_seed",
+            "ouroboros_pm_interview",
+            "ouroboros_brownfield",
+        ),
+    ),
+    (
+        "evaluation",
+        (
+            "ouroboros_evaluate",
+            "ouroboros_start_evaluate",
+            "ouroboros_checklist_verify",
+            "ouroboros_measure_drift",
+            "ouroboros_qa",
+        ),
+    ),
+    (
+        "evolution",
+        (
+            "ouroboros_evolve_step",
+            "ouroboros_start_evolve_step",
+            "ouroboros_lineage_status",
+            "ouroboros_evolve_rewind",
+            "ouroboros_ralph",
+            "ouroboros_start_ralph",
+        ),
+    ),
+    (
+        "subagent_orchestration",
+        (
+            "ouroboros_interview",
+            "ouroboros_lateral_think",
+        ),
+    ),
+)
+
+_OUROBOROS_BACKGROUND_TOOLS = frozenset(
+    {
+        "ouroboros_start_auto",
+        "ouroboros_start_execute_seed",
+        "ouroboros_start_evaluate",
+        "ouroboros_start_evolve_step",
+        "ouroboros_start_ralph",
+    }
+)
+_OUROBOROS_STATUS_TOOLS = frozenset(
+    {
+        "ouroboros_session_status",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+        "ouroboros_ac_tree_hud",
+        "ouroboros_query_events",
+        "ouroboros_query_projection",
+        "ouroboros_lineage_status",
+    }
+)
+_OUROBOROS_CANCEL_TOOLS = frozenset(
+    {
+        "ouroboros_cancel_job",
+        "ouroboros_cancel_execution",
+    }
+)
+_OUROBOROS_WORKSPACE_WRITE_TOOLS = frozenset(
+    {
+        "ouroboros_auto",
+        "ouroboros_start_auto",
+        "ouroboros_execute_seed",
+        "ouroboros_start_execute_seed",
+        "ouroboros_evolve_step",
+        "ouroboros_start_evolve_step",
+        "ouroboros_ralph",
+        "ouroboros_start_ralph",
+        "ouroboros_generate_seed",
+        "ouroboros_checklist_verify",
+        "ouroboros_brownfield",
+    }
+)
+_OUROBOROS_SUBAGENT_TOOLS = frozenset(
+    {
+        "ouroboros_interview",
+        "ouroboros_lateral_think",
+        "ouroboros_pm_interview",
+    }
+)
+_OUROBOROS_DEFAULT_EXECUTION_MODE = "blocking"
+_OUROBOROS_DEFAULT_RETRY_METADATA: Mapping[str, Any] = {
+    "supported": True,
+    "mode": "handler_owned",
+}
+_OUROBOROS_JOB_POLL_RETRY_METADATA: Mapping[str, Any] = {
+    "supported": True,
+    "mode": "job_poll",
+}
+_OUROBOROS_UNSUPPORTED_RETRY_METADATA: Mapping[str, Any] = {
+    "supported": False,
+    "mode": "unsupported",
+}
+_OUROBOROS_DEFAULT_INTERRUPT_METADATA: Mapping[str, Any] = {
+    "supported": True,
+    "mode": "soft",
+}
+_OUROBOROS_BLOCKING_INTERRUPT_METADATA: Mapping[str, Any] = {
+    "supported": True,
+    "mode": "soft",
+    "execution_mode": "blocking",
+    "blocking_semantics": "synchronous_handler",
+    "resumable": False,
+    "background_companions": (),
+    "target_context_keys": (),
+}
+_OUROBOROS_BACKGROUND_INTERRUPT_METADATA: Mapping[str, Any] = {
+    "supported": True,
+    "mode": "resumable_background_job",
+    "resumable": True,
+    "cancellable": True,
+    "resume_companions": (
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+    ),
+    "cancel_companions": ("ouroboros_cancel_job",),
+    "target_context_keys": ("job_id",),
+}
+_OUROBOROS_TERMINAL_CONTROL_INTERRUPT_METADATA_BY_TOOL: Mapping[str, Mapping[str, Any]] = {
+    "ouroboros_cancel_job": {
+        "supported": True,
+        "mode": "terminal_control",
+        "terminal_action": "cancel",
+        "target_type": "background_job",
+        "target_context_keys": ("job_id",),
+        "directive_semantics": "request_terminal_job_cancellation",
+        "terminal_statuses": ("cancelled",),
+        "idempotent": True,
+    },
+    "ouroboros_cancel_execution": {
+        "supported": True,
+        "mode": "terminal_control",
+        "terminal_action": "cancel",
+        "target_type": "execution_session",
+        "target_context_keys": ("execution_id",),
+        "directive_semantics": "request_terminal_execution_cancellation",
+        "terminal_statuses": ("cancelled",),
+        "idempotent": True,
+    },
+}
+_OUROBOROS_UNSUPPORTED_INTERRUPT_METADATA: Mapping[str, Any] = {
+    "supported": False,
+    "mode": "unsupported",
+}
+_OUROBOROS_READ_ONLY_INTERRUPT_METADATA: Mapping[str, Any] = {
+    "supported": True,
+    "mode": "read_only_non_mutating",
+    "mutation_semantics": "no_state_mutation",
+    "resumable": False,
+    "target_context_keys": (),
+}
+_OUROBOROS_UNSUPPORTED_CANCEL_METADATA: Mapping[str, Any] = {
+    "supported": False,
+    "mode": "unsupported",
+    "companions": (),
+    "target_context_keys": (),
+}
+_OUROBOROS_SIDE_EFFECT_FREE_METADATA: tuple[str, ...] = ()
+_OUROBOROS_MUTATION_TARGETS_BY_SIDE_EFFECT: Mapping[str, tuple[str, ...]] = {
+    "background_job_start": ("background_job",),
+    "checkpoint_store_write": ("checkpoint_store",),
+    "event_store_write": ("event_store",),
+    "runtime_control": ("runtime",),
+    "session_state_write": ("session_state",),
+    "side_effect_free": (),
+    "subagent_dispatch": ("subagent",),
+    "workspace_write": ("workspace",),
+}
+_OUROBOROS_STATE_MUTATIONS_BY_TOOL: Mapping[str, tuple[Mapping[str, Any], ...]] = {
+    "ouroboros_auto": (
+        {
+            "target": "auto_session_state",
+            "operation": "run_auto_pipeline_to_seed_and_execution",
+            "side_effect": "event_store_write",
+            "context_keys": ("goal", "resume", "cwd"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_auto_generated_execution_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("cwd",),
+        },
+    ),
+    "ouroboros_start_auto": (
+        {
+            "target": "auto_session_state",
+            "operation": "enqueue_background_auto_pipeline",
+            "side_effect": "event_store_write",
+            "context_keys": ("goal", "resume", "cwd"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_background_auto_execution_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("cwd",),
+        },
+    ),
+    "ouroboros_execute_seed": (
+        {
+            "target": "execution_session",
+            "operation": "run_seed_execution_session",
+            "side_effect": "event_store_write",
+            "context_keys": ("seed_path", "seed_content", "session_id", "cwd"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_seed_execution_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("cwd",),
+        },
+    ),
+    "ouroboros_start_execute_seed": (
+        {
+            "target": "execution_session",
+            "operation": "enqueue_background_seed_execution",
+            "side_effect": "event_store_write",
+            "context_keys": ("seed_content", "session_id", "cwd"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_background_seed_execution_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("cwd",),
+        },
+    ),
+    "ouroboros_evaluate": (
+        {
+            "target": "session_state",
+            "operation": "append_evaluation_result",
+            "side_effect": "session_state_write",
+            "context_keys": ("session_id",),
+        },
+    ),
+    "ouroboros_evolve_step": (
+        {
+            "target": "lineage_state",
+            "operation": "append_evolution_generation_result",
+            "side_effect": "event_store_write",
+            "context_keys": ("lineage_id", "seed_content", "execution_id"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_evolution_generation_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("project_dir",),
+        },
+    ),
+    "ouroboros_evolve_rewind": (
+        {
+            "target": "lineage_state",
+            "operation": "truncate_generations_after_target",
+            "side_effect": "session_state_write",
+            "context_keys": ("lineage_id", "to_generation"),
+        },
+    ),
+    "ouroboros_start_evolve_step": (
+        {
+            "target": "lineage_state",
+            "operation": "enqueue_background_evolution_generation",
+            "side_effect": "event_store_write",
+            "context_keys": ("lineage_id", "seed_content", "execution_id"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_background_evolution_generation_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("project_dir",),
+        },
+    ),
+    "ouroboros_interview": (
+        {
+            "target": "interview_state",
+            "operation": "create_or_update_or_complete_interview_session",
+            "side_effect": "session_state_write",
+            "context_keys": (
+                "initial_context",
+                "session_id",
+                "answer",
+                "last_question",
+            ),
+        },
+        {
+            "target": "subagent_dispatch_log",
+            "operation": "record_interview_subagent_dispatch",
+            "side_effect": "subagent_dispatch",
+            "context_keys": ("session_id",),
+        },
+    ),
+    "ouroboros_lateral_think": (
+        {
+            "target": "lateral_panel_state",
+            "operation": "dispatch_persona_panel_and_synthesize_findings",
+            "side_effect": "subagent_dispatch",
+            "context_keys": (
+                "problem_context",
+                "current_approach",
+                "failed_attempts",
+            ),
+        },
+        {
+            "target": "session_state",
+            "operation": "record_lateral_review_result",
+            "side_effect": "session_state_write",
+            "context_keys": ("problem_context",),
+        },
+    ),
+    "ouroboros_measure_drift": (
+        {
+            "target": "session_state",
+            "operation": "append_drift_measurement",
+            "side_effect": "session_state_write",
+            "context_keys": ("session_id",),
+        },
+    ),
+    "ouroboros_pm_interview": (
+        {
+            "target": "interview_state",
+            "operation": "create_or_update_pm_interview_session",
+            "side_effect": "session_state_write",
+            "context_keys": (
+                "initial_context",
+                "session_id",
+                "answer",
+                "last_question",
+            ),
+        },
+        {
+            "target": "pm_meta_state",
+            "operation": "persist_pm_session_metadata",
+            "side_effect": "session_state_write",
+            "context_keys": ("session_id", "cwd", "selected_repos"),
+        },
+        {
+            "target": "subagent_dispatch_log",
+            "operation": "record_pm_interview_subagent_dispatch",
+            "side_effect": "subagent_dispatch",
+            "context_keys": ("session_id",),
+        },
+    ),
+    "ouroboros_qa": (
+        {
+            "target": "qa_session_state",
+            "operation": "append_qa_iteration_verdict",
+            "side_effect": "session_state_write",
+            "context_keys": ("qa_session_id", "iteration_history"),
+        },
+    ),
+    "ouroboros_ralph": (
+        {
+            "target": "ralph_loop_state",
+            "operation": "run_evolution_loop_until_terminal_condition",
+            "side_effect": "event_store_write",
+            "context_keys": ("lineage_id", "execution_id"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_ralph_loop_generation_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("project_dir",),
+        },
+    ),
+    "ouroboros_start_ralph": (
+        {
+            "target": "ralph_loop_state",
+            "operation": "enqueue_background_evolution_loop",
+            "side_effect": "event_store_write",
+            "context_keys": ("lineage_id", "execution_id"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_background_ralph_loop_generation_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("project_dir",),
+        },
+    ),
+    "ouroboros_cancel_execution": (
+        {
+            "target": "execution_session",
+            "operation": "mark_execution_session_cancelled",
+            "side_effect": "session_state_write",
+            "context_keys": ("execution_id", "reason"),
+        },
+        {
+            "target": "event_store",
+            "operation": "append_session_cancelled_event",
+            "side_effect": "event_store_write",
+            "context_keys": ("execution_id", "reason"),
+        },
+        {
+            "target": "runtime",
+            "operation": "signal_execution_runner_to_stop_via_cancellation_event",
+            "side_effect": "runtime_control",
+            "context_keys": ("execution_id",),
+        },
+    ),
+    "ouroboros_cancel_job": (
+        {
+            "target": "background_job",
+            "operation": "mark_background_job_cancel_requested",
+            "side_effect": "event_store_write",
+            "context_keys": ("job_id",),
+        },
+        {
+            "target": "checkpoint_store",
+            "operation": "persist_durable_agent_process_cancel_signal",
+            "side_effect": "checkpoint_store_write",
+            "context_keys": ("job_id",),
+        },
+        {
+            "target": "runtime",
+            "operation": "cancel_live_background_job_tasks",
+            "side_effect": "runtime_control",
+            "context_keys": ("job_id",),
+        },
+        {
+            "target": "session_state",
+            "operation": "mark_linked_execution_session_cancelled_when_needed",
+            "side_effect": "session_state_write",
+            "context_keys": ("job_id",),
+        },
+    ),
+}
+_OUROBOROS_BACKGROUND_JOB_CANCEL_METADATA: Mapping[str, Any] = {
+    "supported": True,
+    "mode": "background_job",
+    "companions": ("ouroboros_cancel_job",),
+    "target_context_keys": ("job_id",),
+}
+_OUROBOROS_EXECUTION_SESSION_CANCEL_METADATA: Mapping[str, Any] = {
+    "supported": True,
+    "mode": "execution_session",
+    "companions": ("ouroboros_cancel_execution",),
+    "target_context_keys": ("execution_id",),
+}
+_OUROBOROS_BACKGROUND_JOB_CANCEL_CONTROL_METADATA: Mapping[str, Any] = {
+    "supported": True,
+    "mode": "background_job_control",
+    "companions": (
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+    ),
+    "target_context_keys": ("job_id",),
+}
+_OUROBOROS_EXECUTION_SESSION_CANCEL_CONTROL_METADATA: Mapping[str, Any] = {
+    "supported": True,
+    "mode": "execution_session_control",
+    "companions": (
+        "ouroboros_execute_seed",
+        "ouroboros_start_execute_seed",
+    ),
+    "target_context_keys": ("execution_id",),
+}
+
+_OUROBOROS_TOOL_CAPABILITY_SPECS: Mapping[str, _OuroborosToolCapabilitySpec] = {
+    "ouroboros_execute_seed": _OuroborosToolCapabilitySpec(
+        execution_mode="blocking",
+        companions=(
+            "ouroboros_start_execute_seed",
+            "ouroboros_cancel_execution",
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+            "ouroboros_cancel_job",
+        ),
+        side_effects=("workspace_write", "event_store_write"),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_BLOCKING_INTERRUPT_METADATA,
+    ),
+    "ouroboros_start_execute_seed": _OuroborosToolCapabilitySpec(
+        execution_mode="background",
+        companions=(
+            "ouroboros_execute_seed",
+            "ouroboros_cancel_execution",
+            "ouroboros_start_evaluate",
+            "ouroboros_start_evolve_step",
+            "ouroboros_start_ralph",
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+            "ouroboros_cancel_job",
+        ),
+        side_effects=("workspace_write", "event_store_write"),
+        retry=_OUROBOROS_JOB_POLL_RETRY_METADATA,
+        interrupt=_OUROBOROS_BACKGROUND_INTERRUPT_METADATA,
+    ),
+    "ouroboros_auto": _OuroborosToolCapabilitySpec(
+        execution_mode="blocking",
+        companions=("ouroboros_start_auto",),
+        side_effects=("workspace_write", "event_store_write"),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_BLOCKING_INTERRUPT_METADATA,
+    ),
+    "ouroboros_start_auto": _OuroborosToolCapabilitySpec(
+        execution_mode="background",
+        companions=(
+            "ouroboros_auto",
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+            "ouroboros_cancel_job",
+        ),
+        side_effects=("workspace_write", "event_store_write"),
+        retry=_OUROBOROS_JOB_POLL_RETRY_METADATA,
+        interrupt=_OUROBOROS_BACKGROUND_INTERRUPT_METADATA,
+    ),
+    "ouroboros_session_status": _OuroborosToolCapabilitySpec(
+        execution_mode="status",
+        companions=(
+            "ouroboros_query_events",
+            "ouroboros_query_projection",
+            "ouroboros_ac_tree_hud",
+        ),
+        side_effects=_OUROBOROS_SIDE_EFFECT_FREE_METADATA,
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_READ_ONLY_INTERRUPT_METADATA,
+        mutation_class=CapabilityMutationClass.READ_ONLY,
+    ),
+    "ouroboros_job_status": _OuroborosToolCapabilitySpec(
+        execution_mode="status",
+        companions=(
+            "ouroboros_start_auto",
+            "ouroboros_start_execute_seed",
+            "ouroboros_start_evaluate",
+            "ouroboros_start_evolve_step",
+            "ouroboros_start_ralph",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+            "ouroboros_cancel_job",
+        ),
+        side_effects=_OUROBOROS_SIDE_EFFECT_FREE_METADATA,
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_READ_ONLY_INTERRUPT_METADATA,
+        mutation_class=CapabilityMutationClass.READ_ONLY,
+    ),
+    "ouroboros_job_wait": _OuroborosToolCapabilitySpec(
+        execution_mode="status",
+        companions=(
+            "ouroboros_start_auto",
+            "ouroboros_start_execute_seed",
+            "ouroboros_start_evaluate",
+            "ouroboros_start_evolve_step",
+            "ouroboros_start_ralph",
+            "ouroboros_job_status",
+            "ouroboros_job_result",
+            "ouroboros_cancel_job",
+        ),
+        side_effects=_OUROBOROS_SIDE_EFFECT_FREE_METADATA,
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_READ_ONLY_INTERRUPT_METADATA,
+        mutation_class=CapabilityMutationClass.READ_ONLY,
+    ),
+    "ouroboros_job_result": _OuroborosToolCapabilitySpec(
+        execution_mode="status",
+        companions=(
+            "ouroboros_start_auto",
+            "ouroboros_start_execute_seed",
+            "ouroboros_start_evaluate",
+            "ouroboros_start_evolve_step",
+            "ouroboros_start_ralph",
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_cancel_job",
+        ),
+        side_effects=_OUROBOROS_SIDE_EFFECT_FREE_METADATA,
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_READ_ONLY_INTERRUPT_METADATA,
+        mutation_class=CapabilityMutationClass.READ_ONLY,
+    ),
+    "ouroboros_ac_tree_hud": _OuroborosToolCapabilitySpec(
+        execution_mode="status",
+        companions=(
+            "ouroboros_session_status",
+            "ouroboros_query_events",
+            "ouroboros_query_projection",
+        ),
+        side_effects=_OUROBOROS_SIDE_EFFECT_FREE_METADATA,
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_READ_ONLY_INTERRUPT_METADATA,
+        mutation_class=CapabilityMutationClass.READ_ONLY,
+    ),
+    "ouroboros_cancel_job": _OuroborosToolCapabilitySpec(
+        execution_mode="cancel",
+        companions=(
+            "ouroboros_start_auto",
+            "ouroboros_start_execute_seed",
+            "ouroboros_start_evaluate",
+            "ouroboros_start_evolve_step",
+            "ouroboros_start_ralph",
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+        ),
+        side_effects=(
+            "runtime_control",
+            "event_store_write",
+            "checkpoint_store_write",
+            "session_state_write",
+        ),
+        retry=_OUROBOROS_UNSUPPORTED_RETRY_METADATA,
+        interrupt=_OUROBOROS_TERMINAL_CONTROL_INTERRUPT_METADATA_BY_TOOL[
+            "ouroboros_cancel_job"
+        ],
+    ),
+    "ouroboros_query_events": _OuroborosToolCapabilitySpec(
+        execution_mode="status",
+        companions=(
+            "ouroboros_session_status",
+            "ouroboros_query_projection",
+            "ouroboros_ac_tree_hud",
+        ),
+        side_effects=_OUROBOROS_SIDE_EFFECT_FREE_METADATA,
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_READ_ONLY_INTERRUPT_METADATA,
+        mutation_class=CapabilityMutationClass.READ_ONLY,
+    ),
+    "ouroboros_query_projection": _OuroborosToolCapabilitySpec(
+        execution_mode="status",
+        companions=(
+            "ouroboros_session_status",
+            "ouroboros_query_events",
+            "ouroboros_ac_tree_hud",
+        ),
+        side_effects=_OUROBOROS_SIDE_EFFECT_FREE_METADATA,
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_READ_ONLY_INTERRUPT_METADATA,
+        mutation_class=CapabilityMutationClass.READ_ONLY,
+    ),
+    "ouroboros_generate_seed": _OuroborosToolCapabilitySpec(
+        execution_mode="blocking",
+        companions=(
+            "ouroboros_interview",
+            "ouroboros_pm_interview",
+            "ouroboros_brownfield",
+        ),
+        side_effects=("workspace_write", "event_store_write"),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_BLOCKING_INTERRUPT_METADATA,
+    ),
+    "ouroboros_measure_drift": _OuroborosToolCapabilitySpec(
+        execution_mode="blocking",
+        companions=(
+            "ouroboros_evaluate",
+            "ouroboros_start_evaluate",
+            "ouroboros_checklist_verify",
+            "ouroboros_qa",
+        ),
+        side_effects=("session_state_write",),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_BLOCKING_INTERRUPT_METADATA,
+    ),
+    "ouroboros_interview": _OuroborosToolCapabilitySpec(
+        execution_mode="subagent_orchestration",
+        companions=(
+            "ouroboros_generate_seed",
+            "ouroboros_pm_interview",
+            "ouroboros_brownfield",
+            "ouroboros_lateral_think",
+        ),
+        side_effects=("subagent_dispatch", "session_state_write"),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_DEFAULT_INTERRUPT_METADATA,
+    ),
+    "ouroboros_evaluate": _OuroborosToolCapabilitySpec(
+        execution_mode="blocking",
+        companions=(
+            "ouroboros_start_evaluate",
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+            "ouroboros_cancel_job",
+            "ouroboros_checklist_verify",
+            "ouroboros_measure_drift",
+            "ouroboros_qa",
+        ),
+        side_effects=("session_state_write",),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_BLOCKING_INTERRUPT_METADATA,
+    ),
+    "ouroboros_start_evaluate": _OuroborosToolCapabilitySpec(
+        execution_mode="background",
+        companions=(
+            "ouroboros_start_execute_seed",
+            "ouroboros_start_evolve_step",
+            "ouroboros_start_ralph",
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+            "ouroboros_cancel_job",
+            "ouroboros_evaluate",
+            "ouroboros_checklist_verify",
+            "ouroboros_measure_drift",
+            "ouroboros_qa",
+        ),
+        side_effects=("background_job_start", "event_store_write"),
+        retry=_OUROBOROS_JOB_POLL_RETRY_METADATA,
+        interrupt=_OUROBOROS_BACKGROUND_INTERRUPT_METADATA,
+    ),
+    "ouroboros_checklist_verify": _OuroborosToolCapabilitySpec(
+        execution_mode="blocking",
+        companions=(
+            "ouroboros_evaluate",
+            "ouroboros_start_evaluate",
+            "ouroboros_measure_drift",
+            "ouroboros_qa",
+        ),
+        side_effects=("workspace_write", "event_store_write"),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_BLOCKING_INTERRUPT_METADATA,
+    ),
+    "ouroboros_lateral_think": _OuroborosToolCapabilitySpec(
+        execution_mode="subagent_orchestration",
+        companions=("ouroboros_interview",),
+        side_effects=("subagent_dispatch", "session_state_write"),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_DEFAULT_INTERRUPT_METADATA,
+    ),
+    "ouroboros_evolve_step": _OuroborosToolCapabilitySpec(
+        execution_mode="blocking",
+        companions=(
+            "ouroboros_start_evolve_step",
+            "ouroboros_lineage_status",
+            "ouroboros_evolve_rewind",
+            "ouroboros_ralph",
+            "ouroboros_start_ralph",
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+            "ouroboros_cancel_job",
+        ),
+        side_effects=("workspace_write", "event_store_write"),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_BLOCKING_INTERRUPT_METADATA,
+    ),
+    "ouroboros_start_evolve_step": _OuroborosToolCapabilitySpec(
+        execution_mode="background",
+        companions=(
+            "ouroboros_start_execute_seed",
+            "ouroboros_start_evaluate",
+            "ouroboros_start_ralph",
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+            "ouroboros_cancel_job",
+            "ouroboros_evolve_step",
+            "ouroboros_lineage_status",
+            "ouroboros_evolve_rewind",
+            "ouroboros_ralph",
+        ),
+        side_effects=("workspace_write", "event_store_write"),
+        retry=_OUROBOROS_JOB_POLL_RETRY_METADATA,
+        interrupt=_OUROBOROS_BACKGROUND_INTERRUPT_METADATA,
+    ),
+    "ouroboros_ralph": _OuroborosToolCapabilitySpec(
+        execution_mode="blocking",
+        companions=(
+            "ouroboros_evolve_step",
+            "ouroboros_start_evolve_step",
+            "ouroboros_lineage_status",
+            "ouroboros_evolve_rewind",
+            "ouroboros_start_ralph",
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+            "ouroboros_cancel_job",
+        ),
+        side_effects=("workspace_write", "event_store_write"),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_BLOCKING_INTERRUPT_METADATA,
+    ),
+    "ouroboros_start_ralph": _OuroborosToolCapabilitySpec(
+        execution_mode="background",
+        companions=(
+            "ouroboros_start_execute_seed",
+            "ouroboros_start_evaluate",
+            "ouroboros_start_evolve_step",
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+            "ouroboros_cancel_job",
+            "ouroboros_evolve_step",
+            "ouroboros_lineage_status",
+            "ouroboros_evolve_rewind",
+            "ouroboros_ralph",
+        ),
+        side_effects=("workspace_write", "event_store_write"),
+        retry=_OUROBOROS_JOB_POLL_RETRY_METADATA,
+        interrupt=_OUROBOROS_BACKGROUND_INTERRUPT_METADATA,
+    ),
+    "ouroboros_lineage_status": _OuroborosToolCapabilitySpec(
+        execution_mode="status",
+        companions=(
+            "ouroboros_evolve_step",
+            "ouroboros_start_evolve_step",
+            "ouroboros_evolve_rewind",
+            "ouroboros_ralph",
+            "ouroboros_start_ralph",
+        ),
+        side_effects=_OUROBOROS_SIDE_EFFECT_FREE_METADATA,
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_READ_ONLY_INTERRUPT_METADATA,
+        mutation_class=CapabilityMutationClass.READ_ONLY,
+    ),
+    "ouroboros_evolve_rewind": _OuroborosToolCapabilitySpec(
+        execution_mode="blocking",
+        companions=(
+            "ouroboros_evolve_step",
+            "ouroboros_start_evolve_step",
+            "ouroboros_lineage_status",
+            "ouroboros_ralph",
+            "ouroboros_start_ralph",
+        ),
+        side_effects=("session_state_write",),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_BLOCKING_INTERRUPT_METADATA,
+    ),
+    "ouroboros_cancel_execution": _OuroborosToolCapabilitySpec(
+        execution_mode="cancel",
+        companions=("ouroboros_execute_seed", "ouroboros_start_execute_seed"),
+        side_effects=(
+            "runtime_control",
+            "event_store_write",
+            "session_state_write",
+        ),
+        retry=_OUROBOROS_UNSUPPORTED_RETRY_METADATA,
+        interrupt=_OUROBOROS_TERMINAL_CONTROL_INTERRUPT_METADATA_BY_TOOL[
+            "ouroboros_cancel_execution"
+        ],
+    ),
+    "ouroboros_brownfield": _OuroborosToolCapabilitySpec(
+        execution_mode="blocking",
+        companions=(
+            "ouroboros_interview",
+            "ouroboros_generate_seed",
+            "ouroboros_pm_interview",
+        ),
+        side_effects=("workspace_write", "event_store_write"),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_BLOCKING_INTERRUPT_METADATA,
+    ),
+    "ouroboros_pm_interview": _OuroborosToolCapabilitySpec(
+        execution_mode="subagent_orchestration",
+        companions=(
+            "ouroboros_interview",
+            "ouroboros_generate_seed",
+            "ouroboros_brownfield",
+        ),
+        side_effects=("subagent_dispatch", "session_state_write"),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_DEFAULT_INTERRUPT_METADATA,
+    ),
+    "ouroboros_qa": _OuroborosToolCapabilitySpec(
+        execution_mode="blocking",
+        companions=(
+            "ouroboros_evaluate",
+            "ouroboros_start_evaluate",
+            "ouroboros_checklist_verify",
+            "ouroboros_measure_drift",
+        ),
+        side_effects=("session_state_write",),
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_BLOCKING_INTERRUPT_METADATA,
+    ),
+}
+
+_OUROBOROS_CANCEL_METADATA: Mapping[str, Mapping[str, Any]] = {
+    "ouroboros_ac_tree_hud": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_auto": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_brownfield": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_cancel_execution": _OUROBOROS_EXECUTION_SESSION_CANCEL_CONTROL_METADATA,
+    "ouroboros_cancel_job": _OUROBOROS_BACKGROUND_JOB_CANCEL_CONTROL_METADATA,
+    "ouroboros_checklist_verify": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_evaluate": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_evolve_rewind": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_evolve_step": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_execute_seed": _OUROBOROS_EXECUTION_SESSION_CANCEL_METADATA,
+    "ouroboros_generate_seed": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_interview": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_job_result": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_job_status": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_job_wait": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_lateral_think": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_lineage_status": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_measure_drift": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_pm_interview": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_qa": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_query_events": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_query_projection": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_ralph": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_session_status": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+    "ouroboros_start_auto": _OUROBOROS_BACKGROUND_JOB_CANCEL_METADATA,
+    "ouroboros_start_evaluate": _OUROBOROS_BACKGROUND_JOB_CANCEL_METADATA,
+    "ouroboros_start_evolve_step": _OUROBOROS_BACKGROUND_JOB_CANCEL_METADATA,
+    "ouroboros_start_execute_seed": _OUROBOROS_BACKGROUND_JOB_CANCEL_METADATA,
+    "ouroboros_start_ralph": _OUROBOROS_BACKGROUND_JOB_CANCEL_METADATA,
+}
+
+_OUROBOROS_BACKGROUND_BLOCKING_COMPANIONS: Mapping[str, str] = {
+    "ouroboros_start_auto": "ouroboros_auto",
+    "ouroboros_start_evaluate": "ouroboros_evaluate",
+    "ouroboros_start_evolve_step": "ouroboros_evolve_step",
+    "ouroboros_start_execute_seed": "ouroboros_execute_seed",
+    "ouroboros_start_ralph": "ouroboros_ralph",
+}
+
+_OUROBOROS_BACKGROUND_LIFECYCLE_ROLE_TOOLS: Mapping[str, str] = {
+    "status": "ouroboros_job_status",
+    "wait": "ouroboros_job_wait",
+    "result": "ouroboros_job_result",
+    "cancel": "ouroboros_cancel_job",
+}
+_OUROBOROS_JOB_LIFECYCLE_SIBLING_ORDER = (
+    "status",
+    "wait",
+    "result",
+    "cancel",
+)
+
+
+@lru_cache(maxsize=1)
+def _ouroboros_tool_definitions_by_name() -> Mapping[str, MCPToolDefinition]:
+    """Return the owned MCP tool definitions without invoking handlers."""
+    from ouroboros.mcp.tools.definitions import get_ouroboros_tools
+
+    return {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+
+
+def _is_ouroboros_owned_tool(tool: MCPToolDefinition) -> bool:
+    return tool.name in _ouroboros_tool_definitions_by_name()
+
+
+def _is_ouroboros_owned_tool_name(tool_name: str) -> bool:
+    return tool_name in _ouroboros_tool_definitions_by_name()
+
+
+def _spec_for_ouroboros_tool_name(name: str) -> _OuroborosToolCapabilitySpec:
+    try:
+        return _OUROBOROS_TOOL_CAPABILITY_SPECS[name]
+    except KeyError as exc:
+        raise RuntimeError(
+            "Ouroboros MCP capability registry has no explicit spec for "
+            f"{name}; retry metadata must be defined per owned tool"
+        ) from exc
+
+
+def _ouroboros_companions_for_tool(name: str) -> tuple[str, ...]:
+    return _spec_for_ouroboros_tool_name(name).companions
+
+
+def _available_ouroboros_tool_names() -> frozenset[str]:
+    return frozenset(_ouroboros_tool_definitions_by_name())
+
+
+def _filter_available_ouroboros_tools(tool_names: Sequence[str]) -> tuple[str, ...]:
+    available = _available_ouroboros_tool_names()
+    return tuple(tool_name for tool_name in tool_names if tool_name in available)
+
+
+def _available_job_lifecycle_sibling_roles() -> Mapping[str, str]:
+    """Return available generic job lifecycle siblings in stable role order."""
+    definitions = _ouroboros_tool_definitions_by_name()
+    sibling_roles = {
+        role: tool_name
+        for role, tool_name in _OUROBOROS_BACKGROUND_LIFECYCLE_ROLE_TOOLS.items()
+        if tool_name in definitions
+    }
+    return {
+        role: sibling_roles[role]
+        for role in _OUROBOROS_JOB_LIFECYCLE_SIBLING_ORDER
+        if role in sibling_roles
+    }
+
+
+def _derived_ouroboros_companions_for_tool(name: str) -> tuple[str, ...]:
+    """Return catalog-derived companions layered on top of explicit specs."""
+    companions = list(_filter_available_ouroboros_tools(_ouroboros_companions_for_tool(name)))
+    sibling_roles = _available_job_lifecycle_sibling_roles()
+    if name in sibling_roles.values():
+        for sibling_name in sibling_roles.values():
+            if sibling_name != name and sibling_name not in companions:
+                companions.append(sibling_name)
+    return tuple(companions)
+
+
+def _ouroboros_execution_mode(name: str) -> str:
+    return _spec_for_ouroboros_tool_name(name).execution_mode
+
+
+def extract_capability_input_schema(tool: MCPToolDefinition) -> dict[str, Any]:
+    """Convert an MCP tool definition into capability input_schema metadata."""
+    schema = tool.to_input_schema()
+    properties = schema.get("properties", {})
+    required = schema.get("required", [])
+    return {
+        "type": schema.get("type", "object"),
+        "properties": {
+            str(name): dict(property_schema)
+            if isinstance(property_schema, Mapping)
+            else property_schema
+            for name, property_schema in (
+                properties.items() if isinstance(properties, Mapping) else ()
+            )
+        },
+        "required": list(required) if isinstance(required, Sequence) else [],
+    }
+
+
+def _input_schema_for_ouroboros_tool(tool: MCPToolDefinition) -> Mapping[str, Any]:
+    """Return the owned-tool input schema, defaulting to the live descriptor."""
+    canonical_tool = _ouroboros_tool_definitions_by_name().get(tool.name, tool)
+    return extract_capability_input_schema(canonical_tool)
+
+
+def mcp_tool_required_parameter_keys(tool: MCPToolDefinition) -> tuple[str, ...]:
+    """Return required input parameter keys from an MCP tool definition.
+
+    This is the schema-derived extraction point for unknown or external MCP
+    tools. Ouroboros-owned tools use explicit context metadata, but tests still
+    compare that metadata against this source-of-truth extraction.
+    """
+    return tuple(parameter.name for parameter in tool.parameters if parameter.required)
+
+
+def _required_parameter_names(tool: MCPToolDefinition) -> tuple[str, ...]:
+    return mcp_tool_required_parameter_keys(tool)
+
+
+def _merge_required_context_keys(
+    required_parameter_keys: Sequence[str],
+    observed_skill_context_keys: Sequence[str],
+) -> tuple[str, ...]:
+    """Return definition-required plus skill-observed context keys.
+
+    Required MCP parameters stay first in definition order. Skill usage keys
+    are appended in discovery order only when they add new runtime context.
+    """
+    merged: list[str] = []
+    for raw_key in (*required_parameter_keys, *observed_skill_context_keys):
+        key = raw_key.strip() if isinstance(raw_key, str) else ""
+        if key and key not in merged:
+            merged.append(key)
+    return tuple(merged)
+
+
+def _required_context_keys_for_ouroboros_tool(tool: MCPToolDefinition) -> tuple[str, ...]:
+    """Return owned-tool context keys from MCP definitions and skill usage."""
+    canonical_tool = _ouroboros_tool_definitions_by_name().get(tool.name, tool)
+    skill_context_keys = get_packaged_skill_context_keys().get(tool.name, ())
+    return _merge_required_context_keys(
+        mcp_tool_required_parameter_keys(canonical_tool),
+        skill_context_keys,
+    )
+
+
+def _side_effects_for_ouroboros_tool(name: str) -> tuple[str, ...]:
+    return _spec_for_ouroboros_tool_name(name).side_effects
+
+
+def _resolved_side_effects_for_ouroboros_tool(name: str) -> tuple[str, ...]:
+    side_effects = _side_effects_for_ouroboros_tool(name)
+    return side_effects or ("session_state_write",)
+
+
+def _mutation_targets_for_side_effects(side_effects: Sequence[str]) -> tuple[str, ...]:
+    targets: list[str] = []
+    for side_effect in side_effects:
+        for target in _OUROBOROS_MUTATION_TARGETS_BY_SIDE_EFFECT.get(
+            side_effect,
+            ("unknown",),
+        ):
+            if target and target not in targets:
+                targets.append(target)
+    return tuple(targets)
+
+
+def _mutation_targets_for_state_mutations(
+    base_targets: Sequence[str],
+    state_mutations: Sequence[Mapping[str, Any]],
+) -> tuple[str, ...]:
+    targets = list(base_targets)
+    for mutation in state_mutations:
+        target = mutation.get("target")
+        if isinstance(target, str) and target and target not in targets:
+            targets.append(target)
+    return tuple(targets)
+
+
+def _state_mutations_for_ouroboros_tool(name: str) -> tuple[Mapping[str, Any], ...]:
+    """Return explicit state mutation records for an owned MCP tool."""
+    mutations = _OUROBOROS_STATE_MUTATIONS_BY_TOOL.get(name, ())
+    return tuple(
+        {
+            **dict(mutation),
+            "context_keys": tuple(mutation.get("context_keys", ())),
+        }
+        for mutation in mutations
+    )
+
+
+def _retry_metadata_for_ouroboros_tool(name: str) -> Mapping[str, Any]:
+    return dict(_spec_for_ouroboros_tool_name(name).retry)
+
+
+def _interrupt_metadata_for_ouroboros_tool(name: str) -> Mapping[str, Any]:
+    metadata = dict(_spec_for_ouroboros_tool_name(name).interrupt)
+    if metadata.get("execution_mode") == "blocking":
+        background_companions = tuple(
+            start_tool
+            for start_tool, blocking_tool in _OUROBOROS_BACKGROUND_BLOCKING_COMPANIONS.items()
+            if blocking_tool == name and start_tool in _available_ouroboros_tool_names()
+        )
+        return {
+            **metadata,
+            "background_companions": background_companions,
+            "target_context_keys": tuple(metadata.get("target_context_keys", ())),
+        }
+
+    if metadata.get("mode") != "resumable_background_job":
+        return metadata
+
+    resume_companions = _filter_available_ouroboros_tools(
+        metadata.get("resume_companions", ())
+    )
+    cancel_companions = _filter_available_ouroboros_tools(
+        metadata.get("cancel_companions", ())
+    )
+    return {
+        **metadata,
+        "resumable": bool(resume_companions),
+        "cancellable": bool(cancel_companions),
+        "resume_companions": resume_companions,
+        "cancel_companions": cancel_companions,
+        "target_context_keys": tuple(metadata.get("target_context_keys", ())),
+    }
+
+
+def _cancel_metadata_for_ouroboros_tool(name: str) -> Mapping[str, Any]:
+    metadata = _OUROBOROS_CANCEL_METADATA.get(
+        name, _OUROBOROS_UNSUPPORTED_CANCEL_METADATA
+    )
+    raw_companions = metadata.get("companions", ())
+    companions = _filter_available_ouroboros_tools(raw_companions)
+    if metadata.get("supported") and not companions:
+        metadata = _OUROBOROS_UNSUPPORTED_CANCEL_METADATA
+        companions = ()
+    return {
+        key: companions
+        if key == "companions"
+        else tuple(value)
+        if isinstance(value, tuple)
+        else value
+        for key, value in metadata.items()
+    }
+
+
+def _interview_code_investigation_request_schema() -> dict[str, Any]:
+    """Return the runtime request model for interview code-fact investigation."""
+    target_schema: dict[str, Any] = {
+        "type": "object",
+        "oneOf": [
+            {
+                "title": "WorkspaceTarget",
+                "additionalProperties": False,
+                "required": ["target_type", "scope"],
+                "properties": {
+                    "target_type": {"const": "workspace"},
+                    "scope": {
+                        "type": "string",
+                        "enum": ["active", "selected_repositories", "all_available"],
+                    },
+                },
+            },
+            {
+                "title": "RelativePathTarget",
+                "additionalProperties": False,
+                "required": ["target_type", "path"],
+                "properties": {
+                    "target_type": {"const": "relative_path"},
+                    "path": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Repository-relative file or directory path.",
+                    },
+                },
+            },
+            {
+                "title": "GlobTarget",
+                "additionalProperties": False,
+                "required": ["target_type", "pattern"],
+                "properties": {
+                    "target_type": {"const": "glob"},
+                    "pattern": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Repository-relative glob pattern.",
+                    },
+                },
+            },
+            {
+                "title": "SymbolTarget",
+                "additionalProperties": False,
+                "required": ["target_type", "name"],
+                "properties": {
+                    "target_type": {"const": "symbol"},
+                    "name": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Function, class, module, command, or config symbol to locate.",
+                    },
+                    "path_hint": {
+                        "type": "string",
+                        "minLength": 1,
+                        "description": "Optional repository-relative search hint.",
+                    },
+                },
+            },
+        ],
+    }
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [
+            "session_id",
+            "question_identity",
+            "question",
+            "investigation_goal",
+            "investigation_targets",
+            "fact_categories",
+            "allowed_capabilities",
+            "repo_inspection_tool_capabilities",
+            "confidence_policy",
+            "answer_prefixes",
+            "answer_contract",
+            "mcp_tool_capability",
+        ],
+        "properties": {
+            "session_id": {
+                "type": "string",
+                "description": "Current Ouroboros interview session ID.",
+            },
+            "question_identity": {
+                "type": "string",
+                "pattern": r"^interview-question:[0-9a-f]{16}$",
+                "description": (
+                    "Stable identity derived from the originating interview "
+                    "question using stable_code_investigation_question_identity()."
+                ),
+            },
+            "question": {
+                "type": "string",
+                "description": "The MCP-generated interview question requiring code facts.",
+            },
+            "last_question": {
+                "type": "string",
+                "description": "Previously asked question text, when available.",
+            },
+            "investigation_goal": {
+                "type": "string",
+                "enum": ["describe_current_state_from_code"],
+                "description": "Code investigation is descriptive only; decisions route to the user.",
+            },
+            "investigation_targets": {
+                "type": "array",
+                "minItems": 1,
+                "items": target_schema,
+                "description": "Repository-agnostic descriptors for the code facts to inspect.",
+            },
+            "fact_categories": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "string",
+                    "enum": [
+                        "tech_stack",
+                        "frameworks",
+                        "dependencies",
+                        "current_patterns",
+                        "architecture",
+                        "file_structure",
+                        "configuration",
+                    ],
+                },
+            },
+            "allowed_capabilities": {
+                "type": "array",
+                "minItems": 1,
+                "items": {"type": "string", "enum": ["inspect_code"]},
+                "description": "Runtime capability used for local code facts.",
+            },
+            "repo_inspection_tool_capabilities": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": True,
+                    "required": [
+                        "tool_name",
+                        "stable_id",
+                        "source_kind",
+                        "source_name",
+                        "input_schema",
+                        "mutation_class",
+                        "parallel_safety",
+                        "interruptibility",
+                        "approval_class",
+                        "origin",
+                        "scope",
+                        "execution_mode",
+                        "logical_capability",
+                        "side_effects",
+                        "fallback_used",
+                    ],
+                    "properties": {
+                        "tool_name": {"type": "string", "enum": ["Read", "Glob", "Grep"]},
+                        "source_kind": {"const": "builtin"},
+                        "execution_mode": {"const": "repo_inspection"},
+                        "logical_capability": {"const": "inspect_code"},
+                        "fallback_used": {"const": False},
+                    },
+                },
+                "description": (
+                    "Concrete runtime repo-inspection tools a code-fact "
+                    "subagent can use to satisfy allowed_capabilities=inspect_code."
+                ),
+            },
+            "confidence_policy": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "auto_confirm_when",
+                    "confirmation_required_when",
+                    "human_judgment_when",
+                ],
+                "properties": {
+                    "auto_confirm_when": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "confirmation_required_when": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                    "human_judgment_when": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                    },
+                },
+            },
+            "answer_prefixes": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "string",
+                    "enum": ["[from-code]", "[from-code][auto-confirmed]"],
+                },
+            },
+            "answer_contract": {
+                "const": _interview_code_investigation_answer_contract(),
+                "description": "Exact response contract attached to this investigation request.",
+            },
+            "mcp_tool_capability": {
+                "type": "object",
+                "additionalProperties": True,
+                "required": [
+                    "tool_name",
+                    "stable_id",
+                    "source_kind",
+                    "source_name",
+                    "input_schema",
+                    "mutation_class",
+                    "execution_mode",
+                    "companions",
+                    "required_context_keys",
+                    "mutation_targets",
+                    "state_mutations",
+                    "side_effects",
+                    "retry",
+                    "interrupt",
+                    "cancel",
+                    "fallback_used",
+                    "orchestration",
+                ],
+                "properties": {
+                    "tool_name": {"const": "ouroboros_interview"},
+                    "fallback_used": {"const": False},
+                },
+                "description": (
+                    "Explicit Ouroboros-owned MCP capability metadata for the "
+                    "tool that emitted this investigation request."
+                ),
+            },
+        },
+    }
+
+
+def _interview_code_investigation_answer_contract() -> dict[str, Any]:
+    """Return the answer contract for one code-fact investigation request."""
+    answer_schema: dict[str, Any] = {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [
+            "session_id",
+            "question_identity",
+            "answer_prefix",
+            "answer_text",
+            "confidence",
+            "evidence",
+            "requires_user_confirmation",
+        ],
+        "properties": {
+            "session_id": {
+                "type": "string",
+                "description": "Current Ouroboros interview session ID.",
+            },
+            "question_identity": {
+                "type": "string",
+                "pattern": r"^interview-question:[0-9a-f]{16}$",
+                "description": "Matches the originating code investigation request.",
+            },
+            "answer_prefix": {
+                "type": "string",
+                "enum": ["[from-code]", "[from-code][auto-confirmed]"],
+                "description": "Prefix to prepend when forwarding the answer to interview MCP.",
+            },
+            "answer_text": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Concise descriptive fact answer without prescription.",
+            },
+            "confidence": {
+                "type": "string",
+                "enum": ["high_exact_match", "medium_inferred", "low_uncertain"],
+            },
+            "evidence": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["source", "claim"],
+                    "properties": {
+                        "source": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Repository-relative file, symbol, or manifest source.",
+                        },
+                        "claim": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "The factual claim supported by this evidence.",
+                        },
+                        "locator": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Optional line, key, dependency, or symbol locator.",
+                        },
+                    },
+                },
+            },
+            "requires_user_confirmation": {
+                "type": "boolean",
+                "description": "True when the answer must be confirmed before forwarding.",
+            },
+            "user_confirmation_prompt": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Prompt text to show when confirmation is required.",
+            },
+        },
+        "allOf": [
+            {
+                "if": {
+                    "properties": {
+                        "answer_prefix": {"const": "[from-code][auto-confirmed]"}
+                    },
+                    "required": ["answer_prefix"],
+                },
+                "then": {
+                    "properties": {
+                        "confidence": {"const": "high_exact_match"},
+                        "requires_user_confirmation": {"const": False},
+                    }
+                },
+            },
+            {
+                "if": {
+                    "properties": {"requires_user_confirmation": {"const": True}},
+                    "required": ["requires_user_confirmation"],
+                },
+                "then": {"required": ["user_confirmation_prompt"]},
+            },
+        ],
+    }
+    return {
+        "contract_id": "code_fact_investigation_answer.v1",
+        "scope": "single_code_fact_investigation_request",
+        "response_model_schema": answer_schema,
+        "prefix_semantics": {
+            "[from-code][auto-confirmed]": {
+                "confidence": "high_exact_match",
+                "requires_user_confirmation": False,
+                "forwarding": "send_to_mcp_immediately",
+            },
+            "[from-code]": {
+                "confidence": "medium_or_low",
+                "requires_user_confirmation": True,
+                "forwarding": "confirm_with_user_before_mcp",
+            },
+        },
+        "evidence_policy": {
+            "minimum_items": 1,
+            "source_format": "repository_relative_path_or_symbol",
+            "server_local_paths_allowed": False,
+        },
+        "runtime_instruction": (
+            "Produce exactly one structured answer payload for the originating "
+            "question_identity. Use [from-code][auto-confirmed] only for an "
+            "unambiguous manifest/config exact match; otherwise require user "
+            "confirmation and use [from-code] after confirmation."
+        ),
+    }
+
+
+def interview_code_investigation_answer_contract() -> dict[str, Any]:
+    """Return the public code-fact answer contract for generated requests."""
+    return _interview_code_investigation_answer_contract()
+
+
+def _code_investigation_repo_inspection_tool_capabilities() -> tuple[dict[str, Any], ...]:
+    """Return concrete repo-inspection tool capabilities for code-fact subagents."""
+    tool_schemas: Mapping[str, Mapping[str, Any]] = {
+        "Read": {
+            "type": "object",
+            "additionalProperties": True,
+            "required": ["file_path"],
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Repository-local file path to inspect.",
+                },
+                "offset": {"type": "integer", "minimum": 1},
+                "limit": {"type": "integer", "minimum": 1},
+            },
+        },
+        "Glob": {
+            "type": "object",
+            "additionalProperties": True,
+            "required": ["pattern"],
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Repository-local glob pattern to enumerate.",
+                },
+                "path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Optional repository-local search root.",
+                },
+            },
+        },
+        "Grep": {
+            "type": "object",
+            "additionalProperties": True,
+            "required": ["pattern"],
+            "properties": {
+                "pattern": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Search pattern for repository-local evidence.",
+                },
+                "path": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Optional repository-local file or directory scope.",
+                },
+                "glob": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Optional file glob narrowing the search.",
+                },
+            },
+        },
+    }
+    capabilities: list[dict[str, Any]] = []
+    for tool_name in ("Read", "Glob", "Grep"):
+        semantics = _BUILTIN_SEMANTICS[tool_name]
+        capabilities.append(
+            {
+                "tool_name": tool_name,
+                "stable_id": f"builtin:{tool_name}",
+                "source_kind": "builtin",
+                "source_name": "built-in",
+                "input_schema": dict(tool_schemas[tool_name]),
+                "mutation_class": semantics.mutation_class.value,
+                "parallel_safety": semantics.parallel_safety.value,
+                "interruptibility": semantics.interruptibility.value,
+                "approval_class": semantics.approval_class.value,
+                "origin": semantics.origin.value,
+                "scope": semantics.scope.value,
+                "execution_mode": "repo_inspection",
+                "logical_capability": "inspect_code",
+                "side_effects": ["side_effect_free"],
+                "fallback_used": False,
+            }
+        )
+    return tuple(capabilities)
+
+
+def _serialized_metadata_for_descriptor(
+    descriptor: CapabilityDescriptor,
+) -> dict[str, Any] | None:
+    if descriptor.metadata is None:
+        return None
+    return {
+        "input_schema": dict(descriptor.metadata.input_schema),
+        "mutation_class": descriptor.metadata.mutation_class,
+        "execution_mode": descriptor.metadata.execution_mode,
+        "companions": list(descriptor.metadata.companions),
+        "required_context_keys": list(descriptor.metadata.required_context_keys),
+        "mutation_targets": list(descriptor.metadata.mutation_targets),
+        "state_mutations": [
+            {
+                key: list(value) if isinstance(value, tuple) else value
+                for key, value in mutation.items()
+            }
+            for mutation in descriptor.metadata.state_mutations
+        ],
+        "side_effects": list(descriptor.metadata.side_effects),
+        "retry": dict(descriptor.metadata.retry),
+        "interrupt": dict(descriptor.metadata.interrupt),
+        "cancel": {
+            key: list(value) if isinstance(value, tuple) else value
+            for key, value in descriptor.metadata.cancel.items()
+        },
+        "fallback_used": descriptor.metadata.fallback_used,
+        "orchestration": dict(descriptor.metadata.orchestration),
+    }
+
+
+_REQUIRED_TOOL_METADATA_FIELDS = frozenset(
+    {
+        "input_schema",
+        "mutation_class",
+        "execution_mode",
+        "companions",
+        "required_context_keys",
+        "mutation_targets",
+        "state_mutations",
+        "side_effects",
+        "retry",
+        "interrupt",
+        "cancel",
+        "fallback_used",
+        "orchestration",
+    }
+)
+
+
+def _string_tuple_from_payload(value: Any) -> tuple[str, ...]:
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return tuple(str(item) for item in value if isinstance(item, str))
+    return ()
+
+
+def _normalize_tuple_fields(
+    raw: Mapping[str, Any],
+    tuple_fields: frozenset[str],
+) -> dict[str, Any]:
+    """Return a shallow metadata mapping with selected sequence fields as tuples."""
+    return {
+        key: _string_tuple_from_payload(value) if key in tuple_fields else value
+        for key, value in raw.items()
+    }
+
+
+def validate_capability_tool_metadata(
+    metadata: CapabilityToolMetadata,
+    *,
+    tool_name: str = "<unknown>",
+    owned_tool: bool = False,
+) -> None:
+    """Validate the runtime-facing tool-specific metadata contract.
+
+    Owned Ouroboros MCP tools must carry explicit metadata instead of inferred
+    fallback fields. Generic attached MCP metadata may still validate as a
+    fallback contract, but callers can set ``owned_tool=True`` to reject it.
+    """
+    if not isinstance(metadata.input_schema, Mapping):
+        raise ValueError(f"{tool_name}: input_schema must be a mapping")
+    if metadata.input_schema.get("type") != "object":
+        raise ValueError(f"{tool_name}: input_schema.type must be object")
+    if not isinstance(metadata.input_schema.get("properties"), Mapping):
+        raise ValueError(f"{tool_name}: input_schema.properties must be a mapping")
+    required = metadata.input_schema.get("required")
+    if not isinstance(required, Sequence) or isinstance(required, str):
+        raise ValueError(f"{tool_name}: input_schema.required must be a sequence")
+
+    try:
+        mutation_class = CapabilityMutationClass(str(metadata.mutation_class))
+    except ValueError as exc:
+        raise ValueError(f"{tool_name}: invalid mutation_class") from exc
+
+    if not metadata.execution_mode:
+        raise ValueError(f"{tool_name}: execution_mode is required")
+    if not isinstance(metadata.companions, tuple) or not all(
+        isinstance(companion, str) for companion in metadata.companions
+    ):
+        raise ValueError(f"{tool_name}: companions must be a tuple of strings")
+    if not isinstance(metadata.required_context_keys, tuple) or not all(
+        isinstance(key, str) for key in metadata.required_context_keys
+    ):
+        raise ValueError(
+            f"{tool_name}: required_context_keys must be a tuple of strings"
+        )
+    if not isinstance(metadata.mutation_targets, tuple) or not all(
+        isinstance(target, str) for target in metadata.mutation_targets
+    ):
+        raise ValueError(f"{tool_name}: mutation_targets must be a tuple of strings")
+    if not isinstance(metadata.state_mutations, tuple) or not all(
+        isinstance(mutation, Mapping) for mutation in metadata.state_mutations
+    ):
+        raise ValueError(f"{tool_name}: state_mutations must be a tuple of mappings")
+    if not isinstance(metadata.side_effects, tuple) or not all(
+        isinstance(effect, str) for effect in metadata.side_effects
+    ):
+        raise ValueError(f"{tool_name}: side_effects must be a tuple of strings")
+    if (
+        mutation_class is not CapabilityMutationClass.READ_ONLY
+        and not metadata.side_effects
+    ):
+        raise ValueError(
+            f"{tool_name}: mutating capabilities require explicit side_effects"
+        )
+    if (
+        mutation_class is not CapabilityMutationClass.READ_ONLY
+        and not metadata.mutation_targets
+    ):
+        raise ValueError(
+            f"{tool_name}: mutating capabilities require explicit mutation_targets"
+        )
+    for mutation in metadata.state_mutations:
+        if set(mutation) != {"target", "operation", "side_effect", "context_keys"}:
+            raise ValueError(
+                f"{tool_name}: each state mutation must contain target, "
+                "operation, side_effect, and context_keys"
+            )
+        if not all(
+            isinstance(mutation[key], str) and mutation[key]
+            for key in ("target", "operation", "side_effect")
+        ):
+            raise ValueError(
+                f"{tool_name}: state mutation target, operation, and side_effect "
+                "must be non-empty strings"
+            )
+        if not isinstance(mutation["context_keys"], tuple) or not all(
+            isinstance(key, str) for key in mutation["context_keys"]
+        ):
+            raise ValueError(
+                f"{tool_name}: state mutation context_keys must be a tuple of strings"
+            )
+        if mutation["target"] not in metadata.mutation_targets:
+            raise ValueError(
+                f"{tool_name}: state mutation target must be listed in mutation_targets"
+            )
+        if mutation["side_effect"] not in metadata.side_effects:
+            raise ValueError(
+                f"{tool_name}: state mutation side_effect must be listed in side_effects"
+            )
+
+    if set(metadata.retry) != {"supported", "mode"}:
+        raise ValueError(f"{tool_name}: retry must contain supported and mode")
+    if not isinstance(metadata.retry["supported"], bool) or not isinstance(
+        metadata.retry["mode"], str
+    ) or not metadata.retry["mode"]:
+        raise ValueError(f"{tool_name}: retry has invalid supported or mode")
+
+    interrupt_keys = set(metadata.interrupt)
+    if metadata.interrupt.get("execution_mode") == "blocking":
+        expected_interrupt_keys = {
+            "supported",
+            "mode",
+            "execution_mode",
+            "blocking_semantics",
+            "resumable",
+            "background_companions",
+            "target_context_keys",
+        }
+        if interrupt_keys != expected_interrupt_keys:
+            raise ValueError(
+                f"{tool_name}: blocking interrupt must contain supported, mode, "
+                "execution_mode, blocking_semantics, resumable, "
+                "background_companions, and target_context_keys"
+            )
+        if metadata.interrupt["execution_mode"] != "blocking":
+            raise ValueError(f"{tool_name}: blocking interrupt execution_mode mismatch")
+        if not isinstance(metadata.interrupt["blocking_semantics"], str) or not metadata.interrupt[
+            "blocking_semantics"
+        ]:
+            raise ValueError(
+                f"{tool_name}: blocking interrupt requires blocking_semantics"
+            )
+        if not isinstance(metadata.interrupt["resumable"], bool):
+            raise ValueError(f"{tool_name}: blocking interrupt resumable must be a bool")
+        if not isinstance(metadata.interrupt["background_companions"], tuple):
+            raise ValueError(
+                f"{tool_name}: blocking interrupt background_companions must be a tuple"
+            )
+        if not isinstance(metadata.interrupt["target_context_keys"], tuple):
+            raise ValueError(
+                f"{tool_name}: blocking interrupt target_context_keys must be a tuple"
+            )
+    elif metadata.interrupt.get("mode") == "resumable_background_job":
+        expected_interrupt_keys = {
+            "supported",
+            "mode",
+            "resumable",
+            "cancellable",
+            "resume_companions",
+            "cancel_companions",
+            "target_context_keys",
+        }
+        if interrupt_keys != expected_interrupt_keys:
+            raise ValueError(
+                f"{tool_name}: background interrupt must contain "
+                "supported, mode, resumable, cancellable, resume_companions, "
+                "cancel_companions, and target_context_keys"
+            )
+        if not isinstance(metadata.interrupt["resumable"], bool) or not isinstance(
+            metadata.interrupt["cancellable"], bool
+        ):
+            raise ValueError(
+                f"{tool_name}: background interrupt resumable/cancellable "
+                "must be booleans"
+            )
+        if not isinstance(metadata.interrupt["resume_companions"], tuple):
+            raise ValueError(
+                f"{tool_name}: background interrupt resume_companions must be a tuple"
+            )
+        if not isinstance(metadata.interrupt["cancel_companions"], tuple):
+            raise ValueError(
+                f"{tool_name}: background interrupt cancel_companions must be a tuple"
+            )
+        if not isinstance(metadata.interrupt["target_context_keys"], tuple):
+            raise ValueError(
+                f"{tool_name}: background interrupt target_context_keys must be a tuple"
+            )
+        if metadata.interrupt["resumable"] and not metadata.interrupt[
+            "resume_companions"
+        ]:
+            raise ValueError(
+                f"{tool_name}: resumable background interrupt requires resume companions"
+            )
+        if metadata.interrupt["cancellable"] and not metadata.interrupt[
+            "cancel_companions"
+        ]:
+            raise ValueError(
+                f"{tool_name}: cancellable background interrupt requires cancel companions"
+            )
+        if not metadata.interrupt["target_context_keys"]:
+            raise ValueError(
+                f"{tool_name}: background interrupt requires target context keys"
+            )
+    elif metadata.interrupt.get("mode") == "read_only_non_mutating":
+        expected_interrupt_keys = {
+            "supported",
+            "mode",
+            "mutation_semantics",
+            "resumable",
+            "target_context_keys",
+        }
+        if interrupt_keys != expected_interrupt_keys:
+            raise ValueError(
+                f"{tool_name}: read-only interrupt must contain supported, mode, "
+                "mutation_semantics, resumable, and target_context_keys"
+            )
+        if metadata.interrupt["supported"] is not True:
+            raise ValueError(f"{tool_name}: read-only interrupt must be supported")
+        if metadata.interrupt["mutation_semantics"] != "no_state_mutation":
+            raise ValueError(
+                f"{tool_name}: read-only interrupt must declare no_state_mutation"
+            )
+        if metadata.interrupt["resumable"] is not False:
+            raise ValueError(f"{tool_name}: read-only interrupt is not resumable")
+        if not isinstance(metadata.interrupt["target_context_keys"], tuple):
+            raise ValueError(
+                f"{tool_name}: read-only interrupt target_context_keys must be a tuple"
+            )
+        if metadata.interrupt["target_context_keys"]:
+            raise ValueError(
+                f"{tool_name}: read-only interrupt must not require context keys"
+            )
+    elif metadata.interrupt.get("mode") == "terminal_control":
+        expected_interrupt_keys = {
+            "supported",
+            "mode",
+            "terminal_action",
+            "target_type",
+            "target_context_keys",
+            "directive_semantics",
+            "terminal_statuses",
+            "idempotent",
+        }
+        if interrupt_keys != expected_interrupt_keys:
+            raise ValueError(
+                f"{tool_name}: terminal-control interrupt must contain supported, "
+                "mode, terminal_action, target_type, target_context_keys, "
+                "directive_semantics, terminal_statuses, and idempotent"
+            )
+        if metadata.interrupt["supported"] is not True:
+            raise ValueError(
+                f"{tool_name}: terminal-control interrupt must be supported"
+            )
+        if metadata.interrupt["terminal_action"] != "cancel":
+            raise ValueError(
+                f"{tool_name}: terminal-control interrupt action must be cancel"
+            )
+        if not isinstance(metadata.interrupt["target_type"], str) or not metadata.interrupt[
+            "target_type"
+        ]:
+            raise ValueError(
+                f"{tool_name}: terminal-control interrupt requires target_type"
+            )
+        if not isinstance(metadata.interrupt["target_context_keys"], tuple) or not metadata.interrupt[
+            "target_context_keys"
+        ]:
+            raise ValueError(
+                f"{tool_name}: terminal-control interrupt requires target context keys"
+            )
+        if not isinstance(metadata.interrupt["directive_semantics"], str) or not metadata.interrupt[
+            "directive_semantics"
+        ]:
+            raise ValueError(
+                f"{tool_name}: terminal-control interrupt requires directive semantics"
+            )
+        if not isinstance(metadata.interrupt["terminal_statuses"], tuple) or not metadata.interrupt[
+            "terminal_statuses"
+        ]:
+            raise ValueError(
+                f"{tool_name}: terminal-control interrupt requires terminal statuses"
+            )
+        if not all(
+            isinstance(status, str) and status
+            for status in metadata.interrupt["terminal_statuses"]
+        ):
+            raise ValueError(
+                f"{tool_name}: terminal-control interrupt terminal statuses must be strings"
+            )
+        if not isinstance(metadata.interrupt["idempotent"], bool):
+            raise ValueError(
+                f"{tool_name}: terminal-control interrupt idempotent must be a bool"
+            )
+    elif interrupt_keys != {"supported", "mode"}:
+        raise ValueError(f"{tool_name}: interrupt must contain supported and mode")
+    if not isinstance(metadata.interrupt["supported"], bool) or not isinstance(
+        metadata.interrupt["mode"], str
+    ) or not metadata.interrupt["mode"]:
+        raise ValueError(f"{tool_name}: interrupt has invalid supported or mode")
+
+    if set(metadata.cancel) != {
+        "supported",
+        "mode",
+        "companions",
+        "target_context_keys",
+    }:
+        raise ValueError(
+            f"{tool_name}: cancel must contain supported, mode, companions, "
+            "and target_context_keys"
+        )
+    if not isinstance(metadata.cancel["supported"], bool) or not isinstance(
+        metadata.cancel["mode"], str
+    ) or not metadata.cancel["mode"]:
+        raise ValueError(f"{tool_name}: cancel has invalid supported or mode")
+    if not isinstance(metadata.cancel["companions"], tuple):
+        raise ValueError(f"{tool_name}: cancel.companions must be a tuple")
+    if not isinstance(metadata.cancel["target_context_keys"], tuple):
+        raise ValueError(f"{tool_name}: cancel.target_context_keys must be a tuple")
+    if metadata.cancel["supported"] and (
+        not metadata.cancel["companions"]
+        or not metadata.cancel["target_context_keys"]
+    ):
+        raise ValueError(
+            f"{tool_name}: supported cancel requires companions and context keys"
+        )
+    if not metadata.cancel["supported"] and (
+        metadata.cancel["companions"] or metadata.cancel["target_context_keys"]
+    ):
+        raise ValueError(
+            f"{tool_name}: unsupported cancel must carry explicit empty tuples"
+        )
+
+    if not isinstance(metadata.fallback_used, bool):
+        raise ValueError(f"{tool_name}: fallback_used must be a boolean")
+    if owned_tool and metadata.fallback_used:
+        raise ValueError(f"{tool_name}: owned tool metadata cannot use fallback")
+    if not isinstance(metadata.orchestration, Mapping):
+        raise ValueError(f"{tool_name}: orchestration must be a mapping")
+
+
+def _normalize_embedded_ouroboros_tool_capability_metadata(
+    raw_capability: Any,
+) -> dict[str, Any] | None:
+    """Normalize explicit embedded owned-tool metadata without rediscovery.
+
+    Code-fact investigation requests cross runtime boundaries as standalone
+    JSON payloads. Consumers may not have the Ouroboros MCP repository or live
+    tool catalog available, so this helper treats the embedded capability
+    object as the source of truth and refuses to synthesize missing required
+    fields from local definitions.
+    """
+    if not isinstance(raw_capability, Mapping):
+        return None
+    if not _REQUIRED_TOOL_METADATA_FIELDS.issubset(raw_capability):
+        return None
+    if raw_capability.get("fallback_used") is not False:
+        return None
+    tool_name = raw_capability.get("tool_name")
+    if not isinstance(tool_name, str) or not tool_name.startswith("ouroboros_"):
+        return None
+
+    input_schema = raw_capability.get("input_schema")
+    retry = raw_capability.get("retry")
+    interrupt = raw_capability.get("interrupt")
+    cancel = raw_capability.get("cancel")
+    orchestration = raw_capability.get("orchestration")
+    if (
+        not isinstance(input_schema, Mapping)
+        or not isinstance(retry, Mapping)
+        or not isinstance(interrupt, Mapping)
+        or not isinstance(cancel, Mapping)
+        or not isinstance(orchestration, Mapping)
+    ):
+        return None
+
+    return {
+        "tool_name": tool_name,
+        "stable_id": str(raw_capability.get("stable_id", "")),
+        "source_kind": str(raw_capability.get("source_kind", "")),
+        "source_name": str(raw_capability.get("source_name", "")),
+        "input_schema": dict(input_schema),
+        "mutation_class": str(raw_capability.get("mutation_class", "")),
+        "execution_mode": str(raw_capability.get("execution_mode", "")),
+        "companions": list(_string_tuple_from_payload(raw_capability.get("companions"))),
+        "required_context_keys": list(
+            _string_tuple_from_payload(raw_capability.get("required_context_keys"))
+        ),
+        "mutation_targets": list(
+            _string_tuple_from_payload(raw_capability.get("mutation_targets"))
+        ),
+        "state_mutations": [
+            {
+                "target": str(mutation.get("target", "")),
+                "operation": str(mutation.get("operation", "")),
+                "side_effect": str(mutation.get("side_effect", "")),
+                "context_keys": list(
+                    _string_tuple_from_payload(mutation.get("context_keys"))
+                ),
+            }
+            for mutation in raw_capability.get("state_mutations", ())
+            if isinstance(mutation, Mapping)
+        ],
+        "side_effects": list(
+            _string_tuple_from_payload(raw_capability.get("side_effects"))
+        ),
+        "retry": dict(retry),
+        "interrupt": dict(interrupt),
+        "cancel": dict(cancel),
+        "fallback_used": False,
+        "orchestration": dict(orchestration),
+    }
+
+
+def deserialize_code_investigation_request_metadata(
+    payload: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Rehydrate code-fact investigation metadata from its request payload.
+
+    The deserialized request preserves explicit Ouroboros MCP tool-specific
+    capability fields from ``mcp_tool_capability``. It intentionally does not
+    call ``get_ouroboros_tools()`` or rebuild the capability graph; the request
+    payload must already carry the explicit capability contract emitted by the
+    interview MCP handler.
+    """
+    if not isinstance(payload, Mapping):
+        return None
+
+    capability = _normalize_embedded_ouroboros_tool_capability_metadata(
+        payload.get("mcp_tool_capability")
+    )
+    if capability is None:
+        return None
+
+    normalized = dict(payload)
+    normalized["mcp_tool_capability"] = capability
+    return normalized
+
+
+def ouroboros_tool_capability_metadata(tool_name: str) -> dict[str, Any]:
+    """Return explicit JSON-safe capability metadata for one owned MCP tool."""
+    canonical_name = _ouroboros_tool_name_from_identifier(tool_name)
+    if canonical_name is None:
+        raise KeyError(f"Unknown Ouroboros MCP tool: {tool_name}")
+
+    metadata_model = lookup_ouroboros_tool_capability_metadata(canonical_name)
+    if metadata_model is None:
+        raise KeyError(f"Ouroboros MCP tool has no metadata: {tool_name}")
+    if metadata_model.fallback_used:
+        raise KeyError(f"Ouroboros MCP tool used fallback metadata: {tool_name}")
+
+    definitions = _ouroboros_tool_definitions_by_name()
+    descriptor = _descriptor_from_tool(definitions[canonical_name])
+    metadata = _serialized_metadata_for_descriptor(descriptor)
+    if metadata is None:
+        raise KeyError(f"Ouroboros MCP tool has no metadata: {tool_name}")
+    return {
+        "tool_name": descriptor.name,
+        "stable_id": descriptor.stable_id,
+        "source_kind": descriptor.source_kind,
+        "source_name": descriptor.source_name,
+        **metadata,
+    }
+
+
+def _lateral_persona_panel_request_schema() -> dict[str, Any]:
+    """Return the structured request model for lateral persona panels."""
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": ["problem_context", "current_approach"],
+        "properties": {
+            "problem_context": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The stuck state or problem being reframed.",
+            },
+            "current_approach": {
+                "type": "string",
+                "minLength": 1,
+                "description": "What has already been tried.",
+            },
+            "persona": {
+                "type": "string",
+                "enum": [
+                    "hacker",
+                    "researcher",
+                    "simplifier",
+                    "architect",
+                    "contrarian",
+                    "all",
+                ],
+            },
+            "personas": {
+                "type": "array",
+                "items": {
+                    "type": "string",
+                    "enum": [
+                        "hacker",
+                        "researcher",
+                        "simplifier",
+                        "architect",
+                        "contrarian",
+                    ],
+                },
+            },
+            "failed_attempts": {
+                "type": "array",
+                "items": {"type": "string"},
+            },
+        },
+    }
+
+
+def _lateral_persona_panel_metadata() -> LateralPersonaPanelMetadata:
+    """Return the metadata contract for lateral persona panel dispatch."""
+    persona_roles = (
+        ("hacker", "Finds unconventional workarounds"),
+        ("researcher", "Seeks additional information"),
+        ("simplifier", "Reduces complexity"),
+        ("architect", "Restructures the approach"),
+        ("contrarian", "Challenges assumptions"),
+    )
+    return LateralPersonaPanelMetadata(
+        panel_id="lateral_persona_panel.v1",
+        mcp_tool="ouroboros_lateral_think",
+        dispatch_modes=("plugin", "inline_fallback"),
+        parallel_preference="parallel_when_runtime_supports_subagents",
+        sequential_fallback={
+            "supported": True,
+            "mode": "sequential_persona_payload_dispatch",
+            "trigger": "runtime_has_no_native_parallel_subagent_primitive",
+        },
+        personas=tuple(
+            LateralPersonaMetadata(
+                persona_id=persona_id,
+                role=role,
+                prompt={
+                    "source": "build_lateral_multi_subagent",
+                    "payload_field": "payloads[].prompt",
+                    "context_field": "payloads[].context",
+                    "requires_prose_parsing": False,
+                },
+                response_payload_ref={
+                    "plugin": "MCPToolResult.meta._subagents[persona_id]",
+                    "inline_meta": "MCPToolResult.meta.payloads[persona_id]",
+                    "inline_content": (
+                        "content sentinel "
+                        "ouroboros-lateral-inline-dispatch-v1.payloads[persona_id]"
+                    ),
+                },
+            )
+            for persona_id, role in persona_roles
+        ),
+        request_model_schema=_lateral_persona_panel_request_schema(),
+        response_payload_refs={
+            "plugin": "MCPToolResult.meta._subagents",
+            "inline_meta": "MCPToolResult.meta.payloads",
+            "inline_content": (
+                "content sentinel ouroboros-lateral-inline-dispatch-v1.payloads"
+            ),
+            "result_correlation_key": "context.persona",
+            "requires_prose_parsing": False,
+        },
+        runtime_instruction=(
+            "Call ouroboros_lateral_think first. If the response delegates via "
+            "_subagents, consume those payloads. If it returns inline_fallback "
+            "and the runtime has a native subagent primitive, dispatch each "
+            "structured payload by context.persona; otherwise process those "
+            "payloads sequentially."
+        ),
+    )
+
+
+def _pm_interview_subagent_metadata() -> dict[str, Any]:
+    """Return the metadata contract for PM interview subagent dispatch."""
+    return {
+        "directive": "run_pm_interview_subagent",
+        "mcp_tool": "ouroboros_pm_interview",
+        "dispatch_modes": ["plugin"],
+        "payload_builder": "build_pm_interview_subagent",
+        "request_model_schema": {
+            "type": "object",
+            "additionalProperties": True,
+            "properties": {
+                "session_id": {"type": "string"},
+                "action": {
+                    "type": "string",
+                    "enum": ["start", "answer", "resume", "generate", "select_repos"],
+                    "default": "start",
+                },
+                "initial_context": {"type": "string"},
+                "answer": {"type": "string"},
+                "cwd": {"type": "string"},
+                "selected_repos": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+            },
+        },
+        "response_payload_refs": {
+            "plugin": "MCPToolResult.meta._subagent",
+            "content_json": "MCPToolResult.content[0].text._subagent",
+            "result_correlation_key": "context.session_id",
+            "requires_prose_parsing": False,
+        },
+        "subagent_context_keys": [
+            "session_id",
+            "action",
+            "initial_context",
+            "answer",
+            "cwd",
+            "selected_repos",
+        ],
+        "runtime_instruction": (
+            "Dispatch PM interview work through the `_subagent` payload produced "
+            "by build_pm_interview_subagent. Preserve session_id/action context "
+            "and consume the structured payload directly; do not infer PM "
+            "subagent routing from prose."
+        ),
+    }
+
+
+def _background_lifecycle_metadata_for_ouroboros_tool(name: str) -> Mapping[str, Any]:
+    """Return explicit job lifecycle companion metadata for background tools."""
+    if name not in _OUROBOROS_BACKGROUND_TOOLS:
+        return {}
+
+    definitions = _ouroboros_tool_definitions_by_name()
+    role_tools = {
+        role: tool_name
+        for role, tool_name in _OUROBOROS_BACKGROUND_LIFECYCLE_ROLE_TOOLS.items()
+        if tool_name in definitions
+    }
+
+    blocking_companion = _OUROBOROS_BACKGROUND_BLOCKING_COMPANIONS.get(name)
+    companion_roles: dict[str, str] = {"start": name}
+    if blocking_companion in definitions:
+        companion_roles["blocking"] = str(blocking_companion)
+    companion_roles.update(role_tools)
+    available_lifecycle_roles = tuple(
+        role for role in ("status", "wait", "result", "cancel") if role in role_tools
+    )
+
+    return {
+        "family_id": "background_job_lifecycle.v1",
+        "execution_mode": "background",
+        "companion_roles": companion_roles,
+        "required_result_context_keys": ("job_id",),
+        "cancel": _cancel_metadata_for_ouroboros_tool(name),
+        "runtime_instruction": (
+            "After the background tool returns a job_id, use available lifecycle "
+            f"companions: {', '.join(available_lifecycle_roles) or 'none'}."
+        ),
+    }
+
+
+def _job_lifecycle_sibling_metadata_for_ouroboros_tool(
+    name: str,
+) -> Mapping[str, Any]:
+    """Return generic job status/wait/result/cancel sibling metadata."""
+    sibling_roles = _available_job_lifecycle_sibling_roles()
+    if name not in sibling_roles.values():
+        return {}
+
+    current_role = next(
+        role for role, tool_name in sibling_roles.items() if tool_name == name
+    )
+    sibling_companions = {
+        role: tool_name
+        for role, tool_name in sibling_roles.items()
+        if tool_name != name
+    }
+    return {
+        "family_id": "generic_job_lifecycle_siblings.v1",
+        "role": current_role,
+        "companion_roles": sibling_roles,
+        "sibling_companions": sibling_companions,
+        "required_result_context_keys": ("job_id",),
+        "runtime_instruction": (
+            "This generic job lifecycle tool is part of the status/wait/result/"
+            "cancel sibling family. Use job_id to move between sibling tools."
+        ),
+    }
+
+
+def _run_family_metadata_for_ouroboros_tool(name: str) -> Mapping[str, Any]:
+    """Return explicit run/execute companion metadata for the primary run tool."""
+    if name != "ouroboros_execute_seed":
+        return {}
+
+    definitions = _ouroboros_tool_definitions_by_name()
+    role_candidates = {
+        "primary": "ouroboros_execute_seed",
+        "start": "ouroboros_start_execute_seed",
+        "execution_cancel": "ouroboros_cancel_execution",
+        **_OUROBOROS_BACKGROUND_LIFECYCLE_ROLE_TOOLS,
+    }
+    companion_roles = {
+        role: tool_name
+        for role, tool_name in role_candidates.items()
+        if tool_name in definitions
+    }
+    lifecycle_roles = tuple(
+        role
+        for role in ("start", "execution_cancel", "status", "wait", "result", "cancel")
+        if role in companion_roles
+    )
+
+    return {
+        "family_id": "run_execute_lifecycle.v1",
+        "execution_mode": "blocking",
+        "companion_roles": companion_roles,
+        "start_variant": companion_roles.get("start"),
+        "required_result_context_keys": {
+            "execution_cancel": ("execution_id",)
+            if "execution_cancel" in companion_roles
+            else (),
+            "background_job": ("job_id",)
+            if any(role in companion_roles for role in ("status", "wait", "result", "cancel"))
+            else (),
+        },
+        "cancel": _cancel_metadata_for_ouroboros_tool(name),
+        "runtime_instruction": (
+            "Use ouroboros_execute_seed for blocking run execution. Use the "
+            "start variant when background execution is required, then follow "
+            f"available lifecycle companions: {', '.join(lifecycle_roles) or 'none'}."
+        ),
+    }
+
+
+def _evaluate_family_metadata_for_ouroboros_tool(name: str) -> Mapping[str, Any]:
+    """Return explicit evaluate companion metadata for the primary evaluate tool."""
+    if name != "ouroboros_evaluate":
+        return {}
+
+    definitions = _ouroboros_tool_definitions_by_name()
+    role_candidates = {
+        "primary": "ouroboros_evaluate",
+        "start": "ouroboros_start_evaluate",
+        "checklist_verify": "ouroboros_checklist_verify",
+        "measure_drift": "ouroboros_measure_drift",
+        "qa": "ouroboros_qa",
+        **_OUROBOROS_BACKGROUND_LIFECYCLE_ROLE_TOOLS,
+    }
+    companion_roles = {
+        role: tool_name
+        for role, tool_name in role_candidates.items()
+        if tool_name in definitions
+    }
+    lifecycle_roles = tuple(
+        role
+        for role in (
+            "start",
+            "checklist_verify",
+            "measure_drift",
+            "qa",
+            "status",
+            "wait",
+            "result",
+            "cancel",
+        )
+        if role in companion_roles
+    )
+
+    return {
+        "family_id": "evaluate_lifecycle.v1",
+        "execution_mode": "blocking",
+        "companion_roles": companion_roles,
+        "start_variant": companion_roles.get("start"),
+        "required_result_context_keys": {
+            "background_job": ("job_id",)
+            if any(role in companion_roles for role in ("status", "wait", "result", "cancel"))
+            else (),
+        },
+        "cancel": _cancel_metadata_for_ouroboros_tool(name),
+        "background_cancel": _cancel_metadata_for_ouroboros_tool(
+            "ouroboros_start_evaluate"
+        )
+        if "start" in companion_roles
+        else _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+        "runtime_instruction": (
+            "Use ouroboros_evaluate for blocking evaluation. Use the start "
+            "variant when background evaluation is required, then follow "
+            f"available evaluate family companions: {', '.join(lifecycle_roles) or 'none'}."
+        ),
+    }
+
+
+def _evolve_family_metadata_for_ouroboros_tool(name: str) -> Mapping[str, Any]:
+    """Return explicit evolve companion metadata for the primary evolve tool."""
+    if name != "ouroboros_evolve_step":
+        return {}
+
+    definitions = _ouroboros_tool_definitions_by_name()
+    role_candidates = {
+        "primary": "ouroboros_evolve_step",
+        "start": "ouroboros_start_evolve_step",
+        "lineage_status": "ouroboros_lineage_status",
+        "rewind": "ouroboros_evolve_rewind",
+        "ralph": "ouroboros_ralph",
+        "start_ralph": "ouroboros_start_ralph",
+        **_OUROBOROS_BACKGROUND_LIFECYCLE_ROLE_TOOLS,
+    }
+    companion_roles = {
+        role: tool_name
+        for role, tool_name in role_candidates.items()
+        if tool_name in definitions
+    }
+    lifecycle_roles = tuple(
+        role
+        for role in (
+            "start",
+            "lineage_status",
+            "rewind",
+            "ralph",
+            "start_ralph",
+            "status",
+            "wait",
+            "result",
+            "cancel",
+        )
+        if role in companion_roles
+    )
+
+    return {
+        "family_id": "evolve_lifecycle.v1",
+        "execution_mode": "blocking",
+        "companion_roles": companion_roles,
+        "start_variant": companion_roles.get("start"),
+        "required_result_context_keys": {
+            "lineage": ("lineage_id",)
+            if any(
+                role in companion_roles
+                for role in ("lineage_status", "rewind", "ralph", "start_ralph")
+            )
+            else (),
+            "background_job": ("job_id",)
+            if any(role in companion_roles for role in ("status", "wait", "result", "cancel"))
+            else (),
+        },
+        "cancel": _cancel_metadata_for_ouroboros_tool(name),
+        "background_cancel": _cancel_metadata_for_ouroboros_tool(
+            "ouroboros_start_evolve_step"
+        )
+        if "start" in companion_roles
+        else _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+        "runtime_instruction": (
+            "Use ouroboros_evolve_step for blocking evolution. Use the start "
+            "variant when background evolution is required, then follow "
+            f"available evolve family companions: {', '.join(lifecycle_roles) or 'none'}."
+        ),
+    }
+
+
+def _ralph_family_metadata_for_ouroboros_tool(name: str) -> Mapping[str, Any]:
+    """Return explicit Ralph companion metadata for the primary Ralph tool."""
+    if name != "ouroboros_ralph":
+        return {}
+
+    definitions = _ouroboros_tool_definitions_by_name()
+    role_candidates = {
+        "primary": "ouroboros_ralph",
+        "start": "ouroboros_start_ralph",
+        "evolve_step": "ouroboros_evolve_step",
+        "start_evolve_step": "ouroboros_start_evolve_step",
+        "lineage_status": "ouroboros_lineage_status",
+        "rewind": "ouroboros_evolve_rewind",
+        **_OUROBOROS_BACKGROUND_LIFECYCLE_ROLE_TOOLS,
+    }
+    companion_roles = {
+        role: tool_name
+        for role, tool_name in role_candidates.items()
+        if tool_name in definitions
+    }
+    lifecycle_roles = tuple(
+        role
+        for role in (
+            "start",
+            "evolve_step",
+            "start_evolve_step",
+            "lineage_status",
+            "rewind",
+            "status",
+            "wait",
+            "result",
+            "cancel",
+        )
+        if role in companion_roles
+    )
+
+    return {
+        "family_id": "ralph_lifecycle.v1",
+        "execution_mode": "blocking",
+        "companion_roles": companion_roles,
+        "start_variant": companion_roles.get("start"),
+        "required_result_context_keys": {
+            "lineage": ("lineage_id",)
+            if any(
+                role in companion_roles
+                for role in (
+                    "evolve_step",
+                    "start_evolve_step",
+                    "lineage_status",
+                    "rewind",
+                )
+            )
+            else (),
+            "background_job": ("job_id",)
+            if any(role in companion_roles for role in ("status", "wait", "result", "cancel"))
+            else (),
+        },
+        "cancel": _cancel_metadata_for_ouroboros_tool(name),
+        "background_cancel": _cancel_metadata_for_ouroboros_tool(
+            "ouroboros_start_ralph"
+        )
+        if "start" in companion_roles
+        else _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
+        "runtime_instruction": (
+            "Use ouroboros_ralph for blocking Ralph loop orchestration. Use "
+            "the start variant when background Ralph execution is required, "
+            "then follow available Ralph family companions: "
+            f"{', '.join(lifecycle_roles) or 'none'}."
+        ),
+    }
+
+
+def _orchestration_metadata_for_ouroboros_tool(name: str) -> Mapping[str, Any]:
+    metadata: dict[str, Any] = {}
+    lifecycle_metadata = _background_lifecycle_metadata_for_ouroboros_tool(name)
+    if lifecycle_metadata:
+        metadata["background_lifecycle"] = lifecycle_metadata
+    job_lifecycle_siblings = _job_lifecycle_sibling_metadata_for_ouroboros_tool(name)
+    if job_lifecycle_siblings:
+        metadata["job_lifecycle_siblings"] = job_lifecycle_siblings
+    run_family_metadata = _run_family_metadata_for_ouroboros_tool(name)
+    if run_family_metadata:
+        metadata["run_family"] = run_family_metadata
+    evaluate_family_metadata = _evaluate_family_metadata_for_ouroboros_tool(name)
+    if evaluate_family_metadata:
+        metadata["evaluate_family"] = evaluate_family_metadata
+    evolve_family_metadata = _evolve_family_metadata_for_ouroboros_tool(name)
+    if evolve_family_metadata:
+        metadata["evolve_family"] = evolve_family_metadata
+    ralph_family_metadata = _ralph_family_metadata_for_ouroboros_tool(name)
+    if ralph_family_metadata:
+        metadata["ralph_family"] = ralph_family_metadata
+    if name == "ouroboros_pm_interview":
+        return {**metadata, "pm_interview_subagent": _pm_interview_subagent_metadata()}
+    if name not in {"ouroboros_interview", "ouroboros_lateral_think"}:
+        return metadata
+    lateral_panel = _lateral_persona_panel_metadata().to_dict()
+    if name == "ouroboros_lateral_think":
+        return {**metadata, "lateral_panel": lateral_panel}
+    return {
+        **metadata,
+        "code_investigation": {
+            "request_model_schema": _interview_code_investigation_request_schema(),
+            "answer_contract": _interview_code_investigation_answer_contract(),
+            "repo_inspection_tool_capabilities": _code_investigation_repo_inspection_tool_capabilities(),
+            "question_identity": {
+                "source_field": "question",
+                "helper": "stable_code_investigation_question_identity",
+                "algorithm": "sha256",
+                "digest_chars": 16,
+                "normalization": "NFKC + trim + whitespace collapse",
+                "format": "interview-question:{digest}",
+                "deterministic": True,
+            },
+            "derivation_sources": (
+                "get_ouroboros_tools().ouroboros_interview.definition",
+                "skills/interview/SKILL.md inspect_code PATH 1",
+            ),
+            "runtime_instruction": (
+                "Use the active runtime inspect_code capability for descriptive "
+                "repo-local facts before continuing the interview. Route any "
+                "decision or low-confidence confirmation to the user."
+            ),
+        },
+        "lateral_panel": lateral_panel,
+    }
+
+
+def _explicit_ouroboros_semantics(tool: MCPToolDefinition) -> CapabilitySemantics:
+    name = tool.name
+    side_effects = _resolved_side_effects_for_ouroboros_tool(name)
+    spec_mutation_class = _spec_for_ouroboros_tool_name(name).mutation_class
+    if spec_mutation_class is CapabilityMutationClass.READ_ONLY or (
+        spec_mutation_class is None
+        and (
+            name in _OUROBOROS_STATUS_TOOLS
+            or side_effects in {
+                ("event_store_read",),
+                ("runtime_state_read",),
+                _OUROBOROS_SIDE_EFFECT_FREE_METADATA,
+            }
+        )
+    ):
+        mutation_class = CapabilityMutationClass.READ_ONLY
+        parallel_safety = CapabilityParallelSafety.SAFE
+        interruptibility = CapabilityInterruptibility.NONE
+        approval_class = CapabilityApprovalClass.DEFAULT
+    elif name in _OUROBOROS_CANCEL_TOOLS:
+        mutation_class = CapabilityMutationClass.EXTERNAL_SIDE_EFFECT
+        parallel_safety = CapabilityParallelSafety.SERIALIZED
+        interruptibility = CapabilityInterruptibility.HARD
+        approval_class = CapabilityApprovalClass.ELEVATED
+    else:
+        mutation_class = CapabilityMutationClass.WORKSPACE_WRITE
+        parallel_safety = CapabilityParallelSafety.SERIALIZED
+        interruptibility = CapabilityInterruptibility.SOFT
+        approval_class = CapabilityApprovalClass.DEFAULT
+
+    return CapabilitySemantics(
+        mutation_class=mutation_class,
+        parallel_safety=parallel_safety,
+        interruptibility=interruptibility,
+        approval_class=approval_class,
+        origin=CapabilityOrigin.ATTACHED_MCP,
+        scope=CapabilityScope.ATTACHMENT,
+    )
+
+
+def _metadata_from_ouroboros_spec(
+    tool: MCPToolDefinition,
+    spec: _OuroborosToolCapabilitySpec,
+) -> CapabilityToolMetadata:
+    name = tool.name
+    state_mutations = _state_mutations_for_ouroboros_tool(name)
+    return CapabilityToolMetadata(
+        input_schema=_input_schema_for_ouroboros_tool(tool),
+        mutation_class=_explicit_ouroboros_semantics(tool).mutation_class.value,
+        execution_mode=spec.execution_mode,
+        companions=_derived_ouroboros_companions_for_tool(name),
+        required_context_keys=_required_context_keys_for_ouroboros_tool(tool),
+        mutation_targets=_mutation_targets_for_state_mutations(
+            _mutation_targets_for_side_effects(spec.side_effects),
+            state_mutations,
+        ),
+        state_mutations=state_mutations,
+        side_effects=spec.side_effects,
+        retry=_retry_metadata_for_ouroboros_tool(name),
+        interrupt=_interrupt_metadata_for_ouroboros_tool(name),
+        cancel=_cancel_metadata_for_ouroboros_tool(name),
+        fallback_used=False,
+        orchestration=_orchestration_metadata_for_ouroboros_tool(name),
+    )
+
+
+def ouroboros_tool_capability_registry() -> Mapping[str, CapabilityToolMetadata]:
+    """Return explicit capability metadata for every owned MCP tool definition."""
+    definitions = _ouroboros_tool_definitions_by_name()
+    missing_specs = sorted(set(definitions) - set(_OUROBOROS_TOOL_CAPABILITY_SPECS))
+    missing_cancel_metadata = sorted(set(definitions) - set(_OUROBOROS_CANCEL_METADATA))
+    if (
+        missing_specs
+        or missing_cancel_metadata
+    ):
+        raise RuntimeError(
+            "Ouroboros MCP capability registry is out of sync: "
+            f"missing_specs={missing_specs}, "
+            f"missing_cancel_metadata={missing_cancel_metadata}"
+        )
+    registry = {
+        name: _metadata_from_ouroboros_spec(
+            definitions[name],
+            _OUROBOROS_TOOL_CAPABILITY_SPECS[name],
+        )
+        for name in sorted(definitions)
+    }
+    for name, metadata in registry.items():
+        validate_capability_tool_metadata(metadata, tool_name=name, owned_tool=True)
+    return registry
+
+
+def _metadata_for_ouroboros_tool(tool: MCPToolDefinition) -> CapabilityToolMetadata:
+    name = tool.name
+    if name in _OUROBOROS_TOOL_CAPABILITY_SPECS:
+        return ouroboros_tool_capability_registry()[name]
+    raise RuntimeError(
+        "Ouroboros MCP capability registry has no explicit spec for "
+        f"{name}; retry metadata must be defined per owned tool"
+    )
+
+
+def _ouroboros_tool_name_from_identifier(tool_identifier: str) -> str | None:
+    """Return an owned MCP tool name from a known Ouroboros tool identifier."""
+    normalized_identifier = tool_identifier.strip()
+    if not normalized_identifier:
+        return None
+
+    definitions = _ouroboros_tool_definitions_by_name()
+    if normalized_identifier in definitions:
+        return normalized_identifier
+
+    stable_id_prefix = "mcp:ouroboros:"
+    if normalized_identifier.startswith(stable_id_prefix):
+        candidate = normalized_identifier.removeprefix(stable_id_prefix)
+        if candidate in definitions:
+            return candidate
+
+    return None
+
+
+def lookup_ouroboros_tool_capability_metadata(
+    tool_identifier: str,
+) -> CapabilityToolMetadata | None:
+    """Return explicit metadata for a known Ouroboros-owned MCP tool.
+
+    Unknown or external attached MCP tools return ``None`` so their generic
+    fallback inference path stays separate from the owned-tool contract.
+    """
+    tool_name = _ouroboros_tool_name_from_identifier(tool_identifier)
+    if tool_name is None:
+        return None
+    return ouroboros_tool_capability_registry()[tool_name]
+
+
+def _generic_attached_tool_metadata(tool: MCPToolDefinition) -> CapabilityToolMetadata:
+    semantics = _infer_attached_semantics(tool)
+    return CapabilityToolMetadata(
+        input_schema=extract_capability_input_schema(tool),
+        mutation_class=semantics.mutation_class.value,
+        execution_mode="generic_attached",
+        companions=(),
+        required_context_keys=_required_parameter_names(tool),
+        mutation_targets=("external",),
+        state_mutations=(),
+        side_effects=("unknown_external_side_effect",),
+        retry={"supported": False, "mode": "unsupported"},
+        interrupt={"supported": True, "mode": "soft"},
+        cancel={
+            "supported": False,
+            "mode": "unsupported",
+            "companions": (),
+            "target_context_keys": (),
+        },
+        fallback_used=True,
+        orchestration={},
+    )
+
 
 def _fallback_source_metadata(tool: MCPToolDefinition) -> ToolCatalogSourceMetadata:
+    if _is_ouroboros_owned_tool(tool):
+        return ToolCatalogSourceMetadata(
+            kind="attached_mcp",
+            name="ouroboros",
+            original_name=tool.name,
+            server_name=tool.server_name,
+        )
     source_kind = "attached_mcp" if tool.server_name else "builtin"
     source_name = tool.server_name or "built-in"
     return ToolCatalogSourceMetadata(
@@ -451,6 +3401,8 @@ def _semantics_for_entry(
     tool: MCPToolDefinition,
     source: ToolCatalogSourceMetadata,
 ) -> CapabilitySemantics:
+    if _is_ouroboros_owned_tool(tool):
+        return _explicit_ouroboros_semantics(tool)
     if source.kind == "builtin":
         return _BUILTIN_SEMANTICS.get(
             tool.name,
@@ -481,8 +3433,26 @@ def _descriptor_from_tool(
     raw_capability_overrides: Mapping[str, Mapping[str, Any]] | None = None,
 ) -> CapabilityDescriptor:
     resolved_source = source or _fallback_source_metadata(tool)
+    if _is_ouroboros_owned_tool(tool) and resolved_source.kind == "attached_mcp":
+        resolved_source = ToolCatalogSourceMetadata(
+            kind=resolved_source.kind,
+            name="ouroboros",
+            original_name=resolved_source.original_name,
+            server_name=resolved_source.server_name,
+        )
     resolved_stable_id = stable_id or _stable_id(tool, resolved_source)
+    if _is_ouroboros_owned_tool(tool):
+        resolved_stable_id = _stable_id(tool, resolved_source)
     semantics = _semantics_for_entry(tool, resolved_source)
+    metadata = (
+        _metadata_for_ouroboros_tool(tool)
+        if _is_ouroboros_owned_tool(tool)
+        else (
+            _generic_attached_tool_metadata(tool)
+            if resolved_source.kind != "builtin"
+            else None
+        )
+    )
     # Built-in tools deliberately bypass user overrides: their semantics are
     # part of the engine contract (e.g., Bash must remain EXTERNAL_SIDE_EFFECT
     # regardless of user YAML) so that role envelopes cannot be silently
@@ -509,6 +3479,7 @@ def _descriptor_from_tool(
         source_kind=resolved_source.kind,
         source_name=resolved_source.name,
         semantics=semantics,
+        metadata=metadata,
     )
 
 
@@ -543,6 +3514,7 @@ def _descriptor_from_inherited_capability(name: str) -> CapabilityDescriptor:
         source_kind="inherited_capability",
         source_name="delegated_parent",
         semantics=_DEFAULT_ATTACHED_SEMANTICS,
+        metadata=None,
     )
 
 
@@ -593,6 +3565,76 @@ def build_capability_graph(
     return CapabilityGraph(capabilities=tuple(descriptors))
 
 
+def resolve_skill_capability_descriptor(
+    skill_name: str,
+    *,
+    graph: CapabilityGraph | Sequence[CapabilityDescriptor] | None = None,
+) -> CapabilityDescriptor | None:
+    """Resolve a packaged skill name to its Ouroboros-owned MCP capability.
+
+    Skill frontmatter owns the skill-to-tool mapping. The capability graph owns
+    the executable tool metadata. This helper intentionally joins those two
+    contracts without falling back to keyword inference for known Ouroboros MCP
+    tools.
+    """
+
+    from ouroboros.orchestrator.skill_tool_mapping import get_skill_tool_mapping
+
+    mapping = get_skill_tool_mapping(skill_name)
+    if mapping is None:
+        return None
+
+    if graph is None:
+        graph = build_capability_graph(tuple(_ouroboros_tool_definitions_by_name().values()))
+
+    descriptors = graph.capabilities if isinstance(graph, CapabilityGraph) else tuple(graph)
+    descriptor_by_name = {descriptor.name: descriptor for descriptor in descriptors}
+    descriptor = descriptor_by_name.get(mapping.mcp_tool)
+    if descriptor is None:
+        return None
+    if not _is_ouroboros_owned_tool_name(descriptor.name):
+        return None
+    if descriptor.metadata is None or descriptor.metadata.fallback_used:
+        return None
+    return descriptor
+
+
+def resolve_mcp_tool_capability_descriptor(
+    tool_identifier: str,
+    *,
+    graph: CapabilityGraph | Sequence[CapabilityDescriptor] | None = None,
+) -> CapabilityDescriptor | None:
+    """Resolve a known Ouroboros-owned MCP tool identifier to explicit metadata.
+
+    ``tool_identifier`` may be the normalized tool name, catalog stable id, or
+    original MCP name from a resolved runtime catalog entry. Unknown or external
+    attached tools intentionally return ``None`` so callers keep the generic
+    fallback path separate from the owned-tool contract.
+    """
+
+    normalized_identifier = tool_identifier.strip()
+    if not normalized_identifier:
+        return None
+
+    if graph is None:
+        graph = build_capability_graph(tuple(_ouroboros_tool_definitions_by_name().values()))
+
+    descriptors = graph.capabilities if isinstance(graph, CapabilityGraph) else tuple(graph)
+    for descriptor in descriptors:
+        if normalized_identifier not in {
+            descriptor.name,
+            descriptor.original_name,
+            descriptor.stable_id,
+        }:
+            continue
+        if not _is_ouroboros_owned_tool_name(descriptor.name):
+            return None
+        if descriptor.metadata is None or descriptor.metadata.fallback_used:
+            return None
+        return descriptor
+    return None
+
+
 def serialize_capability_graph(
     graph: CapabilityGraph | Sequence[CapabilityDescriptor],
 ) -> list[dict[str, Any]]:
@@ -615,6 +3657,7 @@ def serialize_capability_graph(
                 "origin": descriptor.semantics.origin.value,
                 "scope": descriptor.semantics.scope.value,
             },
+            "metadata": _serialized_metadata_for_descriptor(descriptor),
         }
         for descriptor in capabilities
     ]
@@ -632,6 +3675,89 @@ def normalize_serialized_capability_graph(
         semantics = entry.get("semantics")
         if not isinstance(semantics, Mapping):
             continue
+        raw_metadata = entry.get("metadata")
+        metadata = None
+        if isinstance(raw_metadata, Mapping):
+            metadata = CapabilityToolMetadata(
+                input_schema=raw_metadata.get("input_schema", {})
+                if isinstance(raw_metadata.get("input_schema"), Mapping)
+                else {},
+                mutation_class=str(raw_metadata.get("mutation_class", "")),
+                execution_mode=str(raw_metadata.get("execution_mode", "")),
+                companions=tuple(
+                    str(value)
+                    for value in raw_metadata.get("companions", ())
+                    if isinstance(value, str)
+                )
+                if isinstance(raw_metadata.get("companions"), Sequence)
+                and not isinstance(raw_metadata.get("companions"), str)
+                else (),
+                required_context_keys=tuple(
+                    str(value)
+                    for value in raw_metadata.get("required_context_keys", ())
+                    if isinstance(value, str)
+                )
+                if isinstance(raw_metadata.get("required_context_keys"), Sequence)
+                and not isinstance(raw_metadata.get("required_context_keys"), str)
+                else (),
+                mutation_targets=tuple(
+                    str(value)
+                    for value in raw_metadata.get("mutation_targets", ())
+                    if isinstance(value, str)
+                )
+                if isinstance(raw_metadata.get("mutation_targets"), Sequence)
+                and not isinstance(raw_metadata.get("mutation_targets"), str)
+                else (),
+                state_mutations=tuple(
+                    {
+                        "target": str(value.get("target", "")),
+                        "operation": str(value.get("operation", "")),
+                        "side_effect": str(value.get("side_effect", "")),
+                        "context_keys": _string_tuple_from_payload(
+                            value.get("context_keys")
+                        ),
+                    }
+                    for value in raw_metadata.get("state_mutations", ())
+                    if isinstance(value, Mapping)
+                )
+                if isinstance(raw_metadata.get("state_mutations"), Sequence)
+                and not isinstance(raw_metadata.get("state_mutations"), str)
+                else (),
+                side_effects=tuple(
+                    str(value)
+                    for value in raw_metadata.get("side_effects", ())
+                    if isinstance(value, str)
+                )
+                if isinstance(raw_metadata.get("side_effects"), Sequence)
+                and not isinstance(raw_metadata.get("side_effects"), str)
+                else (),
+                retry=raw_metadata.get("retry", {})
+                if isinstance(raw_metadata.get("retry"), Mapping)
+                else {},
+                interrupt=_normalize_tuple_fields(
+                    raw_metadata.get("interrupt", {}),
+                    frozenset(
+                        {
+                            "background_companions",
+                            "resume_companions",
+                            "cancel_companions",
+                            "target_context_keys",
+                        }
+                    ),
+                )
+                if isinstance(raw_metadata.get("interrupt"), Mapping)
+                else {},
+                cancel=_normalize_tuple_fields(
+                    raw_metadata.get("cancel", {}),
+                    frozenset({"companions", "target_context_keys"}),
+                )
+                if isinstance(raw_metadata.get("cancel"), Mapping)
+                else {},
+                fallback_used=bool(raw_metadata.get("fallback_used", False)),
+                orchestration=raw_metadata.get("orchestration", {})
+                if isinstance(raw_metadata.get("orchestration"), Mapping)
+                else {},
+            )
         try:
             descriptors.append(
                 CapabilityDescriptor(
@@ -660,6 +3786,7 @@ def normalize_serialized_capability_graph(
                         origin=CapabilityOrigin(str(semantics.get("origin"))),
                         scope=CapabilityScope(str(semantics.get("scope"))),
                     ),
+                    metadata=metadata,
                 )
             )
         except ValueError:
@@ -678,7 +3805,20 @@ __all__ = [
     "CapabilityParallelSafety",
     "CapabilityScope",
     "CapabilitySemantics",
+    "CapabilityToolMetadata",
+    "LateralPersonaMetadata",
+    "LateralPersonaPanelMetadata",
     "build_capability_graph",
+    "deserialize_code_investigation_request_metadata",
+    "extract_capability_input_schema",
+    "lookup_ouroboros_tool_capability_metadata",
+    "mcp_tool_required_parameter_keys",
     "normalize_serialized_capability_graph",
+    "ouroboros_tool_capability_registry",
+    "ouroboros_tool_capability_metadata",
+    "resolve_mcp_tool_capability_descriptor",
+    "resolve_skill_capability_descriptor",
     "serialize_capability_graph",
+    "stable_code_investigation_question_identity",
+    "validate_capability_tool_metadata",
 ]

--- a/src/ouroboros/orchestrator/skill_tool_mapping.py
+++ b/src/ouroboros/orchestrator/skill_tool_mapping.py
@@ -1,0 +1,468 @@
+"""Skill-to-MCP-tool mappings derived from packaged skill frontmatter.
+
+This module is intentionally separate from MCP tool descriptor definitions.
+Skill dispatch mappings answer "which tool does this skill invoke?", while
+tool descriptors answer "what is the MCP handler schema?". Keeping those
+questions apart lets capability modeling verify skill usage without consulting
+``get_ouroboros_tools()`` or descriptor metadata.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+import re
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True, slots=True)
+class SkillToolMapping:
+    """Frontmatter-backed mapping from one packaged skill to one MCP tool."""
+
+    skill_name: str
+    mcp_tool: str
+    skill_path: str
+    mcp_args: Mapping[str, Any]
+    context_keys: tuple[str, ...]
+
+
+def _packaged_skills_dir() -> Path:
+    return Path(__file__).resolve().parents[3] / "skills"
+
+
+_TOOL_LINE_RE = re.compile(r"^\s*Tool:\s*`?(ouroboros_[A-Za-z0-9_]+)`?\s*$")
+_ARGUMENTS_LINE_RE = re.compile(r"^(?P<indent>\s*)Arguments:\s*(?:#.*)?$")
+_ARGUMENT_KEY_RE = re.compile(
+    r"^(?P<indent>\s+)(?P<key>[A-Za-z_][A-Za-z0-9_]*):(?P<value>.*)$"
+)
+_INLINE_TOOL_CALL_RE = re.compile(r"\b(ouroboros_[A-Za-z0-9_]+)\(([^)]*)\)")
+_INLINE_KWARG_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*=")
+_CONTEXTISH_WORD_RE = re.compile(
+    r"\b(answer|artifact|context|cursor|cwd|goal|id|job|lineage|output|question|"
+    r"response|seed|session)\b",
+    re.IGNORECASE,
+)
+
+
+def _split_frontmatter_and_body(text: str) -> tuple[str, str]:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return "", text
+
+    frontmatter_lines: list[str] = []
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return "\n".join(frontmatter_lines), "\n".join(lines[index + 1 :])
+        frontmatter_lines.append(line)
+    return "", text
+
+
+def _read_frontmatter(skill_path: Path) -> Mapping[str, Any]:
+    text = skill_path.read_text(encoding="utf-8")
+    frontmatter_text, _body = _split_frontmatter_and_body(text)
+    if not frontmatter_text:
+        return {}
+
+    raw = yaml.safe_load(frontmatter_text)
+    return raw if isinstance(raw, Mapping) else {}
+
+
+def _ordered_merge_context_key(
+    context_keys_by_tool: dict[str, list[str]],
+    tool_name: str,
+    key: str,
+) -> None:
+    normalized_key = key.strip()
+    if not normalized_key:
+        return
+    existing = context_keys_by_tool.setdefault(tool_name, [])
+    if normalized_key not in existing:
+        existing.append(normalized_key)
+
+
+def merge_tool_context_keys(
+    frontmatter_context_keys: tuple[str, ...] = (),
+    body_context_keys: tuple[str, ...] = (),
+) -> tuple[str, ...]:
+    """Merge frontmatter and body context keys for one MCP tool.
+
+    Frontmatter is the skill dispatch contract, so it wins ordering. Body
+    references are appended only when they add new runtime context keys. Empty
+    and whitespace-only keys are discarded, and valid keys are stripped.
+    """
+
+    merged_by_tool: dict[str, list[str]] = {"": []}
+    for key in (*frontmatter_context_keys, *body_context_keys):
+        _ordered_merge_context_key(merged_by_tool, "", key)
+    return tuple(merged_by_tool[""])
+
+
+def _looks_like_context_argument(value: str) -> bool:
+    stripped = value.strip()
+    if not stripped:
+        return True
+    if stripped in {"|", ">"}:
+        return True
+    if stripped == "...":
+        return True
+    if "$" in stripped:
+        return True
+    if "<" in stripped and ">" in stripped:
+        return True
+    if stripped.startswith(("response.", "meta.", "result.")):
+        return True
+    if stripped.startswith(("'", '"', "[", "{")):
+        return False
+    if stripped[0].isdigit():
+        return False
+    if stripped.lower().startswith(("true", "false", "null", "none")):
+        return False
+    return bool(_CONTEXTISH_WORD_RE.search(stripped)) and not stripped.startswith(
+        ("'", '"')
+    )
+
+
+def _collect_tool_block_context_keys(
+    lines: list[str],
+    start_index: int,
+) -> tuple[str, tuple[str, ...], int]:
+    match = _TOOL_LINE_RE.match(lines[start_index])
+    if match is None:
+        return "", (), start_index + 1
+    tool_name = match.group(1)
+
+    index = start_index + 1
+    while index < len(lines):
+        arguments_match = _ARGUMENTS_LINE_RE.match(lines[index])
+        if arguments_match is not None:
+            break
+        if _TOOL_LINE_RE.match(lines[index]) is not None:
+            return tool_name, (), index
+        index += 1
+    if index >= len(lines):
+        return tool_name, (), index
+
+    arguments_indent = len(arguments_match.group("indent"))
+    key_indent: int | None = None
+    context_keys: list[str] = []
+    index += 1
+    while index < len(lines):
+        line = lines[index]
+        if not line.strip():
+            index += 1
+            continue
+        if _TOOL_LINE_RE.match(line) is not None:
+            break
+
+        current_indent = len(line) - len(line.lstrip(" "))
+        if current_indent <= arguments_indent:
+            break
+
+        key_match = _ARGUMENT_KEY_RE.match(line)
+        if key_match is None:
+            index += 1
+            continue
+
+        current_key_indent = len(key_match.group("indent"))
+        if key_indent is None:
+            key_indent = current_key_indent
+        if current_key_indent == key_indent and _looks_like_context_argument(
+            key_match.group("value")
+        ):
+            key = key_match.group("key")
+            if key not in context_keys:
+                context_keys.append(key)
+        index += 1
+
+    return tool_name, tuple(context_keys), index
+
+
+def _split_inline_call_arguments(raw_arguments: str) -> tuple[str, ...]:
+    arguments: list[str] = []
+    depth = 0
+    quote: str | None = None
+    start = 0
+    for index, char in enumerate(raw_arguments):
+        if quote is not None:
+            if char == quote and raw_arguments[index - 1 : index] != "\\":
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            continue
+        if char in "([{":
+            depth += 1
+            continue
+        if char in ")]}":
+            depth = max(0, depth - 1)
+            continue
+        if char == "," and depth == 0:
+            arguments.append(raw_arguments[start:index].strip())
+            start = index + 1
+    tail = raw_arguments[start:].strip()
+    if tail:
+        arguments.append(tail)
+    return tuple(arguments)
+
+
+def _extract_inline_call_context_keys(raw_arguments: str) -> tuple[str, ...]:
+    context_keys: list[str] = []
+    for raw_argument in _split_inline_call_arguments(raw_arguments):
+        if not raw_argument:
+            continue
+        if "=" in raw_argument:
+            keyword_match = _INLINE_KWARG_RE.match(raw_argument)
+            if keyword_match is None:
+                continue
+            key = keyword_match.group(1)
+            value = raw_argument[raw_argument.index("=") + 1 :]
+            if _looks_like_context_argument(value) and key not in context_keys:
+                context_keys.append(key)
+            continue
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", raw_argument):
+            context_keys.append(raw_argument)
+    return tuple(context_keys)
+
+
+def extract_skill_body_tool_context_keys(skill_body: str) -> Mapping[str, tuple[str, ...]]:
+    """Return tool-specific context keys referenced in a skill body.
+
+    The extraction is intentionally syntax-based. It reads the explicit MCP
+    invocation formats used in packaged skills: ``Tool: ouroboros_*`` blocks
+    followed by an ``Arguments:`` mapping, plus compact inline examples such as
+    ``ouroboros_job_wait(job_id, cursor, timeout_seconds=120)``. Literal defaults
+    are ignored; placeholder, variable, and block-scalar values are treated as
+    runtime context keys.
+    """
+
+    context_keys_by_tool: dict[str, list[str]] = {}
+    lines = skill_body.splitlines()
+    index = 0
+    while index < len(lines):
+        if _TOOL_LINE_RE.match(lines[index]) is not None:
+            tool_name, context_keys, next_index = _collect_tool_block_context_keys(
+                lines,
+                index,
+            )
+            for key in context_keys:
+                _ordered_merge_context_key(context_keys_by_tool, tool_name, key)
+            index = max(next_index, index + 1)
+            continue
+
+        for inline_match in _INLINE_TOOL_CALL_RE.finditer(lines[index]):
+            tool_name = inline_match.group(1)
+            for key in _extract_inline_call_context_keys(inline_match.group(2)):
+                _ordered_merge_context_key(context_keys_by_tool, tool_name, key)
+        index += 1
+
+    return {
+        tool_name: tuple(context_keys)
+        for tool_name, context_keys in context_keys_by_tool.items()
+    }
+
+
+def extract_skill_frontmatter_context_keys(
+    frontmatter: Mapping[str, Any],
+) -> tuple[str, ...]:
+    """Return ordered MCP argument keys declared by skill frontmatter.
+
+    The frontmatter ``mcp_args`` mapping describes which runtime context values
+    a skill forwards to its tool-specific MCP input. The mapping keys are the
+    tool input/context keys capability modeling needs; placeholder values such
+    as ``$1`` or ``$CWD`` are runtime binding expressions, not capability keys.
+    """
+
+    raw_mcp_args = frontmatter.get("mcp_args")
+    if not isinstance(raw_mcp_args, Mapping):
+        return ()
+    return tuple(
+        key.strip()
+        for key in raw_mcp_args
+        if isinstance(key, str) and key.strip()
+    )
+
+
+def discover_skill_tool_mappings(
+    skills_dir: str | Path | None = None,
+) -> tuple[SkillToolMapping, ...]:
+    """Discover skill-to-tool mappings from skill frontmatter only.
+
+    The discovery path deliberately does not import or call MCP tool definition
+    factories. Unknown or temporarily unavailable tool descriptors should not
+    affect the recorded skill usage contract.
+    """
+
+    root = Path(skills_dir).expanduser() if skills_dir is not None else _packaged_skills_dir()
+    mappings: list[SkillToolMapping] = []
+    for skill_path in sorted(root.glob("*/SKILL.md")):
+        frontmatter = _read_frontmatter(skill_path)
+        skill_name = frontmatter.get("name")
+        mcp_tool = frontmatter.get("mcp_tool")
+        if not isinstance(skill_name, str) or not skill_name.strip():
+            continue
+        if not isinstance(mcp_tool, str) or not mcp_tool.strip():
+            continue
+        raw_mcp_args = frontmatter.get("mcp_args")
+        mcp_args = dict(raw_mcp_args) if isinstance(raw_mcp_args, Mapping) else {}
+        mappings.append(
+            SkillToolMapping(
+                skill_name=skill_name.strip(),
+                mcp_tool=mcp_tool.strip(),
+                skill_path=str(skill_path.relative_to(root.parent)),
+                mcp_args=mcp_args,
+                context_keys=extract_skill_frontmatter_context_keys(frontmatter),
+            )
+        )
+    return tuple(mappings)
+
+
+def discover_skill_body_context_keys(
+    skills_dir: str | Path | None = None,
+) -> Mapping[str, tuple[str, ...]]:
+    """Discover tool context keys from packaged skill body instructions."""
+
+    root = Path(skills_dir).expanduser() if skills_dir is not None else _packaged_skills_dir()
+    context_keys_by_tool: dict[str, list[str]] = {}
+    for skill_path in sorted(root.glob("*/SKILL.md")):
+        _frontmatter, body = _split_frontmatter_and_body(
+            skill_path.read_text(encoding="utf-8")
+        )
+        for tool_name, context_keys in extract_skill_body_tool_context_keys(body).items():
+            for key in context_keys:
+                _ordered_merge_context_key(context_keys_by_tool, tool_name, key)
+    return {
+        tool_name: tuple(context_keys)
+        for tool_name, context_keys in context_keys_by_tool.items()
+    }
+
+
+@lru_cache(maxsize=1)
+def get_packaged_skill_body_context_keys() -> Mapping[str, tuple[str, ...]]:
+    """Return cached packaged skill body context usage by MCP tool."""
+
+    return discover_skill_body_context_keys()
+
+
+@lru_cache(maxsize=1)
+def get_packaged_skill_tool_mappings() -> tuple[SkillToolMapping, ...]:
+    """Return cached packaged skill mappings for capability verification."""
+
+    return discover_skill_tool_mappings()
+
+
+def skill_tool_mapping_by_skill(
+    mappings: tuple[SkillToolMapping, ...] | None = None,
+) -> Mapping[str, SkillToolMapping]:
+    """Index skill mappings by skill name."""
+
+    resolved_mappings = mappings if mappings is not None else get_packaged_skill_tool_mappings()
+    return {mapping.skill_name: mapping for mapping in resolved_mappings}
+
+
+def skill_frontmatter_context_keys_by_tool(
+    mappings: tuple[SkillToolMapping, ...] | None = None,
+) -> Mapping[str, tuple[str, ...]]:
+    """Index frontmatter-derived context keys by MCP tool name.
+
+    If multiple skills point at the same MCP tool, keys are merged in discovery
+    order with duplicates removed. This keeps skill usage facts separate from
+    MCP descriptor metadata while still making tool-specific context usage easy
+    to test.
+    """
+
+    resolved_mappings = mappings if mappings is not None else get_packaged_skill_tool_mappings()
+    context_keys_by_tool: dict[str, tuple[str, ...]] = {}
+    for mapping in resolved_mappings:
+        existing = list(context_keys_by_tool.get(mapping.mcp_tool, ()))
+        for key in mapping.context_keys:
+            if key not in existing:
+                existing.append(key)
+        context_keys_by_tool[mapping.mcp_tool] = tuple(existing)
+    return context_keys_by_tool
+
+
+def merge_skill_context_keys_by_tool(
+    frontmatter_context_keys_by_tool: Mapping[str, tuple[str, ...]],
+    body_context_keys_by_tool: Mapping[str, tuple[str, ...]],
+) -> Mapping[str, tuple[str, ...]]:
+    """Merge tool-specific context keys from skill frontmatter and bodies.
+
+    The return value is keyed by MCP tool name. Tools that appear only in body
+    instructions are retained so companion polling/status/result usage remains
+    visible to capability verification.
+    """
+
+    tool_names = tuple(
+        dict.fromkeys(
+            (
+                *frontmatter_context_keys_by_tool.keys(),
+                *body_context_keys_by_tool.keys(),
+            )
+        )
+    )
+    return {
+        tool_name: merge_tool_context_keys(
+            frontmatter_context_keys_by_tool.get(tool_name, ()),
+            body_context_keys_by_tool.get(tool_name, ()),
+        )
+        for tool_name in tool_names
+    }
+
+
+def discover_skill_context_keys(
+    skills_dir: str | Path | None = None,
+) -> Mapping[str, tuple[str, ...]]:
+    """Discover merged frontmatter/body context usage by MCP tool."""
+
+    mappings = discover_skill_tool_mappings(skills_dir)
+    return merge_skill_context_keys_by_tool(
+        skill_frontmatter_context_keys_by_tool(mappings),
+        discover_skill_body_context_keys(skills_dir),
+    )
+
+
+@lru_cache(maxsize=1)
+def get_packaged_skill_context_keys() -> Mapping[str, tuple[str, ...]]:
+    """Return cached merged packaged skill context usage by MCP tool."""
+
+    return discover_skill_context_keys()
+
+
+def get_skill_tool_mapping(
+    skill_name: str,
+    *,
+    mappings: tuple[SkillToolMapping, ...] | None = None,
+) -> SkillToolMapping | None:
+    """Return the frontmatter-backed MCP tool mapping for one skill.
+
+    This is the narrow query API capability checks can use when they only need
+    skill usage facts. It intentionally delegates only to frontmatter discovery
+    and never consults MCP tool descriptors.
+    """
+
+    normalized_skill_name = skill_name.strip()
+    if not normalized_skill_name:
+        return None
+    return skill_tool_mapping_by_skill(mappings).get(normalized_skill_name)
+
+
+__all__ = [
+    "SkillToolMapping",
+    "discover_skill_body_context_keys",
+    "discover_skill_tool_mappings",
+    "extract_skill_body_tool_context_keys",
+    "extract_skill_frontmatter_context_keys",
+    "discover_skill_context_keys",
+    "get_packaged_skill_body_context_keys",
+    "get_packaged_skill_context_keys",
+    "get_skill_tool_mapping",
+    "get_packaged_skill_tool_mappings",
+    "merge_skill_context_keys_by_tool",
+    "merge_tool_context_keys",
+    "skill_frontmatter_context_keys_by_tool",
+    "skill_tool_mapping_by_skill",
+]

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -1,9 +1,11 @@
 """Tests for the shared backend capability registry."""
 
+from jsonschema import Draft202012Validator
 import pytest
 
 from ouroboros.backends import (
     backend_supports_tool_envelope,
+    build_runtime_subagent_orchestration_contract,
     get_backend_capability,
     interview_driver_backend_choices,
     llm_backend_choices,
@@ -14,6 +16,12 @@ from ouroboros.backends import (
     runtime_backend_choices,
     soft_tool_enforcement_backends,
 )
+from ouroboros.mcp.tools.definitions import get_ouroboros_tools
+from ouroboros.orchestrator.capabilities import (
+    build_capability_graph,
+    ouroboros_tool_capability_metadata,
+)
+from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
 
 REQUIRED_SKILL_CAPABILITY_NAMES = {
     "ask_user",
@@ -93,6 +101,105 @@ def test_generic_skill_execution_guidance_covers_interview_requirements() -> Non
     assert capability is not None
     names = {item.name for item in capability.skill_execution_capabilities}
     assert names == REQUIRED_SKILL_CAPABILITY_NAMES
+
+
+def test_native_parallel_subagent_runtime_exposes_orchestrate_subagents() -> None:
+    capability = get_backend_capability("opencode_cli")
+
+    assert capability is not None
+    assert capability.supports_native_parallel_subagents is True
+    names = {item.name for item in capability.skill_execution_capabilities}
+    assert names == REQUIRED_SKILL_CAPABILITY_NAMES | {"orchestrate_subagents"}
+
+    guide = render_backend_skill_capability_guide("opencode")
+    assert "### When a skill requires `orchestrate_subagents`" in guide
+    assert "native task/subagent primitive" in guide
+    assert "`_subagents` MCP directive payloads" in guide
+    assert "sequential fallback" in guide
+
+
+def test_unsupported_parallel_subagent_runtime_gets_sequential_fallback_contract() -> None:
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools(include_auto=False))
+    graph = build_capability_graph(assemble_session_tool_catalog(attached_tools=owned_tools))
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    lateral = descriptors["ouroboros_lateral_think"]
+    assert lateral.metadata is not None
+    panel_metadata = lateral.metadata.orchestration["lateral_panel"]
+
+    contract = build_runtime_subagent_orchestration_contract(
+        "codex_cli",
+        directive_metadata=panel_metadata,
+    )
+
+    assert contract.backend_name == "codex"
+    assert contract.supports_native_parallel_subagents is False
+    assert contract.dispatch_mode == "sequential_fallback"
+    assert contract.mcp_directive_keys == ("_subagent", "_subagents")
+    assert contract.sequential_fallback == {
+        "supported": True,
+        "mode": "sequential_persona_payload_dispatch",
+        "trigger": "runtime_has_no_native_parallel_subagent_primitive",
+    }
+    assert "no native parallel subagent primitive" in contract.runtime_instruction_handling
+    assert "process each structured subagent payload sequentially" in (
+        contract.runtime_instruction_handling
+    )
+    assert contract.to_dict()["sequential_fallback"] == dict(panel_metadata["sequential_fallback"])
+
+
+def test_subagent_orchestration_cancel_job_capability_stays_callable_in_same_envelope() -> None:
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools(include_auto=False))
+    definitions = {definition.name: definition for definition in owned_tools}
+    graph = build_capability_graph(assemble_session_tool_catalog(attached_tools=owned_tools))
+    descriptors = graph.by_name()
+    lateral = descriptors["ouroboros_lateral_think"]
+    cancel = descriptors["ouroboros_cancel_job"]
+    assert lateral.metadata is not None
+    assert cancel.metadata is not None
+
+    cancel_capability = ouroboros_tool_capability_metadata("ouroboros_cancel_job")
+    contract = build_runtime_subagent_orchestration_contract(
+        "opencode_cli",
+        directive_metadata=lateral.metadata.orchestration["lateral_panel"],
+        callable_mcp_tool_capabilities=(cancel_capability,),
+    )
+    envelope = contract.to_dict()
+
+    assert envelope["dispatch_mode"] == "native_parallel_subagents"
+    assert envelope["mcp_directive_keys"] == ["_subagent", "_subagents"]
+    assert envelope["callable_mcp_tool_capabilities"] == [cancel_capability]
+
+    callable_cancel = envelope["callable_mcp_tool_capabilities"][0]
+    assert callable_cancel["tool_name"] == "ouroboros_cancel_job"
+    assert callable_cancel["source_kind"] == "attached_mcp"
+    assert callable_cancel["source_name"] == "ouroboros"
+    assert callable_cancel["fallback_used"] is False
+    assert callable_cancel["execution_mode"] == "cancel"
+    assert callable_cancel["input_schema"] == definitions[
+        "ouroboros_cancel_job"
+    ].to_input_schema()
+    assert callable_cancel["required_context_keys"] == ["job_id"]
+    assert callable_cancel["cancel"] == {
+        "supported": True,
+        "mode": "background_job_control",
+        "companions": [
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+        ],
+        "target_context_keys": ["job_id"],
+    }
+    Draft202012Validator(callable_cancel["input_schema"]).validate(
+        {"job_id": "job-subagent-123", "reason": "cancel delegated subagent job"}
+    )
+
+    assert cancel.metadata.fallback_used is False
+    assert cancel.metadata.execution_mode == "cancel"
+    assert cancel.metadata.cancel["mode"] == "background_job_control"
+    assert cancel.name in {
+        capability["tool_name"]
+        for capability in envelope["callable_mcp_tool_capabilities"]
+    }
 
 
 def test_renders_codex_skill_capability_guide_as_stable_markdown() -> None:

--- a/tests/unit/evaluation/test_mechanical.py
+++ b/tests/unit/evaluation/test_mechanical.py
@@ -1,5 +1,6 @@
 """Tests for Stage 1 mechanical verification."""
 
+import sys
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -135,6 +136,23 @@ class TestRunCommand:
         assert result.return_code == -1
         assert "not found" in result.stderr.lower() or "Command not found" in result.stderr
 
+    @pytest.mark.asyncio
+    async def test_command_strips_nested_mcp_sentinel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Mechanical checks should not inherit the MCP server recursion sentinel."""
+        monkeypatch.setenv("_OUROBOROS_NESTED", "1")
+
+        result = await run_command(
+            (
+                sys.executable,
+                "-c",
+                "import os; print(os.environ.get('_OUROBOROS_NESTED', 'missing'))",
+            ),
+            timeout=5,
+        )
+
+        assert result.return_code == 0
+        assert result.stdout.strip() == "missing"
+
 
 class TestMechanicalVerifier:
     """Tests for MechanicalVerifier class."""
@@ -201,6 +219,30 @@ class TestMechanicalVerifier:
             mech_result, _ = result.value
             assert mech_result.passed is False
             assert len(mech_result.failed_checks) == 1
+
+    @pytest.mark.asyncio
+    async def test_verify_failed_check_preserves_command_and_output_tail(self) -> None:
+        """Failed checks keep tail diagnostics instead of only the noisy prefix."""
+        with patch(
+            "ouroboros.evaluation.mechanical.run_command",
+            new_callable=AsyncMock,
+        ) as mock_run:
+            mock_run.return_value = CommandResult(
+                1,
+                "prefix\n" + ("." * 700) + "\nFAILED tests/test_example.py::test_case",
+                "stderr prefix\n" + ("x" * 700) + "\nAssertionError: boom",
+            )
+
+            verifier = MechanicalVerifier(_TEST_CONFIG)
+            result = await verifier.verify("exec-1", checks=[CheckType.TEST])
+
+            assert result.is_ok
+            mech_result, _ = result.value
+            details = mech_result.checks[0].details
+            assert details["command"] == ["echo", "test-ok"]
+            assert "FAILED tests/test_example.py::test_case" in details["stdout_tail"]
+            assert "AssertionError: boom" in details["stderr_tail"]
+            assert "FAILED tests/test_example.py::test_case" not in details["stdout_preview"]
 
     @pytest.mark.asyncio
     async def test_verify_coverage_below_threshold(self) -> None:

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -2251,10 +2251,21 @@ class TestEvaluateHandlerCodeChanges:
     def _make_stage1(self, *, passed: bool):
         from ouroboros.evaluation.models import CheckResult, CheckType, MechanicalResult
 
+        details = (
+            {
+                "command": ["uv", "run", "pytest", "tests/", "-x", "-q"],
+                "working_dir": "/tmp/project",
+                "stdout_tail": "FAILED tests/test_example.py::test_case",
+                "stderr_tail": "AssertionError: boom",
+            }
+            if not passed
+            else {}
+        )
         check = CheckResult(
             check_type=CheckType.TEST,
             passed=passed,
             message="tests passed" if passed else "tests failed",
+            details=details,
         )
         return MechanicalResult(passed=passed, checks=(check,), coverage_score=None)
 
@@ -2276,6 +2287,10 @@ class TestEvaluateHandlerCodeChanges:
         text = handler._format_evaluation_result(result, code_changes=True)
 
         assert "real build/test failures" in text
+        assert "command: uv run pytest tests/ -x -q" in text
+        assert "cwd: /tmp/project" in text
+        assert "FAILED tests/test_example.py::test_case" in text
+        assert "AssertionError: boom" in text
         assert "No code changes detected" not in text
 
     def test_format_result_stage1_fail_no_code_changes(self) -> None:

--- a/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
+++ b/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
@@ -1,6 +1,6 @@
 """Milestone-transition lateral review advisory tests for #817."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBreakdown
 from ouroboros.bigbang.interview import InterviewRound, InterviewState
@@ -8,6 +8,7 @@ from ouroboros.core.types import Result
 from ouroboros.events.interview import interview_lateral_review_recommended
 from ouroboros.mcp.tools.authoring_handlers import (
     InterviewHandler,
+    _build_interview_lateral_review_orchestration,
     _maybe_record_lateral_review_advisory,
 )
 
@@ -198,11 +199,88 @@ async def test_handler_surfaces_runnable_lateral_review_dispatch() -> None:
     assert tool_args["personas"] == ["researcher", "contrarian", "simplifier"]
     assert "Milestone: initial -> progress" in tool_args["problem_context"]
     assert "Next interview question: What edge case remains?" in tool_args["problem_context"]
+    orchestration = result.value.meta["lateral_review_orchestration"]
+    assert orchestration["kind"] == "mcp_directive"
+    assert orchestration["directive"] == "run_lateral_persona_panel"
+    assert orchestration["mcp_tool"] == "ouroboros_lateral_think"
+    assert orchestration["tool_args"] == tool_args
+
+    panel = orchestration["panel"]
+    assert panel["panel_id"] == "lateral_persona_panel.v1"
+    assert panel["mcp_tool"] == "ouroboros_lateral_think"
+    assert panel["dispatch_modes"] == ["plugin", "inline_fallback"]
+    assert panel["parallel_preference"] == "parallel_when_runtime_supports_subagents"
+    assert panel["sequential_fallback"] == {
+        "supported": True,
+        "mode": "sequential_persona_payload_dispatch",
+        "trigger": "runtime_has_no_native_parallel_subagent_primitive",
+    }
+    assert [persona["persona_id"] for persona in panel["personas"]] == [
+        "researcher",
+        "contrarian",
+        "simplifier",
+    ]
+    assert panel["response_payload_refs"]["requires_prose_parsing"] is False
+    assert "structured payload" in panel["runtime_instruction"]
+
+    runtime_handling = orchestration["runtime_handling"]
+    assert runtime_handling == {
+        "call_mcp_tool_first": True,
+        "parallel_capable_execution_mode": "parallel_subagent_panel",
+        "sequential_fallback_mode": "sequential_persona_payload_dispatch",
+        "sequential_fallback_trigger": "runtime_has_no_native_parallel_subagent_primitive",
+        "result_correlation_key": "context.persona",
+        "requires_prose_parsing": False,
+        "synthesize_before_interview_continuation": True,
+    }
     content_text = result.value.content[0].text
     assert content_text.startswith("Lateral review queued:")
     assert "Session sess-817" in content_text
     assert state.lateral_review_advised_milestones == ["progress"]
     handler._emit_event_bg.assert_called()
+
+
+def test_lateral_orchestration_falls_back_to_skill_prose_when_panel_metadata_absent() -> None:
+    tool_args = {
+        "problem_context": (
+            "Session sess-legacy\n"
+            "Milestone: initial -> progress\n"
+            "Next interview question: What edge case remains?"
+        ),
+        "current_approach": "Route the next interview turn.",
+        "personas": ["researcher", "contrarian", "simplifier"],
+        "failed_attempts": [],
+    }
+
+    with patch(
+        "ouroboros.mcp.tools.authoring_handlers."
+        "lateral_persona_panel_metadata_from_capability_definitions",
+        return_value={},
+    ):
+        orchestration = _build_interview_lateral_review_orchestration(
+            tool_args=tool_args
+        )
+
+    assert orchestration["kind"] == "mcp_directive"
+    assert orchestration["directive"] == "run_lateral_persona_panel"
+    assert orchestration["mcp_tool"] == "ouroboros_lateral_think"
+    assert orchestration["tool_args"] == tool_args
+    assert orchestration["structured_lateral_panel_metadata_available"] is False
+    assert orchestration["fallback"] == "skill_prose_instructions"
+    assert orchestration["prose_instruction_source"] == "skills/interview/SKILL.md"
+    assert "call ouroboros_lateral_think with meta.lateral_review_tool_args" in (
+        orchestration["prose_instruction"]
+    )
+    assert 'personas=["researcher","contrarian","simplifier"]' in (
+        orchestration["prose_instruction"]
+    )
+    assert "panel" not in orchestration
+    assert orchestration["runtime_handling"] == {
+        "call_mcp_tool_first": True,
+        "result_correlation_key": None,
+        "requires_prose_parsing": True,
+        "synthesize_before_interview_continuation": True,
+    }
 
 
 async def test_handler_does_not_record_advisory_before_auto_completion() -> None:

--- a/tests/unit/mcp/tools/test_interview_response_diagnostics.py
+++ b/tests/unit/mcp/tools/test_interview_response_diagnostics.py
@@ -16,6 +16,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from jsonschema import Draft202012Validator
 import pytest
 
 from ouroboros.bigbang.interview import (
@@ -28,6 +29,11 @@ from ouroboros.core.types import Result
 from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.errors import MCPServerError
 from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+from ouroboros.mcp.tools.subagent import synthesize_code_investigation_when_complete
+from ouroboros.orchestrator.capabilities import (
+    interview_code_investigation_answer_contract,
+    stable_code_investigation_question_identity,
+)
 
 
 @dataclass(slots=True)
@@ -58,6 +64,7 @@ class _StubInterviewEngine:
     next_question: str = "What is the primary user persona?"
     initial_state: InterviewState | None = None
     saved_states: list[InterviewState] = field(default_factory=list)
+    record_calls: list[dict[str, str]] = field(default_factory=list)
 
     async def start_interview(
         self,
@@ -83,6 +90,7 @@ class _StubInterviewEngine:
         user_response: str,
         question: str,
     ) -> Result[InterviewState, MCPServerError]:
+        self.record_calls.append({"question": question, "answer": user_response})
         state.rounds.append(
             InterviewRound(
                 round_number=state.current_round_number,
@@ -132,6 +140,273 @@ def _assert_reasoning_meta(meta: dict[str, Any], *, phase: str, session_id: str)
     assert f"session: {session_id}" in meta["internal_reasoning"]
 
 
+def _assert_code_investigation_request(
+    meta: dict[str, Any],
+    *,
+    session_id: str,
+    question: str,
+) -> None:
+    request = meta["code_investigation_request"]
+    assert request["session_id"] == session_id
+    assert request["question"] == question
+    assert request["question_identity"] == stable_code_investigation_question_identity(
+        question
+    )
+    assert request["investigation_goal"] == "describe_current_state_from_code"
+    assert request["investigation_targets"] == [
+        {"target_type": "workspace", "scope": "active"}
+    ]
+    assert "configuration" in request["fact_categories"]
+    assert request["allowed_capabilities"] == ["inspect_code"]
+    repo_tool_capabilities = request["repo_inspection_tool_capabilities"]
+    repo_tool_by_name = {tool["tool_name"]: tool for tool in repo_tool_capabilities}
+    assert set(repo_tool_by_name) == {"Read", "Glob", "Grep"}
+    for tool_name, tool_capability in repo_tool_by_name.items():
+        assert tool_capability["stable_id"] == f"builtin:{tool_name}"
+        assert tool_capability["source_kind"] == "builtin"
+        assert tool_capability["execution_mode"] == "repo_inspection"
+        assert tool_capability["logical_capability"] == "inspect_code"
+        assert tool_capability["mutation_class"] == "read_only"
+        assert tool_capability["side_effects"] == ["side_effect_free"]
+        assert tool_capability["fallback_used"] is False
+        Draft202012Validator.check_schema(tool_capability["input_schema"])
+    assert repo_tool_by_name["Read"]["input_schema"]["required"] == ["file_path"]
+    assert repo_tool_by_name["Glob"]["input_schema"]["required"] == ["pattern"]
+    assert repo_tool_by_name["Grep"]["input_schema"]["required"] == ["pattern"]
+    assert request["answer_prefixes"] == ["[from-code]", "[from-code][auto-confirmed]"]
+    assert request["answer_contract"] == interview_code_investigation_answer_contract()
+    capability = request["mcp_tool_capability"]
+    assert capability["tool_name"] == "ouroboros_interview"
+    assert capability["source_kind"] == "attached_mcp"
+    assert capability["source_name"] == "ouroboros"
+    assert capability["fallback_used"] is False
+    assert capability["execution_mode"] == "subagent_orchestration"
+    assert set(capability) >= {
+        "input_schema",
+        "execution_mode",
+        "companions",
+        "required_context_keys",
+        "side_effects",
+        "retry",
+        "interrupt",
+        "cancel",
+    }
+    request_schema = capability["orchestration"]["code_investigation"][
+        "request_model_schema"
+    ]
+    Draft202012Validator(request_schema).validate(request)
+
+
+@pytest.mark.asyncio
+async def test_code_investigation_results_are_collected_before_synthesis(
+    tmp_path: Path,
+) -> None:
+    """Code-fact subagent output is collected and passed to synthesis."""
+    engine = _StubInterviewEngine(state_dir=tmp_path)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=_CapturingEventStore(),
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle(
+        {"initial_context": "Build a CLI", "cwd": str(tmp_path)},
+    )
+    assert outcome.is_ok
+    request = outcome.value.meta["code_investigation_request"]
+    response_schema = request["answer_contract"]["response_model_schema"]
+    code_fact_output = {
+        "session_id": request["session_id"],
+        "question_identity": request["question_identity"],
+        "answer_prefix": "[from-code][auto-confirmed]",
+        "answer_text": "The current project is a Python package managed by pyproject.toml.",
+        "confidence": "high_exact_match",
+        "evidence": [
+            {
+                "source": "pyproject.toml",
+                "locator": "project.name",
+                "claim": "The manifest declares the Python project metadata.",
+            }
+        ],
+        "requires_user_confirmation": False,
+    }
+    Draft202012Validator(response_schema).validate(code_fact_output)
+
+    synthesis_calls: list[list[dict[str, Any]]] = []
+
+    def synthesize(aggregated_outputs: list[dict[str, Any]]) -> dict[str, Any]:
+        synthesis_calls.append(aggregated_outputs)
+        collected = aggregated_outputs[0]["output"]
+        return {
+            "answer": f"{collected['answer_prefix']} {collected['answer_text']}",
+            "evidence_sources": [
+                evidence["source"] for evidence in collected["evidence"]
+            ],
+        }
+
+    partial = synthesize_code_investigation_when_complete(
+        request,
+        {
+            "code_facts": {
+                **code_fact_output,
+                "question_identity": stable_code_investigation_question_identity(
+                    "a different question"
+                ),
+            }
+        },
+        synthesize,
+    )
+    assert partial["ready_for_synthesis"] is False
+    assert partial["missing_result_ids"] == ["code_facts"]
+    assert partial["aggregated_outputs"] == []
+    assert partial["synthesis"] is None
+    assert synthesis_calls == []
+
+    complete = synthesize_code_investigation_when_complete(
+        request,
+        {"code_facts": code_fact_output},
+        synthesize,
+    )
+    assert complete["ready_for_synthesis"] is True
+    assert complete["missing_result_ids"] == []
+    assert complete["aggregated_outputs"] == [
+        {"result_id": "code_facts", "output": code_fact_output}
+    ]
+    assert complete["synthesis"] == {
+        "answer": (
+            "[from-code][auto-confirmed] The current project is a Python "
+            "package managed by pyproject.toml."
+        ),
+        "evidence_sources": ["pyproject.toml"],
+    }
+    assert synthesis_calls == [[{"result_id": "code_facts", "output": code_fact_output}]]
+
+
+@pytest.mark.asyncio
+async def test_interview_answer_records_only_after_code_investigation_synthesis(
+    tmp_path: Path,
+) -> None:
+    """The parent runtime must submit an interview answer only after synthesis.
+
+    ``InterviewHandler`` exposes code-investigation metadata and records whatever
+    answer the parent runtime later submits. This test pins the orchestration
+    boundary: incomplete investigation output does not call the answer path, and
+    the eventual recorded answer is the synthesized code-fact answer.
+    """
+    engine = _StubInterviewEngine(state_dir=tmp_path, next_question="Which framework is used?")
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=_CapturingEventStore(),
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    start = await handler.handle({"initial_context": "Audit the current app"})
+    assert start.is_ok
+    request = start.value.meta["code_investigation_request"]
+    request["required_result_ids"] = ["manifest", "router"]
+
+    contract = request["answer_contract"]
+    response_schema = contract["response_model_schema"]
+    manifest_output = {
+        "session_id": request["session_id"],
+        "question_identity": request["question_identity"],
+        "answer_prefix": "[from-code][auto-confirmed]",
+        "answer_text": "The manifest declares a Python package.",
+        "confidence": "high_exact_match",
+        "evidence": [
+            {
+                "source": "pyproject.toml",
+                "locator": "project.name",
+                "claim": "The project metadata is declared in pyproject.toml.",
+            }
+        ],
+        "requires_user_confirmation": False,
+    }
+    router_output = {
+        "session_id": request["session_id"],
+        "question_identity": request["question_identity"],
+        "answer_prefix": "[from-code]",
+        "answer_text": "No web router is present in the inspected files.",
+        "confidence": "medium_inferred",
+        "evidence": [
+            {
+                "source": "rg --files",
+                "locator": "workspace root",
+                "claim": "No frontend router file was found in the fixture workspace.",
+            }
+        ],
+        "requires_user_confirmation": True,
+        "user_confirmation_prompt": (
+            "Confirm whether the missing web router means this is not a web app."
+        ),
+    }
+    Draft202012Validator(response_schema).validate(manifest_output)
+    Draft202012Validator(response_schema).validate(router_output)
+
+    ordering: list[str] = []
+
+    def synthesize(aggregated_outputs: list[dict[str, Any]]) -> dict[str, Any]:
+        ordering.append("synthesized")
+        answer_lines = [
+            item["output"]["answer_text"]
+            for item in aggregated_outputs
+        ]
+        return {
+            "answer": "[from-code] " + " ".join(answer_lines),
+            "evidence_sources": [
+                evidence["source"]
+                for item in aggregated_outputs
+                for evidence in item["output"]["evidence"]
+            ],
+        }
+
+    partial = synthesize_code_investigation_when_complete(
+        request,
+        {"manifest": manifest_output},
+        synthesize,
+    )
+    assert partial["ready_for_synthesis"] is False
+    assert partial["synthesis"] is None
+    assert ordering == []
+    assert engine.record_calls == []
+
+    complete = synthesize_code_investigation_when_complete(
+        request,
+        {"manifest": manifest_output, "router": router_output},
+        synthesize,
+    )
+    assert complete["ready_for_synthesis"] is True
+    synthesized_answer = complete["synthesis"]["answer"]
+
+    state = engine.saved_states[-1]
+    engine.initial_state = state
+    engine.next_question = "What should acceptance cover?"
+    answer = await handler.handle(
+        {
+            "session_id": request["session_id"],
+            "answer": synthesized_answer,
+            "last_question": request["question"],
+        }
+    )
+
+    assert answer.is_ok
+    assert ordering == ["synthesized"]
+    assert engine.record_calls == [
+        {
+            "question": "Which framework is used?",
+            "answer": synthesized_answer,
+        }
+    ]
+    recorded_round = state.rounds[0]
+    assert recorded_round.question == "Which framework is used?"
+    assert recorded_round.user_response == synthesized_answer
+    assert "pyproject.toml" in complete["synthesis"]["evidence_sources"]
+
+
 @pytest.mark.asyncio
 async def test_start_emits_response_diagnostic_event(tmp_path: Path) -> None:
     """Start path: a normal first question emits the response.emitted event."""
@@ -151,6 +426,11 @@ async def test_start_emits_response_diagnostic_event(tmp_path: Path) -> None:
     assert outcome.is_ok
     _assert_reasoning_meta(
         outcome.value.meta, phase="start", session_id="interview_diagnostics00001"
+    )
+    _assert_code_investigation_request(
+        outcome.value.meta,
+        session_id="interview_diagnostics00001",
+        question="What is the primary user persona?",
     )
     assert outcome.value.meta["interview_reasoning"]["pending_question"] is True
     assert outcome.value.meta["interview_reasoning"]["question_chars"] == len(
@@ -194,6 +474,7 @@ async def test_start_with_length_guard_question_marks_event(tmp_path: Path) -> N
         {"initial_context": "Build a CLI", "cwd": str(tmp_path)},
     )
     assert outcome.is_ok
+    assert "code_investigation_request" not in outcome.value.meta
     await _drain_bg_tasks(handler)
 
     diagnostic = _find_event(event_store.events, event_type="interview.response.emitted")
@@ -234,6 +515,11 @@ async def test_resume_pending_emits_response_diagnostic_event(tmp_path: Path) ->
         outcome.value.meta,
         phase="resume_pending",
         session_id=pending_state.interview_id,
+    )
+    _assert_code_investigation_request(
+        outcome.value.meta,
+        session_id=pending_state.interview_id,
+        question="What is the main goal?",
     )
     assert outcome.value.meta["interview_reasoning"]["pending_question"] is True
     await _drain_bg_tasks(handler)
@@ -326,6 +612,11 @@ async def test_answer_emits_response_diagnostic_event(tmp_path: Path) -> None:
         outcome.value.meta,
         phase="answer",
         session_id=pending_state.interview_id,
+    )
+    _assert_code_investigation_request(
+        outcome.value.meta,
+        session_id=pending_state.interview_id,
+        question="Who uses it first?",
     )
     assert outcome.value.meta["interview_reasoning"]["answered_rounds"] == 1
     assert outcome.value.content[0].text == (

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -17,6 +17,14 @@ import json
 import pytest
 
 from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
+from ouroboros.mcp.tools.subagent import (
+    continue_interview_after_lateral_persona_synthesis,
+    lateral_persona_panel_metadata_from_capability_definitions,
+    lateral_review_response_to_interview_orchestration_entries,
+    lateral_review_response_to_interview_orchestration_metadata,
+    synthesize_lateral_persona_panel_when_complete,
+)
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 
 
 @pytest.mark.asyncio
@@ -40,11 +48,566 @@ async def test_multi_persona_plugin_mode_emits_subagents_envelope() -> None:
     assert payload.meta is not None
     # Envelope is present on meta and as JSON text.
     assert "_subagents" in payload.meta
-    assert len(payload.meta["_subagents"]) == 2
+    subagents = payload.meta["_subagents"]
+    assert len(subagents) == 2
+    assert [subagent["agent"] for subagent in subagents] == ["hacker", "contrarian"]
+    assert [subagent["title"] for subagent in subagents] == [
+        "Lateral (hacker)",
+        "Lateral (contrarian)",
+    ]
+    assert [subagent["context"]["persona"] for subagent in subagents] == [
+        "hacker",
+        "contrarian",
+    ]
     text = payload.content[0].text
     decoded = json.loads(text)
     assert "_subagents" in decoded
-    assert len(decoded["_subagents"]) == 2
+    assert [
+        (subagent["agent"], subagent["context"]["persona"])
+        for subagent in decoded["_subagents"]
+    ] == [("hacker", "hacker"), ("contrarian", "contrarian")]
+
+
+@pytest.mark.asyncio
+async def test_plugin_lateral_response_converts_to_interview_persona_panel_entries() -> None:
+    """Plugin lateral-review responses become per-persona interview metadata."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview crossed a milestone",
+            "current_approach": "continue with the next question",
+            "personas": ["researcher", "contrarian", "simplifier"],
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        payload,
+        session_id="sess-panel",
+        runtime_supports_parallel_subagents=True,
+    )
+
+    assert [entry["persona_id"] for entry in entries] == [
+        "researcher",
+        "contrarian",
+        "simplifier",
+    ]
+    assert {entry["panel_id"] for entry in entries} == {"lateral_persona_panel.v1"}
+    assert {entry["mcp_tool"] for entry in entries} == {"ouroboros_lateral_think"}
+    assert {entry["dispatch_mode"] for entry in entries} == {"plugin"}
+    assert {entry["response_payload_source"] for entry in entries} == {"meta"}
+    assert {entry["execution_mode"] for entry in entries} == {"parallel_subagent_panel"}
+    assert all(entry["requires_prose_parsing"] is False for entry in entries)
+    assert all(entry["sequential_fallback_used"] is False for entry in entries)
+    assert [entry["execution_order"] for entry in entries] == [1, 2, 3]
+    for entry in entries:
+        assert entry["session_id"] == "sess-panel"
+        assert entry["parallel_group"] == "sess-panel:lateral_persona_panel.v1"
+        assert entry["prompt"]
+        assert entry["context"]["persona"] == entry["persona_id"]
+        assert entry["persona_role"]
+
+
+@pytest.mark.asyncio
+async def test_parallel_lateral_synthesis_waits_for_all_persona_outputs() -> None:
+    """Parallel persona collection gates synthesis until every output is present."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview crossed a milestone",
+            "current_approach": "continue only after lateral synthesis",
+            "personas": ["researcher", "contrarian", "simplifier"],
+        }
+    )
+
+    assert result.is_ok, result
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        result.unwrap(),
+        session_id="sess-aggregate",
+        runtime_supports_parallel_subagents=True,
+    )
+    assert [entry["persona_id"] for entry in entries] == [
+        "researcher",
+        "contrarian",
+        "simplifier",
+    ]
+
+    synthesis_calls = []
+
+    def synthesize(aggregated_outputs: list[dict]) -> dict:
+        synthesis_calls.append(aggregated_outputs)
+        return {
+            "persona_ids": [item["persona_id"] for item in aggregated_outputs],
+            "combined": "\n".join(str(item["output"]) for item in aggregated_outputs),
+        }
+
+    partial = synthesize_lateral_persona_panel_when_complete(
+        entries,
+        {
+            "contrarian": "challenge the assumption",
+            "researcher": "verify the current implementation",
+        },
+        synthesize,
+    )
+
+    assert partial["ready_for_synthesis"] is False
+    assert partial["missing_personas"] == ["simplifier"]
+    assert [item["persona_id"] for item in partial["aggregated_outputs"]] == [
+        "researcher",
+        "contrarian",
+    ]
+    assert partial["synthesis"] is None
+    assert synthesis_calls == []
+
+    complete = synthesize_lateral_persona_panel_when_complete(
+        entries,
+        {
+            "contrarian": "challenge the assumption",
+            "simplifier": "reduce the next question",
+            "researcher": "verify the current implementation",
+        },
+        synthesize,
+    )
+
+    assert complete["ready_for_synthesis"] is True
+    assert complete["missing_personas"] == []
+    assert complete["synthesis"] == {
+        "persona_ids": ["researcher", "contrarian", "simplifier"],
+        "combined": (
+            "verify the current implementation\n"
+            "challenge the assumption\n"
+            "reduce the next question"
+        ),
+    }
+    assert len(synthesis_calls) == 1
+    assert [item["persona_id"] for item in synthesis_calls[0]] == [
+        "researcher",
+        "contrarian",
+        "simplifier",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_parallel_lateral_synthesis_precedes_interview_continuation() -> None:
+    """Parallel persona results are synthesized before the interview turn resumes."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview crossed a milestone",
+            "current_approach": "continue only after synthesized lateral review",
+            "personas": ["researcher", "contrarian", "simplifier"],
+        }
+    )
+
+    assert result.is_ok, result
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        result.unwrap(),
+        session_id="sess-continuation-order",
+        runtime_supports_parallel_subagents=True,
+    )
+
+    timeline: list[str] = []
+
+    def synthesize(aggregated_outputs: list[dict]) -> dict:
+        timeline.append("synthesis")
+        return {
+            "persona_ids": [item["persona_id"] for item in aggregated_outputs],
+            "summary": "lateral review is ready",
+        }
+
+    def continue_interview(synthesis: dict) -> dict:
+        assert timeline == ["synthesis"]
+        assert synthesis["persona_ids"] == ["researcher", "contrarian", "simplifier"]
+        timeline.append("interview_continuation")
+        return {
+            "next_question": "What risk should we clarify next?",
+            "lateral_synthesis": synthesis,
+        }
+
+    partial = continue_interview_after_lateral_persona_synthesis(
+        entries,
+        {
+            "researcher": "verify current implementation",
+            "contrarian": "challenge milestone assumption",
+        },
+        synthesize,
+        continue_interview,
+    )
+
+    assert partial["ready_for_synthesis"] is False
+    assert partial["continued_interview"] is False
+    assert partial["interview_continuation"] is None
+    assert timeline == []
+
+    complete = continue_interview_after_lateral_persona_synthesis(
+        entries,
+        {
+            "simplifier": "reduce follow-up scope",
+            "contrarian": "challenge milestone assumption",
+            "researcher": "verify current implementation",
+        },
+        synthesize,
+        continue_interview,
+    )
+
+    assert complete["ready_for_synthesis"] is True
+    assert complete["continued_interview"] is True
+    assert complete["interview_continuation"] == {
+        "next_question": "What risk should we clarify next?",
+        "lateral_synthesis": complete["synthesis"],
+    }
+    assert timeline == ["synthesis", "interview_continuation"]
+
+
+@pytest.mark.asyncio
+async def test_interview_orchestration_reader_uses_capability_panel_metadata() -> None:
+    """Panel identity, roles, and fallback mode come from capability metadata."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview crossed a milestone",
+            "current_approach": "continue with the next question",
+            "personas": ["researcher", "contrarian"],
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    capability_panel = lateral_persona_panel_metadata_from_capability_definitions()
+
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        payload,
+        session_id="sess-capability",
+        runtime_supports_parallel_subagents=True,
+        lateral_panel_metadata=capability_panel,
+    )
+
+    assert entries
+    assert {entry["panel_id"] for entry in entries} == {capability_panel["panel_id"]}
+    assert {entry["mcp_tool"] for entry in entries} == {capability_panel["mcp_tool"]}
+    assert {entry["parallel_group"] for entry in entries} == {
+        f"sess-capability:{capability_panel['panel_id']}"
+    }
+    roles_by_id = {
+        persona["persona_id"]: persona["role"] for persona in capability_panel["personas"]
+    }
+    for entry in entries:
+        assert entry["persona_role"] == roles_by_id[entry["persona_id"]]
+        assert (
+            entry["requires_prose_parsing"]
+            is capability_panel["response_payload_refs"]["requires_prose_parsing"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_interview_orchestration_reader_honors_custom_capability_metadata() -> None:
+    """Regression guard against hard-coded lateral panel metadata in the reader."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview needs a lightweight review",
+            "current_approach": "ask the next Socratic question",
+            "personas": ["researcher"],
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    custom_panel = {
+        "panel_id": "custom_lateral_panel.v9",
+        "mcp_tool": "custom_lateral_tool",
+        "sequential_fallback": {
+            "supported": True,
+            "mode": "custom_sequential_mode",
+            "trigger": "test_runtime_without_parallel_subagents",
+        },
+        "personas": [
+            {"persona_id": "researcher", "role": "Custom research role"},
+        ],
+        "response_payload_refs": {"requires_prose_parsing": True},
+    }
+
+    metadata = lateral_review_response_to_interview_orchestration_metadata(
+        payload,
+        session_id="sess-custom",
+        runtime_supports_parallel_subagents=False,
+        lateral_panel_metadata=custom_panel,
+    )
+
+    panel = metadata["lateral_panel"]
+    entries = panel["entries"]
+    assert panel["panel_id"] == "custom_lateral_panel.v9"
+    assert panel["mcp_tool"] == "custom_lateral_tool"
+    assert panel["execution_mode"] == "custom_sequential_mode"
+    assert panel["requires_prose_parsing"] is True
+    assert entries[0]["panel_id"] == "custom_lateral_panel.v9"
+    assert entries[0]["mcp_tool"] == "custom_lateral_tool"
+    assert entries[0]["persona_role"] == "Custom research role"
+    assert entries[0]["execution_mode"] == "custom_sequential_mode"
+    assert entries[0]["parallel_group"] == "sess-custom:custom_lateral_panel.v9"
+
+
+@pytest.mark.asyncio
+async def test_inline_lateral_content_converts_to_sequential_persona_panel_entries() -> None:
+    """Content-only inline fallback still yields structured panel entries."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview needs a lightweight review",
+            "current_approach": "ask the next Socratic question",
+            "personas": ["researcher", "simplifier"],
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    # Simulate an MCP transport that preserved only visible content and dropped meta.
+    content_only = MCPToolResult(
+        content=(MCPContentItem(type=ContentType.TEXT, text=payload.text_content),),
+        is_error=False,
+        meta={},
+    )
+
+    metadata = lateral_review_response_to_interview_orchestration_metadata(
+        content_only,
+        session_id="sess-inline",
+        runtime_supports_parallel_subagents=False,
+    )
+
+    panel = metadata["lateral_panel"]
+    entries = panel["entries"]
+    assert panel["panel_id"] == "lateral_persona_panel.v1"
+    assert panel["mcp_tool"] == "ouroboros_lateral_think"
+    assert panel["entry_count"] == 2
+    assert panel["execution_mode"] == "sequential_persona_payload_dispatch"
+    assert panel["requires_prose_parsing"] is False
+    assert [entry["persona_id"] for entry in entries] == ["researcher", "simplifier"]
+    assert {entry["dispatch_mode"] for entry in entries} == {"inline_fallback"}
+    assert {entry["response_payload_source"] for entry in entries} == {"inline_content"}
+    assert {entry["execution_mode"] for entry in entries} == {"sequential_persona_payload_dispatch"}
+    assert all(entry["sequential_fallback_used"] is True for entry in entries)
+
+
+@pytest.mark.asyncio
+async def test_sequential_lateral_consumer_receives_persona_payloads_in_order() -> None:
+    """Sequential fallback consumers receive persona payloads in request order."""
+    requested_personas = ["simplifier", "hacker", "researcher"]
+    handler = LateralThinkHandler(
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview needs ordered persona review",
+            "current_approach": "dispatch sequentially when parallel panes are unavailable",
+            "personas": requested_personas,
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        payload,
+        session_id="sess-sequential-consumer",
+        runtime_supports_parallel_subagents=False,
+    )
+
+    sequential_consumer_received = []
+    for entry in entries:
+        assert entry["execution_mode"] == "sequential_persona_payload_dispatch"
+        assert entry["sequential_fallback_used"] is True
+        sequential_consumer_received.append(
+            {
+                "execution_order": entry["execution_order"],
+                "persona_id": entry["persona_id"],
+                "agent": entry["agent"],
+                "context_persona": entry["context"]["persona"],
+                "prompt": entry["prompt"],
+            }
+        )
+
+    assert [item["execution_order"] for item in sequential_consumer_received] == [1, 2, 3]
+    assert [item["persona_id"] for item in sequential_consumer_received] == requested_personas
+    assert [item["agent"] for item in sequential_consumer_received] == requested_personas
+    assert [item["context_persona"] for item in sequential_consumer_received] == requested_personas
+    for item in sequential_consumer_received:
+        assert f"**{item['persona_id']}** persona" in item["prompt"]
+        assert "Task for you (subagent)" in item["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_sequential_lateral_synthesis_waits_for_configured_sequence_outputs() -> None:
+    """Sequential fallback gates synthesis until every ordered persona output arrives."""
+    requested_personas = ["simplifier", "hacker", "researcher"]
+    handler = LateralThinkHandler(
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview needs ordered persona synthesis",
+            "current_approach": "continue only after sequential review completes",
+            "personas": requested_personas,
+        }
+    )
+
+    assert result.is_ok, result
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        result.unwrap(),
+        session_id="sess-sequential-aggregate",
+        runtime_supports_parallel_subagents=False,
+    )
+    assert [entry["persona_id"] for entry in entries] == requested_personas
+    assert {entry["execution_mode"] for entry in entries} == {
+        "sequential_persona_payload_dispatch"
+    }
+    assert all(entry["sequential_fallback_used"] is True for entry in entries)
+
+    synthesis_calls = []
+
+    def synthesize(aggregated_outputs: list[dict]) -> dict:
+        synthesis_calls.append(aggregated_outputs)
+        return {
+            "persona_ids": [item["persona_id"] for item in aggregated_outputs],
+            "combined": "\n".join(str(item["output"]) for item in aggregated_outputs),
+        }
+
+    consumed_outputs: dict[str, str] = {}
+    for index, persona_id in enumerate(requested_personas[:-1], start=1):
+        consumed_outputs[persona_id] = f"{persona_id} output"
+        partial = synthesize_lateral_persona_panel_when_complete(
+            entries,
+            consumed_outputs,
+            synthesize,
+        )
+
+        assert partial["ready_for_synthesis"] is False
+        assert partial["missing_personas"] == requested_personas[index:]
+        assert [item["persona_id"] for item in partial["aggregated_outputs"]] == (
+            requested_personas[:index]
+        )
+        assert partial["synthesis"] is None
+        assert synthesis_calls == []
+
+    consumed_outputs[requested_personas[-1]] = "researcher output"
+    complete = synthesize_lateral_persona_panel_when_complete(
+        entries,
+        consumed_outputs,
+        synthesize,
+    )
+
+    assert complete["ready_for_synthesis"] is True
+    assert complete["missing_personas"] == []
+    assert complete["synthesis"] == {
+        "persona_ids": requested_personas,
+        "combined": "simplifier output\nhacker output\nresearcher output",
+    }
+    assert len(synthesis_calls) == 1
+    assert [item["persona_id"] for item in synthesis_calls[0]] == requested_personas
+
+
+@pytest.mark.asyncio
+async def test_sequential_lateral_synthesis_precedes_interview_continuation() -> None:
+    """Sequential fallback also synthesizes before the interview turn resumes."""
+    requested_personas = ["simplifier", "hacker", "researcher"]
+    handler = LateralThinkHandler(
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview needs ordered persona review",
+            "current_approach": "continue only after sequential synthesis",
+            "personas": requested_personas,
+        }
+    )
+
+    assert result.is_ok, result
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        result.unwrap(),
+        session_id="sess-sequential-continuation-order",
+        runtime_supports_parallel_subagents=False,
+    )
+    assert all(entry["sequential_fallback_used"] is True for entry in entries)
+
+    timeline: list[str] = []
+
+    def synthesize(aggregated_outputs: list[dict]) -> dict:
+        timeline.append("synthesis")
+        return {
+            "persona_ids": [item["persona_id"] for item in aggregated_outputs],
+            "summary": "ordered lateral synthesis is ready",
+        }
+
+    def continue_interview(synthesis: dict) -> dict:
+        assert timeline == ["synthesis"]
+        assert synthesis["persona_ids"] == requested_personas
+        timeline.append("interview_continuation")
+        return {
+            "next_question": "Which assumption remains unclear?",
+            "lateral_synthesis": synthesis,
+        }
+
+    incomplete = continue_interview_after_lateral_persona_synthesis(
+        entries,
+        {
+            "simplifier": "reduce follow-up scope",
+            "hacker": "identify workaround risk",
+        },
+        synthesize,
+        continue_interview,
+    )
+
+    assert incomplete["ready_for_synthesis"] is False
+    assert incomplete["continued_interview"] is False
+    assert timeline == []
+
+    complete = continue_interview_after_lateral_persona_synthesis(
+        entries,
+        {
+            "researcher": "verify implementation facts",
+            "hacker": "identify workaround risk",
+            "simplifier": "reduce follow-up scope",
+        },
+        synthesize,
+        continue_interview,
+    )
+
+    assert complete["ready_for_synthesis"] is True
+    assert complete["continued_interview"] is True
+    assert complete["interview_continuation"] == {
+        "next_question": "Which assumption remains unclear?",
+        "lateral_synthesis": complete["synthesis"],
+    }
+    assert timeline == ["synthesis", "interview_continuation"]
 
 
 @pytest.mark.asyncio
@@ -306,6 +869,7 @@ async def test_inline_fallback_carries_dispatch_block_in_content() -> None:
     assert len(payloads) == 2
 
     for persona_name, persona_payload in zip(["hacker", "contrarian"], payloads, strict=True):
+        assert persona_payload["agent"] == persona_name
         assert persona_payload["title"] == f"Lateral ({persona_name})"
         # The canonical prompt carries the "Task for you (subagent)" wrapper
         # that plugin mode also dispatches — same builder, same prompt.

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -2,20 +2,3779 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
+from collections.abc import Mapping
+from dataclasses import fields, replace
+from types import SimpleNamespace
+from unittest.mock import patch
 
-from ouroboros.mcp.types import MCPToolDefinition
+from jsonschema import Draft202012Validator
+import pytest
+
+from ouroboros.mcp.tools.definitions import get_ouroboros_tools
+from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
+from ouroboros.mcp.tools.subagent import (
+    lateral_review_response_to_interview_orchestration_entries,
+)
+from ouroboros.mcp.types import MCPToolDefinition, MCPToolParameter, ToolInputType
+import ouroboros.orchestrator.capabilities as capabilities_module
 from ouroboros.orchestrator.capabilities import (
     CapabilityApprovalClass,
+    CapabilityInterruptibility,
     CapabilityMutationClass,
     CapabilityOrigin,
     CapabilityParallelSafety,
     CapabilityScope,
+    CapabilityToolMetadata,
     build_capability_graph,
+    deserialize_code_investigation_request_metadata,
+    extract_capability_input_schema,
+    interview_code_investigation_answer_contract,
+    lookup_ouroboros_tool_capability_metadata,
+    mcp_tool_required_parameter_keys,
     normalize_serialized_capability_graph,
+    ouroboros_tool_capability_metadata,
+    ouroboros_tool_capability_registry,
+    resolve_mcp_tool_capability_descriptor,
+    resolve_skill_capability_descriptor,
     serialize_capability_graph,
+    stable_code_investigation_question_identity,
+    validate_capability_tool_metadata,
 )
 from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+from ouroboros.orchestrator.policy import (
+    PolicyContext,
+    PolicyExecutionPhase,
+    PolicySessionRole,
+    allowed_capability_names,
+)
+from ouroboros.orchestrator.skill_tool_mapping import (
+    get_packaged_skill_tool_mappings,
+    get_skill_tool_mapping,
+    skill_tool_mapping_by_skill,
+)
+
+
+def _frontmatter_mcp_tools() -> set[str]:
+    return {mapping.mcp_tool for mapping in get_packaged_skill_tool_mappings()}
+
+
+_EXPECTED_OUROBOROS_TOOL_EXECUTION_MODES = {
+    "ouroboros_ac_tree_hud": "status",
+    "ouroboros_auto": "blocking",
+    "ouroboros_brownfield": "blocking",
+    "ouroboros_cancel_execution": "cancel",
+    "ouroboros_cancel_job": "cancel",
+    "ouroboros_checklist_verify": "blocking",
+    "ouroboros_evaluate": "blocking",
+    "ouroboros_evolve_rewind": "blocking",
+    "ouroboros_evolve_step": "blocking",
+    "ouroboros_execute_seed": "blocking",
+    "ouroboros_generate_seed": "blocking",
+    "ouroboros_interview": "subagent_orchestration",
+    "ouroboros_job_result": "status",
+    "ouroboros_job_status": "status",
+    "ouroboros_job_wait": "status",
+    "ouroboros_lateral_think": "subagent_orchestration",
+    "ouroboros_lineage_status": "status",
+    "ouroboros_measure_drift": "blocking",
+    "ouroboros_pm_interview": "subagent_orchestration",
+    "ouroboros_qa": "blocking",
+    "ouroboros_query_events": "status",
+    "ouroboros_query_projection": "status",
+    "ouroboros_ralph": "blocking",
+    "ouroboros_session_status": "status",
+    "ouroboros_start_auto": "background",
+    "ouroboros_start_evaluate": "background",
+    "ouroboros_start_evolve_step": "background",
+    "ouroboros_start_execute_seed": "background",
+    "ouroboros_start_ralph": "background",
+}
+
+_VALID_OUROBOROS_TOOL_EXECUTION_MODES = frozenset(
+    {"blocking", "background", "status", "cancel", "subagent_orchestration"}
+)
+
+_REQUIRED_OUROBOROS_TOOL_METADATA_FIELDS = frozenset(
+    {
+        "input_schema",
+        "execution_mode",
+        "companions",
+        "required_context_keys",
+        "side_effects",
+        "retry",
+        "interrupt",
+        "cancel",
+    }
+)
+
+_EXPECTED_OUROBOROS_REQUIRED_CONTEXT_KEYS = {
+    "ouroboros_ac_tree_hud": ("session_id", "cursor"),
+    "ouroboros_auto": (),
+    "ouroboros_brownfield": (),
+    "ouroboros_cancel_execution": ("execution_id",),
+    "ouroboros_cancel_job": ("job_id",),
+    "ouroboros_checklist_verify": ("session_id", "seed_content", "artifact"),
+    "ouroboros_evaluate": (
+        "session_id",
+        "artifact",
+        "seed_content",
+        "acceptance_criterion",
+    ),
+    "ouroboros_evolve_rewind": ("lineage_id", "to_generation"),
+    "ouroboros_evolve_step": ("lineage_id",),
+    "ouroboros_execute_seed": ("seed_path", "cwd"),
+    "ouroboros_generate_seed": ("session_id",),
+    "ouroboros_interview": (
+        "initial_context",
+        "cwd",
+        "session_id",
+        "answer",
+        "last_question",
+    ),
+    "ouroboros_job_result": ("job_id",),
+    "ouroboros_job_status": ("job_id",),
+    "ouroboros_job_wait": ("job_id", "cursor"),
+    "ouroboros_lateral_think": (
+        "problem_context",
+        "current_approach",
+        "failed_attempts",
+    ),
+    "ouroboros_lineage_status": ("lineage_id",),
+    "ouroboros_measure_drift": ("session_id", "current_output", "seed_content"),
+    "ouroboros_pm_interview": ("initial_context", "cwd", "session_id"),
+    "ouroboros_qa": (
+        "artifact",
+        "quality_bar",
+        "reference",
+        "seed_content",
+        "qa_session_id",
+        "iteration_history",
+    ),
+    "ouroboros_query_events": (),
+    "ouroboros_query_projection": (),
+    "ouroboros_ralph": ("lineage_id",),
+    "ouroboros_session_status": ("session_id",),
+    "ouroboros_start_auto": (
+        "goal",
+        "resume",
+        "cwd",
+        "max_interview_rounds",
+        "max_repair_rounds",
+        "skip_run",
+        "complete_product",
+        "pipeline_timeout_seconds",
+    ),
+    "ouroboros_start_evaluate": ("session_id", "artifact"),
+    "ouroboros_start_evolve_step": ("lineage_id",),
+    "ouroboros_start_execute_seed": ("seed_content", "session_id"),
+    "ouroboros_start_ralph": ("lineage_id",),
+}
+
+_EXPECTED_OUROBOROS_TOOL_COMPANIONS = {
+    "ouroboros_ac_tree_hud": (
+        "ouroboros_session_status",
+        "ouroboros_query_events",
+        "ouroboros_query_projection",
+    ),
+    "ouroboros_auto": ("ouroboros_start_auto",),
+    "ouroboros_brownfield": (
+        "ouroboros_interview",
+        "ouroboros_generate_seed",
+        "ouroboros_pm_interview",
+    ),
+    "ouroboros_cancel_execution": (
+        "ouroboros_execute_seed",
+        "ouroboros_start_execute_seed",
+    ),
+    "ouroboros_cancel_job": (
+        "ouroboros_start_auto",
+        "ouroboros_start_execute_seed",
+        "ouroboros_start_evaluate",
+        "ouroboros_start_evolve_step",
+        "ouroboros_start_ralph",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+    ),
+    "ouroboros_checklist_verify": (
+        "ouroboros_evaluate",
+        "ouroboros_start_evaluate",
+        "ouroboros_measure_drift",
+        "ouroboros_qa",
+    ),
+    "ouroboros_evaluate": (
+        "ouroboros_start_evaluate",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+        "ouroboros_cancel_job",
+        "ouroboros_checklist_verify",
+        "ouroboros_measure_drift",
+        "ouroboros_qa",
+    ),
+    "ouroboros_evolve_rewind": (
+        "ouroboros_evolve_step",
+        "ouroboros_start_evolve_step",
+        "ouroboros_lineage_status",
+        "ouroboros_ralph",
+        "ouroboros_start_ralph",
+    ),
+    "ouroboros_evolve_step": (
+        "ouroboros_start_evolve_step",
+        "ouroboros_lineage_status",
+        "ouroboros_evolve_rewind",
+        "ouroboros_ralph",
+        "ouroboros_start_ralph",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+        "ouroboros_cancel_job",
+    ),
+    "ouroboros_execute_seed": (
+        "ouroboros_start_execute_seed",
+        "ouroboros_cancel_execution",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+        "ouroboros_cancel_job",
+    ),
+    "ouroboros_generate_seed": (
+        "ouroboros_interview",
+        "ouroboros_pm_interview",
+        "ouroboros_brownfield",
+    ),
+    "ouroboros_interview": (
+        "ouroboros_generate_seed",
+        "ouroboros_pm_interview",
+        "ouroboros_brownfield",
+        "ouroboros_lateral_think",
+    ),
+    "ouroboros_job_result": (
+        "ouroboros_start_auto",
+        "ouroboros_start_execute_seed",
+        "ouroboros_start_evaluate",
+        "ouroboros_start_evolve_step",
+        "ouroboros_start_ralph",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_cancel_job",
+    ),
+    "ouroboros_job_status": (
+        "ouroboros_start_auto",
+        "ouroboros_start_execute_seed",
+        "ouroboros_start_evaluate",
+        "ouroboros_start_evolve_step",
+        "ouroboros_start_ralph",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+        "ouroboros_cancel_job",
+    ),
+    "ouroboros_job_wait": (
+        "ouroboros_start_auto",
+        "ouroboros_start_execute_seed",
+        "ouroboros_start_evaluate",
+        "ouroboros_start_evolve_step",
+        "ouroboros_start_ralph",
+        "ouroboros_job_status",
+        "ouroboros_job_result",
+        "ouroboros_cancel_job",
+    ),
+    "ouroboros_lateral_think": ("ouroboros_interview",),
+    "ouroboros_lineage_status": (
+        "ouroboros_evolve_step",
+        "ouroboros_start_evolve_step",
+        "ouroboros_evolve_rewind",
+        "ouroboros_ralph",
+        "ouroboros_start_ralph",
+    ),
+    "ouroboros_measure_drift": (
+        "ouroboros_evaluate",
+        "ouroboros_start_evaluate",
+        "ouroboros_checklist_verify",
+        "ouroboros_qa",
+    ),
+    "ouroboros_pm_interview": (
+        "ouroboros_interview",
+        "ouroboros_generate_seed",
+        "ouroboros_brownfield",
+    ),
+    "ouroboros_qa": (
+        "ouroboros_evaluate",
+        "ouroboros_start_evaluate",
+        "ouroboros_checklist_verify",
+        "ouroboros_measure_drift",
+    ),
+    "ouroboros_query_events": (
+        "ouroboros_session_status",
+        "ouroboros_query_projection",
+        "ouroboros_ac_tree_hud",
+    ),
+    "ouroboros_query_projection": (
+        "ouroboros_session_status",
+        "ouroboros_query_events",
+        "ouroboros_ac_tree_hud",
+    ),
+    "ouroboros_ralph": (
+        "ouroboros_evolve_step",
+        "ouroboros_start_evolve_step",
+        "ouroboros_lineage_status",
+        "ouroboros_evolve_rewind",
+        "ouroboros_start_ralph",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+        "ouroboros_cancel_job",
+    ),
+    "ouroboros_session_status": (
+        "ouroboros_query_events",
+        "ouroboros_query_projection",
+        "ouroboros_ac_tree_hud",
+    ),
+    "ouroboros_start_auto": (
+        "ouroboros_auto",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+        "ouroboros_cancel_job",
+    ),
+    "ouroboros_start_evaluate": (
+        "ouroboros_start_execute_seed",
+        "ouroboros_start_evolve_step",
+        "ouroboros_start_ralph",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+        "ouroboros_cancel_job",
+        "ouroboros_evaluate",
+        "ouroboros_checklist_verify",
+        "ouroboros_measure_drift",
+        "ouroboros_qa",
+    ),
+    "ouroboros_start_evolve_step": (
+        "ouroboros_start_execute_seed",
+        "ouroboros_start_evaluate",
+        "ouroboros_start_ralph",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+        "ouroboros_cancel_job",
+        "ouroboros_evolve_step",
+        "ouroboros_lineage_status",
+        "ouroboros_evolve_rewind",
+        "ouroboros_ralph",
+    ),
+    "ouroboros_start_execute_seed": (
+        "ouroboros_execute_seed",
+        "ouroboros_cancel_execution",
+        "ouroboros_start_evaluate",
+        "ouroboros_start_evolve_step",
+        "ouroboros_start_ralph",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+        "ouroboros_cancel_job",
+    ),
+    "ouroboros_start_ralph": (
+        "ouroboros_start_execute_seed",
+        "ouroboros_start_evaluate",
+        "ouroboros_start_evolve_step",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+        "ouroboros_cancel_job",
+        "ouroboros_evolve_step",
+        "ouroboros_lineage_status",
+        "ouroboros_evolve_rewind",
+        "ouroboros_ralph",
+    ),
+}
+
+_EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS = {
+    "ouroboros_ac_tree_hud": (),
+    "ouroboros_auto": ("workspace_write", "event_store_write"),
+    "ouroboros_brownfield": ("workspace_write", "event_store_write"),
+    "ouroboros_cancel_execution": (
+        "runtime_control",
+        "event_store_write",
+        "session_state_write",
+    ),
+    "ouroboros_cancel_job": (
+        "runtime_control",
+        "event_store_write",
+        "checkpoint_store_write",
+        "session_state_write",
+    ),
+    "ouroboros_checklist_verify": ("workspace_write", "event_store_write"),
+    "ouroboros_evaluate": ("session_state_write",),
+    "ouroboros_evolve_rewind": ("session_state_write",),
+    "ouroboros_evolve_step": ("workspace_write", "event_store_write"),
+    "ouroboros_execute_seed": ("workspace_write", "event_store_write"),
+    "ouroboros_generate_seed": ("workspace_write", "event_store_write"),
+    "ouroboros_interview": ("subagent_dispatch", "session_state_write"),
+    "ouroboros_job_result": (),
+    "ouroboros_job_status": (),
+    "ouroboros_job_wait": (),
+    "ouroboros_lateral_think": ("subagent_dispatch", "session_state_write"),
+    "ouroboros_lineage_status": (),
+    "ouroboros_measure_drift": ("session_state_write",),
+    "ouroboros_pm_interview": ("subagent_dispatch", "session_state_write"),
+    "ouroboros_qa": ("session_state_write",),
+    "ouroboros_query_events": (),
+    "ouroboros_query_projection": (),
+    "ouroboros_ralph": ("workspace_write", "event_store_write"),
+    "ouroboros_session_status": (),
+    "ouroboros_start_auto": ("workspace_write", "event_store_write"),
+    "ouroboros_start_evaluate": ("background_job_start", "event_store_write"),
+    "ouroboros_start_evolve_step": ("workspace_write", "event_store_write"),
+    "ouroboros_start_execute_seed": ("workspace_write", "event_store_write"),
+    "ouroboros_start_ralph": ("workspace_write", "event_store_write"),
+}
+
+_EXPECTED_MUTATION_TARGETS_BY_SIDE_EFFECT = {
+    "background_job_start": ("background_job",),
+    "checkpoint_store_write": ("checkpoint_store",),
+    "event_store_write": ("event_store",),
+    "runtime_control": ("runtime",),
+    "session_state_write": ("session_state",),
+    "side_effect_free": (),
+    "subagent_dispatch": ("subagent",),
+    "workspace_write": ("workspace",),
+}
+
+
+def _expected_mutation_targets_for_side_effects(
+    side_effects: tuple[str, ...],
+) -> tuple[str, ...]:
+    targets: list[str] = []
+    for side_effect in side_effects:
+        for target in _EXPECTED_MUTATION_TARGETS_BY_SIDE_EFFECT[side_effect]:
+            if target not in targets:
+                targets.append(target)
+    return tuple(targets)
+
+
+_EXPECTED_OUROBOROS_TOOL_STATE_MUTATIONS = dict.fromkeys(
+    _EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS,
+    (),
+) | {
+    "ouroboros_auto": (
+        {
+            "target": "auto_session_state",
+            "operation": "run_auto_pipeline_to_seed_and_execution",
+            "side_effect": "event_store_write",
+            "context_keys": ("goal", "resume", "cwd"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_auto_generated_execution_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("cwd",),
+        },
+    ),
+    "ouroboros_start_auto": (
+        {
+            "target": "auto_session_state",
+            "operation": "enqueue_background_auto_pipeline",
+            "side_effect": "event_store_write",
+            "context_keys": ("goal", "resume", "cwd"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_background_auto_execution_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("cwd",),
+        },
+    ),
+    "ouroboros_execute_seed": (
+        {
+            "target": "execution_session",
+            "operation": "run_seed_execution_session",
+            "side_effect": "event_store_write",
+            "context_keys": ("seed_path", "seed_content", "session_id", "cwd"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_seed_execution_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("cwd",),
+        },
+    ),
+    "ouroboros_start_execute_seed": (
+        {
+            "target": "execution_session",
+            "operation": "enqueue_background_seed_execution",
+            "side_effect": "event_store_write",
+            "context_keys": ("seed_content", "session_id", "cwd"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_background_seed_execution_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("cwd",),
+        },
+    ),
+    "ouroboros_evaluate": (
+        {
+            "target": "session_state",
+            "operation": "append_evaluation_result",
+            "side_effect": "session_state_write",
+            "context_keys": ("session_id",),
+        },
+    ),
+    "ouroboros_evolve_step": (
+        {
+            "target": "lineage_state",
+            "operation": "append_evolution_generation_result",
+            "side_effect": "event_store_write",
+            "context_keys": ("lineage_id", "seed_content", "execution_id"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_evolution_generation_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("project_dir",),
+        },
+    ),
+    "ouroboros_evolve_rewind": (
+        {
+            "target": "lineage_state",
+            "operation": "truncate_generations_after_target",
+            "side_effect": "session_state_write",
+            "context_keys": ("lineage_id", "to_generation"),
+        },
+    ),
+    "ouroboros_start_evolve_step": (
+        {
+            "target": "lineage_state",
+            "operation": "enqueue_background_evolution_generation",
+            "side_effect": "event_store_write",
+            "context_keys": ("lineage_id", "seed_content", "execution_id"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_background_evolution_generation_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("project_dir",),
+        },
+    ),
+    "ouroboros_interview": (
+        {
+            "target": "interview_state",
+            "operation": "create_or_update_or_complete_interview_session",
+            "side_effect": "session_state_write",
+            "context_keys": (
+                "initial_context",
+                "session_id",
+                "answer",
+                "last_question",
+            ),
+        },
+        {
+            "target": "subagent_dispatch_log",
+            "operation": "record_interview_subagent_dispatch",
+            "side_effect": "subagent_dispatch",
+            "context_keys": ("session_id",),
+        },
+    ),
+    "ouroboros_lateral_think": (
+        {
+            "target": "lateral_panel_state",
+            "operation": "dispatch_persona_panel_and_synthesize_findings",
+            "side_effect": "subagent_dispatch",
+            "context_keys": (
+                "problem_context",
+                "current_approach",
+                "failed_attempts",
+            ),
+        },
+        {
+            "target": "session_state",
+            "operation": "record_lateral_review_result",
+            "side_effect": "session_state_write",
+            "context_keys": ("problem_context",),
+        },
+    ),
+    "ouroboros_measure_drift": (
+        {
+            "target": "session_state",
+            "operation": "append_drift_measurement",
+            "side_effect": "session_state_write",
+            "context_keys": ("session_id",),
+        },
+    ),
+    "ouroboros_pm_interview": (
+        {
+            "target": "interview_state",
+            "operation": "create_or_update_pm_interview_session",
+            "side_effect": "session_state_write",
+            "context_keys": (
+                "initial_context",
+                "session_id",
+                "answer",
+                "last_question",
+            ),
+        },
+        {
+            "target": "pm_meta_state",
+            "operation": "persist_pm_session_metadata",
+            "side_effect": "session_state_write",
+            "context_keys": ("session_id", "cwd", "selected_repos"),
+        },
+        {
+            "target": "subagent_dispatch_log",
+            "operation": "record_pm_interview_subagent_dispatch",
+            "side_effect": "subagent_dispatch",
+            "context_keys": ("session_id",),
+        },
+    ),
+    "ouroboros_qa": (
+        {
+            "target": "qa_session_state",
+            "operation": "append_qa_iteration_verdict",
+            "side_effect": "session_state_write",
+            "context_keys": ("qa_session_id", "iteration_history"),
+        },
+    ),
+    "ouroboros_ralph": (
+        {
+            "target": "ralph_loop_state",
+            "operation": "run_evolution_loop_until_terminal_condition",
+            "side_effect": "event_store_write",
+            "context_keys": ("lineage_id", "execution_id"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_ralph_loop_generation_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("project_dir",),
+        },
+    ),
+    "ouroboros_start_ralph": (
+        {
+            "target": "ralph_loop_state",
+            "operation": "enqueue_background_evolution_loop",
+            "side_effect": "event_store_write",
+            "context_keys": ("lineage_id", "execution_id"),
+        },
+        {
+            "target": "workspace",
+            "operation": "apply_background_ralph_loop_generation_changes",
+            "side_effect": "workspace_write",
+            "context_keys": ("project_dir",),
+        },
+    ),
+    "ouroboros_cancel_execution": (
+        {
+            "target": "execution_session",
+            "operation": "mark_execution_session_cancelled",
+            "side_effect": "session_state_write",
+            "context_keys": ("execution_id", "reason"),
+        },
+        {
+            "target": "event_store",
+            "operation": "append_session_cancelled_event",
+            "side_effect": "event_store_write",
+            "context_keys": ("execution_id", "reason"),
+        },
+        {
+            "target": "runtime",
+            "operation": "signal_execution_runner_to_stop_via_cancellation_event",
+            "side_effect": "runtime_control",
+            "context_keys": ("execution_id",),
+        },
+    ),
+    "ouroboros_cancel_job": (
+        {
+            "target": "background_job",
+            "operation": "mark_background_job_cancel_requested",
+            "side_effect": "event_store_write",
+            "context_keys": ("job_id",),
+        },
+        {
+            "target": "checkpoint_store",
+            "operation": "persist_durable_agent_process_cancel_signal",
+            "side_effect": "checkpoint_store_write",
+            "context_keys": ("job_id",),
+        },
+        {
+            "target": "runtime",
+            "operation": "cancel_live_background_job_tasks",
+            "side_effect": "runtime_control",
+            "context_keys": ("job_id",),
+        },
+        {
+            "target": "session_state",
+            "operation": "mark_linked_execution_session_cancelled_when_needed",
+            "side_effect": "session_state_write",
+            "context_keys": ("job_id",),
+        },
+    ),
+}
+
+_EXPECTED_OUROBOROS_TOOL_MUTATION_TARGETS = {
+    name: tuple(
+        dict.fromkeys(
+            (
+                *_expected_mutation_targets_for_side_effects(side_effects),
+                *(
+                    mutation["target"]
+                    for mutation in _EXPECTED_OUROBOROS_TOOL_STATE_MUTATIONS[name]
+                ),
+            )
+        )
+    )
+    for name, side_effects in _EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS.items()
+}
+
+_EXPECTED_READ_ONLY_OUROBOROS_TOOLS = {
+    "ouroboros_ac_tree_hud",
+    "ouroboros_job_result",
+    "ouroboros_job_status",
+    "ouroboros_job_wait",
+    "ouroboros_lineage_status",
+    "ouroboros_query_events",
+    "ouroboros_query_projection",
+    "ouroboros_session_status",
+}
+
+_EXPECTED_OUROBOROS_TOOL_RETRY = {
+    "ouroboros_ac_tree_hud": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_auto": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_brownfield": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_cancel_execution": {"supported": False, "mode": "unsupported"},
+    "ouroboros_cancel_job": {"supported": False, "mode": "unsupported"},
+    "ouroboros_checklist_verify": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_evaluate": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_evolve_rewind": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_evolve_step": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_execute_seed": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_generate_seed": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_interview": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_job_result": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_job_status": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_job_wait": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_lateral_think": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_lineage_status": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_measure_drift": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_pm_interview": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_qa": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_query_events": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_query_projection": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_ralph": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_session_status": {"supported": True, "mode": "handler_owned"},
+    "ouroboros_start_auto": {"supported": True, "mode": "job_poll"},
+    "ouroboros_start_evaluate": {"supported": True, "mode": "job_poll"},
+    "ouroboros_start_evolve_step": {"supported": True, "mode": "job_poll"},
+    "ouroboros_start_execute_seed": {"supported": True, "mode": "job_poll"},
+    "ouroboros_start_ralph": {"supported": True, "mode": "job_poll"},
+}
+
+_BACKGROUND_INTERRUPT = {
+    "supported": True,
+    "mode": "resumable_background_job",
+    "resumable": True,
+    "cancellable": True,
+    "resume_companions": (
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+    ),
+    "cancel_companions": ("ouroboros_cancel_job",),
+    "target_context_keys": ("job_id",),
+}
+
+_READ_ONLY_INTERRUPT = {
+    "supported": True,
+    "mode": "read_only_non_mutating",
+    "mutation_semantics": "no_state_mutation",
+    "resumable": False,
+    "target_context_keys": (),
+}
+
+_TERMINAL_CONTROL_INTERRUPTS = {
+    "ouroboros_cancel_execution": {
+        "supported": True,
+        "mode": "terminal_control",
+        "terminal_action": "cancel",
+        "target_type": "execution_session",
+        "target_context_keys": ("execution_id",),
+        "directive_semantics": "request_terminal_execution_cancellation",
+        "terminal_statuses": ("cancelled",),
+        "idempotent": True,
+    },
+    "ouroboros_cancel_job": {
+        "supported": True,
+        "mode": "terminal_control",
+        "terminal_action": "cancel",
+        "target_type": "background_job",
+        "target_context_keys": ("job_id",),
+        "directive_semantics": "request_terminal_job_cancellation",
+        "terminal_statuses": ("cancelled",),
+        "idempotent": True,
+    },
+}
+
+
+def _blocking_interrupt(*background_companions: str) -> dict[str, object]:
+    return {
+        "supported": True,
+        "mode": "soft",
+        "execution_mode": "blocking",
+        "blocking_semantics": "synchronous_handler",
+        "resumable": False,
+        "background_companions": tuple(background_companions),
+        "target_context_keys": (),
+    }
+
+
+_EXPECTED_OUROBOROS_TOOL_INTERRUPT = {
+    "ouroboros_ac_tree_hud": _READ_ONLY_INTERRUPT,
+    "ouroboros_auto": _blocking_interrupt("ouroboros_start_auto"),
+    "ouroboros_brownfield": _blocking_interrupt(),
+    "ouroboros_cancel_execution": _TERMINAL_CONTROL_INTERRUPTS[
+        "ouroboros_cancel_execution"
+    ],
+    "ouroboros_cancel_job": _TERMINAL_CONTROL_INTERRUPTS["ouroboros_cancel_job"],
+    "ouroboros_checklist_verify": _blocking_interrupt(),
+    "ouroboros_evaluate": _blocking_interrupt("ouroboros_start_evaluate"),
+    "ouroboros_evolve_rewind": _blocking_interrupt(),
+    "ouroboros_evolve_step": _blocking_interrupt("ouroboros_start_evolve_step"),
+    "ouroboros_execute_seed": _blocking_interrupt("ouroboros_start_execute_seed"),
+    "ouroboros_generate_seed": _blocking_interrupt(),
+    "ouroboros_interview": {"supported": True, "mode": "soft"},
+    "ouroboros_job_result": _READ_ONLY_INTERRUPT,
+    "ouroboros_job_status": _READ_ONLY_INTERRUPT,
+    "ouroboros_job_wait": _READ_ONLY_INTERRUPT,
+    "ouroboros_lateral_think": {"supported": True, "mode": "soft"},
+    "ouroboros_lineage_status": _READ_ONLY_INTERRUPT,
+    "ouroboros_measure_drift": _blocking_interrupt(),
+    "ouroboros_pm_interview": {"supported": True, "mode": "soft"},
+    "ouroboros_qa": _blocking_interrupt(),
+    "ouroboros_query_events": _READ_ONLY_INTERRUPT,
+    "ouroboros_query_projection": _READ_ONLY_INTERRUPT,
+    "ouroboros_ralph": _blocking_interrupt("ouroboros_start_ralph"),
+    "ouroboros_session_status": _READ_ONLY_INTERRUPT,
+    "ouroboros_start_auto": _BACKGROUND_INTERRUPT,
+    "ouroboros_start_evaluate": _BACKGROUND_INTERRUPT,
+    "ouroboros_start_evolve_step": _BACKGROUND_INTERRUPT,
+    "ouroboros_start_execute_seed": _BACKGROUND_INTERRUPT,
+    "ouroboros_start_ralph": _BACKGROUND_INTERRUPT,
+}
+
+_UNSUPPORTED_CANCEL = {
+    "supported": False,
+    "mode": "unsupported",
+    "companions": (),
+    "target_context_keys": (),
+}
+_BACKGROUND_JOB_CANCEL = {
+    "supported": True,
+    "mode": "background_job",
+    "companions": ("ouroboros_cancel_job",),
+    "target_context_keys": ("job_id",),
+}
+_EXECUTION_SESSION_CANCEL = {
+    "supported": True,
+    "mode": "execution_session",
+    "companions": ("ouroboros_cancel_execution",),
+    "target_context_keys": ("execution_id",),
+}
+_BACKGROUND_JOB_CANCEL_CONTROL = {
+    "supported": True,
+    "mode": "background_job_control",
+    "companions": (
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_job_result",
+    ),
+    "target_context_keys": ("job_id",),
+}
+_EXECUTION_SESSION_CANCEL_CONTROL = {
+    "supported": True,
+    "mode": "execution_session_control",
+    "companions": (
+        "ouroboros_execute_seed",
+        "ouroboros_start_execute_seed",
+    ),
+    "target_context_keys": ("execution_id",),
+}
+
+_EXPECTED_OUROBOROS_TOOL_CANCEL = {
+    "ouroboros_ac_tree_hud": _UNSUPPORTED_CANCEL,
+    "ouroboros_auto": _UNSUPPORTED_CANCEL,
+    "ouroboros_brownfield": _UNSUPPORTED_CANCEL,
+    "ouroboros_cancel_execution": _EXECUTION_SESSION_CANCEL_CONTROL,
+    "ouroboros_cancel_job": _BACKGROUND_JOB_CANCEL_CONTROL,
+    "ouroboros_checklist_verify": _UNSUPPORTED_CANCEL,
+    "ouroboros_evaluate": _UNSUPPORTED_CANCEL,
+    "ouroboros_evolve_rewind": _UNSUPPORTED_CANCEL,
+    "ouroboros_evolve_step": _UNSUPPORTED_CANCEL,
+    "ouroboros_execute_seed": _EXECUTION_SESSION_CANCEL,
+    "ouroboros_generate_seed": _UNSUPPORTED_CANCEL,
+    "ouroboros_interview": _UNSUPPORTED_CANCEL,
+    "ouroboros_job_result": _UNSUPPORTED_CANCEL,
+    "ouroboros_job_status": _UNSUPPORTED_CANCEL,
+    "ouroboros_job_wait": _UNSUPPORTED_CANCEL,
+    "ouroboros_lateral_think": _UNSUPPORTED_CANCEL,
+    "ouroboros_lineage_status": _UNSUPPORTED_CANCEL,
+    "ouroboros_measure_drift": _UNSUPPORTED_CANCEL,
+    "ouroboros_pm_interview": _UNSUPPORTED_CANCEL,
+    "ouroboros_qa": _UNSUPPORTED_CANCEL,
+    "ouroboros_query_events": _UNSUPPORTED_CANCEL,
+    "ouroboros_query_projection": _UNSUPPORTED_CANCEL,
+    "ouroboros_ralph": _UNSUPPORTED_CANCEL,
+    "ouroboros_session_status": _UNSUPPORTED_CANCEL,
+    "ouroboros_start_auto": _BACKGROUND_JOB_CANCEL,
+    "ouroboros_start_evaluate": _BACKGROUND_JOB_CANCEL,
+    "ouroboros_start_evolve_step": _BACKGROUND_JOB_CANCEL,
+    "ouroboros_start_execute_seed": _BACKGROUND_JOB_CANCEL,
+    "ouroboros_start_ralph": _BACKGROUND_JOB_CANCEL,
+}
+
+_OUROBOROS_TOOL_CONTRACT_CASE_SETS = {
+    "execution_modes": _EXPECTED_OUROBOROS_TOOL_EXECUTION_MODES,
+    "required_context_keys": _EXPECTED_OUROBOROS_REQUIRED_CONTEXT_KEYS,
+    "companions": _EXPECTED_OUROBOROS_TOOL_COMPANIONS,
+    "side_effects": _EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS,
+    "mutation_targets": _EXPECTED_OUROBOROS_TOOL_MUTATION_TARGETS,
+    "state_mutations": _EXPECTED_OUROBOROS_TOOL_STATE_MUTATIONS,
+    "retry": _EXPECTED_OUROBOROS_TOOL_RETRY,
+    "interrupt": _EXPECTED_OUROBOROS_TOOL_INTERRUPT,
+    "cancel": _EXPECTED_OUROBOROS_TOOL_CANCEL,
+}
+
+
+def _assert_lifecycle_metadata_shape(
+    metadata: CapabilityToolMetadata,
+    tool_name: str,
+) -> None:
+    retry = metadata.retry
+    interrupt = metadata.interrupt
+    cancel = metadata.cancel
+
+    assert set(retry) == {"supported", "mode"}, tool_name
+    assert isinstance(retry["supported"], bool), tool_name
+    assert isinstance(retry["mode"], str), tool_name
+    assert retry["mode"], tool_name
+
+    if interrupt.get("execution_mode") == "blocking":
+        assert set(interrupt) == {
+            "supported",
+            "mode",
+            "execution_mode",
+            "blocking_semantics",
+            "resumable",
+            "background_companions",
+            "target_context_keys",
+        }, tool_name
+        assert interrupt["execution_mode"] == "blocking", tool_name
+        assert interrupt["blocking_semantics"] == "synchronous_handler", tool_name
+        assert interrupt["resumable"] is False, tool_name
+        assert isinstance(interrupt["background_companions"], tuple), tool_name
+        assert isinstance(interrupt["target_context_keys"], tuple), tool_name
+    elif interrupt.get("mode") == "resumable_background_job":
+        assert set(interrupt) == {
+            "supported",
+            "mode",
+            "resumable",
+            "cancellable",
+            "resume_companions",
+            "cancel_companions",
+            "target_context_keys",
+        }, tool_name
+        assert isinstance(interrupt["resumable"], bool), tool_name
+        assert isinstance(interrupt["cancellable"], bool), tool_name
+        assert isinstance(interrupt["resume_companions"], tuple), tool_name
+        assert isinstance(interrupt["cancel_companions"], tuple), tool_name
+        assert isinstance(interrupt["target_context_keys"], tuple), tool_name
+    elif interrupt.get("mode") == "read_only_non_mutating":
+        assert set(interrupt) == {
+            "supported",
+            "mode",
+            "mutation_semantics",
+            "resumable",
+            "target_context_keys",
+        }, tool_name
+        assert interrupt["supported"] is True, tool_name
+        assert interrupt["mutation_semantics"] == "no_state_mutation", tool_name
+        assert interrupt["resumable"] is False, tool_name
+        assert interrupt["target_context_keys"] == (), tool_name
+    elif interrupt.get("mode") == "terminal_control":
+        assert set(interrupt) == {
+            "supported",
+            "mode",
+            "terminal_action",
+            "target_type",
+            "target_context_keys",
+            "directive_semantics",
+            "terminal_statuses",
+            "idempotent",
+        }, tool_name
+        assert interrupt["supported"] is True, tool_name
+        assert interrupt["terminal_action"] == "cancel", tool_name
+        assert isinstance(interrupt["target_type"], str), tool_name
+        assert interrupt["target_type"], tool_name
+        assert isinstance(interrupt["target_context_keys"], tuple), tool_name
+        assert interrupt["target_context_keys"], tool_name
+        assert isinstance(interrupt["directive_semantics"], str), tool_name
+        assert interrupt["directive_semantics"], tool_name
+        assert isinstance(interrupt["terminal_statuses"], tuple), tool_name
+        assert interrupt["terminal_statuses"], tool_name
+        assert isinstance(interrupt["idempotent"], bool), tool_name
+    else:
+        assert set(interrupt) == {"supported", "mode"}, tool_name
+    assert isinstance(interrupt["supported"], bool), tool_name
+    assert isinstance(interrupt["mode"], str), tool_name
+    assert interrupt["mode"], tool_name
+
+    assert set(cancel) == {
+        "supported",
+        "mode",
+        "companions",
+        "target_context_keys",
+    }, tool_name
+    assert isinstance(cancel["supported"], bool), tool_name
+    assert isinstance(cancel["mode"], str), tool_name
+    assert cancel["mode"], tool_name
+    assert isinstance(cancel["companions"], tuple), tool_name
+    assert isinstance(cancel["target_context_keys"], tuple), tool_name
+
+
+def _sample_value_for_parameter(parameter: MCPToolParameter) -> object:
+    if parameter.enum:
+        return parameter.enum[0]
+    if parameter.type is ToolInputType.STRING:
+        return "sample"
+    if parameter.type is ToolInputType.NUMBER:
+        return 1.5
+    if parameter.type is ToolInputType.INTEGER:
+        return 1
+    if parameter.type is ToolInputType.BOOLEAN:
+        return True
+    if parameter.type is ToolInputType.ARRAY:
+        return []
+    if parameter.type is ToolInputType.OBJECT:
+        return {}
+    raise AssertionError(f"Unhandled parameter type: {parameter.type}")
+
+
+def _code_investigation_base_request(question: str) -> dict[str, object]:
+    return {
+        "session_id": "sess-123",
+        "question_identity": stable_code_investigation_question_identity(question),
+        "question": question,
+        "investigation_goal": "describe_current_state_from_code",
+        "fact_categories": ["frameworks"],
+        "allowed_capabilities": ["inspect_code"],
+        "repo_inspection_tool_capabilities": list(
+            ouroboros_tool_capability_metadata("ouroboros_interview")["orchestration"][
+                "code_investigation"
+            ]["repo_inspection_tool_capabilities"]
+        ),
+        "confidence_policy": {
+            "auto_confirm_when": ["exact manifest match"],
+            "confirmation_required_when": ["multiple candidates"],
+            "human_judgment_when": ["desired behavior"],
+        },
+        "answer_prefixes": ["[from-code]", "[from-code][auto-confirmed]"],
+        "answer_contract": interview_code_investigation_answer_contract(),
+        "mcp_tool_capability": ouroboros_tool_capability_metadata("ouroboros_interview"),
+    }
+
+
+def test_extract_capability_input_schema_converts_mcp_tool_parameters() -> None:
+    definition = MCPToolDefinition(
+        name="ouroboros_schema_probe",
+        description="Synthetic schema extraction probe.",
+        parameters=(
+            MCPToolParameter(
+                name="session_id",
+                type=ToolInputType.STRING,
+                description="Session identifier.",
+                required=True,
+            ),
+            MCPToolParameter(
+                name="mode",
+                type=ToolInputType.STRING,
+                description="Execution mode.",
+                required=False,
+                default="summary",
+                enum=("summary", "full"),
+            ),
+            MCPToolParameter(
+                name="attempt_ids",
+                type=ToolInputType.ARRAY,
+                description="Attempt identifiers.",
+                required=False,
+                items={"type": "string"},
+            ),
+        ),
+        server_name="ouroboros",
+    )
+
+    schema = extract_capability_input_schema(definition)
+
+    Draft202012Validator.check_schema(schema)
+    assert schema == {
+        "type": "object",
+        "properties": {
+            "session_id": {
+                "type": "string",
+                "description": "Session identifier.",
+            },
+            "mode": {
+                "type": "string",
+                "description": "Execution mode.",
+                "default": "summary",
+                "enum": ["summary", "full"],
+            },
+            "attempt_ids": {
+                "type": "array",
+                "description": "Attempt identifiers.",
+                "items": {"type": "string"},
+            },
+        },
+        "required": ["session_id"],
+    }
+    assert schema == definition.to_input_schema()
+    assert schema is not definition.to_input_schema()
+    Draft202012Validator(schema).validate({"session_id": "sess-123"})
+
+
+def test_extract_capability_input_schema_ignores_free_text_description_fields() -> None:
+    definition = MCPToolDefinition(
+        name="external_free_text_probe",
+        description=(
+            "Parameters: session_id: string required; mode: enum(summary, full) "
+            "optional default=summary; artifact: object with path: string and "
+            "line: integer; retry: boolean = false. This is ordinary operator "
+            "guidance in prose, not a machine-readable input schema."
+        ),
+        parameters=(),
+        server_name="external",
+    )
+
+    schema = extract_capability_input_schema(definition)
+
+    Draft202012Validator.check_schema(schema)
+    assert schema == definition.to_input_schema()
+    assert schema == {"type": "object", "properties": {}, "required": []}
+    assert set(schema["properties"]) == set()
+    assert schema["required"] == []
+    assert "session_id" not in schema["properties"]
+    assert "mode" not in schema["properties"]
+    assert "artifact" not in schema["properties"]
+    assert "path" not in schema["properties"]
+    assert "line" not in schema["properties"]
+    assert "retry" not in schema["properties"]
+
+
+def test_owned_tool_registry_input_schemas_are_extracted_from_definitions() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    registry = ouroboros_tool_capability_registry()
+
+    assert set(registry) == set(definitions)
+    for name, definition in definitions.items():
+        schema = extract_capability_input_schema(definition)
+
+        assert registry[name].input_schema == schema
+        assert registry[name].input_schema == definition.to_input_schema()
+        Draft202012Validator.check_schema(registry[name].input_schema)
+
+
+@pytest.mark.parametrize(
+    "definition",
+    tuple(handler.definition for handler in get_ouroboros_tools()),
+    ids=lambda definition: definition.name,
+)
+def test_each_ouroboros_owned_tool_has_required_capability_metadata_shape(
+    definition: MCPToolDefinition,
+) -> None:
+    graph = build_capability_graph(assemble_session_tool_catalog(attached_tools=(definition,)))
+    descriptor = graph.by_name()[definition.name]
+
+    assert descriptor.metadata is not None
+    metadata = descriptor.metadata
+    metadata_contract_entry = {
+        field_name: getattr(metadata, field_name)
+        for field_name in _REQUIRED_OUROBOROS_TOOL_METADATA_FIELDS
+    }
+    serialized_entry = serialize_capability_graph(graph)[0]
+    serialized_metadata = serialized_entry["metadata"]
+
+    assert set(metadata_contract_entry) == _REQUIRED_OUROBOROS_TOOL_METADATA_FIELDS
+    assert serialized_metadata is not None
+    assert set(serialized_metadata) >= _REQUIRED_OUROBOROS_TOOL_METADATA_FIELDS
+    assert set(metadata_contract_entry) <= {field.name for field in fields(metadata)}
+    assert serialized_entry["name"] == definition.name
+    assert metadata == ouroboros_tool_capability_registry()[definition.name]
+    assert metadata.fallback_used is False
+    assert metadata.input_schema == definition.to_input_schema()
+    Draft202012Validator.check_schema(metadata.input_schema)
+    assert metadata.input_schema["type"] == "object"
+    assert isinstance(metadata.input_schema["properties"], Mapping)
+    assert isinstance(metadata.input_schema["required"], list)
+    assert metadata.execution_mode in _VALID_OUROBOROS_TOOL_EXECUTION_MODES
+    assert isinstance(metadata.companions, tuple)
+    assert isinstance(metadata.required_context_keys, tuple)
+    assert isinstance(metadata.side_effects, tuple)
+    _assert_lifecycle_metadata_shape(metadata, definition.name)
+    validate_capability_tool_metadata(
+        metadata,
+        tool_name=definition.name,
+        owned_tool=True,
+    )
+
+
+def test_each_known_ouroboros_owned_mcp_tool_has_explicit_metadata_entry() -> None:
+    definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+    explicit_specs = capabilities_module._OUROBOROS_TOOL_CAPABILITY_SPECS
+
+    missing_specs = sorted(set(definitions) - set(explicit_specs))
+    assert missing_specs == []
+
+    registry = ouroboros_tool_capability_registry()
+    assert set(registry) == set(definitions)
+    for name in definitions:
+        assert name in explicit_specs
+        assert name in registry
+        assert registry[name].fallback_used is False
+
+
+@pytest.mark.parametrize(
+    "definition",
+    tuple(handler.definition for handler in get_ouroboros_tools()),
+    ids=lambda definition: definition.name,
+)
+def test_each_ouroboros_owned_tool_metadata_is_tool_specific_not_generic_inference(
+    definition: MCPToolDefinition,
+    monkeypatch,
+) -> None:
+    def fail_on_generic_attached_metadata(tool: MCPToolDefinition):
+        raise AssertionError(
+            f"Ouroboros-owned tool used generic attached metadata: {tool.name}"
+        )
+
+    def fail_on_generic_attached_semantics(tool: MCPToolDefinition):
+        raise AssertionError(
+            f"Ouroboros-owned tool used generic attached semantics: {tool.name}"
+        )
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._generic_attached_tool_metadata",
+        fail_on_generic_attached_metadata,
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._infer_attached_semantics",
+        fail_on_generic_attached_semantics,
+    )
+
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=(definition,))
+    )
+    descriptor = graph.by_name()[definition.name]
+
+    assert descriptor.metadata is not None
+    metadata = descriptor.metadata
+    required_metadata = {
+        field_name: getattr(metadata, field_name)
+        for field_name in _REQUIRED_OUROBOROS_TOOL_METADATA_FIELDS
+    }
+
+    assert set(required_metadata) == _REQUIRED_OUROBOROS_TOOL_METADATA_FIELDS
+    assert metadata == ouroboros_tool_capability_registry()[definition.name]
+    assert metadata.fallback_used is False
+    assert metadata.execution_mode != "generic_attached"
+    assert metadata.side_effects != ("unknown_external_side_effect",)
+    assert metadata.mutation_targets != ("external",)
+    assert metadata.input_schema == definition.to_input_schema()
+    assert metadata.execution_mode == (
+        _EXPECTED_OUROBOROS_TOOL_EXECUTION_MODES[definition.name]
+    )
+    assert metadata.companions == _EXPECTED_OUROBOROS_TOOL_COMPANIONS[
+        definition.name
+    ]
+    assert metadata.required_context_keys == (
+        _EXPECTED_OUROBOROS_REQUIRED_CONTEXT_KEYS[definition.name]
+    )
+    assert metadata.mutation_targets == _EXPECTED_OUROBOROS_TOOL_MUTATION_TARGETS[
+        definition.name
+    ]
+    assert metadata.state_mutations == _EXPECTED_OUROBOROS_TOOL_STATE_MUTATIONS[
+        definition.name
+    ]
+    assert metadata.side_effects == _EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS[
+        definition.name
+    ]
+    assert metadata.retry == _EXPECTED_OUROBOROS_TOOL_RETRY[definition.name]
+    assert metadata.interrupt == _EXPECTED_OUROBOROS_TOOL_INTERRUPT[definition.name]
+    assert metadata.cancel == _EXPECTED_OUROBOROS_TOOL_CANCEL[definition.name]
+    validate_capability_tool_metadata(
+        metadata,
+        tool_name=definition.name,
+        owned_tool=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "definition",
+    tuple(handler.definition for handler in get_ouroboros_tools()),
+    ids=lambda definition: definition.name,
+)
+def test_owned_tool_contract_rejects_inferred_attached_snapshot_coverage(
+    definition: MCPToolDefinition,
+) -> None:
+    inferred_snapshot = capabilities_module._generic_attached_tool_metadata(
+        replace(definition, server_name="external")
+    )
+
+    validate_capability_tool_metadata(
+        inferred_snapshot,
+        tool_name=definition.name,
+        owned_tool=False,
+    )
+    assert inferred_snapshot.fallback_used is True
+    assert inferred_snapshot.execution_mode == "generic_attached"
+    assert inferred_snapshot.side_effects == ("unknown_external_side_effect",)
+
+    with pytest.raises(ValueError, match="owned tool metadata cannot use fallback"):
+        validate_capability_tool_metadata(
+            inferred_snapshot,
+            tool_name=definition.name,
+            owned_tool=True,
+        )
+
+
+def test_ouroboros_owned_tool_contract_cases_exactly_match_live_catalog() -> None:
+    live_tool_names = {handler.definition.name for handler in get_ouroboros_tools()}
+
+    for case_set_name, case_set in _OUROBOROS_TOOL_CONTRACT_CASE_SETS.items():
+        assert set(case_set) == live_tool_names, case_set_name
+
+
+def test_owned_tool_descriptor_uses_canonical_schema_not_attached_description_text() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    canonical = definitions["ouroboros_session_status"]
+    attached_stale_definition = MCPToolDefinition(
+        name=canonical.name,
+        description=(
+            "Poisoned stale attached metadata mentions session_id in prose but "
+            "does not carry the canonical parameter schema."
+        ),
+        parameters=(),
+        server_name="third-party-alias",
+    )
+
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=(attached_stale_definition,))
+    )
+
+    descriptor = graph.capabilities[0]
+    assert descriptor.metadata is not None
+    assert descriptor.name == canonical.name
+    assert descriptor.description == attached_stale_definition.description
+    assert descriptor.metadata.fallback_used is False
+    assert descriptor.metadata.input_schema == extract_capability_input_schema(canonical)
+    assert descriptor.metadata.input_schema == canonical.to_input_schema()
+    assert descriptor.metadata.input_schema != attached_stale_definition.to_input_schema()
+    assert descriptor.metadata.input_schema["required"] == ["session_id"]
+    assert descriptor.metadata.input_schema["properties"]["session_id"]["type"] == "string"
+
+
+def _interview_code_investigation_metadata() -> dict[str, object]:
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools(include_auto=False))
+    catalog = assemble_session_tool_catalog(attached_tools=owned_tools)
+    graph = build_capability_graph(catalog)
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    interview = descriptors["ouroboros_interview"]
+    assert interview.metadata is not None
+    return dict(interview.metadata.orchestration["code_investigation"])
+
+
+def test_mcp_tool_required_parameter_keys_extracts_definition_required_keys() -> None:
+    definition = MCPToolDefinition(
+        name="external_contract_probe",
+        description="Synthetic tool with required and optional parameters",
+        parameters=(
+            MCPToolParameter(
+                name="session_id",
+                type=ToolInputType.STRING,
+                required=True,
+            ),
+            MCPToolParameter(
+                name="optional_note",
+                type=ToolInputType.STRING,
+                required=False,
+            ),
+            MCPToolParameter(
+                name="artifact",
+                type=ToolInputType.OBJECT,
+                required=True,
+            ),
+        ),
+    )
+    optional_only_definition = MCPToolDefinition(
+        name="external_optional_probe",
+        description="Synthetic tool without required parameters",
+        parameters=(
+            MCPToolParameter(
+                name="cursor",
+                type=ToolInputType.STRING,
+                required=False,
+            ),
+        ),
+    )
+
+    assert mcp_tool_required_parameter_keys(definition) == ("session_id", "artifact")
+    assert mcp_tool_required_parameter_keys(optional_only_definition) == ()
+
+
+def test_owned_required_context_keys_union_definition_and_skill_usage(
+    monkeypatch,
+) -> None:
+    definition = MCPToolDefinition(
+        name="ouroboros_union_probe",
+        description="Synthetic owned tool for context-key union.",
+        parameters=(
+            MCPToolParameter(
+                name="session_id",
+                type=ToolInputType.STRING,
+                required=True,
+            ),
+            MCPToolParameter(
+                name="cwd",
+                type=ToolInputType.STRING,
+                required=False,
+            ),
+            MCPToolParameter(
+                name="artifact",
+                type=ToolInputType.STRING,
+                required=True,
+            ),
+        ),
+        server_name="ouroboros",
+    )
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._ouroboros_tool_definitions_by_name",
+        lambda: {definition.name: definition},
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities.get_packaged_skill_context_keys",
+        lambda: {
+            definition.name: (
+                "cwd",
+                "session_id",
+                "artifact",
+                "last_question",
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._OUROBOROS_TOOL_CAPABILITY_SPECS",
+        {
+            definition.name: capabilities_module._OuroborosToolCapabilitySpec(
+                execution_mode="blocking",
+                companions=(),
+                side_effects=("session_state_write",),
+                retry={"supported": True, "mode": "handler_owned"},
+                interrupt={"supported": True, "mode": "soft"},
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._OUROBOROS_CANCEL_METADATA",
+        {definition.name: _UNSUPPORTED_CANCEL},
+    )
+
+    graph = build_capability_graph((definition,))
+    descriptor = graph.by_name()[definition.name]
+
+    assert descriptor.metadata is not None
+    assert descriptor.metadata.fallback_used is False
+    assert descriptor.metadata.input_schema["required"] == ["session_id", "artifact"]
+    assert descriptor.metadata.required_context_keys == (
+        "session_id",
+        "artifact",
+        "cwd",
+        "last_question",
+    )
+
+
+def test_packaged_skill_tool_mappings_are_stored_apart_from_descriptors() -> None:
+    expected = {
+        "auto": "ouroboros_start_auto",
+        "run": "ouroboros_execute_seed",
+        "ralph": "ouroboros_ralph",
+        "status": "ouroboros_session_status",
+        "seed": "ouroboros_generate_seed",
+        "interview": "ouroboros_interview",
+    }
+
+    get_packaged_skill_tool_mappings.cache_clear()
+    try:
+        with patch(
+            "ouroboros.mcp.tools.definitions.get_ouroboros_tools",
+            side_effect=AssertionError("descriptor catalog must not be used"),
+        ):
+            queried_mappings = {skill: get_skill_tool_mapping(skill) for skill in expected}
+            assert get_skill_tool_mapping("   ") is None
+            mappings = get_packaged_skill_tool_mappings()
+    finally:
+        get_packaged_skill_tool_mappings.cache_clear()
+
+    by_skill = skill_tool_mapping_by_skill(mappings)
+    assert {skill: by_skill[skill].mcp_tool for skill in expected} == expected
+    assert {
+        skill: mapping.mcp_tool for skill, mapping in queried_mappings.items() if mapping
+    } == expected
+    for skill_name in expected:
+        mapping = by_skill[skill_name]
+        assert mapping.skill_path == f"skills/{skill_name}/SKILL.md"
+        assert mapping.mcp_args is not None
+
+
+def test_skill_capability_resolution_maps_core_skills_to_owned_mcp_tools() -> None:
+    expected = {
+        "auto": "ouroboros_start_auto",
+        "run": "ouroboros_execute_seed",
+        "ralph": "ouroboros_ralph",
+        "status": "ouroboros_session_status",
+        "seed": "ouroboros_generate_seed",
+        "interview": "ouroboros_interview",
+    }
+    tool_definitions = tuple(handler.definition for handler in get_ouroboros_tools())
+    graph = build_capability_graph(assemble_session_tool_catalog(attached_tools=tool_definitions))
+
+    resolved = {
+        skill_name: resolve_skill_capability_descriptor(skill_name, graph=graph)
+        for skill_name in expected
+    }
+
+    assert {skill: descriptor.name for skill, descriptor in resolved.items() if descriptor} == expected
+    for skill_name, descriptor in resolved.items():
+        assert descriptor is not None, skill_name
+        assert descriptor.source_kind == "attached_mcp"
+        assert descriptor.semantics.origin is CapabilityOrigin.ATTACHED_MCP
+        assert descriptor.metadata is not None
+        assert descriptor.metadata.fallback_used is False
+        assert descriptor.metadata.input_schema
+    assert resolve_skill_capability_descriptor("unknown-skill", graph=graph) is None
+
+
+def test_core_skills_resolve_end_to_end_to_explicit_mcp_capabilities() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+
+    expected = {
+        "auto": {
+            "tool_name": "ouroboros_start_auto",
+            "execution_mode": "background",
+            "side_effects": ("workspace_write", "event_store_write"),
+        },
+        "run": {
+            "tool_name": "ouroboros_execute_seed",
+            "execution_mode": "blocking",
+            "side_effects": ("workspace_write", "event_store_write"),
+        },
+        "ralph": {
+            "tool_name": "ouroboros_ralph",
+            "execution_mode": "blocking",
+            "side_effects": ("workspace_write", "event_store_write"),
+        },
+        "status": {
+            "tool_name": "ouroboros_session_status",
+            "execution_mode": "status",
+            "side_effects": (),
+        },
+        "seed": {
+            "tool_name": "ouroboros_generate_seed",
+            "execution_mode": "blocking",
+            "side_effects": ("workspace_write", "event_store_write"),
+        },
+        "interview": {
+            "tool_name": "ouroboros_interview",
+            "execution_mode": "subagent_orchestration",
+            "side_effects": ("subagent_dispatch", "session_state_write"),
+        },
+    }
+
+    for skill_name, expected_metadata in expected.items():
+        descriptor = resolve_skill_capability_descriptor(skill_name, graph=graph)
+
+        assert descriptor is not None, skill_name
+        assert descriptor.name == expected_metadata["tool_name"]
+        assert descriptor.original_name == expected_metadata["tool_name"]
+        assert descriptor.source_kind == "attached_mcp"
+        assert descriptor.source_name == "ouroboros"
+        assert descriptor.stable_id == (
+            f"mcp:{descriptor.source_name}:{expected_metadata['tool_name']}"
+        )
+        assert descriptor.semantics.origin is CapabilityOrigin.ATTACHED_MCP
+        assert descriptor.semantics.scope is CapabilityScope.ATTACHMENT
+        assert descriptor.metadata is not None
+        assert descriptor.metadata.fallback_used is False
+        assert descriptor.metadata.input_schema == definitions[
+            expected_metadata["tool_name"]
+        ].to_input_schema()
+        assert descriptor.metadata.mutation_class == descriptor.semantics.mutation_class.value
+        assert descriptor.metadata.execution_mode == expected_metadata["execution_mode"]
+        assert descriptor.metadata.mutation_targets == (
+            _EXPECTED_OUROBOROS_TOOL_MUTATION_TARGETS[
+                expected_metadata["tool_name"]
+            ]
+        )
+        assert descriptor.metadata.state_mutations == (
+            _EXPECTED_OUROBOROS_TOOL_STATE_MUTATIONS[
+                expected_metadata["tool_name"]
+            ]
+        )
+        assert descriptor.metadata.side_effects == expected_metadata["side_effects"]
+        assert descriptor.metadata.required_context_keys == (
+            _EXPECTED_OUROBOROS_REQUIRED_CONTEXT_KEYS[expected_metadata["tool_name"]]
+        )
+        assert descriptor.metadata == ouroboros_tool_capability_registry()[
+            expected_metadata["tool_name"]
+        ]
+        assert resolve_mcp_tool_capability_descriptor(
+            descriptor.stable_id,
+            graph=graph,
+        ) == descriptor
+
+
+def test_ouroboros_owned_tools_have_explicit_capability_metadata(monkeypatch) -> None:
+    tool_definitions = tuple(handler.definition for handler in get_ouroboros_tools())
+    catalog = assemble_session_tool_catalog(attached_tools=tool_definitions)
+
+    fallback_calls: list[str] = []
+
+    def fail_on_generic_fallback(tool: MCPToolDefinition):
+        fallback_calls.append(tool.name)
+        raise AssertionError(
+            f"Ouroboros-owned tool used generic attached inference: {tool.name}"
+        )
+
+    def fail_on_required_parameter_inference(tool: MCPToolDefinition) -> tuple[str, ...]:
+        raise AssertionError(
+            f"Ouroboros-owned tool used required-parameter inference: {tool.name}"
+        )
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._infer_attached_semantics",
+        fail_on_generic_fallback,
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._required_parameter_names",
+        fail_on_required_parameter_inference,
+    )
+
+    graph = build_capability_graph(catalog)
+    direct_graph = build_capability_graph(tool_definitions)
+
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    direct_descriptors = {
+        descriptor.name: descriptor for descriptor in direct_graph.capabilities
+    }
+    assert set(descriptors) == {definition.name for definition in tool_definitions}
+    assert set(direct_descriptors) == set(descriptors)
+    for definition in tool_definitions:
+        descriptor = descriptors[definition.name]
+        direct_descriptor = direct_descriptors[definition.name]
+        metadata = descriptor.metadata
+        assert metadata is not None, definition.name
+        assert direct_descriptor.metadata is not None, definition.name
+        assert direct_descriptor.source_kind == "attached_mcp"
+        assert direct_descriptor.source_name == "ouroboros"
+        assert metadata.fallback_used is False, definition.name
+        assert direct_descriptor.metadata.fallback_used is False, definition.name
+        assert metadata.input_schema == definition.to_input_schema()
+        assert direct_descriptor.metadata.input_schema == definition.to_input_schema()
+        assert metadata.mutation_class == descriptor.semantics.mutation_class.value
+        assert (
+            direct_descriptor.metadata.mutation_class
+            == direct_descriptor.semantics.mutation_class.value
+        )
+        assert metadata.execution_mode
+        assert isinstance(metadata.companions, tuple)
+        assert all(
+            companion in descriptors for companion in metadata.companions
+        ), definition.name
+        assert metadata.required_context_keys == (
+            _EXPECTED_OUROBOROS_REQUIRED_CONTEXT_KEYS[definition.name]
+        )
+        assert isinstance(metadata.required_context_keys, tuple)
+        assert metadata.mutation_targets == (
+            _EXPECTED_OUROBOROS_TOOL_MUTATION_TARGETS[definition.name]
+        )
+        assert metadata.state_mutations == (
+            _EXPECTED_OUROBOROS_TOOL_STATE_MUTATIONS[definition.name]
+        )
+        assert metadata.side_effects is not None
+        _assert_lifecycle_metadata_shape(metadata, definition.name)
+        _assert_lifecycle_metadata_shape(direct_descriptor.metadata, definition.name)
+        assert descriptor.semantics.origin is CapabilityOrigin.ATTACHED_MCP
+        assert descriptor.semantics.scope is CapabilityScope.ATTACHMENT
+    assert fallback_calls == []
+
+
+def test_ouroboros_capability_registry_covers_every_owned_tool_identifier() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+
+    registry = ouroboros_tool_capability_registry()
+
+    assert set(registry) == set(definitions)
+    assert set(registry) == set(_EXPECTED_OUROBOROS_REQUIRED_CONTEXT_KEYS)
+    for name, metadata in registry.items():
+        definition = definitions[name]
+        required_parameters = tuple(
+            parameter for parameter in definition.parameters if parameter.required
+        )
+        required_parameter_keys = mcp_tool_required_parameter_keys(definition)
+        assert metadata.fallback_used is False, name
+        assert metadata.input_schema == definition.to_input_schema()
+        Draft202012Validator.check_schema(metadata.input_schema)
+        assert metadata.input_schema["type"] == "object"
+        assert set(metadata.input_schema["properties"]) == {
+            parameter.name for parameter in definition.parameters
+        }
+        assert metadata.input_schema["required"] == list(required_parameter_keys)
+        assert metadata.mutation_class in {
+            mutation_class.value for mutation_class in CapabilityMutationClass
+        }
+        for parameter in definition.parameters:
+            property_schema = metadata.input_schema["properties"][parameter.name]
+            assert property_schema["type"] == parameter.type.value
+            if parameter.enum:
+                assert property_schema["enum"] == list(parameter.enum)
+            if parameter.items:
+                assert property_schema["items"] == parameter.items
+        Draft202012Validator(metadata.input_schema).validate(
+            {
+                parameter.name: _sample_value_for_parameter(parameter)
+                for parameter in required_parameters
+            }
+        )
+        assert metadata.execution_mode, name
+        assert isinstance(metadata.companions, tuple)
+        expected_context_keys = _EXPECTED_OUROBOROS_REQUIRED_CONTEXT_KEYS[name]
+        assert metadata.required_context_keys == expected_context_keys
+        assert all(
+            key in metadata.input_schema["properties"] for key in expected_context_keys
+        )
+        if not expected_context_keys:
+            assert metadata.input_schema["required"] == []
+        assert metadata.mutation_targets == _EXPECTED_OUROBOROS_TOOL_MUTATION_TARGETS[name]
+        assert isinstance(metadata.mutation_targets, tuple)
+        assert metadata.state_mutations == _EXPECTED_OUROBOROS_TOOL_STATE_MUTATIONS[name]
+        assert isinstance(metadata.state_mutations, tuple)
+        assert isinstance(metadata.side_effects, tuple)
+        _assert_lifecycle_metadata_shape(metadata, name)
+        assert isinstance(metadata.orchestration, Mapping)
+
+
+@pytest.mark.parametrize(
+    "tool_name",
+    (
+        "ouroboros_interview",
+        "ouroboros_start_execute_seed",
+        "ouroboros_job_status",
+        "ouroboros_cancel_job",
+    ),
+)
+def test_explicit_ouroboros_tool_capability_lookup_returns_tool_specific_metadata(
+    tool_name: str,
+) -> None:
+    definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+    registry = ouroboros_tool_capability_registry()
+
+    by_name = lookup_ouroboros_tool_capability_metadata(tool_name)
+    by_stable_id = lookup_ouroboros_tool_capability_metadata(f"mcp:ouroboros:{tool_name}")
+
+    assert by_name == registry[tool_name]
+    assert by_stable_id == registry[tool_name]
+    assert by_name is not None
+    assert by_name.fallback_used is False
+    assert by_name.execution_mode == _EXPECTED_OUROBOROS_TOOL_EXECUTION_MODES[tool_name]
+    assert by_name.input_schema == definitions[tool_name].to_input_schema()
+    assert by_name.side_effects == _EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS[tool_name]
+    assert by_name.retry == _EXPECTED_OUROBOROS_TOOL_RETRY[tool_name]
+    assert by_name.interrupt == _EXPECTED_OUROBOROS_TOOL_INTERRUPT[tool_name]
+    assert by_name.cancel == _EXPECTED_OUROBOROS_TOOL_CANCEL[tool_name]
+
+
+def test_explicit_ouroboros_tool_capability_lookup_rejects_unknown_ids() -> None:
+    assert lookup_ouroboros_tool_capability_metadata("external_delete_widget") is None
+    assert (
+        lookup_ouroboros_tool_capability_metadata(
+            "mcp:external:ouroboros_interview"
+        )
+        is None
+    )
+
+
+def test_ouroboros_owned_tools_have_explicit_valid_execution_mode_assignments() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+
+    registry = ouroboros_tool_capability_registry()
+    graph = build_capability_graph(assemble_session_tool_catalog(attached_tools=definitions.values()))
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+
+    assert set(registry) == set(_EXPECTED_OUROBOROS_TOOL_EXECUTION_MODES)
+    assert set(definitions) == set(_EXPECTED_OUROBOROS_TOOL_EXECUTION_MODES)
+    for name, expected_mode in _EXPECTED_OUROBOROS_TOOL_EXECUTION_MODES.items():
+        metadata = registry[name]
+        descriptor = descriptors[name]
+        assert expected_mode in _VALID_OUROBOROS_TOOL_EXECUTION_MODES, name
+        assert metadata.execution_mode == expected_mode, name
+        assert descriptor.metadata is not None, name
+        assert descriptor.metadata.mutation_class == descriptor.semantics.mutation_class.value
+        assert descriptor.metadata.execution_mode == expected_mode, name
+        assert descriptor.metadata.fallback_used is False, name
+
+
+def test_ouroboros_owned_tools_have_explicit_tool_specific_companions() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    registry = ouroboros_tool_capability_registry()
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+
+    assert set(registry) == set(_EXPECTED_OUROBOROS_TOOL_COMPANIONS)
+    assert set(definitions) == set(_EXPECTED_OUROBOROS_TOOL_COMPANIONS)
+    for name, expected_companions in _EXPECTED_OUROBOROS_TOOL_COMPANIONS.items():
+        metadata = registry[name]
+        descriptor = descriptors[name]
+
+        assert metadata.companions == expected_companions, name
+        assert name not in metadata.companions
+        assert len(metadata.companions) == len(set(metadata.companions)), name
+        assert all(companion in definitions for companion in metadata.companions), name
+        assert descriptor.metadata is not None, name
+        assert descriptor.metadata.companions == expected_companions, name
+        assert descriptor.metadata.fallback_used is False, name
+
+
+def test_background_tools_expose_explicit_lifecycle_companion_roles() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    background_tools = {
+        "ouroboros_start_auto": "ouroboros_auto",
+        "ouroboros_start_evaluate": "ouroboros_evaluate",
+        "ouroboros_start_evolve_step": "ouroboros_evolve_step",
+        "ouroboros_start_execute_seed": "ouroboros_execute_seed",
+        "ouroboros_start_ralph": "ouroboros_ralph",
+    }
+    lifecycle_roles = {
+        "status": "ouroboros_job_status",
+        "wait": "ouroboros_job_wait",
+        "result": "ouroboros_job_result",
+        "cancel": "ouroboros_cancel_job",
+    }
+
+    assert set(background_tools).issubset(definitions)
+    assert set(lifecycle_roles.values()).issubset(definitions)
+    for start_tool, blocking_tool in background_tools.items():
+        descriptor = descriptors[start_tool]
+
+        assert descriptor.metadata is not None, start_tool
+        assert descriptor.metadata.fallback_used is False, start_tool
+        assert descriptor.metadata.execution_mode == "background", start_tool
+        assert set(lifecycle_roles.values()).issubset(
+            descriptor.metadata.companions
+        ), start_tool
+        lifecycle = descriptor.metadata.orchestration["background_lifecycle"]
+
+        assert lifecycle["family_id"] == "background_job_lifecycle.v1"
+        assert lifecycle["execution_mode"] == "background"
+        assert lifecycle["companion_roles"] == {
+            "start": start_tool,
+            "blocking": blocking_tool,
+            **lifecycle_roles,
+        }
+        assert lifecycle["required_result_context_keys"] == ("job_id",)
+        assert lifecycle["cancel"] == {
+            "supported": True,
+            "mode": "background_job",
+            "companions": ("ouroboros_cancel_job",),
+            "target_context_keys": ("job_id",),
+        }
+        assert "status" in lifecycle["runtime_instruction"]
+        assert "wait" in lifecycle["runtime_instruction"]
+        assert "result" in lifecycle["runtime_instruction"]
+        assert "cancel" in lifecycle["runtime_instruction"]
+
+
+def test_generic_job_lifecycle_tools_derive_sibling_companions_from_catalog(
+    monkeypatch,
+) -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    lifecycle_roles = {
+        "status": "ouroboros_job_status",
+        "wait": "ouroboros_job_wait",
+        "result": "ouroboros_job_result",
+        "cancel": "ouroboros_cancel_job",
+    }
+    lifecycle_tools = set(lifecycle_roles.values())
+    patched_specs = {
+        name: replace(spec, companions=()) if name in lifecycle_tools else spec
+        for name, spec in capabilities_module._OUROBOROS_TOOL_CAPABILITY_SPECS.items()
+    }
+    monkeypatch.setattr(
+        capabilities_module,
+        "_OUROBOROS_TOOL_CAPABILITY_SPECS",
+        patched_specs,
+    )
+
+    registry = ouroboros_tool_capability_registry()
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+
+    assert lifecycle_tools.issubset(definitions)
+    for role, tool_name in lifecycle_roles.items():
+        expected_siblings = tuple(
+            sibling_name
+            for sibling_name in lifecycle_roles.values()
+            if sibling_name != tool_name
+        )
+        metadata = registry[tool_name]
+        descriptor = graph.by_name()[tool_name]
+
+        assert metadata.companions == expected_siblings
+        assert descriptor.metadata is not None
+        assert descriptor.metadata.companions == expected_siblings
+        assert descriptor.metadata.fallback_used is False
+        sibling_metadata = metadata.orchestration["job_lifecycle_siblings"]
+        assert sibling_metadata["family_id"] == "generic_job_lifecycle_siblings.v1"
+        assert sibling_metadata["role"] == role
+        assert sibling_metadata["companion_roles"] == lifecycle_roles
+        assert sibling_metadata["sibling_companions"] == {
+            sibling_role: sibling_name
+            for sibling_role, sibling_name in lifecycle_roles.items()
+            if sibling_name != tool_name
+        }
+        assert sibling_metadata["required_result_context_keys"] == ("job_id",)
+        assert "status/wait/result/cancel" in sibling_metadata["runtime_instruction"]
+
+
+@pytest.mark.parametrize(
+    ("omitted_role", "omitted_tool"),
+    (
+        ("status", "ouroboros_job_status"),
+        ("wait", "ouroboros_job_wait"),
+        ("result", "ouroboros_job_result"),
+        ("cancel", "ouroboros_cancel_job"),
+    ),
+)
+def test_generic_job_lifecycle_sibling_metadata_filters_each_absent_sibling(
+    monkeypatch,
+    omitted_role: str,
+    omitted_tool: str,
+) -> None:
+    full_definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+    partial_definitions = tuple(
+        definition
+        for name, definition in full_definitions.items()
+        if name != omitted_tool
+    )
+    partial_handlers = tuple(
+        SimpleNamespace(definition=definition) for definition in partial_definitions
+    )
+    lifecycle_roles = {
+        "status": "ouroboros_job_status",
+        "wait": "ouroboros_job_wait",
+        "result": "ouroboros_job_result",
+        "cancel": "ouroboros_cancel_job",
+    }
+    lifecycle_tools = set(lifecycle_roles.values())
+    patched_specs = {
+        name: replace(spec, companions=()) if name in lifecycle_tools else spec
+        for name, spec in capabilities_module._OUROBOROS_TOOL_CAPABILITY_SPECS.items()
+    }
+
+    capabilities_module._ouroboros_tool_definitions_by_name.cache_clear()
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.definitions.get_ouroboros_tools",
+        lambda: partial_handlers,
+    )
+    monkeypatch.setattr(
+        capabilities_module,
+        "_OUROBOROS_TOOL_CAPABILITY_SPECS",
+        patched_specs,
+    )
+
+    try:
+        registry = ouroboros_tool_capability_registry()
+    finally:
+        capabilities_module._ouroboros_tool_definitions_by_name.cache_clear()
+
+    assert omitted_tool not in registry
+    available_roles = {
+        role: tool_name
+        for role, tool_name in lifecycle_roles.items()
+        if tool_name != omitted_tool
+    }
+    assert omitted_role not in available_roles
+    for role, tool_name in available_roles.items():
+        metadata = registry[tool_name]
+        expected_siblings = tuple(
+            sibling_name
+            for sibling_name in available_roles.values()
+            if sibling_name != tool_name
+        )
+
+        assert metadata.fallback_used is False
+        assert metadata.companions == expected_siblings
+        assert omitted_tool not in metadata.companions
+        sibling_metadata = metadata.orchestration["job_lifecycle_siblings"]
+        assert sibling_metadata["role"] == role
+        assert sibling_metadata["companion_roles"] == available_roles
+        assert omitted_role not in sibling_metadata["companion_roles"]
+        assert sibling_metadata["sibling_companions"] == {
+            sibling_role: sibling_name
+            for sibling_role, sibling_name in available_roles.items()
+            if sibling_name != tool_name
+        }
+        assert omitted_role not in sibling_metadata["sibling_companions"]
+        assert omitted_tool not in sibling_metadata["sibling_companions"].values()
+
+
+def test_background_lifecycle_omits_absent_companion_tools(monkeypatch) -> None:
+    full_definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+    omitted_companions = {"ouroboros_job_result", "ouroboros_cancel_job"}
+    partial_definitions = tuple(
+        definition
+        for name, definition in full_definitions.items()
+        if name not in omitted_companions
+    )
+    partial_handlers = tuple(
+        SimpleNamespace(definition=definition) for definition in partial_definitions
+    )
+
+    capabilities_module._ouroboros_tool_definitions_by_name.cache_clear()
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.definitions.get_ouroboros_tools",
+        lambda: partial_handlers,
+    )
+
+    try:
+        registry = ouroboros_tool_capability_registry()
+        graph = build_capability_graph(
+            assemble_session_tool_catalog(attached_tools=partial_definitions)
+        )
+    finally:
+        capabilities_module._ouroboros_tool_definitions_by_name.cache_clear()
+
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    assert set(registry) == {definition.name for definition in partial_definitions}
+    assert omitted_companions.isdisjoint(registry)
+
+    start_auto = registry["ouroboros_start_auto"]
+    descriptor = descriptors["ouroboros_start_auto"]
+    assert descriptor.metadata is not None
+    assert descriptor.metadata.fallback_used is False
+    assert descriptor.metadata.companions == start_auto.companions
+    assert "ouroboros_job_status" in start_auto.companions
+    assert "ouroboros_job_wait" in start_auto.companions
+    assert omitted_companions.isdisjoint(start_auto.companions)
+
+    lifecycle = start_auto.orchestration["background_lifecycle"]
+    assert lifecycle["companion_roles"] == {
+        "start": "ouroboros_start_auto",
+        "blocking": "ouroboros_auto",
+        "status": "ouroboros_job_status",
+        "wait": "ouroboros_job_wait",
+    }
+    assert "result" not in lifecycle["runtime_instruction"]
+    assert "cancel" not in lifecycle["runtime_instruction"]
+    assert lifecycle["cancel"] == {
+        "supported": False,
+        "mode": "unsupported",
+        "companions": (),
+        "target_context_keys": (),
+    }
+
+
+def test_run_family_exposes_start_and_lifecycle_companion_metadata() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    execute = graph.by_name()["ouroboros_execute_seed"]
+    expected_roles = {
+        "primary": "ouroboros_execute_seed",
+        "start": "ouroboros_start_execute_seed",
+        "execution_cancel": "ouroboros_cancel_execution",
+        "status": "ouroboros_job_status",
+        "wait": "ouroboros_job_wait",
+        "result": "ouroboros_job_result",
+        "cancel": "ouroboros_cancel_job",
+    }
+
+    assert set(expected_roles.values()).issubset(definitions)
+    assert execute.metadata is not None
+    assert execute.metadata.fallback_used is False
+    assert execute.metadata.execution_mode == "blocking"
+    assert set(expected_roles.values()) - {"ouroboros_execute_seed"} <= set(
+        execute.metadata.companions
+    )
+
+    run_family = execute.metadata.orchestration["run_family"]
+    assert run_family["family_id"] == "run_execute_lifecycle.v1"
+    assert run_family["execution_mode"] == "blocking"
+    assert run_family["companion_roles"] == expected_roles
+    assert run_family["start_variant"] == "ouroboros_start_execute_seed"
+    assert run_family["required_result_context_keys"] == {
+        "execution_cancel": ("execution_id",),
+        "background_job": ("job_id",),
+    }
+    assert run_family["cancel"] == {
+        "supported": True,
+        "mode": "execution_session",
+        "companions": ("ouroboros_cancel_execution",),
+        "target_context_keys": ("execution_id",),
+    }
+    assert "start variant" in run_family["runtime_instruction"]
+    assert "status" in run_family["runtime_instruction"]
+    assert "wait" in run_family["runtime_instruction"]
+    assert "result" in run_family["runtime_instruction"]
+    assert "cancel" in run_family["runtime_instruction"]
+
+
+def test_run_family_omits_absent_lifecycle_companion_tools(monkeypatch) -> None:
+    full_definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+    omitted_companions = {"ouroboros_job_result", "ouroboros_cancel_job"}
+    partial_definitions = tuple(
+        definition
+        for name, definition in full_definitions.items()
+        if name not in omitted_companions
+    )
+    partial_handlers = tuple(
+        SimpleNamespace(definition=definition) for definition in partial_definitions
+    )
+
+    capabilities_module._ouroboros_tool_definitions_by_name.cache_clear()
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.definitions.get_ouroboros_tools",
+        lambda: partial_handlers,
+    )
+
+    try:
+        registry = ouroboros_tool_capability_registry()
+        graph = build_capability_graph(
+            assemble_session_tool_catalog(attached_tools=partial_definitions)
+        )
+    finally:
+        capabilities_module._ouroboros_tool_definitions_by_name.cache_clear()
+
+    execute = graph.by_name()["ouroboros_execute_seed"]
+    assert omitted_companions.isdisjoint(registry)
+    assert execute.metadata is not None
+    assert execute.metadata.fallback_used is False
+    assert "ouroboros_start_execute_seed" in execute.metadata.companions
+    assert "ouroboros_cancel_execution" in execute.metadata.companions
+    assert "ouroboros_job_status" in execute.metadata.companions
+    assert "ouroboros_job_wait" in execute.metadata.companions
+    assert omitted_companions.isdisjoint(execute.metadata.companions)
+
+    run_family = execute.metadata.orchestration["run_family"]
+    assert run_family["companion_roles"] == {
+        "primary": "ouroboros_execute_seed",
+        "start": "ouroboros_start_execute_seed",
+        "execution_cancel": "ouroboros_cancel_execution",
+        "status": "ouroboros_job_status",
+        "wait": "ouroboros_job_wait",
+    }
+    assert run_family["start_variant"] == "ouroboros_start_execute_seed"
+    assert run_family["required_result_context_keys"] == {
+        "execution_cancel": ("execution_id",),
+        "background_job": ("job_id",),
+    }
+    assert "result" not in run_family["runtime_instruction"]
+    assert "execution_cancel" in run_family["runtime_instruction"]
+
+
+def test_evaluate_family_exposes_start_and_lifecycle_companion_metadata() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    evaluate = graph.by_name()["ouroboros_evaluate"]
+    expected_roles = {
+        "primary": "ouroboros_evaluate",
+        "start": "ouroboros_start_evaluate",
+        "checklist_verify": "ouroboros_checklist_verify",
+        "measure_drift": "ouroboros_measure_drift",
+        "qa": "ouroboros_qa",
+        "status": "ouroboros_job_status",
+        "wait": "ouroboros_job_wait",
+        "result": "ouroboros_job_result",
+        "cancel": "ouroboros_cancel_job",
+    }
+
+    assert set(expected_roles.values()).issubset(definitions)
+    assert evaluate.metadata is not None
+    assert evaluate.metadata.fallback_used is False
+    assert evaluate.metadata.execution_mode == "blocking"
+    assert set(expected_roles.values()) - {"ouroboros_evaluate"} <= set(
+        evaluate.metadata.companions
+    )
+
+    evaluate_family = evaluate.metadata.orchestration["evaluate_family"]
+    assert evaluate_family["family_id"] == "evaluate_lifecycle.v1"
+    assert evaluate_family["execution_mode"] == "blocking"
+    assert evaluate_family["companion_roles"] == expected_roles
+    assert evaluate_family["start_variant"] == "ouroboros_start_evaluate"
+    assert evaluate_family["required_result_context_keys"] == {
+        "background_job": ("job_id",),
+    }
+    assert evaluate_family["cancel"] == _UNSUPPORTED_CANCEL
+    assert evaluate_family["background_cancel"] == _BACKGROUND_JOB_CANCEL
+    assert "start variant" in evaluate_family["runtime_instruction"]
+    assert "checklist_verify" in evaluate_family["runtime_instruction"]
+    assert "measure_drift" in evaluate_family["runtime_instruction"]
+    assert "qa" in evaluate_family["runtime_instruction"]
+    assert "status" in evaluate_family["runtime_instruction"]
+    assert "wait" in evaluate_family["runtime_instruction"]
+    assert "result" in evaluate_family["runtime_instruction"]
+    assert "cancel" in evaluate_family["runtime_instruction"]
+
+
+def test_evaluate_family_omits_absent_lifecycle_companion_tools(monkeypatch) -> None:
+    full_definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+    omitted_companions = {
+        "ouroboros_job_result",
+        "ouroboros_cancel_job",
+        "ouroboros_checklist_verify",
+    }
+    partial_definitions = tuple(
+        definition
+        for name, definition in full_definitions.items()
+        if name not in omitted_companions
+    )
+    partial_handlers = tuple(
+        SimpleNamespace(definition=definition) for definition in partial_definitions
+    )
+
+    capabilities_module._ouroboros_tool_definitions_by_name.cache_clear()
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.definitions.get_ouroboros_tools",
+        lambda: partial_handlers,
+    )
+
+    try:
+        registry = ouroboros_tool_capability_registry()
+        graph = build_capability_graph(
+            assemble_session_tool_catalog(attached_tools=partial_definitions)
+        )
+    finally:
+        capabilities_module._ouroboros_tool_definitions_by_name.cache_clear()
+
+    evaluate = graph.by_name()["ouroboros_evaluate"]
+    assert omitted_companions.isdisjoint(registry)
+    assert evaluate.metadata is not None
+    assert evaluate.metadata.fallback_used is False
+    assert "ouroboros_start_evaluate" in evaluate.metadata.companions
+    assert "ouroboros_measure_drift" in evaluate.metadata.companions
+    assert "ouroboros_qa" in evaluate.metadata.companions
+    assert "ouroboros_job_status" in evaluate.metadata.companions
+    assert "ouroboros_job_wait" in evaluate.metadata.companions
+    assert omitted_companions.isdisjoint(evaluate.metadata.companions)
+
+    evaluate_family = evaluate.metadata.orchestration["evaluate_family"]
+    assert evaluate_family["companion_roles"] == {
+        "primary": "ouroboros_evaluate",
+        "start": "ouroboros_start_evaluate",
+        "measure_drift": "ouroboros_measure_drift",
+        "qa": "ouroboros_qa",
+        "status": "ouroboros_job_status",
+        "wait": "ouroboros_job_wait",
+    }
+    assert evaluate_family["start_variant"] == "ouroboros_start_evaluate"
+    assert evaluate_family["required_result_context_keys"] == {
+        "background_job": ("job_id",),
+    }
+    assert evaluate_family["background_cancel"] == {
+        "supported": False,
+        "mode": "unsupported",
+        "companions": (),
+        "target_context_keys": (),
+    }
+    assert "checklist_verify" not in evaluate_family["runtime_instruction"]
+    assert "result" not in evaluate_family["runtime_instruction"]
+    assert "cancel" not in evaluate_family["runtime_instruction"]
+    assert "status" in evaluate_family["runtime_instruction"]
+
+
+def test_evolve_family_exposes_start_and_lifecycle_companion_metadata() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    evolve = graph.by_name()["ouroboros_evolve_step"]
+    expected_roles = {
+        "primary": "ouroboros_evolve_step",
+        "start": "ouroboros_start_evolve_step",
+        "lineage_status": "ouroboros_lineage_status",
+        "rewind": "ouroboros_evolve_rewind",
+        "ralph": "ouroboros_ralph",
+        "start_ralph": "ouroboros_start_ralph",
+        "status": "ouroboros_job_status",
+        "wait": "ouroboros_job_wait",
+        "result": "ouroboros_job_result",
+        "cancel": "ouroboros_cancel_job",
+    }
+
+    assert set(expected_roles.values()).issubset(definitions)
+    assert evolve.metadata is not None
+    assert evolve.metadata.fallback_used is False
+    assert evolve.metadata.execution_mode == "blocking"
+    assert set(expected_roles.values()) - {"ouroboros_evolve_step"} <= set(
+        evolve.metadata.companions
+    )
+
+    evolve_family = evolve.metadata.orchestration["evolve_family"]
+    assert evolve_family["family_id"] == "evolve_lifecycle.v1"
+    assert evolve_family["execution_mode"] == "blocking"
+    assert evolve_family["companion_roles"] == expected_roles
+    assert evolve_family["start_variant"] == "ouroboros_start_evolve_step"
+    assert evolve_family["required_result_context_keys"] == {
+        "lineage": ("lineage_id",),
+        "background_job": ("job_id",),
+    }
+    assert evolve_family["cancel"] == _UNSUPPORTED_CANCEL
+    assert evolve_family["background_cancel"] == _BACKGROUND_JOB_CANCEL
+    assert "start variant" in evolve_family["runtime_instruction"]
+    assert "lineage_status" in evolve_family["runtime_instruction"]
+    assert "rewind" in evolve_family["runtime_instruction"]
+    assert "ralph" in evolve_family["runtime_instruction"]
+    assert "start_ralph" in evolve_family["runtime_instruction"]
+    assert "status" in evolve_family["runtime_instruction"]
+    assert "wait" in evolve_family["runtime_instruction"]
+    assert "result" in evolve_family["runtime_instruction"]
+    assert "cancel" in evolve_family["runtime_instruction"]
+
+
+def test_evolve_family_omits_absent_lifecycle_companion_tools(monkeypatch) -> None:
+    full_definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+    omitted_companions = {
+        "ouroboros_job_result",
+        "ouroboros_cancel_job",
+        "ouroboros_start_ralph",
+    }
+    partial_definitions = tuple(
+        definition
+        for name, definition in full_definitions.items()
+        if name not in omitted_companions
+    )
+    partial_handlers = tuple(
+        SimpleNamespace(definition=definition) for definition in partial_definitions
+    )
+
+    capabilities_module._ouroboros_tool_definitions_by_name.cache_clear()
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.definitions.get_ouroboros_tools",
+        lambda: partial_handlers,
+    )
+
+    try:
+        registry = ouroboros_tool_capability_registry()
+        graph = build_capability_graph(
+            assemble_session_tool_catalog(attached_tools=partial_definitions)
+        )
+    finally:
+        capabilities_module._ouroboros_tool_definitions_by_name.cache_clear()
+
+    evolve = graph.by_name()["ouroboros_evolve_step"]
+    assert omitted_companions.isdisjoint(registry)
+    assert evolve.metadata is not None
+    assert evolve.metadata.fallback_used is False
+    assert "ouroboros_start_evolve_step" in evolve.metadata.companions
+    assert "ouroboros_lineage_status" in evolve.metadata.companions
+    assert "ouroboros_evolve_rewind" in evolve.metadata.companions
+    assert "ouroboros_ralph" in evolve.metadata.companions
+    assert "ouroboros_job_status" in evolve.metadata.companions
+    assert "ouroboros_job_wait" in evolve.metadata.companions
+    assert omitted_companions.isdisjoint(evolve.metadata.companions)
+
+    evolve_family = evolve.metadata.orchestration["evolve_family"]
+    assert evolve_family["companion_roles"] == {
+        "primary": "ouroboros_evolve_step",
+        "start": "ouroboros_start_evolve_step",
+        "lineage_status": "ouroboros_lineage_status",
+        "rewind": "ouroboros_evolve_rewind",
+        "ralph": "ouroboros_ralph",
+        "status": "ouroboros_job_status",
+        "wait": "ouroboros_job_wait",
+    }
+    assert evolve_family["start_variant"] == "ouroboros_start_evolve_step"
+    assert evolve_family["required_result_context_keys"] == {
+        "lineage": ("lineage_id",),
+        "background_job": ("job_id",),
+    }
+    assert evolve_family["background_cancel"] == {
+        "supported": False,
+        "mode": "unsupported",
+        "companions": (),
+        "target_context_keys": (),
+    }
+    assert "start_ralph" not in evolve_family["runtime_instruction"]
+    assert "result" not in evolve_family["runtime_instruction"]
+    assert "cancel" not in evolve_family["runtime_instruction"]
+    assert "status" in evolve_family["runtime_instruction"]
+
+
+def test_ralph_family_exposes_start_and_lifecycle_companion_metadata() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    ralph = graph.by_name()["ouroboros_ralph"]
+    start_ralph = graph.by_name()["ouroboros_start_ralph"]
+    expected_roles = {
+        "primary": "ouroboros_ralph",
+        "start": "ouroboros_start_ralph",
+        "evolve_step": "ouroboros_evolve_step",
+        "start_evolve_step": "ouroboros_start_evolve_step",
+        "lineage_status": "ouroboros_lineage_status",
+        "rewind": "ouroboros_evolve_rewind",
+        "status": "ouroboros_job_status",
+        "wait": "ouroboros_job_wait",
+        "result": "ouroboros_job_result",
+        "cancel": "ouroboros_cancel_job",
+    }
+
+    assert set(expected_roles.values()).issubset(definitions)
+    assert ralph.metadata is not None
+    assert ralph.metadata.fallback_used is False
+    assert ralph.metadata.execution_mode == "blocking"
+    assert set(expected_roles.values()) - {"ouroboros_ralph"} <= set(
+        ralph.metadata.companions
+    )
+    assert start_ralph.metadata is not None
+    assert start_ralph.metadata.fallback_used is False
+    assert start_ralph.metadata.execution_mode == "background"
+    assert set(expected_roles.values()) - {
+        "ouroboros_ralph",
+        "ouroboros_start_ralph",
+    } <= set(start_ralph.metadata.companions)
+
+    ralph_family = ralph.metadata.orchestration["ralph_family"]
+    assert ralph_family["family_id"] == "ralph_lifecycle.v1"
+    assert ralph_family["execution_mode"] == "blocking"
+    assert ralph_family["companion_roles"] == expected_roles
+    assert ralph_family["start_variant"] == "ouroboros_start_ralph"
+    assert ralph_family["required_result_context_keys"] == {
+        "lineage": ("lineage_id",),
+        "background_job": ("job_id",),
+    }
+    assert ralph_family["cancel"] == _UNSUPPORTED_CANCEL
+    assert ralph_family["background_cancel"] == _BACKGROUND_JOB_CANCEL
+    assert "start variant" in ralph_family["runtime_instruction"]
+    assert "evolve_step" in ralph_family["runtime_instruction"]
+    assert "start_evolve_step" in ralph_family["runtime_instruction"]
+    assert "lineage_status" in ralph_family["runtime_instruction"]
+    assert "rewind" in ralph_family["runtime_instruction"]
+    assert "status" in ralph_family["runtime_instruction"]
+    assert "wait" in ralph_family["runtime_instruction"]
+    assert "result" in ralph_family["runtime_instruction"]
+    assert "cancel" in ralph_family["runtime_instruction"]
+
+
+def test_ralph_family_omits_absent_lifecycle_companion_tools(monkeypatch) -> None:
+    full_definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+    omitted_companions = {
+        "ouroboros_job_result",
+        "ouroboros_cancel_job",
+        "ouroboros_start_evolve_step",
+    }
+    partial_definitions = tuple(
+        definition
+        for name, definition in full_definitions.items()
+        if name not in omitted_companions
+    )
+    partial_handlers = tuple(
+        SimpleNamespace(definition=definition) for definition in partial_definitions
+    )
+
+    capabilities_module._ouroboros_tool_definitions_by_name.cache_clear()
+    monkeypatch.setattr(
+        "ouroboros.mcp.tools.definitions.get_ouroboros_tools",
+        lambda: partial_handlers,
+    )
+
+    try:
+        registry = ouroboros_tool_capability_registry()
+        graph = build_capability_graph(
+            assemble_session_tool_catalog(attached_tools=partial_definitions)
+        )
+    finally:
+        capabilities_module._ouroboros_tool_definitions_by_name.cache_clear()
+
+    ralph = graph.by_name()["ouroboros_ralph"]
+    assert omitted_companions.isdisjoint(registry)
+    assert ralph.metadata is not None
+    assert ralph.metadata.fallback_used is False
+    assert "ouroboros_start_ralph" in ralph.metadata.companions
+    assert "ouroboros_evolve_step" in ralph.metadata.companions
+    assert "ouroboros_lineage_status" in ralph.metadata.companions
+    assert "ouroboros_evolve_rewind" in ralph.metadata.companions
+    assert "ouroboros_job_status" in ralph.metadata.companions
+    assert "ouroboros_job_wait" in ralph.metadata.companions
+    assert omitted_companions.isdisjoint(ralph.metadata.companions)
+
+    ralph_family = ralph.metadata.orchestration["ralph_family"]
+    assert ralph_family["companion_roles"] == {
+        "primary": "ouroboros_ralph",
+        "start": "ouroboros_start_ralph",
+        "evolve_step": "ouroboros_evolve_step",
+        "lineage_status": "ouroboros_lineage_status",
+        "rewind": "ouroboros_evolve_rewind",
+        "status": "ouroboros_job_status",
+        "wait": "ouroboros_job_wait",
+    }
+    assert ralph_family["start_variant"] == "ouroboros_start_ralph"
+    assert ralph_family["required_result_context_keys"] == {
+        "lineage": ("lineage_id",),
+        "background_job": ("job_id",),
+    }
+    assert ralph_family["background_cancel"] == {
+        "supported": False,
+        "mode": "unsupported",
+        "companions": (),
+        "target_context_keys": (),
+    }
+    assert "start_evolve_step" not in ralph_family["runtime_instruction"]
+    assert "result" not in ralph_family["runtime_instruction"]
+    assert "cancel" not in ralph_family["runtime_instruction"]
+    assert "status" in ralph_family["runtime_instruction"]
+
+
+def test_ouroboros_owned_tools_have_explicit_mutation_targets_and_side_effects() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    registry = ouroboros_tool_capability_registry()
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+
+    assert set(registry) == set(_EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS)
+    assert set(definitions) == set(_EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS)
+    assert set(registry) == set(_EXPECTED_OUROBOROS_TOOL_MUTATION_TARGETS)
+    assert set(registry) == set(_EXPECTED_OUROBOROS_TOOL_STATE_MUTATIONS)
+    for name, expected_side_effects in _EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS.items():
+        metadata = registry[name]
+        descriptor = descriptors[name]
+        expected_mutation_targets = _EXPECTED_OUROBOROS_TOOL_MUTATION_TARGETS[name]
+        expected_state_mutations = _EXPECTED_OUROBOROS_TOOL_STATE_MUTATIONS[name]
+
+        assert metadata.mutation_class == descriptor.semantics.mutation_class.value, name
+        assert metadata.mutation_targets == expected_mutation_targets, name
+        assert metadata.state_mutations == expected_state_mutations, name
+        assert metadata.side_effects == expected_side_effects, name
+        if descriptor.semantics.mutation_class is not CapabilityMutationClass.READ_ONLY:
+            assert metadata.side_effects, name
+        assert len(metadata.side_effects) == len(set(metadata.side_effects)), name
+        assert len(metadata.mutation_targets) == len(set(metadata.mutation_targets)), name
+        for mutation in metadata.state_mutations:
+            assert mutation["target"] in metadata.mutation_targets, name
+            assert mutation["side_effect"] in metadata.side_effects, name
+            assert isinstance(mutation["context_keys"], tuple), name
+        assert descriptor.metadata is not None, name
+        assert descriptor.metadata.mutation_targets == expected_mutation_targets, name
+        assert descriptor.metadata.state_mutations == expected_state_mutations, name
+        assert descriptor.metadata.side_effects == expected_side_effects, name
+        assert descriptor.metadata.fallback_used is False, name
+
+
+def test_execution_evolution_tools_represent_concrete_execution_side_effects() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    execution_evolution_tools = {
+        "ouroboros_auto": "auto_session_state",
+        "ouroboros_start_auto": "auto_session_state",
+        "ouroboros_execute_seed": "execution_session",
+        "ouroboros_start_execute_seed": "execution_session",
+        "ouroboros_evolve_step": "lineage_state",
+        "ouroboros_start_evolve_step": "lineage_state",
+        "ouroboros_ralph": "ralph_loop_state",
+        "ouroboros_start_ralph": "ralph_loop_state",
+    }
+
+    assert set(execution_evolution_tools).issubset(definitions)
+    for tool_name, expected_state_target in execution_evolution_tools.items():
+        descriptor = graph.by_name()[tool_name]
+        registry_metadata = ouroboros_tool_capability_registry()[tool_name]
+
+        assert descriptor.metadata is not None, tool_name
+        assert descriptor.metadata == registry_metadata, tool_name
+        assert registry_metadata.fallback_used is False, tool_name
+        assert {"workspace_write", "event_store_write"} <= set(
+            registry_metadata.side_effects
+        ), tool_name
+        assert "workspace" in registry_metadata.mutation_targets, tool_name
+        assert "event_store" in registry_metadata.mutation_targets, tool_name
+        assert expected_state_target in registry_metadata.mutation_targets, tool_name
+        assert registry_metadata.state_mutations, tool_name
+        represented_targets = {
+            mutation["target"] for mutation in registry_metadata.state_mutations
+        }
+        represented_side_effects = {
+            mutation["side_effect"] for mutation in registry_metadata.state_mutations
+        }
+        represented_operations = {
+            mutation["operation"] for mutation in registry_metadata.state_mutations
+        }
+
+        assert expected_state_target in represented_targets, tool_name
+        assert "workspace" in represented_targets, tool_name
+        assert {"workspace_write", "event_store_write"} <= represented_side_effects, tool_name
+        assert all(operation for operation in represented_operations), tool_name
+        validate_capability_tool_metadata(
+            registry_metadata,
+            tool_name=tool_name,
+            owned_tool=True,
+        )
+
+
+def test_cancel_tools_represent_runtime_and_persistent_side_effects() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    state_changing_command_names = {
+        name
+        for name in definitions
+        if any(command in name for command in ("cancel", "publish", "update"))
+    }
+    expected_cancel_tools = {
+        "ouroboros_cancel_execution": {
+            "side_effects": {
+                "runtime_control",
+                "event_store_write",
+                "session_state_write",
+            },
+            "mutation_targets": {"runtime", "event_store", "session_state", "execution_session"},
+            "operations": {
+                "mark_execution_session_cancelled",
+                "append_session_cancelled_event",
+                "signal_execution_runner_to_stop_via_cancellation_event",
+            },
+        },
+        "ouroboros_cancel_job": {
+            "side_effects": {
+                "runtime_control",
+                "event_store_write",
+                "checkpoint_store_write",
+                "session_state_write",
+            },
+            "mutation_targets": {
+                "runtime",
+                "event_store",
+                "checkpoint_store",
+                "session_state",
+                "background_job",
+            },
+            "operations": {
+                "mark_background_job_cancel_requested",
+                "persist_durable_agent_process_cancel_signal",
+                "cancel_live_background_job_tasks",
+                "mark_linked_execution_session_cancelled_when_needed",
+            },
+        },
+    }
+
+    assert state_changing_command_names == set(expected_cancel_tools)
+    assert "ouroboros_publish" not in definitions
+    assert "ouroboros_update" not in definitions
+
+    for tool_name, expected in expected_cancel_tools.items():
+        descriptor = graph.by_name()[tool_name]
+        metadata = ouroboros_tool_capability_registry()[tool_name]
+
+        assert descriptor.metadata is not None, tool_name
+        assert descriptor.metadata == metadata, tool_name
+        assert metadata.fallback_used is False, tool_name
+        assert metadata.execution_mode == "cancel", tool_name
+        assert descriptor.semantics.mutation_class is CapabilityMutationClass.EXTERNAL_SIDE_EFFECT
+        assert set(metadata.side_effects) == expected["side_effects"], tool_name
+        assert set(metadata.mutation_targets) == expected["mutation_targets"], tool_name
+        assert {
+            mutation["operation"] for mutation in metadata.state_mutations
+        } == expected["operations"], tool_name
+        assert {
+            mutation["side_effect"] for mutation in metadata.state_mutations
+        } == expected["side_effects"], tool_name
+        assert all(mutation["context_keys"] for mutation in metadata.state_mutations), tool_name
+        validate_capability_tool_metadata(
+            metadata,
+            tool_name=tool_name,
+            owned_tool=True,
+        )
+
+
+def test_read_only_ouroboros_owned_tools_are_explicitly_non_mutating() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    registry = ouroboros_tool_capability_registry()
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    read_only_side_effects = {()}
+
+    assert set(definitions) >= _EXPECTED_READ_ONLY_OUROBOROS_TOOLS
+    assert {
+        name
+        for name, side_effects in _EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS.items()
+        if side_effects in read_only_side_effects
+    } == _EXPECTED_READ_ONLY_OUROBOROS_TOOLS
+    for name in sorted(_EXPECTED_READ_ONLY_OUROBOROS_TOOLS):
+        spec = capabilities_module._OUROBOROS_TOOL_CAPABILITY_SPECS[name]
+        metadata = registry[name]
+        descriptor = descriptors[name]
+
+        assert spec.mutation_class is CapabilityMutationClass.READ_ONLY, name
+        assert metadata.mutation_class == CapabilityMutationClass.READ_ONLY.value, name
+        assert metadata.mutation_targets == (), name
+        assert metadata.state_mutations == (), name
+        assert metadata.side_effects == (), name
+        assert metadata.fallback_used is False, name
+        assert descriptor.metadata is not None, name
+        assert descriptor.metadata.mutation_targets == (), name
+        assert descriptor.metadata.state_mutations == (), name
+        assert descriptor.metadata.side_effects == (), name
+        assert descriptor.metadata.mutation_class == CapabilityMutationClass.READ_ONLY.value
+        assert descriptor.semantics.mutation_class is CapabilityMutationClass.READ_ONLY
+        assert descriptor.semantics.parallel_safety is CapabilityParallelSafety.SAFE
+        assert descriptor.semantics.interruptibility is CapabilityInterruptibility.NONE
+        assert descriptor.semantics.approval_class is CapabilityApprovalClass.DEFAULT
+
+
+def test_read_only_query_status_projection_tools_have_non_mutating_interrupt_metadata() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    registry = ouroboros_tool_capability_registry()
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    expected_query_status_projection_tools = {
+        "ouroboros_ac_tree_hud",
+        "ouroboros_job_result",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_lineage_status",
+        "ouroboros_query_events",
+        "ouroboros_query_projection",
+        "ouroboros_session_status",
+    }
+
+    assert expected_query_status_projection_tools == _EXPECTED_READ_ONLY_OUROBOROS_TOOLS
+    assert expected_query_status_projection_tools.issubset(definitions)
+    assert {
+        name
+        for name, metadata in registry.items()
+        if metadata.execution_mode == "status"
+        and metadata.mutation_class == CapabilityMutationClass.READ_ONLY.value
+    } == expected_query_status_projection_tools
+
+    for name in sorted(expected_query_status_projection_tools):
+        metadata = registry[name]
+        descriptor = descriptors[name]
+
+        assert descriptor.metadata is not None, name
+        assert descriptor.metadata.fallback_used is False, name
+        assert descriptor.metadata.interrupt == _READ_ONLY_INTERRUPT, name
+        assert metadata.interrupt == _READ_ONLY_INTERRUPT, name
+        assert metadata.interrupt["mode"] != "unsupported", name
+        assert metadata.interrupt["supported"] is True, name
+        assert metadata.interrupt["mutation_semantics"] == "no_state_mutation", name
+        assert metadata.interrupt["resumable"] is False, name
+        assert metadata.interrupt["target_context_keys"] == (), name
+        assert metadata.side_effects == (), name
+        assert metadata.mutation_targets == (), name
+        assert metadata.state_mutations == (), name
+        assert descriptor.semantics.mutation_class is CapabilityMutationClass.READ_ONLY
+        assert descriptor.semantics.interruptibility is CapabilityInterruptibility.NONE
+        validate_capability_tool_metadata(metadata, tool_name=name, owned_tool=True)
+
+
+def test_ouroboros_owned_tools_have_explicit_tool_specific_retry_behavior() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    registry = ouroboros_tool_capability_registry()
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+
+    assert set(registry) == set(_EXPECTED_OUROBOROS_TOOL_RETRY)
+    assert set(definitions) == set(_EXPECTED_OUROBOROS_TOOL_RETRY)
+    for name, expected_retry in _EXPECTED_OUROBOROS_TOOL_RETRY.items():
+        metadata = registry[name]
+        descriptor = descriptors[name]
+
+        assert metadata.retry == expected_retry, name
+        assert set(metadata.retry) == {"supported", "mode"}, name
+        assert isinstance(metadata.retry["supported"], bool), name
+        assert metadata.retry["mode"] in {"handler_owned", "job_poll", "unsupported"}
+        assert descriptor.metadata is not None, name
+        assert descriptor.metadata.retry == expected_retry, name
+        assert descriptor.metadata.fallback_used is False, name
+
+
+def test_ouroboros_owned_retry_taxonomy_has_distinct_explicit_semantics() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+
+    retry_capable_tools = {
+        "ouroboros_execute_seed",
+        "ouroboros_interview",
+        "ouroboros_evaluate",
+        "ouroboros_lateral_think",
+        "ouroboros_qa",
+    }
+    conditionally_retryable_tools = {
+        "ouroboros_start_execute_seed",
+        "ouroboros_start_evaluate",
+        "ouroboros_start_evolve_step",
+        "ouroboros_start_ralph",
+    }
+    non_retryable_tools = {
+        "ouroboros_cancel_job",
+        "ouroboros_cancel_execution",
+    }
+
+    expected_by_group = (
+        (
+            retry_capable_tools,
+            {"supported": True, "mode": "handler_owned"},
+            "blocking-or-orchestrated handlers own safe retry decisions",
+        ),
+        (
+            conditionally_retryable_tools,
+            {"supported": True, "mode": "job_poll"},
+            "background starters retry through job lifecycle polling companions",
+        ),
+        (
+            non_retryable_tools,
+            {"supported": False, "mode": "unsupported"},
+            "cancel/runtime-control tools must not be replayed implicitly",
+        ),
+    )
+
+    assert not retry_capable_tools & conditionally_retryable_tools
+    assert not retry_capable_tools & non_retryable_tools
+    assert not conditionally_retryable_tools & non_retryable_tools
+
+    for tool_names, expected_retry, _reason in expected_by_group:
+        for name in tool_names:
+            descriptor = descriptors[name]
+
+            assert descriptor.metadata is not None, name
+            assert descriptor.metadata.retry == expected_retry, name
+            assert descriptor.metadata.fallback_used is False, name
+            assert descriptor.metadata.retry != {"supported": False, "mode": "generic"}, name
+
+    assert {
+        tuple(sorted(descriptors[name].metadata.retry.items()))
+        for names, _expected, _reason in expected_by_group
+        for name in names
+    } == {
+        (("mode", "handler_owned"), ("supported", True)),
+        (("mode", "job_poll"), ("supported", True)),
+        (("mode", "unsupported"), ("supported", False)),
+    }
+
+
+def test_ouroboros_owned_tools_have_explicit_tool_specific_interrupt_behavior() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    registry = ouroboros_tool_capability_registry()
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+
+    assert set(registry) == set(_EXPECTED_OUROBOROS_TOOL_INTERRUPT)
+    assert set(definitions) == set(_EXPECTED_OUROBOROS_TOOL_INTERRUPT)
+    for name, expected_interrupt in _EXPECTED_OUROBOROS_TOOL_INTERRUPT.items():
+        metadata = registry[name]
+        descriptor = descriptors[name]
+
+        assert metadata.interrupt == expected_interrupt, name
+        _assert_lifecycle_metadata_shape(metadata, name)
+        assert isinstance(metadata.interrupt["supported"], bool), name
+        assert metadata.interrupt["mode"] in {
+            "soft",
+            "hard",
+            "terminal_control",
+            "unsupported",
+            "resumable_background_job",
+            "read_only_non_mutating",
+        }
+        assert descriptor.metadata is not None, name
+        assert descriptor.metadata.interrupt == expected_interrupt, name
+        assert descriptor.metadata.fallback_used is False, name
+
+
+def test_blocking_ouroboros_tools_have_synchronous_interrupt_metadata() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    registry = ouroboros_tool_capability_registry()
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    blocking_tools = {
+        name
+        for name, metadata in registry.items()
+        if metadata.execution_mode == "blocking"
+    }
+
+    assert blocking_tools == {
+        "ouroboros_auto",
+        "ouroboros_brownfield",
+        "ouroboros_checklist_verify",
+        "ouroboros_evaluate",
+        "ouroboros_evolve_rewind",
+        "ouroboros_evolve_step",
+        "ouroboros_execute_seed",
+        "ouroboros_generate_seed",
+        "ouroboros_measure_drift",
+        "ouroboros_qa",
+        "ouroboros_ralph",
+    }
+
+    for name in sorted(blocking_tools):
+        descriptor = descriptors[name]
+        metadata = registry[name]
+        interrupt = metadata.interrupt
+
+        assert descriptor.metadata is not None, name
+        assert descriptor.metadata.fallback_used is False, name
+        assert descriptor.metadata.interrupt == interrupt, name
+        assert descriptor.semantics.interruptibility is CapabilityInterruptibility.SOFT
+        assert interrupt["supported"] is True, name
+        assert interrupt["mode"] == "soft", name
+        assert interrupt["execution_mode"] == "blocking", name
+        assert interrupt["blocking_semantics"] == "synchronous_handler", name
+        assert interrupt["resumable"] is False, name
+        assert isinstance(interrupt["background_companions"], tuple), name
+        assert isinstance(interrupt["target_context_keys"], tuple), name
+        assert interrupt["target_context_keys"] == (), name
+        assert interrupt == _EXPECTED_OUROBOROS_TOOL_INTERRUPT[name], name
+        assert all(
+            companion in metadata.companions
+            for companion in interrupt["background_companions"]
+        ), name
+
+
+def test_background_starting_tools_have_resumable_cancellable_interrupt_metadata() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    background_tools = {
+        name
+        for name, expected_mode in _EXPECTED_OUROBOROS_TOOL_EXECUTION_MODES.items()
+        if expected_mode == "background"
+    }
+
+    assert background_tools == {
+        "ouroboros_start_auto",
+        "ouroboros_start_evaluate",
+        "ouroboros_start_evolve_step",
+        "ouroboros_start_execute_seed",
+        "ouroboros_start_ralph",
+    }
+    assert background_tools.issubset(definitions)
+
+    for name in sorted(background_tools):
+        descriptor = descriptors[name]
+
+        assert descriptor.metadata is not None, name
+        assert descriptor.metadata.fallback_used is False, name
+        assert descriptor.metadata.execution_mode == "background", name
+        assert descriptor.semantics.interruptibility is CapabilityInterruptibility.SOFT
+        assert descriptor.metadata.interrupt == _BACKGROUND_INTERRUPT, name
+        assert set(descriptor.metadata.interrupt["resume_companions"]) == {
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+        }, name
+        assert descriptor.metadata.interrupt["cancel_companions"] == (
+            "ouroboros_cancel_job",
+        ), name
+        assert descriptor.metadata.interrupt["target_context_keys"] == ("job_id",)
+        assert all(
+            companion in descriptor.metadata.companions
+            for companion in (
+                *descriptor.metadata.interrupt["resume_companions"],
+                *descriptor.metadata.interrupt["cancel_companions"],
+            )
+        ), name
+        assert descriptor.metadata.cancel == _BACKGROUND_JOB_CANCEL, name
+        lifecycle = descriptor.metadata.orchestration["background_lifecycle"]
+        assert lifecycle["required_result_context_keys"] == ("job_id",)
+        assert lifecycle["cancel"] == _BACKGROUND_JOB_CANCEL
+
+
+def test_cancellation_control_tools_have_terminal_control_interrupt_metadata() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    registry = ouroboros_tool_capability_registry()
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    control_tools = {
+        name for name, metadata in registry.items() if metadata.execution_mode == "cancel"
+    }
+
+    assert control_tools == set(_TERMINAL_CONTROL_INTERRUPTS)
+    assert control_tools == set(capabilities_module._OUROBOROS_CANCEL_TOOLS)
+    assert control_tools.issubset(definitions)
+
+    for name in sorted(control_tools):
+        descriptor = descriptors[name]
+        metadata = registry[name]
+        expected_interrupt = _TERMINAL_CONTROL_INTERRUPTS[name]
+        target_keys = expected_interrupt["target_context_keys"]
+
+        assert descriptor.metadata is not None, name
+        assert descriptor.metadata.fallback_used is False, name
+        assert descriptor.metadata == metadata, name
+        assert descriptor.semantics.mutation_class is (
+            CapabilityMutationClass.EXTERNAL_SIDE_EFFECT
+        )
+        assert descriptor.semantics.parallel_safety is CapabilityParallelSafety.SERIALIZED
+        assert descriptor.semantics.interruptibility is CapabilityInterruptibility.HARD
+        assert descriptor.semantics.approval_class is CapabilityApprovalClass.ELEVATED
+        assert metadata.execution_mode == "cancel", name
+        assert metadata.side_effects == _EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS[name], name
+        assert "runtime_control" in metadata.side_effects, name
+        assert metadata.mutation_targets == _EXPECTED_OUROBOROS_TOOL_MUTATION_TARGETS[
+            name
+        ], name
+        assert "runtime" in metadata.mutation_targets, name
+        assert metadata.state_mutations == _EXPECTED_OUROBOROS_TOOL_STATE_MUTATIONS[
+            name
+        ], name
+        assert metadata.retry == {"supported": False, "mode": "unsupported"}, name
+        assert metadata.interrupt == expected_interrupt, name
+        assert metadata.interrupt["mode"] == "terminal_control", name
+        assert metadata.interrupt["terminal_action"] == "cancel", name
+        assert metadata.interrupt["idempotent"] is True, name
+        assert metadata.interrupt["terminal_statuses"] == ("cancelled",), name
+        assert metadata.interrupt["directive_semantics"].startswith(
+            "request_terminal_"
+        ), name
+        assert target_keys == metadata.required_context_keys, name
+        assert metadata.cancel == _EXPECTED_OUROBOROS_TOOL_CANCEL[name], name
+        assert metadata.cancel["supported"] is True, name
+        assert metadata.cancel["mode"].endswith("_control"), name
+        assert metadata.cancel["target_context_keys"] == target_keys, name
+        assert metadata.cancel["companions"], name
+        assert all(
+            key in definitions[name].to_input_schema()["properties"]
+            for key in target_keys
+        ), name
+        validate_capability_tool_metadata(metadata, tool_name=name, owned_tool=True)
+
+
+def test_ouroboros_owned_tools_have_explicit_tool_specific_cancel_behavior() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    registry = ouroboros_tool_capability_registry()
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+
+    assert set(registry) == set(_EXPECTED_OUROBOROS_TOOL_CANCEL)
+    assert set(definitions) == set(_EXPECTED_OUROBOROS_TOOL_CANCEL)
+    for name, expected_cancel in _EXPECTED_OUROBOROS_TOOL_CANCEL.items():
+        metadata = registry[name]
+        descriptor = descriptors[name]
+
+        assert metadata.cancel == expected_cancel, name
+        assert set(metadata.cancel) == {
+            "supported",
+            "mode",
+            "companions",
+            "target_context_keys",
+        }, name
+        assert isinstance(metadata.cancel["supported"], bool), name
+        assert metadata.cancel["mode"] in {
+            "background_job",
+            "background_job_control",
+            "execution_session",
+            "execution_session_control",
+            "unsupported",
+        }, name
+        assert isinstance(metadata.cancel["companions"], tuple), name
+        assert isinstance(metadata.cancel["target_context_keys"], tuple), name
+        assert all(
+            companion in definitions for companion in metadata.cancel["companions"]
+        ), name
+        if metadata.cancel["supported"]:
+            assert metadata.cancel["companions"], name
+            assert metadata.cancel["target_context_keys"], name
+            if metadata.cancel["mode"].endswith("_control"):
+                assert all(
+                    key in definitions[name].to_input_schema()["properties"]
+                    for key in metadata.cancel["target_context_keys"]
+                ), name
+            else:
+                assert all(
+                    key in definitions[companion].to_input_schema()["properties"]
+                    for companion in metadata.cancel["companions"]
+                    for key in metadata.cancel["target_context_keys"]
+                ), name
+        else:
+            assert metadata.cancel["companions"] == (), name
+            assert metadata.cancel["target_context_keys"] == (), name
+        assert descriptor.metadata is not None, name
+        assert descriptor.metadata.cancel == expected_cancel, name
+        assert descriptor.metadata.fallback_used is False, name
+
+
+def test_ouroboros_owned_cancel_lookup_never_uses_generic_attached_inference(
+    monkeypatch,
+) -> None:
+    definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+
+    def fail_on_generic_fallback(tool: MCPToolDefinition):
+        raise AssertionError(
+            "Ouroboros-owned cancel lookup used generic attached inference: "
+            f"{tool.name}"
+        )
+
+    monkeypatch.setattr(
+        capabilities_module,
+        "_infer_attached_semantics",
+        fail_on_generic_fallback,
+    )
+
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+
+    assert set(graph.by_name()) == set(definitions)
+    for name, expected_cancel in _EXPECTED_OUROBOROS_TOOL_CANCEL.items():
+        descriptor = graph.by_name()[name]
+        by_name = lookup_ouroboros_tool_capability_metadata(name)
+        by_stable_id = lookup_ouroboros_tool_capability_metadata(descriptor.stable_id)
+        resolved = resolve_mcp_tool_capability_descriptor(descriptor.stable_id, graph=graph)
+
+        assert descriptor.metadata is not None, name
+        assert by_name is not None, name
+        assert by_stable_id is not None, name
+        assert resolved is descriptor, name
+        assert descriptor.metadata.fallback_used is False, name
+        assert by_name.fallback_used is False, name
+        assert by_stable_id.fallback_used is False, name
+        assert descriptor.metadata.cancel == expected_cancel, name
+        assert by_name.cancel == expected_cancel, name
+        assert by_stable_id.cancel == expected_cancel, name
+
+
+def test_non_cancel_ouroboros_owned_tools_explicitly_do_not_expose_cancel_semantics() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    registry = ouroboros_tool_capability_registry()
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    serialized = {entry["name"]: entry for entry in serialize_capability_graph(graph)}
+    non_cancel_tools = {
+        name
+        for name, expected_cancel in _EXPECTED_OUROBOROS_TOOL_CANCEL.items()
+        if expected_cancel == _UNSUPPORTED_CANCEL
+    }
+    cancel_capable_tools = set(definitions) - non_cancel_tools
+
+    assert non_cancel_tools == {
+        "ouroboros_ac_tree_hud",
+        "ouroboros_auto",
+        "ouroboros_brownfield",
+        "ouroboros_checklist_verify",
+        "ouroboros_evaluate",
+        "ouroboros_evolve_rewind",
+        "ouroboros_evolve_step",
+        "ouroboros_generate_seed",
+        "ouroboros_interview",
+        "ouroboros_job_result",
+        "ouroboros_job_status",
+        "ouroboros_job_wait",
+        "ouroboros_lateral_think",
+        "ouroboros_lineage_status",
+        "ouroboros_measure_drift",
+        "ouroboros_pm_interview",
+        "ouroboros_qa",
+        "ouroboros_query_events",
+        "ouroboros_query_projection",
+        "ouroboros_ralph",
+        "ouroboros_session_status",
+    }
+    assert cancel_capable_tools == {
+        "ouroboros_cancel_execution",
+        "ouroboros_cancel_job",
+        "ouroboros_execute_seed",
+        "ouroboros_start_auto",
+        "ouroboros_start_evaluate",
+        "ouroboros_start_evolve_step",
+        "ouroboros_start_execute_seed",
+        "ouroboros_start_ralph",
+    }
+    assert non_cancel_tools.isdisjoint(capabilities_module._OUROBOROS_CANCEL_TOOLS)
+
+    for name in sorted(non_cancel_tools):
+        descriptor = descriptors[name]
+        metadata = registry[name]
+        serialized_metadata = serialized[name]["metadata"]
+
+        assert name in capabilities_module._OUROBOROS_CANCEL_METADATA
+        assert capabilities_module._OUROBOROS_CANCEL_METADATA[name] == _UNSUPPORTED_CANCEL
+        assert metadata.cancel == _UNSUPPORTED_CANCEL, name
+        assert metadata.cancel["supported"] is False, name
+        assert metadata.cancel["mode"] == "unsupported", name
+        assert metadata.cancel["companions"] == (), name
+        assert metadata.cancel["target_context_keys"] == (), name
+        assert metadata.execution_mode != "cancel", name
+        assert metadata.fallback_used is False, name
+        assert descriptor.metadata is not None, name
+        assert descriptor.metadata.cancel == _UNSUPPORTED_CANCEL, name
+        assert descriptor.metadata.fallback_used is False, name
+        assert serialized_metadata is not None, name
+        assert serialized_metadata["cancel"] == {
+            "supported": False,
+            "mode": "unsupported",
+            "companions": [],
+            "target_context_keys": [],
+        }, name
+        validate_capability_tool_metadata(metadata, tool_name=name, owned_tool=True)
+
+
+def test_tool_specific_capability_metadata_schema_validates_owned_tools() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=definitions.values())
+    )
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+
+    for name, metadata in ouroboros_tool_capability_registry().items():
+        descriptor = descriptors[name]
+
+        validate_capability_tool_metadata(metadata, tool_name=name, owned_tool=True)
+        assert metadata.fallback_used is False, name
+        assert metadata.mutation_class == descriptor.semantics.mutation_class.value
+        assert isinstance(metadata.mutation_targets, tuple), name
+        assert isinstance(metadata.state_mutations, tuple), name
+        if descriptor.semantics.mutation_class is CapabilityMutationClass.READ_ONLY:
+            assert metadata.mutation_targets == (), name
+            assert metadata.state_mutations == (), name
+            assert metadata.side_effects == (), name
+        else:
+            assert metadata.mutation_targets, name
+            assert metadata.side_effects, name
+
+
+def test_tool_specific_capability_metadata_schema_rejects_invalid_metadata() -> None:
+    metadata = ouroboros_tool_capability_registry()["ouroboros_execute_seed"]
+
+    invalid_cases = (
+        (
+            replace(metadata, mutation_class="not-a-real-mutation"),
+            "invalid mutation_class",
+        ),
+        (
+            replace(metadata, side_effects=()),
+            "mutating capabilities require explicit side_effects",
+        ),
+        (
+            replace(metadata, mutation_targets=()),
+            "mutating capabilities require explicit mutation_targets",
+        ),
+        (
+            replace(
+                metadata,
+                state_mutations=(
+                    {
+                        "target": "missing_target",
+                        "operation": "append_bad_state",
+                        "side_effect": "workspace_write",
+                        "context_keys": (),
+                    },
+                ),
+            ),
+            "state mutation target must be listed in mutation_targets",
+        ),
+        (
+            replace(metadata, fallback_used=True),
+            "owned tool metadata cannot use fallback",
+        ),
+        (
+            replace(metadata, cancel={"supported": False, "companions": ()}),
+            "cancel must contain supported, mode, companions, and target_context_keys",
+        ),
+    )
+
+    for invalid_metadata, expected_message in invalid_cases:
+        with pytest.raises(ValueError, match=expected_message):
+            validate_capability_tool_metadata(
+                invalid_metadata,
+                tool_name="ouroboros_execute_seed",
+                owned_tool=True,
+            )
+
+
+def test_resolved_ouroboros_mcp_tool_identifier_returns_registered_descriptor() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    catalog = assemble_session_tool_catalog(
+        attached_tools=(definitions["ouroboros_interview"],)
+    )
+    graph = build_capability_graph(catalog)
+    descriptor = graph.capabilities[0]
+    assert descriptor.stable_id.endswith(":ouroboros_interview")
+
+    resolved_by_stable_id = resolve_mcp_tool_capability_descriptor(
+        descriptor.stable_id,
+        graph=graph,
+    )
+    resolved_by_name = resolve_mcp_tool_capability_descriptor(
+        "ouroboros_interview",
+        graph=graph,
+    )
+
+    assert resolved_by_stable_id == descriptor
+    assert resolved_by_name == descriptor
+    assert descriptor.metadata == ouroboros_tool_capability_registry()[
+        "ouroboros_interview"
+    ]
+    assert descriptor.metadata is not None
+    assert descriptor.metadata.fallback_used is False
+    assert descriptor.metadata.execution_mode == "subagent_orchestration"
+    assert resolve_mcp_tool_capability_descriptor("mcp:external:unknown", graph=graph) is None
+
+
+def test_resolving_ouroboros_mcp_identifiers_never_uses_generic_attached_inference(
+    monkeypatch,
+) -> None:
+    definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+    owned_definition = definitions["ouroboros_interview"]
+
+    def fail_on_generic_fallback(tool: MCPToolDefinition):
+        raise AssertionError(
+            f"Ouroboros-owned lookup used generic attached inference: {tool.name}"
+        )
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._infer_attached_semantics",
+        fail_on_generic_fallback,
+    )
+
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(attached_tools=(owned_definition,))
+    )
+    descriptor = graph.capabilities[0]
+
+    for identifier in (
+        "ouroboros_interview",
+        owned_definition.name,
+        descriptor.stable_id,
+    ):
+        resolved = resolve_mcp_tool_capability_descriptor(identifier, graph=graph)
+        assert resolved == descriptor
+        assert resolved.metadata is not None
+        assert resolved.metadata.fallback_used is False
+        assert resolved.metadata.execution_mode == "subagent_orchestration"
+
+    implicit_graph_resolved = resolve_mcp_tool_capability_descriptor(
+        "ouroboros_interview"
+    )
+    assert implicit_graph_resolved is not None
+    assert implicit_graph_resolved.name == "ouroboros_interview"
+    assert implicit_graph_resolved.metadata is not None
+    assert implicit_graph_resolved.metadata.fallback_used is False
+
+
+def test_unknown_attached_mcp_tool_keeps_generic_fallback_metadata() -> None:
+    catalog = assemble_session_tool_catalog(
+        attached_tools=(
+            MCPToolDefinition(
+                name="external_delete_widget",
+                description="Delete a widget from an external system",
+                server_name="external",
+            ),
+        ),
+    )
+
+    graph = build_capability_graph(catalog)
+
+    descriptor = graph.capabilities[0]
+    assert descriptor.metadata is not None
+    assert descriptor.metadata.fallback_used is True
+    assert descriptor.metadata.execution_mode == "generic_attached"
+    assert descriptor.metadata.mutation_targets == ("external",)
+    assert descriptor.metadata.side_effects == ("unknown_external_side_effect",)
+    assert descriptor.semantics.mutation_class is CapabilityMutationClass.DESTRUCTIVE
+
+
+def test_unmapped_ouroboros_mcp_tool_descriptor_uses_explicit_metadata() -> None:
+    frontmatter_tools = _frontmatter_mcp_tools()
+    definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+    unmapped_definition = definitions["ouroboros_query_events"]
+    assert unmapped_definition.name not in frontmatter_tools
+    catalog = assemble_session_tool_catalog(
+        attached_tools=(replace(unmapped_definition, server_name="ouroboros"),)
+    )
+
+    graph = build_capability_graph(catalog)
+
+    descriptor = graph.capabilities[0]
+    assert descriptor.name == "ouroboros_query_events"
+    assert descriptor.source_kind == "attached_mcp"
+    assert descriptor.source_name == "ouroboros"
+    assert descriptor.semantics.origin is CapabilityOrigin.ATTACHED_MCP
+    assert descriptor.semantics.mutation_class is CapabilityMutationClass.READ_ONLY
+    assert descriptor.metadata is not None
+    assert descriptor.metadata.fallback_used is False
+    assert descriptor.metadata.input_schema == unmapped_definition.to_input_schema()
+    assert descriptor.metadata.execution_mode == "status"
+    assert set(descriptor.metadata.companions) >= {
+        "ouroboros_session_status",
+        "ouroboros_query_projection",
+    }
+    assert descriptor.metadata.required_context_keys == mcp_tool_required_parameter_keys(
+        unmapped_definition
+    )
+    assert descriptor.metadata.mutation_targets == ()
+    assert descriptor.metadata.side_effects == ()
+    _assert_lifecycle_metadata_shape(descriptor.metadata, descriptor.name)
+
+
+def test_ouroboros_owned_descriptor_requires_explicit_tool_specific_retry_metadata(
+    monkeypatch,
+) -> None:
+    synthetic_definition = MCPToolDefinition(
+        name="ouroboros_contract_probe",
+        description="Synthetic owned tool without explicit retry capability metadata",
+        parameters=(
+            MCPToolParameter(
+                name="session_id",
+                type=ToolInputType.STRING,
+                description="Session identifier.",
+                required=True,
+            ),
+        ),
+        server_name="ouroboros",
+    )
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._ouroboros_tool_definitions_by_name",
+        lambda: {synthetic_definition.name: synthetic_definition},
+    )
+
+    with pytest.raises(RuntimeError, match="retry metadata must be defined"):
+        build_capability_graph((synthetic_definition,))
+
+
+def test_ouroboros_owned_read_only_tool_serializes_explicit_empty_side_effects(
+    monkeypatch,
+) -> None:
+    synthetic_definition = MCPToolDefinition(
+        name="ouroboros_empty_side_effect_probe",
+        description="Synthetic read-only owned tool with no declared side effects",
+        server_name="ouroboros",
+    )
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._ouroboros_tool_definitions_by_name",
+        lambda: {synthetic_definition.name: synthetic_definition},
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._OUROBOROS_TOOL_CAPABILITY_SPECS",
+        {
+            synthetic_definition.name: capabilities_module._OuroborosToolCapabilitySpec(
+                execution_mode="blocking",
+                companions=(),
+                side_effects=(),
+                retry={"supported": True, "mode": "handler_owned"},
+                interrupt=capabilities_module._OUROBOROS_READ_ONLY_INTERRUPT_METADATA,
+                mutation_class=CapabilityMutationClass.READ_ONLY,
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._OUROBOROS_CANCEL_METADATA",
+        {synthetic_definition.name: _UNSUPPORTED_CANCEL},
+    )
+
+    graph = build_capability_graph((synthetic_definition,))
+    descriptor = graph.by_name()[synthetic_definition.name]
+
+    assert descriptor.metadata is not None
+    assert descriptor.metadata.fallback_used is False
+    assert descriptor.metadata.mutation_class == CapabilityMutationClass.READ_ONLY.value
+    assert descriptor.metadata.side_effects == ()
+    validate_capability_tool_metadata(
+        descriptor.metadata,
+        tool_name=synthetic_definition.name,
+        owned_tool=True,
+    )
+
+    serialized = serialize_capability_graph(graph)
+
+    assert serialized[0]["metadata"] is not None
+    assert "side_effects" in serialized[0]["metadata"]
+    assert serialized[0]["metadata"]["side_effects"] == []
+
+    restored = normalize_serialized_capability_graph(serialized)
+
+    assert restored is not None
+    restored_descriptor = restored.by_name()[synthetic_definition.name]
+    assert restored_descriptor.metadata is not None
+    assert restored_descriptor.metadata.fallback_used is False
+    assert restored_descriptor.metadata.side_effects == ()
+
+
+def test_owned_mcp_tool_without_context_keys_serializes_explicit_empty_value(
+    monkeypatch,
+) -> None:
+    synthetic_definition = MCPToolDefinition(
+        name="ouroboros_context_free_probe",
+        description="Synthetic owned tool with no required context keys",
+        server_name="ouroboros",
+    )
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._ouroboros_tool_definitions_by_name",
+        lambda: {synthetic_definition.name: synthetic_definition},
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._OUROBOROS_TOOL_CAPABILITY_SPECS",
+        {
+            synthetic_definition.name: capabilities_module._OuroborosToolCapabilitySpec(
+                execution_mode="status",
+                companions=(),
+                side_effects=(),
+                retry={"supported": True, "mode": "handler_owned"},
+                interrupt=capabilities_module._OUROBOROS_READ_ONLY_INTERRUPT_METADATA,
+                mutation_class=CapabilityMutationClass.READ_ONLY,
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._OUROBOROS_CANCEL_METADATA",
+        {synthetic_definition.name: _UNSUPPORTED_CANCEL},
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities.get_packaged_skill_context_keys",
+        lambda: {},
+    )
+
+    graph = build_capability_graph((synthetic_definition,))
+    descriptor = graph.by_name()[synthetic_definition.name]
+
+    assert descriptor.metadata is not None
+    assert descriptor.metadata.fallback_used is False
+    assert descriptor.metadata.input_schema["required"] == []
+    assert descriptor.metadata.required_context_keys == ()
+
+    serialized = serialize_capability_graph(graph)
+
+    assert serialized[0]["metadata"] is not None
+    assert "required_context_keys" in serialized[0]["metadata"]
+    assert serialized[0]["metadata"]["required_context_keys"] == []
+
+    restored = normalize_serialized_capability_graph(serialized)
+
+    assert restored is not None
+    restored_descriptor = restored.by_name()[synthetic_definition.name]
+    assert restored_descriptor.metadata is not None
+    assert restored_descriptor.metadata.fallback_used is False
+    assert restored_descriptor.metadata.required_context_keys == ()
+    validate_capability_tool_metadata(
+        restored_descriptor.metadata,
+        tool_name=synthetic_definition.name,
+        owned_tool=True,
+    )
+
+
+def test_owned_mcp_tool_without_companions_serializes_explicit_empty_value(
+    monkeypatch,
+) -> None:
+    synthetic_definition = MCPToolDefinition(
+        name="ouroboros_standalone_probe",
+        description="Synthetic owned tool with no companion relationship",
+        parameters=(
+            MCPToolParameter(
+                name="session_id",
+                type=ToolInputType.STRING,
+                description="Session identifier.",
+                required=True,
+            ),
+        ),
+        server_name="ouroboros",
+    )
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._ouroboros_tool_definitions_by_name",
+        lambda: {synthetic_definition.name: synthetic_definition},
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._OUROBOROS_TOOL_CAPABILITY_SPECS",
+        {
+            synthetic_definition.name: capabilities_module._OuroborosToolCapabilitySpec(
+                execution_mode="status",
+                companions=(),
+                side_effects=(),
+                retry={"supported": True, "mode": "handler_owned"},
+                interrupt=capabilities_module._OUROBOROS_READ_ONLY_INTERRUPT_METADATA,
+                mutation_class=CapabilityMutationClass.READ_ONLY,
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._OUROBOROS_CANCEL_METADATA",
+        {synthetic_definition.name: _UNSUPPORTED_CANCEL},
+    )
+
+    graph = build_capability_graph((synthetic_definition,))
+    descriptor = graph.by_name()[synthetic_definition.name]
+
+    assert descriptor.metadata is not None
+    assert descriptor.metadata.fallback_used is False
+    assert descriptor.metadata.companions == ()
+
+    serialized = serialize_capability_graph(graph)
+
+    assert serialized[0]["metadata"] is not None
+    assert "companions" in serialized[0]["metadata"]
+    assert serialized[0]["metadata"]["companions"] == []
+    assert "side_effects" in serialized[0]["metadata"]
+    assert serialized[0]["metadata"]["side_effects"] == []
+
+    restored = normalize_serialized_capability_graph(serialized)
+
+    assert restored is not None
+    restored_descriptor = restored.by_name()[synthetic_definition.name]
+    assert restored_descriptor.metadata is not None
+    assert restored_descriptor.metadata.fallback_used is False
+    assert restored_descriptor.metadata.companions == ()
+    validate_capability_tool_metadata(
+        restored_descriptor.metadata,
+        tool_name=synthetic_definition.name,
+        owned_tool=True,
+    )
+
+
+def test_owned_mcp_tool_without_lifecycle_behaviors_serializes_explicit_empty_values(
+    monkeypatch,
+) -> None:
+    synthetic_definition = MCPToolDefinition(
+        name="ouroboros_lifecycle_empty_probe",
+        description="Synthetic owned tool with no retry, interrupt, or cancel behavior",
+        server_name="ouroboros",
+    )
+    unsupported_retry = {"supported": False, "mode": "unsupported"}
+    unsupported_interrupt = {"supported": False, "mode": "unsupported"}
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._ouroboros_tool_definitions_by_name",
+        lambda: {synthetic_definition.name: synthetic_definition},
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._OUROBOROS_TOOL_CAPABILITY_SPECS",
+        {
+            synthetic_definition.name: capabilities_module._OuroborosToolCapabilitySpec(
+                execution_mode="status",
+                companions=(),
+                side_effects=(),
+                retry=unsupported_retry,
+                interrupt=unsupported_interrupt,
+                mutation_class=CapabilityMutationClass.READ_ONLY,
+            )
+        },
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._OUROBOROS_CANCEL_METADATA",
+        {synthetic_definition.name: _UNSUPPORTED_CANCEL},
+    )
+
+    graph = build_capability_graph((synthetic_definition,))
+    descriptor = graph.by_name()[synthetic_definition.name]
+
+    assert descriptor.metadata is not None
+    assert descriptor.metadata.fallback_used is False
+    assert descriptor.metadata.retry == unsupported_retry
+    assert descriptor.metadata.interrupt == unsupported_interrupt
+    assert descriptor.metadata.cancel == _UNSUPPORTED_CANCEL
+    assert descriptor.metadata.cancel["companions"] == ()
+    assert descriptor.metadata.cancel["target_context_keys"] == ()
+    validate_capability_tool_metadata(
+        descriptor.metadata,
+        tool_name=synthetic_definition.name,
+        owned_tool=True,
+    )
+
+    serialized = serialize_capability_graph(graph)
+    serialized_metadata = serialized[0]["metadata"]
+
+    assert serialized_metadata is not None
+    assert serialized_metadata["retry"] == unsupported_retry
+    assert serialized_metadata["interrupt"] == unsupported_interrupt
+    assert serialized_metadata["cancel"] == {
+        "supported": False,
+        "mode": "unsupported",
+        "companions": [],
+        "target_context_keys": [],
+    }
+
+    restored = normalize_serialized_capability_graph(serialized)
+
+    assert restored is not None
+    restored_descriptor = restored.by_name()[synthetic_definition.name]
+    assert restored_descriptor.metadata is not None
+    assert restored_descriptor.metadata.fallback_used is False
+    assert restored_descriptor.metadata.retry == unsupported_retry
+    assert restored_descriptor.metadata.interrupt == unsupported_interrupt
+    assert restored_descriptor.metadata.cancel == _UNSUPPORTED_CANCEL
+    validate_capability_tool_metadata(
+        restored_descriptor.metadata,
+        tool_name=synthetic_definition.name,
+        owned_tool=True,
+    )
 
 
 def test_build_capability_graph_preserves_builtin_and_attached_semantics() -> None:
@@ -41,6 +3800,1242 @@ def test_build_capability_graph_preserves_builtin_and_attached_semantics() -> No
     assert names["search_docs"].semantics.scope is CapabilityScope.ATTACHMENT
 
 
+def test_unknown_attached_mcp_tool_uses_generic_inference_fallback() -> None:
+    known_ouroboros_tool_names = {
+        handler.definition.name for handler in get_ouroboros_tools(include_auto=False)
+    }
+    unknown_tool = MCPToolDefinition(
+        name="delete_remote_cache",
+        description="Delete a remote cache entry on a third-party service",
+        server_name="cache_vendor",
+    )
+    assert unknown_tool.name not in known_ouroboros_tool_names
+    catalog = assemble_session_tool_catalog(attached_tools=(unknown_tool,))
+
+    graph = build_capability_graph(catalog)
+
+    descriptor = graph.capabilities[0]
+    assert descriptor.name == "delete_remote_cache"
+    assert descriptor.source_kind == "attached_mcp"
+    assert descriptor.source_name == "cache_vendor"
+    assert descriptor.stable_id == "mcp:cache_vendor:delete_remote_cache"
+    assert descriptor.semantics.origin is CapabilityOrigin.ATTACHED_MCP
+    assert descriptor.semantics.scope is CapabilityScope.ATTACHMENT
+    assert descriptor.semantics.mutation_class is CapabilityMutationClass.DESTRUCTIVE
+    assert (
+        descriptor.semantics.parallel_safety
+        is CapabilityParallelSafety.ISOLATED_SESSION_REQUIRED
+    )
+    assert descriptor.semantics.interruptibility is CapabilityInterruptibility.HARD
+    assert descriptor.semantics.approval_class is CapabilityApprovalClass.BYPASS_FORBIDDEN
+    assert descriptor.metadata is not None
+    assert descriptor.metadata.fallback_used is True
+    assert descriptor.metadata.state_mutations == ()
+
+
+def test_interview_capability_exposes_code_investigation_request_model_schema() -> None:
+    code_investigation = _interview_code_investigation_metadata()
+    schema = code_investigation["request_model_schema"]
+
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    assert "working_directory" not in schema["properties"]
+    assert "cwd" not in schema["properties"]
+    assert "repository_path" not in schema["properties"]
+    assert "server_repository_path" not in schema["properties"]
+    assert set(schema["required"]) == {
+        "session_id",
+        "question_identity",
+        "question",
+        "investigation_goal",
+        "investigation_targets",
+        "fact_categories",
+        "allowed_capabilities",
+        "repo_inspection_tool_capabilities",
+        "confidence_policy",
+        "answer_prefixes",
+        "answer_contract",
+        "mcp_tool_capability",
+    }
+    assert schema["properties"]["answer_contract"] == {
+        "const": code_investigation["answer_contract"],
+        "description": "Exact response contract attached to this investigation request.",
+    }
+    capability_schema = schema["properties"]["mcp_tool_capability"]
+    assert set(capability_schema["required"]) == {
+        "tool_name",
+        "stable_id",
+        "source_kind",
+        "source_name",
+        "input_schema",
+        "mutation_class",
+        "execution_mode",
+        "companions",
+        "required_context_keys",
+        "mutation_targets",
+        "state_mutations",
+        "side_effects",
+        "retry",
+        "interrupt",
+        "cancel",
+        "fallback_used",
+        "orchestration",
+    }
+    assert capability_schema["properties"]["tool_name"] == {
+        "const": "ouroboros_interview"
+    }
+    assert capability_schema["properties"]["fallback_used"] == {"const": False}
+    assert schema["properties"]["investigation_goal"]["enum"] == [
+        "describe_current_state_from_code"
+    ]
+    targets = schema["properties"]["investigation_targets"]
+    assert targets["type"] == "array"
+    assert targets["minItems"] == 1
+    assert {
+        option["properties"]["target_type"]["const"]
+        for option in targets["items"]["oneOf"]
+    } == {"workspace", "relative_path", "glob", "symbol"}
+    assert schema["properties"]["allowed_capabilities"]["items"]["enum"] == ["inspect_code"]
+    repo_tool_schema = schema["properties"]["repo_inspection_tool_capabilities"]
+    assert repo_tool_schema["minItems"] == 1
+    assert repo_tool_schema["items"]["properties"]["tool_name"]["enum"] == [
+        "Read",
+        "Glob",
+        "Grep",
+    ]
+    assert repo_tool_schema["items"]["properties"]["execution_mode"] == {
+        "const": "repo_inspection"
+    }
+    assert repo_tool_schema["items"]["properties"]["logical_capability"] == {
+        "const": "inspect_code"
+    }
+    assert repo_tool_schema["items"]["properties"]["fallback_used"] == {"const": False}
+    assert "[from-code]" in schema["properties"]["answer_prefixes"]["items"]["enum"]
+    assert "[from-code][auto-confirmed]" in schema["properties"]["answer_prefixes"][
+        "items"
+    ]["enum"]
+    assert schema["properties"]["question_identity"]["pattern"] == (
+        r"^interview-question:[0-9a-f]{16}$"
+    )
+    assert set(schema["properties"]["confidence_policy"]["required"]) == {
+        "auto_confirm_when",
+        "confirmation_required_when",
+        "human_judgment_when",
+    }
+    assert code_investigation["question_identity"] == {
+        "source_field": "question",
+        "helper": "stable_code_investigation_question_identity",
+        "algorithm": "sha256",
+        "digest_chars": 16,
+        "normalization": "NFKC + trim + whitespace collapse",
+        "format": "interview-question:{digest}",
+        "deterministic": True,
+    }
+    assert "skills/interview/SKILL.md inspect_code PATH 1" in code_investigation[
+        "derivation_sources"
+    ]
+
+
+def test_interview_code_investigation_exposes_repo_inspection_tool_capabilities() -> None:
+    code_investigation = _interview_code_investigation_metadata()
+
+    tool_capabilities = code_investigation["repo_inspection_tool_capabilities"]
+
+    tool_by_name = {tool["tool_name"]: tool for tool in tool_capabilities}
+    assert set(tool_by_name) == {"Read", "Glob", "Grep"}
+
+    for tool_name, capability in tool_by_name.items():
+        assert capability["stable_id"] == f"builtin:{tool_name}"
+        assert capability["source_kind"] == "builtin"
+        assert capability["source_name"] == "built-in"
+        assert capability["mutation_class"] == "read_only"
+        assert capability["parallel_safety"] == "safe"
+        assert capability["interruptibility"] == "none"
+        assert capability["approval_class"] == "default"
+        assert capability["origin"] == "builtin"
+        assert capability["scope"] == "kernel"
+        assert capability["execution_mode"] == "repo_inspection"
+        assert capability["logical_capability"] == "inspect_code"
+        assert capability["side_effects"] == ["side_effect_free"]
+        assert capability["fallback_used"] is False
+        Draft202012Validator.check_schema(capability["input_schema"])
+
+    assert tool_by_name["Read"]["input_schema"]["required"] == ["file_path"]
+    assert tool_by_name["Glob"]["input_schema"]["required"] == ["pattern"]
+    assert tool_by_name["Grep"]["input_schema"]["required"] == ["pattern"]
+
+
+def test_code_investigation_subagent_envelope_permits_modeled_repo_inspection_tools() -> None:
+    code_investigation = _interview_code_investigation_metadata()
+    tool_capabilities = code_investigation["repo_inspection_tool_capabilities"]
+    modeled_tool_names = tuple(
+        str(capability["tool_name"]) for capability in tool_capabilities
+    )
+    catalog = assemble_session_tool_catalog(
+        builtin_tools=(*modeled_tool_names, "Bash", "Edit")
+    )
+
+    allowed = set(
+        allowed_capability_names(
+            build_capability_graph(catalog),
+            PolicyContext(
+                runtime_backend="codex",
+                session_role=PolicySessionRole.INTERVIEW,
+                execution_phase=PolicyExecutionPhase.INTERVIEW,
+            ),
+        )
+    )
+
+    assert set(code_investigation["request_model_schema"]["properties"][
+        "allowed_capabilities"
+    ]["items"]["enum"]) == {"inspect_code"}
+    for capability in tool_capabilities:
+        assert capability["logical_capability"] == "inspect_code"
+        assert capability["execution_mode"] == "repo_inspection"
+        assert capability["mutation_class"] == "read_only"
+        assert capability["source_kind"] == "builtin"
+        assert capability["tool_name"] in allowed
+
+    assert set(modeled_tool_names) <= allowed
+    assert "Bash" not in allowed
+    assert "Edit" not in allowed
+
+
+def test_code_investigation_owned_mcp_tools_have_explicit_tool_specific_metadata(
+    monkeypatch,
+) -> None:
+    definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+    code_investigation_mcp_tools = ("ouroboros_interview",)
+
+    def fail_on_generic_attached_metadata(tool: MCPToolDefinition):
+        raise AssertionError(
+            f"code investigation owned MCP tool used generic metadata: {tool.name}"
+        )
+
+    def fail_on_generic_attached_semantics(tool: MCPToolDefinition):
+        raise AssertionError(
+            f"code investigation owned MCP tool used generic semantics: {tool.name}"
+        )
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._generic_attached_tool_metadata",
+        fail_on_generic_attached_metadata,
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._infer_attached_semantics",
+        fail_on_generic_attached_semantics,
+    )
+
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(
+            attached_tools=(
+                definitions[tool_name] for tool_name in code_investigation_mcp_tools
+            )
+        )
+    )
+    descriptors = graph.by_name()
+
+    for tool_name in code_investigation_mcp_tools:
+        definition = definitions[tool_name]
+        descriptor = descriptors[tool_name]
+
+        assert descriptor.source_kind == "attached_mcp"
+        assert descriptor.source_name == "ouroboros"
+        assert descriptor.semantics.origin is CapabilityOrigin.ATTACHED_MCP
+        assert descriptor.metadata is not None
+        metadata = descriptor.metadata
+        assert metadata == ouroboros_tool_capability_registry()[tool_name]
+        assert metadata.fallback_used is False
+        assert metadata.input_schema == definition.to_input_schema()
+        assert metadata.execution_mode == "subagent_orchestration"
+        assert metadata.companions == _EXPECTED_OUROBOROS_TOOL_COMPANIONS[tool_name]
+        assert metadata.required_context_keys == (
+            _EXPECTED_OUROBOROS_REQUIRED_CONTEXT_KEYS[tool_name]
+        )
+        assert metadata.side_effects == ("subagent_dispatch", "session_state_write")
+        assert metadata.retry == _EXPECTED_OUROBOROS_TOOL_RETRY[tool_name]
+        assert metadata.interrupt == _EXPECTED_OUROBOROS_TOOL_INTERRUPT[tool_name]
+        assert metadata.cancel == _UNSUPPORTED_CANCEL
+        validate_capability_tool_metadata(
+            metadata,
+            tool_name=tool_name,
+            owned_tool=True,
+        )
+
+        code_investigation = metadata.orchestration["code_investigation"]
+        assert code_investigation["derivation_sources"] == (
+            f"get_ouroboros_tools().{tool_name}.definition",
+            "skills/interview/SKILL.md inspect_code PATH 1",
+        )
+        assert code_investigation["request_model_schema"]["properties"][
+            "mcp_tool_capability"
+        ]["properties"]["tool_name"] == {"const": tool_name}
+        assert code_investigation["request_model_schema"]["properties"][
+            "mcp_tool_capability"
+        ]["properties"]["fallback_used"] == {"const": False}
+        assert set(
+            code_investigation["request_model_schema"]["properties"][
+                "mcp_tool_capability"
+            ]["required"]
+        ) >= _REQUIRED_OUROBOROS_TOOL_METADATA_FIELDS
+        assert all(
+            repo_tool["fallback_used"] is False
+            for repo_tool in code_investigation["repo_inspection_tool_capabilities"]
+        )
+
+
+def test_subagent_job_status_polling_tool_is_explicit_and_callable_in_orchestration_envelope(
+    monkeypatch,
+) -> None:
+    definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+
+    def fail_on_generic_attached_metadata(tool: MCPToolDefinition):
+        raise AssertionError(
+            f"subagent status poller used generic attached metadata: {tool.name}"
+        )
+
+    def fail_on_generic_attached_semantics(tool: MCPToolDefinition):
+        raise AssertionError(
+            f"subagent status poller used generic attached semantics: {tool.name}"
+        )
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._generic_attached_tool_metadata",
+        fail_on_generic_attached_metadata,
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._infer_attached_semantics",
+        fail_on_generic_attached_semantics,
+    )
+
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(
+            attached_tools=(
+                definitions["ouroboros_interview"],
+                definitions["ouroboros_lateral_think"],
+                definitions["ouroboros_job_status"],
+            )
+        )
+    )
+    descriptors = graph.by_name()
+    status_descriptor = resolve_mcp_tool_capability_descriptor(
+        "ouroboros_job_status",
+        graph=graph,
+    )
+
+    assert status_descriptor == descriptors["ouroboros_job_status"]
+    assert status_descriptor is not None
+    assert status_descriptor.source_kind == "attached_mcp"
+    assert status_descriptor.source_name == "ouroboros"
+    assert status_descriptor.semantics.mutation_class is CapabilityMutationClass.READ_ONLY
+    assert status_descriptor.semantics.origin is CapabilityOrigin.ATTACHED_MCP
+    assert status_descriptor.metadata is not None
+    metadata = status_descriptor.metadata
+    assert metadata == ouroboros_tool_capability_registry()["ouroboros_job_status"]
+    assert metadata.fallback_used is False
+    assert metadata.execution_mode == "status"
+    assert metadata.input_schema == definitions["ouroboros_job_status"].to_input_schema()
+    assert metadata.input_schema["required"] == ["job_id"]
+    assert metadata.required_context_keys == ("job_id",)
+    assert metadata.side_effects == ()
+    assert metadata.retry == {"supported": True, "mode": "handler_owned"}
+    assert metadata.interrupt == {
+        "supported": True,
+        "mode": "read_only_non_mutating",
+        "mutation_semantics": "no_state_mutation",
+        "resumable": False,
+        "target_context_keys": (),
+    }
+    assert metadata.cancel == _UNSUPPORTED_CANCEL
+    validate_capability_tool_metadata(
+        metadata,
+        tool_name="ouroboros_job_status",
+        owned_tool=True,
+    )
+    Draft202012Validator(metadata.input_schema).validate(
+        {"job_id": "job-subagent-123", "view": "summary"}
+    )
+
+    job_lifecycle = metadata.orchestration["job_lifecycle_siblings"]
+    assert job_lifecycle["role"] == "status"
+    assert job_lifecycle["required_result_context_keys"] == ("job_id",)
+    assert job_lifecycle["sibling_companions"] == {
+        "wait": "ouroboros_job_wait",
+        "result": "ouroboros_job_result",
+        "cancel": "ouroboros_cancel_job",
+    }
+
+    for orchestrator_name in ("ouroboros_interview", "ouroboros_lateral_think"):
+        orchestrator = descriptors[orchestrator_name]
+        assert orchestrator.metadata is not None
+        assert orchestrator.metadata.fallback_used is False
+        assert orchestrator.metadata.execution_mode == "subagent_orchestration"
+
+
+def test_subagent_job_wait_progress_polling_tool_is_explicit_and_callable_in_orchestration_envelope(
+    monkeypatch,
+) -> None:
+    definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+
+    def fail_on_generic_attached_metadata(tool: MCPToolDefinition):
+        raise AssertionError(
+            f"subagent progress wait poller used generic attached metadata: {tool.name}"
+        )
+
+    def fail_on_generic_attached_semantics(tool: MCPToolDefinition):
+        raise AssertionError(
+            f"subagent progress wait poller used generic attached semantics: {tool.name}"
+        )
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._generic_attached_tool_metadata",
+        fail_on_generic_attached_metadata,
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._infer_attached_semantics",
+        fail_on_generic_attached_semantics,
+    )
+
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(
+            attached_tools=(
+                definitions["ouroboros_interview"],
+                definitions["ouroboros_lateral_think"],
+                definitions["ouroboros_job_wait"],
+            )
+        )
+    )
+    descriptors = graph.by_name()
+    wait_descriptor = resolve_mcp_tool_capability_descriptor(
+        "ouroboros_job_wait",
+        graph=graph,
+    )
+
+    assert wait_descriptor == descriptors["ouroboros_job_wait"]
+    assert wait_descriptor is not None
+    assert wait_descriptor.source_kind == "attached_mcp"
+    assert wait_descriptor.source_name == "ouroboros"
+    assert wait_descriptor.semantics.mutation_class is CapabilityMutationClass.READ_ONLY
+    assert wait_descriptor.semantics.origin is CapabilityOrigin.ATTACHED_MCP
+    assert wait_descriptor.metadata is not None
+    metadata = wait_descriptor.metadata
+    assert metadata == ouroboros_tool_capability_registry()["ouroboros_job_wait"]
+    assert metadata.fallback_used is False
+    assert metadata.execution_mode == "status"
+    assert metadata.input_schema == definitions["ouroboros_job_wait"].to_input_schema()
+    assert metadata.input_schema["required"] == ["job_id"]
+    assert metadata.required_context_keys == ("job_id", "cursor")
+    assert metadata.side_effects == ()
+    assert metadata.retry == {"supported": True, "mode": "handler_owned"}
+    assert metadata.interrupt == {
+        "supported": True,
+        "mode": "read_only_non_mutating",
+        "mutation_semantics": "no_state_mutation",
+        "resumable": False,
+        "target_context_keys": (),
+    }
+    assert metadata.cancel == _UNSUPPORTED_CANCEL
+    validate_capability_tool_metadata(
+        metadata,
+        tool_name="ouroboros_job_wait",
+        owned_tool=True,
+    )
+    Draft202012Validator(metadata.input_schema).validate(
+        {
+            "job_id": "job-subagent-123",
+            "cursor": 7,
+            "stream": "linked",
+            "timeout_seconds": 0,
+            "view": "summary",
+        }
+    )
+
+    job_lifecycle = metadata.orchestration["job_lifecycle_siblings"]
+    assert job_lifecycle["role"] == "wait"
+    assert job_lifecycle["required_result_context_keys"] == ("job_id",)
+    assert job_lifecycle["sibling_companions"] == {
+        "status": "ouroboros_job_status",
+        "result": "ouroboros_job_result",
+        "cancel": "ouroboros_cancel_job",
+    }
+    assert "linked session, lineage, and subagent events" in (
+        metadata.input_schema["properties"]["stream"]["description"]
+    )
+
+    for orchestrator_name in ("ouroboros_interview", "ouroboros_lateral_think"):
+        orchestrator = descriptors[orchestrator_name]
+        assert orchestrator.metadata is not None
+        assert orchestrator.metadata.fallback_used is False
+        assert orchestrator.metadata.execution_mode == "subagent_orchestration"
+
+
+def test_subagent_job_cancellation_tool_is_explicit_and_callable_in_orchestration_envelope(
+    monkeypatch,
+) -> None:
+    definitions = {
+        handler.definition.name: handler.definition for handler in get_ouroboros_tools()
+    }
+
+    def fail_on_generic_attached_metadata(tool: MCPToolDefinition):
+        raise AssertionError(
+            f"subagent cancellation tool used generic attached metadata: {tool.name}"
+        )
+
+    def fail_on_generic_attached_semantics(tool: MCPToolDefinition):
+        raise AssertionError(
+            f"subagent cancellation tool used generic attached semantics: {tool.name}"
+        )
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._generic_attached_tool_metadata",
+        fail_on_generic_attached_metadata,
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._infer_attached_semantics",
+        fail_on_generic_attached_semantics,
+    )
+
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(
+            attached_tools=(
+                definitions["ouroboros_interview"],
+                definitions["ouroboros_lateral_think"],
+                definitions["ouroboros_cancel_job"],
+            )
+        )
+    )
+    descriptors = graph.by_name()
+    cancel_descriptor = resolve_mcp_tool_capability_descriptor(
+        "ouroboros_cancel_job",
+        graph=graph,
+    )
+
+    assert cancel_descriptor == descriptors["ouroboros_cancel_job"]
+    assert cancel_descriptor is not None
+    assert cancel_descriptor.source_kind == "attached_mcp"
+    assert cancel_descriptor.source_name == "ouroboros"
+    assert cancel_descriptor.semantics.mutation_class is (
+        CapabilityMutationClass.EXTERNAL_SIDE_EFFECT
+    )
+    assert cancel_descriptor.semantics.parallel_safety is (
+        CapabilityParallelSafety.SERIALIZED
+    )
+    assert cancel_descriptor.semantics.interruptibility is (
+        CapabilityInterruptibility.HARD
+    )
+    assert cancel_descriptor.semantics.approval_class is (
+        CapabilityApprovalClass.ELEVATED
+    )
+    assert cancel_descriptor.metadata is not None
+    metadata = cancel_descriptor.metadata
+    assert metadata == ouroboros_tool_capability_registry()["ouroboros_cancel_job"]
+    assert metadata.fallback_used is False
+    assert metadata.execution_mode == "cancel"
+    assert metadata.input_schema == definitions["ouroboros_cancel_job"].to_input_schema()
+    assert metadata.input_schema["required"] == ["job_id"]
+    assert metadata.required_context_keys == ("job_id",)
+    assert metadata.side_effects == (
+        "runtime_control",
+        "event_store_write",
+        "checkpoint_store_write",
+        "session_state_write",
+    )
+    assert metadata.retry == {"supported": False, "mode": "unsupported"}
+    assert metadata.interrupt == {
+        "supported": True,
+        "mode": "terminal_control",
+        "terminal_action": "cancel",
+        "target_type": "background_job",
+        "target_context_keys": ("job_id",),
+        "directive_semantics": "request_terminal_job_cancellation",
+        "terminal_statuses": ("cancelled",),
+        "idempotent": True,
+    }
+    assert metadata.cancel == {
+        "supported": True,
+        "mode": "background_job_control",
+        "companions": (
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+        ),
+        "target_context_keys": ("job_id",),
+    }
+    validate_capability_tool_metadata(
+        metadata,
+        tool_name="ouroboros_cancel_job",
+        owned_tool=True,
+    )
+    Draft202012Validator(metadata.input_schema).validate(
+        {"job_id": "job-subagent-123", "reason": "cancel delegated subagent job"}
+    )
+
+    job_lifecycle = metadata.orchestration["job_lifecycle_siblings"]
+    assert job_lifecycle["role"] == "cancel"
+    assert job_lifecycle["required_result_context_keys"] == ("job_id",)
+    assert job_lifecycle["sibling_companions"] == {
+        "status": "ouroboros_job_status",
+        "wait": "ouroboros_job_wait",
+        "result": "ouroboros_job_result",
+    }
+    assert job_lifecycle["companion_roles"]["cancel"] == "ouroboros_cancel_job"
+    assert "status/wait/result/cancel sibling family" in (
+        job_lifecycle["runtime_instruction"]
+    )
+
+    for orchestrator_name in ("ouroboros_interview", "ouroboros_lateral_think"):
+        orchestrator = descriptors[orchestrator_name]
+        assert orchestrator.metadata is not None
+        assert orchestrator.metadata.fallback_used is False
+        assert orchestrator.metadata.execution_mode == "subagent_orchestration"
+
+
+def test_interview_capability_exposes_single_code_investigation_answer_contract() -> None:
+    code_investigation = _interview_code_investigation_metadata()
+
+    answer_contract = code_investigation["answer_contract"]
+    assert answer_contract["contract_id"] == "code_fact_investigation_answer.v1"
+    assert answer_contract["scope"] == "single_code_fact_investigation_request"
+    assert answer_contract["evidence_policy"] == {
+        "minimum_items": 1,
+        "source_format": "repository_relative_path_or_symbol",
+        "server_local_paths_allowed": False,
+    }
+    assert "exactly one structured answer payload" in answer_contract[
+        "runtime_instruction"
+    ]
+
+    prefix_semantics = answer_contract["prefix_semantics"]
+    assert prefix_semantics["[from-code][auto-confirmed]"] == {
+        "confidence": "high_exact_match",
+        "requires_user_confirmation": False,
+        "forwarding": "send_to_mcp_immediately",
+    }
+    assert prefix_semantics["[from-code]"] == {
+        "confidence": "medium_or_low",
+        "requires_user_confirmation": True,
+        "forwarding": "confirm_with_user_before_mcp",
+    }
+
+    response_schema = answer_contract["response_model_schema"]
+    Draft202012Validator.check_schema(response_schema)
+    assert response_schema["additionalProperties"] is False
+    assert set(response_schema["required"]) == {
+        "session_id",
+        "question_identity",
+        "answer_prefix",
+        "answer_text",
+        "confidence",
+        "evidence",
+        "requires_user_confirmation",
+    }
+    assert response_schema["properties"]["answer_prefix"]["enum"] == [
+        "[from-code]",
+        "[from-code][auto-confirmed]",
+    ]
+    assert response_schema["properties"]["confidence"]["enum"] == [
+        "high_exact_match",
+        "medium_inferred",
+        "low_uncertain",
+    ]
+    assert response_schema["properties"]["question_identity"]["pattern"] == (
+        r"^interview-question:[0-9a-f]{16}$"
+    )
+
+
+def test_code_investigation_answer_contract_validates_single_auto_confirmed_answer() -> None:
+    code_investigation = _interview_code_investigation_metadata()
+    response_schema = code_investigation["answer_contract"]["response_model_schema"]
+    validator = Draft202012Validator(response_schema)
+    question = "What framework does this project use?"
+
+    validator.validate(
+        {
+            "session_id": "sess-123",
+            "question_identity": stable_code_investigation_question_identity(question),
+            "answer_prefix": "[from-code][auto-confirmed]",
+            "answer_text": "Python 3.12, FastAPI",
+            "confidence": "high_exact_match",
+            "evidence": [
+                {
+                    "source": "pyproject.toml",
+                    "locator": "project.dependencies",
+                    "claim": "FastAPI is declared as a dependency.",
+                }
+            ],
+            "requires_user_confirmation": False,
+        }
+    )
+
+
+def test_code_investigation_answer_contract_rejects_implicit_or_mismatched_answer() -> None:
+    code_investigation = _interview_code_investigation_metadata()
+    response_schema = code_investigation["answer_contract"]["response_model_schema"]
+    validator = Draft202012Validator(response_schema)
+    question = "What framework does this project use?"
+
+    errors = list(
+        validator.iter_errors(
+            {
+                "session_id": "sess-123",
+                "question_identity": stable_code_investigation_question_identity(question),
+                "answer_prefix": "[from-code][auto-confirmed]",
+                "answer_text": "Probably FastAPI",
+                "confidence": "medium_inferred",
+                "evidence": [
+                    {
+                        "source": "src/app.py",
+                        "claim": "Imports look like FastAPI.",
+                    }
+                ],
+                "requires_user_confirmation": True,
+                "server_repository_path": "/server/local/repo",
+            }
+        )
+    )
+
+    messages = [error.message for error in errors]
+    assert any("'high_exact_match' was expected" in message for message in messages)
+    assert any("False was expected" in message for message in messages)
+    assert any(
+        "Additional properties are not allowed" in message
+        and "server_repository_path" in message
+        for message in messages
+    )
+
+
+def test_code_investigation_question_identity_is_stable_from_question_text() -> None:
+    question = "  What framework\n does this project use?  "
+
+    first = stable_code_investigation_question_identity(question)
+    second = stable_code_investigation_question_identity(
+        "What framework does this project use?"
+    )
+    changed = stable_code_investigation_question_identity(
+        "What auth method does this project use?"
+    )
+
+    assert first == second
+    assert first.startswith("interview-question:")
+    assert first != changed
+
+
+def test_code_investigation_request_model_rejects_malformed_question_identity() -> None:
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools(include_auto=False))
+    catalog = assemble_session_tool_catalog(attached_tools=owned_tools)
+    graph = build_capability_graph(catalog)
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    interview = descriptors["ouroboros_interview"]
+    assert interview.metadata is not None
+    schema = interview.metadata.orchestration["code_investigation"][
+        "request_model_schema"
+    ]
+    validator = Draft202012Validator(schema)
+
+    request = {
+        **_code_investigation_base_request("What framework does this project use?"),
+        "question_identity": "question-1",
+        "investigation_targets": [{"target_type": "workspace", "scope": "active"}],
+    }
+
+    errors = list(validator.iter_errors(request))
+    assert any(
+        "'question-1' does not match" in error.message
+        and "interview-question" in error.message
+        for error in errors
+    )
+
+
+def test_code_investigation_request_deserializes_embedded_tool_metadata_without_repo_access(
+    monkeypatch,
+) -> None:
+    question = "What framework does this project use?"
+    request = {
+        **_code_investigation_base_request(question),
+        "investigation_targets": [{"target_type": "workspace", "scope": "active"}],
+    }
+    expected_capability = request["mcp_tool_capability"]
+    assert isinstance(expected_capability, dict)
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._ouroboros_tool_definitions_by_name",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("deserialization must use embedded request metadata")
+        ),
+    )
+
+    deserialized = deserialize_code_investigation_request_metadata(request)
+
+    assert deserialized is not None
+    capability = deserialized["mcp_tool_capability"]
+    assert capability["tool_name"] == "ouroboros_interview"
+    assert capability["stable_id"] == expected_capability["stable_id"]
+    assert capability["source_kind"] == "attached_mcp"
+    assert capability["source_name"] == "ouroboros"
+    assert capability["fallback_used"] is False
+    assert capability["execution_mode"] == "subagent_orchestration"
+    for field_name in (
+        "input_schema",
+        "mutation_class",
+        "execution_mode",
+        "companions",
+        "required_context_keys",
+        "mutation_targets",
+        "side_effects",
+        "retry",
+        "interrupt",
+        "cancel",
+        "fallback_used",
+        "orchestration",
+    ):
+        assert field_name in capability
+    assert capability["input_schema"] == expected_capability["input_schema"]
+    assert capability["mutation_class"] == expected_capability["mutation_class"]
+    assert capability["companions"] == expected_capability["companions"]
+    assert capability["required_context_keys"] == expected_capability[
+        "required_context_keys"
+    ]
+    assert capability["mutation_targets"] == expected_capability["mutation_targets"]
+    assert capability["state_mutations"] == [
+        {
+            **mutation,
+            "context_keys": list(mutation["context_keys"]),
+        }
+        for mutation in expected_capability["state_mutations"]
+    ]
+    assert capability["side_effects"] == expected_capability["side_effects"]
+    assert capability["retry"] == expected_capability["retry"]
+    assert capability["interrupt"] == expected_capability["interrupt"]
+    assert capability["cancel"] == expected_capability["cancel"]
+    assert set(capability["orchestration"]) >= {
+        "code_investigation",
+        "lateral_panel",
+    }
+
+
+def test_lateral_persona_panel_metadata_is_structured_without_prose_parsing() -> None:
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools(include_auto=False))
+    catalog = assemble_session_tool_catalog(attached_tools=owned_tools)
+
+    graph = build_capability_graph(catalog)
+
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    lateral = descriptors["ouroboros_lateral_think"]
+    assert lateral.metadata is not None
+    assert lateral.metadata.fallback_used is False
+    assert lateral.metadata.execution_mode == "subagent_orchestration"
+
+    panel = lateral.metadata.orchestration["lateral_panel"]
+    assert panel["panel_id"] == "lateral_persona_panel.v1"
+    assert panel["mcp_tool"] == "ouroboros_lateral_think"
+    assert panel["dispatch_modes"] == ["plugin", "inline_fallback"]
+    assert panel["parallel_preference"] == "parallel_when_runtime_supports_subagents"
+    assert panel["sequential_fallback"] == {
+        "supported": True,
+        "mode": "sequential_persona_payload_dispatch",
+        "trigger": "runtime_has_no_native_parallel_subagent_primitive",
+    }
+
+    schema = panel["request_model_schema"]
+    assert schema["required"] == ["problem_context", "current_approach"]
+    assert schema["properties"]["personas"]["items"]["enum"] == [
+        "hacker",
+        "researcher",
+        "simplifier",
+        "architect",
+        "contrarian",
+    ]
+
+    persona_by_id = {persona["persona_id"]: persona for persona in panel["personas"]}
+    assert set(persona_by_id) == {
+        "hacker",
+        "researcher",
+        "simplifier",
+        "architect",
+        "contrarian",
+    }
+    assert persona_by_id["hacker"]["role"] == "Finds unconventional workarounds"
+    assert persona_by_id["researcher"]["role"] == "Seeks additional information"
+
+    for persona in persona_by_id.values():
+        assert persona["prompt"] == {
+            "source": "build_lateral_multi_subagent",
+            "payload_field": "payloads[].prompt",
+            "context_field": "payloads[].context",
+            "requires_prose_parsing": False,
+        }
+        refs = persona["response_payload_ref"]
+        assert refs["plugin"] == "MCPToolResult.meta._subagents[persona_id]"
+        assert refs["inline_meta"] == "MCPToolResult.meta.payloads[persona_id]"
+        assert "ouroboros-lateral-inline-dispatch-v1.payloads[persona_id]" in refs[
+            "inline_content"
+        ]
+
+    panel_refs = panel["response_payload_refs"]
+    assert panel_refs["plugin"] == "MCPToolResult.meta._subagents"
+    assert panel_refs["inline_meta"] == "MCPToolResult.meta.payloads"
+    assert panel_refs["result_correlation_key"] == "context.persona"
+    assert panel_refs["requires_prose_parsing"] is False
+    assert "structured payload" in panel["runtime_instruction"]
+
+
+def test_pm_interview_subagent_metadata_is_structured_without_prose_parsing() -> None:
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools(include_auto=False))
+    catalog = assemble_session_tool_catalog(attached_tools=owned_tools)
+
+    graph = build_capability_graph(catalog)
+
+    pm_interview = graph.by_name()["ouroboros_pm_interview"]
+    assert pm_interview.metadata is not None
+    assert pm_interview.metadata.fallback_used is False
+    assert pm_interview.metadata.execution_mode == "subagent_orchestration"
+
+    contract = pm_interview.metadata.orchestration["pm_interview_subagent"]
+    assert contract["directive"] == "run_pm_interview_subagent"
+    assert contract["mcp_tool"] == "ouroboros_pm_interview"
+    assert contract["dispatch_modes"] == ["plugin"]
+    assert contract["payload_builder"] == "build_pm_interview_subagent"
+
+    schema = contract["request_model_schema"]
+    assert schema["properties"]["action"]["enum"] == [
+        "start",
+        "answer",
+        "resume",
+        "generate",
+        "select_repos",
+    ]
+    assert schema["properties"]["selected_repos"]["items"] == {"type": "string"}
+
+    refs = contract["response_payload_refs"]
+    assert refs["plugin"] == "MCPToolResult.meta._subagent"
+    assert refs["content_json"] == "MCPToolResult.content[0].text._subagent"
+    assert refs["result_correlation_key"] == "context.session_id"
+    assert refs["requires_prose_parsing"] is False
+    assert contract["subagent_context_keys"] == [
+        "session_id",
+        "action",
+        "initial_context",
+        "answer",
+        "cwd",
+        "selected_repos",
+    ]
+    assert "structured payload" in contract["runtime_instruction"]
+
+
+@pytest.mark.asyncio
+async def test_owned_lateral_thinking_capability_invokes_subagent_orchestration() -> None:
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools(include_auto=False))
+    catalog = assemble_session_tool_catalog(attached_tools=owned_tools)
+    graph = build_capability_graph(catalog)
+
+    descriptor = graph.by_name()["ouroboros_lateral_think"]
+    metadata = descriptor.metadata
+    assert metadata is not None
+    assert metadata.fallback_used is False
+    assert metadata.execution_mode == "subagent_orchestration"
+    assert metadata.companions == ("ouroboros_interview",)
+    assert metadata.required_context_keys == (
+        "problem_context",
+        "current_approach",
+        "failed_attempts",
+    )
+    assert metadata.side_effects == ("subagent_dispatch", "session_state_write")
+    assert metadata.retry == {"supported": True, "mode": "handler_owned"}
+    assert metadata.interrupt == {"supported": True, "mode": "soft"}
+    assert metadata.cancel == {
+        "supported": False,
+        "mode": "unsupported",
+        "companions": (),
+        "target_context_keys": (),
+    }
+    assert set(metadata.orchestration) >= {"lateral_panel"}
+
+    panel = metadata.orchestration["lateral_panel"]
+    assert panel["mcp_tool"] == "ouroboros_lateral_think"
+    assert panel["parallel_preference"] == "parallel_when_runtime_supports_subagents"
+    assert panel["sequential_fallback"]["supported"] is True
+    assert panel["response_payload_refs"]["requires_prose_parsing"] is False
+
+    tool_args = {
+        "problem_context": "Interview milestone changed from initial to progress.",
+        "current_approach": "Continue with the next Socratic interview question.",
+        "personas": ["researcher", "contrarian"],
+        "failed_attempts": [],
+    }
+    Draft202012Validator(metadata.input_schema).validate(tool_args)
+
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+    result = await handler.handle(tool_args)
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    assert payload.meta is not None
+    assert "_subagents" in payload.meta
+    assert {subagent["tool_name"] for subagent in payload.meta["_subagents"]} == {
+        "ouroboros_lateral_think"
+    }
+
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        payload,
+        session_id="sess-lateral-capability",
+        runtime_supports_parallel_subagents=True,
+        lateral_panel_metadata=panel,
+    )
+
+    assert [entry["persona_id"] for entry in entries] == [
+        "researcher",
+        "contrarian",
+    ]
+    assert {entry["mcp_tool"] for entry in entries} == {"ouroboros_lateral_think"}
+    assert {entry["execution_mode"] for entry in entries} == {
+        "parallel_subagent_panel"
+    }
+    assert all(entry["requires_prose_parsing"] is False for entry in entries)
+    assert all(entry["sequential_fallback_used"] is False for entry in entries)
+    assert all(entry["context"]["persona"] == entry["persona_id"] for entry in entries)
+
+
+@pytest.mark.asyncio
+async def test_owned_lateral_review_tool_path_uses_explicit_metadata_and_is_callable(
+    monkeypatch,
+) -> None:
+    handlers = get_ouroboros_tools(
+        runtime_backend="opencode",
+        opencode_mode="plugin",
+        include_auto=False,
+    )
+    definitions = {handler.definition.name: handler.definition for handler in handlers}
+    review_handler = next(
+        handler
+        for handler in handlers
+        if handler.definition.name == "ouroboros_lateral_think"
+    )
+
+    def fail_on_generic_attached_metadata(tool: MCPToolDefinition):
+        raise AssertionError(f"review tool used generic metadata: {tool.name}")
+
+    def fail_on_generic_attached_semantics(tool: MCPToolDefinition):
+        raise AssertionError(f"review tool used generic semantics: {tool.name}")
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._generic_attached_tool_metadata",
+        fail_on_generic_attached_metadata,
+    )
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.capabilities._infer_attached_semantics",
+        fail_on_generic_attached_semantics,
+    )
+
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(
+            attached_tools=(definitions["ouroboros_lateral_think"],)
+        )
+    )
+    descriptor = graph.by_name()["ouroboros_lateral_think"]
+    metadata = descriptor.metadata
+
+    assert metadata is not None
+    assert metadata == ouroboros_tool_capability_registry()["ouroboros_lateral_think"]
+    assert metadata.fallback_used is False
+    assert metadata.input_schema == definitions["ouroboros_lateral_think"].to_input_schema()
+    assert metadata.execution_mode == "subagent_orchestration"
+    assert metadata.companions == ("ouroboros_interview",)
+    assert metadata.required_context_keys == (
+        "problem_context",
+        "current_approach",
+        "failed_attempts",
+    )
+    assert metadata.side_effects == ("subagent_dispatch", "session_state_write")
+    assert metadata.retry == {"supported": True, "mode": "handler_owned"}
+    assert metadata.interrupt == {"supported": True, "mode": "soft"}
+    assert metadata.cancel == _UNSUPPORTED_CANCEL
+    validate_capability_tool_metadata(
+        metadata,
+        tool_name="ouroboros_lateral_think",
+        owned_tool=True,
+    )
+
+    panel = metadata.orchestration["lateral_panel"]
+    assert panel["mcp_tool"] == "ouroboros_lateral_think"
+    assert panel["parallel_preference"] == "parallel_when_runtime_supports_subagents"
+    assert panel["sequential_fallback"] == {
+        "supported": True,
+        "mode": "sequential_persona_payload_dispatch",
+        "trigger": "runtime_has_no_native_parallel_subagent_primitive",
+    }
+    assert panel["response_payload_refs"]["requires_prose_parsing"] is False
+
+    tool_args = {
+        "problem_context": (
+            "Interview lateral review for milestone transition initial -> progress."
+        ),
+        "current_approach": "Continue only after synthesized review findings.",
+        "personas": ["researcher", "contrarian"],
+        "failed_attempts": [],
+    }
+    Draft202012Validator(metadata.input_schema).validate(tool_args)
+
+    result = await review_handler.handle(tool_args)
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    assert payload.meta is not None
+    assert payload.meta["dispatch_mode"] == "plugin"
+    assert "_subagents" in payload.meta
+    assert {subagent["tool_name"] for subagent in payload.meta["_subagents"]} == {
+        "ouroboros_lateral_think"
+    }
+
+    parallel_entries = lateral_review_response_to_interview_orchestration_entries(
+        payload,
+        session_id="sess-review-tool-capability",
+        runtime_supports_parallel_subagents=True,
+        lateral_panel_metadata=panel,
+    )
+    sequential_entries = lateral_review_response_to_interview_orchestration_entries(
+        payload,
+        session_id="sess-review-tool-capability",
+        runtime_supports_parallel_subagents=False,
+        lateral_panel_metadata=panel,
+    )
+
+    assert [entry["persona_id"] for entry in parallel_entries] == [
+        "researcher",
+        "contrarian",
+    ]
+    assert {entry["mcp_tool"] for entry in parallel_entries} == {
+        "ouroboros_lateral_think"
+    }
+    assert {entry["execution_mode"] for entry in parallel_entries} == {
+        "parallel_subagent_panel"
+    }
+    assert all(entry["sequential_fallback_used"] is False for entry in parallel_entries)
+    assert all(entry["requires_prose_parsing"] is False for entry in parallel_entries)
+
+    assert [entry["persona_id"] for entry in sequential_entries] == [
+        "researcher",
+        "contrarian",
+    ]
+    assert {entry["execution_mode"] for entry in sequential_entries} == {
+        "sequential_persona_payload_dispatch"
+    }
+    assert all(entry["sequential_fallback_used"] is True for entry in sequential_entries)
+    assert all(entry["requires_prose_parsing"] is False for entry in sequential_entries)
+
+
+def test_interview_metadata_includes_lateral_persona_panel_contract() -> None:
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools(include_auto=False))
+    catalog = assemble_session_tool_catalog(attached_tools=owned_tools)
+
+    graph = build_capability_graph(catalog)
+
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    interview = descriptors["ouroboros_interview"]
+    assert interview.metadata is not None
+    panel = interview.metadata.orchestration["lateral_panel"]
+    assert panel["panel_id"] == "lateral_persona_panel.v1"
+    assert panel["response_payload_refs"]["requires_prose_parsing"] is False
+    assert panel["sequential_fallback"]["supported"] is True
+
+
+def test_code_investigation_request_model_validates_supported_target_forms() -> None:
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools(include_auto=False))
+    catalog = assemble_session_tool_catalog(attached_tools=owned_tools)
+    graph = build_capability_graph(catalog)
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    interview = descriptors["ouroboros_interview"]
+    assert interview.metadata is not None
+    schema = interview.metadata.orchestration["code_investigation"][
+        "request_model_schema"
+    ]
+    Draft202012Validator.check_schema(schema)
+    validator = Draft202012Validator(schema)
+
+    base_request = _code_investigation_base_request(
+        "What framework does this project use?"
+    )
+    supported_targets = (
+        {"target_type": "workspace", "scope": "active"},
+        {"target_type": "relative_path", "path": "pyproject.toml"},
+        {"target_type": "glob", "pattern": "**/package.json"},
+        {"target_type": "symbol", "name": "AuthService", "path_hint": "src"},
+    )
+
+    for target in supported_targets:
+        validator.validate({**base_request, "investigation_targets": [target]})
+
+
+def test_code_investigation_request_model_requires_explicit_targets() -> None:
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools(include_auto=False))
+    catalog = assemble_session_tool_catalog(attached_tools=owned_tools)
+    graph = build_capability_graph(catalog)
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    interview = descriptors["ouroboros_interview"]
+    assert interview.metadata is not None
+    schema = interview.metadata.orchestration["code_investigation"][
+        "request_model_schema"
+    ]
+    validator = Draft202012Validator(schema)
+
+    errors = sorted(
+        validator.iter_errors(
+            {
+                **_code_investigation_base_request(
+                    "What framework does this project use?"
+                ),
+                "working_directory": "/repo",
+                "answer_prefixes": ["[from-code]"],
+            }
+        ),
+        key=lambda error: error.message,
+    )
+
+    assert any("'investigation_targets' is a required property" in error.message for error in errors)
+
+
+def test_code_investigation_request_model_rejects_server_local_repository_fields() -> None:
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools(include_auto=False))
+    catalog = assemble_session_tool_catalog(attached_tools=owned_tools)
+    graph = build_capability_graph(catalog)
+    descriptors = {descriptor.name: descriptor for descriptor in graph.capabilities}
+    interview = descriptors["ouroboros_interview"]
+    assert interview.metadata is not None
+    schema = interview.metadata.orchestration["code_investigation"][
+        "request_model_schema"
+    ]
+    validator = Draft202012Validator(schema)
+
+    base_request = {
+        **_code_investigation_base_request("What framework does this project use?"),
+        "investigation_targets": [{"target_type": "workspace", "scope": "active"}],
+        "answer_prefixes": ["[from-code]"],
+    }
+
+    for field_name in (
+        "working_directory",
+        "cwd",
+        "repository_path",
+        "server_repository_path",
+    ):
+        errors = list(
+            validator.iter_errors({**base_request, field_name: "/server/local/repo"})
+        )
+        assert any(
+            "Additional properties are not allowed" in error.message
+            and field_name in error.message
+            for error in errors
+        ), field_name
+
+
 def test_capability_graph_serialization_round_trips() -> None:
     graph = build_capability_graph(assemble_session_tool_catalog(["Read", "Edit"]))
 
@@ -49,6 +5044,55 @@ def test_capability_graph_serialization_round_trips() -> None:
     assert restored is not None
     assert [descriptor.name for descriptor in restored.capabilities] == ["Read", "Edit"]
     assert restored.capabilities[0].semantics.mutation_class is CapabilityMutationClass.READ_ONLY
+
+
+def test_owned_mcp_tool_metadata_serialization_round_trips_mutation_fields() -> None:
+    definitions = {handler.definition.name: handler.definition for handler in get_ouroboros_tools()}
+    graph = build_capability_graph(
+        assemble_session_tool_catalog(
+            attached_tools=(definitions["ouroboros_interview"],)
+        )
+    )
+    serialized = serialize_capability_graph(graph)
+
+    assert serialized[0]["metadata"]["mutation_targets"] == list(
+        _EXPECTED_OUROBOROS_TOOL_MUTATION_TARGETS["ouroboros_interview"]
+    )
+    assert serialized[0]["metadata"]["state_mutations"] == [
+        {
+            **mutation,
+            "context_keys": list(mutation["context_keys"]),
+        }
+        for mutation in _EXPECTED_OUROBOROS_TOOL_STATE_MUTATIONS[
+            "ouroboros_interview"
+        ]
+    ]
+    assert serialized[0]["metadata"]["side_effects"] == [
+        "subagent_dispatch",
+        "session_state_write",
+    ]
+
+    restored = normalize_serialized_capability_graph(serialized)
+
+    assert restored is not None
+    descriptor = restored.by_name()["ouroboros_interview"]
+    assert descriptor.metadata is not None
+    assert descriptor.metadata.fallback_used is False
+    assert descriptor.metadata.mutation_targets == (
+        _EXPECTED_OUROBOROS_TOOL_MUTATION_TARGETS["ouroboros_interview"]
+    )
+    assert descriptor.metadata.state_mutations == (
+        _EXPECTED_OUROBOROS_TOOL_STATE_MUTATIONS["ouroboros_interview"]
+    )
+    assert descriptor.metadata.side_effects == (
+        "subagent_dispatch",
+        "session_state_write",
+    )
+    validate_capability_tool_metadata(
+        descriptor.metadata,
+        tool_name="ouroboros_interview",
+        owned_tool=True,
+    )
 
 
 def test_build_capability_graph_records_inherited_capabilities_without_entries() -> None:

--- a/tests/unit/orchestrator/test_skill_tool_mapping.py
+++ b/tests/unit/orchestrator/test_skill_tool_mapping.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from ouroboros.orchestrator.skill_tool_mapping import (
+    SkillToolMapping,
+    discover_skill_body_context_keys,
+    discover_skill_context_keys,
+    discover_skill_tool_mappings,
+    extract_skill_body_tool_context_keys,
+    extract_skill_frontmatter_context_keys,
+    merge_skill_context_keys_by_tool,
+    merge_tool_context_keys,
+    skill_frontmatter_context_keys_by_tool,
+)
+
+_CORE_FRONTMATTER_SKILL_TOOLS = {
+    "auto": "ouroboros_start_auto",
+    "run": "ouroboros_execute_seed",
+    "ralph": "ouroboros_ralph",
+    "status": "ouroboros_session_status",
+    "seed": "ouroboros_generate_seed",
+    "interview": "ouroboros_interview",
+}
+
+
+def test_extract_skill_frontmatter_context_keys_preserves_mcp_arg_order() -> None:
+    frontmatter = {
+        "mcp_tool": "ouroboros_start_auto",
+        "mcp_args": {
+            "goal": "$goal",
+            "resume": "$resume",
+            "cwd": "$CWD",
+            "max_interview_rounds": "$max_interview_rounds",
+        },
+    }
+
+    assert extract_skill_frontmatter_context_keys(frontmatter) == (
+        "goal",
+        "resume",
+        "cwd",
+        "max_interview_rounds",
+    )
+
+
+def test_extract_skill_frontmatter_context_keys_handles_missing_mcp_args() -> None:
+    assert extract_skill_frontmatter_context_keys({"name": "unstuck"}) == ()
+    assert extract_skill_frontmatter_context_keys({"mcp_args": ["session_id"]}) == ()
+
+
+def test_extract_skill_body_tool_context_keys_reads_tool_blocks_and_inline_calls() -> None:
+    body = """
+## Start
+
+Tool: ouroboros_start_probe
+Arguments:
+  seed_content: <the seed YAML>
+  model_tier: "medium"
+  metadata: |
+    nested_key: ignored
+  max_iterations: 10
+
+Use `ouroboros_job_wait(job_id, cursor, timeout_seconds=120, view="summary")`
+and then `ouroboros_job_result(job_id=<job_id>)`.
+
+Tool: ouroboros_start_probe
+Arguments:
+  session_id: <existing session ID>
+  seed_content: <same seed YAML>
+"""
+
+    assert extract_skill_body_tool_context_keys(body) == {
+        "ouroboros_start_probe": ("seed_content", "metadata", "session_id"),
+        "ouroboros_job_wait": ("job_id", "cursor"),
+        "ouroboros_job_result": ("job_id",),
+    }
+
+
+def test_extract_skill_body_tool_context_keys_ignores_frontmatter_only_usage() -> None:
+    skill_md = """---
+name: run
+mcp_tool: ouroboros_execute_seed
+mcp_args:
+  seed_path: "$1"
+---
+
+The body has no direct tool invocation.
+"""
+
+    assert extract_skill_body_tool_context_keys(skill_md) == {}
+
+
+def test_packaged_skill_frontmatter_exposes_declared_mcp_tools() -> None:
+    mappings = discover_skill_tool_mappings()
+    by_skill = {mapping.skill_name: mapping for mapping in mappings}
+
+    assert set(_CORE_FRONTMATTER_SKILL_TOOLS) == {
+        "auto",
+        "run",
+        "ralph",
+        "status",
+        "seed",
+        "interview",
+    }
+    assert {
+        skill: by_skill[skill].mcp_tool for skill in _CORE_FRONTMATTER_SKILL_TOOLS
+    } == _CORE_FRONTMATTER_SKILL_TOOLS
+    assert {
+        skill: by_skill[skill].skill_path for skill in _CORE_FRONTMATTER_SKILL_TOOLS
+    } == {
+        skill: f"skills/{skill}/SKILL.md"
+        for skill in _CORE_FRONTMATTER_SKILL_TOOLS
+    }
+
+
+def test_packaged_skill_frontmatter_exposes_tool_specific_context_keys() -> None:
+    mappings = discover_skill_tool_mappings()
+    by_skill = {mapping.skill_name: mapping for mapping in mappings}
+
+    expected = {
+        "auto": (
+            "goal",
+            "resume",
+            "cwd",
+            "max_interview_rounds",
+            "max_repair_rounds",
+            "skip_run",
+            "complete_product",
+            "pipeline_timeout_seconds",
+        ),
+        "run": ("seed_path", "cwd"),
+        "ralph": ("lineage_id",),
+        "status": ("session_id",),
+        "seed": ("session_id",),
+        "interview": ("initial_context", "cwd"),
+    }
+
+    assert {skill: by_skill[skill].context_keys for skill in expected} == expected
+    assert skill_frontmatter_context_keys_by_tool(mappings) == {
+        by_skill[skill].mcp_tool: context_keys
+        for skill, context_keys in expected.items()
+    }
+
+
+def test_packaged_skill_bodies_expose_tool_specific_context_keys() -> None:
+    context_keys_by_tool = discover_skill_body_context_keys()
+
+    expected_subset = {
+        "ouroboros_start_execute_seed": ("seed_content", "session_id"),
+        "ouroboros_job_wait": ("job_id", "cursor"),
+        "ouroboros_job_result": ("job_id",),
+        "ouroboros_ac_tree_hud": ("session_id", "cursor"),
+        "ouroboros_interview": (
+            "initial_context",
+            "cwd",
+            "session_id",
+            "answer",
+            "last_question",
+        ),
+        "ouroboros_lateral_think": (
+            "problem_context",
+            "failed_attempts",
+        ),
+        "ouroboros_generate_seed": ("session_id",),
+        "ouroboros_session_status": ("session_id",),
+        "ouroboros_measure_drift": (
+            "session_id",
+            "current_output",
+            "seed_content",
+        ),
+    }
+
+    assert {
+        tool: context_keys_by_tool[tool] for tool in expected_subset
+    } == expected_subset
+
+
+def test_skill_frontmatter_context_keys_by_tool_merges_duplicate_tool_keys() -> None:
+    mappings = (
+        SkillToolMapping(
+            skill_name="first",
+            mcp_tool="ouroboros_probe",
+            skill_path="skills/first/SKILL.md",
+            mcp_args={"session_id": "$1", "cwd": "$CWD"},
+            context_keys=("session_id", "cwd"),
+        ),
+        SkillToolMapping(
+            skill_name="second",
+            mcp_tool="ouroboros_probe",
+            skill_path="skills/second/SKILL.md",
+            mcp_args={"cwd": "$CWD", "artifact": "$artifact"},
+            context_keys=("cwd", "artifact"),
+        ),
+    )
+
+    assert skill_frontmatter_context_keys_by_tool(mappings) == {
+        "ouroboros_probe": ("session_id", "cwd", "artifact")
+    }
+
+
+def test_merge_tool_context_keys_prefers_frontmatter_order_and_normalizes() -> None:
+    assert merge_tool_context_keys(
+        (" session_id ", "cwd", "", "artifact"),
+        ("cwd", " cursor ", "artifact", "  "),
+    ) == ("session_id", "cwd", "artifact", "cursor")
+
+
+def test_merge_skill_context_keys_by_tool_keeps_body_only_tools() -> None:
+    assert merge_skill_context_keys_by_tool(
+        {
+            "ouroboros_execute_seed": ("seed_path", "cwd"),
+            "ouroboros_session_status": ("session_id",),
+        },
+        {
+            "ouroboros_execute_seed": ("seed_content", "session_id"),
+            "ouroboros_job_wait": ("job_id", "cursor"),
+        },
+    ) == {
+        "ouroboros_execute_seed": (
+            "seed_path",
+            "cwd",
+            "seed_content",
+            "session_id",
+        ),
+        "ouroboros_session_status": ("session_id",),
+        "ouroboros_job_wait": ("job_id", "cursor"),
+    }
+
+
+def test_discover_skill_context_keys_merges_packaged_frontmatter_and_body_usage() -> None:
+    context_keys_by_tool = discover_skill_context_keys()
+
+    assert context_keys_by_tool["ouroboros_execute_seed"] == (
+        "seed_path",
+        "cwd",
+    )
+    assert context_keys_by_tool["ouroboros_start_execute_seed"] == (
+        "seed_content",
+        "session_id",
+    )
+    assert context_keys_by_tool["ouroboros_start_auto"] == (
+        "goal",
+        "resume",
+        "cwd",
+        "max_interview_rounds",
+        "max_repair_rounds",
+        "skip_run",
+        "complete_product",
+        "pipeline_timeout_seconds",
+    )
+    assert context_keys_by_tool["ouroboros_interview"] == (
+        "initial_context",
+        "cwd",
+        "session_id",
+        "answer",
+        "last_question",
+    )
+    assert context_keys_by_tool["ouroboros_job_wait"] == ("job_id", "cursor")


### PR DESCRIPTION
## Summary

- Add explicit capability metadata for Ouroboros-owned MCP tools so known tools no longer depend on generic keyword inference.
- Model skill-to-tool mappings, companion families, side effects, retry/interruption/cancel behavior, and subagent orchestration contracts for interview-time code investigation and lateral panels.
- Fix Stage 1 mechanical evaluation diagnostics so MCP-server sentinel env leakage does not create false test failures and failed checks show useful command/output tails.

## Changes

- Extend capability descriptors with `CapabilityToolMetadata` derived from MCP tool definitions and packaged skill usage.
- Add `skill_tool_mapping.py` to keep skill mapping separate from tool descriptors while preserving tools without direct skills.
- Add runtime subagent orchestration contracts and backend metadata for native parallel vs sequential fallback behavior.
- Emit structured interview code-investigation and lateral persona panel metadata, including plugin `_subagents` and non-plugin sequential fallback contracts.
- Add PM subagent metadata coverage and capability tests for status/cancel/subagent execution envelopes.
- Strip `_OUROBOROS_NESTED` from mechanical verification subprocesses and surface failed-check command/cwd/stdout/stderr tails.
- Save the generated Seed used to drive the implementation in `.ouroboros/seeds/seed_814ae54469fb.yaml`.

## Notes

Verification run:

- `uv run pytest tests/unit/orchestrator/test_capabilities.py tests/unit/orchestrator/test_skill_tool_mapping.py tests/unit/backends/test_capabilities.py tests/unit/mcp/tools/test_interview_response_diagnostics.py tests/unit/mcp/tools/test_interview_lateral_review_advisory.py tests/unit/mcp/tools/test_lateral_think_handler.py tests/unit/evaluation/test_mechanical.py tests/unit/mcp/tools/test_definitions.py::TestEvaluateHandlerCodeChanges -q` → 272 passed
- `uv run ruff check ...` for changed source/test files
- `git diff --check`
- Prior full suite on the combined change before PR splitting: `uv run pytest tests/ -x -q` → 10666 passed, 5 skipped
- Current-source `EvaluateHandler` direct run approved Stage 1 + Stage 2; an already-running MCP server must restart before it sees the `_OUROBOROS_NESTED` fix.