### PR TITLE
fix(auto): anchor answer refiner to committed contracts so interview converges

### DIFF
--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -96,13 +96,28 @@ When an auto start response includes `response.meta.job_id`:
    execution/session/lineage handles, progress counters, blocker/error text, or
    a terminal state. If `response.meta.changed is false`, continue silently
    unless the user asked for heartbeat updates.
-4. If the job status is non-terminal (`queued`, `running`, or another active
+4. **During the interview phase, surface the live Q&A — not just the round
+   counter.** Whenever the relayed phase is `interview` (e.g. progress reads
+   `interview round N/50`), call
+   `ouroboros_session_status(session_id=<auto_session_id>)` and relay to the
+   user: (a) the current `meta.pending_question` (the question the interview is
+   asking right now), and (b) the `meta.auto_answer_log` entries — each is
+   `{round, source, question, answer}`, i.e. what the auto-answerer answered and
+   why (`source`: `conservative_default` = safe-default policy,
+   `inference` = model reasoning, `assumption` = auto-answerer fallback). Show
+   this so the user sees what the interview is converging on, not a bare
+   counter. Note: this Q&A lives in the auto-session state, so
+   `session_status` surfaces it even though `ouroboros_query_events` returns
+   nothing for the auto session, and it shows only the last 3 answers (each
+   truncated). Keep it low-noise: relay the pending question and any newly
+   answered rounds, not the same 3 entries every poll.
+5. If the job status is non-terminal (`queued`, `running`, or another active
    status), keep waiting. Do not tell the user to call job tools themselves.
-5. When the job reaches a terminal status, call `ouroboros_job_result(job_id)`
+6. When the job reaches a terminal status, call `ouroboros_job_result(job_id)`
    and summarize the final auto-session outcome. If the final auto result is
    `detached`, keep tracking the surfaced downstream job/Ralph handles when
    available instead of presenting `detached` as completion.
-6. If `response.meta.status == "delegated_to_plugin"` and
+7. If `response.meta.status == "delegated_to_plugin"` and
    `response.meta.job_id is None`, report that OpenCode plugin mode delegated
    the work to the child Task/session. Do not call job wait/result without a
    real job id; follow the host Task widget/session lifecycle.

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 import contextlib
 from dataclasses import dataclass
 import hashlib
@@ -1297,7 +1297,11 @@ class LLMAnswerRefiner:
         "concrete, committed, testable decision for the named section: specific "
         "values, exact commands/flags, a small sample input and its exact expected "
         "output, and explicit error/stderr/exit-code behavior where relevant. No "
-        "options, no clarifying questions, no hedging, no preamble. 1-4 sentences."
+        "options, no clarifying questions, no hedging, no preamble. 1-4 sentences. "
+        "When contracts already committed earlier in this interview are listed, "
+        "keep their exact strings VERBATIM — never reformat, rename, or re-decide "
+        "them — and specify only the detail this question still leaves undecided, "
+        "fully consistent with those commitments."
     )
 
     def __init__(self, llm_adapter: LLMAdapter, *, model: str | None = None) -> None:
@@ -1305,15 +1309,31 @@ class LLMAnswerRefiner:
         self.model = model
 
     async def __call__(
-        self, goal: str, question: str, section: str, generic_text: str
+        self,
+        goal: str,
+        question: str,
+        section: str,
+        generic_text: str,
+        committed: Sequence[tuple[str, str, str]] = (),
     ) -> str | None:
