### PR TITLE
fix(plugin): reload deferred MCP schema before each ouroboros_* call

### DIFF
--- a/.claude-plugin/skills/brownfield/SKILL.md
+++ b/.claude-plugin/skills/brownfield/SKILL.md
@@ -41,6 +41,14 @@ This may take a moment...
 
 **Implementation — use MCP tools only, do NOT use CLI or Python scripts:**
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+This skill can call `ouroboros_brownfield` across multiple turns (`scan`,
+`set_defaults`, `defaults`, and `set`). A deferred schema loaded for one turn is
+NOT guaranteed to remain loaded for the next. Immediately before EVERY
+`ouroboros_brownfield` call, re-run `ToolSearch query: "+ouroboros brownfield"`
+(idempotent — a no-op when already loaded). If the load returns no matching tool,
+stop with the MCP-not-available message instead of retrying the failing call.
+
 1. Load the brownfield MCP tool: `ToolSearch query: "+ouroboros brownfield"`
 2. Call scan+register:
    ```
@@ -117,7 +125,7 @@ Then stop.
 
 The user can select the recommended defaults (if any), choose "None", or type custom numbers.
 
-After the user responds, use ONE MCP call to update all defaults at once:
+After the user responds, re-run `ToolSearch query: "+ouroboros brownfield"`, then use ONE MCP call to update all defaults at once:
 
 ```
 Tool: ouroboros_brownfield
@@ -155,7 +163,7 @@ Scan only, no default selection prompt. Show the numbered list and stop.
 
 ### Subcommand: `defaults`
 
-Load the brownfield MCP tool and call:
+Re-run `ToolSearch query: "+ouroboros brownfield"`, then call:
 ```
 Tool: ouroboros_brownfield
 Arguments: { "action": "scan" }
@@ -170,7 +178,7 @@ No default repos set. Run 'ooo brownfield' to configure.
 
 ### Subcommand: `set <indices>`
 
-Directly set defaults without scanning. Parse the comma-separated indices from the user's input and call:
+Directly set defaults without scanning. Parse the comma-separated indices from the user's input, re-run `ToolSearch query: "+ouroboros brownfield"`, and call:
 
 ```
 Tool: ouroboros_brownfield

--- a/.claude-plugin/skills/evaluate/SKILL.md
+++ b/.claude-plugin/skills/evaluate/SKILL.md
@@ -52,6 +52,18 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+This skill makes `ouroboros_*` MCP calls across multiple turns, and each turn runs
+in a fresh tool context. A deferred tool's schema loaded on one turn is NOT
+guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP tool
+while its schema is not loaded in the **current** turn, the runtime rejects the
+call with **"Invalid tool parameters"** before it ever reaches the server.
+Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
+the same tool-discovery load query you used above** (idempotent — a no-op when the
+schema is already loaded) so the schema is guaranteed present for that call. If a
+load ever returns no matching tool, switch to the documented fallback / Path B
+instead of retrying the failing call.
+
 ### Evaluation Steps
 
 1. Determine what to evaluate:

--- a/.claude-plugin/skills/evaluate/SKILL.md
+++ b/.claude-plugin/skills/evaluate/SKILL.md
@@ -53,16 +53,14 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
 **CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
-This skill makes `ouroboros_*` MCP calls across multiple turns, and each turn runs
-in a fresh tool context. A deferred tool's schema loaded on one turn is NOT
-guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP tool
-while its schema is not loaded in the **current** turn, the runtime rejects the
-call with **"Invalid tool parameters"** before it ever reaches the server.
-Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
-the same tool-discovery load query you used above** (idempotent — a no-op when the
-schema is already loaded) so the schema is guaranteed present for that call. If a
-load ever returns no matching tool, switch to the documented fallback / Path B
-instead of retrying the failing call.
+This skill can call `ouroboros_evaluate` after a fresh turn. A deferred tool's
+schema loaded on one turn is NOT guaranteed to still be loaded on the next. If
+you call it while its schema is not loaded in the **current** turn, the runtime
+rejects the call with **"Invalid tool parameters"** before it reaches the server.
+Therefore: **immediately before EVERY `ouroboros_evaluate` call in this skill,
+re-run `ToolSearch query: "+ouroboros evaluate"`** (idempotent — a no-op when
+already loaded). If the load returns no matching tool, switch to the documented
+fallback instead of retrying the failing call.
 
 ### Evaluation Steps
 

--- a/.claude-plugin/skills/evolve/SKILL.md
+++ b/.claude-plugin/skills/evolve/SKILL.md
@@ -61,10 +61,13 @@ guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP too
 while its schema is not loaded in the **current** turn, the runtime rejects the
 call with **"Invalid tool parameters"** before it ever reaches the server.
 Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
