### PR TITLE
feat(orchestrator): reasoning-effort capability contract (1/6)

### DIFF
--- a/src/ouroboros/orchestrator/adapter.py
+++ b/src/ouroboros/orchestrator/adapter.py
@@ -760,6 +760,13 @@ class RuntimeCapabilities:
     # Codex ``-c model_reasoning_effort``). This lets the orchestrator tell
     # enforced rows apart from advised ones instead of assuming uniform support.
     reasoning_effort_support: ParamSupport = ParamSupport.IGNORED
+    # The reasoning-effort vocabulary this runtime actually enforces. A NATIVE
+    # runtime still only honors the levels its backend accepts (Codex drops
+    # anything outside ``model_reasoning_effort``'s allow-list; Claude has no
+    # ``minimal``), so a level outside this set is recorded as *advised*, not
+    # enforced — keeping the proof's enforced rows truthful. ``None`` means "no
+    # per-level restriction" (any level is enforced when support is NATIVE).
+    enforceable_reasoning_efforts: frozenset[str] | None = None
 
 
 # Default capability profile for first-class backends (Claude, Codex).
@@ -770,6 +777,11 @@ FULL_CAPABILITIES = RuntimeCapabilities(
     targeted_resume=True,
     structured_output=True,
 )
+
+# Reasoning-effort levels the Claude Agent SDK ``effort`` option accepts. Used to
+# declare Claude's enforceable vocabulary so a level it cannot honor (e.g. the
+# Codex-only ``minimal``) is recorded as advised rather than falsely enforced.
+CLAUDE_REASONING_EFFORT_LEVELS = frozenset({"low", "medium", "high", "xhigh", "max"})
 
 
 class AgentRuntime(Protocol):
@@ -972,6 +984,7 @@ class ClaudeAgentAdapter:
         return replace(
             FULL_CAPABILITIES,
             reasoning_effort_support=ParamSupport.NATIVE,
+            enforceable_reasoning_efforts=CLAUDE_REASONING_EFFORT_LEVELS,
         )
 
     def _is_transient_error(self, error: Exception) -> bool:

--- a/src/ouroboros/orchestrator/adapter.py
+++ b/src/ouroboros/orchestrator/adapter.py
@@ -752,6 +752,14 @@ class RuntimeCapabilities:
     system_prompt_support: ParamSupport = ParamSupport.NATIVE
     tool_restriction_support: ParamSupport = ParamSupport.NATIVE
     permission_mode_support: ParamSupport = ParamSupport.NATIVE
+    # The effort-first investment lever (RFC #1405): how the runtime honors the
+    # ``reasoning_effort`` execution parameter. Unlike the three fields above it
+    # defaults to IGNORED, because most agent runtimes have no per-call effort
+    # knob — a runtime must opt in to NATIVE (or TRANSLATED) only when it can
+    # actually route the level to its backend (e.g. Claude Agent SDK ``effort``,
+    # Codex ``-c model_reasoning_effort``). This lets the orchestrator tell
+    # enforced rows apart from advised ones instead of assuming uniform support.
+    reasoning_effort_support: ParamSupport = ParamSupport.IGNORED
 
 
 # Default capability profile for first-class backends (Claude, Codex).
@@ -957,7 +965,14 @@ class ClaudeAgentAdapter:
 
     @property
     def capabilities(self) -> RuntimeCapabilities:
-        return FULL_CAPABILITIES
+        # The Claude runtime drives the Claude Agent SDK, which honors the
+        # per-call ``effort`` option natively (see execute_task), so it opts in
+        # to NATIVE reasoning-effort support. Other capabilities match the
+        # first-class default.
+        return replace(
+            FULL_CAPABILITIES,
+            reasoning_effort_support=ParamSupport.NATIVE,
+        )
 
     def _is_transient_error(self, error: Exception) -> bool:
         """Check if an error is transient and worth retrying.
@@ -1229,6 +1244,7 @@ class ClaudeAgentAdapter:
         system_prompt: str | None = None,
         resume_handle: RuntimeHandle | None = None,
         resume_session_id: str | None = None,
+        reasoning_effort: str | None = None,
     ) -> AsyncIterator[AgentMessage]:
         """Execute a task and yield progress messages.
 
@@ -1330,6 +1346,15 @@ class ClaudeAgentAdapter:
 
                 if self._model:
                     options_kwargs["model"] = self._model
