### PR TITLE
feat(qa): adversarial probe classes + acting-verification guidance (ouroboros-native)

### DIFF
--- a/skills/evaluate/SKILL.md
+++ b/skills/evaluate/SKILL.md
@@ -79,7 +79,9 @@ fallback instead of retrying the failing call.
    exposes acting tools — **computer-use / browser, `Bash`/shell, file reads**: don't
    just reason over the diff, **run the result and observe the real effect** (the
    command's output, the endpoint's response, the rendered UI via a screenshot). Do
-   it via a dedicated verification sub-agent to keep the main session lean. Probe the
+   it via a dedicated verification sub-agent to keep the main session lean — or
+   inline in the main session where the runtime restricts sub-agent spawning (the
+   observation is what matters; the delegation is only an optimization). Probe the
    acceptance criteria against the ACTUAL observable behaviour and the adversarial
    classes (`misleading_output`, `hung_command`, `stale_state`, `dirty_worktree`, …).
    Feed the captured evidence (commands, outputs, artifact paths) into the evaluate

--- a/skills/evaluate/SKILL.md
+++ b/skills/evaluate/SKILL.md
@@ -74,12 +74,24 @@ fallback instead of retrying the failing call.
    - If recent execution output exists in conversation: Use that
    - Ask user if unclear what to evaluate
 
