### PR TITLE
feat(orchestrator): enforce effort on Copilot; declare rest advised (4/6)

### DIFF
--- a/src/ouroboros/orchestrator/copilot_cli_runtime.py
+++ b/src/ouroboros/orchestrator/copilot_cli_runtime.py
@@ -53,6 +53,9 @@ log = structlog.get_logger(__name__)
 # uses everywhere; permission mode is mapped through ``copilot_permissions``.
 _COPILOT_PERMISSION_MODES = frozenset({"default", "acceptEdits", "bypassPermissions"})
 _COPILOT_DEFAULT_PERMISSION_MODE = "default"
+# Levels Copilot CLI's --reasoning-effort flag accepts (verified via --help).
+# Allow-listed so an unexpected effort string is never forwarded to the flag.
+_COPILOT_REASONING_EFFORT_LEVELS = frozenset({"none", "low", "medium", "high", "xhigh", "max"})
 
 #: Maximum Ouroboros nesting depth to prevent fork bombs when Copilot
 #: spawns Ouroboros which spawns Copilot.
@@ -101,6 +104,9 @@ class CopilotCliRuntime(CodexCliRuntime):
             system_prompt_support=ParamSupport.TRANSLATED,
             tool_restriction_support=ParamSupport.TRANSLATED,
             permission_mode_support=ParamSupport.NATIVE,
+            # Copilot CLI enforces effort via a per-invocation --reasoning-effort
+            # flag (verified via --help: none/low/medium/high/xhigh/max).
+            reasoning_effort_support=ParamSupport.NATIVE,
         )
 
     def __init__(
@@ -179,6 +185,7 @@ class CopilotCliRuntime(CodexCliRuntime):
         resume_session_id: str | None = None,
         prompt: str | None = None,
         runtime_handle: RuntimeHandle | None = None,
+        reasoning_effort: str | None = None,
     ) -> list[str]:
         """Build the Copilot CLI command for non-interactive execution.
 
@@ -224,6 +231,13 @@ class CopilotCliRuntime(CodexCliRuntime):
                     if normalized_runtime_model:
                         mapped = map_to_copilot_model(normalized_runtime_model)
                         command.extend(["--model", mapped])
+
+        # Effort-first investment dial (RFC #1405). Copilot CLI honors a
+        # per-invocation --reasoning-effort flag (verified via --help), so the
+        # orchestrator's chosen level is ENFORCED. Allow-listed so an unexpected
+        # value can never be forwarded.
+        if reasoning_effort and reasoning_effort in _COPILOT_REASONING_EFFORT_LEVELS:
+            command.extend(["--reasoning-effort", reasoning_effort])
 
         command.extend(["-p", prompt or ""])
         return command

--- a/src/ouroboros/orchestrator/copilot_cli_runtime.py
+++ b/src/ouroboros/orchestrator/copilot_cli_runtime.py
@@ -107,6 +107,13 @@ class CopilotCliRuntime(CodexCliRuntime):
             # Copilot CLI enforces effort via a per-invocation --reasoning-effort
             # flag (verified via --help: none/low/medium/high/xhigh/max).
             reasoning_effort_support=ParamSupport.NATIVE,
+            # Declare the exact vocabulary the flag accepts. Without this, the
+            # shared contract treats an omitted set as "every level is enforced",
+            # so a caller using a level outside _COPILOT_REASONING_EFFORT_LEVELS
+            # would record an "enforced" proof row while _build_command silently
+            # drops the flag. Pinning the vocabulary downgrades such a level to
+            # "advised" in decide_effort, keeping the proof rows honest.
+            enforceable_reasoning_efforts=_COPILOT_REASONING_EFFORT_LEVELS,
         )
 
     def __init__(

--- a/src/ouroboros/orchestrator/gemini_cli_runtime.py
+++ b/src/ouroboros/orchestrator/gemini_cli_runtime.py
@@ -215,6 +215,10 @@ class GeminiCLIRuntime(CodexCliRuntime):
         resume_session_id: str | None = None,
         prompt: str | None = None,
         runtime_handle: RuntimeHandle | None = None,
+        # Accepted to honor the shared CodexCliRuntime contract, but ignored:
+        # the Gemini CLI exposes no per-invocation effort flag (capabilities
+        # declares reasoning_effort_support=IGNORED, so it is surfaced as advised).
+        reasoning_effort: str | None = None,
     ) -> list[str]:
         """Build the Gemini CLI command arguments for non-interactive execution.
 
@@ -277,6 +281,11 @@ class GeminiCLIRuntime(CodexCliRuntime):
             # guidance rather than enforcing a Gemini-native allow-list.
             system_prompt_support=ParamSupport.TRANSLATED,
             tool_restriction_support=ParamSupport.TRANSLATED,
