### PR TITLE
fix(auto): require real single task class for default AC

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4023,7 +4023,7 @@ class AutoPipeline:
         # L1-d / #1171: derive the task class from the standardized ledger
         # and prepend the catalog's default AC template to the Seed.
         inference = derive_domain_from_ledger(ledger)
-        task_class = inference.single
+        task_class = next(iter(inference.classes)) if inference.is_single else None
         if task_class is not None:
             applied = apply_default_ac_template(seed, task_class)
             if applied.injected_ac:

--- a/tests/unit/auto/test_pipeline_task_class_envelope.py
+++ b/tests/unit/auto/test_pipeline_task_class_envelope.py
@@ -5,8 +5,8 @@ Asserts:
   is populated when the ledger unambiguously matches a single class.
 - The Seed passed downstream has the catalog's ``default_ac_template``
   prepended to ``acceptance_criteria``.
-- An unmatched ledger applies the safe LIBRARY fallback; an ambiguous
-  ledger leaves ``active_task_class`` as None and AC untouched.
+- Unmatched and ambiguous ledgers leave ``active_task_class`` as None and AC
+  untouched.
 """
 
 from __future__ import annotations
@@ -214,11 +214,7 @@ async def test_envelope_carries_active_task_class_on_single_match(tmp_path) -> N
 
 
 @pytest.mark.asyncio
-async def test_envelope_uses_library_fallback_when_unmatched(tmp_path) -> None:
-    """Unmatched inference applies the L1-b safe LIBRARY fallback instead
-    of silently skipping default AC injection."""
-    profile = TASK_CLASS_CATALOG[TaskClass.LIBRARY]
-
+async def test_envelope_leaves_active_task_class_none_when_unmatched(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("What should we verify?", "interview_envelope_unmatched")
 
@@ -248,14 +244,13 @@ async def test_envelope_uses_library_fallback_when_unmatched(tmp_path) -> None:
 
     result = await pipeline.run(state)
 
-    assert result.active_task_class == TaskClass.LIBRARY.value
+    assert result.active_task_class is None
     ac = state.seed_artifact["acceptance_criteria"]
-    for index, expected in enumerate(profile.default_ac_template):
-        # The pipeline may wrap generic/library AC in execution-oriented
-        # phrasing, but it preserves the injected template text as the
-        # original requirement payload.
-        assert expected.removesuffix(".").replace(" are ", " ") in ac[index]
-    assert len(ac) >= len(profile.default_ac_template) + 1
+    library_template_entries = TASK_CLASS_CATALOG[TaskClass.LIBRARY].default_ac_template
+    for template_entry in library_template_entries:
+        assert template_entry not in ac, (
+            f"unmatched inference must not inject library template entry: {template_entry!r}"
+        )
     assert any("Changed behavior" in item and "tests" in item for item in ac)
 
 


### PR DESCRIPTION
## Summary
- stop applying task-class default acceptance criteria when inference only has the fallback/unmatched state
- keep `active_task_class` unset for unmatched ledgers
- update the envelope regression test so unmatched input does not inject LIBRARY defaults

## Test plan
- [x] `PYTHONPATH=src uv run pytest tests/unit/auto/test_pipeline_task_class_envelope.py`
- [x] `uv run ruff check src/ouroboros/auto/pipeline.py tests/unit/auto/test_pipeline_task_class_envelope.py`
- [ ] `uv run pytest tests/ -q` not run locally; focused regression only
- [ ] `uv run mypy src/` not run locally; PR CI is running type checks

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [ ] within 1.5x / [ ] regression flagged with mitigation / [x] N/A: this PR changes unmatched task-class default-AC classification and does not add model calls, interview rounds, EventStore writes, sleeps, subprocesses, or loop work.

## Notes
- The installed local tool was repaired and `ouroboros codex doctor --live-mcp` reports the auto MCP surface is healthy.
- The current Codex conversation still has a stale MCP transport (`Transport closed`), so `ooo auto` needs a fresh Codex/MCP session to pick up the fresh server handle.
