### PR TITLE
feat(auto): add intent provenance guard for interviews

### DIFF
--- a/src/ouroboros/auto/answerer.py
+++ b/src/ouroboros/auto/answerer.py
@@ -1765,7 +1765,7 @@ _INTENT_TO_SECTIONS: dict[QuestionIntent, tuple[str, ...]] = {
     QuestionIntent.ACCEPTANCE_CRITERIA: ("acceptance_criteria",),
     QuestionIntent.ACTOR_IO: ("actors", "inputs", "outputs"),
     QuestionIntent.RUNTIME_CONTEXT: ("runtime_context",),
-    QuestionIntent.PRODUCT_BEHAVIOR: ("constraints",),
+    QuestionIntent.PRODUCT_BEHAVIOR: ("acceptance_criteria", "outputs", "constraints"),
 }
 
 

--- a/src/ouroboros/auto/intent_guard.py
+++ b/src/ouroboros/auto/intent_guard.py
@@ -1,0 +1,474 @@
+"""Pre-Seed intent provenance checks for ``ooo auto`` interviews.
+
+TraceGuard verifies runtime acceptance evidence. IntentGuard runs earlier: it
+checks whether generated interview framing is still subordinate to the original
+user contract before the answer is applied to the Seed draft ledger.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from ouroboros.auto.ledger import (
+    LedgerSource,
+    LedgerStatus,
+    SeedDraftLedger,
+)
+
+
+class IntentGuardStatus(StrEnum):
+    PASS = "pass"
+    WARN = "warn"
+    FAIL = "fail"
+
+
+@dataclass(frozen=True, slots=True)
+class IntentGuardCheck:
+    code: str
+    status: IntentGuardStatus
+    message: str
+    action: str | None = None
+
+    def to_dict(self) -> dict[str, str]:
+        data = {
+            "code": self.code,
+            "status": self.status.value,
+            "message": self.message,
+        }
+        if self.action:
+            data["action"] = self.action
+        return data
+
+
+@dataclass(frozen=True, slots=True)
+class IntentGuardReport:
+    checks: tuple[IntentGuardCheck, ...]
+
+    @property
+    def status(self) -> IntentGuardStatus:
+        if any(check.status is IntentGuardStatus.FAIL for check in self.checks):
+            return IntentGuardStatus.FAIL
+        if any(check.status is IntentGuardStatus.WARN for check in self.checks):
+            return IntentGuardStatus.WARN
+        return IntentGuardStatus.PASS
+
+    @property
+    def failed(self) -> bool:
+        return self.status is IntentGuardStatus.FAIL
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "checks": [check.to_dict() for check in self.checks],
+        }
+
+    def render_lines(self) -> list[str]:
+        lines = [f"IntentGuard: {self.status.value}"]
+        for check in self.checks:
+            line = f"  {check.status.value.upper()} {check.code}: {check.message}"
+            if check.action:
+                line = f"{line} Action: {check.action}"
+            lines.append(line)
+        return lines
+
+
+_OUTPUT_SECTIONS = ("outputs", "acceptance_criteria")
+_EVIDENCE_SOURCES = {
+    LedgerSource.USER_GOAL,
+    LedgerSource.USER_PREFERENCE,
+    LedgerSource.REPO_FACT,
+    LedgerSource.EXISTING_CONVENTION,
+}
+_ACTIVE_STATUSES = {
+    LedgerStatus.CONFIRMED,
+    LedgerStatus.DEFAULTED,
+    LedgerStatus.INFERRED,
+}
+
+_ARTIFACT_OUTPUT_TERMS = (
+    "artifact",
+    "artifacts",
+    "file",
+    "files",
+    "output",
+    "outputs",
+    "export",
+    "exports",
+    "video",
+    "videos",
+    "mp4",
+    "clip",
+    "clips",
+    "short",
+    "shorts",
+    "long-form",
+    "long form",
+    "transcript",
+    "transcripts",
+    "json",
+    "csv",
+    "pdf",
+    "html",
+    "report",
+    "reports",
+)
+
+_ARTIFACT_GENERATION_TERMS = (
+    "make",
+    "makes",
+    "create",
+    "creates",
+    "generate",
+    "generates",
+    "produce",
+    "produces",
+    "export",
+    "exports",
+    "write",
+    "writes",
+)
+
+_REVIEW_ONLY_TERMS = (
+    "review-only",
+    "review only",
+    "review package",
+    "--mode review",
+    "reject automated export",
+    "rejects automated export",
+    "without automated export",
+    "no automated export",
+    "no mp4",
+    "no export",
+)
+
+_DIAGNOSTIC_MARKERS = (
+    "[seed qa repair attempt",
+    "[seed qa lateral repair attempt",
+    "# lateral thinking:",
+    "qa differences:",
+    "qa suggestions:",
+)
+
+_HUMAN_ANSWER_SOURCES = {
+    "human",
+    "user",
+    "user_answer",
+    "user_response",
+}
+
+_EVIDENCE_ANSWER_SOURCES = {
+    "user_goal",
+    "user_preference",
+    "repo_fact",
+    "existing_convention",
+    *_HUMAN_ANSWER_SOURCES,
+}
+
+
+def guard_auto_answer(
+    *,
+    goal: str,
+    user_preferences: Mapping[str, str],
+    ledger: SeedDraftLedger,
+    question: str,
+    answer_text: str,
+    answer_source: str,
+) -> IntentGuardReport:
+    """Check a proposed auto-interview answer before it mutates the ledger."""
+    checks: list[IntentGuardCheck] = []
+    contract = _artifact_contract(goal, user_preferences, ledger)
+    if contract is None:
+        if _looks_like_artifact_generation(goal):
+            checks.append(
+                IntentGuardCheck(
+                    code="intent_lock_missing",
+                    status=IntentGuardStatus.WARN,
+                    message="goal looks artifact-producing, but no evidence-backed output contract is locked",
+                    action="derive outputs/acceptance_criteria from the user goal or ask one more question",
+                )
+            )
+        return IntentGuardReport(tuple(checks))
+
+    checks.append(
+        IntentGuardCheck(
+            code="intent_lock_present",
+            status=IntentGuardStatus.PASS,
+            message="evidence-backed output contract is locked from user intent",
+        )
+    )
+    conflict = _generated_review_option_conflicts(
+        contract_text=contract,
+        question=question,
+        answer_text=answer_text,
+        answer_source=answer_source,
+    )
+    if conflict:
+        checks.append(
+            IntentGuardCheck(
+                code="generated_option_conflict",
+                status=IntentGuardStatus.FAIL,
+                message="generated review-only framing conflicts with the user output contract",
+                action="discard the generated option and answer from USER_GOAL/USER_PREFERENCE; block if retry still conflicts",
+            )
+        )
+    return IntentGuardReport(tuple(checks))
+
+
+def guard_interview_turn(
+    *,
+    goal: str,
+    question: str,
+    answer_text: str,
+    answer_source: str,
+) -> IntentGuardReport:
+    """Check one interactive interview turn using the shared intent contract.
+
+    Human answers may intentionally change the contract, so conflicting human
+    responses produce WARN instead of FAIL. Generated or assumption-class
+    answers still fail closed, matching ``ooo auto``.
+    """
+    ledger = SeedDraftLedger.from_goal(goal)
+    checks: list[IntentGuardCheck] = []
+    contract = _artifact_contract(goal, {}, ledger)
+    if contract is None:
+        if _looks_like_artifact_generation(goal):
+            checks.append(
+                IntentGuardCheck(
+                    code="intent_lock_missing",
+                    status=IntentGuardStatus.WARN,
+                    message="goal looks artifact-producing, but no output contract is locked",
+                    action="ask one clarifying question before accepting generated product-behavior framing",
+                )
+            )
+        return IntentGuardReport(tuple(checks))
+
+    checks.append(
+        IntentGuardCheck(
+            code="intent_lock_present",
+            status=IntentGuardStatus.PASS,
+            message="initial interview context contains an artifact-output contract",
+        )
+    )
+    question_has_generated_choice = _contains_review_only_option(question) or (
+        "--mode auto" in question.casefold() and "--mode review" in question.casefold()
+    )
+    answer_has_review_only = _contains_review_only_option(answer_text) or (
+        "review" in answer_text.casefold()
+        and not _has_artifact_output_terms(answer_text)
+        and question_has_generated_choice
+    )
+    if not question_has_generated_choice or not answer_has_review_only:
+        return IntentGuardReport(tuple(checks))
+
+    source = answer_source.strip().casefold()
+    if source in _HUMAN_ANSWER_SOURCES:
+        checks.append(
+            IntentGuardCheck(
+                code="user_contract_change",
+                status=IntentGuardStatus.WARN,
+                message="human answer appears to change the initial output contract toward review-only behavior",
+                action="record it, but ask/confirm whether this is an intentional scope change before Seed generation",
+            )
+        )
+    elif source not in _EVIDENCE_ANSWER_SOURCES:
+        checks.append(
+            IntentGuardCheck(
+                code="generated_option_conflict",
+                status=IntentGuardStatus.FAIL,
+                message="generated interview answer conflicts with the initial user output contract",
+                action="do not record this answer; ask the human to confirm the product behavior",
+            )
+        )
+    return IntentGuardReport(tuple(checks))
+
+
+def diagnose_auto_state(
+    *,
+    goal: str,
+    user_preferences: Mapping[str, str],
+    ledger: SeedDraftLedger | None,
+    pending_question: str | None,
+    auto_answer_log: Sequence[Mapping[str, Any]],
+    seed_artifact: Mapping[str, Any] | None = None,
+) -> IntentGuardReport:
+    """Return a status/doctor projection for a persisted auto session."""
+    checks: list[IntentGuardCheck] = []
+    ledger = ledger or SeedDraftLedger.from_goal(goal)
+    contract = _artifact_contract(goal, user_preferences, ledger)
+    if contract is None:
+        if _looks_like_artifact_generation(goal):
+            checks.append(
+                IntentGuardCheck(
+                    code="intent_lock_missing",
+                    status=IntentGuardStatus.WARN,
+                    message="artifact-producing goal has no locked outputs/acceptance_criteria preference",
+                    action="re-derive the output contract from the original user goal before answering product-behavior questions",
+                )
+            )
+        else:
+            checks.append(
+                IntentGuardCheck(
+                    code="intent_contract_not_applicable",
+                    status=IntentGuardStatus.PASS,
+                    message="goal does not look like an artifact-output request",
+                )
+            )
+    else:
+        checks.append(
+            IntentGuardCheck(
+                code="intent_lock_present",
+                status=IntentGuardStatus.PASS,
+                message="output contract is anchored in user/repo evidence",
+            )
+        )
+        if pending_question and _contains_review_only_option(pending_question):
+            checks.append(
+                IntentGuardCheck(
+                    code="generated_option_present",
+                    status=IntentGuardStatus.WARN,
+                    message="pending question contains a generated review-only option next to a user output contract",
+                    action="prefer USER_GOAL/USER_PREFERENCE when answering; do not let the generated option win",
+                )
+            )
+        for entry in auto_answer_log[-5:]:
+            question = str(entry.get("question", ""))
+            answer = str(entry.get("answer", ""))
+            source = str(entry.get("source", ""))
+            if _generated_review_option_conflicts(
+                contract_text=contract,
+                question=question,
+                answer_text=answer,
+                answer_source=source,
+            ):
+                checks.append(
+                    IntentGuardCheck(
+                        code="generated_option_conflict",
+                        status=IntentGuardStatus.FAIL,
+                        message="recent auto answer appears to have accepted review-only framing over user output intent",
+                        action="discard that answer, reopen the round, and re-answer from USER_GOAL/USER_PREFERENCE",
+                    )
+                )
+                break
+
+    if _seed_artifact_has_diagnostic_constraints(seed_artifact or {}):
+        checks.append(
+            IntentGuardCheck(
+                code="spec_pollution",
+                status=IntentGuardStatus.FAIL,
+                message="Seed constraints contain pasted QA/lateral diagnostic prose",
+                action="normalize diagnostics into short repair constraints before Seed review",
+            )
+        )
+    else:
+        checks.append(
+            IntentGuardCheck(
+                code="spec_pollution",
+                status=IntentGuardStatus.PASS,
+                message="Seed constraints do not contain known diagnostic markers",
+            )
+        )
+    return IntentGuardReport(tuple(checks))
+
+
+def diagnose_auto_pipeline_state(state: Any) -> IntentGuardReport:
+    """Build an IntentGuard report from a persisted ``AutoPipelineState``-like object."""
+    ledger = None
+    ledger_data = getattr(state, "ledger", None)
+    if ledger_data:
+        try:
+            ledger = SeedDraftLedger.from_dict(ledger_data)
+        except ValueError:
+            ledger = None
+    return diagnose_auto_state(
+        goal=str(getattr(state, "goal", "")),
+        user_preferences=getattr(state, "user_preferences", {}) or {},
+        ledger=ledger,
+        pending_question=getattr(state, "pending_question", None),
+        auto_answer_log=getattr(state, "auto_answer_log", ()) or (),
+        seed_artifact=getattr(state, "seed_artifact", {}) or {},
+    )
+
+
+def _artifact_contract(
+    goal: str,
+    user_preferences: Mapping[str, str],
+    ledger: SeedDraftLedger,
+) -> str | None:
+    parts: list[str] = []
+    for section in _OUTPUT_SECTIONS:
+        value = user_preferences.get(section)
+        if isinstance(value, str) and value.strip():
+            parts.append(value.strip())
+    for section_name in _OUTPUT_SECTIONS:
+        section = ledger.sections.get(section_name)
+        if section is None:
+            continue
+        for entry in section.entries:
+            if entry.source in _EVIDENCE_SOURCES and entry.status in _ACTIVE_STATUSES:
+                parts.append(entry.value.strip())
+    if not parts and _looks_like_artifact_generation(goal):
+        return goal.strip()
+    text = "\n".join(part for part in parts if part)
+    if not _has_artifact_output_terms(text):
+        return None
+    return text
+
+
+def _generated_review_option_conflicts(
+    *,
+    contract_text: str,
+    question: str,
+    answer_text: str,
+    answer_source: str,
+) -> bool:
+    if not _has_artifact_output_terms(contract_text):
+        return False
+    source = answer_source.strip().casefold()
+    if source in {"user_goal", "user_preference", "repo_fact", "existing_convention"}:
+        return False
+    question_has_generated_choice = _contains_review_only_option(question) or (
+        "--mode auto" in question.casefold() and "--mode review" in question.casefold()
+    )
+    if not question_has_generated_choice:
+        return False
+    answer_lower = answer_text.casefold()
+    if _contains_review_only_option(answer_lower):
+        return True
+    return "review" in answer_lower and not _has_artifact_output_terms(answer_lower)
+
+
+def _contains_review_only_option(text: str) -> bool:
+    lowered = text.casefold()
+    return any(term in lowered for term in _REVIEW_ONLY_TERMS)
+
+
+def _looks_like_artifact_generation(text: str) -> bool:
+    lowered = text.casefold()
+    return (
+        bool(text.strip())
+        and any(term in lowered for term in _ARTIFACT_GENERATION_TERMS)
+        and _has_artifact_output_terms(lowered)
+        and not _contains_review_only_option(lowered)
+    )
+
+
+def _has_artifact_output_terms(text: str) -> bool:
+    lowered = text.casefold()
+    return any(term in lowered for term in _ARTIFACT_OUTPUT_TERMS)
+
+
+def _seed_artifact_has_diagnostic_constraints(seed_artifact: Mapping[str, Any]) -> bool:
+    constraints = seed_artifact.get("constraints")
+    if constraints is None:
+        return False
+    if isinstance(constraints, str):
+        text = constraints
+    elif isinstance(constraints, Sequence):
+        text = "\n".join(str(item) for item in constraints)
+    else:
+        text = str(constraints)
+    lowered = text.casefold()
+    return any(marker in lowered for marker in _DIAGNOSTIC_MARKERS)

--- a/src/ouroboros/auto/interview_driver.py
+++ b/src/ouroboros/auto/interview_driver.py
@@ -27,6 +27,7 @@ from ouroboros.auto.answerer import (
 )
 from ouroboros.auto.blocker_attribution import record_authoring_backend
 from ouroboros.auto.gap_detector import GapDetector
+from ouroboros.auto.intent_guard import IntentGuardStatus, guard_auto_answer
 from ouroboros.auto.lateral_routing import (
     select_persona_for_qa_failure,
     select_persona_for_safe_default_block,
@@ -818,6 +819,27 @@ class AutoInterviewDriver:
                     state.current_round,
                     blocker_text,
                 )
+            answer = self._guard_intent_answer(
+                state,
+                answer,
+                ledger,
+                answer_context,
+                question=question_for_record,
+            )
+            if answer.blocker is not None:
+                self.answerer.apply(answer, ledger, question=question_for_record)
+                state.ledger = ledger.to_dict()
+                blocker_text = answer.blocker.reason
+                state.mark_blocked(blocker_text, tool_name="intent_guard")
+                record_authoring_backend(state)
+                self._save(state)
+                return AutoInterviewResult(
+                    "blocked",
+                    state.interview_session_id,
+                    ledger,
+                    state.current_round,
+                    blocker_text,
+                )
             # Apply the answer to the in-memory ledger only. Do NOT persist
             # ``state.ledger`` / ``state.current_round`` / ``state.pending_question``
             # / ``state.auto_answer_log`` until ``backend.answer`` acknowledges
@@ -1386,6 +1408,47 @@ class AutoInterviewDriver:
             source=AutoAnswerSource.BLOCKER,
             confidence=1.0,
             blocker=blocker,
+        )
+
+    def _guard_intent_answer(
+        self,
+        state: AutoPipelineState,
+        answer: AutoAnswer,
+        ledger: SeedDraftLedger,
+        context: AutoAnswerContext,
+        *,
+        question: str,
+    ) -> AutoAnswer:
+        """Fail closed when generated interview framing conflicts with user intent."""
+        if answer.blocker is not None:
+            return answer
+        report = guard_auto_answer(
+            goal=state.goal,
+            user_preferences=context.user_preferences,
+            ledger=ledger,
+            question=question,
+            answer_text=answer.text,
+            answer_source=answer.source.value,
+        )
+        if not report.failed:
+            return answer
+        failure = next(check for check in report.checks if check.status is IntentGuardStatus.FAIL)
+        reason = f"IntentGuard blocked auto answer: {failure.message}"
+        if failure.action:
+            reason = f"{reason} ({failure.action})"
+        log.warning(
+            "auto.interview.intent_guard_blocked",
+            auto_session_id=state.auto_session_id,
+            code=failure.code,
+            answer_source=answer.source.value,
+            question=question[:500],
+            answer=answer.text[:500],
+        )
+        return AutoAnswer(
+            text=f"Cannot safely decide automatically: {reason}",
+            source=AutoAnswerSource.BLOCKER,
+            confidence=1.0,
+            blocker=AutoBlocker(reason=reason, question=question),
         )
 
     def _answer_reduces_open_gaps(

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4662,9 +4662,7 @@ def _normalized_seed_qa_feedback(qa_result: EvaluateResult) -> tuple[str, ...]:
     if "ambiguity_score" in lowered:
         repairs.append("Seed metadata must satisfy the readiness gate: ambiguity_score <= 0.20.")
     if "non_goals" in lowered or "non-goals" in lowered or "runtime_context" in lowered:
-        repairs.append(
-            "Preserve ledger non-goals and runtime context in executable Seed surfaces."
-        )
+        repairs.append("Preserve ledger non-goals and runtime context in executable Seed surfaces.")
     if "polluted" in lowered or "diagnostic" in lowered or "lateral repair" in lowered:
         repairs.append(
             "Constraints must contain only actionable product/runtime constraints; omit QA or lateral diagnostic prose."
@@ -4676,8 +4674,12 @@ def _normalized_seed_qa_feedback(qa_result: EvaluateResult) -> tuple[str, ...]:
     if "review-blocking" in lowered:
         repairs.append("Introduce the review-blocking post-QA constraint before execution.")
     if "templated" in lowered or "indirect" in lowered:
-        repairs.append("Acceptance criteria must be direct executable checks, not generic templates.")
-    if "partial" in lowered and ("output" in lowered or "mp4" in lowered or "transcript" in lowered):
+        repairs.append(
+            "Acceptance criteria must be direct executable checks, not generic templates."
+        )
+    if "partial" in lowered and (
+        "output" in lowered or "mp4" in lowered or "transcript" in lowered
+    ):
         repairs.append("Failure paths must leave no partial output artifacts.")
     if not repairs:
         repairs.append("Resolve Seed QA feedback before execution without adding diagnostic prose.")

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4568,16 +4568,15 @@ def _seed_with_seed_qa_lateral_feedback(
 
 def _seed_with_seed_qa_feedback(seed: Seed, qa_result: EvaluateResult, *, attempt: int) -> Seed:
     """Return a Seed revised with bounded pre-run Seed QA feedback."""
-    feedback = [*qa_result.differences[:3], *qa_result.suggestions[:3]]
-    normalized_feedback = tuple(dict.fromkeys(item.strip() for item in feedback if item.strip()))
-    if not normalized_feedback:
-        normalized_feedback = ("Seed QA failed without actionable differences or suggestions.",)
-    constraint = f"[seed qa repair attempt {attempt}] Resolve before execution: " + " | ".join(
-        normalized_feedback
+    normalized_feedback = _normalized_seed_qa_feedback(qa_result)
+    existing_constraints = tuple(
+        constraint
+        for constraint in seed.constraints
+        if not _is_seed_qa_diagnostic_constraint(constraint)
     )
     return seed.model_copy(
         update={
-            "constraints": tuple(dict.fromkeys((*seed.constraints, constraint))),
+            "constraints": tuple(dict.fromkeys((*existing_constraints, *normalized_feedback))),
             "metadata": seed.metadata.model_copy(
                 update={
                     "seed_id": f"seed_{uuid4().hex[:12]}",
@@ -4585,8 +4584,53 @@ def _seed_with_seed_qa_feedback(seed: Seed, qa_result: EvaluateResult, *, attemp
                     "parent_seed_id": seed.metadata.seed_id,
                 }
             ),
-        }
+        },
     )
+
+
+def _is_seed_qa_diagnostic_constraint(constraint: str) -> bool:
+    lowered = constraint.casefold()
+    return (
+        lowered.startswith("[seed qa repair attempt")
+        or lowered.startswith("[seed qa lateral repair attempt")
+        or "# lateral thinking:" in lowered
+        or "qa differences:" in lowered
+        or "qa suggestions:" in lowered
+    )
+
+
+def _normalized_seed_qa_feedback(qa_result: EvaluateResult) -> tuple[str, ...]:
+    """Translate QA diagnostics into short actionable Seed repair constraints.
+
+    The Seed direction must not absorb raw reviewer/lateral transcripts. Keep
+    the feedback as bounded repair intent, not as pasted diagnostic evidence.
+    """
+    feedback = tuple(
+        item.strip()
+        for item in (*qa_result.differences[:5], *qa_result.suggestions[:5])
+        if item.strip()
+    )
+    lowered = "\n".join(feedback).casefold()
+    repairs: list[str] = []
+    if "ambiguity_score" in lowered:
+        repairs.append("Seed metadata must satisfy the readiness gate: ambiguity_score <= 0.20.")
+    if "non_goals" in lowered or "non-goals" in lowered or "runtime_context" in lowered:
+        repairs.append(
+            "Preserve ledger non-goals and runtime context in executable Seed surfaces."
+        )
+    if "polluted" in lowered or "diagnostic" in lowered or "lateral repair" in lowered:
+        repairs.append(
+            "Constraints must contain only actionable product/runtime constraints; omit QA or lateral diagnostic prose."
+        )
+    if "transcript schema" in lowered or "schema_version" in lowered:
+        repairs.append("Use one transcript JSON schema consistently across acceptance criteria.")
+    if "templated" in lowered or "indirect" in lowered:
+        repairs.append("Acceptance criteria must be direct executable checks, not generic templates.")
+    if "partial" in lowered and ("output" in lowered or "mp4" in lowered or "transcript" in lowered):
+        repairs.append("Failure paths must leave no partial output artifacts.")
+    if not repairs:
+        repairs.append("Resolve Seed QA feedback before execution without adding diagnostic prose.")
+    return tuple(dict.fromkeys(repairs))
 
 
 def _first_nonempty(*values: str | None) -> str | None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -8,6 +8,7 @@ from contextlib import suppress
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
 import inspect
+import re
 import threading
 import time
 from typing import Any, Protocol
@@ -4547,14 +4548,16 @@ def _seed_with_seed_qa_lateral_feedback(
     chosen binding contract) rather than a restatement of the gap. The text is
     length-bounded so an overlong persona dump cannot bloat the Seed.
     """
