### PR TITLE
fix(auto): refine every interview answer section so auto mode converges

### DIFF
--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -1473,23 +1473,31 @@ class AutoInterviewDriver:
         )
 
         refined_updates: list[tuple[str, LedgerEntry]] = []
-        concrete_parts: list[str] = []
+        transcript_parts: list[str] = []
+        refined_count = 0
         for (section, entry), concrete in zip(answer.ledger_updates, results, strict=True):
+            # Rebuild the transcript from the FINAL value of every section —
+            # refined where the call succeeded, original otherwise — so the text
+            # the backend acknowledges always describes the same committed content
+            # as the persisted ledger entries. A partial failure must never leave
+            # a ledger entry that is absent from the acknowledged transcript.
             if concrete:
                 refined_updates.append((section, replace(entry, value=concrete)))
-                concrete_parts.append(concrete)
+                transcript_parts.append(concrete)
+                refined_count += 1
             else:
                 refined_updates.append((section, entry))
-        if not concrete_parts:
+                transcript_parts.append(entry.value)
+        if not refined_count:
             return answer
         log.info(
             "auto.interview.answer_refined",
             auto_session_id=state.auto_session_id,
             sections=[section for section, _ in answer.ledger_updates],
-            refined_count=len(concrete_parts),
+            refined_count=refined_count,
             source=answer.source.value,
         )