-the same tool-discovery load query you used above** (idempotent — a no-op when the
-schema is already loaded) so the schema is guaranteed present for that call. If a
-load ever returns no matching tool, switch to the documented fallback / Path B
-instead of retrying the failing call.
+the tool-discovery load query for the specific MCP tool or documented tool family
+you are about to call**. Use `"+ouroboros evolve"` for `ouroboros_evolve_step`,
+`ouroboros_lineage_status`, and the evolve flow's documented tool family;
+use `"+ouroboros interview"` before `ouroboros_interview`, `"+ouroboros seed"`
+before `ouroboros_generate_seed`, and `"+ouroboros lateral"` before
+`ouroboros_lateral_think`. If a load returns no matching tool, switch to the
+documented fallback / Path B instead of retrying the failing call.
 
 ### Path A: MCP Available (loaded via ToolSearch above)
 

--- a/.claude-plugin/skills/evolve/SKILL.md
+++ b/.claude-plugin/skills/evolve/SKILL.md
@@ -54,6 +54,18 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+This skill makes `ouroboros_*` MCP calls across multiple turns, and each turn runs
+in a fresh tool context. A deferred tool's schema loaded on one turn is NOT
+guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP tool
+while its schema is not loaded in the **current** turn, the runtime rejects the
+call with **"Invalid tool parameters"** before it ever reaches the server.
+Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
+the same tool-discovery load query you used above** (idempotent — a no-op when the
+schema is already loaded) so the schema is guaranteed present for that call. If a
+load ever returns no matching tool, switch to the documented fallback / Path B
+instead of retrying the failing call.
+
 ### Path A: MCP Available (loaded via ToolSearch above)
 
 **Starting a new evolutionary loop:**

--- a/.claude-plugin/skills/interview/SKILL.md
+++ b/.claude-plugin/skills/interview/SKILL.md
@@ -111,10 +111,12 @@ guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP too
 while its schema is not loaded in the **current** turn, the runtime rejects the
 call with **"Invalid tool parameters"** before it ever reaches the server.
 Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
-the same tool-discovery load query you used above** (idempotent — a no-op when the
-schema is already loaded) so the schema is guaranteed present for that call. If a
-load ever returns no matching tool, switch to the documented fallback / Path B
-instead of retrying the failing call.
+the tool-discovery load query for the specific MCP tool you are about to call**
+(idempotent — a no-op when the schema is already loaded) so the correct schema is
+guaranteed present for that call. Use `"+ouroboros interview"` before
+`ouroboros_interview` and `"+ouroboros lateral"` before
+`ouroboros_lateral_think`. If a load ever returns no matching tool, switch to the
+documented fallback / Path B instead of retrying the failing call.
 
 ### Path A: MCP Mode (Preferred)
 

--- a/.claude-plugin/skills/interview/SKILL.md
+++ b/.claude-plugin/skills/interview/SKILL.md
@@ -104,6 +104,18 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+This skill makes `ouroboros_*` MCP calls across multiple turns, and each turn runs
+in a fresh tool context. A deferred tool's schema loaded on one turn is NOT
+guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP tool
+while its schema is not loaded in the **current** turn, the runtime rejects the
+call with **"Invalid tool parameters"** before it ever reaches the server.
+Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
+the same tool-discovery load query you used above** (idempotent — a no-op when the
+schema is already loaded) so the schema is guaranteed present for that call. If a
+load ever returns no matching tool, switch to the documented fallback / Path B
+instead of retrying the failing call.
+
 ### Path A: MCP Mode (Preferred)
 
 If the `ouroboros_interview` MCP tool is available (loaded via runtime tool discovery above), use it for persistent, structured interviews.

