### PR TITLE
feat: emit sequential subagent contracts across providers

### DIFF
--- a/.claude-plugin/skills/interview/SKILL.md
+++ b/.claude-plugin/skills/interview/SKILL.md
@@ -172,14 +172,13 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    parent-session assist layer. The advisory exists to help the human answer;
    it must not hide, replace, or delay the question itself.
 
-   Run the advisory lanes in parallel using your host's native subagent
-   mechanism. In Claude Code that mechanism is the **Task/Agent tool** — spawn
-   one subagent per lane in a single batch so they run concurrently. In Codex,
-   explicitly start a native subagent workflow in natural language: spawn one
-   Codex subagent per lane, pass that lane's payload prompt, wait for all
-   agents, then synthesize. Only fall back to the request's
-   `sequential_fallback` semantics when the host has no subagent mechanism at
-   all. The standard lanes are:
+   Run the advisory lanes through your runtime's native subagent mechanism when
+   one exists. For Claude Code this is the Task/Agent tool; for Codex, explicitly
+   start a native subagent workflow in natural language. Spawn one subagent per
+   lane, pass that lane's payload prompt, wait for all agents, then synthesize.
+   If the runtime has no parallel primitive, process payloads sequentially per
+   `dispatch_mode="sequential"` and the request's `sequential_fallback`
+   semantics. The standard lanes are:
    - `code_context` — inspect repo-local facts and reuse
      `meta.code_investigation_request` when present.
    - `web_context` — browse/search only when current external facts genuinely
@@ -200,7 +199,9 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    and `context`, and dispatch every payload through your host's native subagent
    mechanism (Claude Code → one Task/Agent call per payload in one parallel
    batch; Codex → explicitly spawn one Codex subagent per payload, wait for all
-   results, then synthesize) instead of reconstructing prompts from prose. This
+   results, then synthesize; runtimes without a parallel primitive → process
+   payloads sequentially per `dispatch_mode="sequential"`) instead of
+   reconstructing prompts from prose. This
    is required regardless of dispatch mode: the payloads themselves are the
    spawn signal.
    Treat `meta.question_advisory_host_action=spawn_subagents`, when present, as

--- a/.claude-plugin/skills/unstuck/SKILL.md
+++ b/.claude-plugin/skills/unstuck/SKILL.md
@@ -110,7 +110,7 @@ Two pieces matter:
 Decoded, the body is JSON:
 
 ```json
-{"dispatch_mode": "inline_fallback", "persona_count": N, "payloads": [...]}
+{"dispatch_mode": "sequential", "legacy_dispatch_mode": "inline_fallback", "persona_count": N, "payloads": [...]}
 ```
 
 To recover: locate the substring between `<!-- ouroboros-lateral-inline-dispatch-v1 base64\n` and `\n-->` at the end of `content`, base64-decode it, then `JSON.parse`. (See `tests/unit/mcp/tools/test_lateral_think_handler.py::_extract_inline_dispatch` for the canonical extraction helper.)
@@ -134,7 +134,7 @@ If you expected plugin mode but the response is inline text (neither `_subagent`
 The handler ran the prompt builder internally and returned ready-to-use markdown:
 
 - Solo response: a single `# Lateral Thinking: <approach>` block followed by the reframing prompt.
-- Debate response (`dispatch_mode = "inline_fallback"`): N such blocks concatenated with `\n\n---\n\n` separators.
+- Debate response (`dispatch_mode = "sequential"`; `legacy_dispatch_mode = "inline_fallback"` may also be present): N such blocks concatenated with `\n\n---\n\n` separators.
 
 ##### Solo (any runtime)
 
@@ -158,6 +158,14 @@ Driving fan-out from this dispatch block — instead of from the joined human-di
 4. Wait for all N to return.
 5. (Optional) **Round 2 cross-attack** — only if Round 1 answers diverge meaningfully. Dispatch a second N-fan-out where each persona receives short summaries of the other answers and is asked: "Identify one weakness in each. ≤200 words." Skip if Round 1 already converges.
 6. Synthesize per the **Synthesize** block below.
+
+##### Debate, constrained runtime without sub-agent dispatch
+
+If the response is stamped with `dispatch_mode="sequential"` and the host has no
+native parallel primitive, process each payload in order. Correlate every result
+by `result_correlation_key` (normally `context.persona`), then synthesize after
+the last payload. Treat `legacy_dispatch_mode="inline_fallback"` as compatibility
+metadata only; do not use it to override the canonical sequential contract.
 
 ##### Debate, runtime cannot dispatch sub-agents (constrained subprocess, no Task surface)
 

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -172,14 +172,13 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    parent-session assist layer. The advisory exists to help the human answer;
    it must not hide, replace, or delay the question itself.
 
-   Run the advisory lanes in parallel using your host's native subagent
-   mechanism. In Claude Code that mechanism is the **Task/Agent tool** — spawn
-   one subagent per lane in a single batch so they run concurrently. In Codex,
-   explicitly start a native subagent workflow in natural language: spawn one
-   Codex subagent per lane, pass that lane's payload prompt, wait for all
-   agents, then synthesize. Only fall back to the request's
-   `sequential_fallback` semantics when the host has no subagent mechanism at
-   all. The standard lanes are:
+   Run the advisory lanes through your runtime's native subagent mechanism when
+   one exists. For Claude Code this is the Task/Agent tool; for Codex, explicitly
+   start a native subagent workflow in natural language. Spawn one subagent per
+   lane, pass that lane's payload prompt, wait for all agents, then synthesize.
+   If the runtime has no parallel primitive, process payloads sequentially per
+   `dispatch_mode="sequential"` and the request's `sequential_fallback`
+   semantics. The standard lanes are:
    - `code_context` — inspect repo-local facts and reuse
      `meta.code_investigation_request` when present.
    - `web_context` — browse/search only when current external facts genuinely
@@ -200,7 +199,9 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    and `context`, and dispatch every payload through your host's native subagent
    mechanism (Claude Code → one Task/Agent call per payload in one parallel
    batch; Codex → explicitly spawn one Codex subagent per payload, wait for all
-   results, then synthesize) instead of reconstructing prompts from prose. This
+   results, then synthesize; runtimes without a parallel primitive → process
+   payloads sequentially per `dispatch_mode="sequential"`) instead of
+   reconstructing prompts from prose. This
    is required regardless of dispatch mode: the payloads themselves are the
    spawn signal.
    Treat `meta.question_advisory_host_action=spawn_subagents`, when present, as

