### PR TITLE
feat(backends): [stack 2/7] describe subagent orchestration support

### DIFF
--- a/src/ouroboros/backends/__init__.py
+++ b/src/ouroboros/backends/__init__.py
@@ -2,8 +2,10 @@
 
 from ouroboros.backends.capabilities import (
     BackendCapability,
+    RuntimeSubagentOrchestrationContract,
     SkillExecutionCapability,
     backend_supports_tool_envelope,
+    build_runtime_subagent_orchestration_contract,
     get_backend_capability,
     interview_driver_backend_choices,
     llm_backend_choices,
@@ -18,8 +20,10 @@ from ouroboros.backends.capabilities import (
 
 __all__ = [
     "BackendCapability",
+    "RuntimeSubagentOrchestrationContract",
     "SkillExecutionCapability",
     "backend_supports_tool_envelope",
+    "build_runtime_subagent_orchestration_contract",
     "get_backend_capability",
     "interview_driver_backend_choices",
     "llm_backend_choices",

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -8,7 +8,9 @@ sets.
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass(frozen=True, slots=True)
@@ -33,12 +35,40 @@ class BackendCapability:
     cli_config_key: str | None = None
     soft_tool_enforcement: bool = False
     supports_tool_envelope: bool = True
+    supports_native_parallel_subagents: bool = False
     skill_execution_capabilities: tuple[SkillExecutionCapability, ...] = ()
 
     @property
     def names(self) -> tuple[str, ...]:
         """Canonical name plus accepted aliases."""
         return (self.name, *self.aliases)
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeSubagentOrchestrationContract:
+    """Runtime handling contract for MCP subagent directive metadata."""
+
+    backend_name: str
+    supports_native_parallel_subagents: bool
+    dispatch_mode: str
+    mcp_directive_keys: tuple[str, ...]
+    sequential_fallback: Mapping[str, Any]
+    runtime_instruction_handling: str
+    callable_mcp_tool_capabilities: tuple[Mapping[str, Any], ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the contract for runtime envelopes and tests."""
+        return {
+            "backend_name": self.backend_name,
+            "supports_native_parallel_subagents": self.supports_native_parallel_subagents,
+            "dispatch_mode": self.dispatch_mode,
+            "mcp_directive_keys": list(self.mcp_directive_keys),
+            "sequential_fallback": dict(self.sequential_fallback),
+            "runtime_instruction_handling": self.runtime_instruction_handling,
+            "callable_mcp_tool_capabilities": [
+                dict(capability) for capability in self.callable_mcp_tool_capabilities
+            ],
+        }
 
 
 _CODEX_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
@@ -170,6 +200,19 @@ _GENERIC_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
     ),
 )
 
+_OPENCODE_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
+    *_GENERIC_SKILL_EXECUTION_CAPABILITIES,
+    SkillExecutionCapability(
+        name="orchestrate_subagents",
+        guidance=(
+            "Use OpenCode's native task/subagent primitive for parallel-capable "
+            "Ouroboros subagent fan-out, including `_subagent` and `_subagents` "
+            "MCP directive payloads. Preserve the sequential fallback described "
+            "by the MCP capability metadata when native parallel dispatch is unavailable."
+        ),
+    ),
+)
+
 _CAPABILITIES: tuple[BackendCapability, ...] = (
     BackendCapability(
         name="claude",
@@ -245,8 +288,9 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         supports_interview_driver=True,
         cli_name="opencode",
         cli_config_key="opencode_cli_path",
-        skill_execution_capabilities=_GENERIC_SKILL_EXECUTION_CAPABILITIES,
+        skill_execution_capabilities=_OPENCODE_SKILL_EXECUTION_CAPABILITIES,
         soft_tool_enforcement=True,
+        supports_native_parallel_subagents=True,
     ),
     BackendCapability(
         name="goose",
@@ -305,6 +349,78 @@ def render_backend_skill_capability_guide(name: str) -> str:
             )
         )
     return "\n".join(lines).rstrip() + "\n"
+
+
+def build_runtime_subagent_orchestration_contract(
+    name: str,
+    *,
+    directive_metadata: Mapping[str, Any],
+    opencode_mode: str | None = None,
+    callable_mcp_tool_capabilities: Sequence[Mapping[str, Any]] = (),
+) -> RuntimeSubagentOrchestrationContract:
+    """Build runtime-specific handling metadata for MCP subagent directives.
+
+    ``directive_metadata`` is the explicit MCP-side orchestration metadata from
+    owned Ouroboros tools, such as the lateral panel contract. Runtime support
+    determines whether native parallel subagent dispatch can be used or whether
+    the declared sequential fallback must be followed.
+    """
+    capability = get_backend_capability(name)
+    if capability is None:
+        msg = f"Unsupported backend: {name.strip().lower()}"
+        raise ValueError(msg)
+
+    sequential_fallback = directive_metadata.get("sequential_fallback", {})
+    if not isinstance(sequential_fallback, Mapping):
+        sequential_fallback = {}
+
+    native_parallel_available = _supports_native_parallel_subagent_surface(
+        capability,
+        opencode_mode=opencode_mode,
+    )
+
+    if native_parallel_available:
+        dispatch_mode = "native_parallel_subagents"
+        runtime_instruction_handling = (
+            "Consume MCP `_subagent` or `_subagents` directive payloads with the "
+            "runtime's native parallel subagent primitive. For OpenCode this "
+            "requires the plugin surface (`opencode_mode=plugin`). Keep the "
+            "MCP-declared sequential fallback available for downgraded runtime "
+            "surfaces."
+        )
+    else:
+        dispatch_mode = "sequential_fallback"
+        runtime_instruction_handling = (
+            "This runtime has no native parallel subagent primitive. Follow the "
+            "MCP `sequential_fallback` contract and process each structured "
+            "subagent payload sequentially, preserving the response correlation "
+            "keys declared by the directive metadata."
+        )
+
+    return RuntimeSubagentOrchestrationContract(
+        backend_name=capability.name,
+        supports_native_parallel_subagents=native_parallel_available,
+        dispatch_mode=dispatch_mode,
+        mcp_directive_keys=("_subagent", "_subagents"),
+        sequential_fallback=dict(sequential_fallback),
+        runtime_instruction_handling=runtime_instruction_handling,
+        callable_mcp_tool_capabilities=tuple(
+            dict(capability) for capability in callable_mcp_tool_capabilities
+        ),
+    )
+
+
+def _supports_native_parallel_subagent_surface(
+    capability: BackendCapability,
+    *,
+    opencode_mode: str | None,
+) -> bool:
+    """Return whether the current backend surface has a native subagent receiver."""
+    if not capability.supports_native_parallel_subagents:
+        return False
+    if capability.name != "opencode":
+        return True
+    return (opencode_mode or "").strip().lower() == "plugin"
 
 
 def get_backend_capability(name: str) -> BackendCapability | None:
@@ -386,8 +502,10 @@ def backend_supports_tool_envelope(name: str | None) -> bool:
 
 __all__ = [
     "BackendCapability",
+    "RuntimeSubagentOrchestrationContract",
     "SkillExecutionCapability",
     "backend_supports_tool_envelope",
+    "build_runtime_subagent_orchestration_contract",
     "get_backend_capability",
     "interview_driver_backend_choices",
     "llm_backend_choices",

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -1,9 +1,11 @@
 """Tests for the shared backend capability registry."""
 
+from jsonschema import Draft202012Validator
 import pytest
 
 from ouroboros.backends import (
     backend_supports_tool_envelope,
+    build_runtime_subagent_orchestration_contract,
     get_backend_capability,
     interview_driver_backend_choices,
     llm_backend_choices,
@@ -14,6 +16,41 @@ from ouroboros.backends import (
     runtime_backend_choices,
     soft_tool_enforcement_backends,
 )
+
+_LATERAL_PANEL_DIRECTIVE_METADATA = {
+    "sequential_fallback": {
+        "supported": True,
+        "mode": "sequential_persona_payload_dispatch",
+        "trigger": "runtime_has_no_native_parallel_subagent_primitive",
+    }
+}
+
+_CANCEL_JOB_CAPABILITY = {
+    "tool_name": "ouroboros_cancel_job",
+    "source_kind": "attached_mcp",
+    "source_name": "ouroboros",
+    "fallback_used": False,
+    "execution_mode": "cancel",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "job_id": {"type": "string"},
+            "reason": {"type": "string"},
+        },
+        "required": ["job_id"],
+    },
+    "required_context_keys": ["job_id"],
+    "cancel": {
+        "supported": True,
+        "mode": "background_job_control",
+        "companions": [
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+        ],
+        "target_context_keys": ["job_id"],
+    },
+}
 
 REQUIRED_SKILL_CAPABILITY_NAMES = {
     "ask_user",
@@ -93,6 +130,110 @@ def test_generic_skill_execution_guidance_covers_interview_requirements() -> Non
     assert capability is not None
     names = {item.name for item in capability.skill_execution_capabilities}
     assert names == REQUIRED_SKILL_CAPABILITY_NAMES
+
+
+def test_native_parallel_subagent_runtime_exposes_orchestrate_subagents() -> None:
+    capability = get_backend_capability("opencode_cli")
+
+    assert capability is not None
+    assert capability.supports_native_parallel_subagents is True
+    names = {item.name for item in capability.skill_execution_capabilities}
+    assert names == REQUIRED_SKILL_CAPABILITY_NAMES | {"orchestrate_subagents"}
+
+    guide = render_backend_skill_capability_guide("opencode")
+    assert "### When a skill requires `orchestrate_subagents`" in guide
+    assert "native task/subagent primitive" in guide
+    assert "`_subagents` MCP directive payloads" in guide
+    assert "sequential fallback" in guide
+
+
+def test_unsupported_parallel_subagent_runtime_gets_sequential_fallback_contract() -> None:
+    contract = build_runtime_subagent_orchestration_contract(
+        "codex_cli",
+        directive_metadata=_LATERAL_PANEL_DIRECTIVE_METADATA,
+    )
+
+    assert contract.backend_name == "codex"
+    assert contract.supports_native_parallel_subagents is False
+    assert contract.dispatch_mode == "sequential_fallback"
+    assert contract.mcp_directive_keys == ("_subagent", "_subagents")
+    assert contract.sequential_fallback == {
+        "supported": True,
+        "mode": "sequential_persona_payload_dispatch",
+        "trigger": "runtime_has_no_native_parallel_subagent_primitive",
+    }
+    assert "no native parallel subagent primitive" in contract.runtime_instruction_handling
+    assert "process each structured subagent payload sequentially" in (
+        contract.runtime_instruction_handling
+    )
+    assert contract.to_dict()["sequential_fallback"] == dict(
+        _LATERAL_PANEL_DIRECTIVE_METADATA["sequential_fallback"]
+    )
+
+
+def test_subagent_orchestration_cancel_job_capability_stays_callable_in_same_envelope() -> None:
+    contract = build_runtime_subagent_orchestration_contract(
+        "opencode_cli",
+        directive_metadata=_LATERAL_PANEL_DIRECTIVE_METADATA,
+        opencode_mode="plugin",
+        callable_mcp_tool_capabilities=(_CANCEL_JOB_CAPABILITY,),
+    )
+    envelope = contract.to_dict()
+
+    assert envelope["dispatch_mode"] == "native_parallel_subagents"
+    assert envelope["mcp_directive_keys"] == ["_subagent", "_subagents"]
+    assert envelope["callable_mcp_tool_capabilities"] == [_CANCEL_JOB_CAPABILITY]
+
+    callable_cancel = envelope["callable_mcp_tool_capabilities"][0]
+    assert callable_cancel["tool_name"] == "ouroboros_cancel_job"
+    assert callable_cancel["source_kind"] == "attached_mcp"
+    assert callable_cancel["source_name"] == "ouroboros"
+    assert callable_cancel["fallback_used"] is False
+    assert callable_cancel["execution_mode"] == "cancel"
+    assert callable_cancel["input_schema"] == _CANCEL_JOB_CAPABILITY["input_schema"]
+    assert callable_cancel["required_context_keys"] == ["job_id"]
+    assert callable_cancel["cancel"] == {
+        "supported": True,
+        "mode": "background_job_control",
+        "companions": [
+            "ouroboros_job_status",
+            "ouroboros_job_wait",
+            "ouroboros_job_result",
+        ],
+        "target_context_keys": ["job_id"],
+    }
+    Draft202012Validator(callable_cancel["input_schema"]).validate(
+        {"job_id": "job-subagent-123", "reason": "cancel delegated subagent job"}
+    )
+
+
+@pytest.mark.parametrize("opencode_mode", [None, "subprocess"])
+def test_opencode_without_plugin_surface_uses_sequential_fallback(
+    opencode_mode: str | None,
+) -> None:
+    contract = build_runtime_subagent_orchestration_contract(
+        "opencode",
+        directive_metadata=_LATERAL_PANEL_DIRECTIVE_METADATA,
+        opencode_mode=opencode_mode,
+    )
+
+    assert contract.backend_name == "opencode"
+    assert contract.supports_native_parallel_subagents is False
+    assert contract.dispatch_mode == "sequential_fallback"
+    assert "no native parallel subagent primitive" in contract.runtime_instruction_handling
+
+
+def test_opencode_plugin_surface_uses_native_parallel_subagents() -> None:
+    contract = build_runtime_subagent_orchestration_contract(
+        "opencode",
+        directive_metadata=_LATERAL_PANEL_DIRECTIVE_METADATA,
+        opencode_mode="plugin",
+    )
+
+    assert contract.backend_name == "opencode"
+    assert contract.supports_native_parallel_subagents is True
+    assert contract.dispatch_mode == "native_parallel_subagents"
+    assert "opencode_mode=plugin" in contract.runtime_instruction_handling
 
 
 def test_renders_codex_skill_capability_guide_as_stable_markdown() -> None:


### PR DESCRIPTION
## Stack

This is **2/7** in the smaller replacement stack for closed PR #1363. Stacked on #1365.

| Order | PR | Topic | Base |
|---:|---|---|---|
| 1 | #1365 | Skill-to-tool mapping | `main` |
| 2 | #1366 | Backend subagent capability | #1365 |
| 3 | #1367 | Evaluation diagnostics | #1366 |
| 4 | #1368 | Owned tool capability contracts | #1367 |
| 5 | #1369 | Interview code-investigation metadata | #1368 |
| 6 | #1370 | Lateral persona orchestration metadata | #1369 |
| 7 | #1371 | Review follow-up coverage | #1370 |

Review and merge in order.

## Changes

- Adds backend capability fields for native parallel subagent support.
- Adds runtime subagent orchestration contract rendering.
- Covers native-parallel and sequential-fallback behavior without depending on later stack layers.

## Verification

- `uv run pytest tests/unit/backends/test_capabilities.py -q`
- `uv run ruff format --check src/ tests/`
- `uv run ruff check src/ tests/`
- Full focused stack suite was run from the stack tip.

## Notes

Supersedes the backend capability part of #1363.