--- a/.claude-plugin/skills/pm/SKILL.md
+++ b/.claude-plugin/skills/pm/SKILL.md
@@ -15,6 +15,16 @@ PM-focused Socratic interview that produces a Product Requirements Document.
 ToolSearch query: "+ouroboros pm_interview"
 ```
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+This is a multi-turn loop and each turn runs in a fresh tool context. A deferred
+tool's schema loaded on one turn is NOT guaranteed to still be loaded on the next.
+Calling `ouroboros_pm_interview` while its schema is unloaded in the **current**
+turn makes the runtime reject it with **"Invalid tool parameters"** every message.
+Therefore **re-run `ToolSearch query: "+ouroboros pm_interview"` immediately before
+EVERY `ouroboros_pm_interview` call** below (idempotent — a no-op if already
+loaded). If the load ever returns no matching tool, follow the not-found diagnosis
+below instead of retrying the failing call.
+
 If not found → **diagnose before telling user to run setup**:
 
 1. Check if MCP is already configured:

--- a/.claude-plugin/skills/run/SKILL.md
+++ b/.claude-plugin/skills/run/SKILL.md
@@ -45,16 +45,17 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
 **CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
-This skill makes `ouroboros_*` MCP calls across multiple turns, and each turn runs
+This skill makes execution MCP calls across multiple turns, and each turn runs
 in a fresh tool context. A deferred tool's schema loaded on one turn is NOT
-guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP tool
-while its schema is not loaded in the **current** turn, the runtime rejects the
-call with **"Invalid tool parameters"** before it ever reaches the server.
-Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
-the same tool-discovery load query you used above** (idempotent — a no-op when the
-schema is already loaded) so the schema is guaranteed present for that call. If a
-load ever returns no matching tool, switch to the documented fallback / Path B
-instead of retrying the failing call.
+guaranteed to still be loaded on the next. If you call any execution `ouroboros_*`
+MCP tool while its schema is not loaded in the **current** turn, the runtime
+rejects the call with **"Invalid tool parameters"** before it reaches the server.
+Therefore: **immediately before EVERY execution MCP call in this skill, re-run
+`ToolSearch query: "+ouroboros execute"`** to reload the execution tool family,
+including `ouroboros_start_execute_seed`, `ouroboros_job_wait`,
+`ouroboros_ac_tree_hud`, and `ouroboros_job_result` (idempotent — a no-op when
+already loaded). If the load returns no matching tool, switch to the documented
+fallback instead of retrying the failing call.
 
 ### Execution Steps
 

--- a/.claude-plugin/skills/run/SKILL.md
+++ b/.claude-plugin/skills/run/SKILL.md
@@ -44,6 +44,18 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+This skill makes `ouroboros_*` MCP calls across multiple turns, and each turn runs
+in a fresh tool context. A deferred tool's schema loaded on one turn is NOT
+guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP tool
+while its schema is not loaded in the **current** turn, the runtime rejects the
+call with **"Invalid tool parameters"** before it ever reaches the server.
+Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
+the same tool-discovery load query you used above** (idempotent — a no-op when the
+schema is already loaded) so the schema is guaranteed present for that call. If a
+load ever returns no matching tool, switch to the documented fallback / Path B
+instead of retrying the failing call.
+
 ### Execution Steps
 
 1. **Detect git workflow** (before any code changes):

--- a/.claude-plugin/skills/seed/SKILL.md
+++ b/.claude-plugin/skills/seed/SKILL.md
@@ -52,10 +52,13 @@ guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP too
 while its schema is not loaded in the **current** turn, the runtime rejects the
 call with **"Invalid tool parameters"** before it ever reaches the server.
 Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
-the same tool-discovery load query you used above** (idempotent — a no-op when the
-schema is already loaded) so the schema is guaranteed present for that call. If a
-load ever returns no matching tool, switch to the documented fallback / Path B
-instead of retrying the failing call.
+the tool-discovery load query for the specific MCP tool you are about to call**
+(idempotent — a no-op when the schema is already loaded) so the correct schema is
+guaranteed present for that call. Use `"+ouroboros seed"` before
+`ouroboros_generate_seed`, `"+ouroboros qa"` before `ouroboros_qa`, and
+`"+ouroboros lateral"` before `ouroboros_lateral_think`. If a load ever returns
+no matching tool, switch to the documented fallback / Path B instead of retrying
+the failing call.
 
 ### Path A: MCP Mode (Preferred)
 

--- a/.claude-plugin/skills/seed/SKILL.md
+++ b/.claude-plugin/skills/seed/SKILL.md
@@ -45,6 +45,18 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+This skill makes `ouroboros_*` MCP calls across multiple turns, and each turn runs
+in a fresh tool context. A deferred tool's schema loaded on one turn is NOT
+guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP tool
+while its schema is not loaded in the **current** turn, the runtime rejects the
+call with **"Invalid tool parameters"** before it ever reaches the server.
+Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
+the same tool-discovery load query you used above** (idempotent — a no-op when the
+schema is already loaded) so the schema is guaranteed present for that call. If a
+load ever returns no matching tool, switch to the documented fallback / Path B
+instead of retrying the failing call.
+
 ### Path A: MCP Mode (Preferred)
 
 If the `ouroboros_generate_seed` MCP tool is available (loaded via runtime tool discovery above):

--- a/.claude-plugin/skills/setup/SKILL.md
+++ b/.claude-plugin/skills/setup/SKILL.md
@@ -421,6 +421,14 @@ This may take a moment...
 
 **Implementation — use MCP tools only, do NOT use CLI or Python scripts:**
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+`setup` can call `ouroboros_brownfield` before and after a user-selection turn.
+A deferred schema loaded before scan is NOT guaranteed to remain loaded for the
+later `set_defaults` call. Immediately before EVERY `ouroboros_brownfield` call
+in this section, re-run `ToolSearch query: "+ouroboros brownfield"` (idempotent —
+a no-op when already loaded). If the load returns no matching tool, use the
+non-MCP setup fallback instead of retrying the failing call.
+
 1. Load the brownfield MCP tool: `ToolSearch query: "+ouroboros brownfield"`
 2. Call scan+register:
    ```
