### PR TITLE
fix(providers): avoid FrozenInstanceError when normalizing JSON in ClaudeCodeAdapter

### DIFF
--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -314,8 +314,11 @@ class ClaudeCodeAdapter:
             return result
         extracted = extract_json_payload(result.value.content)
         if extracted:
-            result.value.content = extracted
-            return result
+            # CompletionResponse is a frozen dataclass — build a new instance
+            # instead of mutating (mutation raises FrozenInstanceError).
+            from dataclasses import replace
+
+            return Result.ok(replace(result.value, content=extracted))
         return None
 
     async def _enforce_json(

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -11,12 +11,31 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from ouroboros.core.types import Result
 from ouroboros.providers.base import (
     CompletionConfig,
+    CompletionResponse,
     Message,
     MessageRole,
+    UsageInfo,
 )
 from ouroboros.providers.claude_code_adapter import ClaudeCodeAdapter
+
+
+def _ok_response(content: str) -> Result[CompletionResponse, object]:
+    """A successful Result wrapping a real (frozen) CompletionResponse.
+
+    Use this instead of a MagicMock so tests exercise the real dataclass — a
+    MagicMock's attributes are freely assignable and would hide bugs like
+    mutating the frozen `content` field during JSON normalization.
+    """
+    return Result.ok(
+        CompletionResponse(
+            content=content,
+            model="claude-sonnet-4-6",
+            usage=UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+        )
+    )
 
 
 class TestBuildPrompt:
@@ -243,9 +262,7 @@ class TestExecuteSingleRequestSystemPrompt:
             },
         )
 
-        mock_response = MagicMock(is_ok=True, is_err=False)
-        mock_response.value.content = '{"score": 0.9}'
-        mock_execute = AsyncMock(return_value=mock_response)
+        mock_execute = AsyncMock(return_value=_ok_response('{"score": 0.9}'))
         adapter._execute_single_request = mock_execute
 
         with patch.dict("sys.modules", {"claude_agent_sdk": MagicMock()}):
@@ -268,11 +285,8 @@ class TestExecuteSingleRequestSystemPrompt:
             },
         )
 
-        prose_response = MagicMock(is_ok=True, is_err=False)
-        prose_response.value.content = "Let me verify the acceptance criteria..."
-
-        json_response = MagicMock(is_ok=True, is_err=False)
-        json_response.value.content = '{"score": 0.85}'
+        prose_response = _ok_response("Let me verify the acceptance criteria...")
+        json_response = _ok_response('{"score": 0.85}')
 
         mock_execute = AsyncMock(side_effect=[prose_response, json_response])
         adapter._execute_single_request = mock_execute
@@ -297,8 +311,7 @@ class TestExecuteSingleRequestSystemPrompt:
             },
         )
 
-        prose_response = MagicMock(is_ok=True, is_err=False)
-        prose_response.value.content = "I cannot produce JSON right now"
+        prose_response = _ok_response("I cannot produce JSON right now")
 
         # 1 initial + 3 retries = 4 calls total
         mock_execute = AsyncMock(return_value=prose_response)
@@ -324,8 +337,7 @@ class TestExecuteSingleRequestSystemPrompt:
             },
         )
 
-        mixed_response = MagicMock(is_ok=True, is_err=False)
-        mixed_response.value.content = 'Here is the result:\n{"score": 0.85}\nDone.'
+        mixed_response = _ok_response('Here is the result:\n{"score": 0.85}\nDone.')
 
         mock_execute = AsyncMock(return_value=mixed_response)
         adapter._execute_single_request = mock_execute
@@ -336,6 +348,41 @@ class TestExecuteSingleRequestSystemPrompt:
         assert result.is_ok
         assert result.value.content == '{"score": 0.85}'
         assert mock_execute.call_count == 1  # No retry needed
