### PR TITLE
feat(auto): honor stage runtime routing

### DIFF
--- a/src/ouroboros/auto/runtime_routing.py
+++ b/src/ouroboros/auto/runtime_routing.py
@@ -1,0 +1,110 @@
+"""Stage-aware runtime routing for ``ooo auto`` entry points."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ouroboros.config import get_opencode_mode, load_config
+from ouroboros.core.errors import ConfigError
+from ouroboros.orchestrator import resolve_agent_runtime_backend
+from ouroboros.orchestrator_stage import Stage, parse_stage, resolve_runtime_for_stage
+
+
+@dataclass(frozen=True, slots=True)
+class StageRuntime:
+    """Resolved runtime backend plus the OpenCode mode relevant to it."""
+
+    runtime_backend: str
+    opencode_mode: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class AutoStageRuntimePlan:
+    """Resolved runtime bindings used by auto's coarse pipeline phases."""
+
+    default: StageRuntime
+    interview: StageRuntime
+    execute: StageRuntime
+    evaluate: StageRuntime
+    reflect: StageRuntime
+
+
+def resolve_auto_stage_runtime_plan(
+    *,
+    runtime_override: str | None,
+    fallback_runtime_backend: str | None,
+    fallback_opencode_mode: str | None,
+) -> AutoStageRuntimePlan:
+    """Resolve auto runtime bindings from ``--runtime`` or runtime_profile.
+
+    ``--runtime`` preserves the historical auto contract: one explicit runtime
+    drives both authoring and execution. Without that override, auto now honors
+    ``orchestrator.runtime_profile.stages`` using the shared stage resolver.
+    """
+
+    default_runtime = resolve_agent_runtime_backend(
+        runtime_override or fallback_runtime_backend
+    )
+    default = StageRuntime(
+        runtime_backend=default_runtime,
+        opencode_mode=_opencode_mode_for_runtime(default_runtime, fallback_opencode_mode),
+    )
+
+    profile_stages: dict[Stage, str] | None = None
+    profile_default: str | None = None
+    if runtime_override is None:
+        try:
+            profile = load_config().orchestrator.runtime_profile
+        except ConfigError:
+            profile = None
+        if profile is not None:
+            profile_stages = {parse_stage(key): value for key, value in profile.stages.items()}
+            profile_default = profile.default
+
+    def resolve(stage: Stage) -> StageRuntime:
+        if runtime_override is not None:
+            runtime = default.runtime_backend
+        else:
+            runtime = resolve_agent_runtime_backend(
+                resolve_runtime_for_stage(
+                    stage,
+                    stages=profile_stages,
+                    default=profile_default,
+                    fallback=default.runtime_backend,
+                )
+            )
+        return StageRuntime(
+            runtime_backend=runtime,
+            opencode_mode=_opencode_mode_for_runtime(runtime, fallback_opencode_mode),
+        )
+
+    return AutoStageRuntimePlan(
+        default=default,
+        interview=resolve(Stage.INTERVIEW),
+        execute=resolve(Stage.EXECUTE),
+        evaluate=resolve(Stage.EVALUATE),
+        reflect=resolve(Stage.REFLECT),
+    )
+
+
+def demote_plugin_opencode_mode(opencode_mode: str | None) -> str | None:
+    """Return the in-process-safe OpenCode mode for non-plugin consumers."""
+
+    return "subprocess" if opencode_mode == "plugin" else opencode_mode
+
+
+def _opencode_mode_for_runtime(
+    runtime_backend: str,
+    fallback_opencode_mode: str | None,
+) -> str | None:
+    if runtime_backend != "opencode":
+        return None
+    return fallback_opencode_mode or get_opencode_mode()
+
+
+__all__ = [
+    "AutoStageRuntimePlan",
+    "StageRuntime",
+    "demote_plugin_opencode_mode",
+    "resolve_auto_stage_runtime_plan",
+]

--- a/src/ouroboros/auto/runtime_routing.py
+++ b/src/ouroboros/auto/runtime_routing.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from ouroboros.config import get_opencode_mode, load_config
+from ouroboros.config import get_config_dir, get_opencode_mode, load_config
 from ouroboros.core.errors import ConfigError
 from ouroboros.orchestrator import resolve_agent_runtime_backend
 from ouroboros.orchestrator_stage import Stage, parse_stage, resolve_runtime_for_stage
