### PR TITLE
feat(cli): add read-only job event polling

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -91,7 +91,14 @@ CLI users wait and retrieve with the standard job surfaces:
 ouroboros job status JOB_ID
 ouroboros job wait JOB_ID
 ouroboros job result JOB_ID
+ouroboros job events JOB_ID --since 0 --limit 100
 ```
+
+`ouroboros job events` is the low-cost external observability surface for
+dashboards and schedulers. It opens `~/.ouroboros/ouroboros.db` read-only,
+does not create schema or write WAL/checkpoint state, and prints cursor-paged
+JSON for the job aggregate. Pass the returned `cursor` back as `--since` on
+the next poll.
 
 MCP clients use the matching job tools:
 

--- a/src/ouroboros/cli/commands/job.py
+++ b/src/ouroboros/cli/commands/job.py
@@ -3,13 +3,18 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import os
+from pathlib import Path
 from typing import Annotated
 
 import typer
 
 from ouroboros.cli.formatters.panels import print_error
+from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.tools.job_handlers import JobResultHandler, JobStatusHandler, JobWaitHandler
 from ouroboros.mcp.types import MCPToolResult
+from ouroboros.persistence.event_store import EventStore
 
 app = typer.Typer(
     name="job",
@@ -34,6 +39,69 @@ def _run_job_handler(handler, arguments: dict[str, object]) -> None:
     _emit_result(result.value)
     if result.value.is_error:
         raise typer.Exit(1)
+
+
+def _default_db_path() -> str:
+    """Return the canonical SQLite EventStore path."""
+    return os.path.expanduser("~/.ouroboros/ouroboros.db")
+
+
+async def _open_read_only_event_store(db_path: str | None = None) -> EventStore:
+    """Open the EventStore in true read-only mode without creating files."""
+    resolved = os.path.expanduser(db_path or _default_db_path())
+    if not Path(resolved).exists():
+        raise FileNotFoundError(resolved)
+    event_store = EventStore(f"sqlite+aiosqlite:///{resolved}", read_only=True)
+    try:
+        await event_store.initialize()
+    except Exception:
+        try:
+            await event_store.close()
+        finally:
+            raise
+    return event_store
+
+
+def _event_payload(event: BaseEvent) -> dict[str, object]:
+    """Serialize a persisted event for JSON CLI output."""
+    return {
+        "id": event.id,
+        "type": event.type,
+        "timestamp": event.timestamp.isoformat(),
+        "aggregate_type": event.aggregate_type,
+        "aggregate_id": event.aggregate_id,
+        "data": event.data,
+        "consensus_id": event.consensus_id,
+        "event_version": event.event_version,
+    }
+
+
+async def _read_job_events(
+    job_id: str,
+    *,
+    since: int,
+    limit: int,
+    db_path: str | None,
+) -> dict[str, object]:
+    """Read job aggregate events through a read-only EventStore."""
+    event_store = await _open_read_only_event_store(db_path)
+    try:
+        events, cursor = await event_store.get_events_after(
+            "job",
+            job_id,
+            since,
+            limit=limit,
+        )
+    finally:
+        await event_store.close()
+
+    return {
+        "job_id": job_id,
+        "cursor": cursor,
+        "count": len(events),
+        "events": [_event_payload(event) for event in events],
+        "read_only": True,
+    }
 
 
 @app.command(name="status")
@@ -99,6 +167,52 @@ def result(
 ) -> None:
     """Print the terminal result for a completed background job."""
     _run_job_handler(JobResultHandler(), {"job_id": job_id})
+
+
+@app.command(name="events")
+def events(
+    job_id: Annotated[str, typer.Argument(help="Job ID returned by a start tool.")],
+    since: Annotated[
+        int,
+        typer.Option("--since", help="Last seen EventStore rowid cursor."),
+    ] = 0,
+    limit: Annotated[
+        int,
+        typer.Option("--limit", help="Maximum job events to return."),
+    ] = 100,
+    db_path: Annotated[
+        str | None,
+        typer.Option(
+            "--db-path",
+            help="Path to ouroboros.db; defaults to ~/.ouroboros/ouroboros.db.",
+        ),
+    ] = None,
+) -> None:
+    """Print read-only job EventStore events as cursor-paged JSON."""
+    if since < 0:
+        print_error("since must be a non-negative integer")
+        raise typer.Exit(1)
+    if limit <= 0:
+        print_error("limit must be a positive integer")
+        raise typer.Exit(1)
+
+    try:
+        payload = asyncio.run(
+            _read_job_events(
+                job_id,
+                since=since,
+                limit=limit,
+                db_path=db_path,
+            )
+        )
+    except FileNotFoundError as exc:
+        print_error(f"EventStore database not found: {exc.filename or exc}")
+        raise typer.Exit(1) from exc
+    except Exception as exc:
+        print_error(f"Failed to read EventStore: {exc}")
+        raise typer.Exit(1) from exc
+
+    typer.echo(json.dumps(payload, indent=2, sort_keys=True))
 
 
 __all__ = ["app"]

--- a/tests/unit/cli/test_job_command.py
+++ b/tests/unit/cli/test_job_command.py
@@ -4,8 +4,13 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime, timedelta
+import json
+from pathlib import Path
 import re
 
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
 from typer.testing import CliRunner
 
 from ouroboros.core.types import Result
@@ -394,6 +399,139 @@ def test_documented_job_result_command_exits_zero(monkeypatch) -> None:
 
     assert result.exit_code == 0
     assert "final auto result" in result.output
+
+
+def test_job_events_command_reads_job_events_with_cursor(tmp_path: Path) -> None:
+    """Read-only job event polling returns JSON and an EventStore row cursor."""
+    from ouroboros.cli.main import app
+
+    db_path = tmp_path / "job-events.db"
+    job_id = "job_events_cli"
+
+    async def _persist_job_events() -> None:
+        store = EventStore(f"sqlite+aiosqlite:///{db_path}")
+        await store.initialize()
+        try:
+            await store.append(
+                BaseEvent(
+                    id="evt_job_events_created",
+                    type="mcp.job.created",
+                    timestamp=datetime(2026, 6, 14, 1, 0, tzinfo=UTC),
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "job_type": "execute_seed",
+                        "status": JobStatus.QUEUED.value,
+                    },
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    id="evt_unrelated_execution",
+                    type="workflow.progress.updated",
+                    timestamp=datetime(2026, 6, 14, 1, 1, tzinfo=UTC),
+                    aggregate_type="execution",
+                    aggregate_id="exec_other",
+                    data={"completed_count": 1},
+                )
+            )
+            await store.append(
+                BaseEvent(
+                    id="evt_job_events_updated",
+                    type="mcp.job.updated",
+                    timestamp=datetime(2026, 6, 14, 1, 2, tzinfo=UTC),
+                    aggregate_type="job",
+                    aggregate_id=job_id,
+                    data={
+                        "status": JobStatus.RUNNING.value,
+                        "message": "Running execute_seed",
+                    },
+                )
+            )
+        finally:
+            await store.close()
+
+    asyncio.run(_persist_job_events())
+
+    first = runner.invoke(
+        app,
+        [
+            "job",
+            "events",
+            job_id,
+            "--db-path",
+            str(db_path),
+            "--since",
+            "0",
+            "--limit",
+            "1",
+        ],
+    )
+
+    assert first.exit_code == 0
+    first_payload = json.loads(first.output)
+    assert first_payload["job_id"] == job_id
+    assert first_payload["read_only"] is True
+    assert first_payload["count"] == 1
+    assert first_payload["cursor"] == 1
+    assert first_payload["events"][0]["type"] == "mcp.job.created"
+    assert first_payload["events"][0]["data"]["status"] == "queued"
+
+    second = runner.invoke(
+        app,
+        [
+            "job",
+            "events",
+            job_id,
+            "--db-path",
+            str(db_path),
+            "--since",
+            str(first_payload["cursor"]),
+        ],
+    )
+
+    assert second.exit_code == 0
+    second_payload = json.loads(second.output)
+    assert second_payload["count"] == 1
+    assert second_payload["cursor"] == 3
+    assert second_payload["events"][0]["type"] == "mcp.job.updated"
+    assert second_payload["events"][0]["data"]["status"] == "running"
+
+
+def test_job_events_command_does_not_create_missing_database(tmp_path: Path) -> None:
+    """Read-only polling must not create ~/.ouroboros or a missing DB."""
+    from ouroboros.cli.main import app
+
+    missing_db = tmp_path / "missing" / "ouroboros.db"
+
+    result = runner.invoke(
+        app,
+        ["job", "events", "job_missing", "--db-path", str(missing_db)],
+    )
+
+    assert result.exit_code == 1
+    assert "EventStore database not found" in result.output
+    assert not missing_db.exists()
+
+
+@pytest.mark.asyncio
+async def test_job_events_read_only_store_rejects_writes(tmp_path: Path) -> None:
+    """The job event poller opens SQLite in true read-only mode."""
+    from ouroboros.cli.commands.job import _open_read_only_event_store
+
+    db_path = tmp_path / "job-events-readonly.db"
+    bootstrap = EventStore(f"sqlite+aiosqlite:///{db_path}")
+    await bootstrap.initialize()
+    await bootstrap.close()
+
+    event_store = await _open_read_only_event_store(str(db_path))
+    try:
+        with pytest.raises(OperationalError) as excinfo:
+            async with event_store._engine.begin() as conn:  # type: ignore[union-attr]
+                await conn.execute(text("DELETE FROM events"))
+        assert "readonly database" in str(excinfo.value).lower()
+    finally:
+        await event_store.close()
 
 
 def test_cli_retrieves_previously_tracked_detached_auto_result(monkeypatch, tmp_path) -> None:


### PR DESCRIPTION
## Summary
- Add `ouroboros job events JOB_ID --since <cursor> --limit <n>` for low-cost external job polling.
- Open `ouroboros.db` with `EventStore(read_only=True)` so the command does not create schema, write WAL/checkpoint state, or require MCP.
- Return cursor-paged JSON containing job aggregate events and the next cursor for dashboards/schedulers.

## RCA
The EventStore already had a true read-only SQLite mode, but the public job CLI only exposed MCP-style status/wait/result handlers that open the default store path normally. External monitors therefore had no documented, scriptable read-only path and were pushed toward either direct `sqlite3` reads or token-heavy MCP polling.

## Tests
- `uv run pytest tests/unit/cli/test_job_command.py -q`
- `uv run ruff check src/ouroboros/cli/commands/job.py tests/unit/cli/test_job_command.py docs/cli-reference.md`
- `uv run ruff format --check src/ouroboros/cli/commands/job.py tests/unit/cli/test_job_command.py`

Closes #1424