### PR TITLE
docs(cli): list job command in overview

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -41,6 +41,7 @@ ouroboros [OPTIONS] COMMAND [ARGS]...
 | `setup` | Detect runtimes and configure Ouroboros for your environment |
 | `init` | Start interactive interview to refine requirements |
 | `auto` | Run bounded goal → A-grade Seed → execution handoff pipeline |
+| `job` | Inspect detached job status, waits, results, and event streams |
 | `run` | Execute Ouroboros workflows |
 | `qa` | Evaluate an artifact against a natural-language quality bar |
 | `cancel` | Cancel stuck or orphaned executions |


### PR DESCRIPTION
## Summary
- Add the top-level `job` command to the CLI reference Commands Overview.

## Verification
- `PYTHONDONTWRITEBYTECODE=1 SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0 uv run python -m pytest -p no:cacheprovider tests/unit/test_detached_auto_docs.py -q` (`16 passed`)

Follow-up for #1436 review note.