### PR TITLE
feat(auto): guard inverted interview artifact intent

### DIFF
--- a/docs/rfc/inverted-interview-intent-preservation.md
+++ b/docs/rfc/inverted-interview-intent-preservation.md
@@ -119,12 +119,17 @@ be blocked unless the user explicitly changes the contract.
 
 This PR adds a small IntentGuard extension for narrowed-output artifact drift:
 
-- output-contract detection recognizes CLI/web/tool/app artifacts;
+- output-contract detection recognizes CLI/web/tool/app artifacts with token-aware matching;
 - generated `docs-only` / `handoff-only` / `checkpack` / `checklist package`
-  answers are treated like existing review-only reductions;
+  answers are treated like existing review-only reductions when they are offered
+  as narrowed alternatives;
 - diagnostics warn when a pending question offers a docs-only narrowing next to a
   user-locked output contract;
-- tests cover CLI/web intent drifting toward docs-only handoff.
+- supporting artifacts such as checklist packages may remain in the user goal
+  without disabling the goal-derived contract;
+- tests cover CLI/web intent drifting toward docs-only handoff, supporting
+  checklist outputs, and short-term false positives such as `app` in
+  `approach`.
 
 ## Non-goals
 

--- a/docs/rfc/inverted-interview-intent-preservation.md
+++ b/docs/rfc/inverted-interview-intent-preservation.md
@@ -1,0 +1,144 @@
+# RFC: Inverted Interview Intent Preservation
+
+## Status
+
+Draft proposal. Tracking issue: #1504.
+
+## Problem
+
+Some interviews fail not because the user has not stated intent, but because the
+system drifts away from intent the user already stated.
+
+A recurring failure shape:
+
+1. The user states a strong artifact contract, for example `CLI + web app`.
+2. The interview or auto-answer path introduces a safer narrower option, for
+   example `docs-only handoff`.
+3. The pipeline converges on the narrower option because it is conservative and
+   easy to verify.
+4. The output is safe, but wrong: the final artifact class changed without an
+   explicit user decision.
+
+This is different from ordinary ambiguity. The missing behavior is not “ask more
+open-ended questions.” The missing behavior is “reconstruct and preserve the
+user's already-stated contract before asking the next question.”
+
+## Proposal
+
+Add an **inverted interview** mode or guardrail for interviews that begin with
+strong user intent or prior context.
+
+Instead of starting only with open-ended Socratic questions, the interviewer first
+reconstructs the current requirement as explicit, falsifiable assumptions:
+
+- final artifact class;
+- outputs that are products versus outputs that are supporting artifacts;
+- non-goals;
+- locked user facts;
+- unsafe interpretation changes;
+- unresolved decisions that still need human authority.
+
+Then it asks the user to correct mismatches.
+
+Example:
+
+```text
+My current understanding:
+
+1. Final artifact is a CLI plus web app.
+2. Docs-only handoff is not the final artifact.
+3. Checklist files are generated outputs of the CLI/web system, not the product.
+4. Existing legacy workflow behavior must be inherited where relevant.
+5. Missing source data must be represented as insufficient/unchecked, not OK.
+
+Which line is wrong or incomplete?
+```
+
+The user can answer with a small correction instead of restating the whole task.
+The interview repeats this assumption-led loop until no material mismatch
+remains, then continues through the existing Seed readiness and Restate gates.
+
+## Relationship to Socratic interview
+
+This does not replace the existing Socratic interview. It is a front-loaded
+intent-preservation pass for cases where the user has already supplied material
+requirements.
+
+Normal Socratic interview asks:
+
+```text
+What do you want to build?
+```
+
+Inverted interview asks:
+
+```text
+Here is what I think you already asked for. Which part is wrong?
+```
+
+Both are dialectic. The difference is that inverted interview treats prior user
+intent as the first object of examination.
+
+## Contract
+
+When a user-stated artifact class is locked by goal text, preference, or a
+confirmed ledger entry:
+
+- generated answers must not replace it with a narrower artifact class;
+- docs-only, review-only, handoff-only, or checklist-only options must be treated
+  as scope-reduction candidates;
+- scope reductions require an explicit user answer or a blocked state;
+- if a human chooses the narrower artifact, record a warning and require
+  confirmation before Seed generation;
+- supporting artifacts may still be generated, but they must not be represented
+  as the final product unless the user says so.
+
+## Example failure this guards
+
+A user requests a reusable local tool with both CLI and web surfaces. During
+interview, a conservative default chooses a docs-only handoff package. The handoff
+contains useful material, but the final artifact class changed from executable
+software to static documentation.
+
+In inverted mode, the first interview turn should lock:
+
+```yaml
+final_artifact: CLI + web app
+supporting_artifacts:
+  - checklist files
+  - handoff documents
+  - review summaries
+not_final_artifact:
+  - docs-only handoff
+```
+
+A later generated `docs-only handoff` answer conflicts with this contract and must
+be blocked unless the user explicitly changes the contract.
+
+## Implementation slice in this PR
+
+This PR adds a small IntentGuard extension for narrowed-output artifact drift:
+
+- output-contract detection recognizes CLI/web/tool/app artifacts;
+- generated `docs-only` / `handoff-only` / `checkpack` / `checklist package`
+  answers are treated like existing review-only reductions;
+- diagnostics warn when a pending question offers a docs-only narrowing next to a
+  user-locked output contract;
+- tests cover CLI/web intent drifting toward docs-only handoff.
+
+## Non-goals
+
+- No new interview command flag yet.
+- No full assumption-led UI yet.
+- No replacement of the current Socratic interview.
+- No Seed schema change in this slice.
+
+## Future work
+
+Possible follow-ups:
+
+1. `ooo interview --mode inverted` or `ooo auto --interview-mode inverted`.
+2. A first-turn assumption ledger rendered to the user for correction.
+3. A Seed Draft Ledger field for locked artifact class versus supporting outputs.
+4. Auto-activation when the user corrects artifact scope or when generated options
+   offer docs-only/review-only alternatives to a user-locked executable artifact.

