### PR TITLE
fix(mcp): keep terminal job results after handle ttl

### DIFF
--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -285,8 +285,8 @@ Treat `running` or other non-terminal status output as progress only. A
 `auto` result. Wait with `ouroboros_job_wait`, then fetch the completed result
 with `ouroboros_job_result` after the job reaches a terminal lifecycle status.
 When MCP status reports `completed`, `ouroboros_job_result(job_id="JOB_ID")`
-retrieves the stable completed `auto` result for that job handle. Unknown,
-expired, or otherwise unavailable handles return an MCP error response.
+retrieves the stable completed `auto` result for that job handle. Unknown or
+otherwise unavailable handles return an MCP error response.
 When MCP status cannot resolve the supplied handle, treat the detached work as
 `invalid` or unavailable rather than as running or completed. The stable
 observable status is the MCP error response for that handle, not a detached
@@ -362,24 +362,22 @@ meta.is_terminal = true
 meta.error = "user requested cancellation"
 ```
 
-When `ouroboros_job_result(job_id="JOB_ID")` reports `expired`, the job is
-terminal tracked background work whose retained result is no longer available
-through that job handle. `ouroboros_job_status` still reports the stored
-terminal lifecycle status, while result retrieval returns stable expiration
-error details rather than a detached `auto` result. Next steps are to inspect
-any surfaced auto session, execution, or lineage handle, then resume from that
-handle or restart the detached auto flow when no recoverable handle is present.
+When a terminal job is older than the in-memory handle TTL,
+`ouroboros_job_result(job_id="JOB_ID")` still retrieves the persisted terminal
+result for that job handle. `ouroboros_job_status` reports the stored terminal
+lifecycle status, and result retrieval returns the durable result artifact
+rather than an expiration error.
 
 ```text
 ouroboros_job_result(job_id="job_auto_docs_expired")
 
-error.message = "Job handle expired: job_auto_docs_expired. Result unavailable."
-error.error_code = "job_handle_expired"
-error.details.job_id = "job_auto_docs_expired"
-error.details.lifecycle_status = "expired"
-error.details.is_terminal = true
-error.details.result_available = false
-error.details.reason = "expired"
+is_error = false
+content[0].text = "detached auto result artifact: expired seed.yaml"
+meta.job_id = "job_auto_docs_expired"
+meta.status = "completed"
+meta.lifecycle_status = "completed"
+meta.is_terminal = true
+meta.result_available = true
 ```
 
 ### `ouroboros_brownfield` Scan Boundaries

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -120,15 +120,12 @@ not a successful `auto` result. Next steps are to inspect
 the detached auto flow or resume from the surfaced auto session, execution, or
 lineage handle when one is present. The CLI prints the stable cancellation
 output and exits non-zero because the terminal result is an error result.
-When `ouroboros job result JOB_ID` reports `expired`, the job is terminal
-tracked background work whose retained result is no longer available through
-that job handle. `ouroboros job status JOB_ID` still reports the stored terminal
-lifecycle status, while result retrieval returns stable expiration error
-details rather than a detached `auto` result. Next steps are to inspect any
-surfaced auto session, execution, or lineage handle, then resume from that
-handle or restart the detached auto flow when no recoverable handle is present.
-Unknown, expired, or otherwise unavailable handles fail through the CLI with a
-non-zero status and through MCP with an error response.
+When a terminal job is older than the in-memory handle TTL,
+`ouroboros job result JOB_ID` still retrieves the persisted terminal result for
+that job handle. `ouroboros job status JOB_ID` reports the stored terminal
+lifecycle status, and result retrieval returns the durable result artifact rather
+than an expiration error. Unknown or otherwise unavailable handles fail through
+the CLI with a non-zero status and through MCP with an error response.
 When CLI status cannot resolve the supplied handle, treat the detached work as
 `invalid` or unavailable rather than as running or completed. The stable
 observable status is the non-zero CLI exit plus the human-readable error for
@@ -161,7 +158,7 @@ Example expired CLI retrieval output:
 
 ```bash
 $ ouroboros job result job_auto_docs_expired