+        committed_block = ""
+        if committed:
+            lines = "\n".join(f"- [{sect}] {value}" for sect, _key, value in committed)
+            committed_block = (
+                "\nContracts already committed earlier in THIS interview — preserve "
+                "them EXACTLY and stay consistent with them:\n"
+                f"{lines}\n"
+            )
         prompt = (
             f"Goal: {goal}\n\n"
             f"Seed section to specify: {section}\n\n"
             f"Interview question: {question}\n\n"
-            f"A generic placeholder answer was: {generic_text}\n\n"
+            f"A generic placeholder answer was: {generic_text}\n"
+            f"{committed_block}\n"
             f"Replace it with one concrete, committed answer for the '{section}' "
-            "section that a developer or test could execute against verbatim."
+            "section that a developer or test could execute against verbatim. Do "
+            "not contradict or reformat any already-committed contract above; "
+            "decide only what this question leaves open."
         )
         messages = [
             Message(role=MessageRole.SYSTEM, content=self._SYSTEM),
@@ -1322,7 +1342,10 @@ class LLMAnswerRefiner:
         config = CompletionConfig(
             model=self.model or "",
             role="clarification",
-            temperature=0.2,
+            # Deterministic: with a stable goal + committed-contract anchor, the
+            # same inputs must yield the same concrete answer round-over-round so
+            # the interview converges instead of oscillating on output formats.
+            temperature=0.0,
             max_tokens=400,
         )
         try:

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, field, replace
 import inspect
 import re
@@ -311,8 +311,17 @@ class AutoInterviewDriver:
     # goal-specific answer produced by the interview runtime LLM, applied
     # coherently to the same ledger entry + transcript so ambiguity converges
     # round-over-round. ``None`` preserves the deterministic-only behavior.
-    # Signature: ``(goal, question, section, generic_text) -> concrete | None``.
-    answer_refiner: Callable[[str, str, str, str], Awaitable[str | None]] | None = None
+    # Signature: ``(goal, question, section, generic_text, committed) -> concrete
+    # | None`` where ``committed`` is the ``(section, key, value)`` snapshot of
+    # contracts already decided this interview, so the refiner stays consistent
+    # with prior rounds instead of re-deciding the same facet differently.
+    answer_refiner: (
+        Callable[
+            [str, str, str, str, Sequence[tuple[str, str, str]]],
+            Awaitable[str | None],
+        ]
+        | None
+    ) = None
     # RFC #1256 §I4 — Unified observability for ooo auto interview.
     # When set, the driver emits typed ``auto.interview.*`` events to the
     # EventStore alongside the existing structlog ``log.info(...)`` calls,
@@ -1452,10 +1461,27 @@ class AutoInterviewDriver:
         ):
             return answer
 
-        async def _refine_section(section: str, generic: str) -> str | None:
+        # Anchor refinement to the contracts already committed this interview.
+        # ``committed`` is passed to the refiner so a (non-deterministic) model
+        # stays consistent with prior rounds; ``frozen`` lets an already-decided
+        # ``(section, key)`` facet be reused VERBATIM without any model call, so
+        # convergence does not depend on model determinism. This is the fix for
+        # the oscillation that tripped ``interview_phase_deadline``: without an
+        # anchor the refiner reformatted committed output contracts into
+        # contradictory ones every round and the interview never converged.
+        committed = ledger.committed_decisions()
+        frozen = {(section, key): value for section, key, value in committed}
+
+        async def _refine_section(section: str, entry: LedgerEntry) -> str | None:
+            prior = frozen.get((section, entry.key))
+            if prior is not None:
+                # Facet already decided earlier this interview — freeze it so the
+                # ledger's matching-prior reconciliation clears any conflict and
+                # ambiguity converges instead of thrashing on re-decided formats.
+                return prior
             try:
                 concrete = await asyncio.wait_for(
-                    self.answer_refiner(state.goal, question, section, generic),
+                    self.answer_refiner(state.goal, question, section, entry.value, committed),
                     timeout=self.timeout_seconds,
                 )
             except Exception as exc:  # noqa: BLE001 - refiner is best-effort
@@ -1469,7 +1495,7 @@ class AutoInterviewDriver:
             return concrete.strip() if concrete and concrete.strip() else None
 
         results = await asyncio.gather(
-            *(_refine_section(section, entry.value) for section, entry in answer.ledger_updates)
+            *(_refine_section(section, entry) for section, entry in answer.ledger_updates)
         )
 
         refined_updates: list[tuple[str, LedgerEntry]] = []

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -407,6 +407,34 @@ class SeedDraftLedger:
             for name in REQUIRED_SECTIONS
         }
 