+2.5. Acting verification — reproduce and OBSERVE (do not skip for behaviour-bearing work):
+   Stage 1 already runs mechanical checks (build/test). Go further when the runtime
+   exposes acting tools — **computer-use / browser, `Bash`/shell, file reads**: don't
+   just reason over the diff, **run the result and observe the real effect** (the
+   command's output, the endpoint's response, the rendered UI via a screenshot). Do
+   it via a dedicated verification sub-agent to keep the main session lean. Probe the
+   acceptance criteria against the ACTUAL observable behaviour and the adversarial
+   classes (`misleading_output`, `hung_command`, `stale_state`, `dirty_worktree`, …).
+   Feed the captured evidence (commands, outputs, artifact paths) into the evaluate
+   call as part of the `artifact`. If acting tools are unavailable, note that
+   behaviour was not observed and evaluate on the text alone.
+
 3. Call the `ouroboros_evaluate` MCP tool:
    ```
    Tool: ouroboros_evaluate
    Arguments:
      session_id: <session ID>
-     artifact: <the code/output to evaluate>
+     artifact: <the code/output to evaluate, plus observed-behaviour evidence from 2.5>
      seed_content: <original seed YAML, if available>
      acceptance_criterion: <specific AC to check, optional>
      artifact_type: "code"  (or "docs", "config")

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -18,7 +18,6 @@ Socratic interview to crystallize vague requirements into clear specifications.
 - `ask_user` — ask human-judgment questions through the active runtime's user-question surface.
 - `inspect_code` — answer repo-local factual questions from exact local files before asking the user.
 - `call_mcp` — use Ouroboros MCP tools for persistent interview state and seed generation.
-- `dispatch_research` — when the runtime exposes native sub-agents (e.g. the Task/Agent tool, codex `spawn_agent`), continuously fan out parallel research/exploration sub-agents (codebase-explorer to ground questions in real repo facts, researcher to gather external facts) so grounding is broad and visible, not single-threaded. Falls back to `inspect_code` / `web_research` when native sub-agents are unavailable.
 - `run_lateral_review` — invoke lateral thinking subagents before milestone turns and direct-answer synthesis.
 - `web_research` — fetch current external facts only when the interview genuinely depends on them.
 - `run_shell` — run bounded local commands for version checks and repository inspection.
@@ -135,36 +134,6 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
 - **MCP**: Generates Socratic questions, manages interview state, scores ambiguity. Does NOT read code.
 - **You (main session)**: Receives MCP questions, answers them by reading code through the active runtime's `inspect_code` capability, or routes to the user when human judgment is needed.
 - **User**: Only answers questions that require human decisions (goals, acceptance criteria, business logic, preferences).
-
-#### Native Research Fan-Out (use throughout, not just at milestones)
-
-The interview runs in the MAIN session, so — unlike background execution workers —
-you can spawn **native sub-agents that the human SEES inline**. Use this generously:
-the interview is where ouroboros earns its keep (grounding hidden assumptions in
-real facts before any code), and parallel research makes that both deeper and visible.
-
-Whenever the runtime exposes native sub-agents (the Task/Agent tool, codex
-`spawn_agent`, etc.) **and its policy allows spawning them without a per-spawn
-user request**, prefer fanning out over answering single-threaded — where a
-runtime restricts spawning, do the same research inline in the main session
-(the grounding is what matters; the fan-out is only an optimization):
-
-- **Ground every factual MCP question in the real repo** — dispatch one or more
-  `codebase-explorer` sub-agents (in a single parallel burst) instead of a lone
-  `inspect_code` pass. Different explorers can chase different angles (where a thing
-  is defined, how it's wired, what already exists) concurrently.
-- **Gather external facts** the interview genuinely depends on with a `researcher`
-  sub-agent, in parallel with the codebase explorers.
-- **Keep each assignment lean and self-contained** (the assignment carries the
-  exact question + scope; do NOT fork full parent history) — same discipline as the
-  execution worker pool's TASK/DELIVERABLE/SCOPE/VERIFY messages.
-- **Fold only concrete, user-safe findings** back into the answer or the next user
-  question. Do not dump raw sub-agent reports at the user.
-
-This is additive to `run_lateral_review` (multi-persona milestone checks): research
-sub-agents establish FACTS, lateral sub-agents stress hidden ASSUMPTIONS — run both.
-If native sub-agents are unavailable, degrade to `inspect_code` / `web_research`
-without restarting the interview.
 
 #### Interview Flow
 

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -18,6 +18,7 @@ Socratic interview to crystallize vague requirements into clear specifications.
 - `ask_user` — ask human-judgment questions through the active runtime's user-question surface.
 - `inspect_code` — answer repo-local factual questions from exact local files before asking the user.
 - `call_mcp` — use Ouroboros MCP tools for persistent interview state and seed generation.
+- `dispatch_research` — when the runtime exposes native sub-agents (e.g. the Task/Agent tool, codex `spawn_agent`), continuously fan out parallel research/exploration sub-agents (codebase-explorer to ground questions in real repo facts, researcher to gather external facts) so grounding is broad and visible, not single-threaded. Falls back to `inspect_code` / `web_research` when native sub-agents are unavailable.
 - `run_lateral_review` — invoke lateral thinking subagents before milestone turns and direct-answer synthesis.
 - `web_research` — fetch current external facts only when the interview genuinely depends on them.
 - `run_shell` — run bounded local commands for version checks and repository inspection.
@@ -134,6 +135,33 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
 - **MCP**: Generates Socratic questions, manages interview state, scores ambiguity. Does NOT read code.
 - **You (main session)**: Receives MCP questions, answers them by reading code through the active runtime's `inspect_code` capability, or routes to the user when human judgment is needed.
 - **User**: Only answers questions that require human decisions (goals, acceptance criteria, business logic, preferences).
+
+#### Native Research Fan-Out (use throughout, not just at milestones)
+
+The interview runs in the MAIN session, so — unlike background execution workers —
+you can spawn **native sub-agents that the human SEES inline**. Use this generously:
+the interview is where ouroboros earns its keep (grounding hidden assumptions in
+real facts before any code), and parallel research makes that both deeper and visible.
+
+Whenever the runtime exposes native sub-agents (the Task/Agent tool, codex
+`spawn_agent`, etc.), prefer fanning out over answering single-threaded:
+
+- **Ground every factual MCP question in the real repo** — dispatch one or more
+  `codebase-explorer` sub-agents (in a single parallel burst) instead of a lone
+  `inspect_code` pass. Different explorers can chase different angles (where a thing
+  is defined, how it's wired, what already exists) concurrently.
+- **Gather external facts** the interview genuinely depends on with a `researcher`
+  sub-agent, in parallel with the codebase explorers.
+- **Keep each assignment lean and self-contained** (the assignment carries the
+  exact question + scope; do NOT fork full parent history) — same discipline as the
+  execution worker pool's TASK/DELIVERABLE/SCOPE/VERIFY messages.
+- **Fold only concrete, user-safe findings** back into the answer or the next user
+  question. Do not dump raw sub-agent reports at the user.
+
+This is additive to `run_lateral_review` (multi-persona milestone checks): research
+sub-agents establish FACTS, lateral sub-agents stress hidden ASSUMPTIONS — run both.
+If native sub-agents are unavailable, degrade to `inspect_code` / `web_research`
+without restarting the interview.
 
 #### Interview Flow
 

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -144,7 +144,10 @@ the interview is where ouroboros earns its keep (grounding hidden assumptions in
 real facts before any code), and parallel research makes that both deeper and visible.
 
 Whenever the runtime exposes native sub-agents (the Task/Agent tool, codex
-`spawn_agent`, etc.), prefer fanning out over answering single-threaded:
+`spawn_agent`, etc.) **and its policy allows spawning them without a per-spawn
+user request**, prefer fanning out over answering single-threaded — where a
+runtime restricts spawning, do the same research inline in the main session
+(the grounding is what matters; the fan-out is only an optimization):
 
 - **Ground every factual MCP question in the real repo** — dispatch one or more
   `codebase-explorer` sub-agents (in a single parallel burst) instead of a lone

--- a/skills/qa/SKILL.md
+++ b/skills/qa/SKILL.md
@@ -71,6 +71,24 @@ This skill works in two modes. Determine which one **before** attempting any too
    - `screenshot` — visual artifacts
    - `custom` — anything else
 
+3.5. **Acting verification — reproduce and OBSERVE before judging (do not skip for behaviour-bearing artifacts):**
+   A text judge can be fooled by a hopeful log line. When the artifact actually
+   *does* something (code, an app, an API, a UI) and the runtime exposes acting
+   tools — **computer-use / browser, `Bash`/shell, file reads** — gather real
+   evidence first, ideally via a dedicated verification sub-agent so the main
+   session stays lean:
+   - **Run it** — execute the command / start the app / hit the endpoint.
+   - **Observe the actual effect** — the file written, the endpoint's response,
+     the rendered UI (screenshot via computer-use) — NOT just exit text.
+   - **Probe the applicable adversarial classes** (the QA tool lists them):
+     `misleading_output` (claimed success vs. real effect), `hung_command`
+     (bounded timeout?), `malformed_input`, `stale_state`, `dirty_worktree`, etc.
+   - Capture commands run, outputs, and artifact paths as **evidence**.
+   Pass that evidence into the judge as `reference` (and prefer the observed
+   behaviour over the source text as the `artifact` when they disagree). If no
+   acting tools are available, say so and judge on the text alone — but flag that
+   behaviour was not observed.
+
 4. **Call the `ouroboros_qa` MCP tool:**
    ```
    Tool: ouroboros_qa
