### PR TITLE
fix(evaluate): resolve project working dir fallback

### DIFF
--- a/skills/evaluate/SKILL.md
+++ b/skills/evaluate/SKILL.md
@@ -82,8 +82,11 @@ fallback instead of retrying the failing call.
      seed_content: <original seed YAML, if available>
      acceptance_criterion: <specific AC to check, optional>
      artifact_type: "code"  (or "docs", "config")
+     working_dir: <absolute project root, recommended>
      trigger_consensus: false  (true if user requests Stage 3)
    ```
+
+   `working_dir` controls both Stage 1 command execution and Stage 2 source-file visibility. Pass the absolute project root whenever available; if omitted, the MCP handler falls back to the registered brownfield default, seed project metadata, then the MCP server cwd.
 
 4. Present results clearly:
    - Show each stage's pass/fail status

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -73,7 +73,15 @@ async def _default_brownfield_project_dir() -> Path | None:
 
     if default_repo is None or not default_repo.path:
         return None
-    return Path(default_repo.path).expanduser().resolve()
+
+    resolved = Path(default_repo.path).expanduser().resolve()
+    if not resolved.is_dir():
+        log.warning(
+            "mcp.tool.evaluate.brownfield_default_unusable",
+            path=str(resolved),
+        )
+        return None
+    return resolved
 
 
 def _seed_project_dir(seed: Seed | None, *, stable_base: Path) -> Path | None:
@@ -109,7 +117,12 @@ async def _resolve_evaluate_working_dir(
 
     brownfield_default = await _default_brownfield_project_dir()
     if brownfield_default is not None:
-        return brownfield_default
+        if brownfield_default.is_dir():
+            return brownfield_default.resolve()
+        log.warning(
+            "mcp.tool.evaluate.brownfield_default_unusable",
+            path=str(brownfield_default),
+        )
 
     seed_dir = _seed_project_dir(seed, stable_base=stable_base)
     if seed_dir is not None:

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -18,6 +18,7 @@ import yaml
 
 from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
 from ouroboros.core.errors import ValidationError
+from ouroboros.core.project_paths import resolve_path_against_base
 from ouroboros.core.seed import Seed
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
@@ -54,6 +55,93 @@ from ouroboros.persistence.event_store import EventStore
 from ouroboros.providers import create_llm_adapter
 
 log = structlog.get_logger(__name__)
+
+
+async def _default_brownfield_project_dir() -> Path | None:
+    """Return the registered default brownfield project directory, if any."""
+    from ouroboros.persistence.brownfield import BrownfieldStore
+
+    store = BrownfieldStore()
+    try:
+        await store.initialize()
+        default_repo = await store.get_default()
+    except Exception as exc:  # noqa: BLE001 - fallback discovery must be best-effort
+        log.warning("mcp.tool.evaluate.brownfield_default_lookup_failed", error=str(exc))
+        return None
+    finally:
+        await store.close()
+
+    if default_repo is None or not default_repo.path:
+        return None
+    return Path(default_repo.path).expanduser().resolve()
+
+
+def _seed_project_dir(seed: Seed | None, *, stable_base: Path) -> Path | None:
+    """Resolve a project directory encoded in seed metadata/brownfield context."""
+    if seed is None:
+        return None
+
+    candidates: list[str] = []
+    seed_meta = getattr(seed, "metadata", None)
+    if seed_meta is not None:
+        project_dir = getattr(seed_meta, "project_dir", None) or getattr(
+            seed_meta,
+            "working_directory",
+            None,
+        )
+        if isinstance(project_dir, str) and project_dir:
+            candidates.append(project_dir)
+
+    brownfield_context = getattr(seed, "brownfield_context", None)
+    context_references = getattr(brownfield_context, "context_references", ()) or ()
+    for preferred_role in ("primary", None):
+        for reference in context_references:
+            path = getattr(reference, "path", None)
+            role = getattr(reference, "role", None)
+            if not isinstance(path, str) or not path or path in candidates:
+                continue
+            if preferred_role is None or role == preferred_role:
+                candidates.append(path)
+
+    for candidate in candidates:
+        resolved = resolve_path_against_base(candidate, stable_base=stable_base)
+        if resolved is None:
+            continue
+        if resolved.is_file():
+            return resolved.parent
+        if resolved.exists() and not resolved.is_dir():
+            continue
+        return resolved
+
+    return None
+
+
+async def _resolve_evaluate_working_dir(
+    explicit_working_dir: str | None,
+    seed: Seed | None,
+) -> Path:
+    """Resolve the project root that gates Stage 1 and Stage 2 evaluation.
+
+    Precedence is explicit tool argument, registered brownfield default,
+    seed-declared project directory, then the MCP server cwd. The last
+    fallback preserves the historical behavior, but only after project-aware
+    sources have been exhausted.
+    """
+    stable_base = Path.cwd().resolve()
+    if explicit_working_dir:
+        resolved = resolve_path_against_base(explicit_working_dir, stable_base=stable_base)
+        if resolved is not None:
+            return resolved
+
+    brownfield_default = await _default_brownfield_project_dir()
+    if brownfield_default is not None:
+        return brownfield_default
+
+    seed_dir = _seed_project_dir(seed, stable_base=stable_base)
+    if seed_dir is not None:
+        return seed_dir
+
+    return stable_base
 
 
 def _evaluation_allowed_tools(runtime_backend: str | None) -> list[str]:
@@ -340,7 +428,8 @@ class EvaluateHandler:
                     type=ToolInputType.STRING,
                     description=(
                         "Project root used to resolve Stage 1 mechanical verification "
-                        "commands. Commands are read from .ouroboros/mechanical.toml; "
+                        "commands and Stage 2 source-file visibility. Commands are "
+                        "read from .ouroboros/mechanical.toml; "
                         "when the file is missing, the evaluator makes one AI detect "
                         "call that inspects manifests (package.json, pyproject.toml, "
                         "Cargo.toml, Makefile, ...) and authors the toml. Stage 1 "
@@ -363,8 +452,6 @@ class EvaluateHandler:
         Returns:
             Result containing evaluation results or error.
         """
-        from pathlib import Path
-
         from ouroboros.evaluation import (
             EvaluationContext,
             EvaluationPipeline,
@@ -424,6 +511,26 @@ class EvaluateHandler:
             trigger_consensus=trigger_consensus,
         )
 
+        # Parse seed before dispatch so working_dir fallback is available for
+        # both plugin/subagent and in-process evaluation paths.
+        goal = ""
+        constraints: tuple[str, ...] = ()
+        seed_id = session_id  # fallback
+        seed: Seed | None = None
+
+        if seed_content:
+            try:
+                seed_dict = yaml.safe_load(seed_content)
+                seed = Seed.from_dict(seed_dict)
+                goal = seed.goal
+                constraints = tuple(seed.constraints)
+                seed_id = seed.metadata.seed_id
+            except (yaml.YAMLError, ValidationError, PydanticValidationError) as e:
+                log.warning("mcp.tool.evaluate.seed_parse_warning", error=str(e))
+                # Continue without seed data - not fatal
+
+        working_dir = await _resolve_evaluate_working_dir(arguments.get("working_dir"), seed)
+
         # --- Subagent dispatch: gate on runtime + opencode_mode ---
         payload = build_evaluate_subagent(
             session_id=session_id,
@@ -431,7 +538,7 @@ class EvaluateHandler:
             artifact_type=artifact_type,
             seed_content=seed_content,
             acceptance_criterion=acceptance_criterion,
-            working_dir=arguments.get("working_dir"),
+            working_dir=str(working_dir),
             trigger_consensus=trigger_consensus,
         )
         if should_dispatch_via_plugin(self.agent_runtime_backend, self.opencode_mode):
@@ -456,22 +563,6 @@ class EvaluateHandler:
         owns_event_store = False
 
         try:
-            # Extract goal/constraints from seed if provided
-            goal = ""
-            constraints: tuple[str, ...] = ()
-            seed_id = session_id  # fallback
-
-            if seed_content:
-                try:
-                    seed_dict = yaml.safe_load(seed_content)
-                    seed = Seed.from_dict(seed_dict)
-                    goal = seed.goal
-                    constraints = tuple(seed.constraints)
-                    seed_id = seed.metadata.seed_id
-                except (yaml.YAMLError, ValidationError, PydanticValidationError) as e:
-                    log.warning("mcp.tool.evaluate.seed_parse_warning", error=str(e))
-                    # Continue without seed data - not fatal
-
             # Try to enrich from session repository if event_store available
             if not goal:
                 if store is None:
@@ -508,8 +599,6 @@ class EvaluateHandler:
                 allowed_tools=_evaluation_allowed_tools(backend),
                 max_turns=20,
             )
-            working_dir_str = arguments.get("working_dir")
-            working_dir = Path(working_dir_str).resolve() if working_dir_str else Path.cwd()
             log.info(
                 "mcp.tool.evaluate.started",
                 session_id=session_id,

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -1862,13 +1862,27 @@ class StartEvaluateHandler:
             else:
                 ac_for_payload = None
 
+            seed: Seed | None = None
+            seed_content = arguments.get("seed_content")
+            if seed_content:
+                try:
+                    seed_dict = yaml.safe_load(seed_content)
+                    seed = Seed.from_dict(seed_dict)
+                except (yaml.YAMLError, ValidationError, PydanticValidationError) as e:
+                    log.warning("mcp.tool.start_evaluate.seed_parse_warning", error=str(e))
+
+            working_dir = await _resolve_evaluate_working_dir(
+                arguments.get("working_dir"),
+                seed,
+            )
+
             payload = build_evaluate_subagent(
                 session_id=session_id,
                 artifact=artifact,
                 artifact_type=arguments.get("artifact_type", "code"),
-                seed_content=arguments.get("seed_content"),
+                seed_content=seed_content,
                 acceptance_criterion=ac_for_payload,
-                working_dir=arguments.get("working_dir"),
+                working_dir=str(working_dir),
                 trigger_consensus=arguments.get("trigger_consensus", False),
             )
             return await dispatch_plugin_terminal(

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -18,7 +18,7 @@ import yaml
 
 from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
 from ouroboros.core.errors import ValidationError
-from ouroboros.core.project_paths import resolve_path_against_base
+from ouroboros.core.project_paths import resolve_path_against_base, resolve_seed_project_path
 from ouroboros.core.seed import Seed
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
@@ -77,43 +77,17 @@ async def _default_brownfield_project_dir() -> Path | None:
 
 
 def _seed_project_dir(seed: Seed | None, *, stable_base: Path) -> Path | None:
-    """Resolve a project directory encoded in seed metadata/brownfield context."""
-    if seed is None:
+    """Resolve a contained project directory encoded in seed metadata/context."""
+    resolution = resolve_seed_project_path(seed, stable_base=stable_base)
+    if resolution.path is None:
         return None
 
-    candidates: list[str] = []
-    seed_meta = getattr(seed, "metadata", None)
-    if seed_meta is not None:
-        project_dir = getattr(seed_meta, "project_dir", None) or getattr(
-            seed_meta,
-            "working_directory",
-            None,
-        )
-        if isinstance(project_dir, str) and project_dir:
-            candidates.append(project_dir)
-
-    brownfield_context = getattr(seed, "brownfield_context", None)
-    context_references = getattr(brownfield_context, "context_references", ()) or ()
-    for preferred_role in ("primary", None):
-        for reference in context_references:
-            path = getattr(reference, "path", None)
-            role = getattr(reference, "role", None)
-            if not isinstance(path, str) or not path or path in candidates:
-                continue
-            if preferred_role is None or role == preferred_role:
-                candidates.append(path)
-
-    for candidate in candidates:
-        resolved = resolve_path_against_base(candidate, stable_base=stable_base)
-        if resolved is None:
-            continue
-        if resolved.is_file():
-            return resolved.parent
-        if resolved.exists() and not resolved.is_dir():
-            continue
-        return resolved
-
-    return None
+    resolved = resolution.path
+    if resolved.is_file():
+        return resolved.parent
+    if resolved.exists() and not resolved.is_dir():
+        return None
+    return resolved
 
 
 async def _resolve_evaluate_working_dir(

--- a/tests/unit/mcp/tools/test_evaluate_multi_ac.py
+++ b/tests/unit/mcp/tools/test_evaluate_multi_ac.py
@@ -145,6 +145,52 @@ class TestEvaluateWorkingDirResolution:
 
         assert resolved == default.resolve()
 
+
+    async def test_stale_brownfield_default_falls_back_to_seed(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        cwd = tmp_path / "hermes"
+        stale_default = tmp_path / "missing-default"
+        seed_project = cwd / "seed-project"
+        cwd.mkdir()
+        seed_project.mkdir()
+        monkeypatch.chdir(cwd)
+        seed = SimpleNamespace(
+            metadata=SimpleNamespace(project_dir="seed-project", working_directory=None),
+            brownfield_context=None,
+        )
+
+        with patch(
+            "ouroboros.mcp.tools.evaluation_handlers._default_brownfield_project_dir",
+            new=AsyncMock(return_value=stale_default),
+        ):
+            resolved = await _resolve_evaluate_working_dir(None, seed)
+
+        assert resolved == seed_project.resolve()
+
+    async def test_non_directory_brownfield_default_falls_back_to_seed(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        cwd = tmp_path / "hermes"
+        file_default = tmp_path / "default-file"
+        seed_project = cwd / "seed-project"
+        cwd.mkdir()
+        file_default.write_text("not a directory")
+        seed_project.mkdir()
+        monkeypatch.chdir(cwd)
+        seed = SimpleNamespace(
+            metadata=SimpleNamespace(project_dir="seed-project", working_directory=None),
+            brownfield_context=None,
+        )
+
+        with patch(
+            "ouroboros.mcp.tools.evaluation_handlers._default_brownfield_project_dir",
+            new=AsyncMock(return_value=file_default),
+        ):
+            resolved = await _resolve_evaluate_working_dir(None, seed)
+
+        assert resolved == seed_project.resolve()
+
     async def test_seed_metadata_escape_falls_back_to_cwd(
         self, tmp_path: Path, monkeypatch
     ) -> None:

--- a/tests/unit/mcp/tools/test_evaluate_multi_ac.py
+++ b/tests/unit/mcp/tools/test_evaluate_multi_ac.py
@@ -8,6 +8,8 @@ deliberately left untouched here.
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -20,7 +22,7 @@ from ouroboros.evaluation.models import (
     MechanicalResult,
     SemanticResult,
 )
-from ouroboros.mcp.tools.evaluation_handlers import EvaluateHandler
+from ouroboros.mcp.tools.evaluation_handlers import EvaluateHandler, _resolve_evaluate_working_dir
 from ouroboros.mcp.types import ToolInputType
 
 
@@ -70,6 +72,67 @@ def _failing_eval(execution_id: str, *, reason: str) -> EvaluationResult:
         ),
         final_approved=False,
     )
+
+
+class TestEvaluateWorkingDirResolution:
+    """Working dir fallback keeps Stage 2 pointed at the project root."""
+
+    async def test_explicit_working_dir_wins(self, tmp_path: Path) -> None:
+        explicit = tmp_path / "project"
+        explicit.mkdir()
+
+        with patch(
+            "ouroboros.mcp.tools.evaluation_handlers._default_brownfield_project_dir",
+            new=AsyncMock(return_value=tmp_path / "default"),
+        ):
+            resolved = await _resolve_evaluate_working_dir(str(explicit), None)
+
+        assert resolved == explicit.resolve()
+
+    async def test_brownfield_default_used_before_cwd(self, tmp_path: Path, monkeypatch) -> None:
+        cwd = tmp_path / "hermes"
+        default = tmp_path / "repo"
+        cwd.mkdir()
+        default.mkdir()
+        monkeypatch.chdir(cwd)
+
+        with patch(
+            "ouroboros.mcp.tools.evaluation_handlers._default_brownfield_project_dir",
+            new=AsyncMock(return_value=default),
+        ):
+            resolved = await _resolve_evaluate_working_dir(None, None)
+
+        assert resolved == default.resolve()
+
+    async def test_seed_metadata_used_when_no_default(self, tmp_path: Path, monkeypatch) -> None:
+        cwd = tmp_path / "hermes"
+        project = tmp_path / "project"
+        cwd.mkdir()
+        project.mkdir()
+        monkeypatch.chdir(cwd)
+        seed = SimpleNamespace(
+            metadata=SimpleNamespace(project_dir=str(project), working_directory=None),
+            brownfield_context=None,
+        )
+
+        with patch(
+            "ouroboros.mcp.tools.evaluation_handlers._default_brownfield_project_dir",
+            new=AsyncMock(return_value=None),
+        ):
+            resolved = await _resolve_evaluate_working_dir(None, seed)
+
+        assert resolved == project.resolve()
+
+    async def test_cwd_fallback_last(self, tmp_path: Path, monkeypatch) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        with patch(
+            "ouroboros.mcp.tools.evaluation_handlers._default_brownfield_project_dir",
+            new=AsyncMock(return_value=None),
+        ):
+            resolved = await _resolve_evaluate_working_dir(None, None)
+
+        assert resolved == tmp_path.resolve()
 
 
 class TestDefinitionAcceptsMultiAC:

--- a/tests/unit/mcp/tools/test_evaluate_multi_ac.py
+++ b/tests/unit/mcp/tools/test_evaluate_multi_ac.py
@@ -106,12 +106,11 @@ class TestEvaluateWorkingDirResolution:
 
     async def test_seed_metadata_used_when_no_default(self, tmp_path: Path, monkeypatch) -> None:
         cwd = tmp_path / "hermes"
-        project = tmp_path / "project"
-        cwd.mkdir()
-        project.mkdir()
+        project = cwd / "project"
+        project.mkdir(parents=True)
         monkeypatch.chdir(cwd)
         seed = SimpleNamespace(
-            metadata=SimpleNamespace(project_dir=str(project), working_directory=None),
+            metadata=SimpleNamespace(project_dir="project", working_directory=None),
             brownfield_context=None,
         )
 
@@ -122,6 +121,50 @@ class TestEvaluateWorkingDirResolution:
             resolved = await _resolve_evaluate_working_dir(None, seed)
 
         assert resolved == project.resolve()
+
+    async def test_brownfield_default_wins_over_seed_metadata(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        cwd = tmp_path / "hermes"
+        default = tmp_path / "repo-default"
+        seed_project = cwd / "seed-project"
+        cwd.mkdir()
+        default.mkdir()
+        seed_project.mkdir()
+        monkeypatch.chdir(cwd)
+        seed = SimpleNamespace(
+            metadata=SimpleNamespace(project_dir="seed-project", working_directory=None),
+            brownfield_context=None,
+        )
+
+        with patch(
+            "ouroboros.mcp.tools.evaluation_handlers._default_brownfield_project_dir",
+            new=AsyncMock(return_value=default),
+        ):
+            resolved = await _resolve_evaluate_working_dir(None, seed)
+
+        assert resolved == default.resolve()
+
+    async def test_seed_metadata_escape_falls_back_to_cwd(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        cwd = tmp_path / "hermes"
+        outside = tmp_path / "outside"
+        cwd.mkdir()
+        outside.mkdir()
+        monkeypatch.chdir(cwd)
+        seed = SimpleNamespace(
+            metadata=SimpleNamespace(project_dir=str(outside), working_directory=None),
+            brownfield_context=None,
+        )
+
+        with patch(
+            "ouroboros.mcp.tools.evaluation_handlers._default_brownfield_project_dir",
+            new=AsyncMock(return_value=None),
+        ):
+            resolved = await _resolve_evaluate_working_dir(None, seed)
+
+        assert resolved == cwd.resolve()
 
     async def test_cwd_fallback_last(self, tmp_path: Path, monkeypatch) -> None:
         monkeypatch.chdir(tmp_path)

--- a/tests/unit/mcp/tools/test_evaluate_multi_ac.py
+++ b/tests/unit/mcp/tools/test_evaluate_multi_ac.py
@@ -145,7 +145,6 @@ class TestEvaluateWorkingDirResolution:
 
         assert resolved == default.resolve()
 
-
     async def test_stale_brownfield_default_falls_back_to_seed(
         self, tmp_path: Path, monkeypatch
     ) -> None:

--- a/tests/unit/mcp/tools/test_start_evaluate.py
+++ b/tests/unit/mcp/tools/test_start_evaluate.py
@@ -11,7 +11,8 @@ background task, let callers poll ``job_status`` / ``job_wait`` / ``job_result``
 from __future__ import annotations
 
 import inspect
-from unittest.mock import AsyncMock, MagicMock
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -221,6 +222,23 @@ class TestPluginModeDispatch:
         )
         payload_context = result.value.meta["_subagent"]["context"]
         assert payload_context["acceptance_criterion"] == "Wins"
+
+    @pytest.mark.asyncio
+    async def test_plugin_payload_uses_brownfield_default_when_working_dir_omitted(
+        self, handler, tmp_path: Path
+    ) -> None:
+        default_project = tmp_path / "project"
+        default_project.mkdir()
+
+        with patch(
+            "ouroboros.mcp.tools.evaluation_handlers._default_brownfield_project_dir",
+            new=AsyncMock(return_value=default_project),
+        ):
+            result = await handler.handle({"session_id": "orch_xyz", "artifact": "code"})
+
+        assert result.is_ok
+        payload_context = result.value.meta["_subagent"]["context"]
+        assert payload_context["working_dir"] == str(default_project.resolve())
 
 
 class TestFactoryWiring:

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -123,6 +123,7 @@ _EXPECTED_OUROBOROS_REQUIRED_CONTEXT_KEYS = {
         "artifact",
         "seed_content",
         "acceptance_criterion",
+        "working_dir",
     ),
     "ouroboros_evolve_rewind": ("lineage_id", "to_generation"),
     "ouroboros_evolve_step": ("lineage_id",),


### PR DESCRIPTION
## Summary
- Document `working_dir` in the evaluate skill and clarify that it controls Stage 2 source-file visibility as well as Stage 1 commands.
- Resolve evaluate working directories from explicit `working_dir`, registered brownfield default, seed metadata/context, then cwd.
- Pass the resolved project root through plugin/subagent dispatch and in-process evaluation.
- Add regression coverage for explicit, brownfield-default, seed metadata, and cwd fallback paths.

## Test plan
- `uv run ruff check src/ouroboros/mcp/tools/evaluation_handlers.py tests/unit/mcp/tools/test_evaluate_multi_ac.py`
- `uv run pytest tests/unit/mcp/tools/test_evaluate_multi_ac.py tests/unit/mcp/tools/test_definitions.py -q` — 148 passed
- `uv run pytest tests/unit/mcp/tools/test_evaluate_multi_ac.py tests/unit/mcp/tools/test_definitions.py tests/unit/mcp/tools/test_start_evaluate.py tests/unit/mcp/tools/test_checklist_verify.py tests/unit/mcp/tools/test_handler_subagent_wiring.py -q` — 210 passed

Closes #1490
Refs #1491