### PR TITLE
fix(evaluation): [stack 3/7] preserve mechanical diagnostic changes

### DIFF
--- a/src/ouroboros/evaluation/mechanical.py
+++ b/src/ouroboros/evaluation/mechanical.py
@@ -29,7 +29,10 @@ _COMMAND_OUTPUT_PREVIEW_CHARS = 500
 
 
 def _output_preview(text: str) -> str:
-    """Return a compact output preview preserving the diagnostically useful tail."""
+    """Return a compact preview from the leading portion of command output.
+
+    The diagnostically useful tail is captured separately by ``_output_tail``.
+    """
     if not text:
         return ""
     if len(text) <= _COMMAND_OUTPUT_PREVIEW_CHARS:
@@ -309,7 +312,13 @@ class MechanicalVerifier:
                 check_type=check_type,
                 passed=False,
                 message=f"Check {check_type.value} timed out after {self.config.timeout_seconds}s",
-                details={"timed_out": True},
+                details={
+                    "timed_out": True,
+                    "command": list(command),
+                    "working_dir": str(self.config.working_dir)
+                    if self.config.working_dir
+                    else None,
+                },
             )
 
         passed = cmd_result.return_code == 0

--- a/src/ouroboros/evaluation/mechanical.py
+++ b/src/ouroboros/evaluation/mechanical.py
@@ -12,6 +12,7 @@ The MechanicalVerifier is stateless and produces immutable results.
 
 import asyncio
 from dataclasses import dataclass
+import os
 from pathlib import Path
 from typing import Any
 
@@ -23,6 +24,26 @@ from ouroboros.events.evaluation import (
     create_stage1_completed_event,
     create_stage1_started_event,
 )
+
+_COMMAND_OUTPUT_PREVIEW_CHARS = 500
+
+
+def _output_preview(text: str) -> str:
+    """Return a compact output preview preserving the diagnostically useful tail."""
+    if not text:
+        return ""
+    if len(text) <= _COMMAND_OUTPUT_PREVIEW_CHARS:
+        return text
+    return text[:_COMMAND_OUTPUT_PREVIEW_CHARS]
+
+
+def _output_tail(text: str) -> str:
+    """Return the tail of command output where test failures usually appear."""
+    if not text:
+        return ""
+    if len(text) <= _COMMAND_OUTPUT_PREVIEW_CHARS:
+        return text
+    return text[-_COMMAND_OUTPUT_PREVIEW_CHARS:]
 
 
 @dataclass(frozen=True, slots=True)
