### PR TITLE
fix(config): make web port zero choose free port

### DIFF
--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -45,7 +45,7 @@ def main(
     ] = "localhost",
     port: Annotated[
         int | None,
-        typer.Option("--port", help="Web-mode port (default: a free port)."),
+        typer.Option("--port", help="Web-mode port (0 or omitted picks a free port)."),
     ] = None,
     no_browser: Annotated[
         bool,

--- a/src/ouroboros/config_tui/launcher.py
+++ b/src/ouroboros/config_tui/launcher.py
@@ -67,7 +67,7 @@ def launch_settings(
             hosts where no local screen exists).
         host: Bind address for web mode. Use ``0.0.0.0`` to reach the GUI
             from another machine (e.g. when the agent runs on a server).
-        port: Fixed port for web mode; ``None`` picks a free one.
+        port: Fixed port for web mode; ``None`` or ``0`` picks a free one.
         open_browser: Override browser auto-open. ``None`` = open only when
             this is not a remote session.
     """
@@ -115,7 +115,7 @@ def _launch_web(
         print_info("Manual fallback: run [bold]uv run ouroboros config[/] in a regular terminal.")
         raise SystemExit(1)
 
-    if port is None:
+    if port in (None, 0):
         port = _free_port()
     display_host = "localhost" if host in ("localhost", "127.0.0.1", "0.0.0.0") else host
     url = f"http://{display_host}:{port}"

--- a/tests/unit/config_tui/test_launcher.py
+++ b/tests/unit/config_tui/test_launcher.py
@@ -85,6 +85,24 @@ def test_launch_web_serves_and_opens_browser(monkeypatch) -> None:
     assert opened == ["http://localhost:50123"]
 
 
+def test_launch_web_treats_zero_port_as_free_port(monkeypatch) -> None:
+    served: dict[str, object] = {}
+
+    class _FakeServer:
+        def __init__(self, command, host="localhost", port=8000, title=None) -> None:
+            served.update(host=host, port=port)
+
+        def serve(self) -> None:
+            served["serving"] = True
+
+    monkeypatch.setattr(launcher, "_import_server", lambda: _FakeServer)
+    monkeypatch.setattr(launcher, "_free_port", lambda: 50125)
+
+    launcher._launch_web(port=0, open_browser=False)
+
+    assert served == {"host": "localhost", "port": 50125, "serving": True}
+
+
 def test_launch_web_without_textual_serve_prints_hint(monkeypatch, capsys) -> None:
     monkeypatch.setattr(launcher, "_import_server", lambda: None)
     with pytest.raises(SystemExit):


### PR DESCRIPTION

## Summary
- Treat `ouroboros config --web --port 0` as the same free-port path as an omitted port.
- Update CLI help text so users know `0` selects a free port.
- Add a launcher regression test for the explicit zero-port path.

## Verification
- `uv run pytest tests/unit/config_tui/test_launcher.py tests/unit/cli/commands/test_config_bare_dispatch.py -q`
- `uv run ruff check src/ouroboros/config_tui/launcher.py src/ouroboros/cli/commands/config.py tests/unit/config_tui/test_launcher.py tests/unit/cli/commands/test_config_bare_dispatch.py`
- `uv run ruff format --check src/ouroboros/config_tui/launcher.py src/ouroboros/cli/commands/config.py tests/unit/config_tui/test_launcher.py tests/unit/cli/commands/test_config_bare_dispatch.py`
- Smoke: `env HOME=/tmp/ouro-port0-home XDG_CONFIG_HOME=/tmp/ouro-port0-config OUROBOROS_STATE_DIR=/tmp/ouro-port0-state uv run ouroboros config --web --port 0 --no-browser` printed `http://localhost:60228`; `curl -I http://localhost:60228` returned `HTTP/1.1 200 OK`.

Release verification note: this was found while manually checking the config web surface after the GJC validation fix.