@@ -493,7 +501,7 @@ Use `AskUserQuestion` with the current default numbers from the scan response.
 
 The user can select the recommended defaults (if any), choose "None", or type custom numbers.
 
-After the user responds, use ONE MCP call to update all defaults at once:
+After the user responds, re-run `ToolSearch query: "+ouroboros brownfield"`, then use ONE MCP call to update all defaults at once:
 
 ```
 Tool: ouroboros_brownfield

--- a/skills/brownfield/SKILL.md
+++ b/skills/brownfield/SKILL.md
@@ -41,6 +41,14 @@ This may take a moment...
 
 **Implementation — use MCP tools only, do NOT use CLI or Python scripts:**
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+This skill can call `ouroboros_brownfield` across multiple turns (`scan`,
+`set_defaults`, `defaults`, and `set`). A deferred schema loaded for one turn is
+NOT guaranteed to remain loaded for the next. Immediately before EVERY
+`ouroboros_brownfield` call, re-run `ToolSearch query: "+ouroboros brownfield"`
+(idempotent — a no-op when already loaded). If the load returns no matching tool,
+stop with the MCP-not-available message instead of retrying the failing call.
+
 1. Load the brownfield MCP tool: `ToolSearch query: "+ouroboros brownfield"`
 2. Call scan+register:
    ```
@@ -117,7 +125,7 @@ Then stop.
 
 The user can select the recommended defaults (if any), choose "None", or type custom numbers.
 
-After the user responds, use ONE MCP call to update all defaults at once:
+After the user responds, re-run `ToolSearch query: "+ouroboros brownfield"`, then use ONE MCP call to update all defaults at once:
 
 ```
 Tool: ouroboros_brownfield
@@ -155,7 +163,7 @@ Scan only, no default selection prompt. Show the numbered list and stop.
 
 ### Subcommand: `defaults`
 
-Load the brownfield MCP tool and call:
+Re-run `ToolSearch query: "+ouroboros brownfield"`, then call:
 ```
 Tool: ouroboros_brownfield
 Arguments: { "action": "scan" }
@@ -170,7 +178,7 @@ No default repos set. Run 'ooo brownfield' to configure.
 
 ### Subcommand: `set <indices>`
 
