### PR TITLE
fix(orchestrator): tighten usage-limit pause classification

### DIFF
--- a/src/ouroboros/orchestrator/backend_limits.py
+++ b/src/ouroboros/orchestrator/backend_limits.py
@@ -3,10 +3,10 @@
 Ouroboros plans delivery (the parallel execution of acceptance criteria) and is
 responsible for keeping that fan-out within the concurrency and rate-limit
 constraints of the connected LLM backend — it must not rely on the agent
-runtime to throttle itself. See ``docs/rca-june-2026.md`` (R3): a hermes→Z.AI
-run fanned out 14 acceptance criteria at once and stampeded an already-exhausted
+runtime to throttle itself. This policy was added after a hermes→Z.AI run
+fanned out 14 acceptance criteria at once and stampeded an already-exhausted
 quota because nothing on the Ouroboros side bounded concurrency for that
-runtime (only the native Claude adapter carries a shared rate-limit bucket).
+runtime (only the native Claude adapter carried a shared rate-limit bucket).
 
 Policy: backends whose underlying LLM limits Ouroboros cannot know — every CLI
 runtime (hermes, codex, gemini, opencode, ...) — are **serialized by default**

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -406,6 +406,15 @@ _USAGE_LIMIT_TEXT_PATTERNS = (
         re.IGNORECASE,
     ),
 )
+_USAGE_LIMIT_WINDOW_CONTEXT_PATTERN = re.compile(
+    r"\b(?:usage|quota|allowance|rate|request)\s+"
+    r"(?:limit|quota|cap|window|allowance)\b.{0,120}"
+    r"\b(?:reached|exceeded|exhausted|depleted|hit|reset|resets|available|renews)\b"
+    r"|\b(?:reached|exceeded|exhausted|depleted|hit|reset|resets|available|renews)\b"
+    r".{0,120}\b(?:usage|quota|allowance|rate|request)\s+"
+    r"(?:limit|quota|cap|window|allowance)\b",
+    re.IGNORECASE,
+)
 
 
 class OrchestratorRunner:
@@ -1159,14 +1168,7 @@ class OrchestratorRunner:
             )
             is not None
         )
-        mentions_limit_window = (
-            re.search(
-                r"\b(?:usage|quota|allowance|rate|request)\s+"
-                r"(?:limit|quota|cap|window|allowance)\b",
-                normalized,
-            )
-            is not None
-        )
+        mentions_limit_window = _USAGE_LIMIT_WINDOW_CONTEXT_PATTERN.search(normalized) is not None
 
         if has_quota_phrase and (has_runtime_error_shape or duration_seconds is not None):
             return True

