### PR TITLE
feat(runtime): [stack 2/5] GjcRuntime

### DIFF
--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -318,7 +318,7 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
     BackendCapability(
         name="gjc",
         aliases=("gajae-code", "gajae_code"),
-        supports_runtime=False,
+        supports_runtime=True,
         supports_llm=False,
         supports_interview_driver=False,
         switchable_runtime=False,

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -99,6 +99,7 @@ class AgentRuntimeBackend(str, Enum):  # noqa: UP042
     COPILOT = "copilot"
     KIRO = "kiro"
     PI = "pi"
+    GJC = "gjc"
 
 
 app = typer.Typer(

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -71,6 +71,7 @@ class AgentRuntimeBackend(str, Enum):  # noqa: UP042
     KIRO = "kiro"
     COPILOT = "copilot"
     PI = "pi"
+    GJC = "gjc"
 
 
 class LLMBackend(str, Enum):  # noqa: UP042

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -70,6 +70,7 @@ class AgentRuntimeBackend(str, Enum):  # noqa: UP042
     COPILOT = "copilot"
     GOOSE = "goose"
     PI = "pi"
+    GJC = "gjc"
 
 
 class LLMBackend(str, Enum):  # noqa: UP042

--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -80,6 +80,7 @@ class AgentRuntimeBackend(str, Enum):  # noqa: UP042
     GOOSE = "goose"
     KIRO = "kiro"
     PI = "pi"
+    GJC = "gjc"
 
 
 def _derive_quality_bar(seed: "Seed") -> str:
@@ -803,7 +804,7 @@ def workflow(
         AgentRuntimeBackend | None,
         typer.Option(
             "--runtime",
-            help="Agent runtime backend for orchestrator mode (claude, codex, opencode, hermes, gemini, copilot, goose, kiro, or pi).",
+            help="Agent runtime backend for orchestrator mode (claude, codex, opencode, hermes, gemini, copilot, goose, kiro, pi, or gjc).",
             case_sensitive=False,
         ),
     ] = None,

--- a/src/ouroboros/config/models.py
+++ b/src/ouroboros/config/models.py
@@ -361,6 +361,8 @@ VALID_RUNTIME_BACKENDS = frozenset(
         "goose_cli",
         "pi",
         "pi_cli",
+        "gjc",
+        "gjc_cli",
     }
 )
 
@@ -485,7 +487,7 @@ class OrchestratorConfig(BaseModel, frozen=True):
     """
 
     runtime_backend: Literal[
-        "claude", "codex", "opencode", "hermes", "gemini", "kiro", "copilot", "goose", "pi"
+        "claude", "codex", "opencode", "hermes", "gemini", "kiro", "copilot", "goose", "pi", "gjc"
     ] = "claude"
     runtime_profile: RuntimeProfileConfig | None = None
 

--- a/src/ouroboros/orchestrator/gjc_runtime.py
+++ b/src/ouroboros/orchestrator/gjc_runtime.py
@@ -1,0 +1,665 @@
+"""GJC CLI RPC runtime for Ouroboros orchestrator execution."""
+
+from __future__ import annotations
+
+import asyncio
+import codecs
+from collections import deque
+from collections.abc import AsyncIterator
+import contextlib
+import json
+import os
+from pathlib import Path
+import shutil
+import time
+from typing import Any
+from uuid import uuid4
+
+from ouroboros.core.errors import ProviderError
+from ouroboros.core.types import Result
+from ouroboros.observability.logging import get_logger
+from ouroboros.orchestrator.adapter import (
+    AgentMessage,
+    RuntimeCapabilities,
+    RuntimeHandle,
+    SkillDispatchHandler,
+    TaskResult,
+)
+from ouroboros.orchestrator.skill_intercept import SkillInterceptor
+from ouroboros.providers.gjc_rpc_protocol import (
+    GjcCommandError,
+    GjcProtocolError,
+    UnsupportedGjcRpcFrame,
+    is_passive_lifecycle_event,
+    unsupported_frame_error,
+    validate_response_ack,
+)
+
+log = get_logger(__name__)
+
+_MAX_LINE_BUFFER_BYTES = 50 * 1024 * 1024
+
+
+class MalformedGjcEvent(ProviderError):
+    """Raised when GJC emits malformed JSONL."""
+
+
+class GjcExitError(ProviderError):
+    """Raised when GJC exits non-zero."""
+
+
+class GjcRuntime:
+    """Agent runtime that drives ``gjc --mode rpc`` over persistent stdio."""
+
+    _runtime_handle_backend = "gjc"
+    _runtime_backend = "gjc"
+    _requires_memory_gate = False
+    _provider_name = "gjc"
+    _runtime_error_type = "GjcError"
+    _log_namespace = "gjc_runtime"
+    _display_name = "GJC"
+    _default_cli_name = "gjc"
+    _default_llm_backend = "gjc"
+    _process_shutdown_timeout_seconds = 5.0
+    _startup_output_timeout_seconds = 120.0
+    _stdout_idle_timeout_seconds = 600.0
+    _max_stderr_lines = 512
+
+    def __init__(
+        self,
+        cli_path: str | Path | None = None,
+        permission_mode: str | None = None,
+        model: str | None = None,
+        cwd: str | Path | None = None,
+        skills_dir: str | Path | None = None,
+        skill_dispatcher: SkillDispatchHandler | None = None,
+        llm_backend: str | None = None,
+        startup_output_timeout_seconds: float | None = None,
+        stdout_idle_timeout_seconds: float | None = None,
+        **_kwargs: Any,
+    ) -> None:
+        self._cli_path = self._resolve_cli_path(cli_path)
+        self._permission_mode = permission_mode
+        self._model = model
+        self._cwd = str(Path(cwd).expanduser()) if cwd is not None else os.getcwd()
+        self._skill_dispatcher = skill_dispatcher
+        self._llm_backend = llm_backend or self._default_llm_backend
+        self._skills_dir = Path(skills_dir).expanduser() if skills_dir is not None else None
+        self._interceptor = SkillInterceptor(
+            cwd=self._cwd,
+            runtime_backend=self._runtime_backend,
+            runtime_handle_backend=self._runtime_handle_backend,
+            permission_mode=self._permission_mode,
+            llm_backend=self._llm_backend,
+            log_namespace=self._log_namespace,
+            skills_dir=self._skills_dir,
+            skill_dispatcher=self._skill_dispatcher,
+        )
+        if startup_output_timeout_seconds is not None:
+            self._startup_output_timeout_seconds = (
+                None if startup_output_timeout_seconds <= 0 else startup_output_timeout_seconds
+            )
+        if stdout_idle_timeout_seconds is not None:
+            self._stdout_idle_timeout_seconds = (
+                None if stdout_idle_timeout_seconds <= 0 else stdout_idle_timeout_seconds
+            )
+        log.info(
+            f"{self._log_namespace}.initialized",
+            cli_path=self._cli_path,
+            cwd=self._cwd,
+            model=model,
+        )
+
+    @property
+    def runtime_backend(self) -> str:
+        return self._runtime_handle_backend
+
+    @property
+    def llm_backend(self) -> str | None:
+        return self._llm_backend
+
+    @property
+    def working_directory(self) -> str | None:
+        return self._cwd
+
+    @property
+    def permission_mode(self) -> str | None:
+        return self._permission_mode
+
+    @property
+    def capabilities(self) -> RuntimeCapabilities:
+        return RuntimeCapabilities(
+            skill_dispatch=True, targeted_resume=False, structured_output=True
+        )
+
+    def _resolve_cli_path(self, cli_path: str | Path | None) -> str:
+        if cli_path is not None:
+            candidate = str(Path(cli_path).expanduser())
+        else:
+            candidate = shutil.which(self._default_cli_name) or self._default_cli_name
+        path = Path(candidate).expanduser()
+        return str(path) if path.exists() else candidate
+
+    def _build_command(self, *, prompt: str) -> list[str]:
+        return [self._cli_path, "--mode", "rpc"]
+
+    def _build_child_env(self) -> dict[str, str]:
+        env = os.environ.copy()
+        for key in ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND"):
+            env.pop(key, None)
+        return env
+
+    async def _iter_stream_lines(
+        self,
+        stream: asyncio.StreamReader | None,
+        *,
+        first_chunk_timeout_seconds: float | None = None,
+        chunk_timeout_seconds: float | None = None,
+    ) -> AsyncIterator[str]:
+        if stream is None:
+            return
+        decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
+        buffer = ""
+        buffer_byte_estimate = 0
+        saw_chunk = False
+        while True:
+            timeout_seconds = (
+                first_chunk_timeout_seconds if not saw_chunk else chunk_timeout_seconds
+            )
+            try:
+                chunk = (
+                    await stream.read(16384)
+                    if timeout_seconds is None
+                    else await asyncio.wait_for(stream.read(16384), timeout=timeout_seconds)
+                )
+            except TimeoutError as exc:
+                phase = "startup" if not saw_chunk else "idle"
+                raise TimeoutError(
+                    f"{self._display_name} produced no stdout during {phase} window ({timeout_seconds:.0f}s)"
+                ) from exc
+            if not chunk:
+                break
+            saw_chunk = True
+            decoded = decoder.decode(chunk)
+            buffer += decoded
+            buffer_byte_estimate += len(decoded) * 4
+            if buffer_byte_estimate > _MAX_LINE_BUFFER_BYTES:
+                raise ProviderError(f"JSONL line buffer exceeded {_MAX_LINE_BUFFER_BYTES} bytes")
+            while True:
+                newline_index = buffer.find("\n")
+                if newline_index < 0:
+                    break
+                line = buffer[:newline_index]
+                buffer = buffer[newline_index + 1 :]
+                buffer_byte_estimate = len(buffer) * 4
+                yield line.rstrip("\r")
+        buffer += decoder.decode(b"", final=True)
+        if buffer:
+            yield buffer.rstrip("\r")
+
+    async def _collect_stream_lines(
+        self, stream: asyncio.StreamReader | None, *, max_lines: int | None = None
+    ) -> list[str]:
+        if stream is None:
+            return []
+        lines: deque[str] = deque(maxlen=max_lines if max_lines and max_lines > 0 else None)
+        async for line in self._iter_stream_lines(stream):
+            if line:
+                lines.append(line)
+        return list(lines)
+
+    def _parse_event(self, line: str) -> dict[str, Any]:
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError as exc:
+            raise MalformedGjcEvent(
+                message=self._malformed_event_message(line), provider=self._provider_name
+            ) from exc
+        if not isinstance(event, dict):
+            raise MalformedGjcEvent(
+                message=self._malformed_event_message(line), provider=self._provider_name
+            )
+        return event
+
+    def _malformed_event_message(self, line: str) -> str:
+        preview = line.strip()
+        if len(preview) > 240:
+            preview = f"{preview[:237]}..."
+        return f"Malformed {self._display_name} JSON event: {preview}"
+
+    def _extract_content_delta(self, event: dict[str, Any]) -> str | None:
+        if event.get("type") != "message_update":
+            return None
+        assistant_event = event.get("assistantMessageEvent")
+        if isinstance(assistant_event, dict):
+            if assistant_event.get("type") not in {None, "text_delta"}:
+                return None
+            delta = assistant_event.get("delta")
+            if isinstance(delta, str):
+                return delta
+            text = assistant_event.get("text") or assistant_event.get("content")
+            return text if isinstance(text, str) else None
+        return None
+
+    def _extract_text_from_message(self, message: dict[str, Any]) -> str | None:
+        content = message.get("content") or message.get("text") or ""
+        if isinstance(content, str) and content.strip():
+            return content.strip()
+        if isinstance(content, list):
+            texts: list[str] = []
+            for item in content:
+                if isinstance(item, str):
+                    texts.append(item)
+                elif isinstance(item, dict):
+                    text = item.get("text") or item.get("content")
+                    if isinstance(text, str) and item.get("type") in {None, "text"}:
+                        texts.append(text)
+            joined = "".join(texts).strip()
+            if joined:
+                return joined
+        return None
+
+    def _extract_final_content(self, event: dict[str, Any]) -> str | None:
+        event_type = event.get("type")
+        if event_type in {"message_end", "turn_end"}:
+            message = event.get("message")
+            if isinstance(message, dict) and message.get("role") == "assistant":
+                return self._extract_text_from_message(message)
+            return None
+        if event_type != "agent_end":
+            return None
+        for msg in reversed(event.get("messages") or []):
+            if isinstance(msg, dict) and msg.get("role") == "assistant":
+                text = self._extract_text_from_message(msg)
+                if text:
+                    return text
+        return None
+
+    def _extract_error_content(self, event: dict[str, Any]) -> str | None:
+        def from_message(message: Any) -> str | None:
+            if (
+                not isinstance(message, dict)
+                or message.get("role") != "assistant"
+                or message.get("stopReason") != "error"
+            ):
+                return None
+            error = message.get("errorMessage") or message.get("error")
+            if isinstance(error, str) and error.strip():
+                return error.strip()
+            return self._extract_text_from_message(message)
+
+        if event.get("type") in {"message_start", "message_end", "turn_end"}:
+            return from_message(event.get("message"))
+        if event.get("type") == "agent_end":
+            for msg in reversed(event.get("messages") or []):
+                error = from_message(msg)
+                if error:
+                    return error
+        return None
+
+    def _provider_error(self, exc: Exception) -> ProviderError:
+        if isinstance(exc, ProviderError):
+            return exc
+        return ProviderError(message=str(exc), provider=self._provider_name)
+
+    def _check_unsupported_or_unknown(self, event: dict[str, Any]) -> None:
+        error = unsupported_frame_error(event, provider=self._provider_name)
+        if error is not None:
+            log.warning(
+                f"{self._log_namespace}.unsupported_frame",
+                frame_type=error.details.get("frame_type"),
+                id=error.details.get("id"),
+            )
+            raise error
+
+    def _model_override(self) -> tuple[str, str] | None:
+        if not self._model or "/" not in self._model:
+            return None
+        provider, model_id = self._model.split("/", 1)
+        provider = provider.strip()
+        model_id = model_id.strip()
+        if not provider or not model_id:
+            return None
+        return provider, model_id
+
+    async def _send_command(self, process: Any, payload: dict[str, Any]) -> None:
+        stdin = getattr(process, "stdin", None)
+        if stdin is None:
+            raise GjcProtocolError(
+                message="GJC stdin pipe is unavailable", provider=self._provider_name
+            )
+        stdin.write((json.dumps(payload) + "\n").encode())
+        drain = getattr(stdin, "drain", None)
+        if callable(drain):
+            await drain()
+
+    async def _terminate_process(self, process: Any) -> None:
+        if getattr(process, "returncode", None) is not None:
+            return
+        terminate = getattr(process, "terminate", None)
+        kill = getattr(process, "kill", None)
+        try:
+            if callable(terminate):
+                terminate()
+            elif callable(kill):
+                kill()
+            else:
+                return
+        except ProcessLookupError:
+            return
+        except Exception as exc:
+            log.warning(f"{self._log_namespace}.process_terminate_failed", error=str(exc))
+            return
+        try:
+            await asyncio.wait_for(process.wait(), timeout=self._process_shutdown_timeout_seconds)
+            return
+        except (TimeoutError, ProcessLookupError):
+            pass
+        if callable(kill):
+            with contextlib.suppress(ProcessLookupError, Exception):
+                kill()
+            with contextlib.suppress(asyncio.TimeoutError, ProcessLookupError, Exception):
+                await asyncio.wait_for(
+                    process.wait(), timeout=self._process_shutdown_timeout_seconds
+                )
+
+    def _close_stdin(self, process: Any) -> None:
+        stdin = getattr(process, "stdin", None)
+        if stdin is not None:
+            with contextlib.suppress(Exception):
+                stdin.close()
+
+    def _error_message(self, exc: Exception, stderr_lines: list[str] | None = None) -> str:
+        stderr_text = "\n".join(stderr_lines or []).strip()
+        return stderr_text or str(exc)
+
+    async def execute_task(
+        self,
+        prompt: str,
+        tools: list[str] | None = None,
+        system_prompt: str | None = None,
+        resume_handle: RuntimeHandle | None = None,
+        resume_session_id: str | None = None,
+    ) -> AsyncIterator[AgentMessage]:
+        current_handle = None
+        if resume_handle is not None or resume_session_id is not None:
+            log.info(f"{self._log_namespace}.resume_ignored_non_resumable")
+        intercepted_messages = await self._interceptor.maybe_dispatch(prompt, None)
+        if intercepted_messages is not None:
+            for message in intercepted_messages:
+                yield AgentMessage(
+                    type=message.type,
+                    content=message.content,
+                    data=message.data,
+                    tool_name=message.tool_name,
+                )
+            return
+        parts = []
+        if system_prompt:
+            parts.append(f"## System Instructions\n{system_prompt}")
+        if tools:
+            parts.append(
+                "## Tooling Guidance\nPrefer these tools:\n"
+                + "\n".join(f"- {tool}" for tool in tools)
+            )
+        parts.append(prompt)
+        composed_prompt = "\n\n".join(part for part in parts if part.strip())
+        command = self._build_command(prompt=composed_prompt)
+        log.info(f"{self._log_namespace}.task_started", command=command, cwd=self._cwd)
+        process: Any | None = None
+        stderr_task: asyncio.Task[list[str]] | None = None
+        process_finished = False
+        process_terminated = False
+        spawn_started = time.monotonic()
+        task_started = spawn_started
+        last_content = ""
+        pending_final_content: str | None = None
+        pending_error_content: str | None = None
+        try:
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=self._cwd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=self._build_child_env(),
+            )
+            stderr_task = asyncio.create_task(
+                self._collect_stream_lines(process.stderr, max_lines=self._max_stderr_lines)
+            )
+            line_iter = self._iter_stream_lines(
+                process.stdout,
+                first_chunk_timeout_seconds=self._startup_output_timeout_seconds,
+                chunk_timeout_seconds=self._stdout_idle_timeout_seconds,
+            )
+            try:
+                ready_event = self._parse_event(await anext(line_iter))
+                self._check_unsupported_or_unknown(ready_event)
+            except StopAsyncIteration as exc:
+                raise TimeoutError("GJC produced no ready event") from exc
+            if ready_event.get("type") != "ready":
+                raise GjcProtocolError(
+                    message=f"Expected GJC ready frame before any other frame, got {ready_event.get('type')!r}",
+                    provider=self._provider_name,
+                )
+            spawn_to_ready_ms = int((time.monotonic() - spawn_started) * 1000)
+            log.info(f"{self._log_namespace}.ready_received", spawn_to_ready_ms=spawn_to_ready_ms)
+            override = self._model_override()
+            if override is not None:
+                model_command_id = f"set_model-{uuid4().hex}"
+                await self._send_command(
+                    process,
+                    {
+                        "id": model_command_id,
+                        "type": "set_model",
+                        "provider": override[0],
+                        "modelId": override[1],
+                    },
+                )
+                event = self._parse_event(await anext(line_iter))
+                self._check_unsupported_or_unknown(event)
+                validate_response_ack(
+                    event,
+                    command_id=model_command_id,
+                    command="set_model",
+                    provider=self._provider_name,
+                )
+                log.info(f"{self._log_namespace}.model_acknowledged")
+            prompt_command_id = f"prompt-{uuid4().hex}"
+            await self._send_command(
+                process, {"id": prompt_command_id, "type": "prompt", "message": composed_prompt}
+            )
+            acked = False
+            async for line in line_iter:
+                if not line:
+                    continue
+                event = self._parse_event(line)
+                event_type = event.get("type")
+                self._check_unsupported_or_unknown(event)
+                if event_type == "response" and event.get("id") == prompt_command_id:
+                    validate_response_ack(
+                        event,
+                        command_id=prompt_command_id,
+                        command="prompt",
+                        provider=self._provider_name,
+                    )
+                    if not acked:
+                        acked = True
+                        prompt_ack_ms = int((time.monotonic() - task_started) * 1000)
+                        log.info(
+                            f"{self._log_namespace}.prompt_acknowledged",
+                            prompt_ack_ms=prompt_ack_ms,
+                        )
+                    continue
+                if not acked:
+                    raise GjcProtocolError(
+                        message=f"Expected GJC prompt response before streaming, got {event_type!r}",
+                        provider=self._provider_name,
+                    )
+                if is_passive_lifecycle_event(event):
+                    log.debug(
+                        f"{self._log_namespace}.passive_lifecycle_event", event_type=event_type
+                    )
+                    continue
+                error_content = self._extract_error_content(event)
+                if error_content:
+                    pending_error_content = error_content
+                delta = self._extract_content_delta(event)
+                if delta:
+                    last_content += delta
+                    yield AgentMessage(
+                        type="assistant", content=delta, data={"event_type": "message_update"}
+                    )
+                    continue
+                final_content = self._extract_final_content(event)
+                if final_content:
+                    pending_final_content = final_content
+                if event_type == "agent_end":
+                    break
+            else:
+                raise GjcProtocolError(
+                    message="GJC stream ended before agent_end", provider=self._provider_name
+                )
+            self._close_stdin(process)
+            returncode = await process.wait()
+            process_finished = True
+            stderr_lines = await stderr_task if stderr_task else []
+            task_wall_ms = int((time.monotonic() - task_started) * 1000)
+            if returncode != 0:
+                raise GjcExitError(
+                    message="\n".join(stderr_lines).strip()
+                    or f"GJC exited with code {returncode}.",
+                    provider=self._provider_name,
+                    details={"returncode": returncode},
+                )
+            if pending_error_content:
+                raise ProviderError(message=pending_error_content, provider=self._provider_name)
+            final_message = pending_final_content or last_content or "GJC task completed."
+            log.info(
+                f"{self._log_namespace}.task_completed",
+                task_wall_ms=task_wall_ms,
+                returncode=returncode,
+            )
+            yield AgentMessage(
+                type="result",
+                content=final_message,
+                data={"subtype": "success", "returncode": returncode},
+            )
+        except (
+            TimeoutError,
+            MalformedGjcEvent,
+            GjcProtocolError,
+            GjcCommandError,
+            UnsupportedGjcRpcFrame,
+            GjcExitError,
+            ProviderError,
+        ) as exc:
+            if process is not None and not isinstance(exc, GjcExitError):
+                await self._terminate_process(process)
+                process_terminated = True
+            stderr_lines = await stderr_task if stderr_task else []
+            provider_exc = self._provider_error(exc)
+            log.info(
+                f"{self._log_namespace}.task_failed", error_type=type(exc).__name__, error=str(exc)
+            )
+            yield AgentMessage(
+                type="result",
+                content=(
+                    self._error_message(provider_exc, stderr_lines)
+                    if isinstance(exc, TimeoutError)
+                    else provider_exc.message
+                ),
+                data={
+                    "subtype": "error",
+                    "error_type": type(exc).__name__,
+                    **(
+                        {"returncode": provider_exc.details.get("returncode")}
+                        if isinstance(provider_exc.details, dict)
+                        and "returncode" in provider_exc.details
+                        else {}
+                    ),
+                },
+                resume_handle=current_handle,
+            )
+        except asyncio.CancelledError:
+            if process is not None:
+                await self._terminate_process(process)
+            raise
+        except FileNotFoundError as exc:
+            yield AgentMessage(
+                type="result",
+                content=f"{self._display_name} not found: {exc}",
+                data={"subtype": "error", "error_type": type(exc).__name__},
+            )
+        except Exception as exc:
+            if process is not None:
+                await self._terminate_process(process)
+                process_terminated = True
+            yield AgentMessage(
+                type="result",
+                content=f"Failed to run {self._display_name}: {exc}",
+                data={"subtype": "error", "error_type": type(exc).__name__},
+            )
+        finally:
+            if process is not None:
+                self._close_stdin(process)
+                if (
+                    not process_finished
+                    and not process_terminated
+                    and getattr(process, "returncode", None) is None
+                ):
+                    await self._terminate_process(process)
+            if stderr_task is not None and not stderr_task.done():
+                stderr_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await stderr_task
+
+    async def execute_task_to_result(
+        self,
+        prompt: str,
+        tools: list[str] | None = None,
+        system_prompt: str | None = None,
+        resume_handle: RuntimeHandle | None = None,
+        resume_session_id: str | None = None,
+    ) -> Result[TaskResult, ProviderError]:
+        messages: list[AgentMessage] = []
+        final_message = ""
+        success = True
+        async for message in self.execute_task(
+            prompt=prompt,
+            tools=tools,
+            system_prompt=system_prompt,
+            resume_handle=resume_handle,
+            resume_session_id=resume_session_id,
+        ):
+            messages.append(message)
+            if message.is_final:
+                final_message = message.content
+                success = not message.is_error
+        if not success:
+            return Result.err(
+                ProviderError(
+                    message=final_message,
+                    provider=self._provider_name,
+                    details={"messages": [message.content for message in messages]},
+                )
+            )
+        return Result.ok(
+            TaskResult(
+                success=success,
+                final_message=final_message,
+                messages=tuple(messages),
+                session_id=None,
+                resume_handle=None,
+            )
+        )
+
+
+__all__ = [
+    "GjcRuntime",
+    "GjcCommandError",
+    "GjcExitError",
+    "GjcProtocolError",
+    "MalformedGjcEvent",
+    "UnsupportedGjcRpcFrame",
+]

--- a/src/ouroboros/orchestrator/runtime_factory.py
+++ b/src/ouroboros/orchestrator/runtime_factory.py
@@ -11,6 +11,7 @@ from ouroboros.config import (
     get_cli_path,
     get_codex_cli_path,
     get_copilot_cli_path,
+    get_gjc_cli_path,
     get_goose_cli_path,
     get_hermes_cli_path,
     get_kiro_cli_path,
@@ -150,6 +151,16 @@ def create_agent_runtime(
 
         return PiRuntime(
             cli_path=cli_path or get_pi_cli_path(),
+            startup_output_timeout_seconds=startup_output_timeout_seconds,
+            stdout_idle_timeout_seconds=stdout_idle_timeout_seconds,
+            **runtime_kwargs,
+        )
+
+    if resolved_backend == "gjc":
+        from ouroboros.orchestrator.gjc_runtime import GjcRuntime
+
+        return GjcRuntime(
+            cli_path=cli_path or get_gjc_cli_path(),
             startup_output_timeout_seconds=startup_output_timeout_seconds,
             stdout_idle_timeout_seconds=stdout_idle_timeout_seconds,
             **runtime_kwargs,

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -41,28 +41,30 @@ def test_cli_auto_runtime_enum_matches_supported_backends() -> None:
         "copilot",
         "kiro",
         "pi",
+        "gjc",
     }
 
 
-def test_cli_runtime_enums_keep_inert_gjc_out_of_frontdoor_commands() -> None:
+def test_cli_runtime_enums_accept_gjc_for_frontdoor_commands() -> None:
     from ouroboros.cli.commands import init, mcp, run
     from ouroboros.cli.commands.auto import AgentRuntimeBackend as AutoRuntimeBackend
 
-    with pytest.raises(ValueError):
-        AutoRuntimeBackend("gjc")
-    with pytest.raises(ValueError):
-        run.AgentRuntimeBackend("gjc")
-    with pytest.raises(ValueError):
-        mcp.AgentRuntimeBackend("gjc")
-    with pytest.raises(ValueError):
-        init.AgentRuntimeBackend("gjc")
+    assert AutoRuntimeBackend("gjc") is AutoRuntimeBackend.GJC
+    assert run.AgentRuntimeBackend("gjc") is run.AgentRuntimeBackend.GJC
+    assert mcp.AgentRuntimeBackend("gjc") is mcp.AgentRuntimeBackend.GJC
+    assert init.AgentRuntimeBackend("gjc") is init.AgentRuntimeBackend.GJC
+
+
+def test_cli_llm_enums_keep_gjc_out_until_adapter_lands() -> None:
+    from ouroboros.cli.commands import init, mcp
+
     with pytest.raises(ValueError):
         mcp.LLMBackend("gjc")
     with pytest.raises(ValueError):
         init.LLMBackend("gjc")
 
 
-def test_cli_frontdoor_help_omits_inert_gjc_backend_options() -> None:
+def test_cli_frontdoor_help_lists_gjc_backend_options() -> None:
     runner = CliRunner()
     commands = [
         ["auto", "--help"],
@@ -75,7 +77,21 @@ def test_cli_frontdoor_help_omits_inert_gjc_backend_options() -> None:
     for args in commands:
         result = runner.invoke(app, args)
         assert result.exit_code == 0, result.output
-        assert "gjc" not in result.output
+        assert "gjc" in result.output
+
+
+def test_cli_llm_help_omits_gjc_backend_option() -> None:
+    runner = CliRunner()
+
+    for args in (
+        ["mcp", "serve", "--help"],
+        ["mcp", "info", "--help"],
+        ["init", "start", "--help"],
+    ):
+        result = runner.invoke(app, args)
+        assert result.exit_code == 0, result.output
+        assert "LLM backend" in result.output
+        assert "pi, or gjc" not in result.output
 
 
 def test_interview_allowed_tools_omits_unsupported_hermes_envelope(monkeypatch) -> None:

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -78,6 +78,8 @@ def test_runtime_choices_include_runtime_only_backends() -> None:
     choices = runtime_backend_choices()
     assert "hermes" in choices
     assert "pi" in choices
+    assert "gjc" in choices
+    assert resolve_runtime_backend_name("gajae_code") == "gjc"
     assert "litellm" not in choices
 
 
@@ -123,7 +125,7 @@ def test_switchable_runtime_metadata_is_registry_owned() -> None:
     assert gjc_capability.cli_name == "gjc"
     assert gjc_capability.cli_config_key == "gjc_cli_path"
     assert gjc_capability.switchable_runtime is False
-    assert gjc_capability.supports_runtime is False
+    assert gjc_capability.supports_runtime is True
     assert gjc_capability.supports_llm is False
 
 

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -308,6 +308,23 @@ def test_health_honors_agent_runtime_and_cli_path_environment_overrides(
     assert "codex OAuth file present" in result.output
 
 
+def test_health_honors_gjc_cli_path_environment_override(monkeypatch, tmp_path: Path) -> None:
+    _clear_auth_env(monkeypatch)
+    config_dir = tmp_path / "config"
+    (config_dir / "data").mkdir(parents=True)
+    gjc_cli = _make_cli(tmp_path / "custom-bin" / "gjc")
+    (config_dir / "data" / "ouroboros.db").write_text("")
+    _write_config(config_dir, backend="gjc", extra_orchestrator={"gjc_cli_path": None})
+    _write_credentials(config_dir)
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: config_dir)
+    monkeypatch.setenv("OUROBOROS_GJC_CLI_PATH", str(gjc_cli))
+
+    result = runner.invoke(app, ["health"])
+
+    assert result.exit_code == 0
+    assert f"gjc: {gjc_cli}" in result.output
+
+
 def test_health_honors_effective_backend_configured_cli_when_runtime_env_overrides(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/unit/config/test_models.py
+++ b/tests/unit/config/test_models.py
@@ -226,8 +226,8 @@ class TestLLMConfig:
         config = LLMConfig(backend="pi")
         assert config.backend == "pi"
 
-    def test_llm_config_rejects_inert_gjc_backend(self) -> None:
-        """GJC is registered as inert until the LLM adapter stack lands."""
+    def test_llm_config_rejects_gjc_until_adapter_lands(self) -> None:
+        """Stack 2 wires GJC runtime only; LLM selection lands later."""
         with pytest.raises(ValidationError):
             LLMConfig(backend="gjc")  # type: ignore[arg-type]
 
@@ -592,13 +592,10 @@ class TestOrchestratorConfig:
         assert config.pi_cli_path is not None
         assert "~" not in config.pi_cli_path
 
-    def test_orchestrator_config_rejects_inert_gjc_backend(self) -> None:
-        """GJC path storage is allowed, but runtime selection stays unsupported here."""
-        with pytest.raises(ValidationError):
-            OrchestratorConfig(runtime_backend="gjc", gjc_cli_path="~/bin/gjc")  # type: ignore[arg-type]
-
-        config = OrchestratorConfig(gjc_cli_path="~/bin/gjc")
-        assert config.runtime_backend == "claude"
+    def test_orchestrator_config_accepts_gjc_backend(self) -> None:
+        """GJC is a valid runtime-only backend."""
+        config = OrchestratorConfig(runtime_backend="gjc", gjc_cli_path="~/bin/gjc")
+        assert config.runtime_backend == "gjc"
         assert config.gjc_cli_path is not None
         assert "~" not in config.gjc_cli_path
 
@@ -729,11 +726,10 @@ class TestRuntimeProfileConfig:
         assert profile.default == "pi"
         assert profile.stages == {"execute": "pi_cli"}
 
-    def test_runtime_profile_rejects_inert_gjc_backends(self) -> None:
-        with pytest.raises(ValidationError):
-            RuntimeProfileConfig(default="gjc")  # type: ignore[arg-type]
-        with pytest.raises(ValidationError):
-            RuntimeProfileConfig(stages={"execute": "gjc_cli"})
+    def test_runtime_profile_accepts_gjc_backends(self) -> None:
+        profile = RuntimeProfileConfig(default="gjc", stages={"execute": "gjc_cli"})
+        assert profile.default == "gjc"
+        assert profile.stages == {"execute": "gjc_cli"}
 
     def test_orchestrator_runtime_profile_string_shorthand(self) -> None:
         config = OrchestratorConfig(runtime_profile="worker")

--- a/tests/unit/orchestrator/test_gjc_runtime.py
+++ b/tests/unit/orchestrator/test_gjc_runtime.py
@@ -1,0 +1,611 @@
+"""Unit tests for GjcRuntime."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from ouroboros.orchestrator.gjc_runtime import GjcRuntime
+
+
+class _FakeStream:
+    def __init__(self, lines: list[str], *, never: bool = False) -> None:
+        self._never = never
+        encoded = "".join(f"{line}\n" for line in lines).encode()
+        self._buffer = bytearray(encoded)
+
+    async def read(self, n: int = -1) -> bytes:
+        if self._never:
+            await asyncio.sleep(3600)
+        if not self._buffer:
+            return b""
+        if n < 0 or n >= len(self._buffer):
+            data = bytes(self._buffer)
+            self._buffer.clear()
+            return data
+        data = bytes(self._buffer[:n])
+        del self._buffer[:n]
+        return data
+
+
+class _FakeStdin:
+    def __init__(self, process: _FakeProcess) -> None:
+        self._process = process
+        self.writes: list[dict[str, Any]] = []
+        self.closed = False
+
+    def write(self, data: bytes) -> None:
+        self.writes.append(json.loads(data.decode()))
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self.closed = True
+        self._process.stdin_eof.set()
+
+
+class _FakeProcess:
+    def __init__(
+        self,
+        stdout_lines: list[str],
+        stderr_lines: list[str] | None = None,
+        returncode: int = 0,
+        *,
+        never_stdout: bool = False,
+    ) -> None:
+        self.stdin_eof = asyncio.Event()
+        self.stdin = _FakeStdin(self)
+        self.stdout = _FakeStream(stdout_lines, never=never_stdout)
+        self.stderr = _FakeStream(stderr_lines or [])
+        self._returncode = returncode
+        self.returncode = None
+        self.terminated = False
+        self.pid = 1234
+
+    async def wait(self) -> int:
+        await self.stdin_eof.wait()
+        self.returncode = self._returncode
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.terminated = True
+        self.returncode = self._returncode
+        self.stdin_eof.set()
+
+    def kill(self) -> None:
+        self.returncode = self._returncode
+        self.stdin_eof.set()
+
+
+def _event(event: dict[str, object]) -> str:
+    return json.dumps(event)
+
+
+@pytest.mark.asyncio
+async def test_missing_ready_times_out_and_terminates() -> None:
+    process = _FakeProcess([], never_stdout=True)
+    runtime = GjcRuntime(
+        cli_path="/tmp/gjc", cwd="/tmp/project", startup_output_timeout_seconds=0.01
+    )
+
+    with patch("asyncio.create_subprocess_exec", return_value=process):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    result = messages[-1]
+    assert result.is_error
+    assert result.data["error_type"] == "TimeoutError"
+    assert process.terminated
+    assert process.stdin.closed
+
+
+@pytest.mark.asyncio
+async def test_non_ready_before_ready_is_protocol_error() -> None:
+    process = _FakeProcess([_event({"type": "agent_start"})])
+    runtime = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project")
+
+    with patch("asyncio.create_subprocess_exec", return_value=process):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    assert messages[-1].is_error
+    assert messages[-1].data["error_type"] == "GjcProtocolError"
+    assert process.terminated
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "frame_type",
+    ["workflow_gate", "host_tool_call", "host_uri_request", "extension_ui_request", "mystery"],
+)
+async def test_unsupported_first_frame_raises_unsupported_and_terminates(frame_type: str) -> None:
+    process = _FakeProcess([_event({"type": frame_type, "id": "frame-1"})])
+    runtime = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project")
+
+    with patch("asyncio.create_subprocess_exec", return_value=process):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    assert messages[-1].is_error
+    assert messages[-1].data["error_type"] == "UnsupportedGjcRpcFrame"
+    assert frame_type in messages[-1].content
+    assert process.terminated
+
+
+@pytest.mark.asyncio
+async def test_prompt_success_false_is_command_error() -> None:
+    process = _FakeProcess(
+        [
+            _event({"type": "ready"}),
+            _event({"type": "response", "id": "wrong", "success": False, "error": "no"}),
+        ]
+    )
+    runtime = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project")
+
+    with patch("asyncio.create_subprocess_exec", return_value=process):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    assert messages[-1].is_error
+    # A wrong id before prompt ack is a strict protocol failure.
+    assert messages[-1].data["error_type"] == "GjcProtocolError"
+    assert process.terminated
+
+
+@pytest.mark.asyncio
+async def test_prompt_same_id_success_false_is_command_error() -> None:
+    process = _FakeProcess([_event({"type": "ready"})])
+    runtime = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project")
+    original_send = runtime._send_command
+
+    async def send_and_append(proc: Any, payload: dict[str, Any]) -> None:
+        await original_send(proc, payload)
+        if payload["type"] == "prompt":
+            proc.stdout._buffer.extend(
+                (
+                    _event(
+                        {
+                            "type": "response",
+                            "id": payload["id"],
+                            "command": "prompt",
+                            "success": False,
+                            "error": "denied",
+                        }
+                    )
+                    + "\n"
+                ).encode()
+            )
+
+    with (
+        patch.object(runtime, "_send_command", side_effect=send_and_append),
+        patch("asyncio.create_subprocess_exec", return_value=process),
+    ):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    assert messages[-1].is_error
+    assert messages[-1].content == "denied"
+    assert messages[-1].data["error_type"] == "GjcCommandError"
+    assert process.terminated
+
+
+@pytest.mark.asyncio
+async def test_ack_message_update_agent_end_success_and_stdin_pipe_closed() -> None:
+    process = _FakeProcess([_event({"type": "ready"})])
+    runtime = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project")
+    original_send = runtime._send_command
+
+    async def send_and_append(proc: Any, payload: dict[str, Any]) -> None:
+        await original_send(proc, payload)
+        if payload["type"] == "prompt":
+            proc.stdout._buffer.extend(
+                (
+                    "\n".join(
+                        [
+                            _event(
+                                {
+                                    "type": "response",
+                                    "id": payload["id"],
+                                    "command": "prompt",
+                                    "success": True,
+                                }
+                            ),
+                            _event(
+                                {
+                                    "type": "message_update",
+                                    "assistantMessageEvent": {"type": "text_delta", "delta": "Hel"},
+                                }
+                            ),
+                            _event(
+                                {
+                                    "type": "agent_end",
+                                    "messages": [
+                                        {
+                                            "role": "assistant",
+                                            "content": [{"type": "text", "text": "Hello"}],
+                                        }
+                                    ],
+                                }
+                            ),
+                        ]
+                    )
+                    + "\n"
+                ).encode()
+            )
+
+    with (
+        patch.object(runtime, "_send_command", side_effect=send_and_append),
+        patch("asyncio.create_subprocess_exec", return_value=process) as mock_exec,
+    ):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    assert mock_exec.call_args.args == ("/tmp/gjc", "--mode", "rpc")
+    assert mock_exec.call_args.kwargs["stdin"] == asyncio.subprocess.PIPE
+    assert mock_exec.call_args.kwargs["stdin"] != asyncio.subprocess.DEVNULL
+    assert [m.content for m in messages if m.type == "assistant"] == ["Hel"]
+    assert messages[-1].content == "Hello"
+    assert messages[-1].data == {"subtype": "success", "returncode": 0}
+    assert messages[-1].resume_handle is None
+    assert process.stdin.closed
+
+
+@pytest.mark.asyncio
+async def test_late_same_id_success_false_is_error() -> None:
+    process = _FakeProcess([_event({"type": "ready"})])
+    runtime = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project")
+    original_send = runtime._send_command
+
+    async def send_and_append(proc: Any, payload: dict[str, Any]) -> None:
+        await original_send(proc, payload)
+        if payload["type"] == "prompt":
+            proc.stdout._buffer.extend(
+                (
+                    "\n".join(
+                        [
+                            _event(
+                                {
+                                    "type": "response",
+                                    "id": payload["id"],
+                                    "command": "prompt",
+                                    "success": True,
+                                }
+                            ),
+                            _event(
+                                {
+                                    "type": "message_update",
+                                    "assistantMessageEvent": {"type": "text_delta", "delta": "x"},
+                                }
+                            ),
+                            _event(
+                                {
+                                    "type": "response",
+                                    "id": payload["id"],
+                                    "command": "prompt",
+                                    "success": False,
+                                    "error": "late bad",
+                                }
+                            ),
+                        ]
+                    )
+                    + "\n"
+                ).encode()
+            )
+
+    with (
+        patch.object(runtime, "_send_command", side_effect=send_and_append),
+        patch("asyncio.create_subprocess_exec", return_value=process),
+    ):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    assert messages[-1].is_error
+    assert messages[-1].content == "late bad"
+    assert messages[-1].data["error_type"] == "GjcCommandError"
+    assert process.terminated
+
+
+@pytest.mark.asyncio
+async def test_assistant_stop_reason_error_with_zero_exit_is_runtime_error() -> None:
+    process = _FakeProcess([_event({"type": "ready"})])
+    runtime = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project")
+    original_send = runtime._send_command
+
+    async def send_and_append(proc: Any, payload: dict[str, Any]) -> None:
+        await original_send(proc, payload)
+        if payload["type"] == "prompt":
+            proc.stdout._buffer.extend(
+                (
+                    "\n".join(
+                        [
+                            _event(
+                                {
+                                    "type": "response",
+                                    "id": payload["id"],
+                                    "command": "prompt",
+                                    "success": True,
+                                }
+                            ),
+                            _event(
+                                {
+                                    "type": "agent_end",
+                                    "messages": [
+                                        {
+                                            "role": "assistant",
+                                            "content": [],
+                                            "stopReason": "error",
+                                            "errorMessage": "OpenAI API error (401)",
+                                        }
+                                    ],
+                                }
+                            ),
+                        ]
+                    )
+                    + "\n"
+                ).encode()
+            )
+
+    with (
+        patch.object(runtime, "_send_command", side_effect=send_and_append),
+        patch("asyncio.create_subprocess_exec", return_value=process),
+    ):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    assert messages[-1].is_error
+    assert messages[-1].content == "OpenAI API error (401)"
+    assert messages[-1].data["error_type"] == "ProviderError"
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_is_malformed_gjc_event() -> None:
+    process = _FakeProcess([_event({"type": "ready"}), "not-json"])
+    runtime = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project")
+    original_send = runtime._send_command
+
+    async def send_and_append(proc: Any, payload: dict[str, Any]) -> None:
+        await original_send(proc, payload)
+        if payload["type"] == "prompt":
+            proc.stdout._buffer.extend(
+                (
+                    _event(
+                        {
+                            "type": "response",
+                            "id": payload["id"],
+                            "command": "prompt",
+                            "success": True,
+                        }
+                    )
+                    + "\n"
+                ).encode()
+            )
+
+    with (
+        patch.object(runtime, "_send_command", side_effect=send_and_append),
+        patch("asyncio.create_subprocess_exec", return_value=process),
+    ):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    assert messages[-1].is_error
+    assert messages[-1].content == "Malformed GJC JSON event: not-json"
+    assert messages[-1].data["error_type"] == "MalformedGjcEvent"
+    assert process.terminated
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "frame_type",
+    [
+        "workflow_gate",
+        "extension_ui_request",
+        "host_tool_call",
+        "host_tool_cancel",
+        "host_uri_request",
+        "host_uri_cancel",
+        "mystery",
+    ],
+)
+async def test_unsupported_frames_raise_unsupported_and_terminate(frame_type: str) -> None:
+    process = _FakeProcess([_event({"type": "ready"})])
+    runtime = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project")
+    original_send = runtime._send_command
+
+    async def send_and_append(proc: Any, payload: dict[str, Any]) -> None:
+        await original_send(proc, payload)
+        if payload["type"] == "prompt":
+            proc.stdout._buffer.extend(
+                (
+                    "\n".join(
+                        [
+                            _event(
+                                {
+                                    "type": "response",
+                                    "id": payload["id"],
+                                    "command": "prompt",
+                                    "success": True,
+                                }
+                            ),
+                            _event({"type": frame_type, "id": "frame-1", "gate_id": "gate-1"}),
+                        ]
+                    )
+                    + "\n"
+                ).encode()
+            )
+
+    with (
+        patch.object(runtime, "_send_command", side_effect=send_and_append),
+        patch("asyncio.create_subprocess_exec", return_value=process),
+    ):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    assert messages[-1].is_error
+    assert messages[-1].data["error_type"] == "UnsupportedGjcRpcFrame"
+    assert frame_type in messages[-1].content
+    assert process.terminated
+
+
+@pytest.mark.asyncio
+async def test_nonzero_exit_is_gjc_exit_error() -> None:
+    process = _FakeProcess([_event({"type": "ready"})], stderr_lines=["boom"], returncode=7)
+    runtime = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project")
+    original_send = runtime._send_command
+
+    async def send_and_append(proc: Any, payload: dict[str, Any]) -> None:
+        await original_send(proc, payload)
+        if payload["type"] == "prompt":
+            proc.stdout._buffer.extend(
+                (
+                    "\n".join(
+                        [
+                            _event(
+                                {
+                                    "type": "response",
+                                    "id": payload["id"],
+                                    "command": "prompt",
+                                    "success": True,
+                                }
+                            ),
+                            _event(
+                                {
+                                    "type": "agent_end",
+                                    "messages": [{"role": "assistant", "content": "done"}],
+                                }
+                            ),
+                        ]
+                    )
+                    + "\n"
+                ).encode()
+            )
+
+    with (
+        patch.object(runtime, "_send_command", side_effect=send_and_append),
+        patch("asyncio.create_subprocess_exec", return_value=process),
+    ):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    assert messages[-1].is_error
+    assert messages[-1].content == "boom"
+    assert messages[-1].data == {"subtype": "error", "error_type": "GjcExitError", "returncode": 7}
+
+
+@pytest.mark.asyncio
+async def test_tool_lifecycle_events_are_ignored_and_stream_succeeds() -> None:
+    process = _FakeProcess([_event({"type": "ready"})])
+    runtime = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project")
+    original_send = runtime._send_command
+
+    async def send_and_append(proc: Any, payload: dict[str, Any]) -> None:
+        await original_send(proc, payload)
+        if payload["type"] == "prompt":
+            proc.stdout._buffer.extend(
+                (
+                    "\n".join(
+                        [
+                            _event(
+                                {
+                                    "type": "response",
+                                    "id": payload["id"],
+                                    "command": "prompt",
+                                    "success": True,
+                                }
+                            ),
+                            _event(
+                                {"type": "tool_execution_start", "id": "tool-1", "name": "read"}
+                            ),
+                            _event({"type": "tool_execution_end", "id": "tool-1", "success": True}),
+                            _event(
+                                {
+                                    "type": "agent_end",
+                                    "messages": [{"role": "assistant", "content": "done"}],
+                                }
+                            ),
+                        ]
+                    )
+                    + "\n"
+                ).encode()
+            )
+
+    with (
+        patch.object(runtime, "_send_command", side_effect=send_and_append),
+        patch("asyncio.create_subprocess_exec", return_value=process),
+    ):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    assert messages[-1].content == "done"
+    assert messages[-1].data == {"subtype": "success", "returncode": 0}
+    assert process.stdin.closed
+
+
+@pytest.mark.asyncio
+async def test_wrong_command_prompt_ack_is_protocol_error() -> None:
+    process = _FakeProcess([_event({"type": "ready"})])
+    runtime = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project")
+    original_send = runtime._send_command
+
+    async def send_and_append(proc: Any, payload: dict[str, Any]) -> None:
+        await original_send(proc, payload)
+        if payload["type"] == "prompt":
+            proc.stdout._buffer.extend(
+                (
+                    _event(
+                        {
+                            "type": "response",
+                            "id": payload["id"],
+                            "command": "set_model",
+                            "success": True,
+                        }
+                    )
+                    + "\n"
+                ).encode()
+            )
+
+    with (
+        patch.object(runtime, "_send_command", side_effect=send_and_append),
+        patch("asyncio.create_subprocess_exec", return_value=process),
+    ):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    assert messages[-1].is_error
+    assert messages[-1].data["error_type"] == "GjcProtocolError"
+
+
+@pytest.mark.asyncio
+async def test_unsupported_frame_during_prompt_ack_phase_is_unsupported() -> None:
+    process = _FakeProcess([_event({"type": "ready"})])
+    runtime = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project")
+    original_send = runtime._send_command
+
+    async def send_and_append(proc: Any, payload: dict[str, Any]) -> None:
+        await original_send(proc, payload)
+        if payload["type"] == "prompt":
+            proc.stdout._buffer.extend(
+                (_event({"type": "host_tool_call", "id": "tool-1"}) + "\n").encode()
+            )
+
+    with (
+        patch.object(runtime, "_send_command", side_effect=send_and_append),
+        patch("asyncio.create_subprocess_exec", return_value=process),
+    ):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    assert messages[-1].is_error
+    assert messages[-1].data["error_type"] == "UnsupportedGjcRpcFrame"
+
+
+@pytest.mark.asyncio
+async def test_unsupported_frame_during_set_model_ack_phase_is_unsupported() -> None:
+    process = _FakeProcess(
+        [_event({"type": "ready"}), _event({"type": "host_tool_call", "id": "tool-1"})]
+    )
+    runtime = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project", model="openai/gpt-4.1")
+
+    with patch("asyncio.create_subprocess_exec", return_value=process):
+        messages = [msg async for msg in runtime.execute_task("Do it")]
+
+    assert messages[-1].is_error
+    assert messages[-1].data["error_type"] == "UnsupportedGjcRpcFrame"
+
+
+def test_capabilities_are_non_resumable_structured_skill_dispatch() -> None:
+    caps = GjcRuntime(cli_path="/tmp/gjc", cwd="/tmp/project").capabilities
+
+    assert caps.skill_dispatch is True
+    assert caps.targeted_resume is False
+    assert caps.structured_output is True