-Job handle expired: job_auto_docs_expired. Result unavailable.
+detached auto result artifact: expired seed.yaml
 ```
 
 > **`ooo auto` does not accept `--opencode-mode`.** OpenCode mode is

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -150,23 +150,6 @@ def _read_owner_identity(created_data: dict[str, Any]) -> tuple[int | None, floa
     return pid, start
 
 
-def is_terminal_job_expired(
-    snapshot: JobSnapshot,
-    *,
-    now: datetime | None = None,
-    ttl: timedelta | None = None,
-) -> bool:
-    """Return true when a terminal job handle is past the retrieval TTL."""
-    if not snapshot.is_terminal:
-        return False
-    ttl = ttl if ttl is not None else _JOB_TTL
-    current = now or datetime.now(UTC)
-    updated = snapshot.updated_at
-    if updated.tzinfo is None:
-        updated = updated.replace(tzinfo=UTC)
-    return updated < current - ttl
-
-
 def _consume_task_result(task: asyncio.Task[Any]) -> None:
     """Drain a detached task result so forced cleanup does not log noise."""
     try:

--- a/src/ouroboros/mcp/tools/job_handlers.py
+++ b/src/ouroboros/mcp/tools/job_handlers.py
@@ -21,7 +21,6 @@ from ouroboros.mcp.job_manager import (
     JobManager,
     JobSnapshot,
     JobStatus,
-    is_terminal_job_expired,
 )
 from ouroboros.mcp.tools.ac_tree_hud_handler import (
     format_subtask_progress_summary,
@@ -1228,22 +1227,6 @@ class JobResultHandler:
                         "result_available": False,
                         "reason": "not_found",
                         "source_error": str(exc),
-                    },
-                )
-            )
-
-        if is_terminal_job_expired(snapshot):
-            return Result.err(
-                MCPToolError(
-                    f"Job handle expired: {snapshot.job_id}. Result unavailable.",
-                    tool_name="ouroboros_job_result",
-                    error_code="job_handle_expired",
-                    details={
-                        "job_id": snapshot.job_id,
-                        "lifecycle_status": "expired",
-                        "is_terminal": snapshot.is_terminal,
-                        "result_available": False,
-                        "reason": "expired",
                     },
                 )
             )

--- a/tests/unit/cli/test_job_command.py
+++ b/tests/unit/cli/test_job_command.py
@@ -683,10 +683,10 @@ def test_cli_detached_auto_result_with_invalid_job_handle_exits_nonzero(
     assert "Job handle not found: missing_detached_auto. Result unavailable." in result.output
 
 
-def test_cli_detached_auto_result_with_expired_job_handle_exits_nonzero(
+def test_cli_detached_auto_result_with_expired_job_handle_returns_persisted_result(
     monkeypatch, tmp_path
 ) -> None:
-    """Verify CLI result retrieval fails clearly for an expired detached job handle."""
+    """Verify CLI result retrieval keeps terminal persisted results after handle TTL."""
     from ouroboros.cli.commands import job as job_command
     from ouroboros.cli.main import app
 
@@ -746,9 +746,9 @@ def test_cli_detached_auto_result_with_expired_job_handle_exits_nonzero(
 
     result = runner.invoke(app, ["job", "result", job_id])
 
-    assert result.exit_code == 1
-    assert f"Job handle expired: {job_id}" in result.output
-    assert "Result unavailable." in result.output
+    assert result.exit_code == 0
+    assert "stale detached auto result" in result.output
+    assert f"Job handle expired: {job_id}" not in result.output
 
 
 def test_cli_wait_and_status_with_invalid_detached_auto_handle_fail_stably(

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from dataclasses import replace
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 import os
 from unittest.mock import AsyncMock, patch
 
@@ -1761,6 +1761,52 @@ class TestJobManager:
             )
         finally:
             await store.close()
+
+    async def test_job_result_handler_returns_expired_terminal_result(self, tmp_path) -> None:
+        store = _build_store(tmp_path)
+        job_id = "job_expired_terminal_result"
+        expired_at = datetime.now(UTC) - timedelta(hours=2)
+        await store.initialize()
+
+        try:
+            await store.append(
+                BaseEvent(
+                    id="evt_expired_terminal_created",
+                    type="mcp.job.created",
+                    timestamp=expired_at,
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "job_type": "execute_seed",
+                        "status": JobStatus.QUEUED.value,
+                        "message": "Queued execute_seed",
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    id="evt_expired_terminal_completed",
+                    type="mcp.job.completed",
+                    timestamp=expired_at + timedelta(seconds=1),
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "status": JobStatus.COMPLETED.value,
+                        "message": "Job complete",
+                        "result_text": "overnight QA verdict",
+                        "result_meta": {"qa_passed": True},
+                    },
+                )
+            )
+
+            result = await JobResultHandler(event_store=store).handle({"job_id": job_id})
+        finally:
+            await store.close()
+
+        assert result.is_ok
+        assert result.value.content[0].text == "overnight QA verdict"
+        assert result.value.meta["result_available"] is True
+        assert result.value.meta["qa_passed"] is True
 
     async def test_start_job_default_allocates_job_id(self, tmp_path) -> None:
         store = _build_store(tmp_path)

--- a/tests/unit/mcp/tools/test_job_invalid_arguments.py
+++ b/tests/unit/mcp/tools/test_job_invalid_arguments.py
@@ -88,7 +88,7 @@ async def test_job_result_invalid_handle_returns_structured_error(event_store) -
 
 
 @pytest.mark.asyncio
-async def test_job_result_rejects_expired_terminal_handle(event_store) -> None:
+async def test_job_result_returns_expired_terminal_handle_result(event_store) -> None:
     job_id = "job_expired_result"
     expired_at = datetime.now(UTC) - timedelta(hours=2)
     await event_store.append(
@@ -123,14 +123,9 @@ async def test_job_result_rejects_expired_terminal_handle(event_store) -> None:
 
     result = await handler.handle({"job_id": job_id})
 
-    assert result.is_err
-    assert result.error.tool_name == "ouroboros_job_result"
-    assert result.error.error_code == "job_handle_expired"
-    assert result.error.message == f"Job handle expired: {job_id}. Result unavailable."
-    assert result.error.details == {
-        "job_id": job_id,
-        "lifecycle_status": "expired",
-        "is_terminal": True,
-        "result_available": False,
-        "reason": "expired",
-    }
+    assert result.is_ok
+    assert result.value.content[0].text == "stale result"
+    assert result.value.meta["job_id"] == job_id
+    assert result.value.meta["lifecycle_status"] == "completed"
+    assert result.value.meta["is_terminal"] is True
+    assert result.value.meta["result_available"] is True

--- a/tests/unit/test_detached_auto_docs.py
+++ b/tests/unit/test_detached_auto_docs.py
@@ -761,35 +761,24 @@ def test_docs_verify_expired_state_has_stable_status_semantics_and_next_steps() 
     cli_compact = " ".join(cli_docs.split())
     mcp_compact = " ".join(mcp_docs.split())
 
-    assert "When `ouroboros job result JOB_ID` reports `expired`" in cli_compact
-    assert "retained result is no longer available through that job handle" in cli_compact
-    assert "`ouroboros job status JOB_ID` still reports the stored terminal" in cli_compact
-    assert "result retrieval returns stable expiration error details" in cli_compact
-    assert "rather than a detached `auto` result" in cli_compact
-    assert "Next steps are to inspect any surfaced auto session" in cli_compact
-    assert "resume from that handle or restart the detached auto flow" in cli_compact
-    assert "when no recoverable handle is present" in cli_compact
+    assert "When a terminal job is older than the in-memory handle TTL" in cli_compact
+    assert "`ouroboros job result JOB_ID` still retrieves the persisted terminal" in cli_compact
+    assert "`ouroboros job status JOB_ID` reports the stored terminal" in cli_compact
+    assert "result retrieval returns the durable result artifact" in cli_compact
+    assert "rather than an expiration error" in cli_compact
 
-    assert 'When `ouroboros_job_result(job_id="JOB_ID")` reports `expired`' in mcp_compact
-    assert "retained result is no longer available through that job handle" in mcp_compact
-    assert "`ouroboros_job_status` still reports the stored terminal" in mcp_compact
-    assert "result retrieval returns stable expiration error details" in mcp_compact
-    assert "rather than a detached `auto` result" in mcp_compact
-    assert "Next steps are to inspect any surfaced auto session" in mcp_compact
-    assert "resume from that handle or restart the detached auto flow" in mcp_compact
-    assert "when no recoverable handle is present" in mcp_compact
+    assert "When a terminal job is older than the in-memory handle TTL" in mcp_compact
+    assert 'ouroboros_job_result(job_id="JOB_ID")` still retrieves the persisted' in mcp_compact
+    assert "`ouroboros_job_status` reports the stored terminal" in mcp_compact
+    assert "result retrieval returns the durable result artifact" in mcp_compact
+    assert "rather than an expiration error" in mcp_compact
     assert "ouroboros job result job_auto_docs_expired" in cli_docs
