### PR TITLE
feat(orchestrator): route effort at every live execute_task site (5/6)

### DIFF
--- a/src/ouroboros/orchestrator/coordinator.py
+++ b/src/ouroboros/orchestrator/coordinator.py
@@ -215,6 +215,13 @@ class LevelCoordinator:
         self._task_cwd = task_cwd
         self._level_runtime_handles: dict[tuple[str, int], RuntimeHandle] = {}
         self._announced_param_degradations: set[tuple[str, str]] = set()
+        # Effort-first investment dial (RFC #1405): the coordinator's review pass
+        # is a top-level unit (never a decomposed child), so it runs at the base
+        # level on runtimes that enforce it. None ⇒ dormant. No effort_routed
+        # event is emitted here because a review is not an acceptance criterion.
+        from ouroboros.config import get_agent_reasoning_effort
+
+        self._reasoning_effort = get_agent_reasoning_effort()
 
     def _build_level_runtime_handle(
         self,
@@ -392,11 +399,19 @@ class LevelCoordinator:
                 announced=self._announced_param_degradations,
                 log_event="coordinator.param_degraded",
             )
+            from ouroboros.orchestrator.effort_routing import resolve_execute_effort
+
+            _, effort_kwargs = resolve_execute_effort(
+                self._adapter,
+                base_effort=self._reasoning_effort,
+                is_decomposed_child=False,
+            )
             async for message in self._adapter.execute_task(
                 prompt=prompt,
                 tools=tools,
                 system_prompt=COORDINATOR_SYSTEM_PROMPT,
                 resume_handle=runtime_handle,
+                **effort_kwargs,
             ):
                 messages.append(message)
                 if message.resume_handle is not None:

--- a/src/ouroboros/orchestrator/effort_routing.py
+++ b/src/ouroboros/orchestrator/effort_routing.py
@@ -112,3 +112,43 @@ def decide_effort(
         else EFFORT_MODE_ADVISED
     )
     return EffortDecision(level=level, mode=mode)
+
+
+def resolve_execute_effort(
+    adapter: object,
+    *,
+    base_effort: str | None,
+    is_decomposed_child: bool,
+    floor: str = DEFAULT_EFFORT_FLOOR,
+) -> tuple[EffortDecision, dict[str, str]]:
+    """Decide effort for one ``execute_task`` call and build its kwargs.
+
+    The single place every live execute_task call site lays itself on the
+    capability contract. Reads ``adapter.capabilities.reasoning_effort_support``
+    (defaulting to IGNORED when an adapter declares no capabilities), decides the
+    level, and returns the ``execute_task`` kwargs — which are **empty unless the
+    runtime enforces effort**, so a runtime that does not accept the parameter is
+    never handed it.
+
+    Returns:
+        ``(decision, execute_kwargs)``. ``execute_kwargs`` is ``{"reasoning_effort":
+        <level>}`` only when the chosen runtime declared NATIVE support, else ``{}``.
+    """
+    capabilities = getattr(adapter, "capabilities", None)
+    support = (
+        capabilities.reasoning_effort_support if capabilities is not None else ParamSupport.IGNORED
+    )
+    enforceable_levels = (
+        getattr(capabilities, "enforceable_reasoning_efforts", None)
+        if capabilities is not None
+        else None
+    )
+    decision = decide_effort(
+        support,
+        base_effort=base_effort,
+        is_decomposed_child=is_decomposed_child,
+        floor=floor,
+        enforceable_levels=enforceable_levels,
+    )
+    kwargs = {"reasoning_effort": decision.level} if decision.is_enforced else {}
+    return decision, kwargs

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -47,7 +47,6 @@ from ouroboros.core.seed_contract_prompt import render_auto_recursion_guard
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.adapter import (
     AgentMessage,
-    ParamSupport,
     RuntimeHandle,
     runtime_handle_tool_catalog,
 )
@@ -67,7 +66,7 @@ from ouroboros.orchestrator.decomposition_params import (
     build_decomposition_user_prompt,
     params_from_profile,
 )