-    decision = lateral_result.text.strip()
-    summary = (lateral_result.approach_summary or "").strip()
-    prefix = f"[seed qa lateral repair attempt {attempt}] "
-    body = f"{summary}: {decision}" if summary else decision
-    constraint = (prefix + body)[:2000]
+    del attempt
+    normalized_feedback = _normalized_seed_qa_lateral_feedback(lateral_result)
+    existing_constraints = tuple(
+        constraint
+        for constraint in seed.constraints
+        if not _is_seed_qa_diagnostic_constraint(constraint)
+    )
     return seed.model_copy(
         update={
-            "constraints": tuple(dict.fromkeys((*seed.constraints, constraint))),
+            "constraints": tuple(dict.fromkeys((*existing_constraints, *normalized_feedback))),
             "metadata": seed.metadata.model_copy(
                 update={
                     "seed_id": f"seed_{uuid4().hex[:12]}",
@@ -4568,6 +4571,7 @@ def _seed_with_seed_qa_lateral_feedback(
 
 def _seed_with_seed_qa_feedback(seed: Seed, qa_result: EvaluateResult, *, attempt: int) -> Seed:
     """Return a Seed revised with bounded pre-run Seed QA feedback."""
+    del attempt
     normalized_feedback = _normalized_seed_qa_feedback(qa_result)
     existing_constraints = tuple(
         constraint
@@ -4599,6 +4603,49 @@ def _is_seed_qa_diagnostic_constraint(constraint: str) -> bool:
     )
 
 
+_SEED_QA_DIAGNOSTIC_PREFIX_RE = re.compile(
+    r"\[seed qa(?: lateral)? repair attempt [^\]]+\]\s*",
+    re.IGNORECASE,
+)
+
+
+def _normalized_seed_qa_lateral_feedback(lateral_result: LateralResult) -> tuple[str, ...]:
+    """Translate lateral Seed QA output into durable implementation constraints.
+
+    Persona output is useful evidence for choosing a repair direction, but the
+    Seed must not persist the review transcript, attempt counters, or lateral
+    diagnostic headings that status doctor classifies as spec pollution.
+    """
+    summary = _clean_seed_qa_lateral_text(lateral_result.approach_summary or "", limit=320)
+    decision = _clean_seed_qa_lateral_text(lateral_result.text, limit=1600)
+    repairs: list[str] = []
+    if summary:
+        repairs.append(f"Use this bounded implementation approach to resolve Seed QA: {summary}")
+    if decision:
+        repairs.append(f"Adopt this concrete implementation decision before execution: {decision}")
+    if not repairs:
+        repairs.append("Resolve Seed QA feedback before execution without adding diagnostic prose.")
+    return tuple(dict.fromkeys(repairs))
+
+
+def _clean_seed_qa_lateral_text(text: str, *, limit: int) -> str:
+    text = _SEED_QA_DIAGNOSTIC_PREFIX_RE.sub("", text.strip())
+    cleaned_lines: list[str] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        lowered = line.casefold()
+        if not line:
+            continue
+        if lowered.startswith("# lateral thinking:"):
+            continue
+        if lowered.startswith("qa differences:") or lowered.startswith("qa suggestions:"):
+            continue
+        cleaned_lines.append(line)
+    cleaned = " ".join(cleaned_lines)
+    cleaned = cleaned.replace("# Lateral Thinking:", "").replace("# lateral thinking:", "")
+    return cleaned[:limit].strip()
+
+
 def _normalized_seed_qa_feedback(qa_result: EvaluateResult) -> tuple[str, ...]:
     """Translate QA diagnostics into short actionable Seed repair constraints.
 
@@ -4624,6 +4671,10 @@ def _normalized_seed_qa_feedback(qa_result: EvaluateResult) -> tuple[str, ...]:
         )
     if "transcript schema" in lowered or "schema_version" in lowered:
         repairs.append("Use one transcript JSON schema consistently across acceptance criteria.")
+    if "no-op" in lowered or "noop" in lowered:
+        repairs.append("Define explicit no-op scope for supported command behavior.")
+    if "review-blocking" in lowered:
+        repairs.append("Introduce the review-blocking post-QA constraint before execution.")
     if "templated" in lowered or "indirect" in lowered:
         repairs.append("Acceptance criteria must be direct executable checks, not generic templates.")
     if "partial" in lowered and ("output" in lowered or "mp4" in lowered or "transcript" in lowered):

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4631,6 +4631,7 @@ def _normalized_seed_qa_lateral_feedback(lateral_result: LateralResult) -> tuple
 def _clean_seed_qa_repair_text(text: str, *, limit: int) -> str:
     text = _SEED_QA_DIAGNOSTIC_PREFIX_RE.sub("", text.strip())
     cleaned_lines: list[str] = []
+    skipping_diagnostic_block = False
     for raw_line in text.splitlines():
         line = raw_line.strip()
         lowered = line.casefold()
@@ -4639,7 +4640,12 @@ def _clean_seed_qa_repair_text(text: str, *, limit: int) -> str:
         if lowered.startswith("# lateral thinking:"):
             continue
         if lowered.startswith("qa differences:") or lowered.startswith("qa suggestions:"):
+            skipping_diagnostic_block = True
             continue
+        if skipping_diagnostic_block:
+            if line.startswith(("-", "*")) or re.match(r"^\d+[\.)]\s+", line):
+                continue
+            skipping_diagnostic_block = False
         cleaned_lines.append(line)
     cleaned = " ".join(cleaned_lines)
     cleaned = cleaned.replace("# Lateral Thinking:", "").replace("# lateral thinking:", "")

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4616,8 +4616,8 @@ def _normalized_seed_qa_lateral_feedback(lateral_result: LateralResult) -> tuple
     Seed must not persist the review transcript, attempt counters, or lateral
     diagnostic headings that status doctor classifies as spec pollution.
     """
-    summary = _clean_seed_qa_lateral_text(lateral_result.approach_summary or "", limit=320)
-    decision = _clean_seed_qa_lateral_text(lateral_result.text, limit=1600)
+    summary = _clean_seed_qa_repair_text(lateral_result.approach_summary or "", limit=320)
+    decision = _clean_seed_qa_repair_text(lateral_result.text, limit=1600)
     repairs: list[str] = []
     if summary:
         repairs.append(f"Use this bounded implementation approach to resolve Seed QA: {summary}")
@@ -4628,7 +4628,7 @@ def _normalized_seed_qa_lateral_feedback(lateral_result: LateralResult) -> tuple
     return tuple(dict.fromkeys(repairs))
 
 
-def _clean_seed_qa_lateral_text(text: str, *, limit: int) -> str:
+def _clean_seed_qa_repair_text(text: str, *, limit: int) -> str:
     text = _SEED_QA_DIAGNOSTIC_PREFIX_RE.sub("", text.strip())
     cleaned_lines: list[str] = []
     for raw_line in text.splitlines():
@@ -4682,7 +4682,18 @@ def _normalized_seed_qa_feedback(qa_result: EvaluateResult) -> tuple[str, ...]:
     ):
         repairs.append("Failure paths must leave no partial output artifacts.")
     if not repairs:
+        repairs.extend(_actionable_seed_qa_feedback_constraints(feedback))
+    if not repairs:
         repairs.append("Resolve Seed QA feedback before execution without adding diagnostic prose.")
+    return tuple(dict.fromkeys(repairs))
+
+
+def _actionable_seed_qa_feedback_constraints(feedback: tuple[str, ...]) -> tuple[str, ...]:
+    repairs: list[str] = []
+    for item in feedback[:5]:
+        cleaned = _clean_seed_qa_repair_text(item, limit=420)
+        if cleaned and not _is_seed_qa_diagnostic_constraint(cleaned):
+            repairs.append(f"Address this Seed QA finding before execution: {cleaned}")
     return tuple(dict.fromkeys(repairs))
 
 

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -27,6 +27,7 @@ from ouroboros.auto.adapters import (
 )
 from ouroboros.auto.domain_profile import DEFAULT_REGISTRY
 from ouroboros.auto.handoff_contract import RUN_HANDOFF_STARTED_STATUS
+from ouroboros.auto.intent_guard import diagnose_auto_pipeline_state
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.pipeline import AutoPipeline, AutoPipelineResult
 from ouroboros.auto.policies import apply_domain_policy_defaults
@@ -770,6 +771,12 @@ def _print_status(state: AutoPipelineState) -> None:
         console.print(f"Run reconciled at: {state.run_reconciled_at}")
     if state.last_error:
         console.print(f"Blocker: [yellow]{state.last_error}[/]")
+    intent_guard = diagnose_auto_pipeline_state(state)
+    console.print(f"IntentGuard: [bold]{intent_guard.status.value}[/]")
+    for check in intent_guard.checks:
+        message = _rich_escape(check.message)
+        action = f" Action: {_rich_escape(check.action)}" if check.action else ""
+        console.print(f"  {check.status.value.upper()} {check.code}: {message}{action}")
     if state.auto_answer_log:
         recent = state.auto_answer_log[-5:]
         console.print(f"Recent auto answers (last {len(recent)}):")

--- a/src/ouroboros/cli/commands/status.py
+++ b/src/ouroboros/cli/commands/status.py
@@ -15,6 +15,7 @@ from rich.text import Text
 import typer
 import yaml
 
+from ouroboros.auto.intent_guard import diagnose_auto_pipeline_state
 from ouroboros.auto.state import AutoPhase, AutoStore
 from ouroboros.backends import (
     get_backend_capability,
@@ -106,6 +107,7 @@ def _format_auto_status(state) -> str:
 
     if state.last_error:
         lines.append(f"Blocker: {state.last_error}")
+    lines.extend(diagnose_auto_pipeline_state(state).render_lines())
 
     return "\n".join(lines) + "\n"
 

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -2539,6 +2539,7 @@ class InterviewHandler:
                     )
 
                 lateral_review_meta: dict[str, Any] | None = None
+                intent_guard_report: IntentGuardReport | None = None
 
                 # If answer provided, record it first
                 if answer:
@@ -3039,8 +3040,9 @@ class InterviewHandler:
                         score=live_score,
                         question=question,
                     ),
-                    "intent_guard": intent_guard_report.to_dict(),
                 }
+                if intent_guard_report is not None:
+                    answer_meta["intent_guard"] = intent_guard_report.to_dict()
                 if answer_is_length_guard:
                     # Q00/ouroboros#831 (Direction A): structured signal when
                     # the next question after an answer is again the length-

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError as PydanticValidationError
 import structlog
 import yaml
 
+from ouroboros.auto.intent_guard import IntentGuardReport, IntentGuardStatus, guard_interview_turn
 from ouroboros.backends import backend_supports_tool_envelope
 from ouroboros.bigbang.ambiguity import (
     AMBIGUITY_THRESHOLD,
@@ -779,6 +780,41 @@ def _interview_reasoning_meta(
             "question_chars": len(question) if question else None,
         },
     }
+
+
+def _classify_interview_answer_source(answer: str) -> str:
+    """Return a coarse provenance class for an ``ooo interview`` answer."""
+    lowered = str(answer).lstrip().casefold()
+    if lowered.startswith("[from-code]") or lowered.startswith("[from-repo]"):
+        return "repo_fact"
+    if lowered.startswith("[from-auto]") or lowered.startswith("[from-safe-default]"):
+        return "generated"
+    if lowered.startswith("[from-assumption]") or lowered.startswith("[from-inference]"):
+        return "generated"
+    return "human"
+
+
+def _guard_interview_answer(
+    *,
+    state: InterviewState,
+    question: str,
+    answer: str,
+) -> IntentGuardReport:
+    return guard_interview_turn(
+        goal=state.initial_context,
+        question=question,
+        answer_text=answer,
+        answer_source=_classify_interview_answer_source(answer),
+    )
+
+
+def _format_intent_guard_blocker(report: IntentGuardReport) -> str:
+    for check in report.checks:
+        if check.status is IntentGuardStatus.FAIL:
+            if check.action:
+                return f"IntentGuard blocked interview answer: {check.message} ({check.action})"
+            return f"IntentGuard blocked interview answer: {check.message}"
+    return "IntentGuard blocked interview answer"
 
 
 def _ambiguity_warning_for_failed_question(
@@ -1913,6 +1949,7 @@ class InterviewHandler:
             transcript = ""
             real_session_id = session_id
             plugin_state: InterviewState | None = None
+            plugin_intent_guard_report: IntentGuardReport | None = None
 
             if action == "start" and initial_context:
                 cwd = arguments.get("cwd") or os.getcwd()
@@ -1978,6 +2015,19 @@ class InterviewHandler:
                 # question text instead of a placeholder.
                 if answer:
                     if state.rounds and state.rounds[-1].user_response is None:
+                        question_text = last_question or state.rounds[-1].question
+                        plugin_intent_guard_report = _guard_interview_answer(
+                            state=state,
+                            question=question_text,
+                            answer=answer,
+                        )
+                        if plugin_intent_guard_report.status is IntentGuardStatus.FAIL:
+                            return Result.err(
+                                MCPToolError(
+                                    _format_intent_guard_blocker(plugin_intent_guard_report),
+                                    tool_name="ouroboros_interview",
+                                )
+                            )
                         # Round exists with question but no answer yet — fill it.
                         # If last_question was provided, update the question text
                         # in case the existing one is a stale placeholder from a
@@ -1995,6 +2045,18 @@ class InterviewHandler:
                         question_text = (
                             last_question if last_question else "(continued from subagent)"
                         )
+                        plugin_intent_guard_report = _guard_interview_answer(
+                            state=state,
+                            question=question_text,
+                            answer=answer,
+                        )
+                        if plugin_intent_guard_report.status is IntentGuardStatus.FAIL:
+                            return Result.err(
+                                MCPToolError(
+                                    _format_intent_guard_blocker(plugin_intent_guard_report),
+                                    tool_name="ouroboros_interview",
+                                )
+                            )
                         state.rounds.append(
                             InterviewRound(
                                 round_number=len(state.rounds) + 1,
@@ -2038,6 +2100,11 @@ class InterviewHandler:
                         "When the user answers, pass the child session's "
                         "question text as 'last_question' alongside 'answer' "
                         "to preserve interview transcript fidelity."
+                    ),
+                    **(
+                        {"intent_guard": plugin_intent_guard_report.to_dict()}
+                        if plugin_intent_guard_report is not None
+                        else {}
                     ),
                 },
             )
@@ -2720,7 +2787,6 @@ class InterviewHandler:
                         pass
                     elif state.rounds[-1].user_response is None:
                         pending_question = last_question or state.rounds[-1].question
-                        state.rounds.pop()
                     else:
                         if not last_question:
                             return Result.err(
@@ -2734,6 +2800,21 @@ class InterviewHandler:
                                 )
                             )
                         pending_question = last_question
+
+                    intent_guard_report = _guard_interview_answer(
+                        state=state,
+                        question=pending_question,
+                        answer=answer,
+                    )
+                    if intent_guard_report.status is IntentGuardStatus.FAIL:
+                        return Result.err(
+                            MCPToolError(
+                                _format_intent_guard_blocker(intent_guard_report),
+                                tool_name="ouroboros_interview",
+                            )
+                        )
+                    if state.rounds and state.rounds[-1].user_response is None:
+                        state.rounds.pop()
 
                     record_result = await engine.record_response(state, answer, pending_question)
                     if record_result.is_err:
@@ -2958,6 +3039,7 @@ class InterviewHandler:
                         score=live_score,
                         question=question,
                     ),
