### PR TITLE
feat(mcp): [stack 5/7] emit code-investigation metadata

### DIFF
--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -46,6 +46,7 @@ from ouroboros.mcp.tools.subagent import (
     build_interview_subagent,
     build_subagent_result,
     emit_subagent_dispatched_event,
+    lateral_persona_panel_metadata_from_capability_definitions,
     should_dispatch_via_plugin,
 )
 from ouroboros.mcp.types import (
@@ -55,6 +56,11 @@ from ouroboros.mcp.types import (
     MCPToolParameter,
     MCPToolResult,
     ToolInputType,
+)
+from ouroboros.orchestrator.capabilities import (
+    interview_code_investigation_answer_contract,
+    ouroboros_tool_capability_metadata,
+    stable_code_investigation_question_identity,
 )
 from ouroboros.orchestrator.policy import (
     PolicyContext,
@@ -197,6 +203,18 @@ _INTERVIEW_COMPLETION_NEGATIONS = (
     "do not close",
     "dont close",
     "don't close",
+)
+
+_INTERVIEW_LATERAL_REVIEW_PROSE_FALLBACK_INSTRUCTION = (
+    "Follow skills/interview/SKILL.md milestone lateral-review dispatch: "
+    "call ouroboros_lateral_think with meta.lateral_review_tool_args when "
+    "present. If only legacy advisory fields are present, call it with "
+    'personas=["researcher","contrarian","simplifier"], a problem context '
+    "containing the current interview session, milestone, and question, and a "
+    "current approach describing the next interview-routing decision. Fold only "
+    "concrete, user-safe findings into the next answer or question; if lateral "
+    "tooling is unavailable, continue the interview and say the review could "
+    "not be run."
 )
 
 
@@ -431,6 +449,74 @@ def _build_interview_lateral_review_tool_args(
     }
 
 
+def _build_interview_lateral_review_orchestration(
+    *,
+    tool_args: dict[str, Any],
+) -> dict[str, Any]:
+    """Build runtime handling metadata for interview lateral-review panels."""
+    panel = lateral_persona_panel_metadata_from_capability_definitions()
+    if not panel:
+        return {
+            "kind": "mcp_directive",
+            "directive": "run_lateral_persona_panel",
+            "mcp_tool": "ouroboros_lateral_think",
+            "tool_args": dict(tool_args),
+            "structured_lateral_panel_metadata_available": False,
+            "fallback": "skill_prose_instructions",
+            "prose_instruction_source": "skills/interview/SKILL.md",
+            "prose_instruction": _INTERVIEW_LATERAL_REVIEW_PROSE_FALLBACK_INSTRUCTION,
+            "runtime_handling": {
+                "call_mcp_tool_first": True,
+                "result_correlation_key": None,
+                "requires_prose_parsing": True,
+                "synthesize_before_interview_continuation": True,
+            },
+        }
+    requested_personas = [str(item) for item in tool_args.get("personas", [])]
+    panel_persona_by_id = {
+        str(persona.get("persona_id")): dict(persona)
+        for persona in panel.get("personas", [])
+        if isinstance(persona, dict) and persona.get("persona_id")
+    }
+    panel_personas = [
+        panel_persona_by_id[persona_id]
+        for persona_id in requested_personas
+        if persona_id in panel_persona_by_id
+    ]
+    response_refs = dict(panel.get("response_payload_refs", {}))
+    sequential_fallback = dict(panel.get("sequential_fallback", {}))
+    sequential_mode = str(sequential_fallback.get("mode") or "sequential_persona_payload_dispatch")
+    mcp_tool = str(panel.get("mcp_tool") or "ouroboros_lateral_think")
+
+    return {
+        "kind": "mcp_directive",
+        "directive": "run_lateral_persona_panel",
+        "mcp_tool": mcp_tool,
+        "tool_args": dict(tool_args),
+        "panel": {
+            "panel_id": str(panel.get("panel_id") or "lateral_persona_panel.v1"),
+            "mcp_tool": mcp_tool,
+            "dispatch_modes": list(panel.get("dispatch_modes", [])),
+            "parallel_preference": str(
+                panel.get("parallel_preference") or "parallel_when_runtime_supports_subagents"
+            ),
+            "sequential_fallback": sequential_fallback,
+            "personas": panel_personas,
+            "response_payload_refs": response_refs,
+            "runtime_instruction": str(panel.get("runtime_instruction") or ""),
+        },
+        "runtime_handling": {
+            "call_mcp_tool_first": True,
+            "parallel_capable_execution_mode": "parallel_subagent_panel",
+            "sequential_fallback_mode": sequential_mode,
+            "sequential_fallback_trigger": sequential_fallback.get("trigger"),
+            "result_correlation_key": response_refs.get("result_correlation_key"),
+            "requires_prose_parsing": bool(response_refs.get("requires_prose_parsing")),
+            "synthesize_before_interview_continuation": True,
+        },
+    }
+
+
 def _with_lateral_review_dispatch(
     state: InterviewState,
     *,
@@ -441,17 +527,23 @@ def _with_lateral_review_dispatch(
     """Attach runnable lateral-think dispatch metadata to an advisory."""
     if lateral_review_meta is None:
         return None
+    tool_args = _build_interview_lateral_review_tool_args(
+        state,
+        next_question=next_question,
+        score=score,
+        lateral_review_meta=lateral_review_meta,
+    )
     enriched = dict(lateral_review_meta)
     enriched.update(
         {
             "lateral_review_required": True,
             "lateral_review_tool": "ouroboros_lateral_think",
             "lateral_review_personas": list(_INTERVIEW_LATERAL_PERSONAS),
-            "lateral_review_tool_args": _build_interview_lateral_review_tool_args(
-                state,
-                next_question=next_question,
-                score=score,
-                lateral_review_meta=lateral_review_meta,
+            "lateral_review_tool_args": tool_args,
+            "lateral_review_orchestration": (
+                _build_interview_lateral_review_orchestration(
+                    tool_args=tool_args,
+                )
             ),
         }
     )
@@ -498,6 +590,60 @@ def _format_question_with_ambiguity(question: str, score: AmbiguityScore | None)
     if score is None:
         return question
     return f"(ambiguity: {score.overall_score:.2f}) {question}"
+
+
+def _build_code_investigation_request(
+    *,
+    session_id: str,
+    question: str,
+    last_question: str | None = None,
+) -> dict[str, Any]:
+    """Build stable metadata for caller-side code-fact investigation.
+
+    The interview MCP tool is only the question generator; repo inspection runs
+    in the parent runtime. This metadata gives that runtime a concrete request
+    envelope keyed to the exact question text, so investigation results can be
+    correlated even when the user-facing display has an ambiguity prefix.
+    """
+    mcp_tool_capability = ouroboros_tool_capability_metadata("ouroboros_interview")
+    code_investigation = mcp_tool_capability["orchestration"]["code_investigation"]
+    request: dict[str, Any] = {
+        "session_id": session_id,
+        "question_identity": stable_code_investigation_question_identity(question),
+        "question": question,
+        "investigation_goal": "describe_current_state_from_code",
+        "investigation_targets": [{"target_type": "workspace", "scope": "active"}],
+        "fact_categories": [
+            "tech_stack",
+            "frameworks",
+            "dependencies",
+            "current_patterns",
+            "architecture",
+            "file_structure",
+            "configuration",
+        ],
+        "allowed_capabilities": ["inspect_code"],
+        "repo_inspection_tool_capabilities": list(
+            code_investigation["repo_inspection_tool_capabilities"]
+        ),
+        "confidence_policy": {
+            "auto_confirm_when": ["exact manifest or config match with a single clear answer"],
+            "confirmation_required_when": [
+                "multiple code paths or configuration sources disagree",
+                "the answer implies a product or architecture decision",
+            ],
+            "human_judgment_when": [
+                "desired future behavior",
+                "priority, scope, ownership, rollout, or acceptance criteria",
+            ],
+        },
+        "answer_prefixes": ["[from-code]", "[from-code][auto-confirmed]"],
+        "answer_contract": interview_code_investigation_answer_contract(),
+        "mcp_tool_capability": mcp_tool_capability,
+    }
+    if last_question:
+        request["last_question"] = last_question
+    return request
 
 
 def _is_initial_context_length_guard_question(question: str) -> bool:
@@ -2198,6 +2344,11 @@ class InterviewHandler:
                     # axis must not flip or ``HandlerInterviewBackend.start``
                     # would raise on every oversized ``initial_context``.
                     start_meta.update(_length_guard_meta_fields())
+                else:
+                    start_meta["code_investigation_request"] = _build_code_investigation_request(
+                        session_id=state.interview_id,
+                        question=question,
+                    )
 
                 start_response_text = (
                     f"Interview started. Session ID: {state.interview_id}\n\n{display_question}"
@@ -2282,6 +2433,13 @@ class InterviewHandler:
                         # ``False`` so the auto driver does not treat the
                         # summarize prompt as a hard failure.
                         resume_meta.update(_length_guard_meta_fields())
+                    else:
+                        resume_meta["code_investigation_request"] = (
+                            _build_code_investigation_request(
+                                session_id=session_id,
+                                question=pending_question,
+                            )
+                        )
 
                     resume_response_text = f"Session {session_id}\n\n{display_question}"
                     # Q00/ouroboros#831 (diagnostics): response-shape event for
@@ -2806,6 +2964,11 @@ class InterviewHandler:
                     # guard meta-directive.  ``is_error`` stays ``False`` so
                     # the auto driver's ``answer()`` path is not raised on.
                     answer_meta.update(_length_guard_meta_fields())
+                else:
+                    answer_meta["code_investigation_request"] = _build_code_investigation_request(
+                        session_id=session_id,
+                        question=question,
+                    )
 
                 if lateral_review_dispatch_meta is not None:
                     answer_meta.update(lateral_review_dispatch_meta)

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -32,6 +32,7 @@ Payload structure:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 import json
 import re
@@ -59,6 +60,97 @@ _INTERVIEW_SUBAGENT_MAX_ANSWER_CHARS = 300
 def _canonical_response_json(body: dict[str, Any]) -> str:
     """Render structured MCP dispatch content with deterministic key order."""
     return json.dumps(body, sort_keys=True, separators=(",", ":"))
+
+
+def synthesize_code_investigation_when_complete(
+    request: Mapping[str, Any],
+    investigation_results: Mapping[str, Any],
+    synthesizer: Any,
+) -> dict[str, Any]:
+    """Collect code-fact investigation outputs before interview synthesis."""
+    session_id = str(request.get("session_id") or "")
+    question_identity = str(request.get("question_identity") or "")
+    required_ids = request.get("required_result_ids")
+    if isinstance(required_ids, (list, tuple)) and required_ids:
+        expected_result_ids = [str(item) for item in required_ids]
+    else:
+        expected_result_ids = ["code_facts"]
+
+    outputs_by_result_id: dict[str, Any] = {}
+    for result_id, output in investigation_results.items():
+        normalized_result_id = str(result_id)
+        if normalized_result_id not in expected_result_ids:
+            continue
+        if not isinstance(output, Mapping):
+            continue
+        if str(output.get("session_id") or "") != session_id:
+            continue
+        if str(output.get("question_identity") or "") != question_identity:
+            continue
+        outputs_by_result_id[normalized_result_id] = output
+
+    missing_result_ids = [
+        result_id for result_id in expected_result_ids if result_id not in outputs_by_result_id
+    ]
+    aggregated_outputs = [
+        {
+            "result_id": result_id,
+            "output": outputs_by_result_id[result_id],
+        }
+        for result_id in expected_result_ids
+        if result_id in outputs_by_result_id
+    ]
+    if missing_result_ids:
+        return {
+            "ready_for_synthesis": False,
+            "expected_result_ids": expected_result_ids,
+            "missing_result_ids": missing_result_ids,
+            "aggregated_outputs": aggregated_outputs,
+            "synthesis": None,
+            "requires_user_confirmation": False,
+            "confirmation_required_result_ids": [],
+            "user_confirmation_prompts": [],
+            "ready_for_forward": False,
+        }
+    confirmation_required = [
+        item
+        for item in aggregated_outputs
+        if item["output"].get("requires_user_confirmation") is True
+    ]
+    confirmation_required_result_ids = [str(item["result_id"]) for item in confirmation_required]
+    user_confirmation_prompts = [
+        str(prompt)
+        for item in confirmation_required
+        if (prompt := item["output"].get("user_confirmation_prompt"))
+    ]
+    return {
+        "ready_for_synthesis": True,
+        "expected_result_ids": expected_result_ids,
+        "missing_result_ids": [],
+        "aggregated_outputs": aggregated_outputs,
+        "synthesis": synthesizer(aggregated_outputs),
+        "requires_user_confirmation": bool(confirmation_required),
+        "confirmation_required_result_ids": confirmation_required_result_ids,
+        "user_confirmation_prompts": user_confirmation_prompts,
+        "ready_for_forward": not confirmation_required,
+    }
+
+
+def lateral_persona_panel_metadata_from_capability_definitions() -> dict[str, Any]:
+    """Read lateral persona panel metadata from Ouroboros tool capabilities."""
+    from ouroboros.mcp.tools.definitions import get_ouroboros_tools
+    from ouroboros.orchestrator.capabilities import build_capability_graph
+    from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools())
+    graph = build_capability_graph(assemble_session_tool_catalog(attached_tools=owned_tools))
+    for descriptor in graph.capabilities:
+        if descriptor.name != "ouroboros_lateral_think" or descriptor.metadata is None:
+            continue
+        panel = descriptor.metadata.orchestration.get("lateral_panel")
+        if isinstance(panel, Mapping):
+            return dict(panel)
+    return {}
 
 
 # ---------------------------------------------------------------------------

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -38,6 +38,7 @@ import json
 import re
 from typing import Any
 
+from jsonschema import Draft202012Validator
 import structlog
 
 from ouroboros.core.seed_contract_prompt import render_auto_recursion_guard
@@ -60,6 +61,38 @@ _INTERVIEW_SUBAGENT_MAX_ANSWER_CHARS = 300
 def _canonical_response_json(body: dict[str, Any]) -> str:
     """Render structured MCP dispatch content with deterministic key order."""
     return json.dumps(body, sort_keys=True, separators=(",", ":"))
+
+
+def _contract_violations_for_code_investigation_output(
+    request: Mapping[str, Any],
+    output: Mapping[str, Any],
+) -> list[str]:
+    contract = request.get("answer_contract")
+    if not isinstance(contract, Mapping):
+        return ["missing answer_contract"]
+    response_schema = contract.get("response_model_schema")
+    if not isinstance(response_schema, Mapping):
+        return ["missing answer_contract.response_model_schema"]
+
+    validator = Draft202012Validator(response_schema)
+    return sorted(error.message for error in validator.iter_errors(dict(output)))
+
+
+def _requires_code_investigation_confirmation(output: Mapping[str, Any]) -> bool:
+    answer_prefix = output.get("answer_prefix")
+    confidence = output.get("confidence")
+    if answer_prefix != "[from-code][auto-confirmed]":
+        return True
+    if confidence != "high_exact_match":
+        return True
+    return output.get("requires_user_confirmation") is not False
+
+
+def _default_code_investigation_confirmation_prompt(output: Mapping[str, Any]) -> str:
+    answer_text = str(output.get("answer_text") or "the code investigation result").strip()
+    if len(answer_text) > _INTERVIEW_SUBAGENT_MAX_ANSWER_CHARS:
+        answer_text = answer_text[: _INTERVIEW_SUBAGENT_MAX_ANSWER_CHARS - 1].rstrip() + "…"
+    return f"Confirm before forwarding this code-derived answer: {answer_text}"
 
 
 def synthesize_code_investigation_when_complete(
@@ -110,28 +143,54 @@ def synthesize_code_investigation_when_complete(
             "requires_user_confirmation": False,
             "confirmation_required_result_ids": [],
             "user_confirmation_prompts": [],
+            "contract_violations": [],
             "ready_for_forward": False,
         }
-    confirmation_required = [
-        item
+
+    contract_violations = [
+        {
+            "result_id": str(item["result_id"]),
+            "errors": violations,
+        }
         for item in aggregated_outputs
-        if item["output"].get("requires_user_confirmation") is True
+        if (violations := _contract_violations_for_code_investigation_output(request, item["output"]))
     ]
+    contract_violation_result_ids = {
+        str(item["result_id"]) for item in contract_violations
+    }
+    confirmation_required = []
+    for item in aggregated_outputs:
+        result_id = str(item["result_id"])
+        output = item["output"]
+        if (
+            result_id in contract_violation_result_ids
+            or _requires_code_investigation_confirmation(output)
+        ):
+            confirmation_required.append(item)
+
     confirmation_required_result_ids = [str(item["result_id"]) for item in confirmation_required]
     user_confirmation_prompts = [
         str(prompt)
         for item in confirmation_required
         if (prompt := item["output"].get("user_confirmation_prompt"))
     ]
+    if len(user_confirmation_prompts) < len(confirmation_required):
+        user_confirmation_prompts.extend(
+            _default_code_investigation_confirmation_prompt(item["output"])
+            for item in confirmation_required
+            if not item["output"].get("user_confirmation_prompt")
+        )
+    synthesis = None if contract_violations else synthesizer(aggregated_outputs)
     return {
         "ready_for_synthesis": True,
         "expected_result_ids": expected_result_ids,
         "missing_result_ids": [],
         "aggregated_outputs": aggregated_outputs,
-        "synthesis": synthesizer(aggregated_outputs),
+        "synthesis": synthesis,
         "requires_user_confirmation": bool(confirmation_required),
         "confirmation_required_result_ids": confirmation_required_result_ids,
         "user_confirmation_prompts": user_confirmation_prompts,
+        "contract_violations": contract_violations,
         "ready_for_forward": not confirmation_required,
     }
 

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -153,18 +153,19 @@ def synthesize_code_investigation_when_complete(
             "errors": violations,
         }
         for item in aggregated_outputs
-        if (violations := _contract_violations_for_code_investigation_output(request, item["output"]))
+        if (
+            violations := _contract_violations_for_code_investigation_output(
+                request, item["output"]
+            )
+        )
     ]
-    contract_violation_result_ids = {
-        str(item["result_id"]) for item in contract_violations
-    }
+    contract_violation_result_ids = {str(item["result_id"]) for item in contract_violations}
     confirmation_required = []
     for item in aggregated_outputs:
         result_id = str(item["result_id"])
         output = item["output"]
-        if (
-            result_id in contract_violation_result_ids
-            or _requires_code_investigation_confirmation(output)
+        if result_id in contract_violation_result_ids or _requires_code_investigation_confirmation(
+            output
         ):
             confirmation_required.append(item)
 

--- a/src/ouroboros/orchestrator/capabilities.py
+++ b/src/ouroboros/orchestrator/capabilities.py
@@ -1823,6 +1823,16 @@ def _interview_code_investigation_answer_contract() -> dict[str, Any]:
                 },
                 "then": {"required": ["user_confirmation_prompt"]},
             },
+            {
+                "if": {
+                    "properties": {"answer_prefix": {"const": "[from-code]"}},
+                    "required": ["answer_prefix"],
+                },
+                "then": {
+                    "properties": {"requires_user_confirmation": {"const": True}},
+                    "required": ["user_confirmation_prompt"],
+                },
+            },
         ],
     }
     return {

--- a/tests/unit/mcp/tools/test_interview_response_diagnostics.py
+++ b/tests/unit/mcp/tools/test_interview_response_diagnostics.py
@@ -16,6 +16,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from jsonschema import Draft202012Validator
 import pytest
 
 from ouroboros.bigbang.interview import (
@@ -28,6 +29,11 @@ from ouroboros.core.types import Result
 from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.errors import MCPServerError
 from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+from ouroboros.mcp.tools.subagent import synthesize_code_investigation_when_complete
+from ouroboros.orchestrator.capabilities import (
+    interview_code_investigation_answer_contract,
+    stable_code_investigation_question_identity,
+)
 
 
 @dataclass(slots=True)
@@ -58,6 +64,7 @@ class _StubInterviewEngine:
     next_question: str = "What is the primary user persona?"
     initial_state: InterviewState | None = None
     saved_states: list[InterviewState] = field(default_factory=list)
+    record_calls: list[dict[str, str]] = field(default_factory=list)
 
     async def start_interview(
         self,
@@ -83,6 +90,7 @@ class _StubInterviewEngine:
         user_response: str,
         question: str,
     ) -> Result[InterviewState, MCPServerError]:
+        self.record_calls.append({"question": question, "answer": user_response})
         state.rounds.append(
             InterviewRound(
                 round_number=state.current_round_number,
@@ -132,6 +140,299 @@ def _assert_reasoning_meta(meta: dict[str, Any], *, phase: str, session_id: str)
     assert f"session: {session_id}" in meta["internal_reasoning"]
 
 
+def _assert_code_investigation_request(
+    meta: dict[str, Any],
+    *,
+    session_id: str,
+    question: str,
+) -> None:
+    request = meta["code_investigation_request"]
+    assert request["session_id"] == session_id
+    assert request["question"] == question
+    assert request["question_identity"] == stable_code_investigation_question_identity(question)
+    assert request["investigation_goal"] == "describe_current_state_from_code"
+    assert request["investigation_targets"] == [{"target_type": "workspace", "scope": "active"}]
+    assert "configuration" in request["fact_categories"]
+    assert request["allowed_capabilities"] == ["inspect_code"]
+    repo_tool_capabilities = request["repo_inspection_tool_capabilities"]
+    repo_tool_by_name = {tool["tool_name"]: tool for tool in repo_tool_capabilities}
+    assert set(repo_tool_by_name) == {"Read", "Glob", "Grep"}
+    for tool_name, tool_capability in repo_tool_by_name.items():
+        assert tool_capability["stable_id"] == f"builtin:{tool_name}"
+        assert tool_capability["source_kind"] == "builtin"
+        assert tool_capability["execution_mode"] == "repo_inspection"
+        assert tool_capability["logical_capability"] == "inspect_code"
+        assert tool_capability["mutation_class"] == "read_only"
+        assert tool_capability["side_effects"] == ["side_effect_free"]
+        assert tool_capability["fallback_used"] is False
+        Draft202012Validator.check_schema(tool_capability["input_schema"])
+    assert repo_tool_by_name["Read"]["input_schema"]["required"] == ["file_path"]
+    assert repo_tool_by_name["Glob"]["input_schema"]["required"] == ["pattern"]
+    assert repo_tool_by_name["Grep"]["input_schema"]["required"] == ["pattern"]
+    assert request["answer_prefixes"] == ["[from-code]", "[from-code][auto-confirmed]"]
+    assert request["answer_contract"] == interview_code_investigation_answer_contract()
+    capability = request["mcp_tool_capability"]
+    assert capability["tool_name"] == "ouroboros_interview"
+    assert capability["source_kind"] == "attached_mcp"
+    assert capability["source_name"] == "ouroboros"
+    assert capability["fallback_used"] is False
+    assert capability["execution_mode"] == "subagent_orchestration"
+    assert set(capability) >= {
+        "input_schema",
+        "execution_mode",
+        "companions",
+        "required_context_keys",
+        "side_effects",
+        "retry",
+        "interrupt",
+        "cancel",
+    }
+    request_schema = capability["orchestration"]["code_investigation"]["request_model_schema"]
+    Draft202012Validator(request_schema).validate(request)
+
+
+@pytest.mark.asyncio
+async def test_code_investigation_results_are_collected_before_synthesis(
+    tmp_path: Path,
+) -> None:
+    """Code-fact subagent output is collected and passed to synthesis."""
+    engine = _StubInterviewEngine(state_dir=tmp_path)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=_CapturingEventStore(),
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    outcome = await handler.handle(
+        {"initial_context": "Build a CLI", "cwd": str(tmp_path)},
+    )
+    assert outcome.is_ok
+    request = outcome.value.meta["code_investigation_request"]
+    response_schema = request["answer_contract"]["response_model_schema"]
+    code_fact_output = {
+        "session_id": request["session_id"],
+        "question_identity": request["question_identity"],
+        "answer_prefix": "[from-code][auto-confirmed]",
+        "answer_text": "The current project is a Python package managed by pyproject.toml.",
+        "confidence": "high_exact_match",
+        "evidence": [
+            {
+                "source": "pyproject.toml",
+                "locator": "project.name",
+                "claim": "The manifest declares the Python project metadata.",
+            }
+        ],
+        "requires_user_confirmation": False,
+    }
+    Draft202012Validator(response_schema).validate(code_fact_output)
+
+    synthesis_calls: list[list[dict[str, Any]]] = []
+
+    def synthesize(aggregated_outputs: list[dict[str, Any]]) -> dict[str, Any]:
+        synthesis_calls.append(aggregated_outputs)
+        collected = aggregated_outputs[0]["output"]
+        return {
+            "answer": f"{collected['answer_prefix']} {collected['answer_text']}",
+            "evidence_sources": [evidence["source"] for evidence in collected["evidence"]],
+        }
+
+    partial = synthesize_code_investigation_when_complete(
+        request,
+        {
+            "code_facts": {
+                **code_fact_output,
+                "question_identity": stable_code_investigation_question_identity(
+                    "a different question"
+                ),
+            }
+        },
+        synthesize,
+    )
+    assert partial["ready_for_synthesis"] is False
+    assert partial["ready_for_forward"] is False
+    assert partial["requires_user_confirmation"] is False
+    assert partial["confirmation_required_result_ids"] == []
+    assert partial["user_confirmation_prompts"] == []
+    assert partial["missing_result_ids"] == ["code_facts"]
+    assert partial["aggregated_outputs"] == []
+    assert partial["synthesis"] is None
+    assert synthesis_calls == []
+
+    complete = synthesize_code_investigation_when_complete(
+        request,
+        {"code_facts": code_fact_output},
+        synthesize,
+    )
+    assert complete["ready_for_synthesis"] is True
+    assert complete["ready_for_forward"] is True
+    assert complete["requires_user_confirmation"] is False
+    assert complete["confirmation_required_result_ids"] == []
+    assert complete["user_confirmation_prompts"] == []
+    assert complete["missing_result_ids"] == []
+    assert complete["aggregated_outputs"] == [
+        {"result_id": "code_facts", "output": code_fact_output}
+    ]
+    assert complete["synthesis"] == {
+        "answer": (
+            "[from-code][auto-confirmed] The current project is a Python "
+            "package managed by pyproject.toml."
+        ),
+        "evidence_sources": ["pyproject.toml"],
+    }
+    assert synthesis_calls == [[{"result_id": "code_facts", "output": code_fact_output}]]
+
+
+@pytest.mark.asyncio
+async def test_interview_answer_records_only_after_code_investigation_synthesis(
+    tmp_path: Path,
+) -> None:
+    """The parent runtime must submit only auto-confirmed synthesized answers.
+
+    ``InterviewHandler`` exposes code-investigation metadata and records whatever
+    answer the parent runtime later submits. This test pins the orchestration
+    boundary: incomplete or confirmation-required investigation output does not
+    call the answer path, and only the auto-confirmed synthesis is recorded.
+    """
+    engine = _StubInterviewEngine(state_dir=tmp_path, next_question="Which framework is used?")
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=_CapturingEventStore(),
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    start = await handler.handle({"initial_context": "Audit the current app"})
+    assert start.is_ok
+    request = start.value.meta["code_investigation_request"]
+    request["required_result_ids"] = ["manifest", "router"]
+
+    contract = request["answer_contract"]
+    response_schema = contract["response_model_schema"]
+    manifest_output = {
+        "session_id": request["session_id"],
+        "question_identity": request["question_identity"],
+        "answer_prefix": "[from-code][auto-confirmed]",
+        "answer_text": "The manifest declares a Python package.",
+        "confidence": "high_exact_match",
+        "evidence": [
+            {
+                "source": "pyproject.toml",
+                "locator": "project.name",
+                "claim": "The project metadata is declared in pyproject.toml.",
+            }
+        ],
+        "requires_user_confirmation": False,
+    }
+    router_output = {
+        "session_id": request["session_id"],
+        "question_identity": request["question_identity"],
+        "answer_prefix": "[from-code]",
+        "answer_text": "No web router is present in the inspected files.",
+        "confidence": "medium_inferred",
+        "evidence": [
+            {
+                "source": "rg --files",
+                "locator": "workspace root",
+                "claim": "No frontend router file was found in the fixture workspace.",
+            }
+        ],
+        "requires_user_confirmation": True,
+        "user_confirmation_prompt": (
+            "Confirm whether the missing web router means this is not a web app."
+        ),
+    }
+    Draft202012Validator(response_schema).validate(manifest_output)
+    Draft202012Validator(response_schema).validate(router_output)
+
+    ordering: list[str] = []
+
+    def synthesize(aggregated_outputs: list[dict[str, Any]]) -> dict[str, Any]:
+        ordering.append("synthesized")
+        answer_lines = [item["output"]["answer_text"] for item in aggregated_outputs]
+        return {
+            "answer": "[from-code] " + " ".join(answer_lines),
+            "evidence_sources": [
+                evidence["source"]
+                for item in aggregated_outputs
+                for evidence in item["output"]["evidence"]
+            ],
+        }
+
+    partial = synthesize_code_investigation_when_complete(
+        request,
+        {"manifest": manifest_output},
+        synthesize,
+    )
+    assert partial["ready_for_synthesis"] is False
+    assert partial["ready_for_forward"] is False
+    assert partial["synthesis"] is None
+    assert ordering == []
+    assert engine.record_calls == []
+
+    complete = synthesize_code_investigation_when_complete(
+        request,
+        {"manifest": manifest_output, "router": router_output},
+        synthesize,
+    )
+    assert complete["ready_for_synthesis"] is True
+    assert complete["ready_for_forward"] is False
+    assert complete["requires_user_confirmation"] is True
+    assert complete["confirmation_required_result_ids"] == ["router"]
+    assert complete["user_confirmation_prompts"] == [
+        "Confirm whether the missing web router means this is not a web app."
+    ]
+    assert complete["synthesis"]["answer"] == (
+        "[from-code] The manifest declares a Python package. "
+        "No web router is present in the inspected files."
+    )
+    assert ordering == ["synthesized"]
+    assert engine.record_calls == []
+
+    auto_confirmed = synthesize_code_investigation_when_complete(
+        request,
+        {"manifest": manifest_output},
+        synthesize,
+    )
+    assert auto_confirmed["ready_for_synthesis"] is False
+
+    request["required_result_ids"] = ["manifest"]
+    auto_confirmed = synthesize_code_investigation_when_complete(
+        request,
+        {"manifest": manifest_output},
+        synthesize,
+    )
+    assert auto_confirmed["ready_for_synthesis"] is True
+    assert auto_confirmed["ready_for_forward"] is True
+    synthesized_answer = auto_confirmed["synthesis"]["answer"]
+
+    state = engine.saved_states[-1]
+    engine.initial_state = state
+    engine.next_question = "What should acceptance cover?"
+    answer = await handler.handle(
+        {
+            "session_id": request["session_id"],
+            "answer": synthesized_answer,
+            "last_question": request["question"],
+        }
+    )
+
+    assert answer.is_ok
+    assert ordering == ["synthesized", "synthesized"]
+    assert engine.record_calls == [
+        {
+            "question": "Which framework is used?",
+            "answer": synthesized_answer,
+        }
+    ]
+    recorded_round = state.rounds[0]
+    assert recorded_round.question == "Which framework is used?"
+    assert recorded_round.user_response == synthesized_answer
+    assert "pyproject.toml" in auto_confirmed["synthesis"]["evidence_sources"]
+
+
 @pytest.mark.asyncio
 async def test_start_emits_response_diagnostic_event(tmp_path: Path) -> None:
     """Start path: a normal first question emits the response.emitted event."""
@@ -151,6 +452,11 @@ async def test_start_emits_response_diagnostic_event(tmp_path: Path) -> None:
     assert outcome.is_ok
     _assert_reasoning_meta(
         outcome.value.meta, phase="start", session_id="interview_diagnostics00001"
+    )
+    _assert_code_investigation_request(
+        outcome.value.meta,
+        session_id="interview_diagnostics00001",
+        question="What is the primary user persona?",
     )
     assert outcome.value.meta["interview_reasoning"]["pending_question"] is True
     assert outcome.value.meta["interview_reasoning"]["question_chars"] == len(
@@ -194,6 +500,7 @@ async def test_start_with_length_guard_question_marks_event(tmp_path: Path) -> N
         {"initial_context": "Build a CLI", "cwd": str(tmp_path)},
     )
     assert outcome.is_ok
+    assert "code_investigation_request" not in outcome.value.meta
     await _drain_bg_tasks(handler)
 
     diagnostic = _find_event(event_store.events, event_type="interview.response.emitted")
@@ -234,6 +541,11 @@ async def test_resume_pending_emits_response_diagnostic_event(tmp_path: Path) ->
         outcome.value.meta,
         phase="resume_pending",
         session_id=pending_state.interview_id,
+    )
+    _assert_code_investigation_request(
+        outcome.value.meta,
+        session_id=pending_state.interview_id,
+        question="What is the main goal?",
     )
     assert outcome.value.meta["interview_reasoning"]["pending_question"] is True
     await _drain_bg_tasks(handler)
@@ -326,6 +638,11 @@ async def test_answer_emits_response_diagnostic_event(tmp_path: Path) -> None:
         outcome.value.meta,
         phase="answer",
         session_id=pending_state.interview_id,
+    )
+    _assert_code_investigation_request(
+        outcome.value.meta,
+        session_id=pending_state.interview_id,
+        question="Who uses it first?",
     )
     assert outcome.value.meta["interview_reasoning"]["answered_rounds"] == 1
     assert outcome.value.content[0].text == (

--- a/tests/unit/mcp/tools/test_interview_response_diagnostics.py
+++ b/tests/unit/mcp/tools/test_interview_response_diagnostics.py
@@ -284,6 +284,132 @@ async def test_code_investigation_results_are_collected_before_synthesis(
     assert synthesis_calls == [[{"result_id": "code_facts", "output": code_fact_output}]]
 
 
+def test_code_investigation_synthesis_fails_closed_for_stale_from_code_output() -> None:
+    """A stale inferred [from-code] answer cannot become forwardable by flag drift."""
+    question_identity = stable_code_investigation_question_identity("Which framework is used?")
+    request = {
+        "session_id": "sess-123",
+        "question_identity": question_identity,
+        "answer_contract": interview_code_investigation_answer_contract(),
+    }
+    stale_output = {
+        "session_id": "sess-123",
+        "question_identity": question_identity,
+        "answer_prefix": "[from-code]",
+        "answer_text": "The project appears to use FastAPI.",
+        "confidence": "medium_inferred",
+        "evidence": [
+            {
+                "source": "src/app.py",
+                "locator": "imports",
+                "claim": "The inspected imports resemble a FastAPI application.",
+            }
+        ],
+        "requires_user_confirmation": False,
+    }
+    synthesis_calls: list[list[dict[str, Any]]] = []
+
+    result = synthesize_code_investigation_when_complete(
+        request,
+        {"code_facts": stale_output},
+        lambda outputs: synthesis_calls.append(outputs) or {"answer": "unsafe"},
+    )
+
+    assert result["ready_for_synthesis"] is True
+    assert result["ready_for_forward"] is False
+    assert result["requires_user_confirmation"] is True
+    assert result["confirmation_required_result_ids"] == ["code_facts"]
+    assert result["synthesis"] is None
+    assert result["contract_violations"][0]["result_id"] == "code_facts"
+    assert any(
+        "True was expected" in error for error in result["contract_violations"][0]["errors"]
+    )
+    assert result["user_confirmation_prompts"] == [
+        "Confirm before forwarding this code-derived answer: "
+        "The project appears to use FastAPI."
+    ]
+    assert synthesis_calls == []
+
+
+def test_code_investigation_synthesis_requires_confirmation_for_from_code_prefix() -> None:
+    question_identity = stable_code_investigation_question_identity("Is there a router?")
+    request = {
+        "session_id": "sess-123",
+        "question_identity": question_identity,
+        "answer_contract": interview_code_investigation_answer_contract(),
+    }
+    output = {
+        "session_id": "sess-123",
+        "question_identity": question_identity,
+        "answer_prefix": "[from-code]",
+        "answer_text": "No router was found in the inspected files.",
+        "confidence": "medium_inferred",
+        "evidence": [
+            {
+                "source": "rg --files",
+                "locator": "workspace root",
+                "claim": "No router file was found during repository inspection.",
+            }
+        ],
+        "requires_user_confirmation": True,
+        "user_confirmation_prompt": "Confirm whether this repository has no router.",
+    }
+
+    result = synthesize_code_investigation_when_complete(
+        request,
+        {"code_facts": output},
+        lambda outputs: {"answer": outputs[0]["output"]["answer_text"]},
+    )
+
+    assert result["ready_for_synthesis"] is True
+    assert result["ready_for_forward"] is False
+    assert result["requires_user_confirmation"] is True
+    assert result["confirmation_required_result_ids"] == ["code_facts"]
+    assert result["user_confirmation_prompts"] == [
+        "Confirm whether this repository has no router."
+    ]
+    assert result["contract_violations"] == []
+    assert result["synthesis"] == {"answer": "No router was found in the inspected files."}
+
+
+def test_code_investigation_synthesis_forwards_auto_confirmed_output() -> None:
+    question_identity = stable_code_investigation_question_identity("Which manifest exists?")
+    request = {
+        "session_id": "sess-123",
+        "question_identity": question_identity,
+        "answer_contract": interview_code_investigation_answer_contract(),
+    }
+    output = {
+        "session_id": "sess-123",
+        "question_identity": question_identity,
+        "answer_prefix": "[from-code][auto-confirmed]",
+        "answer_text": "pyproject.toml declares the package metadata.",
+        "confidence": "high_exact_match",
+        "evidence": [
+            {
+                "source": "pyproject.toml",
+                "locator": "project.name",
+                "claim": "The package name is declared in pyproject.toml.",
+            }
+        ],
+        "requires_user_confirmation": False,
+    }
+
+    result = synthesize_code_investigation_when_complete(
+        request,
+        {"code_facts": output},
+        lambda outputs: {"answer": outputs[0]["output"]["answer_text"]},
+    )
+
+    assert result["ready_for_synthesis"] is True
+    assert result["ready_for_forward"] is True
+    assert result["requires_user_confirmation"] is False
+    assert result["confirmation_required_result_ids"] == []
+    assert result["user_confirmation_prompts"] == []
+    assert result["contract_violations"] == []
+    assert result["synthesis"] == {"answer": "pyproject.toml declares the package metadata."}
+
+
 @pytest.mark.asyncio
 async def test_interview_answer_records_only_after_code_investigation_synthesis(
     tmp_path: Path,

--- a/tests/unit/mcp/tools/test_interview_response_diagnostics.py
+++ b/tests/unit/mcp/tools/test_interview_response_diagnostics.py
@@ -321,12 +321,9 @@ def test_code_investigation_synthesis_fails_closed_for_stale_from_code_output() 
     assert result["confirmation_required_result_ids"] == ["code_facts"]
     assert result["synthesis"] is None
     assert result["contract_violations"][0]["result_id"] == "code_facts"
-    assert any(
-        "True was expected" in error for error in result["contract_violations"][0]["errors"]
-    )
+    assert any("True was expected" in error for error in result["contract_violations"][0]["errors"])
     assert result["user_confirmation_prompts"] == [
-        "Confirm before forwarding this code-derived answer: "
-        "The project appears to use FastAPI."
+        "Confirm before forwarding this code-derived answer: The project appears to use FastAPI."
     ]
     assert synthesis_calls == []
 
@@ -365,9 +362,7 @@ def test_code_investigation_synthesis_requires_confirmation_for_from_code_prefix
     assert result["ready_for_forward"] is False
     assert result["requires_user_confirmation"] is True
     assert result["confirmation_required_result_ids"] == ["code_facts"]
-    assert result["user_confirmation_prompts"] == [
-        "Confirm whether this repository has no router."
-    ]
+    assert result["user_confirmation_prompts"] == ["Confirm whether this repository has no router."]
     assert result["contract_violations"] == []
     assert result["synthesis"] == {"answer": "No router was found in the inspected files."}
 


### PR DESCRIPTION
## Stack

This is **5/7** in the smaller replacement stack for closed PR #1363. Stacked on #1368.

| Order | PR | Topic | Base |
|---:|---|---|---|
| 1 | #1365 | Skill-to-tool mapping | `main` |
| 2 | #1366 | Backend subagent capability | #1365 |
| 3 | #1367 | Evaluation diagnostics | #1366 |
| 4 | #1368 | Owned tool capability contracts | #1367 |
| 5 | #1369 | Interview code-investigation metadata | #1368 |
| 6 | #1370 | Lateral persona orchestration metadata | #1369 |
| 7 | #1371 | Review follow-up coverage | #1370 |

Review and merge in order.

## Changes

- Emits structured code-investigation orchestration metadata from interview responses.
- Embeds explicit `ouroboros_interview` capability metadata for runtime consumers.
- Adds diagnostics coverage for code-fact questions, answer contracts, and embedded metadata.

## Verification

- `uv run pytest tests/unit/mcp/tools/test_interview_response_diagnostics.py -q`
- `uv run ruff format --check src/ tests/`
- `uv run ruff check src/ tests/`
- Full focused stack suite was run from the stack tip.

## Notes

Supersedes the interview code-investigation part of #1363.