@@ -78,7 +96,7 @@ This skill works in two modes. Determine which one **before** attempting any too
      artifact: <the content to evaluate>
      quality_bar: <what 'pass' means>
      artifact_type: "code"  (or other type)
-     reference: <optional reference for comparison>
+     reference: <observed-behaviour evidence from step 3.5, plus any reference>
      pass_threshold: 0.80  (adjustable)
      seed_content: <seed YAML if available>
    ```

--- a/src/ouroboros/agents/qa-judge.md
+++ b/src/ouroboros/agents/qa-judge.md
@@ -28,6 +28,11 @@ Verdict rules:
 - score >= 0.40 and < pass_threshold → verdict="revise"
 - score < 0.40 → verdict="fail"
 
+Adversarial probing:
+- The user prompt may include an "Adversarial Probes" checklist of named classes (malformed input, prompt injection, cancel/resume, stale state, dirty worktree, hung command, flaky test, misleading output, repeated interrupt).
+- For each class whose trigger matches the artifact, actually probe it; a "done" claim only counts as strong if it survives the applicable probes.
+- A failed probe is a concrete difference: add it to `differences` with a matching `suggestion`, and let it pull down `correctness`. Skip classes that do not apply — do not pad.
+
 Constraints:
 - Each difference MUST have a corresponding suggestion
 - Suggestions must be actionable in a single revision pass

--- a/src/ouroboros/agents/qa-judge.md
+++ b/src/ouroboros/agents/qa-judge.md
@@ -30,8 +30,9 @@ Verdict rules:
 
 Adversarial probing:
 - The user prompt may include an "Adversarial Probes" checklist of named classes (malformed input, prompt injection, cancel/resume, stale state, dirty worktree, hung command, flaky test, misleading output, repeated interrupt).
-- For each class whose trigger matches the artifact, actually probe it; a "done" claim only counts as strong if it survives the applicable probes.
-- A failed probe is a concrete difference: add it to `differences` with a matching `suggestion`, and let it pull down `correctness`. Skip classes that do not apply — do not pad.
+- You judge from the supplied evidence — you never execute anything yourself. For each class whose trigger matches the artifact, audit the evidence against its probe; a "done" claim only counts as strong if the evidence shows it survives the applicable probes.
+- A probe the evidence shows failing is a concrete difference: add it to `differences` with a matching `suggestion`, and let it pull down `correctness`. Skip classes that do not apply — do not pad.
+- Follow the evidence contract rendered under "Adversarial Probes" in the user prompt: it differs for executable artifacts (missing evidence for an applicable probe is an evidence gap) versus documents/specifications (unrunnable is never a defect — apply the classes only as a completeness lens over the document's substance).
 
 Constraints:
 - Each difference MUST have a corresponding suggestion

--- a/src/ouroboros/evaluation/adversarial.py
+++ b/src/ouroboros/evaluation/adversarial.py
@@ -123,10 +123,51 @@ def render_checklist(classes: tuple[AdversarialClass, ...] = ADVERSARIAL_CLASSES
     return "\n".join(lines)
 
 
+_EXECUTABLE_EVIDENCE_CONTRACT = (
+    'A "done" claim is only as strong as the probes it survives. Use supplied '
+    "artifact/reference/history/seed evidence only; if an applicable probe requires "
+    "execution or observation that is not present, report that as an evidence gap in "
+    "``differences`` (with a matching ``suggestion``) instead of implying you ran it. "
+    "Let any real failure or unverified applicable probe lower ``correctness``."
+)
+
+# A document (e.g. a seed specification) describes FUTURE behaviour and cannot be
+# executed; treating that inability as an evidence gap would penalize every
+# behavioural spec regardless of substance.
+_DOCUMENT_EVIDENCE_CONTRACT = (
+    "This artifact is a document describing future behaviour — it cannot be executed, "
+    "and that is not a defect. Never report an unrunnable probe as an evidence gap and "
+    "never lower any dimension because a probe could not be executed. Instead, use the "
+    "applicable classes as a completeness lens over the document's substance: if it "
+    "clearly triggers a class yet fails to address it (e.g. it shells out but never "
+    "bounds the command), report that omission as a difference with a matching "
+    "``suggestion``. Judge the document's substance only."
+)
+
+
+def render_adversarial_section(artifact_type: str = "code") -> str:
+    """Render the full prompt section: header, checklist, and evidence contract.
+
+    The evidence contract is artifact-kind-aware: executable artifacts are judged
+    on whether the evidence shows they survive the probes; ``document`` artifacts
+    get the completeness-lens contract instead.
+    """
+    contract = (
+        _DOCUMENT_EVIDENCE_CONTRACT
+        if artifact_type == "document"
+        else _EXECUTABLE_EVIDENCE_CONTRACT
+    )
+    return (
+        f"## Adversarial Probes (schema v{ADVERSARIAL_SCHEMA_VERSION})\n"
+        f"{render_checklist()}\n{contract}\n"
+    )
+
+
 __all__ = [
     "ADVERSARIAL_CLASSES",
     "ADVERSARIAL_SCHEMA_VERSION",
     "AdversarialClass",
     "get_class",
+    "render_adversarial_section",
     "render_checklist",
 ]

--- a/src/ouroboros/evaluation/adversarial.py
+++ b/src/ouroboros/evaluation/adversarial.py
@@ -7,7 +7,7 @@ classes whose trigger matches the artifact and reports a finding per class —
 turning verification from a vibe into an auditable contract.
 
 This is ouroboros's adaptation of the "UltraQA" adversarial-class discipline from
-oh-my-openagent / lazycodex (https://github.com/lazyfish-ai/lazycodex), credited
+oh-my-openagent / lazycodex (https://github.com/code-yeongyu/lazycodex), credited
 with thanks. Their insight — independent verification probing explicit attack
 surfaces — fits ouroboros's "verify, don't bluff" ethos; here it is a typed,
 versioned registry the evaluator/qa-judge can render into a prompt.

--- a/src/ouroboros/evaluation/adversarial.py
+++ b/src/ouroboros/evaluation/adversarial.py
@@ -86,8 +86,7 @@ ADVERSARIAL_CLASSES: tuple[AdversarialClass, ...] = (
         id="flaky_test",
         name="Flaky / timing-sensitive test",
         trigger="the artifact adds new or timing-sensitive tests",
-        probe="run repeatedly; confirm deterministic results (no order/timing/network "
-        "dependence)",
+        probe="run repeatedly; confirm deterministic results (no order/timing/network dependence)",
     ),
     AdversarialClass(
         id="misleading_output",

--- a/src/ouroboros/evaluation/adversarial.py
+++ b/src/ouroboros/evaluation/adversarial.py
@@ -1,0 +1,133 @@
+"""Adversarial verification classes — concrete attack surfaces for QA probing.
+
+A verifier that is told to "test edge cases" tests nothing in particular. The
+fix is a CHECKLIST of named, concrete adversarial classes, each with a trigger
+(when it applies) and a probe (what to actually try). The QA judge selects the
+classes whose trigger matches the artifact and reports a finding per class —
+turning verification from a vibe into an auditable contract.
+
+This is ouroboros's adaptation of the "UltraQA" adversarial-class discipline from
+oh-my-openagent / lazycodex (https://github.com/lazyfish-ai/lazycodex), credited
+with thanks. Their insight — independent verification probing explicit attack
+surfaces — fits ouroboros's "verify, don't bluff" ethos; here it is a typed,
+versioned registry the evaluator/qa-judge can render into a prompt.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+ADVERSARIAL_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class AdversarialClass:
+    """One named adversarial verification class.
+
+    Attributes:
+        id: Stable machine id (snake_case) — used in structured findings.
+        name: Human-readable label.
+        trigger: The condition under which this class APPLIES to an artifact.
+        probe: The concrete thing to try / inspect to falsify a "done" claim.
+    """
+
+    id: str
+    name: str
+    trigger: str
+    probe: str
+
+
+# The canonical registry. Order is the suggested probing order (cheap structural
+# checks first, behavioural/timing checks later).
+ADVERSARIAL_CLASSES: tuple[AdversarialClass, ...] = (
+    AdversarialClass(
+        id="malformed_input",
+        name="Malformed / boundary input",
+        trigger="the artifact parses or accepts new input",
+        probe="feed empty, oversized, wrong-type, and boundary values; confirm it "
+        "rejects cleanly (no crash, no silent wrong result)",
+    ),
+    AdversarialClass(
+        id="prompt_injection",
+        name="Prompt / instruction injection",
+        trigger="the artifact incorporates untrusted external text (web, files, tool output)",
+        probe="embed adversarial instructions in that text; confirm they are treated "
+        "as data, not obeyed as commands",
+    ),
+    AdversarialClass(
+        id="cancel_resume",
+        name="Cancel / resume",
+        trigger="the artifact drives a resumable or long-running flow",
+        probe="interrupt mid-flight and resume; confirm no duplicate work, lost state, "
+        "or corrupted checkpoint",
+    ),
+    AdversarialClass(
+        id="stale_state",
+        name="Stale state",
+        trigger="the artifact reads generated, cached, or derived state",
+        probe="run against pre-existing/outdated artifacts; confirm it regenerates or "
+        "invalidates rather than trusting stale data",
+    ),
+    AdversarialClass(
+        id="dirty_worktree",
+        name="Dirty worktree",
+        trigger="the artifact touches files in a working tree",
+        probe="run with uncommitted user changes present; confirm it never clobbers or "
+        "loses unrelated edits",
+    ),
+    AdversarialClass(
+        id="hung_command",
+        name="Hung / long command",
+        trigger="the artifact shells out or calls a long external command",
+        probe="simulate a command that hangs or runs long; confirm a bounded timeout "
+        "and a clear failure, not an indefinite block",
+    ),
+    AdversarialClass(
+        id="flaky_test",
+        name="Flaky / timing-sensitive test",
+        trigger="the artifact adds new or timing-sensitive tests",
+        probe="run repeatedly; confirm deterministic results (no order/timing/network "
+        "dependence)",
+    ),
+    AdversarialClass(
+        id="misleading_output",
+        name="Misleading success output",
+        trigger="success is claimed from logs or exit text",
+        probe="check that the claimed success matches the ACTUAL observable effect "
+        "(file written, endpoint responding) — not just a hopeful log line",
+    ),
+    AdversarialClass(
+        id="repeated_interrupt",
+        name="Repeated interruption",
+        trigger="the artifact performs a multi-step mutating operation",
+        probe="interrupt repeatedly at different steps; confirm idempotence / safe "
+        "rollback with no partial corruption",
+    ),
+)
+
+_CLASS_BY_ID = {c.id: c for c in ADVERSARIAL_CLASSES}
+
+
+def get_class(class_id: str) -> AdversarialClass | None:
+    """Return the class with ``class_id`` or ``None``."""
+    return _CLASS_BY_ID.get(class_id)
+
+
+def render_checklist(classes: tuple[AdversarialClass, ...] = ADVERSARIAL_CLASSES) -> str:
+    """Render the classes as a compact, prompt-ready checklist."""
+    lines = [
+        "Probe each adversarial class whose TRIGGER matches this artifact "
+        "(skip the ones that do not apply):",
+    ]
+    for cls in classes:
+        lines.append(f"- **{cls.id}** ({cls.name}) — if {cls.trigger}: {cls.probe}.")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "ADVERSARIAL_CLASSES",
+    "ADVERSARIAL_SCHEMA_VERSION",
+    "AdversarialClass",
+    "get_class",
+    "render_checklist",
+]

--- a/src/ouroboros/mcp/tools/qa.py
+++ b/src/ouroboros/mcp/tools/qa.py
@@ -148,8 +148,11 @@ def _build_qa_user_prompt(
     adversarial_section = f"""
 ## Adversarial Probes
 {render_checklist()}
-A "done" claim is only as strong as the probes it survives. Fold any failure into
-``differences`` (with a matching ``suggestion``) and let it lower ``correctness``.
+A "done" claim is only as strong as the probes it survives. Use supplied
+artifact/reference/history/seed evidence only; if an applicable probe requires
+execution or observation that is not present, report that as an evidence gap in
+``differences`` (with a matching ``suggestion``) instead of implying you ran it.
+Let any real failure or unverified applicable probe lower ``correctness``.
 """
 
     return f"""## Quality Bar

--- a/src/ouroboros/mcp/tools/qa.py
+++ b/src/ouroboros/mcp/tools/qa.py
@@ -143,6 +143,15 @@ def _build_qa_user_prompt(
 ```
 """
 
+    from ouroboros.evaluation.adversarial import render_checklist
+
+    adversarial_section = f"""
+## Adversarial Probes
+{render_checklist()}
+A "done" claim is only as strong as the probes it survives. Fold any failure into
+``differences`` (with a matching ``suggestion``) and let it lower ``correctness``.
+"""
+
     return f"""## Quality Bar
 {quality_bar}
 
