### PR TITLE
feat(subagent): host-driven dispatch mode for Codex subagent fan-out

### DIFF
--- a/src/ouroboros/backends/__init__.py
+++ b/src/ouroboros/backends/__init__.py
@@ -4,6 +4,7 @@ from ouroboros.backends.capabilities import (
     BackendCapability,
     RuntimeSubagentOrchestrationContract,
     SkillExecutionCapability,
+    SubagentDispatchMode,
     backend_supports_tool_envelope,
     build_runtime_subagent_orchestration_contract,
     get_backend_capability,
@@ -14,6 +15,7 @@ from ouroboros.backends.capabilities import (
     resolve_interview_driver_backend,
     resolve_llm_backend_name,
     resolve_runtime_backend_name,
+    resolve_subagent_dispatch,
     runtime_backend_choices,
     soft_tool_enforcement_backends,
 )
@@ -22,6 +24,7 @@ __all__ = [
     "BackendCapability",
     "RuntimeSubagentOrchestrationContract",
     "SkillExecutionCapability",
+    "SubagentDispatchMode",
     "backend_supports_tool_envelope",
     "build_runtime_subagent_orchestration_contract",
     "get_backend_capability",
@@ -32,6 +35,7 @@ __all__ = [
     "resolve_interview_driver_backend",
     "resolve_llm_backend_name",
     "resolve_runtime_backend_name",
+    "resolve_subagent_dispatch",
     "runtime_backend_choices",
     "soft_tool_enforcement_backends",
 ]

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -188,8 +188,11 @@ _CODEX_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
             "read the inline text: spawn one subagent per entry in the payload array "
             "(`payloads` or `question_advisory_subagents`) using your native "
             "multi-agent spawn primitive (`multi_agent_v1.spawn_agent`), passing "
-            "each payload's `prompt`. Correlate every child result by "
-            "`context.persona`, collect them, then synthesise — preserving the "
+            "each payload's `prompt`. Correlate every child result by the "
+            "payload-specific key named in the result `meta` "
+            "(`result_correlation_key`): lateral payloads use `context.persona`, "
+            "interview advisory payloads use `context.lane_id` (their `persona` is "
+            "absent on some lanes). Collect them, then synthesise — preserving the "
             "user-facing content. If you have no parallel primitive available, "
             "process the payloads sequentially instead."
         ),

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Any
 
 
@@ -35,13 +36,41 @@ class BackendCapability:
     cli_config_key: str | None = None
     soft_tool_enforcement: bool = False
     supports_tool_envelope: bool = True
+    # ``supports_native_parallel_subagents``: a *passive* bridge receiver auto-
+    # consumes ``_subagents`` envelopes (OpenCode plugin). ``supports_host_driven_
+    # subagents``: the host *model* spawns subagents from inline payloads via its
+    # own native primitive (e.g. Codex Desktop). These are different layers — a
+    # backend can have the latter without the former. Do NOT conflate them.
     supports_native_parallel_subagents: bool = False
+    supports_host_driven_subagents: bool = False
     skill_execution_capabilities: tuple[SkillExecutionCapability, ...] = ()
 
     @property
     def names(self) -> tuple[str, ...]:
         """Canonical name plus accepted aliases."""
         return (self.name, *self.aliases)
+
+
+class SubagentDispatchMode(StrEnum):
+    """How a handler should surface subagent fan-out for the active runtime.
+
+    Three distinct layers, not a boolean:
+
+    - ``PLUGIN_PASSIVE``: a passive bridge receiver (the OpenCode plugin) auto-
+      intercepts the ``_subagents`` envelope and spawns children. The handler
+      returns the envelope and skips the real in-process work.
+    - ``HOST_DRIVEN``: there is no passive receiver, but the host *model* can
+      spawn subagents from inline payloads via its own native primitive (e.g.
+      Codex Desktop's multi-agent spawn). The handler returns the inline result
+      plus an explicit ``dispatch_mode=host_driven`` / ``host_action`` stamp so
+      the host deterministically fans out.
+    - ``SEQUENTIAL``: neither a passive receiver nor a native parallel primitive
+      is available; the handler runs the in-process / inline sequential path.
+    """
+
+    PLUGIN_PASSIVE = "plugin_passive"
+    HOST_DRIVEN = "host_driven"
+    SEQUENTIAL = "sequential"
 
 
 @dataclass(frozen=True, slots=True)
@@ -148,6 +177,23 @@ _CODEX_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
             "constraints, and acceptance criteria, then require explicit user approval."
         ),
     ),
+    SkillExecutionCapability(
+        name="orchestrate_subagents",
+        guidance=(
+            "Codex has a native subagent primitive but no passive Ouroboros bridge, "
+            "so subagent fan-out is host-driven. When an Ouroboros MCP tool returns "
+            "`host_action=spawn_subagents` (via `dispatch_mode=host_driven` or "
+            "`question_advisory_dispatch_mode=host_driven` in the result `meta`, or "
+            "the `ouroboros-lateral-inline-dispatch-v1` content block), do NOT just "
+            "read the inline text: spawn one subagent per entry in the payload array "
+            "(`payloads` or `question_advisory_subagents`) using your native "
+            "multi-agent spawn primitive (`multi_agent_v1.spawn_agent`), passing "
+            "each payload's `prompt`. Correlate every child result by "
+            "`context.persona`, collect them, then synthesise — preserving the "
+            "user-facing content. If you have no parallel primitive available, "
+            "process the payloads sequentially instead."
+        ),
+    ),
 )
 
 _GENERIC_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