--- a/src/ouroboros/orchestrator/runtime_error.py
+++ b/src/ouroboros/orchestrator/runtime_error.py
@@ -1,15 +1,14 @@
 """Typed classification of runtime subprocess failures.
 
-CLI-backed runtimes (hermes, gemini-cli, ...) surface upstream failures as a
-non-zero process exit plus free-form stdout/stderr text. Collapsing that to
+Hermes can surface upstream failures as a non-zero process exit plus free-form
+stdout/stderr text. Collapsing that to
 ``{"subtype": "error", "exit_code": N}`` discards the provider's typed signal —
 the HTTP status and quota/usage-limit phrasing — that the orchestrator's
-recoverable-failure classifier keys on. The consequence (see
-``docs/rca-june-2026.md``, issue 1.1) is that a provider usage-limit window
-hard-fails the whole run instead of pausing it gracefully.
+recoverable-failure classifier keys on. The consequence is that a provider
+usage-limit window hard-fails the whole run instead of pausing it gracefully.
 
 ``classify_subprocess_failure`` re-derives those typed fields from the failure
-text so they can be attached to the runtime ``AgentMessage`` metadata. The
+text so Hermes can attach them to runtime ``AgentMessage`` metadata. The
 returned keys are a subset of those recognized by
 ``OrchestratorRunner._metadata_has_runtime_error_shape`` — in particular
 ``error_type`` is always present, which is what marks a failure as
@@ -36,11 +35,11 @@ _HTTP_STATUS_PATTERN = re.compile(
 
 # Phrases that indicate a rate-limit / usage-limit / quota condition.
 _RATE_LIMIT_PATTERN = re.compile(
-    r"\b(?:rate[\s_-]*limit"
-    r"|usage[\s_-]*limit"
-    r"|quota"
-    r"|too\s+many\s+requests"
-    r"|limit\s+reached)\b",
+    r"\b(?:too\s+many\s+requests"
+    r"|(?:rate[\s_-]*limit|usage[\s_-]*limit|quota)"
+    r".{0,80}(?:reached|exceeded|exhausted|depleted|hit)"
+    r"|(?:reached|exceeded|exhausted|depleted|hit)"
+    r".{0,80}(?:rate[\s_-]*limit|usage[\s_-]*limit|quota))\b",
     re.IGNORECASE,
 )
 

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -1526,6 +1526,28 @@ class TestOrchestratorRunner:
 
         assert pause is None
 
+    def test_recoverable_failure_ignores_hermes_task_text_about_usage_limits(
+        self,
+        runner: OrchestratorRunner,
+    ) -> None:
+        """Hermes task text mentioning usage-limit copy is not a provider pause."""
+        failure_text = (
+            "Tests failed while updating usage limit copy. "
+            "Please try again in 5 hours after the flaky suite is fixed."
+        )
+        message = AgentMessage(
+            type="result",
+            content=f"Hermes execution failed:\n{failure_text}",
+            data=classify_subprocess_failure(failure_text, exit_code=1),
+        )
+
+        pause = runner._recoverable_failure_pause(
+            message,
+            now=datetime(2026, 1, 1, tzinfo=UTC),
+        )
+
+        assert pause is None
+
     def test_recoverable_failure_sums_compound_retry_window(
         self,
         runner: OrchestratorRunner,

--- a/tests/unit/orchestrator/test_runtime_error.py
+++ b/tests/unit/orchestrator/test_runtime_error.py
@@ -1,9 +1,8 @@
 """Unit tests for runtime subprocess-failure classification.
 
 These cover the typed-error contract that lets the orchestrator's recoverable-
-failure classifier recognize provider usage-limit windows surfaced by CLI
-runtimes (hermes, gemini-cli, ...) as a non-zero process exit plus free-form
-text. See ``docs/rca-june-2026.md`` (P0).
+failure classifier recognize provider usage-limit windows surfaced by Hermes as
+a non-zero process exit plus free-form text.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

- Addresses follow-up review items from #1360 and #1361.
- Removes stale/missing RCA doc references and narrows the runtime-error helper wording to the Hermes-only integration.
- Tightens usage-limit pause classification so runtime-shaped Hermes task failures that merely discuss usage-limit copy do not pause sessions.

## Changes

- Replaces the missing `docs/rca-june-2026.md` reference in `backend_limits.py` with inline context.
- Updates `runtime_error.py` and its tests to describe the current Hermes scope.
- Adds a Hermes negative regression for non-provider task text with usage-limit wording plus a long retry phrase.
- Requires long retry-window usage-limit text to include quota-window context such as reached/exceeded/reset/available.

## Verification

- `uv run ruff check src/ouroboros/orchestrator/backend_limits.py src/ouroboros/orchestrator/runtime_error.py src/ouroboros/orchestrator/runner.py tests/unit/orchestrator/test_runtime_error.py tests/unit/orchestrator/test_runner.py`
- `uv run pytest tests/unit/orchestrator/test_runtime_error.py tests/unit/orchestrator/test_backend_limits.py tests/unit/orchestrator/test_hermes_runtime.py tests/unit/orchestrator/test_runner.py`