+
+                if reasoning_effort:
+                    # Effort-first investment dial (RFC #1405). The Claude Agent
+                    # SDK honors ``effort`` natively per call (low/medium/high/
+                    # xhigh/max), so the level the orchestrator chose is ENFORCED
+                    # here rather than merely advised in the prompt. This is what
+                    # makes ``reasoning_effort_support = NATIVE`` truthful for the
+                    # Claude runtime.
+                    options_kwargs["effort"] = reasoning_effort
 
                 if self._cli_path:
                     options_kwargs["cli_path"] = self._cli_path

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -1623,13 +1623,21 @@ class CodexCliRuntime:
         composed_prompt = self._compose_prompt(prompt, system_prompt, tools)
         attempted_resume_session_id = self._resolve_resume_session_id(current_handle)
         try:
-            command = self._build_command(
-                output_last_message_path=str(output_path),
-                resume_session_id=attempted_resume_session_id,
-                prompt=composed_prompt,
-                runtime_handle=current_handle,
-                reasoning_effort=reasoning_effort,
-            )
+            build_kwargs: dict[str, Any] = {
+                "output_last_message_path": str(output_path),
+                "resume_session_id": attempted_resume_session_id,
+                "prompt": composed_prompt,
+                "runtime_handle": current_handle,
+            }
+            # Only hand the effort knob to a runtime whose ``_build_command``
+            # declares it. Codex (native) accepts it; advised CLI subclasses that
+            # share this base but expose no effort flag (e.g. Goose) do not override
+            # the signature, so forwarding ``None`` would raise an unexpected-kwarg
+            # TypeError. The orchestrator only sets a non-None level for runtimes
+            # that enforce it, so a None level is correctly dropped here.
+            if reasoning_effort is not None:
+                build_kwargs["reasoning_effort"] = reasoning_effort
+            command = self._build_command(**build_kwargs)
         except Exception as e:
             yield AgentMessage(
                 type="result",

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -176,6 +176,10 @@ class CodexCliRuntime:
             system_prompt_support=ParamSupport.TRANSLATED,
             tool_restriction_support=ParamSupport.TRANSLATED,
             reasoning_effort_support=ParamSupport.NATIVE,
+            # Codex enforces only the allow-listed levels (see _build_command); a
+            # level outside this set is silently dropped, so declare the vocabulary
+            # to keep enforced/advised classification truthful.
+            enforceable_reasoning_efforts=_CODEX_REASONING_EFFORT_LEVELS,
         )
 
     @property

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -64,6 +64,10 @@ _TOP_LEVEL_EVENT_MESSAGE_TYPES: dict[str, str] = {
 _INTERVIEW_SESSION_METADATA_KEY = "ouroboros_interview_session_id"
 
 _SAFE_SESSION_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+# Effort levels Codex's ``model_reasoning_effort`` config key accepts. Used to
+# allow-list the value forwarded via ``-c model_reasoning_effort=<level>`` so an
+# unexpected effort string can never be injected into the override (RFC #1405).
+_CODEX_REASONING_EFFORT_LEVELS = frozenset({"minimal", "low", "medium", "high", "xhigh"})
 _MAX_LINE_BUFFER_BYTES = 50 * 1024 * 1024  # 50 MB
 _RUNTIME_PROFILE_ROLE_PREFIX = "agent_runtime"
 _RUNTIME_PROFILE_METADATA_KEYS = (
@@ -163,10 +167,15 @@ class CodexCliRuntime:
         # Codex composes the system prompt and tool guidance into the user
         # message rather than passing native runtime parameters; surface those
         # as TRANSLATED while preserving the default feature flags.
+        # Reasoning effort IS enforced natively: ``codex exec`` accepts a
+        # per-invocation ``-c model_reasoning_effort=<level>`` override (see
+        # _build_command), so the orchestrator's chosen level is honored, not
+        # merely advised.
         return replace(
             FULL_CAPABILITIES,
             system_prompt_support=ParamSupport.TRANSLATED,
             tool_restriction_support=ParamSupport.TRANSLATED,
+            reasoning_effort_support=ParamSupport.NATIVE,
         )
 
     @property
@@ -806,6 +815,7 @@ class CodexCliRuntime:
         resume_session_id: str | None = None,
         prompt: str | None = None,
         runtime_handle: RuntimeHandle | None = None,
+        reasoning_effort: str | None = None,
     ) -> list[str]:
         """Build the CLI command args.  Prompt is fed via stdin separately."""
         command = [self._cli_path, "exec"]
@@ -827,6 +837,14 @@ class CodexCliRuntime:
                 self._cwd,
             ]
         )
