### PR TITLE
feat(subagent): claude-parity host-driven advisory fan-out (slice of #1516/#1517)

### DIFF
--- a/.claude-plugin/SKILL_CAPABILITY_GUIDE.md
+++ b/.claude-plugin/SKILL_CAPABILITY_GUIDE.md
@@ -29,3 +29,6 @@ Audit required client-side gates even when an MCP response says the workflow is 
 
 ### When a skill requires `restate_goal`
 Restate the goal and require explicit approval before irreversible workflow transitions such as seed generation.
+
+### When a skill requires `orchestrate_subagents`
+Claude Code has a native Task/Agent subagent primitive but no passive Ouroboros bridge, so subagent fan-out is host-driven. When an Ouroboros MCP tool returns inline payloads stamped with `dispatch_mode=host_driven` / `host_action=spawn_subagents`, or when a skill provides spawn-ready payloads such as `question_advisory_subagents`, spawn one Task/Agent subagent per payload in one batch, passing each payload's `prompt`. Correlate results by the payload-specific `result_correlation_key` when present, then synthesize in the parent session. If the Task/Agent primitive is unavailable, follow the sequential fallback.

--- a/.claude-plugin/skills/interview/SKILL.md
+++ b/.claude-plugin/skills/interview/SKILL.md
@@ -170,9 +170,11 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    parent-session assist layer. The advisory exists to help the human answer;
    it must not hide, replace, or delay the question itself.
 
-   Run the advisory lanes in parallel when the runtime supports subagents; use
-   the request's `sequential_fallback` semantics otherwise. The standard lanes
-   are:
+   Run the advisory lanes in parallel using your host's native subagent
+   primitive. In Claude Code that primitive is the **Task/Agent tool** — spawn
+   one subagent per lane in a single batch so they run concurrently. Only fall
+   back to the request's `sequential_fallback` semantics when the host has no
+   subagent primitive at all. The standard lanes are:
    - `code_context` — inspect repo-local facts and reuse
      `meta.code_investigation_request` when present.
    - `web_context` — browse/search only when current external facts genuinely
@@ -188,11 +190,17 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    options, one recommended draft, or a short "I found these ambiguities" note.
    Do not forward advisory output to `ouroboros_interview` until the user
    approves, edits, or explicitly asks you to auto-confirm a safe answer.
-   When `meta.question_advisory_subagents` is present, treat each entry as a
-   spawn-ready advisory payload with `title`, `agent`, `prompt`, and `context`;
-   dispatch those payloads through the runtime's native subagent primitive
-   instead of reconstructing prompts from prose. Preserve the original question
-   text while advisory children run.
+   When `meta.question_advisory_subagents` is present you MUST fan out: treat
+   each entry as a spawn-ready advisory payload with `title`, `agent`, `prompt`,
+   and `context`, and dispatch every payload through your host's native subagent
+   primitive (Claude Code → one Task/Agent call per payload, all in one parallel
+   batch) instead of reconstructing prompts from prose. This is required
+   regardless of dispatch mode: the payloads themselves are the spawn signal.
+   Treat `meta.question_advisory_host_action=spawn_subagents`, when present, as
+   a reinforcing cue for host-driven runtimes such as Codex or Claude Code, not
+   as a prerequisite. The only time you skip spawning is when the host has no
+   subagent primitive at all (then use `sequential_fallback`).
+   Preserve the original question text while advisory children run.
 
    **Milestone lateral-review dispatch**:
    If an MCP response includes `meta.lateral_review_recommended=true`, treat it

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -170,9 +170,11 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    parent-session assist layer. The advisory exists to help the human answer;
    it must not hide, replace, or delay the question itself.
 
-   Run the advisory lanes in parallel when the runtime supports subagents; use
-   the request's `sequential_fallback` semantics otherwise. The standard lanes
-   are:
+   Run the advisory lanes in parallel using your host's native subagent
+   primitive. In Claude Code that primitive is the **Task/Agent tool** — spawn
+   one subagent per lane in a single batch so they run concurrently. Only fall
+   back to the request's `sequential_fallback` semantics when the host has no
+   subagent primitive at all. The standard lanes are:
    - `code_context` — inspect repo-local facts and reuse
      `meta.code_investigation_request` when present.
    - `web_context` — browse/search only when current external facts genuinely
@@ -188,11 +190,17 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    options, one recommended draft, or a short "I found these ambiguities" note.
    Do not forward advisory output to `ouroboros_interview` until the user
    approves, edits, or explicitly asks you to auto-confirm a safe answer.
-   When `meta.question_advisory_subagents` is present, treat each entry as a
-   spawn-ready advisory payload with `title`, `agent`, `prompt`, and `context`;
-   dispatch those payloads through the runtime's native subagent primitive
-   instead of reconstructing prompts from prose. Preserve the original question
-   text while advisory children run.
+   When `meta.question_advisory_subagents` is present you MUST fan out: treat
+   each entry as a spawn-ready advisory payload with `title`, `agent`, `prompt`,
+   and `context`, and dispatch every payload through your host's native subagent
+   primitive (Claude Code → one Task/Agent call per payload, all in one parallel
+   batch) instead of reconstructing prompts from prose. This is required
+   regardless of dispatch mode: the payloads themselves are the spawn signal.
+   Treat `meta.question_advisory_host_action=spawn_subagents`, when present, as
+   a reinforcing cue for host-driven runtimes such as Codex or Claude Code, not
+   as a prerequisite. The only time you skip spawning is when the host has no
+   subagent primitive at all (then use `sequential_fallback`).
+   Preserve the original question text while advisory children run.
 
    **Milestone lateral-review dispatch**:
    If an MCP response includes `meta.lateral_review_recommended=true`, treat it

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -249,6 +249,25 @@ _GENERIC_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
     ),
 )
 