-from ouroboros.orchestrator.effort_routing import decide_effort
+from ouroboros.orchestrator.effort_routing import resolve_execute_effort
 from ouroboros.orchestrator.events import (
     create_ac_stall_detected_event,
     create_heartbeat_event,
@@ -5510,21 +5509,10 @@ Files present:
         # chosen runtime will honor it from its declared capability — enforced via a
         # native knob, or advised. The level is passed to execute_task; an advised
         # runtime ignores it. Dormant by default (base effort None → level None).
-        effort_capabilities = getattr(self._adapter, "capabilities", None)
-        effort_support = (
-            effort_capabilities.reasoning_effort_support
-            if effort_capabilities is not None
-            else ParamSupport.IGNORED
-        )
-        effort_decision = decide_effort(
-            effort_support,
+        effort_decision, execute_effort_kwargs = resolve_execute_effort(
+            self._adapter,
             base_effort=self._reasoning_effort,
             is_decomposed_child=is_sub_ac,
-            enforceable_levels=(
-                effort_capabilities.enforceable_reasoning_efforts
-                if effort_capabilities is not None
-                else None
-            ),
         )
         if effort_decision.level is not None:
             log.debug(
@@ -5568,13 +5556,9 @@ Files present:
                     },
                 )
             )
-        # Only forward the level to runtimes that ENFORCE it (declared NATIVE and
-        # thus accept the kwarg — Claude SDK, Codex). Advised runtimes ignore it
-        # anyway and do not accept the parameter, so passing it would break them;
-        # the chosen level still lives in effort_decision for honest recording.
-        execute_effort_kwargs: dict[str, Any] = (
-            {"reasoning_effort": effort_decision.level} if effort_decision.is_enforced else {}
-        )
+        # execute_effort_kwargs (from resolve_execute_effort) carries
+        # reasoning_effort ONLY for runtimes that enforce it; advised runtimes that
+        # do not accept the parameter are never handed it.
 
         try:
             with anyio.CancelScope(

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -556,23 +556,36 @@ class OrchestratorRunner:
         if decision.level is not None:
             from ouroboros.events.base import BaseEvent
 
-            await self._event_store.append(
-                BaseEvent(
-                    type="execution.ac.effort_routed",
-                    aggregate_type="execution",
-                    aggregate_id=execution_id or session_id or "",
-                    data={
-                        "execution_id": execution_id,
-                        "session_id": session_id,
-                        "is_decomposed_child": False,
-                        "effort_level": decision.level,
-                        "effort_mode": decision.mode,
-                        "base_reasoning_effort": self._reasoning_effort,
-                        "runtime_backend": getattr(self._adapter, "runtime_backend", None),
-                        "call_site": "runner",
-                    },
+            # Observability-only: this event must never make runtime dispatch/resume
+            # depend on event-store health. _route_call_effort runs BEFORE
+            # execute_task on the direct and resume paths, so a raw append would turn
+            # a degraded/locked store into a dispatch failure. Degrade to a warning
+            # instead — matching how the parallel executor treats the same telemetry.
+            try:
+                await self._event_store.append(
+                    BaseEvent(
+                        type="execution.ac.effort_routed",
+                        aggregate_type="execution",
+                        aggregate_id=execution_id or session_id or "",
+                        data={
+                            "execution_id": execution_id,
+                            "session_id": session_id,
+                            "is_decomposed_child": False,
+                            "effort_level": decision.level,
+                            "effort_mode": decision.mode,
+                            "base_reasoning_effort": self._reasoning_effort,
+                            "runtime_backend": getattr(self._adapter, "runtime_backend", None),
+                            "call_site": "runner",
+                        },
+                    )
                 )
-            )
+            except Exception as exc:
+                log.warning(
+                    "orchestrator.runner.effort_routed.persist_failed",
+                    error=str(exc),
+                    effort_level=decision.level,
+                    effort_mode=decision.mode,
+                )
         return kwargs
 
     def _plan_parallel_workers(self) -> int:

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -532,9 +532,19 @@ class OrchestratorRunner:
         These direct paths (single-AC execution, resume) do not go through
         ParallelACExecutor, so without this they would silently skip effort
         routing. Returns the execute_task kwargs (empty unless the runtime
-        enforces effort) and records an ``execution.ac.effort_routed`` event so the
-        proof sees the same data it gets from the parallel path. These are
-        top-level units, never decomposed children, so is_decomposed_child=False.
+        enforces effort).
+
+        It also records an ``execution.ac.effort_routed`` event for
+        OBSERVABILITY — so a direct run's effort routing is visible in the event
+        stream exactly like the parallel path's. This event is deliberately NOT a
+        frugality-proof contribution: a direct run is a single top-level unit
+        (``is_decomposed_child=False``) with no per-AC decomposition, so the
+        payload carries no ``ac_id``. The deterministic proof excludes it on both
+        counts — ``assemble_triads`` skips ``ac_id``-less events, and
+        ``counts_in_proof`` only admits decomposed children — because the
+        hypothesis is about children running at lower effort, which a top-level
+        direct call has nothing to say about. ``call_site="runner"`` marks the
+        origin so the two emission paths are distinguishable in the stream.
         """
         from ouroboros.orchestrator.effort_routing import resolve_execute_effort
 
@@ -2881,9 +2891,9 @@ class OrchestratorRunner:
                 effective_workers=effective_workers,
             )
 
-        # Execute in parallel
-        from ouroboros.config import get_agent_reasoning_effort
-
+        # Execute in parallel. Reuse the base effort resolved once in __init__
+        # (self._reasoning_effort) so a single runner instance has one consistent
+        # effort source across its direct paths and the parallel executor.
         parallel_executor = ParallelACExecutor(
             adapter=self._adapter,
             event_store=self._event_store,
@@ -2896,7 +2906,7 @@ class OrchestratorRunner:
             checkpoint_store=self._checkpoint_store,
             execution_profile=execution_profile,
             fat_harness_mode=self._fat_harness_mode,
-            reasoning_effort=get_agent_reasoning_effort(),
+            reasoning_effort=self._reasoning_effort,
         )
 
         # Check for cancellation before starting parallel execution

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -495,6 +495,12 @@ class OrchestratorRunner:
         self._max_decomposition_depth = max(0, max_decomposition_depth)
         self._max_parallel_workers = max(1, max_parallel_workers)
         self._fat_harness_mode = fat_harness_mode
+        # Effort-first investment dial (RFC #1405): base level for the runner's own
+        # direct execution paths (single-AC / resume), which call execute_task
+        # without going through ParallelACExecutor. Resolved once; None ⇒ dormant.
+        from ouroboros.config import get_agent_reasoning_effort
+
+        self._reasoning_effort = get_agent_reasoning_effort()
         self._announced_param_degradations: set[tuple[str, str]] = set()
         # Track active session for external cancellation by execution_id
         self._active_sessions: dict[str, str] = {}  # execution_id -> session_id
@@ -514,6 +520,50 @@ class OrchestratorRunner:
             console=self._console,
             log_event="orchestrator.runner.param_degraded",
         )
+
+    async def _route_call_effort(
+        self,
+        *,
+        execution_id: str | None,
+        session_id: str | None,
+    ) -> dict[str, str]:
+        """Lay the runner's own execute_task paths on the effort contract.
+
+        These direct paths (single-AC execution, resume) do not go through
+        ParallelACExecutor, so without this they would silently skip effort
+        routing. Returns the execute_task kwargs (empty unless the runtime
+        enforces effort) and records an ``execution.ac.effort_routed`` event so the
+        proof sees the same data it gets from the parallel path. These are
+        top-level units, never decomposed children, so is_decomposed_child=False.
+        """
+        from ouroboros.orchestrator.effort_routing import resolve_execute_effort
+
+        decision, kwargs = resolve_execute_effort(
+            self._adapter,
+            base_effort=self._reasoning_effort,
+            is_decomposed_child=False,
+        )
+        if decision.level is not None:
+            from ouroboros.events.base import BaseEvent
+
+            await self._event_store.append(
+                BaseEvent(
+                    type="execution.ac.effort_routed",
+                    aggregate_type="execution",
+                    aggregate_id=execution_id or session_id or "",
+                    data={
+                        "execution_id": execution_id,
+                        "session_id": session_id,
+                        "is_decomposed_child": False,
+                        "effort_level": decision.level,
+                        "effort_mode": decision.mode,
+                        "base_reasoning_effort": self._reasoning_effort,
+                        "runtime_backend": getattr(self._adapter, "runtime_backend", None),
+                        "call_site": "runner",
+                    },
+                )
+            )
+        return kwargs
 
     def _plan_parallel_workers(self) -> int:
         """Return the effective fan-out worker count for the connected backend.
@@ -2283,12 +2333,17 @@ class OrchestratorRunner:
                     system_prompt=system_prompt,
                     tools=merged_tools,
                 )