--- a/skills/unstuck/SKILL.md
+++ b/skills/unstuck/SKILL.md
@@ -110,7 +110,7 @@ Two pieces matter:
 Decoded, the body is JSON:
 
 ```json
-{"dispatch_mode": "inline_fallback", "persona_count": N, "payloads": [...]}
+{"dispatch_mode": "sequential", "legacy_dispatch_mode": "inline_fallback", "persona_count": N, "payloads": [...]}
 ```
 
 To recover: locate the substring between `<!-- ouroboros-lateral-inline-dispatch-v1 base64\n` and `\n-->` at the end of `content`, base64-decode it, then `JSON.parse`. (See `tests/unit/mcp/tools/test_lateral_think_handler.py::_extract_inline_dispatch` for the canonical extraction helper.)
@@ -134,7 +134,7 @@ If you expected plugin mode but the response is inline text (neither `_subagent`
 The handler ran the prompt builder internally and returned ready-to-use markdown:
 
 - Solo response: a single `# Lateral Thinking: <approach>` block followed by the reframing prompt.
-- Debate response (`dispatch_mode = "inline_fallback"`): N such blocks concatenated with `\n\n---\n\n` separators.
+- Debate response (`dispatch_mode = "sequential"`; `legacy_dispatch_mode = "inline_fallback"` may also be present): N such blocks concatenated with `\n\n---\n\n` separators.
 
 ##### Solo (any runtime)
 
@@ -158,6 +158,14 @@ Driving fan-out from this dispatch block — instead of from the joined human-di
 4. Wait for all N to return.
 5. (Optional) **Round 2 cross-attack** — only if Round 1 answers diverge meaningfully. Dispatch a second N-fan-out where each persona receives short summaries of the other answers and is asked: "Identify one weakness in each. ≤200 words." Skip if Round 1 already converges.
 6. Synthesize per the **Synthesize** block below.
+
+##### Debate, constrained runtime without sub-agent dispatch
+
+If the response is stamped with `dispatch_mode="sequential"` and the host has no
+native parallel primitive, process each payload in order. Correlate every result
+by `result_correlation_key` (normally `context.persona`), then synthesize after
+the last payload. Treat `legacy_dispatch_mode="inline_fallback"` as compatibility
+metadata only; do not use it to override the canonical sequential contract.
 
 ##### Debate, runtime cannot dispatch sub-agents (constrained subprocess, no Task surface)
 

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -307,10 +307,24 @@ _GENERIC_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
         name="restate_goal",
         guidance="Restate the goal and require explicit approval before irreversible workflow transitions such as seed generation.",
     ),
+    SkillExecutionCapability(
+        name="orchestrate_subagents",
+        guidance=(
+            "Process each payload in order. Correlate results by the key named "
+            "in `result_correlation_key`. Synthesize after the last payload."
+        ),
+    ),
+)
+_GENERIC_SKILL_EXECUTION_CAPABILITIES_WITHOUT_SUBAGENTS: tuple[SkillExecutionCapability, ...] = (
+    tuple(
+        capability
+        for capability in _GENERIC_SKILL_EXECUTION_CAPABILITIES
+        if capability.name != "orchestrate_subagents"
+    )
 )
 
 _CLAUDE_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
