### PR TITLE
feat(orchestrator): surface non-native execution-parameter handling (#1374 rebased)

### DIFF
--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -55,10 +55,47 @@ These capabilities depend on the runtime backend's native features and execution
 | ------------------------- | :---------------------------------: | :-------------------: | :-------------------------------------------------------: | :------------------------------------------------------------------------: | :------------------------------------------: | :--------------------------: | :-----------------------------------------------------------------------: | :-----------------------------: | ---------------------------------------------------------------- |
 | **Authentication**        |        Max Plan subscription        |    OpenAI API key     |        Provider API keys (configured in OpenCode)         |        NousResearch (or compatible provider) API key or local model        | Google auth (`gemini auth` or `GOOGLE_API_KEY`) |      Kiro AWS sign-in        | GitHub Copilot subscription via `gh auth login`                           | Pi provider auth via `/login` or provider API key | No separate Ouroboros API key is needed for Claude Code, Kiro, Copilot, or Pi CLI; Pi still needs its own provider credentials |
 | **Underlying model**      |         Claude (Anthropic)          |   GPT-5.4+ (OpenAI)   | Provider-dependent (OpenCode supports multiple providers) | Provider-dependent (Hermes supports multiple providers) or Any local model | Gemini-selected or `--model` value           | Claude (via AWS) + others    | Live-discovered (Claude, GPT-5, etc.; whatever your subscription grants)  | Pi-selected or `--model` value  | Copilot is the only runtime with a live model picker             |
-| **Tool surface**          | Read, Write, Edit, Bash, Glob, Grep | Codex-native tool set |            Read, Write, Edit, Bash, Glob, Grep            |                      Custom skills via MCP + run cmd                       | Gemini-managed tool set                      |   Kiro-native tool set       | Read, Write, Edit, Bash, Glob, Grep (via `--available-tools` allowlist)   | Pi-native tool set              | Different tool implementations; same task outcomes               |
-| **Sandbox / permissions** |    Claude Code permission system    |  Codex sandbox model  |                OpenCode permission system                 |                          Hermes permission system                          | `--approval-mode auto_edit` / `yolo`         | `--trust-tools` / `--trust-all-tools` | `--add-dir <CWD>` boundary + `--allow-tool` envelope             | Pi CLI permission model         | Each runtime manages its own safety boundaries                   |
+| **Tool surface**          | Read, Write, Edit, Bash, Glob, Grep | Codex-native tool set |            Read, Write, Edit, Bash, Glob, Grep            |                      Custom skills via MCP + run cmd                       | Gemini-managed tool set                      |   Kiro-native tool set       | Copilot-managed tool set plus Ouroboros prompt guidance                  | Pi-native tool set              | Different tool implementations; same task outcomes               |
+| **Sandbox / permissions** |    Claude Code permission system    |  Codex sandbox model  |                OpenCode permission system                 |                          Hermes permission system                          | `--approval-mode auto_edit` / `yolo`         | `--trust-tools` / `--trust-all-tools` | `--add-dir <CWD>` boundary plus Copilot permission envelope      | Pi CLI permission model         | Each runtime manages its own safety boundaries                   |
 | **Cost model**            |        Included in Max Plan         | Per-token API charges |              Depends on configured provider               |                            Depends on API/Local                            | Depends on Google account/API usage          |    Included in Kiro plan     | Included in Copilot subscription                                          | Depends on Pi account/provider  | See [OpenAI pricing](https://openai.com/pricing) for Codex costs |
 | **Declared capabilities** | skill_dispatch, targeted_resume, structured_output | all three | all three | all three | skill_dispatch and structured_output; `targeted_resume=False` (no native resume API) | skill_dispatch only; `targeted_resume=False` (headless does not surface session ids), `structured_output=False` (plain-text stdio) | skill_dispatch only; `targeted_resume=False` (no resume API); `structured_output=False` (no `--output-schema`, JSON via prompt directive) | all three | See `RuntimeCapabilities` on the adapter |
+
+### Parameter handling (negotiation)
+
+Beyond the feature flags above, `RuntimeCapabilities` declares how each runtime honors the
+execution **parameters** Ouroboros passes to `execute_task` — `system_prompt`, the `tools`
+allow-list, and `permission_mode`. Each is one of:
+
+- **`native`** — honored directly (e.g. a separate system-prompt field, a real tool allow-list).
+- **`translated`** — honored only through a lossy adaptation (the intent is partially preserved,
+  but not in the form supplied).
+- **`ignored`** — silently dropped.
+
+| Parameter       | Claude Code | Codex | Gemini | Goose | Copilot | OpenCode | Hermes | Pi | Kiro |
+| --------------- | :---------: | :---: | :-----: | :---: | :-----: | :------: | :----: | :-: | :--: |
+| `system_prompt` | native | translated | translated | translated | translated | translated | translated | translated | translated |
+| `permission_mode` | native | native | native | native | native | ignored | ignored | ignored | translated |
+| `tools` (allow-list) | native | translated | translated | translated | translated | translated | translated | translated | native |
+
+> Most CLI runtimes compose the system prompt **into the user message** (e.g.
+> `## System Instructions\n...`) rather than passing a native system directive. Codex,
+> Gemini, Goose, Copilot, OpenCode, Hermes, and Pi also render requested tool
+> allow-lists only as prompt guidance, so `tools` is translated rather than a
+> native runtime allow-list when the list is non-empty. An explicit empty
+> allow-list (`tools=[]`) cannot be translated by those prompt-only composers
+> because no tool names are rendered; the orchestrator reports that no-tools
+> restriction as `ignored` for observability. Kiro
+> additionally maps `permission_mode` onto coarse `--trust-*` flags, which is honored work but
+> not in the form supplied. OpenCode, Hermes, and Pi keep the requested mode in runtime metadata
+> but do not pass it to their CLI commands.
+
+**Observability:** when a workflow supplies a parameter the active runtime does not honor
+natively, the orchestrator surfaces a one-time notice (console + a structured
+degradation log such as `coordinator.param_degraded`, `orchestrator.runner.param_degraded`,
+or `orchestrator.parallel_executor.param_degraded`) so the degradation is visible instead of
+silent. The shared announcer's fallback event is
+`orchestrator.runtime_params.param_degraded`. This is **informational only** — it does not
+change what is passed to the runtime.
 
 ### Integration Surface (UX differences)
 

--- a/src/ouroboros/orchestrator/adapter.py
+++ b/src/ouroboros/orchestrator/adapter.py
@@ -21,6 +21,7 @@ import asyncio
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
+from enum import StrEnum
 import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
@@ -693,6 +694,28 @@ class TaskResult:
     resume_handle: RuntimeHandle | None = None
 
 
+class ParamSupport(StrEnum):
+    """How a runtime honors a given execution parameter.
+
+    Used for observability only: the orchestrator surfaces non-``NATIVE``
+    handling so an operator can see when a parameter is not honored in the form
+    they supplied it. It does **not** change what is passed to the runtime.
+
+    Values:
+        NATIVE: The runtime honors the parameter directly (e.g. a separate
+            system-prompt field, a real tool allow-list, a permission flag).
+        TRANSLATED: The runtime honors it only through a lossy adaptation —
+            e.g. embedding the system prompt into the user message, or mapping
+            a permission mode onto coarser CLI flags. The intent is partially
+            preserved but the supplied form is not.
+        IGNORED: The runtime silently drops the parameter.
+    """
+
+    NATIVE = "native"
+    TRANSLATED = "translated"
+    IGNORED = "ignored"
+
+
 @dataclass(frozen=True, slots=True)
 class RuntimeCapabilities:
     """Declarative feature contract surfaced by an ``AgentRuntime``.
@@ -710,11 +733,23 @@ class RuntimeCapabilities:
         structured_output: Runtime emits structured JSONL events
             (tool calls, thread ids, per-item events). ``False`` means
             plain-text stdout lines only.
+        system_prompt_support: How the runtime honors the ``system_prompt``
+            execution parameter (see :class:`ParamSupport`).
+        tool_restriction_support: How the runtime honors the ``tools``
+            allow-list passed to ``execute_task``.
+        permission_mode_support: How the runtime honors ``permission_mode``.
+
+    The three ``*_support`` fields default to :attr:`ParamSupport.NATIVE` so
+    existing runtimes and ``FULL_CAPABILITIES`` are unchanged; a runtime opts in
+    to a non-native value only when its handling is demonstrably lossy.
     """
 
     skill_dispatch: bool
     targeted_resume: bool
     structured_output: bool
+    system_prompt_support: ParamSupport = ParamSupport.NATIVE
+    tool_restriction_support: ParamSupport = ParamSupport.NATIVE
+    permission_mode_support: ParamSupport = ParamSupport.NATIVE
 
 
 # Default capability profile for first-class backends (Claude, Codex).
@@ -1682,6 +1717,7 @@ __all__ = [
     "ClaudeCodeRuntime",
     "DEFAULT_TOOLS",
     "FULL_CAPABILITIES",
+    "ParamSupport",
     "RuntimeCapabilities",
     "RuntimeHandle",
     "SkillDispatchHandler",

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -33,7 +33,10 @@ from ouroboros.core.errors import ProviderError
 from ouroboros.core.types import Result
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.adapter import (
+    FULL_CAPABILITIES,
     AgentMessage,
+    ParamSupport,
+    RuntimeCapabilities,
     RuntimeHandle,
     SkillDispatchHandler,
     TaskResult,
@@ -137,6 +140,17 @@ class CodexCliRuntime:
     @property
     def runtime_backend(self) -> str:
         return self._runtime_handle_backend
+
+    @property
+    def capabilities(self) -> RuntimeCapabilities:
+        # Codex composes the system prompt and tool guidance into the user
+        # message rather than passing native runtime parameters; surface those
+        # as TRANSLATED while preserving the default feature flags.
+        return replace(
+            FULL_CAPABILITIES,
+            system_prompt_support=ParamSupport.TRANSLATED,
+            tool_restriction_support=ParamSupport.TRANSLATED,
+        )
 
     @property
     def llm_backend(self) -> str | None:

--- a/src/ouroboros/orchestrator/coordinator.py
+++ b/src/ouroboros/orchestrator/coordinator.py
@@ -44,6 +44,9 @@ from ouroboros.orchestrator.policy import (
     PolicySessionRole,
     allowed_capability_names,
 )
+from ouroboros.orchestrator.runtime_param_negotiation import (
+    announce_execution_param_degradations,
+)
 
 if TYPE_CHECKING:
     from ouroboros.orchestrator.adapter import AgentMessage, AgentRuntime
@@ -211,6 +214,7 @@ class LevelCoordinator:
         self._inherited_runtime_handle = inherited_runtime_handle
         self._task_cwd = task_cwd
         self._level_runtime_handles: dict[tuple[str, int], RuntimeHandle] = {}
+        self._announced_param_degradations: set[tuple[str, str]] = set()
 
     def _build_level_runtime_handle(
         self,
@@ -378,11 +382,19 @@ class LevelCoordinator:
         session_id: str | None = None
         final_text = ""
         messages: list[AgentMessage] = []
+        tools = derive_coordinator_tools(self._adapter.runtime_backend)
 
         try:
+            announce_execution_param_degradations(
+                self._adapter,
+                system_prompt=COORDINATOR_SYSTEM_PROMPT,
+                tools=tools,
+                announced=self._announced_param_degradations,
+                log_event="coordinator.param_degraded",
+            )
             async for message in self._adapter.execute_task(
                 prompt=prompt,
-                tools=derive_coordinator_tools(self._adapter.runtime_backend),
+                tools=tools,
                 system_prompt=COORDINATOR_SYSTEM_PROMPT,
                 resume_handle=runtime_handle,
             ):

--- a/src/ouroboros/orchestrator/copilot_cli_runtime.py
+++ b/src/ouroboros/orchestrator/copilot_cli_runtime.py
@@ -37,7 +37,12 @@ from ouroboros.copilot_permissions import (
     build_copilot_exec_permission_args,
     resolve_copilot_permission_mode,
 )
-from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
+from ouroboros.orchestrator.adapter import (
+    AgentMessage,
+    ParamSupport,
+    RuntimeCapabilities,
+    RuntimeHandle,
+)
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime, SkillDispatchHandler
 from ouroboros.providers.base import CompletionConfig
 from ouroboros.providers.profiles import resolve_completion_profile
@@ -45,8 +50,7 @@ from ouroboros.providers.profiles import resolve_completion_profile
 log = structlog.get_logger(__name__)
 
 # Copilot CLI accepts the same three permission mode names that Ouroboros
-# uses everywhere; the mapping to ``--allow-tool`` / ``--deny-tool`` /
-# ``--allow-all`` flags lives in ``copilot_permissions``.
+# uses everywhere; permission mode is mapped through ``copilot_permissions``.
 _COPILOT_PERMISSION_MODES = frozenset({"default", "acceptEdits", "bypassPermissions"})
 _COPILOT_DEFAULT_PERMISSION_MODE = "default"
 
@@ -61,9 +65,9 @@ class CopilotCliRuntime(CodexCliRuntime):
     Extends :class:`CodexCliRuntime` with overrides specific to the Copilot
     CLI process model:
 
-    - Permission flags translated through the Copilot envelope
-      (``--add-dir`` boundary plus ``--available-tools`` / ``--allow-tool``
-      / ``--allow-all-tools`` / ``--allow-all``).
+    - Permission flags translated through the Copilot envelope.
+    - Per-call tool allow-lists are inherited from the Codex prompt composer as
+      tooling guidance, not enforced as native Copilot CLI restrictions.
     - Prompt is passed via the ``-p <prompt>`` flag, not stdin.
     - No ``--output-last-message`` flag (Copilot reconstructs the assistant
       reply from the JSONL event stream).
@@ -86,6 +90,18 @@ class CopilotCliRuntime(CodexCliRuntime):
     _skills_package_uri = "packaged://ouroboros.copilot/skills"
     _process_shutdown_timeout_seconds = 5.0
     _max_resume_retries = 0  # Copilot CLI does not support session resumption
+
+    @property
+    def capabilities(self) -> RuntimeCapabilities:
+        """Report Copilot CLI semantics without inheriting Codex degradations."""
+        return RuntimeCapabilities(
+            skill_dispatch=True,
+            targeted_resume=False,
+            structured_output=False,
+            system_prompt_support=ParamSupport.TRANSLATED,
+            tool_restriction_support=ParamSupport.TRANSLATED,
+            permission_mode_support=ParamSupport.NATIVE,
+        )
 
     def __init__(
         self,

--- a/src/ouroboros/orchestrator/gemini_cli_runtime.py
+++ b/src/ouroboros/orchestrator/gemini_cli_runtime.py
@@ -24,7 +24,12 @@ from typing import Any
 import structlog
 
 from ouroboros.core.security import MAX_LLM_RESPONSE_LENGTH, InputValidator
-from ouroboros.orchestrator.adapter import AgentMessage, RuntimeCapabilities, RuntimeHandle
+from ouroboros.orchestrator.adapter import (
+    AgentMessage,
+    ParamSupport,
+    RuntimeCapabilities,
+    RuntimeHandle,
+)
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime, SkillDispatchHandler
 from ouroboros.providers.gemini_event_normalizer import GeminiEventNormalizer
 
@@ -272,6 +277,12 @@ class GeminiCLIRuntime(CodexCliRuntime):
             skill_dispatch=True,
             targeted_resume=False,
             structured_output=True,
+            # System prompt is composed into the user message (inherited Codex
+            # prompt builder), not passed as a native system directive. The
+            # inherited builder also renders requested tool lists as prompt
+            # guidance rather than enforcing a Gemini-native allow-list.
+            system_prompt_support=ParamSupport.TRANSLATED,
+            tool_restriction_support=ParamSupport.TRANSLATED,
         )
 
     # -- Event parsing and normalization -----------------------------------

--- a/src/ouroboros/orchestrator/goose_runtime.py
+++ b/src/ouroboros/orchestrator/goose_runtime.py
@@ -21,7 +21,12 @@ from uuid import uuid4
 
 from ouroboros.config import get_goose_cli_path
 from ouroboros.observability.logging import get_logger
-from ouroboros.orchestrator.adapter import AgentMessage, RuntimeCapabilities, RuntimeHandle
+from ouroboros.orchestrator.adapter import (
+    AgentMessage,
+    ParamSupport,
+    RuntimeCapabilities,
+    RuntimeHandle,
+)
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
 
 log = get_logger(__name__)
@@ -101,6 +106,12 @@ class GooseCliRuntime(CodexCliRuntime):
             skill_dispatch=True,
             targeted_resume=True,
             structured_output=True,
+            # System prompt is composed into the user message (inherited Codex
+            # prompt builder), not passed as a native system directive. The
+            # inherited builder also renders requested tool lists as prompt
+            # guidance rather than enforcing a Goose-native allow-list.
+            system_prompt_support=ParamSupport.TRANSLATED,
+            tool_restriction_support=ParamSupport.TRANSLATED,
         )
 
     def _resolve_permission_mode(self, permission_mode: str | None) -> str:

--- a/src/ouroboros/orchestrator/hermes_runtime.py
+++ b/src/ouroboros/orchestrator/hermes_runtime.py
@@ -25,8 +25,11 @@ from ouroboros.core.errors import ProviderError
 from ouroboros.core.types import Result
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.adapter import (
+    FULL_CAPABILITIES,
     AgentMessage,
     AgentRuntime,
+    ParamSupport,
+    RuntimeCapabilities,
     RuntimeHandle,
     SkillDispatchHandler,
     TaskResult,
@@ -179,6 +182,7 @@ class HermesCliRuntime(AgentRuntime):
         stdout_idle_timeout_seconds: float | None = None,
     ) -> None:
         self._cli_path = self._resolve_cli_path(cli_path)
+        self._permission_mode_requested = permission_mode is not None
         self._permission_mode = permission_mode or "default"
         self._model = model
         self._cwd = str(Path(cwd).expanduser()) if cwd is not None else os.getcwd()
@@ -220,12 +224,29 @@ class HermesCliRuntime(AgentRuntime):
         return self._runtime_handle_backend
 
     @property
+    def capabilities(self) -> RuntimeCapabilities:
+        # Hermes composes the system prompt and tool guidance into the user
+        # message rather than passing native runtime parameters, and hermes chat
+        # has no permission-mode flag. Surface both truthfully for degradation
+        # notices.
+        return replace(
+            FULL_CAPABILITIES,
+            system_prompt_support=ParamSupport.TRANSLATED,
+            tool_restriction_support=ParamSupport.TRANSLATED,
+            permission_mode_support=ParamSupport.IGNORED,
+        )
+
+    @property
     def working_directory(self) -> str | None:
         return self._cwd
 
     @property
     def permission_mode(self) -> str | None:
         return self._permission_mode
+
+    @property
+    def permission_mode_requested(self) -> bool:
+        return self._permission_mode_requested
 
     @property
     def llm_backend(self) -> str | None:

--- a/src/ouroboros/orchestrator/kiro_adapter.py
+++ b/src/ouroboros/orchestrator/kiro_adapter.py
@@ -21,6 +21,7 @@ from ouroboros.core.types import Result
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.adapter import (
     AgentMessage,
+    ParamSupport,
     RuntimeCapabilities,
     RuntimeHandle,
     SkillDispatchHandler,
@@ -45,6 +46,11 @@ _KIRO_CAPABILITIES = RuntimeCapabilities(
     skill_dispatch=True,
     targeted_resume=False,
     structured_output=False,
+    # System prompt is wrapped into the prompt as <system>...</system>, and
+    # permission_mode is mapped onto coarse --trust-* flags — both lossy
+    # adaptations rather than native handling.
+    system_prompt_support=ParamSupport.TRANSLATED,
+    permission_mode_support=ParamSupport.TRANSLATED,
 )
 
 log = get_logger(__name__)
@@ -146,6 +152,7 @@ class KiroAgentAdapter:
     ) -> None:
         self._cli_path = self._resolve_cli_path(cli_path)
         self._model = model
+        self._permission_mode_requested = permission_mode is not None
         self._cwd = str(Path(cwd).expanduser()) if cwd is not None else os.getcwd()
         self._permission_mode = permission_mode or "acceptEdits"
         self._skill_dispatcher = skill_dispatcher
@@ -176,6 +183,10 @@ class KiroAgentAdapter:
     @property
     def permission_mode(self) -> str | None:
         return self._permission_mode
+
+    @property
+    def permission_mode_requested(self) -> bool:
+        return self._permission_mode_requested
 
     @property
     def llm_backend(self) -> str | None:

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -37,7 +37,10 @@ from ouroboros.core.errors import ProviderError
 from ouroboros.core.types import Result
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.adapter import (
+    FULL_CAPABILITIES,
     AgentMessage,
+    ParamSupport,
+    RuntimeCapabilities,
     RuntimeHandle,
     SkillDispatchHandler,
     TaskResult,
@@ -163,6 +166,7 @@ class OpenCodeRuntime:
                 MCP tool handlers.
         """
         self._cli_path = self._resolve_cli_path(cli_path)
+        self._permission_mode_requested = permission_mode is not None
         self._permission_mode = permission_mode or "bypassPermissions"
         self._model = model
         self._cwd = str(Path(cwd).expanduser()) if cwd is not None else os.getcwd()
@@ -192,6 +196,18 @@ class OpenCodeRuntime:
         return self._runtime_handle_backend
 
     @property
+    def capabilities(self) -> RuntimeCapabilities:
+        # OpenCode composes the system prompt and tool guidance into the user
+        # message rather than passing native runtime parameters; surface those
+        # as TRANSLATED while preserving the default feature flags.
+        return replace(
+            FULL_CAPABILITIES,
+            system_prompt_support=ParamSupport.TRANSLATED,
+            tool_restriction_support=ParamSupport.TRANSLATED,
+            permission_mode_support=ParamSupport.IGNORED,
+        )
+
+    @property
     def llm_backend(self) -> str | None:
         return self._llm_backend
 
@@ -212,6 +228,11 @@ class OpenCodeRuntime:
             Permission mode string (e.g. ``"bypassPermissions"``).
         """
         return self._permission_mode
+
+    @property
+    def permission_mode_requested(self) -> bool:
+        """Return whether permission mode was supplied by the caller."""
+        return self._permission_mode_requested
 
     # -- CLI resolution ----------------------------------------------------
 

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -116,6 +116,9 @@ from ouroboros.orchestrator.rate_limit import (
 from ouroboros.orchestrator.runtime_message_projection import (
     project_runtime_message,
 )
+from ouroboros.orchestrator.runtime_param_negotiation import (
+    announce_execution_param_degradations,
+)
 from ouroboros.orchestrator.verifier import (
     Verifier,
     VerifierContractError,
@@ -2470,6 +2473,9 @@ class ParallelACExecutor:
         self._checkpoint_store = checkpoint_store
         self._execution_counters_lock = asyncio.Lock()
         self._dispatch_rate_gate = self._build_dispatch_rate_gate(adapter)
+        # Param degradations already surfaced this run, keyed by (param, support),
+        # so the operator is told once rather than on every dispatch.
+        self._announced_param_degradations: set[tuple[str, str]] = set()
 
     @staticmethod
     def _build_dispatch_rate_gate(adapter: AgentRuntime) -> RateLimitGate:
@@ -2528,6 +2534,27 @@ class ParallelACExecutor:
             )
 
         await self._dispatch_rate_gate.acquire(estimated_tokens, on_backoff=_log_backoff)
+
+    def _announce_param_degradations(
+        self,
+        *,
+        system_prompt: str | None,
+        tools: list[str] | None,
+    ) -> None:
+        """Surface (once per run) execution params the runtime won't honor natively.
+
+        Observability only — nothing here changes what is passed to the runtime.
+        It makes previously silent degradation (e.g. a CLI runtime folding the
+        system prompt into the user message) visible in logs and the console.
+        """
+        announce_execution_param_degradations(
+            self._adapter,
+            system_prompt=system_prompt,
+            tools=tools,
+            announced=self._announced_param_degradations,
+            console=self._console,
+            log_event="orchestrator.parallel_executor.param_degraded",
+        )
 
     def _flush_console(self) -> None:
         """Flush console output to ensure progress is visible immediately."""
@@ -4670,6 +4697,10 @@ Each Sub-AC should be:
 Respond with either "ATOMIC" or the JSON array only, nothing else.
 """
 
+        self._announce_param_degradations(
+            system_prompt=decomposition_system_prompt,
+            tools=[],
+        )
         # Pace this backend request within the shared budget before starting the
         # decomposition timeout, so rate-limit waiting never eats into it.
         await self._await_dispatch_rate_budget(
@@ -5439,6 +5470,7 @@ Files present:
         exec_start = time.monotonic()
 
         await self._wait_for_memory(label)
+        self._announce_param_degradations(system_prompt=system_prompt, tools=tools)
         # Pace delivery within the backend's shared rate budget (dormant unless
         # an RPM/TPM is configured for this backend) before the stall-scoped run.
         await self._await_dispatch_rate_budget(prompt=prompt, system_prompt=system_prompt)

--- a/src/ouroboros/orchestrator/pi_runtime.py
+++ b/src/ouroboros/orchestrator/pi_runtime.py
@@ -25,6 +25,7 @@ from ouroboros.core.types import Result
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.adapter import (
     AgentMessage,
+    ParamSupport,
     RuntimeCapabilities,
     RuntimeHandle,
     SkillDispatchHandler,
@@ -78,6 +79,7 @@ class PiRuntime:
         **_kwargs: Any,
     ) -> None:
         self._cli_path = self._resolve_cli_path(cli_path)
+        self._permission_mode_requested = permission_mode is not None
         self._permission_mode = permission_mode
         self._model = model
         self._cwd = str(Path(cwd).expanduser()) if cwd is not None else os.getcwd()
@@ -129,11 +131,21 @@ class PiRuntime:
         return self._permission_mode
 
     @property
+    def permission_mode_requested(self) -> bool:
+        return self._permission_mode_requested
+
+    @property
     def capabilities(self) -> RuntimeCapabilities:
         return RuntimeCapabilities(
             skill_dispatch=True,
             targeted_resume=True,
             structured_output=True,
+            # System prompt and tool guidance are composed into the user
+            # message, not passed as native runtime parameters. Pi also has no
+            # permission-mode flag.
+            system_prompt_support=ParamSupport.TRANSLATED,
+            tool_restriction_support=ParamSupport.TRANSLATED,
+            permission_mode_support=ParamSupport.IGNORED,
         )
 
     # -- CLI resolution ----------------------------------------------------

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -102,6 +102,9 @@ from ouroboros.orchestrator.runtime_message_projection import (
     normalized_message_type,
     project_runtime_message,
 )
+from ouroboros.orchestrator.runtime_param_negotiation import (
+    announce_execution_param_degradations,
+)
 from ouroboros.orchestrator.session import SessionRepository, SessionStatus, SessionTracker
 from ouroboros.orchestrator.workflow_state import coerce_ac_marker_update
 from ouroboros.persistence.checkpoint import CheckpointStore
@@ -491,8 +494,25 @@ class OrchestratorRunner:
         self._max_decomposition_depth = max(0, max_decomposition_depth)
         self._max_parallel_workers = max(1, max_parallel_workers)
         self._fat_harness_mode = fat_harness_mode
+        self._announced_param_degradations: set[tuple[str, str]] = set()
         # Track active session for external cancellation by execution_id
         self._active_sessions: dict[str, str] = {}  # execution_id -> session_id
+
+    def _announce_param_degradations(
+        self,
+        *,
+        system_prompt: str | None,
+        tools: list[str] | None,
+    ) -> None:
+        """Surface requested execution params this runtime will degrade."""
+        announce_execution_param_degradations(
+            self._adapter,
+            system_prompt=system_prompt,
+            tools=tools,
+            announced=self._announced_param_degradations,
+            console=self._console,
+            log_event="orchestrator.runner.param_degraded",
+        )
 
     def _plan_parallel_workers(self) -> int:
         """Return the effective fan-out worker count for the connected backend.
@@ -2255,6 +2275,10 @@ class OrchestratorRunner:
                 nonlocal tracker
 
                 active_runtime_handle = resume_handle
+                self._announce_param_degradations(
+                    system_prompt=system_prompt,
+                    tools=merged_tools,
+                )
                 async with aclosing(
                     self._adapter.execute_task(  # type: ignore[type-var]
                         prompt=prompt,
@@ -3175,6 +3199,10 @@ Note: This is a resumed session. Please continue from where execution was interr
                 console=self._console,
                 spinner="dots",
             ) as status:
+                self._announce_param_degradations(
+                    system_prompt=system_prompt,
+                    tools=merged_tools,
+                )
                 async with aclosing(
                     self._adapter.execute_task(  # type: ignore[type-var]
                         prompt=resume_prompt,

--- a/src/ouroboros/orchestrator/runtime_param_negotiation.py
+++ b/src/ouroboros/orchestrator/runtime_param_negotiation.py
@@ -1,0 +1,163 @@
+"""Parameter-level capability negotiation (observability).
+
+The orchestrator builds execution parameters — ``system_prompt``, a ``tools``
+allow-list, ``permission_mode`` — and hands them to whichever runtime is active.
+Runtimes do not all honor those parameters in the form they are supplied: some
+embed the system prompt into the user message, map a permission mode onto
+coarser CLI flags, or drop a parameter entirely. Historically this degradation
+was silent.
+
+This module turns that silence into an explicit, surfaceable signal. It compares
+the *requested* parameters against the runtime's declared
+:class:`~ouroboros.orchestrator.adapter.RuntimeCapabilities` and reports any that
+are not honored natively. It is pure and side-effect free — it never alters what
+is passed to the runtime; callers decide how to surface the result (log, console
+notice, event).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ouroboros.observability.logging import get_logger
+from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, ParamSupport, RuntimeCapabilities
+
+log = get_logger(__name__)
+
+_DEGRADATION_DETAIL = {
+    ParamSupport.TRANSLATED: "honored via lossy translation, not in the form supplied",
+    ParamSupport.IGNORED: "not honored by this runtime; it is silently dropped",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ParamDegradation:
+    """One requested execution parameter the runtime does not honor natively.
+
+    Attributes:
+        parameter: The execution parameter name (``"system_prompt"``,
+            ``"tools"``, ``"permission_mode"``).
+        support: How the runtime handles it (``TRANSLATED`` or ``IGNORED``).
+        detail: Human-readable explanation suitable for a log/console notice.
+    """
+
+    parameter: str
+    support: ParamSupport
+    detail: str
+
+
+def _degradation(parameter: str, support: ParamSupport) -> ParamDegradation | None:
+    """Return a degradation record when ``support`` is non-native, else ``None``."""
+    if support == ParamSupport.NATIVE:
+        return None
+    return ParamDegradation(
+        parameter=parameter,
+        support=support,
+        detail=_DEGRADATION_DETAIL[support],
+    )
+
+
+def _tool_restriction_support_for_request(
+    capabilities: RuntimeCapabilities,
+    tools: list[str],
+) -> ParamSupport:
+    """Return truthful support for this concrete tools allow-list request."""
+    support = capabilities.tool_restriction_support
+    if tools == [] and support == ParamSupport.TRANSLATED:
+        return ParamSupport.IGNORED
+    return support
+
+
+def negotiate_execution_params(
+    capabilities: RuntimeCapabilities,
+    *,
+    system_prompt: str | None,
+    tools: list[str] | None,
+    permission_mode: str | None,
+) -> tuple[ParamDegradation, ...]:
+    """Report execution parameters the runtime will not honor natively.
+
+    Only parameters that were actually *requested* are considered — an absent
+    parameter cannot be degraded. For ``tools``, an explicit empty list is a
+    requested no-tools allow-list, so ``[]`` is distinct from ``None``.
+    """
+    requested: list[tuple[str, ParamSupport]] = []
+    if system_prompt:
+        requested.append(("system_prompt", capabilities.system_prompt_support))
+    if tools is not None:
+        requested.append(("tools", _tool_restriction_support_for_request(capabilities, tools)))
+    if permission_mode:
+        requested.append(("permission_mode", capabilities.permission_mode_support))
+
+    degradations = (_degradation(name, support) for name, support in requested)
+    return tuple(item for item in degradations if item is not None)
+
+
+def runtime_capabilities_for(adapter: object) -> RuntimeCapabilities:
+    """Return an adapter's declared capabilities, falling back to all-native."""
+    declared_capabilities = getattr(adapter, "capabilities", FULL_CAPABILITIES)
+    return (
+        declared_capabilities
+        if isinstance(declared_capabilities, RuntimeCapabilities)
+        else FULL_CAPABILITIES
+    )
+
+
+def adapter_requested_permission_mode(adapter: object) -> str | None:
+    """Return the permission mode only when the adapter marks it caller-requested."""
+    requested = (
+        getattr(adapter, "permission_mode_requested", False) is True
+        or getattr(adapter, "_permission_mode_requested", False) is True
+    )
+    if not requested:
+        return None
+    permission_mode = getattr(adapter, "permission_mode", None)
+    return permission_mode if isinstance(permission_mode, str) and permission_mode else None
+
+
+def announce_execution_param_degradations(
+    adapter: object,
+    *,
+    system_prompt: str | None,
+    tools: list[str] | None,
+    announced: set[tuple[str, str]] | None = None,
+    console: Any | None = None,
+    log_event: str = "orchestrator.runtime_params.param_degraded",
+) -> None:
+    """Log and optionally print requested execution params degraded by a runtime."""
+    degradations = negotiate_execution_params(
+        runtime_capabilities_for(adapter),
+        system_prompt=system_prompt,
+        tools=tools,
+        permission_mode=adapter_requested_permission_mode(adapter),
+    )
+    backend = getattr(adapter, "runtime_backend", "unknown")
+    for degradation in degradations:
+        key = (degradation.parameter, degradation.support.value)
+        if announced is not None:
+            if key in announced:
+                continue
+            announced.add(key)
+        log.info(
+            log_event,
+            runtime_backend=backend,
+            parameter=degradation.parameter,
+            support=degradation.support.value,
+            detail=degradation.detail,
+        )
+        if console is not None:
+            console.print(
+                f"[yellow]Note:[/yellow] runtime '{backend}' does not natively honor "
+                f"'{degradation.parameter}' ({degradation.support.value}): "
+                f"{degradation.detail}."
+            )
+
+
+__all__ = [
+    "ParamDegradation",
+    "adapter_requested_permission_mode",
+    "announce_execution_param_degradations",
+    "negotiate_execution_params",
+    "runtime_capabilities_for",
+]

--- a/tests/unit/orchestrator/test_adapter.py
+++ b/tests/unit/orchestrator/test_adapter.py
@@ -11,8 +11,11 @@ import pytest
 
 from ouroboros.orchestrator.adapter import (
     DEFAULT_TOOLS,
+    FULL_CAPABILITIES,
     AgentMessage,
     ClaudeAgentAdapter,
+    ParamSupport,
+    RuntimeCapabilities,
     RuntimeHandle,
     SkillDispatchHandler,
     TaskResult,
@@ -67,6 +70,50 @@ def _build_mock_claude_agent_sdk(
         "claude_agent_sdk": module,
         "claude_agent_sdk.types": types_module,
     }
+
+
+class TestRuntimeCapabilitiesParamSupport:
+    """The param-support fields are additive and default to NATIVE."""
+
+    def test_param_support_defaults_to_native(self) -> None:
+        caps = RuntimeCapabilities(
+            skill_dispatch=True,
+            targeted_resume=True,
+            structured_output=True,
+        )
+
+        assert caps.system_prompt_support is ParamSupport.NATIVE
+        assert caps.tool_restriction_support is ParamSupport.NATIVE
+        assert caps.permission_mode_support is ParamSupport.NATIVE
+
+    def test_full_capabilities_is_all_native(self) -> None:
+        assert FULL_CAPABILITIES.system_prompt_support is ParamSupport.NATIVE
+        assert FULL_CAPABILITIES.tool_restriction_support is ParamSupport.NATIVE
+        assert FULL_CAPABILITIES.permission_mode_support is ParamSupport.NATIVE
+
+    def test_claude_adapter_honors_system_prompt_natively(self) -> None:
+        adapter = ClaudeAgentAdapter(api_key="test-key")
+
+        assert adapter.capabilities.system_prompt_support is ParamSupport.NATIVE
+
+
+class TestCliRuntimesDeclareTranslatedSystemPrompt:
+    """CLI runtimes that fold the system prompt into the user message say so."""
+
+    def test_hermes_declares_translated_system_prompt(self) -> None:
+        runtime = HermesCliRuntime()
+
+        assert runtime.capabilities.system_prompt_support is ParamSupport.TRANSLATED
+
+    def test_codex_declares_translated_system_prompt(self) -> None:
+        runtime = CodexCliRuntime()
+
+        assert runtime.capabilities.system_prompt_support is ParamSupport.TRANSLATED
+
+    def test_opencode_declares_translated_system_prompt(self) -> None:
+        runtime = OpenCodeRuntime()
+
+        assert runtime.capabilities.system_prompt_support is ParamSupport.TRANSLATED
 
 
 class TestAgentMessage:

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -16,7 +16,7 @@ from ouroboros.config.models import OuroborosConfig
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPToolError
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
-from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
+from ouroboros.orchestrator.adapter import AgentMessage, ParamSupport, RuntimeHandle
 import ouroboros.orchestrator.codex_cli_runtime as codex_cli_runtime_module
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
 from ouroboros.router import Resolved, ResolveRequest
@@ -24,6 +24,13 @@ from ouroboros.router.dispatch import SkillDispatchRouter as SharedSkillDispatch
 
 _EXPECTED_CODEX_PATH = str(Path("/usr/local/bin/codex"))
 _EXPECTED_PROJECT_CWD = str(Path("/tmp/project"))
+
+
+def test_capabilities_report_prompt_only_tool_restrictions_as_translated() -> None:
+    runtime = CodexCliRuntime(cli_path="codex", cwd="/tmp/project")
+
+    assert runtime.capabilities.system_prompt_support is ParamSupport.TRANSLATED
+    assert runtime.capabilities.tool_restriction_support is ParamSupport.TRANSLATED
 
 
 class _FakeStream:

--- a/tests/unit/orchestrator/test_coordinator.py
+++ b/tests/unit/orchestrator/test_coordinator.py
@@ -13,7 +13,12 @@ from __future__ import annotations
 
 import pytest
 
-from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
+from ouroboros.orchestrator.adapter import (
+    AgentMessage,
+    ParamSupport,
+    RuntimeCapabilities,
+    RuntimeHandle,
+)
 from ouroboros.orchestrator.coordinator import (
     CoordinatorReview,
     FileConflict,
@@ -197,6 +202,11 @@ class _StubCoordinatorRuntime:
         self._runtime_handle_backend = "opencode"
         self._cwd = "/tmp/project"
         self._permission_mode = "acceptEdits"
+        self.capabilities = RuntimeCapabilities(
+            skill_dispatch=True,
+            targeted_resume=True,
+            structured_output=True,
+        )
 
     @property
     def runtime_backend(self) -> str:
@@ -530,6 +540,36 @@ class TestParseReviewResponse:
 
 class TestRunReview:
     """Tests for LevelCoordinator.run_review()."""
+
+    @pytest.mark.asyncio
+    async def test_run_review_announces_param_degradation(self):
+        runtime = _StubCoordinatorRuntime(
+            (
+                AgentMessage(
+                    type="result",
+                    content='{"review_summary":"Reviewed","fixes_applied":[],"warnings_for_next_level":[],"conflicts_resolved":[]}',
+                    data={"subtype": "success"},
+                ),
+            )
+        )
+        runtime.capabilities = RuntimeCapabilities(
+            skill_dispatch=True,
+            targeted_resume=True,
+            structured_output=True,
+            system_prompt_support=ParamSupport.TRANSLATED,
+        )
+        coordinator = LevelCoordinator(runtime)
+
+        await coordinator.run_review(
+            execution_id="exec_degrade",
+            conflicts=[FileConflict(file_path="src/app.py", ac_indices=(0, 1))],
+            level_context=LevelContext(level_number=1, completed_acs=()),
+            level_number=1,
+        )
+
+        assert ("system_prompt", ParamSupport.TRANSLATED.value) in (
+            coordinator._announced_param_degradations
+        )
 
     @pytest.mark.asyncio
     async def test_run_review_uses_fresh_level_scoped_runtime_handle(self):

--- a/tests/unit/orchestrator/test_copilot_cli_runtime.py
+++ b/tests/unit/orchestrator/test_copilot_cli_runtime.py
@@ -16,6 +16,7 @@ from dataclasses import replace
 
 import pytest
 
+from ouroboros.orchestrator.adapter import ParamSupport
 from ouroboros.orchestrator.copilot_cli_runtime import (
     _MAX_OUROBOROS_DEPTH,
     CopilotCliRuntime,
@@ -25,6 +26,16 @@ from ouroboros.orchestrator.runtime_factory import resolve_agent_runtime_backend
 
 def _make_runtime(model: str | None = None, cwd: str = "/work") -> CopilotCliRuntime:
     return CopilotCliRuntime(cli_path="/usr/bin/copilot", model=model, cwd=cwd)
+
+
+def test_capabilities_report_prompt_only_tool_restrictions_as_translated() -> None:
+    capabilities = _make_runtime().capabilities
+
+    assert capabilities.system_prompt_support is ParamSupport.TRANSLATED
+    assert capabilities.tool_restriction_support is ParamSupport.TRANSLATED
+    assert capabilities.permission_mode_support is ParamSupport.NATIVE
+    assert capabilities.targeted_resume is False
+    assert capabilities.structured_output is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/orchestrator/test_gemini_cli_runtime.py
+++ b/tests/unit/orchestrator/test_gemini_cli_runtime.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import pytest
 
+from ouroboros.orchestrator.adapter import ParamSupport
 from ouroboros.orchestrator.gemini_cli_runtime import (
     _MAX_OUROBOROS_DEPTH,
     GeminiCLIRuntime,
@@ -234,6 +235,8 @@ def test_runtime_capabilities_mark_targeted_resume_unsupported() -> None:
     assert runtime.capabilities.skill_dispatch is True
     assert runtime.capabilities.targeted_resume is False
     assert runtime.capabilities.structured_output is True
+    assert runtime.capabilities.system_prompt_support is ParamSupport.TRANSLATED
+    assert runtime.capabilities.tool_restriction_support is ParamSupport.TRANSLATED
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/orchestrator/test_goose_runtime.py
+++ b/tests/unit/orchestrator/test_goose_runtime.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
+from ouroboros.orchestrator.adapter import ParamSupport
 from ouroboros.orchestrator.goose_runtime import GooseCliRuntime
 
 
@@ -61,6 +62,13 @@ def test_goose_default_permission_mode_preserves_approval_gate() -> None:
 
     assert runtime.permission_mode == "approve"
     assert runtime._build_child_env()["GOOSE_MODE"] == "approve"
+
+
+def test_goose_capabilities_report_prompt_only_tool_restrictions_as_translated() -> None:
+    runtime = GooseCliRuntime(cli_path="/tmp/goose", cwd="/tmp/project")
+
+    assert runtime.capabilities.system_prompt_support is ParamSupport.TRANSLATED
+    assert runtime.capabilities.tool_restriction_support is ParamSupport.TRANSLATED
 
 
 @pytest.mark.parametrize("mode", ["default", "acceptEdits", "accept_edits", "acceptedits"])

--- a/tests/unit/orchestrator/test_hermes_runtime.py
+++ b/tests/unit/orchestrator/test_hermes_runtime.py
@@ -13,7 +13,7 @@ import pytest
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPToolError
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
-from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
+from ouroboros.orchestrator.adapter import AgentMessage, ParamSupport, RuntimeHandle
 import ouroboros.orchestrator.hermes_runtime as hermes_runtime_module
 from ouroboros.orchestrator.hermes_runtime import HermesCliRuntime, _parse_quiet_output
 from ouroboros.router import Resolved, ResolveRequest, SkillDispatchRouter
@@ -123,6 +123,20 @@ class TestHermesCliRuntime:
         assert runtime.runtime_backend == "hermes_cli"
         assert runtime.working_directory == _EXPECTED_CWD
         assert runtime.permission_mode == "default"
+        assert runtime.permission_mode_requested is False
+
+    def test_tracks_requested_permission_mode_and_declares_ignored_support(self) -> None:
+        runtime = HermesCliRuntime(
+            cli_path="hermes",
+            cwd="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+
+        assert runtime.permission_mode == "acceptEdits"
+        assert runtime.permission_mode_requested is True
+        assert runtime.capabilities.system_prompt_support is ParamSupport.TRANSLATED
+        assert runtime.capabilities.tool_restriction_support is ParamSupport.TRANSLATED
+        assert runtime.capabilities.permission_mode_support is ParamSupport.IGNORED
 
     def test_constructor_accepts_llm_backend(self) -> None:
         runtime = HermesCliRuntime(cli_path="hermes", llm_backend="opencode")

--- a/tests/unit/orchestrator/test_opencode_runtime.py
+++ b/tests/unit/orchestrator/test_opencode_runtime.py
@@ -13,7 +13,7 @@ import pytest
 
 from ouroboros.core.types import Result
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
-from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
+from ouroboros.orchestrator.adapter import AgentMessage, ParamSupport, RuntimeHandle
 import ouroboros.orchestrator.opencode_runtime as opencode_runtime_module
 from ouroboros.orchestrator.opencode_runtime import OpenCodeRuntime
 from ouroboros.router import Resolved, ResolveRequest
@@ -142,10 +142,19 @@ class TestOpenCodeRuntimeProperties:
     def test_permission_mode_default(self) -> None:
         runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
         assert runtime.permission_mode == "bypassPermissions"
+        assert runtime.permission_mode_requested is False
 
     def test_permission_mode_custom(self) -> None:
         runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp", permission_mode="acceptEdits")
         assert runtime.permission_mode == "acceptEdits"
+        assert runtime.permission_mode_requested is True
+
+    def test_capabilities_report_non_native_params_honestly(self) -> None:
+        runtime = OpenCodeRuntime(cli_path="opencode", cwd="/tmp")
+
+        assert runtime.capabilities.system_prompt_support is ParamSupport.TRANSLATED
+        assert runtime.capabilities.tool_restriction_support is ParamSupport.TRANSLATED
+        assert runtime.capabilities.permission_mode_support is ParamSupport.IGNORED
 
 
 class TestOpenCodeRuntimeBuildCommand:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -14,7 +14,13 @@ import pytest
 from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
 from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.types import MCPToolDefinition
-from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
+from ouroboros.orchestrator.adapter import (
+    FULL_CAPABILITIES,
+    AgentMessage,
+    ParamSupport,
+    RuntimeCapabilities,
+    RuntimeHandle,
+)
 from ouroboros.orchestrator.coordinator import CoordinatorReview, FileConflict
 from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
 from ouroboros.orchestrator.evidence_schema import EvidenceRecord, ValidationResult
@@ -10113,3 +10119,132 @@ async def test_try_decompose_ac_accumulates_goose_stream_chunks() -> None:
         "Sub-AC 2: write a focused regression test",
         "Sub-AC 3: document the result",
     ]
+
+
+@pytest.mark.asyncio
+async def test_try_decompose_ac_announces_same_empty_tools_allowlist_it_dispatches() -> None:
+    class _CapturingRuntime:
+        runtime_backend = "codex_cli"
+        capabilities = RuntimeCapabilities(
+            skill_dispatch=True,
+            targeted_resume=True,
+            structured_output=True,
+            tool_restriction_support=ParamSupport.TRANSLATED,
+        )
+
+        def __init__(self) -> None:
+            self.dispatched_tools: list[str] | None = None
+
+        async def execute_task(
+            self,
+            prompt: str,
+            tools: list[str] | None = None,
+            system_prompt: str | None = None,
+            resume_handle: RuntimeHandle | None = None,
+            resume_session_id: str | None = None,
+        ):
+            del prompt, system_prompt, resume_handle, resume_session_id
+            self.dispatched_tools = tools
+            yield AgentMessage(type="assistant", content='["Sub-AC 1: inspect", "Sub-AC 2: test"]')
+
+    runtime = _CapturingRuntime()
+    console = MagicMock()
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=console,
+        enable_decomposition=True,
+    )
+
+    result = await executor._try_decompose_ac(
+        ac_content="Investigate and test sub-AC behavior.",
+        ac_index=0,
+        seed_goal="Verify decomposition tool handling",
+        tools=["Read"],
+        system_prompt="system",
+    )
+
+    assert result == ["Sub-AC 1: inspect", "Sub-AC 2: test"]
+    assert runtime.dispatched_tools == []
+    console.print.assert_called_once()
+    notice = console.print.call_args.args[0]
+    assert "tools" in notice
+    assert "ignored" in notice
+
+
+class _ParamCapsStubAdapter:
+    """Minimal adapter exposing the attributes the param-degradation hook reads."""
+
+    def __init__(self, capabilities: RuntimeCapabilities) -> None:
+        self.capabilities = capabilities
+        self.runtime_backend = "hermes_cli"
+        self.permission_mode = "acceptEdits"
+        self.working_directory = "/workspace"
+
+
+def _make_param_executor(capabilities: RuntimeCapabilities) -> ParallelACExecutor:
+    return ParallelACExecutor(
+        adapter=_ParamCapsStubAdapter(capabilities),
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+    )
+
+
+class TestParamDegradationNotice:
+    """The executor surfaces non-native param handling once per run."""
+
+    def test_translated_system_prompt_surfaces_one_notice(self) -> None:
+        caps = RuntimeCapabilities(
+            skill_dispatch=True,
+            targeted_resume=True,
+            structured_output=True,
+            system_prompt_support=ParamSupport.TRANSLATED,
+        )
+        executor = _make_param_executor(caps)
+
+        # Two dispatches with the same degraded param → surfaced once (deduped).
+        executor._announce_param_degradations(system_prompt="be terse", tools=None)
+        executor._announce_param_degradations(system_prompt="be terse", tools=None)
+
+        assert executor._console.print.call_count == 1
+        notice = executor._console.print.call_args.args[0]
+        assert "system_prompt" in notice
+        assert "hermes_cli" in notice
+
+    def test_all_native_adapter_is_silent(self) -> None:
+        executor = _make_param_executor(FULL_CAPABILITIES)
+
+        executor._announce_param_degradations(system_prompt="be terse", tools=["Read"])
+
+        executor._console.print.assert_not_called()
+
+    def test_absent_system_prompt_produces_no_notice(self) -> None:
+        caps = RuntimeCapabilities(
+            skill_dispatch=True,
+            targeted_resume=True,
+            structured_output=True,
+            system_prompt_support=ParamSupport.TRANSLATED,
+        )
+        executor = _make_param_executor(caps)
+
+        executor._announce_param_degradations(system_prompt=None, tools=None)
+
+        executor._console.print.assert_not_called()
+
+    def test_empty_tools_allowlist_surfaces_one_notice(self) -> None:
+        caps = RuntimeCapabilities(
+            skill_dispatch=True,
+            targeted_resume=True,
+            structured_output=True,
+            tool_restriction_support=ParamSupport.TRANSLATED,
+        )
+        executor = _make_param_executor(caps)
+
+        executor._announce_param_degradations(system_prompt=None, tools=[])
+        executor._announce_param_degradations(system_prompt=None, tools=[])
+
+        assert executor._console.print.call_count == 1
+        notice = executor._console.print.call_args.args[0]
+        assert "tools" in notice
+        assert "ignored" in notice

--- a/tests/unit/orchestrator/test_pi_runtime.py
+++ b/tests/unit/orchestrator/test_pi_runtime.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 
 import pytest
 
-from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
+from ouroboros.orchestrator.adapter import AgentMessage, ParamSupport, RuntimeHandle
 from ouroboros.orchestrator.pi_runtime import PiRuntime
 
 
@@ -73,6 +73,23 @@ def test_build_command_uses_documented_json_prompt_argument() -> None:
         "sess_123-OK",
         "Do the task",
     ]
+
+
+def test_tracks_requested_permission_mode_and_declares_ignored_support() -> None:
+    default_runtime = PiRuntime(cli_path="/tmp/pi", cwd="/tmp/project")
+    requested_runtime = PiRuntime(
+        cli_path="/tmp/pi",
+        cwd="/tmp/project",
+        permission_mode="acceptEdits",
+    )
+
+    assert default_runtime.permission_mode is None
+    assert default_runtime.permission_mode_requested is False
+    assert requested_runtime.permission_mode == "acceptEdits"
+    assert requested_runtime.permission_mode_requested is True
+    assert requested_runtime.capabilities.system_prompt_support is ParamSupport.TRANSLATED
+    assert requested_runtime.capabilities.tool_restriction_support is ParamSupport.TRANSLATED
+    assert requested_runtime.capabilities.permission_mode_support is ParamSupport.IGNORED
 
 
 def test_build_command_rejects_unsafe_resume_session_id() -> None:

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -23,7 +23,12 @@ from ouroboros.core.seed import (
 from ouroboros.core.types import Result
 from ouroboros.core.worktree import TaskWorkspace
 from ouroboros.events.base import BaseEvent
-from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
+from ouroboros.orchestrator.adapter import (
+    AgentMessage,
+    ParamSupport,
+    RuntimeCapabilities,
+    RuntimeHandle,
+)
 from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
 
 # TODO: uncomment when OpenCode runtime is shipped
@@ -314,6 +319,28 @@ class TestOrchestratorRunner:
     ) -> OrchestratorRunner:
         """Create a runner with mocked dependencies."""
         return OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+
+    def test_param_degradation_notice_surfaces_for_serial_runner(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+    ) -> None:
+        mock_adapter.capabilities = RuntimeCapabilities(
+            skill_dispatch=True,
+            targeted_resume=True,
+            structured_output=True,
+            system_prompt_support=ParamSupport.TRANSLATED,
+        )
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+
+        runner._announce_param_degradations(system_prompt="be terse", tools=None)
+        runner._announce_param_degradations(system_prompt="be terse", tools=None)
+
+        assert mock_console.print.call_count == 1
+        notice = mock_console.print.call_args.args[0]
+        assert "system_prompt" in notice
+        assert "opencode" in notice
 
     @pytest.mark.asyncio
     async def test_execute_seed_success(

--- a/tests/unit/orchestrator/test_runtime_param_negotiation.py
+++ b/tests/unit/orchestrator/test_runtime_param_negotiation.py
@@ -1,0 +1,258 @@
+"""Unit tests for observability-only parameter-level capability negotiation.
+
+The orchestrator surfaces when a runtime will not honor a requested execution
+parameter in its supplied form. These tests pin the pure negotiation logic:
+non-native handling of a *requested* parameter yields a degradation record;
+native handling, or an absent parameter, yields nothing.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from ouroboros.orchestrator.adapter import ParamSupport, RuntimeCapabilities
+from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
+from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
+from ouroboros.orchestrator.goose_runtime import GooseCliRuntime
+from ouroboros.orchestrator.runtime_param_negotiation import (
+    adapter_requested_permission_mode,
+    announce_execution_param_degradations,
+    negotiate_execution_params,
+)
+
+
+def _caps(
+    *,
+    system_prompt_support: ParamSupport = ParamSupport.NATIVE,
+    tool_restriction_support: ParamSupport = ParamSupport.NATIVE,
+    permission_mode_support: ParamSupport = ParamSupport.NATIVE,
+) -> RuntimeCapabilities:
+    return RuntimeCapabilities(
+        skill_dispatch=True,
+        targeted_resume=True,
+        structured_output=True,
+        system_prompt_support=system_prompt_support,
+        tool_restriction_support=tool_restriction_support,
+        permission_mode_support=permission_mode_support,
+    )
+
+
+def test_all_native_yields_no_degradations() -> None:
+    result = negotiate_execution_params(
+        _caps(),
+        system_prompt="be terse",
+        tools=["Read", "Edit"],
+        permission_mode="acceptEdits",
+    )
+
+    assert result == ()
+
+
+def test_translated_system_prompt_is_reported_when_requested() -> None:
+    result = negotiate_execution_params(
+        _caps(system_prompt_support=ParamSupport.TRANSLATED),
+        system_prompt="be terse",
+        tools=None,
+        permission_mode=None,
+    )
+
+    assert len(result) == 1
+    assert result[0].parameter == "system_prompt"
+    assert result[0].support is ParamSupport.TRANSLATED
+    assert "translation" in result[0].detail
+
+
+def test_ignored_tools_is_reported_when_requested() -> None:
+    result = negotiate_execution_params(
+        _caps(tool_restriction_support=ParamSupport.IGNORED),
+        system_prompt=None,
+        tools=["Read"],
+        permission_mode=None,
+    )
+
+    assert len(result) == 1
+    assert result[0].parameter == "tools"
+    assert result[0].support is ParamSupport.IGNORED
+    assert "dropped" in result[0].detail
+
+
+def test_translated_non_empty_tools_is_reported_when_requested() -> None:
+    result = negotiate_execution_params(
+        _caps(tool_restriction_support=ParamSupport.TRANSLATED),
+        system_prompt=None,
+        tools=["Read"],
+        permission_mode=None,
+    )
+
+    assert len(result) == 1
+    assert result[0].parameter == "tools"
+    assert result[0].support is ParamSupport.TRANSLATED
+    assert "translation" in result[0].detail
+
+
+def test_translated_empty_tools_allowlist_is_reported_as_ignored() -> None:
+    result = negotiate_execution_params(
+        _caps(tool_restriction_support=ParamSupport.TRANSLATED),
+        system_prompt=None,
+        tools=[],
+        permission_mode=None,
+    )
+
+    assert len(result) == 1
+    assert result[0].parameter == "tools"
+    assert result[0].support is ParamSupport.IGNORED
+    assert "dropped" in result[0].detail
+
+
+def test_absent_parameter_is_never_degraded() -> None:
+    # The runtime does not honor system_prompt natively, but none was supplied.
+    result = negotiate_execution_params(
+        _caps(system_prompt_support=ParamSupport.IGNORED),
+        system_prompt=None,
+        tools=None,
+        permission_mode=None,
+    )
+
+    assert result == ()
+
+
+def test_empty_strings_count_as_absent_but_empty_tools_is_requested() -> None:
+    result = negotiate_execution_params(
+        _caps(
+            system_prompt_support=ParamSupport.IGNORED,
+            tool_restriction_support=ParamSupport.IGNORED,
+        ),
+        system_prompt="",
+        tools=[],
+        permission_mode="",
+    )
+
+    assert len(result) == 1
+    assert result[0].parameter == "tools"
+    assert result[0].support is ParamSupport.IGNORED
+
+
+def test_multiple_non_native_params_are_all_reported() -> None:
+    result = negotiate_execution_params(
+        _caps(
+            system_prompt_support=ParamSupport.TRANSLATED,
+            permission_mode_support=ParamSupport.TRANSLATED,
+        ),
+        system_prompt="be terse",
+        tools=["Read"],  # native → not reported
+        permission_mode="acceptEdits",
+    )
+
+    reported = {item.parameter for item in result}
+    assert reported == {"system_prompt", "permission_mode"}
+
+
+def test_adapter_default_permission_mode_is_not_requested() -> None:
+    adapter = SimpleNamespace(permission_mode="bypassPermissions")
+
+    assert adapter_requested_permission_mode(adapter) is None
+
+
+def test_adapter_explicit_permission_mode_is_requested() -> None:
+    adapter = SimpleNamespace(
+        permission_mode="acceptEdits",
+        permission_mode_requested=True,
+    )
+
+    assert adapter_requested_permission_mode(adapter) == "acceptEdits"
+
+
+def test_shared_notice_suppresses_unrequested_permission_default() -> None:
+    adapter = SimpleNamespace(
+        capabilities=_caps(permission_mode_support=ParamSupport.IGNORED),
+        runtime_backend="opencode",
+        permission_mode="bypassPermissions",
+    )
+    console = MagicMock()
+
+    announce_execution_param_degradations(
+        adapter,
+        system_prompt=None,
+        tools=None,
+        console=console,
+    )
+
+    console.print.assert_not_called()
+
+
+def test_shared_notice_surfaces_requested_permission_degradation_once() -> None:
+    adapter = SimpleNamespace(
+        capabilities=_caps(permission_mode_support=ParamSupport.IGNORED),
+        runtime_backend="opencode",
+        permission_mode="acceptEdits",
+        permission_mode_requested=True,
+    )
+    console = MagicMock()
+    announced: set[tuple[str, str]] = set()
+
+    announce_execution_param_degradations(
+        adapter,
+        system_prompt=None,
+        tools=None,
+        announced=announced,
+        console=console,
+    )
+    announce_execution_param_degradations(
+        adapter,
+        system_prompt=None,
+        tools=None,
+        announced=announced,
+        console=console,
+    )
+
+    assert console.print.call_count == 1
+    assert "permission_mode" in console.print.call_args.args[0]
+
+
+def test_prompt_only_tool_runtimes_announce_tool_degradation() -> None:
+    console = MagicMock()
+
+    runtimes = [
+        GeminiCLIRuntime(cli_path="/tmp/gemini"),
+        GooseCliRuntime(cli_path="/tmp/goose"),
+        CopilotCliRuntime(cli_path="/tmp/copilot"),
+    ]
+
+    for runtime in runtimes:
+        announce_execution_param_degradations(
+            runtime,
+            system_prompt=None,
+            tools=["Read"],
+            console=console,
+        )
+
+    assert console.print.call_count == len(runtimes)
+    notices = [call.args[0] for call in console.print.call_args_list]
+    for notice in notices:
+        assert "tools" in notice
+        assert "translated" in notice
+
+
+def test_prompt_only_tool_runtimes_announce_empty_tools_as_ignored() -> None:
+    console = MagicMock()
+
+    runtimes = [
+        GeminiCLIRuntime(cli_path="/tmp/gemini"),
+        GooseCliRuntime(cli_path="/tmp/goose"),
+        CopilotCliRuntime(cli_path="/tmp/copilot"),
+    ]
+
+    for runtime in runtimes:
+        announce_execution_param_degradations(
+            runtime,
+            system_prompt=None,
+            tools=[],
+            console=console,
+        )
+
+    assert console.print.call_count == len(runtimes)
+    notices = [call.args[0] for call in console.print.call_args_list]
+    for notice in notices:
+        assert "tools" in notice
+        assert "ignored" in notice

--- a/tests/unit/test_kiro_adapters.py
+++ b/tests/unit/test_kiro_adapters.py
@@ -575,6 +575,35 @@ class TestCreateAgentRuntimeKiro:
 # ===========================================================================
 
 
+class TestKiroAgentAdapterParamSupport:
+    """Kiro declares its lossy parameter handling for observability."""
+
+    def test_declares_translated_system_prompt_and_permission_mode(self) -> None:
+        from ouroboros.orchestrator.adapter import ParamSupport
+        from ouroboros.orchestrator.kiro_adapter import KiroAgentAdapter
+
+        adapter = KiroAgentAdapter(cli_path="kiro-cli")
+        caps = adapter.capabilities
+
+        # system_prompt is wrapped as <system>...</system>; permission_mode maps
+        # onto coarse --trust-* flags — both lossy adaptations.
+        assert caps.system_prompt_support is ParamSupport.TRANSLATED
+        assert caps.permission_mode_support is ParamSupport.TRANSLATED
+        # tools restriction is enforced via native trust flags → stays NATIVE.
+        assert caps.tool_restriction_support is ParamSupport.NATIVE
+
+    def test_tracks_caller_requested_permission_mode(self) -> None:
+        from ouroboros.orchestrator.kiro_adapter import KiroAgentAdapter
+
+        default_adapter = KiroAgentAdapter(cli_path="kiro-cli")
+        custom_adapter = KiroAgentAdapter(cli_path="kiro-cli", permission_mode="default")
+
+        assert default_adapter.permission_mode == "acceptEdits"
+        assert default_adapter.permission_mode_requested is False
+        assert custom_adapter.permission_mode == "default"
+        assert custom_adapter.permission_mode_requested is True
+
+
 class TestKiroAgentAdapterExecuteTask:
     @pytest.mark.asyncio
     async def test_streams_output_lines(self) -> None:


### PR DESCRIPTION
## Summary

Rebase of #1374 by @deepakdgupta1 onto current `main` (post-#1372/#1373), preserving original authorship. The original PR was approved with all CI green but went `CONFLICTING` after #1372 landed.

**Conflict resolution** (`parallel_executor.py` only, 3 adjacent-addition hunks — everything else auto-merged):
- `__init__`: keep both the #1372 dispatch rate gate and the #1374 param-degradation dedup set
- Both dispatch sites: announce param degradations (sync, observability-only) **before** the rate-budget wait, so notices are never delayed by backoff

No other changes vs. the approved #1374 head (`454492f3`).

## Verification
- `ruff` + `ruff format` clean, `mypy` clean on touched files
- `tests/unit/orchestrator/` + kiro adapters: **2,135 passed, 1 skipped**

## Note for follow-up
The original PR description's per-runtime table shows hermes `permission_mode` as *native*; the code and `docs/runtime-capability-matrix.md` both (correctly) declare it `ignored` — the artifacts are consistent, only the old PR text was stale.

Closes #1374

🤖 Generated with [Claude Code](https://claude.com/claude-code)