+
+        # Effort-first investment dial (RFC #1405). ``codex exec`` honors a
+        # per-invocation config override, so the orchestrator's chosen level is
+        # ENFORCED (not advised) by overriding ``model_reasoning_effort``. Only
+        # a known-safe token is forwarded, so an unexpected value can never be
+        # injected into the ``key=value`` override.
+        if reasoning_effort and reasoning_effort in _CODEX_REASONING_EFFORT_LEVELS:
+            command.extend(["-c", f"model_reasoning_effort={reasoning_effort}"])
 
         normalized_model = self._normalize_model(self._model)
         if normalized_model:
@@ -1548,6 +1566,7 @@ class CodexCliRuntime:
         system_prompt: str | None = None,
         resume_handle: RuntimeHandle | None = None,
         resume_session_id: str | None = None,
+        reasoning_effort: str | None = None,
     ) -> AsyncIterator[AgentMessage]:
         """Execute a task via Codex CLI and stream normalized messages."""
         async for msg in self._execute_task_impl(
@@ -1556,6 +1575,7 @@ class CodexCliRuntime:
             system_prompt=system_prompt,
             resume_handle=resume_handle,
             resume_session_id=resume_session_id,
+            reasoning_effort=reasoning_effort,
             _resume_depth=0,
         ):
             yield msg
@@ -1567,6 +1587,7 @@ class CodexCliRuntime:
         system_prompt: str | None = None,
         resume_handle: RuntimeHandle | None = None,
         resume_session_id: str | None = None,
+        reasoning_effort: str | None = None,
         _resume_depth: int = 0,
     ) -> AsyncIterator[AgentMessage]:
         """Internal implementation with resume-depth tracking."""
@@ -1607,6 +1628,7 @@ class CodexCliRuntime:
                 resume_session_id=attempted_resume_session_id,
                 prompt=composed_prompt,
                 runtime_handle=current_handle,
+                reasoning_effort=reasoning_effort,
             )
         except Exception as e:
             yield AgentMessage(
@@ -1883,6 +1905,7 @@ class CodexCliRuntime:
                     tools=tools,
                     system_prompt=system_prompt,
                     resume_handle=recovery_handle,
+                    reasoning_effort=reasoning_effort,
                     _resume_depth=_resume_depth + 1,
                 ):
                     yield message

