### PR TITLE
feat(orchestrator): [stack 1/7] map skills to MCP tools

### DIFF
--- a/src/ouroboros/orchestrator/skill_tool_mapping.py
+++ b/src/ouroboros/orchestrator/skill_tool_mapping.py
@@ -1,0 +1,463 @@
+"""Skill-to-MCP-tool mappings derived from packaged skill frontmatter.
+
+This module is intentionally separate from MCP tool descriptor definitions.
+Skill dispatch mappings answer "which tool does this skill invoke?", while
+tool descriptors answer "what is the MCP handler schema?". Keeping those
+questions apart lets capability modeling verify skill usage without consulting
+``get_ouroboros_tools()`` or descriptor metadata.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+import re
+from typing import Any
+
+import yaml
+
+
+@dataclass(frozen=True, slots=True)
+class SkillToolMapping:
+    """Frontmatter-backed mapping from one packaged skill to one MCP tool."""
+
+    skill_name: str
+    mcp_tool: str
+    skill_path: str
+    mcp_args: Mapping[str, Any]
+    context_keys: tuple[str, ...]
+
+
+def _packaged_skills_dir(module_file: Path | None = None) -> Path:
+    """Return the packaged skills directory for source and wheel layouts."""
+    resolved_file = Path(__file__).resolve() if module_file is None else module_file
+    source_checkout_dir = resolved_file.parents[3] / "skills"
+    wheel_package_dir = resolved_file.parents[1] / "skills"
+    for candidate in (source_checkout_dir, wheel_package_dir):
+        if candidate.exists():
+            return candidate
+    return source_checkout_dir
+
+
+_TOOL_LINE_RE = re.compile(r"^\s*Tool:\s*`?(ouroboros_[A-Za-z0-9_]+)`?\s*$")
+_ARGUMENTS_LINE_RE = re.compile(r"^(?P<indent>\s*)Arguments:\s*(?:#.*)?$")
+_ARGUMENT_KEY_RE = re.compile(r"^(?P<indent>\s+)(?P<key>[A-Za-z_][A-Za-z0-9_]*):(?P<value>.*)$")
+_INLINE_TOOL_CALL_RE = re.compile(r"\b(ouroboros_[A-Za-z0-9_]+)\(([^)]*)\)")
+_INLINE_KWARG_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*=")
+_CONTEXTISH_WORD_RE = re.compile(
+    r"\b(answer|artifact|context|cursor|cwd|goal|id|job|lineage|output|question|"
+    r"response|seed|session)\b",
+    re.IGNORECASE,
+)
+
+
+def _split_frontmatter_and_body(text: str) -> tuple[str, str]:
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return "", text
+
+    frontmatter_lines: list[str] = []
+    for index, line in enumerate(lines[1:], start=1):
+        if line.strip() == "---":
+            return "\n".join(frontmatter_lines), "\n".join(lines[index + 1 :])
+        frontmatter_lines.append(line)
+    return "", text
+
+
+def _read_frontmatter(skill_path: Path) -> Mapping[str, Any]:
+    text = skill_path.read_text(encoding="utf-8")
+    frontmatter_text, _body = _split_frontmatter_and_body(text)
+    if not frontmatter_text:
+        return {}
+
+    raw = yaml.safe_load(frontmatter_text)
+    return raw if isinstance(raw, Mapping) else {}
+
+
+def _ordered_merge_context_key(
+    context_keys_by_tool: dict[str, list[str]],
+    tool_name: str,
+    key: str,
+) -> None:
+    normalized_key = key.strip()
+    if not normalized_key:
+        return
+    existing = context_keys_by_tool.setdefault(tool_name, [])
+    if normalized_key not in existing:
+        existing.append(normalized_key)
+
+
+def merge_tool_context_keys(
+    frontmatter_context_keys: tuple[str, ...] = (),
+    body_context_keys: tuple[str, ...] = (),
+) -> tuple[str, ...]:
+    """Merge frontmatter and body context keys for one MCP tool.
+
+    Frontmatter is the skill dispatch contract, so it wins ordering. Body
+    references are appended only when they add new runtime context keys. Empty
+    and whitespace-only keys are discarded, and valid keys are stripped.
+    """
+
+    merged_by_tool: dict[str, list[str]] = {"": []}
+    for key in (*frontmatter_context_keys, *body_context_keys):
+        _ordered_merge_context_key(merged_by_tool, "", key)
+    return tuple(merged_by_tool[""])
+
+
+def _looks_like_context_argument(value: str) -> bool:
+    stripped = value.strip()
+    if not stripped:
+        return True
+    if stripped in {"|", ">"}:
+        return True
+    if stripped == "...":
+        return True
+    if "$" in stripped:
+        return True
+    if "<" in stripped and ">" in stripped:
+        return True
+    if stripped.startswith(("response.", "meta.", "result.")):
+        return True
+    if stripped.startswith(("'", '"', "[", "{")):
+        return False
+    if stripped[0].isdigit():
+        return False
+    if stripped.lower().startswith(("true", "false", "null", "none")):
+        return False
+    return bool(_CONTEXTISH_WORD_RE.search(stripped)) and not stripped.startswith(("'", '"'))
+
+
+def _collect_tool_block_context_keys(
+    lines: list[str],
+    start_index: int,
+) -> tuple[str, tuple[str, ...], int]:
+    match = _TOOL_LINE_RE.match(lines[start_index])
+    if match is None:
+        return "", (), start_index + 1
+    tool_name = match.group(1)
+
+    index = start_index + 1
+    while index < len(lines):
+        arguments_match = _ARGUMENTS_LINE_RE.match(lines[index])
+        if arguments_match is not None:
+            break
+        if _TOOL_LINE_RE.match(lines[index]) is not None:
+            return tool_name, (), index
+        index += 1
+    if index >= len(lines):
+        return tool_name, (), index
+
+    arguments_indent = len(arguments_match.group("indent"))
+    key_indent: int | None = None
+    context_keys: list[str] = []
+    index += 1
+    while index < len(lines):
+        line = lines[index]
+        if not line.strip():
+            index += 1
+            continue
+        if _TOOL_LINE_RE.match(line) is not None:
+            break
+
+        current_indent = len(line) - len(line.lstrip(" "))
+        if current_indent <= arguments_indent:
+            break
+
+        key_match = _ARGUMENT_KEY_RE.match(line)
+        if key_match is None:
+            index += 1
+            continue
+
+        current_key_indent = len(key_match.group("indent"))
+        if key_indent is None:
+            key_indent = current_key_indent
+        if current_key_indent == key_indent and _looks_like_context_argument(
+            key_match.group("value")
+        ):
+            key = key_match.group("key")
+            if key not in context_keys:
+                context_keys.append(key)
+        index += 1
+
+    return tool_name, tuple(context_keys), index
+
+
+def _split_inline_call_arguments(raw_arguments: str) -> tuple[str, ...]:
+    arguments: list[str] = []
+    depth = 0
+    quote: str | None = None
+    start = 0
+    for index, char in enumerate(raw_arguments):
+        if quote is not None:
+            if char == quote and raw_arguments[index - 1 : index] != "\\":
+                quote = None
+            continue
+        if char in {"'", '"'}:
+            quote = char
+            continue
+        if char in "([{":
+            depth += 1
+            continue
+        if char in ")]}":
+            depth = max(0, depth - 1)
+            continue
+        if char == "," and depth == 0:
+            arguments.append(raw_arguments[start:index].strip())
+            start = index + 1
+    tail = raw_arguments[start:].strip()
+    if tail:
+        arguments.append(tail)
+    return tuple(arguments)
+
+
+def _extract_inline_call_context_keys(raw_arguments: str) -> tuple[str, ...]:
+    context_keys: list[str] = []
+    for raw_argument in _split_inline_call_arguments(raw_arguments):
+        if not raw_argument:
+            continue
+        if "=" in raw_argument:
+            keyword_match = _INLINE_KWARG_RE.match(raw_argument)
+            if keyword_match is None:
+                continue
+            key = keyword_match.group(1)
+            value = raw_argument[raw_argument.index("=") + 1 :]
+            if _looks_like_context_argument(value) and key not in context_keys:
+                context_keys.append(key)
+            continue
+        if re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", raw_argument):
+            context_keys.append(raw_argument)
+    return tuple(context_keys)
+
+
+def extract_skill_body_tool_context_keys(skill_body: str) -> Mapping[str, tuple[str, ...]]:
+    """Return tool-specific context keys referenced in a skill body.
+
+    The extraction is intentionally syntax-based. It reads the explicit MCP
+    invocation formats used in packaged skills: ``Tool: ouroboros_*`` blocks
+    followed by an ``Arguments:`` mapping, plus compact inline examples such as
+    ``ouroboros_job_wait(job_id, cursor, timeout_seconds=120)``. Literal defaults
+    are ignored; placeholder, variable, and block-scalar values are treated as
+    runtime context keys.
+    """
+
+    context_keys_by_tool: dict[str, list[str]] = {}
+    lines = skill_body.splitlines()
+    index = 0
+    while index < len(lines):
+        if _TOOL_LINE_RE.match(lines[index]) is not None:
+            tool_name, context_keys, next_index = _collect_tool_block_context_keys(
+                lines,
+                index,
+            )
+            for key in context_keys:
+                _ordered_merge_context_key(context_keys_by_tool, tool_name, key)
+            index = max(next_index, index + 1)
+            continue
+
+        for inline_match in _INLINE_TOOL_CALL_RE.finditer(lines[index]):
+            tool_name = inline_match.group(1)
+            for key in _extract_inline_call_context_keys(inline_match.group(2)):
+                _ordered_merge_context_key(context_keys_by_tool, tool_name, key)
+        index += 1
+
+    return {
+        tool_name: tuple(context_keys) for tool_name, context_keys in context_keys_by_tool.items()
+    }
+
+
+def extract_skill_frontmatter_context_keys(
+    frontmatter: Mapping[str, Any],
+) -> tuple[str, ...]:
+    """Return ordered MCP argument keys declared by skill frontmatter.
+
+    The frontmatter ``mcp_args`` mapping describes which runtime context values
+    a skill forwards to its tool-specific MCP input. The mapping keys are the
+    tool input/context keys capability modeling needs; placeholder values such
+    as ``$1`` or ``$CWD`` are runtime binding expressions, not capability keys.
+    """
+
+    raw_mcp_args = frontmatter.get("mcp_args")
+    if not isinstance(raw_mcp_args, Mapping):
+        return ()
+    return tuple(key.strip() for key in raw_mcp_args if isinstance(key, str) and key.strip())
+
+
+def discover_skill_tool_mappings(
+    skills_dir: str | Path | None = None,
+) -> tuple[SkillToolMapping, ...]:
+    """Discover skill-to-tool mappings from skill frontmatter only.
+
+    The discovery path deliberately does not import or call MCP tool definition
+    factories. Unknown or temporarily unavailable tool descriptors should not
+    affect the recorded skill usage contract.
+    """
+
+    root = Path(skills_dir).expanduser() if skills_dir is not None else _packaged_skills_dir()
+    mappings: list[SkillToolMapping] = []
+    for skill_path in sorted(root.glob("*/SKILL.md")):
+        frontmatter = _read_frontmatter(skill_path)
+        skill_name = frontmatter.get("name")
+        mcp_tool = frontmatter.get("mcp_tool")
+        if not isinstance(skill_name, str) or not skill_name.strip():
+            continue
+        if not isinstance(mcp_tool, str) or not mcp_tool.strip():
+            continue
+        raw_mcp_args = frontmatter.get("mcp_args")
+        mcp_args = dict(raw_mcp_args) if isinstance(raw_mcp_args, Mapping) else {}
+        mappings.append(
+            SkillToolMapping(
+                skill_name=skill_name.strip(),
+                mcp_tool=mcp_tool.strip(),
+                skill_path=str(skill_path.relative_to(root.parent)),
+                mcp_args=mcp_args,
+                context_keys=extract_skill_frontmatter_context_keys(frontmatter),
+            )
+        )
+    return tuple(mappings)
+
+
+def discover_skill_body_context_keys(
+    skills_dir: str | Path | None = None,
+) -> Mapping[str, tuple[str, ...]]:
+    """Discover tool context keys from packaged skill body instructions."""
+
+    root = Path(skills_dir).expanduser() if skills_dir is not None else _packaged_skills_dir()
+    context_keys_by_tool: dict[str, list[str]] = {}
+    for skill_path in sorted(root.glob("*/SKILL.md")):
+        _frontmatter, body = _split_frontmatter_and_body(skill_path.read_text(encoding="utf-8"))
+        for tool_name, context_keys in extract_skill_body_tool_context_keys(body).items():
+            for key in context_keys:
+                _ordered_merge_context_key(context_keys_by_tool, tool_name, key)
+    return {
+        tool_name: tuple(context_keys) for tool_name, context_keys in context_keys_by_tool.items()
+    }
+
+
+@lru_cache(maxsize=1)
+def get_packaged_skill_body_context_keys() -> Mapping[str, tuple[str, ...]]:
+    """Return cached packaged skill body context usage by MCP tool."""
+
+    return discover_skill_body_context_keys()
+
+
+@lru_cache(maxsize=1)
+def get_packaged_skill_tool_mappings() -> tuple[SkillToolMapping, ...]:
+    """Return cached packaged skill mappings for capability verification."""
+
+    return discover_skill_tool_mappings()
+
+
+def skill_tool_mapping_by_skill(
+    mappings: tuple[SkillToolMapping, ...] | None = None,
+) -> Mapping[str, SkillToolMapping]:
+    """Index skill mappings by skill name."""
+
+    resolved_mappings = mappings if mappings is not None else get_packaged_skill_tool_mappings()
+    return {mapping.skill_name: mapping for mapping in resolved_mappings}
+
+
+def skill_frontmatter_context_keys_by_tool(
+    mappings: tuple[SkillToolMapping, ...] | None = None,
+) -> Mapping[str, tuple[str, ...]]:
+    """Index frontmatter-derived context keys by MCP tool name.
+
+    If multiple skills point at the same MCP tool, keys are merged in discovery
+    order with duplicates removed. This keeps skill usage facts separate from
+    MCP descriptor metadata while still making tool-specific context usage easy
+    to test.
+    """
+
+    resolved_mappings = mappings if mappings is not None else get_packaged_skill_tool_mappings()
+    context_keys_by_tool: dict[str, tuple[str, ...]] = {}
+    for mapping in resolved_mappings:
+        existing = list(context_keys_by_tool.get(mapping.mcp_tool, ()))
+        for key in mapping.context_keys:
+            if key not in existing:
+                existing.append(key)
+        context_keys_by_tool[mapping.mcp_tool] = tuple(existing)
+    return context_keys_by_tool
+
+
+def merge_skill_context_keys_by_tool(
+    frontmatter_context_keys_by_tool: Mapping[str, tuple[str, ...]],
+    body_context_keys_by_tool: Mapping[str, tuple[str, ...]],
+) -> Mapping[str, tuple[str, ...]]:
+    """Merge tool-specific context keys from skill frontmatter and bodies.
+
+    The return value is keyed by MCP tool name. Tools that appear only in body
+    instructions are retained so companion polling/status/result usage remains
+    visible to capability verification.
+    """
+
+    tool_names = tuple(
+        dict.fromkeys(
+            (
+                *frontmatter_context_keys_by_tool.keys(),
+                *body_context_keys_by_tool.keys(),
+            )
+        )
+    )
+    return {
+        tool_name: merge_tool_context_keys(
+            frontmatter_context_keys_by_tool.get(tool_name, ()),
+            body_context_keys_by_tool.get(tool_name, ()),
+        )
+        for tool_name in tool_names
+    }
+
+
+def discover_skill_context_keys(
+    skills_dir: str | Path | None = None,
+) -> Mapping[str, tuple[str, ...]]:
+    """Discover merged frontmatter/body context usage by MCP tool."""
+
+    mappings = discover_skill_tool_mappings(skills_dir)
+    return merge_skill_context_keys_by_tool(
+        skill_frontmatter_context_keys_by_tool(mappings),
+        discover_skill_body_context_keys(skills_dir),
+    )
+
+
+@lru_cache(maxsize=1)
+def get_packaged_skill_context_keys() -> Mapping[str, tuple[str, ...]]:
+    """Return cached merged packaged skill context usage by MCP tool."""
+
+    return discover_skill_context_keys()
+
+
+def get_skill_tool_mapping(
+    skill_name: str,
+    *,
+    mappings: tuple[SkillToolMapping, ...] | None = None,
+) -> SkillToolMapping | None:
+    """Return the frontmatter-backed MCP tool mapping for one skill.
+
+    This is the narrow query API capability checks can use when they only need
+    skill usage facts. It intentionally delegates only to frontmatter discovery
+    and never consults MCP tool descriptors.
+    """
+
+    normalized_skill_name = skill_name.strip()
+    if not normalized_skill_name:
+        return None
+    return skill_tool_mapping_by_skill(mappings).get(normalized_skill_name)
+
+
+__all__ = [
+    "SkillToolMapping",
+    "discover_skill_body_context_keys",
+    "discover_skill_tool_mappings",
+    "extract_skill_body_tool_context_keys",
+    "extract_skill_frontmatter_context_keys",
+    "discover_skill_context_keys",
+    "get_packaged_skill_body_context_keys",
+    "get_packaged_skill_context_keys",
+    "get_skill_tool_mapping",
+    "get_packaged_skill_tool_mappings",
+    "merge_skill_context_keys_by_tool",
+    "merge_tool_context_keys",
+    "skill_frontmatter_context_keys_by_tool",
+    "skill_tool_mapping_by_skill",
+]

--- a/src/ouroboros/orchestrator/skill_tool_mapping.py
+++ b/src/ouroboros/orchestrator/skill_tool_mapping.py
@@ -42,7 +42,7 @@ def _packaged_skills_dir(module_file: Path | None = None) -> Path:
 
 
 _TOOL_LINE_RE = re.compile(r"^\s*Tool:\s*`?(ouroboros_[A-Za-z0-9_]+)`?\s*$")
-_ARGUMENTS_LINE_RE = re.compile(r"^(?P<indent>\s*)Arguments:\s*(?:#.*)?$")
+_ARGUMENTS_LINE_RE = re.compile(r"^(?P<indent>\s*)Arguments:\s*(?P<inline>.*)$")
 _ARGUMENT_KEY_RE = re.compile(r"^(?P<indent>\s+)(?P<key>[A-Za-z_][A-Za-z0-9_]*):(?P<value>.*)$")
 _INLINE_TOOL_CALL_RE = re.compile(r"\b(ouroboros_[A-Za-z0-9_]+)\(([^)]*)\)")
 _INLINE_KWARG_RE = re.compile(r"\b([A-Za-z_][A-Za-z0-9_]*)\s*=")
@@ -149,6 +149,14 @@ def _collect_tool_block_context_keys(
     if index >= len(lines):
         return tool_name, (), index
 
+    inline_arguments = arguments_match.group("inline").strip()
+    if inline_arguments and not inline_arguments.startswith("#"):
+        return (
+            tool_name,
+            _extract_mapping_context_keys(inline_arguments),
+            index + 1,
+        )
+
     arguments_indent = len(arguments_match.group("indent"))
     key_indent: int | None = None
     context_keys: list[str] = []
@@ -182,6 +190,23 @@ def _collect_tool_block_context_keys(
         index += 1
 
     return tool_name, tuple(context_keys), index
+
+
+def _extract_mapping_context_keys(raw_mapping: str) -> tuple[str, ...]:
+    try:
+        raw = yaml.safe_load(raw_mapping)
+    except yaml.YAMLError:
+        return ()
+    if not isinstance(raw, Mapping):
+        return ()
+
+    context_keys: list[str] = []
+    for key, value in raw.items():
+        if not isinstance(key, str):
+            continue
+        if isinstance(value, str) and _looks_like_context_argument(value):
+            context_keys.append(key)
+    return tuple(context_keys)
 
 
 def _split_inline_call_arguments(raw_arguments: str) -> tuple[str, ...]:

--- a/tests/unit/orchestrator/test_skill_tool_mapping.py
+++ b/tests/unit/orchestrator/test_skill_tool_mapping.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ouroboros.orchestrator.skill_tool_mapping import (
+    SkillToolMapping,
+    _packaged_skills_dir,
+    discover_skill_body_context_keys,
+    discover_skill_context_keys,
+    discover_skill_tool_mappings,
+    extract_skill_body_tool_context_keys,
+    extract_skill_frontmatter_context_keys,
+    merge_skill_context_keys_by_tool,
+    merge_tool_context_keys,
+    skill_frontmatter_context_keys_by_tool,
+)
+
+_CORE_FRONTMATTER_SKILL_TOOLS = {
+    "auto": "ouroboros_start_auto",
+    "run": "ouroboros_execute_seed",
+    "ralph": "ouroboros_ralph",
+    "status": "ouroboros_session_status",
+    "seed": "ouroboros_generate_seed",
+    "interview": "ouroboros_interview",
+}
+
+
+def test_extract_skill_frontmatter_context_keys_preserves_mcp_arg_order() -> None:
+    frontmatter = {
+        "mcp_tool": "ouroboros_start_auto",
+        "mcp_args": {
+            "goal": "$goal",
+            "resume": "$resume",
+            "cwd": "$CWD",
+            "max_interview_rounds": "$max_interview_rounds",
+        },
+    }
+
+    assert extract_skill_frontmatter_context_keys(frontmatter) == (
+        "goal",
+        "resume",
+        "cwd",
+        "max_interview_rounds",
+    )
+
+
+def test_extract_skill_frontmatter_context_keys_handles_missing_mcp_args() -> None:
+    assert extract_skill_frontmatter_context_keys({"name": "unstuck"}) == ()
+    assert extract_skill_frontmatter_context_keys({"mcp_args": ["session_id"]}) == ()
+
+
+def test_extract_skill_body_tool_context_keys_reads_tool_blocks_and_inline_calls() -> None:
+    body = """
+## Start
+
+Tool: ouroboros_start_probe
+Arguments:
+  seed_content: <the seed YAML>
+  model_tier: "medium"
+  metadata: |
+    nested_key: ignored
+  max_iterations: 10
+
+Use `ouroboros_job_wait(job_id, cursor, timeout_seconds=120, view="summary")`
+and then `ouroboros_job_result(job_id=<job_id>)`.
+
+Tool: ouroboros_start_probe
+Arguments:
+  session_id: <existing session ID>
+  seed_content: <same seed YAML>
+"""
+
+    assert extract_skill_body_tool_context_keys(body) == {
+        "ouroboros_start_probe": ("seed_content", "metadata", "session_id"),
+        "ouroboros_job_wait": ("job_id", "cursor"),
+        "ouroboros_job_result": ("job_id",),
+    }
+
+
+def test_extract_skill_body_tool_context_keys_ignores_frontmatter_only_usage() -> None:
+    skill_md = """---
+name: run
+mcp_tool: ouroboros_execute_seed
+mcp_args:
+  seed_path: "$1"
+---
+
+The body has no direct tool invocation.
+"""
+
+    assert extract_skill_body_tool_context_keys(skill_md) == {}
+
+
+def test_packaged_skills_dir_supports_installed_wheel_layout(tmp_path: Path) -> None:
+    package_root = tmp_path / "site-packages" / "ouroboros"
+    module_file = package_root / "orchestrator" / "skill_tool_mapping.py"
+    wheel_skills_dir = package_root / "skills"
+    module_file.parent.mkdir(parents=True)
+    module_file.write_text("", encoding="utf-8")
+    wheel_skills_dir.mkdir(parents=True)
+
+    assert _packaged_skills_dir(module_file) == wheel_skills_dir
+
+
+def test_packaged_skill_frontmatter_exposes_declared_mcp_tools() -> None:
+    mappings = discover_skill_tool_mappings()
+    by_skill = {mapping.skill_name: mapping for mapping in mappings}
+
+    assert set(_CORE_FRONTMATTER_SKILL_TOOLS) == {
+        "auto",
+        "run",
+        "ralph",
+        "status",
+        "seed",
+        "interview",
+    }
+    assert {
+        skill: by_skill[skill].mcp_tool for skill in _CORE_FRONTMATTER_SKILL_TOOLS
+    } == _CORE_FRONTMATTER_SKILL_TOOLS
+    assert {skill: by_skill[skill].skill_path for skill in _CORE_FRONTMATTER_SKILL_TOOLS} == {
+        skill: f"skills/{skill}/SKILL.md" for skill in _CORE_FRONTMATTER_SKILL_TOOLS
+    }
+
+
+def test_packaged_skill_frontmatter_exposes_tool_specific_context_keys() -> None:
+    mappings = discover_skill_tool_mappings()
+    by_skill = {mapping.skill_name: mapping for mapping in mappings}
+
+    expected = {
+        "auto": (
+            "goal",
+            "resume",
+            "cwd",
+            "max_interview_rounds",
+            "max_repair_rounds",
+            "skip_run",
+            "complete_product",
+            "pipeline_timeout_seconds",
+        ),
+        "run": ("seed_path", "cwd"),
+        "ralph": ("lineage_id",),
+        "status": ("session_id",),
+        "seed": ("session_id",),
+        "interview": ("initial_context", "cwd"),
+    }
+
+    assert {skill: by_skill[skill].context_keys for skill in expected} == expected
+    assert skill_frontmatter_context_keys_by_tool(mappings) == {
+        by_skill[skill].mcp_tool: context_keys for skill, context_keys in expected.items()
+    }
+
+
+def test_packaged_skill_bodies_expose_tool_specific_context_keys() -> None:
+    context_keys_by_tool = discover_skill_body_context_keys()
+
+    expected_subset = {
+        "ouroboros_start_execute_seed": ("seed_content", "session_id"),
+        "ouroboros_job_wait": ("job_id", "cursor"),
+        "ouroboros_job_result": ("job_id",),
+        "ouroboros_ac_tree_hud": ("session_id", "cursor"),
+        "ouroboros_interview": (
+            "initial_context",
+            "cwd",
+            "session_id",
+            "answer",
+            "last_question",
+        ),
+        "ouroboros_lateral_think": (
+            "problem_context",
+            "failed_attempts",
+        ),
+        "ouroboros_generate_seed": ("session_id",),
+        "ouroboros_session_status": ("session_id",),
+        "ouroboros_measure_drift": (
+            "session_id",
+            "current_output",
+            "seed_content",
+        ),
+    }
+
+    assert {tool: context_keys_by_tool[tool] for tool in expected_subset} == expected_subset
+
+
+def test_skill_frontmatter_context_keys_by_tool_merges_duplicate_tool_keys() -> None:
+    mappings = (
+        SkillToolMapping(
+            skill_name="first",
+            mcp_tool="ouroboros_probe",
+            skill_path="skills/first/SKILL.md",
+            mcp_args={"session_id": "$1", "cwd": "$CWD"},
+            context_keys=("session_id", "cwd"),
+        ),
+        SkillToolMapping(
+            skill_name="second",
+            mcp_tool="ouroboros_probe",
+            skill_path="skills/second/SKILL.md",
+            mcp_args={"cwd": "$CWD", "artifact": "$artifact"},
+            context_keys=("cwd", "artifact"),
+        ),
+    )
+
+    assert skill_frontmatter_context_keys_by_tool(mappings) == {
+        "ouroboros_probe": ("session_id", "cwd", "artifact")
+    }
+
+
+def test_merge_tool_context_keys_prefers_frontmatter_order_and_normalizes() -> None:
+    assert merge_tool_context_keys(
+        (" session_id ", "cwd", "", "artifact"),
+        ("cwd", " cursor ", "artifact", "  "),
+    ) == ("session_id", "cwd", "artifact", "cursor")
+
+
+def test_merge_skill_context_keys_by_tool_keeps_body_only_tools() -> None:
+    assert merge_skill_context_keys_by_tool(
+        {
+            "ouroboros_execute_seed": ("seed_path", "cwd"),
+            "ouroboros_session_status": ("session_id",),
+        },
+        {
+            "ouroboros_execute_seed": ("seed_content", "session_id"),
+            "ouroboros_job_wait": ("job_id", "cursor"),
+        },
+    ) == {
+        "ouroboros_execute_seed": (
+            "seed_path",
+            "cwd",
+            "seed_content",
+            "session_id",
+        ),
+        "ouroboros_session_status": ("session_id",),
+        "ouroboros_job_wait": ("job_id", "cursor"),
+    }
+
+
+def test_discover_skill_context_keys_merges_packaged_frontmatter_and_body_usage() -> None:
+    context_keys_by_tool = discover_skill_context_keys()
+
+    assert context_keys_by_tool["ouroboros_execute_seed"] == (
+        "seed_path",
+        "cwd",
+    )
+    assert context_keys_by_tool["ouroboros_start_execute_seed"] == (
+        "seed_content",
+        "session_id",
+    )
+    assert context_keys_by_tool["ouroboros_start_auto"] == (
+        "goal",
+        "resume",
+        "cwd",
+        "max_interview_rounds",
+        "max_repair_rounds",
+        "skip_run",
+        "complete_product",
+        "pipeline_timeout_seconds",
+    )
+    assert context_keys_by_tool["ouroboros_interview"] == (
+        "initial_context",
+        "cwd",
+        "session_id",
+        "answer",
+        "last_question",
+    )
+    assert context_keys_by_tool["ouroboros_job_wait"] == ("job_id", "cursor")

--- a/tests/unit/orchestrator/test_skill_tool_mapping.py
+++ b/tests/unit/orchestrator/test_skill_tool_mapping.py
@@ -77,6 +77,18 @@ Arguments:
     }
 
 
+def test_extract_skill_body_tool_context_keys_reads_inline_arguments_mapping() -> None:
+    body = """
+Tool: ouroboros_brownfield
+Arguments: { "action": "scan" }
+
+Tool: ouroboros_brownfield
+Arguments: { "action": "set_defaults", "indices": "<comma-separated IDs>" }
+"""
+
+    assert extract_skill_body_tool_context_keys(body) == {"ouroboros_brownfield": ("indices",)}
+
+
 def test_extract_skill_body_tool_context_keys_ignores_frontmatter_only_usage() -> None:
     skill_md = """---
 name: run