@@ -54,6 +54,15 @@ def resolve_auto_stage_runtime_plan(
         try:
             profile = load_config().orchestrator.runtime_profile
         except ConfigError:
+            # Only a genuinely ABSENT config file is a legitimate "no profile" →
+            # fall back to the default runtime. A config that exists but fails to
+            # load (malformed YAML or failed validation — e.g. an unknown
+            # runtime_profile stage key or backend name, which RuntimeProfileConfig
+            # rejects) must FAIL FAST: swallowing it would let an operator routing
+            # mistake silently reroute ``ooo auto`` to the fallback runtime instead
+            # of surfacing the misconfiguration.
+            if (get_config_dir() / "config.yaml").exists():
+                raise
             profile = None
         if profile is not None:
             profile_stages = {parse_stage(key): value for key, value in profile.stages.items()}

--- a/src/ouroboros/auto/runtime_routing.py
+++ b/src/ouroboros/auto/runtime_routing.py
@@ -42,9 +42,7 @@ def resolve_auto_stage_runtime_plan(
     ``orchestrator.runtime_profile.stages`` using the shared stage resolver.
     """
 
-    default_runtime = resolve_agent_runtime_backend(
-        runtime_override or fallback_runtime_backend
-    )
+    default_runtime = resolve_agent_runtime_backend(runtime_override or fallback_runtime_backend)
     default = StageRuntime(
         runtime_backend=default_runtime,
         opencode_mode=_opencode_mode_for_runtime(default_runtime, fallback_opencode_mode),

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -35,6 +35,10 @@ import ouroboros.auto.profiles  # noqa: F401,E402
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.provenance import resolve_provenance
 from ouroboros.auto.resume_render import render_resume_lines
+from ouroboros.auto.runtime_routing import (
+    demote_plugin_opencode_mode,
+    resolve_auto_stage_runtime_plan,
+)
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.state import (
     DEFAULT_PIPELINE_TIMEOUT_SECONDS,
@@ -50,7 +54,6 @@ from ouroboros.auto.state import (
 from ouroboros.auto.worktree import ensure_auto_worktree, release_auto_worktree
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success
-from ouroboros.config import get_opencode_mode
 from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler
 from ouroboros.mcp.tools.qa import QAHandler
@@ -349,6 +352,7 @@ async def _run_auto(
     progress_callback: AutoProgressCallback | None = None,
 ) -> AutoPipelineResult:
     store = AutoStore()
+    runtime_override = runtime
     incoming_provenance = resolve_provenance()
     attach_requested = any(
         isinstance(item, str) and item.strip()
@@ -461,6 +465,14 @@ async def _run_auto(
     if worktree_policy is not None:
         state.worktree_policy = parse_auto_worktree_policy(worktree_policy)
 
+    runtime_plan = resolve_auto_stage_runtime_plan(
+        runtime_override=runtime_override,
+        fallback_runtime_backend=runtime,
+        fallback_opencode_mode=state.opencode_mode,
+    )
+    runtime = runtime_plan.default.runtime_backend
+    raw_default_opencode_mode = runtime_plan.default.opencode_mode
+
     if runtime == "opencode":
         # Q00/ouroboros#782 review-7 BLOCKING #3 + review-8 BLOCKING #1: keep
         # the un-demoted opencode_mode for the Ralph handoff so a CLI launched
@@ -474,12 +486,9 @@ async def _run_auto(
         # honor a previously persisted value on resume — ``state.opencode_mode``
         # itself stores the demoted form (used by authoring/run-handoff
         # handlers), so it cannot serve as a source of truth for plugin Ralph.
-        ralph_opencode_mode = (
-            state.ralph_opencode_mode or state.opencode_mode or get_opencode_mode()
-        )
+        ralph_opencode_mode = state.ralph_opencode_mode or raw_default_opencode_mode
         opencode_mode = ralph_opencode_mode
-        if opencode_mode == "plugin":
-            opencode_mode = "subprocess"
+        opencode_mode = demote_plugin_opencode_mode(opencode_mode)
     else:
         opencode_mode = None
         ralph_opencode_mode = None
@@ -504,18 +513,29 @@ async def _run_auto(
 
     auto_workspace = ensure_auto_worktree(state)
 
-    authoring_opencode_mode = "subprocess" if opencode_mode == "plugin" else opencode_mode
+    authoring_opencode_mode = demote_plugin_opencode_mode(runtime_plan.interview.opencode_mode)
+    execute_opencode_mode = demote_plugin_opencode_mode(runtime_plan.execute.opencode_mode)
     interview = InterviewHandler(
-        agent_runtime_backend=runtime, opencode_mode=authoring_opencode_mode
+        agent_runtime_backend=runtime_plan.interview.runtime_backend,
+        opencode_mode=authoring_opencode_mode,
     )
     generate_seed = GenerateSeedHandler(
-        agent_runtime_backend=runtime, opencode_mode=authoring_opencode_mode
+        agent_runtime_backend=runtime_plan.interview.runtime_backend,
+        opencode_mode=authoring_opencode_mode,
     )
-    execute_seed = ExecuteSeedHandler(agent_runtime_backend=runtime, opencode_mode=opencode_mode)
+    execute_seed = ExecuteSeedHandler(
+        agent_runtime_backend=runtime_plan.execute.runtime_backend,
+        opencode_mode=execute_opencode_mode,
+    )
     start_execute = StartExecuteSeedHandler(
-        execute_handler=execute_seed, agent_runtime_backend=runtime, opencode_mode=opencode_mode
+        execute_handler=execute_seed,
+        agent_runtime_backend=runtime_plan.execute.runtime_backend,
+        opencode_mode=execute_opencode_mode,
     )
-    seed_qa = QAHandler(agent_runtime_backend=runtime, opencode_mode=authoring_opencode_mode)
+    seed_qa = QAHandler(
+        agent_runtime_backend=runtime_plan.interview.runtime_backend,
+        opencode_mode=authoring_opencode_mode,
+    )
     driver = AutoInterviewDriver(
         HandlerInterviewBackend(interview, cwd=state.cwd),
         store=store,
@@ -529,7 +549,10 @@ async def _run_auto(
         # still correct for the authoring/run-handoff handlers above.
         # Q00/ouroboros#1090: use the full MCP composition root rather than a
         # bare RalphHandler so job-mode Ralph has an EvolutionaryLoop.
-        _build_configured_ralph_handler(runtime=runtime, opencode_mode=ralph_opencode_mode)
+        _build_configured_ralph_handler(
+            runtime=runtime_plan.execute.runtime_backend,
+            opencode_mode=runtime_plan.execute.opencode_mode,
+        )
         if complete_product
         else None
     )

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -54,6 +54,7 @@ from ouroboros.auto.state import (
 from ouroboros.auto.worktree import ensure_auto_worktree, release_auto_worktree
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success
+from ouroboros.config import get_opencode_mode
 from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler
 from ouroboros.mcp.tools.qa import QAHandler
@@ -468,7 +469,7 @@ async def _run_auto(
     runtime_plan = resolve_auto_stage_runtime_plan(
         runtime_override=runtime_override,
         fallback_runtime_backend=runtime,
-        fallback_opencode_mode=state.opencode_mode,
+        fallback_opencode_mode=state.opencode_mode or get_opencode_mode(),
     )
     runtime = runtime_plan.default.runtime_backend
     raw_default_opencode_mode = runtime_plan.default.opencode_mode
@@ -551,7 +552,11 @@ async def _run_auto(
         # bare RalphHandler so job-mode Ralph has an EvolutionaryLoop.
         _build_configured_ralph_handler(
             runtime=runtime_plan.execute.runtime_backend,
-            opencode_mode=runtime_plan.execute.opencode_mode,
+            opencode_mode=(
+                state.ralph_opencode_mode or runtime_plan.execute.opencode_mode
+                if runtime_plan.execute.runtime_backend == "opencode"
+                else None
+            ),
         )
         if complete_product
         else None

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -463,16 +463,19 @@ class AutoHandler:
         # Issue #1248 — construct ``lateral_thinker`` ahead of the driver so
         # the safe-default escalation path (interview phase, runs regardless
         # of complete-product mode) has the same lateral handle the
-        # EVALUATE → UNSTUCK_LATERAL path uses below. ``LateralThinkHandler``
-        # is plugin-mode-skipped because it dispatches to OpenCode Task
-        # panes — the synchronous auto pipeline cannot consume that
-        # out-of-band response.
-        opencode_plugin_mode = opencode_mode == "plugin"
+        # EVALUATE → UNSTUCK_LATERAL path uses below. Gate this on the
+        # resolved REFLECT stage rather than the default runtime: a default
+        # OpenCode plugin profile can still route reflect work to an inline
+        # backend that the synchronous auto pipeline can consume.
+        reflect_plugin_mode = should_dispatch_via_plugin(
+            runtime_plan.reflect.runtime_backend,
+            runtime_plan.reflect.opencode_mode,
+        )
         lateral_thinker = None
-        if not opencode_plugin_mode:
+        if not reflect_plugin_mode:
             lateral_handler = LateralThinkHandler(
                 agent_runtime_backend=runtime_plan.reflect.runtime_backend,
-                opencode_mode=runtime_plan.reflect.opencode_mode,
+                opencode_mode=demote_plugin_opencode_mode(runtime_plan.reflect.opencode_mode),
             )
             lateral_thinker = HandlerLateralThinker(lateral_handler)
 
@@ -524,18 +527,14 @@ class AutoHandler:
         # RUN/skip-run transitions. For OpenCode plugin sessions, use the same
         # demoted authoring mode as Interview/GenerateSeed so QA executes
         # inline instead of emitting an out-of-band ``_subagent`` envelope that
-        # the synchronous pipeline cannot consume. Keep the optional
-        # complete-product execution evaluator plugin-skipped: that later
-        # EVALUATE-stage advisory path still grades post-run artifacts and
-        # cannot consume plugin Task-pane output.
+        # the synchronous pipeline cannot consume.
         #
         # Issue #1248 — ``lateral_thinker`` is constructed above (before
         # the driver) so it is available to both the driver's
         # safe-default escalation path and the pipeline's
-        # EVALUATE → UNSTUCK_LATERAL path. The EVALUATE side stays gated
-        # by ``evaluator``, which keeps the complete-product invariant
-        # for that callsite without re-instantiating ``lateral_thinker``
-        # here.
+        # EVALUATE → UNSTUCK_LATERAL path. The complete-product evaluator is
+        # plugin-skipped based on the resolved EVALUATE stage, not the default
+        # runtime, so explicit non-plugin stage overrides remain consumable.
         evaluator = None
         seed_qa_handler = QAHandler(
             llm_backend=self.llm_backend,
@@ -543,8 +542,17 @@ class AutoHandler:
             opencode_mode=authoring_opencode_mode,
         )
         seed_qa_evaluator = HandlerSeedQAEvaluator(seed_qa_handler)
-        if complete_product and not opencode_plugin_mode:
-            evaluator = HandlerEvaluator(seed_qa_handler)
+        evaluate_plugin_mode = should_dispatch_via_plugin(
+            runtime_plan.evaluate.runtime_backend,
+            runtime_plan.evaluate.opencode_mode,
+        )
+        if complete_product and not evaluate_plugin_mode:
+            evaluation_handler = QAHandler(
+                llm_backend=self.llm_backend,
+                agent_runtime_backend=runtime_plan.evaluate.runtime_backend,
+                opencode_mode=demote_plugin_opencode_mode(runtime_plan.evaluate.opencode_mode),
+            )
+            evaluator = HandlerEvaluator(evaluation_handler)
         watchdog_event_store = self.event_store or EventStore()
         await watchdog_event_store.initialize()
         watchdog = Watchdog(

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -489,17 +489,22 @@ class AutoHandler:
         # OpenCode plugin mode is intentionally preserved here: unlike
         # interview/Seed authoring, Ralph can surface a plugin delegation
         # receipt to the caller.
+        ralph_opencode_mode = (
+            state.ralph_opencode_mode or runtime_plan.execute.opencode_mode
+            if runtime_plan.execute.runtime_backend == "opencode"
+            else None
+        )
         ralph_handler = None
         if complete_product:
             ralph_handler = (
                 self.ralph_handler_factory(
                     runtime_plan.execute.runtime_backend,
-                    runtime_plan.execute.opencode_mode,
+                    ralph_opencode_mode,
                 )
                 if self.ralph_handler_factory is not None
                 else RalphHandler(
                     agent_runtime_backend=runtime_plan.execute.runtime_backend,
-                    opencode_mode=runtime_plan.execute.opencode_mode,
+                    opencode_mode=ralph_opencode_mode,
                 )
             )
         ralph_starter = (

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -50,6 +50,10 @@ from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
 from ouroboros.auto.policies import apply_domain_policy_defaults
 from ouroboros.auto.repo_context import repo_auto_answer_context
 from ouroboros.auto.resume_render import render_resume_lines
+from ouroboros.auto.runtime_routing import (
+    demote_plugin_opencode_mode,
+    resolve_auto_stage_runtime_plan,
+)
 from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.state import (
     DEFAULT_PIPELINE_TIMEOUT_SECONDS,
@@ -427,24 +431,31 @@ class AutoHandler:
 
         auto_workspace = ensure_auto_worktree(state)
 
-        authoring_opencode_mode = "subprocess" if opencode_mode == "plugin" else opencode_mode
+        runtime_plan = resolve_auto_stage_runtime_plan(
+            runtime_override=None,
+            fallback_runtime_backend=runtime_backend,
+            fallback_opencode_mode=opencode_mode,
+        )
+        authoring_opencode_mode = demote_plugin_opencode_mode(
+            runtime_plan.interview.opencode_mode
+        )
         interview_handler = _authoring_interview_handler(
             self.interview_handler,
             llm_backend=self.llm_backend,
-            agent_runtime_backend=runtime_backend,
+            agent_runtime_backend=runtime_plan.interview.runtime_backend,
             opencode_mode=authoring_opencode_mode,
         )
         generate_seed_handler = _authoring_seed_handler(
             self.generate_seed_handler,
             llm_backend=self.llm_backend,
-            agent_runtime_backend=runtime_backend,
+            agent_runtime_backend=runtime_plan.interview.runtime_backend,
             opencode_mode=authoring_opencode_mode,
         )
         start_execute = _execution_start_handler(
             self.start_execute_seed_handler,
             llm_backend=self.llm_backend,
-            agent_runtime_backend=runtime_backend,
-            opencode_mode=opencode_mode,
+            agent_runtime_backend=runtime_plan.execute.runtime_backend,
+            opencode_mode=runtime_plan.execute.opencode_mode,
             mcp_manager=self.mcp_manager,
             mcp_tool_prefix=self.mcp_tool_prefix,
         )
@@ -462,8 +473,8 @@ class AutoHandler:
         lateral_thinker = None
         if not opencode_plugin_mode:
             lateral_handler = LateralThinkHandler(
-                agent_runtime_backend=runtime_backend,
-                opencode_mode=opencode_mode,
+                agent_runtime_backend=runtime_plan.reflect.runtime_backend,
+                opencode_mode=runtime_plan.reflect.opencode_mode,
             )
             lateral_thinker = HandlerLateralThinker(lateral_handler)
 
@@ -475,22 +486,22 @@ class AutoHandler:
             context_provider=context_provider,
             lateral_thinker=lateral_thinker,
         )
-        # Q00/ouroboros#782 review-11 BLOCKING #1: pass the un-demoted
-        # ``state.ralph_opencode_mode`` (already populated above at line 251-252,
-        # and preserved across CLI-created sessions where ``state.opencode_mode``
-        # holds the demoted authoring/run-handoff form) so MCP-side resumes of
-        # an OpenCode plugin ``--complete-product`` session take the plugin
-        # ``_subagent`` dispatch path instead of silently downgrading Ralph to
-        # in-process job mode. Mirrors the CLI fix in ``cli/commands/auto.py``.
-        ralph_opencode_mode = state.ralph_opencode_mode or opencode_mode
+        # Complete-product Ralph follows the execute-stage runtime because it
+        # continues product mutation/evaluation after the initial run handoff.
+        # OpenCode plugin mode is intentionally preserved here: unlike
+        # interview/Seed authoring, Ralph can surface a plugin delegation
+        # receipt to the caller.
         ralph_handler = None
         if complete_product:
             ralph_handler = (
-                self.ralph_handler_factory(runtime_backend, ralph_opencode_mode)
+                self.ralph_handler_factory(
+                    runtime_plan.execute.runtime_backend,
+                    runtime_plan.execute.opencode_mode,
+                )
                 if self.ralph_handler_factory is not None
                 else RalphHandler(
-                    agent_runtime_backend=runtime_backend,
-                    opencode_mode=ralph_opencode_mode,
+                    agent_runtime_backend=runtime_plan.execute.runtime_backend,
+                    opencode_mode=runtime_plan.execute.opencode_mode,
                 )
             )
         ralph_starter = (
@@ -525,7 +536,7 @@ class AutoHandler:
         evaluator = None
         seed_qa_handler = QAHandler(
             llm_backend=self.llm_backend,
-            agent_runtime_backend=runtime_backend,
+            agent_runtime_backend=runtime_plan.interview.runtime_backend,
             opencode_mode=authoring_opencode_mode,
         )
         seed_qa_evaluator = HandlerSeedQAEvaluator(seed_qa_handler)
@@ -1099,7 +1110,15 @@ def _state_dispatches_via_plugin(
         runtime_backend,
         state.opencode_mode or fallback_opencode_mode,
     )
-    return should_dispatch_via_plugin(runtime_backend, opencode_mode)
+    runtime_plan = resolve_auto_stage_runtime_plan(
+        runtime_override=None,
+        fallback_runtime_backend=runtime_backend,
+        fallback_opencode_mode=opencode_mode,
+    )
+    return should_dispatch_via_plugin(
+        runtime_plan.interview.runtime_backend,
+        runtime_plan.interview.opencode_mode,
+    )
 
 
 def _start_auto_lease_token_from_arguments(arguments: dict[str, Any]) -> str | None:

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -436,9 +436,7 @@ class AutoHandler:
             fallback_runtime_backend=runtime_backend,
             fallback_opencode_mode=opencode_mode,
         )
-        authoring_opencode_mode = demote_plugin_opencode_mode(
-            runtime_plan.interview.opencode_mode
-        )
+        authoring_opencode_mode = demote_plugin_opencode_mode(runtime_plan.interview.opencode_mode)
         interview_handler = _authoring_interview_handler(
             self.interview_handler,
             llm_backend=self.llm_backend,

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1126,10 +1126,15 @@ def _state_dispatches_via_plugin(
         fallback_runtime_backend=runtime_backend,
         fallback_opencode_mode=opencode_mode,
     )
-    return should_dispatch_via_plugin(
+    interview_dispatch = should_dispatch_via_plugin(
         runtime_plan.interview.runtime_backend,
         runtime_plan.interview.opencode_mode,
     )
+    execute_dispatch = (not state.skip_run) and should_dispatch_via_plugin(
+        runtime_plan.execute.runtime_backend,
+        runtime_plan.execute.opencode_mode,
+    )
+    return interview_dispatch or execute_dispatch
 
 
 def _start_auto_lease_token_from_arguments(arguments: dict[str, Any]) -> str | None:

--- a/tests/unit/auto/test_runtime_routing.py
+++ b/tests/unit/auto/test_runtime_routing.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import pytest
+
 from ouroboros.auto import runtime_routing
 from ouroboros.config.models import OrchestratorConfig, OuroborosConfig, RuntimeProfileConfig
+from ouroboros.core.errors import ConfigError
 
 
 def test_auto_stage_runtime_plan_honors_runtime_profile(monkeypatch) -> None:
@@ -59,3 +62,53 @@ def test_auto_stage_runtime_plan_explicit_runtime_overrides_profile(monkeypatch)
     assert plan.interview.runtime_backend == "codex"
     assert plan.execute.runtime_backend == "codex"
     assert plan.evaluate.runtime_backend == "codex"
+
+
+def test_invalid_profile_config_fails_fast_when_config_file_exists(monkeypatch, tmp_path) -> None:
+    """A present-but-invalid config must FAIL FAST, not silently fall back.
+
+    If ``load_config()`` raises (malformed YAML or failed validation — e.g. an
+    unknown runtime_profile stage key/backend) AND the config file exists, the
+    resolver must propagate the error so an operator routing mistake surfaces
+    instead of silently rerouting auto to the fallback runtime.
+    """
+
+    def _raise() -> OuroborosConfig:
+        raise ConfigError("Configuration validation failed: bad runtime_profile stage")
+
+    (tmp_path / "config.yaml").write_text("orchestrator: {}\n")
+    monkeypatch.setattr(runtime_routing, "load_config", _raise)
+    monkeypatch.setattr(runtime_routing, "get_config_dir", lambda: tmp_path)
+
+    with pytest.raises(ConfigError):
+        runtime_routing.resolve_auto_stage_runtime_plan(
+            runtime_override=None,
+            fallback_runtime_backend="opencode",
+            fallback_opencode_mode="plugin",
+        )
+
+
+def test_absent_config_file_falls_back_without_error(monkeypatch, tmp_path) -> None:
+    """A genuinely absent config file is a legitimate "no profile" → fall back.
+
+    ``load_config()`` raises ConfigError when no config file exists; with no
+    ``config.yaml`` in the config dir the resolver must swallow it and use the
+    fallback runtime rather than failing.
+    """
+
+    def _raise() -> OuroborosConfig:
+        raise ConfigError("Configuration file not found")
+
+    # tmp_path has no config.yaml → genuinely absent.
+    monkeypatch.setattr(runtime_routing, "load_config", _raise)
+    monkeypatch.setattr(runtime_routing, "get_config_dir", lambda: tmp_path)
+
+    plan = runtime_routing.resolve_auto_stage_runtime_plan(
+        runtime_override=None,
+        fallback_runtime_backend="opencode",
+        fallback_opencode_mode="plugin",
+    )
+
+    assert plan.default.runtime_backend == "opencode"
+    assert plan.interview.runtime_backend == "opencode"
+    assert plan.execute.runtime_backend == "opencode"

--- a/tests/unit/auto/test_runtime_routing.py
+++ b/tests/unit/auto/test_runtime_routing.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from ouroboros.auto import runtime_routing
+from ouroboros.config.models import OrchestratorConfig, OuroborosConfig, RuntimeProfileConfig
+
+
+def test_auto_stage_runtime_plan_honors_runtime_profile(monkeypatch) -> None:
+    config = OuroborosConfig(
+        orchestrator=OrchestratorConfig(
+            runtime_backend="opencode",
+            opencode_mode="plugin",
+            runtime_profile=RuntimeProfileConfig(
+                stages={
+                    "interview": "gjc",
+                    "execute": "pi",
+                }
+            ),
+        )
+    )
+    monkeypatch.setattr(runtime_routing, "load_config", lambda: config)
+
+    plan = runtime_routing.resolve_auto_stage_runtime_plan(
+        runtime_override=None,
+        fallback_runtime_backend="opencode",
+        fallback_opencode_mode="plugin",
+    )
+
+    assert plan.default.runtime_backend == "opencode"
+    assert plan.default.opencode_mode == "plugin"
+    assert plan.interview.runtime_backend == "gjc"
+    assert plan.interview.opencode_mode is None
+    assert plan.execute.runtime_backend == "pi"
+    assert plan.execute.opencode_mode is None
+    assert plan.evaluate.runtime_backend == "opencode"
+    assert plan.evaluate.opencode_mode == "plugin"
+
+
+def test_auto_stage_runtime_plan_explicit_runtime_overrides_profile(monkeypatch) -> None:
+    config = OuroborosConfig(
+        orchestrator=OrchestratorConfig(
+            runtime_backend="opencode",
+            runtime_profile=RuntimeProfileConfig(
+                stages={
+                    "interview": "gjc",
+                    "execute": "pi",
+                }
+            ),
+        )
+    )
+    monkeypatch.setattr(runtime_routing, "load_config", lambda: config)
+
+    plan = runtime_routing.resolve_auto_stage_runtime_plan(
+        runtime_override="codex",
+        fallback_runtime_backend="opencode",
+        fallback_opencode_mode="plugin",
+    )
+
+    assert plan.default.runtime_backend == "codex"
+    assert plan.interview.runtime_backend == "codex"
+    assert plan.execute.runtime_backend == "codex"
+    assert plan.evaluate.runtime_backend == "codex"

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1380,6 +1380,65 @@ async def test_auto_handler_routes_interview_and_execute_from_stage_plan(
 
 
 @pytest.mark.asyncio
+async def test_auto_handler_routes_complete_product_evaluate_and_reflect_from_stage_plan(
+    monkeypatch, tmp_path
+) -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.auto.state import AutoStore
+    from ouroboros.mcp.tools import auto_handler as auto_module
+
+    captured: dict[str, object] = {}
+
+    class FakePipeline:
+        def __init__(self, driver, seed_generator, **kwargs):  # noqa: ANN001, ANN003, ARG002
+            evaluator = kwargs["evaluator"]
+            lateral_thinker = kwargs["lateral_thinker"]
+            captured["evaluator_runtime"] = evaluator.qa_handler.agent_runtime_backend
+            captured["evaluator_mode"] = evaluator.qa_handler.opencode_mode
+            captured["lateral_runtime"] = lateral_thinker.handler.agent_runtime_backend
+            captured["lateral_mode"] = lateral_thinker.handler.opencode_mode
+            captured["seed_qa_runtime"] = kwargs[
+                "seed_qa_evaluator"
+            ].qa_handler.agent_runtime_backend
+
+        async def run(self, run_state):  # noqa: ANN001
+            captured["state_runtime"] = run_state.runtime_backend
+            return AutoPipelineResult(
+                status="complete",
+                auto_session_id=run_state.auto_session_id,
+                phase="complete",
+            )
+
+    monkeypatch.setattr(auto_module, "AutoStore", lambda: AutoStore(tmp_path / "store"))
+    monkeypatch.setattr(auto_module, "AutoPipeline", FakePipeline)
+    monkeypatch.setattr(
+        auto_module,
+        "resolve_auto_stage_runtime_plan",
+        lambda **_kwargs: AutoStageRuntimePlan(
+            default=StageRuntime("opencode", "plugin"),
+            interview=StageRuntime("gjc", None),
+            execute=StageRuntime("pi", None),
+            evaluate=StageRuntime("codex", None),
+            reflect=StageRuntime("hermes", None),
+        ),
+    )
+
+    result = await AutoHandler(agent_runtime_backend="opencode", opencode_mode="plugin").handle(
+        {"goal": "Build a CLI", "cwd": str(tmp_path), "complete_product": True}
+    )
+
+    assert result.is_ok
+    assert captured == {
+        "evaluator_runtime": "codex",
+        "evaluator_mode": None,
+        "lateral_runtime": "hermes",
+        "lateral_mode": None,
+        "seed_qa_runtime": "gjc",
+        "state_runtime": "opencode",
+    }
+
+
+@pytest.mark.asyncio
 async def test_auto_handler_resume_uses_persisted_cwd_without_revalidating_server_cwd(
     monkeypatch, tmp_path
 ) -> None:

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -7,6 +7,7 @@ import pytest
 from typer.testing import CliRunner
 
 from ouroboros.auto.adapters import HandlerInterviewBackend
+from ouroboros.auto.runtime_routing import AutoStageRuntimePlan, StageRuntime
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 from ouroboros.cli.main import app
 from ouroboros.core.types import Result
@@ -659,17 +660,14 @@ def test_cli_opencode_plugin_uses_subprocess_for_plain_cli(monkeypatch) -> None:
         def __init__(self, **kwargs):
             captured["start_mode"] = kwargs.get("opencode_mode")
 
-    monkeypatch.setattr(auto_command, "get_opencode_mode", lambda: "plugin")
     monkeypatch.setattr(auto_command, "InterviewHandler", FakeInterviewHandler)
     monkeypatch.setattr(auto_command, "GenerateSeedHandler", FakeGenerateSeedHandler)
     monkeypatch.setattr(auto_command, "ExecuteSeedHandler", FakeExecuteSeedHandler)
     monkeypatch.setattr(auto_command, "StartExecuteSeedHandler", FakeStartExecuteSeedHandler)
 
     # Instantiate the dependency block without running the whole pipeline.
-    opencode_mode = auto_command.get_opencode_mode()
-    if opencode_mode == "plugin":
-        opencode_mode = "subprocess"
-    authoring_opencode_mode = "subprocess" if opencode_mode == "plugin" else opencode_mode
+    opencode_mode = auto_command.demote_plugin_opencode_mode("plugin")
+    authoring_opencode_mode = auto_command.demote_plugin_opencode_mode(opencode_mode)
     auto_command.InterviewHandler(
         agent_runtime_backend="opencode", opencode_mode=authoring_opencode_mode
     )
@@ -735,6 +733,70 @@ def test_auto_handler_explicit_cwd_rejects_regular_file(tmp_path) -> None:
 
     with pytest.raises(ValueError, match="not a directory"):
         _resolve_cwd(str(file_path))
+
+
+@pytest.mark.asyncio
+async def test_cli_auto_routes_interview_and_execute_from_stage_plan(
+    monkeypatch, tmp_path
+) -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.auto.state import AutoStore
+    from ouroboros.cli.commands import auto as auto_command
+
+    captured: dict[str, object] = {}
+
+    class FakePipeline:
+        def __init__(self, driver, seed_generator, **kwargs):  # noqa: ANN001, ANN003
+            run_starter = kwargs["run_starter"]
+            captured["interview_runtime"] = driver.backend.handler.agent_runtime_backend
+            captured["seed_runtime"] = seed_generator.handler.agent_runtime_backend
+            captured["run_runtime"] = run_starter.handler.agent_runtime_backend
+            captured["execute_runtime"] = run_starter.handler.execute_handler.agent_runtime_backend
+            captured["qa_runtime"] = kwargs["seed_qa_evaluator"].qa_handler.agent_runtime_backend
+
+        async def run(self, run_state):  # noqa: ANN001
+            captured["state_runtime"] = run_state.runtime_backend
+            return AutoPipelineResult(
+                status="complete",
+                auto_session_id=run_state.auto_session_id,
+                phase="complete",
+            )
+
+    monkeypatch.setattr(auto_command, "AutoStore", lambda: AutoStore(tmp_path / "store"))
+    monkeypatch.setattr(auto_command, "AutoPipeline", FakePipeline)
+    monkeypatch.setattr(auto_command, "ensure_auto_worktree", lambda _state: None)
+    monkeypatch.setattr(auto_command, "release_auto_worktree", lambda _workspace: None)
+    monkeypatch.setattr(auto_command, "resolve_agent_runtime_backend", lambda value=None: value or "opencode")
+    monkeypatch.setattr(
+        auto_command,
+        "resolve_auto_stage_runtime_plan",
+        lambda **_kwargs: AutoStageRuntimePlan(
+            default=StageRuntime("opencode", "plugin"),
+            interview=StageRuntime("gjc", None),
+            execute=StageRuntime("pi", None),
+            evaluate=StageRuntime("opencode", "plugin"),
+            reflect=StageRuntime("opencode", "plugin"),
+        ),
+    )
+
+    result = await auto_command._run_auto(
+        goal="Build a CLI",
+        resume=None,
+        runtime=None,
+        max_interview_rounds=1,
+        max_repair_rounds=1,
+        skip_run=False,
+    )
+
+    assert result.status == "complete"
+    assert captured == {
+        "interview_runtime": "gjc",
+        "seed_runtime": "gjc",
+        "run_runtime": "pi",
+        "execute_runtime": "pi",
+        "qa_runtime": "gjc",
+        "state_runtime": "opencode",
+    }
 
 
 @pytest.mark.asyncio
@@ -1258,6 +1320,62 @@ async def test_auto_handler_resume_rebuilds_injected_handlers_for_persisted_runt
         "run_llm_backend": "anthropic",
         "run_mcp_manager": manager,
         "run_mcp_prefix": "bridge__",
+    }
+
+
+@pytest.mark.asyncio
+async def test_auto_handler_routes_interview_and_execute_from_stage_plan(
+    monkeypatch, tmp_path
+) -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.auto.state import AutoStore
+    from ouroboros.mcp.tools import auto_handler as auto_module
+
+    captured: dict[str, object] = {}
+
+    class FakePipeline:
+        def __init__(self, driver, seed_generator, **kwargs):  # noqa: ANN001, ANN003
+            run_starter = kwargs["run_starter"]
+            captured["interview_runtime"] = driver.backend.handler.agent_runtime_backend
+            captured["seed_runtime"] = seed_generator.handler.agent_runtime_backend
+            captured["run_runtime"] = run_starter.handler.agent_runtime_backend
+            captured["execute_runtime"] = run_starter.handler.execute_handler.agent_runtime_backend
+            captured["qa_runtime"] = kwargs["seed_qa_evaluator"].qa_handler.agent_runtime_backend
+
+        async def run(self, run_state):  # noqa: ANN001
+            captured["state_runtime"] = run_state.runtime_backend
+            return AutoPipelineResult(
+                status="complete",
+                auto_session_id=run_state.auto_session_id,
+                phase="complete",
+            )
+
+    monkeypatch.setattr(auto_module, "AutoStore", lambda: AutoStore(tmp_path / "store"))
+    monkeypatch.setattr(auto_module, "AutoPipeline", FakePipeline)
+    monkeypatch.setattr(
+        auto_module,
+        "resolve_auto_stage_runtime_plan",
+        lambda **_kwargs: AutoStageRuntimePlan(
+            default=StageRuntime("opencode", "plugin"),
+            interview=StageRuntime("gjc", None),
+            execute=StageRuntime("pi", None),
+            evaluate=StageRuntime("opencode", "plugin"),
+            reflect=StageRuntime("opencode", "plugin"),
+        ),
+    )
+
+    result = await AutoHandler(agent_runtime_backend="opencode", opencode_mode="plugin").handle(
+        {"goal": "Build a CLI", "cwd": str(tmp_path)}
+    )
+
+    assert result.is_ok
+    assert captured == {
+        "interview_runtime": "gjc",
+        "seed_runtime": "gjc",
+        "run_runtime": "pi",
+        "execute_runtime": "pi",
+        "qa_runtime": "gjc",
+        "state_runtime": "opencode",
     }
 
 

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -736,9 +736,7 @@ def test_auto_handler_explicit_cwd_rejects_regular_file(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_cli_auto_routes_interview_and_execute_from_stage_plan(
-    monkeypatch, tmp_path
-) -> None:
+async def test_cli_auto_routes_interview_and_execute_from_stage_plan(monkeypatch, tmp_path) -> None:
     from ouroboros.auto.pipeline import AutoPipelineResult
     from ouroboros.auto.state import AutoStore
     from ouroboros.cli.commands import auto as auto_command
@@ -766,7 +764,9 @@ async def test_cli_auto_routes_interview_and_execute_from_stage_plan(
     monkeypatch.setattr(auto_command, "AutoPipeline", FakePipeline)
     monkeypatch.setattr(auto_command, "ensure_auto_worktree", lambda _state: None)
     monkeypatch.setattr(auto_command, "release_auto_worktree", lambda _workspace: None)
-    monkeypatch.setattr(auto_command, "resolve_agent_runtime_backend", lambda value=None: value or "opencode")
+    monkeypatch.setattr(
+        auto_command, "resolve_agent_runtime_backend", lambda value=None: value or "opencode"
+    )
     monkeypatch.setattr(
         auto_command,
         "resolve_auto_stage_runtime_plan",

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -21,6 +21,7 @@ import pytest
 
 from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipelineResult
+from ouroboros.auto.runtime_routing import AutoStageRuntimePlan, StageRuntime
 from ouroboros.auto.state import (
     AutoCommitPolicy,
     AutoPipelineState,
@@ -1337,6 +1338,53 @@ class TestBackgroundJobPath:
         assert body["auto_session_id"] == meta["auto_session_id"]
         job_manager.start_job.assert_not_called()
         fake_inner_auto.handle.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_stage_routed_interview_bypasses_opencode_plugin_dispatch(
+        self, event_store, tmp_path, fake_inner_auto, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Non-OpenCode interview stages should run as normal jobs."""
+
+        from ouroboros.mcp.tools import auto_handler as auto_module
+
+        monkeypatch.setattr(
+            auto_module,
+            "resolve_auto_stage_runtime_plan",
+            lambda **_kwargs: AutoStageRuntimePlan(
+                default=StageRuntime("opencode", "plugin"),
+                interview=StageRuntime("gjc", None),
+                execute=StageRuntime("pi", None),
+                evaluate=StageRuntime("opencode", "plugin"),
+                reflect=StageRuntime("opencode", "plugin"),
+            ),
+        )
+        job_manager = MagicMock()
+        job_manager.allocate_job_id = AsyncMock(return_value="job_alloc")
+        snapshot = MagicMock()
+        snapshot.job_id = "job_auto_stage_routed"
+
+        async def _start_job(*, runner, **_):
+            if inspect.iscoroutine(runner):
+                runner.close()
+            return snapshot
+
+        job_manager.start_job = AsyncMock(side_effect=_start_job)
+        store = AutoStore(tmp_path)
+        h = StartAutoHandler(
+            event_store=event_store,
+            job_manager=job_manager,
+            store=store,
+            agent_runtime_backend="opencode",
+            opencode_mode="plugin",
+        )
+        h._inner_auto = fake_inner_auto
+
+        result = await h.handle({"goal": "build a CLI"})
+
+        assert result.is_ok
+        assert result.value.meta["dispatch_mode"] == "job"
+        assert result.value.meta["job_id"] == "job_auto_stage_routed"
+        job_manager.start_job.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_plugin_detached_auto_response_is_deterministic_after_scrubbing_handles(

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -1387,6 +1387,49 @@ class TestBackgroundJobPath:
         job_manager.start_job.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_stage_routed_execute_plugin_dispatches_before_job_enqueue(
+        self, event_store, tmp_path, fake_inner_auto, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Execute-stage plugin dispatch must be visible to the bridge."""
+
+        from ouroboros.mcp.tools import auto_handler as auto_module
+
+        monkeypatch.setattr(
+            auto_module,
+            "resolve_auto_stage_runtime_plan",
+            lambda **_kwargs: AutoStageRuntimePlan(
+                default=StageRuntime("opencode", "plugin"),
+                interview=StageRuntime("gjc", None),
+                execute=StageRuntime("opencode", "plugin"),
+                evaluate=StageRuntime("opencode", "plugin"),
+                reflect=StageRuntime("opencode", "plugin"),
+            ),
+        )
+        job_manager = MagicMock()
+        job_manager.allocate_job_id = AsyncMock(return_value="job_alloc")
+        job_manager.start_job = AsyncMock()
+        store = AutoStore(tmp_path)
+        h = StartAutoHandler(
+            event_store=event_store,
+            job_manager=job_manager,
+            store=store,
+            agent_runtime_backend="opencode",
+            opencode_mode="plugin",
+        )
+        h._inner_auto = fake_inner_auto
+
+        result = await h.handle({"goal": "build a CLI"})
+
+        assert result.is_ok
+        meta = result.value.meta
+        assert meta["job_id"] is None
+        assert meta["dispatch_mode"] == "plugin"
+        assert meta["status"] == "delegated_to_plugin"
+        assert meta["_subagent"]["context"]["arguments"]["resume"] == meta["auto_session_id"]
+        job_manager.start_job.assert_not_called()
+        fake_inner_auto.handle.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_plugin_detached_auto_response_is_deterministic_after_scrubbing_handles(
         self, event_store, tmp_path, fake_inner_auto
     ) -> None:


### PR DESCRIPTION
## Summary

- Make `ooo auto` honor `orchestrator.runtime_profile.stages` so authoring can run on one backend while execution handoff runs on another.
- Route Interview, Seed generation, and Seed QA through the interview stage, ExecuteSeed/StartExecuteSeed and complete-product Ralph through execute, and complete-product evaluator/lateral hooks through evaluate/reflect.
- Keep explicit `--runtime` behavior unchanged: a CLI override still drives all auto stages.

## Changes

- Added a shared auto runtime plan resolver for default/interview/execute/evaluate/reflect stages.
- Updated CLI and MCP auto entrypoints to construct handlers from the resolved stage plan.
- Adjusted `ouroboros_start_auto` plugin-dispatch gating to check the resolved interview and execute stages, so execute-stage OpenCode plugin dispatch remains visible to the bridge instead of being buried in a background job.
- Preserved existing OpenCode CLI demotion and persisted Ralph plugin-mode resume contracts.
- Routed MCP complete-product evaluator/lateral plugin eligibility from `runtime_plan.evaluate` and `runtime_plan.reflect`, not the default runtime.
- Added unit coverage for runtime plan resolution, CLI/MCP handler routing, start-auto dispatch behavior, complete-product evaluate/reflect overrides, and execute-stage plugin dispatch.

## Test plan

- [x] `ruff check src/ouroboros/auto/runtime_routing.py src/ouroboros/cli/commands/auto.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_runtime_routing.py tests/unit/auto/test_surface.py tests/unit/mcp/tools/test_start_auto.py tests/unit/auto/test_runtime_semantics.py tests/unit/cli/test_auto_runtime_dispatch.py tests/unit/mcp/tools/test_auto_handler_ralph_runtime.py`
- [x] `ruff format --check src/ouroboros/auto/runtime_routing.py src/ouroboros/cli/commands/auto.py src/ouroboros/mcp/tools/auto_handler.py tests/unit/auto/test_runtime_routing.py tests/unit/auto/test_surface.py tests/unit/mcp/tools/test_start_auto.py tests/unit/auto/test_runtime_semantics.py tests/unit/cli/test_auto_runtime_dispatch.py tests/unit/mcp/tools/test_auto_handler_ralph_runtime.py`
- [x] `pytest -p no:cacheprovider tests/unit/auto/test_runtime_routing.py tests/unit/auto/test_surface.py tests/unit/mcp/tools/test_start_auto.py -q` (`147 passed`)
- [x] `pytest -p no:cacheprovider tests/unit/auto/test_surface.py::test_auto_handler_routes_complete_product_evaluate_and_reflect_from_stage_plan tests/unit/auto/test_runtime_semantics.py tests/unit/cli/test_auto_runtime_dispatch.py tests/unit/mcp/tools/test_auto_handler_ralph_runtime.py -q` (`38 passed`)
- [x] `pytest -p no:cacheprovider tests/unit/mcp/tools/test_start_auto.py::TestBackgroundJobPath::test_stage_routed_interview_bypasses_opencode_plugin_dispatch tests/unit/mcp/tools/test_start_auto.py::TestBackgroundJobPath::test_stage_routed_execute_plugin_dispatches_before_job_enqueue -q` (`2 passed`)

## R-run comparison (required for `src/ouroboros/auto/` changes)

This PR changes auto stage runtime resolution and handler wiring only; it does not change the per-round interview loop, repair loop, scheduling policy, or EventStore write path. Using the template's substrate-only allowance.

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [ ] within 1.5x / [ ] regression flagged with mitigation / [x] N/A (substrate-only routing change)