+_CLAUDE_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
+    *_GENERIC_SKILL_EXECUTION_CAPABILITIES,
+    SkillExecutionCapability(
+        name="orchestrate_subagents",
+        guidance=(
+            "Claude Code has a native Task/Agent subagent primitive but no "
+            "passive Ouroboros bridge, so subagent fan-out is host-driven. "
+            "When an Ouroboros MCP tool returns inline payloads stamped with "
+            "`dispatch_mode=host_driven` / `host_action=spawn_subagents`, or "
+            "when a skill provides spawn-ready payloads such as "
+            "`question_advisory_subagents`, spawn one Task/Agent subagent per "
+            "payload in one batch, passing each payload's `prompt`. Correlate "
+            "results by the payload-specific `result_correlation_key` when "
+            "present, then synthesize in the parent session. If the Task/Agent "
+            "primitive is unavailable, follow the sequential fallback."
+        ),
+    ),
+)
+
 _OPENCODE_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
     *_GENERIC_SKILL_EXECUTION_CAPABILITIES,
     SkillExecutionCapability(
@@ -272,7 +291,8 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         switchable_runtime=True,
         cli_name="claude",
         cli_config_key="cli_path",
-        skill_execution_capabilities=_GENERIC_SKILL_EXECUTION_CAPABILITIES,
+        skill_execution_capabilities=_CLAUDE_SKILL_EXECUTION_CAPABILITIES,
+        supports_host_driven_subagents=True,
     ),
     BackendCapability(
         name="codex",

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -160,12 +160,20 @@ def test_codex_host_driven_subagent_orchestration_is_registry_owned() -> None:
     assert "result_correlation_key" in guide
 
 
-def test_generic_skill_execution_guidance_covers_interview_requirements() -> None:
+def test_claude_host_driven_subagent_orchestration_is_registry_owned() -> None:
     capability = get_backend_capability("claude")
 
     assert capability is not None
+    assert capability.supports_host_driven_subagents is True
+    assert capability.supports_native_parallel_subagents is False
     names = {item.name for item in capability.skill_execution_capabilities}
-    assert names == REQUIRED_SKILL_CAPABILITY_NAMES
+    assert names == REQUIRED_SKILL_CAPABILITY_NAMES | {"orchestrate_subagents"}
+
+    guide = render_backend_skill_capability_guide("claude")
+    assert "### When a skill requires `orchestrate_subagents`" in guide
+    assert "Task/Agent" in guide
+    assert "host_action=spawn_subagents" in guide
+    assert "question_advisory_subagents" in guide
 
 
 def test_native_parallel_subagent_runtime_exposes_orchestrate_subagents() -> None:
@@ -209,20 +217,27 @@ def test_unsupported_parallel_subagent_runtime_gets_sequential_fallback_contract
     )
 
 