--- a/tests/unit/orchestrator/test_skill_tool_mapping.py
+++ b/tests/unit/orchestrator/test_skill_tool_mapping.py
@@ -188,6 +188,11 @@ def test_packaged_skill_bodies_expose_tool_specific_context_keys() -> None:
             "current_output",
             "seed_content",
         ),
+        # Corpus guard: brownfield/setup declare ``indices`` only via inline
+        # ``Arguments: { ... }`` maps. If inline-mapping parsing regresses or the
+        # skill format drifts, this fails instead of silently dropping a mutating
+        # tool input from the capability contract.
+        "ouroboros_brownfield": ("indices",),
     }
 
     assert {tool: context_keys_by_tool[tool] for tool in expected_subset} == expected_subset


### PR DESCRIPTION
## Stack

This is **1/7** in the smaller replacement stack for closed PR #1363.

| Order | PR | Topic | Base |
|---:|---|---|---|
| 1 | #1365 | Skill-to-tool mapping | `main` |
| 2 | #1366 | Backend subagent capability | #1365 |
| 3 | #1367 | Evaluation diagnostics | #1366 |
| 4 | #1368 | Owned tool capability contracts | #1367 |
| 5 | #1369 | Interview code-investigation metadata | #1368 |
| 6 | #1370 | Lateral persona orchestration metadata | #1369 |
| 7 | #1371 | Review follow-up coverage | #1370 |

Review and merge in order.

## Changes

- Adds a dedicated packaged skill-to-MCP-tool mapping module.
- Extracts MCP context keys from skill frontmatter and body instructions.
- Supports both source checkout layout (`repo/skills`) and installed wheel layout (`ouroboros/skills`).
- Keeps skill usage facts separate from MCP tool descriptors.

## Verification

- `uv run ruff format --check src/ tests/`
- `uv run ruff check src/ tests/`
- `uv run pytest tests/unit/orchestrator/test_skill_tool_mapping.py -q`
- Full focused stack suite was run from the stack tip.

## Notes

Supersedes the skill mapping part of #1363.