-Directly set defaults without scanning. Parse the comma-separated indices from the user's input and call:
+Directly set defaults without scanning. Parse the comma-separated indices from the user's input, re-run `ToolSearch query: "+ouroboros brownfield"`, and call:
 
 ```
 Tool: ouroboros_brownfield

--- a/skills/evaluate/SKILL.md
+++ b/skills/evaluate/SKILL.md
@@ -52,6 +52,18 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+This skill makes `ouroboros_*` MCP calls across multiple turns, and each turn runs
+in a fresh tool context. A deferred tool's schema loaded on one turn is NOT
+guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP tool
+while its schema is not loaded in the **current** turn, the runtime rejects the
+call with **"Invalid tool parameters"** before it ever reaches the server.
+Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
+the same tool-discovery load query you used above** (idempotent — a no-op when the
+schema is already loaded) so the schema is guaranteed present for that call. If a
+load ever returns no matching tool, switch to the documented fallback / Path B
+instead of retrying the failing call.
+
 ### Evaluation Steps
 
 1. Determine what to evaluate:

--- a/skills/evaluate/SKILL.md
+++ b/skills/evaluate/SKILL.md
@@ -53,16 +53,14 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
 **CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
-This skill makes `ouroboros_*` MCP calls across multiple turns, and each turn runs
-in a fresh tool context. A deferred tool's schema loaded on one turn is NOT
-guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP tool
-while its schema is not loaded in the **current** turn, the runtime rejects the
-call with **"Invalid tool parameters"** before it ever reaches the server.
-Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
-the same tool-discovery load query you used above** (idempotent — a no-op when the
-schema is already loaded) so the schema is guaranteed present for that call. If a
-load ever returns no matching tool, switch to the documented fallback / Path B
-instead of retrying the failing call.
+This skill can call `ouroboros_evaluate` after a fresh turn. A deferred tool's
+schema loaded on one turn is NOT guaranteed to still be loaded on the next. If
+you call it while its schema is not loaded in the **current** turn, the runtime
+rejects the call with **"Invalid tool parameters"** before it reaches the server.
+Therefore: **immediately before EVERY `ouroboros_evaluate` call in this skill,
+re-run `ToolSearch query: "+ouroboros evaluate"`** (idempotent — a no-op when
+already loaded). If the load returns no matching tool, switch to the documented
+fallback instead of retrying the failing call.
 
 ### Evaluation Steps
 

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -61,10 +61,13 @@ guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP too
 while its schema is not loaded in the **current** turn, the runtime rejects the
 call with **"Invalid tool parameters"** before it ever reaches the server.
 Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
-the same tool-discovery load query you used above** (idempotent — a no-op when the
-schema is already loaded) so the schema is guaranteed present for that call. If a
-load ever returns no matching tool, switch to the documented fallback / Path B
-instead of retrying the failing call.
+the tool-discovery load query for the specific MCP tool or documented tool family
+you are about to call**. Use `"+ouroboros evolve"` for `ouroboros_evolve_step`,
+`ouroboros_lineage_status`, and the evolve flow's documented tool family;
+use `"+ouroboros interview"` before `ouroboros_interview`, `"+ouroboros seed"`
+before `ouroboros_generate_seed`, and `"+ouroboros lateral"` before
+`ouroboros_lateral_think`. If a load returns no matching tool, switch to the
+documented fallback / Path B instead of retrying the failing call.
 
 ### Path A: MCP Available (loaded via ToolSearch above)
 

--- a/skills/evolve/SKILL.md
+++ b/skills/evolve/SKILL.md
@@ -54,6 +54,18 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+This skill makes `ouroboros_*` MCP calls across multiple turns, and each turn runs
+in a fresh tool context. A deferred tool's schema loaded on one turn is NOT
+guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP tool
+while its schema is not loaded in the **current** turn, the runtime rejects the
+call with **"Invalid tool parameters"** before it ever reaches the server.
+Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
+the same tool-discovery load query you used above** (idempotent — a no-op when the
+schema is already loaded) so the schema is guaranteed present for that call. If a
+load ever returns no matching tool, switch to the documented fallback / Path B
+instead of retrying the failing call.
+
 ### Path A: MCP Available (loaded via ToolSearch above)
 
 **Starting a new evolutionary loop:**

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -111,10 +111,12 @@ guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP too
 while its schema is not loaded in the **current** turn, the runtime rejects the
 call with **"Invalid tool parameters"** before it ever reaches the server.
 Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
-the same tool-discovery load query you used above** (idempotent — a no-op when the
-schema is already loaded) so the schema is guaranteed present for that call. If a
-load ever returns no matching tool, switch to the documented fallback / Path B
-instead of retrying the failing call.
+the tool-discovery load query for the specific MCP tool you are about to call**
+(idempotent — a no-op when the schema is already loaded) so the correct schema is
+guaranteed present for that call. Use `"+ouroboros interview"` before
+`ouroboros_interview` and `"+ouroboros lateral"` before
+`ouroboros_lateral_think`. If a load ever returns no matching tool, switch to the
+documented fallback / Path B instead of retrying the failing call.
 
 ### Path A: MCP Mode (Preferred)
 

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -104,6 +104,18 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+This skill makes `ouroboros_*` MCP calls across multiple turns, and each turn runs
+in a fresh tool context. A deferred tool's schema loaded on one turn is NOT
+guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP tool
+while its schema is not loaded in the **current** turn, the runtime rejects the
+call with **"Invalid tool parameters"** before it ever reaches the server.
+Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
+the same tool-discovery load query you used above** (idempotent — a no-op when the
+schema is already loaded) so the schema is guaranteed present for that call. If a
+load ever returns no matching tool, switch to the documented fallback / Path B
+instead of retrying the failing call.
+
 ### Path A: MCP Mode (Preferred)
 
 If the `ouroboros_interview` MCP tool is available (loaded via runtime tool discovery above), use it for persistent, structured interviews.

--- a/skills/pm/SKILL.md
+++ b/skills/pm/SKILL.md
@@ -15,6 +15,16 @@ PM-focused Socratic interview that produces a Product Requirements Document.
 ToolSearch query: "+ouroboros pm_interview"
 ```
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+This is a multi-turn loop and each turn runs in a fresh tool context. A deferred
+tool's schema loaded on one turn is NOT guaranteed to still be loaded on the next.
+Calling `ouroboros_pm_interview` while its schema is unloaded in the **current**
+turn makes the runtime reject it with **"Invalid tool parameters"** every message.
+Therefore **re-run `ToolSearch query: "+ouroboros pm_interview"` immediately before
+EVERY `ouroboros_pm_interview` call** below (idempotent — a no-op if already
+loaded). If the load ever returns no matching tool, follow the not-found diagnosis
+below instead of retrying the failing call.
+
 If not found → **diagnose before telling user to run setup**:
 
 1. Check if MCP is already configured:

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -45,16 +45,17 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
 **CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