+                    "intent_guard": intent_guard_report.to_dict(),
                 }
                 if answer_is_length_guard:
                     # Q00/ouroboros#831 (Direction A): structured signal when

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -433,7 +433,7 @@ class AutoHandler:
         auto_workspace = ensure_auto_worktree(state)
 
         runtime_plan = resolve_auto_stage_runtime_plan(
-            runtime_override=None,
+            runtime_override=runtime_backend if self.agent_runtime_backend is not None else None,
             fallback_runtime_backend=runtime_backend,
             fallback_opencode_mode=opencode_mode,
         )
@@ -1805,6 +1805,11 @@ def _derive_goal_user_preferences(goal: str) -> dict[str, str]:
     outputs = _section_text(sections, "outputs", "deliverables")
     if outputs:
         preferences["outputs"] = outputs
+    elif not sections:
+        inline_outputs = _inline_artifact_output_contract(goal)
+        if inline_outputs:
+            preferences["outputs"] = inline_outputs
+            preferences.setdefault("acceptance_criteria", inline_outputs)
 
     constraint_lines = _matching_lines(
         goal,
@@ -1849,6 +1854,72 @@ def _derive_goal_user_preferences(goal: str) -> dict[str, str]:
         preferences["failure_modes"] = "\n".join(failure_lines)
 
     return preferences
+
+
+_ARTIFACT_OUTPUT_TERMS: tuple[str, ...] = (
+    "artifact",
+    "artifacts",
+    "file",
+    "files",
+    "output",
+    "outputs",
+    "export",
+    "exports",
+    "video",
+    "videos",
+    "mp4",
+    "clip",
+    "clips",
+    "short",
+    "shorts",
+    "long-form",
+    "long form",
+    "transcript",
+    "transcripts",
+    "json",
+    "csv",
+    "pdf",
+    "html",
+    "report",
+    "reports",
+)
+
+_ARTIFACT_GENERATION_TERMS: tuple[str, ...] = (
+    "make",
+    "makes",
+    "create",
+    "creates",
+    "generate",
+    "generates",
+    "produce",
+    "produces",
+    "export",
+    "exports",
+    "write",
+    "writes",
+)
+
+
+def _inline_artifact_output_contract(goal: str) -> str:
+    """Extract an explicit artifact-output contract from a sentence-shaped goal.
+
+    Structured prompts already use ``Outputs:`` / ``Success criteria:`` blocks.
+    Natural ``ooo auto "..."`` prompts often state the same contract inline, e.g.
+    "when I put a video in, the harness will make shorts and transcript".  Treat
+    only artifact-generation language as evidence-backed; broad wishes like
+    "make it better" intentionally do not match.
+    """
+    cleaned = _clean_prompt_line(goal)
+    lowered = cleaned.casefold()
+    if not cleaned:
+        return ""
+    if not any(term in lowered for term in _ARTIFACT_GENERATION_TERMS):
+        return ""
+    if not any(term in lowered for term in _ARTIFACT_OUTPUT_TERMS):
+        return ""
+    if re.search(r"\b(review[- ]only|review package|only review)\b", lowered):
+        return ""
+    return cleaned
 
 
 def _extract_goal_sections(goal: str) -> dict[str, list[str]]:

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -433,7 +433,7 @@ class AutoHandler:
         auto_workspace = ensure_auto_worktree(state)
 
         runtime_plan = resolve_auto_stage_runtime_plan(
-            runtime_override=runtime_backend if self.agent_runtime_backend is not None else None,
+            runtime_override=None,
             fallback_runtime_backend=runtime_backend,
             fallback_opencode_mode=opencode_mode,
         )

--- a/src/ouroboros/mcp/tools/query_handlers.py
+++ b/src/ouroboros/mcp/tools/query_handlers.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import structlog
 
+from ouroboros.auto.intent_guard import diagnose_auto_pipeline_state
 from ouroboros.auto.state import AutoPhase, AutoStore
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
@@ -186,6 +187,7 @@ class SessionStatusHandler:
             AutoPhase.FAILED,
         }
         ralph_block = self._build_ralph_block(state)