-def test_host_driven_runtime_gets_host_driven_contract() -> None:
-    """Codex has a native primitive but no passive bridge → host_driven contract.
+@pytest.mark.parametrize(
+    ("backend_name", "canonical_name"),
+    (("codex_cli", "codex"), ("claude_code", "claude")),
+)
+def test_host_driven_runtime_gets_host_driven_contract(
+    backend_name: str,
+    canonical_name: str,
+) -> None:
+    """Host-driven runtimes have a native primitive but no passive bridge.
 
     Guards against the contract regressing to ``sequential_fallback`` (which
     would emit a wrong instruction once a consumer reads the contract) while
     the resolver says ``host_driven``.
     """
     contract = build_runtime_subagent_orchestration_contract(
-        "codex_cli",
+        backend_name,
         directive_metadata=_LATERAL_PANEL_DIRECTIVE_METADATA,
         opencode_mode="plugin",
     )
 
-    assert contract.backend_name == "codex"
+    assert contract.backend_name == canonical_name
     # The boolean is the *passive bridge* axis only — host-driven runtimes are False here.
     assert contract.supports_native_parallel_subagents is False
     assert contract.dispatch_mode == "host_driven"

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -317,7 +317,7 @@ async def test_interview_orchestration_reader_uses_capability_panel_metadata() -
 async def test_interview_orchestration_reader_honors_custom_capability_metadata() -> None:
     """Regression guard against hard-coded lateral panel metadata in the reader."""
     handler = LateralThinkHandler(
-        agent_runtime_backend="claude_code",
+        agent_runtime_backend="gemini",
         opencode_mode=None,
     )
 
@@ -369,7 +369,7 @@ async def test_interview_orchestration_reader_honors_custom_capability_metadata(
 async def test_inline_lateral_content_converts_to_sequential_persona_panel_entries() -> None:
     """Content-only inline fallback still yields structured panel entries."""
     handler = LateralThinkHandler(
-        agent_runtime_backend="claude_code",
+        agent_runtime_backend="gemini",
         opencode_mode=None,
     )
 
@@ -445,11 +445,36 @@ async def test_codex_runtime_emits_host_driven_spawn_directive() -> None:
 
 
 @pytest.mark.asyncio
+async def test_claude_code_runtime_emits_host_driven_spawn_directive() -> None:
+    """Claude Code has Task/Agent fan-out but no passive bridge → host_driven."""
+    handler = LateralThinkHandler(
+        agent_runtime_backend="claude_code",
+        opencode_mode=None,
+    )
+
+    result = await handler.handle(
+        {
+            "problem_context": "interview needs a lightweight review",
+            "current_approach": "ask the next Socratic question",
+            "personas": ["researcher", "simplifier"],
+        }
+    )
+
+    assert result.is_ok, result
+    payload = result.unwrap()
+    assert payload.meta["dispatch_mode"] == "host_driven"
+    assert payload.meta["host_action"] == "spawn_subagents"
+    assert payload.meta["result_correlation_key"] == "context.persona"
+    assert len(payload.meta["payloads"]) == 2
+    assert "Host action — spawn subagents" in payload.text_content
+
+
+@pytest.mark.asyncio
 async def test_sequential_lateral_consumer_receives_persona_payloads_in_order() -> None:
     """Sequential fallback consumers receive persona payloads in request order."""
     requested_personas = ["simplifier", "hacker", "researcher"]
     handler = LateralThinkHandler(
-        agent_runtime_backend="claude_code",
+        agent_runtime_backend="gemini",
         opencode_mode=None,
     )
 
@@ -497,7 +522,7 @@ async def test_sequential_lateral_synthesis_waits_for_configured_sequence_output
     """Sequential fallback gates synthesis until every ordered persona output arrives."""
     requested_personas = ["simplifier", "hacker", "researcher"]
     handler = LateralThinkHandler(
-        agent_runtime_backend="claude_code",
+        agent_runtime_backend="gemini",
         opencode_mode=None,
     )
 
@@ -567,7 +592,7 @@ async def test_sequential_lateral_synthesis_precedes_interview_continuation() ->
     """Sequential fallback also synthesizes before the interview turn resumes."""
     requested_personas = ["simplifier", "hacker", "researcher"]
     handler = LateralThinkHandler(
-        agent_runtime_backend="claude_code",
+        agent_runtime_backend="gemini",
         opencode_mode=None,
     )
 
@@ -672,7 +697,7 @@ async def test_multi_persona_subprocess_mode_falls_back_inline() -> None:
 async def test_multi_persona_non_opencode_runtime_falls_back_inline() -> None:
     """Non-OpenCode runtime → inline fallback regardless of ``opencode_mode``."""
     handler = LateralThinkHandler(
-        agent_runtime_backend="claude_code",
+        agent_runtime_backend="gemini",
         opencode_mode="plugin",
     )
 
@@ -869,7 +894,7 @@ def _extract_inline_dispatch(content_text: str) -> dict:
 async def test_inline_fallback_carries_dispatch_block_in_content() -> None:
     """Non-plugin debate response embeds canonical payloads in ``content``."""
     handler = LateralThinkHandler(
-        agent_runtime_backend="claude_code",
+        agent_runtime_backend="gemini",
         opencode_mode=None,
     )
 
@@ -919,7 +944,7 @@ async def test_inline_fallback_dispatch_survives_html_close_in_user_context() ->
     ``[A-Za-z0-9+/=]`` — ``-->`` cannot occur inside the encoded body.
     """
     handler = LateralThinkHandler(
-        agent_runtime_backend="claude_code",
+        agent_runtime_backend="gemini",
         opencode_mode=None,
     )
 