-This skill makes `ouroboros_*` MCP calls across multiple turns, and each turn runs
+This skill makes execution MCP calls across multiple turns, and each turn runs
 in a fresh tool context. A deferred tool's schema loaded on one turn is NOT
-guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP tool
-while its schema is not loaded in the **current** turn, the runtime rejects the
-call with **"Invalid tool parameters"** before it ever reaches the server.
-Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
-the same tool-discovery load query you used above** (idempotent — a no-op when the
-schema is already loaded) so the schema is guaranteed present for that call. If a
-load ever returns no matching tool, switch to the documented fallback / Path B
-instead of retrying the failing call.
+guaranteed to still be loaded on the next. If you call any execution `ouroboros_*`
+MCP tool while its schema is not loaded in the **current** turn, the runtime
+rejects the call with **"Invalid tool parameters"** before it reaches the server.
+Therefore: **immediately before EVERY execution MCP call in this skill, re-run
+`ToolSearch query: "+ouroboros execute"`** to reload the execution tool family,
+including `ouroboros_start_execute_seed`, `ouroboros_job_wait`,
+`ouroboros_ac_tree_hud`, and `ouroboros_job_result` (idempotent — a no-op when
+already loaded). If the load returns no matching tool, switch to the documented
+fallback instead of retrying the failing call.
 
 ### Execution Steps
 

--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -44,6 +44,18 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+This skill makes `ouroboros_*` MCP calls across multiple turns, and each turn runs
+in a fresh tool context. A deferred tool's schema loaded on one turn is NOT
+guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP tool
+while its schema is not loaded in the **current** turn, the runtime rejects the
+call with **"Invalid tool parameters"** before it ever reaches the server.
+Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
+the same tool-discovery load query you used above** (idempotent — a no-op when the
+schema is already loaded) so the schema is guaranteed present for that call. If a
+load ever returns no matching tool, switch to the documented fallback / Path B
+instead of retrying the failing call.
+
 ### Execution Steps
 
 1. **Detect git workflow** (before any code changes):

--- a/skills/seed/SKILL.md
+++ b/skills/seed/SKILL.md
@@ -52,10 +52,13 @@ guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP too
 while its schema is not loaded in the **current** turn, the runtime rejects the
 call with **"Invalid tool parameters"** before it ever reaches the server.
 Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
-the same tool-discovery load query you used above** (idempotent — a no-op when the
-schema is already loaded) so the schema is guaranteed present for that call. If a
-load ever returns no matching tool, switch to the documented fallback / Path B
-instead of retrying the failing call.
+the tool-discovery load query for the specific MCP tool you are about to call**
+(idempotent — a no-op when the schema is already loaded) so the correct schema is
+guaranteed present for that call. Use `"+ouroboros seed"` before
+`ouroboros_generate_seed`, `"+ouroboros qa"` before `ouroboros_qa`, and
+`"+ouroboros lateral"` before `ouroboros_lateral_think`. If a load ever returns
+no matching tool, switch to the documented fallback / Path B instead of retrying
+the failing call.
 
 ### Path A: MCP Mode (Preferred)
 

--- a/skills/seed/SKILL.md
+++ b/skills/seed/SKILL.md
@@ -45,6 +45,18 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 
 **IMPORTANT**: Do NOT skip this step. Do NOT assume MCP tools are unavailable just because they don't appear in your immediate tool list. They are almost always available as deferred tools that need to be loaded first.
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+This skill makes `ouroboros_*` MCP calls across multiple turns, and each turn runs
+in a fresh tool context. A deferred tool's schema loaded on one turn is NOT
+guaranteed to still be loaded on the next. If you call any `ouroboros_*` MCP tool
+while its schema is not loaded in the **current** turn, the runtime rejects the
+call with **"Invalid tool parameters"** before it ever reaches the server.
+Therefore: **immediately before EVERY `ouroboros_*` MCP call in this skill, re-run
+the same tool-discovery load query you used above** (idempotent — a no-op when the
+schema is already loaded) so the schema is guaranteed present for that call. If a
+load ever returns no matching tool, switch to the documented fallback / Path B
+instead of retrying the failing call.
+
 ### Path A: MCP Mode (Preferred)
 
 If the `ouroboros_generate_seed` MCP tool is available (loaded via runtime tool discovery above):

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -421,6 +421,14 @@ This may take a moment...
 
 **Implementation — use MCP tools only, do NOT use CLI or Python scripts:**
 
