### PR TITLE
feat(config): add guided settings GUI and effective config view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ When the user types any of these commands, read the corresponding SKILL.md file 
 | `ooo setup` | Read `skills/setup/SKILL.md` and follow it |
 | `ooo welcome` | Read `skills/welcome/SKILL.md` and follow it |
 | `ooo cancel` | Read `skills/cancel/SKILL.md` and follow it |
+| `ooo config` | Read `skills/config/SKILL.md` and follow it |
 | `ooo qa` or `ooo qa ...` | Read `skills/qa/SKILL.md` and follow it |
 | `ooo help` | Read `skills/help/SKILL.md` and follow it |
 | `ooo update` | Read `skills/update/SKILL.md` and follow it |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ copilot = []
 litellm = ["litellm==1.86.2"]
 dashboard = []
 mcp = ["mcp==1.27.2"]
-tui = ["textual==8.2.7"]
+tui = ["textual==8.2.7", "textual-serve==1.1.3"]
 all = ["ouroboros-ai[claude,copilot,litellm,mcp,tui,dashboard]"]
 
 [project.scripts]

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -464,6 +464,7 @@ if [ "$HAS_UV" = true ]; then
         --with "anthropic==0.105.2"
         --with "litellm==1.86.2"
         --with "textual==8.2.7"
+        --with "textual-serve==1.1.3"
       )
       ;;
   esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -557,7 +557,7 @@ if command -v claude &>/dev/null && { [ "$RUNTIME" = "claude" ] || [ "$EXTRAS" =
   # MCP command matches the installer that actually ran in step 3
   if [ "$INSTALL_METHOD" = "uv" ]; then
     case "$EXTRAS" in
-      "[mcp,claude]")
+      "[mcp,claude]" | "[mcp,claude,tui]")
         OUROBOROS_ENTRY='{"command":"uvx","args":["--from","ouroboros-ai[mcp,claude]","ouroboros","mcp","serve"]}'
         ;;
       "[all]")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -274,17 +274,19 @@ RUNTIME_COUNT=0
 # able to see why Claude/Hermes pull MCP dependencies while file-based runtimes
 # only need the base CLI.
 _runtime_to_extras() {
+  # `tui` ships with every selection so the settings GUI
+  # (`ouroboros config`) works out of the box (#1414).
   case "$1" in
-    claude)  EXTRAS="[mcp,claude]"; RUNTIME="claude" ;;
-    codex)   EXTRAS=""; RUNTIME="codex" ;;
-    opencode) EXTRAS=""; RUNTIME="opencode" ;;
-    hermes)  EXTRAS="[mcp]"; RUNTIME="hermes" ;;
-    gemini)  EXTRAS=""; RUNTIME="gemini" ;;
-    kiro)    EXTRAS=""; RUNTIME="kiro" ;;
-    copilot) EXTRAS=""; RUNTIME="copilot" ;;
-    pi)      EXTRAS=""; RUNTIME="pi" ;;
+    claude)  EXTRAS="[mcp,claude,tui]"; RUNTIME="claude" ;;
+    codex)   EXTRAS="[tui]"; RUNTIME="codex" ;;
+    opencode) EXTRAS="[tui]"; RUNTIME="opencode" ;;
+    hermes)  EXTRAS="[mcp,tui]"; RUNTIME="hermes" ;;
+    gemini)  EXTRAS="[tui]"; RUNTIME="gemini" ;;
+    kiro)    EXTRAS="[tui]"; RUNTIME="kiro" ;;
+    copilot) EXTRAS="[tui]"; RUNTIME="copilot" ;;
+    pi)      EXTRAS="[tui]"; RUNTIME="pi" ;;
     all)     EXTRAS="[all]"; RUNTIME="" ;;
-    "")      EXTRAS=""; RUNTIME="" ;;
+    "")      EXTRAS="[tui]"; RUNTIME="" ;;
     *)
       _err "unsupported runtime '$1'"
       _info "Expected one of: claude, codex, opencode, hermes, gemini, kiro, copilot, pi, all"
@@ -337,14 +339,14 @@ elif [ "$RUNTIME_COUNT" -gt 1 ]; then
   if [ -t 0 ]; then
     _blank
     _say "${BOLD}Multiple runtimes detected. Pick where Ouroboros should appear first:${RESET}"
-    _choice 1 "Claude" "Claude Code plugin + MCP server (${PACKAGE_NAME}[mcp,claude])"
-    _choice 2 "Codex" "Codex plugin artifacts (${PACKAGE_NAME})"
-    _choice 3 "Hermes" "Hermes agent guides + MCP server (${PACKAGE_NAME}[mcp])"
-    _choice 4 "OpenCode" "OpenCode commands and agent files (${PACKAGE_NAME})"
-    _choice 5 "Gemini" "Gemini CLI integration (${PACKAGE_NAME})"
-    _choice 6 "Kiro" "Kiro CLI integration (${PACKAGE_NAME})"
-    _choice 7 "Copilot" "GitHub Copilot integration (${PACKAGE_NAME})"
-    _choice 8 "Pi" "Pi CLI bridge and instruction artifacts (${PACKAGE_NAME})"
+    _choice 1 "Claude" "Claude Code plugin + MCP server (${PACKAGE_NAME}[mcp,claude,tui])"
+    _choice 2 "Codex" "Codex plugin artifacts (${PACKAGE_NAME}[tui])"
+    _choice 3 "Hermes" "Hermes agent guides + MCP server (${PACKAGE_NAME}[mcp,tui])"
+    _choice 4 "OpenCode" "OpenCode commands and agent files (${PACKAGE_NAME}[tui])"
+    _choice 5 "Gemini" "Gemini CLI integration (${PACKAGE_NAME}[tui])"
+    _choice 6 "Kiro" "Kiro CLI integration (${PACKAGE_NAME}[tui])"
+    _choice 7 "Copilot" "GitHub Copilot integration (${PACKAGE_NAME}[tui])"
+    _choice 8 "Pi" "Pi CLI bridge and instruction artifacts (${PACKAGE_NAME}[tui])"
     _choice 9 "All" "Install every optional integration (${PACKAGE_NAME}[all])"
     _prompt "Select [1]: "
     read -r choice
@@ -386,14 +388,14 @@ else
   if [ -t 0 ]; then
     _blank
     _say "${BOLD}No runtime CLI detected yet. Choose the agent you plan to use:${RESET}"
-    _choice 1 "Claude" "Recommended: plugin + MCP server (${PACKAGE_NAME}[mcp,claude])"
-    _choice 2 "Codex" "Codex plugin artifacts (${PACKAGE_NAME})"
-    _choice 3 "Hermes" "Hermes agent guides + MCP server (${PACKAGE_NAME}[mcp])"
-    _choice 4 "OpenCode" "OpenCode commands and agent files (${PACKAGE_NAME})"
-    _choice 5 "Gemini" "Gemini CLI integration (${PACKAGE_NAME})"
-    _choice 6 "Kiro" "Kiro CLI integration (${PACKAGE_NAME})"
-    _choice 7 "Copilot" "GitHub Copilot integration (${PACKAGE_NAME})"
-    _choice 8 "Pi" "Pi CLI bridge and instruction artifacts (${PACKAGE_NAME})"
+    _choice 1 "Claude" "Recommended: plugin + MCP server (${PACKAGE_NAME}[mcp,claude,tui])"
+    _choice 2 "Codex" "Codex plugin artifacts (${PACKAGE_NAME}[tui])"
+    _choice 3 "Hermes" "Hermes agent guides + MCP server (${PACKAGE_NAME}[mcp,tui])"
+    _choice 4 "OpenCode" "OpenCode commands and agent files (${PACKAGE_NAME}[tui])"
+    _choice 5 "Gemini" "Gemini CLI integration (${PACKAGE_NAME}[tui])"
+    _choice 6 "Kiro" "Kiro CLI integration (${PACKAGE_NAME}[tui])"
+    _choice 7 "Copilot" "GitHub Copilot integration (${PACKAGE_NAME}[tui])"
+    _choice 8 "Pi" "Pi CLI bridge and instruction artifacts (${PACKAGE_NAME}[tui])"
     _choice 9 "All" "Install every optional integration (${PACKAGE_NAME}[all])"
     _choice 0 "None" "Base CLI only; choose a backend later"
     _prompt "Select [1]: "
@@ -451,14 +453,14 @@ if [ "$HAS_UV" = true ]; then
   # (e.g. forgetting `tui`) is caught in CI rather than discovered by a
   # user with a half-installed `[all]` tree.
   case "$EXTRAS" in
-    "[mcp,claude]")
+    "[mcp,claude,tui]")
       UV_ARGS+=(
         --with "mcp==1.27.2"
         --with "claude-agent-sdk==0.2.87"
         --with "anthropic==0.105.2"
       )
       ;;
-    "[mcp]")
+    "[mcp,tui]")
       UV_ARGS+=(--with "mcp==1.27.2")
       ;;
     "[all]")
@@ -467,11 +469,14 @@ if [ "$HAS_UV" = true ]; then
         --with "claude-agent-sdk==0.2.87"
         --with "anthropic==0.105.2"
         --with "litellm==1.86.2"
-        --with "textual==8.2.7"
-        --with "textual-serve==1.1.3"
       )
       ;;
   esac
+  # Every install ships the settings GUI (`ouroboros config`).
+  UV_ARGS+=(
+    --with "textual==8.2.7"
+    --with "textual-serve==1.1.3"
+  )
   uv "${UV_ARGS[@]}"
 elif [ "$HAS_PIPX" = true ]; then
   INSTALL_METHOD="pipx"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -633,7 +633,9 @@ if [ -n "$RUNTIME" ]; then
   _info "Current backend: $RUNTIME"
 fi
 _info "Switch backend later: ouroboros setup --runtime <claude|codex|opencode|hermes|gemini|kiro|copilot|pi>"
-_info "Tune per-stage agents & models anytime: ouroboros config (settings GUI)"
+_say "${BOLD}Settings GUI — pick per-stage agents & models${RESET}"
+_info 'Inside your AI agent: > ooo config   (opens in your browser)'
+_info 'From this terminal:  ouroboros config   (full-screen TUI)'
 
 # 6. Optional first-run settings GUI (interactive installs only).
 # install.sh always runs in a real terminal when interactive, so the
@@ -670,7 +672,9 @@ if [ -t 0 ] && [ -z "${OUROBOROS_INSTALL_SKIP_CONFIG_GUI:-}" ]; then
       fi
       ;;
     *)
-      _info "Skipped. Run it anytime: ouroboros config"
+      _info "Skipped. Open it anytime:"
+      _info '  in your AI agent: > ooo config'
+      _info '  in a terminal:    ouroboros config'
       ;;
   esac
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -297,6 +297,10 @@ _runtime_to_extras() {
 # Preserves user choice across upgrades unless --reconfigure / --runtime is set.
 EXISTING_RUNTIME=""
 EXISTING_CONFIG="$HOME/.ouroboros/config.yaml"
+# Fresh install (no config yet) → the post-install settings-GUI offer
+# defaults to yes; upgrades default to no.
+FRESH_CONFIG=true
+[ -f "$EXISTING_CONFIG" ] && FRESH_CONFIG=false
 if [ -z "$EXPLICIT_RUNTIME" ] && [ -z "$RECONFIGURE" ] && [ -f "$EXISTING_CONFIG" ] && command -v python3 &>/dev/null; then
   EXISTING_RUNTIME=$(EXISTING_CONFIG="$EXISTING_CONFIG" python3 -c "
 import os, re
@@ -629,3 +633,44 @@ if [ -n "$RUNTIME" ]; then
   _info "Current backend: $RUNTIME"
 fi
 _info "Switch backend later: ouroboros setup --runtime <claude|codex|opencode|hermes|gemini|kiro|copilot|pi>"
+_info "Tune per-stage agents & models anytime: ouroboros config (settings GUI)"
+
+# 6. Optional first-run settings GUI (interactive installs only).
+# install.sh always runs in a real terminal when interactive, so the
+# full-screen Textual settings app can open right here. curl|bash pipe
+# installs skip this automatically ([ -t 0 ] is false).
+if [ -t 0 ] && [ -z "${OUROBOROS_INSTALL_SKIP_CONFIG_GUI:-}" ]; then
+  if [ "$FRESH_CONFIG" = true ]; then
+    GUI_DEFAULT="y"
+    GUI_HINT="[Y/n]"
+  else
+    GUI_DEFAULT="n"
+    GUI_HINT="[y/N]"
+  fi
+  _blank
+  _say "${BOLD}First-time setup: pick per-stage agents & models in the settings GUI?${RESET}"
+  _prompt "Open settings GUI now $GUI_HINT: "
+  read -r gui_choice
+  case "${gui_choice:-$GUI_DEFAULT}" in
+    y | Y | yes | YES)
+      GUI_OK=false
+      if [ -n "${OUROBOROS_SETUP_CMD:-}" ] && "$OUROBOROS_SETUP_CMD" config; then
+        GUI_OK=true
+      elif command -v uvx &>/dev/null; then
+        # The selected extras may not include [tui]; run the GUI from an
+        # ephemeral env with the tui extra instead of fattening the install.
+        _info "Settings GUI needs the tui extra; running it via uvx..."
+        if uvx --from "${PACKAGE_NAME}[tui]" ouroboros config; then
+          GUI_OK=true
+        fi
+      fi
+      if [ "$GUI_OK" = false ]; then
+        _warn "Could not open the settings GUI."
+        _info "Run it later with: uvx --from '${PACKAGE_NAME}[tui]' ouroboros config"
+      fi
+      ;;
+    *)
+      _info "Skipped. Run it anytime: ouroboros config"
+      ;;
+  esac
+fi

