### PR TITLE
feat(auto): persist closure ladder events

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -612,7 +612,7 @@ class AutoInterviewDriver:
         except TimeoutError as exc:
             self._record_evidence_based_session_id(state, exc, preassigned_id)
             if interview_tool_name == "interview.start":
-                fallback = self._try_close_after_backend_start_failure(state, ledger, exc)
+                fallback = await self._try_close_after_backend_start_failure(state, ledger, exc)
                 if fallback is not None:
                     return fallback
             message = str(exc)
@@ -626,7 +626,7 @@ class AutoInterviewDriver:
             self._record_evidence_based_session_id(state, exc, preassigned_id)
             action = "resume" if interview_tool_name == "interview.resume" else "start"
             if action == "start":
-                fallback = self._try_close_after_backend_start_failure(state, ledger, exc)
+                fallback = await self._try_close_after_backend_start_failure(state, ledger, exc)
                 if fallback is not None:
                     return fallback
             blocker = f"interview {action} failed: {exc}"
@@ -1091,7 +1091,7 @@ class AutoInterviewDriver:
                 interview_session_id=state.interview_session_id,
             )
             await self._emit_event(
-                "auto.closure.partial_seed_generated",
+                "auto.closure.safe_default_blocked",
                 state.auto_session_id,
                 aggregate_type="auto_session",
                 **partial_payload,
@@ -1158,7 +1158,7 @@ class AutoInterviewDriver:
             "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
         )
 
-    def _try_close_after_backend_start_failure(
+    async def _try_close_after_backend_start_failure(
         self,
         state: AutoPipelineState,
         ledger: SeedDraftLedger,
@@ -1176,6 +1176,8 @@ class AutoInterviewDriver:
         if not _is_authoring_backend_unavailable(exc):
             return None
         closure_mode = "ledger_only_no_backend"
+        finalization = None
+        open_gaps_before_finalization = list(ledger.open_gaps())
         if not ledger.is_seed_ready():
             finalization = finalize_safe_defaultable_gaps(
                 ledger,
@@ -1189,6 +1191,30 @@ class AutoInterviewDriver:
                     _revert_safe_default_entries(ledger, finalization.defaulted_sections)
                 return None
             closure_mode = "safe_default_no_backend"
+
+        if closure_mode == "safe_default_no_backend" and finalization is not None:
+            await self._emit_event(
+                "auto.closure.safe_default_entered",
+                state.auto_session_id,
+                aggregate_type="auto_session",
+                backend_done=False,
+                ledger_done=False,
+                open_gaps=open_gaps_before_finalization,
+                ambiguity_score=None,
+                max_rounds=self.max_rounds,
+                closure_mode=closure_mode,
+                error=str(exc),
+            )
+            await self._emit_event(
+                "auto.closure.safe_default_closed",
+                state.auto_session_id,
+                aggregate_type="auto_session",
+                closure_mode=closure_mode,
+                defaulted_sections=list(finalization.defaulted_sections),
+                synthesis_pushed=False,
+                interview_session_id=state.interview_session_id,
+                backend_start_failed=True,
+            )
 
         state.ledger = ledger.to_dict()
         state.pending_question = None

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -292,6 +292,8 @@ class AutoInterviewDriver:
         event_type: str,
         aggregate_id: str,
         data: dict[str, object],
+        *,
+        aggregate_type: str = "auto_interview",
     ) -> None:
         """Append a single event with bounded fail-open semantics.
 
@@ -306,7 +308,7 @@ class AutoInterviewDriver:
                 self.event_store.append(
                     BaseEvent(
                         type=event_type,
-                        aggregate_type="auto_interview",
+                        aggregate_type=aggregate_type,
                         aggregate_id=aggregate_id,
                         data=data,
                     )
@@ -339,6 +341,8 @@ class AutoInterviewDriver:
         self,
         event_type: str,
         aggregate_id: str | None,
+        *,
+        aggregate_type: str = "auto_interview",
         **data: object,
     ) -> None:
         """Schedule a typed ``auto.interview.*`` event for background
@@ -366,7 +370,9 @@ class AutoInterviewDriver:
         if not aggregate_id:
             return
         task = asyncio.create_task(
-            self._append_with_fail_open(event_type, aggregate_id, dict(data))
+            self._append_with_fail_open(
+                event_type, aggregate_id, dict(data), aggregate_type=aggregate_type
+            )
         )
         # Hold a strong reference so the task is not garbage-collected
         # mid-flight, and clean it up on completion so the set stays
@@ -867,14 +873,23 @@ class AutoInterviewDriver:
             )
 
         open_gaps = ledger.open_gaps()
+        entered_payload = {
+            "backend_done": backend_done,
+            "ledger_done": ledger_done,
+            "open_gaps": list(open_gaps),
+            "ambiguity_score": turn.ambiguity_score,
+            "max_rounds": self.max_rounds,
+        }
         log.info(
             "auto.interview.safe_default.entered",
             auto_session_id=state.auto_session_id,
-            backend_done=backend_done,
-            ledger_done=ledger_done,
-            open_gaps=list(open_gaps),
-            ambiguity_score=turn.ambiguity_score,
-            max_rounds=self.max_rounds,
+            **entered_payload,
+        )
+        await self._emit_event(
+            "auto.closure.safe_default_entered",
+            state.auto_session_id,
+            aggregate_type="auto_session",
+            **entered_payload,
         )
 
         finalization = None
@@ -1004,11 +1019,23 @@ class AutoInterviewDriver:
                     return AutoInterviewResult(
                         "blocked", state.interview_session_id, ledger, self.max_rounds, blocker
                     )
+            closed_payload = {
+                "closure_mode": "safe_default",
+                "defaulted_sections": list(finalization.defaulted_sections),
+                "synthesis_pushed": synthesis_pushed,
+                "interview_session_id": state.interview_session_id,
+            }
             log.info(
                 "auto.interview.safe_default.closed",
                 auto_session_id=state.auto_session_id,
                 defaulted_sections=finalization.defaulted_sections,
                 synthesis_pushed=synthesis_pushed,
+            )
+            await self._emit_event(
+                "auto.closure.safe_default_closed",
+                state.auto_session_id,
+                aggregate_type="auto_session",
+                **closed_payload,
             )
             state.ledger = ledger.to_dict()
             state.pending_question = None
@@ -1049,6 +1076,12 @@ class AutoInterviewDriver:
             and finalization.defaulted_sections
             and finalization.unsafe_gaps
         ):