-    *_GENERIC_SKILL_EXECUTION_CAPABILITIES,
+    *_GENERIC_SKILL_EXECUTION_CAPABILITIES_WITHOUT_SUBAGENTS,
     SkillExecutionCapability(
         name="orchestrate_subagents",
         guidance=(
@@ -329,7 +343,7 @@ _CLAUDE_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
 )
 
 _OPENCODE_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
-    *_GENERIC_SKILL_EXECUTION_CAPABILITIES,
+    *_GENERIC_SKILL_EXECUTION_CAPABILITIES_WITHOUT_SUBAGENTS,
     SkillExecutionCapability(
         name="orchestrate_subagents",
         guidance=(
@@ -466,6 +480,7 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         cli_name="goose",
         cli_config_key="goose_cli_path",
         soft_tool_enforcement=True,
+        skill_execution_capabilities=_GENERIC_SKILL_EXECUTION_CAPABILITIES,
     ),
     BackendCapability(
         name="pi",
@@ -647,10 +662,10 @@ def build_runtime_subagent_orchestration_contract(
     determines whether native parallel subagent dispatch can be used or whether
     the declared sequential fallback must be followed.
     """
-    capability = get_backend_capability(name)
+    normalized_name = name.strip().lower()
+    capability = get_backend_capability(normalized_name)
     if capability is None:
-        msg = f"Unsupported backend: {name.strip().lower()}"
-        raise ValueError(msg)
+        capability = BackendCapability(name=normalized_name or "unknown")
 
     sequential_fallback = directive_metadata.get("sequential_fallback", {})
     if not isinstance(sequential_fallback, Mapping):

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -17,7 +17,10 @@ import structlog
 import yaml
 
 from ouroboros.auto.intent_guard import IntentGuardReport, IntentGuardStatus, guard_interview_turn
-from ouroboros.backends import backend_supports_tool_envelope
+from ouroboros.backends import (
+    backend_supports_tool_envelope,
+    build_runtime_subagent_orchestration_contract,
+)
 from ouroboros.bigbang.ambiguity import (
     AMBIGUITY_THRESHOLD,
     AUTO_COMPLETE_STREAK_REQUIRED,
@@ -506,6 +509,7 @@ def _build_interview_lateral_review_orchestration(
             "panel_id": str(panel.get("panel_id") or "lateral_persona_panel.v1"),
             "mcp_tool": mcp_tool,
             "dispatch_modes": list(panel.get("dispatch_modes", [])),
+            "legacy_dispatch_modes": list(panel.get("legacy_dispatch_modes", [])),
             "parallel_preference": str(
                 panel.get("parallel_preference") or "parallel_when_runtime_supports_subagents"
             ),
@@ -699,6 +703,8 @@ def _attach_question_assist_requests(
     score: AmbiguityScore | None,
     last_question: str | None = None,
     dispatch_mode: SubagentDispatchMode = SubagentDispatchMode.SEQUENTIAL,
+    runtime_backend: str | None = None,
+    opencode_mode: str | None = None,
 ) -> None:
     """Attach code-fact and advisory fanout requests for a question turn.
 
@@ -735,11 +741,30 @@ def _attach_question_assist_requests(
         return
     meta["question_advisory_subagents"] = [payload.to_dict() for payload in advisory_payloads]
     meta["question_advisory_preserve_content"] = True
+    contract_backend = runtime_backend
+    if not contract_backend:
+        contract_backend = (
+            "codex"
+            if dispatch_mode is SubagentDispatchMode.HOST_DRIVEN
+            else "opencode"
+            if dispatch_mode is SubagentDispatchMode.PLUGIN_PASSIVE
+            else "gemini"
+        )
+    contract = build_runtime_subagent_orchestration_contract(
+        contract_backend,
+        directive_metadata=advisory_request,
+        opencode_mode=opencode_mode,
+    )
+    meta["subagent_orchestration_instruction"] = contract.runtime_instruction_handling
     if dispatch_mode is SubagentDispatchMode.HOST_DRIVEN:
         meta["question_advisory_dispatch_mode"] = "host_driven"
         meta["question_advisory_host_action"] = "spawn_subagents"
         # Advisory lanes are keyed by lane_id; their persona is absent on some
         # lanes (code_context, web_context), so correlate by lane_id, not persona.
+        meta["question_advisory_result_correlation_key"] = "context.lane_id"
+    elif dispatch_mode is SubagentDispatchMode.SEQUENTIAL:
+        meta["question_advisory_dispatch_mode"] = "sequential"
+        meta["question_advisory_host_action"] = "process_payloads_sequentially"
         meta["question_advisory_result_correlation_key"] = "context.lane_id"
 
 
@@ -2526,6 +2551,8 @@ class InterviewHandler:
                         dispatch_mode=resolve_subagent_dispatch(
                             self.agent_runtime_backend, self.opencode_mode
                         ),
+                        runtime_backend=self.agent_runtime_backend,
+                        opencode_mode=self.opencode_mode,
                     )
 
                 start_response_text = (
@@ -2621,6 +2648,8 @@ class InterviewHandler:
                             dispatch_mode=resolve_subagent_dispatch(
                                 self.agent_runtime_backend, self.opencode_mode
                             ),
+                            runtime_backend=self.agent_runtime_backend,
+                            opencode_mode=self.opencode_mode,
                         )
 
                     resume_response_text = f"Session {session_id}\n\n{display_question}"
@@ -3173,6 +3202,8 @@ class InterviewHandler:
                         dispatch_mode=resolve_subagent_dispatch(
                             self.agent_runtime_backend, self.opencode_mode
                         ),
+                        runtime_backend=self.agent_runtime_backend,
+                        opencode_mode=self.opencode_mode,
                     )
 
                 if lateral_review_dispatch_meta is not None:

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError as PydanticValidationError
 import structlog
 import yaml
 
+from ouroboros.backends import build_runtime_subagent_orchestration_contract
 from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
 from ouroboros.core.errors import ValidationError
 from ouroboros.core.project_paths import resolve_path_against_base, resolve_seed_project_path
@@ -1307,7 +1308,8 @@ class LateralThinkHandler(BridgeAwareMixin):
       ``dispatch_mode=host_driven`` / ``host_action=spawn_subagents`` so the
       host fans out via its native primitive.
     - ``SEQUENTIAL`` (subprocess / runtimes without a parallel primitive): fall
-      back to a plain inline multi-persona ``inline_fallback`` text response.
+      back to a plain inline multi-persona ``sequential`` text response
+      (`inline_fallback` is preserved as a legacy alias in metadata).
 
     Attributes:
         agent_runtime_backend: Configured runtime (e.g. ``"opencode"``).
@@ -1464,6 +1466,7 @@ class LateralThinkHandler(BridgeAwareMixin):
                 SubagentDispatchMode,
                 build_lateral_multi_subagent,
                 build_multi_subagent_result,
+                lateral_persona_panel_metadata_from_capability_definitions,
                 resolve_subagent_dispatch,
             )
 
@@ -1539,7 +1542,7 @@ class LateralThinkHandler(BridgeAwareMixin):
                     },
                 )
 