--- a/tests/unit/mcp/tools/test_subagent.py
+++ b/tests/unit/mcp/tools/test_subagent.py
@@ -1052,13 +1052,24 @@ class TestResolveSubagentDispatch:
             resolve_subagent_dispatch("codex_cli", "subprocess") is SubagentDispatchMode.HOST_DRIVEN
         )
 
+    def test_claude_is_host_driven_via_task_primitive(self) -> None:
+        """Claude Code has a native Task/Agent primitive but no passive bridge."""
+        from ouroboros.mcp.tools.subagent import (
+            SubagentDispatchMode,
+            resolve_subagent_dispatch,
+        )
+
+        assert resolve_subagent_dispatch("claude", None) is SubagentDispatchMode.HOST_DRIVEN
+        # opencode_mode is irrelevant for claude — no passive bridge exists.
+        assert resolve_subagent_dispatch("claude", "plugin") is SubagentDispatchMode.HOST_DRIVEN
+
     def test_runtimes_without_any_subagent_surface_are_sequential(self) -> None:
         from ouroboros.mcp.tools.subagent import (
             SubagentDispatchMode,
             resolve_subagent_dispatch,
         )
 
-        for backend in ("claude", "gemini", "gjc", "opencode", "", None):
+        for backend in ("gemini", "gjc", "opencode", "", None):
             assert resolve_subagent_dispatch(backend, None) is SubagentDispatchMode.SEQUENTIAL, (
                 backend
             )

--- a/tests/unit/test_claude_plugin_skill_guide.py
+++ b/tests/unit/test_claude_plugin_skill_guide.py
@@ -17,6 +17,10 @@ def test_claude_plugin_interview_skill_includes_lateral_review_dispatch() -> Non
     skill_path = Path(".claude-plugin") / "skills" / "interview" / "SKILL.md"
     skill_text = skill_path.read_text(encoding="utf-8")
 
+    assert "question_advisory_subagents` is present you MUST fan out" in skill_text
+    assert "Task/Agent" in skill_text
+    assert "a reinforcing cue for host-driven runtimes" in skill_text
+    assert "as a prerequisite" in skill_text
     assert "`run_lateral_review`" in skill_text
     assert "**Milestone lateral-review dispatch**" in skill_text
     assert "meta.lateral_review_tool_args" in skill_text


### PR DESCRIPTION
## Summary

Bring the **`claude` backend to parity** with the bounded host-driven subagent fan-out that #1517 landed for Codex. This is the claude-side slice of the **same advisory/fan-out surface** — not a new substrate.

### Problem
Claude Code has a native **Task/Agent** subagent primitive but no passive Ouroboros bridge, so `resolve_subagent_dispatch("claude")` resolved to `SEQUENTIAL`. The interview advisory payloads (`question_advisory_subagents`, shipped in #1516) were always attached, but only Codex received the `host_action=spawn_subagents` cue (#1517), so on the default backend the host just read the question and never fanned out.

### Change
- Mark `claude` host-driven (`supports_host_driven_subagents=True`) + add a claude-specific `orchestrate_subagents` capability (spawn one Task/Agent subagent per inline payload).
- `resolve_subagent_dispatch("claude")` now returns `HOST_DRIVEN`, so the existing #1517 cue path fires for claude too — no new mechanism.
- Harden interview `SKILL.md` (+ plugin mirror) to fan out whenever `question_advisory_subagents` is present.

### Scope / roadmap linkage
- Precursor evidence: **#1516** (advisory fanout payloads, merged) + **#1517** (Codex host-driven dispatch, merged).
- This PR is the **bounded claude-parity** of that surface. It does **not** add new runtimes or broaden the substrate — the install/runtime (goose/gjc) work that was originally bundled here has been **split out into a separate PR** per the roadmap-warden's anti-sprawl gate.

> Scope note: because `resolve_subagent_dispatch` also feeds `evaluation_handlers` and lateral-think, claude's evaluation/lateral dispatch now behaves host-driven (same as Codex post-#1517).

## Testing
- `tests/unit/mcp/tools/` + `tests/unit/backends/` + orchestrator capabilities — **1074 passed**.
- `test_subagent.py`: moved `claude` out of the sequential set; added `test_claude_is_host_driven_via_task_primitive`.
- `ruff format --check` / `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
