### PR TITLE
fix(mcp): mark run results as unevaluated

### DIFF
--- a/skills/run/SKILL.md
+++ b/skills/run/SKILL.md
@@ -26,6 +26,8 @@ Execute a Seed specification through the Ouroboros workflow engine.
 3. **Execution**: The orchestrator runs the workflow with PAL routing
 4. **Progress**: Real-time progress updates via session tracking
 5. **Result**: Execution summary with pass/fail status
+6. **Verification status**: Run-only results are `executed_unverified` until
+   `ooo evaluate <session_id>` performs formal 3-stage verification
 
 ## Instructions
 
@@ -238,7 +240,9 @@ The Ouroboros MCP tools are often registered as **deferred tools** that must be 
 
 10. **Post-execution QA** (automatic):
    `ouroboros_start_execute_seed` automatically runs QA after successful execution.
-   The QA verdict is included in the final job result text.
+   The QA verdict is included in the final job result text. This QA check is
+   **not** the formal 3-stage evaluator, so the run result remains
+   `executed_unverified` and `evaluated: false` until `ooo evaluate` runs.
    To skip: pass `skip_qa: true` to the tool.
 
    Present QA verdict with next step:
@@ -289,6 +293,8 @@ Result:
   Goal: Build a CLI task manager
   Duration: 45.2s
   Messages Processed: 12