+        intent_guard = diagnose_auto_pipeline_state(state)
 
         # Render a short text block; the structured detail lives in ``meta``
         # so machine consumers do not have to parse strings. Keep the layout
@@ -230,6 +232,7 @@ class SessionStatusHandler:
                     lines.append(f"  {key}: {ralph_block[key]}")
         if state.last_error:
             lines.append(f"Blocker: {state.last_error}")
+        lines.extend(intent_guard.render_lines())
         status_text = "\n".join(lines) + "\n"
 
         meta: dict[str, Any] = {
@@ -241,6 +244,7 @@ class SessionStatusHandler:
             "ralph_lineage_id": state.ralph_lineage_id,
             "last_progress_message": state.last_progress_message,
             "last_progress_at": state.last_progress_at,
+            "intent_guard": intent_guard.to_dict(),
         }
         if state.pending_question:
             meta["pending_question"] = state.pending_question

--- a/tests/integration/auto/test_status_unified.py
+++ b/tests/integration/auto/test_status_unified.py
@@ -174,6 +174,7 @@ def test_mcp_auto_status_surfaces_pending_question_and_recent_answers(tmp_path) 
     meta = result.value.meta
     assert meta["pending_question"] == "Which runtime should handle this?\nAny credentials?"
     assert meta["auto_answer_log"] == state.auto_answer_log
