### PR TITLE
fix(run): honor execute stage runtime profile

### DIFF
--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 from ouroboros.cli.formatters import console
 from ouroboros.cli.formatters.panels import print_error, print_info, print_success, print_warning
 from ouroboros.config._model_defaults import DEFAULT_SONNET_MODEL
-from ouroboros.config.loader import get_max_parallel_workers
+from ouroboros.config.loader import get_config_dir, get_max_parallel_workers, load_config
 from ouroboros.core.errors import ConfigError
 from ouroboros.core.project_paths import resolve_path_against_base, resolve_seed_project_path
 from ouroboros.core.security import InputValidator
@@ -44,6 +44,46 @@ def _resolve_execution_model(runtime_backend: str | None) -> str | None:
     if runtime_backend == "claude":
         return DEFAULT_SONNET_MODEL
     return None
+
+
+def _resolve_run_execute_runtime_backend(
+    runtime_backend: str | None,
+    *,
+    resolve_backend,
+) -> str:
+    """Resolve the agent runtime backend used by ``ooo run`` execution.
+
+    ``--runtime`` remains an explicit whole-run override. Without it, the CLI
+    honors ``orchestrator.runtime_profile.stages.execute`` with the same
+    precedence as auto/MCP: execute stage mapping, profile default, then
+    ``orchestrator.runtime_backend``.
+    """
+
+    resolved_default = resolve_backend(runtime_backend)
+    if runtime_backend is not None:
+        return resolved_default
+
+    from ouroboros.orchestrator_stage import Stage, parse_stage, resolve_runtime_for_stage
+
+    try:
+        profile = load_config().orchestrator.runtime_profile
+    except ConfigError:
+        if (get_config_dir() / "config.yaml").exists():
+            raise
+        profile = None
+
+    if profile is None:
+        return resolved_default
+
+    profile_stages = {parse_stage(key): value for key, value in profile.stages.items()}
+    return resolve_backend(
+        resolve_runtime_for_stage(
+            Stage.EXECUTE,
+            stages=profile_stages,
+            default=profile.default,
+            fallback=resolved_default,
+        )
+    )
 
 
 class _DefaultWorkflowGroup(typer.core.TyperGroup):