--- a/src/ouroboros/auto/intent_guard.py
+++ b/src/ouroboros/auto/intent_guard.py
@@ -157,6 +157,17 @@ _NARROWED_OUTPUT_COMPETING_ARTIFACT_TERMS = tuple(
     term for term in _BROAD_ARTIFACT_OUTPUT_TERMS if term not in {"json", "csv", "pdf", "html"}
 )
 
+_NARROWED_OUTPUT_CONTEXT_FOLLOWERS = {
+    "audience",
+    "audiences",
+    "group",
+    "groups",
+    "stakeholder",
+    "stakeholders",
+    "team",
+    "teams",
+}
+
 _ARTIFACT_GENERATION_TERMS = (
     "build",
     "builds",
@@ -406,7 +417,11 @@ def diagnose_auto_state(
                 message="output contract is anchored in user/repo evidence",
             )
         )
-        if pending_question and _contains_scope_reduction_option(pending_question):
+        if (
+            pending_question
+            and _contains_scope_reduction_option(pending_question)
+            and not _is_explicit_narrowed_output_contract(contract)
+        ):
             checks.append(
                 IntentGuardCheck(
                     code="generated_option_present",
@@ -536,9 +551,31 @@ def _is_explicit_narrowed_output_contract(text: str) -> bool:
     """
     return (
         _contains_scope_reduction_option(text)
-        and not _contains_any_phrase(text, _NARROWED_OUTPUT_COMPETING_ARTIFACT_TERMS)
+        and not _contains_competing_artifact_contract(text)
         and not _contains_any_phrase(text, _NARROWED_OUTPUT_EXCLUSION_TERMS)
     )
+
+
+def _contains_competing_artifact_contract(text: str) -> bool:
+    """Return true when text names a competing final artifact class.
+
+    Broad tokens such as ``web`` and ``app`` are also used as audience/context
+    descriptors (``web team``, ``app team``). Those should not prevent an
+    explicitly narrowed user contract (for example, docs-only handoff files for
+    that team) from passing the guard.
+    """
+    lowered = text.casefold()
+    for term in _NARROWED_OUTPUT_COMPETING_ARTIFACT_TERMS:
+        escaped = re.escape(term.casefold())
+        prefix = r"(?<!\w)" if term[:1].isalnum() else ""
+        suffix = r"(?!\w)" if term[-1:].isalnum() else ""
+        for match in re.finditer(f"{prefix}{escaped}{suffix}", lowered):
+            after = lowered[match.end() :]
+            next_word = re.match(r"(?:\s+|-)+(\w+)", after)
+            if next_word and next_word.group(1) in _NARROWED_OUTPUT_CONTEXT_FOLLOWERS:
+                continue
+            return True
+    return False
 
 
 def _contains_review_only_option(text: str) -> bool:

--- a/src/ouroboros/auto/intent_guard.py
+++ b/src/ouroboros/auto/intent_guard.py
@@ -127,6 +127,32 @@ _ARTIFACT_OUTPUT_TERMS = (
     "tools",
 )
 
+_BROAD_ARTIFACT_OUTPUT_TERMS = (
+    "video",
+    "videos",
+    "mp4",
+    "clip",
+    "clips",
+    "short",
+    "shorts",
+    "long-form",
+    "long form",
+    "json",
+    "csv",
+    "pdf",
+    "html",
+    "cli",
+    "command",
+    "commands",
+    "web",
+    "webapp",
+    "web app",
+    "app",
+    "application",
+    "tool",
+    "tools",
+)
+
 _ARTIFACT_GENERATION_TERMS = (
     "make",
     "makes",
@@ -374,7 +400,7 @@ def diagnose_auto_state(
                     IntentGuardCheck(
                         code="generated_option_conflict",
                         status=IntentGuardStatus.FAIL,
-                        message="recent auto answer appears to have accepted review-only framing over user output intent",
+                        message="recent auto answer appears to have accepted narrowed-output framing over user output intent",
                         action="discard that answer, reopen the round, and re-answer from USER_GOAL/USER_PREFERENCE",
                     )
                 )
@@ -461,10 +487,26 @@ def _generated_review_option_conflicts(
     )
     if not question_has_generated_choice:
         return False
+    if _is_explicit_narrowed_output_contract(contract_text):
+        return False
     answer_lower = answer_text.casefold()
     if _contains_scope_reduction_option(answer_lower):
         return True
     return "review" in answer_lower and not _has_artifact_output_terms(answer_lower)
+
+
+def _is_explicit_narrowed_output_contract(text: str) -> bool:
+    """Return true when the user contract itself is the narrowed output.
+
+    Scope-reduction phrases are only failures when a generated answer narrows a
+    broader user artifact class. If the user's locked contract is already a
+    docs-only/review-only/checklist-only handoff, a generated answer that
+    repeats that contract should pass instead of being treated as drift.
+    """
+    return _contains_scope_reduction_option(text) and not _contains_any_phrase(
+        text,
+        _BROAD_ARTIFACT_OUTPUT_TERMS,
+    )
 
 
 def _contains_review_only_option(text: str) -> bool:

--- a/src/ouroboros/auto/intent_guard.py
+++ b/src/ouroboros/auto/intent_guard.py
@@ -167,6 +167,8 @@ _SCOPE_REDUCTION_TERMS = (
     "handoff package",
     "checkpack",
     "check pack",
+    "checklist-only",
+    "checklist only",
     "checklist package",
 )
 

--- a/src/ouroboros/auto/intent_guard.py
+++ b/src/ouroboros/auto/intent_guard.py
@@ -114,6 +114,16 @@ _ARTIFACT_OUTPUT_TERMS = (
     "html",
     "report",
     "reports",
+    "cli",
+    "command",
+    "commands",
+    "web",
+    "webapp",
+    "web app",
+    "app",
+    "application",
+    "tool",
+    "tools",
 )
 
 _ARTIFACT_GENERATION_TERMS = (
@@ -142,6 +152,21 @@ _REVIEW_ONLY_TERMS = (
     "no automated export",
     "no mp4",
     "no export",
+)
+
+_SCOPE_REDUCTION_TERMS = (
+    "docs-only",
+    "docs only",
+    "documentation-only",
+    "documentation only",
+    "document-only",
+    "document only",
+    "handoff-only",
+    "handoff only",
+    "handoff package",
+    "checkpack",
+    "check pack",
+    "checklist package",
 )
 
 _DIAGNOSTIC_MARKERS = (
@@ -210,7 +235,7 @@ def guard_auto_answer(
             IntentGuardCheck(
                 code="generated_option_conflict",
                 status=IntentGuardStatus.FAIL,
-                message="generated review-only framing conflicts with the user output contract",
+                message="generated narrowed-output framing conflicts with the user output contract",
                 action="discard the generated option and answer from USER_GOAL/USER_PREFERENCE; block if retry still conflicts",
             )
         )
@@ -252,14 +277,13 @@ def guard_interview_turn(
             message="initial interview context contains an artifact-output contract",
         )
     )
-    question_has_generated_choice = _contains_review_only_option(question) or (
+    question_has_generated_choice = _contains_scope_reduction_option(question) or (
         "--mode auto" in question.casefold() and "--mode review" in question.casefold()
     )
-    answer_has_review_only = _contains_review_only_option(answer_text) or (
-        "review" in answer_text.casefold()
-        and not _has_artifact_output_terms(answer_text)
-        and question_has_generated_choice
+    answer_has_review_only = _contains_scope_reduction_option(answer_text) or (
+        "review" in answer_text.casefold() and not _has_artifact_output_terms(answer_text)
     )
+
     if not question_has_generated_choice or not answer_has_review_only:
         return IntentGuardReport(tuple(checks))
 
@@ -269,7 +293,7 @@ def guard_interview_turn(
             IntentGuardCheck(
                 code="user_contract_change",
                 status=IntentGuardStatus.WARN,
-                message="human answer appears to change the initial output contract toward review-only behavior",
+                message="human answer appears to change the initial output contract toward a narrower output class",
                 action="record it, but ask/confirm whether this is an intentional scope change before Seed generation",
             )
         )
@@ -324,7 +348,7 @@ def diagnose_auto_state(
                 message="output contract is anchored in user/repo evidence",
             )
         )
-        if pending_question and _contains_review_only_option(pending_question):
+        if pending_question and _contains_scope_reduction_option(pending_question):
             checks.append(
                 IntentGuardCheck(
                     code="generated_option_present",
@@ -429,13 +453,13 @@ def _generated_review_option_conflicts(
     source = answer_source.strip().casefold()
     if source in {"user_goal", "user_preference", "repo_fact", "existing_convention"}:
         return False
-    question_has_generated_choice = _contains_review_only_option(question) or (
+    question_has_generated_choice = _contains_scope_reduction_option(question) or (
         "--mode auto" in question.casefold() and "--mode review" in question.casefold()
     )
     if not question_has_generated_choice:
         return False
     answer_lower = answer_text.casefold()
-    if _contains_review_only_option(answer_lower):
+    if _contains_scope_reduction_option(answer_lower):
         return True
     return "review" in answer_lower and not _has_artifact_output_terms(answer_lower)
 
@@ -445,13 +469,18 @@ def _contains_review_only_option(text: str) -> bool:
     return any(term in lowered for term in _REVIEW_ONLY_TERMS)
 
 
+def _contains_scope_reduction_option(text: str) -> bool:
+    lowered = text.casefold()
+    return any(term in lowered for term in (*_REVIEW_ONLY_TERMS, *_SCOPE_REDUCTION_TERMS))
+
+
 def _looks_like_artifact_generation(text: str) -> bool:
     lowered = text.casefold()
     return (
         bool(text.strip())
         and any(term in lowered for term in _ARTIFACT_GENERATION_TERMS)
         and _has_artifact_output_terms(lowered)
-        and not _contains_review_only_option(lowered)
+        and not _contains_scope_reduction_option(lowered)
     )
 
 

--- a/src/ouroboros/auto/intent_guard.py
+++ b/src/ouroboros/auto/intent_guard.py
@@ -153,7 +153,13 @@ _BROAD_ARTIFACT_OUTPUT_TERMS = (
     "tools",
 )
 
+_NARROWED_OUTPUT_COMPETING_ARTIFACT_TERMS = tuple(
+    term for term in _BROAD_ARTIFACT_OUTPUT_TERMS if term not in {"json", "csv", "pdf", "html"}
+)
+
 _ARTIFACT_GENERATION_TERMS = (
+    "build",
+    "builds",
     "make",
     "makes",
     "create",
@@ -196,6 +202,27 @@ _SCOPE_REDUCTION_TERMS = (
     "checklist-only",
     "checklist only",
     "checklist package",
+)
+
+_NARROWED_OUTPUT_EXCLUSION_TERMS = (
+    "not the final artifact",
+    "not final artifact",
+    "not the final output",
+    "not final output",
+    "not the final deliverable",
+    "not final deliverable",
+    "not the deliverable",
+    "not deliverable",
+    "not the artifact",
+    "not artifact",
+    "only generated output",
+    "only generated outputs",
+    "only supporting output",
+    "only supporting outputs",
+    "supporting output",
+    "supporting outputs",
+    "supporting artifact",
+    "supporting artifacts",
 )
 
 _DIAGNOSTIC_MARKERS = (
@@ -314,6 +341,8 @@ def guard_interview_turn(
     )
 
     if not question_has_generated_choice or not answer_has_review_only:
+        return IntentGuardReport(tuple(checks))
+    if _is_explicit_narrowed_output_contract(contract):
         return IntentGuardReport(tuple(checks))
 
     source = answer_source.strip().casefold()
@@ -501,11 +530,14 @@ def _is_explicit_narrowed_output_contract(text: str) -> bool:
     Scope-reduction phrases are only failures when a generated answer narrows a
     broader user artifact class. If the user's locked contract is already a
     docs-only/review-only/checklist-only handoff, a generated answer that
-    repeats that contract should pass instead of being treated as drift.
+    repeats that contract should pass instead of being treated as drift. Narrow
+    artifact terms that are explicitly excluded from the final deliverable do
+    not make the user contract a narrowed-output contract.
     """
-    return _contains_scope_reduction_option(text) and not _contains_any_phrase(
-        text,
-        _BROAD_ARTIFACT_OUTPUT_TERMS,
+    return (
+        _contains_scope_reduction_option(text)
+        and not _contains_any_phrase(text, _NARROWED_OUTPUT_COMPETING_ARTIFACT_TERMS)
+        and not _contains_any_phrase(text, _NARROWED_OUTPUT_EXCLUSION_TERMS)
     )
 
 

--- a/src/ouroboros/auto/intent_guard.py
+++ b/src/ouroboros/auto/intent_guard.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
+import re
 from typing import Any
 
 from ouroboros.auto.ledger import (
@@ -353,7 +354,7 @@ def diagnose_auto_state(
                 IntentGuardCheck(
                     code="generated_option_present",
                     status=IntentGuardStatus.WARN,
-                    message="pending question contains a generated review-only option next to a user output contract",
+                    message="pending question contains a generated narrowed-output option next to a user output contract",
                     action="prefer USER_GOAL/USER_PREFERENCE when answering; do not let the generated option win",
                 )
             )
@@ -465,28 +466,43 @@ def _generated_review_option_conflicts(
 
 
 def _contains_review_only_option(text: str) -> bool:
-    lowered = text.casefold()
-    return any(term in lowered for term in _REVIEW_ONLY_TERMS)
+    return _contains_any_phrase(text, _REVIEW_ONLY_TERMS)
 
 
 def _contains_scope_reduction_option(text: str) -> bool:
-    lowered = text.casefold()
-    return any(term in lowered for term in (*_REVIEW_ONLY_TERMS, *_SCOPE_REDUCTION_TERMS))
+    return _contains_any_phrase(text, (*_REVIEW_ONLY_TERMS, *_SCOPE_REDUCTION_TERMS))
 
 
 def _looks_like_artifact_generation(text: str) -> bool:
-    lowered = text.casefold()
     return (
         bool(text.strip())
-        and any(term in lowered for term in _ARTIFACT_GENERATION_TERMS)
-        and _has_artifact_output_terms(lowered)
-        and not _contains_scope_reduction_option(lowered)
+        and _contains_any_phrase(text, _ARTIFACT_GENERATION_TERMS)
+        and _has_artifact_output_terms(text)
     )
 
 
 def _has_artifact_output_terms(text: str) -> bool:
+    return _contains_any_phrase(text, _ARTIFACT_OUTPUT_TERMS)
+
+
+def _contains_any_phrase(text: str, phrases: Sequence[str]) -> bool:
     lowered = text.casefold()
-    return any(term in lowered for term in _ARTIFACT_OUTPUT_TERMS)
+    return any(_contains_phrase(lowered, phrase.casefold()) for phrase in phrases)
+
+
+def _contains_phrase(lowered_text: str, phrase: str) -> bool:
+    """Return true when ``phrase`` appears as a token/phrase, not a substring.
+
+    IntentGuard uses short artifact terms such as ``app`` and ``web``. Raw
+    substring matching would treat prose like ``approach`` or ``webbing`` as an
+    artifact contract, so alphanumeric phrase edges must align to non-word
+    boundaries. Phrases that start or end with punctuation keep substring
+    semantics for CLI flags such as ``--mode review``.
+    """
+    escaped = re.escape(phrase)
+    prefix = r"(?<!\w)" if phrase[:1].isalnum() else ""
+    suffix = r"(?!\w)" if phrase[-1:].isalnum() else ""
+    return re.search(f"{prefix}{escaped}{suffix}", lowered_text) is not None
 
 
 def _seed_artifact_has_diagnostic_constraints(seed_artifact: Mapping[str, Any]) -> bool:

--- a/tests/integration/auto/test_status_unified.py
+++ b/tests/integration/auto/test_status_unified.py
@@ -640,7 +640,7 @@ def test_cli_status_auto_snapshot(tmp_path) -> None:
         "  current_generation: 3\n"
         "  stop_reason: qa passed\n"
         "IntentGuard: pass\n"
-        "  PASS intent_contract_not_applicable: goal does not look like an artifact-output request\n"
+        "  PASS intent_lock_present: output contract is anchored in user/repo evidence\n"
         "  PASS spec_pollution: Seed constraints do not contain known diagnostic markers\n"
     )
     assert rendered == expected

--- a/tests/unit/auto/test_inverted_interview_intent_guard.py
+++ b/tests/unit/auto/test_inverted_interview_intent_guard.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from ouroboros.auto.intent_guard import (
+    IntentGuardStatus,
+    diagnose_auto_state,
+    guard_auto_answer,
+    guard_interview_turn,
+)
+from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
+
+
+def _cli_web_ledger() -> SeedDraftLedger:
+    ledger = SeedDraftLedger.from_goal(
+        "Build a local CLI and web app that generate reusable review outputs."
+    )
+    ledger.add_entry(
+        "outputs",
+        LedgerEntry(
+            key="outputs.user_locked_artifact_class",
+            value="Final artifact is a local CLI plus web app; docs/checklists are only generated outputs.",
+            source=LedgerSource.USER_GOAL,
+            confidence=0.95,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+    return ledger
+
+
+def test_inverted_intent_guard_blocks_generated_docs_only_scope_reduction() -> None:
+    report = guard_auto_answer(
+        goal="Build a local CLI and web app that generate reusable review outputs.",
+        user_preferences={},
+        ledger=_cli_web_ledger(),
+        question="Should the MVP be a CLI/web implementation or a docs-only handoff package?",
+        answer_text="[from-auto][conservative_default] Use a docs-only handoff package.",
+        answer_source="conservative_default",
+    )
+
+    assert report.status is IntentGuardStatus.FAIL
+    assert any(check.code == "generated_option_conflict" for check in report.checks)
+
+
+def test_inverted_intent_guard_warns_when_pending_question_offers_docs_only() -> None:
+    report = diagnose_auto_state(
+        goal="Build a local CLI and web app that generate reusable review outputs.",
+        user_preferences={},
+        ledger=_cli_web_ledger(),
+        pending_question="Should this become a docs-only handoff package instead of the CLI/web app?",
+        auto_answer_log=(),
+    )
+
+    assert report.status is IntentGuardStatus.WARN
+    assert any(check.code == "generated_option_present" for check in report.checks)
+
+
+def test_inverted_intent_guard_warns_when_human_changes_to_docs_only() -> None:
+    report = guard_interview_turn(
+        goal="Build a local CLI and web app that generate reusable review outputs.",
+        question="Should the MVP be a CLI/web implementation or a docs-only handoff package?",
+        answer_text="Use docs-only for this run.",
+        answer_source="user",
+    )
+
+    assert report.status is IntentGuardStatus.WARN
+    assert any(check.code == "user_contract_change" for check in report.checks)

--- a/tests/unit/auto/test_inverted_interview_intent_guard.py
+++ b/tests/unit/auto/test_inverted_interview_intent_guard.py
@@ -93,6 +93,44 @@ def test_inverted_intent_guard_preserves_goal_contract_when_checklist_is_support
     assert any(check.code == "generated_option_conflict" for check in report.checks)
 
 
+@pytest.mark.parametrize(
+    ("goal", "question", "answer"),
+    [
+        (
+            "Create docs-only handoff files for the team.",
+            "Should this produce docs-only handoff files?",
+            "[from-auto][conservative_default] Use docs-only handoff files.",
+        ),
+        (
+            "Write a review-only package for maintainers.",
+            "Should this stay review-only?",
+            "[from-auto][conservative_default] Use review-only mode.",
+        ),
+        (
+            "Generate checklist-only output for release triage.",
+            "Should this produce checklist-only output?",
+            "[from-auto][conservative_default] Use checklist-only output.",
+        ),
+    ],
+)
+def test_inverted_intent_guard_allows_explicit_narrowed_output_user_contracts(
+    goal: str,
+    question: str,
+    answer: str,
+) -> None:
+    report = guard_auto_answer(
+        goal=goal,
+        user_preferences={},
+        ledger=SeedDraftLedger.from_goal(goal),
+        question=question,
+        answer_text=answer,
+        answer_source="conservative_default",
+    )
+
+    assert report.status is IntentGuardStatus.PASS
+    assert not any(check.code == "generated_option_conflict" for check in report.checks)
+
+
 def test_inverted_intent_guard_does_not_treat_app_substrings_as_artifact_contracts() -> None:
     report = guard_auto_answer(
         goal="Make the interview approach clearer for maintainers.",

--- a/tests/unit/auto/test_inverted_interview_intent_guard.py
+++ b/tests/unit/auto/test_inverted_interview_intent_guard.py
@@ -42,6 +42,20 @@ def test_inverted_intent_guard_blocks_generated_docs_only_scope_reduction() -> N
     assert any(check.code == "generated_option_conflict" for check in report.checks)
 
 
+def test_inverted_intent_guard_blocks_build_goal_docs_only_reduction_without_ledger() -> None:
+    report = guard_auto_answer(
+        goal="Build a local CLI and web app.",
+        user_preferences={},
+        ledger=SeedDraftLedger.from_goal("Build a local CLI and web app."),
+        question="Should the MVP be a CLI/web implementation or a docs-only handoff package?",
+        answer_text="[from-auto][conservative_default] Use a docs-only handoff package.",
+        answer_source="conservative_default",
+    )
+
+    assert report.status is IntentGuardStatus.FAIL
+    assert any(check.code == "generated_option_conflict" for check in report.checks)
+
+
 def test_inverted_intent_guard_warns_when_pending_question_offers_docs_only() -> None:
     report = diagnose_auto_state(
         goal="Build a local CLI and web app that generate reusable review outputs.",
@@ -65,6 +79,20 @@ def test_inverted_intent_guard_warns_when_human_changes_to_docs_only() -> None:
 
     assert report.status is IntentGuardStatus.WARN
     assert any(check.code == "user_contract_change" for check in report.checks)
+
+
+def test_inverted_intent_guard_allows_generated_interview_answer_for_explicit_narrowed_goal() -> (
+    None
+):
+    report = guard_interview_turn(
+        goal="Create docs-only handoff files for the team.",
+        question="Should this produce docs-only handoff files?",
+        answer_text="[from-auto][conservative_default] Use docs-only handoff files.",
+        answer_source="conservative_default",
+    )
+
+    assert report.status is IntentGuardStatus.PASS
+    assert not any(check.code == "generated_option_conflict" for check in report.checks)
 
 
 @pytest.mark.parametrize(
@@ -111,6 +139,16 @@ def test_inverted_intent_guard_preserves_goal_contract_when_checklist_is_support
             "Should this produce checklist-only output?",
             "[from-auto][conservative_default] Use checklist-only output.",
         ),
+        (
+            "Create a docs-only PDF handoff for the team.",
+            "Should this produce a docs-only handoff?",
+            "[from-auto][conservative_default] Use a docs-only handoff.",
+        ),
+        (
+            "Create docs-only HTML handoff files for the team.",
+            "Should this produce docs-only handoff files?",
+            "[from-auto][conservative_default] Use docs-only handoff files.",
+        ),
     ],
 )
 def test_inverted_intent_guard_allows_explicit_narrowed_output_user_contracts(
@@ -129,6 +167,37 @@ def test_inverted_intent_guard_allows_explicit_narrowed_output_user_contracts(
 
     assert report.status is IntentGuardStatus.PASS
     assert not any(check.code == "generated_option_conflict" for check in report.checks)
+
+
+def test_inverted_intent_guard_blocks_generated_docs_only_when_contract_excludes_it() -> None:
+    ledger = SeedDraftLedger.from_goal(
+        "Build executable software that can produce docs as a supporting output."
+    )
+    ledger.add_entry(
+        "outputs",
+        LedgerEntry(
+            key="outputs.not_final_artifact",
+            value=(
+                "Final artifact is executable software; docs-only handoff is not "
+                "the final artifact."
+            ),
+            source=LedgerSource.USER_GOAL,
+            confidence=0.95,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+
+    report = guard_auto_answer(
+        goal="Build executable software that can produce docs as a supporting output.",
+        user_preferences={},
+        ledger=ledger,
+        question="Should the MVP be executable software or a docs-only handoff package?",
+        answer_text="[from-auto][conservative_default] Use a docs-only handoff package.",
+        answer_source="conservative_default",
+    )
+
+    assert report.status is IntentGuardStatus.FAIL
+    assert any(check.code == "generated_option_conflict" for check in report.checks)
 
 
 def test_inverted_intent_guard_does_not_treat_app_substrings_as_artifact_contracts() -> None:

--- a/tests/unit/auto/test_inverted_interview_intent_guard.py
+++ b/tests/unit/auto/test_inverted_interview_intent_guard.py
@@ -149,6 +149,16 @@ def test_inverted_intent_guard_preserves_goal_contract_when_checklist_is_support
             "Should this produce docs-only handoff files?",
             "[from-auto][conservative_default] Use docs-only handoff files.",
         ),
+        (
+            "Create docs-only handoff files for the web team.",
+            "Should this produce docs-only handoff files?",
+            "[from-auto][conservative_default] Use docs-only handoff files.",
+        ),
+        (
+            "Create docs-only handoff files for the app team.",
+            "Should this produce docs-only handoff files?",
+            "[from-auto][conservative_default] Use docs-only handoff files.",
+        ),
     ],
 )
 def test_inverted_intent_guard_allows_explicit_narrowed_output_user_contracts(
@@ -167,6 +177,23 @@ def test_inverted_intent_guard_allows_explicit_narrowed_output_user_contracts(
 
     assert report.status is IntentGuardStatus.PASS
     assert not any(check.code == "generated_option_conflict" for check in report.checks)
+
+
+def test_inverted_intent_guard_does_not_warn_when_pending_question_matches_explicit_narrowed_contract() -> (
+    None
+):
+    goal = "Create docs-only handoff files for the web team."
+
+    report = diagnose_auto_state(
+        goal=goal,
+        user_preferences={},
+        ledger=SeedDraftLedger.from_goal(goal),
+        pending_question="Should this produce docs-only handoff files?",
+        auto_answer_log=(),
+    )
+
+    assert report.status is IntentGuardStatus.PASS
+    assert not any(check.code == "generated_option_present" for check in report.checks)
 
 
 def test_inverted_intent_guard_blocks_generated_docs_only_when_contract_excludes_it() -> None:

--- a/tests/unit/auto/test_inverted_interview_intent_guard.py
+++ b/tests/unit/auto/test_inverted_interview_intent_guard.py
@@ -63,3 +63,35 @@ def test_inverted_intent_guard_warns_when_human_changes_to_docs_only() -> None:
 
     assert report.status is IntentGuardStatus.WARN
     assert any(check.code == "user_contract_change" for check in report.checks)
+
+
+def test_inverted_intent_guard_preserves_goal_contract_when_checklist_is_supporting_output() -> (
+    None
+):
+    report = guard_auto_answer(
+        goal="Build a local CLI and web app that generate checklist packages.",
+        user_preferences={},
+        ledger=SeedDraftLedger.from_goal(
+            "Build a local CLI and web app that generate checklist packages."
+        ),
+        question="Should the MVP be a CLI/web implementation or a docs-only handoff package?",
+        answer_text="[from-auto][conservative_default] Use a docs-only handoff package.",
+        answer_source="conservative_default",
+    )
+
+    assert report.status is IntentGuardStatus.FAIL
+    assert any(check.code == "generated_option_conflict" for check in report.checks)
+
+
+def test_inverted_intent_guard_does_not_treat_app_substrings_as_artifact_contracts() -> None:
+    report = guard_auto_answer(
+        goal="Make the interview approach clearer for maintainers.",
+        user_preferences={},
+        ledger=SeedDraftLedger.from_goal("Make the interview approach clearer for maintainers."),
+        question="Should this be a normal improvement or review-only mode?",
+        answer_text="[from-auto][conservative_default] Use review-only mode.",
+        answer_source="conservative_default",
+    )
+
+    assert report.status is IntentGuardStatus.PASS
+    assert report.checks == ()

--- a/tests/unit/auto/test_inverted_interview_intent_guard.py
+++ b/tests/unit/auto/test_inverted_interview_intent_guard.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from ouroboros.auto.intent_guard import (
     IntentGuardStatus,
     diagnose_auto_state,
@@ -65,17 +67,25 @@ def test_inverted_intent_guard_warns_when_human_changes_to_docs_only() -> None:
     assert any(check.code == "user_contract_change" for check in report.checks)
 
 
-def test_inverted_intent_guard_preserves_goal_contract_when_checklist_is_supporting_output() -> (
-    None
-):
+@pytest.mark.parametrize(
+    "generated_reduction",
+    [
+        "docs-only handoff package",
+        "checklist-only output",
+        "checklist only output",
+    ],
+)
+def test_inverted_intent_guard_preserves_goal_contract_when_checklist_is_supporting_output(
+    generated_reduction: str,
+) -> None:
     report = guard_auto_answer(
         goal="Build a local CLI and web app that generate checklist packages.",
         user_preferences={},
         ledger=SeedDraftLedger.from_goal(
             "Build a local CLI and web app that generate checklist packages."
         ),
-        question="Should the MVP be a CLI/web implementation or a docs-only handoff package?",
-        answer_text="[from-auto][conservative_default] Use a docs-only handoff package.",
+        question=(f"Should the MVP be a CLI/web implementation or {generated_reduction}?"),
+        answer_text=(f"[from-auto][conservative_default] Use a {generated_reduction}."),
         answer_source="conservative_default",
     )
 


### PR DESCRIPTION
## Summary

Adds an initial implementation slice for the `inverted interview` intent-preservation proposal.

The core failure mode: a user asks for an executable artifact class such as CLI + web, but interview/auto introduces a safer narrowed output such as docs-only handoff/checkpack and lets that generated option win.

This PR:

- adds an RFC for inverted interview intent preservation;
- extends IntentGuard's output-contract vocabulary to recognize CLI/web/tool/app artifacts;
- treats `docs-only`, `handoff-only`, `checkpack`, and checklist-package answers as narrowed-output reductions, analogous to the existing review-only guard;
- adds regression tests for CLI/web intent drifting toward docs-only handoff.

Closes #1504.

## Why

This is not a replacement for the Socratic interview. It is a guardrail for cases where the user already stated intent and the system must verify, not rediscover, that intent.

Without this, auto/interview can produce a safe but wrong artifact class.

## Test plan

- [x] `uv run --python 3.12 pytest tests/unit/auto/test_inverted_interview_intent_guard.py tests/unit/mcp/tools/test_interview_intent_guard.py -q`
- [x] `uv run --python 3.12 ruff check src/ouroboros/auto/intent_guard.py tests/unit/auto/test_inverted_interview_intent_guard.py`
- [x] `uv run --python 3.12 ruff format --check src/ouroboros/auto/intent_guard.py tests/unit/auto/test_inverted_interview_intent_guard.py`
- [ ] Full `uv run pytest tests/ -q` not run locally.
- [ ] `uv run mypy src/` not run locally.

Result:

```text
6 passed
All checks passed
```

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation /
[x] N/A (IntentGuard lexical contract only; no interview-loop runtime path or R-run execution path changed.)

## Non-goals

- Does not add a new `ooo interview --mode inverted` flag yet.
- Does not change Seed schema.
- Does not replace the current Socratic interview.
