### PR TITLE
test(orchestrator): [stack 7/7] cover capability review follow-ups

### DIFF
--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -171,6 +171,20 @@ def test_unsupported_parallel_subagent_runtime_gets_sequential_fallback_contract
     )
 
 
+@pytest.mark.parametrize("directive_metadata", [{}, {"sequential_fallback": "invalid"}])
+def test_subagent_orchestration_contract_handles_absent_or_malformed_fallback(
+    directive_metadata: dict[str, object],
+) -> None:
+    contract = build_runtime_subagent_orchestration_contract(
+        "codex_cli",
+        directive_metadata=directive_metadata,
+    )
+
+    assert contract.dispatch_mode == "sequential_fallback"
+    assert contract.sequential_fallback == {}
+    assert "MCP `sequential_fallback` contract" in contract.runtime_instruction_handling
+
+
 def test_subagent_orchestration_cancel_job_capability_stays_callable_in_same_envelope() -> None:
     contract = build_runtime_subagent_orchestration_contract(
         "opencode_cli",


### PR DESCRIPTION
## Stack

This is **7/7** in the smaller replacement stack for closed PR #1363. Stacked on #1370.

| Order | PR | Topic | Base |
|---:|---|---|---|
| 1 | #1365 | Skill-to-tool mapping | `main` |
| 2 | #1366 | Backend subagent capability | #1365 |
| 3 | #1367 | Evaluation diagnostics | #1366 |
| 4 | #1368 | Owned tool capability contracts | #1367 |
| 5 | #1369 | Interview code-investigation metadata | #1368 |
| 6 | #1370 | Lateral persona orchestration metadata | #1369 |
| 7 | #1371 | Review follow-up coverage | #1370 |

Review and merge in order.

## Changes

- Parses one-line `Arguments: { ... }` skill body examples.
- Updates the owned capability contract expectation for `ouroboros_brownfield` to include the discovered `indices` context key.
- Adds backend contract coverage for absent or malformed `sequential_fallback` metadata.

## Verification

- `uv run ruff format --check src/ tests/`
- `uv run ruff check src/ tests/`
- `uv run pytest tests/unit/orchestrator/test_skill_tool_mapping.py tests/unit/backends/test_capabilities.py tests/unit/evaluation/test_mechanical.py tests/unit/mcp/tools/test_definitions.py tests/unit/mcp/tools/test_interview_response_diagnostics.py tests/unit/mcp/tools/test_interview_lateral_review_advisory.py tests/unit/mcp/tools/test_lateral_think_handler.py tests/unit/orchestrator/test_capabilities.py -q` -> 398 passed

## Notes

Addresses non-blocking/follow-up review notes from #1365 and #1366.