+  Verification Status: executed_unverified
+  Formal Evaluation: NOT evaluated by the 3-stage evaluator
 
   Next: `ooo evaluate orch_x1y2z3` for formal 3-stage verification
 ```

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -5,6 +5,8 @@ protocol using the MCP SDK (FastMCP). It handles tool registration, resource
 handling, and server lifecycle.
 """
 
+from __future__ import annotations
+
 import asyncio
 from collections.abc import Sequence
 import inspect

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -507,6 +507,9 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     "dispatch_mode": "plugin",
                     "runtime_backend": self.agent_runtime_backend,
                     "model_tier": model_tier,
+                    **_run_only_verification_meta(
+                        session_id, verification_status="delegated_unverified"
+                    ),
                 },
             )
 

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -232,6 +232,36 @@ def _classify_synchronous_execution_status(
     return "unknown", False, True, "Seed Execution FINISHED"
 
 
+def _run_only_verification_meta(
+    session_id: str | None,
+    *,
+    verification_status: str = "executed_unverified",
+) -> dict[str, Any]:
+    """Expose that execute_seed completion is not formal 3-stage verification."""
+    next_step = f"ooo evaluate {session_id}" if session_id else "ooo evaluate <session_id>"
+    return {
+        "evaluated": False,
+        "verification_status": verification_status,
+        "formal_evaluation_required": True,
+        "next_step": next_step,
+    }
+
+
+def _run_only_verification_text(
+    session_id: str | None,
+    *,
+    verification_status: str = "executed_unverified",
+) -> str:
+    """Render the run-only verification warning for human-readable tool output."""
+    next_step = f"ooo evaluate {session_id}" if session_id else "ooo evaluate <session_id>"
+    return (
+        f"Verification Status: {verification_status}\n"
+        "Formal Evaluation: NOT evaluated by the 3-stage evaluator\n"
+        "Warning: execution results are run-only and must not be treated as verified.\n"
+        f"Next: {next_step}\n"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Delegation context extraction
 # ---------------------------------------------------------------------------
@@ -805,6 +835,7 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     f"Runtime Backend: {effective_runtime_backend}\n"
                     f"LLM Backend: {resolved_llm_backend}\n"
                 )
+                message += _run_only_verification_text(tracker.session_id)
                 if pause_metadata:
                     if pause_metadata.get("pause_kind") is not None:
                         message += f"Pause Kind: {pause_metadata['pause_kind']}\n"
@@ -835,6 +866,7 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     "runtime_backend": effective_runtime_backend,
                     "llm_backend": resolved_llm_backend,
                     "resume_requested": is_resume,
+                    **_run_only_verification_meta(tracker.session_id),
                 }
                 if success is not None:
                     meta["success"] = success
@@ -1181,12 +1213,16 @@ class StartExecuteSeedHandler:
             )
         if idempotency_key and idempotency_key in self._idempotency_meta:
             cached_meta = dict(self._idempotency_meta[idempotency_key])
+            cached_session_id = (
+                str(cached_meta.get("session_id")) if cached_meta.get("session_id") else None
+            )
             text = (
                 "Replayed prior background execution via idempotency key.\n\n"
                 f"Idempotency Key: {idempotency_key}\n"
                 f"Job ID: {cached_meta.get('job_id') or 'pending'}\n"
                 f"Session ID: {cached_meta.get('session_id') or 'pending'}\n"
-                f"Execution ID: {cached_meta.get('execution_id') or 'pending'}\n"
+                f"Execution ID: {cached_meta.get('execution_id') or 'pending'}\n\n"
+                + _run_only_verification_text(cached_session_id)
             )
             return Result.ok(
                 MCPToolResult(
@@ -1291,6 +1327,10 @@ class StartExecuteSeedHandler:
                 "status": DELEGATED_TO_PLUGIN,
                 "dispatch_mode": "plugin",
                 "runtime_backend": self.agent_runtime_backend,
+                **_run_only_verification_meta(
+                    plugin_session_id,
+                    verification_status="delegated_unverified",
+                ),
             }
             # Cache for idempotent replay: a second handle() with the same
             # key must NOT re-dispatch (no second subagent_dispatched event)
@@ -1400,6 +1440,7 @@ class StartExecuteSeedHandler:
             f"Execution ID: {snapshot.links.execution_id or 'pending'}\n\n"
             f"Runtime Backend: {runtime_backend}\n"
             f"LLM Backend: {llm_backend}\n\n"
+            f"{_run_only_verification_text(snapshot.links.session_id)}\n"
             "Use ouroboros_ac_tree_hud(session_id, cursor) for live progress and "
             "ouroboros_job_result(job_id) for the final output."
         )
@@ -1411,6 +1452,7 @@ class StartExecuteSeedHandler:
             "cursor": snapshot.cursor,
             "runtime_backend": runtime_backend,
             "llm_backend": llm_backend,
+            **_run_only_verification_meta(snapshot.links.session_id),
         }
         if idempotency_key:
             self._idempotency_meta[idempotency_key] = dict(meta)

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -421,6 +421,27 @@ class TestExecuteSeedHandler:
         assert result.is_err
         assert "execution_mode='legacy' was removed" in str(result.error)
 
+    async def test_handle_plugin_marks_direct_delegation_unverified(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Direct plugin-dispatched execute_seed still reports formal evaluation state."""
+        handler = ExecuteSeedHandler(
+            event_store=memory_event_store,
+            agent_runtime_backend="opencode",
+            opencode_mode="plugin",
+        )
+
+        result = await handler.handle({"seed_content": VALID_SEED_YAML})
+
+        assert result.is_ok
+        assert result.value.meta["status"] == "delegated_to_subagent"
+        assert result.value.meta["dispatch_mode"] == "plugin"
+        assert result.value.meta["evaluated"] is False
+        assert result.value.meta["verification_status"] == "delegated_unverified"
+        assert result.value.meta["formal_evaluation_required"] is True
+        assert result.value.meta["next_step"].startswith("ooo evaluate orch_")
+
     async def test_handle_plugin_rejects_removed_legacy_execution_mode(
         self,
         memory_event_store: EventStore,

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -322,6 +322,91 @@ class TestExecuteSeedHandler:
         assert captured_runtime_kwargs["model"] == "openai-codex/gpt-5.4-mini"
         assert captured_runtime_kwargs["llm_backend"] == "claude_code"
 
+    async def test_handle_marks_completed_run_as_unverified_without_formal_evaluation(
+        self,
+        memory_event_store: EventStore,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A completed execute_seed run is not the same as 3-stage evaluation."""
+        running_tracker = SessionTracker.create(
+            "exec_verify",
+            "test-seed-123",
+            session_id="orch_verify",
+        )
+        completed_tracker = running_tracker.with_status(SessionStatus.COMPLETED)
+        workspace = SimpleNamespace(
+            effective_cwd="/tmp/ouroboros-worktree",
+            worktree_path="/tmp/ouroboros-worktree",
+            branch="ooo/test",
+            lock_path="/tmp/ouroboros.lock",
+        )
+
+        class FakeSessionRepository:
+            def __init__(self, _event_store: EventStore) -> None:
+                pass
+
+            async def reconstruct_session(self, session_id: str) -> Result:
+                assert session_id == "orch_verify"
+                return Result.ok(completed_tracker)
+
+            async def mark_failed(self, session_id: str, *, error_message: str) -> None:
+                raise AssertionError(f"unexpected failure mark for {session_id}: {error_message}")
+
+        class FakeRunner:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                pass
+
+            async def prepare_session(self, *args: object, **kwargs: object) -> Result:
+                return Result.ok(running_tracker)
+
+            async def execute_precreated_session(self, *args: object, **kwargs: object) -> Result:
+                return Result.ok(
+                    SimpleNamespace(
+                        success=True,
+                        execution_id="exec_verify",
+                        summary={},
+                        final_message="done",
+                    )
+                )
+
+        monkeypatch.setattr(
+            "ouroboros.mcp.tools.execution_handlers.SessionRepository",
+            FakeSessionRepository,
+        )
+        monkeypatch.setattr("ouroboros.mcp.tools.execution_handlers.OrchestratorRunner", FakeRunner)
+        monkeypatch.setattr(
+            "ouroboros.mcp.tools.execution_handlers.create_agent_runtime",
+            lambda **_kwargs: SimpleNamespace(runtime_backend="test"),
+        )
+        monkeypatch.setattr(
+            "ouroboros.mcp.tools.execution_handlers.maybe_prepare_task_workspace",
+            lambda *_args, **_kwargs: workspace,
+        )
+        monkeypatch.setattr(
+            "ouroboros.mcp.tools.execution_handlers.release_lock", lambda *_args: None
+        )
+
+        handler = ExecuteSeedHandler(event_store=memory_event_store)
+
+        result = await handler.handle(
+            {"seed_content": VALID_SEED_YAML, "skip_qa": True},
+            execution_id="exec_verify",
+            session_id_override="orch_verify",
+            synchronous=True,
+        )
+
+        assert result.is_ok
+        assert result.value.is_error is False
+        assert result.value.meta["status"] == "completed"
+        assert result.value.meta["success"] is True
+        assert result.value.meta["evaluated"] is False
+        assert result.value.meta["verification_status"] == "executed_unverified"
+        assert result.value.meta["formal_evaluation_required"] is True
+        assert result.value.meta["next_step"] == "ooo evaluate orch_verify"
+        assert "Verification Status: executed_unverified" in result.value.text_content
+        assert "Formal Evaluation: NOT evaluated" in result.value.text_content
+        assert "Next: ooo evaluate orch_verify" in result.value.text_content
+
     async def test_handle_rejects_removed_legacy_execution_mode(self) -> None:
         """MCP execute_seed matches the CLI removal of the legacy selector."""
         handler = ExecuteSeedHandler()
@@ -1811,6 +1896,34 @@ class TestAsyncJobHandlers:
         assert result.is_ok
         assert result.value.meta["execution_id"].startswith("exec_")
         assert result.value.meta["session_id"].startswith("orch_")
+        assert result.value.meta["evaluated"] is False
+        assert result.value.meta["verification_status"] == "executed_unverified"
+        assert result.value.meta["formal_evaluation_required"] is True
+        assert result.value.meta["next_step"].startswith("ooo evaluate orch_")
+        assert "Verification Status: executed_unverified" in result.value.text_content
+        assert "Formal Evaluation: NOT evaluated" in result.value.text_content
+        assert "Next: ooo evaluate orch_" in result.value.text_content
+
+    async def test_start_execute_seed_plugin_marks_delegation_unverified(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Plugin-dispatched execute runs are delegated but still not formally evaluated."""
+        handler = StartExecuteSeedHandler(
+            event_store=memory_event_store,
+            agent_runtime_backend="opencode",
+            opencode_mode="plugin",
+        )
+
+        result = await handler.handle({"seed_content": VALID_SEED_YAML})
+
+        assert result.is_ok
+        assert result.value.meta["job_id"] is None
+        assert result.value.meta["status"] == "delegated_to_plugin"
+        assert result.value.meta["evaluated"] is False
+        assert result.value.meta["verification_status"] == "delegated_unverified"
+        assert result.value.meta["formal_evaluation_required"] is True
+        assert result.value.meta["next_step"].startswith("ooo evaluate orch_")
 
     async def test_start_execute_seed_plugin_rejects_removed_legacy_execution_mode(
         self,


### PR DESCRIPTION
## Summary

- Closes #1427 by making run-only execution status explicit instead of implying formal verification.
- Adds machine-readable metadata (`evaluated=false`, `verification_status`, `formal_evaluation_required`, `next_step`) to `execute_seed` terminal results and `start_execute_seed` receipts.
- Updates the run skill docs to clarify that post-execution QA is not the formal 3-stage evaluator.

## Changes

- Added shared helpers for run-only verification metadata and warning text.
- Surfaced `executed_unverified` on synchronous terminal execution, background start receipts, idempotency replay receipts, and job-result persisted metadata.
- Surfaced `delegated_unverified` for plugin-dispatched start responses where no pollable job exists.
- Added MCP contract tests covering completed run output, queued background output, and plugin delegation output.

## Notes

This intentionally does not auto-chain `ooo evaluate` after every run. Issue #1427 is labeled `needs-design`; this PR fixes the unsafe status contract now and leaves automatic evaluation chaining as a separate design decision.

Verification:
- `uv run pytest tests/unit/mcp/tools/test_definitions.py -q`
- `uv run ruff check src/ouroboros/mcp/tools/execution_handlers.py tests/unit/mcp/tools/test_definitions.py skills/run/SKILL.md`
- `uv run ruff format --check src/ouroboros/mcp/tools/execution_handlers.py tests/unit/mcp/tools/test_definitions.py`