@@ -235,6 +281,7 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         cli_name="codex",
         cli_config_key="codex_cli_path",
         skill_execution_capabilities=_CODEX_SKILL_EXECUTION_CAPABILITIES,
+        supports_host_driven_subagents=True,
     ),
     BackendCapability(
         name="copilot",
@@ -401,13 +448,13 @@ def build_runtime_subagent_orchestration_contract(
     if not isinstance(sequential_fallback, Mapping):
         sequential_fallback = {}
 
-    native_parallel_available = _supports_native_parallel_subagent_surface(
-        capability,
-        opencode_mode=opencode_mode,
-    )
+    mode = resolve_subagent_dispatch(name, opencode_mode)
+    # The contract speaks the same vocabulary as the resolver: ``dispatch_mode``
+    # is exactly the ``SubagentDispatchMode`` value, so there is one source of
+    # truth for the mode string ({plugin_passive | host_driven | sequential}).
+    dispatch_mode = mode.value
 
-    if native_parallel_available:
-        dispatch_mode = "native_parallel_subagents"
+    if mode is SubagentDispatchMode.PLUGIN_PASSIVE:
         runtime_instruction_handling = (
             "Consume MCP `_subagent` or `_subagents` directive payloads with the "
             "runtime's native parallel subagent primitive. For OpenCode this "
@@ -415,8 +462,17 @@ def build_runtime_subagent_orchestration_contract(
             "MCP-declared sequential fallback available for downgraded runtime "
             "surfaces."
         )
+    elif mode is SubagentDispatchMode.HOST_DRIVEN:
+        runtime_instruction_handling = (
+            "This runtime has a native subagent primitive but no passive "
+            "Ouroboros bridge. Consume the inline `host_driven` dispatch payloads "
+            "(the `payloads` array stamped with `host_action=spawn_subagents`) "
+            "and spawn each one with the runtime's own subagent primitive, "
+            "correlating results by the directive metadata's correlation key. "
+            "Fall back to the MCP `sequential_fallback` contract only when no "
+            "parallel primitive is available."
+        )
     else:
-        dispatch_mode = "sequential_fallback"
         runtime_instruction_handling = (
             "This runtime has no native parallel subagent primitive. Follow the "
             "MCP `sequential_fallback` contract and process each structured "
@@ -426,7 +482,9 @@ def build_runtime_subagent_orchestration_contract(
 
     return RuntimeSubagentOrchestrationContract(
         backend_name=capability.name,
-        supports_native_parallel_subagents=native_parallel_available,
+        # This boolean is the *passive bridge* axis only; ``HOST_DRIVEN`` runtimes
+        # report False here and carry their capability via ``dispatch_mode``.
+        supports_native_parallel_subagents=mode is SubagentDispatchMode.PLUGIN_PASSIVE,
         dispatch_mode=dispatch_mode,
         mcp_directive_keys=("_subagent", "_subagents"),
         sequential_fallback=dict(sequential_fallback),
@@ -453,6 +511,35 @@ def _supports_native_parallel_subagent_surface(
 def get_backend_capability(name: str) -> BackendCapability | None:
     """Return capability metadata for a canonical backend name or alias."""
     return _BY_NAME.get(name.strip().lower())
+
+
+def resolve_subagent_dispatch(
+    runtime_backend: str | None,
+    opencode_mode: str | None,
+) -> SubagentDispatchMode:
+    """Resolve the subagent dispatch mode for a runtime — the production SoT.
+
+    Separates two registry axes that must not be conflated:
+
+    - ``supports_native_parallel_subagents`` → a *passive* ``_subagents``
+      envelope receiver exists (OpenCode plugin surface, gated on
+      ``opencode_mode``). Maps to ``PLUGIN_PASSIVE``.
+    - ``supports_host_driven_subagents`` → the host *model* spawns from inline
+      payloads with its own primitive (e.g. Codex). No passive receiver. Maps
+      to ``HOST_DRIVEN``.
+
+    A backend may have the second without the first; routing such a backend
+    into the passive-envelope path would drop the envelope (no receiver) AND
+    skip the real work, so they stay on separate axes.
+    """
+    capability = get_backend_capability((runtime_backend or "").strip().lower())
+    if capability is None:
+        return SubagentDispatchMode.SEQUENTIAL
+    if _supports_native_parallel_subagent_surface(capability, opencode_mode=opencode_mode):
+        return SubagentDispatchMode.PLUGIN_PASSIVE
+    if capability.supports_host_driven_subagents:
+        return SubagentDispatchMode.HOST_DRIVEN
+    return SubagentDispatchMode.SEQUENTIAL
 
 
 def resolve_backend_alias(name: str) -> str:
@@ -531,6 +618,7 @@ __all__ = [
     "BackendCapability",
     "RuntimeSubagentOrchestrationContract",
     "SkillExecutionCapability",
+    "SubagentDispatchMode",
     "backend_supports_tool_envelope",
     "build_runtime_subagent_orchestration_contract",
     "get_backend_capability",
@@ -541,6 +629,7 @@ __all__ = [
     "resolve_interview_driver_backend",
     "resolve_llm_backend_name",
     "resolve_runtime_backend_name",
+    "resolve_subagent_dispatch",
     "runtime_backend_choices",
     "soft_tool_enforcement_backends",
 ]

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -44,11 +44,13 @@ from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.tools.subagent import (
     DELEGATED_TO_SUBAGENT,
+    SubagentDispatchMode,
     build_generate_seed_subagent,
     build_interview_question_advisory_subagents,
     build_interview_subagent,
     dispatch_plugin_terminal,
     lateral_persona_panel_metadata_from_capability_definitions,
+    resolve_subagent_dispatch,
     should_dispatch_via_plugin,
 )
 from ouroboros.mcp.types import (
@@ -696,8 +698,16 @@ def _attach_question_assist_requests(
     phase: str,
     score: AmbiguityScore | None,
     last_question: str | None = None,
+    dispatch_mode: SubagentDispatchMode = SubagentDispatchMode.SEQUENTIAL,
 ) -> None:
-    """Attach code-fact and advisory fanout requests for a question turn."""
+    """Attach code-fact and advisory fanout requests for a question turn.
+
+    ``dispatch_mode`` carries the runtime's resolved subagent dispatch mode. On
+    a ``HOST_DRIVEN`` runtime (e.g. Codex) there is no passive bridge to consume
+    ``question_advisory_subagents``, so the response is stamped with an explicit
+    ``host_action=spawn_subagents`` cue for the host model to fan the advisory
+    lanes out itself.
+    """
     code_request = _build_code_investigation_request(
         session_id=session_id,
         question=question,
@@ -725,6 +735,9 @@ def _attach_question_assist_requests(
         return
     meta["question_advisory_subagents"] = [payload.to_dict() for payload in advisory_payloads]
     meta["question_advisory_preserve_content"] = True
+    if dispatch_mode is SubagentDispatchMode.HOST_DRIVEN:
+        meta["question_advisory_dispatch_mode"] = "host_driven"
+        meta["question_advisory_host_action"] = "spawn_subagents"
 
 
 def _is_initial_context_length_guard_question(question: str) -> bool:
@@ -2496,6 +2509,9 @@ class InterviewHandler:
                         question=question,
                         phase="start",
                         score=live_score,
+                        dispatch_mode=resolve_subagent_dispatch(
+                            self.agent_runtime_backend, self.opencode_mode
+                        ),
                     )
 
                 start_response_text = (
@@ -2588,6 +2604,9 @@ class InterviewHandler:
                             question=pending_question,
                             phase="resume_pending",
                             score=_load_state_ambiguity_score(state),
+                            dispatch_mode=resolve_subagent_dispatch(
+                                self.agent_runtime_backend, self.opencode_mode
+                            ),
                         )
 
                     resume_response_text = f"Session {session_id}\n\n{display_question}"
@@ -3137,6 +3156,9 @@ class InterviewHandler:
                         question=question,
                         phase="answer",
                         score=live_score,
+                        dispatch_mode=resolve_subagent_dispatch(
+                            self.agent_runtime_backend, self.opencode_mode
+                        ),
                     )
 
                 if lateral_review_dispatch_meta is not None:

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -738,6 +738,9 @@ def _attach_question_assist_requests(
     if dispatch_mode is SubagentDispatchMode.HOST_DRIVEN:
         meta["question_advisory_dispatch_mode"] = "host_driven"
         meta["question_advisory_host_action"] = "spawn_subagents"
+        # Advisory lanes are keyed by lane_id; their persona is absent on some
+        # lanes (code_context, web_context), so correlate by lane_id, not persona.
+        meta["question_advisory_result_correlation_key"] = "context.lane_id"
 
 
 def _is_initial_context_length_guard_question(question: str) -> bool:

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -1221,18 +1221,23 @@ class LateralThinkHandler(BridgeAwareMixin):
     the lateral-think dispatch path so dynamic external MCP servers
     reach the unstuck pipeline.
 
-    The multi-persona fan-out path emits a ``_subagents`` envelope that is
-    consumed by the OpenCode bridge plugin. It is gated on
-    ``should_dispatch_via_plugin(agent_runtime_backend, opencode_mode)`` —
-    identical to the other subagent-emitting handlers — so that subprocess
-    mode (or non-OpenCode runtimes) falls back to an inline multi-persona
-    text response instead of emitting an envelope nobody will consume.
+    The multi-persona fan-out path resolves a 3-way dispatch mode via
+    ``resolve_subagent_dispatch(agent_runtime_backend, opencode_mode)``:
+
+    - ``PLUGIN_PASSIVE`` (OpenCode + ``opencode_mode=plugin``): emit a
+      ``_subagents`` envelope for the bridge plugin to consume.
+    - ``HOST_DRIVEN`` (e.g. Codex): no passive bridge, but the host model can
+      spawn subagents itself, so emit the inline result stamped with
+      ``dispatch_mode=host_driven`` / ``host_action=spawn_subagents`` so the
+      host fans out via its native primitive.
+    - ``SEQUENTIAL`` (subprocess / runtimes without a parallel primitive): fall
+      back to a plain inline multi-persona ``inline_fallback`` text response.
 
     Attributes:
         agent_runtime_backend: Configured runtime (e.g. ``"opencode"``).
         opencode_mode: Configured ``orchestrator.opencode_mode`` value
             (``"plugin"`` or ``"subprocess"``). ``None`` falls through as
-            non-plugin (safe default — see ``should_dispatch_via_plugin``).
+            non-plugin (safe default — see ``resolve_subagent_dispatch``).
     """
 
     agent_runtime_backend: str | None = field(default=None, repr=False)
@@ -1380,9 +1385,10 @@ class LateralThinkHandler(BridgeAwareMixin):
 
         if explicit_list or dispatch_all:
             from ouroboros.mcp.tools.subagent import (
+                SubagentDispatchMode,
                 build_lateral_multi_subagent,
                 build_multi_subagent_result,
-                should_dispatch_via_plugin,
+                resolve_subagent_dispatch,
             )
 
             if explicit_list:
@@ -1435,12 +1441,15 @@ class LateralThinkHandler(BridgeAwareMixin):
                 failed_count=len(failed_attempts),
             )
 
-            # Gate on runtime + opencode_mode — identical contract to the
-            # other subagent-emitting handlers. Subprocess mode (or a
-            # non-OpenCode runtime) falls back to synthesising a combined
-            # persona-prompt text inline, because no bridge plugin will
-            # consume the ``_subagents`` envelope.
-            if should_dispatch_via_plugin(self.agent_runtime_backend, self.opencode_mode):
+            # Resolve the 3-way dispatch mode (the production source of truth).
+            #   - PLUGIN_PASSIVE: a bridge plugin will consume the ``_subagents``
+            #     envelope, so emit it and skip the inline work.
+            #   - HOST_DRIVEN: no passive receiver, but the host model can spawn
+            #     from inline payloads via its own primitive (e.g. Codex). Emit
+            #     the inline result stamped with ``host_action=spawn_subagents``.
+            #   - SEQUENTIAL: no parallel surface at all → plain inline fallback.
+            dispatch = resolve_subagent_dispatch(self.agent_runtime_backend, self.opencode_mode)
+            if dispatch is SubagentDispatchMode.PLUGIN_PASSIVE:
                 # Preserve public response shape (#442): ouroboros_lateral_think
                 # natural response documents alternative-thinking metadata.
                 # Expose persona_count + dispatch status at top level so callers
@@ -1500,17 +1509,39 @@ class LateralThinkHandler(BridgeAwareMixin):
             #      payload into the visible markdown.
             #   2. Base64 has no significant whitespace, so line wrapping
             #      and trimming can't corrupt the encoded body.
+            # HOST_DRIVEN runtimes (e.g. Codex) have no passive bridge but can
+            # spawn subagents themselves. Stamp the response with an explicit
+            # ``dispatch_mode=host_driven`` / ``host_action=spawn_subagents``
+            # signal — in structured ``meta`` (primary) and a visible banner
+            # (so meta-dropping transports still get a deterministic cue) — so
+            # the host's capability guide fans out instead of reading inline.
+            # SEQUENTIAL runtimes keep the byte-identical ``inline_fallback``
+            # output they emitted before.
+            host_driven = dispatch is SubagentDispatchMode.HOST_DRIVEN
+            dispatch_mode_value = "host_driven" if host_driven else "inline_fallback"
             payload_dicts = [p.to_dict() for p in payloads]
-            dispatch_blob = json.dumps(
-                {
-                    "dispatch_mode": "inline_fallback",
-                    "persona_count": len(sections),
-                    "payloads": payload_dicts,
-                }
-            )
+            dispatch_record: dict[str, Any] = {
+                "dispatch_mode": dispatch_mode_value,
+                "persona_count": len(sections),
+                "payloads": payload_dicts,
+            }
+            if host_driven:
+                dispatch_record["host_action"] = "spawn_subagents"
+            dispatch_blob = json.dumps(dispatch_record)
             dispatch_b64 = base64.b64encode(dispatch_blob.encode("utf-8")).decode("ascii")
+            host_banner = (
+                (
+                    "> **Host action — spawn subagents:** this runtime drives "
+                    "fan-out itself. Spawn one subagent per payload below with "
+                    "your native subagent primitive, correlate results by "
+                    f"`context.persona`, then synthesise. Payloads: {len(sections)} "
+                    "(structured copy in `meta` and the dispatch block).\n\n"
+                )
+                if host_driven
+                else ""
+            )
             content_text = (
-                f"{combined}\n\n"
+                f"{host_banner}{combined}\n\n"
                 "<!-- ouroboros-lateral-inline-dispatch-v1 base64\n"
                 f"{dispatch_b64}\n"
                 "-->"
@@ -1519,11 +1550,7 @@ class LateralThinkHandler(BridgeAwareMixin):
                 MCPToolResult(
                     content=(MCPContentItem(type=ContentType.TEXT, text=content_text),),
                     is_error=False,
-                    meta={
-                        "persona_count": len(sections),
-                        "dispatch_mode": "inline_fallback",
-                        "payloads": payload_dicts,
-                    },
+                    meta=dispatch_record,
                 )
             )
 

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -1527,6 +1527,8 @@ class LateralThinkHandler(BridgeAwareMixin):
             }
             if host_driven:
                 dispatch_record["host_action"] = "spawn_subagents"
+                # Lateral payloads are keyed by persona (always set, one per lane).
+                dispatch_record["result_correlation_key"] = "context.persona"
             dispatch_blob = json.dumps(dispatch_record)
             dispatch_b64 = base64.b64encode(dispatch_blob.encode("utf-8")).decode("ascii")
             host_banner = (

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -43,6 +43,10 @@ from typing import Any
 from jsonschema import Draft202012Validator
 import structlog
 
+from ouroboros.backends.capabilities import (
+    SubagentDispatchMode,
+    resolve_subagent_dispatch,
+)
 from ouroboros.core.seed_contract_prompt import render_auto_recursion_guard
 from ouroboros.core.types import Result
 from ouroboros.mcp.types import (
@@ -755,9 +759,6 @@ def build_subagent_result(
 # ---------------------------------------------------------------------------
 
 
-_OPENCODE_RUNTIMES = frozenset({"opencode", "opencode_cli"})
-
-
 def should_dispatch_via_plugin(
     runtime_backend: str | None,
     opencode_mode: str | None,
@@ -769,15 +770,11 @@ def should_dispatch_via_plugin(
     (claude, codex, opencode subprocess, none) the envelope has no receiver
     and the handler must run the real in-process execution path instead.
 
-    Rules:
-        - runtime_backend not OpenCode → False.
-        - runtime_backend OpenCode, opencode_mode="plugin" → True.
-        - runtime_backend OpenCode, opencode_mode="subprocess" → False.
-        - runtime_backend OpenCode, opencode_mode None/empty → False.
-            Safe default: upgraded users who haven't re-run ``ouroboros setup``
-            will have opencode_mode=None. They don't have the bridge plugin
-            installed, so dispatching envelopes would break their flows.
-            Require explicit opt-in via ``ouroboros setup --opencode-mode=plugin``.
+    This is now a thin alias over :func:`resolve_subagent_dispatch` — it is
+    True iff the resolved mode is ``PLUGIN_PASSIVE`` — so existing call sites
+    keep their exact behaviour while the 3-way resolver becomes the source of
+    truth. New code should prefer :func:`resolve_subagent_dispatch` to also
+    distinguish ``HOST_DRIVEN`` from ``SEQUENTIAL``.
 
     Args:
         runtime_backend: Resolved agent runtime backend name.
@@ -786,11 +783,10 @@ def should_dispatch_via_plugin(
     Returns:
         True when dispatch envelope should be returned; False otherwise.
     """
-    backend = (runtime_backend or "").strip().lower()
-    if backend not in _OPENCODE_RUNTIMES:
-        return False
-    mode = (opencode_mode or "").strip().lower()
-    return mode == "plugin"
+    return (
+        resolve_subagent_dispatch(runtime_backend, opencode_mode)
+        is SubagentDispatchMode.PLUGIN_PASSIVE
+    )
 
 
 def _truncate_tail(text: str | None, max_chars: int) -> str:

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -136,7 +136,24 @@ def test_codex_skill_execution_guidance_is_registry_owned() -> None:
 
     assert capability is not None
     names = {item.name for item in capability.skill_execution_capabilities}
-    assert names == REQUIRED_SKILL_CAPABILITY_NAMES
+    # Codex additionally exposes host-driven subagent orchestration guidance so
+    # the host model fans out the inline ``host_driven`` dispatch itself.
+    assert names == REQUIRED_SKILL_CAPABILITY_NAMES | {"orchestrate_subagents"}
+
+
+def test_codex_host_driven_subagent_orchestration_is_registry_owned() -> None:
+    capability = get_backend_capability("codex")
+
+    assert capability is not None
+    assert capability.supports_host_driven_subagents is True
+    assert capability.supports_native_parallel_subagents is False
+
+    guide = render_backend_skill_capability_guide("codex")
+    assert "### When a skill requires `orchestrate_subagents`" in guide
+    assert "dispatch_mode=host_driven" in guide
+    assert "host_action=spawn_subagents" in guide
+    assert "multi_agent_v1.spawn_agent" in guide
+    assert "context.persona" in guide
 
 
 def test_generic_skill_execution_guidance_covers_interview_requirements() -> None:
@@ -163,14 +180,16 @@ def test_native_parallel_subagent_runtime_exposes_orchestrate_subagents() -> Non
 
 
 def test_unsupported_parallel_subagent_runtime_gets_sequential_fallback_contract() -> None:
+    # ``gemini`` has neither a passive bridge nor a host-driven primitive flag,
+    # so it stays on the sequential-fallback branch.
     contract = build_runtime_subagent_orchestration_contract(
-        "codex_cli",
+        "gemini_cli",
         directive_metadata=_LATERAL_PANEL_DIRECTIVE_METADATA,
     )
 
-    assert contract.backend_name == "codex"
+    assert contract.backend_name == "gemini"
     assert contract.supports_native_parallel_subagents is False
-    assert contract.dispatch_mode == "sequential_fallback"
+    assert contract.dispatch_mode == "sequential"
     assert contract.mcp_directive_keys == ("_subagent", "_subagents")
     assert contract.sequential_fallback == {
         "supported": True,
@@ -186,16 +205,37 @@ def test_unsupported_parallel_subagent_runtime_gets_sequential_fallback_contract
     )
 
 
+def test_host_driven_runtime_gets_host_driven_contract() -> None:
+    """Codex has a native primitive but no passive bridge → host_driven contract.
+
+    Guards against the contract regressing to ``sequential_fallback`` (which
+    would emit a wrong instruction once a consumer reads the contract) while
+    the resolver says ``host_driven``.
+    """
+    contract = build_runtime_subagent_orchestration_contract(
+        "codex_cli",
+        directive_metadata=_LATERAL_PANEL_DIRECTIVE_METADATA,
+        opencode_mode="plugin",
+    )
+
+    assert contract.backend_name == "codex"
+    # The boolean is the *passive bridge* axis only — host-driven runtimes are False here.
+    assert contract.supports_native_parallel_subagents is False
+    assert contract.dispatch_mode == "host_driven"
+    assert "host_action=spawn_subagents" in contract.runtime_instruction_handling
+    assert "no passive" in contract.runtime_instruction_handling
+
+
 @pytest.mark.parametrize("directive_metadata", [{}, {"sequential_fallback": "invalid"}])
 def test_subagent_orchestration_contract_handles_absent_or_malformed_fallback(
     directive_metadata: dict[str, object],
 ) -> None:
     contract = build_runtime_subagent_orchestration_contract(
-        "codex_cli",
+        "gemini_cli",
         directive_metadata=directive_metadata,
     )
 
-    assert contract.dispatch_mode == "sequential_fallback"
+    assert contract.dispatch_mode == "sequential"
     assert contract.sequential_fallback == {}
     assert "MCP `sequential_fallback` contract" in contract.runtime_instruction_handling
 
@@ -209,7 +249,7 @@ def test_subagent_orchestration_cancel_job_capability_stays_callable_in_same_env
     )
     envelope = contract.to_dict()
 
-    assert envelope["dispatch_mode"] == "native_parallel_subagents"
+    assert envelope["dispatch_mode"] == "plugin_passive"
     assert envelope["mcp_directive_keys"] == ["_subagent", "_subagents"]
     assert envelope["callable_mcp_tool_capabilities"] == [_CANCEL_JOB_CAPABILITY]
 
@@ -248,7 +288,7 @@ def test_opencode_without_plugin_surface_uses_sequential_fallback(
 
     assert contract.backend_name == "opencode"
     assert contract.supports_native_parallel_subagents is False
-    assert contract.dispatch_mode == "sequential_fallback"
+    assert contract.dispatch_mode == "sequential"
     assert "no native parallel subagent primitive" in contract.runtime_instruction_handling
 
 
@@ -261,7 +301,7 @@ def test_opencode_plugin_surface_uses_native_parallel_subagents() -> None:
 
     assert contract.backend_name == "opencode"
     assert contract.supports_native_parallel_subagents is True
-    assert contract.dispatch_mode == "native_parallel_subagents"
+    assert contract.dispatch_mode == "plugin_passive"
     assert "opencode_mode=plugin" in contract.runtime_instruction_handling
 
 

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -153,7 +153,11 @@ def test_codex_host_driven_subagent_orchestration_is_registry_owned() -> None:
     assert "dispatch_mode=host_driven" in guide
     assert "host_action=spawn_subagents" in guide
     assert "multi_agent_v1.spawn_agent" in guide
+    # Correlation keys are payload-specific — the guide must not tell the host to
+    # blanket-correlate advisory results by persona (absent on some lanes).
     assert "context.persona" in guide
+    assert "context.lane_id" in guide
+    assert "result_correlation_key" in guide
 
 
 def test_generic_skill_execution_guidance_covers_interview_requirements() -> None:

--- a/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
+++ b/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
@@ -273,6 +273,56 @@ async def test_handler_surfaces_runnable_lateral_review_dispatch() -> None:
     handler._emit_event_bg.assert_called()
 
 
+async def test_advisory_fanout_is_host_driven_stamped_on_codex_runtime() -> None:
+    """Codex (host-driven) advisory fanout must carry an explicit spawn directive."""
+    state = InterviewState(
+        interview_id="sess-codex",
+        ambiguity_score=None,
+        rounds=[
+            InterviewRound(round_number=1, question="Q1?", user_response="A1"),
+            InterviewRound(round_number=2, question="Q2?", user_response="A2"),
+            InterviewRound(round_number=3, question="Q3?", user_response=None),
+        ],
+    )
+
+    async def record_response(
+        state: InterviewState, user_response: str, question: str
+    ) -> Result[InterviewState, object]:
+        state.rounds.append(
+            InterviewRound(
+                round_number=state.current_round_number,
+                question=question,
+                user_response=user_response,
+            )
+        )
+        return Result.ok(state)
+
+    mock_engine = MagicMock()
+    mock_engine.load_state = AsyncMock(return_value=Result.ok(state))
+    mock_engine.record_response = AsyncMock(side_effect=record_response)
+    mock_engine.save_state = AsyncMock(return_value=MagicMock(is_err=False))
+    mock_engine.ask_next_question = AsyncMock(return_value=Result.ok("What edge case remains?"))
+
+    handler = InterviewHandler(
+        interview_engine=mock_engine,
+        agent_runtime_backend="codex",
+        opencode_mode="plugin",
+    )
+    handler.llm_adapter = MagicMock()
+    handler._score_interview_state = AsyncMock(return_value=_score(0.35))  # type: ignore[method-assign]
+    handler._emit_event_bg = MagicMock()  # type: ignore[method-assign]
+
+    result = await handler.handle({"session_id": "sess-codex", "answer": "A3"})
+
+    assert result.is_ok
+    meta = result.value.meta
+    # Advisory lanes are still attached...
+    assert len(meta["question_advisory_subagents"]) == 5
+    # ...but now stamped so the Codex host fans them out itself.
+    assert meta["question_advisory_dispatch_mode"] == "host_driven"
+    assert meta["question_advisory_host_action"] == "spawn_subagents"
+
+
 def test_lateral_orchestration_falls_back_to_skill_prose_when_panel_metadata_absent() -> None:
     tool_args = {
         "problem_context": (

--- a/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
+++ b/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
@@ -321,6 +321,8 @@ async def test_advisory_fanout_is_host_driven_stamped_on_codex_runtime() -> None
     # ...but now stamped so the Codex host fans them out itself.
     assert meta["question_advisory_dispatch_mode"] == "host_driven"
     assert meta["question_advisory_host_action"] == "spawn_subagents"
+    # Advisory lanes correlate by lane_id (persona is None on some lanes).
+    assert meta["question_advisory_result_correlation_key"] == "context.lane_id"
 
 
 def test_lateral_orchestration_falls_back_to_skill_prose_when_panel_metadata_absent() -> None:

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -411,6 +411,39 @@ async def test_inline_lateral_content_converts_to_sequential_persona_panel_entri
 
 
 @pytest.mark.asyncio
+async def test_codex_runtime_emits_host_driven_spawn_directive() -> None:
+    """Codex has a native subagent primitive but no passive bridge → host_driven.
+
+    Regression guard for the real user config (``runtime=codex`` with
+    ``opencode_mode=plugin``): codex must NOT be misrouted to the passive
+    ``plugin`` envelope path; it must get an explicit host-driven spawn stamp.
+    """
+    handler = LateralThinkHandler(
+        agent_runtime_backend="codex",
+        opencode_mode="plugin",
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview needs a lightweight review",
+            "current_approach": "ask the next Socratic question",
+            "personas": ["researcher", "simplifier"],
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    assert payload.meta["dispatch_mode"] == "host_driven"
+    assert payload.meta["host_action"] == "spawn_subagents"
+    assert payload.meta["persona_count"] == 2
+    assert len(payload.meta["payloads"]) == 2
+    # Visible deterministic cue for transports that drop ``meta``.
+    assert "Host action — spawn subagents" in payload.text_content
+    # The inline base64 dispatch block still rides in content for older consumers.
+    assert "ouroboros-lateral-inline-dispatch-v1" in payload.text_content
+
+
+@pytest.mark.asyncio
 async def test_sequential_lateral_consumer_receives_persona_payloads_in_order() -> None:
     """Sequential fallback consumers receive persona payloads in request order."""
     requested_personas = ["simplifier", "hacker", "researcher"]

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -435,6 +435,7 @@ async def test_codex_runtime_emits_host_driven_spawn_directive() -> None:
     payload = result.unwrap()
     assert payload.meta["dispatch_mode"] == "host_driven"
     assert payload.meta["host_action"] == "spawn_subagents"
+    assert payload.meta["result_correlation_key"] == "context.persona"
     assert payload.meta["persona_count"] == 2
     assert len(payload.meta["payloads"]) == 2
     # Visible deterministic cue for transports that drop ``meta``.

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -1021,6 +1021,74 @@ class TestShouldDispatchViaPlugin:
         assert should_dispatch_via_plugin("OPENCODE", "Subprocess") is False
 
 
+class TestResolveSubagentDispatch:
+    """resolve_subagent_dispatch() — the 3-way source of truth."""
+
+    def test_opencode_plugin_is_plugin_passive(self) -> None:
+        from ouroboros.mcp.tools.subagent import (
+            SubagentDispatchMode,
+            resolve_subagent_dispatch,
+        )
+
+        assert (
+            resolve_subagent_dispatch("opencode", "plugin") is SubagentDispatchMode.PLUGIN_PASSIVE
+        )
+        assert (
+            resolve_subagent_dispatch("opencode_cli", "plugin")
+            is SubagentDispatchMode.PLUGIN_PASSIVE
+        )
+
+    def test_codex_is_host_driven_even_with_plugin_mode(self) -> None:
+        """Codex has a native primitive but no passive bridge — never plugin_passive."""
+        from ouroboros.mcp.tools.subagent import (
+            SubagentDispatchMode,
+            resolve_subagent_dispatch,
+        )
+
+        # The real user config: runtime=codex, opencode_mode=plugin.
+        assert resolve_subagent_dispatch("codex", "plugin") is SubagentDispatchMode.HOST_DRIVEN
+        assert resolve_subagent_dispatch("codex", None) is SubagentDispatchMode.HOST_DRIVEN
+        assert (
+            resolve_subagent_dispatch("codex_cli", "subprocess") is SubagentDispatchMode.HOST_DRIVEN
+        )
+
+    def test_runtimes_without_any_subagent_surface_are_sequential(self) -> None:
+        from ouroboros.mcp.tools.subagent import (
+            SubagentDispatchMode,
+            resolve_subagent_dispatch,
+        )
+
+        for backend in ("claude", "gemini", "gjc", "opencode", "", None):
+            assert resolve_subagent_dispatch(backend, None) is SubagentDispatchMode.SEQUENTIAL, (
+                backend
+            )
+        # OpenCode without the plugin surface is sequential, not plugin_passive.
+        assert (
+            resolve_subagent_dispatch("opencode", "subprocess") is SubagentDispatchMode.SEQUENTIAL
+        )
+
+    def test_should_dispatch_is_plugin_passive_alias(self) -> None:
+        """should_dispatch_via_plugin must stay exactly True iff PLUGIN_PASSIVE."""
+        from ouroboros.mcp.tools.subagent import (
+            SubagentDispatchMode,
+            resolve_subagent_dispatch,
+            should_dispatch_via_plugin,
+        )
+
+        for backend, mode in (
+            ("opencode", "plugin"),
+            ("opencode", "subprocess"),
+            ("codex", "plugin"),
+            ("claude", None),
+            ("gemini", "plugin"),
+            (None, None),
+        ):
+            expected = (
+                resolve_subagent_dispatch(backend, mode) is SubagentDispatchMode.PLUGIN_PASSIVE
+            )
+            assert should_dispatch_via_plugin(backend, mode) is expected
+
+
 class TestEmitSubagentDispatchedEvent:
     """emit_subagent_dispatched_event() audit emission."""
 


### PR DESCRIPTION
## Problem

On Ouroboros 0.43.0, MCP subagent fan-out (`_subagent`/`_subagents`) only auto-spawns on `opencode + opencode_mode=plugin`. Every other runtime falls to `inline_fallback`. For **Codex** specifically this is felt as "sub-agents don't fan out" even though Codex Desktop has a working native multi-agent primitive (`multi_agent_v1.spawn_agent`) — there is simply no path connecting MCP fan-out payloads to it.

Root cause: the production gate `should_dispatch_via_plugin` is a **boolean** (passive OpenCode-plugin receiver: yes/no), but the real world has **three** modes. A runtime can have a native subagent primitive (host-driven) without having a passive bridge receiver. Routing such a runtime through the boolean gate either drops the envelope (no receiver) or silently never fans out.

## Solution

Introduce a 3-way source of truth:

```
SubagentDispatchMode = { plugin_passive | host_driven | sequential }
resolve_subagent_dispatch(backend, opencode_mode) -> SubagentDispatchMode
```

- **`plugin_passive`** (opencode + plugin): emit `_subagents` envelope; the bridge plugin spawns. *(unchanged)*
- **`host_driven`** (Codex): no passive receiver, but the host model can spawn — emit the inline result stamped with `dispatch_mode=host_driven` / `host_action=spawn_subagents` so the host fans out via its native primitive.
- **`sequential`**: no parallel surface → plain inline fallback.

`should_dispatch_via_plugin` becomes a thin `== PLUGIN_PASSIVE` alias, so all 13 existing call sites keep **exactly** their prior behaviour (verified by a behaviour-preservation matrix test).

## Two separate axes (the key insight)

`supports_native_parallel_subagents` = a **passive bridge receiver** exists (OpenCode plugin). `supports_host_driven_subagents` = the **host model** can spawn from inline payloads (Codex). A backend may have the latter without the former — they are deliberately kept on different axes so Codex is never misrouted into the passive-envelope path.

## What's wired for `host_driven`

The genuine **parallel multi-subagent assist** paths, where the inline content is already a complete fallback:
- `ouroboros_lateral_think` multi-persona fan-out (`evaluation_handlers.py`)
- Interview question **advisory fan-out** (5 lanes, #1516) (`authoring_handlers.py`)

## What's intentionally NOT wired

Single-dispatch **work** handlers (qa / execute / evolve / ralph / generate) keep the plugin-only gate. Their non-plugin path runs the **real work in-process** (Ralph's is "the only path with hard timeout enforcement"). Converting them to `host_driven` would replace deterministic in-process execution with model-dependent spawning — a downgrade, not a fix. Fan-out (parallel) doesn't apply to single dispatch anyway.

## Provider matrix (resolver == contract)

| runtime | resolver | contract.dispatch_mode |
|---|---|---|
| opencode + plugin | plugin_passive | plugin_passive |
| codex / codex_cli | host_driven | host_driven |
| claude / gemini / … | sequential | sequential |
| opencode subprocess | sequential | sequential |

Contract `dispatch_mode` now speaks the **same vocabulary** as the resolver (one source of truth).

## Codex guide

`_CODEX_SKILL_EXECUTION_CAPABILITIES` gains an `orchestrate_subagents` entry that deterministically chains the stamp to action: "when you see `host_action=spawn_subagents`, spawn one subagent per payload via `multi_agent_v1.spawn_agent`, correlate by `context.persona`, synthesise." This is injected into `~/.codex/rules/ouroboros.md` (requires `ooo setup`/`update` to refresh).

## Tests

- New: 3-way resolver matrix, `should_dispatch` alias preservation, codex host_driven contract, codex host_driven lateral + advisory stamps, codex orchestrate guide.
- Updated: contract dispatch_mode assertions to the unified vocabulary; sequential-branch test repointed to `gemini`.
- backends + mcp suites: **1251 passed** (isolated HOME); ruff clean.

> Note: Codex's actual spawn remains host-model-driven (a passive bridge cannot exist for Codex); the stamp + guide make it deterministic. Single-dispatch host_driven opt-in (keeping in-process as fallback) is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)