@@ -81,12 +102,18 @@ async def run_command(
     Returns:
         CommandResult with output and status
     """
+    env = os.environ.copy()
+    # The MCP server sets this sentinel to prevent recursive server spawning.
+    # Mechanical verification must test the repository as a fresh process would;
+    # leaking the sentinel makes CLI tests take the nested-server early exit.
+    env.pop("_OUROBOROS_NESTED", None)
     try:
         process = await asyncio.create_subprocess_exec(
             *command,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
             cwd=working_dir,
+            env=env,
         )
 
         try:
@@ -287,9 +314,13 @@ class MechanicalVerifier:
 
         passed = cmd_result.return_code == 0
         details: dict[str, Any] = {
+            "command": list(command),
+            "working_dir": str(self.config.working_dir) if self.config.working_dir else None,
             "return_code": cmd_result.return_code,
-            "stdout_preview": cmd_result.stdout[:500] if cmd_result.stdout else "",
-            "stderr_preview": cmd_result.stderr[:500] if cmd_result.stderr else "",
+            "stdout_preview": _output_preview(cmd_result.stdout),
+            "stderr_preview": _output_preview(cmd_result.stderr),
+            "stdout_tail": _output_tail(cmd_result.stdout),
+            "stderr_tail": _output_tail(cmd_result.stderr),
         }
 
         # Extract coverage if this was a coverage check

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -909,6 +909,22 @@ class EvaluateHandler:
             for check in s1.checks:
                 status = "PASS" if check.passed else "FAIL"
                 lines.append(f"  [{status}] {check.check_type}: {check.message}")
+                if not check.passed:
+                    details = check.details
+                    command = details.get("command")
+                    if isinstance(command, list) and command:
+                        lines.append(f"    command: {' '.join(str(part) for part in command)}")
+                    working_dir = details.get("working_dir")
+                    if working_dir:
+                        lines.append(f"    cwd: {working_dir}")
+                    stdout_tail = str(details.get("stdout_tail") or "").strip()
+                    stderr_tail = str(details.get("stderr_tail") or "").strip()
+                    if stdout_tail:
+                        lines.append("    stdout tail:")
+                        lines.extend(f"      {line}" for line in stdout_tail.splitlines())
+                    if stderr_tail:
+                        lines.append("    stderr tail:")
+                        lines.extend(f"      {line}" for line in stderr_tail.splitlines())
             lines.append("")
 
         # Stage 2 results

--- a/tests/unit/evaluation/test_mechanical.py
+++ b/tests/unit/evaluation/test_mechanical.py
@@ -319,6 +319,13 @@ class TestMechanicalVerifier:
             assert mech_result.passed is False
             assert "timed out" in mech_result.checks[0].message.lower()
 
+            # Timeout failures must carry the same command/cwd diagnostics as
+            # other failures so the formatter can show which check hung.
+            timeout_details = mech_result.checks[0].details
+            assert timeout_details["timed_out"] is True
+            assert timeout_details["command"] == ["echo", "test-ok"]
+            assert "working_dir" in timeout_details
+
     @pytest.mark.asyncio
     async def test_verify_skips_unconfigured_checks(self) -> None:
         """Checks with no command configured are skipped (passed with skip message)."""

--- a/tests/unit/evaluation/test_mechanical.py
+++ b/tests/unit/evaluation/test_mechanical.py
@@ -1,5 +1,6 @@
 """Tests for Stage 1 mechanical verification."""
 
+import sys
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -135,6 +136,25 @@ class TestRunCommand:
         assert result.return_code == -1
         assert "not found" in result.stderr.lower() or "Command not found" in result.stderr
 
+    @pytest.mark.asyncio
+    async def test_command_strips_nested_mcp_sentinel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Mechanical checks should not inherit the MCP server recursion sentinel."""
+        monkeypatch.setenv("_OUROBOROS_NESTED", "1")
+
+        result = await run_command(
+            (
+                sys.executable,
+                "-c",
+                "import os; print(os.environ.get('_OUROBOROS_NESTED', 'missing'))",
+            ),
+            timeout=5,
+        )
+
+        assert result.return_code == 0
+        assert result.stdout.strip() == "missing"
+
 
 class TestMechanicalVerifier:
     """Tests for MechanicalVerifier class."""
@@ -201,6 +221,30 @@ class TestMechanicalVerifier:
             mech_result, _ = result.value
             assert mech_result.passed is False
             assert len(mech_result.failed_checks) == 1
+
+    @pytest.mark.asyncio
+    async def test_verify_failed_check_preserves_command_and_output_tail(self) -> None:
+        """Failed checks keep tail diagnostics instead of only the noisy prefix."""
+        with patch(
+            "ouroboros.evaluation.mechanical.run_command",
+            new_callable=AsyncMock,
+        ) as mock_run:
+            mock_run.return_value = CommandResult(
+                1,
+                "prefix\n" + ("." * 700) + "\nFAILED tests/test_example.py::test_case",
+                "stderr prefix\n" + ("x" * 700) + "\nAssertionError: boom",
+            )
+
+            verifier = MechanicalVerifier(_TEST_CONFIG)
+            result = await verifier.verify("exec-1", checks=[CheckType.TEST])
+
+            assert result.is_ok
+            mech_result, _ = result.value
+            details = mech_result.checks[0].details
+            assert details["command"] == ["echo", "test-ok"]
+            assert "FAILED tests/test_example.py::test_case" in details["stdout_tail"]
+            assert "AssertionError: boom" in details["stderr_tail"]
+            assert "FAILED tests/test_example.py::test_case" not in details["stdout_preview"]
 
     @pytest.mark.asyncio
     async def test_verify_coverage_below_threshold(self) -> None:

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -2251,10 +2251,21 @@ class TestEvaluateHandlerCodeChanges:
     def _make_stage1(self, *, passed: bool):
         from ouroboros.evaluation.models import CheckResult, CheckType, MechanicalResult
 
+        details = (
+            {
+                "command": ["uv", "run", "pytest", "tests/", "-x", "-q"],
+                "working_dir": "/tmp/project",
+                "stdout_tail": "FAILED tests/test_example.py::test_case",
+                "stderr_tail": "AssertionError: boom",
+            }
+            if not passed
+            else {}
+        )
         check = CheckResult(
             check_type=CheckType.TEST,
             passed=passed,
             message="tests passed" if passed else "tests failed",
+            details=details,
         )
         return MechanicalResult(passed=passed, checks=(check,), coverage_score=None)
 
@@ -2276,6 +2287,10 @@ class TestEvaluateHandlerCodeChanges:
         text = handler._format_evaluation_result(result, code_changes=True)
 
         assert "real build/test failures" in text
+        assert "command: uv run pytest tests/ -x -q" in text
+        assert "cwd: /tmp/project" in text
+        assert "FAILED tests/test_example.py::test_case" in text
+        assert "AssertionError: boom" in text
         assert "No code changes detected" not in text
 
     def test_format_result_stage1_fail_no_code_changes(self) -> None:


### PR DESCRIPTION
## Stack

This is **3/7** in the smaller replacement stack for closed PR #1363. Stacked on #1366.

| Order | PR | Topic | Base |
|---:|---|---|---|
| 1 | #1365 | Skill-to-tool mapping | `main` |
| 2 | #1366 | Backend subagent capability | #1365 |
| 3 | #1367 | Evaluation diagnostics | #1366 |
| 4 | #1368 | Owned tool capability contracts | #1367 |
| 5 | #1369 | Interview code-investigation metadata | #1368 |
| 6 | #1370 | Lateral persona orchestration metadata | #1369 |
| 7 | #1371 | Review follow-up coverage | #1370 |

Review and merge in order.

## Changes

- Preserves mechanical evaluation diagnostics for code-change reporting.
- Adds EvaluateHandler coverage for code-change metadata.

## Verification

- `uv run pytest tests/unit/evaluation/test_mechanical.py tests/unit/mcp/tools/test_definitions.py -q`
- `uv run ruff format --check src/ tests/`
- `uv run ruff check src/ tests/`
- Full focused stack suite was run from the stack tip.

## Notes

Supersedes the evaluation diagnostics part of #1363.