-            # --- Inline fallback: concatenate persona prompts ---
+            # --- Inline/sequential fallback: concatenate persona prompts ---
             thinker = LateralThinker()
             sections: list[str] = []
             for p_str in personas_list:
@@ -1586,25 +1589,33 @@ class LateralThinkHandler(BridgeAwareMixin):
             #   2. Base64 has no significant whitespace, so line wrapping
             #      and trimming can't corrupt the encoded body.
             # HOST_DRIVEN runtimes (e.g. Codex) have no passive bridge but can
-            # spawn subagents themselves. Stamp the response with an explicit
-            # ``dispatch_mode=host_driven`` / ``host_action=spawn_subagents``
-            # signal — in structured ``meta`` (primary) and a visible banner
-            # (so meta-dropping transports still get a deterministic cue) — so
-            # the host's capability guide fans out instead of reading inline.
-            # SEQUENTIAL runtimes keep the byte-identical ``inline_fallback``
-            # output they emitted before.
+            # spawn subagents themselves. SEQUENTIAL runtimes now get the same
+            # machine-readable contract vocabulary, while preserving
+            # ``inline_fallback`` as a legacy alias for older skill prose.
             host_driven = dispatch is SubagentDispatchMode.HOST_DRIVEN
-            dispatch_mode_value = "host_driven" if host_driven else "inline_fallback"
+            dispatch_mode_value = "host_driven" if host_driven else "sequential"
             payload_dicts = [p.to_dict() for p in payloads]
+            panel_metadata = lateral_persona_panel_metadata_from_capability_definitions()
+            contract_backend = self.agent_runtime_backend
+            if not contract_backend:
+                contract_backend = "codex" if host_driven else "gemini"
+            contract = build_runtime_subagent_orchestration_contract(
+                contract_backend,
+                directive_metadata=panel_metadata,
+                opencode_mode=self.opencode_mode,
+            )
             dispatch_record: dict[str, Any] = {
                 "dispatch_mode": dispatch_mode_value,
                 "persona_count": len(sections),
                 "payloads": payload_dicts,
+                "result_correlation_key": "context.persona",
+                "subagent_orchestration_instruction": contract.runtime_instruction_handling,
             }
             if host_driven:
                 dispatch_record["host_action"] = "spawn_subagents"