--- a/tests/unit/orchestrator/test_runtime_factory.py
+++ b/tests/unit/orchestrator/test_runtime_factory.py
@@ -9,6 +9,7 @@ import pytest
 from ouroboros.orchestrator.adapter import ClaudeAgentAdapter
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
 from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
+from ouroboros.orchestrator.gjc_runtime import GjcRuntime
 from ouroboros.orchestrator.hermes_runtime import HermesCliRuntime
 from ouroboros.orchestrator.opencode_runtime import OpenCodeRuntime
 from ouroboros.orchestrator.runtime_factory import (
@@ -36,6 +37,12 @@ class TestResolveAgentRuntimeBackend:
         """OpenCode aliases normalize to opencode."""
         assert resolve_agent_runtime_backend("opencode") == "opencode"
         assert resolve_agent_runtime_backend("opencode_cli") == "opencode"
+
+    def test_resolve_gjc_aliases(self) -> None:
+        """GJC aliases normalize to gjc."""
+        assert resolve_agent_runtime_backend("gjc") == "gjc"
+        assert resolve_agent_runtime_backend("gajae-code") == "gjc"
+        assert resolve_agent_runtime_backend("gajae_code") == "gjc"
 
     def test_resolve_hermes_aliases(self) -> None:
         """Hermes aliases normalize to hermes."""
@@ -371,3 +378,51 @@ def test_create_goose_runtime_uses_configured_cli_path() -> None:
     assert runtime._cwd == "/tmp/project"
     assert runtime._skill_dispatcher is mock_dispatcher
     assert mock_create_dispatcher.call_args.kwargs["runtime_backend"] == "goose"
+
+
+def test_create_gjc_runtime_uses_configured_cli_path() -> None:
+    """Creates GJC runtime with the configured CLI path and dispatcher context."""
+    mock_dispatcher = object()
+
+    with (
+        patch(
+            "ouroboros.orchestrator.runtime_factory.get_gjc_cli_path",
+            return_value="/tmp/gjc",
+        ),
+        patch(
+            "ouroboros.orchestrator.runtime_factory.create_codex_command_dispatcher",
+            return_value=mock_dispatcher,
+        ) as mock_create_dispatcher,
+    ):
+        runtime = create_agent_runtime(
+            backend="gjc",
+            permission_mode="acceptEdits",
+            cwd="/tmp/project",
+            llm_backend="gjc",
+        )
+
+    assert isinstance(runtime, GjcRuntime)
+    assert runtime._cli_path == "/tmp/gjc"
+    assert runtime._cwd == "/tmp/project"
+    assert runtime._skill_dispatcher is mock_dispatcher
+    assert runtime._llm_backend == "gjc"
+    assert mock_create_dispatcher.call_args.kwargs["runtime_backend"] == "gjc"
+
+
+def test_create_gjc_runtime_accepts_stream_timeout_overrides() -> None:
+    """GJC RPC runtime can disable quiet-stream guards explicitly."""
+    with patch(
+        "ouroboros.orchestrator.runtime_factory.create_codex_command_dispatcher",
+        return_value=object(),
+    ):
+        runtime = create_agent_runtime(
+            backend="gjc",
+            cli_path="/tmp/gjc",
+            cwd="/tmp/project",
+            startup_output_timeout_seconds=0,
+            stdout_idle_timeout_seconds=0,
+        )
+
+    assert isinstance(runtime, GjcRuntime)
+    assert runtime._startup_output_timeout_seconds is None
+    assert runtime._stdout_idle_timeout_seconds is None


### PR DESCRIPTION
## [stack 2/5] GjcRuntime

Second of the 5-PR stack splitting #1378. **Depends on #1379 (stack 1)** — review/merge
after it; the diff collapses to just the runtime once stack 1 lands on `main`.

### What's here
- `orchestrator/gjc_runtime.py` — `GjcRuntime`, built on the shared GJC RPC protocol from stack 1.
- `orchestrator/runtime_factory.py` — dispatch the resolved `gjc` backend to `GjcRuntime`.
- tests: `test_gjc_runtime`, `test_runtime_factory`.

### Blockers fixed here (per #1378 red checks)
- Ruff `UP037` quoted annotation `"_FakeProcess"` and `I001` import ordering in the new test files.

### Verification (local)
- `uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/` ✅
- `uv run mypy src/ouroboros` ✅
- `uv run pytest tests/` — full suite green (one pre-existing gjc-unrelated local-sandbox failure deselected).

### Stack
1. [stack 1/5] gjc foundation — #1379
2. **[stack 2/5] GjcRuntime ← this PR**
3. [stack 3/5] GjcLLMAdapter
4. [stack 4/5] setup --runtime gjc + ooo bridge
5. [stack 5/5] docs