+            # Reasoning effort is advised, not enforced: the Gemini API has a
+            # thinkingBudget, but no per-invocation effort flag on the Gemini CLI
+            # has been verified. Declared IGNORED (also the default) until a real
+            # per-call mechanism is confirmed — revisit if the CLI exposes one.
+            reasoning_effort_support=ParamSupport.IGNORED,
         )
 
     # -- Event parsing and normalization -----------------------------------

--- a/src/ouroboros/orchestrator/goose_runtime.py
+++ b/src/ouroboros/orchestrator/goose_runtime.py
@@ -112,6 +112,10 @@ class GooseCliRuntime(CodexCliRuntime):
             # guidance rather than enforcing a Goose-native allow-list.
             system_prompt_support=ParamSupport.TRANSLATED,
             tool_restriction_support=ParamSupport.TRANSLATED,
+            # Reasoning effort is advised, not enforced: `goose run` exposes no
+            # per-invocation effort flag (verified via --help). Declared IGNORED
+            # explicitly (also the default) to document the verified decision.
+            reasoning_effort_support=ParamSupport.IGNORED,
         )
 
     def _resolve_permission_mode(self, permission_mode: str | None) -> str:
@@ -163,6 +167,10 @@ class GooseCliRuntime(CodexCliRuntime):
         resume_session_id: str | None = None,
         prompt: str | None = None,
         runtime_handle: RuntimeHandle | None = None,
