### PR TITLE
fix(auto): surface partial artifact state

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4112,6 +4112,7 @@ class AutoPipeline:
             execution_id=state.execution_id,
             job_id=state.job_id,
             run_session_id=state.run_session_id,
+            run_handoff_status=state.run_handoff_status,
             partial_product=partial_product,
         )
         return AutoPipelineResult(
@@ -4364,6 +4365,7 @@ def _artifact_state_for_result(
     job_id: str | None,
     run_session_id: str | None,
     partial_product: bool,
+    run_handoff_status: str | None = None,
 ) -> str:
     """Classify the generated-artifact outcome separately from orchestration.
 
@@ -4376,7 +4378,9 @@ def _artifact_state_for_result(
     if status in {AutoPhase.BLOCKED.value, AutoPhase.FAILED.value}:
         return "partial_artifact_generated" if has_generated_artifact else status
     if status == AutoPhase.COMPLETE.value:
-        return "complete_unverified" if partial_product else "complete_verified"
+        if partial_product or run_handoff_status == RUN_HANDOFF_STARTED_STATUS:
+            return "complete_unverified"
+        return "complete_verified"
     if phase in {AutoPhase.BLOCKED, AutoPhase.FAILED}:
         return "partial_artifact_generated" if has_generated_artifact else phase.value
     return "artifact_in_progress" if has_generated_artifact else "not_generated"

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4379,7 +4379,7 @@ def _artifact_state_for_result(
         return "complete_unverified" if partial_product else "complete_verified"
     if phase in {AutoPhase.BLOCKED, AutoPhase.FAILED}:
         return "partial_artifact_generated" if has_generated_artifact else phase.value
-    return "complete_unverified"
+    return "artifact_in_progress" if has_generated_artifact else "not_generated"
 
 
 def _mark_invalid_seed_artifact(state: AutoPipelineState, message: str) -> None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4114,6 +4114,7 @@ class AutoPipeline:
             run_session_id=state.run_session_id,
             run_handoff_status=state.run_handoff_status,
             partial_product=partial_product,
+            product_verified=_has_verified_product_completion(state),
         )
         return AutoPipelineResult(
             status=result_status,
@@ -4366,6 +4367,7 @@ def _artifact_state_for_result(
     run_session_id: str | None,
     partial_product: bool,
     run_handoff_status: str | None = None,
+    product_verified: bool = False,
 ) -> str:
     """Classify the generated-artifact outcome separately from orchestration.
 
@@ -4378,12 +4380,36 @@ def _artifact_state_for_result(
     if status in {AutoPhase.BLOCKED.value, AutoPhase.FAILED.value}:
         return "partial_artifact_generated" if has_generated_artifact else status
     if status == AutoPhase.COMPLETE.value:
-        if partial_product or run_handoff_status == RUN_HANDOFF_STARTED_STATUS:
+        if partial_product:
+            return "complete_unverified"
+        if product_verified:
+            return "complete_verified"
+        if run_handoff_status == RUN_HANDOFF_STARTED_STATUS:
             return "complete_unverified"
         return "complete_verified"
     if phase in {AutoPhase.BLOCKED, AutoPhase.FAILED}:
         return "partial_artifact_generated" if has_generated_artifact else phase.value
     return "artifact_in_progress" if has_generated_artifact else "not_generated"
+
+
+def _has_verified_product_completion(state: AutoPipelineState) -> bool:
+    """Return True when COMPLETE represents a verified product terminal.
+
+    ``run_handoff_status=started`` can persist after a complete-product run moves
+    through Ralph/EVALUATE success. Treat those terminal success signals as
+    stronger evidence than the stale handoff marker so final surfaces do not
+    downgrade verified product completion to handoff-only completion.
+    """
+
+    if state.phase is not AutoPhase.COMPLETE:
+        return False
+    if state.ralph_job_status == "completed":
+        return True
+    if state.last_qa_passed is True:
+        return True
+    if state.complete_product and state.ralph_stop_reason is not None:
+        return True
+    return state.run_handoff_status == "completed"
 
 
 def _mark_invalid_seed_artifact(state: AutoPipelineState, message: str) -> None:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -385,6 +385,11 @@ class AutoPipelineResult:
     partial_product: bool = False
     partial_product_reason: str | None = None
     partial_unresolved_slots: tuple[str, ...] = ()
+    # #1509: final-status surfaces must distinguish orchestration state
+    # from artifact state so BLOCKED/FAILED sessions with generated files are
+    # not mistaken for verified completion. Values are intentionally stringly
+    # typed for stable CLI/MCP wire compatibility.
+    artifact_state: str | None = None
 
 
 @dataclass(slots=True)
@@ -4099,8 +4104,18 @@ class AutoPipeline:
         # (e.g. on a safety blocker) keeps ``partial_product=False`` so the
         # field cannot be misread as "deadline recovery succeeded".
         partial_product = seed_degraded and state.phase == AutoPhase.COMPLETE
+        result_status = status_override or state.phase.value
+        artifact_state = _artifact_state_for_result(
+            status=result_status,
+            phase=state.phase,
+            seed_path=state.seed_path,
+            execution_id=state.execution_id,
+            job_id=state.job_id,
+            run_session_id=state.run_session_id,
+            partial_product=partial_product,
+        )
         return AutoPipelineResult(
-            status=status_override or state.phase.value,
+            status=result_status,
             auto_session_id=state.auto_session_id,
             phase=state.phase.value,
             grade=review.grade_result.grade.value if review else state.last_grade,
@@ -4157,6 +4172,7 @@ class AutoPipeline:
             partial_product=partial_product,
             partial_product_reason=partial_product_reason,
             partial_unresolved_slots=partial_unresolved_slots,
+            artifact_state=artifact_state,
         )
 
     def _checkpoint_final_commit(self, state: AutoPipelineState) -> None:
@@ -4337,6 +4353,33 @@ class AutoPipeline:
         except Exception:
             # Observers must never break the pipeline. Swallow callback errors.
             pass
+
+
+def _artifact_state_for_result(
+    *,
+    status: str,
+    phase: AutoPhase,
+    seed_path: str | None,
+    execution_id: str | None,
+    job_id: str | None,
+    run_session_id: str | None,
+    partial_product: bool,
+) -> str:
+    """Classify the generated-artifact outcome separately from orchestration.
+
+    ``status`` remains the authoritative orchestration state. This companion
+    value prevents final renderers from implying completion when a BLOCKED or
+    FAILED run still left useful generated files behind.
+    """
+
+    has_generated_artifact = bool(seed_path or execution_id or job_id or run_session_id)
+    if status in {AutoPhase.BLOCKED.value, AutoPhase.FAILED.value}:
+        return "partial_artifact_generated" if has_generated_artifact else status
+    if status == AutoPhase.COMPLETE.value:
+        return "complete_unverified" if partial_product else "complete_verified"
+    if phase in {AutoPhase.BLOCKED, AutoPhase.FAILED}:
+        return "partial_artifact_generated" if has_generated_artifact else phase.value
+    return "complete_unverified"
 
 
 def _mark_invalid_seed_artifact(state: AutoPipelineState, message: str) -> None:

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -871,6 +871,8 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
     console.print(f"Auto session: [cyan]{result.auto_session_id}[/]")
     displayed_status = "run_handoff_started" if handoff_only else result.status
     console.print(f"Status: [bold]{displayed_status}[/]")
+    if result.artifact_state:
+        console.print(f"Artifact state: [bold]{result.artifact_state}[/]")
     if handoff_only:
         console.print(
             "Product status: [yellow]not verified complete; execution is still external/pending[/]"

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1376,6 +1376,8 @@ def _result_meta(result: AutoPipelineResult) -> dict[str, Any]:
         "job_id": result.job_id,
         "run_session_id": result.run_session_id,
     }
+    if result.artifact_state is not None:
+        meta["artifact_state"] = result.artifact_state
     if handoff_only:
         meta["presentation_status"] = _presentation_status(result)
         meta["product_status"] = "not_verified_complete"
@@ -2171,6 +2173,8 @@ def _format_result(result: AutoPipelineResult) -> str:
         f"Status: {_presentation_status(result)}",
         f"Phase: {result.phase}",
     ]
+    if result.artifact_state:
+        lines.append(f"Artifact state: {result.artifact_state}")
     if handoff_only:
         lines.append("Product status: not verified complete; execution is still external/pending")
     elif result.status == "detached":

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -2637,6 +2637,25 @@ def test_auto_handler_meta_and_text_distinguish_handoff_from_product_completion(
     assert "Artifact state: complete_unverified" in text
 
 
+def test_auto_artifact_state_preserves_verified_ralph_completion_with_stale_handoff() -> None:
+    from ouroboros.auto.pipeline import _artifact_state_for_result
+
+    assert (
+        _artifact_state_for_result(
+            status="complete",
+            phase=AutoPhase.COMPLETE,
+            seed_path="/tmp/seed.yaml",
+            execution_id="exec_123",
+            job_id="job_123",
+            run_session_id=None,
+            run_handoff_status="started",
+            partial_product=False,
+            product_verified=True,
+        )
+        == "complete_verified"
+    )
+
+
 def test_auto_artifact_state_marks_blocked_seed_as_partial_artifact() -> None:
     from ouroboros.auto.pipeline import _artifact_state_for_result
 

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -2622,3 +2622,43 @@ def test_auto_handler_meta_and_text_distinguish_handoff_from_product_completion(
     assert meta["product_status"] == "not_verified_complete"
     assert "Status: run_handoff_started" in text
     assert "Product status: not verified complete" in text
+
+
+def test_auto_artifact_state_marks_blocked_seed_as_partial_artifact() -> None:
+    from ouroboros.auto.pipeline import _artifact_state_for_result
+
+    assert (
+        _artifact_state_for_result(
+            status="blocked",
+            phase=AutoPhase.BLOCKED,
+            seed_path="/tmp/seed.yaml",
+            execution_id=None,
+            job_id=None,
+            run_session_id=None,
+            partial_product=False,
+        )
+        == "partial_artifact_generated"
+    )
+
+
+def test_auto_handler_surfaces_orchestration_and_artifact_state_for_blocked_result() -> None:
+    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.mcp.tools.auto_handler import _format_result, _result_meta
+
+    result = AutoPipelineResult(
+        status="blocked",
+        auto_session_id="auto_blocked_artifact",
+        phase="blocked",
+        seed_path="/tmp/seed.yaml",
+        artifact_state="partial_artifact_generated",
+        blocker="Seed QA timed out",
+    )
+
+    meta = _result_meta(result)
+    text = _format_result(result)
+
+    assert meta["status"] == "blocked"
+    assert meta["artifact_state"] == "partial_artifact_generated"
+    assert "Status: blocked" in text
+    assert "Artifact state: partial_artifact_generated" in text
+    assert "Status: complete" not in text

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -2636,6 +2636,7 @@ def test_auto_handler_meta_and_text_distinguish_handoff_from_product_completion(
     assert "Product status: not verified complete" in text
     assert "Artifact state: complete_unverified" in text
 
+
 def test_auto_artifact_state_marks_blocked_seed_as_partial_artifact() -> None:
     from ouroboros.auto.pipeline import _artifact_state_for_result
 

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -2641,6 +2641,40 @@ def test_auto_artifact_state_marks_blocked_seed_as_partial_artifact() -> None:
     )
 
 
+def test_auto_artifact_state_does_not_report_completion_for_pending_interview() -> None:
+    from ouroboros.auto.pipeline import _artifact_state_for_result
+
+    assert (
+        _artifact_state_for_result(
+            status="interview",
+            phase=AutoPhase.INTERVIEW,
+            seed_path=None,
+            execution_id=None,
+            job_id=None,
+            run_session_id=None,
+            partial_product=False,
+        )
+        == "not_generated"
+    )
+
+
+def test_auto_artifact_state_marks_nonterminal_handles_as_in_progress() -> None:
+    from ouroboros.auto.pipeline import _artifact_state_for_result
+
+    assert (
+        _artifact_state_for_result(
+            status="running",
+            phase=AutoPhase.RUN,
+            seed_path="/tmp/seed.yaml",
+            execution_id="exec-123",
+            job_id=None,
+            run_session_id="run-123",
+            partial_product=False,
+        )
+        == "artifact_in_progress"
+    )
+
+
 def test_auto_handler_surfaces_orchestration_and_artifact_state_for_blocked_result() -> None:
     from ouroboros.auto.pipeline import AutoPipelineResult
     from ouroboros.mcp.tools.auto_handler import _format_result, _result_meta

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -2602,9 +2602,19 @@ def test_auto_handler_attached_completion_is_not_handoff_started() -> None:
 
 
 def test_auto_handler_meta_and_text_distinguish_handoff_from_product_completion() -> None:
-    from ouroboros.auto.pipeline import AutoPipelineResult
+    from ouroboros.auto.pipeline import AutoPipelineResult, _artifact_state_for_result
     from ouroboros.mcp.tools.auto_handler import _format_result, _result_meta
 
+    artifact_state = _artifact_state_for_result(
+        status="complete",
+        phase=AutoPhase.COMPLETE,
+        seed_path=None,
+        execution_id="exec_123",
+        job_id="job_123",
+        run_session_id=None,
+        run_handoff_status="started",
+        partial_product=False,
+    )
     result = AutoPipelineResult(
         status="complete",
         auto_session_id="auto_handoff",
@@ -2612,6 +2622,7 @@ def test_auto_handler_meta_and_text_distinguish_handoff_from_product_completion(
         run_handoff_status="started",
         job_id="job_123",
         execution_id="exec_123",
+        artifact_state=artifact_state,
     )
 
     meta = _result_meta(result)
@@ -2620,9 +2631,10 @@ def test_auto_handler_meta_and_text_distinguish_handoff_from_product_completion(
     assert meta["status"] == "complete"
     assert meta["presentation_status"] == "run_handoff_started"
     assert meta["product_status"] == "not_verified_complete"
+    assert meta["artifact_state"] == "complete_unverified"
     assert "Status: run_handoff_started" in text
     assert "Product status: not verified complete" in text
-
+    assert "Artifact state: complete_unverified" in text
 
 def test_auto_artifact_state_marks_blocked_seed_as_partial_artifact() -> None:
     from ouroboros.auto.pipeline import _artifact_state_for_result
@@ -2635,6 +2647,7 @@ def test_auto_artifact_state_marks_blocked_seed_as_partial_artifact() -> None:
             execution_id=None,
             job_id=None,
             run_session_id=None,
+            run_handoff_status=None,
             partial_product=False,
         )
         == "partial_artifact_generated"
@@ -2652,6 +2665,7 @@ def test_auto_artifact_state_does_not_report_completion_for_pending_interview() 
             execution_id=None,
             job_id=None,
             run_session_id=None,
+            run_handoff_status=None,
             partial_product=False,
         )
         == "not_generated"


### PR DESCRIPTION
## Summary

- separates the orchestration status from generated artifact status on auto results
- reports `partial_artifact_generated` for blocked/failed sessions that still produced a Seed/execution artifact
- surfaces the artifact state through CLI output and MCP result metadata/text

Closes #1509.

## R-run comparison

This PR only adds result classification/rendering for terminal status surfaces; no auto interview/run loop execution path or per-round scheduler behavior changes. The required table is marked N/A for auditability.

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation / [x] N/A (status-surface-only auto change)

## Test plan

- `uv run --python 3.12 ruff check src/ouroboros/auto/pipeline.py src/ouroboros/mcp/tools/auto_handler.py src/ouroboros/cli/commands/auto.py tests/unit/auto/test_surface.py`
- `uv run --python 3.12 pytest tests/unit/auto/test_surface.py -q`

_Posted by [agentos-roadmap-warden](https://github.com/Q00/ouroboros/blob/main/agents/agentos-roadmap-warden.md) — bot. Reply with `/warden ignore` to suppress further comments on this thread._