+                effort_kwargs = await self._route_call_effort(
+                    execution_id=exec_id,
+                    session_id=tracker.session_id,
+                )
                 async with aclosing(
                     self._adapter.execute_task(  # type: ignore[type-var]
                         prompt=prompt,
                         tools=merged_tools,
                         system_prompt=system_prompt,
                         resume_handle=active_runtime_handle,
+                        **effort_kwargs,
                     )
                 ) as message_stream:
                     async for message in message_stream:
@@ -3210,12 +3265,17 @@ Note: This is a resumed session. Please continue from where execution was interr
                     system_prompt=system_prompt,
                     tools=merged_tools,
                 )
+                effort_kwargs = await self._route_call_effort(
+                    execution_id=None,
+                    session_id=session_id,
+                )
                 async with aclosing(
                     self._adapter.execute_task(  # type: ignore[type-var]
                         prompt=resume_prompt,
                         tools=merged_tools,
                         system_prompt=system_prompt,
                         resume_handle=runtime_handle,
+                        **effort_kwargs,
                     )
                 ) as message_stream:
                     async for message in message_stream:

--- a/tests/unit/orchestrator/test_effort_routing.py
+++ b/tests/unit/orchestrator/test_effort_routing.py
@@ -108,3 +108,70 @@ class TestDecideEffortEnforceableLevels:
             enforceable_levels=None,
         )
         assert d.mode == "enforced"