@@ -156,7 +165,7 @@ def _build_qa_user_prompt(
 ```
 {artifact}
 ```
-{reference_section}{history_section}{seed_section}
+{reference_section}{history_section}{seed_section}{adversarial_section}
 Provide your evaluation as a JSON object."""
 
 

--- a/src/ouroboros/mcp/tools/qa.py
+++ b/src/ouroboros/mcp/tools/qa.py
@@ -143,17 +143,9 @@ def _build_qa_user_prompt(
 ```
 """
 
-    from ouroboros.evaluation.adversarial import render_checklist
+    from ouroboros.evaluation.adversarial import render_adversarial_section
 
-    adversarial_section = f"""
-## Adversarial Probes
-{render_checklist()}
-A "done" claim is only as strong as the probes it survives. Use supplied
-artifact/reference/history/seed evidence only; if an applicable probe requires
-execution or observation that is not present, report that as an evidence gap in
-``differences`` (with a matching ``suggestion``) instead of implying you ran it.
-Let any real failure or unverified applicable probe lower ``correctness``.
-"""
+    adversarial_section = "\n" + render_adversarial_section(artifact_type)
 
     return f"""## Quality Bar
 {quality_bar}

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -1074,17 +1074,9 @@ def build_qa_subagent(
     if seed_content:
         seed_section = f"\n## Seed Specification\n```yaml\n{seed_content}\n```\n"
 
-    from ouroboros.evaluation.adversarial import render_checklist
+    from ouroboros.evaluation.adversarial import render_adversarial_section
 
-    adversarial_section = f"""
-## Adversarial Probes
-{render_checklist()}
-A "done" claim is only as strong as the probes it survives. Use supplied
-artifact/reference/history/seed evidence only; if an applicable probe requires
-execution or observation that is not present, report that as an evidence gap in
-``differences`` (with a matching ``suggestion``) instead of implying you ran it.
-Let any real failure or unverified applicable probe lower ``correctness``.
-"""
+    adversarial_section = "\n" + render_adversarial_section(artifact_type)
 
     prompt = f"""{system_prompt}
 

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -1079,8 +1079,11 @@ def build_qa_subagent(
     adversarial_section = f"""
 ## Adversarial Probes
 {render_checklist()}
-A "done" claim is only as strong as the probes it survives. Fold any failure into
-``differences`` (with a matching ``suggestion``) and let it lower ``correctness``.
+A "done" claim is only as strong as the probes it survives. Use supplied
+artifact/reference/history/seed evidence only; if an applicable probe requires
+execution or observation that is not present, report that as an evidence gap in
+``differences`` (with a matching ``suggestion``) instead of implying you ran it.
+Let any real failure or unverified applicable probe lower ``correctness``.
 """
 
     prompt = f"""{system_prompt}

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -1074,6 +1074,15 @@ def build_qa_subagent(
     if seed_content:
         seed_section = f"\n## Seed Specification\n```yaml\n{seed_content}\n```\n"
 
+    from ouroboros.evaluation.adversarial import render_checklist
+
+    adversarial_section = f"""
+## Adversarial Probes
+{render_checklist()}
+A "done" claim is only as strong as the probes it survives. Fold any failure into
+``differences`` (with a matching ``suggestion``) and let it lower ``correctness``.
+"""
+
     prompt = f"""{system_prompt}
 
 ---
@@ -1102,7 +1111,7 @@ as a JSON object with these exact fields:
 ```
 {artifact}
 ```
-{reference_section}{history_section}{seed_section}
+{reference_section}{history_section}{seed_section}{adversarial_section}
 Return ONLY the JSON verdict object. No other text."""
 
     context: dict[str, Any] = {

--- a/tests/unit/evaluation/test_adversarial.py
+++ b/tests/unit/evaluation/test_adversarial.py
@@ -1,0 +1,68 @@
+"""Adversarial QA class registry — canonical, renderable, prompt-wired."""
+
+from __future__ import annotations
+
+from ouroboros.evaluation.adversarial import (
+    ADVERSARIAL_CLASSES,
+    AdversarialClass,
+    get_class,
+    render_checklist,
+)
+
+
+class TestRegistry:
+    def test_nine_canonical_classes_present(self) -> None:
+        ids = {c.id for c in ADVERSARIAL_CLASSES}
+        assert ids == {
+            "malformed_input",
+            "prompt_injection",
+            "cancel_resume",
+            "stale_state",
+            "dirty_worktree",
+            "hung_command",
+            "flaky_test",
+            "misleading_output",
+            "repeated_interrupt",
+        }
+
+    def test_every_class_has_trigger_and_probe(self) -> None:
+        for c in ADVERSARIAL_CLASSES:
+            assert isinstance(c, AdversarialClass)
+            assert c.id and c.name and c.trigger and c.probe
+
+    def test_ids_are_unique(self) -> None:
+        ids = [c.id for c in ADVERSARIAL_CLASSES]
+        assert len(ids) == len(set(ids))
+
+    def test_get_class_roundtrip(self) -> None:
+        assert get_class("prompt_injection").name == "Prompt / instruction injection"
+        assert get_class("nonexistent") is None
+
+
+class TestRender:
+    def test_checklist_lists_every_class_id(self) -> None:
+        text = render_checklist()
+        for c in ADVERSARIAL_CLASSES:
+            assert c.id in text
+        # trigger-conditional phrasing so the judge skips non-applicable classes
+        assert "if " in text
+
+    def test_render_subset(self) -> None:
+        subset = (ADVERSARIAL_CLASSES[0],)
+        text = render_checklist(subset)
+        assert ADVERSARIAL_CLASSES[0].id in text
+        assert ADVERSARIAL_CLASSES[1].id not in text
+
+
+class TestPromptWiring:
+    def test_qa_user_prompt_includes_adversarial_section(self) -> None:
+        from ouroboros.mcp.tools.qa import _build_qa_user_prompt
+
+        prompt = _build_qa_user_prompt(
+            artifact="def f(): pass",
+            artifact_type="code",
+            quality_bar="must work",
+        )
+        assert "Adversarial Probes" in prompt
+        assert "malformed_input" in prompt
+        assert "prompt_injection" in prompt

--- a/tests/unit/evaluation/test_adversarial.py
+++ b/tests/unit/evaluation/test_adversarial.py
@@ -66,3 +66,5 @@ class TestPromptWiring:
         assert "Adversarial Probes" in prompt
         assert "malformed_input" in prompt
         assert "prompt_injection" in prompt
+        assert "evidence gap" in prompt
+        assert "instead of implying you ran it" in prompt

--- a/tests/unit/evaluation/test_adversarial.py
+++ b/tests/unit/evaluation/test_adversarial.py
@@ -53,6 +53,33 @@ class TestRender:
         assert ADVERSARIAL_CLASSES[0].id in text
         assert ADVERSARIAL_CLASSES[1].id not in text
 
+    def test_section_stamps_schema_version(self) -> None:
+        from ouroboros.evaluation.adversarial import (
+            ADVERSARIAL_SCHEMA_VERSION,
+            render_adversarial_section,
+        )
+
+        assert f"schema v{ADVERSARIAL_SCHEMA_VERSION}" in render_adversarial_section()
+
+    def test_section_code_mode_keeps_evidence_gap_contract(self) -> None:
+        from ouroboros.evaluation.adversarial import render_adversarial_section
+
+        text = render_adversarial_section("code")
+        assert "evidence gap" in text
+        assert "instead of implying you ran it" in text
+
+    def test_section_document_mode_never_penalizes_unrunnable(self) -> None:
+        from ouroboros.evaluation.adversarial import render_adversarial_section
+
+        text = render_adversarial_section("document")
+        # A spec cannot be executed; that must never be scored as missing evidence
+        # (the seed-QA gate feeds artifact_type="document" on every auto run).
+        assert "Never report an unrunnable probe as an evidence gap" in text
+        assert "never lower any dimension" in text
+        assert "completeness lens" in text
+        assert "unverified applicable probe lower" not in text
+        assert "instead of implying you ran it" not in text
+
 
 class TestPromptWiring:
     def test_qa_user_prompt_includes_adversarial_section(self) -> None:
@@ -68,3 +95,16 @@ class TestPromptWiring:
         assert "prompt_injection" in prompt
         assert "evidence gap" in prompt
         assert "instead of implying you ran it" in prompt
+
+    def test_qa_user_prompt_document_mode_uses_completeness_contract(self) -> None:
+        from ouroboros.mcp.tools.qa import _build_qa_user_prompt
+
+        prompt = _build_qa_user_prompt(
+            artifact="goal: ship\nacceptance_criteria: [works]",
+            artifact_type="document",
+            quality_bar="clear spec",
+        )
+        assert "Adversarial Probes" in prompt
+        assert "completeness lens" in prompt
+        assert "unverified applicable probe lower" not in prompt
+        assert "instead of implying you ran it" not in prompt

--- a/tests/unit/mcp/tools/test_handler_subagent_wiring.py
+++ b/tests/unit/mcp/tools/test_handler_subagent_wiring.py
@@ -71,6 +71,8 @@ class TestQAHandlerSubagentDispatch:
         assert "Adversarial Probes" in prompt
         assert "malformed_input" in prompt
         assert "prompt_injection" in prompt
+        assert "evidence gap" in prompt
+        assert "instead of implying you ran it" in prompt
 
     async def test_still_validates_missing_artifact(self, handler) -> None:
         result = await handler.handle({"quality_bar": "good"})

--- a/tests/unit/mcp/tools/test_handler_subagent_wiring.py
+++ b/tests/unit/mcp/tools/test_handler_subagent_wiring.py
@@ -59,6 +59,19 @@ class TestQAHandlerSubagentDispatch:
         assert "_subagent" in mcp_result.meta
         assert mcp_result.meta["_subagent"]["tool_name"] == "ouroboros_qa"
 
+    async def test_subagent_prompt_includes_adversarial_probes(self, handler) -> None:
+        result = await handler.handle(
+            {
+                "artifact": "def foo(): pass",
+                "quality_bar": "All functions have docstrings",
+            }
+        )
+        assert result.is_ok
+        prompt = result.value.meta["_subagent"]["prompt"]
+        assert "Adversarial Probes" in prompt
+        assert "malformed_input" in prompt
+        assert "prompt_injection" in prompt
+
     async def test_still_validates_missing_artifact(self, handler) -> None:
         result = await handler.handle({"quality_bar": "good"})
         assert result.is_err


### PR DESCRIPTION
Studying [lazycodex](https://github.com/code-yeongyu/lazycodex) / oh-my-openagent and borrowing its verification discipline where it fits ouroboros. **Slimmed after a 3-lens adversarial review** — the interview research fan-out borrow was dropped (see below).

## 1. Adversarial QA classes (`evaluation/adversarial.py`)
A verifier told to "test edge cases" tests nothing. A typed registry of **nine concrete adversarial classes** (malformed input, prompt injection, cancel/resume, stale state, dirty worktree, hung command, flaky test, misleading output, repeated interrupt) — each with a *trigger* + *probe* — rendered into BOTH QA prompt paths (in-process `_build_qa_user_prompt` and `build_qa_subagent`), with tests pinning the live wiring. Class applicability is judged by the LLM against each trigger (all nine are always rendered; there is no code-level filtering). `ADVERSARIAL_SCHEMA_VERSION` is stamped into the rendered header.

**Artifact-kind-aware evidence contract** (added in the slim pass): executable artifacts are judged on whether the supplied evidence shows they survive the probes — a missing observation for an applicable probe is an evidence gap that lowers `correctness`. `document` artifacts (the seed-QA gate feeds `artifact_type="document"` on every auto run) instead get a **completeness-lens contract**: a spec's inability to be executed is never an evidence gap and never lowers a score; only substance omissions (the spec shells out but never bounds the command) count. This guards against the over-harshness failure class that has stalled auto twice before.

## 2. Acting-verification guidance (`skills/qa`, `skills/evaluate`)
Host-instruction prose (no server-side enforcement): when the runtime exposes computer-use / browser / Bash, reproduce and OBSERVE the real effect via a dedicated verification sub-agent and fold that evidence into the `artifact` before judging. Falls back to judging on text alone, explicitly noting behaviour was not observed.

## Dropped in the slim pass: interview research fan-out
The original borrow 3 added a `dispatch_research` fan-out to `skills/interview/SKILL.md`. Adversarial review showed it predated the question-advisory fan-out that landed on main, so a clean merge would have produced two overlapping, mutually-unaware fan-outs in the same skill (double-spawning, no gate on "continuously"). The planned interview fan-out design supersedes it — server-stamped payloads, correlation keys, and stagnation gating — so the prose version was removed rather than patched.

Tests: `tests/unit/evaluation/test_adversarial.py` (registry, per-kind contracts, live prompt wiring incl. document mode), `tests/unit/mcp/tools/test_handler_subagent_wiring.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)