### PR TITLE
fix(orchestrator): register runtime-only backends in RuntimeHandle contract

### DIFF
--- a/src/ouroboros/orchestrator/adapter.py
+++ b/src/ouroboros/orchestrator/adapter.py
@@ -266,6 +266,12 @@ _RUNTIME_HANDLE_BACKEND_ALIASES = {
     "pi_cli": "pi",
     "gjc": "gjc",
     "gjc_cli": "gjc",
+    "gemini": "gemini_cli",
+    "gemini_cli": "gemini_cli",
+    "grok": "grok_cli",
+    "grok_cli": "grok_cli",
+    "antigravity": "antigravity_cli",
+    "antigravity_cli": "antigravity_cli",
 }
 
 

--- a/tests/unit/orchestrator/test_adapter.py
+++ b/tests/unit/orchestrator/test_adapter.py
@@ -262,6 +262,12 @@ class TestRuntimeHandle:
             ("claude_code", "claude"),
             ("codex", "codex_cli"),
             ("opencode_cli", "opencode"),
+            ("gemini", "gemini_cli"),
+            ("gemini_cli", "gemini_cli"),
+            ("grok", "grok_cli"),
+            ("grok_cli", "grok_cli"),
+            ("antigravity", "antigravity_cli"),
+            ("antigravity_cli", "antigravity_cli"),
         ],
     )
     def test_init_normalizes_legacy_backend_aliases(
@@ -282,6 +288,47 @@ class TestRuntimeHandle:
             native_session_id="sess_123",
             cwd="/tmp/project",
         )
+
+    def test_runtime_only_backends_register_in_handle_contract(self) -> None:
+        """Regression for #1483 review (ouroboros-agent CHANGES_REQUESTED).
+
+        The gemini/grok/antigravity runtimes declare ``_runtime_handle_backend``
+        values that must be accepted by the shared RuntimeHandle contract. They
+        inherit Codex's ``_build_runtime_handle``, which constructs a
+        ``RuntimeHandle(backend=<cli>)`` on every execute/resume/control
+        iteration -- if the selector is unregistered, those generic paths crash
+        with ``ValueError`` before producing a typed runtime error.
+        """
+        from types import SimpleNamespace
+
+        from ouroboros.orchestrator.antigravity_cli_runtime import (
+            AntigravityCLIRuntime,
+        )
+        from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
+        from ouroboros.orchestrator.grok_cli_runtime import GrokCliRuntime
+
+        for runtime_cls, expected in (
+            (GeminiCLIRuntime, "gemini_cli"),
+            (GrokCliRuntime, "grok_cli"),
+            (AntigravityCLIRuntime, "antigravity_cli"),
+        ):
+            handle = RuntimeHandle(
+                backend=runtime_cls._runtime_handle_backend,
+                native_session_id="sess_123",
+                cwd="/tmp/project",
+            )
+            assert handle.backend == expected
+
+        # Exercise Grok's inherited Codex handle builder against the real method.
+        stub = SimpleNamespace(
+            _runtime_handle_backend="grok_cli",
+            _cwd="/tmp/project",
+            _permission_mode=None,
+        )
+        built = GrokCliRuntime._build_runtime_handle(stub, "sess_123")
+        assert built is not None
+        assert built.backend == "grok_cli"
+        assert built.native_session_id == "sess_123"
 
     def test_non_dict_payload_returns_none(self) -> None:
         """Missing runtime payloads still deserialize to None."""
@@ -329,6 +376,47 @@ class TestRuntimeHandle:
                     native_session_id="oc-session-123",
                 ),
                 id="matching-backend-provider-aliases",
+            ),
+            pytest.param(
+                {
+                    "provider": "grok",
+                    "kind": "agent_runtime",
+                    "native_session_id": "grok-session-123",
+                    "cwd": "/tmp/project",
+                },
+                RuntimeHandle(
+                    backend="grok_cli",
+                    kind="agent_runtime",
+                    native_session_id="grok-session-123",
+                    cwd="/tmp/project",
+                ),
+                id="grok-provider-only-alias",
+            ),
+            pytest.param(
+                {
+                    "backend": "antigravity",
+                    "native_session_id": "agy-session-123",
+                    "cwd": "/tmp/project",
+                },
+                RuntimeHandle(
+                    backend="antigravity_cli",
+                    native_session_id="agy-session-123",
+                    cwd="/tmp/project",
+                ),
+                id="antigravity-backend-alias",
+            ),
+            pytest.param(
+                {
+                    "backend": "gemini",
+                    "native_session_id": "gemini-session-123",
+                    "cwd": "/tmp/project",
+                },
+                RuntimeHandle(
+                    backend="gemini_cli",
+                    native_session_id="gemini-session-123",
+                    cwd="/tmp/project",
+                ),
+                id="gemini-backend-alias",
             ),
         ],
     )


### PR DESCRIPTION
## What & why

Post-merge review on #1483 (ouroboros-agent, CHANGES_REQUESTED) surfaced a real crash that landed on `main`: the `grok` runtime backend is unusable through generic resume/replay/control paths.

`GrokCliRuntime` subclasses `CodexCliRuntime` and inherits `_build_runtime_handle`, which constructs `RuntimeHandle(backend="grok_cli")` on every execute/resume/control iteration. But `grok_cli` was never added to `_RUNTIME_HANDLE_BACKEND_ALIASES` in `orchestrator/adapter.py`, so `RuntimeHandle.__post_init__` raised:

```
ValueError: Unsupported RuntimeHandle backend selector: grok_cli
```

Reproduced directly:

```python
>>> from ouroboros.orchestrator.adapter import RuntimeHandle
>>> RuntimeHandle(backend="grok_cli")
ValueError: Unsupported RuntimeHandle backend selector: grok_cli
```

## Scope

The same latent gap affects the other Codex/Gemini-derived runtimes that declare a `_cli` handle backend but were never registered, so this fixes all of them to keep the contract complete:

| runtime | `_runtime_handle_backend` | canonical |
|---|---|---|
| `GrokCliRuntime` | `grok_cli` | `grok_cli` |
| `AntigravityCLIRuntime` → `GeminiCLIRuntime` | `antigravity_cli` | `antigravity_cli` |
| `GeminiCLIRuntime` (pre-existing since #504) | `gemini_cli` | `gemini_cli` |

Canonicalizing to the `_cli` form matches each runtime's declared `_runtime_handle_backend` and the existing `codex`/`hermes`/`copilot` precedent. Config-layer spellings (`agy`, `grok_build`, etc.) are resolved to runtime classes before any handle exists and never flow into `RuntimeHandle`, so they are intentionally out of scope for the boundary map.

## Tests

`tests/unit/orchestrator/test_adapter.py`:
- extended the alias-normalization parametrization (construction) for gemini/grok/antigravity;
- added `from_dict` deserialization cases (backend-keyed and legacy provider-keyed);
- added `test_runtime_only_backends_register_in_handle_contract`, which exercises Grok's inherited `_build_runtime_handle` against the real method.

Local: `ruff` / `ruff format --check` / `mypy` clean; `pytest tests/unit/orchestrator/test_adapter.py tests/unit/orchestrator/test_grok_cli_runtime.py` → 102 passed.

Relates to #1481. Addresses the post-merge review on #1483.