+
+
+class _Caps:
+    def __init__(self, support: ParamSupport, enforceable: frozenset[str] | None = None) -> None:
+        self.reasoning_effort_support = support
+        self.enforceable_reasoning_efforts = enforceable
+
+
+class _Adapter:
+    def __init__(self, support: ParamSupport | None) -> None:
+        if support is not None:
+            self.capabilities = _Caps(support)
+
+
+class TestResolveExecuteEffort:
+    """The shared helper every live execute_task call site uses."""
+
+    def test_enforced_runtime_yields_kwarg(self) -> None:
+        from ouroboros.orchestrator.effort_routing import resolve_execute_effort
+
+        decision, kwargs = resolve_execute_effort(
+            _Adapter(ParamSupport.NATIVE), base_effort="high", is_decomposed_child=False
+        )
+        assert decision.mode == "enforced"
+        assert kwargs == {"reasoning_effort": "high"}
+
+    def test_advised_runtime_yields_no_kwarg(self) -> None:
+        from ouroboros.orchestrator.effort_routing import resolve_execute_effort
+
+        decision, kwargs = resolve_execute_effort(
+            _Adapter(ParamSupport.IGNORED), base_effort="high", is_decomposed_child=False
+        )
+        assert decision.mode == "advised"
+        assert kwargs == {}  # never hand the kwarg to a runtime that ignores it
+
+    def test_adapter_without_capabilities_is_treated_as_advised(self) -> None:
+        from ouroboros.orchestrator.effort_routing import resolve_execute_effort
+
+        decision, kwargs = resolve_execute_effort(
+            _Adapter(None), base_effort="high", is_decomposed_child=False
+        )
+        assert decision.mode == "advised"
+        assert kwargs == {}
+
+    def test_dormant_yields_no_kwarg(self) -> None:
+        from ouroboros.orchestrator.effort_routing import resolve_execute_effort
+
+        decision, kwargs = resolve_execute_effort(
+            _Adapter(ParamSupport.NATIVE), base_effort=None, is_decomposed_child=False
+        )
+        assert decision.mode == "none"
+        assert kwargs == {}
+
+    def test_unenforceable_level_is_advised_with_no_kwarg(self) -> None:
+        # A NATIVE runtime that cannot enforce the chosen level (declared via
+        # enforceable_reasoning_efforts) records it advised and is not handed the kwarg.
+        from ouroboros.orchestrator.effort_routing import resolve_execute_effort
+
+        adapter = _Adapter(ParamSupport.NATIVE)
+        adapter.capabilities = _Caps(
+            ParamSupport.NATIVE, enforceable=frozenset({"low", "medium", "high", "xhigh"})
+        )
+        decision, kwargs = resolve_execute_effort(
+            adapter, base_effort="minimal", is_decomposed_child=False
+        )
+        assert decision.mode == "advised"
+        assert kwargs == {}

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -382,6 +382,35 @@ class TestOrchestratorRunner:
         assert data["effort_mode"] == "enforced"
 
     @pytest.mark.asyncio