+**CRITICAL — deferred-schema guard (prevents "Invalid tool parameters"):**
+`setup` can call `ouroboros_brownfield` before and after a user-selection turn.
+A deferred schema loaded before scan is NOT guaranteed to remain loaded for the
+later `set_defaults` call. Immediately before EVERY `ouroboros_brownfield` call
+in this section, re-run `ToolSearch query: "+ouroboros brownfield"` (idempotent —
+a no-op when already loaded). If the load returns no matching tool, use the
+non-MCP setup fallback instead of retrying the failing call.
+
 1. Load the brownfield MCP tool: `ToolSearch query: "+ouroboros brownfield"`
 2. Call scan+register:
    ```
@@ -493,7 +501,7 @@ Use `AskUserQuestion` with the current default numbers from the scan response.
 
 The user can select the recommended defaults (if any), choose "None", or type custom numbers.
 
-After the user responds, use ONE MCP call to update all defaults at once:
+After the user responds, re-run `ToolSearch query: "+ouroboros brownfield"`, then use ONE MCP call to update all defaults at once:
 
 ```
 Tool: ouroboros_brownfield

--- a/tests/unit/skills/test_skill_artifacts.py
+++ b/tests/unit/skills/test_skill_artifacts.py
@@ -32,3 +32,28 @@ def test_resolve_packaged_skills_dir_falls_back_to_repo_root_bundle_when_package
 
     with resolve_packaged_skills_dir(anchor_file=anchor_file) as resolved_dir:
         assert resolved_dir == repo_skills_dir
+
+
+def test_multitool_deferred_schema_guards_name_each_discovery_query() -> None:
+    """Multi-tool skill guards must not reuse the wrong deferred schema query."""
+    repo_root = Path(__file__).resolve().parents[3]
+    expected = {
+        "seed": [
+            ('"+ouroboros seed"', "ouroboros_generate_seed"),
+            ('"+ouroboros qa"', "ouroboros_qa"),
+            ('"+ouroboros lateral"', "ouroboros_lateral_think"),
+        ],
+        "interview": [
+            ('"+ouroboros interview"', "ouroboros_interview"),
+            ('"+ouroboros lateral"', "ouroboros_lateral_think"),
+        ],
+    }
+
+    for root in (repo_root / "skills", repo_root / ".claude-plugin" / "skills"):
+        for skill, pairs in expected.items():
+            text = (root / skill / "SKILL.md").read_text(encoding="utf-8")
+            assert "the specific MCP tool you are about to call" in text
+            assert "the same tool-discovery load query you used above" not in text
+            for query, tool in pairs:
+                assert query in text
+                assert tool in text

--- a/tests/unit/skills/test_skill_artifacts.py
+++ b/tests/unit/skills/test_skill_artifacts.py
@@ -69,6 +69,7 @@ def test_multitool_deferred_schema_guards_name_each_discovery_query() -> None:
             ('"+ouroboros execute"', "ouroboros_start_execute_seed"),
             ('"+ouroboros execute"', "ouroboros_job_wait"),
             ('"+ouroboros execute"', "ouroboros_job_result"),
+            ('"+ouroboros execute"', "ouroboros_ac_tree_hud"),
         ],
     }
 

--- a/tests/unit/skills/test_skill_artifacts.py
+++ b/tests/unit/skills/test_skill_artifacts.py
@@ -57,8 +57,7 @@ def test_multitool_deferred_schema_guards_name_each_discovery_query() -> None:
 
     for root in (repo_root / "skills", repo_root / ".claude-plugin" / "skills"):
         assert "the same tool-discovery load query you used above" not in "\n".join(
-            skill_path.read_text(encoding="utf-8")
-            for skill_path in root.glob("*/SKILL.md")
+            skill_path.read_text(encoding="utf-8") for skill_path in root.glob("*/SKILL.md")
         )
         for skill, pairs in expected.items():
             text = (root / skill / "SKILL.md").read_text(encoding="utf-8")