--- a/src/ouroboros/orchestrator/effort_routing.py
+++ b/src/ouroboros/orchestrator/effort_routing.py
@@ -1,0 +1,106 @@
+"""Effort-first investment routing for the Agent-OS execution contract (RFC #1405).
+
+The orchestrator decides an abstract reasoning-effort *level* per unit of work and
+hands it to whichever runtime will execute that unit. Each runtime declares, via
+:class:`~ouroboros.orchestrator.adapter.RuntimeCapabilities.reasoning_effort_support`,
+whether it can ENFORCE the level through a native per-call knob (Claude Agent SDK
+``effort``, Codex ``-c model_reasoning_effort``) or can only be *advised* of it.
+
+This module is the single, pure decision point that sits between "what level do we
+want" and "what each runtime can actually honor". Keeping it free of executor state
+makes the policy testable in isolation and keeps the live executor a thin caller —
+it lays ``parallel_executor`` on the capability contract instead of hard-coding a
+backend-specific effort path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ouroboros.orchestrator.adapter import ParamSupport
+
+# Ordered weakest -> strongest. Shared vocabulary across the runtimes that expose
+# an effort knob (Claude Agent SDK: low/medium/high/xhigh/max; Codex
+# model_reasoning_effort: minimal/low/medium/high/xhigh). ``max`` is Claude-only
+# and deliberately omitted from the ladder used for the one-notch-lower rule so
+# the rule never depends on a level a CLI runtime cannot accept.
+EFFORT_LADDER: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
+
+# Default floor for the decomposed-child rule: never strip a unit below "low".
+DEFAULT_EFFORT_FLOOR = "low"
+
+# Effort modes recorded per unit so enforced rows can be told apart from advised
+# ones — the distinction the deterministic frugality proof depends on.
+EFFORT_MODE_ENFORCED = "enforced"
+EFFORT_MODE_ADVISED = "advised"
+EFFORT_MODE_NONE = "none"
+
+
+def lower_one_notch(level: str, *, floor: str = DEFAULT_EFFORT_FLOOR) -> str:
+    """Return ``level`` dropped one rung, never below ``floor``.
+
+    Unknown levels (not on :data:`EFFORT_LADDER`) are returned unchanged — the
+    caller chose a vocabulary this module does not model, so it is not this
+    function's place to silently rewrite it.
+    """
+    if level not in EFFORT_LADDER:
+        return level
+    floor_index = EFFORT_LADDER.index(floor) if floor in EFFORT_LADDER else 0
+    current_index = EFFORT_LADDER.index(level)
+    return EFFORT_LADDER[max(floor_index, current_index - 1)]
+
+
+@dataclass(frozen=True)
+class EffortDecision:
+    """The effort level for one unit plus how the chosen runtime will honor it.
+
+    Attributes:
+        level: The reasoning-effort level to pass to ``execute_task``, or ``None``
+            when no base effort is configured (the dormant default — no behavior
+            change until an effort is wired in).
+        mode: ``"enforced"`` when the runtime applies the level through a native
+            per-call knob, ``"advised"`` when it cannot (the level is recorded but
+            not guaranteed), or ``"none"`` when there is no level to route.
+    """
+
+    level: str | None
+    mode: str
+
+    @property
+    def is_enforced(self) -> bool:
+        return self.mode == EFFORT_MODE_ENFORCED and self.level is not None
+
+
+def decide_effort(
+    reasoning_effort_support: ParamSupport,
+    *,
+    base_effort: str | None,
+    is_decomposed_child: bool,
+    floor: str = DEFAULT_EFFORT_FLOOR,
+) -> EffortDecision:
+    """Decide the per-unit effort level and whether the runtime will enforce it.
+
+    Args:
+        reasoning_effort_support: The chosen runtime's declared support, read from
+            ``runtime.capabilities.reasoning_effort_support``.
+        base_effort: The configured base level for full-strength units, or ``None``
+            to leave effort routing dormant.
+        is_decomposed_child: Whether this unit is a verified-MECE child, which is
+            run one notch lower than its parent (the frugality hypothesis).
+        floor: The lowest level a child may be dropped to.
+
+    Returns:
+        An :class:`EffortDecision`. ``mode`` is ``"enforced"`` only when the runtime
+        declared ``NATIVE`` support, so an advised runtime can never be mistaken for
+        an enforced one — exactly the property the proof's enforced rows rely on.
+    """
+    if not base_effort:
+        return EffortDecision(level=None, mode=EFFORT_MODE_NONE)
+
+    level = lower_one_notch(base_effort, floor=floor) if is_decomposed_child else base_effort
+    mode = (
+        EFFORT_MODE_ENFORCED
+        if reasoning_effort_support is ParamSupport.NATIVE
+        else EFFORT_MODE_ADVISED
+    )
+    return EffortDecision(level=level, mode=mode)

--- a/src/ouroboros/orchestrator/effort_routing.py
+++ b/src/ouroboros/orchestrator/effort_routing.py
@@ -77,6 +77,7 @@ def decide_effort(
     base_effort: str | None,
     is_decomposed_child: bool,
     floor: str = DEFAULT_EFFORT_FLOOR,
+    enforceable_levels: frozenset[str] | None = None,
 ) -> EffortDecision:
     """Decide the per-unit effort level and whether the runtime will enforce it.
 