--- a/skills/config/SKILL.md
+++ b/skills/config/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: config
+description: "Open the Ouroboros settings GUI (browser from a harness, TUI from a terminal)"
+---
+
+# /ouroboros:config
+
+Open the mouse-friendly settings GUI for `~/.ouroboros/config.yaml`: per-stage
+runtime/model selects, global runtime + LLM backend, install badges for
+missing CLIs, and env-override warnings.
+
+## Usage
+
+```
+ooo config
+/ouroboros:config
+```
+
+**Trigger keywords:** "ooo config", "open settings", "configure ouroboros"
+
+## Instructions
+
+When the user invokes this skill:
+
+1. **Launch the GUI in the background** (the command serves until stopped):
+
+   ```bash
+   ouroboros config
+   ```
+
+   Run it with the Bash tool in background mode. Inside a harness session
+   the command detects the non-interactive context (`CLAUDECODE=1` /
+   captured stdout) by itself and serves the settings app over a local web
+   server, auto-opening the user's browser.
+
+   In a development checkout, use `uv run ouroboros config` instead.
+
+2. **Relay the URL.** Read the command output and surface the
+   `http://localhost:<port>` line so the user can open it manually if the
+   browser did not pop up.
+
+3. **Tell the user how to finish:** edit settings in the browser, press
+   Save, then stop the server (kill the background command) when done.
+   Config changes apply to *new* MCP work; remind the user that a running
+   MCP server may need a reconnect to pick up backend changes.
+
+4. If the command fails with a missing-dependency hint, relay it verbatim
+   (`pip install 'ouroboros-ai[tui]'`).
+
+Scriptable edits stay on the existing surface: `ouroboros config show|set|backend|init|validate`.
+
+End your final message with the state breadcrumb footer (RFC #1392):
+
+```
+◆ Settings GUI serving at <url> → next: Save in browser, then stop the server
+```

--- a/skills/config/SKILL.md
+++ b/skills/config/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: config
-description: "Open the Ouroboros settings GUI (browser from a harness, TUI from a terminal)"
+description: "Open or drive the Ouroboros settings GUI (browser, TUI, or conversational fallback)"
 ---
 
 # /ouroboros:config
 
-Open the mouse-friendly settings GUI for `~/.ouroboros/config.yaml`: per-stage
-runtime/model selects, global runtime + LLM backend, install badges for
-missing CLIs, and env-override warnings.
+Settings for `~/.ouroboros/config.yaml`: per-stage runtime/model selects,
+global runtime + LLM backend, install badges for missing CLIs, and
+env-override warnings.
 
 ## Usage
 
@@ -16,41 +16,84 @@ ooo config
 /ouroboros:config
 ```
 
-**Trigger keywords:** "ooo config", "open settings", "configure ouroboros"
+**Trigger keywords:** "ooo config", "open settings", "configure ouroboros", "change model", "change agent"
 
 ## Instructions
 
-When the user invokes this skill:
+Pick the branch that matches where you (the agent) are running. The decisive
+question: **can the user open a browser pointed at this machine?**
 
-1. **Launch the GUI in the background** (the command serves until stopped):
+### Branch A — local harness (Claude Code / Codex on the user's own machine)
+
+1. Launch in the background (the command serves until stopped):
 
    ```bash
    ouroboros config
    ```
 
-   Run it with the Bash tool in background mode. Inside a harness session
-   the command detects the non-interactive context (`CLAUDECODE=1` /
-   captured stdout) by itself and serves the settings app over a local web
-   server, auto-opening the user's browser.
+   The command detects the non-interactive context itself and serves the
+   settings app over a local web server, auto-opening the user's browser.
+   In a development checkout use `uv run ouroboros config`.
 
-   In a development checkout, use `uv run ouroboros config` instead.
+2. Relay the `http://localhost:<port>` line from the output so the user can
+   open it manually if the browser did not pop up.
 
-2. **Relay the URL.** Read the command output and surface the
-   `http://localhost:<port>` line so the user can open it manually if the
-   browser did not pop up.
+3. Tell the user: edit → Save → then ask you to stop the server. Remind them
+   a running MCP server may need a reconnect to pick up backend changes.
 
-3. **Tell the user how to finish:** edit settings in the browser, press
-   Save, then stop the server (kill the background command) when done.
-   Config changes apply to *new* MCP work; remind the user that a running
-   MCP server may need a reconnect to pick up backend changes.
+### Branch B — remote host the user can reach over the network (SSH box, home server)
 
-4. If the command fails with a missing-dependency hint, relay it verbatim
-   (`pip install 'ouroboros-ai[tui]'`).
+The user cannot see a browser opened *here*, but may be able to reach this
+host. Serve without auto-open and hand over the URL:
 
-Scriptable edits stay on the existing surface: `ouroboros config show|set|backend|init|validate`.
+```bash
+ouroboros config --web --host 0.0.0.0 --no-browser
+```
 
-End your final message with the state breadcrumb footer (RFC #1392):
+Relay the printed URL with this host's address substituted, plus the SSH
+tunnel fallback the command prints
+(`ssh -L <port>:localhost:<port> <this-host>`).
+
+### Branch C — chat gateway, no browser path at all (e.g. hermes driven from Discord)
+
+Do NOT start a server nobody can reach. Drive the same settings
+conversationally over the scriptable surface:
+
+1. Show the current state:
+
+   ```bash
+   ouroboros config show
+   ```
+
+2. Present the user a short menu in chat — default agent, per-stage agents,
+   per-stage models — with the current values, and ask what to change.
+
+3. Apply each choice with the validated setter (same write path as the GUI):
+
+   ```bash
+   ouroboros config set orchestrator.runtime_backend <agent>
+   ouroboros config set orchestrator.runtime_profile.stages.<interview|execute|evaluate|reflect> <agent>
+   ouroboros config set clarification.default_model <model>        # interview & seed
+   ouroboros config set execution.double_diamond_model <model>     # execute
+   ouroboros config set evaluation.semantic_model <model>          # evaluate
+   ouroboros config set resilience.reflect_model <model>           # reflect
+   ouroboros config set llm.backend <backend>                      # internal LLM calls
+   ```
+
+4. Confirm with `ouroboros config show` and summarize what changed.
+
+If a `set` is rejected, relay the validation error verbatim — it lists the
+valid keys/values.
+
+### All branches
+
+If the command fails with a missing-dependency hint, relay it verbatim
+(`pip install 'ouroboros-ai[tui]'`). Scriptable edits always remain on
+`ouroboros config show|set|backend|init|validate`.
+
+End your final message with the state breadcrumb footer (RFC #1392), e.g.:
 
 ```
 ◆ Settings GUI serving at <url> → next: Save in browser, then stop the server
+◆ Config updated via chat (<keys>) → next: reconnect MCP if the backend changed
 ```

--- a/skills/help/SKILL.md
+++ b/skills/help/SKILL.md
@@ -39,6 +39,7 @@ Ouroboros is a **requirement crystallization engine** for AI workflows. It trans
 | `ooo status` | Session status + drift check | MCP |
 | `ooo resume-session` | List in-flight sessions and re-attach commands | CLI |
 | `ooo setup` | Installation wizard | Plugin |
+| `ooo config` | Settings GUI — per-stage agents & models (browser here, TUI in a terminal) | CLI |
 | `ooo welcome` | First-touch welcome guide | Plugin |
 | `ooo tutorial` | Interactive hands-on learning | Plugin |
 | `ooo help` | This reference guide | Plugin |
@@ -79,6 +80,7 @@ Ouroboros is a **requirement crystallization engine** for AI workflows. It trans
 | "cancel execution", "stop job", "kill stuck", "abort execution" | `ooo cancel` |
 | "in-flight sessions", "mcp disconnected", "lost Ouroboros execution" | `ooo resume-session` |
 | "update ouroboros", "upgrade ouroboros" | `ooo update` |
+| "open settings", "change model", "change agent", "configure backend" | `ooo config` |
 | "brownfield defaults", "brownfield scan" | `ooo brownfield` |
 | "publish to github", "create issues from seed", "seed to issues" | `ooo publish` |
 

--- a/skills/welcome/SKILL.md
+++ b/skills/welcome/SKILL.md
@@ -202,6 +202,7 @@ Available Commands:
 | ooo run         | Execute with visual TUI          |
 | ooo evaluate    | 3-stage verification             |
 | ooo unstuck     | Lateral thinking when stuck      |
+| ooo config      | Settings GUI: agents & models    |
 | ooo help        | Full command reference           |
 +---------------------------------------------------+
 ```

--- a/src/ouroboros/backends/model_catalog.py
+++ b/src/ouroboros/backends/model_catalog.py
@@ -14,10 +14,9 @@ is duplicated here instead of imported because ``config.loader`` imports
 circular.
 
 Dynamic refresh is an explicit opt-in hook: a backend may declare a
-``list_command`` argv that prints one model id per line. No backend ships
-one yet — per-CLI support must be verified individually before wiring it —
-so ``refresh_models`` currently degrades to ``None`` (use the static
-catalog) for every backend.
+``list_command`` argv that prints one model id per line. OpenCode is wired
+because ``opencode models`` has been verified; other backends degrade to
+``None`` (use the static catalog) until their CLI support is verified.
 """
 
 from __future__ import annotations
@@ -36,9 +35,7 @@ from ouroboros.config._model_defaults import DEFAULT_OPUS_MODEL, DEFAULT_SONNET_
 # Backends whose runnable model is the CLI's own configured default rather
 # than a Claude model id. Mirrors the loader's sentinel frozensets
 # (_CODEX_LLM_BACKENDS et al.); the mirror is locked by a unit test.
-_SENTINEL_MODEL_BACKENDS = frozenset(
-    {"codex", "opencode", "kiro", "copilot", "hermes", "pi", "gjc"}
-)
+_SENTINEL_MODEL_BACKENDS = frozenset({"codex", "opencode", "kiro", "copilot", "hermes", "pi"})
 
 # The sentinel the loader maps Claude-incapable backends to.
 DEFAULT_MODEL_SENTINEL = "default"
@@ -177,7 +174,6 @@ _CLI_PATH_GETTERS: dict[str, str] = {
     "opencode": "get_opencode_cli_path",
     "goose": "get_goose_cli_path",
     "pi": "get_pi_cli_path",
-    "gjc": "get_gjc_cli_path",
 }
 
 

--- a/src/ouroboros/backends/model_catalog.py
+++ b/src/ouroboros/backends/model_catalog.py
@@ -35,7 +35,9 @@ from ouroboros.config._model_defaults import DEFAULT_OPUS_MODEL, DEFAULT_SONNET_
 # Backends whose runnable model is the CLI's own configured default rather
 # than a Claude model id. Mirrors the loader's sentinel frozensets
 # (_CODEX_LLM_BACKENDS et al.); the mirror is locked by a unit test.
-_SENTINEL_MODEL_BACKENDS = frozenset({"codex", "opencode", "kiro", "copilot", "hermes", "pi"})
+_SENTINEL_MODEL_BACKENDS = frozenset(
+    {"codex", "opencode", "kiro", "copilot", "hermes", "pi", "gjc"}
+)
 
 # The sentinel the loader maps Claude-incapable backends to.
 DEFAULT_MODEL_SENTINEL = "default"
@@ -174,6 +176,7 @@ _CLI_PATH_GETTERS: dict[str, str] = {
     "opencode": "get_opencode_cli_path",
     "goose": "get_goose_cli_path",
     "pi": "get_pi_cli_path",
+    "gjc": "get_gjc_cli_path",
 }
 
 

--- a/src/ouroboros/backends/model_catalog.py
+++ b/src/ouroboros/backends/model_catalog.py
@@ -1,0 +1,188 @@
+"""Per-backend model catalog and installed-CLI detection (#1412).
+
+Settings surfaces (the ``ouroboros config`` GUI, ourocode) need to offer
+model choices per runtime backend without hardcoding model ids in UI code.
+This module owns that catalog as a sibling of the capability registry.
+
+The static catalog deliberately **mirrors** the backend-default-model
+mapping in ``ouroboros.config.loader._default_model_for_backend``: backends
+that cannot run Claude model ids get the ``"default"`` sentinel (the CLI's
+own configured model), everything else gets the shipped Claude defaults.
+A unit test locks the mirror so the two cannot drift silently. The mapping
+is duplicated here instead of imported because ``config.loader`` imports
+``ouroboros.backends`` — a module-level import in this direction would be
+circular.
+
+Dynamic refresh is an explicit opt-in hook: a backend may declare a
+``list_command`` argv that prints one model id per line. No backend ships
+one yet — per-CLI support must be verified individually before wiring it —
+so ``refresh_models`` currently degrades to ``None`` (use the static
+catalog) for every backend.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import shutil
+import subprocess
+
+from ouroboros.backends.capabilities import (
+    get_backend_capability,
+    runtime_backend_choices,
+)
+from ouroboros.config._model_defaults import DEFAULT_OPUS_MODEL, DEFAULT_SONNET_MODEL
+
+# Backends whose runnable model is the CLI's own configured default rather
+# than a Claude model id. Mirrors the loader's sentinel frozensets
+# (_CODEX_LLM_BACKENDS et al.); the mirror is locked by a unit test.
+_SENTINEL_MODEL_BACKENDS = frozenset({"codex", "opencode", "kiro", "copilot", "hermes", "pi"})
+
+# The sentinel the loader maps Claude-incapable backends to.
+DEFAULT_MODEL_SENTINEL = "default"
+
+_LIST_COMMAND_TIMEOUT_SECONDS = 5.0
+
+
+@dataclass(frozen=True, slots=True)
+class BackendModelCatalog:
+    """Known model choices for one canonical backend.
+
+    Attributes:
+        backend: Canonical backend name.
+        models: Known model ids, best-default first. May be empty for
+            backends whose model space is free-form (e.g. litellm provider
+            routes) — UIs must always offer a free-text custom entry on top
+            of this tuple regardless of its length.
+        list_command: Optional argv that prints one available model id per
+            line. ``None`` means dynamic listing is not verified for this
+            backend and callers must use the static ``models``.
+    """
+
+    backend: str
+    models: tuple[str, ...]
+    list_command: tuple[str, ...] | None = None
+
+    @property
+    def default_model(self) -> str:
+        """Best default model id, matching the loader's backend mapping."""
+        return self.models[0] if self.models else DEFAULT_MODEL_SENTINEL
+
+
+def _build_catalogs() -> dict[str, BackendModelCatalog]:
+    catalogs: dict[str, BackendModelCatalog] = {}
+    for name in runtime_backend_choices():
+        if name in _SENTINEL_MODEL_BACKENDS:
+            models: tuple[str, ...] = (DEFAULT_MODEL_SENTINEL,)
+        else:
+            models = (DEFAULT_OPUS_MODEL, DEFAULT_SONNET_MODEL)
+        catalogs[name] = BackendModelCatalog(backend=name, models=models)
+    # LLM-only backend: model ids are provider-prefixed free-form strings,
+    # so the catalog is custom-entry-only.
+    catalogs["litellm"] = BackendModelCatalog(backend="litellm", models=())
+    return catalogs
+
+
+_CATALOGS: dict[str, BackendModelCatalog] = _build_catalogs()
+
+
+def get_model_catalog(backend: str) -> BackendModelCatalog:
+    """Return the model catalog for a backend name or alias.
+
+    Raises:
+        ValueError: If the backend is unknown.
+    """
+    capability = get_backend_capability(backend)
+    if capability is None or capability.name not in _CATALOGS:
+        msg = f"No model catalog for backend: {backend.strip().lower()}"
+        raise ValueError(msg)
+    return _CATALOGS[capability.name]
+
+
+def model_choices(backend: str) -> tuple[str, ...]:
+    """Known model choices for a backend (UIs append a custom entry)."""
+    return get_model_catalog(backend).models
+
+
+def refresh_models(
+    backend: str,
+    *,
+    timeout_seconds: float = _LIST_COMMAND_TIMEOUT_SECONDS,
+) -> tuple[str, ...] | None:
+    """Dynamically list models for a backend, or ``None`` to use the static catalog.
+
+    Degrades to ``None`` (never raises) when the backend declares no
+    verified ``list_command``, the command fails, times out, or produces
+    no parseable output.
+    """
+    catalog = get_model_catalog(backend)
+    if catalog.list_command is None:
+        return None
+    try:
+        result = subprocess.run(  # noqa: S603 - argv is a code-owned constant
+            catalog.list_command,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    models = tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+    return models or None
+
+
+# Maps canonical backend name → loader getter for its configured CLI path.
+# claude's getter is get_cli_path (the SDK-bundled CLI override).
+_CLI_PATH_GETTERS: dict[str, str] = {
+    "claude": "get_cli_path",
+    "codex": "get_codex_cli_path",
+    "copilot": "get_copilot_cli_path",
+    "gemini": "get_gemini_cli_path",
+    "hermes": "get_hermes_cli_path",
+    "kiro": "get_kiro_cli_path",
+    "opencode": "get_opencode_cli_path",
+    "goose": "get_goose_cli_path",
+    "pi": "get_pi_cli_path",
+}
+
+
+def detect_backend_cli(backend: str) -> str | None:
+    """Return the resolved CLI path for a backend, or ``None`` if not installed.
+
+    Resolution mirrors runtime construction: the explicitly configured path
+    (env var / config.yaml, via the loader getter) wins, then ``PATH``
+    lookup of the capability's ``cli_name``. Backends without a CLI surface
+    (litellm) return ``None``.
+    """
+    capability = get_backend_capability(backend)
+    if capability is None:
+        msg = f"Unsupported backend: {backend.strip().lower()}"
+        raise ValueError(msg)
+    getter_name = _CLI_PATH_GETTERS.get(capability.name)
+    if getter_name is not None:
+        # Deferred import: config.loader imports ouroboros.backends, so a
+        # module-level import here would be circular.
+        from ouroboros.config import loader as config_loader
+
+        configured = getattr(config_loader, getter_name)()
+        if configured:
+            return configured
+    if capability.cli_name:
+        return shutil.which(capability.cli_name)
+    return None
+
+
+def installed_backends() -> dict[str, str | None]:
+    """Map every runtime-capable backend to its CLI path (``None`` = not installed)."""
+    return {name: detect_backend_cli(name) for name in runtime_backend_choices()}
+
+
+__all__ = [
+    "DEFAULT_MODEL_SENTINEL",
+    "BackendModelCatalog",
+    "detect_backend_cli",
+    "get_model_catalog",
+    "installed_backends",
+    "model_choices",
+    "refresh_models",
+]

--- a/src/ouroboros/backends/model_catalog.py
+++ b/src/ouroboros/backends/model_catalog.py
@@ -53,19 +53,35 @@ class BackendModelCatalog:
             backends whose model space is free-form (e.g. litellm provider
             routes) — UIs must always offer a free-text custom entry on top
             of this tuple regardless of its length.
-        list_command: Optional argv that prints one available model id per
-            line. ``None`` means dynamic listing is not verified for this
-            backend and callers must use the static ``models``.
+        list_args: Optional CLI subcommand argv (appended to the resolved
+            backend binary) that prints one available model id per line.
+            Wired only where verified by hand — e.g. ``opencode models``.
+            ``None`` means dynamic listing is unsupported and callers must
+            use the static ``models``.
     """
 
     backend: str
     models: tuple[str, ...]
-    list_command: tuple[str, ...] | None = None
+    list_args: tuple[str, ...] | None = None
 
     @property
     def default_model(self) -> str:
         """Best default model id, matching the loader's backend mapping."""
         return self.models[0] if self.models else DEFAULT_MODEL_SENTINEL
+
+
+# Hand-curated additions per backend, appended after the loader-mirroring
+# default entry. Keep entries verifiable: the codex ids below were confirmed
+# against a live `opencode models` listing of the OpenAI catalog.
+_EXTRA_KNOWN_MODELS: dict[str, tuple[str, ...]] = {
+    "claude": ("claude-haiku-4-5-20251001",),
+    "codex": ("gpt-5-codex", "gpt-5", "gpt-5-mini"),
+}
+
+# Verified model-listing subcommands (one model id per line on stdout).
+_LIST_ARGS: dict[str, tuple[str, ...]] = {
+    "opencode": ("models",),
+}
 
 
 def _build_catalogs() -> dict[str, BackendModelCatalog]:
@@ -75,7 +91,12 @@ def _build_catalogs() -> dict[str, BackendModelCatalog]:
             models: tuple[str, ...] = (DEFAULT_MODEL_SENTINEL,)
         else:
             models = (DEFAULT_OPUS_MODEL, DEFAULT_SONNET_MODEL)
-        catalogs[name] = BackendModelCatalog(backend=name, models=models)
+        models = models + _EXTRA_KNOWN_MODELS.get(name, ())
+        catalogs[name] = BackendModelCatalog(
+            backend=name,
+            models=models,
+            list_args=_LIST_ARGS.get(name),
+        )
     # LLM-only backend: model ids are provider-prefixed free-form strings,
     # so the catalog is custom-entry-only.
     catalogs["litellm"] = BackendModelCatalog(backend="litellm", models=())
@@ -110,16 +131,20 @@ def refresh_models(
 ) -> tuple[str, ...] | None:
     """Dynamically list models for a backend, or ``None`` to use the static catalog.
 
-    Degrades to ``None`` (never raises) when the backend declares no
-    verified ``list_command``, the command fails, times out, or produces
-    no parseable output.
+    Runs the backend's verified listing subcommand against its resolved CLI
+    binary (configured path first, then PATH). Degrades to ``None`` (never
+    raises) when the backend declares no listing subcommand, the CLI is not
+    installed, the command fails or times out, or output is unparseable.
     """
     catalog = get_model_catalog(backend)
-    if catalog.list_command is None:
+    if catalog.list_args is None:
+        return None
+    cli_path = detect_backend_cli(backend)
+    if cli_path is None:
         return None
     try:
-        result = subprocess.run(  # noqa: S603 - argv is a code-owned constant
-            catalog.list_command,
+        result = subprocess.run(  # noqa: S603 - resolved binary + code-owned args
+            (cli_path, *catalog.list_args),
             capture_output=True,
             text=True,
             timeout=timeout_seconds,

--- a/src/ouroboros/backends/model_catalog.py
+++ b/src/ouroboros/backends/model_catalog.py
@@ -127,6 +127,12 @@ def model_choices(backend: str) -> tuple[str, ...]:
     return get_model_catalog(backend).models
 
 
+def uses_default_model_sentinel(backend: str) -> bool:
+    """Whether ``"default"`` is a safe persisted model value for this backend."""
+    capability = get_backend_capability(backend)
+    return capability is not None and capability.name in _SENTINEL_MODEL_BACKENDS
+
+
 def refresh_models(
     backend: str,
     *,
@@ -254,4 +260,5 @@ __all__ = [
     "installed_backends",
     "model_choices",
     "refresh_models",
+    "uses_default_model_sentinel",
 ]

--- a/src/ouroboros/backends/model_catalog.py
+++ b/src/ouroboros/backends/model_catalog.py
@@ -23,6 +23,7 @@ catalog) for every backend.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
 import shutil
 import subprocess
 
@@ -202,9 +203,49 @@ def installed_backends() -> dict[str, str | None]:
     return {name: detect_backend_cli(name) for name in runtime_backend_choices()}
 
 
+def configured_default_model(backend: str) -> str | None:
+    """Resolve what the ``"default"`` sentinel currently means for a backend.
+
+    Sentinel backends defer model choice to the CLI's own user config; this
+    reads only the model field from that file so settings UIs can render
+    "default — currently <model>" instead of an opaque sentinel. Returns
+    ``None`` when the backend keeps no such file, the file is missing, or
+    parsing fails — never raises.
+    """
+    capability = get_backend_capability(backend)
+    if capability is None:
+        return None
+    try:
+        if capability.name == "hermes":
+            import yaml
+
+            config_path = Path.home() / ".hermes" / "config.yaml"
+            if not config_path.exists():
+                return None
+            data = yaml.safe_load(config_path.read_text()) or {}
+            model = data.get("model")
+            if isinstance(model, dict):
+                value = model.get("default")
+                return str(value) if value else None
+            return None
+        if capability.name == "codex":
+            import tomllib
+
+            config_path = Path.home() / ".codex" / "config.toml"
+            if not config_path.exists():
+                return None
+            data = tomllib.loads(config_path.read_text())
+            value = data.get("model")
+            return str(value) if value else None
+    except Exception:  # noqa: BLE001 - a hint must never break the caller
+        return None
+    return None
+
+
 __all__ = [
     "DEFAULT_MODEL_SENTINEL",
     "BackendModelCatalog",
+    "configured_default_model",
     "detect_backend_cli",
     "get_model_catalog",
     "installed_backends",

--- a/src/ouroboros/backends/model_catalog.py
+++ b/src/ouroboros/backends/model_catalog.py
@@ -36,7 +36,9 @@ from ouroboros.config._model_defaults import DEFAULT_OPUS_MODEL, DEFAULT_SONNET_
 # Backends whose runnable model is the CLI's own configured default rather
 # than a Claude model id. Mirrors the loader's sentinel frozensets
 # (_CODEX_LLM_BACKENDS et al.); the mirror is locked by a unit test.
-_SENTINEL_MODEL_BACKENDS = frozenset({"codex", "opencode", "kiro", "copilot", "hermes", "pi"})
+_SENTINEL_MODEL_BACKENDS = frozenset(
+    {"codex", "opencode", "kiro", "copilot", "hermes", "pi", "gjc"}
+)
 
 # The sentinel the loader maps Claude-incapable backends to.
 DEFAULT_MODEL_SENTINEL = "default"
@@ -169,6 +171,7 @@ _CLI_PATH_GETTERS: dict[str, str] = {
     "opencode": "get_opencode_cli_path",
     "goose": "get_goose_cli_path",
     "pi": "get_pi_cli_path",
+    "gjc": "get_gjc_cli_path",
 }
 
 

--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -289,10 +289,8 @@ def _render_effective_view(data: dict, config_path: Path) -> None:
         "claude",
     )
     defaults_table.add_row("Default agent", _agent_cell(agent_value, installed), agent_source)
-    llm_value, llm_source = _effective_value(
-        GLOBAL_LLM_BACKEND_FIELD.env_vars,
-        get_value(data, GLOBAL_LLM_BACKEND_FIELD.key),
-        "claude_code",
+    llm_value, llm_source = _effective_llm_backend_value(
+        get_value(data, GLOBAL_LLM_BACKEND_FIELD.key)
     )
     defaults_table.add_row("LLM backend (internal calls)", llm_value, llm_source)
     print_table(defaults_table)

--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -182,6 +182,66 @@ def _agent_cell(backend: str, installed: dict[str, str | None]) -> str:
     return backend if installed.get(backend) else f"{backend} ⚠ not installed"
 
 
+def _effective_view_data(data: dict, config_path: Path) -> dict:
+    """Machine-readable effective view (what `show --json` emits)."""
+    from ouroboros.backends.model_catalog import installed_backends
+    from ouroboros.config_tui.fields import (
+        GLOBAL_LLM_BACKEND_FIELD,
+        GLOBAL_RUNTIME_FIELD,
+        STAGE_MODEL_FIELDS,
+        get_value,
+    )
+    from ouroboros.orchestrator_stage import Stage
+
+    installed = installed_backends()
+    agent_value, agent_source = _effective_value(
+        GLOBAL_RUNTIME_FIELD.env_vars,
+        get_value(data, GLOBAL_RUNTIME_FIELD.key),
+        "claude",
+    )
+    llm_value, llm_source = _effective_value(
+        GLOBAL_LLM_BACKEND_FIELD.env_vars,
+        get_value(data, GLOBAL_LLM_BACKEND_FIELD.key),
+        "claude_code",
+    )
+    profile_default = get_value(data, "orchestrator.runtime_profile.default")
+    stages: dict[str, dict] = {}
+    for stage in Stage:
+        stage_agent = get_value(data, f"orchestrator.runtime_profile.stages.{stage.value}")
+        resolved = str(stage_agent or profile_default or agent_value)
+        model_field = STAGE_MODEL_FIELDS[stage]
+        model_value, model_source = _effective_value(
+            model_field.env_vars,
+            get_value(data, model_field.key),
+            "backend default",
+        )
+        stages[stage.value] = {
+            "agent": resolved,
+            "inherited": stage_agent is None,
+            "agent_installed": bool(installed.get(resolved)),
+            "model": model_value,
+            "model_source": model_source,
+            "model_key": model_field.key,
+        }
+    return {
+        "defaults": {
+            "default_agent": {
+                "value": agent_value,
+                "source": agent_source,
+                "installed": bool(installed.get(agent_value)),
+            },
+            "llm_backend": {"value": llm_value, "source": llm_source},
+        },
+        "stages": stages,
+        "environment": {
+            "config_path": str(config_path),
+            "cli_path": _resolve_cli_path(data),
+            "database": _resolve_db_path(data, config_path),
+            "log_level": str(data.get("logging", {}).get("level", "info")),
+        },
+    }
+
+
 def _render_effective_view(data: dict, config_path: Path) -> None:
     """GUI-equivalent effective view: defaults, per-stage agents/models, sources.
 
@@ -264,15 +324,26 @@ def show(
         str | None,
         typer.Argument(help="Configuration section to display (e.g., 'orchestrator')."),
     ] = None,
+    json_output: Annotated[
+        bool,
+        typer.Option("--json", help="Emit the effective view as JSON (for agents/scripts)."),
+    ] = False,
 ) -> None:
     """Display the effective configuration.
 
     Without arguments, renders the GUI-equivalent effective view: defaults,
     per-stage agents and models with resolved inheritance, value sources
     (env override / config / default), and CLI install status. Pass a
-    section name for the raw section contents.
+    section name for the raw section contents, or --json for a
+    machine-readable effective view.
     """
     data, config_path = _load_config()
+
+    if json_output:
+        import json
+
+        typer.echo(json.dumps(_effective_view_data(data, config_path), indent=2))
+        return
 
     if section:
         section_data = data.get(section)
@@ -592,6 +663,41 @@ def set_value(
         print_success(f"{key}: {old_value} → {parsed_value}")
     else:
         print_success(f"{key}: {parsed_value}")
+
+
+@app.command()
+def undo() -> None:
+    """Restore the configuration saved before the last settings change.
+
+    Every successful save (GUI or `config set` via the settings layer)
+    keeps the previous file as config.yaml.bak; undo swaps it back in,
+    so running undo twice redoes the change.
+    """
+    from ouroboros.config.models import get_config_dir
+
+    config_path = get_config_dir() / "config.yaml"
+    backup_path = get_config_dir() / "config.yaml.bak"
+    if not backup_path.exists():
+        print_error("Nothing to undo: no config.yaml.bak found.")
+        raise typer.Exit(1)
+    if not config_path.exists():
+        print_error(f"Config not found: {config_path}")
+        raise typer.Exit(1)
+
+    current_text = config_path.read_text()
+    backup_text = backup_path.read_text()
+    config_path.write_text(backup_text)
+    try:
+        from ouroboros.config.loader import load_config
+
+        load_config()
+    except Exception as exc:
+        config_path.write_text(current_text)
+        print_error(f"Backup is not a valid config — undo aborted.\n{exc}")
+        raise typer.Exit(1) from None
+    # Swap: the replaced config becomes the new backup, so undo ↔ redo.
+    backup_path.write_text(current_text)
+    print_success("Restored previous configuration (run undo again to redo).")
 
 
 @app.command()

--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -177,6 +177,26 @@ def _effective_value(
     return str(default), "default"
 
 
+def _effective_llm_backend_value(raw_value: object) -> tuple[str, str]:
+    """Resolve the effective LLM backend using the loader's env fallback order."""
+    import os
+
+    env_backend = os.environ.get("OUROBOROS_LLM_BACKEND", "").strip()
+    if env_backend:
+        return env_backend, "env OUROBOROS_LLM_BACKEND ⚠"
+
+    env_runtime = os.environ.get("OUROBOROS_RUNTIME", "").strip()
+    capability = get_backend_capability(env_runtime)
+    if capability is not None and capability.supports_llm:
+        if env_runtime.strip().lower() == "claude_code":
+            return "claude_code", "env OUROBOROS_RUNTIME ⚠"
+        return capability.name, "env OUROBOROS_RUNTIME ⚠"
+
+    if raw_value is not None:
+        return str(raw_value), "config"
+    return "claude_code", "default"
+
+
 def _agent_cell(backend: str, installed: dict[str, str | None]) -> str:
     """Render an agent name with an install marker."""
     return backend if installed.get(backend) else f"{backend} ⚠ not installed"
@@ -199,10 +219,8 @@ def _effective_view_data(data: dict, config_path: Path) -> dict:
         get_value(data, GLOBAL_RUNTIME_FIELD.key),
         "claude",
     )
-    llm_value, llm_source = _effective_value(
-        GLOBAL_LLM_BACKEND_FIELD.env_vars,
-        get_value(data, GLOBAL_LLM_BACKEND_FIELD.key),
-        "claude_code",
+    llm_value, llm_source = _effective_llm_backend_value(
+        get_value(data, GLOBAL_LLM_BACKEND_FIELD.key)
     )
     profile_default = get_value(data, "orchestrator.runtime_profile.default")
     stages: dict[str, dict] = {}

--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -29,17 +29,49 @@ app = typer.Typer(
 
 
 @app.callback(invoke_without_command=True)
-def main(ctx: typer.Context) -> None:
+def main(
+    ctx: typer.Context,
+    web: Annotated[
+        bool,
+        typer.Option("--web", help="Force web mode even in an interactive terminal."),
+    ] = False,
+    host: Annotated[
+        str,
+        typer.Option(
+            "--host",
+            help="Web-mode bind address. Use 0.0.0.0 to reach the GUI from another "
+            "machine when this host runs a remote agent (e.g. hermes).",
+        ),
+    ] = "localhost",
+    port: Annotated[
+        int | None,
+        typer.Option("--port", help="Web-mode port (default: a free port)."),
+    ] = None,
+    no_browser: Annotated[
+        bool,
+        typer.Option(
+            "--no-browser",
+            help="Never auto-open a browser; just print the URL (remote/SSH hosts).",
+        ),
+    ] = False,
+) -> None:
     """Manage Ouroboros configuration.
 
     Without a subcommand, opens the interactive settings GUI: a full-screen
     TUI in a regular terminal, or a browser-served session inside an AI
-    harness (#1414). Subcommands keep the scriptable surface unchanged.
+    harness (#1414). On remote/agent hosts (SSH, chat gateways) web mode
+    prints a reachable URL instead of opening a browser there. Subcommands
+    keep the scriptable surface unchanged.
     """
     if ctx.invoked_subcommand is None:
         from ouroboros.config_tui.launcher import launch_settings
 
-        launch_settings()
+        launch_settings(
+            force_web=web,
+            host=host,
+            port=port,
+            open_browser=False if no_browser else None,
+        )
 
 
 _VALID_BACKENDS = runtime_backend_choices()

--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -24,8 +24,23 @@ from ouroboros.cli.formatters.tables import create_key_value_table, print_table
 app = typer.Typer(
     name="config",
     help="Manage Ouroboros configuration.",
-    no_args_is_help=True,
+    no_args_is_help=False,
 )
+
+
+@app.callback(invoke_without_command=True)
+def main(ctx: typer.Context) -> None:
+    """Manage Ouroboros configuration.
+
+    Without a subcommand, opens the interactive settings GUI: a full-screen
+    TUI in a regular terminal, or a browser-served session inside an AI
+    harness (#1414). Subcommands keep the scriptable surface unchanged.
+    """
+    if ctx.invoked_subcommand is None:
+        from ouroboros.config_tui.launcher import launch_settings
+
+        launch_settings()
+
 
 _VALID_BACKENDS = runtime_backend_choices()
 _SWITCHABLE_BACKENDS = tuple(

--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -19,7 +19,7 @@ from ouroboros.backends import (
 )
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success, print_warning
-from ouroboros.cli.formatters.tables import create_key_value_table, print_table
+from ouroboros.cli.formatters.tables import create_key_value_table, create_table, print_table
 
 app = typer.Typer(
     name="config",
@@ -160,6 +160,104 @@ def _resolve_db_path(data: dict, config_path: Path) -> str:
     return f"ouroboros.db ({resolved})"
 
 
+def _effective_value(
+    env_vars: tuple[str, ...],
+    raw_value: object,
+    default: object,
+) -> tuple[str, str]:
+    """Resolve the effective value and its source (env > config > default)."""
+    import os
+
+    for name in env_vars:
+        env_value = os.environ.get(name, "").strip()
+        if env_value:
+            return env_value, f"env {name} ⚠"
+    if raw_value is not None:
+        return str(raw_value), "config"
+    return str(default), "default"
+
+
+def _agent_cell(backend: str, installed: dict[str, str | None]) -> str:
+    """Render an agent name with an install marker."""
+    return backend if installed.get(backend) else f"{backend} ⚠ not installed"
+
+
+def _render_effective_view(data: dict, config_path: Path) -> None:
+    """GUI-equivalent effective view: defaults, per-stage agents/models, sources.
+
+    This is the text surface chat-gateway agents (e.g. hermes via Discord)
+    relay when no browser or TUI can reach the user, so it must carry the
+    same information the settings GUI shows: resolved inheritance, env
+    overrides, and install status (#1395's effective-view concern).
+    """
+    from ouroboros.backends.model_catalog import installed_backends
+    from ouroboros.config_tui.fields import (
+        GLOBAL_LLM_BACKEND_FIELD,
+        GLOBAL_RUNTIME_FIELD,
+        STAGE_MODEL_FIELDS,
+        get_value,
+    )
+    from ouroboros.orchestrator_stage import Stage
+
+    installed = installed_backends()
+
+    defaults_table = create_table("Defaults", show_lines=False)
+    defaults_table.add_column("Setting", style="cyan")
+    defaults_table.add_column("Value")
+    defaults_table.add_column("Source", style="dim")
+    agent_value, agent_source = _effective_value(
+        GLOBAL_RUNTIME_FIELD.env_vars,
+        get_value(data, GLOBAL_RUNTIME_FIELD.key),
+        "claude",
+    )
+    defaults_table.add_row("Default agent", _agent_cell(agent_value, installed), agent_source)
+    llm_value, llm_source = _effective_value(
+        GLOBAL_LLM_BACKEND_FIELD.env_vars,
+        get_value(data, GLOBAL_LLM_BACKEND_FIELD.key),
+        "claude_code",
+    )
+    defaults_table.add_row("LLM backend (internal calls)", llm_value, llm_source)
+    print_table(defaults_table)
+
+    stages_table = create_table("Per-stage overrides", show_lines=False)
+    stages_table.add_column("Stage", style="cyan")
+    stages_table.add_column("Agent")
+    stages_table.add_column("Model")
+    stages_table.add_column("Model source", style="dim")
+    profile_default = get_value(data, "orchestrator.runtime_profile.default")
+    for stage in Stage:
+        stage_agent = get_value(data, f"orchestrator.runtime_profile.stages.{stage.value}")
+        if stage_agent:
+            agent_cell = _agent_cell(str(stage_agent), installed)
+        else:
+            resolved = str(profile_default or agent_value)
+            agent_cell = f"(inherit) → {_agent_cell(resolved, installed)}"
+        model_field = STAGE_MODEL_FIELDS[stage]
+        model_value, model_source = _effective_value(
+            model_field.env_vars,
+            get_value(data, model_field.key),
+            "backend default",
+        )
+        stages_table.add_row(stage.value, agent_cell, model_value, model_source)
+    print_table(stages_table)
+
+    env_table = create_key_value_table(
+        {
+            "config_path": str(config_path),
+            "cli_path": _resolve_cli_path(data) or "?",
+            "database": _resolve_db_path(data, config_path),
+            "log_level": str(data.get("logging", {}).get("level", "info")),
+        },
+        "Environment",
+    )
+    print_table(env_table)
+    console.print(
+        "[dim]Change values: settings GUI (`ouroboros config`) or "
+        "`ouroboros config set <key> <value>`. "
+        "⚠ env sources override saved config until unset.[/dim]"
+    )
+
+
 @app.command()
 def show(
     section: Annotated[
@@ -167,9 +265,12 @@ def show(
         typer.Argument(help="Configuration section to display (e.g., 'orchestrator')."),
     ] = None,
 ) -> None:
-    """Display current configuration.
+    """Display the effective configuration.
 
-    Shows all configuration if no section specified.
+    Without arguments, renders the GUI-equivalent effective view: defaults,
+    per-stage agents and models with resolved inheritance, value sources
+    (env override / config / default), and CLI install status. Pass a
+    section name for the raw section contents.
     """
     data, config_path = _load_config()
 
@@ -187,16 +288,7 @@ def show(
         else:
             console.print(f"[cyan]{section}[/] = {section_data}")
     else:
-        config_summary = {
-            "config_path": str(config_path),
-            "runtime_backend": data.get("orchestrator", {}).get("runtime_backend", "?"),
-            "llm_backend": data.get("llm", {}).get("backend", "?"),
-            "cli_path": _resolve_cli_path(data) or "?",
-            "database": _resolve_db_path(data, config_path),
-            "log_level": data.get("logging", {}).get("level", "info"),
-        }
-        table = create_key_value_table(config_summary, "Current Configuration")
-        print_table(table)
+        _render_effective_view(data, config_path)
 
 
 @app.command()

--- a/src/ouroboros/config_tui/__init__.py
+++ b/src/ouroboros/config_tui/__init__.py
@@ -1,0 +1,8 @@
+"""Standalone settings GUI for Ouroboros configuration (#1411).
+
+This package is deliberately independent from :mod:`ouroboros.tui` (the
+monitor TUI): importing it must not pull in ``OuroborosTUI``, so a separate
+consumer (ourocode) can embed the settings app on its own. Keep this
+``__init__`` free of heavy imports — the Textual app lives in
+:mod:`ouroboros.config_tui.app` and is imported lazily by the launcher.
+"""

--- a/src/ouroboros/config_tui/__main__.py
+++ b/src/ouroboros/config_tui/__main__.py
@@ -1,0 +1,10 @@
+"""Run the settings app directly: ``python -m ouroboros.config_tui``.
+
+This entry point is what the web mode serves (textual-serve runs it as a
+subprocess), and it doubles as a debugging convenience.
+"""
+
+from ouroboros.config_tui.app import SettingsApp
+
+if __name__ == "__main__":
+    SettingsApp().run()

--- a/src/ouroboros/config_tui/app.py
+++ b/src/ouroboros/config_tui/app.py
@@ -81,13 +81,48 @@ class SettingsApp(App[None]):
 
     CSS = """
     #settings-body { padding: 1 2; }
-    .section-title { text-style: bold; margin: 1 0 0 0; }
-    .stage-card { border: round $primary; padding: 0 1; margin: 1 0 0 0; }
+    #config-path { color: $text-muted; text-style: italic; margin: 0 0 1 0; }
+
+    .section-title { text-style: bold; color: $accent; margin: 1 0 0 0; }
+
+    /* Left-to-right stage row: one card per pipeline stage (#1411 mockup). */
+    #stage-row {
+        layout: grid;
+        grid-size: 4;
+        grid-gutter: 0 1;
+        height: auto;
+        margin: 1 0 0 0;
+    }
+    .stage-card { border: round $primary; padding: 0 1; height: auto; }
+    .stage-card:focus-within { border: round $accent; }
+    .stage-title { text-style: bold; color: $accent; }
+    .field-label { color: $text-muted; margin: 1 0 0 0; }
+
+    /* Global selects share one horizontal band under the stage row. */
+    #global-row {
+        layout: grid;
+        grid-size: 2;
+        grid-gutter: 0 1;
+        height: auto;
+        margin: 1 0 0 0;
+    }
+    .global-cell { border: round $secondary; padding: 0 1; height: auto; }
+
+    #action-bar { layout: horizontal; height: auto; margin: 1 0 0 0; }
+    #status-bar { width: 1fr; margin: 0 0 0 2; content-align: left middle; }
+
     .env-warning { color: $warning; }
     .install-warning { color: $error; }
     .hidden { display: none; }
-    #status-bar { margin: 1 0 0 0; }
     """
+
+    # Terminal-safe stage glyphs for the card headers.
+    _STAGE_GLYPHS = {
+        Stage.INTERVIEW: "✎",
+        Stage.EXECUTE: "⚙",
+        Stage.EVALUATE: "✓",
+        Stage.REFLECT: "↻",
+    }
 
     BINDINGS = [
         ("ctrl+s", "save", "Save"),
@@ -142,31 +177,37 @@ class SettingsApp(App[None]):
         yield Header()
         with VerticalScroll(id="settings-body"):
             yield Static(
-                f"Editing {get_config_dir() / 'config.yaml'} — Ctrl+S to save",
+                f"∞  {get_config_dir() / 'config.yaml'} — Ctrl+S to save",
                 id="config-path",
             )
 
-            yield Static("Global", classes="section-title")
-            yield from self._compose_select_field(
-                GLOBAL_RUNTIME_FIELD,
-                options=self._runtime_options(include_inherit=False),
-                value=_canonical_backend(self._current(GLOBAL_RUNTIME_FIELD.key)),
-                select_id="global-runtime",
+            yield Static(
+                "Stages — interview → execute → evaluate → reflect", classes="section-title"
             )
-            yield from self._compose_select_field(
-                GLOBAL_LLM_BACKEND_FIELD,
-                options=[(name, name) for name in llm_backend_choices()],
-                value=_canonical_backend(self._current(GLOBAL_LLM_BACKEND_FIELD.key)),
-                select_id="global-llm-backend",
-            )
+            with Container(id="stage-row"):
+                for stage in Stage:
+                    yield from self._compose_stage_card(stage)
 
-            yield Static("Stages", classes="section-title")
-            for stage in Stage:
-                yield from self._compose_stage_card(stage)
+            yield Static("Global", classes="section-title")
+            with Container(id="global-row"):
+                with Container(classes="global-cell"):
+                    yield from self._compose_select_field(
+                        GLOBAL_RUNTIME_FIELD,
+                        options=self._runtime_options(include_inherit=False),
+                        value=_canonical_backend(self._current(GLOBAL_RUNTIME_FIELD.key)),
+                        select_id="global-runtime",
+                    )
+                with Container(classes="global-cell"):
+                    yield from self._compose_select_field(
+                        GLOBAL_LLM_BACKEND_FIELD,
+                        options=[(name, name) for name in llm_backend_choices()],
+                        value=_canonical_backend(self._current(GLOBAL_LLM_BACKEND_FIELD.key)),
+                        select_id="global-llm-backend",
+                    )
 
             with Collapsible(title="Advanced models", collapsed=True):
                 for field in ADVANCED_MODEL_FIELDS:
-                    yield Static(field.label)
+                    yield Static(field.label, classes="field-label")
                     warning = _env_warning_text(field)
                     if warning:
                         yield Static(warning, classes="env-warning")
@@ -175,8 +216,9 @@ class SettingsApp(App[None]):
                         id=f"adv-{_slug(field.key)}",
                     )
 
-            yield Button("Save", variant="primary", id="save-button")
-            yield Static("", id="status-bar")
+            with Container(id="action-bar"):
+                yield Button("Save", variant="primary", id="save-button")
+                yield Static("", id="status-bar")
         yield Footer()
 
     def _compose_select_field(
@@ -187,7 +229,7 @@ class SettingsApp(App[None]):
         value: str,
         select_id: str,
     ) -> ComposeResult:
-        yield Static(field.label)
+        yield Static(field.label, classes="field-label")
         warning = _env_warning_text(field)
         if warning:
             yield Static(warning, classes="env-warning")
@@ -207,8 +249,11 @@ class SettingsApp(App[None]):
         current_model = str(self._current(model_field.key) or "")
 
         with Container(classes="stage-card", id=f"stage-card-{stage.value}"):
-            yield Static(stage.value.title(), classes="section-title")
-            yield Static(runtime_field.label)
+            yield Static(
+                f"{self._STAGE_GLYPHS.get(stage, '·')} {stage.value.title()}",
+                classes="stage-title",
+            )
+            yield Static(runtime_field.label, classes="field-label")
             yield Select(
                 self._runtime_options(include_inherit=True),
                 value=str(stage_value) if stage_value else INHERIT_SENTINEL,
@@ -220,7 +265,7 @@ class SettingsApp(App[None]):
                 classes="install-warning hidden",
                 id=f"stage-install-warning-{stage.value}",
             )
-            yield Static(model_field.label)
+            yield Static(model_field.label, classes="field-label")
             warning = _env_warning_text(model_field)
             if warning:
                 yield Static(warning, classes="env-warning")

--- a/src/ouroboros/config_tui/app.py
+++ b/src/ouroboros/config_tui/app.py
@@ -35,6 +35,7 @@ from ouroboros.backends.model_catalog import (
     installed_backends,
     model_choices,
     refresh_models,
+    uses_default_model_sentinel,
 )
 from ouroboros.config._model_defaults import DEFAULT_OPUS_MODEL, DEFAULT_SONNET_MODEL
 from ouroboros.config.models import OuroborosConfig, get_config_dir
@@ -563,6 +564,13 @@ class SettingsApp(App[None]):
             return str(global_value)
         return str(value)
 
+    def _selected_llm_backend(self) -> str:
+        llm_select = self.query_one("#global-llm-backend", Select)
+        value = llm_select.value
+        if _is_blank(value):
+            return _canonical_backend(self._current(GLOBAL_LLM_BACKEND_FIELD.key))
+        return _canonical_backend(value)
+
     def _refresh_stage_model_options(self, stage: Stage) -> None:
         """Repopulate the model select with the effective backend's catalog.
 
@@ -659,7 +667,14 @@ class SettingsApp(App[None]):
                 if custom:
                     record(model_field.key, custom)
             elif not _is_blank(model_value):
-                record(model_field.key, str(model_value))
+                model_text = str(model_value)
+                if model_text == DEFAULT_MODEL_SENTINEL and not uses_default_model_sentinel(
+                    self._selected_llm_backend()
+                ):
+                    if get_value(self._raw, model_field.key) == DEFAULT_MODEL_SENTINEL:
+                        changes[model_field.key] = None
+                    continue
+                record(model_field.key, model_text)
 
         for field in ADVANCED_MODEL_FIELDS:
             raw_value = self.query_one(f"#adv-{_slug(field.key)}", Input).value.strip()

--- a/src/ouroboros/config_tui/app.py
+++ b/src/ouroboros/config_tui/app.py
@@ -144,21 +144,14 @@ class SettingsApp(App[None]):
             value = get_value(self._defaults, key)
         return value
 
-    def _global_runtime_value(self) -> str:
-        """The default agent as currently selected (falling back to config)."""
-        try:
-            global_value = self.query_one("#global-runtime", Select).value
-        except NoMatches:
-            global_value = Select.NULL
-        if _is_blank(global_value):
-            return _canonical_backend(self._current(GLOBAL_RUNTIME_FIELD.key))
-        return str(global_value)
-
     def _runtime_options(self, *, include_inherit: bool) -> list[tuple[str, str]]:
+        # Option labels must stay static: Textual's Select does not re-render
+        # the selected label after set_options when the value is unchanged, so
+        # dynamic text (the resolved default) lives in the per-card caption
+        # (#stage-resolved-*) instead.
         options: list[tuple[str, str]] = []
         if include_inherit:
-            # Show the resolved default inline so "(inherit)" is concrete.
-            options.append((f"(inherit — {self._global_runtime_value()})", INHERIT_SENTINEL))
+            options.append(("(inherit default)", INHERIT_SENTINEL))
         for name in runtime_backend_choices():
             if self._installed.get(name):
                 options.append((name, name))
@@ -283,6 +276,11 @@ class SettingsApp(App[None]):
                 id=f"stage-runtime-{stage.value}",
             )
             yield Static(
+                f"→ runs on {effective_backend}",
+                classes="field-help",
+                id=f"stage-resolved-{stage.value}",
+            )
+            yield Static(
                 "",
                 classes="install-warning hidden",
                 id=f"stage-install-warning-{stage.value}",
@@ -318,22 +316,32 @@ class SettingsApp(App[None]):
         select_id = event.select.id or ""
         if select_id.startswith("stage-runtime-"):
             stage = Stage(select_id.removeprefix("stage-runtime-"))
+            self._update_resolved_caption(stage)
             self._refresh_stage_model_options(stage)
             self._refresh_install_warning(stage, event.value)
         elif select_id == "global-runtime":
+            # Cascade: every inheriting card re-resolves its agent and pulls
+            # the matching model catalog. Guard per card so one failure
+            # cannot skip the rest.
             for stage in Stage:
-                runtime_select = self.query_one(f"#stage-runtime-{stage.value}", Select)
-                current = runtime_select.value
-                # Rebuild so the "(inherit — <agent>)" label tracks the new default.
-                runtime_select.set_options(self._runtime_options(include_inherit=True))
-                if not _is_blank(current):
-                    runtime_select.value = current
-                if runtime_select.value == INHERIT_SENTINEL:
-                    self._refresh_stage_model_options(stage)
+                try:
+                    self._sync_stage_card(stage)
+                except NoMatches:
+                    continue
         elif select_id.startswith("stage-model-"):
             stage_name = select_id.removeprefix("stage-model-")
             custom_input = self.query_one(f"#stage-model-custom-{stage_name}", Input)
             custom_input.set_class(event.value != CUSTOM_SENTINEL, "hidden")
+
+    def _sync_stage_card(self, stage: Stage) -> None:
+        runtime_select = self.query_one(f"#stage-runtime-{stage.value}", Select)
+        self._update_resolved_caption(stage)
+        if runtime_select.value == INHERIT_SENTINEL:
+            self._refresh_stage_model_options(stage)
+
+    def _update_resolved_caption(self, stage: Stage) -> None:
+        caption = self.query_one(f"#stage-resolved-{stage.value}", Static)
+        caption.update(f"→ runs on {self._selected_runtime(stage)}")
 
     def _selected_runtime(self, stage: Stage) -> str:
         runtime_select = self.query_one(f"#stage-runtime-{stage.value}", Select)
@@ -347,14 +355,28 @@ class SettingsApp(App[None]):
         return str(value)
 
     def _refresh_stage_model_options(self, stage: Stage) -> None:
+        """Repopulate the model select with the effective backend's catalog.
+
+        The value *follows* the backend: a model the new backend cannot run
+        is replaced by that backend's catalog default rather than carried
+        over (the user changed the agent; the old model id is stale).
+        """
         backend = self._selected_runtime(stage)
         model_select = self.query_one(f"#stage-model-{stage.value}", Select)
         current = model_select.value
         current_str = None if _is_blank(current) else str(current)
-        options = self._model_options(backend, current_str)
+        try:
+            known = list(model_choices(backend))
+        except ValueError:
+            known = []
+        options = [(model, model) for model in known]
+        options.append(("Custom…", CUSTOM_SENTINEL))
         model_select.set_options(options)
-        if current_str and any(value == current_str for _, value in options):
+        if current_str and current_str in known:
             model_select.value = current_str
+        elif known:
+            model_select.value = known[0]
+        # Custom-only backends (no known models) stay blank for free text.
 
     def _refresh_install_warning(self, stage: Stage, value: Any) -> None:
         warning = self.query_one(f"#stage-install-warning-{stage.value}", Static)

--- a/src/ouroboros/config_tui/app.py
+++ b/src/ouroboros/config_tui/app.py
@@ -98,15 +98,16 @@ class SettingsApp(App[None]):
     .stage-title { text-style: bold; color: $accent; }
     .field-label { color: $text-muted; margin: 1 0 0 0; }
 
-    /* Global selects share one horizontal band under the stage row. */
+    /* Defaults band above the stage row. */
     #global-row {
         layout: grid;
-        grid-size: 2;
+        grid-size: 1;
         grid-gutter: 0 1;
         height: auto;
         margin: 1 0 0 0;
     }
     .global-cell { border: round $secondary; padding: 0 1; height: auto; }
+    .field-help { color: $text-muted; text-style: italic; margin: 0 0 1 0; }
 
     #action-bar { layout: horizontal; height: auto; margin: 1 0 0 0; }
     #status-bar { width: 1fr; margin: 0 0 0 2; content-align: left middle; }
@@ -143,10 +144,21 @@ class SettingsApp(App[None]):
             value = get_value(self._defaults, key)
         return value
 
+    def _global_runtime_value(self) -> str:
+        """The default agent as currently selected (falling back to config)."""
+        try:
+            global_value = self.query_one("#global-runtime", Select).value
+        except NoMatches:
+            global_value = Select.NULL
+        if _is_blank(global_value):
+            return _canonical_backend(self._current(GLOBAL_RUNTIME_FIELD.key))
+        return str(global_value)
+
     def _runtime_options(self, *, include_inherit: bool) -> list[tuple[str, str]]:
         options: list[tuple[str, str]] = []
         if include_inherit:
-            options.append(("(inherit default)", INHERIT_SENTINEL))
+            # Show the resolved default inline so "(inherit)" is concrete.
+            options.append((f"(inherit — {self._global_runtime_value()})", INHERIT_SENTINEL))
         for name in runtime_backend_choices():
             if self._installed.get(name):
                 options.append((name, name))
@@ -181,14 +193,7 @@ class SettingsApp(App[None]):
                 id="config-path",
             )
 
-            yield Static(
-                "Stages — interview → execute → evaluate → reflect", classes="section-title"
-            )
-            with Container(id="stage-row"):
-                for stage in Stage:
-                    yield from self._compose_stage_card(stage)
-
-            yield Static("Global", classes="section-title")
+            yield Static("Defaults", classes="section-title")
             with Container(id="global-row"):
                 with Container(classes="global-cell"):
                     yield from self._compose_select_field(
@@ -197,15 +202,32 @@ class SettingsApp(App[None]):
                         value=_canonical_backend(self._current(GLOBAL_RUNTIME_FIELD.key)),
                         select_id="global-runtime",
                     )
-                with Container(classes="global-cell"):
-                    yield from self._compose_select_field(
-                        GLOBAL_LLM_BACKEND_FIELD,
-                        options=[(name, name) for name in llm_backend_choices()],
-                        value=_canonical_backend(self._current(GLOBAL_LLM_BACKEND_FIELD.key)),
-                        select_id="global-llm-backend",
+                    yield Static(
+                        "The coding agent that runs your work. Every stage below "
+                        "inherits this unless you override it.",
+                        classes="field-help",
                     )
 
-            with Collapsible(title="Advanced models", collapsed=True):
+            yield Static(
+                "Per-stage overrides — interview → execute → evaluate → reflect",
+                classes="section-title",
+            )
+            with Container(id="stage-row"):
+                for stage in Stage:
+                    yield from self._compose_stage_card(stage)
+
+            with Collapsible(title="Advanced", collapsed=True):
+                yield from self._compose_select_field(
+                    GLOBAL_LLM_BACKEND_FIELD,
+                    options=[(name, name) for name in llm_backend_choices()],
+                    value=_canonical_backend(self._current(GLOBAL_LLM_BACKEND_FIELD.key)),
+                    select_id="global-llm-backend",
+                )
+                yield Static(
+                    "Engine for Ouroboros' own internal LLM calls (QA verdicts, "
+                    "semantic evaluation) — usually the same as the default agent.",
+                    classes="field-help",
+                )
                 for field in ADVANCED_MODEL_FIELDS:
                     yield Static(field.label, classes="field-label")
                     warning = _env_warning_text(field)
@@ -301,6 +323,11 @@ class SettingsApp(App[None]):
         elif select_id == "global-runtime":
             for stage in Stage:
                 runtime_select = self.query_one(f"#stage-runtime-{stage.value}", Select)
+                current = runtime_select.value
+                # Rebuild so the "(inherit — <agent>)" label tracks the new default.
+                runtime_select.set_options(self._runtime_options(include_inherit=True))
+                if not _is_blank(current):
+                    runtime_select.value = current
                 if runtime_select.value == INHERIT_SENTINEL:
                     self._refresh_stage_model_options(stage)
         elif select_id.startswith("stage-model-"):

--- a/src/ouroboros/config_tui/app.py
+++ b/src/ouroboros/config_tui/app.py
@@ -687,9 +687,7 @@ class SettingsApp(App[None]):
     def _save_summary(changes: dict[str, Any], old_values: dict[str, Any]) -> str:
         """Render what changed (old → new) and flag keys needing an MCP reconnect."""
         diffs = []
-        ordered = sorted(
-            changes, key=lambda k: (not k.startswith(_RECONNECT_KEY_PREFIXES), k)
-        )
+        ordered = sorted(changes, key=lambda k: (not k.startswith(_RECONNECT_KEY_PREFIXES), k))
         for key in ordered:
             old = old_values.get(key)
             old_text = "unset" if old is None else str(old)

--- a/src/ouroboros/config_tui/app.py
+++ b/src/ouroboros/config_tui/app.py
@@ -1,0 +1,359 @@
+"""Textual settings app for Ouroboros configuration (#1413).
+
+Standalone by design: this module imports Textual and the pure helpers in
+this package, never :mod:`ouroboros.tui` — the import-isolation contract
+that lets ourocode embed the settings screen without the monitor TUI.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual.app import App, ComposeResult
+from textual.containers import Container, VerticalScroll
+from textual.css.query import NoMatches
+from textual.widgets import (
+    Button,
+    Collapsible,
+    Footer,
+    Header,
+    Input,
+    Select,
+    Static,
+)
+
+from ouroboros.backends import resolve_backend_alias, runtime_backend_choices
+from ouroboros.backends.capabilities import llm_backend_choices
+from ouroboros.backends.model_catalog import installed_backends, model_choices
+from ouroboros.config.models import OuroborosConfig, get_config_dir
+from ouroboros.config_tui import persistence
+from ouroboros.config_tui.fields import (
+    ADVANCED_MODEL_FIELDS,
+    GLOBAL_LLM_BACKEND_FIELD,
+    GLOBAL_RUNTIME_FIELD,
+    STAGE_MODEL_FIELDS,
+    SettingField,
+    active_env_overrides,
+    get_value,
+    stage_runtime_field,
+)
+from ouroboros.orchestrator_stage import Stage
+
+INHERIT_SENTINEL = "__inherit__"
+CUSTOM_SENTINEL = "__custom__"
+
+INSTALL_REQUIRED_SUFFIX = "install required"
+
+# Textual's no-selection sentinel compares by identity only; isinstance is
+# the robust blank check across widget interactions.
+_NO_SELECTION = type(Select.NULL)
+
+
+def _is_blank(value: Any) -> bool:
+    return isinstance(value, _NO_SELECTION)
+
+
+def _slug(key: str) -> str:
+    return key.replace(".", "-").replace("_", "-")
+
+
+def _canonical_backend(value: Any) -> str:
+    """Resolve backend aliases (e.g. ``claude_code`` → ``claude``) for display."""
+    candidate = str(value or "")
+    try:
+        return resolve_backend_alias(candidate)
+    except ValueError:
+        return candidate
+
+
+def _env_warning_text(field: SettingField) -> str | None:
+    overrides = active_env_overrides(field)
+    if not overrides:
+        return None
+    names = ", ".join(overrides)
+    return f"⚠ overridden by {names} — saved value takes effect only after unsetting it"
+
+
+class SettingsApp(App[None]):
+    """Mouse-friendly editor for ``~/.ouroboros/config.yaml``."""
+
+    TITLE = "Ouroboros Settings"
+
+    CSS = """
+    #settings-body { padding: 1 2; }
+    .section-title { text-style: bold; margin: 1 0 0 0; }
+    .stage-card { border: round $primary; padding: 0 1; margin: 1 0 0 0; }
+    .env-warning { color: $warning; }
+    .install-warning { color: $error; }
+    .hidden { display: none; }
+    #status-bar { margin: 1 0 0 0; }
+    """
+
+    BINDINGS = [
+        ("ctrl+s", "save", "Save"),
+        ("q", "quit", "Quit"),
+    ]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._raw = persistence.load_raw_config()
+        self._defaults: dict[str, Any] = OuroborosConfig().model_dump(mode="json")
+        self._installed: dict[str, str | None] = installed_backends()
+
+    # ── value helpers ────────────────────────────────────────────────
+
+    def _current(self, key: str) -> Any:
+        value = get_value(self._raw, key)
+        if value is None:
+            value = get_value(self._defaults, key)
+        return value
+
+    def _runtime_options(self, *, include_inherit: bool) -> list[tuple[str, str]]:
+        options: list[tuple[str, str]] = []
+        if include_inherit:
+            options.append(("(inherit default)", INHERIT_SENTINEL))
+        for name in runtime_backend_choices():
+            if self._installed.get(name):
+                options.append((name, name))
+            else:
+                options.append((f"{name} — ⚠ {INSTALL_REQUIRED_SUFFIX}", name))
+        return options
+
+    def _model_options(self, backend: str, current: str | None) -> list[tuple[str, str]]:
+        try:
+            known = list(model_choices(backend))
+        except ValueError:
+            known = []
+        if current and current not in known:
+            known.insert(0, current)
+        options = [(model, model) for model in known]
+        options.append(("Custom…", CUSTOM_SENTINEL))
+        return options
+
+    def _effective_stage_backend(self, stage: Stage) -> str:
+        stage_value = get_value(self._raw, f"orchestrator.runtime_profile.stages.{stage.value}")
+        profile_default = get_value(self._raw, "orchestrator.runtime_profile.default")
+        fallback = self._current("orchestrator.runtime_backend")
+        return str(stage_value or profile_default or fallback)
+
+    # ── compose ──────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        with VerticalScroll(id="settings-body"):
+            yield Static(
+                f"Editing {get_config_dir() / 'config.yaml'} — Ctrl+S to save",
+                id="config-path",
+            )
+
+            yield Static("Global", classes="section-title")
+            yield from self._compose_select_field(
+                GLOBAL_RUNTIME_FIELD,
+                options=self._runtime_options(include_inherit=False),
+                value=_canonical_backend(self._current(GLOBAL_RUNTIME_FIELD.key)),
+                select_id="global-runtime",
+            )
+            yield from self._compose_select_field(
+                GLOBAL_LLM_BACKEND_FIELD,
+                options=[(name, name) for name in llm_backend_choices()],
+                value=_canonical_backend(self._current(GLOBAL_LLM_BACKEND_FIELD.key)),
+                select_id="global-llm-backend",
+            )
+
+            yield Static("Stages", classes="section-title")
+            for stage in Stage:
+                yield from self._compose_stage_card(stage)
+
+            with Collapsible(title="Advanced models", collapsed=True):
+                for field in ADVANCED_MODEL_FIELDS:
+                    yield Static(field.label)
+                    warning = _env_warning_text(field)
+                    if warning:
+                        yield Static(warning, classes="env-warning")
+                    yield Input(
+                        value=str(self._current(field.key) or ""),
+                        id=f"adv-{_slug(field.key)}",
+                    )
+
+            yield Button("Save", variant="primary", id="save-button")
+            yield Static("", id="status-bar")
+        yield Footer()
+
+    def _compose_select_field(
+        self,
+        field: SettingField,
+        *,
+        options: list[tuple[str, str]],
+        value: str,
+        select_id: str,
+    ) -> ComposeResult:
+        yield Static(field.label)
+        warning = _env_warning_text(field)
+        if warning:
+            yield Static(warning, classes="env-warning")
+        values = {option_value for _, option_value in options}
+        yield Select(
+            options,
+            value=value if value in values else Select.NULL,
+            allow_blank=True,
+            id=select_id,
+        )
+
+    def _compose_stage_card(self, stage: Stage) -> ComposeResult:
+        runtime_field = stage_runtime_field(stage)
+        model_field = STAGE_MODEL_FIELDS[stage]
+        stage_value = get_value(self._raw, runtime_field.key)
+        effective_backend = self._effective_stage_backend(stage)
+        current_model = str(self._current(model_field.key) or "")
+
+        with Container(classes="stage-card", id=f"stage-card-{stage.value}"):
+            yield Static(stage.value.title(), classes="section-title")
+            yield Static(runtime_field.label)
+            yield Select(
+                self._runtime_options(include_inherit=True),
+                value=str(stage_value) if stage_value else INHERIT_SENTINEL,
+                allow_blank=False,
+                id=f"stage-runtime-{stage.value}",
+            )
+            yield Static(
+                "",
+                classes="install-warning hidden",
+                id=f"stage-install-warning-{stage.value}",
+            )
+            yield Static(model_field.label)
+            warning = _env_warning_text(model_field)
+            if warning:
+                yield Static(warning, classes="env-warning")
+            yield Select(
+                self._model_options(effective_backend, current_model),
+                value=current_model if current_model else Select.NULL,
+                allow_blank=True,
+                id=f"stage-model-{stage.value}",
+            )
+            yield Input(
+                placeholder="custom model id",
+                classes="hidden",
+                id=f"stage-model-custom-{stage.value}",
+            )
+
+    # ── events ───────────────────────────────────────────────────────
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        # Selects post an initial Changed while the screen is still composing,
+        # before later-composed sibling widgets exist. Those events carry no
+        # user intent; the NoMatches guard skips them.
+        try:
+            self._handle_select_changed(event)
+        except NoMatches:
+            return
+
+    def _handle_select_changed(self, event: Select.Changed) -> None:
+        select_id = event.select.id or ""
+        if select_id.startswith("stage-runtime-"):
+            stage = Stage(select_id.removeprefix("stage-runtime-"))
+            self._refresh_stage_model_options(stage)
+            self._refresh_install_warning(stage, event.value)
+        elif select_id == "global-runtime":
+            for stage in Stage:
+                runtime_select = self.query_one(f"#stage-runtime-{stage.value}", Select)
+                if runtime_select.value == INHERIT_SENTINEL:
+                    self._refresh_stage_model_options(stage)
+        elif select_id.startswith("stage-model-"):
+            stage_name = select_id.removeprefix("stage-model-")
+            custom_input = self.query_one(f"#stage-model-custom-{stage_name}", Input)
+            custom_input.set_class(event.value != CUSTOM_SENTINEL, "hidden")
+
+    def _selected_runtime(self, stage: Stage) -> str:
+        runtime_select = self.query_one(f"#stage-runtime-{stage.value}", Select)
+        value = runtime_select.value
+        if value == INHERIT_SENTINEL or _is_blank(value):
+            global_select = self.query_one("#global-runtime", Select)
+            global_value = global_select.value
+            if _is_blank(global_value):
+                return str(self._current("orchestrator.runtime_backend"))
+            return str(global_value)
+        return str(value)
+
+    def _refresh_stage_model_options(self, stage: Stage) -> None:
+        backend = self._selected_runtime(stage)
+        model_select = self.query_one(f"#stage-model-{stage.value}", Select)
+        current = model_select.value
+        current_str = None if _is_blank(current) else str(current)
+        options = self._model_options(backend, current_str)
+        model_select.set_options(options)
+        if current_str and any(value == current_str for _, value in options):
+            model_select.value = current_str
+
+    def _refresh_install_warning(self, stage: Stage, value: Any) -> None:
+        warning = self.query_one(f"#stage-install-warning-{stage.value}", Static)
+        backend = None if value == INHERIT_SENTINEL or _is_blank(value) else str(value)
+        if backend and not self._installed.get(backend):
+            warning.update(f"⚠ {backend} CLI not installed — {INSTALL_REQUIRED_SUFFIX}")
+            warning.set_class(False, "hidden")
+        else:
+            warning.set_class(True, "hidden")
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        if event.button.id == "save-button":
+            self.action_save()
+
+    # ── save ─────────────────────────────────────────────────────────
+
+    def _collect_changes(self) -> dict[str, Any]:
+        changes: dict[str, Any] = {}
+
+        def record(key: str, new_value: Any) -> None:
+            if new_value != get_value(self._raw, key) and not (
+                get_value(self._raw, key) is None and new_value == get_value(self._defaults, key)
+            ):
+                changes[key] = new_value
+
+        global_runtime = self.query_one("#global-runtime", Select).value
+        if not _is_blank(global_runtime):
+            record(GLOBAL_RUNTIME_FIELD.key, str(global_runtime))
+        llm_backend = self.query_one("#global-llm-backend", Select).value
+        if not _is_blank(llm_backend):
+            record(GLOBAL_LLM_BACKEND_FIELD.key, str(llm_backend))
+
+        for stage in Stage:
+            runtime_field = stage_runtime_field(stage)
+            runtime_value = self.query_one(f"#stage-runtime-{stage.value}", Select).value
+            if runtime_value == INHERIT_SENTINEL:
+                if get_value(self._raw, runtime_field.key) is not None:
+                    changes[runtime_field.key] = None
+            elif not _is_blank(runtime_value):
+                record(runtime_field.key, str(runtime_value))
+
+            model_field = STAGE_MODEL_FIELDS[stage]
+            model_value = self.query_one(f"#stage-model-{stage.value}", Select).value
+            if model_value == CUSTOM_SENTINEL:
+                custom = self.query_one(f"#stage-model-custom-{stage.value}", Input).value.strip()
+                if custom:
+                    record(model_field.key, custom)
+            elif not _is_blank(model_value):
+                record(model_field.key, str(model_value))
+
+        for field in ADVANCED_MODEL_FIELDS:
+            raw_value = self.query_one(f"#adv-{_slug(field.key)}", Input).value.strip()
+            if raw_value:
+                record(field.key, raw_value)
+
+        return changes
+
+    def action_save(self) -> None:
+        status = self.query_one("#status-bar", Static)
+        changes = self._collect_changes()
+        if not changes:
+            status.update("No changes to save.")
+            return
+        try:
+            persistence.apply_config_values(changes)
+        except persistence.ConfigWriteError as exc:
+            status.update(f"[red]Save failed:[/red] {exc}")
+            return
+        self._raw = persistence.load_raw_config()
+        summary = ", ".join(sorted(changes))
+        status.update(f"[green]Saved:[/green] {summary}")
+
+
+__all__ = ["CUSTOM_SENTINEL", "INHERIT_SENTINEL", "INSTALL_REQUIRED_SUFFIX", "SettingsApp"]

--- a/src/ouroboros/config_tui/app.py
+++ b/src/ouroboros/config_tui/app.py
@@ -31,10 +31,12 @@ from ouroboros.backends.capabilities import llm_backend_choices
 from ouroboros.backends.model_catalog import (
     DEFAULT_MODEL_SENTINEL,
     configured_default_model,
+    get_model_catalog,
     installed_backends,
     model_choices,
     refresh_models,
 )
+from ouroboros.config._model_defaults import DEFAULT_OPUS_MODEL, DEFAULT_SONNET_MODEL
 from ouroboros.config.models import OuroborosConfig, get_config_dir
 from ouroboros.config_tui import persistence
 from ouroboros.config_tui.fields import (
@@ -58,6 +60,18 @@ INSTALL_REQUIRED_SUFFIX = "install required"
 # Above this many fetched models, the select offers a search modal instead
 # of inlining the whole listing (opencode reports ~400 ids).
 SEARCH_THRESHOLD = 20
+
+# One-click model presets: per-backend picks, falling back to the backend's
+# catalog default where no differentiated tier exists (sentinel backends).
+PRESET_MODELS: dict[str, dict[str, str]] = {
+    "frugal": {"claude": "claude-haiku-4-5-20251001", "codex": "gpt-5-mini"},
+    "balanced": {"claude": DEFAULT_SONNET_MODEL, "codex": "gpt-5"},
+    "frontier": {"claude": DEFAULT_OPUS_MODEL, "codex": "gpt-5-codex"},
+}
+
+# Saving these keys only takes effect for a running MCP server after a
+# reconnect (#1376 friction log) — surface that instead of failing silently.
+_RECONNECT_KEY_PREFIXES = ("orchestrator.runtime", "llm.backend")
 
 # Cap the rows rendered in the search modal while filtering.
 _SEARCH_MAX_ROWS = 200
@@ -184,6 +198,10 @@ class SettingsApp(App[None]):
     }
     .global-cell { border: round $secondary; padding: 0 1; height: auto; }
     .field-help { color: $text-muted; text-style: italic; margin: 0 0 1 0; }
+
+    #preset-row { layout: horizontal; height: auto; margin: 1 0 0 0; }
+    #preset-row Button { margin: 0 1 0 0; min-width: 14; }
+    #preset-help { margin: 1 0 0 1; width: 1fr; }
 
     #action-bar { layout: horizontal; height: auto; margin: 1 0 0 0; }
     #status-bar { width: 1fr; margin: 0 0 0 2; content-align: left middle; }
@@ -361,6 +379,15 @@ class SettingsApp(App[None]):
                 "Per-stage overrides — interview → execute → evaluate → reflect",
                 classes="section-title",
             )
+            with Container(id="preset-row"):
+                yield Button("⚡ Frugal", id="preset-frugal")
+                yield Button("⚖ Balanced", id="preset-balanced")
+                yield Button("🚀 Frontier", id="preset-frontier")
+                yield Static(
+                    "one-click models for every stage — review, then Save",
+                    classes="field-help",
+                    id="preset-help",
+                )
             with Container(id="stage-row"):
                 for stage in Stage:
                     yield from self._compose_stage_card(stage)
@@ -568,8 +595,28 @@ class SettingsApp(App[None]):
             warning.set_class(True, "hidden")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "save-button":
+        button_id = event.button.id or ""
+        if button_id == "save-button":
             self.action_save()
+        elif button_id.startswith("preset-"):
+            self._apply_preset(button_id.removeprefix("preset-"))
+
+    def _apply_preset(self, level: str) -> None:
+        """Stage a one-click model preset across all stage cards (not saved yet)."""
+        picks = PRESET_MODELS.get(level)
+        if picks is None:
+            return
+        for stage in Stage:
+            try:
+                backend = self._selected_runtime(stage)
+                model = picks.get(backend)
+                if model is None:
+                    model = get_model_catalog(backend).default_model
+                self._set_stage_model(stage, model)
+            except (NoMatches, ValueError):
+                continue
+        status = self.query_one("#status-bar", Static)
+        status.update(f"Preset [bold]{level}[/bold] staged — review the cards, then Save.")
 
     # ── save ─────────────────────────────────────────────────────────
 
@@ -582,12 +629,19 @@ class SettingsApp(App[None]):
             ):
                 changes[key] = new_value
 
+        def record_backend(key: str, new_value: str) -> None:
+            old = get_value(self._raw, key) or get_value(self._defaults, key)
+            # claude_code → claude is the same backend; alias-only diffs are noise.
+            if _canonical_backend(old) == _canonical_backend(new_value):
+                return
+            record(key, new_value)
+
         global_runtime = self.query_one("#global-runtime", Select).value
         if not _is_blank(global_runtime):
-            record(GLOBAL_RUNTIME_FIELD.key, str(global_runtime))
+            record_backend(GLOBAL_RUNTIME_FIELD.key, str(global_runtime))
         llm_backend = self.query_one("#global-llm-backend", Select).value
         if not _is_blank(llm_backend):
-            record(GLOBAL_LLM_BACKEND_FIELD.key, str(llm_backend))
+            record_backend(GLOBAL_LLM_BACKEND_FIELD.key, str(llm_backend))
 
         for stage in Stage:
             runtime_field = stage_runtime_field(stage)
@@ -620,14 +674,38 @@ class SettingsApp(App[None]):
         if not changes:
             status.update("No changes to save.")
             return
+        old_values = {key: get_value(self._raw, key) for key in changes}
         try:
             persistence.apply_config_values(changes)
         except persistence.ConfigWriteError as exc:
             status.update(f"[red]Save failed:[/red] {exc}")
             return
         self._raw = persistence.load_raw_config()
-        summary = ", ".join(sorted(changes))
-        status.update(f"[green]Saved:[/green] {summary}")
+        status.update(self._save_summary(changes, old_values))
+
+    @staticmethod
+    def _save_summary(changes: dict[str, Any], old_values: dict[str, Any]) -> str:
+        """Render what changed (old → new) and flag keys needing an MCP reconnect."""
+        diffs = []
+        ordered = sorted(
+            changes, key=lambda k: (not k.startswith(_RECONNECT_KEY_PREFIXES), k)
+        )
+        for key in ordered:
+            old = old_values.get(key)
+            old_text = "unset" if old is None else str(old)
+            new_text = "unset" if changes[key] is None else str(changes[key])
+            short_key = key.rsplit(".", 1)[-1] if key.count(".") > 1 else key
+            diffs.append(f"{short_key}: {old_text} → {new_text}")
+        shown = "; ".join(diffs[:4])
+        if len(diffs) > 4:
+            shown += f"; … +{len(diffs) - 4} more"
+        summary = f"[green]Saved.[/green] {shown}"
+        if any(key.startswith(_RECONNECT_KEY_PREFIXES) for key in changes):
+            summary += (
+                "\n[yellow]⚠ backend changes apply to new sessions — "
+                "reconnect the MCP server to pick them up now.[/yellow]"
+            )
+        return summary
 
 
 __all__ = ["CUSTOM_SENTINEL", "INHERIT_SENTINEL", "INSTALL_REQUIRED_SUFFIX", "SettingsApp"]

--- a/src/ouroboros/config_tui/app.py
+++ b/src/ouroboros/config_tui/app.py
@@ -28,7 +28,13 @@ from textual.widgets.option_list import Option
 
 from ouroboros.backends import resolve_backend_alias, runtime_backend_choices
 from ouroboros.backends.capabilities import llm_backend_choices
-from ouroboros.backends.model_catalog import installed_backends, model_choices, refresh_models
+from ouroboros.backends.model_catalog import (
+    DEFAULT_MODEL_SENTINEL,
+    configured_default_model,
+    installed_backends,
+    model_choices,
+    refresh_models,
+)
 from ouroboros.config.models import OuroborosConfig, get_config_dir
 from ouroboros.config_tui import persistence
 from ouroboros.config_tui.fields import (
@@ -212,6 +218,9 @@ class SettingsApp(App[None]):
         self._fetch_pending: set[str] = set()
         # Last concrete model per stage, restored when a search is cancelled.
         self._last_model_value: dict[str, str | None] = {}
+        # What the "default" sentinel resolves to per backend (config-file
+        # hint, e.g. hermes → gpt-5.5). Cached: file reads once per backend.
+        self._default_hints: dict[str, str | None] = {}
 
     def on_mount(self) -> None:
         # Config-derived (not widget-derived): widgets may still be mounting.
@@ -268,11 +277,20 @@ class SettingsApp(App[None]):
             known = self._static_models(backend)
         if current and current not in known:
             known.insert(0, current)
-        options = [(model, model) for model in known]
+        options = [(self._model_label(backend, model), model) for model in known]
         if len(fetched) > SEARCH_THRESHOLD:
             options.append((f"Search {len(fetched)} models…", SEARCH_SENTINEL))
         options.append(("Custom…", CUSTOM_SENTINEL))
         return options
+
+    def _model_label(self, backend: str, model: str) -> str:
+        """Make the 'default' sentinel concrete: 'default — currently <model>'."""
+        if model != DEFAULT_MODEL_SENTINEL:
+            return model
+        if backend not in self._default_hints:
+            self._default_hints[backend] = configured_default_model(backend)
+        hint = self._default_hints[backend]
+        return f"default — currently {hint}" if hint else model
 
     # ── dynamic model listings ───────────────────────────────────────
 

--- a/src/ouroboros/config_tui/app.py
+++ b/src/ouroboros/config_tui/app.py
@@ -9,22 +9,26 @@ from __future__ import annotations
 
 from typing import Any
 
+from textual import work
 from textual.app import App, ComposeResult
 from textual.containers import Container, VerticalScroll
 from textual.css.query import NoMatches
+from textual.screen import ModalScreen
 from textual.widgets import (
     Button,
     Collapsible,
     Footer,
     Header,
     Input,
+    OptionList,
     Select,
     Static,
 )
+from textual.widgets.option_list import Option
 
 from ouroboros.backends import resolve_backend_alias, runtime_backend_choices
 from ouroboros.backends.capabilities import llm_backend_choices
-from ouroboros.backends.model_catalog import installed_backends, model_choices
+from ouroboros.backends.model_catalog import installed_backends, model_choices, refresh_models
 from ouroboros.config.models import OuroborosConfig, get_config_dir
 from ouroboros.config_tui import persistence
 from ouroboros.config_tui.fields import (
@@ -41,8 +45,16 @@ from ouroboros.orchestrator_stage import Stage
 
 INHERIT_SENTINEL = "__inherit__"
 CUSTOM_SENTINEL = "__custom__"
+SEARCH_SENTINEL = "__search__"
 
 INSTALL_REQUIRED_SUFFIX = "install required"
+
+# Above this many fetched models, the select offers a search modal instead
+# of inlining the whole listing (opencode reports ~400 ids).
+SEARCH_THRESHOLD = 20
+
+# Cap the rows rendered in the search modal while filtering.
+_SEARCH_MAX_ROWS = 200
 
 # Textual's no-selection sentinel compares by identity only; isinstance is
 # the robust blank check across widget interactions.
@@ -72,6 +84,64 @@ def _env_warning_text(field: SettingField) -> str | None:
         return None
     names = ", ".join(overrides)
     return f"⚠ overridden by {names} — saved value takes effect only after unsetting it"
+
+
+class ModelSearchScreen(ModalScreen[str | None]):
+    """Type-to-filter picker for large model listings."""
+
+    BINDINGS = [("escape", "cancel", "Close")]
+
+    CSS = """
+    ModelSearchScreen { align: center middle; }
+    #search-dialog {
+        width: 70%;
+        max-width: 90;
+        height: 70%;
+        border: round $accent;
+        background: $surface;
+        padding: 1 2;
+    }
+    #search-title { text-style: bold; color: $accent; }
+    #search-input { margin: 1 0; }
+    #search-results { height: 1fr; }
+    """
+
+    def __init__(self, models: tuple[str, ...], *, title: str) -> None:
+        super().__init__()
+        self._models = models
+        self._title = title
+
+    def compose(self) -> ComposeResult:
+        with Container(id="search-dialog"):
+            yield Static(self._title, id="search-title")
+            yield Input(placeholder="Type to filter…", id="search-input")
+            yield OptionList(id="search-results")
+
+    def on_mount(self) -> None:
+        self._apply_filter("")
+        self.query_one("#search-input", Input).focus()
+
+    def _apply_filter(self, needle: str) -> None:
+        needle = needle.strip().lower()
+        matches = [model for model in self._models if needle in model.lower()]
+        results = self.query_one("#search-results", OptionList)
+        results.clear_options()
+        results.add_options(Option(model, id=None) for model in matches[:_SEARCH_MAX_ROWS])
+        overflow = len(matches) - _SEARCH_MAX_ROWS
+        if overflow > 0:
+            results.add_options(
+                [Option(f"… {overflow} more — keep typing to narrow down", disabled=True)]
+            )
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if (event.input.id or "") == "search-input":
+            self._apply_filter(event.value)
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        self.dismiss(str(event.option.prompt))
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
 
 
 class SettingsApp(App[None]):
@@ -135,6 +205,18 @@ class SettingsApp(App[None]):
         self._raw = persistence.load_raw_config()
         self._defaults: dict[str, Any] = OuroborosConfig().model_dump(mode="json")
         self._installed: dict[str, str | None] = installed_backends()
+        # Dynamic model listings fetched from backend CLIs (None = attempted,
+        # nothing usable). Fetches run in background threads so the UI never
+        # blocks on a slow CLI.
+        self._fetched_models: dict[str, tuple[str, ...] | None] = {}
+        self._fetch_pending: set[str] = set()
+        # Last concrete model per stage, restored when a search is cancelled.
+        self._last_model_value: dict[str, str | None] = {}
+
+    def on_mount(self) -> None:
+        # Config-derived (not widget-derived): widgets may still be mounting.
+        for backend in {self._effective_stage_backend(stage) for stage in Stage}:
+            self._request_model_listing(backend)
 
     # ── value helpers ────────────────────────────────────────────────
 
@@ -159,16 +241,72 @@ class SettingsApp(App[None]):
                 options.append((f"{name} — ⚠ {INSTALL_REQUIRED_SUFFIX}", name))
         return options
 
-    def _model_options(self, backend: str, current: str | None) -> list[tuple[str, str]]:
+    def _static_models(self, backend: str) -> list[str]:
         try:
-            known = list(model_choices(backend))
+            return list(model_choices(backend))
         except ValueError:
-            known = []
+            return []
+
+    def _all_models(self, backend: str) -> list[str]:
+        """Static catalog merged with the full CLI-fetched listing."""
+        known = self._static_models(backend)
+        fetched = self._fetched_models.get(backend) or ()
+        known.extend(model for model in fetched if model not in known)
+        return known
+
+    def _model_options(self, backend: str, current: str | None) -> list[tuple[str, str]]:
+        """Select options for a backend.
+
+        Small fetched listings merge inline; large ones (e.g. opencode's
+        ~400 ids) stay behind a "Search…" entry that opens a filter modal,
+        keeping the dropdown scannable.
+        """
+        fetched = self._fetched_models.get(backend) or ()
+        if len(fetched) <= SEARCH_THRESHOLD:
+            known = self._all_models(backend)
+        else:
+            known = self._static_models(backend)
         if current and current not in known:
             known.insert(0, current)
         options = [(model, model) for model in known]
+        if len(fetched) > SEARCH_THRESHOLD:
+            options.append((f"Search {len(fetched)} models…", SEARCH_SENTINEL))
         options.append(("Custom…", CUSTOM_SENTINEL))
         return options
+
+    # ── dynamic model listings ───────────────────────────────────────
+
+    def _request_model_listing(self, backend: str) -> None:
+        """Fetch the backend CLI's model listing once, in the background."""
+        if backend in self._fetched_models or backend in self._fetch_pending:
+            return
+        self._fetch_pending.add(backend)
+        self._fetch_models_worker(backend)
+
+    @work(thread=True, exclusive=False)
+    def _fetch_models_worker(self, backend: str) -> None:
+        models = refresh_models(backend)
+        self.call_from_thread(self._on_models_fetched, backend, models)
+
+    def _on_models_fetched(self, backend: str, models: tuple[str, ...] | None) -> None:
+        self._fetch_pending.discard(backend)
+        self._fetched_models[backend] = models
+        if not models:
+            return
+        for stage in Stage:
+            try:
+                if self._selected_runtime(stage) == backend:
+                    self._merge_fetched_into_stage(stage, backend)
+            except NoMatches:
+                continue
+
+    def _merge_fetched_into_stage(self, stage: Stage, backend: str) -> None:
+        model_select = self.query_one(f"#stage-model-{stage.value}", Select)
+        current = model_select.value
+        current_str = None if _is_blank(current) else str(current)
+        model_select.set_options(self._model_options(backend, current_str))
+        if current_str:
+            model_select.value = current_str
 
     def _effective_stage_backend(self, stage: Stage) -> str:
         stage_value = get_value(self._raw, f"orchestrator.runtime_profile.stages.{stage.value}")
@@ -328,10 +466,36 @@ class SettingsApp(App[None]):
                     self._sync_stage_card(stage)
                 except NoMatches:
                     continue
-        elif select_id.startswith("stage-model-"):
-            stage_name = select_id.removeprefix("stage-model-")
-            custom_input = self.query_one(f"#stage-model-custom-{stage_name}", Input)
+        elif select_id.startswith("stage-model-") and not select_id.startswith(
+            "stage-model-custom-"
+        ):
+            stage = Stage(select_id.removeprefix("stage-model-"))
+            custom_input = self.query_one(f"#stage-model-custom-{stage.value}", Input)
             custom_input.set_class(event.value != CUSTOM_SENTINEL, "hidden")
+            if event.value == SEARCH_SENTINEL:
+                self._open_model_search(stage)
+            elif not _is_blank(event.value) and event.value != CUSTOM_SENTINEL:
+                self._last_model_value[stage.value] = str(event.value)
+
+    def _open_model_search(self, stage: Stage) -> None:
+        backend = self._selected_runtime(stage)
+        models = tuple(self._all_models(backend))
+
+        def _picked(model: str | None) -> None:
+            previous = self._last_model_value.get(stage.value)
+            self._set_stage_model(stage, model or previous)
+
+        self.push_screen(
+            ModelSearchScreen(models, title=f"{stage.value.title()} model — {backend}"),
+            _picked,
+        )
+
+    def _set_stage_model(self, stage: Stage, model: str | None) -> None:
+        backend = self._selected_runtime(stage)
+        model_select = self.query_one(f"#stage-model-{stage.value}", Select)
+        model_select.set_options(self._model_options(backend, model))
+        if model:
+            model_select.value = model
 
     def _sync_stage_card(self, stage: Stage) -> None:
         runtime_select = self.query_one(f"#stage-runtime-{stage.value}", Select)
@@ -362,20 +526,18 @@ class SettingsApp(App[None]):
         over (the user changed the agent; the old model id is stale).
         """
         backend = self._selected_runtime(stage)
+        self._request_model_listing(backend)
         model_select = self.query_one(f"#stage-model-{stage.value}", Select)
         current = model_select.value
         current_str = None if _is_blank(current) else str(current)
-        try:
-            known = list(model_choices(backend))
-        except ValueError:
-            known = []
-        options = [(model, model) for model in known]
-        options.append(("Custom…", CUSTOM_SENTINEL))
+        keep = current_str if current_str and current_str in self._all_models(backend) else None
+        options = self._model_options(backend, keep)
         model_select.set_options(options)
-        if current_str and current_str in known:
-            model_select.value = current_str
-        elif known:
-            model_select.value = known[0]
+        concrete = [v for _, v in options if v not in (SEARCH_SENTINEL, CUSTOM_SENTINEL)]
+        if keep:
+            model_select.value = keep
+        elif concrete:
+            model_select.value = concrete[0]
         # Custom-only backends (no known models) stay blank for free text.
 
     def _refresh_install_warning(self, stage: Stage, value: Any) -> None:

--- a/src/ouroboros/config_tui/app.py
+++ b/src/ouroboros/config_tui/app.py
@@ -7,6 +7,7 @@ that lets ourocode embed the settings screen without the monitor TUI.
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 from textual import work
@@ -50,7 +51,7 @@ from ouroboros.config_tui.fields import (
     get_value,
     stage_runtime_field,
 )
-from ouroboros.orchestrator_stage import Stage
+from ouroboros.orchestrator_stage import Stage, resolve_runtime_for_stage
 
 INHERIT_SENTINEL = "__inherit__"
 CUSTOM_SENTINEL = "__custom__"
@@ -311,6 +312,28 @@ class SettingsApp(App[None]):
         hint = self._default_hints[backend]
         return f"default — currently {hint}" if hint else model
 
+    def _runtime_env_override(self) -> str | None:
+        for name in GLOBAL_RUNTIME_FIELD.env_vars:
+            value = os.environ.get(name, "").strip()
+            if value:
+                return _canonical_backend(value)
+        return None
+
+    def _effective_default_runtime(self) -> str:
+        return self._runtime_env_override() or _canonical_backend(
+            self._current(GLOBAL_RUNTIME_FIELD.key)
+        )
+
+    def _selected_default_runtime(self) -> str:
+        override = self._runtime_env_override()
+        if override:
+            return override
+        global_select = self.query_one("#global-runtime", Select)
+        global_value = global_select.value
+        if _is_blank(global_value):
+            return self._effective_default_runtime()
+        return _canonical_backend(global_value)
+
     # ── dynamic model listings ───────────────────────────────────────
 
     def _request_model_listing(self, backend: str) -> None:
@@ -348,8 +371,14 @@ class SettingsApp(App[None]):
     def _effective_stage_backend(self, stage: Stage) -> str:
         stage_value = get_value(self._raw, f"orchestrator.runtime_profile.stages.{stage.value}")
         profile_default = get_value(self._raw, "orchestrator.runtime_profile.default")
-        fallback = self._current("orchestrator.runtime_backend")
-        return str(stage_value or profile_default or fallback)
+        stages = {stage: _canonical_backend(stage_value)} if stage_value else None
+        default = _canonical_backend(profile_default) if profile_default else None
+        return resolve_runtime_for_stage(
+            stage,
+            stages=stages,
+            default=default,
+            fallback=self._effective_default_runtime(),
+        )
 
     # ── compose ──────────────────────────────────────────────────────
 
@@ -557,12 +586,15 @@ class SettingsApp(App[None]):
         runtime_select = self.query_one(f"#stage-runtime-{stage.value}", Select)
         value = runtime_select.value
         if value == INHERIT_SENTINEL or _is_blank(value):
-            global_select = self.query_one("#global-runtime", Select)
-            global_value = global_select.value
-            if _is_blank(global_value):
-                return str(self._current("orchestrator.runtime_backend"))
-            return str(global_value)
-        return str(value)
+            profile_default = get_value(self._raw, "orchestrator.runtime_profile.default")
+            default = _canonical_backend(profile_default) if profile_default else None
+            return resolve_runtime_for_stage(
+                stage,
+                stages=None,
+                default=default,
+                fallback=self._selected_default_runtime(),
+            )
+        return _canonical_backend(value)
 
     def _selected_llm_backend(self) -> str:
         llm_select = self.query_one("#global-llm-backend", Select)

--- a/src/ouroboros/config_tui/fields.py
+++ b/src/ouroboros/config_tui/fields.py
@@ -41,13 +41,13 @@ class SettingField:
 
 GLOBAL_RUNTIME_FIELD = SettingField(
     key="orchestrator.runtime_backend",
-    label="Default runtime",
+    label="Default agent (runtime)",
     env_vars=_RUNTIME_ENV_VARS,
 )
 
 GLOBAL_LLM_BACKEND_FIELD = SettingField(
     key="llm.backend",
-    label="LLM backend",
+    label="LLM backend (internal calls)",
     env_vars=("OUROBOROS_LLM_BACKEND",),
 )
 
@@ -56,7 +56,7 @@ def stage_runtime_field(stage: Stage) -> SettingField:
     """Per-stage runtime select (writes ``orchestrator.runtime_profile.stages.<stage>``)."""
     return SettingField(
         key=f"orchestrator.runtime_profile.stages.{stage.value}",
-        label=f"{stage.value.title()} runtime",
+        label="Agent",
         stage=stage.value,
     )
 

--- a/src/ouroboros/config_tui/fields.py
+++ b/src/ouroboros/config_tui/fields.py
@@ -1,0 +1,149 @@
+"""Field schema for the settings GUI — pure logic, no Textual imports.
+
+Defines which config keys the settings app surfaces, their friendly labels,
+and which environment variables override each key's effective value (so the
+UI can warn that a saved value will not take effect — the silent-failure
+mode reported in discussion #1376 / RFC issue #1395).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+from typing import Any
+
+from ouroboros.orchestrator_stage import Stage
+
+# Env vars that force the global runtime selection (loader precedence:
+# env → config.yaml). Explicit runtime_profile.stages entries are NOT
+# overridden by these (they only replace the fallback), so stage selects
+# carry no env_vars.
+_RUNTIME_ENV_VARS = ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_RUNTIME")
+
+
+@dataclass(frozen=True, slots=True)
+class SettingField:
+    """One configurable key surfaced by the settings UI.
+
+    Attributes:
+        key: Dot-notation config key (the ``config set`` surface).
+        label: Friendly UI label.
+        env_vars: Environment variables whose presence overrides the
+            effective value of this key at load time.
+        stage: Stage name when the field belongs to a stage card.
+    """
+
+    key: str
+    label: str
+    env_vars: tuple[str, ...] = ()
+    stage: str | None = None
+
+
+GLOBAL_RUNTIME_FIELD = SettingField(
+    key="orchestrator.runtime_backend",
+    label="Default runtime",
+    env_vars=_RUNTIME_ENV_VARS,
+)
+
+GLOBAL_LLM_BACKEND_FIELD = SettingField(
+    key="llm.backend",
+    label="LLM backend",
+    env_vars=("OUROBOROS_LLM_BACKEND",),
+)
+
+
+def stage_runtime_field(stage: Stage) -> SettingField:
+    """Per-stage runtime select (writes ``orchestrator.runtime_profile.stages.<stage>``)."""
+    return SettingField(
+        key=f"orchestrator.runtime_profile.stages.{stage.value}",
+        label=f"{stage.value.title()} runtime",
+        stage=stage.value,
+    )
+
+
+# Friendly per-stage model bindings. "seed" is not a separate stage: it
+# shares clarification config with interview (see Stage docstring).
+STAGE_MODEL_FIELDS: dict[Stage, SettingField] = {
+    Stage.INTERVIEW: SettingField(
+        key="clarification.default_model",
+        label="Interview & Seed model",
+        env_vars=("OUROBOROS_CLARIFICATION_MODEL",),
+        stage=Stage.INTERVIEW.value,
+    ),
+    Stage.EXECUTE: SettingField(
+        key="execution.double_diamond_model",
+        label="Execution model",
+        env_vars=("OUROBOROS_DOUBLE_DIAMOND_MODEL",),
+        stage=Stage.EXECUTE.value,
+    ),
+    Stage.EVALUATE: SettingField(
+        key="evaluation.semantic_model",
+        label="Evaluation model",
+        env_vars=("OUROBOROS_SEMANTIC_MODEL",),
+        stage=Stage.EVALUATE.value,
+    ),
+    Stage.REFLECT: SettingField(
+        key="resilience.reflect_model",
+        label="Reflect model",
+        env_vars=("OUROBOROS_REFLECT_MODEL",),
+        stage=Stage.REFLECT.value,
+    ),
+}
+
+ADVANCED_MODEL_FIELDS: tuple[SettingField, ...] = (
+    SettingField("llm.qa_model", "QA model", ("OUROBOROS_QA_MODEL",)),
+    SettingField(
+        "llm.dependency_analysis_model",
+        "Dependency analysis model",
+        ("OUROBOROS_DEPENDENCY_ANALYSIS_MODEL",),
+    ),
+    SettingField(
+        "llm.ontology_analysis_model",
+        "Ontology analysis model",
+        ("OUROBOROS_ONTOLOGY_ANALYSIS_MODEL",),
+    ),
+    SettingField(
+        "llm.context_compression_model",
+        "Context compression model",
+        ("OUROBOROS_CONTEXT_COMPRESSION_MODEL",),
+    ),
+    SettingField("execution.atomicity_model", "Atomicity model", ("OUROBOROS_ATOMICITY_MODEL",)),
+    SettingField(
+        "execution.decomposition_model",
+        "Decomposition model",
+        ("OUROBOROS_DECOMPOSITION_MODEL",),
+    ),
+    SettingField("resilience.wonder_model", "Wonder model", ("OUROBOROS_WONDER_MODEL",)),
+    SettingField(
+        "evaluation.assertion_extraction_model",
+        "Assertion extraction model",
+        ("OUROBOROS_ASSERTION_EXTRACTION_MODEL",),
+    ),
+)
+
+
+def active_env_overrides(field: SettingField) -> tuple[str, ...]:
+    """Names of this field's override env vars that are currently set (non-empty)."""
+    return tuple(name for name in field.env_vars if os.environ.get(name, "").strip())
+
+
+def get_value(data: dict[str, Any], key: str) -> Any:
+    """Read a dot-notation key from a raw config dict (``None`` when absent)."""
+    node: Any = data
+    for part in key.split("."):
+        if not isinstance(node, dict):
+            return None
+        node = node.get(part)
+    return node
+
+
+__all__ = [
+    "ADVANCED_MODEL_FIELDS",
+    "GLOBAL_LLM_BACKEND_FIELD",
+    "GLOBAL_RUNTIME_FIELD",
+    "STAGE_MODEL_FIELDS",
+    "SettingField",
+    "active_env_overrides",
+    "get_value",
+    "stage_runtime_field",
+]

--- a/src/ouroboros/config_tui/launcher.py
+++ b/src/ouroboros/config_tui/launcher.py
@@ -41,10 +41,40 @@ def is_harness_context() -> bool:
     return not sys.stdout.isatty()
 
 
-def launch_settings() -> None:
-    """Launch the settings GUI in the mode that fits the environment."""
-    if is_harness_context():
-        _launch_web()
+def is_remote_session() -> bool:
+    """True when this process runs on a machine the user is not sitting at.
+
+    Covers SSH sessions and headless gateways (e.g. hermes driven from
+    Discord on another box): opening a browser *here* would open it on the
+    wrong machine, so web mode must print a reachable URL instead.
+    """
+    return bool(
+        os.environ.get("SSH_CONNECTION", "").strip() or os.environ.get("SSH_TTY", "").strip()
+    )
+
+
+def launch_settings(
+    *,
+    force_web: bool = False,
+    host: str = "localhost",
+    port: int | None = None,
+    open_browser: bool | None = None,
+) -> None:
+    """Launch the settings GUI in the mode that fits the environment.
+
+    Args:
+        force_web: Skip TTY detection and serve over HTTP (for remote/agent
+            hosts where no local screen exists).
+        host: Bind address for web mode. Use ``0.0.0.0`` to reach the GUI
+            from another machine (e.g. when the agent runs on a server).
+        port: Fixed port for web mode; ``None`` picks a free one.
+        open_browser: Override browser auto-open. ``None`` = open only when
+            this is not a remote session.
+    """
+    if force_web or is_harness_context():
+        if open_browser is None:
+            open_browser = not is_remote_session()
+        _launch_web(host=host, port=port, open_browser=open_browser)
     else:
         _launch_inline()
 
@@ -73,25 +103,41 @@ def _import_server() -> type | None:
     return Server
 
 
-def _launch_web(*, open_browser: bool = True) -> None:
+def _launch_web(
+    *,
+    host: str = "localhost",
+    port: int | None = None,
+    open_browser: bool = True,
+) -> None:
     server_cls = _import_server()
     if server_cls is None:
         print_error(_TUI_INSTALL_HINT)
         print_info("Manual fallback: run [bold]uv run ouroboros config[/] in a regular terminal.")
         raise SystemExit(1)
 
-    port = _free_port()
-    url = f"http://localhost:{port}"
-    print_info(
-        f"Serving Ouroboros Settings at [bold]{url}[/] — opening your browser.\n"
-        "Press Ctrl+C to stop."
-    )
+    if port is None:
+        port = _free_port()
+    display_host = "localhost" if host in ("localhost", "127.0.0.1", "0.0.0.0") else host
+    url = f"http://{display_host}:{port}"
     if open_browser:
+        print_info(
+            f"Serving Ouroboros Settings at [bold]{url}[/] — opening your browser.\n"
+            "Press Ctrl+C to stop."
+        )
         # serve() blocks; open the browser once the server has had a beat to bind.
         threading.Timer(1.0, webbrowser.open, args=(url,)).start()
+    else:
+        # Remote/agent host: a browser opened *here* would be on the wrong
+        # machine. Hand the user a reachable URL instead.
+        print_info(
+            f"Serving Ouroboros Settings at [bold]{url}[/] (no browser on this host).\n"
+            "From your own machine, open the URL directly, or tunnel first:\n"
+            f"  ssh -L {port}:localhost:{port} <this-host>\n"
+            "Press Ctrl+C to stop."
+        )
     command = f"{sys.executable} -m ouroboros.config_tui"
-    server = server_cls(command, host="localhost", port=port, title="Ouroboros Settings")
+    server = server_cls(command, host=host, port=port, title="Ouroboros Settings")
     server.serve()
 
 
-__all__ = ["is_harness_context", "launch_settings"]
+__all__ = ["is_harness_context", "is_remote_session", "launch_settings"]

--- a/src/ouroboros/config_tui/launcher.py
+++ b/src/ouroboros/config_tui/launcher.py
@@ -1,0 +1,97 @@
+"""Environment-aware launch dispatch for the settings GUI (#1414).
+
+A bare ``ouroboros config`` cannot host a full-screen TUI everywhere it is
+typed. In a real terminal the Textual app runs in-place; inside an AI
+harness session (Claude Code / Codex), the Bash tool captures output and
+owns the screen, so the same app is served over a local web server
+(textual-serve) and the browser is opened instead. Browser *cockpit*
+dashboards remain ourocode territory per the transparency RFC (#1392) —
+this web mode is a thin transport for the identical settings app, not a
+separate web UI.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+import threading
+import webbrowser
+
+from ouroboros.cli.formatters.panels import print_error, print_info
+
+# Note the escaped brackets: rich would otherwise treat [tui] as a markup tag.
+_TUI_INSTALL_HINT = (
+    "Settings GUI dependencies not installed.\n\n"
+    "Install with:\n"
+    "  pip install 'ouroboros-ai\\[tui]'\n\n"
+    "Or run directly with uvx:\n"
+    "  uvx --from 'ouroboros-ai\\[tui]' ouroboros config"
+)
+
+
+def is_harness_context() -> bool:
+    """True when running inside an AI harness (or any non-interactive stdout).
+
+    ``CLAUDECODE=1`` is exported by Claude Code to its child processes; a
+    non-TTY stdout covers Codex-style harnesses and pipes generally.
+    """
+    if os.environ.get("CLAUDECODE", "").strip():
+        return True
+    return not sys.stdout.isatty()
+
+
+def launch_settings() -> None:
+    """Launch the settings GUI in the mode that fits the environment."""
+    if is_harness_context():
+        _launch_web()
+    else:
+        _launch_inline()
+
+
+def _launch_inline() -> None:
+    try:
+        from ouroboros.config_tui.app import SettingsApp
+    except ImportError:
+        print_error(_TUI_INSTALL_HINT)
+        raise SystemExit(1) from None
+    SettingsApp().run()
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _import_server() -> type | None:
+    """Import textual-serve's Server, or ``None`` when the extra is missing."""
+    try:
+        from textual_serve.server import Server
+    except ImportError:
+        return None
+    return Server
+
+
+def _launch_web(*, open_browser: bool = True) -> None:
+    server_cls = _import_server()
+    if server_cls is None:
+        print_error(_TUI_INSTALL_HINT)
+        print_info("Manual fallback: run [bold]uv run ouroboros config[/] in a regular terminal.")
+        raise SystemExit(1)
+
+    port = _free_port()
+    url = f"http://localhost:{port}"
+    print_info(
+        f"Serving Ouroboros Settings at [bold]{url}[/] — opening your browser.\n"
+        "Press Ctrl+C to stop."
+    )
+    if open_browser:
+        # serve() blocks; open the browser once the server has had a beat to bind.
+        threading.Timer(1.0, webbrowser.open, args=(url,)).start()
+    command = f"{sys.executable} -m ouroboros.config_tui"
+    server = server_cls(command, host="localhost", port=port, title="Ouroboros Settings")
+    server.serve()
+
+
+__all__ = ["is_harness_context", "launch_settings"]

--- a/src/ouroboros/config_tui/persistence.py
+++ b/src/ouroboros/config_tui/persistence.py
@@ -70,6 +70,9 @@ def apply_config_values(values: Mapping[str, Any]) -> None:
             target[keys[-1]] = value
 
     config_path.parent.mkdir(parents=True, exist_ok=True)
+    if original_text is not None:
+        # One-step undo support: `ouroboros config undo` swaps this back in.
+        (config_path.parent / "config.yaml.bak").write_text(original_text)
     config_path.write_text(yaml.dump(data, default_flow_style=False, sort_keys=False))
 
     try:

--- a/src/ouroboros/config_tui/persistence.py
+++ b/src/ouroboros/config_tui/persistence.py
@@ -1,0 +1,88 @@
+"""Validated batch writes for the settings GUI.
+
+Writes go through the exact contract `ouroboros config set` enforces: the
+schema key-path validator is shared (imported from the CLI command module,
+not duplicated), the YAML serialization options match ``_save_config``, and
+the post-write ``load_config()`` check rolls the whole batch back on any
+Pydantic validation failure — the settings app never becomes a second,
+unvalidated write path to ``~/.ouroboros/config.yaml``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import yaml
+
+from ouroboros.config.models import get_config_dir
+
+
+class ConfigWriteError(Exception):
+    """A settings write was rejected; the file was left (or rolled back) unmodified."""
+
+
+def load_raw_config() -> dict[str, Any]:
+    """Read ``config.yaml`` as a plain dict (empty when the file is missing)."""
+    config_path = get_config_dir() / "config.yaml"
+    if not config_path.exists():
+        return {}
+    data = yaml.safe_load(config_path.read_text()) or {}
+    if not isinstance(data, dict):
+        msg = f"Invalid config format in {config_path} (expected mapping)"
+        raise ConfigWriteError(msg)
+    return data
+
+
+def apply_config_values(values: Mapping[str, Any]) -> None:
+    """Apply dot-notation ``{key: value}`` updates atomically.
+
+    A ``None`` value deletes the key (used to clear a per-stage runtime
+    override back to "inherit"). Raises :class:`ConfigWriteError` on an
+    unknown key or when the resulting config fails schema validation; in
+    the latter case the previous file content is restored byte-for-byte.
+    """
+    if not values:
+        return
+
+    # Shared with `config set` — the single schema-aware key validator.
+    from ouroboros.cli.commands.config import _validate_key_path
+
+    config_path = get_config_dir() / "config.yaml"
+    original_text = config_path.read_text() if config_path.exists() else None
+    data = load_raw_config()
+
+    for key, value in values.items():
+        keys = key.split(".")
+        error = _validate_key_path(keys)
+        if error:
+            raise ConfigWriteError(error)
+        target = data
+        for part in keys[:-1]:
+            node = target.setdefault(part, {})
+            if not isinstance(node, dict):
+                msg = f"Cannot set nested key: {key} ({part!r} is not a section)"
+                raise ConfigWriteError(msg)
+            target = node
+        if value is None:
+            target.pop(keys[-1], None)
+        else:
+            target[keys[-1]] = value
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(yaml.dump(data, default_flow_style=False, sort_keys=False))
+
+    try:
+        from ouroboros.config.loader import load_config
+
+        load_config()
+    except Exception as exc:
+        if original_text is None:
+            config_path.unlink(missing_ok=True)
+        else:
+            config_path.write_text(original_text)
+        msg = f"Invalid value — rolled back. {exc}"
+        raise ConfigWriteError(msg) from exc
+
+
+__all__ = ["ConfigWriteError", "apply_config_values", "load_raw_config"]

--- a/tests/unit/backends/test_model_catalog.py
+++ b/tests/unit/backends/test_model_catalog.py
@@ -128,3 +128,36 @@ def test_installed_backends_covers_all_runtime_backends(monkeypatch) -> None:
     monkeypatch.setattr(mc, "detect_backend_cli", lambda name: f"/bin/{name}")
     result = mc.installed_backends()
     assert set(result) == set(runtime_backend_choices())
+
+
+def test_configured_default_model_hermes(monkeypatch, tmp_path) -> None:
+    (tmp_path / ".hermes").mkdir()
+    (tmp_path / ".hermes" / "config.yaml").write_text(
+        "model:\n  default: gpt-9-hermes\n  provider: openai-codex\n"
+    )
+    monkeypatch.setattr(mc.Path, "home", classmethod(lambda _cls: tmp_path))
+    assert mc.configured_default_model("hermes") == "gpt-9-hermes"
+
+
+def test_configured_default_model_codex(monkeypatch, tmp_path) -> None:
+    (tmp_path / ".codex").mkdir()
+    (tmp_path / ".codex" / "config.toml").write_text('model = "gpt-9-codex"\n')
+    monkeypatch.setattr(mc.Path, "home", classmethod(lambda _cls: tmp_path))
+    assert mc.configured_default_model("codex") == "gpt-9-codex"
+
+
+def test_configured_default_model_missing_file(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr(mc.Path, "home", classmethod(lambda _cls: tmp_path))
+    assert mc.configured_default_model("hermes") is None
+    assert mc.configured_default_model("codex") is None
+
+
+def test_configured_default_model_malformed_never_raises(monkeypatch, tmp_path) -> None:
+    (tmp_path / ".hermes").mkdir()
+    (tmp_path / ".hermes" / "config.yaml").write_text("model: [broken\n")
+    monkeypatch.setattr(mc.Path, "home", classmethod(lambda _cls: tmp_path))
+    assert mc.configured_default_model("hermes") is None
+
+
+def test_configured_default_model_non_sentinel_backend() -> None:
+    assert mc.configured_default_model("claude") is None

--- a/tests/unit/backends/test_model_catalog.py
+++ b/tests/unit/backends/test_model_catalog.py
@@ -1,0 +1,109 @@
+"""Tests for the per-backend model catalog and installed-CLI detection (#1412)."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from ouroboros.backends import model_catalog as mc
+from ouroboros.backends import runtime_backend_choices
+from ouroboros.config._model_defaults import DEFAULT_OPUS_MODEL, DEFAULT_SONNET_MODEL
+from ouroboros.config.loader import _default_model_for_backend
+
+
+@pytest.mark.parametrize("backend", runtime_backend_choices())
+def test_every_runtime_backend_has_catalog_with_models(backend: str) -> None:
+    catalog = mc.get_model_catalog(backend)
+    assert catalog.backend == backend
+    assert len(catalog.models) >= 1
+    assert catalog.default_model == catalog.models[0]
+
+
+@pytest.mark.parametrize("backend", runtime_backend_choices())
+def test_catalog_default_mirrors_loader_backend_mapping(backend: str) -> None:
+    """The static catalog must not drift from the loader's sentinel mapping."""
+    loader_default = _default_model_for_backend(DEFAULT_OPUS_MODEL, backend=backend)
+    assert mc.get_model_catalog(backend).default_model == loader_default
+
+
+def test_claude_catalog_lists_shipped_defaults() -> None:
+    assert mc.model_choices("claude") == (DEFAULT_OPUS_MODEL, DEFAULT_SONNET_MODEL)
+
+
+def test_alias_resolves_to_canonical_catalog() -> None:
+    assert mc.get_model_catalog("claude_code") is mc.get_model_catalog("claude")
+    assert mc.get_model_catalog("codex_cli") is mc.get_model_catalog("codex")
+
+
+def test_litellm_catalog_is_custom_only() -> None:
+    catalog = mc.get_model_catalog("litellm")
+    assert catalog.models == ()
+    assert catalog.default_model == mc.DEFAULT_MODEL_SENTINEL
+
+
+def test_unknown_backend_raises() -> None:
+    with pytest.raises(ValueError, match="No model catalog"):
+        mc.get_model_catalog("not-a-backend")
+
+
+def test_refresh_models_without_list_command_degrades_to_none() -> None:
+    # No backend ships a verified list_command yet (see module docstring).
+    for backend in runtime_backend_choices():
+        assert mc.refresh_models(backend) is None
+
+
+def test_refresh_models_failing_command_degrades_to_none(monkeypatch) -> None:
+    catalog = mc.BackendModelCatalog(backend="claude", models=("m",), list_command=("x",))
+    monkeypatch.setitem(mc._CATALOGS, "claude", catalog)
+
+    def _boom(*args, **kwargs):
+        raise subprocess.SubprocessError("listing failed")
+
+    monkeypatch.setattr(mc.subprocess, "run", _boom)
+    assert mc.refresh_models("claude") is None
+
+
+def test_refresh_models_parses_one_model_per_line(monkeypatch) -> None:
+    catalog = mc.BackendModelCatalog(backend="claude", models=("m",), list_command=("x",))
+    monkeypatch.setitem(mc._CATALOGS, "claude", catalog)
+
+    class _Result:
+        stdout = "model-a\n  model-b  \n\n"
+
+    monkeypatch.setattr(mc.subprocess, "run", lambda *_args, **_kwargs: _Result())
+    assert mc.refresh_models("claude") == ("model-a", "model-b")
+
+
+def test_detect_backend_cli_prefers_configured_path(monkeypatch) -> None:
+    from ouroboros.config import loader as config_loader
+
+    monkeypatch.setattr(config_loader, "get_codex_cli_path", lambda: "/opt/bin/codex")
+    monkeypatch.setattr(mc.shutil, "which", lambda _name: "/usr/bin/should-not-win")
+    assert mc.detect_backend_cli("codex") == "/opt/bin/codex"
+
+
+def test_detect_backend_cli_falls_back_to_path_lookup(monkeypatch) -> None:
+    from ouroboros.config import loader as config_loader
+
+    monkeypatch.setattr(config_loader, "get_hermes_cli_path", lambda: None)
+    monkeypatch.setattr(mc.shutil, "which", lambda _name: "/usr/local/bin/hermes")
+    assert mc.detect_backend_cli("hermes") == "/usr/local/bin/hermes"
+
+
+def test_detect_backend_cli_missing_everywhere_returns_none(monkeypatch) -> None:
+    from ouroboros.config import loader as config_loader
+
+    monkeypatch.setattr(config_loader, "get_pi_cli_path", lambda: None)
+    monkeypatch.setattr(mc.shutil, "which", lambda _name: None)
+    assert mc.detect_backend_cli("pi") is None
+
+
+def test_detect_backend_cli_litellm_has_no_cli() -> None:
+    assert mc.detect_backend_cli("litellm") is None
+
+
+def test_installed_backends_covers_all_runtime_backends(monkeypatch) -> None:
+    monkeypatch.setattr(mc, "detect_backend_cli", lambda name: f"/bin/{name}")
+    result = mc.installed_backends()
+    assert set(result) == set(runtime_backend_choices())

--- a/tests/unit/backends/test_model_catalog.py
+++ b/tests/unit/backends/test_model_catalog.py
@@ -27,8 +27,16 @@ def test_catalog_default_mirrors_loader_backend_mapping(backend: str) -> None:
     assert mc.get_model_catalog(backend).default_model == loader_default
 
 
-def test_claude_catalog_lists_shipped_defaults() -> None:
-    assert mc.model_choices("claude") == (DEFAULT_OPUS_MODEL, DEFAULT_SONNET_MODEL)
+def test_claude_catalog_lists_shipped_defaults_first() -> None:
+    choices = mc.model_choices("claude")
+    assert choices[:2] == (DEFAULT_OPUS_MODEL, DEFAULT_SONNET_MODEL)
+    assert "claude-haiku-4-5-20251001" in choices
+
+
+def test_codex_catalog_offers_known_models_after_sentinel() -> None:
+    choices = mc.model_choices("codex")
+    assert choices[0] == mc.DEFAULT_MODEL_SENTINEL
+    assert "gpt-5-codex" in choices
 
 
 def test_alias_resolves_to_canonical_catalog() -> None:
@@ -47,32 +55,45 @@ def test_unknown_backend_raises() -> None:
         mc.get_model_catalog("not-a-backend")
 
 
-def test_refresh_models_without_list_command_degrades_to_none() -> None:
-    # No backend ships a verified list_command yet (see module docstring).
+def test_refresh_models_without_list_args_degrades_to_none() -> None:
     for backend in runtime_backend_choices():
-        assert mc.refresh_models(backend) is None
+        if mc.get_model_catalog(backend).list_args is None:
+            assert mc.refresh_models(backend) is None
+
+
+def test_opencode_ships_verified_list_args() -> None:
+    assert mc.get_model_catalog("opencode").list_args == ("models",)
+
+
+def test_refresh_models_uninstalled_cli_degrades_to_none(monkeypatch) -> None:
+    monkeypatch.setattr(mc, "detect_backend_cli", lambda _name: None)
+    assert mc.refresh_models("opencode") is None
 
 
 def test_refresh_models_failing_command_degrades_to_none(monkeypatch) -> None:
-    catalog = mc.BackendModelCatalog(backend="claude", models=("m",), list_command=("x",))
-    monkeypatch.setitem(mc._CATALOGS, "claude", catalog)
+    monkeypatch.setattr(mc, "detect_backend_cli", lambda _name: "/bin/opencode")
 
     def _boom(*args, **kwargs):
         raise subprocess.SubprocessError("listing failed")
 
     monkeypatch.setattr(mc.subprocess, "run", _boom)
-    assert mc.refresh_models("claude") is None
+    assert mc.refresh_models("opencode") is None
 
 
 def test_refresh_models_parses_one_model_per_line(monkeypatch) -> None:
-    catalog = mc.BackendModelCatalog(backend="claude", models=("m",), list_command=("x",))
-    monkeypatch.setitem(mc._CATALOGS, "claude", catalog)
+    monkeypatch.setattr(mc, "detect_backend_cli", lambda _name: "/bin/opencode")
+    captured: dict[str, object] = {}
 
     class _Result:
         stdout = "model-a\n  model-b  \n\n"
 
-    monkeypatch.setattr(mc.subprocess, "run", lambda *_args, **_kwargs: _Result())
-    assert mc.refresh_models("claude") == ("model-a", "model-b")
+    def _fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return _Result()
+
+    monkeypatch.setattr(mc.subprocess, "run", _fake_run)
+    assert mc.refresh_models("opencode") == ("model-a", "model-b")
+    assert captured["argv"] == ("/bin/opencode", "models")
 
 
 def test_detect_backend_cli_prefers_configured_path(monkeypatch) -> None:

--- a/tests/unit/backends/test_model_catalog.py
+++ b/tests/unit/backends/test_model_catalog.py
@@ -39,6 +39,13 @@ def test_codex_catalog_offers_known_models_after_sentinel() -> None:
     assert "gpt-5-codex" in choices
 
 
+def test_default_model_sentinel_support_follows_backend_contract() -> None:
+    assert mc.uses_default_model_sentinel("codex") is True
+    assert mc.uses_default_model_sentinel("codex_cli") is True
+    assert mc.uses_default_model_sentinel("claude") is False
+    assert mc.uses_default_model_sentinel("claude_code") is False
+
+
 def test_alias_resolves_to_canonical_catalog() -> None:
     assert mc.get_model_catalog("claude_code") is mc.get_model_catalog("claude")
     assert mc.get_model_catalog("codex_cli") is mc.get_model_catalog("codex")

--- a/tests/unit/cli/commands/test_config_bare_dispatch.py
+++ b/tests/unit/cli/commands/test_config_bare_dispatch.py
@@ -1,0 +1,60 @@
+"""Regression tests for the `ouroboros config` bare-invocation dispatch (#1414).
+
+The bare invocation must launch the settings GUI while every existing
+subcommand keeps its scriptable behavior unchanged.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+import yaml
+
+from ouroboros.cli.commands.config import app
+
+runner = CliRunner()
+
+
+def test_bare_invocation_launches_settings_gui(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "ouroboros.config_tui.launcher.launch_settings", lambda: calls.append("launched")
+    )
+    result = runner.invoke(app, [])
+    assert result.exit_code == 0
+    assert calls == ["launched"]
+
+
+def test_subcommand_does_not_launch_settings_gui(monkeypatch, tmp_path) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "ouroboros.config_tui.launcher.launch_settings", lambda: calls.append("launched")
+    )
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({"orchestrator": {"runtime_backend": "claude"}})
+    )
+    result = runner.invoke(app, ["show"])
+    assert result.exit_code == 0
+    assert calls == []
+
+
+def test_config_show_unchanged(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: tmp_path)
+    (tmp_path / "config.yaml").write_text(yaml.dump({"orchestrator": {"runtime_backend": "codex"}}))
+    result = runner.invoke(app, ["show"])
+    assert result.exit_code == 0
+    assert "codex" in result.output
+
+
+def test_config_set_unknown_key_still_rejected(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: tmp_path)
+    (tmp_path / "config.yaml").write_text(yaml.dump({}))
+    result = runner.invoke(app, ["set", "orchestrator.not_a_key_xyz", "v"])
+    assert result.exit_code == 1
+
+
+def test_config_help_lists_subcommands() -> None:
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    for subcommand in ("show", "set", "backend", "init", "validate"):
+        assert subcommand in result.output

--- a/tests/unit/cli/commands/test_config_bare_dispatch.py
+++ b/tests/unit/cli/commands/test_config_bare_dispatch.py
@@ -17,7 +17,7 @@ runner = CliRunner()
 def test_bare_invocation_launches_settings_gui(monkeypatch) -> None:
     calls: list[str] = []
     monkeypatch.setattr(
-        "ouroboros.config_tui.launcher.launch_settings", lambda: calls.append("launched")
+        "ouroboros.config_tui.launcher.launch_settings", lambda **_kwargs: calls.append("launched")
     )
     result = runner.invoke(app, [])
     assert result.exit_code == 0
@@ -27,7 +27,7 @@ def test_bare_invocation_launches_settings_gui(monkeypatch) -> None:
 def test_subcommand_does_not_launch_settings_gui(monkeypatch, tmp_path) -> None:
     calls: list[str] = []
     monkeypatch.setattr(
-        "ouroboros.config_tui.launcher.launch_settings", lambda: calls.append("launched")
+        "ouroboros.config_tui.launcher.launch_settings", lambda **_kwargs: calls.append("launched")
     )
     monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: tmp_path)
     (tmp_path / "config.yaml").write_text(
@@ -58,3 +58,20 @@ def test_config_help_lists_subcommands() -> None:
     assert result.exit_code == 0
     for subcommand in ("show", "set", "backend", "init", "validate"):
         assert subcommand in result.output
+
+
+def test_bare_invocation_forwards_web_flags(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_launch(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr("ouroboros.config_tui.launcher.launch_settings", _fake_launch)
+    result = runner.invoke(app, ["--web", "--host", "0.0.0.0", "--port", "8765", "--no-browser"])
+    assert result.exit_code == 0
+    assert captured == {
+        "force_web": True,
+        "host": "0.0.0.0",
+        "port": 8765,
+        "open_browser": False,
+    }

--- a/tests/unit/cli/commands/test_config_bare_dispatch.py
+++ b/tests/unit/cli/commands/test_config_bare_dispatch.py
@@ -179,6 +179,33 @@ def test_show_json_emits_machine_readable_effective_view(monkeypatch, tmp_path) 
     assert payload["stages"]["interview"]["agent"] == "opencode"
 
 
+def test_show_json_uses_runtime_env_as_llm_backend_fallback(monkeypatch, tmp_path) -> None:
+    import json
+
+    _show_env(
+        monkeypatch,
+        tmp_path,
+        {
+            "orchestrator": {"runtime_backend": "claude"},
+            "llm": {"backend": "claude_code"},
+        },
+    )
+    monkeypatch.setenv("OUROBOROS_RUNTIME", "codex")
+    monkeypatch.setattr(
+        "ouroboros.backends.model_catalog.installed_backends",
+        lambda: {"codex": "/bin/codex"},
+    )
+
+    result = runner.invoke(app, ["show", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["defaults"]["llm_backend"] == {
+        "value": "codex",
+        "source": "env OUROBOROS_RUNTIME ⚠",
+    }
+
+
 def test_undo_swaps_in_backup_and_supports_redo(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: tmp_path)
     from ouroboros.config import loader as config_loader

--- a/tests/unit/cli/commands/test_config_bare_dispatch.py
+++ b/tests/unit/cli/commands/test_config_bare_dispatch.py
@@ -206,6 +206,29 @@ def test_show_json_uses_runtime_env_as_llm_backend_fallback(monkeypatch, tmp_pat
     }
 
 
+def test_show_text_uses_runtime_env_as_llm_backend_fallback(monkeypatch, tmp_path) -> None:
+    _show_env(
+        monkeypatch,
+        tmp_path,
+        {
+            "orchestrator": {"runtime_backend": "claude"},
+            "llm": {"backend": "claude_code"},
+        },
+    )
+    monkeypatch.setenv("OUROBOROS_RUNTIME", "codex")
+    monkeypatch.setattr(
+        "ouroboros.backends.model_catalog.installed_backends",
+        lambda: {"codex": "/bin/codex"},
+    )
+
+    result = runner.invoke(app, ["show"])
+
+    assert result.exit_code == 0
+    assert "LLM backend" in result.output
+    assert "codex" in result.output
+    assert "OUROBOROS_RUNTIME" in result.output
+
+
 def test_undo_swaps_in_backup_and_supports_redo(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: tmp_path)
     from ouroboros.config import loader as config_loader

--- a/tests/unit/cli/commands/test_config_bare_dispatch.py
+++ b/tests/unit/cli/commands/test_config_bare_dispatch.py
@@ -75,3 +75,72 @@ def test_bare_invocation_forwards_web_flags(monkeypatch) -> None:
         "port": 8765,
         "open_browser": False,
     }
+
+
+def _show_env(monkeypatch, tmp_path, config: dict) -> None:
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: tmp_path)
+    (tmp_path / "config.yaml").write_text(yaml.dump(config))
+    for name in (
+        "OUROBOROS_AGENT_RUNTIME",
+        "OUROBOROS_RUNTIME",
+        "OUROBOROS_LLM_BACKEND",
+        "OUROBOROS_CLARIFICATION_MODEL",
+    ):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_show_effective_view_renders_stages_and_inheritance(monkeypatch, tmp_path) -> None:
+    _show_env(
+        monkeypatch,
+        tmp_path,
+        {
+            "orchestrator": {
+                "runtime_backend": "opencode",
+                "runtime_profile": {"stages": {"execute": "codex"}},
+            },
+            "clarification": {"default_model": "my-model"},
+        },
+    )
+    monkeypatch.setattr(
+        "ouroboros.backends.model_catalog.installed_backends",
+        lambda: {"opencode": "/bin/opencode", "codex": "/bin/codex"},
+    )
+    result = runner.invoke(app, ["show"])
+    assert result.exit_code == 0
+    out = result.output
+    assert "Per-stage overrides" in out
+    assert "(inherit)" in out and "opencode" in out  # inheriting stages resolved
+    assert "codex" in out  # explicit execute override
+    assert "my-model" in out  # configured stage model
+    assert "interview" in out and "reflect" in out
+
+
+def test_show_effective_view_marks_env_override(monkeypatch, tmp_path) -> None:
+    _show_env(monkeypatch, tmp_path, {"orchestrator": {"runtime_backend": "opencode"}})
+    monkeypatch.setattr(
+        "ouroboros.backends.model_catalog.installed_backends",
+        lambda: {"hermes": "/bin/hermes", "opencode": "/bin/opencode"},
+    )
+    monkeypatch.setenv("OUROBOROS_AGENT_RUNTIME", "hermes")
+    result = runner.invoke(app, ["show"])
+    assert result.exit_code == 0
+    assert "hermes" in result.output  # env wins over config
+    assert "OUROBOROS_AGENT_RUNTIME" in result.output  # and the source says so
+
+
+def test_show_effective_view_marks_uninstalled_agent(monkeypatch, tmp_path) -> None:
+    _show_env(monkeypatch, tmp_path, {"orchestrator": {"runtime_backend": "kiro"}})
+    monkeypatch.setattr(
+        "ouroboros.backends.model_catalog.installed_backends",
+        lambda: {"kiro": None},
+    )
+    result = runner.invoke(app, ["show"])
+    assert result.exit_code == 0
+    assert "not installed" in result.output
+
+
+def test_show_section_still_returns_raw_contents(monkeypatch, tmp_path) -> None:
+    _show_env(monkeypatch, tmp_path, {"logging": {"level": "debug"}})
+    result = runner.invoke(app, ["show", "logging"])
+    assert result.exit_code == 0
+    assert "debug" in result.output

--- a/tests/unit/cli/commands/test_config_bare_dispatch.py
+++ b/tests/unit/cli/commands/test_config_bare_dispatch.py
@@ -144,3 +144,86 @@ def test_show_section_still_returns_raw_contents(monkeypatch, tmp_path) -> None:
     result = runner.invoke(app, ["show", "logging"])
     assert result.exit_code == 0
     assert "debug" in result.output
+
+
+def test_show_json_emits_machine_readable_effective_view(monkeypatch, tmp_path) -> None:
+    import json
+
+    _show_env(
+        monkeypatch,
+        tmp_path,
+        {
+            "orchestrator": {
+                "runtime_backend": "opencode",
+                "runtime_profile": {"stages": {"execute": "codex"}},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        "ouroboros.backends.model_catalog.installed_backends",
+        lambda: {"opencode": "/bin/opencode", "codex": "/bin/codex"},
+    )
+    result = runner.invoke(app, ["show", "--json"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["defaults"]["default_agent"]["value"] == "opencode"
+    assert payload["stages"]["execute"] == {
+        "agent": "codex",
+        "inherited": False,
+        "agent_installed": True,
+        "model": payload["stages"]["execute"]["model"],
+        "model_source": payload["stages"]["execute"]["model_source"],
+        "model_key": "execution.double_diamond_model",
+    }
+    assert payload["stages"]["interview"]["inherited"] is True
+    assert payload["stages"]["interview"]["agent"] == "opencode"
+
+
+def test_undo_swaps_in_backup_and_supports_redo(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: tmp_path)
+    from ouroboros.config import loader as config_loader
+
+    monkeypatch.setattr(config_loader, "get_config_dir", lambda: tmp_path)
+    (tmp_path / "config.yaml").write_text(
+        yaml.dump({"orchestrator": {"runtime_backend": "hermes"}})
+    )
+    (tmp_path / "config.yaml.bak").write_text(
+        yaml.dump({"orchestrator": {"runtime_backend": "codex"}})
+    )
+
+    result = runner.invoke(app, ["undo"])
+    assert result.exit_code == 0
+    assert (
+        yaml.safe_load((tmp_path / "config.yaml").read_text())["orchestrator"]["runtime_backend"]
+        == "codex"
+    )
+
+    # undo again = redo
+    result = runner.invoke(app, ["undo"])
+    assert result.exit_code == 0
+    assert (
+        yaml.safe_load((tmp_path / "config.yaml").read_text())["orchestrator"]["runtime_backend"]
+        == "hermes"
+    )
+
+
+def test_undo_without_backup_errors(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: tmp_path)
+    (tmp_path / "config.yaml").write_text(yaml.dump({}))
+    result = runner.invoke(app, ["undo"])
+    assert result.exit_code == 1
+
+
+def test_undo_invalid_backup_aborts_safely(monkeypatch, tmp_path) -> None:
+    monkeypatch.setattr("ouroboros.config.models.get_config_dir", lambda: tmp_path)
+    from ouroboros.config import loader as config_loader
+
+    monkeypatch.setattr(config_loader, "get_config_dir", lambda: tmp_path)
+    good = yaml.dump({"orchestrator": {"runtime_backend": "hermes"}})
+    (tmp_path / "config.yaml").write_text(good)
+    (tmp_path / "config.yaml.bak").write_text(
+        yaml.dump({"orchestrator": {"runtime_backend": "not-a-backend"}})
+    )
+    result = runner.invoke(app, ["undo"])
+    assert result.exit_code == 1
+    assert (tmp_path / "config.yaml").read_text() == good  # untouched

--- a/tests/unit/config_tui/test_app.py
+++ b/tests/unit/config_tui/test_app.py
@@ -344,3 +344,44 @@ async def test_default_sentinel_label_shows_configured_model(app_env) -> None:
         labels = {str(label) for label, _ in model_select._options}
         assert any("default — currently gpt-9-test" in label for label in labels)
         assert model_select.value == "default"  # value stays the sentinel
+
+
+@pytest.mark.asyncio
+async def test_preset_button_stages_models_for_every_card(app_env) -> None:
+    """One click sets a coherent model tier across all stages, respecting
+    each card's effective backend (claude inherit vs explicit codex)."""
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        await pilot.click("#preset-frugal")
+        await pilot.pause()
+        interview_model = pilot.app.query_one(f"#stage-model-{Stage.INTERVIEW.value}", Select)
+        assert interview_model.value == "claude-haiku-4-5-20251001"  # claude frugal
+        execute_model = pilot.app.query_one(f"#stage-model-{Stage.EXECUTE.value}", Select)
+        assert execute_model.value == "gpt-5-mini"  # codex frugal
+        status = pilot.app.query_one("#status-bar", Static)
+        assert "frugal" in str(status.render())
+        assert "Save" in str(status.render())  # staged, not saved
+
+
+@pytest.mark.asyncio
+async def test_save_summary_shows_diff_and_reconnect_hint(app_env, monkeypatch) -> None:
+    monkeypatch.setattr(persistence, "apply_config_values", lambda values: None)
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        pilot.app.query_one("#global-runtime", Select).value = "codex"
+        await pilot.pause()
+        pilot.app.query_one("#save-button").scroll_visible(animate=False)
+        await pilot.pause()
+        await pilot.click("#save-button")
+        await pilot.pause()
+        status = str(pilot.app.query_one("#status-bar", Static).render())
+        assert "claude → codex" in status  # old → new diff
+        assert "reconnect" in status  # backend change needs MCP reconnect
+
+
+def test_save_summary_without_backend_change_has_no_reconnect_hint() -> None:
+    summary = SettingsApp._save_summary(
+        {"clarification.default_model": "m2"}, {"clarification.default_model": "m1"}
+    )
+    assert "m1 → m2" in summary
+    assert "reconnect" not in summary

--- a/tests/unit/config_tui/test_app.py
+++ b/tests/unit/config_tui/test_app.py
@@ -12,13 +12,15 @@ import subprocess
 import sys
 
 import pytest
-from textual.widgets import Input, Select, Static
+from textual.widgets import Input, OptionList, Select, Static
 
 from ouroboros.config_tui import persistence
 from ouroboros.config_tui.app import (
     CUSTOM_SENTINEL,
     INHERIT_SENTINEL,
     INSTALL_REQUIRED_SUFFIX,
+    SEARCH_SENTINEL,
+    ModelSearchScreen,
     SettingsApp,
 )
 from ouroboros.orchestrator_stage import Stage
@@ -40,6 +42,8 @@ def app_env(monkeypatch):
         "ouroboros.config_tui.app.installed_backends",
         lambda: dict(installed),
     )
+    # Never let unit tests shell out to real backend CLIs.
+    monkeypatch.setattr("ouroboros.config_tui.app.refresh_models", lambda _backend: None)
     return raw
 
 
@@ -212,3 +216,110 @@ async def test_explicit_stage_agent_not_affected_by_global_change(app_env) -> No
 
         assert "codex" in str(caption.render())
         assert model_select.value == before_value
+
+
+@pytest.mark.asyncio
+async def test_dynamic_model_listing_merges_into_select(app_env, monkeypatch) -> None:
+    """A verified CLI listing expands the model choices in the background,
+    without displacing the static default or the current selection."""
+
+    def _fake_listing(backend):
+        if backend == "codex":
+            return ("openai/gpt-5.2-codex", "openai/o5-mini")
+        return None
+
+    monkeypatch.setattr("ouroboros.config_tui.app.refresh_models", _fake_listing)
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        stage = Stage.INTERVIEW.value
+        pilot.app.query_one(f"#stage-runtime-{stage}", Select).value = "codex"
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        model_select = pilot.app.query_one(f"#stage-model-{stage}", Select)
+        values = {value for _, value in model_select._options}
+        assert "openai/gpt-5.2-codex" in values  # fetched entries merged
+        assert "default" in values  # static catalog kept first
+        assert model_select.value == "default"  # selection not displaced
+
+
+@pytest.mark.asyncio
+async def test_large_listing_collapses_into_search_option(app_env, monkeypatch) -> None:
+    """Hundreds of fetched models stay behind a 'Search N models…' entry
+    instead of flooding the dropdown."""
+    big = tuple(f"provider/model-{i}" for i in range(300))
+    monkeypatch.setattr(
+        "ouroboros.config_tui.app.refresh_models",
+        lambda backend: big if backend == "codex" else None,
+    )
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        stage = Stage.INTERVIEW.value
+        pilot.app.query_one(f"#stage-runtime-{stage}", Select).value = "codex"
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        model_select = pilot.app.query_one(f"#stage-model-{stage}", Select)
+        values = [value for _, value in model_select._options]
+        assert SEARCH_SENTINEL in values
+        assert len(values) < 30  # static catalog + sentinels only, not 300 rows
+        labels = {str(label) for label, _ in model_select._options}
+        assert any("Search 300 models" in label for label in labels)
+
+
+@pytest.mark.asyncio
+async def test_search_modal_filters_and_applies_choice(app_env, monkeypatch) -> None:
+    big = tuple(f"provider/model-{i}" for i in range(300)) + ("anthropic/claude-opus-4-8",)
+    monkeypatch.setattr(
+        "ouroboros.config_tui.app.refresh_models",
+        lambda backend: big if backend == "codex" else None,
+    )
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        stage = Stage.INTERVIEW.value
+        pilot.app.query_one(f"#stage-runtime-{stage}", Select).value = "codex"
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        model_select = pilot.app.query_one(f"#stage-model-{stage}", Select)
+        model_select.value = SEARCH_SENTINEL
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, ModelSearchScreen)
+
+        search_input = pilot.app.screen.query_one("#search-input", Input)
+        search_input.value = "anthropic"
+        await pilot.pause()
+        results = pilot.app.screen.query_one("#search-results", OptionList)
+        assert results.option_count == 1
+
+        results.highlighted = 0
+        results.action_select()
+        await pilot.pause()
+        assert model_select.value == "anthropic/claude-opus-4-8"
+
+
+@pytest.mark.asyncio
+async def test_search_modal_cancel_restores_previous_value(app_env, monkeypatch) -> None:
+    big = tuple(f"provider/model-{i}" for i in range(300))
+    monkeypatch.setattr(
+        "ouroboros.config_tui.app.refresh_models",
+        lambda backend: big if backend == "codex" else None,
+    )
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        stage = Stage.INTERVIEW.value
+        pilot.app.query_one(f"#stage-runtime-{stage}", Select).value = "codex"
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        model_select = pilot.app.query_one(f"#stage-model-{stage}", Select)
+        assert model_select.value == "default"
+        model_select.value = SEARCH_SENTINEL
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert model_select.value == "default"

--- a/tests/unit/config_tui/test_app.py
+++ b/tests/unit/config_tui/test_app.py
@@ -1,0 +1,171 @@
+"""Textual pilot tests for the settings app (#1413).
+
+UI behavior under test: stage cards render, runtime selection re-populates
+the dependent model options, uninstalled backends are badged, env-override
+warnings show, and Save routes every change through the validated
+persistence layer.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+from textual.widgets import Input, Select, Static
+
+from ouroboros.config_tui import persistence
+from ouroboros.config_tui.app import (
+    CUSTOM_SENTINEL,
+    INHERIT_SENTINEL,
+    INSTALL_REQUIRED_SUFFIX,
+    SettingsApp,
+)
+from ouroboros.orchestrator_stage import Stage
+
+
+@pytest.fixture
+def app_env(monkeypatch):
+    """Isolate the app from the real ~/.ouroboros and PATH."""
+    raw = {
+        "orchestrator": {
+            "runtime_backend": "claude",
+            "runtime_profile": {"stages": {"execute": "codex"}},
+        },
+        "llm": {"backend": "claude_code"},
+    }
+    monkeypatch.setattr(persistence, "load_raw_config", lambda: dict(raw))
+    installed = {name: f"/bin/{name}" for name in ("claude", "codex")}
+    monkeypatch.setattr(
+        "ouroboros.config_tui.app.installed_backends",
+        lambda: dict(installed),
+    )
+    return raw
+
+
+async def _run_app() -> SettingsApp:
+    return SettingsApp()
+
+
+@pytest.mark.asyncio
+async def test_stage_cards_render_for_all_stages(app_env) -> None:
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        for stage in Stage:
+            assert pilot.app.query_one(f"#stage-card-{stage.value}")
+            assert pilot.app.query_one(f"#stage-runtime-{stage.value}", Select)
+            assert pilot.app.query_one(f"#stage-model-{stage.value}", Select)
+        assert pilot.app.query_one("#global-runtime", Select)
+        assert pilot.app.query_one("#global-llm-backend", Select)
+
+
+@pytest.mark.asyncio
+async def test_uninstalled_backend_option_is_badged(app_env) -> None:
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        select = pilot.app.query_one("#global-runtime", Select)
+        labels = {str(label) for label, _ in select._options}
+        assert any("hermes" in label and INSTALL_REQUIRED_SUFFIX in label for label in labels)
+        assert "claude" in labels  # installed backends carry no badge
+
+
+@pytest.mark.asyncio
+async def test_runtime_change_repopulates_model_options(app_env) -> None:
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        runtime_select = pilot.app.query_one(f"#stage-runtime-{Stage.INTERVIEW.value}", Select)
+        runtime_select.value = "codex"
+        await pilot.pause()
+        model_select = pilot.app.query_one(f"#stage-model-{Stage.INTERVIEW.value}", Select)
+        values = {value for _, value in model_select._options}
+        assert "default" in values  # codex catalog sentinel
+        assert CUSTOM_SENTINEL in values
+
+
+@pytest.mark.asyncio
+async def test_selecting_uninstalled_runtime_shows_install_warning(app_env) -> None:
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        runtime_select = pilot.app.query_one(f"#stage-runtime-{Stage.REFLECT.value}", Select)
+        runtime_select.value = "hermes"
+        await pilot.pause()
+        warning = pilot.app.query_one(f"#stage-install-warning-{Stage.REFLECT.value}", Static)
+        assert not warning.has_class("hidden")
+        runtime_select.value = "codex"
+        await pilot.pause()
+        assert warning.has_class("hidden")
+
+
+@pytest.mark.asyncio
+async def test_custom_model_choice_reveals_input(app_env) -> None:
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        model_select = pilot.app.query_one(f"#stage-model-{Stage.EVALUATE.value}", Select)
+        model_select.value = CUSTOM_SENTINEL
+        await pilot.pause()
+        custom = pilot.app.query_one(f"#stage-model-custom-{Stage.EVALUATE.value}", Input)
+        assert not custom.has_class("hidden")
+
+
+@pytest.mark.asyncio
+async def test_env_override_badge_rendered(app_env, monkeypatch) -> None:
+    monkeypatch.setenv("OUROBOROS_LLM_BACKEND", "codex")
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        warnings = [str(w.render()) for w in pilot.app.query(".env-warning").results(Static)]
+        assert any("OUROBOROS_LLM_BACKEND" in text for text in warnings)
+
+
+@pytest.mark.asyncio
+async def test_env_override_badge_absent_when_unset(app_env, monkeypatch) -> None:
+    for name in ("OUROBOROS_LLM_BACKEND", "OUROBOROS_AGENT_RUNTIME", "OUROBOROS_RUNTIME"):
+        monkeypatch.delenv(name, raising=False)
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        warnings = [str(w.render()) for w in pilot.app.query(".env-warning").results(Static)]
+        assert not any("OUROBOROS_LLM_BACKEND" in text for text in warnings)
+
+
+@pytest.mark.asyncio
+async def test_save_routes_changes_through_validated_persistence(app_env, monkeypatch) -> None:
+    applied: dict[str, object] = {}
+    monkeypatch.setattr(persistence, "apply_config_values", lambda values: applied.update(values))
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        pilot.app.query_one("#global-runtime", Select).value = "codex"
+        runtime_select = pilot.app.query_one(f"#stage-runtime-{Stage.EXECUTE.value}", Select)
+        runtime_select.value = INHERIT_SENTINEL  # clears the existing codex override
+        await pilot.pause()
+        pilot.app.query_one("#save-button").scroll_visible(animate=False)
+        await pilot.pause()
+        await pilot.click("#save-button")
+        await pilot.pause()
+    assert applied["orchestrator.runtime_backend"] == "codex"
+    assert applied["orchestrator.runtime_profile.stages.execute"] is None
+
+
+@pytest.mark.asyncio
+async def test_save_failure_is_surfaced_inline(app_env, monkeypatch) -> None:
+    def _reject(values):
+        raise persistence.ConfigWriteError("Unknown config key 'x'")
+
+    monkeypatch.setattr(persistence, "apply_config_values", _reject)
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        pilot.app.query_one("#global-runtime", Select).value = "codex"
+        pilot.app.query_one("#save-button").scroll_visible(animate=False)
+        await pilot.pause()
+        await pilot.click("#save-button")
+        await pilot.pause()
+        status = pilot.app.query_one("#status-bar", Static)
+        assert "Save failed" in str(status.render())
+
+
+def test_settings_app_imports_without_monitor_tui() -> None:
+    """Import-isolation contract for ourocode reuse (#1413 AC)."""
+    code = (
+        "import sys; import ouroboros.config_tui.app; "
+        "assert 'ouroboros.tui.app' not in sys.modules, 'monitor TUI leaked'; "
+        "assert 'ouroboros.tui' not in sys.modules, 'monitor TUI package leaked'"
+    )
+    subprocess.run([sys.executable, "-c", code], check=True)

--- a/tests/unit/config_tui/test_app.py
+++ b/tests/unit/config_tui/test_app.py
@@ -44,6 +44,11 @@ def app_env(monkeypatch):
     )
     # Never let unit tests shell out to real backend CLIs.
     monkeypatch.setattr("ouroboros.config_tui.app.refresh_models", lambda _backend: None)
+    # ...or read the real ~/.hermes / ~/.codex configs.
+    monkeypatch.setattr(
+        "ouroboros.config_tui.app.configured_default_model",
+        lambda backend: "gpt-9-test" if backend == "codex" else None,
+    )
     return raw
 
 
@@ -157,6 +162,7 @@ async def test_save_failure_is_surfaced_inline(app_env, monkeypatch) -> None:
     app = SettingsApp()
     async with app.run_test() as pilot:
         pilot.app.query_one("#global-runtime", Select).value = "codex"
+        await pilot.pause()  # let the cascade settle before measuring layout
         pilot.app.query_one("#save-button").scroll_visible(animate=False)
         await pilot.pause()
         await pilot.click("#save-button")
@@ -323,3 +329,18 @@ async def test_search_modal_cancel_restores_previous_value(app_env, monkeypatch)
         await pilot.press("escape")
         await pilot.pause()
         assert model_select.value == "default"
+
+
+@pytest.mark.asyncio
+async def test_default_sentinel_label_shows_configured_model(app_env) -> None:
+    """For sentinel backends the 'default' entry names the model it resolves
+    to (read from the CLI's own config), e.g. 'default — currently gpt-9-test'."""
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        stage = Stage.INTERVIEW.value
+        pilot.app.query_one(f"#stage-runtime-{stage}", Select).value = "codex"
+        await pilot.pause()
+        model_select = pilot.app.query_one(f"#stage-model-{stage}", Select)
+        labels = {str(label) for label, _ in model_select._options}
+        assert any("default — currently gpt-9-test" in label for label in labels)
+        assert model_select.value == "default"  # value stays the sentinel

--- a/tests/unit/config_tui/test_app.py
+++ b/tests/unit/config_tui/test_app.py
@@ -136,6 +136,21 @@ async def test_env_override_badge_absent_when_unset(app_env, monkeypatch) -> Non
 
 
 @pytest.mark.asyncio
+async def test_runtime_env_override_drives_inherited_stage_cards(app_env, monkeypatch) -> None:
+    monkeypatch.setenv("OUROBOROS_RUNTIME", "codex")
+
+    app = SettingsApp()
+    assert app._effective_stage_backend(Stage.INTERVIEW) == "codex"
+    async with app.run_test() as pilot:
+        caption = pilot.app.query_one(f"#stage-resolved-{Stage.INTERVIEW.value}", Static)
+        assert "codex" in str(caption.render())
+
+        model_select = pilot.app.query_one(f"#stage-model-{Stage.INTERVIEW.value}", Select)
+        values = {value for _, value in model_select._options}
+        assert "default" in values
+
+
+@pytest.mark.asyncio
 async def test_save_routes_changes_through_validated_persistence(app_env, monkeypatch) -> None:
     applied: dict[str, object] = {}
     monkeypatch.setattr(persistence, "apply_config_values", lambda values: applied.update(values))

--- a/tests/unit/config_tui/test_app.py
+++ b/tests/unit/config_tui/test_app.py
@@ -379,6 +379,58 @@ async def test_save_summary_shows_diff_and_reconnect_hint(app_env, monkeypatch) 
         assert "reconnect" in status  # backend change needs MCP reconnect
 
 
+@pytest.mark.asyncio
+async def test_save_skips_default_sentinel_when_llm_backend_is_claude(monkeypatch) -> None:
+    raw = {
+        "orchestrator": {"runtime_backend": "claude"},
+        "llm": {"backend": "claude_code"},
+    }
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(persistence, "load_raw_config", lambda: dict(raw))
+    monkeypatch.setattr(persistence, "apply_config_values", lambda values: captured.update(values))
+    monkeypatch.setattr(
+        "ouroboros.config_tui.app.installed_backends",
+        lambda: {"claude": "/bin/claude", "codex": "/bin/codex"},
+    )
+    monkeypatch.setattr("ouroboros.config_tui.app.refresh_models", lambda _backend: None)
+    monkeypatch.setattr("ouroboros.config_tui.app.configured_default_model", lambda _backend: None)
+
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        stage = Stage.EXECUTE.value
+        pilot.app.query_one(f"#stage-runtime-{stage}", Select).value = "codex"
+        await pilot.pause()
+        assert pilot.app.query_one(f"#stage-model-{stage}", Select).value == "default"
+
+        pilot.app.action_save()
+        await pilot.pause()
+
+    assert captured["orchestrator.runtime_profile.stages.execute"] == "codex"
+    assert "execution.double_diamond_model" not in captured
+
+
+@pytest.mark.asyncio
+async def test_save_keeps_default_sentinel_when_llm_backend_supports_it(
+    app_env, monkeypatch
+) -> None:
+    captured: dict[str, object] = {}
+    monkeypatch.setattr(persistence, "apply_config_values", lambda values: captured.update(values))
+
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        pilot.app.query_one("#global-llm-backend", Select).value = "codex"
+        await pilot.pause()
+        stage = Stage.EXECUTE.value
+        pilot.app.query_one(f"#stage-model-{stage}", Select).value = "default"
+        await pilot.pause()
+
+        pilot.app.action_save()
+        await pilot.pause()
+
+    assert captured["llm.backend"] == "codex"
+    assert captured["execution.double_diamond_model"] == "default"
+
+
 def test_save_summary_without_backend_change_has_no_reconnect_hint() -> None:
     summary = SettingsApp._save_summary(
         {"clarification.default_model": "m2"}, {"clarification.default_model": "m1"}

--- a/tests/unit/config_tui/test_app.py
+++ b/tests/unit/config_tui/test_app.py
@@ -169,3 +169,20 @@ def test_settings_app_imports_without_monitor_tui() -> None:
         "assert 'ouroboros.tui' not in sys.modules, 'monitor TUI package leaked'"
     )
     subprocess.run([sys.executable, "-c", code], check=True)
+
+
+@pytest.mark.asyncio
+async def test_inherit_label_tracks_global_default(app_env) -> None:
+    """The stage inherit option shows the resolved default agent (UX: #1411)."""
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        runtime_select = pilot.app.query_one(f"#stage-runtime-{Stage.INTERVIEW.value}", Select)
+        labels = {str(label) for label, value in runtime_select._options if value}
+        assert any("(inherit — claude)" in label for label in labels)
+
+        pilot.app.query_one("#global-runtime", Select).value = "codex"
+        await pilot.pause()
+        labels = {str(label) for label, value in runtime_select._options if value}
+        assert any("(inherit — codex)" in label for label in labels)
+        # Rebuilding options must not lose the user's selection.
+        assert runtime_select.value == INHERIT_SENTINEL

--- a/tests/unit/config_tui/test_app.py
+++ b/tests/unit/config_tui/test_app.py
@@ -365,7 +365,7 @@ async def test_preset_button_stages_models_for_every_card(app_env) -> None:
 
 @pytest.mark.asyncio
 async def test_save_summary_shows_diff_and_reconnect_hint(app_env, monkeypatch) -> None:
-    monkeypatch.setattr(persistence, "apply_config_values", lambda values: None)
+    monkeypatch.setattr(persistence, "apply_config_values", lambda _values: None)
     app = SettingsApp()
     async with app.run_test() as pilot:
         pilot.app.query_one("#global-runtime", Select).value = "codex"

--- a/tests/unit/config_tui/test_app.py
+++ b/tests/unit/config_tui/test_app.py
@@ -172,17 +172,43 @@ def test_settings_app_imports_without_monitor_tui() -> None:
 
 
 @pytest.mark.asyncio
-async def test_inherit_label_tracks_global_default(app_env) -> None:
-    """The stage inherit option shows the resolved default agent (UX: #1411)."""
+async def test_global_change_cascades_to_inheriting_cards(app_env) -> None:
+    """Changing the default agent re-resolves inheriting cards: the
+    '→ runs on <agent>' caption updates and the model select repopulates to
+    the new backend's catalog with its default selected (UX: #1411)."""
     app = SettingsApp()
     async with app.run_test() as pilot:
-        runtime_select = pilot.app.query_one(f"#stage-runtime-{Stage.INTERVIEW.value}", Select)
-        labels = {str(label) for label, value in runtime_select._options if value}
-        assert any("(inherit — claude)" in label for label in labels)
+        stage = Stage.INTERVIEW.value
+        caption = pilot.app.query_one(f"#stage-resolved-{stage}", Static)
+        assert "claude" in str(caption.render())
 
         pilot.app.query_one("#global-runtime", Select).value = "codex"
         await pilot.pause()
-        labels = {str(label) for label, value in runtime_select._options if value}
-        assert any("(inherit — codex)" in label for label in labels)
-        # Rebuilding options must not lose the user's selection.
-        assert runtime_select.value == INHERIT_SENTINEL
+
+        assert "codex" in str(caption.render())
+        runtime_select = pilot.app.query_one(f"#stage-runtime-{stage}", Select)
+        assert runtime_select.value == INHERIT_SENTINEL  # selection preserved
+        model_select = pilot.app.query_one(f"#stage-model-{stage}", Select)
+        assert model_select.value == "default"  # codex catalog default
+        values = {value for _, value in model_select._options}
+        assert "claude-opus-4-8" not in values  # stale claude id dropped
+
+
+@pytest.mark.asyncio
+async def test_explicit_stage_agent_not_affected_by_global_change(app_env) -> None:
+    """A card with an explicit agent keeps its model catalog when the
+    default changes — only inheriting cards cascade."""
+    app = SettingsApp()
+    async with app.run_test() as pilot:
+        stage = Stage.EXECUTE.value  # fixture pins execute to codex
+        caption = pilot.app.query_one(f"#stage-resolved-{stage}", Static)
+        model_select = pilot.app.query_one(f"#stage-model-{stage}", Select)
+        runtime_select = pilot.app.query_one(f"#stage-runtime-{stage}", Select)
+        assert runtime_select.value == "codex"
+        before_value = model_select.value
+
+        pilot.app.query_one("#global-runtime", Select).value = "hermes"
+        await pilot.pause()
+
+        assert "codex" in str(caption.render())
+        assert model_select.value == before_value

--- a/tests/unit/config_tui/test_fields.py
+++ b/tests/unit/config_tui/test_fields.py
@@ -1,0 +1,58 @@
+"""Tests for the settings field schema and env-override detection (#1413)."""
+
+from __future__ import annotations
+
+from ouroboros.config_tui import fields
+from ouroboros.orchestrator_stage import VALID_STAGE_KEYS, Stage
+
+
+def test_stage_model_fields_cover_every_stage() -> None:
+    assert {stage.value for stage in fields.STAGE_MODEL_FIELDS} == VALID_STAGE_KEYS
+
+
+def test_stage_runtime_field_targets_runtime_profile() -> None:
+    field = fields.stage_runtime_field(Stage.EXECUTE)
+    assert field.key == "orchestrator.runtime_profile.stages.execute"
+    assert field.stage == "execute"
+
+
+def test_active_env_overrides_set(monkeypatch) -> None:
+    monkeypatch.setenv("OUROBOROS_LLM_BACKEND", "codex")
+    assert fields.active_env_overrides(fields.GLOBAL_LLM_BACKEND_FIELD) == (
+        "OUROBOROS_LLM_BACKEND",
+    )
+
+
+def test_active_env_overrides_unset(monkeypatch) -> None:
+    monkeypatch.delenv("OUROBOROS_LLM_BACKEND", raising=False)
+    assert fields.active_env_overrides(fields.GLOBAL_LLM_BACKEND_FIELD) == ()
+
+
+def test_active_env_overrides_blank_value_does_not_count(monkeypatch) -> None:
+    monkeypatch.setenv("OUROBOROS_CLARIFICATION_MODEL", "   ")
+    field = fields.STAGE_MODEL_FIELDS[Stage.INTERVIEW]
+    assert fields.active_env_overrides(field) == ()
+
+
+def test_runtime_field_tracks_both_runtime_env_vars(monkeypatch) -> None:
+    monkeypatch.setenv("OUROBOROS_AGENT_RUNTIME", "codex")
+    monkeypatch.setenv("OUROBOROS_RUNTIME", "hermes")
+    assert fields.active_env_overrides(fields.GLOBAL_RUNTIME_FIELD) == (
+        "OUROBOROS_AGENT_RUNTIME",
+        "OUROBOROS_RUNTIME",
+    )
+
+
+def test_stage_runtime_selects_have_no_env_override() -> None:
+    # Env runtime vars replace only the fallback, never an explicit
+    # runtime_profile.stages entry — so stage selects carry no badge.
+    for stage in Stage:
+        assert fields.stage_runtime_field(stage).env_vars == ()
+
+
+def test_get_value_dot_navigation() -> None:
+    data = {"orchestrator": {"runtime_profile": {"stages": {"execute": "codex"}}}}
+    assert fields.get_value(data, "orchestrator.runtime_profile.stages.execute") == "codex"
+    assert fields.get_value(data, "orchestrator.runtime_profile.stages.reflect") is None
+    assert fields.get_value(data, "missing.key") is None
+    assert fields.get_value({"a": "leaf"}, "a.b") is None

--- a/tests/unit/config_tui/test_launcher.py
+++ b/tests/unit/config_tui/test_launcher.py
@@ -38,7 +38,7 @@ def test_launch_settings_routes_to_inline_on_tty(monkeypatch) -> None:
     monkeypatch.delenv("CLAUDECODE", raising=False)
     monkeypatch.setattr(launcher.sys, "stdout", _FakeStdout(True))
     monkeypatch.setattr(launcher, "_launch_inline", lambda: calls.append("inline"))
-    monkeypatch.setattr(launcher, "_launch_web", lambda: calls.append("web"))
+    monkeypatch.setattr(launcher, "_launch_web", lambda **_kwargs: calls.append("web"))
     launcher.launch_settings()
     assert calls == ["inline"]
 
@@ -47,7 +47,7 @@ def test_launch_settings_routes_to_web_in_harness(monkeypatch) -> None:
     calls: list[str] = []
     monkeypatch.setenv("CLAUDECODE", "1")
     monkeypatch.setattr(launcher, "_launch_inline", lambda: calls.append("inline"))
-    monkeypatch.setattr(launcher, "_launch_web", lambda: calls.append("web"))
+    monkeypatch.setattr(launcher, "_launch_web", lambda **_kwargs: calls.append("web"))
     launcher.launch_settings()
     assert calls == ["web"]
 
@@ -95,3 +95,78 @@ def test_launch_web_without_textual_serve_prints_hint(monkeypatch, capsys) -> No
     output = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().out)
     flattened = "".join(line.strip("│╭╮╰╯─ ") for line in output.splitlines())
     assert "ouroboros-ai[tui]" in flattened
+
+
+@pytest.mark.parametrize(
+    ("env_vars", "expected_remote"),
+    [
+        ({"SSH_CONNECTION": "10.0.0.1 22 10.0.0.2 22"}, True),
+        ({"SSH_TTY": "/dev/pts/1"}, True),
+        ({}, False),
+    ],
+)
+def test_is_remote_session(monkeypatch, env_vars, expected_remote) -> None:
+    for name in ("SSH_CONNECTION", "SSH_TTY"):
+        monkeypatch.delenv(name, raising=False)
+    for name, value in env_vars.items():
+        monkeypatch.setenv(name, value)
+    assert launcher.is_remote_session() is expected_remote
+
+
+def test_remote_web_mode_prints_url_instead_of_opening_browser(monkeypatch, capsys) -> None:
+    """On a remote host (hermes box driven from Discord/SSH), a browser
+    opened locally is useless — print a reachable URL + tunnel hint."""
+    served: dict[str, object] = {}
+
+    class _FakeServer:
+        def __init__(self, command, host="localhost", port=8000, title=None) -> None:
+            served.update(host=host, port=port)
+
+        def serve(self) -> None:
+            served["serving"] = True
+
+    opened: list[str] = []
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("SSH_CONNECTION", "10.0.0.1 22 10.0.0.2 22")
+    monkeypatch.setattr(launcher, "_import_server", lambda: _FakeServer)
+    monkeypatch.setattr(launcher, "_free_port", lambda: 50124)
+    monkeypatch.setattr(launcher.webbrowser, "open", lambda url: opened.append(url))
+
+    launcher.launch_settings()
+
+    assert served["serving"] is True
+    assert opened == []  # never opened on the wrong machine
+    import re
+
+    output = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().out)
+    assert "ssh -L 50124:localhost:50124" in output
+
+
+def test_force_web_with_host_and_port(monkeypatch) -> None:
+    served: dict[str, object] = {}
+
+    class _FakeServer:
+        def __init__(self, command, host="localhost", port=8000, title=None) -> None:
+            served.update(host=host, port=port)
+
+        def serve(self) -> None:
+            served["serving"] = True
+
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.delenv("SSH_CONNECTION", raising=False)
+    monkeypatch.delenv("SSH_TTY", raising=False)
+    # force_web bypasses TTY detection entirely — no stdout fake needed
+    # (rich's console must keep a real write()able stream).
+    monkeypatch.setattr(launcher, "_import_server", lambda: _FakeServer)
+    monkeypatch.setattr(launcher.webbrowser, "open", lambda _url: None)
+
+    class _NoopTimer:
+        def __init__(self, *_args, **_kwargs) -> None: ...
+
+        def start(self) -> None: ...
+
+    monkeypatch.setattr(launcher.threading, "Timer", _NoopTimer)
+
+    launcher.launch_settings(force_web=True, host="0.0.0.0", port=8765, open_browser=False)
+
+    assert served == {"host": "0.0.0.0", "port": 8765, "serving": True}

--- a/tests/unit/config_tui/test_launcher.py
+++ b/tests/unit/config_tui/test_launcher.py
@@ -1,0 +1,97 @@
+"""Dispatch-matrix tests for the bare `ouroboros config` launcher (#1414)."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.config_tui import launcher
+
+
+class _FakeStdout:
+    def __init__(self, tty: bool) -> None:
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        return self._tty
+
+
+@pytest.mark.parametrize(
+    ("claudecode", "tty", "expected_harness"),
+    [
+        ("1", True, True),  # harness env wins even on a TTY
+        ("1", False, True),
+        ("", True, False),  # interactive terminal
+        ("", False, True),  # piped/captured stdout
+    ],
+)
+def test_is_harness_context_matrix(monkeypatch, claudecode, tty, expected_harness) -> None:
+    if claudecode:
+        monkeypatch.setenv("CLAUDECODE", claudecode)
+    else:
+        monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.setattr(launcher.sys, "stdout", _FakeStdout(tty))
+    assert launcher.is_harness_context() is expected_harness
+
+
+def test_launch_settings_routes_to_inline_on_tty(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.delenv("CLAUDECODE", raising=False)
+    monkeypatch.setattr(launcher.sys, "stdout", _FakeStdout(True))
+    monkeypatch.setattr(launcher, "_launch_inline", lambda: calls.append("inline"))
+    monkeypatch.setattr(launcher, "_launch_web", lambda: calls.append("web"))
+    launcher.launch_settings()
+    assert calls == ["inline"]
+
+
+def test_launch_settings_routes_to_web_in_harness(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setattr(launcher, "_launch_inline", lambda: calls.append("inline"))
+    monkeypatch.setattr(launcher, "_launch_web", lambda: calls.append("web"))
+    launcher.launch_settings()
+    assert calls == ["web"]
+
+
+def test_launch_web_serves_and_opens_browser(monkeypatch) -> None:
+    served: dict[str, object] = {}
+
+    class _FakeServer:
+        def __init__(self, command, host="localhost", port=8000, title=None) -> None:
+            served.update(command=command, host=host, port=port, title=title)
+
+        def serve(self) -> None:
+            served["serving"] = True
+
+    opened: list[str] = []
+
+    class _ImmediateTimer:
+        def __init__(self, interval, function, args=()) -> None:
+            self._function = function
+            self._args = args
+
+        def start(self) -> None:
+            self._function(*self._args)
+
+    monkeypatch.setattr(launcher, "_import_server", lambda: _FakeServer)
+    monkeypatch.setattr(launcher, "_free_port", lambda: 50123)
+    monkeypatch.setattr(launcher.threading, "Timer", _ImmediateTimer)
+    monkeypatch.setattr(launcher.webbrowser, "open", lambda url: opened.append(url))
+
+    launcher._launch_web()
+
+    assert served["serving"] is True
+    assert served["port"] == 50123
+    assert "ouroboros.config_tui" in str(served["command"])
+    assert opened == ["http://localhost:50123"]
+
+
+def test_launch_web_without_textual_serve_prints_hint(monkeypatch, capsys) -> None:
+    monkeypatch.setattr(launcher, "_import_server", lambda: None)
+    with pytest.raises(SystemExit):
+        launcher._launch_web()
+    # Rich panels add ANSI styling and box borders; strip both before matching.
+    import re
+
+    output = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().out)
+    flattened = "".join(line.strip("│╭╮╰╯─ ") for line in output.splitlines())
+    assert "ouroboros-ai[tui]" in flattened

--- a/tests/unit/config_tui/test_persistence.py
+++ b/tests/unit/config_tui/test_persistence.py
@@ -92,3 +92,10 @@ def test_empty_batch_is_noop(config_dir: Path) -> None:
 
 def test_load_raw_config_missing_file_returns_empty(config_dir: Path) -> None:
     assert persistence.load_raw_config() == {}
+
+
+def test_apply_writes_backup_for_undo(config_dir: Path) -> None:
+    persistence.apply_config_values({"orchestrator.runtime_backend": "codex"})
+    before = (config_dir / "config.yaml").read_text()
+    persistence.apply_config_values({"orchestrator.runtime_backend": "hermes"})
+    assert (config_dir / "config.yaml.bak").read_text() == before

--- a/tests/unit/config_tui/test_persistence.py
+++ b/tests/unit/config_tui/test_persistence.py
@@ -1,0 +1,94 @@
+"""Tests for the validated batch write path (#1413).
+
+The contract under test: writes share `config set`'s key validator, pass
+the full Pydantic load check after writing, and roll back byte-for-byte on
+validation failure.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ouroboros.config_tui import persistence
+
+
+@pytest.fixture
+def config_dir(tmp_path, monkeypatch) -> Path:
+    monkeypatch.setattr(persistence, "get_config_dir", lambda: tmp_path)
+    # The post-write validation reads the same canonical path.
+    from ouroboros.config import loader as config_loader
+    from ouroboros.config import models as config_models
+
+    monkeypatch.setattr(config_models, "get_config_dir", lambda: tmp_path)
+    monkeypatch.setattr(config_loader, "get_config_dir", lambda: tmp_path)
+    return tmp_path
+
+
+def _read(config_dir: Path) -> dict:
+    return yaml.safe_load((config_dir / "config.yaml").read_text()) or {}
+
+
+def test_apply_valid_values_persists(config_dir: Path) -> None:
+    persistence.apply_config_values(
+        {
+            "orchestrator.runtime_backend": "codex",
+            "orchestrator.runtime_profile.stages.execute": "hermes",
+            "clarification.default_model": "my-model",
+        }
+    )
+    data = _read(config_dir)
+    assert data["orchestrator"]["runtime_backend"] == "codex"
+    assert data["orchestrator"]["runtime_profile"]["stages"]["execute"] == "hermes"
+    assert data["clarification"]["default_model"] == "my-model"
+
+
+def test_apply_none_deletes_stage_override(config_dir: Path) -> None:
+    persistence.apply_config_values({"orchestrator.runtime_profile.stages.execute": "codex"})
+    persistence.apply_config_values({"orchestrator.runtime_profile.stages.execute": None})
+    data = _read(config_dir)
+    assert "execute" not in data["orchestrator"]["runtime_profile"]["stages"]
+
+
+def test_unknown_key_rejected_without_writing(config_dir: Path) -> None:
+    with pytest.raises(persistence.ConfigWriteError, match="Unknown config key"):
+        persistence.apply_config_values({"orchestrator.not_a_real_key_xyz": "value"})
+    assert not (config_dir / "config.yaml").exists()
+
+
+def test_invalid_value_rolls_back_file(config_dir: Path) -> None:
+    persistence.apply_config_values({"orchestrator.runtime_backend": "codex"})
+    before = (config_dir / "config.yaml").read_text()
+
+    with pytest.raises(persistence.ConfigWriteError, match="rolled back"):
+        persistence.apply_config_values({"orchestrator.runtime_backend": "not-a-backend"})
+
+    assert (config_dir / "config.yaml").read_text() == before
+
+
+def test_invalid_stage_backend_rolls_back(config_dir: Path) -> None:
+    # The key path is structurally valid (validator cannot drill past the
+    # Optional runtime_profile), so rejection must come from the Pydantic
+    # load check — proving the post-write gate carries real weight.
+    with pytest.raises(persistence.ConfigWriteError, match="rolled back"):
+        persistence.apply_config_values(
+            {"orchestrator.runtime_profile.stages.execute": "not-a-backend"}
+        )
+    assert not (config_dir / "config.yaml").exists()
+
+
+def test_invalid_value_on_fresh_file_removes_it(config_dir: Path) -> None:
+    with pytest.raises(persistence.ConfigWriteError):
+        persistence.apply_config_values({"llm.backend": "not-a-backend"})
+    assert not (config_dir / "config.yaml").exists()
+
+
+def test_empty_batch_is_noop(config_dir: Path) -> None:
+    persistence.apply_config_values({})
+    assert not (config_dir / "config.yaml").exists()
+
+
+def test_load_raw_config_missing_file_returns_empty(config_dir: Path) -> None:
+    assert persistence.load_raw_config() == {}

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
 import re
@@ -160,6 +161,20 @@ def test_explicit_claude_installs_mcp_and_claude_extras(tmp_path: Path) -> None:
     )
     _assert_calls_include_pyproject_pins(calls, "mcp", "claude")
     assert "ouroboros setup --runtime claude --non-interactive" in calls
+
+    mcp_config = json.loads(
+        (tmp_path / "home" / ".claude" / "mcp.json").read_text(encoding="utf-8")
+    )
+    assert mcp_config["mcpServers"]["ouroboros"] == {
+        "command": "uvx",
+        "args": [
+            "--from",
+            "ouroboros-ai[mcp,claude]",
+            "ouroboros",
+            "mcp",
+            "serve",
+        ],
+    }
 
 
 def test_explicit_hermes_mcp_extra_matches_pyproject_pins(tmp_path: Path) -> None:

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -137,9 +137,9 @@ def test_preserves_opencode_backend_from_existing_config(tmp_path: Path) -> None
 
     assert result.returncode == 0, result.stderr
     assert "Runtime: opencode (preserved from" in result.stdout
-    assert "Installing . ..." in result.stdout
+    assert "Installing .[tui] ..." in result.stdout
     assert (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines() == [
-        "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0",
+        "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0 --with textual==8.2.7 --with textual-serve==1.1.3",
         "ouroboros setup --runtime opencode --non-interactive",
     ]
 
@@ -155,7 +155,7 @@ def test_explicit_claude_installs_mcp_and_claude_extras(tmp_path: Path) -> None:
     calls = (tmp_path / "calls.log").read_text(encoding="utf-8")
     assert "Runtime: claude (from --runtime / OUROBOROS_INSTALL_RUNTIME)" in result.stdout
     assert (
-        "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0 --with mcp==1.27.2 --with claude-agent-sdk==0.2.87 --with anthropic==0.105.2"
+        "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0 --with mcp==1.27.2 --with claude-agent-sdk==0.2.87 --with anthropic==0.105.2 --with textual==8.2.7 --with textual-serve==1.1.3"
         in calls
     )
     _assert_calls_include_pyproject_pins(calls, "mcp", "claude")
@@ -187,7 +187,7 @@ def test_explicit_pi_installs_base_and_runs_pi_setup(tmp_path: Path) -> None:
     calls = (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines()
     assert "Runtime: pi (from --runtime / OUROBOROS_INSTALL_RUNTIME)" in result.stdout
     assert calls == [
-        "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0",
+        "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0 --with textual==8.2.7 --with textual-serve==1.1.3",
         "ouroboros setup --runtime pi --non-interactive",
     ]
 
@@ -270,7 +270,7 @@ def test_detects_pi_as_single_runtime_and_runs_pi_setup(tmp_path: Path) -> None:
     calls = (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines()
     assert "Pi:" in result.stdout
     assert calls == [
-        "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0",
+        "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0 --with textual==8.2.7 --with textual-serve==1.1.3",
         "ouroboros setup --runtime pi --non-interactive",
     ]
 
@@ -286,7 +286,8 @@ def test_pypi_lookup_failure_stays_stable_only_for_remote_install(tmp_path: Path
     assert result.returncode == 0, result.stderr
     calls = (tmp_path / "calls.log").read_text(encoding="utf-8")
     assert (
-        "uv tool install --upgrade --python >=3.12 ouroboros-ai --with click>=8.1.0,<9.0.0" in calls
+        "uv tool install --upgrade --python >=3.12 ouroboros-ai --with click>=8.1.0,<9.0.0 --with textual==8.2.7 --with textual-serve==1.1.3"
+        in calls
     )
     assert "--prerelease=allow" not in calls
 

--- a/uv.lock
+++ b/uv.lock
@@ -108,6 +108,19 @@ wheels = [
 ]
 
 [[package]]
+name = "aiohttp-jinja2"
+version = "1.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "jinja2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/39/da5a94dd89b1af7241fb7fc99ae4e73505b5f898b540b6aba6dc7afe600e/aiohttp-jinja2-1.6.tar.gz", hash = "sha256:a3a7ff5264e5bca52e8ae547bbfd0761b72495230d438d05b6c0915be619b0e2", size = 53057, upload-time = "2023-11-18T15:30:52.559Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/90/65238d4246307195411b87a07d03539049819b022c01bcc773826f600138/aiohttp_jinja2-1.6-py3-none-any.whl", hash = "sha256:0df405ee6ad1b58e5a068a105407dc7dcc1704544c559f1938babde954f945c7", size = 11736, upload-time = "2023-11-18T15:30:50.743Z" },
+]
+
+[[package]]
 name = "aiosignal"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1439,6 +1452,7 @@ all = [
     { name = "litellm" },
     { name = "mcp" },
     { name = "textual" },
+    { name = "textual-serve" },
 ]
 claude = [
     { name = "anthropic" },
@@ -1452,6 +1466,7 @@ mcp = [
 ]
 tui = [
     { name = "textual" },
+    { name = "textual-serve" },
 ]
 
 [package.dev-dependencies]
@@ -1488,6 +1503,8 @@ requires-dist = [
     { name = "structlog", specifier = ">=24.0.0,<26.0.0" },
     { name = "textual", marker = "extra == 'all'", specifier = "==8.2.7" },
     { name = "textual", marker = "extra == 'tui'", specifier = "==8.2.7" },
+    { name = "textual-serve", marker = "extra == 'all'", specifier = "==1.1.3" },
+    { name = "textual-serve", marker = "extra == 'tui'", specifier = "==1.1.3" },
     { name = "typer", specifier = ">=0.12.0,<0.27.0" },
 ]
 provides-extras = ["all", "claude", "copilot", "dashboard", "litellm", "mcp", "tui"]
@@ -2279,6 +2296,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9b/7a/c519db0aba5024f86e71e9631810bfdd6866ed2c8695bd7fa34b90e7ef59/textual-8.2.7.tar.gz", hash = "sha256:658f568ff81e30ed43890c3e07520390e5cf1b4763822006e060656b0a88f105", size = 1859249, upload-time = "2026-05-19T10:52:49.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/f5/c1e18bc0707300a0e90204343abbf7d7acd6fb7ebe03a6d4893b99a234b8/textual-8.2.7-py3-none-any.whl", hash = "sha256:4caaa13a90bc4cf9c6c862c067ccd34fe84e9c161710a2a907a8026313b6bd73", size = 731129, upload-time = "2026-05-19T10:52:51.773Z" },
+]
+
+[[package]]
+name = "textual-serve"
+version = "1.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-jinja2" },
+    { name = "jinja2" },
+    { name = "rich" },
+    { name = "textual" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/7e/62fecc552853ec6a178cb1faa2d6f73b34d5512924770e7b08b58ff14148/textual_serve-1.1.3.tar.gz", hash = "sha256:f8f636ae2f5fd651b79d965473c3e9383d3521cdf896f9bc289709185da3f683", size = 448340, upload-time = "2025-11-01T16:22:36.723Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/fe/108e7773349d500cf363328c3d0b7123e03feda51e310a3a5b136ac8ca71/textual_serve-1.1.3-py3-none-any.whl", hash = "sha256:207a472bc6604e725b1adab4ab8bf12f4c4dc25b04eea31e4d04731d8bf30f18", size = 447339, upload-time = "2025-11-01T16:22:35.209Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds a mouse-friendly `ouroboros config` settings UI for choosing runtimes, stage backends, and models without editing YAML by hand.
- Makes config usable across local terminals, harness/browser launches, SSH/headless environments, and agent gateways via `config show`, `config set`, and JSON output.
- Updates installer flow so first-time setup nudges users toward `ooo config` / `ouroboros config` while bundling the TUI extra for runtime selections.

## Changes

- Adds backend model catalog detection, curated model choices, live CLI listings, and searchable large model pickers.
- Adds standalone Textual config TUI with stage cards, inherited defaults, presets, save diffs, reconnect hints, undo support, and validated persistence.
- Dispatches bare `ouroboros config` to the settings launcher and upgrades `config show` to a GUI-equivalent effective view.
- Updates installer and skills/docs for config onboarding and runtime setup.
- Adds unit coverage for model catalog, config command dispatch, TUI fields/app/launcher/persistence, and installer runtime selection.

## Notes

This replaces #1415 with a clean branch that excludes the later unexpected commits pushed to `config`.