-    assert "Job handle expired: job_auto_docs_expired. Result unavailable." in cli_docs
+    assert "detached auto result artifact: expired seed.yaml" in cli_docs
     assert 'ouroboros_job_result(job_id="job_auto_docs_expired")' in mcp_docs
-    assert (
-        'error.message = "Job handle expired: job_auto_docs_expired. Result unavailable."'
-        in mcp_docs
-    )
-    assert 'error.error_code = "job_handle_expired"' in mcp_docs
-    assert 'error.details.lifecycle_status = "expired"' in mcp_docs
-    assert "error.details.is_terminal = true" in mcp_docs
-    assert "error.details.result_available = false" in mcp_docs
-    assert 'error.details.reason = "expired"' in mcp_docs
+    assert 'content[0].text = "detached auto result artifact: expired seed.yaml"' in mcp_docs
+    assert 'meta.lifecycle_status = "completed"' in mcp_docs
+    assert "meta.is_terminal = true" in mcp_docs
+    assert "meta.result_available = true" in mcp_docs
 
 
 def test_docs_api_check_verifies_expired_detached_work_observable_contract(
@@ -853,19 +842,12 @@ def test_docs_api_check_verifies_expired_detached_work_observable_contract(
 
     api_result = asyncio.run(_persist_expired_auto_job_and_fetch_result())
 
-    assert api_result.is_err
-    assert api_result.error.tool_name == "ouroboros_job_result"
-    assert api_result.error.error_code == "job_handle_expired"
-    assert api_result.error.message == (
-        "Job handle expired: job_auto_docs_expired. Result unavailable."
-    )
-    assert api_result.error.details == {
-        "job_id": job_id,
-        "lifecycle_status": "expired",
-        "is_terminal": True,
-        "result_available": False,
-        "reason": "expired",
-    }
+    assert api_result.is_ok
+    assert api_result.value.content[0].text == ("detached auto result artifact: expired seed.yaml")
+    assert api_result.value.meta["job_id"] == job_id
+    assert api_result.value.meta["lifecycle_status"] == "completed"
+    assert api_result.value.meta["is_terminal"] is True
+    assert api_result.value.meta["result_available"] is True
 
     monkeypatch.setattr(
         job_command,
@@ -874,17 +856,15 @@ def test_docs_api_check_verifies_expired_detached_work_observable_contract(
     )
     cli_result = runner.invoke(app, ["job", "result", job_id])
 
-    assert cli_result.exit_code == 1
-    assert api_result.error.message in cli_result.output
+    assert cli_result.exit_code == 0
+    assert api_result.value.content[0].text in cli_result.output
     assert f"$ ouroboros job result {job_id}" in cli_docs
-    assert api_result.error.message in cli_docs
+    assert api_result.value.content[0].text in cli_docs
     assert f'ouroboros_job_result(job_id="{job_id}")' in mcp_docs
-    assert f'error.message = "{api_result.error.message}"' in mcp_docs
-    assert f'error.error_code = "{api_result.error.error_code}"' in mcp_docs
-    assert 'error.details.lifecycle_status = "expired"' in mcp_docs
-    assert "error.details.is_terminal = true" in mcp_docs
-    assert "error.details.result_available = false" in mcp_docs
-    assert 'error.details.reason = "expired"' in mcp_docs
+    assert f'content[0].text = "{api_result.value.content[0].text}"' in mcp_docs
+    assert 'meta.lifecycle_status = "completed"' in mcp_docs
+    assert "meta.is_terminal = true" in mcp_docs
+    assert "meta.result_available = true" in mcp_docs
 
 
 def test_docs_verify_invalid_detached_work_has_stable_status_semantics_and_next_steps() -> None:
@@ -895,7 +875,7 @@ def test_docs_verify_invalid_detached_work_has_stable_status_semantics_and_next_
     cli_compact = " ".join(cli_docs.split())
     mcp_compact = " ".join(mcp_docs.split())
 
-    assert "Unknown, expired, or otherwise unavailable handles fail" in cli_compact
+    assert "Unknown or otherwise unavailable handles fail" in cli_compact
     assert (
         "When CLI status cannot resolve the supplied handle, treat the detached work "
         "as `invalid` or unavailable rather than as running or completed" in cli_compact
@@ -906,10 +886,7 @@ def test_docs_verify_invalid_detached_work_has_stable_status_semantics_and_next_
     assert "inspect any surfaced auto session, execution, or lineage handle" in cli_compact
     assert "restart the detached auto flow when no valid handle can be recovered" in cli_compact
 
-    assert (
-        "Unknown, expired, or otherwise unavailable handles return an MCP error response"
-        in mcp_compact
-    )
+    assert "Unknown or otherwise unavailable handles return an MCP error response" in mcp_compact
     assert (
         "When MCP status cannot resolve the supplied handle, treat the detached work "
         "as `invalid` or unavailable rather than as running or completed" in mcp_compact


### PR DESCRIPTION
## Summary
- Allow `ouroboros_job_result` to return persisted terminal result data even after the in-memory handle TTL window has passed.
- Keep missing/non-terminal handle behavior unchanged.
- Update MCP and CLI regression tests for overnight-result retrieval.

Closes #1421

## Test plan
- `uv run pytest tests/unit/mcp/test_job_manager.py::TestJobManager::test_job_result_handler_returns_expired_terminal_result tests/unit/cli/test_job_command.py::test_cli_detached_auto_result_with_expired_job_handle_returns_persisted_result -q`
- `uv run ruff check src/ouroboros/mcp/tools/job_handlers.py tests/unit/mcp/test_job_manager.py tests/unit/cli/test_job_command.py`
- `uv run pytest tests/unit/mcp/test_job_manager.py tests/unit/cli/test_job_command.py -q`

_Posted by [agentos-roadmap-warden](https://github.com/Q00/ouroboros/blob/main/agents/agentos-roadmap-warden.md) — bot. Reply with `/warden ignore` to suppress further comments on this thread._