@@ -88,19 +89,26 @@ def decide_effort(
         is_decomposed_child: Whether this unit is a verified-MECE child, which is
             run one notch lower than its parent (the frugality hypothesis).
         floor: The lowest level a child may be dropped to.
+        enforceable_levels: The runtime's enforceable vocabulary
+            (``capabilities.enforceable_reasoning_efforts``). When provided, a level
+            outside it is recorded as *advised* even on a NATIVE runtime, because the
+            backend silently drops a level it does not accept (Codex ignores ``max``,
+            Claude has no ``minimal``). ``None`` imposes no per-level restriction.
 
     Returns:
         An :class:`EffortDecision`. ``mode`` is ``"enforced"`` only when the runtime
-        declared ``NATIVE`` support, so an advised runtime can never be mistaken for
-        an enforced one — exactly the property the proof's enforced rows rely on.
+        declared ``NATIVE`` support **and** the chosen level is one it actually
+        enforces, so a silently-dropped or advised level can never be mistaken for an
+        enforced one — exactly the property the proof's enforced rows rely on.
     """
     if not base_effort:
         return EffortDecision(level=None, mode=EFFORT_MODE_NONE)
 
     level = lower_one_notch(base_effort, floor=floor) if is_decomposed_child else base_effort
+    enforces_level = enforceable_levels is None or level in enforceable_levels
     mode = (
         EFFORT_MODE_ENFORCED
-        if reasoning_effort_support is ParamSupport.NATIVE
+        if reasoning_effort_support is ParamSupport.NATIVE and enforces_level
         else EFFORT_MODE_ADVISED
     )
     return EffortDecision(level=level, mode=mode)

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -47,6 +47,7 @@ from ouroboros.core.seed_contract_prompt import render_auto_recursion_guard
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.adapter import (
     AgentMessage,
+    ParamSupport,
     RuntimeHandle,
     runtime_handle_tool_catalog,
 )
@@ -66,6 +67,7 @@ from ouroboros.orchestrator.decomposition_params import (
     build_decomposition_user_prompt,
     params_from_profile,
 )
+from ouroboros.orchestrator.effort_routing import decide_effort
 from ouroboros.orchestrator.events import (
     create_ac_stall_detected_event,
     create_heartbeat_event,
@@ -2431,6 +2433,7 @@ class ParallelACExecutor:
         execution_profile: ExecutionProfile | None = None,
         fat_harness_mode: bool = False,
         atomic_verifier: Verifier | None = None,
+        reasoning_effort: str | None = None,
     ):
         """Initialize executor.
 
@@ -2462,6 +2465,11 @@ class ParallelACExecutor:
         self._task_cwd = task_cwd
         self._execution_profile = execution_profile
         self._fat_harness_mode = fat_harness_mode
+        # Effort-first investment dial (RFC #1405). Base level for full-strength
+        # units; decomposed children run one notch lower. ``None`` leaves effort
+        # routing dormant (execute_task receives no level → no behavior change),
+        # so laying the executor on the capability contract is safe by default.
+        self._reasoning_effort = reasoning_effort
         self._atomic_verifier = atomic_verifier
         self._coordinator = LevelCoordinator(
             adapter,
@@ -5497,6 +5505,39 @@ Files present:
         # an RPM/TPM is configured for this backend) before the stall-scoped run.
         await self._await_dispatch_rate_budget(prompt=prompt, system_prompt=system_prompt)
 
+        # Lay the executor on the capability contract: decide the effort level for
+        # this unit (a decomposed child runs one notch lower) and classify how the
+        # chosen runtime will honor it from its declared capability — enforced via a
+        # native knob, or advised. The level is passed to execute_task; an advised
+        # runtime ignores it. Dormant by default (base effort None → level None).
+        effort_capabilities = getattr(self._adapter, "capabilities", None)
+        effort_support = (
+            effort_capabilities.reasoning_effort_support
+            if effort_capabilities is not None
+            else ParamSupport.IGNORED
+        )
+        effort_decision = decide_effort(
+            effort_support,
+            base_effort=self._reasoning_effort,
+            is_decomposed_child=is_sub_ac,
+        )
+        if effort_decision.level is not None:
+            log.debug(
+                "orchestrator.executor.effort_routed",
+                ac_index=ac_index,
+                is_sub_ac=is_sub_ac,
+                effort_level=effort_decision.level,
+                effort_mode=effort_decision.mode,
+                backend=getattr(self._adapter, "runtime_backend", None),
+            )
+        # Only forward the level to runtimes that ENFORCE it (declared NATIVE and
+        # thus accept the kwarg — Claude SDK, Codex). Advised runtimes ignore it
+        # anyway and do not accept the parameter, so passing it would break them;
+        # the chosen level still lives in effort_decision for honest recording.
+        execute_effort_kwargs: dict[str, Any] = (
+            {"reasoning_effort": effort_decision.level} if effort_decision.is_enforced else {}
+        )
+
         try:
             with anyio.CancelScope(
                 deadline=anyio.current_time() + STALL_TIMEOUT_SECONDS,
@@ -5506,6 +5547,7 @@ Files present:
                     tools=tools,
                     system_prompt=system_prompt,
                     resume_handle=runtime_handle,
+                    **execute_effort_kwargs,
                 ):
                     # Reset stall deadline on every message (RC6 core)
                     stall_scope.deadline = anyio.current_time() + STALL_TIMEOUT_SECONDS

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -5520,6 +5520,11 @@ Files present:
             effort_support,
             base_effort=self._reasoning_effort,
             is_decomposed_child=is_sub_ac,
+            enforceable_levels=(
+                effort_capabilities.enforceable_reasoning_efforts
+                if effort_capabilities is not None
+                else None
+            ),
         )
         if effort_decision.level is not None:
             log.debug(

--- a/tests/unit/orchestrator/test_effort_routing.py
+++ b/tests/unit/orchestrator/test_effort_routing.py
@@ -62,3 +62,49 @@ class TestDecideEffort:
     def test_child_respects_floor(self) -> None:
         child = decide_effort(ParamSupport.NATIVE, base_effort="low", is_decomposed_child=True)
         assert child.level == "low"  # floor=low, cannot drop further
+
+
+class TestDecideEffortEnforceableLevels:
+    """A NATIVE runtime only enforces the levels its backend actually accepts."""
+
+    def test_level_outside_vocabulary_is_advised_not_enforced(self) -> None:
+        # Codex drops 'max' silently — declaring it enforced would be untruthful.
+        codex_levels = frozenset({"minimal", "low", "medium", "high", "xhigh"})
+        d = decide_effort(
+            ParamSupport.NATIVE,
+            base_effort="max",
+            is_decomposed_child=False,
+            enforceable_levels=codex_levels,
+        )
+        assert d.level == "max"
+        assert d.mode == "advised"
+        assert not d.is_enforced
+
+    def test_level_inside_vocabulary_is_enforced(self) -> None:
+        codex_levels = frozenset({"minimal", "low", "medium", "high", "xhigh"})
+        d = decide_effort(
+            ParamSupport.NATIVE,
+            base_effort="high",
+            is_decomposed_child=False,
+            enforceable_levels=codex_levels,
+        )
+        assert d.mode == "enforced"
+
+    def test_claude_only_minimal_is_advised(self) -> None:
+        claude_levels = frozenset({"low", "medium", "high", "xhigh", "max"})
+        d = decide_effort(
+            ParamSupport.NATIVE,
+            base_effort="minimal",
+            is_decomposed_child=False,
+            enforceable_levels=claude_levels,
+        )
+        assert d.mode == "advised"
+
+    def test_none_vocabulary_imposes_no_restriction(self) -> None:
+        d = decide_effort(
+            ParamSupport.NATIVE,
+            base_effort="max",
+            is_decomposed_child=False,
+            enforceable_levels=None,
+        )
+        assert d.mode == "enforced"

--- a/tests/unit/orchestrator/test_effort_routing.py
+++ b/tests/unit/orchestrator/test_effort_routing.py
@@ -1,0 +1,64 @@
+"""Effort routing policy: the pure decision the live executor lays itself on."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.adapter import ParamSupport
+from ouroboros.orchestrator.effort_routing import (
+    EFFORT_LADDER,
+    EffortDecision,
+    decide_effort,
+    lower_one_notch,
+)
+
+
+class TestLowerOneNotch:
+    def test_drops_one_rung(self) -> None:
+        assert lower_one_notch("high") == "medium"
+        assert lower_one_notch("xhigh") == "high"
+
+    def test_never_below_floor(self) -> None:
+        assert lower_one_notch("low", floor="low") == "low"
+        assert lower_one_notch("medium", floor="low") == "low"
+        assert lower_one_notch("minimal", floor="low") == "low"  # clamps UP to floor
+
+    def test_custom_floor(self) -> None:
+        assert lower_one_notch("medium", floor="medium") == "medium"
+        assert lower_one_notch("high", floor="medium") == "medium"
+
+    def test_unknown_level_passthrough(self) -> None:
+        assert lower_one_notch("bananas") == "bananas"
+
+    def test_ladder_is_ordered_weak_to_strong(self) -> None:
+        assert EFFORT_LADDER.index("low") < EFFORT_LADDER.index("high")
+
+
+class TestDecideEffort:
+    def test_dormant_when_no_base_effort(self) -> None:
+        d = decide_effort(ParamSupport.NATIVE, base_effort=None, is_decomposed_child=True)
+        assert d == EffortDecision(level=None, mode="none")
+        assert d.is_enforced is False
+
+    def test_enforced_on_native_runtime(self) -> None:
+        d = decide_effort(ParamSupport.NATIVE, base_effort="high", is_decomposed_child=False)
+        assert d.level == "high"
+        assert d.mode == "enforced"
+        assert d.is_enforced is True
+
+    @pytest.mark.parametrize("support", [ParamSupport.IGNORED, ParamSupport.TRANSLATED])
+    def test_advised_on_non_native_runtime(self, support: ParamSupport) -> None:
+        d = decide_effort(support, base_effort="high", is_decomposed_child=False)
+        assert d.level == "high"
+        assert d.mode == "advised"
+        assert d.is_enforced is False  # advised never counts as enforced
+
+    def test_decomposed_child_runs_one_notch_lower(self) -> None:
+        parent = decide_effort(ParamSupport.NATIVE, base_effort="high", is_decomposed_child=False)
+        child = decide_effort(ParamSupport.NATIVE, base_effort="high", is_decomposed_child=True)
+        assert parent.level == "high"
+        assert child.level == "medium"
+
+    def test_child_respects_floor(self) -> None:
+        child = decide_effort(ParamSupport.NATIVE, base_effort="low", is_decomposed_child=True)
+        assert child.level == "low"  # floor=low, cannot drop further

--- a/tests/unit/orchestrator/test_reasoning_effort_routing.py
+++ b/tests/unit/orchestrator/test_reasoning_effort_routing.py
@@ -1,0 +1,88 @@
+"""Effort-first investment dial routing across agent runtimes (RFC #1405).
+
+These tests pin the Agent-OS contract: the orchestrator hands every runtime an
+abstract ``reasoning_effort`` level, and each runtime either ENFORCES it through
+its native per-call mechanism (declaring ``reasoning_effort_support = NATIVE``)
+or honestly declares that it cannot (the IGNORED default → advised). The proof's
+"enforced rows" depend on this distinction being truthful, so it is tested
+directly rather than assumed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from ouroboros.orchestrator.adapter import (
+    FULL_CAPABILITIES,
+    ParamSupport,
+    RuntimeCapabilities,
+)
+from ouroboros.orchestrator.codex_cli_runtime import (
+    _CODEX_REASONING_EFFORT_LEVELS,
+    CodexCliRuntime,
+)
+
+
+class TestCapabilityDeclarations:
+    def test_default_and_full_capabilities_ignore_effort(self) -> None:
+        """A runtime that does not opt in must NOT claim native effort support.
+
+        Guards the latent bug flagged in review: ``replace(FULL_CAPABILITIES, …)``
+        runtimes (opencode, gjc, …) must inherit IGNORED, never a stray NATIVE.
+        """
+        bare = RuntimeCapabilities(
+            skill_dispatch=True, targeted_resume=True, structured_output=True
+        )
+        assert bare.reasoning_effort_support is ParamSupport.IGNORED
+        assert FULL_CAPABILITIES.reasoning_effort_support is ParamSupport.IGNORED
+        # An inheriting runtime that overrides only other fields stays IGNORED.
+        inherited = replace(FULL_CAPABILITIES, system_prompt_support=ParamSupport.TRANSLATED)
+        assert inherited.reasoning_effort_support is ParamSupport.IGNORED
+
+    def test_codex_runtime_declares_native_effort(self) -> None:
+        runtime = CodexCliRuntime(cli_path="codex", cwd="/tmp")
+        assert runtime.capabilities.reasoning_effort_support is ParamSupport.NATIVE
+
+
+class TestCodexEffortEnforcement:
+    def _runtime(self) -> CodexCliRuntime:
+        return CodexCliRuntime(cli_path="codex", cwd="/tmp")
+
+    def test_known_level_is_enforced_via_config_override(self) -> None:
+        command = self._runtime()._build_command(
+            output_last_message_path="/tmp/out.txt",
+            reasoning_effort="high",
+        )
+        # Codex enforces it as a per-invocation config override, contiguous pair.
+        assert "-c" in command
+        idx = command.index("-c")
+        assert command[idx + 1] == "model_reasoning_effort=high"
+
+    def test_no_effort_emits_no_override(self) -> None:
+        command = self._runtime()._build_command(
+            output_last_message_path="/tmp/out.txt",
+            reasoning_effort=None,
+        )
+        assert "model_reasoning_effort=high" not in command
+        assert not any(
+            isinstance(arg, str) and arg.startswith("model_reasoning_effort=") for arg in command
+        )
+
+    def test_unknown_level_is_not_injected(self) -> None:
+        """An unexpected token must never reach the ``key=value`` override."""
+        command = self._runtime()._build_command(
+            output_last_message_path="/tmp/out.txt",
+            reasoning_effort="; rm -rf /",
+        )
+        assert not any(
+            isinstance(arg, str) and arg.startswith("model_reasoning_effort=") for arg in command
+        )
+
+    def test_every_advertised_level_is_accepted(self) -> None:
+        runtime = self._runtime()
+        for level in _CODEX_REASONING_EFFORT_LEVELS:
+            command = runtime._build_command(
+                output_last_message_path="/tmp/out.txt",
+                reasoning_effort=level,
+            )
+            assert f"model_reasoning_effort={level}" in command

--- a/tests/unit/test_kiro_adapters.py
+++ b/tests/unit/test_kiro_adapters.py
@@ -1011,17 +1011,24 @@ class TestKiroCapabilities:
         from dataclasses import replace
 
         from ouroboros.orchestrator.adapter import (
+            CLAUDE_REASONING_EFFORT_LEVELS,
             FULL_CAPABILITIES,
             ClaudeAgentAdapter,
             ParamSupport,
         )
 
         caps = ClaudeAgentAdapter().capabilities
-        # Claude matches the first-class default in every dimension except that it
-        # opts into NATIVE reasoning-effort support (the Agent SDK honors the
-        # per-call effort knob), so it is FULL_CAPABILITIES with that one override.
-        assert caps == replace(FULL_CAPABILITIES, reasoning_effort_support=ParamSupport.NATIVE)
+        # Claude matches the first-class default except that it opts into NATIVE
+        # reasoning-effort support (the Agent SDK honors the per-call effort knob)
+        # and declares the effort vocabulary it can actually enforce.
+        assert caps == replace(
+            FULL_CAPABILITIES,
+            reasoning_effort_support=ParamSupport.NATIVE,
+            enforceable_reasoning_efforts=CLAUDE_REASONING_EFFORT_LEVELS,
+        )
         assert caps.reasoning_effort_support is ParamSupport.NATIVE
+        assert "minimal" not in caps.enforceable_reasoning_efforts
+        assert "max" in caps.enforceable_reasoning_efforts
         assert caps.skill_dispatch is True
         assert caps.targeted_resume is True
         assert caps.structured_output is True

--- a/tests/unit/test_kiro_adapters.py
+++ b/tests/unit/test_kiro_adapters.py
@@ -1008,13 +1008,20 @@ class TestKiroCapabilities:
         assert caps.structured_output is False
 
     def test_claude_declares_full_capabilities(self) -> None:
+        from dataclasses import replace
+
         from ouroboros.orchestrator.adapter import (
             FULL_CAPABILITIES,
             ClaudeAgentAdapter,
+            ParamSupport,
         )
 
         caps = ClaudeAgentAdapter().capabilities
-        assert caps == FULL_CAPABILITIES
+        # Claude matches the first-class default in every dimension except that it
+        # opts into NATIVE reasoning-effort support (the Agent SDK honors the
+        # per-call effort knob), so it is FULL_CAPABILITIES with that one override.
+        assert caps == replace(FULL_CAPABILITIES, reasoning_effort_support=ParamSupport.NATIVE)
+        assert caps.reasoning_effort_support is ParamSupport.NATIVE
         assert caps.skill_dispatch is True
         assert caps.targeted_resume is True
         assert caps.structured_output is True


### PR DESCRIPTION
Adds `RuntimeCapabilities.reasoning_effort_support` (defaults IGNORED; opt-in NATIVE) and wires the Claude (Agent SDK `effort`) and Codex (`-c model_reasoning_effort`) runtimes to enforce it, plus the pure `effort_routing.decide_effort` policy and the ParallelACExecutor consumer. Dormant by default.

---
**Stacked PR 1/6** for Epic #1465 / Task #1468 (RFC #1405). Base: `main`. Review/merge in order.
🤖 Generated with [Claude Code](https://claude.com/claude-code)