+    assert meta["intent_guard"]["status"] == "pass"
     text = result.value.content[0].text
     assert "Pending question:" in text
     assert "  Which runtime should handle this?" in text
@@ -181,6 +182,7 @@ def test_mcp_auto_status_surfaces_pending_question_and_recent_answers(tmp_path) 
     assert "Recent auto answers (last 2):" in text
     assert "  round 2 [auto] Q: Which runtime should handle this?" in text
     assert "    A: Codex runtime." in text
+    assert "IntentGuard: pass" in text
 
 
 def test_listener_prefers_terminal_generations_over_iterations(tmp_path) -> None:
@@ -637,5 +639,8 @@ def test_cli_status_auto_snapshot(tmp_path) -> None:
         "  status: running\n"
         "  current_generation: 3\n"
         "  stop_reason: qa passed\n"
+        "IntentGuard: pass\n"
+        "  PASS intent_contract_not_applicable: goal does not look like an artifact-output request\n"
+        "  PASS spec_pollution: Seed constraints do not contain known diagnostic markers\n"
     )
     assert rendered == expected

--- a/tests/unit/auto/test_intent_guard.py
+++ b/tests/unit/auto/test_intent_guard.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from ouroboros.auto.answerer import AutoAnswerSource
+from ouroboros.auto.intent_guard import (
+    IntentGuardStatus,
+    diagnose_auto_state,
+    guard_auto_answer,
+    guard_interview_turn,
+)
+from ouroboros.auto.ledger import SeedDraftLedger
+
+VIDEO_GOAL = (
+    "I want to make a video harness when I put a video to harness, "
+    "the harness will make some shorts and long form video with transcript"
+)
+
+
+def test_intent_guard_blocks_generated_review_only_option_over_user_contract() -> None:
+    report = guard_auto_answer(
+        goal=VIDEO_GOAL,
+        user_preferences={
+            "outputs": VIDEO_GOAL,
+            "acceptance_criteria": VIDEO_GOAL,
+        },
+        ledger=SeedDraftLedger.from_goal(VIDEO_GOAL),
+        question=(
+            "Which one is the actual MVP behavior to lock: `--mode auto` creates MP4s "
+            "and transcripts, or `--mode review` creates only the review package and "
+            "rejects automated export?"
+        ),
+        answer_text="Use REVIEW REVIEW as the MVP behavior.",
+        answer_source=AutoAnswerSource.CONSERVATIVE_DEFAULT.value,
+    )
+
+    assert report.status is IntentGuardStatus.FAIL
+    assert any(check.code == "generated_option_conflict" for check in report.checks)
+
+
+def test_intent_guard_allows_user_preference_contract_answer() -> None:
+    report = guard_auto_answer(
+        goal=VIDEO_GOAL,
+        user_preferences={
+            "outputs": VIDEO_GOAL,
+            "acceptance_criteria": VIDEO_GOAL,
+        },
+        ledger=SeedDraftLedger.from_goal(VIDEO_GOAL),
+        question=(
+            "Which one is the actual MVP behavior to lock: `--mode auto` creates MP4s "
+            "and transcripts, or `--mode review` creates only the review package?"
+        ),
+        answer_text=VIDEO_GOAL,
+        answer_source=AutoAnswerSource.USER_PREFERENCE.value,
+    )
+
+    assert report.status is IntentGuardStatus.PASS
+
+
+def test_intent_guard_doctor_surfaces_pending_generated_option_and_spec_pollution() -> None:
+    report = diagnose_auto_state(
+        goal=VIDEO_GOAL,
+        user_preferences={},
+        ledger=SeedDraftLedger.from_goal(VIDEO_GOAL),
+        pending_question=(
+            "Should this be --mode auto exporting MP4s or --mode review with review-only "
+            "package output?"
+        ),
+        auto_answer_log=(),
+        seed_artifact={
+            "constraints": [
+                "Use local files",
+                "[seed qa lateral repair attempt 1] # Lateral Thinking:\nQA differences: bad",
+            ]
+        },
+    )
+
+    assert report.status is IntentGuardStatus.FAIL
+    codes = {check.code: check.status for check in report.checks}
+    assert codes["generated_option_present"] is IntentGuardStatus.WARN
+    assert codes["spec_pollution"] is IntentGuardStatus.FAIL
+
+
+def test_interview_turn_guard_warns_when_human_changes_output_contract() -> None:
+    report = guard_interview_turn(
+        goal=VIDEO_GOAL,
+        question=(
+            "Should this be --mode auto exporting MP4s or --mode review with review-only "
+            "package output?"
+        ),
+        answer_text="Let's make it review-only for now.",
+        answer_source="human",
+    )
+
+    assert report.status is IntentGuardStatus.WARN
+    assert any(check.code == "user_contract_change" for check in report.checks)
+
+
+def test_interview_turn_guard_fails_generated_contract_drift() -> None:
+    report = guard_interview_turn(
+        goal=VIDEO_GOAL,
+        question=(
+            "Should this be --mode auto exporting MP4s or --mode review with review-only "
+            "package output?"
+        ),
+        answer_text="[from-auto][conservative_default] Use review-only mode.",
+        answer_source="generated",
+    )
+
+    assert report.status is IntentGuardStatus.FAIL
+    assert any(check.code == "generated_option_conflict" for check in report.checks)

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1623,7 +1623,7 @@ async def test_pipeline_repairs_seed_qa_feedback_before_run(tmp_path) -> None:
                 differences=("missing explicit no-op scope",),
                 suggestions=("add no-op scope constraint",),
             )
