### PR TITLE
test(canonical): smoke generated cli-todo artifact

### DIFF
--- a/tests/canonical/README.md
+++ b/tests/canonical/README.md
@@ -46,7 +46,8 @@ OUROBOROS_RUN_CANONICAL=1 uv run pytest tests/canonical/ -v
 ```
 
 This command invokes the `ouroboros_auto` MCP tool against each
-scenario and asserts the documented terminal state — **use sparingly**,
+scenario, asserts the documented terminal state, and then executes any
+scenario-declared generated-artifact smoke commands — **use sparingly**,
 each scenario will consume real LLM tokens (cli-todo ≈ \$1,
 kart-racer ≈ \$5 with Sonnet-class models). Without the environment
 variable, the live test skips and only the hermetic shape/catalog checks
@@ -72,7 +73,7 @@ Each `tests/canonical/<slug>/` directory contains:
 | File | Purpose |
 |---|---|
 | `goal.txt` | One-line goal string fed to `ooo auto`. No leading/trailing whitespace beyond a final newline. |
-| `expected.yaml` | Frozen metadata: `domain_class`, `completion_mode`, `runtime_probe_kinds`, optional `wall_clock_budget_seconds`. |
+| `expected.yaml` | Frozen metadata: `domain_class`, `completion_mode`, `runtime_probe_kinds`, optional `wall_clock_budget_seconds`, and optional live product-reality smoke checks. |
 | `env/` *(optional)* | Fixture files seeded into the temp workdir before `ouroboros_auto` is invoked. Often empty for greenfield scenarios. |
 
 `expected.yaml` schema (validated by `conftest.py`):
@@ -87,6 +88,17 @@ runtime_probe_kinds:
   - headless_run
   - stdout_golden
 wall_clock_budget_seconds: 600       # default: 7200
+
+# optional live product-reality smoke checks
+product_artifact_path: habit_tracker.py
+declared_output_paths:
+  - habits.json
+product_smoke_commands:
+  - argv: ["python", "{artifact}", "add", "drink water"]
+    expect_exit_code: 0
+    stdout_contains: ["drink water"]
+  - argv: ["python", "{artifact}", "unknown-command"]
+    expect_exit_code: 2
 ```
 
 ## When to extend
@@ -151,7 +163,17 @@ Schema (stable, parseable):
   "mcp_result_is_error": false,
   "mcp_result_meta": { ... raw envelope ... },
   "mcp_result_content": [ ... raw content items ... ],
