### PR TITLE
fix(#1537): salvage phantom tool calls under the sealed no-tools envelope

### DIFF
--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -2236,6 +2236,17 @@ class InterviewHandler:
             ),
             strict_mcp_config=True,
         )
+        # A sealed no-tools envelope must pair with the tool-less prompt
+        # variant: the full socratic-interviewer prompt advertises tool use,
+        # and a subprocess whose catalog is emptied (``--tools ""``) has
+        # nothing to answer that temptation with — tool-happy models then
+        # emit phantom tool calls that burn the single turn (#1537). Only
+        # applies when this handler constructed the sealed adapter itself;
+        # injected adapters (tests, custom wiring) keep the caller's mode.
+        suppress_question_tool_cues = self.suppress_tool_use_prompt_cues or (
+            self.llm_adapter is None
+            and backend_supports_tool_envelope(resolve_llm_backend(backend))
+        )
         # Build a per-call InterviewEngine when a real engine is supplied, to
         # avoid mutating shared engine state in place. Mutating a shared
         # engine's llm_adapter and suppress_tool_use_prompt_cues is race-prone:
@@ -2272,7 +2283,7 @@ class InterviewHandler:
                 llm_adapter=llm_adapter,
                 state_dir=template.state_dir,
                 model=template.model or get_llm_model_for_role("interview", backend=backend),
-                suppress_tool_use_prompt_cues=self.suppress_tool_use_prompt_cues,
+                suppress_tool_use_prompt_cues=suppress_question_tool_cues,
             )
             engine.temperature = template.temperature
             engine.max_tokens = template.max_tokens
@@ -2283,7 +2294,7 @@ class InterviewHandler:
                 llm_adapter=llm_adapter,
                 state_dir=self.data_dir or _DATA_DIR,
                 model=get_llm_model_for_role("interview", backend=backend),
-                suppress_tool_use_prompt_cues=self.suppress_tool_use_prompt_cues,
+                suppress_tool_use_prompt_cues=suppress_question_tool_cues,
             )
 
         _interview_id: str | None = None  # Track for error event emission

--- a/src/ouroboros/providers/claude_code_adapter.py
+++ b/src/ouroboros/providers/claude_code_adapter.py
@@ -58,6 +58,16 @@ log = structlog.get_logger(__name__)
 # Retry configuration for transient API errors
 _MAX_RETRIES = 5
 _MAX_JSON_RETRIES = 3  # Extra retries when response_format requires JSON but LLM returns prose
+# Recovery cue for phantom tool calls under the sealed no-tools envelope
+# (#1537/#1530): some models — notably non-Claude models behind an
+# Anthropic-format proxy — emit tool_use blocks even when the visible tool
+# catalog is emptied via ``--tools ""``. No CLI flag can prevent that, so the
+# one retry the adapter grants gets this hard instruction appended.
+_NO_TOOLS_RECOVERY_CUE = (
+    "CRITICAL: You have NO tools in this session. Tool calls are impossible "
+    "and will be discarded unexecuted. Do NOT emit any tool call or "
+    "function-call markup. Respond with plain text only."
+)
 _INITIAL_BACKOFF_SECONDS = (
     0.5  # Keep low for interactive loops; exponential backoff handles sustained failures
 )
@@ -302,6 +312,29 @@ class ClaudeCodeAdapter:
         is_cli_process_exit = error_type in {"ProcessError", "CalledProcessError"}
         return is_cli_process_exit and "command failed with exit code" in message
 