+            partial_payload = {
+                "defaulted_sections": list(finalization.defaulted_sections),
+                "unsafe_gaps": list(finalization.unsafe_gaps),
+                "ambiguity_score": turn.ambiguity_score,
+                "interview_session_id": state.interview_session_id,
+            }
             log.info(
                 "auto.interview.safe_default_partial_unsafe_gaps",
                 auto_session_id=state.auto_session_id,
@@ -1056,6 +1089,12 @@ class AutoInterviewDriver:
                 unsafe_gaps=finalization.unsafe_gaps,
                 ambiguity_score=turn.ambiguity_score,
                 interview_session_id=state.interview_session_id,
+            )
+            await self._emit_event(
+                "auto.closure.partial_seed_generated",
+                state.auto_session_id,
+                aggregate_type="auto_session",
+                **partial_payload,
             )
             _revert_safe_default_entries(ledger, finalization.defaulted_sections)
             blocker = (

--- a/tests/unit/auto/test_safe_default_observability.py
+++ b/tests/unit/auto/test_safe_default_observability.py
@@ -222,6 +222,50 @@ async def test_safe_default_logs_synthesis_nonclosure(tmp_path) -> None:
     assert "did not close" in (result.blocker or "")
 
 
+@pytest.mark.asyncio
+async def test_no_backend_safe_default_persists_closure_events(tmp_path) -> None:
+    """No-backend safe-default success has queryable closure evidence."""
+    ledger = SeedDraftLedger.from_goal("Build a tiny local CLI")
+
+    async def start(goal: str, cwd: str, *, interview_id: str | None = None) -> InterviewTurn:  # noqa: ARG001
+        raise RuntimeError("codex profile failed before first question")
+
+    async def answer(
+        session_id: str, text: str, *, last_question: str | None = None
+    ) -> InterviewTurn:  # noqa: ARG001
+        raise AssertionError("answer must not run when start fails")
+
+    state = AutoPipelineState(goal="Build a tiny local CLI", cwd=str(tmp_path))
+    event_store = _RecordingEventStore()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer, is_session_persisted=lambda _id: False),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+        timeout_seconds=1,
+        event_store=event_store,
+    )
+
+    result = await driver.run(state, ledger)
+    await driver.wait_for_pending_emits()
+
+    closure_events = [
+        event for event in event_store.appended if event.type.startswith("auto.closure.")
+    ]
+    assert [event.type for event in closure_events] == [
+        "auto.closure.safe_default_entered",
+        "auto.closure.safe_default_closed",
+    ]
+    assert all(event.aggregate_type == "auto_session" for event in closure_events)
+    assert all(event.aggregate_id == state.auto_session_id for event in closure_events)
+    assert closure_events[0].data["closure_mode"] == "safe_default_no_backend"
+    assert closure_events[0].data["open_gaps"]
+    assert closure_events[1].data["closure_mode"] == "safe_default_no_backend"
+    assert closure_events[1].data["backend_start_failed"] is True
+    assert closure_events[1].data["defaulted_sections"]
+    assert result.status == "seed_ready"
+    assert state.interview_closure_mode == "safe_default_no_backend"
+
+
 # ---------------------------------------------------------------------------
 # Test 3: unsafe_context_match logs pattern_name and safe metrics
 # ---------------------------------------------------------------------------