-        assert any("missing explicit no-op scope" in item for item in seed.constraints)
+        assert any("Define explicit no-op scope" in item for item in seed.constraints)
         return EvaluateResult(passed=True, score=0.88, verdict="pass")
 
     async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
@@ -1655,7 +1655,7 @@ async def test_pipeline_repairs_seed_qa_feedback_before_run(tmp_path) -> None:
     assert result.job_id == "job_seed_qa_repaired"
     assert qa_calls == 2
     assert captured_run_seed is not None
-    assert any("missing explicit no-op scope" in item for item in captured_run_seed.constraints)
+    assert any("Define explicit no-op scope" in item for item in captured_run_seed.constraints)
 
 
 @pytest.mark.asyncio
@@ -1802,8 +1802,7 @@ async def test_pipeline_seed_qa_lateral_repair_falls_back_when_lateral_errors(tm
                 differences=("missing explicit no-op scope",),
                 suggestions=("add no-op scope constraint",),
             )
-        # Fallback mechanical repair echoes the QA difference as a constraint.
-        assert any("missing explicit no-op scope" in item for item in seed.constraints)
+        assert any("Define explicit no-op scope" in item for item in seed.constraints)
         return EvaluateResult(passed=True, score=0.9, verdict="pass")
 
     async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -471,6 +471,32 @@ def test_auto_answerer_preserves_product_behavior_phrasing_variants() -> None:
     assert all("product behavior" in answer.text.lower() for answer in answers)
 
 
+def test_product_behavior_question_prefers_user_output_contract_over_generated_option() -> None:
+    """Interview options must not outrank explicit output intent from the user goal."""
+    goal = (
+        "I want to make a video harness when I put a video to harness, "
+        "the harness will make some shorts and long form video with transcript"
+    )
+    context = AutoAnswerContext(
+        user_preferences={
+            "outputs": goal,
+            "acceptance_criteria": goal,
+        }
+    )
+    question = (
+        "Which one is the actual MVP behavior to lock: `--mode auto` creates MP4s "
+        "and transcripts, or `--mode review` creates only the review package and "
+        "rejects automated export?"
+    )
+
+    answer = AutoAnswerer().answer(question, SeedDraftLedger.from_goal(goal), context)
+
+    assert answer.source == AutoAnswerSource.USER_PREFERENCE
+    assert "shorts" in answer.text
+    assert "transcript" in answer.text
+    assert "review package" not in answer.text
+
+
 def test_auto_answerer_preserves_passive_product_behavior_variants() -> None:
     answerer = AutoAnswerer()
     ledger = SeedDraftLedger.from_goal("Build a source-control compliance tool")

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -161,6 +161,7 @@ def test_seed_qa_lateral_feedback_does_not_trip_intent_guard_pollution() -> None
     assert "[seed qa lateral repair attempt" not in constraints
     assert "# Lateral Thinking" not in constraints
     assert "QA differences:" not in constraints
