### PR TITLE
docs(mcp): align durable job result contract

### DIFF
--- a/docs/api/mcp.md
+++ b/docs/api/mcp.md
@@ -267,9 +267,9 @@ skill routing.
 background work. A successful start response returns a `job_id` immediately;
 that handle identifies tracked background work, not a completed workflow result.
 The job remains observable through its lifecycle status until it reaches a
-terminal state such as `completed`, `failed`, or `cancelled`. Expired retention
-is reported by `ouroboros_job_result` when the stored terminal result is no
-longer available.
+terminal state such as `completed`, `failed`, or `cancelled`. Terminal results
+are read from persisted job events; the in-memory handle TTL only bounds live
+registry cleanup, not completed result retrieval.
 
 MCP clients wait for and retrieve detached `auto` results with the standard job
 tools:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -81,9 +81,9 @@ Auto mode starts execution only after the generated Seed reaches A-grade. If a p
 Detached `auto` work is non-terminal tracked background work. Starting it does
 not mean the workflow has completed; the returned `job_id` is a handle for a
 tracked job whose lifecycle remains observable until it reaches a terminal
-state such as `completed`, `failed`, or `cancelled`. Expired retention is
-reported by `ouroboros job result` when the stored terminal result is no longer
-available.
+state such as `completed`, `failed`, or `cancelled`. Terminal results are read
+from persisted job events; the in-memory handle TTL only bounds live registry
+cleanup, not completed result retrieval.
 
 CLI users wait and retrieve with the standard job surfaces:
 

--- a/tests/unit/test_detached_auto_docs.py
+++ b/tests/unit/test_detached_auto_docs.py
@@ -57,7 +57,8 @@ def test_mcp_docs_describe_detached_auto_as_tracked_non_terminal_background_work
         "that handle identifies tracked background work, not a completed workflow result" in compact
     )
     assert "terminal state such as `completed`, `failed`, or `cancelled`" in compact
-    assert "Expired retention is reported by `ouroboros_job_result`" in compact
+    assert "in-memory handle TTL only bounds live registry cleanup" in compact
+    assert "not completed result retrieval" in compact
 
     for mcp_tool in (
         'ouroboros_job_status(job_id="JOB_ID")',


### PR DESCRIPTION
## Summary
- Remove stale expired-retention wording left after #1433 merged for #1421.
- Document that in-memory handle TTL only bounds live registry cleanup, not persisted terminal result retrieval.
- Update the docs contract test so it no longer preserves the old unavailable-result contract.

Follow-up to #1433 / #1421.

## Test plan
- `uv run pytest tests/unit/test_detached_auto_docs.py -q`
- `uv run pytest tests/unit/mcp/test_job_manager.py tests/unit/mcp/tools/test_job_invalid_arguments.py tests/unit/cli/test_job_command.py tests/unit/test_detached_auto_docs.py -q`
- `uv run ruff check src/ouroboros/mcp/job_manager.py src/ouroboros/mcp/tools/job_handlers.py tests/unit/mcp/test_job_manager.py tests/unit/mcp/tools/test_job_invalid_arguments.py tests/unit/cli/test_job_command.py tests/unit/test_detached_auto_docs.py docs/api/mcp.md docs/cli-reference.md`
- `git grep -n "Expired retention\|expired, or otherwise\|job_handle_expired\|retained result is no longer" -- docs/api/mcp.md docs/cli-reference.md tests/unit/test_detached_auto_docs.py src/ouroboros/mcp` returned no matches