+    async def test_route_call_effort_persist_failure_does_not_abort(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+    ) -> None:
+        """A degraded event store must not abort dispatch/resume.
+
+        _route_call_effort runs before execute_task on the direct and resume paths,
+        and the effort event is observability-only — so a failing append degrades to
+        a warning and still returns the execute_task kwargs, never propagating.
+        """
+        mock_adapter.capabilities = RuntimeCapabilities(
+            skill_dispatch=True,
+            targeted_resume=True,
+            structured_output=True,
+            reasoning_effort_support=ParamSupport.NATIVE,
+        )
+        mock_event_store.append.side_effect = RuntimeError("event store unavailable")
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        runner._reasoning_effort = "high"
+
+        # Must not raise even though append fails; kwargs still come back for dispatch.
+        kwargs = await runner._route_call_effort(execution_id="exec_1", session_id="sess_1")
+
+        assert kwargs == {"reasoning_effort": "high"}
+        assert mock_event_store.append.await_count >= 1
+
+    @pytest.mark.asyncio
     async def test_route_call_effort_advised_runtime_emits_no_kwarg(
         self,
         mock_adapter: MagicMock,

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -343,6 +343,70 @@ class TestOrchestratorRunner:
         assert "opencode" in notice
 
     @pytest.mark.asyncio
+    async def test_route_call_effort_emits_observability_only_event(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+    ) -> None:
+        """The runner's direct-path effort event is observability, not proof input.
+
+        It must carry NO ``ac_id`` (a direct run is a single top-level unit with no
+        per-AC decomposition) and be marked ``is_decomposed_child=False`` with
+        ``call_site="runner"`` — so the deterministic frugality proof excludes it by
+        design (both ``assemble_triads`` ac_id-skip and ``counts_in_proof`` only
+        admitting decomposed children) rather than mis-joining a whole-seed run.
+        """
+        mock_adapter.capabilities = RuntimeCapabilities(
+            skill_dispatch=True,
+            targeted_resume=True,
+            structured_output=True,
+            reasoning_effort_support=ParamSupport.NATIVE,
+        )
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        runner._reasoning_effort = "high"  # NATIVE runtime enforces it
+
+        kwargs = await runner._route_call_effort(execution_id="exec_1", session_id="sess_1")
+
+        # Enforcing runtime is handed the level for execute_task.
+        assert kwargs == {"reasoning_effort": "high"}
+        # Exactly one effort_routed event was emitted, with the proof-excluded shape.
+        appended = [c.args[0] for c in mock_event_store.append.call_args_list]
+        routed = [e for e in appended if e.type == "execution.ac.effort_routed"]
+        assert len(routed) == 1
+        data = routed[0].data
+        assert "ac_id" not in data  # no per-AC identity → proof skips it
+        assert data["is_decomposed_child"] is False
+        assert data["call_site"] == "runner"
+        assert data["effort_level"] == "high"
+        assert data["effort_mode"] == "enforced"
+
+    @pytest.mark.asyncio
+    async def test_route_call_effort_advised_runtime_emits_no_kwarg(
+        self,
+        mock_adapter: MagicMock,
+        mock_event_store: AsyncMock,
+        mock_console: MagicMock,
+    ) -> None:
+        """An advised (non-enforcing) runtime records the event but gets no kwarg."""
+        mock_adapter.capabilities = RuntimeCapabilities(
+            skill_dispatch=True,
+            targeted_resume=True,
+            structured_output=True,
+            # reasoning_effort_support defaults to IGNORED → advised
+        )
+        runner = OrchestratorRunner(mock_adapter, mock_event_store, mock_console)
+        runner._reasoning_effort = "high"
+
+        kwargs = await runner._route_call_effort(execution_id="exec_1", session_id="sess_1")
+
+        assert kwargs == {}  # never hand the kwarg to a runtime that ignores it
+        appended = [c.args[0] for c in mock_event_store.append.call_args_list]
+        routed = [e for e in appended if e.type == "execution.ac.effort_routed"]
+        assert len(routed) == 1
+        assert routed[0].data["effort_mode"] == "advised"
+
+    @pytest.mark.asyncio
     async def test_execute_seed_success(
         self,
         runner: OrchestratorRunner,


### PR DESCRIPTION
New `resolve_execute_effort` helper; the runner's single-AC and resume paths and the coordinator review now route effort (previously only ParallelACExecutor did). Verified live: a single-AC run now records `mode=enforced`.

---
**Stacked PR 5/6** for Epic #1465 / Task #1468 (RFC #1405). Base: `effort/04-copilot`. Review/merge in order.
🤖 Generated with [Claude Code](https://claude.com/claude-code)