### PR TITLE
fix(orchestrator): honor Codex stream timeout overrides

### DIFF
--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -103,6 +103,8 @@ class CodexCliRuntime:
         skill_dispatcher: SkillDispatchHandler | None = None,
         llm_backend: str | None = None,
         runtime_profile: str | None = None,
+        startup_output_timeout_seconds: float | None = None,
+        stdout_idle_timeout_seconds: float | None = None,
     ) -> None:
         self._cli_path = self._resolve_cli_path(cli_path)
         self._permission_mode = self._resolve_permission_mode(permission_mode)
@@ -118,6 +120,14 @@ class CodexCliRuntime:
             log_namespace=self._log_namespace,
         )
         self._builtin_mcp_handlers: dict[str, Any] | None = None
+        if startup_output_timeout_seconds is not None:
+            self._startup_output_timeout_seconds = (
+                None if startup_output_timeout_seconds <= 0 else startup_output_timeout_seconds
+            )
+        if stdout_idle_timeout_seconds is not None:
+            self._stdout_idle_timeout_seconds = (
+                None if stdout_idle_timeout_seconds <= 0 else stdout_idle_timeout_seconds
+            )
 
         log.info(
             f"{self._log_namespace}.initialized",
@@ -127,6 +137,8 @@ class CodexCliRuntime:
             cwd=self._cwd,
             runtime_profile=runtime_profile,
             codex_profile=self._codex_profile,
+            startup_output_timeout_seconds=self._startup_output_timeout_seconds,
+            stdout_idle_timeout_seconds=self._stdout_idle_timeout_seconds,
             skills_dir=(
                 str(self._skills_dir) if self._skills_dir is not None else self._skills_package_uri
             ),

--- a/src/ouroboros/orchestrator/runtime_factory.py
+++ b/src/ouroboros/orchestrator/runtime_factory.py
@@ -78,6 +78,8 @@ def create_agent_runtime(
         return CodexCliRuntime(
             cli_path=cli_path or get_codex_cli_path(),
             runtime_profile=get_runtime_profile(),
+            startup_output_timeout_seconds=startup_output_timeout_seconds,
+            stdout_idle_timeout_seconds=stdout_idle_timeout_seconds,
             **runtime_kwargs,
         )
 

--- a/tests/unit/orchestrator/test_runtime_factory.py
+++ b/tests/unit/orchestrator/test_runtime_factory.py
@@ -285,8 +285,8 @@ class TestCreateAgentRuntime:
         assert runtime._startup_output_timeout_seconds is None
         assert runtime._stdout_idle_timeout_seconds is None
 
-    def test_create_non_hermes_runtime_ignores_stream_timeout_overrides(self) -> None:
-        """The Hermes-specific override API must not affect other runtimes."""
+    def test_create_codex_runtime_accepts_stream_timeout_overrides(self) -> None:
+        """MCP seed execution can disable Codex quiet-stream guards explicitly."""
         with patch(
             "ouroboros.orchestrator.runtime_factory.create_codex_command_dispatcher",
             return_value=object(),
@@ -298,6 +298,8 @@ class TestCreateAgentRuntime:
             )
 
         assert isinstance(runtime, CodexCliRuntime)
+        assert runtime._startup_output_timeout_seconds is None
+        assert runtime._stdout_idle_timeout_seconds is None
 
     def test_opencode_runtime_always_uses_subprocess_mode(self) -> None:
         """OpenCodeRuntime always gets opencode_mode='subprocess' regardless of config.


### PR DESCRIPTION
## Summary

- Wire `startup_output_timeout_seconds` and `stdout_idle_timeout_seconds` through the Codex runtime factory path.
- Allow `CodexCliRuntime` to apply explicit stream timeout overrides, with `0` or negative values disabling the guard.
- Cover the Codex factory wiring with a unit test.

Closes #1386.

## Why

The execute-seed MCP path already passes `startup_output_timeout_seconds=0` and `stdout_idle_timeout_seconds=0` so runner/watchdog liveness can own long-running seed execution. Codex ignored those overrides because the factory did not forward them and the runtime constructor did not accept them.

## Tests

- `uv run --python 3.12 pytest tests/unit/orchestrator/test_runtime_factory.py tests/unit/orchestrator/test_codex_cli_runtime.py -q`
- `uv run --python 3.12 ruff check src/ouroboros/orchestrator/codex_cli_runtime.py src/ouroboros/orchestrator/runtime_factory.py tests/unit/orchestrator/test_runtime_factory.py`
- `uv run --python 3.12 ruff format --check src/ouroboros/orchestrator/codex_cli_runtime.py src/ouroboros/orchestrator/runtime_factory.py tests/unit/orchestrator/test_runtime_factory.py`