+    def committed_decisions(
+        self, *, exclude_sections: frozenset[str] = frozenset({"goal"})
+    ) -> list[tuple[str, str, str]]:
+        """Return already-decided, active contracts as ``(section, key, value)``.
+
+        These are the concrete decisions the interview has locked in so far —
+        every entry whose authority is *active* (``CONFIRMED`` / ``DEFAULTED`` /
+        ``INFERRED``), one per ``(section, key)`` keeping the latest active
+        value, with the goal echo excluded (the goal is surfaced to the refiner
+        separately). ``WEAK`` / ``CONFLICTING`` / ``BLOCKED`` / ``MISSING``
+        entries are omitted because they are superseded or unresolved.
+
+        The answer refiner consumes this snapshot to stay CONSISTENT with prior
+        rounds instead of re-deciding the same facet differently every round —
+        the root cause of interview oscillation (a non-deterministic refiner
+        reformatting an already-committed output contract into a contradictory
+        one, which never converges and trips ``interview_phase_deadline``).
+        """
+        active = {LedgerStatus.CONFIRMED, LedgerStatus.DEFAULTED, LedgerStatus.INFERRED}
+        decided: dict[tuple[str, str], str] = {}
+        for name, section in self.sections.items():
+            if name in exclude_sections:
+                continue
+            for entry in section.entries:
+                if entry.status in active and entry.value.strip():
+                    decided[(name, entry.key)] = entry.value
+        return [(section, key, value) for (section, key), value in decided.items()]
+
     def open_gaps(self) -> list[str]:
         """Return required sections that are not Seed-ready."""
         blocked = {

--- a/tests/unit/auto/test_answer_refiner_adapter.py
+++ b/tests/unit/auto/test_answer_refiner_adapter.py
@@ -1,0 +1,101 @@
+"""Tests for ``LLMAnswerRefiner`` (the LLM-backed answer refiner adapter).
+
+These pin the two properties that make the refiner converge instead of
+oscillate: it is DETERMINISTIC (temperature 0) and it is ANCHORED (the
+contracts already committed this interview are injected into the prompt so the
+model preserves them verbatim instead of re-deciding them every round).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.auto.adapters import LLMAnswerRefiner
+from ouroboros.core.types import Result
+from ouroboros.providers.base import (
+    CompletionConfig,
+    CompletionResponse,
+    Message,
+    MessageRole,
+    UsageInfo,
+)
+
+
+class _CapturingAdapter:
+    """Fake ``LLMAdapter`` that records the last call and returns fixed text."""
+
+    def __init__(self, content: str = "concrete answer") -> None:
+        self.content = content
+        self.messages: list[Message] | None = None
+        self.config: CompletionConfig | None = None
+
+    async def complete(self, messages, config):
+        self.messages = messages
+        self.config = config
+        return Result.ok(
+            CompletionResponse(
+                content=self.content,
+                model="fake",
+                usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+        )
+
+
+def _user_text(adapter: _CapturingAdapter) -> str:
+    assert adapter.messages is not None
+    return "\n".join(m.content for m in adapter.messages if m.role == MessageRole.USER)
+
+
+@pytest.mark.asyncio
+async def test_refiner_is_deterministic_temperature_zero() -> None:
+    adapter = _CapturingAdapter()
+    refiner = LLMAnswerRefiner(adapter)
+
+    out = await refiner("goal", "question", "constraints", "generic")
+
+    assert out == "concrete answer"
+    assert adapter.config is not None
+    # Determinism is the convergence guarantee: same inputs -> same answer.
+    assert adapter.config.temperature == 0.0
+
+
+@pytest.mark.asyncio
+async def test_committed_contracts_are_injected_into_prompt() -> None:
+    adapter = _CapturingAdapter()
+    refiner = LLMAnswerRefiner(adapter)
+
+    committed = [
+        ("outputs", "outputs.add", 'todo add "X" prints "Added #1: X"'),
+        ("constraints", "constraints.exit", "invalid id exits 1"),
+    ]
+    await refiner("build a todo CLI", "what list format?", "outputs", "generic", committed)
+
+    text = _user_text(adapter)
+    # The model must SEE every prior commitment so it can preserve them verbatim.
+    assert 'todo add "X" prints "Added #1: X"' in text
+    assert "invalid id exits 1" in text
+    assert "committed" in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_no_committed_block_when_none_committed() -> None:
+    adapter = _CapturingAdapter()
+    refiner = LLMAnswerRefiner(adapter)
+
+    await refiner("goal", "question", "constraints", "generic")
+
+    text = _user_text(adapter)
+    # Round 1 (nothing decided yet) must not fabricate a commitments section.
+    assert "already committed" not in text.lower()
+
+
+@pytest.mark.asyncio
+async def test_provider_error_returns_none() -> None:
+    from ouroboros.core.errors import ProviderError
+
+    class _FailingAdapter:
+        async def complete(self, messages, config):  # noqa: ARG002
+            return Result.err(ProviderError("provider down"))
+
+    refiner = LLMAnswerRefiner(_FailingAdapter())
+    assert await refiner("g", "q", "constraints", "generic") is None

--- a/tests/unit/auto/test_interview_answer_refiner.py
+++ b/tests/unit/auto/test_interview_answer_refiner.py
@@ -56,7 +56,7 @@ def _answer(
 async def test_refines_generic_answer_into_ledger_and_transcript(tmp_path) -> None:
     calls: list[tuple] = []
 
-    async def refiner(goal: str, question: str, section: str, generic: str) -> str:
+    async def refiner(goal: str, question: str, section: str, generic: str, committed=()) -> str:  # noqa: ARG001
         calls.append((goal, question, section, generic))
         return _CONCRETE
 
@@ -102,7 +102,7 @@ async def test_multi_section_answer_is_refined_per_section(tmp_path) -> None:
 
     calls: list[str] = []
 
-    async def refiner(goal: str, question: str, section: str, generic: str) -> str:  # noqa: ARG001
+    async def refiner(goal: str, question: str, section: str, generic: str, committed=()) -> str:  # noqa: ARG001
         calls.append(section)
         return f"concrete::{section}"
 
@@ -144,7 +144,9 @@ async def test_partial_section_refine_keeps_transcript_and_ledger_in_sync(tmp_pa
     persisted ledger entry — a refined section must never leave its peer absent
     from the transcript (the desync invariant the refiner must preserve)."""
 
-    async def refiner(goal: str, question: str, section: str, generic: str) -> str | None:  # noqa: ARG001
+    async def refiner(  # noqa: ARG001
+        goal: str, question: str, section: str, generic: str, committed=()
+    ) -> str | None:
         return "concrete::constraints" if section == "constraints" else None
 
     def _entry(section: str, value: str) -> LedgerEntry:
@@ -188,7 +190,9 @@ async def test_refined_transcript_covers_every_applied_ledger_entry(tmp_path) ->
     where a partial-refinement desync would actually surface, not just the
     helper's return shape."""
 
-    async def refiner(goal: str, question: str, section: str, generic: str) -> str | None:  # noqa: ARG001
+    async def refiner(  # noqa: ARG001
+        goal: str, question: str, section: str, generic: str, committed=()
+    ) -> str | None:
         # Partial: refine constraints, fail acceptance_criteria.
         if section == "constraints":
             return "Store todos in ~/.todo-cli.json; ids are 1-based list positions."
@@ -288,3 +292,133 @@ async def test_empty_refiner_output_keeps_original(tmp_path) -> None:
         SeedDraftLedger.from_goal("g"),
     )
     assert out.text == "orig"