--- a/tests/unit/auto/test_safe_default_observability.py
+++ b/tests/unit/auto/test_safe_default_observability.py
@@ -64,13 +64,13 @@ def _ledger_all_filled_except(
     return ledger
 
 
-
 class _RecordingEventStore:
     def __init__(self) -> None:
         self.appended = []
 
     async def append(self, event, **_kwargs) -> None:
         self.appended.append(event)
+
 
 # ---------------------------------------------------------------------------
 # Test 1: no_gaps_to_default + mutual_agreement_deadlock_at_max_rounds

--- a/tests/unit/auto/test_safe_default_observability.py
+++ b/tests/unit/auto/test_safe_default_observability.py
@@ -64,6 +64,14 @@ def _ledger_all_filled_except(
     return ledger
 
 
+
+class _RecordingEventStore:
+    def __init__(self) -> None:
+        self.appended = []
+
+    async def append(self, event, **_kwargs) -> None:
+        self.appended.append(event)
+
 # ---------------------------------------------------------------------------
 # Test 1: no_gaps_to_default + mutual_agreement_deadlock_at_max_rounds
 # ---------------------------------------------------------------------------
@@ -136,15 +144,18 @@ async def test_safe_default_logs_closed_path(tmp_path) -> None:
         return InterviewTurn("What else should we know?", session_id, seed_ready=False)
 
     state = AutoPipelineState(goal="Build a tiny local CLI", cwd=str(tmp_path))
+    event_store = _RecordingEventStore()
     driver = AutoInterviewDriver(
         FunctionInterviewBackend(start, answer),
         store=AutoStore(tmp_path),
         max_rounds=1,
         timeout_seconds=1,
+        event_store=event_store,
     )
 
     with capture_logs() as captured:
         result = await driver.run(state, ledger)
+    await driver.wait_for_pending_emits()
 
     events = [e["event"] for e in captured]
     assert "auto.interview.safe_default.entered" in events
@@ -155,6 +166,18 @@ async def test_safe_default_logs_closed_path(tmp_path) -> None:
     assert len(closed_events) == 1
     defaulted = closed_events[0]["defaulted_sections"]
     assert "runtime_context" in defaulted
+
+    closure_events = [
+        event for event in event_store.appended if event.type.startswith("auto.closure.")
+    ]
+    assert [event.type for event in closure_events] == [
+        "auto.closure.safe_default_entered",
+        "auto.closure.safe_default_closed",
+    ]
+    assert all(event.aggregate_type == "auto_session" for event in closure_events)
+    assert all(event.aggregate_id == state.auto_session_id for event in closure_events)
+    assert closure_events[0].data["open_gaps"]
+    assert "runtime_context" in closure_events[1].data["defaulted_sections"]
 
     # Behaviour unchanged: seed ready after safe-default closure.
     assert result.status == "seed_ready"


### PR DESCRIPTION
## Summary
- adds typed `auto.closure.*` EventStore events for safe-default closure ladder decisions
- keeps the events on the `auto_session_id` aggregate so `ouroboros_query_events(auto_session_id)` can return them without structlog scraping
- extends safe-default observability coverage while preserving existing structured logs

Closes #1449

## Test plan
- `uv run pytest tests/unit/auto/test_safe_default_observability.py tests/unit/auto/test_pipeline_interview_deadline_closure.py -q`
- `uv run ruff check src/ouroboros/auto/interview_driver.py tests/unit/auto/test_safe_default_observability.py`
- `uv run ruff format --check src/ouroboros/auto/interview_driver.py tests/unit/auto/test_safe_default_observability.py`
- `uv run mypy src/ouroboros/auto/interview_driver.py`

## R-run comparison

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A (observer-only EventStore slice) | N/A (observer-only EventStore slice) | n/a |
| Per-round wall-clock (s/round) | N/A (observer-only EventStore slice) | N/A (observer-only EventStore slice) | n/a |
| Terminal reason                | N/A (observer-only EventStore slice) | N/A (observer-only EventStore slice) | n/a |
| EventStore event count         | Expected unchanged for canonical happy path | Expected unchanged for canonical happy path; adds closure events only on safe-default closure paths | n/a |

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation /
[x] N/A (observer-only closure-event slice; no canonical R-run behavior change expected)

_Posted by [agentos-roadmap-warden](https://github.com/Q00/ouroboros/blob/main/agents/agentos-roadmap-warden.md) — bot. Reply with `/warden ignore` to suppress further comments on this thread._