--- a/tests/unit/skills/test_skill_artifacts.py
+++ b/tests/unit/skills/test_skill_artifacts.py
@@ -38,6 +38,12 @@ def test_multitool_deferred_schema_guards_name_each_discovery_query() -> None:
     """Multi-tool skill guards must not reuse the wrong deferred schema query."""
     repo_root = Path(__file__).resolve().parents[3]
     expected = {
+        "brownfield": [
+            ('"+ouroboros brownfield"', "ouroboros_brownfield"),
+        ],
+        "setup": [
+            ('"+ouroboros brownfield"', "ouroboros_brownfield"),
+        ],
         "seed": [
             ('"+ouroboros seed"', "ouroboros_generate_seed"),
             ('"+ouroboros qa"', "ouroboros_qa"),
@@ -50,10 +56,13 @@ def test_multitool_deferred_schema_guards_name_each_discovery_query() -> None:
     }
 
     for root in (repo_root / "skills", repo_root / ".claude-plugin" / "skills"):
+        assert "the same tool-discovery load query you used above" not in "\n".join(
+            skill_path.read_text(encoding="utf-8")
+            for skill_path in root.glob("*/SKILL.md")
+        )
         for skill, pairs in expected.items():
             text = (root / skill / "SKILL.md").read_text(encoding="utf-8")
-            assert "the specific MCP tool you are about to call" in text
-            assert "the same tool-discovery load query you used above" not in text
+            assert "deferred-schema guard" in text
             for query, tool in pairs:
                 assert query in text
                 assert tool in text

--- a/tests/unit/skills/test_skill_artifacts.py
+++ b/tests/unit/skills/test_skill_artifacts.py
@@ -53,6 +53,23 @@ def test_multitool_deferred_schema_guards_name_each_discovery_query() -> None:
             ('"+ouroboros interview"', "ouroboros_interview"),
             ('"+ouroboros lateral"', "ouroboros_lateral_think"),
         ],
+        "evaluate": [
+            ('"+ouroboros evaluate"', "ouroboros_evaluate"),
+        ],
+        "evolve": [
+            ('"+ouroboros evolve"', "ouroboros_evolve_step"),
+            ('"+ouroboros interview"', "ouroboros_interview"),
+            ('"+ouroboros seed"', "ouroboros_generate_seed"),
+            ('"+ouroboros lateral"', "ouroboros_lateral_think"),
+        ],
+        "pm": [
+            ('"+ouroboros pm_interview"', "ouroboros_pm_interview"),
+        ],
+        "run": [
+            ('"+ouroboros execute"', "ouroboros_start_execute_seed"),
+            ('"+ouroboros execute"', "ouroboros_job_wait"),
+            ('"+ouroboros execute"', "ouroboros_job_result"),
+        ],
     }
 
     for root in (repo_root / "skills", repo_root / ".claude-plugin" / "skills"):


### PR DESCRIPTION
## Summary

Multi-turn skills (`interview`, `pm`, `seed`, `run`, `evaluate`, `evolve`) load the deferred `ouroboros_*` MCP tool schema **only once at skill entry**. On Claude Code builds that register plugin MCP tools as *deferred tools*, a schema loaded on one turn is not guaranteed to remain loaded on the next turn's fresh tool context. The first `ouroboros_*` call on a later turn is then rejected client-side with **"Invalid tool parameters"** before it ever reaches the server.

This fixes #1417.

## Symptom

The error flashes on nearly every step of the pipeline (interview → seed → run/evaluate/evolve, and the deferred calls in `setup`). In many cases the runtime re-discovers the schema and the retry succeeds, so work still completes — but it reads as a broken tool and erodes trust. At user-decision gates (interview confirm/decide, seed User-Adoption-Gate / `Balance:` line, setup Step 3) a first-attempt failure that does not auto-retry can stall the flow.

## Root cause (verified)

- After explicitly loading a deferred tool's schema, calling it returns a normal application response — e.g. `ouroboros_session_status {session_id:"__probe__"}` → `Session not found: ...` — i.e. the call dispatches fine. So the failure is purely **schema-load timing**, not a genuine parameter-shape error (the relevant params are all optional/simple).
- A real `setup` session showed `ToolSearch "+ouroboros brownfield"` immediately preceding `ouroboros_brownfield {action:"scan"}` → success; where the skill reloads right before the call, no error occurs.

## Fix

Add a **deferred-schema guard** to each affected skill instructing the agent to re-run the *idempotent* tool-discovery load immediately before **every** `ouroboros_*` call (a no-op when already loaded), and to fall through to the documented Path B / not-found fallback when the load returns no tool.

Applied to both trees:
- `skills/` (the tree referenced by `.claude-plugin/plugin.json` → `"skills": "./skills/"`)
- `.claude-plugin/skills/` mirror (kept in sync)

Docs-only change (skill instructions); no code paths touched.

## Files

`interview`, `pm`, `seed`, `run`, `evaluate`, `evolve` — `SKILL.md` in each of the two skill trees (12 files, +140 lines).

## Testing

- Confirmed the guard's discovery queries (`+ouroboros interview`, `+ouroboros pm_interview`, etc.) load the schemas and that a subsequently-issued call validates and dispatches (returns app-level result, not "Invalid tool parameters").
- Verified anchor uniqueness and that the guard text inserts cleanly in all 12 files.

## Notes

- `skills/` and `.claude-plugin/skills/` are largely duplicated in the repo (only `pm` currently differs between them). If one is intended to be generated from the other, happy to drop the mirror edits and wire up generation instead — let me know.