-  "mcp_result_fallback_text": null
+  "mcp_result_fallback_text": null,
+  "product_reality": {
+    "artifact_path": "habit_tracker.py",
+    "declared_output_paths": ["habits.json"],
+    "smoke_results": [
+      {"argv": ["python", "/tmp/.../habit_tracker.py", "list"], "exit_code": 0, "stdout_preview": "...", "stderr_preview": ""}
+    ],
+    "auto_session_id": "...",
+    "execution_id": "...",
+    "run_session_id": "..."
+  }
 }
 ```
 

--- a/tests/canonical/cli-todo/expected.yaml
+++ b/tests/canonical/cli-todo/expected.yaml
@@ -18,3 +18,21 @@ runtime_probe_kinds:
 
 # 30-minute soft budget honored by the opt-in live canonical runner.
 wall_clock_budget_seconds: 1800
+
+# Live product-reality smoke contract (#1452). The live harness executes
+# these after ouroboros_auto reaches a successful product terminal.
+product_artifact_path: habit_tracker.py
+declared_output_paths:
+  - habits.json
+product_smoke_commands:
+  - argv: ["python", "{artifact}", "add", "drink water"]
+    expect_exit_code: 0
+    stdout_contains: ["drink water"]
+  - argv: ["python", "{artifact}", "list"]
+    expect_exit_code: 0
+    stdout_contains: ["drink water"]
+  - argv: ["python", "{artifact}", "done", "drink water"]
+    expect_exit_code: 0
+    stdout_contains: ["drink water"]
+  - argv: ["python", "{artifact}", "unknown-command"]
+    expect_exit_code: 2

--- a/tests/canonical/conftest.py
+++ b/tests/canonical/conftest.py
@@ -77,6 +77,39 @@ class CanonicalScenario:
         assert isinstance(value, int)
         return value
 
+
+    @property
+    def declared_output_paths(self) -> tuple[str, ...]:
+        value = self.metadata.get("declared_output_paths", ())
+        if not value:
+            return ()
+        assert isinstance(value, (list, tuple))
+        out: list[str] = []
+        for item in value:
+            assert isinstance(item, str)
+            out.append(item)
+        return tuple(out)
+
+    @property
+    def product_artifact_path(self) -> str | None:
+        value = self.metadata.get("product_artifact_path")
+        if value is None:
+            return None
+        assert isinstance(value, str)
+        return value
+
+    @property
+    def product_smoke_commands(self) -> tuple[dict[str, object], ...]:
+        value = self.metadata.get("product_smoke_commands", ())
+        if not value:
+            return ()
+        assert isinstance(value, (list, tuple))
+        out: list[dict[str, object]] = []
+        for item in value:
+            assert isinstance(item, dict)
+            out.append(dict(item))
+        return tuple(out)
+
     @property
     def env_dir(self) -> Path | None:
         candidate = self.directory / "env"
@@ -171,12 +204,69 @@ def _load_scenario(directory: Path) -> CanonicalScenario:
             pytrace=False,
         )
 
+    _validate_product_reality_metadata(slug, raw_metadata)
+
     return CanonicalScenario(
         slug=slug,
         directory=directory,
         goal=goal,
         metadata=dict(raw_metadata),
     )
+
+
+
+def _validate_product_reality_metadata(slug: str, metadata: dict[str, object]) -> None:
+    """Validate optional live product-reality smoke metadata."""
+    artifact_path = metadata.get("product_artifact_path")
+    if artifact_path is not None and not isinstance(artifact_path, str):
+        pytest.fail(
+            f"canonical scenario {slug!r} product_artifact_path must be a string",
+            pytrace=False,
+        )
+    declared_paths = metadata.get("declared_output_paths", ())
+    if declared_paths:
+        if not isinstance(declared_paths, (list, tuple)) or not all(
+            isinstance(item, str) and item for item in declared_paths
+        ):
+            pytest.fail(
+                f"canonical scenario {slug!r} declared_output_paths must be a list of strings",
+                pytrace=False,
+            )
+    commands = metadata.get("product_smoke_commands", ())
+    if not commands:
+        return
+    if not isinstance(commands, (list, tuple)):
+        pytest.fail(
+            f"canonical scenario {slug!r} product_smoke_commands must be a list",
+            pytrace=False,
+        )
+    for index, command in enumerate(commands):
+        if not isinstance(command, dict):
+            pytest.fail(
+                f"canonical scenario {slug!r} product_smoke_commands[{index}] must be a mapping",
+                pytrace=False,
+            )
+        argv = command.get("argv")
+        if not isinstance(argv, list) or not argv or not all(isinstance(item, str) for item in argv):
+            pytest.fail(
+                f"canonical scenario {slug!r} product_smoke_commands[{index}].argv must be a non-empty string list",
+                pytrace=False,
+            )
+        expected_exit = command.get("expect_exit_code", 0)
+        if isinstance(expected_exit, bool) or not isinstance(expected_exit, int):
+            pytest.fail(
+                f"canonical scenario {slug!r} product_smoke_commands[{index}].expect_exit_code must be an integer",
+                pytrace=False,
+            )
+        for key in ("stdout_contains", "stderr_contains"):
+            value = command.get(key, ())
+            if value and (
+                not isinstance(value, (list, tuple)) or not all(isinstance(item, str) for item in value)
+            ):
+                pytest.fail(
+                    f"canonical scenario {slug!r} product_smoke_commands[{index}].{key} must be a list of strings",
+                    pytrace=False,
+                )
 
 
 def _runtime_is_inside_repo(runtime_file: Path, repo_root: Path) -> bool:

--- a/tests/canonical/conftest.py
+++ b/tests/canonical/conftest.py
@@ -77,7 +77,6 @@ class CanonicalScenario:
         assert isinstance(value, int)
         return value
 
-
     @property
     def declared_output_paths(self) -> tuple[str, ...]:
         value = self.metadata.get("declared_output_paths", ())
@@ -214,7 +213,6 @@ def _load_scenario(directory: Path) -> CanonicalScenario:
     )
 
 
-
 def _validate_product_reality_metadata(slug: str, metadata: dict[str, object]) -> None:
     """Validate optional live product-reality smoke metadata."""
     artifact_path = metadata.get("product_artifact_path")
@@ -247,7 +245,11 @@ def _validate_product_reality_metadata(slug: str, metadata: dict[str, object]) -
                 pytrace=False,
             )
         argv = command.get("argv")
-        if not isinstance(argv, list) or not argv or not all(isinstance(item, str) for item in argv):
+        if (
+            not isinstance(argv, list)
+            or not argv
+            or not all(isinstance(item, str) for item in argv)
+        ):
             pytest.fail(
                 f"canonical scenario {slug!r} product_smoke_commands[{index}].argv must be a non-empty string list",
                 pytrace=False,
@@ -261,7 +263,8 @@ def _validate_product_reality_metadata(slug: str, metadata: dict[str, object]) -
         for key in ("stdout_contains", "stderr_contains"):
             value = command.get(key, ())
             if value and (
-                not isinstance(value, (list, tuple)) or not all(isinstance(item, str) for item in value)
+                not isinstance(value, (list, tuple))
+                or not all(isinstance(item, str) for item in value)
             ):
                 pytest.fail(
                     f"canonical scenario {slug!r} product_smoke_commands[{index}].{key} must be a list of strings",

--- a/tests/canonical/test_canonical.py
+++ b/tests/canonical/test_canonical.py
@@ -173,7 +173,6 @@ def test_scenario_runtime_probe_kinds_subset_of_l1_catalog(
     )
 
 
-
 # ---------------------------------------------------------------------------
 # Live product-reality smoke checks (#1452)
 # ---------------------------------------------------------------------------
@@ -208,8 +207,7 @@ def _run_product_reality_smoke_checks(
     if scenario.product_artifact_path:
         artifact_path = _resolve_canonical_path(workdir, scenario.product_artifact_path)
         assert artifact_path.is_file(), (
-            f"{scenario.slug}: expected generated artifact at {artifact_path}; "
-            f"auto meta was {meta}"
+            f"{scenario.slug}: expected generated artifact at {artifact_path}; auto meta was {meta}"
         )
 
     smoke_results: list[dict[str, Any]] = []
@@ -248,7 +246,9 @@ def _run_product_reality_smoke_checks(
             )
     for output_path in scenario.declared_output_paths:
         expected = _resolve_canonical_path(workdir, output_path)
-        assert expected.exists(), f"{scenario.slug}: expected declared output path {expected} to exist"
+        assert expected.exists(), (
+            f"{scenario.slug}: expected declared output path {expected} to exist"
+        )
     return smoke_results
 
 
@@ -559,6 +559,6 @@ else:
     obs_files = list((tmp_path / scenario.slug / ".ooo-observability").glob("canonical-*.json"))
     assert obs_files, "expected at least one evidence file"
     evidence_payloads = [json.loads(path.read_text(encoding="utf-8")) for path in obs_files]
-    assert any(
-        payload["product_reality"]["smoke_results"] for payload in evidence_payloads
-    ), "expected product-reality smoke results in persisted evidence"
+    assert any(payload["product_reality"]["smoke_results"] for payload in evidence_payloads), (
+        "expected product-reality smoke results in persisted evidence"
+    )

--- a/tests/canonical/test_canonical.py
+++ b/tests/canonical/test_canonical.py
@@ -17,7 +17,9 @@ Two cost regimes:
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
+import subprocess
 from typing import Any
 
 import pytest
@@ -171,6 +173,85 @@ def test_scenario_runtime_probe_kinds_subset_of_l1_catalog(
     )
 
 
+
+# ---------------------------------------------------------------------------
+# Live product-reality smoke checks (#1452)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_canonical_path(workdir: Path, relative_path: str) -> Path:
+    candidate = (workdir / relative_path).resolve()
+    root = workdir.resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as exc:
+        raise AssertionError(f"canonical path escapes workdir: {relative_path!r}") from exc
+    return candidate
+
+
+def _run_product_reality_smoke_checks(
+    scenario: CanonicalScenario,
+    workdir: Path,
+    meta: dict[str, Any],
+) -> list[dict[str, Any]]:
+    """Execute scenario-declared product smoke commands after live completion.
+
+    The harness intentionally reads commands from ``expected.yaml`` so adding
+    future canonical scenarios does not require new Python code. Commands run
+    relative to the generated product workdir and may reference the generated
+    artifact through the ``{artifact}`` placeholder.
+    """
+    if not scenario.product_artifact_path and not scenario.product_smoke_commands:
+        return []
+
+    artifact_path: Path | None = None
+    if scenario.product_artifact_path:
+        artifact_path = _resolve_canonical_path(workdir, scenario.product_artifact_path)
+        assert artifact_path.is_file(), (
+            f"{scenario.slug}: expected generated artifact at {artifact_path}; "
+            f"auto meta was {meta}"
+        )
+
+    smoke_results: list[dict[str, Any]] = []
+    timeout_seconds = min(float(scenario.wall_clock_budget_seconds), 30.0)
+    for index, command in enumerate(scenario.product_smoke_commands):
+        argv = list(command["argv"])
+        if artifact_path is not None:
+            argv = [part.format(artifact=str(artifact_path)) for part in argv]
+        completed = subprocess.run(  # noqa: S603 - canonical smoke command
+            argv,
+            cwd=str(workdir),
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        expected_exit = int(command.get("expect_exit_code", 0))
+        smoke_record = {
+            "argv": argv,
+            "exit_code": completed.returncode,
+            "stdout_preview": completed.stdout[:1000],
+            "stderr_preview": completed.stderr[:1000],
+        }
+        smoke_results.append(smoke_record)
+        assert completed.returncode == expected_exit, (
+            f"{scenario.slug}: smoke command {index} expected exit {expected_exit}, "
+            f"got {completed.returncode}: {smoke_record}"
+        )
+        for expected in command.get("stdout_contains", ()):
+            assert expected in completed.stdout, (
+                f"{scenario.slug}: smoke command {index} stdout missing {expected!r}: {smoke_record}"
+            )
+        for expected in command.get("stderr_contains", ()):
+            assert expected in completed.stderr, (
+                f"{scenario.slug}: smoke command {index} stderr missing {expected!r}: {smoke_record}"
+            )
+    for output_path in scenario.declared_output_paths:
+        expected = _resolve_canonical_path(workdir, output_path)
+        assert expected.exists(), f"{scenario.slug}: expected declared output path {expected} to exist"
+    return smoke_results
+
+
 # ---------------------------------------------------------------------------
 # Live invocation (opt-in via OUROBOROS_RUN_CANONICAL=1)
 # ---------------------------------------------------------------------------
@@ -211,6 +292,8 @@ def _persist_raw_evidence(
     workdir: Path,
     result: Any,
     request: pytest.FixtureRequest,
+    *,
+    product_smoke_results: list[dict[str, Any]] | None = None,
 ) -> Path:
     """Persist the verbatim MCP handler response under
     ``<workdir>/.ooo-observability/`` as JSON evidence.
@@ -271,6 +354,14 @@ def _persist_raw_evidence(
         "mcp_result_meta": raw_meta,
         "mcp_result_content": raw_content_repr,
         "mcp_result_fallback_text": raw_text,
+        "product_reality": {
+            "artifact_path": scenario.product_artifact_path,
+            "declared_output_paths": list(scenario.declared_output_paths),
+            "smoke_results": product_smoke_results or [],
+            "auto_session_id": raw_meta.get("auto_session_id"),
+            "execution_id": raw_meta.get("execution_id"),
+            "run_session_id": raw_meta.get("run_session_id"),
+        },
     }
     out_path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
     return out_path
@@ -373,10 +464,25 @@ async def test_scenario_live_run_or_skip(
             f"{scenario.slug}: product_complete scenario must not stop at an "
             f"unverified run handoff: {tool_result.meta}"
         )
+    product_smoke_results = _run_product_reality_smoke_checks(scenario, workdir, tool_result.meta)
+    if product_smoke_results:
+        evidence_path = _persist_raw_evidence(
+            scenario,
+            workdir,
+            result,
+            request,
+            product_smoke_results=product_smoke_results,
+        )
+        print(f"CANONICAL {scenario.slug}: product reality smoke -> {evidence_path}")
     print(
         f"CANONICAL {scenario.slug}: status={tool_result.meta['status']} "
         f"phase={tool_result.meta.get('phase')} "
-        f"closure_mode={closure_mode} completion_mode={scenario.completion_mode}"
+        f"closure_mode={closure_mode} completion_mode={scenario.completion_mode} "
+        f"artifact={scenario.product_artifact_path or 'none'} "
+        f"smoke_commands={len(product_smoke_results)} "
+        f"auto_session_id={tool_result.meta.get('auto_session_id')} "
+        f"execution_id={tool_result.meta.get('execution_id')} "
+        f"run_session_id={tool_result.meta.get('run_session_id')}"
     )
 
 
@@ -403,6 +509,37 @@ async def test_live_run_opt_in_invokes_auto_handler(
 
     async def fake_invoke(selected: CanonicalScenario, workdir: Path) -> Result[object, str]:
         calls.append((selected.slug, workdir))
+        (workdir / "habit_tracker.py").write_text(
+            """
+from __future__ import annotations
+import json
+import sys
+from pathlib import Path
+
+store = Path('habits.json')
+habits = json.loads(store.read_text()) if store.exists() else []
+if len(sys.argv) < 2:
+    sys.exit(2)
+cmd = sys.argv[1]
+name = ' '.join(sys.argv[2:])
+if cmd == 'add' and name:
+    habits.append({'name': name, 'done': False})
+    store.write_text(json.dumps(habits))
+    print(name)
+elif cmd == 'list':
+    for item in habits:
+        print(item['name'])
+elif cmd == 'done' and name:
+    for item in habits:
+        if item['name'] == name:
+            item['done'] = True
+    store.write_text(json.dumps(habits))
+    print(name)
+else:
+    sys.exit(2)
+""".strip(),
+            encoding="utf-8",
+        )
         return Result.ok(_ToolResult())
 
     monkeypatch.setattr(
@@ -420,4 +557,8 @@ async def test_live_run_opt_in_invokes_auto_handler(
     assert calls == [(scenario.slug, tmp_path / scenario.slug)]
     # PR-γ evidence-integrity contract: the raw envelope must be persisted.
     obs_files = list((tmp_path / scenario.slug / ".ooo-observability").glob("canonical-*.json"))
-    assert len(obs_files) == 1, f"expected one evidence file; found {obs_files}"
+    assert obs_files, "expected at least one evidence file"
+    evidence_payloads = [json.loads(path.read_text(encoding="utf-8")) for path in obs_files]
+    assert any(
+        payload["product_reality"]["smoke_results"] for payload in evidence_payloads
+    ), "expected product-reality smoke results in persisted evidence"


### PR DESCRIPTION
## Summary
- add scenario-level product-reality smoke metadata for the canonical `cli-todo` run
- execute the generated CLI artifact after successful live auto completion and assert add/list/done plus an invalid-command failure path
- persist artifact path, smoke command results, and auto/run lookup ids in canonical evidence output
- document the optional smoke-check schema in the canonical harness README

Closes #1452

## Verification
- `uv run pytest tests/canonical/ -q` — 21 passed, 1 skipped
- `uv run ruff check tests/canonical/conftest.py tests/canonical/test_canonical.py` — passed

## Notes
The live canonical path still remains opt-in via `OUROBOROS_RUN_CANONICAL=1`; this PR only extends what the opt-in path asserts after the product terminal.