### PR TITLE
fix(seed): accept prose exit condition lists

### DIFF
--- a/skills/seed/SKILL.md
+++ b/skills/seed/SKILL.md
@@ -351,6 +351,20 @@ ontology_schema:
     - name: title
       type: string
       description: Task title
+evaluation_principles:
+  - name: completeness
+    description: All requirements are implemented
+    weight: 1.0
+  - name: usability
+    description: CLI commands are clear and easy to use
+    weight: 0.7
+exit_conditions:
+  - name: all_criteria_met
+    description: All acceptance criteria pass
+    criteria: 100% of acceptance criteria are satisfied
+  - name: tests_green
+    description: The project test suite passes
+    criteria: Required automated tests exit successfully
 metadata:
   ambiguity_score: 0.15
 ```

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -20,7 +20,7 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class ExitCondition(BaseModel, frozen=True):
@@ -277,6 +277,42 @@ class Seed(BaseModel, frozen=True):
         ...,
         description="Generation metadata (version, timestamp, etc.)",
     )
+
+    @field_validator("evaluation_principles", mode="before")
+    @classmethod
+    def _coerce_string_evaluation_principles(cls, value: Any) -> Any:
+        """Accept prose lists for hand-written seeds.
+
+        Human-authored seed drafts often express evaluation principles as a
+        simple YAML string list. Lift those entries into the documented object
+        shape so manual ``ooo run`` users get a usable seed instead of an
+        opaque Pydantic ``model_type`` error.
+        """
+        if isinstance(value, list | tuple):
+            return tuple(
+                {"name": f"principle_{index}", "description": item}
+                if isinstance(item, str)
+                else item
+                for index, item in enumerate(value, start=1)
+            )
+        return value
+
+    @field_validator("exit_conditions", mode="before")
+    @classmethod
+    def _coerce_string_exit_conditions(cls, value: Any) -> Any:
+        """Accept prose lists for hand-written seed exit conditions."""
+        if isinstance(value, list | tuple):
+            return tuple(
+                {
+                    "name": f"condition_{index}",
+                    "description": item,
+                    "criteria": item,
+                }
+                if isinstance(item, str)
+                else item
+                for index, item in enumerate(value, start=1)
+            )
+        return value
 
     def to_dict(self) -> dict[str, Any]:
         """Convert seed to dictionary for serialization.

--- a/tests/unit/core/test_seed.py
+++ b/tests/unit/core/test_seed.py
@@ -467,8 +467,7 @@ class TestSeed:
         assert reconstructed.exit_conditions[0].name == "condition_1"
         assert reconstructed.exit_conditions[0].description == "All invariant tests are green"
         assert (
-            reconstructed.exit_conditions[0].evaluation_criteria
-            == "All invariant tests are green"
+            reconstructed.exit_conditions[0].evaluation_criteria == "All invariant tests are green"
         )
 
     def test_seed_roundtrip_serialization(self, full_seed: Seed) -> None:

--- a/tests/unit/core/test_seed.py
+++ b/tests/unit/core/test_seed.py
@@ -446,6 +446,31 @@ class TestSeed:
         assert reconstructed.ontology_schema.name == full_seed.ontology_schema.name
         assert reconstructed.metadata.ambiguity_score == full_seed.metadata.ambiguity_score
 
+    def test_seed_from_dict_coerces_string_principles_and_conditions(self) -> None:
+        """Seed.from_dict() accepts prose lists from hand-written seed YAML."""
+        reconstructed = Seed.from_dict(
+            {
+                "goal": "Build a CLI task manager",
+                "ontology_schema": {
+                    "name": "TaskManager",
+                    "description": "Task management domain",
+                },
+                "evaluation_principles": ["Prefer simple code"],
+                "exit_conditions": ["All invariant tests are green"],
+                "metadata": {"ambiguity_score": 0.15},
+            }
+        )
+
+        assert reconstructed.evaluation_principles[0].name == "principle_1"
+        assert reconstructed.evaluation_principles[0].description == "Prefer simple code"
+        assert reconstructed.evaluation_principles[0].weight == 1.0
+        assert reconstructed.exit_conditions[0].name == "condition_1"
+        assert reconstructed.exit_conditions[0].description == "All invariant tests are green"
+        assert (
+            reconstructed.exit_conditions[0].evaluation_criteria
+            == "All invariant tests are green"
+        )
+
     def test_seed_roundtrip_serialization(self, full_seed: Seed) -> None:
         """Seed can roundtrip through dict serialization."""
         seed_dict = full_seed.to_dict()

--- a/tests/unit/core/test_seed.py
+++ b/tests/unit/core/test_seed.py
@@ -353,6 +353,39 @@ class TestSeed:
         assert len(full_seed.evaluation_principles) == 2
         assert len(full_seed.exit_conditions) == 1
 
+    def test_seed_coerces_string_evaluation_principles(self) -> None:
+        """Hand-written seed principle string lists are lifted into objects."""
+        seed = Seed(
+            goal="Build a CLI task manager",
+            ontology_schema=OntologySchema(
+                name="TaskManager",
+                description="Task management domain",
+            ),
+            evaluation_principles=("Prefer simple code", "Keep UX clear"),
+            metadata=SeedMetadata(ambiguity_score=0.15),
+        )
+
+        assert seed.evaluation_principles[0].name == "principle_1"
+        assert seed.evaluation_principles[0].description == "Prefer simple code"
+        assert seed.evaluation_principles[0].weight == 1.0
+        assert seed.evaluation_principles[1].name == "principle_2"
+
+    def test_seed_coerces_string_exit_conditions(self) -> None:
+        """Hand-written seed exit condition string lists are lifted into objects."""
+        seed = Seed(
+            goal="Build a CLI task manager",
+            ontology_schema=OntologySchema(
+                name="TaskManager",
+                description="Task management domain",
+            ),
+            exit_conditions=("All invariant tests are green",),
+            metadata=SeedMetadata(ambiguity_score=0.15),
+        )
+
+        assert seed.exit_conditions[0].name == "condition_1"
+        assert seed.exit_conditions[0].description == "All invariant tests are green"
+        assert seed.exit_conditions[0].evaluation_criteria == "All invariant tests are green"
+
     def test_seed_goal_immutability(self, minimal_seed: Seed) -> None:
         """Seed.goal cannot be modified (frozen=True raises error)."""
         with pytest.raises(PydanticValidationError):


### PR DESCRIPTION
## Summary
- Coerce string-list `evaluation_principles` entries into documented `EvaluationPrinciple` objects for hand-written seeds.
- Coerce string-list `exit_conditions` entries into documented `ExitCondition` objects using the prose as both description and criteria.
- Expand the seed skill example to show the required object shape for both fields.

Closes #1420

## Test plan
- `uv run pytest tests/unit/core/test_seed.py`
- `uv run ruff check src/ouroboros/core/seed.py tests/unit/core/test_seed.py skills/seed/SKILL.md`

_Posted by [agentos-roadmap-warden](https://github.com/Q00/ouroboros/blob/main/agents/agentos-roadmap-warden.md) — bot. Reply with `/warden ignore` to suppress further comments on this thread._