@@ -535,7 +575,11 @@ async def _run_orchestrator(
         project_dir: Optional explicit project directory for seed path resolution.
     """
     from ouroboros.core.seed import Seed
-    from ouroboros.orchestrator import OrchestratorRunner, create_agent_runtime
+    from ouroboros.orchestrator import (
+        OrchestratorRunner,
+        create_agent_runtime,
+        resolve_agent_runtime_backend,
+    )
     from ouroboros.orchestrator.session import SessionRepository
     from ouroboros.persistence.event_store import EventStore
 
@@ -630,9 +674,16 @@ async def _run_orchestrator(
         print_info(f"Task worktree: {workspace.worktree_path}")
         print_info(f"Task branch: {workspace.branch}")
 
+    resolved_runtime_backend = _resolve_run_execute_runtime_backend(
+        runtime_backend,
+        resolve_backend=resolve_agent_runtime_backend,
+    )
+    if debug:
+        print_info(f"Execution runtime: {resolved_runtime_backend}")
+
     adapter = create_agent_runtime(
-        backend=runtime_backend,
-        model=_resolve_execution_model(runtime_backend),
+        backend=resolved_runtime_backend,
+        model=_resolve_execution_model(resolved_runtime_backend),
         cwd=Path(workspace.effective_cwd) if workspace else project_dir,
     )
     runner = OrchestratorRunner(

--- a/tests/unit/cli/test_run_qa.py
+++ b/tests/unit/cli/test_run_qa.py
@@ -729,7 +729,11 @@ async def test_run_orchestrator_uses_seed_relative_project_dir_for_runtime_and_q
         mock_event_store_cls.return_value.initialize = AsyncMock()
         await _run_orchestrator(seed_file)
 
-    mock_runtime.assert_called_once_with(backend=None, model=None, cwd=expected_project_dir)
+    mock_runtime.assert_called_once_with(
+        backend="claude",
+        model="claude-sonnet-4-6",
+        cwd=expected_project_dir,
+    )
     mock_verification.assert_awaited_once_with(
         "exec-test",
         "Parallel Execution Verification Report",

--- a/tests/unit/cli/test_run_qa.py
+++ b/tests/unit/cli/test_run_qa.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 import typer
@@ -729,11 +729,7 @@ async def test_run_orchestrator_uses_seed_relative_project_dir_for_runtime_and_q
         mock_event_store_cls.return_value.initialize = AsyncMock()
         await _run_orchestrator(seed_file)
 
-    mock_runtime.assert_called_once_with(
-        backend="claude",
-        model="claude-sonnet-4-6",
-        cwd=expected_project_dir,
-    )
+    mock_runtime.assert_called_once_with(backend=ANY, model=ANY, cwd=expected_project_dir)
     mock_verification.assert_awaited_once_with(
         "exec-test",
         "Parallel Execution Verification Report",

--- a/tests/unit/cli/test_run_runtime_routing.py
+++ b/tests/unit/cli/test_run_runtime_routing.py
@@ -56,3 +56,35 @@ def test_run_runtime_profile_config_error_fails_fast_when_config_exists(
             None,
             resolve_backend=lambda value=None: value or "claude",
         )
+
+
+def test_run_execute_runtime_honors_runtime_profile_default(monkeypatch) -> None:
+    config = OuroborosConfig(
+        orchestrator=OrchestratorConfig(
+            runtime_backend="claude",
+            runtime_profile=RuntimeProfileConfig(default="opencode"),
+        )
+    )
+    monkeypatch.setattr(run, "load_config", lambda: config)
+
+    resolved = run._resolve_run_execute_runtime_backend(
+        None,
+        resolve_backend=lambda value=None: value or "claude",
+    )
+
+    assert resolved == "opencode"
+
+
+def test_run_runtime_profile_absent_config_falls_back(monkeypatch, tmp_path) -> None:
+    def _raise() -> OuroborosConfig:
+        raise ConfigError("Configuration file not found")
+
+    monkeypatch.setattr(run, "load_config", _raise)
+    monkeypatch.setattr(run, "get_config_dir", lambda: tmp_path)
+
+    resolved = run._resolve_run_execute_runtime_backend(
+        None,
+        resolve_backend=lambda value=None: value or "claude",
+    )
+
+    assert resolved == "claude"

--- a/tests/unit/cli/test_run_runtime_routing.py
+++ b/tests/unit/cli/test_run_runtime_routing.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.cli.commands import run
+from ouroboros.config.models import OrchestratorConfig, OuroborosConfig, RuntimeProfileConfig
+from ouroboros.core.errors import ConfigError
+
+
+def test_run_execute_runtime_honors_runtime_profile(monkeypatch) -> None:
+    config = OuroborosConfig(
+        orchestrator=OrchestratorConfig(
+            runtime_backend="claude",
+            runtime_profile=RuntimeProfileConfig(stages={"execute": "opencode"}),
+        )
+    )
+    monkeypatch.setattr(run, "load_config", lambda: config)
+
+    resolved = run._resolve_run_execute_runtime_backend(
+        None,
+        resolve_backend=lambda value=None: value or "claude",
+    )
+
+    assert resolved == "opencode"
+
+
+def test_run_explicit_runtime_overrides_runtime_profile(monkeypatch) -> None:
+    config = OuroborosConfig(
+        orchestrator=OrchestratorConfig(
+            runtime_backend="claude",
+            runtime_profile=RuntimeProfileConfig(stages={"execute": "opencode"}),
+        )
+    )
+    monkeypatch.setattr(run, "load_config", lambda: config)
+
+    resolved = run._resolve_run_execute_runtime_backend(
+        "codex",
+        resolve_backend=lambda value=None: value or "claude",
+    )
+
+    assert resolved == "codex"
+
+
+def test_run_runtime_profile_config_error_fails_fast_when_config_exists(
+    monkeypatch, tmp_path
+) -> None:
+    def _raise() -> OuroborosConfig:
+        raise ConfigError("bad runtime_profile")
+
+    (tmp_path / "config.yaml").write_text("orchestrator: {}\n")
+    monkeypatch.setattr(run, "load_config", _raise)
+    monkeypatch.setattr(run, "get_config_dir", lambda: tmp_path)
+
+    with pytest.raises(ConfigError):
+        run._resolve_run_execute_runtime_backend(
+            None,
+            resolve_backend=lambda value=None: value or "claude",
+        )


### PR DESCRIPTION
## Summary
- make `ooo run --orchestrator` resolve the execute runtime from `orchestrator.runtime_profile.stages.execute` when no explicit `--runtime` is passed
- keep explicit `--runtime` as the whole-run override
- fail fast on present-but-invalid runtime profile config, matching auto routing behavior
- update CLI orchestrator tests so project-dir assertions do not depend on a local default runtime backend

Closes #1520

## Test plan
- `uv run ruff format src/ouroboros/cli/commands/run.py tests/unit/cli/test_run_runtime_routing.py`
- `uv run ruff check src/ouroboros/cli/commands/run.py tests/unit/cli/test_run_runtime_routing.py`
- `uv run pytest tests/unit/cli/test_run_runtime_routing.py tests/unit/auto/test_runtime_routing.py tests/unit/orchestrator/test_stage_resolution.py tests/unit/cli/test_main.py -q`
- `uv run pytest tests/unit/orchestrator/test_runtime_factory.py tests/unit/config/test_loader.py -q`
- `uv run pytest tests/unit/cli/test_run_qa.py tests/unit/cli/test_run_runtime_routing.py -q`
- `uv run ruff check src/ouroboros/cli/commands/run.py tests/unit/cli/test_run_runtime_routing.py tests/unit/cli/test_run_qa.py`
