### PR TITLE
fix(mcp): detect client death behind uvx, bound shutdown, drain jobs before store close

### DIFF
--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -14,17 +14,45 @@ from pathlib import Path
 import signal
 import subprocess
 import sys
-from typing import Annotated
+import time
+from typing import Annotated, Any
 
 from rich.console import Console
 import typer
 
 from ouroboros.cli.commands.mcp_doctor import register_doctor_command
 from ouroboros.cli.formatters.panels import print_info, print_success
+from ouroboros.orchestrator.heartbeat import (
+    current_process_identity,
+    is_process_identity_alive,
+    process_start_time,
+)
 
-# PID file for detecting stale instances
+# Per-instance PID registry for stale-instance accounting. Many servers run
+# concurrently (one per MCP client session), so a single-slot PID file is
+# last-writer-wins and guards nothing: any exiting server used to delete the
+# record of whichever server wrote last, and kill-advice built on it could
+# target a healthy server owned by a live session. Each instance owns exactly
+# one record keyed by its pid, stamped with the process start time so a
+# recycled pid is never mistaken for a live server.
 _PID_DIR = Path.home() / ".ouroboros"
-_PID_FILE = _PID_DIR / "mcp-server.pid"
+_PID_REGISTRY_DIR = _PID_DIR / "mcp-servers"
+# Single-slot file written by pre-registry versions; swept when stale.
+_LEGACY_PID_FILE = _PID_DIR / "mcp-server.pid"
+
+# Identity of the record this process wrote — compare-and-delete on cleanup.
+_own_pid_file: Path | None = None
+_own_pid_payload: str | None = None
+
+# Shutdown pacing: how long to wait for the serve loop / background jobs to
+# unwind before escalating (closing fd 0) or proceeding with store cleanup.
+_SHUTDOWN_DRAIN_GRACE_SECONDS = 5.0
+_JOB_DRAIN_GRACE_SECONDS = 5.0
+
+# Idle WAL relief: long-lived idle servers pin the shared SQLite WAL (passive
+# autocheckpoints cannot truncate while any reader is active).
+_IDLE_CHECKPOINT_POLL_SECONDS = 300.0
+_IDLE_CHECKPOINT_THRESHOLD_SECONDS = 600.0
 
 # Separate stderr console for stdio transport (stdout is JSON-RPC channel)
 _stderr_console = Console(stderr=True)
@@ -59,60 +87,186 @@ class LLMBackend(str, Enum):  # noqa: UP042
 
 
 def _write_pid_file() -> bool:
-    """Write current PID to file for stale instance detection.
+    """Register this instance in the per-instance PID registry.
 
     Returns:
-        True if the PID file was written successfully, False otherwise.
+        True if the record was written successfully, False otherwise.
     """
+    global _own_pid_file, _own_pid_payload
+    pid, start_time = current_process_identity()
+    payload = f"{pid} {start_time if start_time is not None else 'None'}"
     try:
-        _PID_DIR.mkdir(parents=True, exist_ok=True)
-        _PID_FILE.write_text(str(os.getpid()), encoding="utf-8")
+        _PID_REGISTRY_DIR.mkdir(parents=True, exist_ok=True)
+        path = _PID_REGISTRY_DIR / f"{pid}.pid"
+        path.write_text(payload, encoding="utf-8")
     except OSError:
         return False
+    _own_pid_file = path
+    _own_pid_payload = payload
     return True
 
 
 def _cleanup_pid_file() -> None:
-    """Remove PID file on clean shutdown."""
+    """Remove only the registry record this process wrote (compare-and-delete).
+
+    A blind unlink could delete a record that a pid-recycled successor wrote
+    after a crash sweep; comparing the payload (pid + start time) guarantees
+    each server only ever removes its own record.
+    """
+    global _own_pid_file, _own_pid_payload
+    path, payload = _own_pid_file, _own_pid_payload
+    _own_pid_file = None
+    _own_pid_payload = None
+    if path is None or payload is None:
+        return
     try:
-        _PID_FILE.unlink(missing_ok=True)
+        if path.read_text(encoding="utf-8").strip() == payload.strip():
+            path.unlink(missing_ok=True)
     except OSError:
         pass
 
 
-def _check_stale_instance() -> bool:
-    """Check for and clean up stale MCP server instances.
+def _parse_pid_record(text: str) -> tuple[int, float | None] | None:
+    """Parse a registry record of the form ``"<pid> <start_time|None>"``."""
+    parts = text.strip().split()
+    if not parts:
+        return None
+    try:
+        pid = int(parts[0])
+    except ValueError:
+        return None
+    start_time: float | None = None
+    if len(parts) > 1 and parts[1] != "None":
+        try:
+            start_time = float(parts[1])
+        except ValueError:
+            return None
+    return pid, start_time
 
-    Returns:
-        True if a stale instance was cleaned up.
+
+def _record_is_stale(pid: int, start_time: float | None) -> bool:
+    """True when a record's process identity is provably not running.
+
+    Windows cannot probe liveness via signal 0 (``os.kill(pid, 0)`` raises
+    ``OSError`` WinError 87) — treat as stale, preserving the degradation the
+    legacy single-slot check used.
     """
     try:
-        pid_exists = _PID_FILE.exists()
+        return not is_process_identity_alive(pid, start_time)
     except OSError:
-        return False
-
-    if not pid_exists:
-        return False
-
-    try:
-        old_pid = int(_PID_FILE.read_text(encoding="utf-8").strip())
-    except (ValueError, OSError):
-        _cleanup_pid_file()
         return True
 
+
+def _sweep_stale_instances() -> int:
+    """Drop registry records (and the legacy single-slot file) of dead servers.
+
+    Returns the number of stale records removed.
+    """
+    removed = 0
     try:
-        os.kill(old_pid, 0)  # Signal 0 = check existence
-        return False  # Process is alive
-    except ProcessLookupError:
-        _cleanup_pid_file()
-        return True
-    except PermissionError:
-        return False  # Process exists but we can't signal it
+        if _LEGACY_PID_FILE.exists():
+            record = _parse_pid_record(_LEGACY_PID_FILE.read_text(encoding="utf-8"))
+            if record is None or _record_is_stale(record[0], record[1]):
+                _LEGACY_PID_FILE.unlink(missing_ok=True)
+                removed += 1
     except OSError:
-        # Windows: os.kill(pid, 0) raises OSError (WinError 87)
-        # since signal 0 is not supported. Treat as stale.
-        _cleanup_pid_file()
-        return True
+        pass
+    try:
+        entries = list(_PID_REGISTRY_DIR.iterdir())
+    except OSError:
+        return removed
+    for entry in entries:
+        try:
+            record = _parse_pid_record(entry.read_text(encoding="utf-8"))
+        except OSError:
+            continue
+        if record is None or _record_is_stale(record[0], record[1]):
+            try:
+                entry.unlink(missing_ok=True)
+            except OSError:
+                continue
+            removed += 1
+    return removed
+
+
+def _live_instances() -> list[int]:
+    """PIDs of registered, provably-live MCP server instances."""
+    alive: list[int] = []
+    try:
+        entries = list(_PID_REGISTRY_DIR.iterdir())
+    except OSError:
+        return alive
+    for entry in entries:
+        try:
+            record = _parse_pid_record(entry.read_text(encoding="utf-8"))
+        except OSError:
+            continue
+        if record is not None and not _record_is_stale(record[0], record[1]):
+            alive.append(record[0])
+    return sorted(alive)
+
+
+# Login-shell env import: cache + whitelist. Without the cache, every server
+# start for subscription-auth users (no ANTHROPIC_API_KEY, so the fast path
+# never engages) pays a full login shell sourcing ~/.zshrc — up to the 10s
+# timeout — per instance. Without the whitelist, arbitrary login vars
+# (PYTHONPATH, VIRTUAL_ENV, other vendors' secrets) leak into the server and
+# every runtime it spawns.
+_SHELL_ENV_CACHE_FILE = _PID_DIR / "shell-env.json"
+_SHELL_ENV_CACHE_TTL_SECONDS = 3600.0
+
+
+# Network plumbing the spawned runtimes need even though it is neither an API
+# key nor ouroboros config: corporate proxies, custom CA bundles, gh auth.
+_SHELL_ENV_EXACT_ALLOWED = frozenset(
+    {
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "ALL_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+        "all_proxy",
+        "GH_TOKEN",
+        "GITHUB_TOKEN",
+        "SSL_CERT_FILE",
+        "REQUESTS_CA_BUNDLE",
+    }
+)
+
+
+def _shell_env_key_allowed(key: str) -> bool:
+    """Whitelist for login-shell env import (PATH is merged separately)."""
+    return (
+        key in _SHELL_ENV_EXACT_ALLOWED
+        or key.endswith(("_API_KEY", "_BASE_URL", "_API_BASE"))
+        or key.startswith("OUROBOROS_")
+    )
+
+
+def _load_cached_shell_env() -> dict[str, str] | None:
+    """Return the cached login-shell env dump, or None when absent/stale."""
+    try:
+        stat = _SHELL_ENV_CACHE_FILE.stat()
+        if time.time() - stat.st_mtime > _SHELL_ENV_CACHE_TTL_SECONDS:
+            return None
+        data = json.loads(_SHELL_ENV_CACHE_FILE.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return {k: v for k, v in data.items() if isinstance(k, str) and isinstance(v, str)}
+
+
+def _store_shell_env_cache(env: dict[str, str]) -> None:
+    """Persist the (already whitelisted) shell env dump; 0600 — it holds keys."""
+    try:
+        _PID_DIR.mkdir(parents=True, exist_ok=True)
+        _SHELL_ENV_CACHE_FILE.write_text(json.dumps(env), encoding="utf-8")
+        _SHELL_ENV_CACHE_FILE.chmod(0o600)
+    except OSError:
+        pass
 
 
 def _ensure_shell_env(*, timeout: float = 10.0) -> None:
@@ -129,39 +283,62 @@ def _ensure_shell_env(*, timeout: float = 10.0) -> None:
     if os.environ.get("ANTHROPIC_API_KEY"):
         return
 
-    shell = os.environ.get("SHELL", "/bin/zsh" if sys.platform == "darwin" else "/bin/bash")
-    shell_name = Path(shell).name
+    env = _load_cached_shell_env()
+    if env is None:
+        shell = os.environ.get("SHELL", "/bin/zsh" if sys.platform == "darwin" else "/bin/bash")
+        shell_name = Path(shell).name
 
-    # Dump env as JSON — unambiguous, handles multiline values
-    dump_cmd = 'python3 -c "import os,json,sys; json.dump(dict(os.environ), sys.stdout)"'
+        # Dump env as JSON — unambiguous, handles multiline values
+        dump_cmd = 'python3 -c "import os,json,sys; json.dump(dict(os.environ), sys.stdout)"'
 
-    if shell_name == "zsh":
-        cmd = [shell, "-l", "-c", f"[[ -f ~/.zshrc ]] && source ~/.zshrc 2>/dev/null; {dump_cmd}"]
-    elif shell_name == "bash":
-        cmd = [shell, "-l", "-c", f"[[ -f ~/.bashrc ]] && source ~/.bashrc 2>/dev/null; {dump_cmd}"]
-    else:
-        cmd = [shell, "-l", "-c", dump_cmd]
+        if shell_name == "zsh":
+            cmd = [
+                shell,
+                "-l",
+                "-c",
+                f"[[ -f ~/.zshrc ]] && source ~/.zshrc 2>/dev/null; {dump_cmd}",
+            ]
+        elif shell_name == "bash":
+            cmd = [
+                shell,
+                "-l",
+                "-c",
+                f"[[ -f ~/.bashrc ]] && source ~/.bashrc 2>/dev/null; {dump_cmd}",
+            ]
+        else:
+            cmd = [shell, "-l", "-c", dump_cmd]
 
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            stdin=subprocess.DEVNULL,
-            text=True,
-            timeout=timeout,
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                stdin=subprocess.DEVNULL,
+                text=True,
+                timeout=timeout,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
+            _stderr_console.print(f"[yellow]Warning: shell env load failed: {e}[/yellow]")
+            return
+
+        if result.returncode != 0:
+            return
+
+        try:
+            env = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            _stderr_console.print("[yellow]Warning: could not parse shell env output[/yellow]")
+            return
+        if not isinstance(env, dict):
+            return
+        # Cache only what the merge below may use — keeps the secret surface
+        # of the on-disk cache as small as the merge itself.
+        _store_shell_env_cache(
+            {
+                k: v
+                for k, v in env.items()
+                if isinstance(v, str) and (k == "PATH" or _shell_env_key_allowed(k))
+            }
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
-        _stderr_console.print(f"[yellow]Warning: shell env load failed: {e}[/yellow]")
-        return
-
-    if result.returncode != 0:
-        return
-
-    try:
-        env = json.loads(result.stdout)
-    except json.JSONDecodeError:
-        _stderr_console.print("[yellow]Warning: could not parse shell env output[/yellow]")
-        return
 
     current_path_dirs = set(os.environ.get("PATH", "").split(os.pathsep))
     for key, val in env.items():
@@ -171,8 +348,96 @@ def _ensure_shell_env(*, timeout: float = 10.0) -> None:
                 os.environ["PATH"] = (
                     os.pathsep.join(new_dirs) + os.pathsep + os.environ.get("PATH", "")
                 )
-        elif key not in os.environ:
+        elif key not in os.environ and _shell_env_key_allowed(key):
             os.environ[key] = val
+
+
+# Process-tree wrappers that sit between the real MCP client and this server.
+# The shipped install path (`uvx --from ouroboros-ai ... ouroboros mcp serve`)
+# interposes a uv wrapper that blocks on waitpid() and survives the client's
+# death, so the *direct* parent is not the process whose lifetime matters.
+_WRAPPER_BASENAMES = frozenset(
+    {"uv", "uvx", "uv.exe", "uvx.exe", "sh", "bash", "zsh", "dash", "fish", "env"}
+)
+
+
+def _ps_value(pid: int, column: str) -> str | None:
+    """Best-effort single-column ``ps`` lookup (POSIX only)."""
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", f"{column}="],
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def _client_is_alive(pid: int, start_time: float | None) -> bool:
+    """Client liveness = identity-alive AND not a defunct (zombie) entry.
+
+    A SIGKILLed client whose parent never reaps it keeps a signalable
+    process-table entry — ``os.kill(pid, 0)`` succeeds — while its file
+    descriptors are long gone. stdin EOF covers that case for stdio
+    transports, but streamable-http has no EOF to fall back on, so the
+    watchdog must treat a Z-state client as dead.
+    """
+    try:
+        if not is_process_identity_alive(pid, start_time):
+            return False
+    except OSError:
+        return False
+    stat = _ps_value(pid, "stat")
+    if stat is not None and stat.startswith("Z"):
+        return False
+    return True
+
+
+def _resolve_client_identity(orig_ppid: int) -> tuple[int, float | None] | None:
+    """Resolve the real MCP client's process identity (pid, start time).
+
+    Walks the ancestor chain from the direct parent, skipping known wrapper
+    binaries (uv/uvx/shells), and returns the first non-wrapper ancestor —
+    the process whose death means this server is orphaned. The recorded
+    start time guards the later liveness polls against pid recycling.
+
+    ``OUROBOROS_CLIENT_PID`` overrides the walk for spawners that want to
+    pin the watched process explicitly. Returns None when the client cannot
+    be resolved (Windows, ps failures, chain dead-ends at pid 1) — callers
+    fall back to the plain getppid() watchdog.
+    """
+    if sys.platform == "win32":
+        return None
+    override = os.environ.get("OUROBOROS_CLIENT_PID")
+    if override:
+        try:
+            override_pid = int(override)
+        except ValueError:
+            override_pid = 0
+        if override_pid > 1:
+            return override_pid, process_start_time(override_pid)
+    pid = orig_ppid
+    for _ in range(16):
+        if pid <= 1:
+            return None
+        comm = _ps_value(pid, "comm")
+        if comm is None:
+            return None
+        if Path(comm).name.lower() not in _WRAPPER_BASENAMES:
+            return pid, process_start_time(pid)
+        ppid_raw = _ps_value(pid, "ppid")
+        if ppid_raw is None:
+            return None
+        try:
+            pid = int(ppid_raw)
+        except ValueError:
+            return None
+    return None
 
 
 app = typer.Typer(
@@ -236,208 +501,312 @@ async def _run_mcp_server(
     # request handling, so a partial init must surface as a clean startup
     # failure rather than a server that runs with a half-initialized store.
     await event_store.initialize()
-    await brownfield_store.initialize()
 
-    # Orphan cleanup is intentionally deferred into the background so large
-    # SQLite histories do not block the initial MCP handshake on startup (#304).
-    repo = SessionRepository(event_store)
+    server: Any | None = None
+    mcp_bridge: Any = None
+    serve_task: asyncio.Task[None] | None = None
+    stop_task: asyncio.Task[bool] | None = None
+    watchdog_task: asyncio.Task[None] | None = None
+    idle_checkpoint_task: asyncio.Task[None] | None = None
+    serve_exc: BaseException | None = None
 
-    async def _run_startup_cleanup() -> None:
-        try:
-            cancelled = await repo.cancel_orphaned_sessions()
-            if cancelled:
-                _console_out.print(
-                    f"[yellow]Auto-cancelled {len(cancelled)} orphaned session(s)[/yellow]"
-                )
-        except Exception as e:
-            # Auto-cleanup is best-effort — don't prevent server startup
-            _console_out.print(f"[yellow]Warning: auto-cleanup failed: {e}[/yellow]")
+    # The protective try spans store init -> composition -> serve: a failure
+    # anywhere after a store initialized (bridge discovery, backend validation
+    # in create_ouroboros_server, transport setup) must still release the
+    # stores — and run the WAL TRUNCATE checkpoint — instead of escaping with
+    # them dangling.
+    try:
+        await brownfield_store.initialize()
 
-    cleanup_task = asyncio.create_task(
-        _run_startup_cleanup(),
-        name="ouroboros-mcp-startup-cleanup",
-    )
+        # Orphan cleanup is intentionally deferred into the background so large
+        # SQLite histories do not block the initial MCP handshake on startup (#304).
+        repo = SessionRepository(event_store)
 
-    # Auto-discover and connect MCP bridge for server-to-server communication
-    from ouroboros.mcp.bridge import create_bridge_from_env
+        async def _run_startup_cleanup() -> None:
+            try:
+                cancelled = await repo.cancel_orphaned_sessions()
+                if cancelled:
+                    _console_out.print(
+                        f"[yellow]Auto-cancelled {len(cancelled)} orphaned session(s)[/yellow]"
+                    )
+            except Exception as e:
+                # Auto-cleanup is best-effort — don't prevent server startup
+                _console_out.print(f"[yellow]Warning: auto-cleanup failed: {e}[/yellow]")
 
-    mcp_bridge = create_bridge_from_env(cwd=Path.cwd())
-    if mcp_bridge is not None:
-        try:
-            results = await mcp_bridge.connect()
-            connected = sum(1 for r in results.values() if r.is_ok)
-            _console_out.print(
-                f"[blue]MCP Bridge: {connected}/{len(results)} upstream server(s) connected[/blue]"
-            )
-        except Exception as e:
-            _console_out.print(f"[yellow]MCP Bridge connection failed: {e}[/yellow]")
-            mcp_bridge = None
-
-    # Create server with all tools pre-registered via dependency injection.
-    # Do NOT re-register OUROBOROS_TOOLS here — create_ouroboros_server already
-    # registers handlers with proper dependencies (event_store, llm_adapter, etc.).
-    server = create_ouroboros_server(
-        name="ouroboros-mcp",
-        version="1.0.0",
-        event_store=event_store,
-        brownfield_store=brownfield_store,
-        runtime_backend=runtime_backend,
-        llm_backend=llm_backend,
-        mcp_bridge=mcp_bridge,
-    )
-
-    tool_count = len(server.info.tools)
-
-    # Detect Codex seatbelt sandbox and warn about network restrictions.
-    _sandbox_network_disabled = os.environ.get("CODEX_SANDBOX_NETWORK_DISABLED") == "1"
-
-    if transport == "stdio":
-        # In stdio mode, stdout is the JSON-RPC channel.
-        # All human-readable output must go to stderr.
-        _stderr_console.print(f"[green]MCP Server starting on {transport}...[/green]")
-        _stderr_console.print(f"[blue]Registered {tool_count} tools[/blue]")
-        _stderr_console.print("[blue]Reading from stdin, writing to stdout[/blue]")
-        _stderr_console.print("[blue]Press Ctrl+C to stop[/blue]")
-    else:
-        print_success(f"MCP Server starting on {transport}...")
-        print_info(f"Registered {tool_count} tools")
-        if transport == "streamable-http":
-            print_info(f"Listening on http://{host}:{port}/mcp")
-        else:
-            print_info(f"Listening on {host}:{port}")
-        print_info("Press Ctrl+C to stop")
-
-    if _sandbox_network_disabled:
-        _console_out.print(
-            "[dim]Note: CODEX_SANDBOX_NETWORK_DISABLED=1 detected. "
-            "MCP-spawned runtimes usually retain network access. "
-            "If agent tasks fail with network errors, try: "
-            "--sandbox danger-full-access[/dim]"
+        cleanup_task = asyncio.create_task(
+            _run_startup_cleanup(),
+            name="ouroboros-mcp-startup-cleanup",
         )
 
-    # Manage PID file for stale instance detection
-    if _check_stale_instance():
+        # Auto-discover and connect MCP bridge for server-to-server communication
+        from ouroboros.mcp.bridge import create_bridge_from_env
+
+        mcp_bridge = create_bridge_from_env(cwd=Path.cwd())
+        if mcp_bridge is not None:
+            try:
+                results = await mcp_bridge.connect()
+                connected = sum(1 for r in results.values() if r.is_ok)
+                _console_out.print(
+                    f"[blue]MCP Bridge: {connected}/{len(results)} upstream server(s) "
+                    "connected[/blue]"
+                )
+            except Exception as e:
+                _console_out.print(f"[yellow]MCP Bridge connection failed: {e}[/yellow]")
+                mcp_bridge = None
+
+        # Create server with all tools pre-registered via dependency injection.
+        # Do NOT re-register OUROBOROS_TOOLS here — create_ouroboros_server already
+        # registers handlers with proper dependencies (event_store, llm_adapter, etc.).
+        server = create_ouroboros_server(
+            name="ouroboros-mcp",
+            version="1.0.0",
+            event_store=event_store,
+            brownfield_store=brownfield_store,
+            runtime_backend=runtime_backend,
+            llm_backend=llm_backend,
+            mcp_bridge=mcp_bridge,
+        )
+
+        tool_count = len(server.info.tools)
+
+        # Detect Codex seatbelt sandbox and warn about network restrictions.
+        _sandbox_network_disabled = os.environ.get("CODEX_SANDBOX_NETWORK_DISABLED") == "1"
+
         if transport == "stdio":
-            _stderr_console.print("[yellow]Cleaned up stale MCP server PID file[/yellow]")
+            # In stdio mode, stdout is the JSON-RPC channel.
+            # All human-readable output must go to stderr.
+            _stderr_console.print(f"[green]MCP Server starting on {transport}...[/green]")
+            _stderr_console.print(f"[blue]Registered {tool_count} tools[/blue]")
+            _stderr_console.print("[blue]Reading from stdin, writing to stdout[/blue]")
+            _stderr_console.print("[blue]Press Ctrl+C to stop[/blue]")
         else:
-            print_info("Cleaned up stale MCP server PID file")
+            print_success(f"MCP Server starting on {transport}...")
+            print_info(f"Registered {tool_count} tools")
+            if transport == "streamable-http":
+                print_info(f"Listening on http://{host}:{port}/mcp")
+            else:
+                print_info(f"Listening on {host}:{port}")
+            print_info("Press Ctrl+C to stop")
 
-    _write_pid_file()
+        if _sandbox_network_disabled:
+            _console_out.print(
+                "[dim]Note: CODEX_SANDBOX_NETWORK_DISABLED=1 detected. "
+                "MCP-spawned runtimes usually retain network access. "
+                "If agent tasks fail with network errors, try: "
+                "--sandbox danger-full-access[/dim]"
+            )
 
-    # Start serving with graceful shutdown + orphan reaping.
-    #
-    # asyncio.run() only translates SIGINT into KeyboardInterrupt; an unhandled
-    # SIGTERM would terminate the process immediately and skip the finally block
-    # below — leaking the PID file and, more importantly, skipping the
-    # EventStore.close() WAL TRUNCATE checkpoint (the -wal file then grows
-    # unbounded across many concurrent sessions). Install explicit handlers and
-    # race the serve task against a stop Event so every shutdown path is clean.
-    stop = asyncio.Event()
-    loop = asyncio.get_running_loop()
+        # Register this instance and sweep records of dead peers.
+        swept = _sweep_stale_instances()
+        if swept:
+            msg = f"Cleaned up {swept} stale MCP server PID record(s)"
+            if transport == "stdio":
+                _stderr_console.print(f"[yellow]{msg}[/yellow]")
+            else:
+                print_info(msg)
 
-    def _request_stop(signame: str) -> None:
-        _console_out.print(f"[blue]Received {signame}, shutting down...[/blue]")
-        stop.set()
+        _write_pid_file()
 
-    # Resolve signals by name: SIGHUP is POSIX-only, so referencing
-    # ``signal.SIGHUP`` directly would raise AttributeError while *building* the
-    # loop iterable on Windows — before the suppress() below could catch it.
-    # getattr keeps SIGHUP on POSIX and skips it where the constant is absent.
-    for _signame in ("SIGTERM", "SIGINT", "SIGHUP"):
-        _sig = getattr(signal, _signame, None)
-        if _sig is None:
-            continue
-        # add_signal_handler is unavailable on some event loops (e.g. the
-        # Windows Proactor loop); fall back silently — KeyboardInterrupt still
-        # covers SIGINT there.
-        with contextlib.suppress(NotImplementedError, ValueError, RuntimeError):
-            loop.add_signal_handler(_sig, _request_stop, _sig.name)
+        # Start serving with graceful shutdown + orphan reaping.
+        #
+        # asyncio.run() only translates SIGINT into KeyboardInterrupt; an unhandled
+        # SIGTERM would terminate the process immediately and skip the finally block
+        # below — leaking the PID record and, more importantly, skipping the
+        # EventStore.close() WAL TRUNCATE checkpoint (the -wal file then grows
+        # unbounded across many concurrent sessions). Install explicit handlers and
+        # race the serve task against a stop Event so every shutdown path is clean.
+        stop = asyncio.Event()
+        loop = asyncio.get_running_loop()
 
-    # Parent-death watchdog: when the MCP client that spawned us dies, this
-    # process is reparented away from its original parent so a vanished client
-    # never leaves an orphaned server pinning the SQLite database (the
-    # streamable-http case in particular has no stdin EOF to rely on). macOS
-    # lacks Linux's PR_SET_PDEATHSIG, so we poll getppid() — a POSIX best-effort
-    # backstop. We compare against the *original* ppid rather than testing
-    # ``== 1`` so detection still fires under a child-subreaper (systemd --user,
-    # tini, some container runtimes) where the orphan reparents to the subreaper
-    # rather than to pid 1. Skipped when launched already-detached on purpose
-    # (orig_ppid is already 1, e.g. a real launchd/systemd service). Not
-    # effective on Windows (no reparent-on-death model); SIGINT/stdin EOF cover
-    # the common cases there.
-    orig_ppid = os.getppid()
+        def _request_stop(signame: str) -> None:
+            _console_out.print(f"[blue]Received {signame}, shutting down...[/blue]")
+            stop.set()
 
-    async def _orphan_watchdog() -> None:
-        if orig_ppid == 1:
-            return
-        while not stop.is_set():
-            if os.getppid() != orig_ppid:
-                _console_out.print("[yellow]Parent client gone — orphan exit[/yellow]")
-                stop.set()
+        # Resolve signals by name: SIGHUP is POSIX-only, so referencing
+        # ``signal.SIGHUP`` directly would raise AttributeError while *building* the
+        # loop iterable on Windows — before the suppress() below could catch it.
+        # getattr keeps SIGHUP on POSIX and skips it where the constant is absent.
+        for _signame in ("SIGTERM", "SIGINT", "SIGHUP"):
+            _sig = getattr(signal, _signame, None)
+            if _sig is None:
+                continue
+            # add_signal_handler is unavailable on some event loops (e.g. the
+            # Windows Proactor loop); fall back silently — KeyboardInterrupt still
+            # covers SIGINT there.
+            with contextlib.suppress(NotImplementedError, ValueError, RuntimeError):
+                loop.add_signal_handler(_sig, _request_stop, _sig.name)
+
+        # Client-death watchdog: when the MCP client that spawned us dies, exit
+        # instead of pinning the SQLite database forever (streamable-http has no
+        # stdin EOF to rely on; for stdio, EOF stays the primary defense). Two
+        # complementary checks, polled every 5s:
+        #  - getppid() vs the original parent: catches death of whatever spawned
+        #    us directly. Under the shipped `client -> uvx -> python` topology the
+        #    direct parent is the uv wrapper, which blocks on waitpid() and
+        #    survives the client's death — this check alone can never fire there
+        #    (the orphaned wrapper is reparented; our own ppid never changes).
+        #  - the resolved *client* identity (nearest non-wrapper ancestor at
+        #    startup, pid + start time): catches the real client dying behind the
+        #    wrapper. Polling an absolute pid identity is immune to subreapers
+        #    (systemd --user, tini) and to pid recycling. OUROBOROS_CLIENT_PID
+        #    overrides the ancestor walk for spawners that want to pin the
+        #    watched process explicitly.
+        # Skipped when launched already-detached on purpose (orig_ppid == 1,
+        # e.g. a real launchd/systemd service — such servers must never
+        # self-terminate). Not effective on Windows (no POSIX ps, no
+        # reparent-on-death model); SIGINT/stdin EOF cover the common cases
+        # there.
+        orig_ppid = os.getppid()
+        client_identity: tuple[int, float | None] | None = None
+        if orig_ppid != 1:
+            # ps lookups can block up to their subprocess timeout — resolve off
+            # the event loop so a slow ps never stalls the MCP handshake.
+            client_identity = await asyncio.to_thread(_resolve_client_identity, orig_ppid)
+
+        async def _orphan_watchdog() -> None:
+            if orig_ppid == 1:
                 return
-            with contextlib.suppress(asyncio.TimeoutError):
-                await asyncio.wait_for(stop.wait(), timeout=5.0)
+            while not stop.is_set():
+                if os.getppid() != orig_ppid:
+                    _console_out.print("[yellow]Parent client gone — orphan exit[/yellow]")
+                    stop.set()
+                    return
+                if client_identity is not None:
+                    client_pid, client_start = client_identity
+                    alive = await asyncio.to_thread(_client_is_alive, client_pid, client_start)
+                    if not alive:
+                        _console_out.print(
+                            f"[yellow]MCP client (pid {client_pid}) gone — orphan exit[/yellow]"
+                        )
+                        stop.set()
+                        return
+                with contextlib.suppress(asyncio.TimeoutError):
+                    await asyncio.wait_for(stop.wait(), timeout=5.0)
 
-    serve_task = asyncio.create_task(
-        server.serve(transport=transport, host=host, port=port),
-        name="ouroboros-mcp-serve",
-    )
-    stop_task = asyncio.create_task(stop.wait(), name="ouroboros-mcp-stop")
-    watchdog_task = asyncio.create_task(_orphan_watchdog(), name="ouroboros-mcp-watchdog")
+        async def _idle_wal_checkpoint() -> None:
+            # Long-lived idle servers pin the shared WAL: passive autocheckpoints
+            # cannot truncate while any reader is active, so N concurrent idle
+            # sessions let the -wal file grow unbounded. Best-effort TRUNCATE
+            # when no tool call has arrived for a while; deliberately never on
+            # the startup path (#304) and silent on contention.
+            while not stop.is_set():
+                with contextlib.suppress(asyncio.TimeoutError):
+                    await asyncio.wait_for(stop.wait(), timeout=_IDLE_CHECKPOINT_POLL_SECONDS)
+                if stop.is_set():
+                    return
+                idle_for = getattr(server, "seconds_since_last_tool_call", None)
+                if not isinstance(idle_for, int | float):
+                    return
+                if idle_for < _IDLE_CHECKPOINT_THRESHOLD_SECONDS:
+                    continue
+                with contextlib.suppress(Exception):
+                    await event_store.checkpoint_wal()
 
-    serve_exc: BaseException | None = None
-    try:
+        serve_task = asyncio.create_task(
+            server.serve(transport=transport, host=host, port=port),
+            name="ouroboros-mcp-serve",
+        )
+        stop_task = asyncio.create_task(stop.wait(), name="ouroboros-mcp-stop")
+        watchdog_task = asyncio.create_task(_orphan_watchdog(), name="ouroboros-mcp-watchdog")
+        idle_checkpoint_task = asyncio.create_task(
+            _idle_wal_checkpoint(), name="ouroboros-mcp-idle-checkpoint"
+        )
+
         await asyncio.wait(
             {serve_task, stop_task},
             return_when=asyncio.FIRST_COMPLETED,
         )
-        # When the serve loop itself is what finished (rather than a stop
-        # signal), preserve any failure it raised. asyncio.wait() leaves the
-        # exception parked on the task, so a bind/listen/runtime error from
-        # server.serve() would otherwise be discarded by the suppressing
-        # cleanup below and reported as a clean shutdown. A normal serve return
-        # or a stop-driven shutdown leaves serve_exc None.
-        if serve_task.done() and not serve_task.cancelled():
-            serve_exc = serve_task.exception()
     finally:
         # Runs for SIGTERM, orphan-exit and KeyboardInterrupt too, so
-        # EventStore.close() always gets to collapse the WAL. Cancel the serve
-        # loop and helpers, then release the persistent stores in reverse init
-        # order. Draining under suppress() guarantees cleanup is never skipped;
-        # the genuine serve-loop outcome is re-inspected afterwards.
-        for _task in (serve_task, watchdog_task, stop_task):
+        # EventStore.close() always gets to collapse the WAL.
+        helper_tasks = [
+            t for t in (watchdog_task, stop_task, idle_checkpoint_task) if t is not None
+        ]
+        for _task in helper_tasks:
             if not _task.done():
                 _task.cancel()
-        for _task in (serve_task, watchdog_task, stop_task):
-            with contextlib.suppress(BaseException):
-                await _task
+        if serve_task is not None and not serve_task.done():
+            serve_task.cancel()
+        # Bound the serve drain: the MCP SDK's stdio session reads stdin via a
+        # shielded worker thread (anyio readline, abandon_on_cancel=False), so an
+        # unbounded ``await serve_task`` hangs forever when shutdown was requested
+        # by a signal or the watchdog while the client is alive but quiescent —
+        # the exact "server survives kill" symptom. After the grace, closing fd 0
+        # EOFs the blocked readline (verified empirically on macOS, the primary
+        # fleet; best-effort elsewhere — a second bounded wait below means a
+        # non-waking platform still proceeds to cleanup). os._exit is
+        # deliberately NOT used anywhere here: every exit must run the store
+        # cleanup below.
+        pending: set[asyncio.Task[Any]] = {
+            t for t in (serve_task, *helper_tasks) if t is not None and not t.done()
+        }
+        if pending:
+            _, pending = await asyncio.wait(pending, timeout=_SHUTDOWN_DRAIN_GRACE_SECONDS)
+            if serve_task is not None and serve_task in pending and transport == "stdio":
+                with contextlib.suppress(OSError):
+                    os.close(0)
+                _, pending = await asyncio.wait(pending, timeout=_SHUTDOWN_DRAIN_GRACE_SECONDS)
+            if pending:
+                _console_out.print(
+                    "[yellow]Serve loop did not stop within the shutdown grace; "
+                    "continuing cleanup[/yellow]"
+                )
+        # Retrieve parked results so completed tasks never log
+        # "exception was never retrieved" during interpreter teardown.
+        for _task in (serve_task, *helper_tasks):
+            if _task is not None and _task.done():
+                with contextlib.suppress(BaseException):
+                    _task.exception()
         if cleanup_task is not None and not cleanup_task.done():
             cleanup_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await cleanup_task
-        # Route teardown through the adapter so its owned resources close in the
-        # documented order: the ControlBus reactive surface is drained first
-        # (cancelling subscriber tasks), then the EventStore (whose close()
-        # collapses the WAL) and BrownfieldStore, then the MCP bridge. Closing
-        # the stores directly here would bypass that contract and leave
-        # control-bus tasks and upstream bridge connections dangling. Best
-        # effort — a drain/close failure is already logged inside shutdown();
-        # never let it escape the cleanup path.
-        with contextlib.suppress(Exception):
-            await server.shutdown()
+        if server is not None:
+            # Drain background jobs BEFORE the stores close: job tasks killed by
+            # asyncio.run teardown after EventStore.close() fail their terminal
+            # appends with PersistenceError and leave RUNNING zombie rows that
+            # the dead-owner reconciler must repair on a later read.
+            from ouroboros.mcp.job_manager import JobManager
+
+            job_manager = getattr(server, "job_manager", None)
+            if isinstance(job_manager, JobManager):
+                with contextlib.suppress(Exception):
+                    await job_manager.drain(grace_seconds=_JOB_DRAIN_GRACE_SECONDS)
+            # Route teardown through the adapter so its owned resources close in
+            # the documented order: the ControlBus reactive surface is drained
+            # first (cancelling subscriber tasks), then the EventStore (whose
+            # close() collapses the WAL) and BrownfieldStore, then the MCP
+            # bridge. Closing the stores directly here would bypass that
+            # contract and leave control-bus tasks and upstream bridge
+            # connections dangling. Best effort — a drain/close failure is
+            # already logged inside shutdown(); never let it escape the cleanup
+            # path.
+            with contextlib.suppress(Exception):
+                await server.shutdown()
+        else:
+            # Composition failed before the adapter existed: release what this
+            # function owns directly, in reverse init order, so an early failure
+            # cannot leak initialized stores (and their WAL).
+            if mcp_bridge is not None:
+                with contextlib.suppress(Exception):
+                    await mcp_bridge.close()
+            with contextlib.suppress(Exception):
+                await brownfield_store.close()
+            with contextlib.suppress(Exception):
+                await event_store.close()
         _cleanup_pid_file()
-        # Surface an abnormal serve-loop termination. A cancellation is the
-        # intended shutdown path (SIGTERM/orphan-exit/stdin EOF), but any other
-        # exception means the transport loop itself crashed — re-raise it after
-        # cleanup so the command exits non-zero with a trace instead of a silent
-        # exit 0 that would hide exactly the failure class this server must report.
-        if not serve_task.cancelled():
+        # Single error-propagation point: preserve a serve-loop failure (bind/
+        # listen/runtime errors — asyncio.wait() leaves the exception parked on
+        # the task) but raise it only after cleanup, from OUTSIDE this finally.
+        # A raise inside finally can mask an in-flight CancelledError and bypass
+        # the KeyboardInterrupt clean-exit handler on the signal-fallback path.
+        # A cancelled serve task is the intended shutdown path
+        # (SIGTERM/orphan-exit/stdin EOF) and propagates nothing.
+        if serve_task is not None and serve_task.done() and not serve_task.cancelled():
             serve_exc = serve_task.exception()
-            if serve_exc is not None:
-                raise serve_exc
 
     # Surface a serve-loop failure only after cleanup has collapsed the WAL and
-    # released the stores. This restores the error-propagation contract of the
+    # released the stores. This preserves the error-propagation contract of the
     # prior ``await server.serve(...)`` so ``ouroboros mcp serve`` exits non-zero
     # on startup/runtime failures instead of reporting a clean stop.
     if serve_exc is not None:
@@ -555,12 +924,19 @@ def serve(
         raise typer.Exit(1) from e
     except OSError as e:
         _stderr_console.print(f"[red]MCP Server failed to start: {e}[/red]")
+        live = _live_instances()
+        if live:
+            _stderr_console.print(
+                "[blue]Live MCP server instances (one per connected client): "
+                f"{', '.join(str(pid) for pid in live)}. These are normally owned "
+                "by running agent sessions — do not kill them blindly; stop the "
+                "owning client instead.[/blue]"
+            )
         _stderr_console.print(
             "[blue]If this keeps happening, try:\n"
-            "  1. Check if another MCP server is running: cat ~/.ouroboros/mcp-server.pid\n"
-            "  2. Kill stale process: kill $(cat ~/.ouroboros/mcp-server.pid)\n"
-            "  3. Remove stale PID: rm ~/.ouroboros/mcp-server.pid\n"
-            "  4. Restart your MCP client[/blue]"
+            f"  1. Inspect registered instances: ls {_PID_REGISTRY_DIR}\n"
+            "  2. Run diagnostics: ouroboros mcp doctor\n"
+            "  3. Restart your MCP client[/blue]"
         )
         raise typer.Exit(1) from e
 

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -393,9 +393,7 @@ def _client_is_alive(pid: int, start_time: float | None) -> bool:
     except OSError:
         return False
     stat = _ps_value(pid, "stat")
-    if stat is not None and stat.startswith("Z"):
-        return False
-    return True
+    return stat is None or not stat.startswith("Z")
 
 
 def _resolve_client_identity(orig_ppid: int) -> tuple[int, float | None] | None:

--- a/src/ouroboros/cli/commands/mcp_doctor.py
+++ b/src/ouroboros/cli/commands/mcp_doctor.py
@@ -51,6 +51,7 @@ class CheckResult:
 # ---------------------------------------------------------------------------
 
 _PID_FILE = Path.home() / ".ouroboros" / "mcp-server.pid"
+_PID_REGISTRY_DIR = Path.home() / ".ouroboros" / "mcp-servers"
 _EVENT_STORE_PATH = Path.home() / ".ouroboros" / "ouroboros.db"
 _EVENT_STORE_WARN_BYTES = 500 * 1024 * 1024  # 500 MB
 
@@ -358,8 +359,34 @@ def _pid_is_alive(pid: int) -> bool:
         return False
 
 
-def check_pid_file() -> CheckResult:
-    """Check the MCP server PID file for liveness."""
+def _scan_instance_registry() -> tuple[list[int], list[Path]]:
+    """Split per-instance registry records into live PIDs and stale files.
+
+    Records live at ``~/.ouroboros/mcp-servers/<pid>.pid`` containing
+    ``"<pid> <start_time|None>"`` — one per concurrently running server
+    (one server per connected MCP client is the normal steady state).
+    """
+    live: list[int] = []
+    stale: list[Path] = []
+    try:
+        entries = sorted(_PID_REGISTRY_DIR.iterdir())
+    except OSError:
+        return live, stale
+    for entry in entries:
+        try:
+            pid = int(entry.read_text(encoding="utf-8").strip().split()[0])
+        except (ValueError, IndexError, OSError):
+            stale.append(entry)
+            continue
+        if _pid_is_alive(pid):
+            live.append(pid)
+        else:
+            stale.append(entry)
+    return live, stale
+
+
+def _check_legacy_pid_file() -> CheckResult:
+    """Check the legacy single-slot PID file (pre-registry server versions)."""
     if not _PID_FILE.exists():
         return CheckResult(
             name="pid_file",
@@ -391,6 +418,37 @@ def check_pid_file() -> CheckResult:
         status="warn",
         message=f"Stale PID file: process {pid} is not running",
         remediation=f"Remove the stale file: {_rm_cmd} {_PID_FILE}",
+    )
+
+
+def check_pid_file() -> CheckResult:
+    """Check MCP server instance liveness (per-instance registry + legacy file)."""
+    live, stale = _scan_instance_registry()
+    if not live and not stale:
+        return _check_legacy_pid_file()
+
+    parts: list[str] = []
+    if live:
+        parts.append(
+            f"{len(live)} MCP server instance(s) running "
+            f"(PIDs {', '.join(str(pid) for pid in live)})"
+        )
+    if stale:
+        parts.append(f"{len(stale)} stale instance record(s)")
+        return CheckResult(
+            name="pid_file",
+            status="warn",
+            message="; ".join(parts),
+            remediation=(
+                "Stale records are swept automatically by the next "
+                "`ouroboros mcp serve`; live instances are owned by running "
+                "agent sessions — do not kill them blindly."
+            ),
+        )
+    return CheckResult(
+        name="pid_file",
+        status="pass",
+        message=parts[0],
     )
 
 

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime, timedelta
 from enum import StrEnum
 import inspect
 import logging
+import time
 from typing import Any
 from uuid import uuid4
 
@@ -112,6 +113,22 @@ _COMPLETED_EXECUTION_CANCEL_GRACE_SECONDS = 5.0
 _RECOVERED_COMPLETION_EVENT_ID_PREFIX = "mcp-job-recovered-completed-"
 _RECOVERED_FAILURE_EVENT_ID_PREFIX = "mcp-job-recovered-failed-"
 _RECOVERED_INTERRUPTED_EVENT_ID_PREFIX = "mcp-job-recovered-interrupted-"
+_DRAIN_INTERRUPTED_EVENT_ID_PREFIX = "mcp-job-drain-interrupted-"
+_DRAIN_GRACE_SECONDS = 5.0
+
+
+def _drain_interrupted_data() -> dict[str, Any]:
+    """Terminal payload for jobs interrupted by server shutdown (drain)."""
+    return {
+        "status": JobStatus.INTERRUPTED.value,
+        "message": "Job interrupted: MCP server shut down before the job finished",
+        "error": "MCP server shut down before the job reached a terminal state",
+        "result_text": "MCP server shut down before the job reached a terminal state",
+        "result_meta": {"interrupted_from_shutdown": True},
+        "is_error": True,
+    }
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -142,7 +159,7 @@ def is_terminal_job_expired(
     """Return true when a terminal job handle is past the retrieval TTL."""
     if not snapshot.is_terminal:
         return False
-    ttl = ttl or _JOB_TTL
+    ttl = ttl if ttl is not None else _JOB_TTL
     current = now or datetime.now(UTC)
     updated = snapshot.updated_at
     if updated.tzinfo is None:
@@ -289,6 +306,9 @@ class JobManager:
         self._initialized = False
         self._known_job_ids: set[str] = set()
         self._reserved_job_ids: set[str] = set()
+        self._draining = False
+        self._cleanup_running = False
+        self._last_cleanup_monotonic = time.monotonic()
 
     async def _ensure_initialized(self) -> None:
         if not self._initialized:
@@ -406,6 +426,18 @@ class JobManager:
                     await runner
                 except asyncio.CancelledError:
                     pass
+            if self._draining:
+                # Server shutdown, not a user cancel: persist INTERRUPTED
+                # (matching the dead-owner reconciliation semantics) — unless a
+                # live external holder owns the terminal state for this job.
+                if self._drain_should_terminalize(snapshot):
+                    await self._append_event(
+                        "mcp.job.interrupted",
+                        job_id,
+                        _drain_interrupted_data(),
+                        event_id=f"{_DRAIN_INTERRUPTED_EVENT_ID_PREFIX}{job_id}",
+                    )
+                raise
             await self._append_event(
                 "mcp.job.cancelled",
                 job_id,
@@ -876,6 +908,7 @@ class JobManager:
     async def get_snapshot(self, job_id: str) -> JobSnapshot:
         """Reconstruct the latest state of a job from persisted events."""
         await self._ensure_initialized()
+        await self._maybe_cleanup_expired()
         events, cursor = await self._event_store.get_events_after("job", job_id, last_row_id=0)
         if not events:
             raise ValueError(f"Job not found: {job_id}")
@@ -1415,12 +1448,122 @@ class JobManager:
             source_process_id=job_id,
         )
 
+    def _drain_should_terminalize(self, snapshot: JobSnapshot) -> bool:
+        """During drain, terminalize only when no live external holder owns the job.
+
+        A linked runtime running in *another* live process (heartbeat holder)
+        is the progress authority and will emit the terminal event itself —
+        interrupting its job here would permanently terminalize still-active
+        work. A holder owned by *this* (exiting) process is about to die with
+        us, so its job must be terminalized now while the store is still open.
+        """
+        session_id = snapshot.links.session_id
+        if session_id is None:
+            return True
+        if not is_holder_alive(session_id):
+            return True
+        return is_owned_by_current_process(session_id)
+
+    async def drain(self, grace_seconds: float = _DRAIN_GRACE_SECONDS) -> int:
+        """Terminalize in-process background jobs before the shared EventStore closes.
+
+        Called by the serve shutdown path *before* ``server.shutdown()``.
+        Without an explicit drain, job tasks are killed by ``asyncio.run``
+        teardown after ``EventStore.close()``, so their terminal appends fail
+        with ``PersistenceError`` and the rows stay RUNNING forever —
+        manufacturing exactly the dead-owner zombies that
+        :meth:`_reconcile_orphaned_job_snapshot` exists to clean up.
+
+        Returns the number of jobs whose tasks finished within the grace.
+        """
+        self._draining = True
+        live_job_ids = [job_id for job_id, task in self._tasks.items() if not task.done()]
+        # Monitors are progress mirrors with no terminal authority — stop them
+        # first so they cannot race the terminal events written below.
+        for job_id, monitor in list(self._monitors.items()):
+            if not monitor.done():
+                monitor.cancel()
+                monitor.add_done_callback(_consume_task_result)
+            self._monitors.pop(job_id, None)
+        if not live_job_ids:
+            return 0
+        # Cancel runners (not the _run_job wrappers): the CancelledError path
+        # in _run_job persists the terminal event — INTERRUPTED while draining.
+        for job_id in live_job_ids:
+            runner = self._runner_tasks.get(job_id)
+            if runner is not None and not runner.done():
+                runner.cancel()
+            else:
+                task = self._tasks.get(job_id)
+                if task is not None and not task.done():
+                    task.cancel()
+        job_tasks = {
+            self._tasks[job_id]
+            for job_id in live_job_ids
+            if job_id in self._tasks and not self._tasks[job_id].done()
+        }
+        drained = 0
+        if job_tasks:
+            done, pending = await asyncio.wait(job_tasks, timeout=grace_seconds)
+            drained = len(done)
+            for task in done:
+                _consume_task_result(task)
+            for task in pending:
+                task.cancel()
+                task.add_done_callback(_consume_task_result)
+        # Jobs whose tasks did not unwind within the grace still get an
+        # authoritative terminal row (idempotent event id) while the store is
+        # open; the wedged task itself dies with the event loop.
+        for job_id in live_job_ids:
+            task = self._tasks.get(job_id)
+            if task is None or task.done():
+                continue
+            try:
+                snapshot = await self.get_snapshot(job_id)
+                if snapshot.is_terminal or not self._drain_should_terminalize(snapshot):
+                    continue
+                await self._append_event(
+                    "mcp.job.interrupted",
+                    job_id,
+                    _drain_interrupted_data(),
+                    event_id=f"{_DRAIN_INTERRUPTED_EVENT_ID_PREFIX}{job_id}",
+                )
+            except (PersistenceError, ValueError):
+                logger.warning(
+                    "mcp.job.drain_terminalize_failed",
+                    extra={"job_id": job_id},
+                    exc_info=True,
+                )
+        return drained
+
+    async def _maybe_cleanup_expired(self) -> None:
+        """Throttled TTL sweep of the in-memory job registries.
+
+        Piggybacks on the read path (``get_snapshot``) so the idle case costs
+        two comparisons; the sweep itself replays every known job id, so it
+        runs at most once per TTL window. Reentrancy-guarded because the
+        sweep's own snapshot reads come back through ``get_snapshot``.
+        """
+        if self._draining or self._cleanup_running:
+            return
+        now = time.monotonic()
+        if now - self._last_cleanup_monotonic < _JOB_TTL.total_seconds():
+            return
+        self._last_cleanup_monotonic = now
+        self._cleanup_running = True
+        try:
+            await self.cleanup_expired_jobs()
+        except Exception:
+            logger.warning("mcp.job.ttl_cleanup_failed", exc_info=True)
+        finally:
+            self._cleanup_running = False
+
     async def cleanup_expired_jobs(self, ttl: timedelta | None = None) -> int:
         """Remove terminal jobs older than *ttl* from the in-memory registry.
 
         Returns the number of cleaned-up job IDs.
         """
-        ttl = ttl or _JOB_TTL
+        ttl = ttl if ttl is not None else _JOB_TTL
         now = datetime.now(UTC)
         expired: list[str] = []
         for job_id in list(self._known_job_ids):
@@ -1439,6 +1582,8 @@ class JobManager:
             self._tasks.pop(job_id, None)
             self._runner_tasks.pop(job_id, None)
             self._monitors.pop(job_id, None)
+            self._recovery_locks.pop(job_id, None)
+            self._monitor_terminalized_jobs.discard(job_id)
         return len(expired)
 
     async def _append_event(

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -12,7 +12,8 @@ import keyword
 import os
 from pathlib import Path
 import re
-from typing import Any
+import time
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
@@ -39,6 +40,9 @@ from ouroboros.mcp.types import (
 )
 from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
 from ouroboros.orchestrator.control_bus import ControlBus, ControlBusDrainError
+
+if TYPE_CHECKING:
+    from ouroboros.mcp.job_manager import JobManager
 
 log = structlog.get_logger(__name__)
 
@@ -597,6 +601,8 @@ class MCPServerAdapter:
         self._mcp_server: Any = None
         self._owned_resources: list[Any] = []  # objects with async close()
         self._runtime_context: AgentRuntimeContext | None = None
+        self._job_manager: JobManager | None = None
+        self._last_tool_activity = time.monotonic()
 
         # Initialize security layer
         self._security = SecurityLayer(
@@ -722,6 +728,7 @@ class MCPServerAdapter:
         Returns:
             Result containing the tool result or an error.
         """
+        self._last_tool_activity = time.monotonic()
         handler = self._tool_handlers.get(name)
         if not handler:
             return Result.err(
@@ -1029,6 +1036,26 @@ class MCPServerAdapter:
     def register_owned_resource(self, resource: Any) -> None:
         """Register a resource whose ``close()`` will be called on shutdown."""
         self._owned_resources.append(resource)
+
+    @property
+    def job_manager(self) -> JobManager | None:
+        """Return the background-job manager owned by this server, if any.
+
+        Exposed so the serve shutdown path can drain live jobs *before* the
+        EventStore closes; job tasks killed by ``asyncio.run`` teardown after
+        the store is gone fail their terminal appends and leave RUNNING
+        zombie rows in the DB.
+        """
+        return self._job_manager
+
+    def set_job_manager(self, job_manager: JobManager) -> None:
+        """Attach the background-job manager to the server object graph."""
+        self._job_manager = job_manager
+
+    @property
+    def seconds_since_last_tool_call(self) -> float:
+        """Seconds since the last tool call (or server creation) — idle gauge."""
+        return time.monotonic() - self._last_tool_activity
 
     def _io_recorder_for_tool_call(
         self,
@@ -1878,6 +1905,7 @@ def create_ouroboros_server(
         control=control_bus,
     )
     server.set_runtime_context(agent_runtime_context)
+    server.set_job_manager(job_manager)
 
     # Close the reactive control surface before stores/bridges it may
     # reference from subscriber tasks.

--- a/src/ouroboros/orchestrator/agent_process.py
+++ b/src/ouroboros/orchestrator/agent_process.py
@@ -66,6 +66,7 @@ _DIRECTIVE_EMIT_TIMEOUT_SECONDS: Final[float] = 1.0
 _CANCELLED_PHASE: Final[str] = "agent_process_cancelled"
 _CANCEL_CONSUMED_PHASE: Final[str] = "agent_process_cancel_consumed"
 _CANCEL_CONTROL_SEED_PREFIX: Final[str] = "__ouroboros_agent_process_cancel__:"
+_CANCELLED_WORK_DRAIN_GRACE_SECONDS: Final[float] = 10.0
 
 
 class AgentProcessStatus(StrEnum):
@@ -1126,9 +1127,25 @@ async def run_with_agent_process[T](
     except asyncio.CancelledError:
         work_task = await _request_work_cancellation()
         if work_task is not None:
+            deadline = asyncio.get_running_loop().time() + _CANCELLED_WORK_DRAIN_GRACE_SECONDS
             while not work_task.done():
+                remaining = deadline - asyncio.get_running_loop().time()
+                if remaining <= 0:
+                    # A work task that ignores cancellation must not pin the
+                    # event loop (or asyncio.run teardown) forever. Re-raise
+                    # while it is still pending WITHOUT asserting a terminal
+                    # state — mirroring the pending TimeoutError branch below —
+                    # so live work is never falsely terminalized (#880) and the
+                    # INTERRUPTED reconciliation owns the final state instead.
+                    raise
                 try:
-                    await asyncio.shield(work_task)
+                    # asyncio.wait neither cancels work_task on our re-cancel
+                    # nor swallows its result; it just bounds the drain.
+                    await asyncio.wait({work_task}, timeout=remaining)
+                    if work_task.done():
+                        # Preserve the pre-bound contract: a non-cancel failure
+                        # raised by the work task propagates to the caller.
+                        await asyncio.shield(work_task)
                 except asyncio.CancelledError:
                     # The JobManager may cancel this wrapper more than once.
                     # Do not re-cancel the work task while it is already

--- a/src/ouroboros/orchestrator/heartbeat.py
+++ b/src/ouroboros/orchestrator/heartbeat.py
@@ -149,6 +149,11 @@ def current_process_identity() -> tuple[int, float | None]:
     return pid, _get_process_start_time(pid)
 
 
+def process_start_time(pid: int) -> float | None:
+    """Return the start time of ``pid`` (epoch seconds) when the platform exposes it."""
+    return _get_process_start_time(pid)
+
+
 def is_process_identity_alive(pid: int, start_time: float | None = None) -> bool:
     """Return True when ``pid`` is alive and still has ``start_time``.
 

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
-import contextlib
 from dataclasses import dataclass
 import logging
 from pathlib import Path

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -1305,28 +1305,44 @@ class EventStore:
         """
         return await self.replay("lineage", lineage_id)
 
+    async def checkpoint_wal(self) -> bool:
+        """Best-effort WAL TRUNCATE checkpoint without closing the store.
+
+        Collapses the WAL back into the main DB. Without an explicit TRUNCATE
+        checkpoint, long-lived multi-connection setups (many concurrent
+        MCP/TUI sessions) let the -wal file grow unbounded: passive
+        autocheckpoints cannot truncate while any other reader is active, so
+        the file only ever appends. Long-lived *idle* servers can call this
+        periodically so they stop pinning a growing WAL between requests.
+
+        Uses a short per-connection busy_timeout instead of the 30s default
+        (set in initialize()): the checkpoint needs the write lock, and a
+        peer process mid-write could otherwise stall the caller for up to
+        30s. A missed checkpoint is harmless — a later attempt retries — so
+        the wait is capped at ~2s. ``connect()`` (not ``begin()``) avoids an
+        upfront BEGIN IMMEDIATE; the checkpoint acquires its own lock under
+        the bounded timeout.
+
+        Returns:
+            True when the checkpoint ran, False when skipped or it failed
+            (read-only store, no engine, lock contention).
+        """
+        if self._engine is None or self._read_only:
+            return False
+        try:
+            async with self._engine.connect() as conn:
+                await conn.exec_driver_sql("PRAGMA busy_timeout=2000")
+                await conn.exec_driver_sql("PRAGMA wal_checkpoint(TRUNCATE)")
+        except Exception:
+            return False
+        return True
+
     async def close(self) -> None:
         """Close the database connection."""
         if self._engine is not None:
-            # Collapse the WAL back into the main DB before disposing. Without
-            # an explicit TRUNCATE checkpoint, long-lived multi-connection
-            # setups (many concurrent MCP/TUI sessions) let the -wal file grow
-            # unbounded: passive autocheckpoints cannot truncate while any
-            # other reader is active, so the file only ever appends. Best
-            # effort — ignore failures (read-only stores, lock contention).
-            #
-            # Use a short per-connection busy_timeout instead of the 30s default
-            # (set in initialize()): the checkpoint needs the write lock, and a
-            # peer process mid-write could otherwise stall this shutdown path for
-            # up to 30s. A missed checkpoint is harmless — the next clean close
-            # retries — so we cap the wait at ~2s. ``connect()`` (not ``begin()``)
-            # avoids an upfront BEGIN IMMEDIATE; the checkpoint acquires its own
-            # lock under the bounded timeout.
-            if not self._read_only:
-                with contextlib.suppress(Exception):
-                    async with self._engine.connect() as conn:
-                        await conn.exec_driver_sql("PRAGMA busy_timeout=2000")
-                        await conn.exec_driver_sql("PRAGMA wal_checkpoint(TRUNCATE)")
+            # Collapse the WAL before disposing so the -wal file does not
+            # survive shutdown. Best effort — see checkpoint_wal().
+            await self.checkpoint_wal()
             await self._engine.dispose()
             self._engine = None
 

--- a/tests/unit/cli/test_mcp_doctor.py
+++ b/tests/unit/cli/test_mcp_doctor.py
@@ -398,18 +398,29 @@ class TestCheckEventStore:
 
 
 class TestCheckPidFile:
+    def _patch_paths(self, tmp_path):
+        """Isolate both the legacy PID file and the per-instance registry."""
+        return (
+            patch("ouroboros.cli.commands.mcp_doctor._PID_FILE", tmp_path / "mcp-server.pid"),
+            patch(
+                "ouroboros.cli.commands.mcp_doctor._PID_REGISTRY_DIR",
+                tmp_path / "mcp-servers",
+            ),
+        )
+
     def test_passes_when_no_pid_file(self, tmp_path):
-        fake_pid = tmp_path / "mcp-server.pid"
-        with patch("ouroboros.cli.commands.mcp_doctor._PID_FILE", fake_pid):
+        pid_patch, registry_patch = self._patch_paths(tmp_path)
+        with pid_patch, registry_patch:
             result = check_pid_file()
         assert result.status == "pass"
         assert "not running" in result.message.lower() or "no pid" in result.message.lower()
 
     def test_passes_when_pid_alive(self, tmp_path):
-        fake_pid = tmp_path / "mcp-server.pid"
-        fake_pid.write_text("12345", encoding="utf-8")
+        (tmp_path / "mcp-server.pid").write_text("12345", encoding="utf-8")
+        pid_patch, registry_patch = self._patch_paths(tmp_path)
         with (
-            patch("ouroboros.cli.commands.mcp_doctor._PID_FILE", fake_pid),
+            pid_patch,
+            registry_patch,
             patch("ouroboros.cli.commands.mcp_doctor._pid_is_alive", return_value=True),
         ):
             result = check_pid_file()
@@ -417,10 +428,11 @@ class TestCheckPidFile:
         assert "12345" in result.message
 
     def test_warns_when_pid_stale(self, tmp_path):
-        fake_pid = tmp_path / "mcp-server.pid"
-        fake_pid.write_text("99999", encoding="utf-8")
+        (tmp_path / "mcp-server.pid").write_text("99999", encoding="utf-8")
+        pid_patch, registry_patch = self._patch_paths(tmp_path)
         with (
-            patch("ouroboros.cli.commands.mcp_doctor._PID_FILE", fake_pid),
+            pid_patch,
+            registry_patch,
             patch("ouroboros.cli.commands.mcp_doctor._pid_is_alive", return_value=False),
         ):
             result = check_pid_file()
@@ -428,12 +440,44 @@ class TestCheckPidFile:
         assert result.remediation != ""
 
     def test_warns_when_pid_file_unreadable(self, tmp_path):
-        fake_pid = tmp_path / "mcp-server.pid"
-        fake_pid.write_text("not_a_number", encoding="utf-8")
-        with patch("ouroboros.cli.commands.mcp_doctor._PID_FILE", fake_pid):
+        (tmp_path / "mcp-server.pid").write_text("not_a_number", encoding="utf-8")
+        pid_patch, registry_patch = self._patch_paths(tmp_path)
+        with pid_patch, registry_patch:
             result = check_pid_file()
         assert result.status == "warn"
         assert result.remediation != ""
+
+    def test_registry_live_instances_pass(self, tmp_path):
+        registry = tmp_path / "mcp-servers"
+        registry.mkdir()
+        (registry / "111.pid").write_text("111 1700000000.0", encoding="utf-8")
+        (registry / "222.pid").write_text("222 None", encoding="utf-8")
+        pid_patch, registry_patch = self._patch_paths(tmp_path)
+        with (
+            pid_patch,
+            registry_patch,
+            patch("ouroboros.cli.commands.mcp_doctor._pid_is_alive", return_value=True),
+        ):
+            result = check_pid_file()
+        assert result.status == "pass"
+        assert "2 MCP server instance(s)" in result.message
+        assert "111" in result.message
+        assert "222" in result.message
+
+    def test_registry_stale_records_warn_without_kill_advice(self, tmp_path):
+        registry = tmp_path / "mcp-servers"
+        registry.mkdir()
+        (registry / "333.pid").write_text("333 1700000000.0", encoding="utf-8")
+        pid_patch, registry_patch = self._patch_paths(tmp_path)
+        with (
+            pid_patch,
+            registry_patch,
+            patch("ouroboros.cli.commands.mcp_doctor._pid_is_alive", return_value=False),
+        ):
+            result = check_pid_file()
+        assert result.status == "warn"
+        assert "stale instance record" in result.message
+        assert "kill" not in result.remediation.lower() or "do not kill" in result.remediation
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_mcp_pid_registry.py
+++ b/tests/unit/cli/test_mcp_pid_registry.py
@@ -1,0 +1,206 @@
+"""Tests for the per-instance MCP server PID registry and client resolution.
+
+The registry replaces the single-slot ``mcp-server.pid`` file, which was
+last-writer-wins under the routine N-concurrent-servers steady state: any
+exiting server deleted whichever record was written last, and the kill-advice
+built on it could target a healthy server owned by a live session.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from ouroboros.cli.commands import mcp
+
+
+@pytest.fixture
+def registry(tmp_path, monkeypatch):
+    registry_dir = tmp_path / "mcp-servers"
+    monkeypatch.setattr(mcp, "_PID_REGISTRY_DIR", registry_dir)
+    monkeypatch.setattr(mcp, "_LEGACY_PID_FILE", tmp_path / "mcp-server.pid")
+    monkeypatch.setattr(mcp, "_own_pid_file", None)
+    monkeypatch.setattr(mcp, "_own_pid_payload", None)
+    return registry_dir
+
+
+class TestPidRegistry:
+    def test_write_creates_own_record(self, registry):
+        assert mcp._write_pid_file() is True
+        record = registry / f"{os.getpid()}.pid"
+        assert record.exists()
+        parsed = mcp._parse_pid_record(record.read_text(encoding="utf-8"))
+        assert parsed is not None
+        assert parsed[0] == os.getpid()
+
+    def test_cleanup_removes_only_own_record(self, registry):
+        mcp._write_pid_file()
+        peer = registry / "99999999.pid"
+        peer.write_text("99999999 1700000000.0", encoding="utf-8")
+
+        mcp._cleanup_pid_file()
+
+        assert not (registry / f"{os.getpid()}.pid").exists()
+        assert peer.exists()
+
+    def test_cleanup_compare_and_delete_spares_recycled_record(self, registry):
+        mcp._write_pid_file()
+        record = registry / f"{os.getpid()}.pid"
+        # Simulate a successor (recycled pid) re-registering after a sweep.
+        record.write_text(f"{os.getpid()} 1.0", encoding="utf-8")
+
+        mcp._cleanup_pid_file()
+
+        assert record.exists(), "another instance's record must never be deleted"
+
+    def test_cleanup_is_idempotent_without_write(self, registry):
+        mcp._cleanup_pid_file()  # no record written — must be a no-op
+
+    def test_sweep_removes_dead_records_keeps_live(self, registry, monkeypatch):
+        registry.mkdir(parents=True)
+        live = registry / "111.pid"
+        live.write_text("111 1700000000.0", encoding="utf-8")
+        dead = registry / "222.pid"
+        dead.write_text("222 1700000000.0", encoding="utf-8")
+        unparseable = registry / "garbage.pid"
+        unparseable.write_text("not-a-record", encoding="utf-8")
+
+        monkeypatch.setattr(
+            mcp,
+            "is_process_identity_alive",
+            lambda pid, _start_time=None: pid == 111,
+        )
+
+        removed = mcp._sweep_stale_instances()
+
+        assert removed == 2
+        assert live.exists()
+        assert not dead.exists()
+        assert not unparseable.exists()
+
+    def test_sweep_removes_stale_legacy_single_slot_file(self, registry, monkeypatch):
+        legacy = mcp._LEGACY_PID_FILE
+        legacy.write_text("31337", encoding="utf-8")
+        monkeypatch.setattr(mcp, "is_process_identity_alive", lambda _pid, _start_time=None: False)
+
+        removed = mcp._sweep_stale_instances()
+
+        assert removed == 1
+        assert not legacy.exists()
+
+    def test_sweep_keeps_live_legacy_file(self, registry, monkeypatch):
+        legacy = mcp._LEGACY_PID_FILE
+        legacy.write_text("31337", encoding="utf-8")
+        monkeypatch.setattr(mcp, "is_process_identity_alive", lambda _pid, _start_time=None: True)
+
+        removed = mcp._sweep_stale_instances()
+
+        assert removed == 0
+        assert legacy.exists()
+
+    def test_live_instances_lists_only_alive(self, registry, monkeypatch):
+        registry.mkdir(parents=True)
+        (registry / "111.pid").write_text("111 None", encoding="utf-8")
+        (registry / "222.pid").write_text("222 None", encoding="utf-8")
+        monkeypatch.setattr(
+            mcp,
+            "is_process_identity_alive",
+            lambda pid, _start_time=None: pid == 222,
+        )
+
+        assert mcp._live_instances() == [222]
+
+    def test_record_is_stale_treats_windows_oserror_as_stale(self, monkeypatch):
+        def raise_oserror(_pid, _start_time=None):
+            raise OSError(87, "signal 0 unsupported")
+
+        monkeypatch.setattr(mcp, "is_process_identity_alive", raise_oserror)
+        assert mcp._record_is_stale(123, None) is True
+
+
+class TestResolveClientIdentity:
+    """The watchdog must watch the real client, not the uvx wrapper.
+
+    Shipped topology: ``claude -> uv tool uvx ... -> python ouroboros mcp
+    serve``. The wrapper blocks on waitpid() and survives the client's death,
+    so a getppid()-only watchdog can never fire there.
+    """
+
+    def test_walks_past_uvx_wrapper_to_client(self, monkeypatch):
+        monkeypatch.delenv("OUROBOROS_CLIENT_PID", raising=False)
+        tree = {
+            100: {"comm": "/Users/u/.local/bin/uv", "ppid": "50"},
+            50: {"comm": "claude", "ppid": "1"},
+        }
+
+        def fake_ps(pid, column):
+            entry = tree.get(pid)
+            return entry[column] if entry else None
+
+        monkeypatch.setattr(mcp, "_ps_value", fake_ps)
+        monkeypatch.setattr(mcp, "process_start_time", lambda _pid: 1700000000.0)
+
+        resolved = mcp._resolve_client_identity(100)
+
+        assert resolved == (50, 1700000000.0)
+
+    def test_direct_spawn_returns_parent(self, monkeypatch):
+        monkeypatch.delenv("OUROBOROS_CLIENT_PID", raising=False)
+        monkeypatch.setattr(
+            mcp, "_ps_value", lambda _pid, column: {"comm": "codex", "ppid": "1"}[column]
+        )
+        monkeypatch.setattr(mcp, "process_start_time", lambda _pid: None)
+
+        resolved = mcp._resolve_client_identity(77)
+
+        assert resolved == (77, None)
+
+    def test_chain_dead_ending_at_pid1_returns_none(self, monkeypatch):
+        monkeypatch.delenv("OUROBOROS_CLIENT_PID", raising=False)
+        tree = {100: {"comm": "uvx", "ppid": "1"}}
+
+        def fake_ps(pid, column):
+            entry = tree.get(pid)
+            return entry[column] if entry else None
+
+        monkeypatch.setattr(mcp, "_ps_value", fake_ps)
+
+        assert mcp._resolve_client_identity(100) is None
+
+    def test_ps_failure_returns_none(self, monkeypatch):
+        monkeypatch.delenv("OUROBOROS_CLIENT_PID", raising=False)
+        monkeypatch.setattr(mcp, "_ps_value", lambda _pid, _column: None)
+
+        assert mcp._resolve_client_identity(100) is None
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv("OUROBOROS_CLIENT_PID", "4242")
+        monkeypatch.setattr(mcp, "process_start_time", lambda _pid: 5.0)
+        monkeypatch.setattr(
+            mcp,
+            "_ps_value",
+            lambda _pid, _column: pytest.fail("override must skip the ancestor walk"),
+        )
+
+        assert mcp._resolve_client_identity(100) == (4242, 5.0)
+
+
+class TestClientIsAlive:
+    def test_defunct_zombie_client_counts_as_dead(self, monkeypatch):
+        """kill(pid, 0) succeeds on an unreaped zombie; ps stat 'Z' must catch it."""
+        monkeypatch.setattr(mcp, "is_process_identity_alive", lambda _pid, _start=None: True)
+        monkeypatch.setattr(mcp, "_ps_value", lambda _pid, _column: "Z+")
+        assert mcp._client_is_alive(123, None) is False
+
+    def test_live_client_stays_alive(self, monkeypatch):
+        monkeypatch.setattr(mcp, "is_process_identity_alive", lambda _pid, _start=None: True)
+        monkeypatch.setattr(mcp, "_ps_value", lambda _pid, _column: "S+")
+        assert mcp._client_is_alive(123, None) is True
+
+    def test_dead_identity_short_circuits(self, monkeypatch):
+        monkeypatch.setattr(mcp, "is_process_identity_alive", lambda _pid, _start=None: False)
+        monkeypatch.setattr(
+            mcp, "_ps_value", lambda _pid, _column: pytest.fail("must short-circuit")
+        )
+        assert mcp._client_is_alive(123, None) is False

--- a/tests/unit/cli/test_mcp_shell_env.py
+++ b/tests/unit/cli/test_mcp_shell_env.py
@@ -11,10 +11,13 @@ import sys
 from ouroboros.cli.commands import mcp
 
 
-def test_shell_env_loader_preserves_mcp_stdin(monkeypatch) -> None:
+def test_shell_env_loader_preserves_mcp_stdin(monkeypatch, tmp_path) -> None:
     monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
     monkeypatch.setenv("PATH", "/usr/bin")
     monkeypatch.setenv("SHELL", "/bin/zsh")
+    monkeypatch.delenv("OUROBOROS_TEST_ENV", raising=False)
+    # Force a cache miss so the login shell actually runs.
+    monkeypatch.setattr(mcp, "_SHELL_ENV_CACHE_FILE", tmp_path / "shell-env.json")
 
     initialize_message = '{"jsonrpc":"2.0","id":1,"method":"initialize"}\n'
     fake_stdin = io.StringIO(initialize_message)
@@ -36,3 +39,109 @@ def test_shell_env_loader_preserves_mcp_stdin(monkeypatch) -> None:
     assert fake_stdin.read() == initialize_message
     assert calls[0]["stdin"] == subprocess.DEVNULL
     assert os.environ["OUROBOROS_TEST_ENV"] == "loaded"
+
+
+def test_shell_env_merge_is_whitelisted(monkeypatch, tmp_path) -> None:
+    """Arbitrary login-shell vars must not leak into the server environment."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    monkeypatch.delenv("SOME_VENDOR_API_KEY", raising=False)
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    monkeypatch.delenv("VIRTUAL_ENV", raising=False)
+    monkeypatch.setattr(mcp, "_SHELL_ENV_CACHE_FILE", tmp_path / "shell-env.json")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        stdout = json.dumps(
+            {
+                "PATH": "/usr/bin:/extra/bin",
+                "SOME_VENDOR_API_KEY": "sk-secret",
+                "PYTHONPATH": "/should/not/leak",
+                "VIRTUAL_ENV": "/should/not/leak/either",
+            }
+        )
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+
+    mcp._ensure_shell_env(timeout=1.25)
+
+    assert os.environ["SOME_VENDOR_API_KEY"] == "sk-secret"
+    assert "/extra/bin" in os.environ["PATH"]
+    assert "PYTHONPATH" not in os.environ
+    assert "VIRTUAL_ENV" not in os.environ
+    monkeypatch.delenv("SOME_VENDOR_API_KEY", raising=False)
+
+
+def test_shell_env_cache_skips_login_shell(monkeypatch, tmp_path) -> None:
+    """A fresh cache must satisfy the load without spawning a login shell."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.delenv("CACHED_TEST_API_KEY", raising=False)
+    cache_file = tmp_path / "shell-env.json"
+    cache_file.write_text(json.dumps({"CACHED_TEST_API_KEY": "cached"}), encoding="utf-8")
+    monkeypatch.setattr(mcp, "_SHELL_ENV_CACHE_FILE", cache_file)
+
+    def fail_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise AssertionError("login shell must not run on a cache hit")
+
+    monkeypatch.setattr(mcp.subprocess, "run", fail_run)
+
+    mcp._ensure_shell_env(timeout=1.25)
+
+    assert os.environ["CACHED_TEST_API_KEY"] == "cached"
+    monkeypatch.delenv("CACHED_TEST_API_KEY", raising=False)
+
+
+def test_shell_env_cache_written_with_whitelisted_subset(monkeypatch, tmp_path) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    cache_file = tmp_path / "shell-env.json"
+    monkeypatch.setattr(mcp, "_SHELL_ENV_CACHE_FILE", cache_file)
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        stdout = json.dumps({"PATH": "/usr/bin", "FOO_API_KEY": "x", "RANDOM_VAR": "y"})
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+    monkeypatch.delenv("FOO_API_KEY", raising=False)
+
+    mcp._ensure_shell_env(timeout=1.25)
+
+    cached = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert "FOO_API_KEY" in cached
+    assert "RANDOM_VAR" not in cached
+    monkeypatch.delenv("FOO_API_KEY", raising=False)
+
+
+def test_shell_env_whitelist_admits_proxy_and_gateway_vars(monkeypatch, tmp_path) -> None:
+    """Subscription-auth users behind proxies/gateways must keep network config."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.setenv("PATH", "/usr/bin")
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    for key in ("HTTPS_PROXY", "NO_PROXY", "ANTHROPIC_BASE_URL", "GH_TOKEN"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(mcp, "_SHELL_ENV_CACHE_FILE", tmp_path / "shell-env.json")
+
+    def fake_run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        stdout = json.dumps(
+            {
+                "HTTPS_PROXY": "http://proxy:8080",
+                "NO_PROXY": "localhost",
+                "ANTHROPIC_BASE_URL": "https://gw.example.com",
+                "GH_TOKEN": "gho_x",
+            }
+        )
+        return subprocess.CompletedProcess(cmd, 0, stdout=stdout, stderr="")
+
+    monkeypatch.setattr(mcp.subprocess, "run", fake_run)
+
+    mcp._ensure_shell_env(timeout=1.25)
+
+    assert os.environ["HTTPS_PROXY"] == "http://proxy:8080"
+    assert os.environ["NO_PROXY"] == "localhost"
+    assert os.environ["ANTHROPIC_BASE_URL"] == "https://gw.example.com"
+    assert os.environ["GH_TOKEN"] == "gho_x"
+    for key in ("HTTPS_PROXY", "NO_PROXY", "ANTHROPIC_BASE_URL", "GH_TOKEN"):
+        monkeypatch.delenv(key, raising=False)

--- a/tests/unit/cli/test_mcp_shutdown_drain.py
+++ b/tests/unit/cli/test_mcp_shutdown_drain.py
@@ -1,0 +1,245 @@
+"""Tests for the bounded MCP serve shutdown drain and the client watchdog.
+
+The MCP SDK's stdio session reads stdin via a shielded anyio worker thread
+(``abandon_on_cancel=False``), so an unbounded ``await serve_task`` in the
+shutdown path hangs forever whenever a stop was requested by a signal or the
+watchdog while the client is alive but quiescent — the "server survives kill"
+symptom. The drain is bounded; after the grace, fd 0 is closed (stdio only)
+to EOF the blocked readline so the normal cleanup path completes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ouroboros.cli.commands import mcp as mcp_module
+
+
+@pytest.fixture(autouse=True)
+def _stub_brownfield_store():
+    """Keep ``_run_mcp_server`` off the real ~/.ouroboros database."""
+    mock_brownfield = AsyncMock()
+    mock_brownfield.initialize = AsyncMock()
+    with patch(
+        "ouroboros.persistence.brownfield.BrownfieldStore",
+        return_value=mock_brownfield,
+    ):
+        yield mock_brownfield
+
+
+@pytest.fixture(autouse=True)
+def _isolate_pid_registry(tmp_path, monkeypatch):
+    monkeypatch.setattr(mcp_module, "_PID_REGISTRY_DIR", tmp_path / "mcp-servers")
+    monkeypatch.setattr(mcp_module, "_LEGACY_PID_FILE", tmp_path / "mcp-server.pid")
+    monkeypatch.setattr(mcp_module, "_own_pid_file", None)
+    monkeypatch.setattr(mcp_module, "_own_pid_payload", None)
+
+
+def _make_mocks():
+    mock_es = AsyncMock()
+    mock_es.initialize = AsyncMock()
+    mock_repo = AsyncMock()
+    mock_repo.cancel_orphaned_sessions = AsyncMock(return_value=[])
+    mock_server = MagicMock()
+    mock_server.info.tools = []
+    mock_server.serve = AsyncMock()
+    mock_server.shutdown = AsyncMock()
+    return mock_es, mock_repo, mock_server
+
+
+def _patches(mock_es, mock_repo, mock_server):
+    return (
+        patch("ouroboros.persistence.event_store.EventStore", return_value=mock_es),
+        patch("ouroboros.orchestrator.session.SessionRepository", return_value=mock_repo),
+        patch(
+            "ouroboros.mcp.server.adapter.create_ouroboros_server",
+            return_value=mock_server,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_watchdog_dead_client_stops_server(monkeypatch) -> None:
+    """A resolved client identity that dies must stop the serve loop.
+
+    Under the shipped ``client -> uvx -> python`` topology the direct parent
+    (uvx) survives the client's death, so the getppid() check alone can never
+    fire — the absolute client-identity poll is what catches this case.
+    """
+    mock_es, mock_repo, mock_server = _make_mocks()
+
+    async def cooperative_serve(*args, **kwargs):
+        await asyncio.sleep(3600)
+
+    mock_server.serve.side_effect = cooperative_serve
+
+    monkeypatch.setattr(mcp_module, "_resolve_client_identity", lambda _ppid: (4242, 1.0))
+    monkeypatch.setattr(
+        mcp_module, "is_process_identity_alive", lambda _pid, _start_time=None: False
+    )
+
+    es_patch, repo_patch, server_patch = _patches(mock_es, mock_repo, mock_server)
+    with es_patch, repo_patch, server_patch:
+        await asyncio.wait_for(
+            mcp_module._run_mcp_server("localhost", 8080, "stdio"),
+            timeout=10.0,
+        )
+
+    mock_server.shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stuck_serve_loop_is_bounded_and_unblocked_by_fd0_close(monkeypatch) -> None:
+    """A serve loop that swallows cancellation must not hang shutdown."""
+    mock_es, mock_repo, mock_server = _make_mocks()
+    monkeypatch.setattr(mcp_module, "_SHUTDOWN_DRAIN_GRACE_SECONDS", 0.2)
+
+    closed_fds: list[int] = []
+    release = asyncio.Event()
+    real_close = mcp_module.os.close
+
+    def fake_close(fd: int) -> None:
+        # Intercept only fd 0 (the drain's EOF escalation); everything else
+        # must really close or subprocess plumbing (ps lookups) deadlocks.
+        if fd == 0:
+            closed_fds.append(fd)
+            release.set()
+            return
+        real_close(fd)
+
+    monkeypatch.setattr(mcp_module.os, "close", fake_close)
+
+    async def stuck_serve(*args, **kwargs):
+        # Emulates the shielded stdin readline: swallows cancellation and only
+        # returns once fd 0 is closed (EOF reaches the worker thread).
+        while True:
+            try:
+                await release.wait()
+                return
+            except asyncio.CancelledError:
+                continue
+
+    mock_server.serve.side_effect = stuck_serve
+
+    # Dead client fires the watchdog -> stop -> shutdown path.
+    monkeypatch.setattr(mcp_module, "_resolve_client_identity", lambda _ppid: (4242, 1.0))
+    monkeypatch.setattr(
+        mcp_module, "is_process_identity_alive", lambda _pid, _start_time=None: False
+    )
+
+    es_patch, repo_patch, server_patch = _patches(mock_es, mock_repo, mock_server)
+    with es_patch, repo_patch, server_patch:
+        await asyncio.wait_for(
+            mcp_module._run_mcp_server("localhost", 8080, "stdio"),
+            timeout=10.0,
+        )
+
+    assert 0 in closed_fds, "the drain must EOF fd 0 after the grace expired"
+    mock_server.shutdown.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_non_stdio_transport_never_closes_fd0(monkeypatch) -> None:
+    mock_es, mock_repo, mock_server = _make_mocks()
+    monkeypatch.setattr(mcp_module, "_SHUTDOWN_DRAIN_GRACE_SECONDS", 0.1)
+
+    closed_fds: list[int] = []
+    real_close = mcp_module.os.close
+
+    def fake_close(fd: int) -> None:
+        if fd == 0:
+            closed_fds.append(fd)
+            return
+        real_close(fd)
+
+    monkeypatch.setattr(mcp_module.os, "close", fake_close)
+
+    stop_probe = asyncio.Event()
+
+    async def slow_then_cooperative_serve(*args, **kwargs):
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            # One slow unwind beyond the first grace window, then exit.
+            stop_probe.set()
+            await asyncio.sleep(0.3)
+            raise
+
+    mock_server.serve.side_effect = slow_then_cooperative_serve
+
+    monkeypatch.setattr(mcp_module, "_resolve_client_identity", lambda _ppid: (4242, 1.0))
+    monkeypatch.setattr(
+        mcp_module, "is_process_identity_alive", lambda _pid, _start_time=None: False
+    )
+
+    es_patch, repo_patch, server_patch = _patches(mock_es, mock_repo, mock_server)
+    with es_patch, repo_patch, server_patch:
+        await asyncio.wait_for(
+            mcp_module._run_mcp_server("localhost", 8080, "streamable-http"),
+            timeout=10.0,
+        )
+
+    assert stop_probe.is_set()
+    assert closed_fds == [], "fd 0 belongs to the console on network transports"
+
+
+@pytest.mark.asyncio
+async def test_job_manager_drained_before_server_shutdown(monkeypatch) -> None:
+    """Live jobs must be terminalized while the EventStore is still open."""
+    from ouroboros.mcp.job_manager import JobManager
+
+    mock_es, mock_repo, mock_server = _make_mocks()
+
+    call_order: list[str] = []
+
+    job_manager = MagicMock(spec=JobManager)
+
+    async def record_drain(grace_seconds: float) -> int:
+        call_order.append("drain")
+        return 0
+
+    job_manager.drain = record_drain
+    mock_server.job_manager = job_manager
+
+    async def record_shutdown() -> None:
+        call_order.append("shutdown")
+
+    mock_server.shutdown = AsyncMock(side_effect=record_shutdown)
+
+    async def quick_serve(*args, **kwargs):
+        await asyncio.sleep(0)
+
+    mock_server.serve.side_effect = quick_serve
+    monkeypatch.setattr(mcp_module, "_resolve_client_identity", lambda _ppid: None)
+
+    es_patch, repo_patch, server_patch = _patches(mock_es, mock_repo, mock_server)
+    with es_patch, repo_patch, server_patch:
+        await asyncio.wait_for(
+            mcp_module._run_mcp_server("localhost", 8080, "stdio"),
+            timeout=10.0,
+        )
+
+    assert call_order == ["drain", "shutdown"]
+
+
+@pytest.mark.asyncio
+async def test_early_composition_failure_closes_stores(monkeypatch) -> None:
+    """A failure before the adapter exists must still release the stores."""
+    mock_es, mock_repo, _ = _make_mocks()
+
+    es_patch, repo_patch, _ = _patches(mock_es, mock_repo, MagicMock())
+    with (
+        es_patch,
+        repo_patch,
+        patch(
+            "ouroboros.mcp.server.adapter.create_ouroboros_server",
+            side_effect=ValueError("bad backend"),
+        ),
+        pytest.raises(ValueError, match="bad backend"),
+    ):
+        await mcp_module._run_mcp_server("localhost", 8080, "stdio")
+
+    mock_es.close.assert_awaited_once()

--- a/tests/unit/mcp/test_job_manager_drain.py
+++ b/tests/unit/mcp/test_job_manager_drain.py
@@ -1,0 +1,194 @@
+"""Tests for JobManager.drain — shutdown-time terminalization of live jobs.
+
+Without an explicit drain, job tasks are killed by ``asyncio.run`` teardown
+*after* ``EventStore.close()``, so their terminal appends fail with
+``PersistenceError`` and the rows stay RUNNING forever — manufacturing the
+dead-owner zombie rows the #1373 reconciler then has to repair.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from ouroboros.mcp import job_manager as job_manager_module
+from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
+from ouroboros.persistence.event_store import EventStore
+
+
+def _build_store(tmp_path) -> EventStore:
+    db_path = tmp_path / "jobs.db"
+    return EventStore(f"sqlite+aiosqlite:///{db_path}")
+
+
+async def _start_blocked_job(manager: JobManager, *, session_id: str | None = None):
+    started = asyncio.Event()
+
+    async def _runner() -> str:
+        started.set()
+        await asyncio.sleep(3600)
+        return "never"
+
+    snapshot = await manager.start_job(
+        job_type="test_drain",
+        initial_message="blocked",
+        runner=_runner(),
+        links=JobLinks(session_id=session_id),
+    )
+    await asyncio.wait_for(started.wait(), timeout=2.0)
+    return snapshot
+
+
+class TestJobManagerDrain:
+    async def test_drain_persists_interrupted_before_store_closes(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+        try:
+            snapshot = await _start_blocked_job(manager)
+
+            drained = await manager.drain(grace_seconds=2.0)
+
+            assert drained == 1
+            final = await manager.get_snapshot(snapshot.job_id)
+            assert final.status is JobStatus.INTERRUPTED
+            assert final.result_meta.get("interrupted_from_shutdown") is True
+        finally:
+            await store.close()
+
+    async def test_drain_writes_interrupted_not_cancelled(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+        try:
+            snapshot = await _start_blocked_job(manager)
+
+            await manager.drain(grace_seconds=2.0)
+
+            events, _ = await store.get_events_after("job", snapshot.job_id, last_row_id=0)
+            types = [event.type for event in events]
+            assert "mcp.job.interrupted" in types
+            assert "mcp.job.cancelled" not in types
+        finally:
+            await store.close()
+
+    async def test_drain_skips_jobs_owned_by_live_external_holder(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        """A live heartbeat holder in another process owns the terminal state."""
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+        try:
+            snapshot = await _start_blocked_job(manager, session_id="sess_external")
+            monkeypatch.setattr(job_manager_module, "is_holder_alive", lambda _session_id: True)
+            monkeypatch.setattr(
+                job_manager_module,
+                "is_owned_by_current_process",
+                lambda _session_id: False,
+            )
+
+            await manager.drain(grace_seconds=2.0)
+
+            final = await manager.get_snapshot(snapshot.job_id)
+            assert not final.is_terminal, (
+                "drain must not terminalize a job whose live external holder "
+                "is the progress authority"
+            )
+        finally:
+            await store.close()
+
+    async def test_drain_terminalizes_wedged_job_directly(self, tmp_path) -> None:
+        """A runner that swallows cancellation still gets a terminal row."""
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+        try:
+            started = asyncio.Event()
+
+            async def _stubborn_runner() -> str:
+                started.set()
+                try:
+                    await asyncio.sleep(3600)
+                except asyncio.CancelledError:
+                    pass  # swallows the drain's cancel...
+                await asyncio.sleep(3600)  # ...and keeps running past the grace
+                return "never"
+
+            snapshot = await manager.start_job(
+                job_type="test_drain_wedged",
+                initial_message="wedged",
+                runner=_stubborn_runner(),
+            )
+            await asyncio.wait_for(started.wait(), timeout=2.0)
+
+            await manager.drain(grace_seconds=0.2)
+
+            final = await manager.get_snapshot(snapshot.job_id)
+            assert final.status is JobStatus.INTERRUPTED
+        finally:
+            for task in [*manager._tasks.values(), *manager._runner_tasks.values()]:
+                if not task.done():
+                    task.cancel()
+            await asyncio.gather(
+                *manager._tasks.values(),
+                *manager._runner_tasks.values(),
+                return_exceptions=True,
+            )
+            await store.close()
+
+    async def test_drain_with_no_jobs_is_noop(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+        try:
+            assert await manager.drain(grace_seconds=0.1) == 0
+        finally:
+            await store.close()
+
+    async def test_user_cancel_still_writes_cancelled_when_not_draining(self, tmp_path) -> None:
+        """The draining branch must not change normal cancel semantics."""
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+        try:
+            snapshot = await _start_blocked_job(manager)
+            runner = manager._runner_tasks[snapshot.job_id]
+            job_task = manager._tasks[snapshot.job_id]
+            runner.cancel()
+            await asyncio.gather(job_task, return_exceptions=True)
+
+            final = await manager.get_snapshot(snapshot.job_id)
+            assert final.status is JobStatus.CANCELLED
+        finally:
+            await store.close()
+
+
+class TestCleanupExpiredJobs:
+    async def test_cleanup_evicts_recovery_locks_and_terminalized_markers(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+        try:
+
+            async def _quick() -> str:
+                return "done"
+
+            snapshot = await manager.start_job(
+                job_type="test_ttl", initial_message="quick", runner=_quick()
+            )
+            job_task = manager._tasks.get(snapshot.job_id)
+            if job_task is not None:
+                await asyncio.gather(job_task, return_exceptions=True)
+            # Simulate registry residue that the TTL sweep must also evict.
+            manager._recovery_locks[snapshot.job_id] = asyncio.Lock()
+            manager._monitor_terminalized_jobs.add(snapshot.job_id)
+
+            from datetime import timedelta
+
+            removed = await manager.cleanup_expired_jobs(ttl=timedelta(seconds=0))
+
+            assert removed == 1
+            assert snapshot.job_id not in manager._recovery_locks
+            assert snapshot.job_id not in manager._monitor_terminalized_jobs
+        finally:
+            await store.close()

--- a/tests/unit/orchestrator/test_agent_process.py
+++ b/tests/unit/orchestrator/test_agent_process.py
@@ -2155,3 +2155,49 @@ async def test_run_with_agent_process_separates_lifecycle_id_from_cancel_key(tmp
 
     assert fresh_result == "fresh"
     assert fresh_called is True
+
+
+@pytest.mark.asyncio
+async def test_cancel_drain_grace_bounds_uncooperative_work(monkeypatch) -> None:
+    """A work task that swallows cancellation must not pin the wrapper forever.
+
+    The unbounded shield loop (#880) protected live work from false terminal
+    cancellation, but it also let a wedged work task pin asyncio.run teardown
+    indefinitely — keeping the MCP server process alive after the serve loop
+    ended. The bounded drain re-raises while the task is still pending WITHOUT
+    asserting a terminal state, deferring to INTERRUPTED reconciliation.
+    """
+    from ouroboros.orchestrator import agent_process as agent_process_module
+
+    monkeypatch.setattr(agent_process_module, "_CANCELLED_WORK_DRAIN_GRACE_SECONDS", 0.2)
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def stubborn_work(handle):
+        entered.set()
+        try:
+            await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            pass  # swallow the runner's cancel...
+        await release.wait()  # ...and keep running past the grace
+        return "late"
+
+    wrapper = asyncio.create_task(
+        run_with_agent_process(
+            event_store=_FakeEventStore(),
+            intent="helper",
+            work_fn=stubborn_work,
+        )
+    )
+    await asyncio.wait_for(entered.wait(), timeout=2.0)
+    wrapper.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        # Far below 3600s: the grace (0.2s) bounds the drain.
+        await asyncio.wait_for(wrapper, timeout=2.0)
+
+    # Let the leftover work task finish so the loop closes cleanly.
+    release.set()
+    leftovers = [t for t in asyncio.all_tasks() if t is not asyncio.current_task()]
+    await asyncio.gather(*leftovers, return_exceptions=True)


### PR DESCRIPTION
## Summary

Fixes the four adversarially-verified mechanisms behind "zombie" MCP server accumulation. Forensics on a live fleet first proved what this is NOT: stdin-EOF exit works (empirically: exit 0 in 0.14–2.5s across startup / live-session / in-flight-call scenarios), and every observed lingering `uvx + python ouroboros mcp serve` pair was owned by a live client. The real defects are latent lifecycle holes:

1. **Watchdog was structurally blind under the shipped topology.** `_orphan_watchdog` polled `getppid()` against the uvx wrapper, which blocks on `waitpid()` and survives the real client's death (proven by SIGKILLing the client in a controlled chain — uvx is merely reparented; the server's ppid never changes; uv has no exec mode, astral-sh/uv#14123). The watchdog now resolves the nearest non-wrapper ancestor at startup (pid + start time) and polls that absolute identity — subreaper- and pid-recycling-immune, defunct(Z-state)-aware, `OUROBOROS_CLIENT_PID` override supported. This is also the only client-death defense streamable-http has. The `orig_ppid == 1` detached-service skip is preserved.

2. **Any non-EOF stop hung forever while stdin was open.** The MCP SDK's stdio session reads stdin via a shielded anyio worker thread (`abandon_on_cancel=False`), so the unbounded `await serve_task` drain never returned after SIGTERM/SIGINT/watchdog stop — the literal "server survives kill" symptom. The drain is now bounded (5s grace); on expiry, fd 0 is closed (stdio only) so the blocked readline EOFs and the normal cancel → drain → `server.shutdown()` path completes. No `os._exit` anywhere — every exit still runs `EventStore.close()`'s WAL TRUNCATE. Verified live: SIGTERM with stdin held open exits in 5.3s with rc=0.

3. **Shutdown manufactured the zombie job rows that #1373 reconciles.** The EventStore closed before JobManager tasks unwound, so terminal appends failed with `PersistenceError` and rows stayed RUNNING. New `JobManager.drain()` runs before `server.shutdown()`: cooperative cancel, bounded wait, terminal `mcp.job.interrupted` events (`interrupted_from_shutdown`) — skipping jobs whose live external heartbeat holder owns the terminal state (detached jobs remain a supported surface). `run_with_agent_process`'s unbounded post-cancel shield loop is grace-bounded, re-raising while pending **without** asserting a terminal state (preserves #880).

4. **Single-slot PID file was last-writer-wins and its kill-advice targeted healthy servers.** Replaced with a per-instance registry (`~/.ouroboros/mcp-servers/<pid>.pid`, pid+start-time stamped, compare-and-delete cleanup, identity-checked stale sweep, Windows treat-as-stale degradation preserved). `mcp doctor` reports instances instead of advising blind kills.

Also included: protective try now spans store init → composition → serve (early failures release initialized stores); single error-propagation point (the in-finally re-raise made the post-cleanup raise unreachable dead code); login-shell env import cached (1h TTL, 0600) and whitelisted — PATH, `*_API_KEY`, `*_BASE_URL`/`*_API_BASE`, proxy/CA/gh-token vars, `OUROBOROS_*` (the `#482` stdin=DEVNULL guard is untouched and still pinned by test); idle servers run a best-effort `wal_checkpoint(TRUNCATE)` after 10min without tool calls (the 17GB-WAL incident mechanism); dead `cleanup_expired_jobs` wired throttled and extended to evict recovery locks + monitor markers; two falsy-0 TTL coercions fixed (`timedelta(0)` silently became 1h).

## Test plan

- New: `test_mcp_shutdown_drain.py` (bounded drain, fd-0 escalation, non-stdio never touches fd 0, drain-before-shutdown ordering, early-failure store release), `test_mcp_pid_registry.py` (registry + ancestor walk + zombie-stat), `test_job_manager_drain.py` (INTERRUPTED-not-CANCELLED, external-holder skip, wedged-runner direct terminalization, TTL eviction), bounded-cancel test in `test_agent_process.py`, shell-env whitelist/cache tests.
- Pinned regression suites green: `test_mcp_startup_cleanup.py` (shutdown routing, failure propagation), nested guard, shell-env stdin=DEVNULL, doctor. 1,500+ affected unit tests pass; mypy + ruff clean.
- Live end-to-end on macOS: SIGTERM-with-open-stdin exits 5.3s/rc=0 with WAL checkpoint; client SIGKILL behind `sh → uv` wrapper chain triggers "MCP client gone — orphan exit" within one poll; unreaped-defunct client variant also detected (Z-state check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)