### PR TITLE
fix(config): allow GJC backend validation

### DIFF
--- a/src/ouroboros/config/models.py
+++ b/src/ouroboros/config/models.py
@@ -134,6 +134,7 @@ class LLMConfig(BaseModel, frozen=True):
         "hermes",
         "goose",
         "pi",
+        "gjc",
     ] = "claude_code"
     permission_mode: Literal["default", "acceptEdits", "bypassPermissions"] = "default"
     opencode_permission_mode: Literal["default", "acceptEdits", "bypassPermissions"] = "acceptEdits"

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -349,6 +349,22 @@ class TestConfigValidate:
             result = runner.invoke(app, ["validate"])
         assert result.exit_code == 0
 
+    def test_gjc_runtime_and_llm_backend_are_valid(self, tmp_path: Path) -> None:
+        """validate should accept the config written by `config backend gjc`."""
+        config = {
+            "orchestrator": {"runtime_backend": "gjc", "gjc_cli_path": "/usr/bin/gjc"},
+            "llm": {"backend": "gjc"},
+        }
+        (tmp_path / "config.yaml").write_text(yaml.dump(config))
+
+        with (
+            patch("ouroboros.config.models.get_config_dir", return_value=tmp_path),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("ouroboros.config.loader.load_config"),
+        ):
+            result = runner.invoke(app, ["validate"])
+        assert result.exit_code == 0
+
     @pytest.mark.parametrize(
         "alias",
         ["claude_code", "codex_cli", "opencode_cli", "gemini_cli", "hermes_cli"],

--- a/tests/unit/config/test_models.py
+++ b/tests/unit/config/test_models.py
@@ -226,10 +226,10 @@ class TestLLMConfig:
         config = LLMConfig(backend="pi")
         assert config.backend == "pi"
 
-    def test_llm_config_rejects_gjc_until_adapter_lands(self) -> None:
-        """Stack 2 wires GJC runtime only; LLM selection lands later."""
-        with pytest.raises(ValidationError):
-            LLMConfig(backend="gjc")  # type: ignore[arg-type]
+    def test_llm_config_accepts_gjc_backend(self) -> None:
+        """LLMConfig accepts GJC now that the GJC LLM adapter is registered."""
+        config = LLMConfig(backend="gjc")
+        assert config.backend == "gjc"
 
 
 class TestLLMTaskProfileConfig:


### PR DESCRIPTION
## Summary
- Allow `llm.backend: gjc` in `LLMConfig` now that the GJC LLM adapter is registered.
- Replace the stale test that expected GJC rejection with an acceptance test.
- Add a config validate regression test for the config shape written by `ouroboros config backend gjc`.

## Reproduction
Before this change, `ouroboros config backend gjc` could write `llm.backend: gjc`, but `ouroboros config validate` rejected the same config schema.

## Verification
- `uv run ruff check src/ tests/`
- `uv run ruff format --check src/ tests/`
- `uv run mypy src/ouroboros`
- `uv run pytest tests/unit/config/test_models.py::TestLLMConfig::test_llm_config_accepts_gjc_backend tests/unit/cli/test_config.py::TestConfigValidate::test_gjc_runtime_and_llm_backend_are_valid tests/unit/config/test_loader.py::TestLLMHelperLookups::test_gjc_backend_uses_default_model_sentinel tests/unit/config/test_loader.py::TestLLMHelperLookups::test_gjc_backend_normalizes_config_default_models_to_default_sentinel -q`
- `env HOME=/tmp/ouro-smoke-home XDG_CONFIG_HOME=/tmp/ouro-smoke-config OUROBOROS_STATE_DIR=/tmp/ouro-smoke-state uv run ouroboros config validate`
- `env HOME=/tmp/ouro-test-home-full XDG_CONFIG_HOME=/tmp/ouro-test-config-full OUROBOROS_STATE_DIR=/tmp/ouro-test-state-full uv run pytest tests/ -q` (`10658 passed, 5 skipped`)

Release validation note: the non-isolated local full pytest used the developer machine config and routed `start_auto` through OpenCode plugin mode; isolated HOME passed and latest main GitHub Actions were green before this PR.