+        # Accepted to honor the shared CodexCliRuntime contract, but ignored:
+        # `goose run` exposes no per-invocation effort flag (capabilities declares
+        # reasoning_effort_support=IGNORED, so it is surfaced as advised).
+        reasoning_effort: str | None = None,
     ) -> list[str]:
         """Build ``goose run`` args. Prompt is fed through stdin.
 

--- a/src/ouroboros/orchestrator/hermes_runtime.py
+++ b/src/ouroboros/orchestrator/hermes_runtime.py
@@ -238,11 +238,17 @@ class HermesCliRuntime(AgentRuntime):
         # message rather than passing native runtime parameters, and hermes chat
         # has no permission-mode flag. Surface both truthfully for degradation
         # notices.
+        # Reasoning effort is advised, not enforced: `hermes chat` exposes only
+        # -q/--image/-m/-t — no per-invocation effort flag and no `-c` config
+        # override (its config.yaml reasoning_effort is global, not per-call), so
+        # the level cannot be routed deterministically per AC. Declared IGNORED
+        # explicitly (it is also the default) to document the verified decision.
         return replace(
             FULL_CAPABILITIES,
             system_prompt_support=ParamSupport.TRANSLATED,
             tool_restriction_support=ParamSupport.TRANSLATED,
             permission_mode_support=ParamSupport.IGNORED,
+            reasoning_effort_support=ParamSupport.IGNORED,
         )
 
     @property

--- a/tests/unit/orchestrator/test_reasoning_effort_routing.py
+++ b/tests/unit/orchestrator/test_reasoning_effort_routing.py
@@ -43,6 +43,58 @@ class TestCapabilityDeclarations:
         runtime = CodexCliRuntime(cli_path="codex", cwd="/tmp")
         assert runtime.capabilities.reasoning_effort_support is ParamSupport.NATIVE
 
+    def test_copilot_runtime_declares_native_effort(self) -> None:
+        from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
+
+        runtime = CopilotCliRuntime(cli_path="copilot", cwd="/tmp")
+        assert runtime.capabilities.reasoning_effort_support is ParamSupport.NATIVE
+
+    def test_gemini_and_goose_declare_advised_effort(self) -> None:
+        from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
+        from ouroboros.orchestrator.goose_runtime import GooseCliRuntime
+
+        gemini = GeminiCLIRuntime(cli_path="gemini", cwd="/tmp")
+        goose = GooseCliRuntime(cli_path="goose", cwd="/tmp")
+        assert gemini.capabilities.reasoning_effort_support is ParamSupport.IGNORED
+        assert goose.capabilities.reasoning_effort_support is ParamSupport.IGNORED
+
+
+class TestCopilotEffortEnforcement:
+    def _runtime(self):
+        from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
+
+        return CopilotCliRuntime(cli_path="copilot", cwd="/tmp")
+
+    def test_known_level_is_enforced_via_flag(self) -> None:
+        command = self._runtime()._build_command("out.txt", prompt="hi", reasoning_effort="high")
+        assert "--reasoning-effort" in command
+        idx = command.index("--reasoning-effort")
+        assert command[idx + 1] == "high"
+
+    def test_unknown_level_is_not_injected(self) -> None:
+        command = self._runtime()._build_command(
+            "out.txt", prompt="hi", reasoning_effort="; rm -rf /"
+        )
+        assert "--reasoning-effort" not in command
+
+    def test_no_effort_emits_no_flag(self) -> None:
+        command = self._runtime()._build_command("out.txt", prompt="hi", reasoning_effort=None)
+        assert "--reasoning-effort" not in command
+
+    def test_subclasses_accept_effort_kwarg_without_error(self) -> None:
+        """codex execute_task forwards reasoning_effort to _build_command on every
+        CodexCliRuntime subclass — each override must accept it (regression guard).
+        """
+        from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
+        from ouroboros.orchestrator.goose_runtime import GooseCliRuntime
+
+        for runtime in (
+            GeminiCLIRuntime(cli_path="gemini", cwd="/tmp"),
+            GooseCliRuntime(cli_path="goose", cwd="/tmp"),
+        ):
+            # Must not raise; gemini/goose accept-and-ignore (no per-call flag).
+            runtime._build_command("out.txt", prompt="hi", reasoning_effort="high")
+
 
 class TestCodexEffortEnforcement:
     def _runtime(self) -> CodexCliRuntime:

--- a/tests/unit/orchestrator/test_reasoning_effort_routing.py
+++ b/tests/unit/orchestrator/test_reasoning_effort_routing.py
@@ -44,10 +44,19 @@ class TestCapabilityDeclarations:
         assert runtime.capabilities.reasoning_effort_support is ParamSupport.NATIVE
 
     def test_copilot_runtime_declares_native_effort(self) -> None:
-        from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
+        from ouroboros.orchestrator.copilot_cli_runtime import (
+            _COPILOT_REASONING_EFFORT_LEVELS,
+            CopilotCliRuntime,
+        )
 
         runtime = CopilotCliRuntime(cli_path="copilot", cwd="/tmp")
         assert runtime.capabilities.reasoning_effort_support is ParamSupport.NATIVE
+        # The enforceable vocabulary must be declared so a level the flag does not
+        # accept is downgraded to advised instead of recorded as a false "enforced"
+        # row. It must match exactly the allow-list _build_command applies.
+        assert (
+            runtime.capabilities.enforceable_reasoning_efforts == _COPILOT_REASONING_EFFORT_LEVELS
+        )
 
     def test_gemini_and_goose_declare_advised_effort(self) -> None:
         from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
@@ -94,6 +103,38 @@ class TestCopilotEffortEnforcement:
         ):
             # Must not raise; gemini/goose accept-and-ignore (no per-call flag).
             runtime._build_command("out.txt", prompt="hi", reasoning_effort="high")
+
+    def test_supported_level_is_enforced_unsupported_is_advised(self) -> None:
+        """The capability vocabulary keeps proof rows honest end to end.
+
+        decide_effort must mark a level inside Copilot's enforceable set as
+        ``enforced`` and a level outside it (e.g. Codex-only ``minimal``) as
+        ``advised`` even though Copilot declares NATIVE — because _build_command
+        silently drops a flag value it does not accept.
+        """
+        from ouroboros.orchestrator.copilot_cli_runtime import (
+            _COPILOT_REASONING_EFFORT_LEVELS,
+        )
+        from ouroboros.orchestrator.effort_routing import decide_effort
+
+        enforced = decide_effort(
+            ParamSupport.NATIVE,
+            base_effort="high",
+            is_decomposed_child=False,
+            enforceable_levels=_COPILOT_REASONING_EFFORT_LEVELS,
+        )
+        assert enforced.is_enforced
+        assert enforced.mode == "enforced"
+
+        advised = decide_effort(
+            ParamSupport.NATIVE,
+            base_effort="minimal",  # in EFFORT_LADDER, not in Copilot's flag vocab
+            is_decomposed_child=False,
+            enforceable_levels=_COPILOT_REASONING_EFFORT_LEVELS,
+        )
+        assert not advised.is_enforced
+        assert advised.mode == "advised"
+        assert advised.level == "minimal"  # still recorded, just not guaranteed
 
 
 class TestCodexEffortEnforcement:


### PR DESCRIPTION
Copilot CLI `--reasoning-effort` joins Claude/Codex as NATIVE; Gemini/Goose/Hermes declared IGNORED (advised) with the verified reason. Fixes a TypeError regression: the three CodexCliRuntime subclasses' `_build_command` overrides now accept reasoning_effort.

---
**Stacked PR 4/6** for Epic #1465 / Task #1468 (RFC #1405). Base: `effort/03-event`. Review/merge in order.
🤖 Generated with [Claude Code](https://claude.com/claude-code)