### PR TITLE
feat(interview): add advisory fanout for questions

### DIFF
--- a/.claude-plugin/skills/interview/SKILL.md
+++ b/.claude-plugin/skills/interview/SKILL.md
@@ -164,6 +164,36 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    `last_question` is required on this path so MCP can persist the real
    transcript even though the parent session generated the question.
 
+   **Question-first advisory fanout**:
+   If an MCP response includes `meta.question_advisory_request`, show the
+   interview question to the user first, then use the advisory request as a
+   parent-session assist layer. The advisory exists to help the human answer;
+   it must not hide, replace, or delay the question itself.
+
+   Run the advisory lanes in parallel when the runtime supports subagents; use
+   the request's `sequential_fallback` semantics otherwise. The standard lanes
+   are:
+   - `code_context` — inspect repo-local facts and reuse
+     `meta.code_investigation_request` when present.
+   - `web_context` — browse/search only when current external facts genuinely
+     affect the answer.
+   - `ambiguity_contrarian` — find hidden assumptions, vague terms, missing
+     decisions, and risky defaults.
+   - `answer_simplifier` — turn the question into 2-3 easy choices or one
+     concise draft answer.
+   - `architecture_implications` — check whether the answer changes ownership,
+     interfaces, rollout, or system shape.
+
+   Synthesize advisory results into a compact helper for the user: 2-3 answer
+   options, one recommended draft, or a short "I found these ambiguities" note.
+   Do not forward advisory output to `ouroboros_interview` until the user
+   approves, edits, or explicitly asks you to auto-confirm a safe answer.
+   When `meta.question_advisory_subagents` is present, treat each entry as a
+   spawn-ready advisory payload with `title`, `agent`, `prompt`, and `context`;
+   dispatch those payloads through the runtime's native subagent primitive
+   instead of reconstructing prompts from prose. Preserve the original question
+   text while advisory children run.
+
    **Milestone lateral-review dispatch**:
    If an MCP response includes `meta.lateral_review_recommended=true`, treat it
    as a required lightweight subagent review for that turn. The interview just
@@ -171,7 +201,7 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    `progress -> refined`, or `refined -> ready`, which is exactly when hidden
    assumptions tend to matter.
 
-   Before answering or asking the returned question:
+   After showing the returned question to the user:
    - Tell the user briefly that a few perspectives are checking the question.
    - Call `ouroboros_lateral_think` with `meta.lateral_review_tool_args` when
      present. If only the legacy advisory fields are present, call it with