+
+
+def _update(section: str, key: str, value: str) -> AutoAnswer:
+    """An incoming generic answer that targets one explicit ``(section, key)``."""
+    entry = LedgerEntry(
+        key=key,
+        value=value,
+        source=LedgerSource.CONSERVATIVE_DEFAULT,
+        confidence=0.8,
+        status=LedgerStatus.DEFAULTED,
+    )
+    return AutoAnswer(
+        text=value,
+        source=AutoAnswerSource.CONSERVATIVE_DEFAULT,
+        confidence=0.8,
+        ledger_updates=[(section, entry)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_committed_facet_is_frozen_and_skips_refiner(tmp_path) -> None:
+    """A facet already committed (active) earlier this interview is reused
+    VERBATIM and the refiner is never consulted for it. This is the
+    deterministic backstop that stops output-contract oscillation: a
+    non-deterministic refiner can no longer re-decide a settled facet."""
+    called: list = []
+
+    async def refiner(*a) -> str:
+        called.append(a)
+        return "a DIFFERENT, contradictory contract"
+
+    driver = _driver(tmp_path, refiner)
+    state = AutoPipelineState(goal="g", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal("g")
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.output_contract",
+            value='todo add "X" prints exactly "Added #1: X\\n"',
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.8,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+
+    out = await driver._refine_answer(
+        _update("constraints", "constraints.output_contract", "generic placeholder"),
+        "a rephrased output-format question",
+        state,
+        ledger,
+    )
+
+    assert out.ledger_updates[0][1].value == 'todo add "X" prints exactly "Added #1: X\\n"'
+    assert called == []  # decided facet never reaches the model
+
+
+@pytest.mark.asyncio
+async def test_refiner_receives_committed_contract_anchor(tmp_path) -> None:
+    """A genuinely NEW facet (unseen key) still goes to the refiner, but the
+    refiner is handed the committed-contract snapshot so it can stay consistent
+    with prior rounds instead of contradicting them."""
+    seen: dict = {}
+
+    async def refiner(goal, question, section, generic, committed=()) -> str:  # noqa: ARG001
+        seen["committed"] = list(committed)
+        return "concrete new facet"
+
+    driver = _driver(tmp_path, refiner)
+    state = AutoPipelineState(goal="g", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal("g")
+    ledger.add_entry(
+        "outputs",
+        LedgerEntry(
+            key="outputs.add",
+            value="Added #1: X",
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.8,
+            status=LedgerStatus.DEFAULTED,
+        ),
+    )
+
+    out = await driver._refine_answer(
+        _update("constraints", "constraints.new_facet", "generic"),
+        "q",
+        state,
+        ledger,
+    )
+
+    assert out.ledger_updates[0][1].value == "concrete new facet"
+    assert ("outputs", "outputs.add", "Added #1: X") in seen["committed"]
+
+
+@pytest.mark.asyncio
+async def test_frozen_facet_prevents_conflict_under_nondeterministic_refiner(tmp_path) -> None:
+    """End-to-end convergence: a refiner that drifts to a different contract on
+    every call (modeling LLM non-determinism) cannot make the ledger CONFLICTING
+    for an already-decided facet, because round 2 freezes it to round 1's value
+    (matching-prior reconciliation clears any conflict)."""
+    drift = iter(["Added #1: X", "added 1", "Added 1: x"])
+
+    async def refiner(*_a) -> str:
+        return next(drift)
+
+    driver = _driver(tmp_path, refiner)
+    state = AutoPipelineState(goal="g", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal("g")
+    answerer = AutoAnswerer()
+
+    # Round 1: facet undecided -> refiner concretizes it; apply commits it.
+    r1 = await driver._refine_answer(
+        _update("constraints", "constraints.output_contract", "generic placeholder"),
+        "q1",
+        state,
+        ledger,
+    )
+    answerer.apply(r1, ledger, question="q1")
+    v1 = r1.ledger_updates[0][1].value
+    assert v1 == "Added #1: X"
+
+    # Round 2: same facet re-asked (rephrased) -> frozen to v1, NOT the drift.
+    r2 = await driver._refine_answer(
+        _update("constraints", "constraints.output_contract", "generic placeholder"),
+        "q2 rephrased differently",
+        state,
+        ledger,
+    )
+    answerer.apply(r2, ledger, question="q2 rephrased differently")
+
+    assert r2.ledger_updates[0][1].value == v1  # did not drift to "added 1"
+    assert ledger.sections["constraints"].status() != LedgerStatus.CONFLICTING

--- a/tests/unit/auto/test_ledger_committed_decisions.py
+++ b/tests/unit/auto/test_ledger_committed_decisions.py
@@ -1,0 +1,66 @@
+"""Tests for ``SeedDraftLedger.committed_decisions`` — the anchor snapshot the
+answer refiner consumes to stay consistent across interview rounds."""
+
+from __future__ import annotations
+
+from ouroboros.auto.ledger import (
+    LedgerEntry,
+    LedgerSource,
+    LedgerStatus,
+    SeedDraftLedger,
+)
+
+
+def _entry(key: str, value: str, status: LedgerStatus) -> LedgerEntry:
+    return LedgerEntry(
+        key=key,
+        value=value,
+        source=LedgerSource.CONSERVATIVE_DEFAULT,
+        confidence=0.8,
+        status=status,
+    )
+
+
+def test_returns_active_decisions_excluding_goal() -> None:
+    ledger = SeedDraftLedger.from_goal("build a todo CLI")
+    ledger.add_entry("outputs", _entry("outputs.add", "Added #1: X", LedgerStatus.DEFAULTED))
+    ledger.add_entry(
+        "constraints", _entry("constraints.exit", "invalid exits 1", LedgerStatus.CONFIRMED)
+    )
+
+    decided = ledger.committed_decisions()
+
+    assert ("outputs", "outputs.add", "Added #1: X") in decided
+    assert ("constraints", "constraints.exit", "invalid exits 1") in decided
+    # The goal echo is surfaced to the refiner separately, never as a contract.
+    assert all(section != "goal" for section, _key, _value in decided)
+
+
+def test_omits_weak_conflicting_and_blank_entries() -> None:
+    ledger = SeedDraftLedger.from_goal("g")
+    ledger.add_entry("outputs", _entry("outputs.weak", "superseded", LedgerStatus.WEAK))
+    ledger.add_entry("outputs", _entry("outputs.conflict", "A", LedgerStatus.CONFLICTING))
+    ledger.add_entry("outputs", _entry("outputs.blank", "   ", LedgerStatus.DEFAULTED))
+    ledger.add_entry("outputs", _entry("outputs.ok", "keep me", LedgerStatus.DEFAULTED))
+
+    values = {value for _s, _k, value in ledger.committed_decisions()}
+
+    assert "keep me" in values
+    assert "superseded" not in values
+    assert "A" not in values
+    assert "   " not in values
+
+
+def test_dedupes_repeated_same_key_commitment() -> None:
+    ledger = SeedDraftLedger.from_goal("g")
+    ledger.add_entry("outputs", _entry("outputs.add", "Added #1: X", LedgerStatus.DEFAULTED))
+    # The freeze backstop re-commits the SAME value on a later round
+    # (matching-prior reconciliation keeps both active). The snapshot must
+    # collapse them to a single contract, not report a duplicate.
+    ledger.add_entry("outputs", _entry("outputs.add", "Added #1: X", LedgerStatus.DEFAULTED))
+
+    matches = [
+        v for s, k, v in ledger.committed_decisions() if (s, k) == ("outputs", "outputs.add")
+    ]
+
+    assert matches == ["Added #1: X"]


### PR DESCRIPTION
## Problem

`ooo auto` on a trivial goal (\"simple todo CLI\") oscillates in the interview phase on **arbitrary output-format details** (`Added #1: Buy milk` ↔ `added 1` ↔ `Added 1: x`; command `todo` ↔ `./todo`; exit code `1` ↔ `2`), never converges, hits `interview_phase_deadline`, and emits a **degraded B-grade Seed** (`degraded: true`, ambiguity `1.0`) with 4 contradictory contracts baked in. No working CLI is produced.

## Root cause

The AI answer refiner (`LLMAnswerRefiner`, shipped in #1485/#1487) is **stateless across rounds and non-deterministic**:

- It is called every round with only `(goal, question, section, generic_text)` — it has **no anchor** to the contracts already committed earlier in the interview (`interview_driver.py` `_refine_answer`).
- It runs at `temperature=0.2`, so identical intent yields a different concrete string each round.
- Two differently-formatted refiner outputs for the same `(section, key)` at equal source priority/confidence resolve to **`CONFLICTING`** in the ledger (`ledger.add_entry`), and `open_gaps()` keeps reporting them unresolved → backend ambiguity never falls → wall-clock deadline → degraded Seed.

#1485 activated this refiner, converting a *stable-but-generic* stall into a *visible oscillation*. Both end in a degraded Seed; this fixes the underlying non-convergence.

## Fix — anchor the refiner to prior commitments

1. **`SeedDraftLedger.committed_decisions()`** — a snapshot of active (`CONFIRMED`/`DEFAULTED`/`INFERRED`) contracts as `(section, key, value)`, goal excluded, deduped by `(section, key)`.
2. **`LLMAnswerRefiner`** — receives the committed snapshot, is instructed to **preserve those exact strings verbatim** and decide only what the question leaves open, and runs at **`temperature=0.0`** (deterministic given a stable anchor).
3. **Deterministic backstop in `_refine_answer`** — a `(section, key)` facet already committed this interview is **reused VERBATIM with no model call**. Convergence no longer depends on model determinism; the ledger's matching-prior reconciliation clears any conflict. Genuinely new facets still go to the refiner, now carrying the committed anchor.

Also surfaces the live interview Q&A during `ooo auto` background monitoring (`session_status`) so this class of stall is visible instead of hidden behind a bare `round N/50` counter.

## Why this converges

- **Stable-key facets** (e.g. `verification.observable`): frozen by the deterministic backstop → identical value re-committed → `matching_prior` clears any conflict.
- **Question-derived-key facets** (e.g. `acceptance.{slug(question)}`, the ones that actually oscillated): the refiner now sees the committed contracts and is told to stay consistent, at `temperature=0` → no contradictory reformatting.
- Existing `max_rounds` safe-default / ledger-only closure remains the ultimate floor.

## Tests

New deterministic coverage (no live LLM):
- `test_committed_facet_is_frozen_and_skips_refiner` — decided facet reused verbatim, refiner never called.
- `test_refiner_receives_committed_contract_anchor` — new facet still refined, with the committed snapshot passed in.
- `test_frozen_facet_prevents_conflict_under_nondeterministic_refiner` — a deliberately drifting refiner cannot make the ledger `CONFLICTING`.
- `test_refiner_is_deterministic_temperature_zero`, `test_committed_contracts_are_injected_into_prompt`.
- `committed_decisions` status filtering / goal exclusion / dedup.

`tests/unit/auto/` — **1190 passed** (isolated HOME). ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## R-run comparison

| Metric | Baseline | This PR | Ratio |
|---|---|---|---|
| Rounds completed in 600s | N/A | N/A | n/a |
| Per-round wall-clock (s/round) | N/A | N/A | n/a |
| Terminal reason | N/A | N/A | n/a |
| EventStore event count | N/A | N/A | n/a |

**Why N/A (honest disclosure, not a substrate-only claim):** a live canonical
R-run (`OUROBOROS_RUN_CANONICAL=1 uv run pytest tests/canonical/ -k cli-todo`)
needs an LLM-backed interview/refiner backend that is not available in this
authoring environment, so I could not capture real per-round numbers and will
not fabricate them (same constraint disclosed in #1487).

**Expected per-round impact is neutral-to-positive, by construction:**
- The deterministic backstop in `_refine_answer` **removes** the per-section
  LLM refiner call for any facet already committed this interview (reused
  verbatim, no `await`), so per-round wall-clock is **≤ baseline**, never higher.
- `temperature=0.2 → 0.0` does not add latency.
- The dominant effect is on **total rounds to terminal**: the bug under fix
  caused the interview to oscillate until `interview_phase_deadline` (~12+
  rounds, terminal = degraded seed). Anchoring drives ambiguity down, so the
  expected terminal shifts from `interview_phase_deadline` (degraded) to
  `seed_ready` in **fewer** rounds — a wall-clock reduction, not a regression.

A maintainer with canonical-harness access should capture a real R-run before
merge if §I5 numbers are required; the change cannot regress per-round cost.

Budget compliance: [x] within 1.5× (per-round cost is non-increasing by construction)