+
+    @pytest.mark.asyncio
+    async def test_json_normalization_on_real_frozen_response(self) -> None:
+        """JSON extraction must not mutate the frozen CompletionResponse.
+
+        Regression: _normalize_json_content used to assign result.value.content,
+        which raises FrozenInstanceError on the real (frozen) dataclass. The
+        MagicMock-based tests above didn't catch it because mock attributes are
+        freely assignable; this test uses a real CompletionResponse.
+        """
+        adapter = ClaudeCodeAdapter()
+        messages = [Message(role=MessageRole.USER, content="Evaluate this")]
+        config = CompletionConfig(
+            model="claude-sonnet-4-6",
+            response_format={
+                "type": "json_schema",
+                "json_schema": {"type": "object", "properties": {"score": {"type": "number"}}},
+            },
+        )
+
+        real_response = CompletionResponse(
+            content='Here is the result:\n{"score": 0.85}\nDone.',
+            model="claude-sonnet-4-6",
+            usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+        )
+        mock_execute = AsyncMock(return_value=Result.ok(real_response))
+        adapter._execute_single_request = mock_execute
+
+        with patch.dict("sys.modules", {"claude_agent_sdk": MagicMock()}):
+            result = await adapter.complete(messages, config)
+
+        assert result.is_ok
+        assert result.value.content == '{"score": 0.85}'
+        # original frozen instance is left untouched
+        assert real_response.content == 'Here is the result:\n{"score": 0.85}\nDone.'
 
     @pytest.mark.asyncio
     async def test_json_schema_array_gets_correct_prompt_steering(self) -> None:
@@ -353,9 +400,7 @@ class TestExecuteSingleRequestSystemPrompt:
             },
         )
 
-        mock_response = MagicMock(is_ok=True, is_err=False)
-        mock_response.value.content = '[{"name": "a"}]'
-        mock_execute = AsyncMock(return_value=mock_response)
+        mock_execute = AsyncMock(return_value=_ok_response('[{"name": "a"}]'))
         adapter._execute_single_request = mock_execute
 
         with patch.dict("sys.modules", {"claude_agent_sdk": MagicMock()}):
@@ -377,9 +422,7 @@ class TestExecuteSingleRequestSystemPrompt:
             response_format={"type": "json_object"},
         )
 
-        mock_response = MagicMock(is_ok=True, is_err=False)
-        mock_response.value.content = '{"data": "value"}'
-        mock_execute = AsyncMock(return_value=mock_response)
+        mock_execute = AsyncMock(return_value=_ok_response('{"data": "value"}'))
         adapter._execute_single_request = mock_execute
 
         with patch.dict("sys.modules", {"claude_agent_sdk": MagicMock()}):


### PR DESCRIPTION
## Summary

`ClaudeCodeAdapter._normalize_json_content` assigned `result.value.content` in place, but `CompletionResponse` is a **frozen** dataclass (`@dataclass(frozen=True, slots=True)`). So whenever a JSON `response_format` response needs extraction from surrounding prose/fences, the assignment raises:

```
File ".../providers/claude_code_adapter.py", line 317, in _normalize_json_content
    result.value.content = extracted
dataclasses.FrozenInstanceError: cannot assign to field 'content'
```

This makes **every semantic evaluation (Stage 2 of the evaluation pipeline) crash** when using the `claude_code` backend — `ouroboros_evaluate` / `ouroboros_qa` fail with `cannot assign to field 'content'`, and the pipeline only ever reaches Stage 1.

## Fix

Build a new instance via `dataclasses.replace(...)` instead of mutating the frozen dataclass:

```python
return Result.ok(replace(result.value, content=extracted))
```

## Why existing tests missed it

The JSON tests in `test_claude_code_adapter.py` used `MagicMock` responses, whose attributes are freely assignable — so the in-place mutation never raised and the bug was invisible. This PR:

- converts those tests to use **real `CompletionResponse`** objects via a small `_ok_response` helper, and
- adds a regression test (`test_json_normalization_on_real_frozen_response`) that drives the frozen dataclass directly. It **fails before this fix** with `FrozenInstanceError` and **passes after**.

## Verification

```
uv run pytest tests/unit/providers/test_claude_code_adapter.py -q   # 18 passed
uv run pytest tests/unit/providers/ -q                              # 119 passed, 4 skipped
uv run ruff check src/ouroboros/providers/claude_code_adapter.py tests/unit/providers/test_claude_code_adapter.py  # clean
```

Reproduced originally while running the full three-stage evaluation pipeline against an external project via the `claude_code` backend; after this fix the pipeline completes Stage 2 (semantic) successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)