+    assert "- stale diagnostic" not in constraints
     assert "treat every CSV cell as a string" in constraints
 
     report = diagnose_auto_state(

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -19,12 +19,17 @@ from ouroboros.auto.adapters import (
     LateralResult,
 )
 from ouroboros.auto.grading import GradeResult, SeedGrade
+from ouroboros.auto.intent_guard import IntentGuardStatus, diagnose_auto_state
 from ouroboros.auto.interview_driver import AutoInterviewResult
 from ouroboros.auto.lateral_routing import (
     classify_qa_failure_to_pattern,
     select_persona_for_qa_failure,
 )
-from ouroboros.auto.pipeline import AutoPipeline, _seed_with_seed_qa_feedback
+from ouroboros.auto.pipeline import (
+    AutoPipeline,
+    _seed_with_seed_qa_feedback,
+    _seed_with_seed_qa_lateral_feedback,
+)
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import (
     _ALLOWED_TRANSITIONS,
@@ -106,6 +111,48 @@ def test_seed_qa_feedback_does_not_pollute_constraints_with_diagnostics() -> Non
     assert "omit QA or lateral diagnostic prose" in constraints
     assert repaired.metadata.ambiguity_score == 0.206
     assert repaired.metadata.parent_seed_id == "seed_dirty"
+
+
+def test_seed_qa_lateral_feedback_does_not_trip_intent_guard_pollution() -> None:
+    seed = _build_seed().model_copy(
+        update={
+            "constraints": (
+                "Use existing project patterns",
+                "[seed qa repair attempt 1] QA differences: stale diagnostic",
+            ),
+            "metadata": SeedMetadata(seed_id="seed_dirty_lateral", ambiguity_score=0.12),
+        }
+    )
+    lateral_result = LateralResult(
+        persona="hacker",
+        approach_summary="# Lateral Thinking: Hacker",
+        text=(
+            "[seed qa lateral repair attempt 1] Decision: treat every CSV cell as a string.\n"
+            "QA differences:\n"
+            "- stale diagnostic"
+        ),
+    )
+
+    repaired = _seed_with_seed_qa_lateral_feedback(seed, lateral_result, attempt=1)
+    constraints = "\n".join(repaired.constraints)
+
+    assert "[seed qa repair attempt" not in constraints
+    assert "[seed qa lateral repair attempt" not in constraints
+    assert "# Lateral Thinking" not in constraints
+    assert "QA differences:" not in constraints
+    assert "treat every CSV cell as a string" in constraints
+
+    report = diagnose_auto_state(
+        goal="Build a CLI",
+        user_preferences={},
+        ledger=None,
+        pending_question=None,
+        auto_answer_log=(),
+        seed_artifact=repaired.to_dict(),
+    )
+    assert report.status is not IntentGuardStatus.FAIL
+    spec_pollution = next(check for check in report.checks if check.code == "spec_pollution")
+    assert spec_pollution.status is IntentGuardStatus.PASS
 
 
 class _StubInterviewDriver:

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -113,6 +113,27 @@ def test_seed_qa_feedback_does_not_pollute_constraints_with_diagnostics() -> Non
     assert repaired.metadata.parent_seed_id == "seed_dirty"
 
 
+def test_seed_qa_feedback_preserves_generic_actionable_feedback() -> None:
+    seed = _build_seed().model_copy(
+        update={"metadata": SeedMetadata(seed_id="seed_generic_feedback", ambiguity_score=0.12)}
+    )
+    qa_result = EvaluateResult(
+        passed=False,
+        score=0.61,
+        verdict="revise",
+        differences=("missing audit-log retention policy",),
+        suggestions=("add a 30-day retention constraint",),
+    )
+
+    repaired = _seed_with_seed_qa_feedback(seed, qa_result, attempt=1)
+    constraints = "\n".join(repaired.constraints)
+
+    assert "missing audit-log retention policy" in constraints
+    assert "add a 30-day retention constraint" in constraints
+    assert "QA differences:" not in constraints
+    assert "[seed qa repair attempt" not in constraints
+
+
 def test_seed_qa_lateral_feedback_does_not_trip_intent_guard_pollution() -> None:
     seed = _build_seed().model_copy(
         update={

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -24,7 +24,7 @@ from ouroboros.auto.lateral_routing import (
     classify_qa_failure_to_pattern,
     select_persona_for_qa_failure,
 )
-from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.pipeline import AutoPipeline, _seed_with_seed_qa_feedback
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import (
     _ALLOWED_TRANSITIONS,
@@ -72,6 +72,40 @@ def _build_seed(seed_id: str = "seed_lateral_001") -> Seed:
         ),
         metadata=SeedMetadata(seed_id=seed_id, ambiguity_score=0.12),
     )
+
+
+def test_seed_qa_feedback_does_not_pollute_constraints_with_diagnostics() -> None:
+    seed = _build_seed().model_copy(
+        update={
+            "constraints": (
+                "Use existing project patterns",
+                "[seed qa lateral repair attempt 1] Hacker: # Lateral Thinking: Hacker\n\nQA differences:\n- bad",
+            ),
+            "metadata": SeedMetadata(seed_id="seed_dirty", ambiguity_score=0.206),
+        }
+    )
+    qa_result = EvaluateResult(
+        passed=False,
+        score=0.52,
+        verdict="revise",
+        differences=(
+            "metadata.ambiguity_score is 0.206, exceeding the required readiness gate of <= 0.20.",
+            "The constraints section is polluted with pasted lateral repair and QA diagnostic text.",
+        ),
+        suggestions=(
+            "Remove all pasted lateral repair and QA diagnostic blocks from constraints.",
+        ),
+    )
+
+    repaired = _seed_with_seed_qa_feedback(seed, qa_result, attempt=1)
+    constraints = "\n".join(repaired.constraints)
+
+    assert "# Lateral Thinking" not in constraints
+    assert "QA differences:" not in constraints
+    assert "[seed qa lateral repair attempt" not in constraints
+    assert "omit QA or lateral diagnostic prose" in constraints
+    assert repaired.metadata.ambiguity_score == 0.206
+    assert repaired.metadata.parent_seed_id == "seed_dirty"
 
 
 class _StubInterviewDriver:

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -1352,17 +1352,18 @@ async def test_auto_handler_routes_interview_and_execute_from_stage_plan(
 
     monkeypatch.setattr(auto_module, "AutoStore", lambda: AutoStore(tmp_path / "store"))
     monkeypatch.setattr(auto_module, "AutoPipeline", FakePipeline)
-    monkeypatch.setattr(
-        auto_module,
-        "resolve_auto_stage_runtime_plan",
-        lambda **_kwargs: AutoStageRuntimePlan(
+
+    def fake_runtime_plan(**kwargs):  # noqa: ANN003
+        captured["runtime_plan_kwargs"] = kwargs
+        return AutoStageRuntimePlan(
             default=StageRuntime("opencode", "plugin"),
             interview=StageRuntime("gjc", None),
             execute=StageRuntime("pi", None),
             evaluate=StageRuntime("opencode", "plugin"),
             reflect=StageRuntime("opencode", "plugin"),
-        ),
-    )
+        )
+
+    monkeypatch.setattr(auto_module, "resolve_auto_stage_runtime_plan", fake_runtime_plan)
 
     result = await AutoHandler(agent_runtime_backend="opencode", opencode_mode="plugin").handle(
         {"goal": "Build a CLI", "cwd": str(tmp_path)}
@@ -1376,6 +1377,11 @@ async def test_auto_handler_routes_interview_and_execute_from_stage_plan(
         "execute_runtime": "pi",
         "qa_runtime": "gjc",
         "state_runtime": "opencode",
+        "runtime_plan_kwargs": {
+            "runtime_override": None,
+            "fallback_runtime_backend": "opencode",
+            "fallback_opencode_mode": "plugin",
+        },
     }
 
 

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -407,6 +407,32 @@ def test_structured_auto_goal_seeds_required_ledger_sections() -> None:
     assert "`hello_auto.py` exists" in preferences["acceptance_criteria"]
 
 
+def test_inline_artifact_goal_seeds_output_contract() -> None:
+    """Sentence-shaped artifact goals are intent evidence, not loose hints.
+
+    Regression coverage for a video-harness auto run where the initial goal
+    explicitly requested shorts, long-form videos, and transcripts but the
+    interview later introduced a review-only alternative.
+    """
+    goal = (
+        "I want to make a video harness when I put a video to harness, "
+        "the harness will make some shorts and long form video with transcript"
+    )
+
+    preferences = _derive_goal_user_preferences(goal)
+    ledger = _seed_initial_ledger_from_user_preferences(goal, preferences)
+
+    assert "outputs" in preferences
+    assert "acceptance_criteria" in preferences
+    assert "shorts" in preferences["outputs"]
+    assert "transcript" in preferences["outputs"]
+    assert any(
+        entry.source.value == "user_preference"
+        and "long form video" in entry.value
+        for entry in ledger.sections["outputs"].entries
+    )
+
+
 def test_structured_auto_goal_does_not_preconfirm_risky_preference() -> None:
     """Pre-seeding must not bypass the answerer's risky USER_PREFERENCE gate."""
     risky_goal = """

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -427,8 +427,7 @@ def test_inline_artifact_goal_seeds_output_contract() -> None:
     assert "shorts" in preferences["outputs"]
     assert "transcript" in preferences["outputs"]
     assert any(
-        entry.source.value == "user_preference"
-        and "long form video" in entry.value
+        entry.source.value == "user_preference" and "long form video" in entry.value
         for entry in ledger.sections["outputs"].entries
     )
 

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -23,6 +23,7 @@ from ouroboros.auto.adapters import HandlerError, HandlerInterviewBackend
 from ouroboros.auto.interview_driver import AutoInterviewDriver
 from ouroboros.auto.ledger import SeedDraftLedger
 from ouroboros.auto.pipeline import AutoPipelineResult
+from ouroboros.auto.runtime_routing import AutoStageRuntimePlan, StageRuntime
 from ouroboros.auto.state import AutoPipelineState, AutoResumeCapability, AutoStore
 from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
 from ouroboros.core.types import Result
@@ -970,6 +971,16 @@ def test_auto_handler_run_constructs_and_invokes_authoring_interviewer_path(
         patch(
             "ouroboros.mcp.tools.authoring_handlers.resolve_llm_backend",
             side_effect=lambda backend: backend or "claude",
+        ),
+        patch(
+            "ouroboros.mcp.tools.auto_handler.resolve_auto_stage_runtime_plan",
+            return_value=AutoStageRuntimePlan(
+                default=StageRuntime("opencode", "plugin"),
+                interview=StageRuntime("opencode", "plugin"),
+                execute=StageRuntime("opencode", "plugin"),
+                evaluate=StageRuntime("opencode", "plugin"),
+                reflect=StageRuntime("opencode", "plugin"),
+            ),
         ),
         patch(
             "ouroboros.mcp.tools.auto_handler.AutoPipeline.run",

--- a/tests/unit/mcp/tools/test_interview_intent_guard.py
+++ b/tests/unit/mcp/tools/test_interview_intent_guard.py
@@ -12,8 +12,7 @@ VIDEO_GOAL = (
 )
 
 REVIEW_ONLY_QUESTION = (
-    "Should this be --mode auto exporting MP4s or --mode review with review-only "
-    "package output?"
+    "Should this be --mode auto exporting MP4s or --mode review with review-only package output?"
 )
 
 

--- a/tests/unit/mcp/tools/test_interview_intent_guard.py
+++ b/tests/unit/mcp/tools/test_interview_intent_guard.py
@@ -91,3 +91,34 @@ async def test_interview_handler_records_human_contract_change_with_intent_guard
         for check in result.value.meta["intent_guard"]["checks"]
     )
     mock_engine.record_response.assert_awaited_once()
+
+
+async def test_interview_handler_resume_without_answer_omits_intent_guard() -> None:
+    state = InterviewState(
+        interview_id="interview_resume_no_answer",
+        initial_context=VIDEO_GOAL,
+        rounds=[
+            InterviewRound(
+                round_number=1,
+                question="What should be exported?",
+                user_response="MP4 shorts and transcript.",
+            )
+        ],
+    )
+    mock_engine = MagicMock()
+    mock_engine.load_state = AsyncMock(return_value=Result.ok(state))
+    mock_engine.ask_next_question = AsyncMock(return_value=Result.ok("What clip length?"))
+    mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
+    mock_engine.record_response = AsyncMock()
+
+    handler = InterviewHandler(interview_engine=mock_engine, llm_adapter=MagicMock())
+    handler._emit_event_bg = MagicMock()  # type: ignore[method-assign]
+
+    result = await handler.handle({"session_id": state.interview_id})
+
+    assert result.is_ok
+    assert result.value.meta["session_id"] == state.interview_id
+    assert "intent_guard" not in result.value.meta
+    assert result.value.content[0].text.endswith("What clip length?")
+    mock_engine.record_response.assert_not_called()
+    mock_engine.ask_next_question.assert_awaited_once()

--- a/tests/unit/mcp/tools/test_interview_intent_guard.py
+++ b/tests/unit/mcp/tools/test_interview_intent_guard.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from ouroboros.bigbang.interview import InterviewRound, InterviewState
+from ouroboros.core.types import Result
+from ouroboros.mcp.tools.definitions import InterviewHandler
+
+VIDEO_GOAL = (
+    "I want to make a video harness when I put a video to harness, "
+    "the harness will make some shorts and long form video with transcript"
+)
+
+REVIEW_ONLY_QUESTION = (
+    "Should this be --mode auto exporting MP4s or --mode review with review-only "
+    "package output?"
+)
+
+
+def _pending_video_state() -> InterviewState:
+    return InterviewState(
+        interview_id="interview_intentguard1",
+        initial_context=VIDEO_GOAL,
+        rounds=[
+            InterviewRound(
+                round_number=1,
+                question=REVIEW_ONLY_QUESTION,
+                user_response=None,
+            )
+        ],
+    )
+
+
+async def test_interview_handler_blocks_generated_review_only_answer_before_recording() -> None:
+    state = _pending_video_state()
+    mock_engine = MagicMock()
+    mock_engine.load_state = AsyncMock(return_value=Result.ok(state))
+    mock_engine.record_response = AsyncMock()
+    mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
+
+    handler = InterviewHandler(interview_engine=mock_engine, llm_adapter=MagicMock())
+    handler._emit_event_bg = MagicMock()  # type: ignore[method-assign]
+
+    result = await handler.handle(
+        {
+            "session_id": state.interview_id,
+            "answer": "[from-auto][conservative_default] Use review-only mode.",
+        }
+    )
+
+    assert result.is_err
+    assert "IntentGuard blocked interview answer" in str(result.error)
+    mock_engine.record_response.assert_not_called()
+    assert state.rounds[-1].user_response is None
+
+
+async def test_interview_handler_records_human_contract_change_with_intent_guard_warning() -> None:
+    state = _pending_video_state()
+
+    async def record_response(
+        current_state: InterviewState, answer: str, question: str
+    ) -> Result[InterviewState, object]:
+        current_state.rounds.append(
+            InterviewRound(
+                round_number=current_state.current_round_number,
+                question=question,
+                user_response=answer,
+            )
+        )
+        return Result.ok(current_state)
+
+    mock_engine = MagicMock()
+    mock_engine.load_state = AsyncMock(return_value=Result.ok(state))
+    mock_engine.record_response = AsyncMock(side_effect=record_response)
+    mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
+    mock_engine.ask_next_question = AsyncMock(return_value=Result.ok("What should be exported?"))
+
+    handler = InterviewHandler(interview_engine=mock_engine, llm_adapter=MagicMock())
+    handler._emit_event_bg = MagicMock()  # type: ignore[method-assign]
+
+    result = await handler.handle(
+        {
+            "session_id": state.interview_id,
+            "answer": "Let's make it review-only for now.",
+        }
+    )
+
+    assert result.is_ok
+    assert result.value.meta["intent_guard"]["status"] == "warn"
+    assert any(
+        check["code"] == "user_contract_change"
+        for check in result.value.meta["intent_guard"]["checks"]
+    )
+    mock_engine.record_response.assert_awaited_once()


### PR DESCRIPTION
## Summary

- Add a shared IntentGuard provenance layer so generated interview framing cannot outrank the original user output contract.
- Apply the guard to both `ooo auto` and `ouroboros_interview`: auto/generated answers fail closed, while explicit human contract changes surface as warnings.
- Surface IntentGuard status in auto status/MCP doctor views and prevent Seed QA/lateral diagnostics from polluting Seed constraints.

## Changes

- Extract inline artifact-output intent from sentence-shaped auto goals into `outputs` and `acceptance_criteria`.
- Prefer user output contracts when answering product-behavior questions, preventing review-only generated options from winning over requested artifacts.
- Add `IntentGuard` reports with `pass` / `warn` / `fail` checks for auto answers, interactive interview turns, persisted auto status, and spec-pollution diagnostics.
- Normalize Seed QA feedback into bounded repair constraints instead of copying raw QA/lateral prose into Seed constraints.
- Preserve explicit MCP auto runtime overrides when constructing nested authoring handlers.

## Verification

- `PYTHONPATH=src uv run ruff check src/ouroboros/auto/intent_guard.py src/ouroboros/auto/interview_driver.py src/ouroboros/mcp/tools/authoring_handlers.py src/ouroboros/mcp/tools/auto_handler.py src/ouroboros/cli/commands/auto.py src/ouroboros/cli/commands/status.py src/ouroboros/mcp/tools/query_handlers.py tests/unit/auto/test_intent_guard.py tests/unit/mcp/tools/test_interview_intent_guard.py tests/integration/auto/test_status_unified.py`
- `PYTHONPATH=src uv run pytest tests/unit/auto/test_intent_guard.py tests/unit/mcp/tools/test_interview_intent_guard.py tests/unit/mcp/tools/test_auto_interview_construction.py tests/unit/auto/test_user_preference_and_floor.py tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_pipeline_lateral.py tests/unit/auto/test_answer_source_log.py tests/integration/auto/test_status_unified.py`
- `PYTHONPATH=src uv run ruff check src/ouroboros/auto/pipeline.py tests/unit/auto/test_pipeline_lateral.py tests/unit/auto/test_interview_pipeline.py`
- `PYTHONPATH=src uv run pytest tests/unit/auto/test_interview_pipeline.py::test_pipeline_repairs_seed_qa_feedback_before_run tests/unit/auto/test_interview_pipeline.py::test_pipeline_seed_qa_lateral_repair_falls_back_when_lateral_errors tests/unit/auto/test_interview_pipeline.py::test_pipeline_blocks_qa_repaired_seed_when_review_no_longer_may_run tests/unit/auto/test_pipeline_lateral.py::test_seed_qa_feedback_does_not_pollute_constraints_with_diagnostics tests/unit/auto/test_pipeline_lateral.py::test_seed_qa_lateral_feedback_does_not_trip_intent_guard_pollution -q`
- `PYTHONPATH=src uv run pytest tests/unit/auto/test_intent_guard.py tests/unit/auto/test_pipeline_lateral.py -q`
- `PYTHONPATH=src uv run ruff check src tests`
- `uv run ruff format --check src/ tests/`
- `PYTHONPATH=src uv run pytest tests/unit/auto/test_intent_guard.py tests/unit/auto/test_pipeline_lateral.py tests/unit/mcp/tools/test_interview_intent_guard.py tests/unit/mcp/tools/test_auto_interview_construction.py tests/integration/auto/test_status_unified.py tests/unit/auto/test_surface.py::test_auto_handler_routes_interview_and_execute_from_stage_plan -q`
- `PYTHONPATH=src uv run pytest tests/unit/auto/test_intent_guard.py tests/unit/mcp/tools/test_interview_intent_guard.py tests/unit/mcp/tools/test_auto_interview_construction.py tests/unit/auto/test_user_preference_and_floor.py tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_pipeline_lateral.py tests/unit/auto/test_answer_source_log.py tests/integration/auto/test_status_unified.py -q`
- `PYTHONPATH=src uv run pytest tests/unit/auto/test_interview_pipeline.py -q`
- `PYTHONPATH=src uv run pytest tests/unit/mcp/tools/test_interview_intent_guard.py tests/unit/auto/test_pipeline_lateral.py::test_seed_qa_lateral_feedback_does_not_trip_intent_guard_pollution -q`
- `PYTHONPATH=src uv run pytest tests/unit/auto/test_intent_guard.py tests/unit/mcp/tools/test_interview_intent_guard.py tests/unit/auto/test_pipeline_lateral.py -q`

## R-run comparison

This PR changes auto/interview intent provenance, status surfacing, and Seed QA
repair normalization. It does not change dispatch-loop scheduling, model retry
budgets, or per-round execution cadence, so no live canonical R-run was
captured for this patch set.

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [x] N/A (logic-only guard/normalization changes; no
performance-bearing auto loop path changed)
