### PR TITLE
fix(mcp): pair the injected sealed interview adapter with the tool-less prompt

### DIFF
--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1356,6 +1356,17 @@ def create_ouroboros_server(
     evaluation_llm_adapter = shared_stage_llm_adapter(evaluate_llm_backend)
     reflect_llm_adapter = shared_stage_llm_adapter(reflect_llm_backend)
 
+    # The shared interview adapter above is catalog-sealed for
+    # envelope-capable backends (``allowed_tools=[]`` → ``--tools ""``), so
+    # everything it is injected into must pair it with the tool-less prompt
+    # variant: the full socratic-interviewer prompt advertises tool use the
+    # subprocess cannot answer, which tempts phantom tool calls (#1537).
+    # The gate inside ``InterviewHandler`` only covers adapters the handler
+    # constructs itself — injected adapters need this wiring here.
+    interview_envelope_sealed = backend_supports_tool_envelope(
+        resolve_llm_backend(interview_llm_backend)
+    )
+
     # Create or use provided EventStore
     if event_store is None:
         from ouroboros.persistence.event_store import EventStore
@@ -1373,6 +1384,7 @@ def create_ouroboros_server(
         llm_adapter=llm_adapter,
         state_dir=state_dir_path,
         model=get_llm_model_for_role("interview", backend=interview_llm_backend),
+        suppress_tool_use_prompt_cues=interview_envelope_sealed,
     )
 
     seed_generator = SeedGenerator(
@@ -1823,6 +1835,7 @@ def create_ouroboros_server(
         llm_backend=interview_llm_backend,
         agent_runtime_backend=interview_runtime_backend,
         opencode_mode=opencode_mode,
+        suppress_tool_use_prompt_cues=interview_envelope_sealed,
     )
     generate_seed = GenerateSeedHandler(
         event_store=event_store,
@@ -1904,6 +1917,7 @@ def create_ouroboros_server(
             llm_backend=interview_llm_backend,
             agent_runtime_backend=interview_runtime_backend,
             opencode_mode=opencode_mode,
+            suppress_tool_use_prompt_cues=interview_envelope_sealed,
         ),
         PMInterviewHandler(
             data_dir=state_dir_path,

--- a/tests/unit/mcp/server/test_interview_prompt_mode_wiring.py
+++ b/tests/unit/mcp/server/test_interview_prompt_mode_wiring.py
@@ -1,0 +1,64 @@
+"""Wiring lock: the composition root pairs sealed adapters with the tool-less prompt.
+
+PR #1541 gates the tool-less prompt variant inside ``InterviewHandler`` on
+*handler-constructed* sealed adapters (``self.llm_adapter is None``). The MCP
+composition root, however, injects the shared stage adapter — which is
+catalog-sealed for envelope-capable backends (``allowed_tools=[]`` →
+``--tools ""``) — so without wiring here the plugin MCP path would keep
+sending the tool-advertising socratic-interviewer prompt into a subprocess
+that has no tools, reproducing the phantom tool calls of #1537.
+
+``create_ouroboros_server`` must therefore forward
+``suppress_tool_use_prompt_cues`` to the ``InterviewHandler`` it wires
+whenever the shared interview adapter is sealed, and must not force it when
+the backend has no tool envelope at all.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from ouroboros.mcp.server.adapter import create_ouroboros_server
+
+
+def _build_server() -> object:
+    with (
+        patch("ouroboros.providers.create_llm_adapter") as mock_create_llm_adapter,
+        patch("ouroboros.orchestrator.create_agent_runtime") as mock_create_runtime,
+    ):
+        mock_create_llm_adapter.return_value = MagicMock()
+        mock_create_runtime.return_value = MagicMock()
+        return create_ouroboros_server()
+
+
+def test_mcp_interview_handler_gets_toolless_prompt_for_sealed_envelope() -> None:
+    """Envelope-capable backend ⇒ injected-adapter handler suppresses tool cues."""
+    with patch(
+        "ouroboros.backends.backend_supports_tool_envelope",
+        return_value=True,
+    ):
+        server = _build_server()
+
+    handler = server._tool_handlers["ouroboros_interview"]
+    assert handler.suppress_tool_use_prompt_cues is True, (
+        "the composition root injects the sealed shared adapter into "
+        "InterviewHandler, so it must also select the tool-less prompt "
+        "variant — the handler's own gate only covers self-constructed "
+        "adapters (#1537 / PR #1541 follow-up)"
+    )
+
+
+def test_mcp_interview_handler_keeps_full_prompt_without_envelope() -> None:
+    """No tool envelope ⇒ the adapter is not sealed ⇒ keep the full prompt."""
+    with patch(
+        "ouroboros.backends.backend_supports_tool_envelope",
+        return_value=False,
+    ):
+        server = _build_server()
+
+    handler = server._tool_handlers["ouroboros_interview"]
+    assert handler.suppress_tool_use_prompt_cues is False, (
+        "backends without a tool envelope run un-sealed adapters; forcing the "
+        "tool-less prompt there would degrade brownfield question quality for "
+        "no safety gain"
+    )


### PR DESCRIPTION
## Summary

Follow-up to #1541 (#1537). Adversarial review of the merged fix found a wiring gap: the tool-less prompt pairing was gated on `self.llm_adapter is None` (handler-constructed adapters), but the MCP composition root **injects** the shared stage adapter into `InterviewHandler` — so on the actual plugin MCP path the gate never fired, and the tool-advertising socratic-interviewer prompt still reached the sealed subprocess. #1541's adapter-level salvage + recovery still applied (the abort is fixed); this closes the remaining *prevention* layer.

## Changes

- `create_ouroboros_server` computes `interview_envelope_sealed` (same condition that seals the shared adapter) and forwards `suppress_tool_use_prompt_cues` to both `InterviewHandler` wiring sites and the shared `InterviewEngine`.
- Non-envelope backends keep the full prompt — their adapters are not sealed, so the tool-less variant would only degrade question quality.
- New wiring lock `test_interview_prompt_mode_wiring.py` (sealed ⇒ suppressed; no envelope ⇒ full prompt).

Known sibling left out of scope: `PMInterviewHandler` has no prompt-mode field and closes its envelope separately.

## Verification

`tests/unit/mcp/` + `tests/integration/mcp/test_server_adapter.py` + `tests/unit/bigbang/` — 1,794 passed; the 11 failures are the documented pre-existing `test_start_auto`/`test_auto_handler_ralph_runtime` env issues (reproduce on clean main). `ruff`/`mypy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)