### PR TITLE
fix(auto): keep recovery text out of seed contracts

### DIFF
--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -336,8 +336,7 @@ def _with_autoresearch_seed_extras(seed: Seed, context_text: str) -> Seed:
     runtime_context = data.get("runtime_context")
     if not isinstance(runtime_context, dict):
         runtime_context = {}
-    data["runtime_context"] = {
-        **runtime_context,
+    defaults = {
         "repository_path": runtime_context.get("repository_path")
         or _extract_autoresearch_repository_path(context_text),
         "research_program": "program.md",
@@ -352,6 +351,7 @@ def _with_autoresearch_seed_extras(seed: Seed, context_text: str) -> Seed:
         "memory_source": "maximum resident set size from /usr/bin/time -l stderr, recorded as bytes.",
         "memory_heavy_threshold": "discard if experiment memory exceeds baseline by more than max(10% of baseline, 67108864 bytes).",
     }
+    data["runtime_context"] = {**defaults, **runtime_context}
     data.setdefault("non_goals", list(_AUTORESEARCH_NON_GOALS))
     data.setdefault(
         "candidate_sequence",
@@ -382,27 +382,17 @@ def _is_autoresearch_generic_or_covered(criterion: str) -> bool:
         return True
     if "command/api check returns stable observable output" in key:
         return True
-    covered_markers = (
+    covered_phrases = (
         "seed has explicit runtime context",
         "seed preserves explicit runtime context",
-        "runtime context and non-goals",
-        "first-class content",
-        "baseline",
-        "uv run train.py",
-        "sequential",
-        "current best",
-        "at most 2",
-        "at most two",
-        "diff summary",
-        "changed files",
-        "val_bpb",
-        "memory",
-        "train.py",
-        "scope widening",
-        "discard",
-        "keep/discard",
+        "seed requires execution to record a baseline",
+        "execution records baseline val_bpb before train.py experiments",
+        "seed requires up to two post-baseline experiments",
+        "seed requires every baseline and experiment ledger entry",
+        "seed requires final kept changes to limited to train.py",
+        "seed defines discard behavior for ties, regressions, invalid runs, missing val_bpb, missing memory, timeouts, memory-heavy behavior, nonzero exits, and unauthorized file changes",
     )
-    return any(marker in key for marker in covered_markers)
+    return any(key.startswith(phrase) for phrase in covered_phrases)
 
 
 def _is_library_default_acceptance(criterion: str) -> bool:

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -142,6 +142,28 @@ _FILE_ARTIFACT_SIGNALS = (
     " exact",
 )
 
+_AUTORESEARCH_CONTEXT_SIGNALS = (
+    "autoresearch",
+    "train.py",
+    "val_bpb",
+)
+
+_AUTORESEARCH_CANONICAL_AC = (
+    "The experiment ledger artifact contains a baseline entry written before any edit; it includes measured command `/usr/bin/time -l uv run train.py`, inner command, exit status, val_bpb, maximum resident set size bytes, and baseline status.",
+    "The experiment ledger artifact contains at most two train.py-only experiment entries, each evaluated with the same measured command and timeout budget.",
+    "The experiment ledger artifact contains sequential decision entries; each entry includes keep/revert status from the current best state, keeping strict val_bpb improvements and reverting ties, regressions, invalid runs, timeouts, crashes, missing metrics, missing memory, and unauthorized scope changes before the next attempt.",
+    "Every baseline and experiment ledger artifact entry includes command, changed files, diff summary, observed val_bpb, memory, status, and keep/discard conclusion.",
+    "The final git diff artifact contains only train.py changes unless scope_widening_ledger contains an explicit justification for a wider edit.",
+    "The final report artifact includes baseline val_bpb, each attempted experiment result, final best val_bpb, and the keep/discard reason for every candidate.",
+)
+
+_AUTORESEARCH_NON_GOALS = (
+    "Do not edit prepare.py.",
+    "Do not edit files outside train.py unless scope_widening_ledger explicitly widens scope.",
+    "Do not install dependencies, change package metadata, or modify the evaluation harness.",
+    "Do not run training during Seed creation.",
+)
+
 
 def normalize_execution_acceptance(seed: Seed) -> Seed:
     """Remove auto-observation/reporting criteria from execution Seeds.
@@ -166,9 +188,20 @@ def normalize_execution_acceptance(seed: Seed) -> Seed:
         filtered,
         context_text=direction_context,
     )
-    if not filtered or filtered == criteria:
+    normalized_seed = seed
+    if _has_autoresearch_context(direction_context, filtered):
+        filtered = normalize_autoresearch_execution_criteria(
+            filtered,
+            context_text=direction_context,
+        )
+        normalized_seed = _with_autoresearch_seed_extras(normalized_seed, direction_context)
+    if not filtered or (filtered == criteria and normalized_seed is seed):
         return seed
-    return seed.model_copy(update={"acceptance_criteria": filtered})
+    if filtered != criteria:
+        data = normalized_seed.to_dict()
+        data["acceptance_criteria"] = list(filtered)
+        normalized_seed = Seed.from_dict(data)
+    return normalized_seed
 
 
 def normalize_observation_execution_criteria(
@@ -242,6 +275,33 @@ def normalize_file_artifact_execution_criteria(
     return filtered or criteria
 
 
+def normalize_autoresearch_execution_criteria(
+    criteria: tuple[str, ...],
+    *,
+    context_text: str = "",
+) -> tuple[str, ...]:
+    """Return direct observable ACs for Karpathy-style autoresearch handoffs.
+
+    The generic Seed repairer wraps vague ACs with
+    ``A command/API check returns ...``. That wrapper is useful as a fallback
+    for unknown tasks, but it violates the autoresearch plugin contract: the
+    executor needs an experiment ledger contract, not a placeholder proof
+    phrase. Keep this scoped to the plugin's distinctive train.py/val_bpb
+    surface.
+    """
+    if not _has_autoresearch_context(context_text, criteria):
+        return criteria
+    passthrough: list[str] = []
+    for criterion in criteria:
+        subject = _unwrap_seed_repairer_original_requirement(criterion).strip()
+        if not subject:
+            continue
+        if _is_autoresearch_generic_or_covered(subject):
+            continue
+        passthrough.append(subject)
+    return tuple(dict.fromkeys((*_AUTORESEARCH_CANONICAL_AC, *passthrough)))
+
+
 def has_auto_wrapper_context(text: str) -> bool:
     """Return true only for the known hello_auto observation prompt shape."""
     lowered = text.casefold()
@@ -264,6 +324,85 @@ def _has_file_artifact_context(context_text: str, criteria: tuple[str, ...]) -> 
         marker in criterion.casefold() for criterion in criteria for marker in ("content", "line")
     )
     return has_file_path and (has_file_check or has_content_check)
+
+
+def _has_autoresearch_context(context_text: str, criteria: tuple[str, ...]) -> bool:
+    text = "\n".join((context_text, *criteria)).casefold()
+    return all(signal in text for signal in _AUTORESEARCH_CONTEXT_SIGNALS)
+
+
+def _with_autoresearch_seed_extras(seed: Seed, context_text: str) -> Seed:
+    data = seed.to_dict()
+    runtime_context = data.get("runtime_context")
+    if not isinstance(runtime_context, dict):
+        runtime_context = {}
+    data["runtime_context"] = {
+        **runtime_context,
+        "repository_path": runtime_context.get("repository_path")
+        or _extract_autoresearch_repository_path(context_text),
+        "research_program": "program.md",
+        "editable_files": ["train.py"],
+        "fixed_files": ["prepare.py"],
+        "verification_command": "uv run train.py",
+        "measurement_command": "/usr/bin/time -l uv run train.py",
+        "experiment_budget": 2,
+        "timeout_seconds": 60,
+        "primary_metric": "val_bpb",
+        "metric_direction": "lower_is_better",
+        "memory_source": "maximum resident set size from /usr/bin/time -l stderr, recorded as bytes.",
+        "memory_heavy_threshold": "discard if experiment memory exceeds baseline by more than max(10% of baseline, 67108864 bytes).",
+    }
+    data.setdefault("non_goals", list(_AUTORESEARCH_NON_GOALS))
+    data.setdefault(
+        "candidate_sequence",
+        {
+            "baseline_first": True,
+            "sequential_from_current_best": True,
+            "keep_rule": "keep only strict val_bpb improvements",
+            "revert_rule": "revert discarded candidates before the next attempt",
+        },
+    )
+    return Seed.from_dict(data)
+
+
+def _extract_autoresearch_repository_path(context_text: str) -> str:
+    for pattern in (
+        r"repository(?: root)?:\s*([^\n]+)",
+        r"work in repository:?\s*([^\n]+)",
+    ):
+        match = re.search(pattern, context_text, flags=re.IGNORECASE)
+        if match:
+            return match.group(1).strip().strip("`")
+    return ""
+
+
+def _is_autoresearch_generic_or_covered(criterion: str) -> bool:
+    key = _criterion_key(criterion)
+    if key.startswith(_SEED_REPAIRER_ORIGINAL_REQUIREMENT_PREFIX):
+        return True
+    if "command/api check returns stable observable output" in key:
+        return True
+    covered_markers = (
+        "seed has explicit runtime context",
+        "seed preserves explicit runtime context",
+        "runtime context and non-goals",
+        "first-class content",
+        "baseline",
+        "uv run train.py",
+        "sequential",
+        "current best",
+        "at most 2",
+        "at most two",
+        "diff summary",
+        "changed files",
+        "val_bpb",
+        "memory",
+        "train.py",
+        "scope widening",
+        "discard",
+        "keep/discard",
+    )
+    return any(marker in key for marker in covered_markers)
 
 
 def _is_library_default_acceptance(criterion: str) -> bool:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4674,6 +4674,7 @@ def _is_seed_qa_diagnostic_constraint(constraint: str) -> bool:
     return (
         lowered.startswith("[seed qa repair attempt")
         or lowered.startswith("[seed qa lateral repair attempt")
+        or lowered.startswith("adopt this concrete implementation decision before execution:")
         or "# lateral thinking:" in lowered
         or "qa differences:" in lowered
         or "qa suggestions:" in lowered
@@ -4695,11 +4696,23 @@ def _normalized_seed_qa_lateral_feedback(lateral_result: LateralResult) -> tuple
     """
     summary = _clean_seed_qa_repair_text(lateral_result.approach_summary or "", limit=320)
     decision = _clean_seed_qa_repair_text(lateral_result.text, limit=1600)
+    persona_prefix = (lateral_result.persona or "").casefold()
     repairs: list[str] = []
-    if summary and not _is_seed_qa_recovery_transcript(summary):
+    if (
+        summary
+        and not _is_seed_qa_recovery_transcript(summary)
+        and not (persona_prefix and summary.casefold().startswith(f"{persona_prefix}:"))
+    ):
         repairs.append(f"Use this bounded implementation approach to resolve Seed QA: {summary}")
-    if decision and not _is_seed_qa_recovery_transcript(decision):
-        repairs.append(f"Adopt this concrete implementation decision before execution: {decision}")
+    # Seed QA lateral output often includes the persona prompt and full problem
+    # context in ``text``. Preserve only short explicit Decision lines; raw
+    # bodies are too likely to be diagnostic transcript material.
+    if (
+        decision
+        and decision.casefold().startswith("decision:")
+        and not _is_seed_qa_recovery_transcript(decision)
+    ):
+        repairs.append(f"Use this bounded implementation approach to resolve Seed QA: {decision}")
     if not repairs:
         repairs.append(
             "Resolve Seed QA feedback before execution without copying recovery persona prompts, failed-run transcripts, or diagnostic prose."
@@ -4709,8 +4722,6 @@ def _normalized_seed_qa_lateral_feedback(lateral_result: LateralResult) -> tuple
 
 def _clean_seed_qa_repair_text(text: str, *, limit: int) -> str:
     text = _SEED_QA_DIAGNOSTIC_PREFIX_RE.sub("", text.strip())
-    if _is_seed_qa_recovery_transcript(text):
-        return ""
     cleaned_lines: list[str] = []
     skipping_diagnostic_block = False
     for raw_line in text.splitlines():
@@ -4718,7 +4729,9 @@ def _clean_seed_qa_repair_text(text: str, *, limit: int) -> str:
         lowered = line.casefold()
         if not line:
             continue
-        if _is_seed_qa_recovery_transcript(line):
+        if _starts_seed_qa_recovery_context_block(line):
+            break
+        if _is_seed_qa_recovery_transcript_line(line):
             skipping_diagnostic_block = True
             continue
         if lowered.startswith("# lateral thinking:"):
@@ -4733,12 +4746,14 @@ def _clean_seed_qa_repair_text(text: str, *, limit: int) -> str:
         cleaned_lines.append(line)
     cleaned = " ".join(cleaned_lines)
     cleaned = cleaned.replace("# Lateral Thinking:", "").replace("# lateral thinking:", "")
-    if _is_seed_qa_recovery_transcript(cleaned):
-        return ""
     return cleaned[:limit].strip()
 
 
 def _is_seed_qa_recovery_transcript(text: str) -> bool:
+    return any(_is_seed_qa_recovery_transcript_line(line) for line in text.splitlines())
+
+
+def _is_seed_qa_recovery_transcript_line(text: str) -> bool:
     lowered = text.casefold()
     return any(
         marker in lowered
@@ -4746,16 +4761,21 @@ def _is_seed_qa_recovery_transcript(text: str) -> bool:
             "## persona:",
             "# persona:",
             "persona:",
-            "hacker:",
-            "contrarian:",
             "current approach (not working)",
             "most recent run artifact",
+            "problem context",
+            "concrete constraints for the generated ouroboros seed",
             "evaluate failed",
             "failed-run transcript",
             "repair transcript",
             "diagnostic recovery text",
         )
     )
+
+
+def _starts_seed_qa_recovery_context_block(text: str) -> bool:
+    lowered = text.casefold()
+    return lowered.startswith("## problem context") or lowered.startswith("# problem context")
 
 
 def _normalized_seed_qa_feedback(qa_result: EvaluateResult) -> tuple[str, ...]:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4598,7 +4598,11 @@ def _seed_with_recovery_constraint(seed: Seed, plan: AutoRecoveryPlan) -> Seed:
     reframing context while preserving the user-approved ACs that EVALUATE
     will grade after redispatch.
     """
-    instruction = plan.instruction.strip()
+    instruction = _clean_seed_qa_repair_text(plan.instruction.strip(), limit=420)
+    if not instruction:
+        instruction = (
+            "Do not copy recovery persona prompts or failed-run transcripts into Seed constraints."
+        )
     constraint = (
         "[auto recovery] Previous QA failed. Use this lateral recovery "
         "instruction to change implementation/verification approach without "
@@ -4692,23 +4696,30 @@ def _normalized_seed_qa_lateral_feedback(lateral_result: LateralResult) -> tuple
     summary = _clean_seed_qa_repair_text(lateral_result.approach_summary or "", limit=320)
     decision = _clean_seed_qa_repair_text(lateral_result.text, limit=1600)
     repairs: list[str] = []
-    if summary:
+    if summary and not _is_seed_qa_recovery_transcript(summary):
         repairs.append(f"Use this bounded implementation approach to resolve Seed QA: {summary}")
-    if decision:
+    if decision and not _is_seed_qa_recovery_transcript(decision):
         repairs.append(f"Adopt this concrete implementation decision before execution: {decision}")
     if not repairs:
-        repairs.append("Resolve Seed QA feedback before execution without adding diagnostic prose.")
+        repairs.append(
+            "Resolve Seed QA feedback before execution without copying recovery persona prompts, failed-run transcripts, or diagnostic prose."
+        )
     return tuple(dict.fromkeys(repairs))
 
 
 def _clean_seed_qa_repair_text(text: str, *, limit: int) -> str:
     text = _SEED_QA_DIAGNOSTIC_PREFIX_RE.sub("", text.strip())
+    if _is_seed_qa_recovery_transcript(text):
+        return ""
     cleaned_lines: list[str] = []
     skipping_diagnostic_block = False
     for raw_line in text.splitlines():
         line = raw_line.strip()
         lowered = line.casefold()
         if not line:
+            continue
+        if _is_seed_qa_recovery_transcript(line):
+            skipping_diagnostic_block = True
             continue
         if lowered.startswith("# lateral thinking:"):
             continue
@@ -4722,7 +4733,29 @@ def _clean_seed_qa_repair_text(text: str, *, limit: int) -> str:
         cleaned_lines.append(line)
     cleaned = " ".join(cleaned_lines)
     cleaned = cleaned.replace("# Lateral Thinking:", "").replace("# lateral thinking:", "")
+    if _is_seed_qa_recovery_transcript(cleaned):
+        return ""
     return cleaned[:limit].strip()
+
+
+def _is_seed_qa_recovery_transcript(text: str) -> bool:
+    lowered = text.casefold()
+    return any(
+        marker in lowered
+        for marker in (
+            "## persona:",
+            "# persona:",
+            "persona:",
+            "hacker:",
+            "contrarian:",
+            "current approach (not working)",
+            "most recent run artifact",
+            "evaluate failed",
+            "failed-run transcript",
+            "repair transcript",
+            "diagnostic recovery text",
+        )
+    )
 
 
 def _normalized_seed_qa_feedback(qa_result: EvaluateResult) -> tuple[str, ...]:

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4704,14 +4704,7 @@ def _normalized_seed_qa_lateral_feedback(lateral_result: LateralResult) -> tuple
         and not (persona_prefix and summary.casefold().startswith(f"{persona_prefix}:"))
     ):
         repairs.append(f"Use this bounded implementation approach to resolve Seed QA: {summary}")
-    # Seed QA lateral output often includes the persona prompt and full problem
-    # context in ``text``. Preserve only short explicit Decision lines; raw
-    # bodies are too likely to be diagnostic transcript material.
-    if (
-        decision
-        and decision.casefold().startswith("decision:")
-        and not _is_seed_qa_recovery_transcript(decision)
-    ):
+    if _is_clean_seed_qa_lateral_decision(decision, raw_text=lateral_result.text):
         repairs.append(f"Use this bounded implementation approach to resolve Seed QA: {decision}")
     if not repairs:
         repairs.append(
@@ -4747,6 +4740,25 @@ def _clean_seed_qa_repair_text(text: str, *, limit: int) -> str:
     cleaned = " ".join(cleaned_lines)
     cleaned = cleaned.replace("# Lateral Thinking:", "").replace("# lateral thinking:", "")
     return cleaned[:limit].strip()
+
+
+def _is_clean_seed_qa_lateral_decision(decision: str, *, raw_text: str) -> bool:
+    if not decision or _is_seed_qa_recovery_transcript(decision):
+        return False
+    if decision.casefold().startswith("decision:"):
+        return True
+    if _is_seed_qa_recovery_transcript(raw_text) or _starts_seed_qa_recovery_context_block(
+        raw_text.strip()
+    ):
+        return False
+    lowered = raw_text.casefold()
+    if (
+        "# lateral thinking:" in lowered
+        or "qa differences:" in lowered
+        or "qa suggestions:" in lowered
+    ):
+        return False
+    return len(decision) <= 420
 
 
 def _is_seed_qa_recovery_transcript(text: str) -> bool:

--- a/src/ouroboros/auto/task_class_application.py
+++ b/src/ouroboros/auto/task_class_application.py
@@ -83,6 +83,8 @@ def apply_default_ac_template(seed: Seed, task_class: TaskClass) -> AppliedTaskC
     template = profile.default_ac_template
     if not template:
         return AppliedTaskClassDefaults(seed=seed, injected_ac=(), task_class=task_class)
+    if _has_explicit_execution_contract(seed):
+        return AppliedTaskClassDefaults(seed=seed, injected_ac=(), task_class=task_class)
 
     existing = set(seed.acceptance_criteria)
     new_entries = tuple(item for item in template if item not in existing)
@@ -92,3 +94,13 @@ def apply_default_ac_template(seed: Seed, task_class: TaskClass) -> AppliedTaskC
     updated_ac = new_entries + tuple(seed.acceptance_criteria)
     new_seed = seed.model_copy(update={"acceptance_criteria": updated_ac})
     return AppliedTaskClassDefaults(seed=new_seed, injected_ac=new_entries, task_class=task_class)
+
+
+def _has_explicit_execution_contract(seed: Seed) -> bool:
+    """Return True when a Seed already carries a concrete domain contract."""
+    haystack = "\n".join((*seed.constraints, *seed.acceptance_criteria)).casefold()
+    return (
+        "runtime context" in haystack
+        and "non-goal" in haystack
+        and ("acceptance criteria" in haystack or bool(seed.acceptance_criteria))
+    )

--- a/src/ouroboros/auto/task_class_application.py
+++ b/src/ouroboros/auto/task_class_application.py
@@ -83,7 +83,7 @@ def apply_default_ac_template(seed: Seed, task_class: TaskClass) -> AppliedTaskC
     template = profile.default_ac_template
     if not template:
         return AppliedTaskClassDefaults(seed=seed, injected_ac=(), task_class=task_class)
-    if _has_explicit_execution_contract(seed):
+    if _has_autoresearch_execution_contract(seed):
         return AppliedTaskClassDefaults(seed=seed, injected_ac=(), task_class=task_class)
 
     existing = set(seed.acceptance_criteria)
@@ -96,11 +96,15 @@ def apply_default_ac_template(seed: Seed, task_class: TaskClass) -> AppliedTaskC
     return AppliedTaskClassDefaults(seed=new_seed, injected_ac=new_entries, task_class=task_class)
 
 
-def _has_explicit_execution_contract(seed: Seed) -> bool:
-    """Return True when a Seed already carries a concrete domain contract."""
+def _has_autoresearch_execution_contract(seed: Seed) -> bool:
+    """Return True when an autoresearch plugin Seed already owns its AC surface."""
     haystack = "\n".join((*seed.constraints, *seed.acceptance_criteria)).casefold()
     return (
-        "runtime context" in haystack
+        "autoresearch" in haystack
+        and "val_bpb" in haystack
+        and "train.py" in haystack
         and "non-goal" in haystack
-        and ("acceptance criteria" in haystack or bool(seed.acceptance_criteria))
+        and "runtime context" in haystack
+        and "baseline" in haystack
+        and "experiment" in haystack
     )

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -384,6 +384,12 @@ def _thaw_seed_extra_value(value: Any) -> Any:
 
 
 class _FrozenDict(dict[str, Any]):
+    def __copy__(self) -> _FrozenDict:
+        return self
+
+    def __deepcopy__(self, _memo: dict[int, Any]) -> _FrozenDict:
+        return self
+
     def _readonly(self, *_args: Any, **_kwargs: Any) -> None:
         raise TypeError("Seed extra fields are immutable")
 

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -385,3 +385,71 @@ def test_normalize_execution_acceptance_preserves_library_defaults_for_api_goal(
     ).model_copy(update={"goal": "Build an importable SDK package with a public API"})
 
     assert normalize_execution_acceptance(seed) is seed
+
+
+def test_normalize_execution_acceptance_canonicalizes_autoresearch_contract() -> None:
+    seed = _seed(
+        "A command/API check returns stable observable output or artifacts proving the original requirement for Seed preserves explicit Runtime Context, Non-Goals, and Acceptance Criteria as first-class content for the autoresearch contract.",
+        "A command/API check returns stable observable output or artifacts proving the original requirement for Seed requires execution to record a baseline uv run train.py result before any experiment changes evaluated.",
+        "A command/API check returns stable observable output or artifacts proving the original requirement for Seed requires up to two post-baseline experiments to selected sequentially from the current best state, with improvements kept and all non-improvements reverted before the next attempt.",
+        "A command/API check returns stable observable output or artifacts proving the original requirement for Seed requires every baseline and experiment ledger entry to report command, changed files, diff summary, observed val_bpb, memory, status, and keep/discard conclusion.",
+        "A command/API check returns stable observable output or artifacts proving the original requirement for Seed requires final kept changes to limited to train.py unless explicit scope widening recorded in the ledger.",
+        "Seed defines discard behavior for ties, regressions, invalid runs, missing val_bpb, missing memory, timeouts, memory-heavy behavior, nonzero exits, and unauthorized file changes.",
+    ).model_copy(
+        update={
+            "goal": (
+                "Run a bounded Karpathy-style autoresearch loop.\n"
+                "Repository: /tmp/autoresearch-demo\n"
+                "Treat program.md as instructions, edit only "
+                "train.py, use val_bpb as the primary metric, and verify with uv run train.py."
+            ),
+            "constraints": (
+                "Runtime Context: local autoresearch repository with train.py and prepare.py.",
+                "Non-Goals: do not edit prepare.py.",
+                "Run at most 2 experiments.",
+            ),
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert normalized.acceptance_criteria == (
+        "The experiment ledger artifact contains a baseline entry written before any edit; it includes measured command `/usr/bin/time -l uv run train.py`, inner command, exit status, val_bpb, maximum resident set size bytes, and baseline status.",
+        "The experiment ledger artifact contains at most two train.py-only experiment entries, each evaluated with the same measured command and timeout budget.",
+        "The experiment ledger artifact contains sequential decision entries; each entry includes keep/revert status from the current best state, keeping strict val_bpb improvements and reverting ties, regressions, invalid runs, timeouts, crashes, missing metrics, missing memory, and unauthorized scope changes before the next attempt.",
+        "Every baseline and experiment ledger artifact entry includes command, changed files, diff summary, observed val_bpb, memory, status, and keep/discard conclusion.",
+        "The final git diff artifact contains only train.py changes unless scope_widening_ledger contains an explicit justification for a wider edit.",
+        "The final report artifact includes baseline val_bpb, each attempted experiment result, final best val_bpb, and the keep/discard reason for every candidate.",
+    )
+    assert normalized.to_dict()["runtime_context"] == {
+        "repository_path": "/tmp/autoresearch-demo",
+        "research_program": "program.md",
+        "editable_files": ["train.py"],
+        "fixed_files": ["prepare.py"],
+        "verification_command": "uv run train.py",
+        "measurement_command": "/usr/bin/time -l uv run train.py",
+        "experiment_budget": 2,
+        "timeout_seconds": 60,
+        "primary_metric": "val_bpb",
+        "metric_direction": "lower_is_better",
+        "memory_source": "maximum resident set size from /usr/bin/time -l stderr, recorded as bytes.",
+        "memory_heavy_threshold": "discard if experiment memory exceeds baseline by more than max(10% of baseline, 67108864 bytes).",
+    }
+    assert normalized.to_dict()["non_goals"] == [
+        "Do not edit prepare.py.",
+        "Do not edit files outside train.py unless scope_widening_ledger explicitly widens scope.",
+        "Do not install dependencies, change package metadata, or modify the evaluation harness.",
+        "Do not run training during Seed creation.",
+    ]
+
+
+def test_normalize_execution_acceptance_leaves_non_autoresearch_train_metric_seed_alone() -> None:
+    seed = _seed(
+        "A command/API check returns stable observable output or artifacts proving the task goal.",
+    ).model_copy(
+        update={
+            "goal": "Build a training dashboard that can display a val_bpb column for train.py runs."
+        }
+    )
+
+    assert normalize_execution_acceptance(seed) is seed

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -443,6 +443,61 @@ def test_normalize_execution_acceptance_canonicalizes_autoresearch_contract() ->
     ]
 
 
+def test_normalize_execution_acceptance_preserves_distinct_autoresearch_user_ac() -> None:
+    seed = _seed(
+        "Seed requires execution to record a baseline uv run train.py result before any experiment changes evaluated.",
+        "train.py must preserve the existing --device CLI flag behavior.",
+        "Final report must include the baseline val_bpb and memory.",
+    ).model_copy(
+        update={
+            "goal": (
+                "Run a bounded Karpathy-style autoresearch loop. "
+                "Edit train.py and optimize val_bpb."
+            ),
+            "constraints": (
+                "Runtime Context: local autoresearch repository with train.py.",
+                "Non-Goals: do not edit prepare.py.",
+            ),
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert "train.py must preserve the existing --device CLI flag behavior." in (
+        normalized.acceptance_criteria
+    )
+    assert "Final report must include the baseline val_bpb and memory." in (
+        normalized.acceptance_criteria
+    )
+
+
+def test_normalize_execution_acceptance_preserves_existing_autoresearch_runtime_context() -> None:
+    seed = Seed.from_dict(
+        {
+            **_seed(
+                "Seed requires execution to record a baseline uv run train.py result before any experiment changes evaluated."
+            ).to_dict(),
+            "goal": "Run a bounded Karpathy-style autoresearch loop over train.py val_bpb.",
+            "constraints": ["Runtime Context: local autoresearch repository with train.py."],
+            "runtime_context": {
+                "repository_path": "/custom/repo",
+                "measurement_command": "python custom_measure.py",
+                "timeout_seconds": 120,
+                "experiment_budget": 3,
+            },
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    runtime_context = normalized.to_dict()["runtime_context"]
+    assert runtime_context["repository_path"] == "/custom/repo"
+    assert runtime_context["measurement_command"] == "python custom_measure.py"
+    assert runtime_context["timeout_seconds"] == 120
+    assert runtime_context["experiment_budget"] == 3
+    assert runtime_context["verification_command"] == "uv run train.py"
+
+
 def test_normalize_execution_acceptance_leaves_non_autoresearch_train_metric_seed_alone() -> None:
     seed = _seed(
         "A command/API check returns stable observable output or artifacts proving the task goal.",

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -27,9 +27,11 @@ from ouroboros.auto.lateral_routing import (
 )
 from ouroboros.auto.pipeline import (
     AutoPipeline,
+    _seed_with_recovery_constraint,
     _seed_with_seed_qa_feedback,
     _seed_with_seed_qa_lateral_feedback,
 )
+from ouroboros.auto.recovery_plan import AutoRecoveryPlan, RecoveryPlanAction
 from ouroboros.auto.seed_reviewer import SeedReview, SeedReviewer
 from ouroboros.auto.state import (
     _ALLOWED_TRANSITIONS,
@@ -175,6 +177,55 @@ def test_seed_qa_lateral_feedback_does_not_trip_intent_guard_pollution() -> None
     assert report.status is not IntentGuardStatus.FAIL
     spec_pollution = next(check for check in report.checks if check.code == "spec_pollution")
     assert spec_pollution.status is IntentGuardStatus.PASS
+
+
+def test_seed_qa_lateral_feedback_discards_persona_transcripts() -> None:
+    seed = _build_seed().model_copy(
+        update={"metadata": SeedMetadata(seed_id="seed_persona_transcript", ambiguity_score=0.12)}
+    )
+    lateral_result = LateralResult(
+        persona="contrarian",
+        approach_summary="Contrarian: Challenges assumptions",
+        text=(
+            "## Persona: Contrarian\n"
+            "EVALUATE failed. Current Approach (Not Working):\n"
+            "Most recent run artifact: goal: bad yaml"
+        ),
+    )
+
+    repaired = _seed_with_seed_qa_lateral_feedback(seed, lateral_result, attempt=1)
+    constraints = "\n".join(repaired.constraints)
+
+    assert "## Persona" not in constraints
+    assert "Contrarian" not in constraints
+    assert "Most recent run artifact" not in constraints
+    assert "without copying recovery persona prompts" in constraints
+
+
+def test_lateral_recovery_constraint_sanitizes_persona_transcripts() -> None:
+    seed = _build_seed()
+    plan = AutoRecoveryPlan(
+        action=RecoveryPlanAction.RALPH_REDISPATCH,
+        safe_to_redispatch=True,
+        reason="QA failed and lateral recovery advice is available.",
+        qa_score=0.58,
+        qa_verdict="revise",
+        differences=("bad contract",),
+        suggestions=("fix contract",),
+        persona="hacker",
+        instruction=(
+            "## Persona: Hacker\n"
+            "EVALUATE failed. Current Approach (Not Working): Most recent run artifact..."
+        ),
+    )
+
+    recovered = _seed_with_recovery_constraint(seed, plan)
+    constraints = "\n".join(recovered.constraints)
+
+    assert "## Persona" not in constraints
+    assert "Hacker" not in constraints
+    assert "Most recent run artifact" not in constraints
+    assert "Do not copy recovery persona prompts" in constraints
 
 
 class _StubInterviewDriver:

--- a/tests/unit/auto/test_pipeline_lateral.py
+++ b/tests/unit/auto/test_pipeline_lateral.py
@@ -202,6 +202,52 @@ def test_seed_qa_lateral_feedback_discards_persona_transcripts() -> None:
     assert "without copying recovery persona prompts" in constraints
 
 
+def test_seed_qa_lateral_feedback_preserves_clean_summary_with_dirty_body() -> None:
+    seed = _build_seed().model_copy(
+        update={"metadata": SeedMetadata(seed_id="seed_mixed_lateral", ambiguity_score=0.12)}
+    )
+    lateral_result = LateralResult(
+        persona="hacker",
+        approach_summary="Rewrite ACs as exact command scenarios.",
+        text=(
+            "## Persona: Hacker\n"
+            "EVALUATE failed. Current Approach (Not Working):\n"
+            "Most recent run artifact: goal: bad yaml"
+        ),
+    )
+
+    repaired = _seed_with_seed_qa_lateral_feedback(seed, lateral_result, attempt=1)
+    constraints = "\n".join(repaired.constraints)
+
+    assert "Rewrite ACs as exact command scenarios" in constraints
+    assert "## Persona" not in constraints
+    assert "Most recent run artifact" not in constraints
+
+
+def test_seed_qa_lateral_feedback_discards_problem_context_body() -> None:
+    seed = _build_seed().model_copy(
+        update={"metadata": SeedMetadata(seed_id="seed_problem_context", ambiguity_score=0.12)}
+    )
+    lateral_result = LateralResult(
+        persona="architect",
+        approach_summary="Use the existing measurement command consistently.",
+        text=(
+            "_You see problems as structural, not just tactical._\n"
+            "## Problem Context\n"
+            "goal: Run a bounded Karpathy-style autoresearch loop\n"
+            "Concrete constraints for the generated Ouroboros Seed: ..."
+        ),
+    )
+
+    repaired = _seed_with_seed_qa_lateral_feedback(seed, lateral_result, attempt=1)
+    constraints = "\n".join(repaired.constraints)
+
+    assert "Use the existing measurement command consistently" in constraints
+    assert "Adopt this concrete implementation decision" not in constraints
+    assert "Problem Context" not in constraints
+    assert "Concrete constraints for the generated Ouroboros Seed" not in constraints
+
+
 def test_lateral_recovery_constraint_sanitizes_persona_transcripts() -> None:
     seed = _build_seed()
     plan = AutoRecoveryPlan(
@@ -226,6 +272,32 @@ def test_lateral_recovery_constraint_sanitizes_persona_transcripts() -> None:
     assert "Hacker" not in constraints
     assert "Most recent run artifact" not in constraints
     assert "Do not copy recovery persona prompts" in constraints
+
+
+def test_lateral_recovery_constraint_preserves_clean_prefix_with_dirty_body() -> None:
+    seed = _build_seed()
+    plan = AutoRecoveryPlan(
+        action=RecoveryPlanAction.RALPH_REDISPATCH,
+        safe_to_redispatch=True,
+        reason="QA failed and lateral recovery advice is available.",
+        qa_score=0.58,
+        qa_verdict="revise",
+        differences=("bad contract",),
+        suggestions=("fix contract",),
+        persona="hacker",
+        instruction=(
+            "Rewrite ACs as exact command scenarios.\n\n"
+            "## Persona: Hacker\n"
+            "EVALUATE failed. Current Approach (Not Working): Most recent run artifact..."
+        ),
+    )
+
+    recovered = _seed_with_recovery_constraint(seed, plan)
+    constraints = "\n".join(recovered.constraints)
+
+    assert "Rewrite ACs as exact command scenarios" in constraints
+    assert "## Persona" not in constraints
+    assert "Most recent run artifact" not in constraints
 
 
 class _StubInterviewDriver:

--- a/tests/unit/auto/test_task_class_application.py
+++ b/tests/unit/auto/test_task_class_application.py
@@ -71,6 +71,28 @@ def test_user_ac_appears_after_template_entries() -> None:
     assert applied.injected_ac == profile.default_ac_template
 
 
+def test_explicit_execution_contract_skips_generic_template() -> None:
+    seed = _seed(
+        ac=(
+            "Seed has explicit runtime context and non-goals sections.",
+            "Execution records baseline val_bpb before experiments.",
+        ),
+    ).model_copy(
+        update={
+            "constraints": (
+                "Runtime Context: local repository with train.py.",
+                "Non-Goals: do not edit prepare.py.",
+            )
+        }
+    )
+
+    applied = apply_default_ac_template(seed, TaskClass.LIBRARY)
+
+    assert applied.injected_ac == ()
+    assert applied.seed is seed
+    assert not any("public API symbols" in item for item in seed.acceptance_criteria)
+
+
 def test_does_not_duplicate_when_user_already_supplied_one_template_entry() -> None:
     """If the user accidentally wrote one of the canonical template
     AC entries verbatim, the helper must not duplicate it."""

--- a/tests/unit/auto/test_task_class_application.py
+++ b/tests/unit/auto/test_task_class_application.py
@@ -71,16 +71,16 @@ def test_user_ac_appears_after_template_entries() -> None:
     assert applied.injected_ac == profile.default_ac_template
 
 
-def test_explicit_execution_contract_skips_generic_template() -> None:
+def test_autoresearch_execution_contract_skips_generic_template() -> None:
     seed = _seed(
         ac=(
-            "Seed has explicit runtime context and non-goals sections.",
-            "Execution records baseline val_bpb before experiments.",
+            "Seed has explicit runtime context and non-goals sections for this autoresearch contract.",
+            "Execution records baseline val_bpb before train.py experiments.",
         ),
     ).model_copy(
         update={
             "constraints": (
-                "Runtime Context: local repository with train.py.",
+                "Runtime Context: local autoresearch repository with train.py.",
                 "Non-Goals: do not edit prepare.py.",
             )
         }
@@ -91,6 +91,23 @@ def test_explicit_execution_contract_skips_generic_template() -> None:
     assert applied.injected_ac == ()
     assert applied.seed is seed
     assert not any("public API symbols" in item for item in seed.acceptance_criteria)
+
+
+def test_generic_cli_execution_contract_still_gets_template() -> None:
+    seed = _seed(
+        ac=("Command writes the requested file.",),
+    ).model_copy(
+        update={
+            "constraints": (
+                "Runtime Context: local CLI repository.",
+                "Non-Goals: no network calls.",
+            )
+        }
+    )
+
+    applied = apply_default_ac_template(seed, TaskClass.CLI)
+
+    assert applied.injected_ac == TASK_CLASS_CATALOG[TaskClass.CLI].default_ac_template
 
 
 def test_does_not_duplicate_when_user_already_supplied_one_template_entry() -> None:

--- a/tests/unit/core/test_seed.py
+++ b/tests/unit/core/test_seed.py
@@ -521,6 +521,21 @@ class TestSeed:
         assert reconstructed.to_dict()["plugin_contract"] == seed_dict["plugin_contract"]
         assert "bad" not in reconstructed.to_dict()
 
+    def test_seed_model_copy_preserves_immutable_plugin_extra_fields(self, full_seed: Seed) -> None:
+        """Pydantic model_copy works after plugin extras are frozen."""
+        seed_dict = full_seed.to_dict()
+        seed_dict["plugin_contract"] = {"plugin": "example"}
+        reconstructed = Seed.from_dict(seed_dict)
+
+        copied = reconstructed.model_copy(
+            update={"acceptance_criteria": ("Updated observable criterion.",)}
+        )
+
+        assert copied.acceptance_criteria == ("Updated observable criterion.",)
+        assert copied.to_dict()["plugin_contract"] == {"plugin": "example"}
+        with pytest.raises(TypeError):
+            copied.model_extra["plugin_contract"] = {"plugin": "mutated"}  # type: ignore[index]
+
     def test_seed_plugin_extra_fields_use_standard_pydantic_serialization(
         self, full_seed: Seed
     ) -> None:


### PR DESCRIPTION
## Summary
- sanitize Seed QA and lateral recovery feedback so persona/problem-context diagnostics do not persist in Seed constraints
- preserve autoresearch plugin contracts by canonicalizing generic Seed-repair AC wrappers into observable experiment-ledger ACs
- keep autoresearch runtime context, non-goals, measurement command, memory source, and candidate sequencing as JSON/YAML-safe Seed extras
- narrow task-class default AC suppression to explicit autoresearch contracts while preserving normal CLI defaults
- fix Seed extra-field immutability so `Seed.model_copy(update=...)` works after plugin extras are frozen

## Verification
- `uv run ruff check src/ouroboros/core/seed.py tests/unit/core/test_seed.py src/ouroboros/auto/execution_acceptance.py tests/unit/auto/test_execution_acceptance.py src/ouroboros/auto/pipeline.py src/ouroboros/auto/task_class_application.py tests/unit/auto/test_pipeline_lateral.py tests/unit/auto/test_task_class_application.py`
- `uv run pytest tests/unit/core/test_seed.py tests/unit/auto/test_execution_acceptance.py tests/unit/auto/test_task_class_application.py tests/unit/auto/test_pipeline_lateral.py tests/unit/auto/test_pipeline_task_class_envelope.py tests/unit/auto/test_recovery_plan.py` -> 154 passed
- patched v0.44-based CLI installed with `uv tool install --force -e .[tui]`
- autoresearch plugin handoff resume: `ouroboros auto --resume auto_22cb213c2fcb` -> `complete_verified`, Seed grade A, skip-run requested
- final Seed pollution check against `seed_0ee63a29c172.yaml`: no `Adopt this concrete`, persona/problem-context, generic `command/API check`, public API, unit-test, ruff, or type-check pollution

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | autoresearch skip-run resumed to Seed grade A / complete_verified | n/a |
| Per-round wall-clock (s/round) | N/A                   | N/A; Seed contract/QA repair path only | n/a |
| Terminal reason                | N/A                   | complete_verified, skip-run requested | n/a |
| EventStore event count         | N/A                   | N/A for local CLI smoke | n/a |

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation /
[x] N/A (Seed contract sanitization and plugin handoff normalization; no execution/perf loop change)
