### PR TITLE
fix: split plugin auto handoff and claimed leases

### DIFF
--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -1259,6 +1259,7 @@ def _claim_start_lease(
         token_error = _validate_start_lease_payload(auto_session_id, token, lease)
         if token_error is not None:
             return token_error
+        assert lease is not None
         mode = str(lease.get("mode") or "")
         if mode in {"job", "job_pending"}:
             claimed_mode = "job"

--- a/src/ouroboros/mcp/tools/auto_handler.py
+++ b/src/ouroboros/mcp/tools/auto_handler.py
@@ -269,9 +269,19 @@ class AutoHandler:
                 )
             )
         if auto_session_id is not None and start_lease_token is not None:
-            token_error = _validate_start_lease_token(store, auto_session_id, start_lease_token)
-            if token_error is not None:
-                return Result.err(token_error)
+            try:
+                state = store.load(auto_session_id)
+            except ValueError as exc:
+                _release_start_lease(store, auto_session_id, token=start_lease_token)
+                return Result.err(MCPToolError(str(exc), tool_name="ouroboros_auto"))
+            claim_error = _claim_start_lease(
+                store,
+                auto_session_id,
+                token=start_lease_token,
+                ttl_seconds=max(1.0, state.pipeline_timeout_seconds),
+            )
+            if claim_error is not None:
+                return Result.err(claim_error)
             release_start_lease = True
         elif auto_session_id is not None:
             try:
@@ -784,7 +794,7 @@ class StartAutoHandler:
                     auto_session_id,
                     token=lease_token,
                     mode="plugin_dispatched",
-                    ttl_seconds=max(1.0, state.pipeline_timeout_seconds),
+                    ttl_seconds=_START_AUTO_PENDING_LEASE_SECONDS,
                 )
             except Exception as exc:
                 _release_start_lease(self._store, auto_session_id, token=lease_token)