-                # Lateral payloads are keyed by persona (always set, one per lane).
-                dispatch_record["result_correlation_key"] = "context.persona"
+            else:
+                dispatch_record["host_action"] = "process_payloads_sequentially"
+                dispatch_record["legacy_dispatch_mode"] = "inline_fallback"
             dispatch_blob = json.dumps(dispatch_record)
             dispatch_b64 = base64.b64encode(dispatch_blob.encode("utf-8")).decode("ascii")
             host_banner = (

--- a/src/ouroboros/orchestrator/capabilities.py
+++ b/src/ouroboros/orchestrator/capabilities.py
@@ -153,6 +153,7 @@ class LateralPersonaPanelMetadata:
     request_model_schema: Mapping[str, Any]
     response_payload_refs: Mapping[str, Any]
     runtime_instruction: str
+    legacy_dispatch_modes: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to JSON-safe capability metadata."""
@@ -160,6 +161,7 @@ class LateralPersonaPanelMetadata:
             "panel_id": self.panel_id,
             "mcp_tool": self.mcp_tool,
             "dispatch_modes": list(self.dispatch_modes),
+            "legacy_dispatch_modes": list(self.legacy_dispatch_modes),
             "parallel_preference": self.parallel_preference,
             "sequential_fallback": dict(self.sequential_fallback),
             "personas": [persona.to_dict() for persona in self.personas],
@@ -2752,7 +2754,8 @@ def _lateral_persona_panel_metadata() -> LateralPersonaPanelMetadata:
     return LateralPersonaPanelMetadata(
         panel_id="lateral_persona_panel.v1",
         mcp_tool="ouroboros_lateral_think",
-        dispatch_modes=("plugin", "inline_fallback"),
+        dispatch_modes=("plugin", "sequential"),
+        legacy_dispatch_modes=("inline_fallback",),
         parallel_preference="parallel_when_runtime_supports_subagents",
         sequential_fallback={
             "supported": True,
@@ -2789,10 +2792,11 @@ def _lateral_persona_panel_metadata() -> LateralPersonaPanelMetadata:
         },
         runtime_instruction=(
             "Call ouroboros_lateral_think first. If the response delegates via "
-            "_subagents, consume those payloads. If it returns inline_fallback "
-            "and the runtime has a native subagent primitive, dispatch each "
-            "structured payload by context.persona; otherwise process those "
-            "payloads sequentially."
+            "_subagents, consume those payloads. If it returns sequential "
+            "payload metadata and the runtime has a native subagent primitive, "
+            "dispatch each structured payload by context.persona; otherwise "
+            "process those payloads sequentially. Treat inline_fallback as a "
+            "legacy alias for sequential."
         ),
     )
 

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -190,6 +190,7 @@ def test_claude_host_driven_subagent_orchestration_is_registry_owned() -> None:
 
     guide = render_backend_skill_capability_guide("claude")
     assert "### When a skill requires `orchestrate_subagents`" in guide
+    assert guide.count("### When a skill requires `orchestrate_subagents`") == 1
     assert "Task/Agent" in guide
     assert "host_action=spawn_subagents" in guide
     assert "question_advisory_subagents" in guide
@@ -205,6 +206,7 @@ def test_native_parallel_subagent_runtime_exposes_orchestrate_subagents() -> Non
 
     guide = render_backend_skill_capability_guide("opencode")
     assert "### When a skill requires `orchestrate_subagents`" in guide
+    assert guide.count("### When a skill requires `orchestrate_subagents`") == 1
     assert "native task/subagent primitive" in guide
     assert "`_subagents` MCP directive payloads" in guide
     assert "sequential fallback" in guide
@@ -234,6 +236,21 @@ def test_unsupported_parallel_subagent_runtime_gets_sequential_fallback_contract
     assert contract.to_dict()["sequential_fallback"] == dict(
         _LATERAL_PANEL_DIRECTIVE_METADATA["sequential_fallback"]
     )
+
+
+def test_unknown_subagent_runtime_gets_sequential_fallback_contract() -> None:
+    contract = build_runtime_subagent_orchestration_contract(
+        "custom-runtime",
+        directive_metadata=_LATERAL_PANEL_DIRECTIVE_METADATA,
+    )
+
+    assert contract.backend_name == "custom-runtime"
+    assert contract.supports_native_parallel_subagents is False
+    assert contract.dispatch_mode == "sequential"
+    assert (
+        contract.spawn_trigger_mechanism == SubagentSpawnTriggerMechanism.SEQUENTIAL_FALLBACK.value
+    )
+    assert "no native parallel subagent primitive" in contract.runtime_instruction_handling
 
 
 @pytest.mark.parametrize(
@@ -406,12 +423,31 @@ def test_renders_codex_skill_capability_guide_as_stable_markdown() -> None:
 
 
 def test_renders_generic_skill_capability_guides_for_runtime_backends() -> None:
-    for backend_name in ("hermes", "claude", "opencode", "gemini", "kiro", "copilot", "pi", "gjc"):
+    for backend_name in (
+        "hermes",
+        "claude",
+        "opencode",
+        "gemini",
+        "kiro",
+        "copilot",
+        "goose",
+        "pi",
+        "gjc",
+    ):
+        capability = get_backend_capability(backend_name)
+        assert capability is not None
+        names = [item.name for item in capability.skill_execution_capabilities]
+        assert len(names) == len(set(names))
+
         guide = render_backend_skill_capability_guide(backend_name)
 
         assert guide.startswith(f"## Ouroboros Skill Capability Guide: {backend_name.title()}\n")
         for capability_name in REQUIRED_SKILL_CAPABILITY_NAMES:
             assert f"### When a skill requires `{capability_name}`" in guide
+        assert "### When a skill requires `orchestrate_subagents`" in guide
+        assert guide.count("### When a skill requires `orchestrate_subagents`") == 1
+        if backend_name not in {"claude", "opencode"}:
+            assert "Process each payload in order" in guide
 
 
 def test_resolve_tool_discovery_maps_each_runtime_to_its_mechanism() -> None:

--- a/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
+++ b/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
@@ -8,9 +8,11 @@ from ouroboros.core.types import Result
 from ouroboros.events.interview import interview_lateral_review_recommended
 from ouroboros.mcp.tools.authoring_handlers import (
     InterviewHandler,
+    _attach_question_assist_requests,
     _build_interview_lateral_review_orchestration,
     _maybe_record_lateral_review_advisory,
 )
+from ouroboros.mcp.tools.subagent import SubagentDispatchMode
 
 
 def _score(value: float) -> AmbiguityScore:
@@ -208,7 +210,8 @@ async def test_handler_surfaces_runnable_lateral_review_dispatch() -> None:
     panel = orchestration["panel"]
     assert panel["panel_id"] == "lateral_persona_panel.v1"
     assert panel["mcp_tool"] == "ouroboros_lateral_think"
-    assert panel["dispatch_modes"] == ["plugin", "inline_fallback"]
+    assert panel["dispatch_modes"] == ["plugin", "sequential"]
+    assert panel["legacy_dispatch_modes"] == ["inline_fallback"]
     assert panel["parallel_preference"] == "parallel_when_runtime_supports_subagents"
     assert panel["sequential_fallback"] == {
         "supported": True,
@@ -222,6 +225,7 @@ async def test_handler_surfaces_runnable_lateral_review_dispatch() -> None:
     ]
     assert panel["response_payload_refs"]["requires_prose_parsing"] is False
     assert "structured payload" in panel["runtime_instruction"]
+    assert "legacy alias" in panel["runtime_instruction"]
 
     runtime_handling = orchestration["runtime_handling"]
     assert runtime_handling == {
@@ -323,6 +327,30 @@ async def test_advisory_fanout_is_host_driven_stamped_on_codex_runtime() -> None
     assert meta["question_advisory_host_action"] == "spawn_subagents"
     # Advisory lanes correlate by lane_id (persona is None on some lanes).
     assert meta["question_advisory_result_correlation_key"] == "context.lane_id"
+    assert "subagent_orchestration_instruction" in meta
+
+
+def test_question_advisory_sequential_runtime_emits_processing_contract() -> None:
+    meta: dict[str, object] = {}
+
+    _attach_question_assist_requests(
+        meta,
+        session_id="sess-sequential",
+        question="What constraint remains?",
+        phase="answer",
+        score=_score(0.35),
+        dispatch_mode=SubagentDispatchMode.SEQUENTIAL,
+        runtime_backend="gemini",
+    )
+
+    assert len(meta["question_advisory_subagents"]) == 5
+    assert meta["question_advisory_dispatch_mode"] == "sequential"
+    assert meta["question_advisory_host_action"] == "process_payloads_sequentially"
+    assert meta["question_advisory_result_correlation_key"] == "context.lane_id"
+    assert (
+        "process each structured subagent payload sequentially"
+        in (meta["subagent_orchestration_instruction"])
+    )
 
 
 def test_lateral_orchestration_falls_back_to_skill_prose_when_panel_metadata_absent() -> None:

--- a/tests/unit/mcp/tools/test_lateral_think_handler.py
+++ b/tests/unit/mcp/tools/test_lateral_think_handler.py
@@ -404,7 +404,7 @@ async def test_inline_lateral_content_converts_to_sequential_persona_panel_entri
     assert panel["execution_mode"] == "sequential_persona_payload_dispatch"
     assert panel["requires_prose_parsing"] is False
     assert [entry["persona_id"] for entry in entries] == ["researcher", "simplifier"]
-    assert {entry["dispatch_mode"] for entry in entries} == {"inline_fallback"}
+    assert {entry["dispatch_mode"] for entry in entries} == {"sequential"}
     assert {entry["response_payload_source"] for entry in entries} == {"inline_content"}
     assert {entry["execution_mode"] for entry in entries} == {"sequential_persona_payload_dispatch"}
     assert all(entry["sequential_fallback_used"] is True for entry in entries)
@@ -685,7 +685,10 @@ async def test_multi_persona_subprocess_mode_falls_back_inline() -> None:
     assert payload.meta is not None
     # No envelope in the subprocess fallback path.
     assert "_subagents" not in (payload.meta or {})
-    assert payload.meta.get("dispatch_mode") == "inline_fallback"
+    assert payload.meta.get("dispatch_mode") == "sequential"
+    assert payload.meta.get("legacy_dispatch_mode") == "inline_fallback"
+    assert payload.meta.get("host_action") == "process_payloads_sequentially"
+    assert payload.meta.get("result_correlation_key") == "context.persona"
     assert payload.meta.get("persona_count") == 2
     text = payload.content[0].text
     # Each persona section is separated by the canonical delimiter.
@@ -712,7 +715,10 @@ async def test_multi_persona_non_opencode_runtime_falls_back_inline() -> None:
     assert result.is_ok, result
     payload = result.unwrap()
     assert "_subagents" not in (payload.meta or {})
-    assert payload.meta.get("dispatch_mode") == "inline_fallback"
+    assert payload.meta.get("dispatch_mode") == "sequential"
+    assert payload.meta.get("legacy_dispatch_mode") == "inline_fallback"
+    assert payload.meta.get("host_action") == "process_payloads_sequentially"
+    assert payload.meta.get("result_correlation_key") == "context.persona"
     # persona='all' expands to every ThinkingPersona (5).
     assert payload.meta.get("persona_count") == 5
 
@@ -802,7 +808,8 @@ async def test_personas_list_takes_precedence_over_blank_persona() -> None:
 
     assert result.is_ok, result
     payload = result.unwrap()
-    assert payload.meta.get("dispatch_mode") == "inline_fallback"
+    assert payload.meta.get("dispatch_mode") == "sequential"
+    assert payload.meta.get("legacy_dispatch_mode") == "inline_fallback"
     assert payload.meta.get("persona_count") == 2
 
 
@@ -891,7 +898,7 @@ def _extract_inline_dispatch(content_text: str) -> dict:
 
 
 @pytest.mark.asyncio
-async def test_inline_fallback_carries_dispatch_block_in_content() -> None:
+async def test_sequential_dispatch_carries_dispatch_block_in_content() -> None:
     """Non-plugin debate response embeds canonical payloads in ``content``."""
     handler = LateralThinkHandler(
         agent_runtime_backend="gemini",
@@ -917,7 +924,10 @@ async def test_inline_fallback_carries_dispatch_block_in_content() -> None:
     # The dispatch block survives transport and decodes to canonical
     # structured payloads (one per requested persona).
     dispatch = _extract_inline_dispatch(text)
-    assert dispatch["dispatch_mode"] == "inline_fallback"
+    assert dispatch["dispatch_mode"] == "sequential"
+    assert dispatch["legacy_dispatch_mode"] == "inline_fallback"
+    assert dispatch["host_action"] == "process_payloads_sequentially"
+    assert dispatch["result_correlation_key"] == "context.persona"
     assert dispatch["persona_count"] == 2
     payloads = dispatch["payloads"]
     assert len(payloads) == 2
@@ -934,7 +944,7 @@ async def test_inline_fallback_carries_dispatch_block_in_content() -> None:
 
 
 @pytest.mark.asyncio
-async def test_inline_fallback_dispatch_survives_html_close_in_user_context() -> None:
+async def test_sequential_dispatch_survives_html_close_in_user_context() -> None:
     """User context containing ``-->`` cannot prematurely close the comment.
 
     The dispatch JSON is base64-encoded inside the HTML comment exactly so
@@ -985,7 +995,8 @@ async def test_inline_fallback_dispatch_survives_html_close_in_user_context() ->
     # adversarial `problem_context`/`current_approach` verbatim — no
     # corruption from the encoding round-trip.
     dispatch = _extract_inline_dispatch(text)
-    assert dispatch["dispatch_mode"] == "inline_fallback"
+    assert dispatch["dispatch_mode"] == "sequential"
+    assert dispatch["legacy_dispatch_mode"] == "inline_fallback"
     assert dispatch["persona_count"] == 2
     for persona_payload in dispatch["payloads"]:
         ctx = persona_payload["context"]

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -4542,7 +4542,8 @@ def test_lateral_persona_panel_metadata_is_structured_without_prose_parsing() ->
     panel = lateral.metadata.orchestration["lateral_panel"]
     assert panel["panel_id"] == "lateral_persona_panel.v1"
     assert panel["mcp_tool"] == "ouroboros_lateral_think"
-    assert panel["dispatch_modes"] == ["plugin", "inline_fallback"]
+    assert panel["dispatch_modes"] == ["plugin", "sequential"]
+    assert panel["legacy_dispatch_modes"] == ["inline_fallback"]
     assert panel["parallel_preference"] == "parallel_when_runtime_supports_subagents"
     assert panel["sequential_fallback"] == {
         "supported": True,

--- a/tests/unit/test_claude_plugin_skill_guide.py
+++ b/tests/unit/test_claude_plugin_skill_guide.py
@@ -18,8 +18,11 @@ def test_claude_plugin_interview_skill_includes_lateral_review_dispatch() -> Non
     skill_text = skill_path.read_text(encoding="utf-8")
 
     assert "question_advisory_subagents` is present you MUST fan out" in skill_text
+    assert "Run the advisory lanes through your runtime's native subagent mechanism" in skill_text
     assert "Task/Agent" in skill_text
     assert "spawn one Codex subagent per payload" in skill_text
+    assert "runtimes without a parallel primitive" in skill_text
+    assert 'dispatch_mode="sequential"' in skill_text
     assert "a reinforcing cue for host-driven runtimes" in skill_text
     assert "as a prerequisite" in skill_text
     assert "`run_lateral_review`" in skill_text
@@ -27,3 +30,22 @@ def test_claude_plugin_interview_skill_includes_lateral_review_dispatch() -> Non
     assert "meta.lateral_review_tool_args" in skill_text
     assert "required lightweight subagent review" in skill_text
     assert "Main-session direct-answer assistance" in skill_text
+
+
+def test_claude_plugin_unstuck_skill_includes_sequential_dispatch_contract() -> None:
+    skill_path = Path(".claude-plugin") / "skills" / "unstuck" / "SKILL.md"
+    skill_text = skill_path.read_text(encoding="utf-8")
+
+    assert (
+        '{"dispatch_mode": "sequential", "legacy_dispatch_mode": "inline_fallback", '
+        '"persona_count": N, "payloads": [...]}'
+    ) in skill_text
+    assert (
+        'Debate response (`dispatch_mode = "sequential"`; '
+        '`legacy_dispatch_mode = "inline_fallback"` may also be present)'
+    ) in skill_text
+    assert "##### Debate, constrained runtime without sub-agent dispatch" in skill_text
+    assert 'dispatch_mode="sequential"' in skill_text
+    assert "result_correlation_key" in skill_text
+    assert 'legacy_dispatch_mode="inline_fallback"` as compatibility' in skill_text
+    assert 'Debate response (`dispatch_mode = "inline_fallback"`)' not in skill_text


### PR DESCRIPTION
## Summary
- Implements PR-C from the July roadmap: sequential runtimes now receive first-class in-band subagent orchestration contracts.
- Adds SSOT contract usage in interview advisory and lateral dispatch paths, with `inline_fallback` preserved only as legacy compatibility metadata.
- Updates provider capability guides and shipped skill artifacts so generic, Goose, Claude, OpenCode, and plugin docs expose coherent orchestration guidance.

## Changes
- Added sequential `dispatch_mode`, `host_action=process_payloads_sequentially`, and result correlation metadata for interview advisory and lateral fan-out.
- Emits `subagent_orchestration_instruction` from `build_runtime_subagent_orchestration_contract` in both stamping paths.
- Adds generic/goose `orchestrate_subagents` guidance and de-duplicates provider-specific Claude/OpenCode guide sections.
- Makes unknown/custom runtime orchestration contracts fall back to sequential, matching resolver behavior.
- Syncs PR-C dispatch contract language into `.claude-plugin` skill artifacts.
- Extends tests for sequential metadata, legacy alias behavior, guide rendering, plugin artifacts, and contract fallback.

## Validation
- 5/5 senior subagent approvals before push/PR: Curie, Bacon, Erdos, Euler, Rawls.
- `git diff --check origin/main...HEAD`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/`
- `uv run pytest tests/unit/backends/test_capabilities.py tests/unit/orchestrator/test_capabilities.py tests/unit/mcp/tools/test_interview_lateral_review_advisory.py tests/unit/mcp/tools/test_lateral_think_handler.py tests/unit/skills/test_skill_artifacts.py tests/unit/test_claude_plugin_skill_guide.py tests/unit/mcp/server/test_interview_prompt_mode_wiring.py -q` → 253 passed

## Notes
- Full non-e2e currently has 17 auto/opencode handoff failures outside PR-C. The same 17 nodeids fail on latest `origin/main` in a detached worktree, so they are documented as baseline failures rather than PR-C regressions.