+    def _is_phantom_tool_use_error(self, error: ProviderError) -> bool:
+        """Whether a failure is a phantom tool call under the sealed envelope.
+
+        With ``allowed_tools=[]`` the visible tool catalog is emptied
+        (``tools=[]`` → ``--tools ""``), so a tool-use turn cannot be an
+        execution leak — only model noise that consumed the turn budget
+        (#1537/#1530). That noise surfaces as either the spy's explicit
+        ``ToolUseBlockViolation``, or as the max-turns failures the CLI/SDK
+        raise when the phantom call exhausts ``max_turns`` before any text
+        streams (``subtype=error_max_turns`` from the result stream, or the
+        SDK's bare ``Reached maximum number of turns`` / ``returned an error
+        result`` exceptions).
+        """
+        if self._allowed_tools is None or self._allowed_tools:
+            return False
+        details = error.details or {}
+        if details.get("error_type") == "ToolUseBlockViolation":
+            return True
+        if details.get("subtype") == "error_max_turns":
+            return True
+        message = error.message or ""
+        return "Reached maximum number of turns" in message or "returned an error result" in message
+
     async def complete(
         self,
         messages: list[Message],
@@ -496,17 +529,19 @@ class ClaudeCodeAdapter:
         enforcement is handled by the caller.
         """
         last_error: ProviderError | None = None
+        effective_system_prompt = system_prompt
+        phantom_recovery_used = False
 
         for attempt in range(_MAX_RETRIES):
             try:
                 if self._timeout is None:
                     result = await self._execute_single_request(
-                        prompt, config, system_prompt=system_prompt
+                        prompt, config, system_prompt=effective_system_prompt
                     )
                 else:
                     async with asyncio.timeout(self._timeout):
                         result = await self._execute_single_request(
-                            prompt, config, system_prompt=system_prompt
+                            prompt, config, system_prompt=effective_system_prompt
                         )
 
                 if result.is_ok:
@@ -516,6 +551,30 @@ class ClaudeCodeAdapter:
                             attempts=attempt + 1,
                         )
                     return result
+
+                # Phantom tool call under the sealed no-tools envelope: the
+                # catalog is empty so nothing executed — grant exactly one
+                # recovery attempt with a hard plain-text instruction before
+                # failing loud (#1537/#1530).
+                if (
+                    not phantom_recovery_used
+                    and attempt < _MAX_RETRIES - 1
+                    and self._is_phantom_tool_use_error(result.error)
+                ):
+                    phantom_recovery_used = True
+                    effective_system_prompt = (
+                        f"{system_prompt}\n\n{_NO_TOOLS_RECOVERY_CUE}"
+                        if system_prompt
+                        else _NO_TOOLS_RECOVERY_CUE
+                    )
+                    log.warning(
+                        "claude_code_adapter.phantom_tool_use_recovery",
+                        error_type=result.error.details.get("error_type"),
+                        subtype=result.error.details.get("subtype"),
+                        attempt=attempt + 1,
+                    )
+                    last_error = result.error
+                    continue
 
                 # Check if error is retryable
                 error_msg = result.error.message
@@ -1115,6 +1174,31 @@ class ClaudeCodeAdapter:
             )
 
         # After generator completes naturally, check for errors
+        if (
+            error_result is not None
+            and error_result.details.get("error_type") == "ToolUseBlockViolation"
+            and content.strip()
+        ):
+            # Sealed no-tools envelope: the visible catalog is emptied via
+            # ``tools=[]`` (forwarded as ``--tools ""``), so the emitted tool
+            # call never executed — it is model noise, not an envelope leak.
+            # When a usable final text still streamed, surface it instead of
+            # discarding a good response; the incident stays observable via
+            # the structured warning and ``raw_response`` marker (#1537).
+            log.warning(
+                "claude_code_adapter.phantom_tool_use_salvaged",
+                session_id=session_id,
+                tool_name=error_result.details.get("tool_name"),
+                content_length=len(content),
+            )
+            raw_response.update(
+                {
+                    "phantom_tool_use": True,
+                    "phantom_tool_name": error_result.details.get("tool_name"),
+                }
+            )
+            error_result = None
+
         if error_result:
             return Result.err(error_result)
 

--- a/tests/unit/mcp/tools/test_auto_interview_construction.py
+++ b/tests/unit/mcp/tools/test_auto_interview_construction.py
@@ -1408,13 +1408,15 @@ def test_auto_sub_interview_spy_adapter_fails_on_any_tool_request(
     monkeypatch,
     tmp_path: Path,
 ) -> None:
-    """Auto's nested interviewer must fail closed on a tool request.
+    """Auto's nested interviewer salvages text past a phantom tool request.
 
     This starts at ``AutoHandler`` and exercises the constructed
     ``HandlerInterviewBackend``.  The fake SDK emits a ``ToolUseBlock`` before
-    a valid text result; the spy assertion is that the auto sub-interview
-    treats the tool request as the failure, not as a recoverable prelude to the
-    later question text.
+    a valid text result. Under the sealed envelope the tool catalog is
+    emptied via ``tools=[]`` (``--tools ""``), so the request can never
+    execute — the sub-interview surfaces the streamed question instead of
+    failing (#1537), while the envelope assertions below keep the seal
+    itself locked.
     """
     from ouroboros.providers import claude_code_adapter as adapter_mod
 
@@ -1526,9 +1528,14 @@ def test_auto_sub_interview_spy_adapter_fails_on_any_tool_request(
         )
 
     assert result.is_ok, result.error
-    assert captured["turn"] is None
-    assert captured["error_type"] == "HandlerError"
-    assert "What is the primary user goal?" not in captured["error"]
+    # Sealed-envelope contract (#1537): the phantom tool request cannot
+    # execute (catalog emptied via ``tools=[]``), so the streamed question
+    # is salvaged instead of discarded — the incident stays observable via
+    # the adapter's structured warning and ``raw_response`` marker.
+    turn = captured["turn"]
+    assert turn is not None, captured.get("error")
+    assert turn.question == "What is the primary user goal?"
+    assert "error" not in captured
 
     factory_kwargs = mock_factory.call_args.kwargs
     assert factory_kwargs["max_turns"] == 1
@@ -1550,8 +1557,10 @@ def test_auto_sub_interview_isolates_parent_skill_invocations(
 
     The parent execution context can expose Claude Code skills for the main
     agentic session.  The auto sub-interviewer is a pure question generator,
-    so its SDK envelope must explicitly clear ``skills`` and fail closed if a
-    ``Skill`` tool request is still emitted before text.
+    so its SDK envelope must explicitly clear ``skills``. A ``Skill`` tool
+    request emitted anyway is a phantom call (the sealed catalog cannot
+    execute it) — the streamed question is salvaged and the seal itself is
+    asserted below (#1537).
     """
     from ouroboros.providers import claude_code_adapter as adapter_mod
 
@@ -1670,9 +1679,14 @@ def test_auto_sub_interview_isolates_parent_skill_invocations(
         )
 
     assert result.is_ok, result.error
-    assert captured["turn"] is None
-    assert captured["error_type"] == "HandlerError"
-    assert "What should the first auto interview question clarify?" not in captured["error"]
+    # Sealed-envelope contract (#1537): the phantom tool request cannot
+    # execute (catalog emptied via ``tools=[]``), so the streamed question
+    # is salvaged instead of discarded. Isolation is enforced by the
+    # envelope assertions below, not by failing the question.
+    turn = captured["turn"]
+    assert turn is not None, captured.get("error")
+    assert turn.question == "What should the first auto interview question clarify?"
+    assert "error" not in captured
 
     factory_kwargs = mock_factory.call_args.kwargs
     assert factory_kwargs["max_turns"] == 1
@@ -1696,9 +1710,10 @@ def test_auto_sub_interview_isolates_parent_agent_invocations(
 
     The parent execution context can expose sub-agents for the main agentic
     workflow.  The auto sub-interviewer is constrained to one turn and must
-    generate text only, so its SDK envelope must explicitly clear ``agents``
-    and fail closed if a sub-agent ``Task`` request is still emitted before
-    the question text.
+    generate text only, so its SDK envelope must explicitly clear ``agents``.
+    A sub-agent ``Task`` request emitted anyway is a phantom call (the sealed
+    catalog cannot execute it) — the streamed question is salvaged and the
+    seal itself is asserted below (#1537).
     """
     from ouroboros.providers import claude_code_adapter as adapter_mod
 
@@ -1821,9 +1836,14 @@ def test_auto_sub_interview_isolates_parent_agent_invocations(
         )
 
     assert result.is_ok, result.error
-    assert captured["turn"] is None
-    assert captured["error_type"] == "HandlerError"
-    assert "What should the first auto interview question clarify?" not in captured["error"]
+    # Sealed-envelope contract (#1537): the phantom tool request cannot
+    # execute (catalog emptied via ``tools=[]``), so the streamed question
+    # is salvaged instead of discarded. Isolation is enforced by the
+    # envelope assertions below, not by failing the question.
+    turn = captured["turn"]
+    assert turn is not None, captured.get("error")
+    assert turn.question == "What should the first auto interview question clarify?"
+    assert "error" not in captured
 
     factory_kwargs = mock_factory.call_args.kwargs
     assert factory_kwargs["max_turns"] == 1
@@ -1846,9 +1866,10 @@ def test_auto_sub_interview_isolates_parent_plugin_invocations(
     """Auto's nested interviewer must not inherit parent Claude plugins.
 
     Parent plugin contexts can register additional tool surfaces for the main
-    agentic run.  The auto sub-interviewer must clear that plugin list and
-    fail closed if a plugin-sourced tool request is still emitted before the
-    single text question.
+    agentic run.  The auto sub-interviewer must clear that plugin list. A
+    plugin-sourced tool request emitted anyway is a phantom call (the sealed
+    catalog cannot execute it) — the streamed question is salvaged and the
+    seal itself is asserted below (#1537).
     """
     from ouroboros.providers import claude_code_adapter as adapter_mod
 
@@ -1967,9 +1988,14 @@ def test_auto_sub_interview_isolates_parent_plugin_invocations(
         )
 
     assert result.is_ok, result.error
-    assert captured["turn"] is None
-    assert captured["error_type"] == "HandlerError"
-    assert "What should the first auto interview question clarify?" not in captured["error"]
+    # Sealed-envelope contract (#1537): the phantom tool request cannot
+    # execute (catalog emptied via ``tools=[]``), so the streamed question
+    # is salvaged instead of discarded. Isolation is enforced by the
+    # envelope assertions below, not by failing the question.
+    turn = captured["turn"]
+    assert turn is not None, captured.get("error")
+    assert turn.question == "What should the first auto interview question clarify?"
+    assert "error" not in captured
 
     factory_kwargs = mock_factory.call_args.kwargs
     assert factory_kwargs["max_turns"] == 1
@@ -1991,9 +2017,11 @@ def test_auto_sub_interview_isolates_parent_hook_context(
     """Auto's nested interviewer must not inherit parent Claude hooks.
 
     Parent Claude sessions can attach hooks that run commands around tool and
-    prompt events.  The auto sub-interviewer must clear those hooks, suppress
-    hook event streaming, and fail closed if any hook-adjacent tool request is
-    still emitted before the single text question.
+    prompt events.  The auto sub-interviewer must clear those hooks and
+    suppress hook event streaming. A hook-adjacent tool request emitted
+    anyway is a phantom call (the sealed catalog cannot execute it) — the
+    streamed question is salvaged and the seal itself is asserted below
+    (#1537).
     """
     from ouroboros.providers import claude_code_adapter as adapter_mod
 
@@ -2124,9 +2152,14 @@ def test_auto_sub_interview_isolates_parent_hook_context(
         )
 
     assert result.is_ok, result.error
-    assert captured["turn"] is None
-    assert captured["error_type"] == "HandlerError"
-    assert "What should the first auto interview question clarify?" not in captured["error"]
+    # Sealed-envelope contract (#1537): the phantom tool request cannot
+    # execute (catalog emptied via ``tools=[]``), so the streamed question
+    # is salvaged instead of discarded. Isolation is enforced by the
+    # envelope assertions below, not by failing the question.
+    turn = captured["turn"]
+    assert turn is not None, captured.get("error")
+    assert turn.question == "What should the first auto interview question clarify?"
+    assert "error" not in captured
 
     factory_kwargs = mock_factory.call_args.kwargs
     assert factory_kwargs["max_turns"] == 1

--- a/tests/unit/mcp/tools/test_interview_toolless_prompt_wiring.py
+++ b/tests/unit/mcp/tools/test_interview_toolless_prompt_wiring.py
@@ -1,0 +1,136 @@
+"""Wiring lock: sealed no-tools envelope pairs with the tool-less prompt.
+
+The nested ``ouroboros_interview`` question generator runs with
+``allowed_tools=[]`` — its subprocess catalog is emptied via ``tools=[]``
+(``--tools ""``). The full socratic-interviewer prompt advertises tool use,
+so pairing it with a sealed envelope tempts tool-happy models into phantom
+tool calls that burn the single ``max_turns=1`` turn (#1537). When the
+handler constructs the sealed adapter itself, the per-call engine MUST use
+the tool-less prompt variant (``suppress_tool_use_prompt_cues=True``).
+
+Injected adapters (tests, custom wiring) keep the caller's prompt mode —
+the handler cannot know whether an injected adapter is sealed.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, ClassVar
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ouroboros.bigbang.interview import InterviewState, InterviewStatus
+from ouroboros.core.types import Result
+from ouroboros.mcp.tools.authoring_handlers import InterviewHandler
+
+
+class _RecordingEngine:
+    """Stands in for ``InterviewEngine`` via patching.
+
+    A real class (not a MagicMock instance) so the handler's
+    ``isinstance(InterviewEngine, type)`` clone-branch guard passes and the
+    per-call engine construction kwargs can be recorded.
+    """
+
+    constructed: ClassVar[list[dict[str, Any]]] = []
+
+    def __init__(
+        self,
+        llm_adapter: Any = None,
+        state_dir: Path | None = None,
+        model: str | None = None,
+        suppress_tool_use_prompt_cues: bool = False,
+    ) -> None:
+        type(self).constructed.append(
+            {
+                "llm_adapter": llm_adapter,
+                "state_dir": state_dir,
+                "model": model,
+                "suppress_tool_use_prompt_cues": suppress_tool_use_prompt_cues,
+            }
+        )
+        self.llm_adapter = llm_adapter
+        self.state_dir = state_dir
+        self.model = model
+        self.suppress_tool_use_prompt_cues = suppress_tool_use_prompt_cues
+        self.temperature: float | None = None
+        self.max_tokens: int | None = None
+
+    async def start_interview(
+        self,
+        initial_context: str,
+        cwd: str | None = None,
+        interview_id: str | None = None,
+    ) -> Result[InterviewState, Any]:
+        state = InterviewState(
+            interview_id=interview_id or "interview_toolless0001",
+            initial_context=initial_context,
+            status=InterviewStatus.IN_PROGRESS,
+        )
+        return Result.ok(state)
+
+    async def ask_next_question(self, state: InterviewState) -> Result[str, Any]:
+        return Result.ok("What is the primary user goal?")
+
+    async def save_state(self, state: InterviewState) -> Result[Path, Any]:
+        assert self.state_dir is not None
+        path = self.state_dir / f"interview_{state.interview_id}.json"
+        path.write_text("{}", encoding="utf-8")
+        return Result.ok(path)
+
+
+async def _run_handler(tmp_path: Path, *, injected_adapter: Any) -> list[dict[str, Any]]:
+    _RecordingEngine.constructed = []
+    template = _RecordingEngine(state_dir=tmp_path, model="claude-sonnet-4-6")
+    handler = InterviewHandler(
+        interview_engine=template,  # type: ignore[arg-type]
+        llm_adapter=injected_adapter,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    with (
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.InterviewEngine",
+            _RecordingEngine,
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.create_llm_adapter",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.backend_supports_tool_envelope",
+            return_value=True,
+        ),
+    ):
+        outcome = await handler.handle({"initial_context": "Build a CLI", "cwd": str(tmp_path)})
+
+    assert outcome.is_ok, "handler must complete successfully on the happy path"
+    # constructed[0] is the template built above; the handler's per-call
+    # clone is the last construction.
+    clones = _RecordingEngine.constructed[1:]
+    assert clones, "handler must build a per-call engine from the template"
+    return clones
+
+
+@pytest.mark.asyncio
+async def test_sealed_envelope_uses_toolless_prompt_variant(tmp_path: Path) -> None:
+    """Handler-constructed sealed adapters must suppress tool-use prompt cues."""
+    clones = await _run_handler(tmp_path, injected_adapter=None)
+    assert clones[-1]["suppress_tool_use_prompt_cues"] is True, (
+        "a question generator whose tool catalog is emptied (allowed_tools=[]) "
+        "must not receive the tool-advertising socratic-interviewer prompt — "
+        "that pairing produces phantom tool calls on max_turns=1 (#1537)"
+    )
+
+
+@pytest.mark.asyncio
+async def test_injected_adapter_keeps_caller_prompt_mode(tmp_path: Path) -> None:
+    """Injected adapters are opaque — the handler must not force suppression."""
+    clones = await _run_handler(tmp_path, injected_adapter=MagicMock())
+    assert clones[-1]["suppress_tool_use_prompt_cues"] is False, (
+        "the handler cannot know whether an injected adapter is sealed, so it "
+        "must preserve the caller's prompt mode"
+    )

--- a/tests/unit/providers/test_claude_code_adapter.py
+++ b/tests/unit/providers/test_claude_code_adapter.py
@@ -724,15 +724,16 @@ class TestJsonSchemaHandling:
         assert "Read" in options_call_kwargs["disallowed_tools"]
 
     @pytest.mark.asyncio
-    async def test_empty_allowed_tools_spy_fails_on_tool_use_block(
+    async def test_empty_allowed_tools_phantom_tool_use_salvages_streamed_text(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """Spy regression: a no-tools request must fail on any ToolUseBlock.
+        """A phantom tool call under the sealed envelope must not discard text.
 
-        The ``ooo auto`` sub-interview path runs with ``max_turns=1`` and
-        ``allowed_tools=[]``.  If Claude emits a tool block anyway, accepting a
-        later text result would hide the turn-stealing leak this path is meant
-        to prevent.
+        With ``allowed_tools=[]`` the visible catalog is emptied via
+        ``tools=[]`` (``--tools ""``), so an emitted ToolUseBlock can never
+        execute — it is model noise (#1537), not an envelope leak. When a
+        usable final text still streams, surface it and keep the incident
+        observable through the ``raw_response`` marker instead of failing.
         """
         from ouroboros.providers import claude_code_adapter as adapter_mod
 
@@ -774,11 +775,174 @@ class TestJsonSchemaHandling:
         ):
             result = await adapter._execute_single_request("test prompt", config)
 
+        assert result.is_ok
+        assert result.value.content == "What is the primary user goal?"
+        assert result.value.raw_response["phantom_tool_use"] is True
+        assert result.value.raw_response["phantom_tool_name"] == "Read"
+
+    @pytest.mark.asyncio
+    async def test_empty_allowed_tools_phantom_tool_use_without_text_fails_loud(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Fail-loud is preserved when a phantom tool call yields no text.
+
+        Salvage only applies when a usable final text streamed. A tool block
+        with no recoverable content must still surface the structured
+        ``ToolUseBlockViolation`` so the recovery/retry layer (and ultimately
+        the caller) sees the real failure instead of an empty success.
+        """
+        from ouroboros.providers import claude_code_adapter as adapter_mod
+
+        monkeypatch.setattr(
+            adapter_mod,
+            "_claude_options_field_names",
+            lambda: frozenset({"extra_args", "allowed_tools", "tools"}),
+        )
+
+        adapter = ClaudeCodeAdapter(allowed_tools=[], strict_mcp_config=True)
+        config = CompletionConfig(model="claude-sonnet-4-6", max_turns=1)
+
+        class ToolUseBlock:
+            name = "Read"
+            input = {"file_path": "README.md"}
+
+        class AssistantMessage:
+            content = [ToolUseBlock()]
+
+        class ResultMessage:
+            structured_output = None
+            result = ""
+            is_error = False
+
+        mock_options_cls = MagicMock()
+
+        async def fake_query(*args, **kwargs):
+            yield AssistantMessage()
+            yield ResultMessage()
+
+        sdk_module = _make_sdk_mock(mock_options_cls, MagicMock(side_effect=fake_query))
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "claude_agent_sdk": sdk_module,
+                "claude_agent_sdk._errors": sdk_module._errors,
+            },
+        ):
+            result = await adapter._execute_single_request("test prompt", config)
+
         assert result.is_err
         assert result.error.details["error_type"] == "ToolUseBlockViolation"
         assert result.error.details["tool_name"] == "Read"
         assert result.error.details["allowed_tools"] == []
         assert result.error.details["max_turns"] == 1
+
+    @pytest.mark.asyncio
+    async def test_phantom_tool_use_error_grants_one_recovery_with_no_tools_cue(self) -> None:
+        """The retry loop grants exactly one hardened retry for phantom failures.
+
+        First attempt fails with ``ToolUseBlockViolation`` under the sealed
+        envelope; the second attempt must carry the plain-text-only recovery
+        cue in its system prompt. A second phantom failure is terminal.
+        """
+        adapter = ClaudeCodeAdapter(allowed_tools=[], strict_mcp_config=True)
+        config = CompletionConfig(model="claude-sonnet-4-6", max_turns=1)
+
+        phantom_error = ProviderError(
+            message="Claude Agent SDK emitted a ToolUseBlock despite allowed_tools=[]",
+            details={"error_type": "ToolUseBlockViolation", "tool_name": "Read"},
+        )
+        success = CompletionResponse(
+            content="What is the primary user goal?",
+            model="claude-sonnet-4-6",
+            usage=UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+            finish_reason="stop",
+            raw_response={},
+        )
+        seen_system_prompts: list[str | None] = []
+
+        async def fake_execute(prompt, cfg, system_prompt=None):
+            seen_system_prompts.append(system_prompt)
+            if len(seen_system_prompts) == 1:
+                return Result.err(phantom_error)
+            return Result.ok(success)
+
+        with patch.object(adapter, "_execute_single_request", side_effect=fake_execute):
+            result = await adapter._complete_with_transient_retry(
+                "test prompt", config, "Ask a Socratic question."
+            )
+
+        assert result.is_ok
+        assert len(seen_system_prompts) == 2
+        assert seen_system_prompts[0] == "Ask a Socratic question."
+        assert "Respond with plain text only" in (seen_system_prompts[1] or "")
+        assert seen_system_prompts[1].startswith("Ask a Socratic question.")
+
+    @pytest.mark.asyncio
+    async def test_phantom_recovery_not_granted_without_sealed_envelope(self) -> None:
+        """Phantom recovery is scoped to ``allowed_tools=[]`` adapters only.
+
+        For permissive adapters (``allowed_tools=None``) a tool-use max-turns
+        failure is a genuine turn-budget problem, not phantom noise, and must
+        not be masked by a hardened retry.
+        """
+        adapter = ClaudeCodeAdapter(allowed_tools=None)
+        config = CompletionConfig(model="claude-sonnet-4-6", max_turns=1)
+
+        max_turns_error = ProviderError(
+            message="Claude Code returned an error result: Reached maximum number of turns (1)",
+            details={"error_type": "Exception"},
+        )
+        calls: list[str | None] = []
+
+        async def fake_execute(prompt, cfg, system_prompt=None):
+            calls.append(system_prompt)
+            return Result.err(max_turns_error)
+
+        with patch.object(adapter, "_execute_single_request", side_effect=fake_execute):
+            result = await adapter._complete_with_transient_retry("test prompt", config, None)
+
+        assert result.is_err
+        assert len(calls) == 1
+        assert calls[0] is None
+
+    @pytest.mark.asyncio
+    async def test_phantom_recovery_covers_sdk_max_turns_exception_shape(self) -> None:
+        """#1537's observed failure shape triggers recovery under the seal.
+
+        The SDK surfaces the phantom-consumed turn as a bare exception
+        (``Claude Code returned an error result: ...``) rather than the spy's
+        structured violation; the sealed-envelope predicate must catch that
+        shape too.
+        """
+        adapter = ClaudeCodeAdapter(allowed_tools=[], strict_mcp_config=True)
+        config = CompletionConfig(model="claude-sonnet-4-6", max_turns=1)
+
+        sdk_error = ProviderError(
+            message="Claude Agent SDK request failed: Claude Code returned an error result: success",
+            details={"error_type": "Exception"},
+        )
+        success = CompletionResponse(
+            content="What is the primary user goal?",
+            model="claude-sonnet-4-6",
+            usage=UsageInfo(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+            finish_reason="stop",
+            raw_response={},
+        )
+        calls: list[str | None] = []
+
+        async def fake_execute(prompt, cfg, system_prompt=None):
+            calls.append(system_prompt)
+            if len(calls) == 1:
+                return Result.err(sdk_error)
+            return Result.ok(success)
+
+        with patch.object(adapter, "_execute_single_request", side_effect=fake_execute):
+            result = await adapter._complete_with_transient_retry("test prompt", config, None)
+
+        assert result.is_ok
+        assert len(calls) == 2
+        assert "Respond with plain text only" in (calls[1] or "")
 
     @pytest.mark.asyncio
     async def test_explicit_allowed_tools_sets_visible_sdk_tools(self) -> None:


### PR DESCRIPTION
## Summary

Fixes #1537 and #1530 at their shared root: the interview question-generator's no-tools envelope was blamed for leaking, but empirical CLI checks show it is **already sealed on CLI 2.1.x** — the real failure is *phantom tool calls* the seal cannot prevent, which the adapter's fail-loud spy then turned into a deterministic abort.

## Empirical findings (CLI 2.1.198, local)

| Check | Result |
|---|---|
| `--allowedTools ""` alone + tool-tempting prompt | real tool use → `error_max_turns`, `num_turns=2` (reproduces #1537's CLI check exactly) |
| `--tools ""` + same prompt | tool-call attempt degrades to literal text → `num_turns=1`, success |
| Full adapter combo (`--tools ""` + `--allowedTools ""` + `--disallowedTools …`) | still sealed, success |

The adapter has forwarded `tools=[]` since #597 (`options_kwargs["tools"]`, present in v0.44.0), and every published `claude-agent-sdk` 0.2.87–0.2.110 forwards it as `--tools ""`. So the catalog is empty; a `ToolUseBlock` that arrives anyway (e.g. a non-Claude model behind an Anthropic-format proxy emitting `tool_use` with **no schema in the request**, as in #1537's environment) can never execute. No flag can prevent it — the fix is to stop treating unexecutable noise as an envelope leak.

## Changes

1. **Tool-less prompt pairing** (`authoring_handlers.py`) — a handler-constructed sealed adapter now uses the tool-less prompt variant (`suppress_tool_use_prompt_cues=True`, previously only the `ooo auto` path). The full socratic-interviewer prompt advertises tool use the subprocess doesn't have — matching #1537's observation that only the full prompt reproduces the failure. Injected adapters keep the caller's mode.
2. **Salvage** (`claude_code_adapter.py`) — a phantom `ToolUseBlock` followed by usable final text returns that text (structured `phantom_tool_use_salvaged` warning + `raw_response` marker) instead of discarding a good question.
3. **One recovery retry** (`claude_code_adapter.py`) — when no text streamed, exactly one retry with a hard plain-text-only cue before failing loud. The predicate is scoped to `allowed_tools=[]` adapters and covers the spy violation, `subtype=error_max_turns`, and the SDK's bare max-turns/error-result exception shapes — the `stop_reason=tool_use` loop from #1530 included.

Fail-loud is preserved: a phantom call with no recoverable text after recovery still errors with `ToolUseBlockViolation`, and the seal itself stays locked by the existing envelope wiring tests (`allowed_tools == [] / tools == [] / extra_args allowedTools == ""`).

**Deliberately not done:** rerouting question-gen to a chat-completion backend (#1537's option 2) — it breaks subscription-only plugin users and wouldn't help the proxy-model case anyway; and raising `max_turns` (#1530's suggestion / PR #1531) — the spy fires regardless of `max_turns`, so that only converts `error_max_turns` into `ToolUseBlockViolation` (see review note on #1531).

## Tests

- `test_empty_allowed_tools_phantom_tool_use_salvages_streamed_text` (replaces the unconditional-fail spy test with the new contract)
- `test_empty_allowed_tools_phantom_tool_use_without_text_fails_loud`
- `test_phantom_tool_use_error_grants_one_recovery_with_no_tools_cue` / `…_not_granted_without_sealed_envelope` / `…_covers_sdk_max_turns_exception_shape`
- `test_interview_toolless_prompt_wiring.py` (new wiring lock: sealed ⇒ tool-less prompt; injected adapter ⇒ caller's mode)
- 5 auto sub-interview isolation tests updated to the salvage contract (isolation still asserted via envelope kwargs)

`uv run pytest tests/unit/` — 10 755+ passed; remaining failures (`test_start_auto` 9, `test_auto_handler_ralph_runtime` 2, `test_surface` 4, `test_auto_runtime_dispatch` 1) all reproduce on clean `origin/main` (pre-existing env issues). `ruff format`/`check` and `mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)