-        return replace(answer, text=" ".join(concrete_parts), ledger_updates=refined_updates)
+        return replace(answer, text=" ".join(transcript_parts), ledger_updates=refined_updates)
 
     async def _maybe_concretize_on_stagnation(
         self,

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -31,7 +31,7 @@ from ouroboros.auto.lateral_routing import (
     select_persona_for_qa_failure,
     select_persona_for_safe_default_block,
 )
-from ouroboros.auto.ledger import LedgerSource, LedgerStatus, SeedDraftLedger
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.auto.progress import AutoProgressCallback, AutoProgressEvent
 from ouroboros.auto.repo_context import repo_auto_answer_context
 from ouroboros.auto.safe_defaults import (
@@ -1417,60 +1417,79 @@ class AutoInterviewDriver:
     ) -> AutoAnswer:
         """Replace a *generic* auto-answer with a concrete, AI-generated one.
 
-        The deterministic answerer has already chosen the section and enforced
+        The deterministic answerer has already chosen the sections and enforced
         safety (blocker detection, intent routing, source tagging). Only a
         refinable generic answer — ``CONSERVATIVE_DEFAULT`` / ``ASSUMPTION`` with
-        no blocker — is upgraded, so every safety guard is preserved. The
-        concrete text is written into both ``answer.text`` (→ transcript, which
-        the backend re-scores) and the single ledger-update entry value (→ Seed
-        content), keeping them in sync.
+        no blocker — is upgraded, so every safety guard is preserved.
 
-        Only answers with **at most one** ledger update are refined. A
-        multi-section answer (e.g. the verification route updates both
-        ``verification_plan`` and ``acceptance_criteria``; the actor/IO route
-        updates three sections) carries distinct per-section ledger values that a
-        single refined string cannot coherently replace — refining only
-        ``answer.text`` while leaving those entries generic would desync the
-        transcript from the persisted ledger for an acknowledged round, breaking
-        resume/review/safe-default/Seed-generation. Such answers are returned
-        unchanged. Best-effort otherwise: on no refiner, a non-generic answer, or
-        any failure, the original answer is returned unchanged.
+        **Every** ledger-update section is refined, not just single-update
+        answers. The refiner is per-section by construction (it takes the target
+        section plus that section's generic value and returns one concrete value
+        *for that section*), so multi-section answers — the common case, e.g. the
+        product-behavior route updates ``constraints`` + ``acceptance_criteria``,
+        the actor/IO route updates three sections — get a distinct concrete value
+        per entry. Transcript and ledger stay in sync because each entry is
+        replaced with its own refined value (not one shared string), and
+        ``answer.text`` (→ transcript, which the backend re-scores) is rebuilt
+        from those same concrete values. The per-section calls run concurrently,
+        so wall-clock stays ~one refiner call and the interview phase deadline is
+        respected.
+
+        Restricting refinement to single-update answers (the prior behavior) made
+        the refiner inert: every real ``AutoAnswerer`` route emits ≥2 updates, so
+        the generic placeholder — including the raw interview question echoed into
+        ``constraints``/``acceptance_criteria`` — was never upgraded and ambiguity
+        never converged. Best-effort throughout: on no refiner, a non-generic
+        answer, or a section whose refiner call fails or returns blank, that part
+        is left unchanged; if nothing is refined, the original answer is returned.
         """
         refinable = {AutoAnswerSource.CONSERVATIVE_DEFAULT, AutoAnswerSource.ASSUMPTION}
         if (
             self.answer_refiner is None
             or answer.blocker is not None
             or answer.source not in refinable
-            or len(answer.ledger_updates) > 1
+            or not answer.ledger_updates
         ):
             return answer
-        section = answer.ledger_updates[0][0] if answer.ledger_updates else "constraints"
-        try:
-            concrete = await asyncio.wait_for(
-                self.answer_refiner(state.goal, question, section, answer.text),
-                timeout=self.timeout_seconds,
-            )
-        except Exception as exc:  # noqa: BLE001 - refiner is best-effort
-            log.warning(
-                "auto.interview.answer_refine_failed",
-                auto_session_id=state.auto_session_id,
-                error=str(exc),
-            )
+
+        async def _refine_section(section: str, generic: str) -> str | None:
+            try:
+                concrete = await asyncio.wait_for(
+                    self.answer_refiner(state.goal, question, section, generic),
+                    timeout=self.timeout_seconds,
+                )
+            except Exception as exc:  # noqa: BLE001 - refiner is best-effort
+                log.warning(
+                    "auto.interview.answer_refine_failed",
+                    auto_session_id=state.auto_session_id,
+                    section=section,
+                    error=str(exc),
+                )
+                return None
+            return concrete.strip() if concrete and concrete.strip() else None
+
+        results = await asyncio.gather(
+            *(_refine_section(section, entry.value) for section, entry in answer.ledger_updates)
+        )
+
+        refined_updates: list[tuple[str, LedgerEntry]] = []
+        concrete_parts: list[str] = []
+        for (section, entry), concrete in zip(answer.ledger_updates, results, strict=True):
+            if concrete:
+                refined_updates.append((section, replace(entry, value=concrete)))
+                concrete_parts.append(concrete)
+            else:
+                refined_updates.append((section, entry))
+        if not concrete_parts:
             return answer
-        if not concrete or not concrete.strip():
-            return answer
-        concrete = concrete.strip()
-        refined_updates = answer.ledger_updates
-        if len(answer.ledger_updates) == 1:
-            sec, entry = answer.ledger_updates[0]
-            refined_updates = [(sec, replace(entry, value=concrete))]
         log.info(
             "auto.interview.answer_refined",
             auto_session_id=state.auto_session_id,
-            section=section,
+            sections=[section for section, _ in answer.ledger_updates],
+            refined_count=len(concrete_parts),
             source=answer.source.value,
         )
-        return replace(answer, text=concrete, ledger_updates=refined_updates)
+        return replace(answer, text=" ".join(concrete_parts), ledger_updates=refined_updates)
 
     async def _maybe_concretize_on_stagnation(
         self,

--- a/tests/unit/auto/test_interview_answer_refiner.py
+++ b/tests/unit/auto/test_interview_answer_refiner.py
@@ -93,13 +93,18 @@ async def test_assumption_source_is_also_refined(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_multi_section_answer_is_not_refined(tmp_path) -> None:
-    """A multi-ledger-update answer is left untouched to preserve transcript/ledger
-    sync — a single refined string cannot coherently replace distinct per-section
-    values (e.g. the verification route updates verification_plan + acceptance_criteria)."""
+async def test_multi_section_answer_is_refined_per_section(tmp_path) -> None:
+    """A multi-ledger-update answer is refined PER SECTION. The refiner is
+    section-aware, so each entry gets its own concrete value and the transcript
+    stays in sync with the ledger. This is the common case (every real
+    ``AutoAnswerer`` route emits >=2 updates); skipping it left the refiner inert
+    and interview ambiguity unconverged."""
 
-    async def refiner(*_a) -> str:
-        raise AssertionError("must not refine a multi-section answer (would desync)")
+    calls: list[str] = []
+
+    async def refiner(goal: str, question: str, section: str, generic: str) -> str:  # noqa: ARG001
+        calls.append(section)
+        return f"concrete::{section}"
 
     def _entry(section: str, value: str) -> LedgerEntry:
         return LedgerEntry(
@@ -124,10 +129,47 @@ async def test_multi_section_answer_is_not_refined(tmp_path) -> None:
     state = AutoPipelineState(goal="g", cwd=str(tmp_path))
     out = await driver._refine_answer(multi, "q", state, SeedDraftLedger.from_goal("g"))
 
-    # Untouched: text + both ledger entries keep their original (in-sync) values.
-    assert out.text == "generic verification text"
-    assert out.ledger_updates[0][1].value == "run tests"
-    assert out.ledger_updates[1][1].value == "command prints output"
+    # Each section refined with its own concrete value; transcript rebuilt from them.
+    assert calls == ["verification_plan", "acceptance_criteria"]
+    assert out.ledger_updates[0][1].value == "concrete::verification_plan"
+    assert out.ledger_updates[1][1].value == "concrete::acceptance_criteria"
+    assert out.text == "concrete::verification_plan concrete::acceptance_criteria"
+
+
+@pytest.mark.asyncio
+async def test_partial_section_refine_keeps_failed_section_in_sync(tmp_path) -> None:
+    """If one section's refiner call fails/blanks, that entry keeps its original
+    value while the others are upgraded — never a desync."""
+
+    async def refiner(goal: str, question: str, section: str, generic: str) -> str | None:  # noqa: ARG001
+        return "concrete::constraints" if section == "constraints" else None
+
+    def _entry(section: str, value: str) -> LedgerEntry:
+        return LedgerEntry(
+            key=f"{section}.x",
+            value=value,
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.8,
+            status=LedgerStatus.DEFAULTED,
+        )
+
+    multi = AutoAnswer(
+        text="generic",
+        source=AutoAnswerSource.CONSERVATIVE_DEFAULT,
+        confidence=0.8,
+        ledger_updates=[
+            ("constraints", _entry("constraints", "orig constraints")),
+            ("acceptance_criteria", _entry("acceptance_criteria", "orig acceptance")),
+        ],
+    )
+
+    driver = _driver(tmp_path, refiner)
+    state = AutoPipelineState(goal="g", cwd=str(tmp_path))
+    out = await driver._refine_answer(multi, "q", state, SeedDraftLedger.from_goal("g"))
+
+    assert out.ledger_updates[0][1].value == "concrete::constraints"
+    assert out.ledger_updates[1][1].value == "orig acceptance"  # untouched, still in sync
+    assert out.text == "concrete::constraints"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_interview_answer_refiner.py
+++ b/tests/unit/auto/test_interview_answer_refiner.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import pytest
 
-from ouroboros.auto.answerer import AutoAnswer, AutoAnswerSource
+from ouroboros.auto.answerer import AutoAnswer, AutoAnswerer, AutoAnswerSource
 from ouroboros.auto.interview_driver import (
     AutoInterviewDriver,
     FunctionInterviewBackend,
@@ -137,9 +137,12 @@ async def test_multi_section_answer_is_refined_per_section(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_partial_section_refine_keeps_failed_section_in_sync(tmp_path) -> None:
+async def test_partial_section_refine_keeps_transcript_and_ledger_in_sync(tmp_path) -> None:
     """If one section's refiner call fails/blanks, that entry keeps its original
-    value while the others are upgraded — never a desync."""
+    value AND that original value stays in the rebuilt transcript. The text the
+    backend acknowledges must describe the same committed content as every
+    persisted ledger entry — a refined section must never leave its peer absent
+    from the transcript (the desync invariant the refiner must preserve)."""
 
     async def refiner(goal: str, question: str, section: str, generic: str) -> str | None:  # noqa: ARG001
         return "concrete::constraints" if section == "constraints" else None
@@ -167,9 +170,63 @@ async def test_partial_section_refine_keeps_failed_section_in_sync(tmp_path) -> 
     state = AutoPipelineState(goal="g", cwd=str(tmp_path))
     out = await driver._refine_answer(multi, "q", state, SeedDraftLedger.from_goal("g"))
 
+    # Ledger: refined where it succeeded, original where it failed.
     assert out.ledger_updates[0][1].value == "concrete::constraints"
-    assert out.ledger_updates[1][1].value == "orig acceptance"  # untouched, still in sync
-    assert out.text == "concrete::constraints"
+    assert out.ledger_updates[1][1].value == "orig acceptance"
+    # Transcript represents BOTH ledger entries — no desync.
+    assert out.text == "concrete::constraints orig acceptance"
+    assert "orig acceptance" in out.prefixed_text
+
+
+@pytest.mark.asyncio
+async def test_refined_transcript_covers_every_applied_ledger_entry(tmp_path) -> None:
+    """Boundary invariant across the refine -> apply seam: the text the backend
+    acknowledges — ``prefixed_text``, which the driver passes verbatim to
+    ``backend.answer`` and which ``apply`` records into the ledger transcript —
+    must contain every ledger entry value that ``apply`` persists, including a
+    fallback (unrefined) section. This observes the transcript/backend boundary
+    where a partial-refinement desync would actually surface, not just the
+    helper's return shape."""
+
+    async def refiner(goal: str, question: str, section: str, generic: str) -> str | None:  # noqa: ARG001
+        # Partial: refine constraints, fail acceptance_criteria.
+        if section == "constraints":
+            return "Store todos in ~/.todo-cli.json; ids are 1-based list positions."
+        return None
+
+    def _entry(section: str, value: str) -> LedgerEntry:
+        return LedgerEntry(
+            key=f"{section}.x",
+            value=value,
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.8,
+            status=LedgerStatus.DEFAULTED,
+        )
+
+    answer = AutoAnswer(
+        text="generic product behavior",
+        source=AutoAnswerSource.CONSERVATIVE_DEFAULT,
+        confidence=0.8,
+        ledger_updates=[
+            ("constraints", _entry("constraints", "Preserve the requested product behavior.")),
+            (
+                "acceptance_criteria",
+                _entry("acceptance_criteria", "A command check exits 0 with evidence."),
+            ),
+        ],
+    )
+
+    driver = _driver(tmp_path, refiner)
+    state = AutoPipelineState(goal="build a todo CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    refined = await driver._refine_answer(answer, "Where should todos be stored?", state, ledger)
+
+    # Apply persists ledger_updates and records prefixed_text into the transcript.
+    AutoAnswerer().apply(refined, ledger, question="Where should todos be stored?")
+
+    backend_text = refined.prefixed_text  # exactly what backend.answer(session_id, ...) receives
+    for section, entry in refined.ledger_updates:
+        assert entry.value in backend_text, f"{section} value absent from acknowledged transcript"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`ooo auto "아주 간단한 todo CLI 만들어줘"` stalled in the interview at the
first product-decision question:

> 기존 관례가 없을 때는 할 일을 `~/.todo-cli.json` 같은 사용자별 로컬 JSON 파일에 저장하고,
> `done`/`delete`는 `list`에 표시되는 안정적인 숫자 ID로 지정하는 방식으로 확정해도 될까요?

In **auto mode there is no human** to answer, so the pipeline must auto-decide
and converge. Instead it hit `interview_phase_deadline` and produced a
`degraded: true` Seed (`recovery_reason: interview_phase_deadline`) — and never
executed, so no product was built.

## Root cause

The AI answer refiner (#1485) — the component that replaces the deterministic
answerer's generic placeholder with a concrete, goal-specific decision and
thereby drives ambiguity down — **never fired**. `_refine_answer` bailed out on:

```python
or len(answer.ledger_updates) > 1
```

But **every** real `AutoAnswerer` route emits ≥2 ledger updates:

| route | sections |
|---|---|
| `_product_behavior_answer` | constraints + acceptance_criteria |
| `_verification_answer` | verification_plan + acceptance_criteria |
| `_io_actor_answer` | actors + inputs + outputs |
| `_default_answer` | constraints + failure_modes |

So the guard skipped all of them: the backend only ever saw generic templates,
ambiguity never reached the 0.20 convergence threshold, and the phase deadline
fired. As a side effect, the generic placeholder
(`"Preserve the product behavior requested by the interview question: <raw question>"`)
was never replaced, leaking the raw question text into the Seed's
`constraints` / `acceptance_criteria`.

## Fix

Refine **every** ledger-update section. The refiner is already section-aware
(`refiner(goal, question, section, generic_value) -> concrete`), so each entry
gets its own concrete value — the transcript/ledger desync the old single-update
guard was avoiding **cannot occur** (we replace each entry with its own refined
value, not one shared string, and rebuild `answer.text` from those same values).

- Per-section calls run **concurrently** (`asyncio.gather`), so wall-clock stays
  ~one refiner call → phase deadline respected.
- **Partial failure is safe**: a section whose refiner call fails or returns
  blank keeps its original (in-sync) value; the rest are upgraded. If nothing
  refines, the original answer is returned unchanged.
- Fixing the refiner also removes the raw-question pollution, since the generic
  placeholder values are now replaced with concrete decisions.

## Tests

- Rewrote `test_multi_section_answer_is_not_refined` →
  `test_multi_section_answer_is_refined_per_section` (asserts each section gets
  its own concrete value + transcript rebuilt from them).
- Added `test_partial_section_refine_keeps_failed_section_in_sync`.
- `uv run pytest tests/unit/auto/test_interview_answer_refiner.py` → 8 passed.
- `uv run pytest tests/unit/auto/` → 1175 passed; 4 pre-existing `test_surface`
  failures (codex-config-leak env issue, identical on `main` — unrelated).
- ruff + mypy clean on changed files.

## Follow-ups (not in this PR)

- The interview-deadline recovery path (`partial_seed_from_evidence`) still
  injects unresolved-slot text into constraints; worth a separate hardening pass.
- Stagnation-lateral can consume the full phase timeout; consider a smaller
  per-intervention budget.

## R-run comparison

| Metric | Baseline | This PR | Ratio |
|---|---|---|---|
| Rounds completed in 600s | N/A | N/A | n/a |
| Per-round wall-clock (s/round) | N/A | N/A | n/a |
| Terminal reason | N/A | N/A | n/a |
| EventStore event count | N/A | N/A | n/a |

**Why N/A (honest disclosure, not a substrate-only claim):** a canonical R-run
(`OUROBOROS_RUN_CANONICAL=1 uv run pytest tests/canonical/ -k cli-todo`) needs an
LLM-backed interview/refiner backend that is not available in this authoring
environment, so I could not capture real per-round numbers and will not fabricate
them. Expected per-round impact is neutral-to-positive: the per-section refiner
calls run **concurrently** (`asyncio.gather`) so they add ~one refiner call of
wall-clock per answered round, and prior to this change the refiner never fired at
all — the interview burned rounds on un-converging generic answers until it hit the
phase deadline. Driving ambiguity down should **reduce total rounds to terminal**,
not add latency. A maintainer with canonical-harness access should capture a real
R-run before merge if §I5 numbers are required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
