### PR TITLE
feat(mcp): [stack 6/7] consume lateral persona metadata

### DIFF
--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -32,8 +32,10 @@ Payload structure:
 
 from __future__ import annotations
 
+import base64
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from functools import lru_cache
 import json
 import re
 from typing import Any
@@ -51,11 +53,17 @@ from ouroboros.mcp.types import (
 
 log = structlog.get_logger(__name__)
 
+_LATERAL_INLINE_DISPATCH_OPEN = "<!-- ouroboros-lateral-inline-dispatch-v1 base64\n"
+_LATERAL_INLINE_DISPATCH_CLOSE = "\n-->"
 _INTERVIEW_SUBAGENT_MAX_CONTEXT_CHARS = 600
 _INTERVIEW_SUBAGENT_MAX_PREVIOUS_TRANSCRIPT_CHARS = 200
 _INTERVIEW_SUBAGENT_MAX_TRANSCRIPT_QUESTION_CHARS = 900
 _INTERVIEW_SUBAGENT_MAX_TRANSCRIPT_ANSWER_CHARS = 220
 _INTERVIEW_SUBAGENT_MAX_ANSWER_CHARS = 300
+_LATERAL_PANEL_FALLBACK_ID = "lateral_persona_panel.v1"
+_LATERAL_PANEL_FALLBACK_TOOL = "ouroboros_lateral_think"
+_LATERAL_PANEL_FALLBACK_SEQUENTIAL_MODE = "sequential_persona_payload_dispatch"
+_LATERAL_PANEL_FALLBACK_PARALLEL_MODE = "parallel_subagent_panel"
 
 
 def _canonical_response_json(body: dict[str, Any]) -> str:
@@ -95,12 +103,351 @@ def _default_code_investigation_confirmation_prompt(output: Mapping[str, Any]) -
     return f"Confirm before forwarding this code-derived answer: {answer_text}"
 
 
+def _payload_persona(payload: Mapping[str, Any]) -> str:
+    context = payload.get("context")
+    if isinstance(context, Mapping):
+        persona = context.get("persona")
+        if persona:
+            return str(persona)
+    title = str(payload.get("title") or "")
+    match = re.search(r"\(([^)]+)\)", title)
+    if match:
+        return match.group(1)
+    return "unknown"
+
+
+def _response_text_json_payload(result: MCPToolResult) -> dict[str, Any] | None:
+    text = result.text_content.strip()
+    if not text or not text.startswith("{"):
+        return None
+    try:
+        decoded = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
+def _inline_lateral_dispatch_payload(result: MCPToolResult) -> dict[str, Any] | None:
+    text = result.text_content
+    open_idx = text.rfind(_LATERAL_INLINE_DISPATCH_OPEN)
+    if open_idx == -1:
+        return None
+    close_idx = text.rfind(_LATERAL_INLINE_DISPATCH_CLOSE)
+    if close_idx <= open_idx:
+        return None
+    encoded = text[open_idx + len(_LATERAL_INLINE_DISPATCH_OPEN) : close_idx]
+    try:
+        decoded = base64.b64decode(encoded.encode("ascii")).decode("utf-8")
+        payload = json.loads(decoded)
+    except (ValueError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _lateral_payload_container(result: MCPToolResult) -> tuple[dict[str, Any], str]:
+    """Return the first structured lateral dispatch container and its source."""
+    if isinstance(result.meta, dict):
+        if "_subagents" in result.meta or "_subagent" in result.meta:
+            return result.meta, "meta"
+        if "payloads" in result.meta:
+            return result.meta, "inline_meta"
+
+    content_payload = _response_text_json_payload(result)
+    if content_payload and ("_subagents" in content_payload or "_subagent" in content_payload):
+        return content_payload, "content_json"
+
+    inline_payload = _inline_lateral_dispatch_payload(result)
+    if inline_payload and "payloads" in inline_payload:
+        return inline_payload, "inline_content"
+
+    return {}, "none"
+
+
+@lru_cache(maxsize=1)
+def lateral_persona_panel_metadata_from_capability_definitions() -> dict[str, Any]:
+    """Read lateral persona panel metadata from Ouroboros tool capabilities.
+
+    The interview orchestration reader intentionally consumes the same
+    capability graph exposed to runtimes, rather than duplicating the
+    ``ouroboros_lateral_think`` panel contract in this response-normalization
+    layer.
+    """
+    from ouroboros.mcp.tools.definitions import get_ouroboros_tools
+    from ouroboros.orchestrator.capabilities import build_capability_graph
+    from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
+
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools())
+    graph = build_capability_graph(assemble_session_tool_catalog(attached_tools=owned_tools))
+    for descriptor in graph.capabilities:
+        if descriptor.name != _LATERAL_PANEL_FALLBACK_TOOL or descriptor.metadata is None:
+            continue
+        panel = descriptor.metadata.orchestration.get("lateral_panel")
+        if isinstance(panel, Mapping):
+            return dict(panel)
+    return {}
+
+
+def _lateral_panel_capability_metadata(
+    lateral_panel_metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Normalize caller-supplied or capability-derived lateral panel metadata."""
+    raw = (
+        lateral_panel_metadata
+        if lateral_panel_metadata is not None
+        else lateral_persona_panel_metadata_from_capability_definitions()
+    )
+    return dict(raw) if isinstance(raw, Mapping) else {}
+
+
+def _lateral_panel_persona_roles(
+    lateral_panel_metadata: Mapping[str, Any],
+) -> dict[str, str]:
+    raw_personas = lateral_panel_metadata.get("personas")
+    if not isinstance(raw_personas, list | tuple):
+        return {}
+    roles: dict[str, str] = {}
+    for persona in raw_personas:
+        if not isinstance(persona, Mapping):
+            continue
+        persona_id = persona.get("persona_id")
+        role = persona.get("role")
+        if persona_id and role:
+            roles[str(persona_id)] = str(role)
+    return roles
+
+
+def _lateral_panel_id(lateral_panel_metadata: Mapping[str, Any]) -> str:
+    return str(lateral_panel_metadata.get("panel_id") or _LATERAL_PANEL_FALLBACK_ID)
+
+
+def _lateral_panel_tool(lateral_panel_metadata: Mapping[str, Any]) -> str:
+    return str(lateral_panel_metadata.get("mcp_tool") or _LATERAL_PANEL_FALLBACK_TOOL)
+
+
+def _lateral_panel_requires_prose_parsing(
+    lateral_panel_metadata: Mapping[str, Any],
+) -> bool:
+    refs = lateral_panel_metadata.get("response_payload_refs")
+    if isinstance(refs, Mapping) and "requires_prose_parsing" in refs:
+        return bool(refs["requires_prose_parsing"])
+    return False
+
+
+def _lateral_panel_sequential_mode(lateral_panel_metadata: Mapping[str, Any]) -> str:
+    fallback = lateral_panel_metadata.get("sequential_fallback")
+    if isinstance(fallback, Mapping) and fallback.get("mode"):
+        return str(fallback["mode"])
+    return _LATERAL_PANEL_FALLBACK_SEQUENTIAL_MODE
+
+
+def lateral_review_response_to_interview_orchestration_entries(
+    result: MCPToolResult,
+    *,
+    session_id: str | None = None,
+    runtime_supports_parallel_subagents: bool = True,
+    lateral_panel_metadata: Mapping[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    """Convert a lateral-review MCP response into interview persona-panel entries.
+
+    ``ouroboros_lateral_think`` can return plugin-native ``_subagents``, a
+    single ``_subagent``, inline-fallback ``meta.payloads``, or a content-only
+    base64 dispatch block when a transport drops ``meta``. This helper
+    normalizes every supported shape into deterministic interview orchestration
+    metadata entries so the interview runtime can dispatch persona panels
+    without prose parsing.
+    """
+    container, source = _lateral_payload_container(result)
+    if not container:
+        return []
+
+    dispatch_mode = str(container.get("dispatch_mode") or "plugin")
+    raw_payloads: Any
+    if isinstance(container.get("_subagents"), list):
+        raw_payloads = container["_subagents"]
+    elif isinstance(container.get("payloads"), list):
+        raw_payloads = container["payloads"]
+    elif isinstance(container.get("_subagent"), Mapping):
+        raw_payloads = [container["_subagent"]]
+    else:
+        return []
+
+    payloads = [payload for payload in raw_payloads if isinstance(payload, Mapping)]
+    if not payloads:
+        return []
+
+    panel_metadata = _lateral_panel_capability_metadata(lateral_panel_metadata)
+    panel_id = _lateral_panel_id(panel_metadata)
+    mcp_tool = _lateral_panel_tool(panel_metadata)
+    sequential_mode = _lateral_panel_sequential_mode(panel_metadata)
+    requires_prose_parsing = _lateral_panel_requires_prose_parsing(panel_metadata)
+    persona_roles = _lateral_panel_persona_roles(panel_metadata)
+    execution_mode = (
+        _LATERAL_PANEL_FALLBACK_PARALLEL_MODE
+        if len(payloads) > 1 and runtime_supports_parallel_subagents
+        else sequential_mode
+    )
+    parallel_group = f"{session_id}:{panel_id}" if session_id else panel_id
+
+    entries: list[dict[str, Any]] = []
+    for index, payload in enumerate(payloads, start=1):
+        context = payload.get("context") if isinstance(payload.get("context"), Mapping) else {}
+        persona = _payload_persona(payload)
+        entries.append(
+            {
+                "kind": "interview_orchestration_metadata",
+                "panel_id": panel_id,
+                "panel_role": "persona",
+                "persona_id": persona,
+                "persona_role": persona_roles.get(persona, ""),
+                "session_id": session_id,
+                "mcp_tool": mcp_tool,
+                "tool_name": str(payload.get("tool_name") or mcp_tool),
+                "title": str(payload.get("title") or f"Lateral ({persona})"),
+                "agent": str(payload.get("agent") or "general"),
+                "model": payload.get("model"),
+                "prompt": str(payload.get("prompt") or ""),
+                "context": dict(context),
+                "dispatch_mode": dispatch_mode,
+                "response_payload_source": source,
+                "execution_mode": execution_mode,
+                "parallel_group": parallel_group,
+                "execution_order": index,
+                "requires_prose_parsing": requires_prose_parsing,
+                "sequential_fallback_used": execution_mode == sequential_mode,
+            }
+        )
+    return entries
+
+
+def lateral_review_response_to_interview_orchestration_metadata(
+    result: MCPToolResult,
+    *,
+    session_id: str | None = None,
+    runtime_supports_parallel_subagents: bool = True,
+    lateral_panel_metadata: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the interview metadata envelope for a lateral persona-panel result."""
+    panel_metadata = _lateral_panel_capability_metadata(lateral_panel_metadata)
+    panel_id = _lateral_panel_id(panel_metadata)
+    mcp_tool = _lateral_panel_tool(panel_metadata)
+    sequential_mode = _lateral_panel_sequential_mode(panel_metadata)
+    requires_prose_parsing = _lateral_panel_requires_prose_parsing(panel_metadata)
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        result,
+        session_id=session_id,
+        runtime_supports_parallel_subagents=runtime_supports_parallel_subagents,
+        lateral_panel_metadata=panel_metadata,
+    )
+    return {
+        "lateral_panel": {
+            "panel_id": panel_id,
+            "mcp_tool": mcp_tool,
+            "entry_count": len(entries),
+            "execution_mode": (entries[0]["execution_mode"] if entries else sequential_mode),
+            "requires_prose_parsing": requires_prose_parsing,
+            "entries": entries,
+        }
+    }
+
+
+def synthesize_lateral_persona_panel_when_complete(
+    entries: list[Mapping[str, Any]],
+    persona_outputs: Mapping[str, Any],
+    synthesizer: Any,
+) -> dict[str, Any]:
+    """Aggregate lateral persona outputs and synthesize only when complete.
+
+    Parent runtimes receive one orchestration entry per persona and may get
+    child results in any order. This helper preserves dispatch order, checks
+    completion by ``persona_id``, and calls ``synthesizer`` only after every
+    dispatched persona has a corresponding output.
+    """
+    expected_personas = [
+        str(entry["persona_id"])
+        for entry in sorted(
+            entries,
+            key=lambda item: int(item.get("execution_order") or 0),
+        )
+        if entry.get("persona_id")
+    ]
+    outputs_by_persona = {
+        str(persona): output
+        for persona, output in persona_outputs.items()
+        if str(persona) in expected_personas
+    }
+    missing_personas = [
+        persona for persona in expected_personas if persona not in outputs_by_persona
+    ]
+    aggregated_outputs = [
+        {
+            "persona_id": persona,
+            "output": outputs_by_persona[persona],
+        }
+        for persona in expected_personas
+        if persona in outputs_by_persona
+    ]
+    if missing_personas:
+        return {
+            "ready_for_synthesis": False,
+            "expected_personas": expected_personas,
+            "missing_personas": missing_personas,
+            "aggregated_outputs": aggregated_outputs,
+            "synthesis": None,
+        }
+    return {
+        "ready_for_synthesis": True,
+        "expected_personas": expected_personas,
+        "missing_personas": [],
+        "aggregated_outputs": aggregated_outputs,
+        "synthesis": synthesizer(aggregated_outputs),
+    }
+
+
+def continue_interview_after_lateral_persona_synthesis(
+    entries: list[Mapping[str, Any]],
+    persona_outputs: Mapping[str, Any],
+    synthesizer: Any,
+    interview_continuation: Any,
+) -> dict[str, Any]:
+    """Run interview continuation only after lateral panel synthesis is ready.
+
+    Runtimes may collect persona panel outputs out of order. This helper keeps
+    the runtime handoff deterministic: it returns the incomplete synthesis
+    state without calling the continuation, and calls the continuation only
+    after ``synthesize_lateral_persona_panel_when_complete`` has produced a
+    synthesized lateral result.
+    """
+    synthesis_state = synthesize_lateral_persona_panel_when_complete(
+        entries,
+        persona_outputs,
+        synthesizer,
+    )
+    if not synthesis_state["ready_for_synthesis"]:
+        return {
+            **synthesis_state,
+            "continued_interview": False,
+            "interview_continuation": None,
+        }
+    return {
+        **synthesis_state,
+        "continued_interview": True,
+        "interview_continuation": interview_continuation(synthesis_state["synthesis"]),
+    }
+
+
 def synthesize_code_investigation_when_complete(
     request: Mapping[str, Any],
     investigation_results: Mapping[str, Any],
     synthesizer: Any,
 ) -> dict[str, Any]:
-    """Collect code-fact investigation outputs before interview synthesis."""
+    """Collect code-fact investigation outputs before interview synthesis.
+
+    Parent runtimes may dispatch one or more repo-inspection subagents for a
+    single interview question. This helper filters child outputs to the
+    originating request and calls ``synthesizer`` only when every required result
+    is present, so interview continuation receives factual code context rather
+    than partially collected child state.
+    """
     session_id = str(request.get("session_id") or "")
     question_identity = str(request.get("question_identity") or "")
     required_ids = request.get("required_result_ids")
@@ -111,8 +458,7 @@ def synthesize_code_investigation_when_complete(
 
     outputs_by_result_id: dict[str, Any] = {}
     for result_id, output in investigation_results.items():
-        normalized_result_id = str(result_id)
-        if normalized_result_id not in expected_result_ids:
+        if str(result_id) not in expected_result_ids:
             continue
         if not isinstance(output, Mapping):
             continue
@@ -120,7 +466,7 @@ def synthesize_code_investigation_when_complete(
             continue
         if str(output.get("question_identity") or "") != question_identity:
             continue
-        outputs_by_result_id[normalized_result_id] = output
+        outputs_by_result_id[str(result_id)] = output
 
     missing_result_ids = [
         result_id for result_id in expected_result_ids if result_id not in outputs_by_result_id
@@ -194,23 +540,6 @@ def synthesize_code_investigation_when_complete(
         "contract_violations": contract_violations,
         "ready_for_forward": not confirmation_required,
     }
-
-
-def lateral_persona_panel_metadata_from_capability_definitions() -> dict[str, Any]:
-    """Read lateral persona panel metadata from Ouroboros tool capabilities."""
-    from ouroboros.mcp.tools.definitions import get_ouroboros_tools
-    from ouroboros.orchestrator.capabilities import build_capability_graph
-    from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
-
-    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools())
-    graph = build_capability_graph(assemble_session_tool_catalog(attached_tools=owned_tools))
-    for descriptor in graph.capabilities:
-        if descriptor.name != "ouroboros_lateral_think" or descriptor.metadata is None:
-            continue
-        panel = descriptor.metadata.orchestration.get("lateral_panel")
-        if isinstance(panel, Mapping):
-            return dict(panel)
-    return {}
 
 
 # ---------------------------------------------------------------------------
@@ -1297,6 +1626,7 @@ def build_lateral_multi_subagent(
             build_subagent_payload(
                 tool_name="ouroboros_lateral_think",
                 title=f"Lateral ({persona.value})",
+                agent=persona.value,
                 prompt=prompt,
                 context=context,
             )

--- a/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
+++ b/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
@@ -1,6 +1,6 @@
 """Milestone-transition lateral review advisory tests for #817."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBreakdown
 from ouroboros.bigbang.interview import InterviewRound, InterviewState
@@ -8,6 +8,7 @@ from ouroboros.core.types import Result
 from ouroboros.events.interview import interview_lateral_review_recommended
 from ouroboros.mcp.tools.authoring_handlers import (
     InterviewHandler,
+    _build_interview_lateral_review_orchestration,
     _maybe_record_lateral_review_advisory,
 )
 
@@ -198,11 +199,87 @@ async def test_handler_surfaces_runnable_lateral_review_dispatch() -> None:
     assert tool_args["personas"] == ["researcher", "contrarian", "simplifier"]
     assert "Milestone: initial -> progress" in tool_args["problem_context"]
     assert "Next interview question: What edge case remains?" in tool_args["problem_context"]
+    orchestration = result.value.meta["lateral_review_orchestration"]
+    assert orchestration["kind"] == "mcp_directive"
+    assert orchestration["directive"] == "run_lateral_persona_panel"
+    assert orchestration["mcp_tool"] == "ouroboros_lateral_think"
+    assert orchestration["tool_args"] == tool_args
+
+    panel = orchestration["panel"]
+    assert panel["panel_id"] == "lateral_persona_panel.v1"
+    assert panel["mcp_tool"] == "ouroboros_lateral_think"
+    assert panel["dispatch_modes"] == ["plugin", "inline_fallback"]
+    assert panel["parallel_preference"] == "parallel_when_runtime_supports_subagents"
+    assert panel["sequential_fallback"] == {
+        "supported": True,
+        "mode": "sequential_persona_payload_dispatch",
+        "trigger": "runtime_has_no_native_parallel_subagent_primitive",
+    }
+    assert [persona["persona_id"] for persona in panel["personas"]] == [
+        "researcher",
+        "contrarian",
+        "simplifier",
+    ]
+    assert panel["response_payload_refs"]["requires_prose_parsing"] is False
+    assert "structured payload" in panel["runtime_instruction"]
+
+    runtime_handling = orchestration["runtime_handling"]
+    assert runtime_handling == {
+        "call_mcp_tool_first": True,
+        "parallel_capable_execution_mode": "parallel_subagent_panel",
+        "sequential_fallback_mode": "sequential_persona_payload_dispatch",
+        "sequential_fallback_trigger": "runtime_has_no_native_parallel_subagent_primitive",
+        "result_correlation_key": "context.persona",
+        "requires_prose_parsing": False,
+        "synthesize_before_interview_continuation": True,
+    }
     content_text = result.value.content[0].text
     assert content_text.startswith("Lateral review queued:")
     assert "Session sess-817" in content_text
     assert state.lateral_review_advised_milestones == ["progress"]
     handler._emit_event_bg.assert_called()
+
+
+def test_lateral_orchestration_falls_back_to_skill_prose_when_panel_metadata_absent() -> None:
+    tool_args = {
+        "problem_context": (
+            "Session sess-legacy\n"
+            "Milestone: initial -> progress\n"
+            "Next interview question: What edge case remains?"
+        ),
+        "current_approach": "Route the next interview turn.",
+        "personas": ["researcher", "contrarian", "simplifier"],
+        "failed_attempts": [],
+    }
+
+    with patch(
+        "ouroboros.mcp.tools.authoring_handlers."
+        "lateral_persona_panel_metadata_from_capability_definitions",
+        return_value={},
+    ):
+        orchestration = _build_interview_lateral_review_orchestration(tool_args=tool_args)
+
+    assert orchestration["kind"] == "mcp_directive"
+    assert orchestration["directive"] == "run_lateral_persona_panel"
+    assert orchestration["mcp_tool"] == "ouroboros_lateral_think"
+    assert orchestration["tool_args"] == tool_args
+    assert orchestration["structured_lateral_panel_metadata_available"] is False
+    assert orchestration["fallback"] == "skill_prose_instructions"
+    assert orchestration["prose_instruction_source"] == "skills/interview/SKILL.md"
+    assert (
+        "call ouroboros_lateral_think with meta.lateral_review_tool_args"
+        in (orchestration["prose_instruction"])
+    )
+    assert (
+        'personas=["researcher","contrarian","simplifier"]' in (orchestration["prose_instruction"])
+    )
+    assert "panel" not in orchestration
+    assert orchestration["runtime_handling"] == {
+        "call_mcp_tool_first": True,
+        "result_correlation_key": None,
+        "requires_prose_parsing": True,
+        "synthesize_before_interview_continuation": True,
+    }
 
 
 async def test_handler_does_not_record_advisory_before_auto_completion() -> None:

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -17,6 +17,14 @@ import json
 import pytest
 
 from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
+from ouroboros.mcp.tools.subagent import (
+    continue_interview_after_lateral_persona_synthesis,
+    lateral_persona_panel_metadata_from_capability_definitions,
+    lateral_review_response_to_interview_orchestration_entries,
+    lateral_review_response_to_interview_orchestration_metadata,
+    synthesize_lateral_persona_panel_when_complete,
+)
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 
 
 @pytest.mark.asyncio
@@ -40,11 +48,561 @@ async def test_multi_persona_plugin_mode_emits_subagents_envelope() -> None:
     assert payload.meta is not None
     # Envelope is present on meta and as JSON text.
     assert "_subagents" in payload.meta
-    assert len(payload.meta["_subagents"]) == 2
+    subagents = payload.meta["_subagents"]
+    assert len(subagents) == 2
+    assert [subagent["agent"] for subagent in subagents] == ["hacker", "contrarian"]
+    assert [subagent["title"] for subagent in subagents] == [
+        "Lateral (hacker)",
+        "Lateral (contrarian)",
+    ]
+    assert [subagent["context"]["persona"] for subagent in subagents] == [
+        "hacker",
+        "contrarian",
+    ]
     text = payload.content[0].text
     decoded = json.loads(text)
     assert "_subagents" in decoded
-    assert len(decoded["_subagents"]) == 2
+    assert [
+        (subagent["agent"], subagent["context"]["persona"]) for subagent in decoded["_subagents"]
+    ] == [("hacker", "hacker"), ("contrarian", "contrarian")]
+
+
+@pytest.mark.asyncio
+async def test_plugin_lateral_response_converts_to_interview_persona_panel_entries() -> None:
+    """Plugin lateral-review responses become per-persona interview metadata."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview crossed a milestone",
+            "current_approach": "continue with the next question",
+            "personas": ["researcher", "contrarian", "simplifier"],
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        payload,
+        session_id="sess-panel",
+        runtime_supports_parallel_subagents=True,
+    )
+
+    assert [entry["persona_id"] for entry in entries] == [
+        "researcher",
+        "contrarian",
+        "simplifier",
+    ]
+    assert {entry["panel_id"] for entry in entries} == {"lateral_persona_panel.v1"}
+    assert {entry["mcp_tool"] for entry in entries} == {"ouroboros_lateral_think"}
+    assert {entry["dispatch_mode"] for entry in entries} == {"plugin"}
+    assert {entry["response_payload_source"] for entry in entries} == {"meta"}
+    assert {entry["execution_mode"] for entry in entries} == {"parallel_subagent_panel"}
+    assert all(entry["requires_prose_parsing"] is False for entry in entries)
+    assert all(entry["sequential_fallback_used"] is False for entry in entries)
+    assert [entry["execution_order"] for entry in entries] == [1, 2, 3]
+    for entry in entries:
+        assert entry["session_id"] == "sess-panel"
+        assert entry["parallel_group"] == "sess-panel:lateral_persona_panel.v1"
+        assert entry["prompt"]
+        assert entry["context"]["persona"] == entry["persona_id"]
+        assert entry["persona_role"]
+
+
+@pytest.mark.asyncio
+async def test_parallel_lateral_synthesis_waits_for_all_persona_outputs() -> None:
+    """Parallel persona collection gates synthesis until every output is present."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview crossed a milestone",
+            "current_approach": "continue only after lateral synthesis",
+            "personas": ["researcher", "contrarian", "simplifier"],
+        }
+    )
+
+    assert result.is_ok, result
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        result.unwrap(),
+        session_id="sess-aggregate",
+        runtime_supports_parallel_subagents=True,
+    )
+    assert [entry["persona_id"] for entry in entries] == [
+        "researcher",
+        "contrarian",
+        "simplifier",
+    ]
+
+    synthesis_calls = []
+
+    def synthesize(aggregated_outputs: list[dict]) -> dict:
+        synthesis_calls.append(aggregated_outputs)
+        return {
+            "persona_ids": [item["persona_id"] for item in aggregated_outputs],
+            "combined": "\n".join(str(item["output"]) for item in aggregated_outputs),
+        }
+
+    partial = synthesize_lateral_persona_panel_when_complete(
+        entries,
+        {
+            "contrarian": "challenge the assumption",
+            "researcher": "verify the current implementation",
+        },
+        synthesize,
+    )
+
+    assert partial["ready_for_synthesis"] is False
+    assert partial["missing_personas"] == ["simplifier"]
+    assert [item["persona_id"] for item in partial["aggregated_outputs"]] == [
+        "researcher",
+        "contrarian",
+    ]
+    assert partial["synthesis"] is None
+    assert synthesis_calls == []
+
+    complete = synthesize_lateral_persona_panel_when_complete(
+        entries,
+        {
+            "contrarian": "challenge the assumption",
+            "simplifier": "reduce the next question",
+            "researcher": "verify the current implementation",
+        },
+        synthesize,
+    )
+
+    assert complete["ready_for_synthesis"] is True
+    assert complete["missing_personas"] == []
+    assert complete["synthesis"] == {
+        "persona_ids": ["researcher", "contrarian", "simplifier"],
+        "combined": (
+            "verify the current implementation\nchallenge the assumption\nreduce the next question"
+        ),
+    }
+    assert len(synthesis_calls) == 1
+    assert [item["persona_id"] for item in synthesis_calls[0]] == [
+        "researcher",
+        "contrarian",
+        "simplifier",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_parallel_lateral_synthesis_precedes_interview_continuation() -> None:
+    """Parallel persona results are synthesized before the interview turn resumes."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview crossed a milestone",
+            "current_approach": "continue only after synthesized lateral review",
+            "personas": ["researcher", "contrarian", "simplifier"],
+        }
+    )
+
+    assert result.is_ok, result
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        result.unwrap(),
+        session_id="sess-continuation-order",
+        runtime_supports_parallel_subagents=True,
+    )
+
+    timeline: list[str] = []
+
+    def synthesize(aggregated_outputs: list[dict]) -> dict:
+        timeline.append("synthesis")
+        return {
+            "persona_ids": [item["persona_id"] for item in aggregated_outputs],
+            "summary": "lateral review is ready",
+        }
+
+    def continue_interview(synthesis: dict) -> dict:
+        assert timeline == ["synthesis"]
+        assert synthesis["persona_ids"] == ["researcher", "contrarian", "simplifier"]
+        timeline.append("interview_continuation")
+        return {
+            "next_question": "What risk should we clarify next?",
+            "lateral_synthesis": synthesis,
+        }
+
+    partial = continue_interview_after_lateral_persona_synthesis(
+        entries,
+        {
+            "researcher": "verify current implementation",
+            "contrarian": "challenge milestone assumption",
+        },
+        synthesize,
+        continue_interview,
+    )
+
+    assert partial["ready_for_synthesis"] is False
+    assert partial["continued_interview"] is False
+    assert partial["interview_continuation"] is None
+    assert timeline == []
+
+    complete = continue_interview_after_lateral_persona_synthesis(
+        entries,
+        {
+            "simplifier": "reduce follow-up scope",
+            "contrarian": "challenge milestone assumption",
+            "researcher": "verify current implementation",
+        },
+        synthesize,
+        continue_interview,
+    )
+
+    assert complete["ready_for_synthesis"] is True
+    assert complete["continued_interview"] is True
+    assert complete["interview_continuation"] == {
+        "next_question": "What risk should we clarify next?",
+        "lateral_synthesis": complete["synthesis"],
+    }
+    assert timeline == ["synthesis", "interview_continuation"]
+
+
+@pytest.mark.asyncio
+async def test_interview_orchestration_reader_uses_capability_panel_metadata() -> None:
+    """Panel identity, roles, and fallback mode come from capability metadata."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="opencode",
+        opencode_mode="plugin",
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview crossed a milestone",
+            "current_approach": "continue with the next question",
+            "personas": ["researcher", "contrarian"],
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    capability_panel = lateral_persona_panel_metadata_from_capability_definitions()
+
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        payload,
+        session_id="sess-capability",
+        runtime_supports_parallel_subagents=True,
+        lateral_panel_metadata=capability_panel,
+    )
+
+    assert entries
+    assert {entry["panel_id"] for entry in entries} == {capability_panel["panel_id"]}
+    assert {entry["mcp_tool"] for entry in entries} == {capability_panel["mcp_tool"]}
+    assert {entry["parallel_group"] for entry in entries} == {
+        f"sess-capability:{capability_panel['panel_id']}"
+    }
+    roles_by_id = {
+        persona["persona_id"]: persona["role"] for persona in capability_panel["personas"]
+    }
+    for entry in entries:
+        assert entry["persona_role"] == roles_by_id[entry["persona_id"]]
+        assert (
+            entry["requires_prose_parsing"]
+            is capability_panel["response_payload_refs"]["requires_prose_parsing"]
+        )
+
+
+@pytest.mark.asyncio
+async def test_interview_orchestration_reader_honors_custom_capability_metadata() -> None:
+    """Regression guard against hard-coded lateral panel metadata in the reader."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview needs a lightweight review",
+            "current_approach": "ask the next Socratic question",
+            "personas": ["researcher"],
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    custom_panel = {
+        "panel_id": "custom_lateral_panel.v9",
+        "mcp_tool": "custom_lateral_tool",
+        "sequential_fallback": {
+            "supported": True,
+            "mode": "custom_sequential_mode",
+            "trigger": "test_runtime_without_parallel_subagents",
+        },
+        "personas": [
+            {"persona_id": "researcher", "role": "Custom research role"},
+        ],
+        "response_payload_refs": {"requires_prose_parsing": True},
+    }
+
+    metadata = lateral_review_response_to_interview_orchestration_metadata(
+        payload,
+        session_id="sess-custom",
+        runtime_supports_parallel_subagents=False,
+        lateral_panel_metadata=custom_panel,
+    )
+
+    panel = metadata["lateral_panel"]
+    entries = panel["entries"]
+    assert panel["panel_id"] == "custom_lateral_panel.v9"
+    assert panel["mcp_tool"] == "custom_lateral_tool"
+    assert panel["execution_mode"] == "custom_sequential_mode"
+    assert panel["requires_prose_parsing"] is True
+    assert entries[0]["panel_id"] == "custom_lateral_panel.v9"
+    assert entries[0]["mcp_tool"] == "custom_lateral_tool"
+    assert entries[0]["persona_role"] == "Custom research role"
+    assert entries[0]["execution_mode"] == "custom_sequential_mode"
+    assert entries[0]["parallel_group"] == "sess-custom:custom_lateral_panel.v9"
+
+
+@pytest.mark.asyncio
+async def test_inline_lateral_content_converts_to_sequential_persona_panel_entries() -> None:
+    """Content-only inline fallback still yields structured panel entries."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview needs a lightweight review",
+            "current_approach": "ask the next Socratic question",
+            "personas": ["researcher", "simplifier"],
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    # Simulate an MCP transport that preserved only visible content and dropped meta.
+    content_only = MCPToolResult(
+        content=(MCPContentItem(type=ContentType.TEXT, text=payload.text_content),),
+        is_error=False,
+        meta={},
+    )
+
+    metadata = lateral_review_response_to_interview_orchestration_metadata(
+        content_only,
+        session_id="sess-inline",
+        runtime_supports_parallel_subagents=False,
+    )
+
+    panel = metadata["lateral_panel"]
+    entries = panel["entries"]
+    assert panel["panel_id"] == "lateral_persona_panel.v1"
+    assert panel["mcp_tool"] == "ouroboros_lateral_think"
+    assert panel["entry_count"] == 2
+    assert panel["execution_mode"] == "sequential_persona_payload_dispatch"
+    assert panel["requires_prose_parsing"] is False
+    assert [entry["persona_id"] for entry in entries] == ["researcher", "simplifier"]
+    assert {entry["dispatch_mode"] for entry in entries} == {"inline_fallback"}
+    assert {entry["response_payload_source"] for entry in entries} == {"inline_content"}
+    assert {entry["execution_mode"] for entry in entries} == {"sequential_persona_payload_dispatch"}
+    assert all(entry["sequential_fallback_used"] is True for entry in entries)
+
+
+@pytest.mark.asyncio
+async def test_sequential_lateral_consumer_receives_persona_payloads_in_order() -> None:
+    """Sequential fallback consumers receive persona payloads in request order."""
+    requested_personas = ["simplifier", "hacker", "researcher"]
+    handler = LateralThinkHandler(
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview needs ordered persona review",
+            "current_approach": "dispatch sequentially when parallel panes are unavailable",
+            "personas": requested_personas,
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        payload,
+        session_id="sess-sequential-consumer",
+        runtime_supports_parallel_subagents=False,
+    )
+
+    sequential_consumer_received = []
+    for entry in entries:
+        assert entry["execution_mode"] == "sequential_persona_payload_dispatch"
+        assert entry["sequential_fallback_used"] is True
+        sequential_consumer_received.append(
+            {
+                "execution_order": entry["execution_order"],
+                "persona_id": entry["persona_id"],
+                "agent": entry["agent"],
+                "context_persona": entry["context"]["persona"],
+                "prompt": entry["prompt"],
+            }
+        )
+
+    assert [item["execution_order"] for item in sequential_consumer_received] == [1, 2, 3]
+    assert [item["persona_id"] for item in sequential_consumer_received] == requested_personas
+    assert [item["agent"] for item in sequential_consumer_received] == requested_personas
+    assert [item["context_persona"] for item in sequential_consumer_received] == requested_personas
+    for item in sequential_consumer_received:
+        assert f"**{item['persona_id']}** persona" in item["prompt"]
+        assert "Task for you (subagent)" in item["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_sequential_lateral_synthesis_waits_for_configured_sequence_outputs() -> None:
+    """Sequential fallback gates synthesis until every ordered persona output arrives."""
+    requested_personas = ["simplifier", "hacker", "researcher"]
+    handler = LateralThinkHandler(
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview needs ordered persona synthesis",
+            "current_approach": "continue only after sequential review completes",
+            "personas": requested_personas,
+        }
+    )
+
+    assert result.is_ok, result
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        result.unwrap(),
+        session_id="sess-sequential-aggregate",
+        runtime_supports_parallel_subagents=False,
+    )
+    assert [entry["persona_id"] for entry in entries] == requested_personas
+    assert {entry["execution_mode"] for entry in entries} == {"sequential_persona_payload_dispatch"}
+    assert all(entry["sequential_fallback_used"] is True for entry in entries)
+
+    synthesis_calls = []
+
+    def synthesize(aggregated_outputs: list[dict]) -> dict:
+        synthesis_calls.append(aggregated_outputs)
+        return {
+            "persona_ids": [item["persona_id"] for item in aggregated_outputs],
+            "combined": "\n".join(str(item["output"]) for item in aggregated_outputs),
+        }
+
+    consumed_outputs: dict[str, str] = {}
+    for index, persona_id in enumerate(requested_personas[:-1], start=1):
+        consumed_outputs[persona_id] = f"{persona_id} output"
+        partial = synthesize_lateral_persona_panel_when_complete(
+            entries,
+            consumed_outputs,
+            synthesize,
+        )
+
+        assert partial["ready_for_synthesis"] is False
+        assert partial["missing_personas"] == requested_personas[index:]
+        assert [item["persona_id"] for item in partial["aggregated_outputs"]] == (
+            requested_personas[:index]
+        )
+        assert partial["synthesis"] is None
+        assert synthesis_calls == []
+
+    consumed_outputs[requested_personas[-1]] = "researcher output"
+    complete = synthesize_lateral_persona_panel_when_complete(
+        entries,
+        consumed_outputs,
+        synthesize,
+    )
+
+    assert complete["ready_for_synthesis"] is True
+    assert complete["missing_personas"] == []
+    assert complete["synthesis"] == {
+        "persona_ids": requested_personas,
+        "combined": "simplifier output\nhacker output\nresearcher output",
+    }
+    assert len(synthesis_calls) == 1
+    assert [item["persona_id"] for item in synthesis_calls[0]] == requested_personas
+
+
+@pytest.mark.asyncio
+async def test_sequential_lateral_synthesis_precedes_interview_continuation() -> None:
+    """Sequential fallback also synthesizes before the interview turn resumes."""
+    requested_personas = ["simplifier", "hacker", "researcher"]
+    handler = LateralThinkHandler(
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview needs ordered persona review",
+            "current_approach": "continue only after sequential synthesis",
+            "personas": requested_personas,
+        }
+    )
+
+    assert result.is_ok, result
+    entries = lateral_review_response_to_interview_orchestration_entries(
+        result.unwrap(),
+        session_id="sess-sequential-continuation-order",
+        runtime_supports_parallel_subagents=False,
+    )
+    assert all(entry["sequential_fallback_used"] is True for entry in entries)
+
+    timeline: list[str] = []
+
+    def synthesize(aggregated_outputs: list[dict]) -> dict:
+        timeline.append("synthesis")
+        return {
+            "persona_ids": [item["persona_id"] for item in aggregated_outputs],
+            "summary": "ordered lateral synthesis is ready",
+        }
+
+    def continue_interview(synthesis: dict) -> dict:
+        assert timeline == ["synthesis"]
+        assert synthesis["persona_ids"] == requested_personas
+        timeline.append("interview_continuation")
+        return {
+            "next_question": "Which assumption remains unclear?",
+            "lateral_synthesis": synthesis,
+        }
+
+    incomplete = continue_interview_after_lateral_persona_synthesis(
+        entries,
+        {
+            "simplifier": "reduce follow-up scope",
+            "hacker": "identify workaround risk",
+        },
+        synthesize,
+        continue_interview,
+    )
+
+    assert incomplete["ready_for_synthesis"] is False
+    assert incomplete["continued_interview"] is False
+    assert timeline == []
+
+    complete = continue_interview_after_lateral_persona_synthesis(
+        entries,
+        {
+            "researcher": "verify implementation facts",
+            "hacker": "identify workaround risk",
+            "simplifier": "reduce follow-up scope",
+        },
+        synthesize,
+        continue_interview,
+    )
+
+    assert complete["ready_for_synthesis"] is True
+    assert complete["continued_interview"] is True
+    assert complete["interview_continuation"] == {
+        "next_question": "Which assumption remains unclear?",
+        "lateral_synthesis": complete["synthesis"],
+    }
+    assert timeline == ["synthesis", "interview_continuation"]
 
 
 @pytest.mark.asyncio
@@ -306,6 +864,7 @@ async def test_inline_fallback_carries_dispatch_block_in_content() -> None:
     assert len(payloads) == 2
 
     for persona_name, persona_payload in zip(["hacker", "contrarian"], payloads, strict=True):
+        assert persona_payload["agent"] == persona_name
         assert persona_payload["title"] == f"Lateral ({persona_name})"
         # The canonical prompt carries the "Task for you (subagent)" wrapper
         # that plugin mode also dispatches — same builder, same prompt.


### PR DESCRIPTION
## Stack

This is **6/7** in the smaller replacement stack for closed PR #1363. Stacked on #1369.

| Order | PR | Topic | Base |
|---:|---|---|---|
| 1 | #1365 | Skill-to-tool mapping | `main` |
| 2 | #1366 | Backend subagent capability | #1365 |
| 3 | #1367 | Evaluation diagnostics | #1366 |
| 4 | #1368 | Owned tool capability contracts | #1367 |
| 5 | #1369 | Interview code-investigation metadata | #1368 |
| 6 | #1370 | Lateral persona orchestration metadata | #1369 |
| 7 | #1371 | Review follow-up coverage | #1370 |

Review and merge in order.

## Changes

- Reads lateral persona panel metadata from capability definitions.
- Converts plugin and inline lateral responses into structured interview orchestration entries.
- Adds synthesis/continuation coverage for parallel and sequential persona payload consumption.

## Verification

- `uv run pytest tests/unit/mcp/tools/test_lateral_think_handler.py tests/unit/mcp/tools/test_interview_lateral_review_advisory.py -q`
- `uv run ruff format --check src/ tests/`
- `uv run ruff check src/ tests/`
- Full focused stack suite was run from the stack tip.

## Notes

Supersedes the lateral persona orchestration part of #1363.