@@ -1236,10 +1246,54 @@ def _release_start_lease(
         path.unlink(missing_ok=True)
 
 
-def _validate_start_lease_token(
-    store: AutoStore, auto_session_id: str, token: str
+def _claim_start_lease(
+    store: AutoStore,
+    auto_session_id: str,
+    *,
+    token: str,
+    ttl_seconds: float,
 ) -> MCPToolError | None:
-    lease = _read_start_lease(store, auto_session_id)
+    path = _start_lease_path(store, auto_session_id)
+    with file_lock(path):
+        lease = _read_start_lease_locked(path)
+        token_error = _validate_start_lease_payload(auto_session_id, token, lease)
+        if token_error is not None:
+            return token_error
+        mode = str(lease.get("mode") or "")
+        if mode in {"job", "job_pending"}:
+            claimed_mode = "job"
+            claimed_ttl_seconds = None
+        elif mode == "plugin_dispatched":
+            claimed_mode = "plugin_claimed"
+            claimed_ttl_seconds = ttl_seconds
+        else:
+            return MCPToolError(
+                "Invalid start_auto lease token: lease is not claimable for "
+                f"auto_session_id={auto_session_id}.",
+                tool_name="ouroboros_auto",
+                is_retriable=True,
+                details={
+                    "auto_session_id": auto_session_id,
+                    "session_id": auto_session_id,
+                    "lease_mode": mode or lease.get("mode"),
+                },
+            )
+        lease["mode"] = claimed_mode
+        lease["updated_at"] = _utc_iso()
+        if claimed_ttl_seconds is None:
+            lease.pop("expires_at", None)
+        else:
+            lease["expires_at"] = _utc_iso(ttl_seconds=claimed_ttl_seconds)
+        lease.update(_current_lease_owner())
+        _write_start_lease_locked(path, lease)
+    return None
+
+
+def _validate_start_lease_payload(
+    auto_session_id: str,
+    token: str,
+    lease: dict[str, Any] | None,
+) -> MCPToolError | None:
     if lease is None:
         return MCPToolError(
             "Invalid start_auto lease token: no active lease exists for "

--- a/tests/unit/mcp/tools/test_start_auto.py
+++ b/tests/unit/mcp/tools/test_start_auto.py
@@ -31,6 +31,7 @@ from ouroboros.auto.state import (
 from ouroboros.core.types import Result
 from ouroboros.mcp.job_manager import JobManager, JobStatus
 from ouroboros.mcp.tools.auto_handler import (
+    _START_AUTO_PENDING_LEASE_SECONDS,
     AutoHandler,
     StartAutoHandler,
     _reconcile_execution_job_snapshot,
@@ -1903,7 +1904,7 @@ class TestBackgroundJobPath:
         fake_inner_auto.handle.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_plugin_dispatch_lease_uses_pipeline_timeout(
+    async def test_plugin_dispatch_lease_uses_short_handoff_timeout(
         self, event_store, tmp_path, fake_inner_auto
     ) -> None:
         store = AutoStore(tmp_path)
@@ -1929,7 +1930,139 @@ class TestBackgroundJobPath:
             lease["updated_at"]
         )
         assert lease["mode"] == "plugin_dispatched"
-        assert lease_window >= timedelta(seconds=890)
+        assert lease_window <= timedelta(seconds=_START_AUTO_PENDING_LEASE_SECONDS + 1)
+
+    @pytest.mark.asyncio
+    async def test_plugin_child_claim_refreshes_lease_while_auto_is_running(
+        self, event_store, tmp_path, fake_inner_auto, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ouroboros.mcp.tools import auto_handler as auto_module
+
+        store = AutoStore(tmp_path)
+        state = AutoPipelineState(goal="build a CLI", cwd=str(tmp_path))
+        state.pipeline_timeout_seconds = 900
+        state.runtime_backend = "opencode"
+        state.opencode_mode = "plugin"
+        store.save(state)
+        lease_path = store.path_for(state.auto_session_id).with_suffix(".start_auto_lease.json")
+        started = asyncio.Event()
+        release = asyncio.Event()
+        now = datetime.now(UTC)
+        lease_path.write_text(
+            json.dumps(
+                {
+                    "token": "lease_active",
+                    "mode": "plugin_dispatched",
+                    "created_at": now.isoformat(),
+                    "updated_at": now.isoformat(),
+                    "expires_at": (
+                        now + timedelta(seconds=_START_AUTO_PENDING_LEASE_SECONDS)
+                    ).isoformat(),
+                    "owner_pid": 99999999,
+                    "owner_start_time": None,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        class StubAutoHandler(AutoHandler):
+            async def _run(self, arguments):
+                started.set()
+                await release.wait()
+                return AutoPipelineResult(
+                    status="running",
+                    auto_session_id=state.auto_session_id,
+                    phase="interview",
+                    pending_question="Which runtime?",
+                )
+
+        class LaterDateTime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                value = now + timedelta(seconds=_START_AUTO_PENDING_LEASE_SECONDS + 1)
+                return value if tz is not None else value.replace(tzinfo=None)
+
+        child = asyncio.create_task(
+            StubAutoHandler(store=store).handle(
+                {"resume": state.auto_session_id, "_start_auto_lease_token": "lease_active"}
+            )
+        )
+        try:
+            await asyncio.wait_for(started.wait(), timeout=2.0)
+            lease = json.loads(lease_path.read_text(encoding="utf-8"))
+            lease_window = datetime.fromisoformat(lease["expires_at"]) - datetime.fromisoformat(
+                lease["updated_at"]
+            )
+            assert lease["mode"] == "plugin_claimed"
+            assert lease["owner_pid"] == os.getpid()
+            assert lease_window > timedelta(seconds=_START_AUTO_PENDING_LEASE_SECONDS)
+
+            monkeypatch.setattr(auto_module, "datetime", LaterDateTime)
+            job_manager = MagicMock()
+            job_manager.allocate_job_id = AsyncMock(return_value="job_alloc")
+            job_manager.find_active_job_by_session = AsyncMock(return_value=None)
+            job_manager.start_job = AsyncMock()
+            h = StartAutoHandler(
+                event_store=event_store,
+                job_manager=job_manager,
+                store=store,
+                agent_runtime_backend="opencode",
+                opencode_mode="plugin",
+            )
+            h._inner_auto = fake_inner_auto
+
+            result = await h.handle({"resume": state.auto_session_id})
+
+            assert result.is_err
+            assert "active plugin dispatch" in result.error.message
+            job_manager.start_job.assert_not_called()
+            fake_inner_auto.handle.assert_not_called()
+        finally:
+            release.set()
+            await child
+
+    @pytest.mark.asyncio
+    async def test_plugin_subagent_arguments_claim_and_release_parent_handoff(
+        self, event_store, tmp_path, fake_inner_auto
+    ) -> None:
+        store = AutoStore(tmp_path)
+        starter = StartAutoHandler(
+            event_store=event_store,
+            job_manager=MagicMock(),
+            store=store,
+            agent_runtime_backend="opencode",
+            opencode_mode="plugin",
+        )
+        starter._inner_auto = fake_inner_auto
+
+        dispatched = await starter.handle({"goal": "build a CLI", "pipeline_timeout_seconds": 900})
+
+        assert dispatched.is_ok
+        subagent = dispatched.value.meta["_subagent"]
+        child_arguments = subagent["context"]["arguments"]
+        auto_session_id = dispatched.value.meta["auto_session_id"]
+        lease_path = store.path_for(auto_session_id).with_suffix(".start_auto_lease.json")
+
+        class StubAutoHandler(AutoHandler):
+            async def _run(self, arguments):
+                lease = json.loads(lease_path.read_text(encoding="utf-8"))
+                lease_window = datetime.fromisoformat(lease["expires_at"]) - datetime.fromisoformat(
+                    lease["updated_at"]
+                )
+                assert lease["mode"] == "plugin_claimed"
+                assert lease["owner_pid"] == os.getpid()
+                assert lease_window > timedelta(seconds=_START_AUTO_PENDING_LEASE_SECONDS)
+                return AutoPipelineResult(
+                    status="running",
+                    auto_session_id=auto_session_id,
+                    phase="interview",
+                    pending_question="Which runtime?",
+                )
+
+        claimed = await StubAutoHandler(store=store).handle(child_arguments)
+
+        assert claimed.is_ok
+        assert not lease_path.exists()
 
 
 class TestAutoHandlerLeaseRelease:
@@ -1999,6 +2132,80 @@ class TestAutoHandlerLeaseRelease:
         assert (
             not store.path_for(state.auto_session_id).with_suffix(".start_auto_lease.json").exists()
         )
+
+    @pytest.mark.asyncio
+    async def test_start_auto_token_can_only_claim_plugin_handoff_once(self, tmp_path) -> None:
+        store = AutoStore(tmp_path)
+        state = AutoPipelineState(goal="build a CLI", cwd=str(tmp_path))
+        store.save(state)
+        lease_path = store.path_for(state.auto_session_id).with_suffix(".start_auto_lease.json")
+        lease_path.write_text(
+            json.dumps(
+                {
+                    "token": "lease_active",
+                    "mode": "plugin_claimed",
+                    "created_at": datetime.now(UTC).isoformat(),
+                    "updated_at": datetime.now(UTC).isoformat(),
+                    "expires_at": (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        class StubAutoHandler(AutoHandler):
+            async def _run(self, arguments):
+                raise AssertionError("_run must not run for an already-claimed token")
+
+        result = await StubAutoHandler(store=store).handle(
+            {"resume": state.auto_session_id, "_start_auto_lease_token": "lease_active"}
+        )
+
+        assert result.is_err
+        assert "not claimable" in result.error.message
+        assert json.loads(lease_path.read_text(encoding="utf-8"))["mode"] == "plugin_claimed"
+
+    @pytest.mark.asyncio
+    async def test_start_auto_job_token_claim_promotes_pending_to_job_mode(self, tmp_path) -> None:
+        store = AutoStore(tmp_path)
+        state = AutoPipelineState(goal="build a CLI", cwd=str(tmp_path))
+        state.pipeline_timeout_seconds = 900
+        store.save(state)
+        lease_path = store.path_for(state.auto_session_id).with_suffix(".start_auto_lease.json")
+        lease_path.write_text(
+            json.dumps(
+                {
+                    "token": "lease_active",
+                    "mode": "job_pending",
+                    "job_id": "job_active",
+                    "created_at": datetime.now(UTC).isoformat(),
+                    "updated_at": datetime.now(UTC).isoformat(),
+                    "owner_pid": 99999999,
+                    "owner_start_time": None,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        class StubAutoHandler(AutoHandler):
+            async def _run(self, arguments):
+                lease = json.loads(lease_path.read_text(encoding="utf-8"))
+                assert lease["mode"] == "job"
+                assert lease["job_id"] == "job_active"
+                assert lease["owner_pid"] == os.getpid()
+                assert "expires_at" not in lease
+                return AutoPipelineResult(
+                    status="running",
+                    auto_session_id=state.auto_session_id,
+                    phase="interview",
+                    pending_question="Which runtime?",
+                )
+
+        result = await StubAutoHandler(store=store).handle(
+            {"resume": state.auto_session_id, "_start_auto_lease_token": "lease_active"}
+        )
+
+        assert result.is_ok
+        assert not lease_path.exists()
 
     @pytest.mark.asyncio
     async def test_direct_auto_resume_without_token_respects_start_auto_lease(


### PR DESCRIPTION
## Summary

Fixes the Python-side `ouroboros_start_auto` lease handoff for OpenCode plugin dispatches.

Previously, a plugin dispatch was promoted to `plugin_dispatched` with the full `pipeline_timeout_seconds` before the OpenCode child had claimed the `_start_auto_lease_token`. If the bridge never consumed the `_subagent`, the child failed before calling `ouroboros_auto`, or startup stalled, retries could be blocked until the long pipeline lease expired.

This PR separates the short plugin handoff window from claimed child execution:

- `plugin_dispatched` now keeps the short `_START_AUTO_PENDING_LEASE_SECONDS` handoff TTL.
- A child calling `ouroboros_auto` with the matching `_start_auto_lease_token` claims the lease under the file lock.
- A plugin claim promotes `plugin_dispatched` to `plugin_claimed`, refreshes owner identity, and extends expiry to the session `pipeline_timeout_seconds`.
- A plugin handoff token can only be claimed once.
- Job claims keep existing job semantics: `job_pending` / `job` claims become non-expiring `job` leases.
- Completion and failure paths still release the lease using token ownership.

This does not claim that the OpenCode bridge executed the child. It only makes the existing file-lease contract distinguish “plugin handoff dispatched” from “child reached `ouroboros_auto` and claimed execution.”

## Why

A short plugin-dispatch TTL alone would be unsafe: a real child may start within the handoff window and then run longer than that window. This patch pairs the short handoff TTL with a token claim that extends the lease only after the child reaches `ouroboros_auto`.

If the child starts after the short handoff TTL, its claim fails and the session can be retried/re-dispatched. That is intentional recovery behavior for unclaimed or stuck plugin handoffs.

## Test plan

- `uv run pytest tests/unit/mcp/tools/test_start_auto.py -q` (`53 passed`)
- `uv run pytest tests/unit/mcp/tools -q` (`839 passed`)
- `uv run ruff check src/ouroboros/mcp/tools/auto_handler.py tests/unit/mcp/tools/test_start_auto.py`
- `uv run ruff format --check src/ouroboros/mcp/tools/auto_handler.py tests/unit/mcp/tools/test_start_auto.py`
- `python3 scripts/check-auto-boundary.py`

Coverage added/updated:

- unclaimed plugin dispatches use the short handoff TTL
- parent `_subagent.context.arguments` carries the token used by the child claim
- child claim promotes `plugin_dispatched` to `plugin_claimed`
- plugin claim refreshes owner identity and TTL
- already-claimed plugin tokens are rejected before `_run`
- forged or stray `_start_auto_lease_token` values are rejected
- `job_pending` claim preserves non-expiring `job` lease behavior
- success and failure paths release owned leases

Not covered: a real OpenCode bridge end-to-end ack/fail path or child session ID tracking.

## Tradeoffs / Non-goals

- A child that does not call `ouroboros_auto` before the short handoff TTL expires is treated as unclaimed; its later token claim fails and a retry may redispatch.
- This does not add a bridge-level ack/fail protocol.
- This does not track OpenCode child session IDs.
- This does not detect a dead coroutine inside a still-live MCP process after `plugin_claimed`; claimed work remains protected until completion/failure release, owner death, terminal state, or lease expiry.
- The dispatch event emission and child claim remain separate operations; only the lease claim/update itself is file-lock atomic.