--- a/docs/interview-advisory-fanout-comparison.html
+++ b/docs/interview-advisory-fanout-comparison.html
@@ -1,0 +1,477 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Ouroboros Interview Flow Comparison</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --ink: #17202a;
+      --muted: #617083;
+      --line: #d8dee8;
+      --paper: #f7f9fc;
+      --panel: #ffffff;
+      --old: #7a4c12;
+      --old-bg: #fff5df;
+      --new: #175f55;
+      --new-bg: #e7f7f2;
+      --accent: #3f5edb;
+      --accent-bg: #edf1ff;
+      --risk: #9b2d27;
+      --risk-bg: #fff0ef;
+      --shadow: 0 18px 55px rgba(34, 45, 70, 0.12);
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      background: var(--paper);
+      color: var(--ink);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.55;
+    }
+
+    main {
+      max-width: 1180px;
+      margin: 0 auto;
+      padding: 48px 24px 64px;
+    }
+
+    header {
+      margin-bottom: 34px;
+    }
+
+    .eyebrow {
+      color: var(--accent);
+      font-size: 13px;
+      font-weight: 700;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      margin-bottom: 10px;
+    }
+
+    h1 {
+      margin: 0;
+      font-size: clamp(34px, 5vw, 64px);
+      line-height: 1.02;
+      letter-spacing: 0;
+      max-width: 900px;
+    }
+
+    .lead {
+      margin: 18px 0 0;
+      color: var(--muted);
+      font-size: 18px;
+      max-width: 860px;
+    }
+
+    section {
+      margin-top: 28px;
+    }
+
+    h2 {
+      margin: 0 0 14px;
+      font-size: 24px;
+      letter-spacing: 0;
+    }
+
+    h3 {
+      margin: 0 0 8px;
+      font-size: 18px;
+      letter-spacing: 0;
+    }
+
+    p {
+      margin: 0;
+    }
+
+    .grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 18px;
+    }
+
+    .panel {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      box-shadow: var(--shadow);
+      padding: 22px;
+    }
+
+    .panel.old {
+      border-top: 5px solid var(--old);
+    }
+
+    .panel.new {
+      border-top: 5px solid var(--new);
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      min-height: 28px;
+      padding: 4px 10px;
+      border-radius: 999px;
+      font-size: 13px;
+      font-weight: 700;
+      margin-bottom: 14px;
+    }
+
+    .tag.old {
+      background: var(--old-bg);
+      color: var(--old);
+    }
+
+    .tag.new {
+      background: var(--new-bg);
+      color: var(--new);
+    }
+
+    .tag.accent {
+      background: var(--accent-bg);
+      color: var(--accent);
+    }
+
+    .tag.risk {
+      background: var(--risk-bg);
+      color: var(--risk);
+    }
+
+    .steps {
+      list-style: none;
+      margin: 16px 0 0;
+      padding: 0;
+      display: grid;
+      gap: 10px;
+    }
+
+    .steps li {
+      display: grid;
+      grid-template-columns: 34px 1fr;
+      gap: 10px;
+      align-items: start;
+      color: var(--muted);
+    }
+
+    .num {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      display: inline-grid;
+      place-items: center;
+      background: #eef2f7;
+      color: var(--ink);
+      font-size: 13px;
+      font-weight: 800;
+    }
+
+    .new .num {
+      background: var(--new-bg);
+      color: var(--new);
+    }
+
+    .old .num {
+      background: var(--old-bg);
+      color: var(--old);
+    }
+
+    .compare {
+      width: 100%;
+      border-collapse: collapse;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: var(--shadow);
+    }
+
+    .compare th,
+    .compare td {
+      border-bottom: 1px solid var(--line);
+      padding: 14px 16px;
+      text-align: left;
+      vertical-align: top;
+    }
+
+    .compare th {
+      background: #eef2f7;
+      font-size: 14px;
+    }
+
+    .compare tr:last-child td {
+      border-bottom: 0;
+    }
+
+    .compare td {
+      color: var(--muted);
+    }
+
+    .flow {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 10px;
+    }
+
+    .flow-card {
+      min-height: 120px;
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px;
+      box-shadow: 0 10px 32px rgba(34, 45, 70, 0.08);
+    }
+
+    .flow-card strong {
+      display: block;
+      margin-bottom: 8px;
+      font-size: 15px;
+    }
+
+    .flow-card span {
+      display: block;
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .lanes {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .lane {
+      background: var(--panel);
+      border: 1px solid var(--line);
+      border-radius: 8px;
+      padding: 14px;
+      min-height: 148px;
+    }
+
+    .lane h3 {
+      color: var(--new);
+      font-size: 15px;
+      overflow-wrap: anywhere;
+    }
+
+    .lane p {
+      color: var(--muted);
+      font-size: 14px;
+    }
+
+    .note {
+      background: var(--accent-bg);
+      border: 1px solid #cdd7ff;
+      border-radius: 8px;
+      padding: 18px;
+      color: #263b8f;
+    }
+
+    code {
+      padding: 2px 5px;
+      border-radius: 5px;
+      background: #eef2f7;
+      color: #243044;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.92em;
+    }
+
+    @media (max-width: 920px) {
+      main {
+        padding: 34px 16px 46px;
+      }
+
+      .grid,
+      .flow,
+      .lanes {
+        grid-template-columns: 1fr;
+      }
+
+      .compare {
+        display: block;
+        overflow-x: auto;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <div class="eyebrow">Ouroboros Interview Upgrade</div>
+      <h1>기존 인터뷰 vs 새 인터뷰</h1>
+      <p class="lead">
+        새 흐름은 MCP가 질문을 만들면 질문을 먼저 보여주고, 동시에 subagent들이 코드, 웹, 모호함, 답변 선택지, 아키텍처 영향을 나눠 조사해 사용자가 더 쉽게 답하도록 돕는다.
+      </p>
+    </header>
+
+    <section class="grid" aria-label="old and new summary">
+      <article class="panel old">
+        <div class="tag old">기존 인터뷰</div>
+        <h2>질문 생성 중심</h2>
+        <p>
+          MCP interview tool이 다음 질문을 만들고, 메인 세션은 그 질문을 사용자에게 전달한 뒤 사용자의 답변을 다시 MCP에 넘기는 구조였다.
+        </p>
+        <ol class="steps">
+          <li><span class="num">1</span><span>MCP가 현재 transcript와 ambiguity score를 보고 다음 질문 생성</span></li>
+          <li><span class="num">2</span><span>메인 세션이 질문을 사용자에게 전달</span></li>
+          <li><span class="num">3</span><span>사용자는 맥락을 스스로 정리해서 답변</span></li>
+          <li><span class="num">4</span><span>메인 세션이 답변을 그대로 MCP에 전달</span></li>
+        </ol>
+      </article>
+
+      <article class="panel new">
+        <div class="tag new">새 인터뷰</div>
+        <h2>질문-first advisory fanout</h2>
+        <p>
+          질문은 그대로 먼저 노출하고, 그 뒤 subagent fanout이 사용자의 빈칸을 찾아 답변 후보와 위험한 모호함을 정리한다.
+        </p>
+        <ol class="steps">
+          <li><span class="num">1</span><span>MCP가 질문과 함께 advisory fanout metadata 생성</span></li>
+          <li><span class="num">2</span><span>브리지가 질문 텍스트를 보존한 채 subagent들을 병렬 dispatch</span></li>
+          <li><span class="num">3</span><span>각 lane이 독립적으로 코드, 웹, 모호함, 선택지, 아키텍처를 점검</span></li>
+          <li><span class="num">4</span><span>메인 세션이 child 결과를 합성해 사용자의 답변을 쉽게 만든 뒤 승인된 답만 MCP에 전달</span></li>
+        </ol>
+      </article>
+    </section>
+
+    <section aria-label="side by side table">
+      <h2>무엇이 달라졌나</h2>
+      <table class="compare">
+        <thead>
+          <tr>
+            <th>관점</th>
+            <th>기존</th>
+            <th>현재</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>메인 세션 역할</td>
+            <td>질문 전달자와 답변 라우터에 가까웠다.</td>
+            <td>질문을 보존하고 subagent 결과를 조율하는 interview conductor가 됐다.</td>
+          </tr>
+          <tr>
+            <td>사용자 경험</td>
+            <td>사용자가 혼자 의도를 정리해서 답해야 했다.</td>
+            <td>답변 전 선택지, 초안, 남은 모호함을 받을 수 있다.</td>
+          </tr>
+          <tr>
+            <td>코드베이스 반영</td>
+            <td>질문 생성 자체는 코드 사실 조사와 느슨하게 연결됐다.</td>
+            <td><code>code_context</code> lane이 repo-local evidence를 찾아 답변을 제약한다.</td>
+          </tr>
+          <tr>
+            <td>웹 조사</td>
+            <td>필요하면 사람이 별도로 요청하거나 메인 세션이 판단해야 했다.</td>
+            <td><code>web_context</code> lane이 최신 외부 사실이 필요한지 먼저 판단하고 최소 조사한다.</td>
+          </tr>
+          <tr>
+            <td>모호함 탐지</td>
+            <td>MCP ambiguity score와 질문 품질에 의존했다.</td>
+            <td><code>ambiguity_contrarian</code>이 숨은 가정, 빠진 결정, 애매한 용어를 따로 찾는다.</td>
+          </tr>
+          <tr>
+            <td>답변 보조</td>
+            <td>질문만 받고 사용자가 직접 문장을 만들어야 했다.</td>
+            <td><code>answer_simplifier</code>가 2-3개 선택지나 승인 가능한 draft를 만든다.</td>
+          </tr>
+          <tr>
+            <td>시스템 영향</td>
+            <td>답변이 구조, ownership, rollout에 미치는 영향이 뒤늦게 드러날 수 있었다.</td>
+            <td><code>architecture_implications</code>가 구현 전에 영향도를 짚는다.</td>
+          </tr>
+          <tr>
+            <td>실패 모드</td>
+            <td>보조 dispatch 실패라는 개념이 없었다.</td>
+            <td>dispatch가 실패해도 질문 텍스트는 유지되고 실패 안내만 뒤에 붙는다.</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section aria-label="new flow">
+      <h2>새 흐름</h2>
+      <div class="flow">
+        <div class="flow-card">
+          <strong>1. MCP 질문</strong>
+          <span><code>ouroboros_interview</code>가 다음 질문과 advisory metadata를 반환한다.</span>
+        </div>
+        <div class="flow-card">
+          <strong>2. 질문 먼저 표시</strong>
+          <span>사용자는 기다리지 않고 질문을 먼저 본다. advisory는 질문을 가리지 않는다.</span>
+        </div>
+        <div class="flow-card">
+          <strong>3. Subagent fanout</strong>
+          <span>브리지가 lane별 child task를 만들고 Task widget으로 진행을 보여준다.</span>
+        </div>
+        <div class="flow-card">
+          <strong>4. Advisory 합성</strong>
+          <span>메인 세션이 child 결과를 읽고 짧은 선택지나 draft로 정리한다.</span>
+        </div>
+        <div class="flow-card">
+          <strong>5. 승인 후 전달</strong>
+          <span>사용자가 승인하거나 고친 답변만 MCP state에 저장된다.</span>
+        </div>
+      </div>
+    </section>
+
+    <section aria-label="advisory lanes">
+      <h2>Subagent lanes</h2>
+      <div class="lanes">
+        <article class="lane">
+          <h3>code_context</h3>
+          <p>코드와 설정에서 질문 답변을 제한하는 사실을 찾는다.</p>
+        </article>
+        <article class="lane">
+          <h3>web_context</h3>
+          <p>가격, API, 정책, 표준처럼 최신 외부 사실이 필요할 때만 조사한다.</p>
+        </article>
+        <article class="lane">
+          <h3>ambiguity_contrarian</h3>
+          <p>사용자가 놓치기 쉬운 가정, 애매한 단어, 빠진 의사결정을 드러낸다.</p>
+        </article>
+        <article class="lane">
+          <h3>answer_simplifier</h3>
+          <p>답하기 쉽게 2-3개 선택지나 짧은 draft를 만든다.</p>
+        </article>
+        <article class="lane">
+          <h3>architecture_implications</h3>
+          <p>답변이 ownership, interface, rollout, data, verification에 미치는 영향을 본다.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="grid" aria-label="runtime details">
+      <article class="panel">
+        <div class="tag accent">OpenCode bridge</div>
+        <h2>질문을 절대 덮지 않음</h2>
+        <p>
+          브리지는 <code>question_advisory_subagents</code> metadata를 읽어 dispatch한다.
+          성공, 중복, 실패 어느 경우에도 <code>question_advisory_preserve_content</code>가 켜져 있으면 원래 질문 텍스트를 앞에 둔다.
+        </p>
+      </article>
+
+      <article class="panel">
+        <div class="tag accent">Plugin mode</div>
+        <h2>Child interviewer가 보조</h2>
+        <p>
+          plugin mode에서는 실제 질문이 child interview session 안에서 생성된다.
+          그래서 child prompt 자체에 Question-first Advisory Fanout 지침을 넣어 질문 뒤에 compact helper를 만들게 했다.
+        </p>
+      </article>
+    </section>
+
+    <section aria-label="why it matters">
+      <div class="note">
+        <strong>한 줄 요약:</strong>
+        기존 인터뷰는 질문을 잘 만드는 쪽에 집중했다면, 새 인터뷰는 질문을 받은 사람이 더 잘 답할 수 있게 주변 맥락을 병렬로 찾아주는 구조다.
+        사람의 기억, 코드 맥락 부족, 최신 정보 부족, 모호한 표현을 subagent들이 보완하고, 메인 세션은 그 결과를 사용자가 결정하기 쉬운 형태로 정리한다.
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -164,6 +164,36 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    `last_question` is required on this path so MCP can persist the real
    transcript even though the parent session generated the question.
 
+   **Question-first advisory fanout**:
+   If an MCP response includes `meta.question_advisory_request`, show the
+   interview question to the user first, then use the advisory request as a
+   parent-session assist layer. The advisory exists to help the human answer;
+   it must not hide, replace, or delay the question itself.
+
+   Run the advisory lanes in parallel when the runtime supports subagents; use
+   the request's `sequential_fallback` semantics otherwise. The standard lanes
+   are:
+   - `code_context` — inspect repo-local facts and reuse
+     `meta.code_investigation_request` when present.
+   - `web_context` — browse/search only when current external facts genuinely
+     affect the answer.
+   - `ambiguity_contrarian` — find hidden assumptions, vague terms, missing
+     decisions, and risky defaults.
+   - `answer_simplifier` — turn the question into 2-3 easy choices or one
+     concise draft answer.
+   - `architecture_implications` — check whether the answer changes ownership,
+     interfaces, rollout, or system shape.
+
+   Synthesize advisory results into a compact helper for the user: 2-3 answer
+   options, one recommended draft, or a short "I found these ambiguities" note.
+   Do not forward advisory output to `ouroboros_interview` until the user
+   approves, edits, or explicitly asks you to auto-confirm a safe answer.
+   When `meta.question_advisory_subagents` is present, treat each entry as a
+   spawn-ready advisory payload with `title`, `agent`, `prompt`, and `context`;
+   dispatch those payloads through the runtime's native subagent primitive
+   instead of reconstructing prompts from prose. Preserve the original question
+   text while advisory children run.
+
    **Milestone lateral-review dispatch**:
    If an MCP response includes `meta.lateral_review_recommended=true`, treat it
    as a required lightweight subagent review for that turn. The interview just
@@ -171,7 +201,7 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    `progress -> refined`, or `refined -> ready`, which is exactly when hidden
    assumptions tend to matter.
 
-   Before answering or asking the returned question:
+   After showing the returned question to the user:
    - Tell the user briefly that a few perspectives are checking the question.
    - Call `ouroboros_lateral_think` with `meta.lateral_review_tool_args` when
      present. If only the legacy advisory fields are present, call it with

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -45,6 +45,7 @@ from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.tools.subagent import (
     DELEGATED_TO_SUBAGENT,
     build_generate_seed_subagent,
+    build_interview_question_advisory_subagents,
     build_interview_subagent,
     dispatch_plugin_terminal,
     lateral_persona_panel_metadata_from_capability_definitions,
@@ -556,19 +557,19 @@ def _with_lateral_review_dispatch(
     return enriched
 
 
-def _prepend_lateral_review_notice(
+def _append_lateral_review_notice(
     response_text: str,
     lateral_review_meta: dict[str, Any] | None,
 ) -> str:
-    """Surface a short user-visible cue when a lateral review should run."""
+    """Surface a short user-visible cue without hiding the question first."""
     if lateral_review_meta is None:
         return response_text
     personas = ", ".join(str(p) for p in lateral_review_meta["lateral_review_personas"])
     milestone = lateral_review_meta["lateral_review_milestone"]
     return (
-        "Lateral review queued: running "
+        f"{response_text}\n\nLateral review queued: running "
         f"{personas} before this interview turn "
-        f"(milestone: {milestone}).\n\n{response_text}"
+        f"(milestone: {milestone})."
     )
 
 
@@ -650,6 +651,80 @@ def _build_code_investigation_request(
     if last_question:
         request["last_question"] = last_question
     return request
+
+
+def _build_question_advisory_request(
+    *,
+    session_id: str,
+    question: str,
+    phase: str,
+    score: AmbiguityScore | None,
+    code_investigation_request: dict[str, Any] | None = None,
+    last_question: str | None = None,
+) -> dict[str, Any]:
+    """Build parent-runtime request metadata for per-question answer help."""
+    mcp_tool_capability = ouroboros_tool_capability_metadata("ouroboros_interview")
+    advisory = mcp_tool_capability["orchestration"]["question_advisory_fanout"]
+    request: dict[str, Any] = {
+        "session_id": session_id,
+        "question_identity": stable_code_investigation_question_identity(question),
+        "question": question,
+        "phase": phase,
+        "ambiguity_score": score.overall_score if score is not None else None,
+        "milestone": _milestone_for_score(score),
+        "user_question_first": True,
+        "advisory_goal": "help_human_answer_interview_question",
+        "parallel_preference": advisory["parallel_preference"],
+        "sequential_fallback": dict(advisory["sequential_fallback"]),
+        "allowed_capabilities": ["inspect_code", "web_research", "run_lateral_review"],
+        "lanes": list(advisory["lanes"]),
+        "synthesis_contract": dict(advisory["synthesis_contract"]),
+        "mcp_tool_capability": mcp_tool_capability,
+    }
+    if last_question:
+        request["last_question"] = last_question
+    if code_investigation_request is not None:
+        request["code_investigation_request"] = code_investigation_request
+    return request
+
+
+def _attach_question_assist_requests(
+    meta: dict[str, Any],
+    *,
+    session_id: str,
+    question: str,
+    phase: str,
+    score: AmbiguityScore | None,
+    last_question: str | None = None,
+) -> None:
+    """Attach code-fact and advisory fanout requests for a question turn."""
+    code_request = _build_code_investigation_request(
+        session_id=session_id,
+        question=question,
+        last_question=last_question,
+    )
+    meta["code_investigation_request"] = code_request
+    meta["question_advisory_recommended"] = True
+    advisory_request = _build_question_advisory_request(
+        session_id=session_id,
+        question=question,
+        phase=phase,
+        score=score,
+        code_investigation_request=code_request,
+        last_question=last_question,
+    )
+    meta["question_advisory_request"] = advisory_request
+    try:
+        advisory_payloads = build_interview_question_advisory_subagents(advisory_request)
+    except ValueError as exc:
+        log.warning(
+            "mcp.tool.interview.question_advisory_build_failed",
+            session_id=session_id,
+            error=str(exc),
+        )
+        return
+    meta["question_advisory_subagents"] = [payload.to_dict() for payload in advisory_payloads]
+    meta["question_advisory_preserve_content"] = True
 
 
 def _is_initial_context_length_guard_question(question: str) -> bool:
@@ -2090,6 +2165,8 @@ class InterviewHandler:
                     "action": action,
                     "status": DELEGATED_TO_SUBAGENT,
                     "dispatch_mode": "plugin",
+                    "question_advisory_strategy": "plugin_child_question_first_advisory",
+                    "question_advisory_recommended": True,
                     **_interview_reasoning_meta(
                         state=plugin_state,
                         session_id=real_session_id,
@@ -2413,9 +2490,12 @@ class InterviewHandler:
                     # would raise on every oversized ``initial_context``.
                     start_meta.update(_length_guard_meta_fields())
                 else:
-                    start_meta["code_investigation_request"] = _build_code_investigation_request(
+                    _attach_question_assist_requests(
+                        start_meta,
                         session_id=state.interview_id,
                         question=question,
+                        phase="start",
+                        score=live_score,
                     )
 
                 start_response_text = (
@@ -2502,11 +2582,12 @@ class InterviewHandler:
                         # summarize prompt as a hard failure.
                         resume_meta.update(_length_guard_meta_fields())
                     else:
-                        resume_meta["code_investigation_request"] = (
-                            _build_code_investigation_request(
-                                session_id=session_id,
-                                question=pending_question,
-                            )
+                        _attach_question_assist_requests(
+                            resume_meta,
+                            session_id=session_id,
+                            question=pending_question,
+                            phase="resume_pending",
+                            score=_load_state_ambiguity_score(state),
                         )
 
                     resume_response_text = f"Session {session_id}\n\n{display_question}"
@@ -3050,16 +3131,19 @@ class InterviewHandler:
                     # the auto driver's ``answer()`` path is not raised on.
                     answer_meta.update(_length_guard_meta_fields())
                 else:
-                    answer_meta["code_investigation_request"] = _build_code_investigation_request(
+                    _attach_question_assist_requests(
+                        answer_meta,
                         session_id=session_id,
                         question=question,
+                        phase="answer",
+                        score=live_score,
                     )
 
                 if lateral_review_dispatch_meta is not None:
                     answer_meta.update(lateral_review_dispatch_meta)
 
                 answer_response_text = f"Session {session_id}\n\n{display_question}"
-                answer_response_text = _prepend_lateral_review_notice(
+                answer_response_text = _append_lateral_review_notice(
                     answer_response_text,
                     lateral_review_dispatch_meta,
                 )

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -60,6 +60,8 @@ _INTERVIEW_SUBAGENT_MAX_PREVIOUS_TRANSCRIPT_CHARS = 200
 _INTERVIEW_SUBAGENT_MAX_TRANSCRIPT_QUESTION_CHARS = 900
 _INTERVIEW_SUBAGENT_MAX_TRANSCRIPT_ANSWER_CHARS = 220
 _INTERVIEW_SUBAGENT_MAX_ANSWER_CHARS = 300
+_INTERVIEW_ADVISORY_MAX_QUESTION_CHARS = 900
+_INTERVIEW_ADVISORY_MAX_JSON_CHARS = 2_400
 _LATERAL_PANEL_FALLBACK_ID = "lateral_persona_panel.v1"
 _LATERAL_PANEL_FALLBACK_TOOL = "ouroboros_lateral_think"
 _LATERAL_PANEL_FALLBACK_SEQUENTIAL_MODE = "sequential_persona_payload_dispatch"
@@ -120,6 +122,17 @@ def _default_code_investigation_confirmation_prompt(output: Mapping[str, Any]) -
     if len(answer_text) > _INTERVIEW_SUBAGENT_MAX_ANSWER_CHARS:
         answer_text = answer_text[: _INTERVIEW_SUBAGENT_MAX_ANSWER_CHARS - 1].rstrip() + "…"
     return f"Confirm before forwarding this code-derived answer: {answer_text}"
+
+
+def _bounded_json(value: Any, max_chars: int) -> str:
+    """Render JSON for prompts without letting metadata dominate context."""
+    try:
+        rendered = json.dumps(value, ensure_ascii=False, sort_keys=True, indent=2)
+    except (TypeError, ValueError):
+        rendered = json.dumps(str(value), ensure_ascii=False)
+    if len(rendered) <= max_chars:
+        return rendered
+    return rendered[:max_chars].rstrip() + "\n... [truncated]"
 
 
 def _payload_persona(payload: Mapping[str, Any]) -> str:
@@ -1131,6 +1144,12 @@ def build_interview_subagent(
 
     system_prompt = load_agent_prompt("socratic-interviewer")
     seed_closer_summary = _load_seed_closer_summary()
+    plugin_question_advisory = """
+## Question-first Advisory Fanout
+1. Show the interview question first.
+2. Then add a compact helper from: code_context, web_context, ambiguity_contrarian,
+   answer_simplifier, architecture_implications.
+3. Offer options, a draft, or unresolved ambiguities; preserve user agency."""
 
     transcript_section = ""
     if transcript:
@@ -1160,6 +1179,7 @@ Do not treat ambiguity <= 0.2 as sufficient for closure.
 Start a Socratic interview to clarify requirements for the following project idea.
 Ask probing questions to reduce ambiguity. Score ambiguity after each exchange.
 {seed_ready_guard}
+{plugin_question_advisory}
 
 ## Initial Context
 {bounded_initial_context}
@@ -1180,6 +1200,7 @@ Continue the Socratic interview. The user has answered your previous question.
 Analyze their answer, update your understanding, score current ambiguity,
 and ask the next clarifying question or declare ready only after the Seed-ready Guard passes.
 {seed_ready_guard}
+{plugin_question_advisory}
 
 ## Session ID
 {session_id}
@@ -1200,6 +1221,7 @@ Resume the Socratic interview for session {session_id}.
 Review the conversation history and continue from where we left off.
 {transcript_section}
 {seed_ready_guard}
+{plugin_question_advisory}
 
 ## Action: {action}
 
@@ -1211,6 +1233,7 @@ Continue the interview."""
         "initial_context": initial_context,
         "answer": answer,
         "cwd": cwd,
+        "question_advisory_strategy": "plugin_child_question_first_advisory",
     }
 
     return build_subagent_payload(
@@ -1219,6 +1242,167 @@ Continue the interview."""
         prompt=prompt,
         context=context,
     )
+
+
+def build_interview_question_advisory_subagents(
+    request: Mapping[str, Any],
+) -> list[SubagentPayload]:
+    """Build per-lane advisory subagents for an interview question.
+
+    The parent session owns the user-facing question. These payloads are an
+    assist layer: independent child contexts inspect code, check current facts
+    when needed, challenge ambiguity, and make the answer easier to provide.
+    """
+    session_id = str(request.get("session_id") or "")
+    question_identity = str(request.get("question_identity") or "")
+    question = str(request.get("question") or "")
+    if not session_id:
+        raise ValueError("request.session_id must not be empty")
+    if not question_identity:
+        raise ValueError("request.question_identity must not be empty")
+    if not question:
+        raise ValueError("request.question must not be empty")
+
+    raw_lanes = request.get("lanes")
+    if not isinstance(raw_lanes, (list, tuple)) or not raw_lanes:
+        raise ValueError("request.lanes must be a non-empty list")
+
+    bounded_question = _truncate_head(question, _INTERVIEW_ADVISORY_MAX_QUESTION_CHARS)
+    code_request_json = _bounded_json(
+        request.get("code_investigation_request"),
+        _INTERVIEW_ADVISORY_MAX_JSON_CHARS,
+    )
+    synthesis_contract = request.get("synthesis_contract")
+    synthesis_contract_json = _bounded_json(
+        synthesis_contract,
+        _INTERVIEW_ADVISORY_MAX_JSON_CHARS,
+    )
+    ambiguity_score = request.get("ambiguity_score")
+    milestone = request.get("milestone")
+
+    payloads: list[SubagentPayload] = []
+    seen: set[str] = set()
+    for raw_lane in raw_lanes:
+        if not isinstance(raw_lane, Mapping):
+            continue
+        lane_id = str(raw_lane.get("lane_id") or "").strip()
+        capability = str(raw_lane.get("capability") or "").strip()
+        if not lane_id or lane_id in seen:
+            continue
+        seen.add(lane_id)
+
+        persona = str(raw_lane.get("persona") or "").strip()
+        agent = persona or (
+            "researcher" if capability in {"inspect_code", "web_research"} else "general"
+        )
+        purpose = str(raw_lane.get("purpose") or "Help answer the interview question.").strip()
+        required = bool(raw_lane.get("required"))
+
+        if lane_id == "code_context":
+            lane_task = (
+                "Inspect the local repository for facts that directly answer or "
+                "constrain the question. Use exact file/config evidence. Do not "
+                "make product decisions. If the code does not answer it, say so."
+            )
+            extra = f"## Code Investigation Request\n```json\n{code_request_json}\n```"
+        elif lane_id == "web_context":
+            lane_task = (
+                "Decide whether current external knowledge is needed. If yes, "
+                "research the minimum necessary current facts and cite sources. "
+                "If no current web facts are needed, return that no-op finding."
+            )
+            extra = "Use web research only when the answer depends on current external facts."
+        elif lane_id == "ambiguity_contrarian":
+            lane_task = (
+                "Challenge the question and the likely answer. Identify hidden "
+                "assumptions, overloaded terms, missing constraints, and decisions "
+                "the human might accidentally skip."
+            )
+            extra = "Lean into the contrarian role, but keep the advice user-safe and actionable."
+        elif lane_id == "answer_simplifier":
+            lane_task = (
+                "Turn the question into an easy response surface: 2-3 concrete "
+                "answer options or one recommended draft the user can approve or edit."
+            )
+            extra = "Prefer concise choices over a broad essay."
+        elif lane_id == "architecture_implications":
+            lane_task = (
+                "Check whether the answer would affect system shape, ownership, "
+                "interfaces, rollout, data model, or verification strategy."
+            )
+            extra = "Only raise architecture implications that materially affect implementation."
+        else:
+            lane_task = "Help the parent session answer this interview question."
+            extra = ""
+
+        prompt = f"""## Task
+You are an Ouroboros interview advisory subagent.
+
+The parent session has already shown the interview question to the user. Your job
+is to help the user answer it; do not answer on behalf of the user unless the
+answer is a descriptive fact with clear evidence.
+
+## Interview Question
+{bounded_question}
+
+## Session
+- session_id: {session_id}
+- question_identity: {question_identity}
+- ambiguity_score: {ambiguity_score}
+- milestone: {milestone}
+
+## Advisory Lane
+- lane_id: {lane_id}
+- capability: {capability}
+- required: {str(required).lower()}
+- purpose: {purpose}
+
+## Lane Task
+{lane_task}
+
+{extra}
+
+## Synthesis Contract
+```json
+{synthesis_contract_json}
+```
+
+## Output
+Return a compact JSON object with:
+- lane_id
+- finding: the single most useful advisory finding
+- evidence: short list of file paths, source URLs, or reasoning anchors
+- suggested_options: up to 3 answer options or draft snippets
+- unresolved_ambiguities: short list of what the human still must decide
+
+Keep it brief. The parent session will synthesize multiple advisory lanes before
+forwarding anything back to ouroboros_interview."""
+
+        payloads.append(
+            build_subagent_payload(
+                tool_name="ouroboros_interview",
+                title=f"Interview advisory: {lane_id}",
+                agent=agent,
+                prompt=prompt,
+                context={
+                    "session_id": session_id,
+                    "question_identity": question_identity,
+                    "question": question,
+                    "lane_id": lane_id,
+                    "capability": capability,
+                    "required": required,
+                    "persona": persona or None,
+                    "user_question_first": bool(request.get("user_question_first")),
+                    "synthesis_contract": dict(synthesis_contract)
+                    if isinstance(synthesis_contract, Mapping)
+                    else {},
+                },
+            )
+        )
+
+    if not payloads:
+        raise ValueError("request.lanes did not contain any valid advisory lanes")
+    return payloads
 
 
 def build_generate_seed_subagent(

--- a/src/ouroboros/opencode/plugin/ouroboros-bridge.test.ts
+++ b/src/ouroboros/opencode/plugin/ouroboros-bridge.test.ts
@@ -29,7 +29,9 @@ import {
   markRalphChild,
   notify,
   num,
+  OuroborosBridge,
   parse,
+  parseMetadata,
   parseChildTimeout,
   rand62,
   readText,
@@ -419,6 +421,54 @@ describe("parse", () => {
     const out = parse(raw)
     expect(out.subs.length).toBe(1)
     expect(out.responseShape).toEqual({ job_id: "job_789" })
+  })
+})
+
+describe("parseMetadata", () => {
+  const empty = { subs: [], responseShape: {}, preserveContent: false }
+
+  test("empty metadata returns empty", () => {
+    expect(parseMetadata(undefined)).toEqual(empty)
+    expect(parseMetadata({})).toEqual(empty)
+  })
+
+  test("question advisory metadata produces subs and preserves content flag", () => {
+    const out = parseMetadata({
+      session_id: "sess-1",
+      ambiguity_score: 0.35,
+      milestone: "progress",
+      seed_ready: false,
+      question_advisory_recommended: true,
+      question_advisory_preserve_content: true,
+      question_advisory_subagents: [
+        { tool_name: "ouroboros_interview", title: "Code", agent: "researcher", prompt: "inspect" },
+        { tool_name: "ouroboros_interview", title: "Simplify", agent: "simplifier", prompt: "simplify" },
+      ],
+    })
+
+    expect(out.subs.length).toBe(2)
+    expect(out.subs.map((s) => s.title)).toEqual(["Code", "Simplify"])
+    expect(out.subs.map((s) => s.agent)).toEqual(["researcher", "simplifier"])
+    expect(out.preserveContent).toBe(true)
+    expect(out.responseShape).toEqual({
+      session_id: "sess-1",
+      ambiguity_score: 0.35,
+      milestone: "progress",
+      seed_ready: false,
+      question_advisory_recommended: true,
+    })
+  })
+
+  test("invalid advisory children are skipped", () => {
+    const out = parseMetadata({
+      question_advisory_subagents: [
+        { prompt: "missing tool" },
+        { tool_name: "ouroboros_interview", prompt: "ok" },
+      ],
+    })
+
+    expect(out.subs.length).toBe(1)
+    expect(out.subs[0].tool).toBe("ouroboros_interview")
   })
 })
 
@@ -943,5 +993,123 @@ describe("_dispatch — child session lifecycle", () => {
     expect(errorPatch.state.error).toContain("stop_reason=iteration_timeout")
     expect(errorPatch.state.metadata.stop_reason).toBe("iteration_timeout")
     expect(errorPatch.state.metadata.timeout_source).toBe("per_iteration_timeout_seconds")
+  })
+})
+
+describe("OuroborosBridge hook — metadata advisory fanout", () => {
+  test("preserves interview question text while dispatching metadata subagents", async () => {
+    _resetDedupe()
+    let created = 0
+    const promptCalls: unknown[] = []
+    const patchBodies: unknown[] = []
+    const cli = {
+      session: {
+        _client: {
+          patch: async (a: unknown) => {
+            patchBodies.push((a as { body?: unknown }).body)
+            return {}
+          },
+        },
+        create: async () => ({ data: { id: `child_${++created}` } }),
+        prompt: async (a: unknown) => {
+          promptCalls.push(a)
+          return { data: { parts: [{ type: "text", text: "done" }] } }
+        },
+        abort: async () => ({}),
+        messages: async () => ({
+          data: [
+            {
+              info: { id: "msg_1", role: "assistant" },
+              parts: [{ type: "tool", callID: "call_advisory" }],
+            },
+          ],
+        }),
+      },
+    }
+    const plugin = await OuroborosBridge({ client: cli, directory: "/tmp/ouroboros-test" } as never)
+    const hook = (plugin as Record<string, (...args: unknown[]) => Promise<void>>)["tool.execute.after"]
+    const originalQuestion = "Session sess-1\n\nWhich users need this first?"
+    const output = {
+      content: [{ type: "text", text: originalQuestion }],
+      metadata: {
+        session_id: "sess-1",
+        ambiguity_score: 0.35,
+        milestone: "progress",
+        seed_ready: false,
+        question_advisory_recommended: true,
+        question_advisory_preserve_content: true,
+        question_advisory_subagents: [
+          {
+            tool_name: "ouroboros_interview",
+            title: "Interview advisory: code_context",
+            agent: "researcher",
+            prompt: "Inspect code facts.",
+          },
+          {
+            tool_name: "ouroboros_interview",
+            title: "Interview advisory: answer_simplifier",
+            agent: "simplifier",
+            prompt: "Suggest answer options.",
+          },
+        ],
+      },
+    }
+
+    await hook(
+      { tool: "ouroboros_interview", sessionID: "parent_1", callID: "call_advisory" },
+      output,
+    )
+
+    const text = readText(output)
+    expect(text.startsWith(originalQuestion)).toBe(true)
+    expect(text).toContain("[Ouroboros] Dispatched 2 subagents.")
+    expect(text).toContain('"question_advisory_recommended": true')
+    expect(output.metadata.ouroboros_dispatch.status).toBe("dispatched")
+    expect(output.metadata.ouroboros_children).toEqual([
+      { title: "Interview advisory: code_context", childID: "child_1" },
+      { title: "Interview advisory: answer_simplifier", childID: "child_2" },
+    ])
+    expect(promptCalls.length).toBe(2)
+    const runningPatches = patchBodies.filter(
+      (body) => (body as { state?: { status?: string } })?.state?.status === "running",
+    )
+    expect(runningPatches).toHaveLength(2)
+  })
+
+  test("preserves interview question text when metadata advisory dispatch fails early", async () => {
+    _resetDedupe()
+    const cli = {
+      session: {
+        _client: { patch: async () => ({}) },
+        create: async () => ({ data: { id: "child_unused" } }),
+        prompt: async () => ({ data: { parts: [{ type: "text", text: "unused" }] } }),
+        abort: async () => ({}),
+        messages: async () => ({ data: [] }),
+      },
+    }
+    const plugin = await OuroborosBridge({ client: cli, directory: "/tmp/ouroboros-test" } as never)
+    const hook = (plugin as Record<string, (...args: unknown[]) => Promise<void>>)["tool.execute.after"]
+    const originalQuestion = "Session sess-1\n\nWhich risk should we resolve first?"
+    const output = {
+      content: [{ type: "text", text: originalQuestion }],
+      metadata: {
+        question_advisory_preserve_content: true,
+        question_advisory_subagents: [
+          {
+            tool_name: "ouroboros_interview",
+            title: "Interview advisory: ambiguity_contrarian",
+            agent: "contrarian",
+            prompt: "Find ambiguity.",
+          },
+        ],
+      },
+    }
+
+    await hook({ tool: "ouroboros_interview", callID: "call_missing_session" }, output)
+
+    const text = readText(output)
+    expect(text.startsWith(originalQuestion)).toBe(true)
+    expect(text).toContain("Dispatch failed")
+    expect(text).toContain("empty sessionID")
   })
 })

--- a/src/ouroboros/opencode/plugin/ouroboros-bridge.test.ts
+++ b/src/ouroboros/opencode/plugin/ouroboros-bridge.test.ts
@@ -1064,8 +1064,9 @@ describe("OuroborosBridge hook — metadata advisory fanout", () => {
     expect(text.startsWith(originalQuestion)).toBe(true)
     expect(text).toContain("[Ouroboros] Dispatched 2 subagents.")
     expect(text).toContain('"question_advisory_recommended": true')
-    expect(output.metadata.ouroboros_dispatch.status).toBe("dispatched")
-    expect(output.metadata.ouroboros_children).toEqual([
+    const metadata = output.metadata as Record<string, any>
+    expect(metadata.ouroboros_dispatch.status).toBe("dispatched")
+    expect(metadata.ouroboros_children).toEqual([
       { title: "Interview advisory: code_context", childID: "child_1" },
       { title: "Interview advisory: answer_simplifier", childID: "child_2" },
     ])

--- a/src/ouroboros/opencode/plugin/ouroboros-bridge.ts
+++ b/src/ouroboros/opencode/plugin/ouroboros-bridge.ts
@@ -222,6 +222,35 @@ export function parse(raw: string): { subs: Sub[]; responseShape: Record<string,
   return empty
 }
 
+export function parseMetadata(meta: unknown): { subs: Sub[]; responseShape: Record<string, unknown>; preserveContent: boolean } {
+  const empty = { subs: [], responseShape: {}, preserveContent: false }
+  if (!meta || typeof meta !== "object") return empty
+  const record = meta as Record<string, unknown>
+  const raw = record.question_advisory_subagents
+  if (!Array.isArray(raw) || raw.length === 0) return empty
+  if (raw.length > MAX_FANOUT) log(`WARN metadata_fanout_capped requested=${raw.length} cap=${MAX_FANOUT}`)
+  const subs = raw.slice(0, MAX_FANOUT).flatMap((p, i) => {
+    const s = build(p, i)
+    return s ? [s] : []
+  })
+  if (subs.length === 0) return empty
+  const responseShape: Record<string, unknown> = {}
+  for (const key of [
+    "session_id",
+    "ambiguity_score",
+    "milestone",
+    "seed_ready",
+    "question_advisory_recommended",
+  ]) {
+    if (key in record) responseShape[key] = record[key]
+  }
+  return {
+    subs,
+    responseShape,
+    preserveContent: record.question_advisory_preserve_content === true,
+  }
+}
+
 export function readText(r: Output): string {
   if (Array.isArray(r.content)) {
     const texts = r.content
@@ -310,8 +339,9 @@ export function buildEnvelope(
   }
 }
 
-function fail(r: Output, label: string, err: unknown): void {
-  stamp(r, `[Ouroboros] Dispatch failed for '${label}': ${errMsg(err)}. See ${LOG}.`)
+function fail(r: Output, label: string, err: unknown, preservePrefix?: string): void {
+  const msg = `[Ouroboros] Dispatch failed for '${label}': ${errMsg(err)}. See ${LOG}.`
+  stamp(r, preservePrefix ? `${preservePrefix}\n\n${msg}` : msg)
 }
 
 const seen = new Map<string, number>()
@@ -556,16 +586,22 @@ export const OuroborosBridge: Plugin = async (ctx) => {
         if (!output || typeof output !== "object") return
 
         const out = output as Output
-        const { subs, responseShape } = parse(readText(out))
+        const originalText = readText(out)
+        const parsedText = parse(originalText)
+        const parsedMeta = parsedText.subs.length === 0 ? parseMetadata(out.metadata) : { subs: [], responseShape: {}, preserveContent: false }
+        const subs = parsedText.subs.length > 0 ? parsedText.subs : parsedMeta.subs
+        const responseShape = parsedText.subs.length > 0 ? parsedText.responseShape : parsedMeta.responseShape
+        const preserveContent = parsedText.subs.length === 0 && parsedMeta.preserveContent
         if (subs.length === 0) return
 
         const pid = typeof input.sessionID === "string" ? input.sessionID : ""
         const callID = typeof input.callID === "string" ? input.callID : ""
-        if (!pid) { log(`REJECT reason=empty_sessionID tool=${subs[0].tool}`); fail(out, subs[0].tool, new Error("empty sessionID")); return }
-        if (!callID) { log(`REJECT reason=empty_callID tool=${subs[0].tool}`); fail(out, subs[0].tool, new Error("empty callID")); return }
+        const failurePrefix = preserveContent ? originalText : undefined
+        if (!pid) { log(`REJECT reason=empty_sessionID tool=${subs[0].tool}`); fail(out, subs[0].tool, new Error("empty sessionID"), failurePrefix); return }
+        if (!callID) { log(`REJECT reason=empty_callID tool=${subs[0].tool}`); fail(out, subs[0].tool, new Error("empty callID"), failurePrefix); return }
         if (isNestedRalphDispatch(pid, subs)) {
           log(`REJECT reason=nested_ralph pid=${pid} tool=${subs[0].tool}`)
-          fail(out, "ouroboros_ralph", new Error("nested ouroboros_ralph delegation is not allowed"))
+          fail(out, "ouroboros_ralph", new Error("nested ouroboros_ralph delegation is not allowed"), failurePrefix)
           return
         }
 
@@ -573,7 +609,7 @@ export const OuroborosBridge: Plugin = async (ctx) => {
         const b = base(ctx.client)
         if (!cli?.session?.create || !cli.session.prompt || !cli.session.abort || !cli.session.messages || !b) {
           log(`REJECT reason=client_not_ready tool=${subs[0].tool}`)
-          fail(out, subs[0].tool, new Error("client not ready"))
+          fail(out, subs[0].tool, new Error("client not ready"), failurePrefix)
           return
         }
 
@@ -582,7 +618,8 @@ export const OuroborosBridge: Plugin = async (ctx) => {
           const dedupeShapeSuffix = Object.keys(responseShape).length > 0
             ? "\n\n```json\n" + JSON.stringify(responseShape, null, 2) + "\n```"
             : ""
-          stamp(out, notify([], [], subs) + dedupeShapeSuffix)
+          const dedupeBanner = notify([], [], subs) + dedupeShapeSuffix
+          stamp(out, preserveContent ? `${originalText}\n\n${dedupeBanner}` : dedupeBanner)
           const meta = (out.metadata ?? {}) as Record<string, unknown>
           meta.ouroboros_dispatch = buildEnvelope([], [], subs)
           if (Object.keys(responseShape).length > 0) meta.ouroboros_response_shape = responseShape
@@ -593,7 +630,7 @@ export const OuroborosBridge: Plugin = async (ctx) => {
         const mid = await resolveMid(cli, pid, callID)
         if (!mid) {
           log(`REJECT reason=no_message_found pid=${pid} callID=${callID}`)
-          fail(out, subs[0].tool, new Error("could not resolve messageID"))
+          fail(out, subs[0].tool, new Error("could not resolve messageID"), failurePrefix)
           return
         }
 
@@ -622,7 +659,7 @@ export const OuroborosBridge: Plugin = async (ctx) => {
         const shapeSuffix = Object.keys(responseShape).length > 0
           ? "\n\n```json\n" + JSON.stringify(responseShape, null, 2) + "\n```"
           : ""
-        stamp(out, banner + shapeSuffix)
+        stamp(out, preserveContent ? `${originalText}\n\n${banner}${shapeSuffix}` : banner + shapeSuffix)
 
         const envelope = buildEnvelope(ok, failed, [])
         const meta = (out.metadata ?? {}) as Record<string, unknown>

--- a/src/ouroboros/orchestrator/capabilities.py
+++ b/src/ouroboros/orchestrator/capabilities.py
@@ -1952,6 +1952,271 @@ def _code_investigation_repo_inspection_tool_capabilities() -> tuple[dict[str, A
     return tuple(capabilities)
 
 
+def _interview_question_advisory_request_schema() -> dict[str, Any]:
+    """Return the runtime request model for per-question answer assistance."""
+    return {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [
+            "session_id",
+            "question_identity",
+            "question",
+            "phase",
+            "user_question_first",
+            "advisory_goal",
+            "parallel_preference",
+            "sequential_fallback",
+            "allowed_capabilities",
+            "lanes",
+            "synthesis_contract",
+            "mcp_tool_capability",
+        ],
+        "properties": {
+            "session_id": {
+                "type": "string",
+                "description": "Current Ouroboros interview session ID.",
+            },
+            "question_identity": {
+                "type": "string",
+                "pattern": r"^interview-question:[0-9a-f]{16}$",
+                "description": (
+                    "Stable identity derived from the originating interview "
+                    "question using stable_code_investigation_question_identity()."
+                ),
+            },
+            "question": {
+                "type": "string",
+                "minLength": 1,
+                "description": "The already user-visible MCP interview question.",
+            },
+            "last_question": {
+                "type": "string",
+                "description": "Previously asked question text, when available.",
+            },
+            "phase": {
+                "type": "string",
+                "enum": ["start", "resume_pending", "answer"],
+            },
+            "ambiguity_score": {
+                "type": ["number", "null"],
+                "minimum": 0,
+                "maximum": 1,
+            },
+            "milestone": {
+                "type": ["string", "null"],
+                "enum": ["initial", "progress", "refined", "ready", None],
+            },
+            "user_question_first": {
+                "const": True,
+                "description": (
+                    "The parent runtime must surface the interview question before "
+                    "or while advisory fanout runs; advisory must never hide the "
+                    "question behind background research."
+                ),
+            },
+            "advisory_goal": {
+                "const": "help_human_answer_interview_question",
+                "description": (
+                    "Generate concise answer options, uncertainty notes, and a "
+                    "recommended draft without mutating interview state."
+                ),
+            },
+            "parallel_preference": {
+                "const": "parallel_when_runtime_supports_subagents",
+            },
+            "sequential_fallback": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": ["supported", "mode", "trigger"],
+                "properties": {
+                    "supported": {"const": True},
+                    "mode": {"const": "sequential_advisory_lane_dispatch"},
+                    "trigger": {"const": "runtime_has_no_native_parallel_subagent_primitive"},
+                },
+            },
+            "allowed_capabilities": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "string",
+                    "enum": ["inspect_code", "web_research", "run_lateral_review"],
+                },
+            },
+            "lanes": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                    "type": "object",
+                    "additionalProperties": False,
+                    "required": ["lane_id", "purpose", "capability", "required"],
+                    "properties": {
+                        "lane_id": {
+                            "type": "string",
+                            "enum": [
+                                "code_context",
+                                "web_context",
+                                "ambiguity_contrarian",
+                                "answer_simplifier",
+                                "architecture_implications",
+                            ],
+                        },
+                        "purpose": {"type": "string", "minLength": 1},
+                        "capability": {
+                            "type": "string",
+                            "enum": ["inspect_code", "web_research", "run_lateral_review"],
+                        },
+                        "persona": {
+                            "type": "string",
+                            "enum": ["researcher", "contrarian", "simplifier", "architect"],
+                        },
+                        "required": {"type": "boolean"},
+                    },
+                },
+            },
+            "code_investigation_request": {
+                "type": "object",
+                "additionalProperties": True,
+                "description": (
+                    "Optional code-fact request emitted alongside this advisory; "
+                    "reuse it for the code_context lane when present."
+                ),
+            },
+            "synthesis_contract": {
+                "type": "object",
+                "additionalProperties": False,
+                "required": [
+                    "output_shape",
+                    "max_options",
+                    "include_recommended_draft",
+                    "preserve_user_agency",
+                    "forward_to_mcp_only_after_user_or_auto_confirm",
+                ],
+                "properties": {
+                    "output_shape": {
+                        "const": "answer_advisory",
+                    },
+                    "max_options": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 5,
+                    },
+                    "include_recommended_draft": {"type": "boolean"},
+                    "preserve_user_agency": {"const": True},
+                    "forward_to_mcp_only_after_user_or_auto_confirm": {"const": True},
+                },
+            },
+            "mcp_tool_capability": {
+                "type": "object",
+                "additionalProperties": True,
+                "required": [
+                    "tool_name",
+                    "stable_id",
+                    "source_kind",
+                    "source_name",
+                    "input_schema",
+                    "mutation_class",
+                    "execution_mode",
+                    "companions",
+                    "required_context_keys",
+                    "mutation_targets",
+                    "state_mutations",
+                    "side_effects",
+                    "retry",
+                    "interrupt",
+                    "cancel",
+                    "fallback_used",
+                    "orchestration",
+                ],
+                "properties": {
+                    "tool_name": {"const": "ouroboros_interview"},
+                    "fallback_used": {"const": False},
+                },
+            },
+        },
+    }
+
+
+def _interview_question_advisory_fanout_metadata() -> dict[str, Any]:
+    """Return structured metadata for parent-session interview answer help."""
+    lanes = [
+        {
+            "lane_id": "code_context",
+            "purpose": "Find repo-local facts that may answer or constrain the question.",
+            "capability": "inspect_code",
+            "required": False,
+        },
+        {
+            "lane_id": "web_context",
+            "purpose": (
+                "Check current external facts only when the question depends on "
+                "third-party APIs, pricing, standards, security, or recent changes."
+            ),
+            "capability": "web_research",
+            "required": False,
+        },
+        {
+            "lane_id": "ambiguity_contrarian",
+            "purpose": "Name hidden assumptions, missing decisions, and risky vague words.",
+            "capability": "run_lateral_review",
+            "persona": "contrarian",
+            "required": True,
+        },
+        {
+            "lane_id": "answer_simplifier",
+            "purpose": "Turn the question into easy choices or a concise answer draft.",
+            "capability": "run_lateral_review",
+            "persona": "simplifier",
+            "required": True,
+        },
+        {
+            "lane_id": "architecture_implications",
+            "purpose": (
+                "Check whether the answer would change system shape, ownership, "
+                "interfaces, or rollout strategy."
+            ),
+            "capability": "run_lateral_review",
+            "persona": "architect",
+            "required": False,
+        },
+    ]
+    return {
+        "contract_id": "interview_question_advisory_fanout.v1",
+        "mcp_tool": "ouroboros_interview",
+        "companion_tool": "ouroboros_lateral_think",
+        "dispatch_timing": "after_question_is_visible_to_user",
+        "parallel_preference": "parallel_when_runtime_supports_subagents",
+        "sequential_fallback": {
+            "supported": True,
+            "mode": "sequential_advisory_lane_dispatch",
+            "trigger": "runtime_has_no_native_parallel_subagent_primitive",
+        },
+        "request_model_schema": _interview_question_advisory_request_schema(),
+        "lanes": lanes,
+        "synthesis_contract": {
+            "output_shape": "answer_advisory",
+            "max_options": 3,
+            "include_recommended_draft": True,
+            "preserve_user_agency": True,
+            "forward_to_mcp_only_after_user_or_auto_confirm": True,
+        },
+        "response_payload_refs": {
+            "plugin": "parent_runtime.ouroboros_dispatch.children",
+            "result_correlation_key": "lane_id",
+            "requires_prose_parsing": False,
+            "synthesis_owner": "parent_session",
+        },
+        "runtime_instruction": (
+            "Show the MCP interview question to the user first, then fan out "
+            "advisory lanes for code context, current web facts when needed, "
+            "ambiguity critique, simplification, and architecture implications. "
+            "Read child task results as they complete and synthesize them into "
+            "two or three answer options or one recommended draft. Do not forward advisory text to "
+            "ouroboros_interview until the user approves, edits, or explicitly "
+            "chooses auto-confirm."
+        ),
+    }
+
+
 def _serialized_metadata_for_descriptor(
     descriptor: CapabilityDescriptor,
 ) -> dict[str, Any] | None:
@@ -2930,6 +3195,7 @@ def _orchestration_metadata_for_ouroboros_tool(name: str) -> Mapping[str, Any]:
                 "decision or low-confidence confirmation to the user."
             ),
         },
+        "question_advisory_fanout": _interview_question_advisory_fanout_metadata(),
         "lateral_panel": lateral_panel,
     }
 

--- a/tests/unit/mcp/tools/test_handler_subagent_wiring.py
+++ b/tests/unit/mcp/tools/test_handler_subagent_wiring.py
@@ -218,6 +218,12 @@ class TestInterviewHandlerSubagentDispatch:
         payload = result.value.meta["_subagent"]
         assert payload["tool_name"] == "ouroboros_interview"
         assert "Build a web app" in payload["prompt"]
+        assert "## Question-first Advisory Fanout" in payload["prompt"]
+        assert result.value.meta["question_advisory_recommended"] is True
+        assert (
+            result.value.meta["question_advisory_strategy"]
+            == "plugin_child_question_first_advisory"
+        )
 
     async def test_answer_returns_subagent(self, handler) -> None:
         result = await handler.handle(

--- a/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
+++ b/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
@@ -233,8 +233,41 @@ async def test_handler_surfaces_runnable_lateral_review_dispatch() -> None:
         "requires_prose_parsing": False,
         "synthesize_before_interview_continuation": True,
     }
+    assert result.value.meta["question_advisory_recommended"] is True
+    advisory = result.value.meta["question_advisory_request"]
+    assert advisory["session_id"] == "sess-817"
+    assert advisory["question"] == "What edge case remains?"
+    assert advisory["phase"] == "answer"
+    assert advisory["user_question_first"] is True
+    assert advisory["allowed_capabilities"] == [
+        "inspect_code",
+        "web_research",
+        "run_lateral_review",
+    ]
+    assert {lane["lane_id"] for lane in advisory["lanes"]} == {
+        "code_context",
+        "web_context",
+        "ambiguity_contrarian",
+        "answer_simplifier",
+        "architecture_implications",
+    }
+    assert advisory["code_investigation_request"]["question"] == "What edge case remains?"
+    advisory_subagents = result.value.meta["question_advisory_subagents"]
+    assert [subagent["context"]["lane_id"] for subagent in advisory_subagents] == [
+        "code_context",
+        "web_context",
+        "ambiguity_contrarian",
+        "answer_simplifier",
+        "architecture_implications",
+    ]
+    assert result.value.meta["question_advisory_preserve_content"] is True
     content_text = result.value.content[0].text
-    assert content_text.startswith("Lateral review queued:")
+    assert content_text.startswith("Session sess-817\n\n")
+    assert "What edge case remains?" in content_text
+    assert "Lateral review queued:" in content_text
+    assert content_text.index("What edge case remains?") < content_text.index(
+        "Lateral review queued:"
+    )
     assert "Session sess-817" in content_text
     assert state.lateral_review_advised_milestones == ["progress"]
     handler._emit_event_bg.assert_called()

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -22,6 +22,7 @@ from ouroboros.mcp.tools.subagent import (
     build_evaluate_subagent,
     build_execute_subagent,
     build_generate_seed_subagent,
+    build_interview_question_advisory_subagents,
     build_interview_subagent,
     build_pm_interview_subagent,
     build_qa_subagent,
@@ -692,6 +693,98 @@ class TestBuildInterviewSubagent:
             action="start",
         )
         assert p.context["session_id"] == "sess-123"
+
+    def test_plugin_interview_prompt_embeds_question_first_advisory_strategy(self) -> None:
+        p = build_interview_subagent(
+            session_id="sess-123",
+            action="start",
+            initial_context="Build a planning assistant",
+        )
+
+        assert "## Question-first Advisory Fanout" in p.prompt
+        assert "1. Show the interview question first." in p.prompt
+        assert "code_context" in p.prompt
+        assert "ambiguity_contrarian" in p.prompt
+        assert "answer_simplifier" in p.prompt
+        assert (
+            p.context["question_advisory_strategy"]
+            == "plugin_child_question_first_advisory"
+        )
+
+
+class TestBuildInterviewQuestionAdvisorySubagents:
+    """Test per-question advisory fanout payloads."""
+
+    def test_builds_one_payload_per_lane(self) -> None:
+        request = {
+            "session_id": "sess-123",
+            "question_identity": "interview-question:0123456789abcdef",
+            "question": "Which users need this first?",
+            "ambiguity_score": 0.35,
+            "milestone": "progress",
+            "user_question_first": True,
+            "lanes": [
+                {
+                    "lane_id": "code_context",
+                    "capability": "inspect_code",
+                    "purpose": "Find code facts.",
+                    "required": False,
+                },
+                {
+                    "lane_id": "ambiguity_contrarian",
+                    "capability": "run_lateral_review",
+                    "persona": "contrarian",
+                    "purpose": "Find hidden assumptions.",
+                    "required": True,
+                },
+                {
+                    "lane_id": "answer_simplifier",
+                    "capability": "run_lateral_review",
+                    "persona": "simplifier",
+                    "purpose": "Make it easy to answer.",
+                    "required": True,
+                },
+            ],
+            "synthesis_contract": {
+                "output_shape": "answer_advisory",
+                "max_options": 3,
+                "include_recommended_draft": True,
+                "preserve_user_agency": True,
+                "forward_to_mcp_only_after_user_or_auto_confirm": True,
+            },
+            "code_investigation_request": {"question": "Which users need this first?"},
+        }
+
+        payloads = build_interview_question_advisory_subagents(request)
+
+        assert [payload.title for payload in payloads] == [
+            "Interview advisory: code_context",
+            "Interview advisory: ambiguity_contrarian",
+            "Interview advisory: answer_simplifier",
+        ]
+        assert [payload.agent for payload in payloads] == [
+            "researcher",
+            "contrarian",
+            "simplifier",
+        ]
+        assert all(payload.tool_name == "ouroboros_interview" for payload in payloads)
+        assert all(
+            "The parent session has already shown the interview question" in payload.prompt
+            for payload in payloads
+        )
+        assert payloads[0].context["lane_id"] == "code_context"
+        assert payloads[0].context["user_question_first"] is True
+        assert payloads[1].context["persona"] == "contrarian"
+
+    def test_requires_question_identity(self) -> None:
+        with pytest.raises(ValueError, match="question_identity"):
+            build_interview_question_advisory_subagents(
+                {
+                    "session_id": "sess-123",
+                    "question": "Q?",
+                    "lanes": [{"lane_id": "answer_simplifier"}],
+                }
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -706,10 +706,7 @@ class TestBuildInterviewSubagent:
         assert "code_context" in p.prompt
         assert "ambiguity_contrarian" in p.prompt
         assert "answer_simplifier" in p.prompt
-        assert (
-            p.context["question_advisory_strategy"]
-            == "plugin_child_question_first_advisory"
-        )
+        assert p.context["question_advisory_strategy"] == "plugin_child_question_first_advisory"
 
 
 class TestBuildInterviewQuestionAdvisorySubagents:

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -4872,10 +4872,7 @@ def test_interview_metadata_includes_question_advisory_fanout_contract() -> None
         "preserve_user_agency": True,
         "forward_to_mcp_only_after_user_or_auto_confirm": True,
     }
-    assert (
-        fanout["response_payload_refs"]["plugin"]
-        == "parent_runtime.ouroboros_dispatch.children"
-    )
+    assert fanout["response_payload_refs"]["plugin"] == "parent_runtime.ouroboros_dispatch.children"
     assert fanout["response_payload_refs"]["requires_prose_parsing"] is False
     assert fanout["response_payload_refs"]["synthesis_owner"] == "parent_session"
     assert "Show the MCP interview question to the user first" in fanout["runtime_instruction"]

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -4848,6 +4848,84 @@ def test_interview_metadata_includes_lateral_persona_panel_contract() -> None:
     assert panel["sequential_fallback"]["supported"] is True
 
 
+def test_interview_metadata_includes_question_advisory_fanout_contract() -> None:
+    owned_tools = tuple(handler.definition for handler in get_ouroboros_tools(include_auto=False))
+    catalog = assemble_session_tool_catalog(attached_tools=owned_tools)
+
+    graph = build_capability_graph(catalog)
+
+    interview = graph.by_name()["ouroboros_interview"]
+    assert interview.metadata is not None
+    fanout = interview.metadata.orchestration["question_advisory_fanout"]
+    assert fanout["contract_id"] == "interview_question_advisory_fanout.v1"
+    assert fanout["dispatch_timing"] == "after_question_is_visible_to_user"
+    assert fanout["parallel_preference"] == "parallel_when_runtime_supports_subagents"
+    assert fanout["sequential_fallback"] == {
+        "supported": True,
+        "mode": "sequential_advisory_lane_dispatch",
+        "trigger": "runtime_has_no_native_parallel_subagent_primitive",
+    }
+    assert fanout["synthesis_contract"] == {
+        "output_shape": "answer_advisory",
+        "max_options": 3,
+        "include_recommended_draft": True,
+        "preserve_user_agency": True,
+        "forward_to_mcp_only_after_user_or_auto_confirm": True,
+    }
+    assert (
+        fanout["response_payload_refs"]["plugin"]
+        == "parent_runtime.ouroboros_dispatch.children"
+    )
+    assert fanout["response_payload_refs"]["requires_prose_parsing"] is False
+    assert fanout["response_payload_refs"]["synthesis_owner"] == "parent_session"
+    assert "Show the MCP interview question to the user first" in fanout["runtime_instruction"]
+
+    lane_by_id = {lane["lane_id"]: lane for lane in fanout["lanes"]}
+    assert set(lane_by_id) == {
+        "code_context",
+        "web_context",
+        "ambiguity_contrarian",
+        "answer_simplifier",
+        "architecture_implications",
+    }
+    assert lane_by_id["code_context"]["capability"] == "inspect_code"
+    assert lane_by_id["web_context"]["capability"] == "web_research"
+    assert lane_by_id["ambiguity_contrarian"]["persona"] == "contrarian"
+    assert lane_by_id["answer_simplifier"]["persona"] == "simplifier"
+    assert lane_by_id["architecture_implications"]["persona"] == "architect"
+
+
+def test_question_advisory_request_model_validates_parent_runtime_payload() -> None:
+    metadata = ouroboros_tool_capability_metadata("ouroboros_interview")
+    fanout = metadata["orchestration"]["question_advisory_fanout"]
+    schema = fanout["request_model_schema"]
+    Draft202012Validator.check_schema(schema)
+
+    question = "Which users need this first?"
+    request = {
+        "session_id": "sess-123",
+        "question_identity": stable_code_investigation_question_identity(question),
+        "question": question,
+        "phase": "answer",
+        "ambiguity_score": 0.35,
+        "milestone": "progress",
+        "user_question_first": True,
+        "advisory_goal": "help_human_answer_interview_question",
+        "parallel_preference": fanout["parallel_preference"],
+        "sequential_fallback": dict(fanout["sequential_fallback"]),
+        "allowed_capabilities": ["inspect_code", "web_research", "run_lateral_review"],
+        "lanes": list(fanout["lanes"]),
+        "synthesis_contract": dict(fanout["synthesis_contract"]),
+        "code_investigation_request": {
+            **_code_investigation_base_request(question),
+            "investigation_targets": [{"target_type": "workspace", "scope": "active"}],
+        },
+        "mcp_tool_capability": metadata,
+    }
+
+    Draft202012Validator(schema).validate(request)
+
+
 def test_code_investigation_request_model_validates_supported_target_forms() -> None:
     owned_tools = tuple(handler.definition for handler in get_ouroboros_tools(include_auto=False))
     catalog = assemble_session_tool_catalog(attached_tools=owned_tools)


### PR DESCRIPTION
Add question-first advisory fanout metadata for Ouroboros interviews, including code, web, ambiguity, simplifier, and architecture advisory lanes. This lets the main session preserve the MCP question while spawning helper subagents and synthesizing answer guidance before forwarding approved answers back to interview state.

The OpenCode bridge now reads advisory subagents from metadata, preserves the original question on dispatch success and failure, and records dispatch metadata for parent synthesis. Interview plugin-mode prompts and skill docs now describe the child-session fallback, while tests cover the capability contract, payload builder, bridge behavior, milestone question ordering, and plugin wiring.

Services: shared
Affected files:
- .claude-plugin/skills/interview/SKILL.md
- docs/interview-advisory-fanout-comparison.html
- skills/interview/SKILL.md
- src/ouroboros/mcp/tools/authoring_handlers.py
- src/ouroboros/mcp/tools/subagent.py
- src/ouroboros/opencode/plugin/ouroboros-bridge.test.ts
- src/ouroboros/opencode/plugin/ouroboros-bridge.ts
- src/ouroboros/orchestrator/capabilities.py
- tests/unit/mcp/tools/test_handler_subagent_wiring.py
- tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
- tests/unit/mcp/tools/test_subagent.py
- tests/unit/orchestrator/test_capabilities.py

<!-- Thanks for contributing to Ouroboros! Fill in the sections below. -->

## Summary

<!-- 1-3 sentences. What does this PR do and why? -->

## Test plan

<!-- Bulleted checklist of how this PR was verified. -->
- [ ] `uv run pytest tests/ -q` passes
- [ ] `uv run ruff check src/ tests/` and `uv run ruff format --check src/ tests/` clean
- [ ] `uv run mypy src/` clean (or noted exception)

## R-run comparison (required for `src/ouroboros/auto/` changes)

<!--
RFC #1256 §I5 requires every PR that touches `src/ouroboros/auto/` to include
a per-round wall-clock comparison against the latest canonical baseline.
This guards against silent performance regressions like the ~3× per-round
slowdown observed in the PR-A/B/β/γ merge train (#1258).

If your PR does NOT touch `src/ouroboros/auto/`, delete this whole section.

If it does, fill in the table below. Every metric row must have ALL
three comparison cells (Baseline, This PR, Ratio) populated — partially
filled rows (e.g. only `Baseline=TBD` with blank PR/Ratio) are rejected
by the gate. For substrate-only PRs that genuinely have no per-round
comparison, fill every cell explicitly (`N/A | N/A | n/a`) so the
intent is auditable; one filled cell with two blanks is treated as
"author skipped the requirement".

A baseline R-run is at `~/.ooo-observability/` or in #1258 evidence;
capture a fresh run on your branch with:

    OUROBOROS_RUN_CANONICAL=1 uv run pytest tests/canonical/ -k cli-todo -v

The §I5 budget is 1.5× the latest baseline per-round cost. Greater
regressions require a separate performance budget RFC.
-->

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      |                       |                       |          |
| Per-round wall-clock (s/round) |                       |                       |          |
| Terminal reason                |                       |                       |          |
| EventStore event count         |                       |                       |          |

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation /
[ ] N/A (PR does not touch `src/ouroboros/auto/`)

## Related issues

<!-- Link issues this PR closes or references, e.g. "Fixes #1234", "Refs #1256". -->
