### PR TITLE
feat(orchestrator): verify-by-default — AC success contracts, orchestrator-run verify gate, retry, fat-harness ON

### DIFF
--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -421,33 +421,28 @@ def _load_skip_completed_markers(
 def _resolve_fat_harness_mode(seed_data: dict[str, Any]) -> bool:
     """Resolve the fresh-run fat-harness selector.
 
-    Fat-harness acceptance is opt-in until the shipped authoring/QA pipeline can
-    reliably produce profile-compatible typed evidence for every AC. Seeds that
-    request ``seed.orchestrator.execution_mode: fat_harness`` keep the stricter
-    verifier-gated path; missing/blank selectors use the legacy runner.
+    Verify-by-default: ``ooo run`` enforces typed evidence plus a verifier PASS
+    at AC acceptance unless the seed explicitly opts out with
+    ``seed.orchestrator.execution_mode: legacy``. Missing/blank selectors and an
+    explicit ``fat_harness`` selector both enable the stricter path.
     """
     orchestrator_config = seed_data.get("orchestrator")
     if not isinstance(orchestrator_config, dict):
-        return False
+        return True
 
     execution_mode = orchestrator_config.get("execution_mode")
+    if execution_mode in (None, "", "fat_harness"):
+        return True
     if execution_mode == "legacy":
-        print_error(
-            "seed.orchestrator.execution_mode='legacy' was removed after #978 P5; "
-            "omit the selector for the default runner or set execution_mode='fat_harness' "
-            "to opt in to typed evidence plus verifier PASS acceptance."
-        )
-        raise typer.Exit(1)
-    if execution_mode in (None, ""):
+        # Explicit opt-out of verify-by-default: fall back to the self-report
+        # runner. This is the supported escape hatch, not an error.
         return False
-    if execution_mode != "fat_harness":
-        print_error(
-            "seed.orchestrator.execution_mode must be 'fat_harness' when set "
-            f"(got {execution_mode!r})."
-        )
-        raise typer.Exit(1)
 
-    return True
+    print_error(
+        "seed.orchestrator.execution_mode must be 'fat_harness' or 'legacy' when set "
+        f"(got {execution_mode!r})."
+    )
+    raise typer.Exit(1)
 
 
 def _resolve_resume_fat_harness_mode(
@@ -456,19 +451,19 @@ def _resolve_resume_fat_harness_mode(
 ) -> bool:
     """Resolve resume acceptance mode from persisted contract with safe migration.
 
-    New sessions persist ``fat_harness_mode`` at prepare time. Historical
-    sessions may not have that field, so only an explicit ``fat_harness``
-    selector resumes with verifier-gated typed-evidence enforcement;
-    unknown/missing state falls back to the default runner.
+    New sessions persist ``fat_harness_mode`` at prepare time and that durable
+    value always wins. Sessions without a persisted contract resume with
+    verify-by-default enabled unless the seed explicitly opts out with
+    ``execution_mode: legacy``.
     """
     persisted = progress.get("fat_harness_mode")
     if isinstance(persisted, bool):
         return persisted
 
     orchestrator_config = seed_data.get("orchestrator")
-    return (
+    return not (
         isinstance(orchestrator_config, dict)
-        and orchestrator_config.get("execution_mode") == "fat_harness"
+        and orchestrator_config.get("execution_mode") == "legacy"
     )
 
 

--- a/src/ouroboros/config/models.py
+++ b/src/ouroboros/config/models.py
@@ -203,12 +203,21 @@ class ExecutionConfig(BaseModel, frozen=True):
         tui_autolaunch: Whether `ooo run` should open the TUI without prompting
         auto_evaluate: When true, a successful `execute_seed` run automatically
             enqueues formal evaluation as a background job.
+        run_verify_commands: Whether the orchestrator runs an AC's
+            ``verify_command`` itself and requires exit code 0 (plus any
+            ``output_assertion``) before accepting the AC. On by default.
+        verify_command_timeout_seconds: Timeout for an AC verify command.
+        ac_retry_attempts: How many times a failed AC is re-dispatched before
+            it is marked FAILED (per-AC, excludes stall retries).
     """
 
     max_iterations_per_ac: int = Field(default=10, ge=1)
     retrospective_interval: int = Field(default=3, ge=1)
     tui_autolaunch: bool = False
     auto_evaluate: bool = True
+    run_verify_commands: bool = True
+    verify_command_timeout_seconds: int = Field(default=600, ge=1)
+    ac_retry_attempts: int = Field(default=2, ge=0)
 
 
 class ResilienceConfig(BaseModel, frozen=True):

--- a/src/ouroboros/config/models.py
+++ b/src/ouroboros/config/models.py
@@ -203,9 +203,10 @@ class ExecutionConfig(BaseModel, frozen=True):
         tui_autolaunch: Whether `ooo run` should open the TUI without prompting
         auto_evaluate: When true, a successful `execute_seed` run automatically
             enqueues formal evaluation as a background job.
-        run_verify_commands: Whether the orchestrator runs an AC's
-            ``verify_command`` itself and requires exit code 0 (plus any
-            ``output_assertion``) before accepting the AC. On by default.
+        run_verify_commands: Whether the orchestrator checks an AC's success
+            contract itself before accepting the AC: all ``expected_artifacts``
+            must exist under the run workspace and ``verify_command`` must exit
+            0 (plus any ``output_assertion``). On by default.
         verify_command_timeout_seconds: Timeout for an AC verify command.
         ac_retry_attempts: How many times a failed AC is re-dispatched before
             it is marked FAILED (per-AC, excludes stall retries).

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -118,25 +118,46 @@ def _validate_fresh_execution_mode(
     *,
     tool_name: str,
 ) -> Result[None, MCPToolError]:
-    """Reject removed/unknown fresh execution-mode selectors on every MCP path."""
-    if execution_mode == "legacy":
+    """Reject unknown fresh execution-mode selectors on every MCP path.
+
+    ``legacy`` was removed after #978 P5 while the default runner was
+    observe-mode (the opt-out token was redundant then). With verify-by-default
+    the default runner enforces typed evidence plus verifier PASS acceptance,
+    so ``legacy`` is re-admitted as the explicit opt-out — mirroring the CLI
+    ``_resolve_fat_harness_mode`` contract.
+    """
+    if execution_mode not in (None, "", "fat_harness", "legacy"):
         return Result.err(
             MCPToolError(
-                "seed.orchestrator.execution_mode='legacy' was removed after #978 P5; "
-                "omit the selector for the default runner or set execution_mode='fat_harness' "
-                "to opt in to typed evidence plus verifier PASS acceptance.",
-                tool_name=tool_name,
-            )
-        )
-    if execution_mode not in (None, "", "fat_harness"):
-        return Result.err(
-            MCPToolError(
-                "seed.orchestrator.execution_mode must be 'fat_harness' when set "
-                f"(got {execution_mode!r}).",
+                "seed.orchestrator.execution_mode must be 'fat_harness' or 'legacy' "
+                f"when set (got {execution_mode!r}).",
                 tool_name=tool_name,
             )
         )
     return Result.ok(None)
+
+
+def _fresh_fat_harness_mode(execution_mode: Any) -> bool:
+    """Verify-by-default resolution shared with the CLI.
+
+    Missing/blank selector OR explicit ``fat_harness`` → True; explicit
+    ``legacy`` is the supported opt-out → False.
+    """
+    return execution_mode != "legacy"
+
+
+def _plugin_fat_harness_downgrade_meta(execution_mode: Any) -> dict[str, str]:
+    """Stamp the verify-by-default downgrade for fresh plugin dispatch.
+
+    Plugin dispatch cannot enforce typed evidence plus verifier PASS in the
+    child task. Explicit ``fat_harness`` requests are rejected upstream and an
+    explicit ``legacy`` opted out; only the missing/blank selector — where the
+    default would have enabled fat-harness — is silently downgraded, so it must
+    carry a visible note in the response meta.
+    """
+    if execution_mode in (None, ""):
+        return {"fat_harness_downgraded": "plugin_dispatch_cannot_enforce"}
+    return {}
 
 
 def _validate_plugin_execution_mode(
@@ -651,6 +672,7 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                     "dispatch_mode": "plugin",
                     "runtime_backend": self.agent_runtime_backend,
                     "model_tier": model_tier,
+                    **({} if is_resume else _plugin_fat_harness_downgrade_meta(execution_mode)),
                     **_plugin_verification_meta(
                         session_id,
                         auto_evaluate=auto_evaluate,
@@ -782,13 +804,16 @@ class ExecuteSeedHandler(BridgeAwareMixin):
                 # Create checkpoint store for execution state persistence
                 checkpoint_store = CheckpointStore()
                 checkpoint_store.initialize()
-                fat_harness_mode = execution_mode == "fat_harness"
+                fat_harness_mode = _fresh_fat_harness_mode(execution_mode)
                 if is_resume:
                     persisted_fat_harness_mode = tracker.progress.get("fat_harness_mode")
                     if isinstance(persisted_fat_harness_mode, bool):
                         fat_harness_mode = persisted_fat_harness_mode
                     else:
-                        fat_harness_mode = execution_mode == "fat_harness"
+                        # No persisted contract (historical session): mirror the
+                        # CLI resume semantics — verify-by-default unless the
+                        # seed opts out with execution_mode='legacy'.
+                        fat_harness_mode = _fresh_fat_harness_mode(execution_mode)
 
                 # Create orchestrator runner
                 runner = OrchestratorRunner(
@@ -1582,6 +1607,7 @@ class StartExecuteSeedHandler:
                 "status": DELEGATED_TO_PLUGIN,
                 "dispatch_mode": "plugin",
                 "runtime_backend": self.agent_runtime_backend,
+                **({} if is_resume else _plugin_fat_harness_downgrade_meta(execution_mode)),
                 **_plugin_verification_meta(
                     plugin_session_id,
                     auto_evaluate=auto_evaluate,

--- a/src/ouroboros/orchestrator/evidence/typed_evidence.py
+++ b/src/ouroboros/orchestrator/evidence/typed_evidence.py
@@ -203,6 +203,7 @@ def _complete_sibling_acs_from_evidence(
     completed_count: int,
     level_success: int,
     level_failed: int,
+    flip_gated_out: frozenset[int] = frozenset(),
 ) -> tuple[int, int, int, list[ACExecutionResult]]:
     """Mark sibling ACs satisfied when a successful sibling has exact evidence.
 
@@ -210,6 +211,10 @@ def _complete_sibling_acs_from_evidence(
     file exists", and "pytest passes". A single worker can legitimately create
     both files and run the test. This function reconciles those concrete sibling
     ACs from runtime/typed evidence instead of leaving them failed or pending.
+
+    ``flip_gated_out`` names ACs whose own ``verify_command`` did not pass the
+    orchestrator gate; they must not be flipped from evidence alone (PR-V V4).
+    ACs without a verify contract are never gated out, preserving prior behavior.
     """
     replacements: dict[int, ACExecutionResult] = {}
     successful_evidence = [
@@ -222,6 +227,10 @@ def _complete_sibling_acs_from_evidence(
 
     for result in level_results:
         if result.success or result.outcome != ACExecutionOutcome.FAILED:
+            continue
+        if result.ac_index in flip_gated_out:
+            # A contract AC cannot be flipped by sibling evidence unless its own
+            # verify_command passes the orchestrator gate.
             continue
         for source_idx, files, run_commands, passed_commands in successful_evidence:
             if source_idx == result.ac_index:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -28,7 +28,7 @@ Example:
 from __future__ import annotations
 
 import asyncio
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 import json
 import os
@@ -39,7 +39,7 @@ from typing import TYPE_CHECKING, Any
 import anyio
 from rich.console import Console
 
-from ouroboros.core.seed import ac_text
+from ouroboros.core.seed import AcceptanceCriterionSpec, ac_text
 from ouroboros.core.seed_contract_prompt import render_auto_recursion_guard
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.ac_runtime_handle_manager import ACRuntimeHandleManager
@@ -266,6 +266,17 @@ MIN_SUB_ACS = 2
 MAX_SUB_ACS = 5
 DECOMPOSITION_TIMEOUT_SECONDS = 60.0
 _IMPLEMENTATION_SESSION_KIND = "implementation_session"
+_VERIFY_OUTPUT_TAIL_CHARS = 2000  # How much verify-command output to attach
+
+
+@dataclass(frozen=True)
+class _VerifyGateOutcome:
+    """Outcome of the orchestrator-run AC verify-command gate (PR-V V1)."""
+
+    passed: bool
+    reason: str | None
+    output_tail: str
+
 
 
 def _collect_decomposition_depth_warning_paths(
@@ -406,6 +417,9 @@ class ParallelACExecutor:
         fat_harness_mode: bool = False,
         atomic_verifier: Verifier | None = None,
         reasoning_effort: str | None = None,
+        run_verify_commands: bool = True,
+        verify_command_timeout_seconds: int = 600,
+        ac_retry_attempts: int = 0,
     ):
         """Initialize executor.
 
@@ -427,6 +441,15 @@ class ParallelACExecutor:
             atomic_verifier: Optional verifier callable for the separate
                 atomic evidence PASS gate. Defaults to the harness-owned
                 structural verifier.
+            run_verify_commands: When True (default), the orchestrator runs an
+                AC's ``spec.verify_command`` itself and requires exit code 0
+                (plus any ``output_assertion``) before accepting the AC.
+            verify_command_timeout_seconds: Timeout for an AC verify command.
+            ac_retry_attempts: How many times a failed AC is re-dispatched
+                before it is marked FAILED (excludes stall retries). The
+                low-level constructor default is 0 so direct/test callers keep
+                today's single-dispatch behavior; real run paths (CLI `ooo run`
+                via the runner) pass the config value (default 2).
         """
         self._adapter = adapter
         self._event_store = event_store
@@ -437,6 +460,9 @@ class ParallelACExecutor:
         self._task_cwd = task_cwd
         self._execution_profile = execution_profile
         self._fat_harness_mode = fat_harness_mode
+        self._run_verify_commands = run_verify_commands
+        self._verify_command_timeout_seconds = max(1, verify_command_timeout_seconds)
+        self._ac_retry_attempts = max(0, ac_retry_attempts)
         # Effort-first investment dial (RFC #1405). Base level for full-strength
         # units; decomposed children run one notch lower. ``None`` leaves effort
         # routing dormant (execute_task receives no level → no behavior change),
@@ -989,6 +1015,7 @@ class ParallelACExecutor:
         level_contexts: list[LevelContext],
         ac_retry_attempts: dict[int, int],
         execution_counters: dict[str, int] | None = None,
+        retry_prompts: dict[int, str] | None = None,
     ) -> list[ACExecutionResult | BaseException]:
         """Execute one batch of stage-ready ACs using the shared worker pool."""
         batch_results: list[ACExecutionResult | BaseException] = [None] * len(batch_indices)
@@ -1015,6 +1042,7 @@ class ParallelACExecutor:
                         sibling_acs=sibling_acs,
                         retry_attempt=ac_retry_attempts[ac_idx],
                         execution_counters=execution_counters,
+                        retry_prompt_extra=(retry_prompts or {}).get(ac_idx, ""),
                     )
                 except BaseException as e:
                     # Never suppress anyio Cancelled — doing so breaks
@@ -1297,6 +1325,30 @@ class ParallelACExecutor:
                     metadata = external_completed.get(ac_idx, {})
                     reason = metadata.get("reason")
                     commit = metadata.get("commit")
+
+                    # PR-V V4: --skip-completed trusts working-tree state. When the
+                    # AC carries a verify_command, prove it with the gate before
+                    # skipping; on gate failure, execute the AC normally instead.
+                    spec = seed.acceptance_criteria[ac_idx]
+                    verification_status = "assumed"
+                    if (
+                        self._run_verify_commands
+                        and isinstance(spec, AcceptanceCriterionSpec)
+                        and spec.verify_command
+                    ):
+                        cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
+                        gate = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+                        if not gate.passed:
+                            executable.append(ac_idx)
+                            log.info(
+                                "parallel_executor.ac.skip_completed_gate_failed",
+                                session_id=session_id,
+                                ac_index=ac_idx,
+                                reason=gate.reason,
+                            )
+                            continue
+                        verification_status = "verified"
+
                     notes: list[str] = [
                         "Skipped via --skip-completed; existing working tree state is treated as satisfied."
                     ]
@@ -1304,6 +1356,7 @@ class ParallelACExecutor:
                         notes.append(f"Reason: {reason.strip()}")
                     if isinstance(commit, str) and commit.strip():
                         notes.append(f"Commit: {commit.strip()}")
+                    notes.append(f"verification_status={verification_status}")
 
                     satisfied_result = ACExecutionResult(
                         ac_index=ac_idx,
@@ -1418,9 +1471,9 @@ class ParallelACExecutor:
                         tool_calls_count=execution_counters["tool_calls_count"],
                     )
 
-                    batch_results = await self._execute_ac_batch(
+                    batch_results = await self._run_batch_with_verify_and_retry(
                         seed=seed,
-                        batch_indices=batch_executable,
+                        batch_executable=batch_executable,
                         session_id=session_id,
                         execution_id=execution_id,
                         tools=tools,
@@ -1503,6 +1556,12 @@ class ParallelACExecutor:
                         all_results.append(ac_result)
                         stage_ac_results.append(ac_result)
 
+                flip_gated_out = await self._compute_sibling_flip_gated_out(
+                    seed=seed,
+                    level_results=stage_ac_results,
+                    session_id=session_id,
+                    execution_id=execution_id,
+                )
                 (
                     completed_count,
                     level_success,
@@ -1515,6 +1574,7 @@ class ParallelACExecutor:
                     completed_count=completed_count,
                     level_success=level_success,
                     level_failed=level_failed,
+                    flip_gated_out=flip_gated_out,
                 )
 
                 reconciled_by_index = {result.ac_index: result for result in stage_ac_results}
@@ -1738,6 +1798,7 @@ class ParallelACExecutor:
         parent_ac_index: int | None = None,
         sub_ac_index: int | None = None,
         node_identity: ExecutionNodeIdentity | None = None,
+        retry_prompt_extra: str = "",
     ) -> ACExecutionResult:
         """Execute a single AC via the sole recursive AC execution entry point.
 
@@ -1961,6 +2022,7 @@ class ParallelACExecutor:
                 sibling_acs=sibling_acs,
                 retry_attempt=atomic_retry_attempt,
                 execution_counters=execution_counters,
+                retry_prompt_extra=retry_prompt_extra,
                 is_sub_ac=is_sub_ac,
                 parent_ac_index=parent_ac_index,
                 sub_ac_index=sub_ac_index,
@@ -2623,6 +2685,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         retry_attempt: int = 0,
         tool_catalog: tuple[MCPToolDefinition, ...] | None = None,
         execution_counters: dict[str, int] | None = None,
+        retry_prompt_extra: str = "",
     ) -> ACExecutionResult:
         """Execute an atomic AC directly via Claude Agent.
 
@@ -2668,6 +2731,11 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 "Resume from the current shared workspace state, including any "
                 "coordinator-reconciled changes already applied.\n"
             )
+        if retry_prompt_extra:
+            # Verify-by-default retry enrichment (failure taxonomy, error tail,
+            # verify-command output, and — on the final attempt — a lateral
+            # change-of-approach directive) built by the batch retry loop.
+            retry_section += "\n" + retry_prompt_extra + "\n"
 
         # Build parallel awareness section
         parallel_section = ""
@@ -3375,6 +3443,359 @@ Files present:
         except EvidenceError as exc:
             return None, None, str(exc)
         return record, validation, None
+
+    async def _run_ac_verify_gate(
+        self, *, spec: AcceptanceCriterionSpec, cwd: str
+    ) -> _VerifyGateOutcome:
+        """Run an AC's ``verify_command`` and judge the outcome (PR-V V1).
+
+        The orchestrator — not the worker — runs the command so a failing check
+        cannot be self-reported away. Success requires exit code 0 and, when
+        ``output_assertion`` is set, that substring in the combined output.
+        """
+        import contextlib
+
+        command = spec.verify_command
+        if not command:
+            return _VerifyGateOutcome(passed=True, reason=None, output_tail="")
+        try:
+            proc = await asyncio.create_subprocess_shell(
+                command,
+                cwd=cwd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+            )
+        except Exception as exc:  # pragma: no cover - spawn failure is environmental
+            return _VerifyGateOutcome(
+                passed=False,
+                reason=f"verify_command could not start: {exc}",
+                output_tail="",
+            )
+        try:
+            stdout_bytes, _ = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=self._verify_command_timeout_seconds,
+            )
+        except TimeoutError:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            with contextlib.suppress(Exception):
+                await proc.wait()
+            return _VerifyGateOutcome(
+                passed=False,
+                reason=(f"verify_command timed out after {self._verify_command_timeout_seconds}s"),
+                output_tail="",
+            )
+
+        combined = (stdout_bytes or b"").decode("utf-8", errors="replace")
+        tail = combined[-_VERIFY_OUTPUT_TAIL_CHARS:]
+        returncode = proc.returncode
+        if returncode != 0:
+            return _VerifyGateOutcome(
+                passed=False,
+                reason=f"verify_command exited with status {returncode}",
+                output_tail=tail,
+            )
+        if spec.output_assertion and spec.output_assertion not in combined:
+            return _VerifyGateOutcome(
+                passed=False,
+                reason=(
+                    f"output_assertion {spec.output_assertion!r} not found in verify_command output"
+                ),
+                output_tail=tail,
+            )
+        return _VerifyGateOutcome(passed=True, reason=None, output_tail=tail)
+
+    async def _apply_verify_gate(
+        self,
+        *,
+        seed: Seed,
+        ac_index: int,
+        result: ACExecutionResult,
+        session_id: str,
+        execution_id: str,
+    ) -> ACExecutionResult:
+        """Gate a successful AC on its ``verify_command`` (PR-V V1).
+
+        Contract-less ACs (no spec / no verify_command) and ACs that already
+        failed are returned untouched, so contract-less behavior — and the
+        single fat-harness failure event for an already-failed AC — is
+        preserved (no double-fail for one root cause).
+        """
+        if not self._run_verify_commands or not result.success:
+            return result
+        if ac_index < 0 or ac_index >= len(seed.acceptance_criteria):
+            return result
+        spec = seed.acceptance_criteria[ac_index]
+        if not isinstance(spec, AcceptanceCriterionSpec) or not spec.verify_command:
+            return result
+
+        cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
+        outcome = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+        if outcome.passed:
+            return result
+
+        from ouroboros.events.base import BaseEvent
+        from ouroboros.orchestrator.failure_taxonomy import FailureClass
+
+        reason = f"Verify gate failed: {outcome.reason}"
+        detail = reason
+        if outcome.output_tail:
+            detail = f"{reason}\n--- verify_command output (tail) ---\n{outcome.output_tail}"
+        verdict = VerifierVerdict(
+            passed=False,
+            reasons=(reason,),
+            failure_class=FailureClass.EVIDENCE_MISSING.value,
+        )
+        await self._safe_emit_event(
+            BaseEvent(
+                type="execution.verify.failed",
+                aggregate_type="execution",
+                aggregate_id=execution_id or session_id,
+                data={
+                    "session_id": session_id,
+                    "execution_id": execution_id,
+                    "ac_index": ac_index,
+                    "ac_content": ac_text(spec),
+                    "verify_command": spec.verify_command,
+                    "reason": outcome.reason,
+                    "failure_class": FailureClass.EVIDENCE_MISSING.value,
+                    "output_tail": outcome.output_tail,
+                },
+            )
+        )
+        log.warning(
+            "parallel_executor.ac.verify_gate_failed",
+            session_id=session_id,
+            ac_index=ac_index,
+            reason=outcome.reason,
+        )
+        return replace(
+            result,
+            success=False,
+            error=detail,
+            final_message=detail,
+            outcome=ACExecutionOutcome.FAILED,
+            atomic_verifier_verdict=verdict,
+        )
+
+    async def _compute_sibling_flip_gated_out(
+        self,
+        *,
+        seed: Seed,
+        level_results: list[ACExecutionResult],
+        session_id: str,
+        execution_id: str,
+    ) -> frozenset[int]:
+        """Gate sibling-evidence flips for FAILED contract ACs (PR-V V4).
+
+        A FAILED AC whose spec carries a ``verify_command`` may only be flipped
+        to satisfied by sibling evidence if its own verify command passes the
+        orchestrator gate now. ACs without a verify contract are never gated out.
+        """
+        if not self._run_verify_commands:
+            return frozenset()
+        gated_out: set[int] = set()
+        cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
+        for result in level_results:
+            if result.success or result.outcome != ACExecutionOutcome.FAILED:
+                continue
+            ac_idx = result.ac_index
+            if ac_idx < 0 or ac_idx >= len(seed.acceptance_criteria):
+                continue
+            spec = seed.acceptance_criteria[ac_idx]
+            if not isinstance(spec, AcceptanceCriterionSpec) or not spec.verify_command:
+                continue
+            outcome = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+            if not outcome.passed:
+                gated_out.add(ac_idx)
+        return frozenset(gated_out)
+
+    def _failure_class_for_result(self, result: ACExecutionResult) -> str | None:
+        """Best-effort failure taxonomy label for a failed AC result."""
+        verdict = result.atomic_verifier_verdict
+        if verdict is not None and verdict.failure_class:
+            return verdict.failure_class
+        if result.error == _STALL_SENTINEL:
+            from ouroboros.orchestrator.failure_taxonomy import FailureClass
+
+            return FailureClass.STALL.value
+        return None
+
+    def _is_retryable_failure(self, result: ACExecutionResult | BaseException) -> bool:
+        """Whether a batch result is a non-stall, non-blocked AC failure (PR-V V3)."""
+        if not isinstance(result, ACExecutionResult):
+            return False
+        if result.success or result.is_blocked:
+            return False
+        # Stall retries are handled separately by the atomic leaf loop.
+        return result.error != _STALL_SENTINEL
+
+    def _build_ac_retry_prompt(
+        self,
+        *,
+        result: ACExecutionResult,
+        ac_content: str,
+        is_final_attempt: bool,
+    ) -> str:
+        """Build the enriched retry prompt section for a re-dispatched AC (PR-V V3/V4)."""
+        parts: list[str] = []
+        failure_class = self._failure_class_for_result(result)
+        if failure_class:
+            parts.append(f"### Prior failure classification\n{failure_class}")
+        last_error = result.error or result.final_message or ""
+        if last_error and last_error != _STALL_SENTINEL:
+            parts.append("### Last error (tail)\n" + last_error[-500:])
+        if is_final_attempt:
+            from ouroboros.resilience.lateral import (
+                build_lateral_change_of_approach_directive,
+            )
+
+            parts.append(
+                build_lateral_change_of_approach_directive(
+                    problem_context=ac_content,
+                    current_approach=(
+                        "The previous attempts failed as described above; the same "
+                        "approach is not working."
+                    ),
+                    failed_attempts=(failure_class,) if failure_class else (),
+                )
+            )
+        return "\n\n".join(parts)
+
+    async def _run_batch_with_verify_and_retry(
+        self,
+        *,
+        seed: Seed,
+        batch_executable: list[int],
+        session_id: str,
+        execution_id: str,
+        tools: list[str],
+        tool_catalog: tuple[MCPToolDefinition, ...] | None,
+        system_prompt: str,
+        level_contexts: list[LevelContext],
+        ac_retry_attempts: dict[int, int],
+        execution_counters: dict[str, int] | None,
+    ) -> list[ACExecutionResult | BaseException]:
+        """Dispatch a batch, apply the V1 verify gate, and retry failures (PR-V V1/V3/V4).
+
+        Contract-less ACs with the verify gate off/absent and zero configured
+        retries reduce to a single ``_execute_ac_batch`` call plus the identity
+        gate, so today's behavior is preserved.
+        """
+        results = await self._execute_ac_batch(
+            seed=seed,
+            batch_indices=batch_executable,
+            session_id=session_id,
+            execution_id=execution_id,
+            tools=tools,
+            tool_catalog=tool_catalog,
+            system_prompt=system_prompt,
+            level_contexts=level_contexts,
+            ac_retry_attempts=ac_retry_attempts,
+            execution_counters=execution_counters,
+        )
+        # V1 gate on freshly-successful ACs.
+        for position, ac_idx in enumerate(batch_executable):
+            result = results[position]
+            if isinstance(result, ACExecutionResult):
+                results[position] = await self._apply_verify_gate(
+                    seed=seed,
+                    ac_index=ac_idx,
+                    result=result,
+                    session_id=session_id,
+                    execution_id=execution_id,
+                )
+
+        if self._ac_retry_attempts <= 0:
+            return results
+
+        # V3 retry loop: re-dispatch non-stall failures up to the configured
+        # attempts. Kill criterion: stop early when the failure class repeats.
+        position_by_idx = {ac_idx: position for position, ac_idx in enumerate(batch_executable)}
+        pending = {
+            ac_idx
+            for position, ac_idx in enumerate(batch_executable)
+            if self._is_retryable_failure(results[position])
+        }
+        last_failure_class = {
+            ac_idx: self._failure_class_for_result(results[position_by_idx[ac_idx]])
+            for ac_idx in pending
+        }
+
+        while pending:
+            retry_idxs = [
+                ac_idx for ac_idx in pending if ac_retry_attempts[ac_idx] < self._ac_retry_attempts
+            ]
+            if not retry_idxs:
+                break
+
+            retry_prompts: dict[int, str] = {}
+            for ac_idx in retry_idxs:
+                ac_retry_attempts[ac_idx] += 1
+                is_final = ac_retry_attempts[ac_idx] >= self._ac_retry_attempts
+                prior = results[position_by_idx[ac_idx]]
+                if isinstance(prior, ACExecutionResult):
+                    retry_prompts[ac_idx] = self._build_ac_retry_prompt(
+                        result=prior,
+                        ac_content=ac_text(seed.acceptance_criteria[ac_idx]),
+                        is_final_attempt=is_final,
+                    )
+
+            retry_results = await self._execute_ac_batch(
+                seed=seed,
+                batch_indices=retry_idxs,
+                session_id=session_id,
+                execution_id=execution_id,
+                tools=tools,
+                tool_catalog=tool_catalog,
+                system_prompt=system_prompt,
+                level_contexts=level_contexts,
+                ac_retry_attempts=ac_retry_attempts,
+                execution_counters=execution_counters,
+                retry_prompts=retry_prompts,
+            )
+
+            for retry_position, ac_idx in enumerate(retry_idxs):
+                gated = retry_results[retry_position]
+                if isinstance(gated, ACExecutionResult):
+                    gated = await self._apply_verify_gate(
+                        seed=seed,
+                        ac_index=ac_idx,
+                        result=gated,
+                        session_id=session_id,
+                        execution_id=execution_id,
+                    )
+                results[position_by_idx[ac_idx]] = gated
+
+                if not self._is_retryable_failure(gated):
+                    pending.discard(ac_idx)
+                    continue
+                new_class = (
+                    self._failure_class_for_result(gated)
+                    if isinstance(gated, ACExecutionResult)
+                    else None
+                )
+                if (
+                    new_class is not None
+                    and last_failure_class.get(ac_idx) is not None
+                    and new_class == last_failure_class[ac_idx]
+                ):
+                    # Identical failure class on every attempt: stop early
+                    # rather than burning the last attempt.
+                    log.info(
+                        "parallel_executor.ac.retry_early_stop",
+                        session_id=session_id,
+                        ac_index=ac_idx,
+                        failure_class=new_class,
+                    )
+                    pending.discard(ac_idx)
+                    continue
+                last_failure_class[ac_idx] = new_class
+                if ac_retry_attempts[ac_idx] >= self._ac_retry_attempts:
+                    pending.discard(ac_idx)
+
+        return results
 
     def _fat_harness_acceptance_error(
         self,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 import json
 import os
+from pathlib import Path
 import re
 import time
 from typing import TYPE_CHECKING, Any
@@ -271,12 +272,32 @@ _VERIFY_OUTPUT_TAIL_CHARS = 2000  # How much verify-command output to attach
 
 @dataclass(frozen=True)
 class _VerifyGateOutcome:
-    """Outcome of the orchestrator-run AC verify-command gate (PR-V V1)."""
+    """Outcome of the orchestrator-run AC success-contract gate (PR-V V1)."""
 
     passed: bool
     reason: str | None
     output_tail: str
+    missing_artifacts: tuple[str, ...] = ()
 
+
+def _missing_expected_artifacts(artifacts: tuple[str, ...], cwd: str) -> tuple[str, ...]:
+    """Return the expected artifacts absent relative to ``cwd``.
+
+    Each entry must resolve to an existing file or directory under ``cwd``.
+    Absolute paths and ``..`` escapes are rejected — treated as missing with the
+    escape named — so a contract cannot be satisfied by files outside the run
+    workspace.
+    """
+    root = Path(cwd).resolve()
+    missing: list[str] = []
+    for artifact in artifacts:
+        candidate = (root / artifact).resolve()
+        if not candidate.is_relative_to(root):
+            missing.append(f"{artifact} (escapes workspace)")
+            continue
+        if not candidate.exists():
+            missing.append(artifact)
+    return tuple(missing)
 
 
 def _collect_decomposition_depth_warning_paths(
@@ -441,9 +462,11 @@ class ParallelACExecutor:
             atomic_verifier: Optional verifier callable for the separate
                 atomic evidence PASS gate. Defaults to the harness-owned
                 structural verifier.
-            run_verify_commands: When True (default), the orchestrator runs an
-                AC's ``spec.verify_command`` itself and requires exit code 0
-                (plus any ``output_assertion``) before accepting the AC.
+            run_verify_commands: When True (default), the orchestrator checks
+                an AC's success contract itself before accepting the AC: all
+                ``spec.expected_artifacts`` must exist under the run workspace
+                and ``spec.verify_command`` must exit 0 (plus any
+                ``output_assertion``).
             verify_command_timeout_seconds: Timeout for an AC verify command.
             ac_retry_attempts: How many times a failed AC is re-dispatched
                 before it is marked FAILED (excludes stall retries). The
@@ -1327,14 +1350,15 @@ class ParallelACExecutor:
                     commit = metadata.get("commit")
 
                     # PR-V V4: --skip-completed trusts working-tree state. When the
-                    # AC carries a verify_command, prove it with the gate before
-                    # skipping; on gate failure, execute the AC normally instead.
+                    # AC carries a success contract (verify_command OR expected
+                    # artifacts), prove it with the gate before skipping; on gate
+                    # failure, execute the AC normally instead.
                     spec = seed.acceptance_criteria[ac_idx]
                     verification_status = "assumed"
                     if (
                         self._run_verify_commands
                         and isinstance(spec, AcceptanceCriterionSpec)
-                        and spec.verify_command
+                        and (spec.verify_command or spec.expected_artifacts)
                     ):
                         cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
                         gate = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
@@ -3447,13 +3471,25 @@ Files present:
     async def _run_ac_verify_gate(
         self, *, spec: AcceptanceCriterionSpec, cwd: str
     ) -> _VerifyGateOutcome:
-        """Run an AC's ``verify_command`` and judge the outcome (PR-V V1).
+        """Judge an AC's success contract: expected artifacts + verify command.
 
-        The orchestrator — not the worker — runs the command so a failing check
-        cannot be self-reported away. Success requires exit code 0 and, when
-        ``output_assertion`` is set, that substring in the combined output.
+        The orchestrator — not the worker — checks the contract so a failing
+        check cannot be self-reported away. All ``expected_artifacts`` must
+        exist under ``cwd`` (checked first — it is cheap — and every missing
+        entry is reported in one failure). ``verify_command``, when set, must
+        then exit 0 and, when ``output_assertion`` is set, print that substring
+        in the combined output.
         """
         import contextlib
+
+        missing_artifacts = _missing_expected_artifacts(spec.expected_artifacts, cwd)
+        if missing_artifacts:
+            return _VerifyGateOutcome(
+                passed=False,
+                reason="expected_artifacts missing: " + ", ".join(missing_artifacts),
+                output_tail="",
+                missing_artifacts=missing_artifacts,
+            )
 
         command = spec.verify_command
         if not command:
@@ -3515,9 +3551,10 @@ Files present:
         session_id: str,
         execution_id: str,
     ) -> ACExecutionResult:
-        """Gate a successful AC on its ``verify_command`` (PR-V V1).
+        """Gate a successful AC on its success contract (PR-V V1).
 
-        Contract-less ACs (no spec / no verify_command) and ACs that already
+        The contract gate applies when the spec carries a ``verify_command`` OR
+        non-empty ``expected_artifacts``. Contract-less ACs and ACs that already
         failed are returned untouched, so contract-less behavior — and the
         single fat-harness failure event for an already-failed AC — is
         preserved (no double-fail for one root cause).
@@ -3527,7 +3564,9 @@ Files present:
         if ac_index < 0 or ac_index >= len(seed.acceptance_criteria):
             return result
         spec = seed.acceptance_criteria[ac_index]
-        if not isinstance(spec, AcceptanceCriterionSpec) or not spec.verify_command:
+        if not isinstance(spec, AcceptanceCriterionSpec) or not (
+            spec.verify_command or spec.expected_artifacts
+        ):
             return result
 
         cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
@@ -3558,6 +3597,8 @@ Files present:
                     "ac_index": ac_index,
                     "ac_content": ac_text(spec),
                     "verify_command": spec.verify_command,
+                    "expected_artifacts": list(spec.expected_artifacts),
+                    "missing_artifacts": list(outcome.missing_artifacts),
                     "reason": outcome.reason,
                     "failure_class": FailureClass.EVIDENCE_MISSING.value,
                     "output_tail": outcome.output_tail,
@@ -3589,9 +3630,10 @@ Files present:
     ) -> frozenset[int]:
         """Gate sibling-evidence flips for FAILED contract ACs (PR-V V4).
 
-        A FAILED AC whose spec carries a ``verify_command`` may only be flipped
-        to satisfied by sibling evidence if its own verify command passes the
-        orchestrator gate now. ACs without a verify contract are never gated out.
+        A FAILED AC whose spec carries a success contract (``verify_command``
+        OR non-empty ``expected_artifacts``) may only be flipped to satisfied by
+        sibling evidence if its own contract passes the orchestrator gate now.
+        ACs without a contract are never gated out.
         """
         if not self._run_verify_commands:
             return frozenset()
@@ -3604,7 +3646,9 @@ Files present:
             if ac_idx < 0 or ac_idx >= len(seed.acceptance_criteria):
                 continue
             spec = seed.acceptance_criteria[ac_idx]
-            if not isinstance(spec, AcceptanceCriterionSpec) or not spec.verify_command:
+            if not isinstance(spec, AcceptanceCriterionSpec) or not (
+                spec.verify_command or spec.expected_artifacts
+            ):
                 continue
             outcome = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
             if not outcome.passed:

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -503,6 +503,19 @@ class OrchestratorRunner:
         from ouroboros.config import get_agent_reasoning_effort
 
         self._reasoning_effort = get_agent_reasoning_effort()
+        # Verify-by-default execution knobs (PR-V). Read once from config with a
+        # safe fallback so direct/test construction never fails on config IO.
+        try:
+            from ouroboros.config import load_config
+
+            _execution_config = load_config().execution
+            self._run_verify_commands = _execution_config.run_verify_commands
+            self._verify_command_timeout_seconds = _execution_config.verify_command_timeout_seconds
+            self._ac_retry_attempts = _execution_config.ac_retry_attempts
+        except Exception:  # pragma: no cover - defensive config fallback
+            self._run_verify_commands = True
+            self._verify_command_timeout_seconds = 600
+            self._ac_retry_attempts = 2
         self._announced_param_degradations: set[tuple[str, str]] = set()
         # Track active session for external cancellation by execution_id
         self._active_sessions: dict[str, str] = {}  # execution_id -> session_id
@@ -2924,6 +2937,9 @@ class OrchestratorRunner:
             execution_profile=execution_profile,
             fat_harness_mode=self._fat_harness_mode,
             reasoning_effort=self._reasoning_effort,
+            run_verify_commands=self._run_verify_commands,
+            verify_command_timeout_seconds=self._verify_command_timeout_seconds,
+            ac_retry_attempts=self._ac_retry_attempts,
         )
 
         # Check for cancellation before starting parallel execution

--- a/src/ouroboros/resilience/lateral.py
+++ b/src/ouroboros/resilience/lateral.py
@@ -363,6 +363,49 @@ class LateralThinker:
         return tuple(ThinkingPersona)
 
 
+def build_lateral_change_of_approach_directive(
+    *,
+    problem_context: str,
+    current_approach: str,
+    failed_attempts: tuple[str, ...] = (),
+) -> str:
+    """Build a loop-independent "change of approach" directive.
+
+    This is the directive-text core of lateral thinking extracted so callers
+    outside the sequential recovery loop (for example the parallel executor's
+    final AC retry) can inject a lateral nudge without pulling in the sequential
+    machinery or an LLM/persona-file round trip. It borrows the SIMPLIFIER
+    persona's intent: abandon the repeatedly-failing approach and try a
+    fundamentally simpler, different one.
+
+    Args:
+        problem_context: What the unit is trying to achieve.
+        current_approach: The approach that has repeatedly failed.
+        failed_attempts: Short summaries of what already failed.
+
+    Returns:
+        A markdown directive suitable for appending to a retry prompt.
+    """
+    lines = [
+        "## Change of Approach (Lateral Thinking)",
+        "Previous attempts on this acceptance criterion have failed the same "
+        "way. Do NOT simply repeat the same approach with minor tweaks. Step "
+        "back and take a fundamentally different, simpler route to the same "
+        "outcome:",
+        "- Challenge an assumption the earlier attempts took for granted.",
+        "- Prefer the smallest change that makes the verification pass over a broad refactor.",
+        "- If a tool, path, or command kept failing, reach the same outcome a different way.",
+    ]
+    if problem_context.strip():
+        lines += ["", "### Outcome to achieve", problem_context.strip()]
+    if current_approach.strip():
+        lines += ["", "### Approach that is NOT working", current_approach.strip()]
+    if failed_attempts:
+        lines += ["", "### What already failed"]
+        lines += [f"- {attempt}" for attempt in failed_attempts if attempt]
+    return "\n".join(lines)
+
+
 # =============================================================================
 # Event Classes
 # =============================================================================

--- a/tests/unit/cli/test_run_qa.py
+++ b/tests/unit/cli/test_run_qa.py
@@ -310,9 +310,9 @@ def test_resolve_cli_project_dir_global_seed_store_still_uses_brownfield_target_
     assert resolved == target_dir.resolve()
 
 
-def test_resolve_fat_harness_mode_defaults_to_disabled() -> None:
-    """Fresh runs use the default runner unless the seed opts into fat-harness."""
-    assert _resolve_fat_harness_mode(VALID_SEED_DATA) is False
+def test_resolve_fat_harness_mode_defaults_to_enabled() -> None:
+    """Verify-by-default: fresh runs enforce fat-harness unless opted out."""
+    assert _resolve_fat_harness_mode(VALID_SEED_DATA) is True
 
 
 def test_resolve_fat_harness_mode_accepts_fat_harness_execution_mode() -> None:
@@ -322,12 +322,11 @@ def test_resolve_fat_harness_mode_accepts_fat_harness_execution_mode() -> None:
     assert _resolve_fat_harness_mode(seed_data) is True
 
 
-def test_resolve_fat_harness_mode_rejects_legacy_execution_mode() -> None:
-    """#978 P5 removes the legacy self-report fallback selector."""
+def test_resolve_fat_harness_mode_legacy_execution_mode_opts_out() -> None:
+    """`execution_mode: legacy` is the supported verify-by-default escape hatch."""
     seed_data = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": "legacy"}}
 
-    with pytest.raises(typer.Exit):
-        _resolve_fat_harness_mode(seed_data)
+    assert _resolve_fat_harness_mode(seed_data) is False
 
 
 def test_resolve_fat_harness_mode_rejects_unknown_execution_mode() -> None:
@@ -346,11 +345,13 @@ def test_resolve_resume_fat_harness_mode_uses_persisted_contract() -> None:
 
 
 def test_resolve_resume_fat_harness_mode_migrates_missing_contract_to_default_runner() -> None:
-    """Only explicit fat-harness selectors resume with verifier-gated acceptance."""
+    """Sessions with no persisted contract resume verify-by-default unless opted out."""
     fat_harness_seed = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": "fat_harness"}}
+    legacy_seed = {**VALID_SEED_DATA, "orchestrator": {"execution_mode": "legacy"}}
 
     assert _resolve_resume_fat_harness_mode(fat_harness_seed, {}) is True
-    assert _resolve_resume_fat_harness_mode(VALID_SEED_DATA, {}) is False
+    assert _resolve_resume_fat_harness_mode(VALID_SEED_DATA, {}) is True
+    assert _resolve_resume_fat_harness_mode(legacy_seed, {}) is False
 
 
 def test_resolve_max_decomposition_depth_defaults_to_two(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -538,12 +539,12 @@ async def test_run_orchestrator_passes_resolved_execution_caps_to_runner(tmp_pat
 
     assert mock_runner_cls.call_args.kwargs["max_decomposition_depth"] == 3
     assert mock_runner_cls.call_args.kwargs["max_parallel_workers"] == 7
-    assert mock_runner_cls.call_args.kwargs["fat_harness_mode"] is False
+    assert mock_runner_cls.call_args.kwargs["fat_harness_mode"] is True
 
 
 @pytest.mark.asyncio
 async def test_run_orchestrator_passes_default_runner_mode_to_runner(tmp_path: Path) -> None:
-    """The default path leaves fat-harness disabled unless the seed opts in."""
+    """Verify-by-default: the default path enables fat-harness unless opted out."""
     seed_file = tmp_path / "seed.yaml"
     seed_file.write_text("goal: ignored\n", encoding="utf-8")
 
@@ -582,7 +583,7 @@ async def test_run_orchestrator_passes_default_runner_mode_to_runner(tmp_path: P
         mock_event_store_cls.return_value.initialize = AsyncMock()
         await _run_orchestrator(seed_file)
 
-    assert mock_runner_cls.call_args.kwargs["fat_harness_mode"] is False
+    assert mock_runner_cls.call_args.kwargs["fat_harness_mode"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -135,6 +135,9 @@ class TestExecuteSeedHandler:
         gated_resume_tracker = SessionTracker.create("exec_resume", "seed-123").with_progress(
             {"fat_harness_mode": True}
         )
+        opted_out_resume_tracker = SessionTracker.create(
+            "exec_opted_out", "seed-123"
+        ).with_progress({"fat_harness_mode": False})
         legacy_resume_tracker = SessionTracker.create("exec_legacy", "seed-123")
         missing_contract_tracker = SessionTracker.create("exec_missing", "seed-123")
 
@@ -152,6 +155,7 @@ class TestExecuteSeedHandler:
             async def reconstruct_session(self, session_id: str) -> Result:
                 trackers = {
                     "sess_resume": gated_resume_tracker,
+                    "sess_opted_out": opted_out_resume_tracker,
                     "sess_legacy": legacy_resume_tracker,
                     "sess_missing": missing_contract_tracker,
                 }
@@ -214,8 +218,21 @@ class TestExecuteSeedHandler:
             {"seed_content": VALID_SEED_YAML, "skip_qa": True},
             synchronous=True,
         )
+        legacy_fresh = await handler.handle(
+            {
+                "seed_content": VALID_SEED_YAML.replace(
+                    "metadata:", "orchestrator:\n  execution_mode: legacy\nmetadata:", 1
+                ),
+                "skip_qa": True,
+            },
+            synchronous=True,
+        )
         resumed = await handler.handle(
             {"seed_content": VALID_SEED_YAML, "session_id": "sess_resume", "skip_qa": True},
+            synchronous=True,
+        )
+        opted_out_resumed = await handler.handle(
+            {"seed_content": VALID_SEED_YAML, "session_id": "sess_opted_out", "skip_qa": True},
             synchronous=True,
         )
         legacy_resumed = await handler.handle(
@@ -238,10 +255,16 @@ class TestExecuteSeedHandler:
         )
 
         assert fresh.is_ok
+        assert legacy_fresh.is_ok
         assert resumed.is_ok
+        assert opted_out_resumed.is_ok
         assert legacy_resumed.is_ok
         assert missing_contract_resumed.is_ok
-        assert captured_modes == [False, True, False, False]
+        # Verify-by-default: fresh runs enforce fat-harness unless the seed
+        # opts out with execution_mode='legacy'; a persisted contract always
+        # wins on resume (True stays True, False stays False); resume without
+        # a persisted contract mirrors the fresh default.
+        assert captured_modes == [True, False, True, False, False, True]
 
     async def test_handle_passes_execution_model_to_runtime(
         self,
@@ -408,19 +431,25 @@ class TestExecuteSeedHandler:
         assert "Formal Evaluation: NOT evaluated" in result.value.text_content
         assert "Next: ooo evaluate orch_verify" in result.value.text_content
 
-    async def test_handle_rejects_removed_legacy_execution_mode(self) -> None:
-        """MCP execute_seed matches the CLI removal of the legacy selector."""
-        handler = ExecuteSeedHandler()
-        result = await handler.handle(
-            {
-                "seed_content": VALID_SEED_YAML.replace(
-                    "metadata:", "orchestrator:\n  execution_mode: legacy\nmetadata:", 1
-                )
-            }
+    def test_fresh_execution_mode_gate_readmits_legacy_opt_out(self) -> None:
+        """Verify-by-default re-admits 'legacy' as the explicit opt-out.
+
+        #978 P5 removed 'legacy' while the default runner was observe-mode
+        (the token was redundant). With verify-by-default the opt-out token is
+        meaningful again, matching the CLI resolver vocabulary.
+        """
+        from ouroboros.mcp.tools.execution_handlers import (
+            _fresh_fat_harness_mode,
+            _validate_fresh_execution_mode,
         )
 
-        assert result.is_err
-        assert "execution_mode='legacy' was removed" in str(result.error)
+        for mode in (None, "", "fat_harness", "legacy"):
+            assert _validate_fresh_execution_mode(mode, tool_name="t").is_ok
+
+        assert _fresh_fat_harness_mode(None) is True
+        assert _fresh_fat_harness_mode("") is True
+        assert _fresh_fat_harness_mode("fat_harness") is True
+        assert _fresh_fat_harness_mode("legacy") is False
 
     async def test_handle_plugin_marks_direct_delegation_unverified(
         self,
@@ -448,11 +477,11 @@ class TestExecuteSeedHandler:
         )
         assert result.value.meta["manual_retry_next_step"].startswith("ooo evaluate orch_")
 
-    async def test_handle_plugin_rejects_removed_legacy_execution_mode(
+    async def test_handle_plugin_accepts_legacy_opt_out_without_downgrade_note(
         self,
         memory_event_store: EventStore,
     ) -> None:
-        """Plugin-dispatched execute_seed uses the same fresh execution-mode gate."""
+        """An explicit legacy opt-out dispatches via plugin with no downgrade stamp."""
         handler = ExecuteSeedHandler(
             event_store=memory_event_store,
             agent_runtime_backend="opencode",
@@ -466,8 +495,26 @@ class TestExecuteSeedHandler:
             }
         )
 
-        assert result.is_err
-        assert "execution_mode='legacy' was removed" in str(result.error)
+        assert result.is_ok
+        assert result.value.meta["dispatch_mode"] == "plugin"
+        assert "fat_harness_downgraded" not in result.value.meta
+
+    async def test_handle_plugin_default_stamps_fat_harness_downgrade(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """Verify-by-default would enable fat-harness; plugin dispatch cannot
+        enforce it, so the silent downgrade must be visible in the meta."""
+        handler = ExecuteSeedHandler(
+            event_store=memory_event_store,
+            agent_runtime_backend="opencode",
+            opencode_mode="plugin",
+        )
+        result = await handler.handle({"seed_content": VALID_SEED_YAML})
+
+        assert result.is_ok
+        assert result.value.meta["dispatch_mode"] == "plugin"
+        assert result.value.meta["fat_harness_downgraded"] == "plugin_dispatch_cannot_enforce"
 
     async def test_handle_plugin_rejects_fat_harness_execution_mode(
         self,
@@ -577,7 +624,7 @@ class TestExecuteSeedHandler:
         )
 
         assert result.is_err
-        assert "execution_mode must be 'fat_harness' when set" in str(result.error)
+        assert "execution_mode must be 'fat_harness' or 'legacy' when set" in str(result.error)
 
     async def test_handle_reports_execution_handler_config_error(self) -> None:
         """Config failures should surface with execution-handler context."""
@@ -1957,11 +2004,11 @@ class TestAsyncJobHandlers:
         )
         assert result.value.meta["manual_retry_next_step"].startswith("ooo evaluate orch_")
 
-    async def test_start_execute_seed_plugin_rejects_removed_legacy_execution_mode(
+    async def test_start_execute_seed_plugin_accepts_legacy_opt_out(
         self,
         memory_event_store: EventStore,
     ) -> None:
-        """Plugin-dispatched start_execute_seed uses the same fresh execution-mode gate."""
+        """An explicit legacy opt-out dispatches via plugin with no downgrade stamp."""
         handler = StartExecuteSeedHandler(
             event_store=memory_event_store,
             agent_runtime_backend="opencode",
@@ -1976,8 +2023,26 @@ class TestAsyncJobHandlers:
             }
         )
 
-        assert result.is_err
-        assert "execution_mode='legacy' was removed" in str(result.error)
+        assert result.is_ok
+        assert result.value.meta["dispatch_mode"] == "plugin"
+        assert "fat_harness_downgraded" not in result.value.meta
+
+    async def test_start_execute_seed_plugin_default_stamps_fat_harness_downgrade(
+        self,
+        memory_event_store: EventStore,
+    ) -> None:
+        """The default-ON fat-harness downgrade is visible on start_execute_seed too."""
+        handler = StartExecuteSeedHandler(
+            event_store=memory_event_store,
+            agent_runtime_backend="opencode",
+            opencode_mode="plugin",
+        )
+
+        result = await handler.handle({"seed_content": VALID_SEED_YAML})
+
+        assert result.is_ok
+        assert result.value.meta["dispatch_mode"] == "plugin"
+        assert result.value.meta["fat_harness_downgraded"] == "plugin_dispatch_cannot_enforce"
 
     async def test_start_execute_seed_plugin_rejects_fat_harness_execution_mode(
         self,

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -502,3 +502,204 @@ async def test_skip_completed_executes_when_verify_gate_fails(tmp_path: Any) -> 
 
     # The failing verify gate forced normal execution instead of skipping.
     assert dispatched == [[0]]
+
+
+# ---------------------------------------------------------------------------
+# V1 gate — expected_artifacts enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_artifacts_only_gate_passes_when_files_exist(tmp_path: Any) -> None:
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "guide.md").write_text("guide\n")
+    (tmp_path / "README.md").write_text("readme\n")
+    executor = _make_executor(working_directory=str(tmp_path))
+    spec = AcceptanceCriterionSpec(
+        description="docs exist",
+        expected_artifacts=("README.md", "docs/guide.md", "docs"),
+    )
+
+    outcome = await executor._run_ac_verify_gate(spec=spec, cwd=str(tmp_path))
+
+    assert outcome.passed is True
+    assert outcome.missing_artifacts == ()
+
+
+@pytest.mark.asyncio
+async def test_artifacts_only_gate_reports_all_missing(tmp_path: Any) -> None:
+    (tmp_path / "present.md").write_text("here\n")
+    executor = _make_executor(working_directory=str(tmp_path))
+    spec = AcceptanceCriterionSpec(
+        description="docs exist",
+        expected_artifacts=("present.md", "absent-one.md", "absent/two.md"),
+    )
+
+    outcome = await executor._run_ac_verify_gate(spec=spec, cwd=str(tmp_path))
+
+    assert outcome.passed is False
+    assert outcome.missing_artifacts == ("absent-one.md", "absent/two.md")
+    assert "absent-one.md" in (outcome.reason or "")
+    assert "absent/two.md" in (outcome.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_artifact_path_escape_is_treated_as_missing(tmp_path: Any) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    # The escape target EXISTS outside the workspace — it still must not count.
+    (tmp_path / "outside.md").write_text("outside\n")
+    executor = _make_executor(working_directory=str(workspace))
+    relative_escape = AcceptanceCriterionSpec(
+        description="escape", expected_artifacts=("../outside.md",)
+    )
+    absolute_escape = AcceptanceCriterionSpec(
+        description="escape", expected_artifacts=(str(tmp_path / "outside.md"),)
+    )
+
+    for spec in (relative_escape, absolute_escape):
+        outcome = await executor._run_ac_verify_gate(spec=spec, cwd=str(workspace))
+        assert outcome.passed is False
+        assert len(outcome.missing_artifacts) == 1
+        assert "escapes workspace" in outcome.missing_artifacts[0]
+
+
+@pytest.mark.asyncio
+async def test_combined_contract_fails_when_either_leg_fails(tmp_path: Any) -> None:
+    (tmp_path / "artifact.md").write_text("built\n")
+    executor = _make_executor(working_directory=str(tmp_path))
+
+    command_ok_artifact_missing = AcceptanceCriterionSpec(
+        description="combined",
+        verify_command="exit 0",
+        expected_artifacts=("missing.md",),
+    )
+    artifact_ok_command_fails = AcceptanceCriterionSpec(
+        description="combined",
+        verify_command="exit 1",
+        expected_artifacts=("artifact.md",),
+    )
+    both_ok = AcceptanceCriterionSpec(
+        description="combined",
+        verify_command="exit 0",
+        expected_artifacts=("artifact.md",),
+    )
+
+    missing_leg = await executor._run_ac_verify_gate(
+        spec=command_ok_artifact_missing, cwd=str(tmp_path)
+    )
+    assert missing_leg.passed is False
+    assert missing_leg.missing_artifacts == ("missing.md",)
+
+    command_leg = await executor._run_ac_verify_gate(
+        spec=artifact_ok_command_fails, cwd=str(tmp_path)
+    )
+    assert command_leg.passed is False
+    assert "status 1" in (command_leg.reason or "")
+
+    assert (await executor._run_ac_verify_gate(spec=both_ok, cwd=str(tmp_path))).passed is True
+
+
+@pytest.mark.asyncio
+async def test_apply_verify_gate_fails_artifacts_only_ac(tmp_path: Any) -> None:
+    """An artifacts-only contract (verify: NONE) is enforced, not decorative."""
+    executor = _make_executor(working_directory=str(tmp_path))
+    seed = _seed_with_specs(
+        AcceptanceCriterionSpec(description="docs AC", expected_artifacts=("docs/out.md",))
+    )
+    result = ACExecutionResult(ac_index=0, ac_content="docs AC", success=True)
+
+    gated = await executor._apply_verify_gate(
+        seed=seed, ac_index=0, result=result, session_id="s", execution_id="e"
+    )
+
+    assert gated.success is False
+    assert gated.outcome == ACExecutionOutcome.FAILED
+    assert "expected_artifacts missing" in (gated.error or "")
+    assert gated.atomic_verifier_verdict is not None
+    assert gated.atomic_verifier_verdict.failure_class == "EVIDENCE_MISSING"
+
+    # And with the artifact present the same AC passes untouched.
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "docs" / "out.md").write_text("done\n")
+    passed = await executor._apply_verify_gate(
+        seed=seed, ac_index=0, result=result, session_id="s", execution_id="e"
+    )
+    assert passed is result
+
+
+@pytest.mark.asyncio
+async def test_sibling_flip_gated_out_by_artifacts_only_contract(tmp_path: Any) -> None:
+    executor = _make_executor(working_directory=str(tmp_path))
+    (tmp_path / "present.md").write_text("here\n")
+    seed = _seed_with_specs(
+        "sibling did work",
+        AcceptanceCriterionSpec(description="missing docs", expected_artifacts=("absent.md",)),
+        AcceptanceCriterionSpec(description="present docs", expected_artifacts=("present.md",)),
+    )
+    level_results = [
+        ACExecutionResult(ac_index=0, ac_content="sibling did work", success=True),
+        ACExecutionResult(
+            ac_index=1, ac_content="missing docs", success=False, outcome=ACExecutionOutcome.FAILED
+        ),
+        ACExecutionResult(
+            ac_index=2, ac_content="present docs", success=False, outcome=ACExecutionOutcome.FAILED
+        ),
+    ]
+
+    gated = await executor._compute_sibling_flip_gated_out(
+        seed=seed, level_results=level_results, session_id="s", execution_id="e"
+    )
+
+    assert gated == frozenset({1})
+
+
+@pytest.mark.asyncio
+async def test_skip_completed_gates_artifacts_only_contract(tmp_path: Any) -> None:
+    from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
+
+    seed = _seed_with_specs(
+        AcceptanceCriterionSpec(description="docs AC", expected_artifacts=("out.md",))
+    )
+    executor = _make_executor(working_directory=str(tmp_path))
+    dispatched: list[list[int]] = []
+
+    async def fake_batch(**kwargs: Any) -> list[ACExecutionResult]:
+        dispatched.append(list(kwargs["batch_indices"]))
+        return [ACExecutionResult(ac_index=0, ac_content="docs AC", success=True)]
+
+    executor._execute_ac_batch = fake_batch  # type: ignore[method-assign]
+    graph = DependencyGraph(
+        nodes=(ACNode(index=0, content="docs AC", depends_on=()),),
+        execution_levels=((0,),),
+    )
+
+    # Missing artifact → the skip is refused and the AC executes normally.
+    await executor.execute_parallel(
+        seed=seed,
+        execution_plan=graph.to_execution_plan(),
+        session_id="s1",
+        execution_id="e1",
+        tools=["Read"],
+        tool_catalog=None,
+        system_prompt="sys",
+        externally_satisfied_acs={0: {"reason": "claims done"}},
+    )
+    assert dispatched == [[0]]
+
+    # Present artifact → skipped and stamped verified.
+    (tmp_path / "out.md").write_text("done\n")
+    dispatched.clear()
+    result = await executor.execute_parallel(
+        seed=seed,
+        execution_plan=graph.to_execution_plan(),
+        session_id="s2",
+        execution_id="e2",
+        tools=["Read"],
+        tool_catalog=None,
+        system_prompt="sys",
+        externally_satisfied_acs={0: {"reason": "claims done"}},
+    )
+    assert dispatched == []
+    assert result.externally_satisfied_count == 1
+    assert "verification_status=verified" in result.results[0].final_message

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1,0 +1,504 @@
+"""Tests for PR-V verify-by-default: V1 gate, retry, lateral, trust leaks."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ouroboros.core.seed import (
+    AcceptanceCriterionSpec,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+from ouroboros.orchestrator.parallel_executor import (
+    ACExecutionOutcome,
+    ACExecutionResult,
+    ParallelACExecutor,
+    _complete_sibling_acs_from_evidence,
+)
+from ouroboros.orchestrator.verifier import VerifierVerdict
+
+
+class _StubAdapter:
+    """Minimal adapter satisfying the executor constructor + verify gate cwd."""
+
+    def __init__(self, working_directory: str) -> None:
+        self.runtime_backend = "claude"
+        self.self_governs_rate_limit = True
+        self.working_directory = working_directory
+        self.permission_mode = "acceptEdits"
+
+
+def _make_executor(
+    *,
+    working_directory: str = "/workspace",
+    run_verify_commands: bool = True,
+    ac_retry_attempts: int = 0,
+    verify_command_timeout_seconds: int = 30,
+) -> ParallelACExecutor:
+    return ParallelACExecutor(
+        adapter=_StubAdapter(working_directory),
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        run_verify_commands=run_verify_commands,
+        ac_retry_attempts=ac_retry_attempts,
+        verify_command_timeout_seconds=verify_command_timeout_seconds,
+    )
+
+
+def _seed_with_specs(*specs: AcceptanceCriterionSpec | str) -> Seed:
+    return Seed(
+        goal="verify-by-default",
+        acceptance_criteria=specs,
+        ontology_schema=OntologySchema(name="n", description="d"),
+        metadata=SeedMetadata(ambiguity_score=0.05),
+    )
+
+
+# ---------------------------------------------------------------------------
+# V1 gate — _run_ac_verify_gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_verify_gate_passes_on_exit_zero(tmp_path: Any) -> None:
+    executor = _make_executor(working_directory=str(tmp_path))
+    spec = AcceptanceCriterionSpec(description="ok", verify_command="exit 0")
+
+    outcome = await executor._run_ac_verify_gate(spec=spec, cwd=str(tmp_path))
+
+    assert outcome.passed is True
+    assert outcome.reason is None
+
+
+@pytest.mark.asyncio
+async def test_verify_gate_fails_on_nonzero_exit(tmp_path: Any) -> None:
+    executor = _make_executor(working_directory=str(tmp_path))
+    spec = AcceptanceCriterionSpec(description="bad", verify_command="exit 3")
+
+    outcome = await executor._run_ac_verify_gate(spec=spec, cwd=str(tmp_path))
+
+    assert outcome.passed is False
+    assert "status 3" in (outcome.reason or "")
+
+
+@pytest.mark.asyncio
+async def test_verify_gate_output_assertion_match_and_mismatch(tmp_path: Any) -> None:
+    executor = _make_executor(working_directory=str(tmp_path))
+    match_spec = AcceptanceCriterionSpec(
+        description="doc",
+        verify_command="printf 'BUILD SUCCESS'",
+        output_assertion="SUCCESS",
+    )
+    mismatch_spec = AcceptanceCriterionSpec(
+        description="doc",
+        verify_command="printf 'BUILD SUCCESS'",
+        output_assertion="FAILURE",
+    )
+
+    assert (await executor._run_ac_verify_gate(spec=match_spec, cwd=str(tmp_path))).passed is True
+    mismatch = await executor._run_ac_verify_gate(spec=mismatch_spec, cwd=str(tmp_path))
+    assert mismatch.passed is False
+    assert "output_assertion" in (mismatch.reason or "")
+
+
+# ---------------------------------------------------------------------------
+# V1 gate integration — _apply_verify_gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_verify_gate_flips_success_to_failed(tmp_path: Any) -> None:
+    executor = _make_executor(working_directory=str(tmp_path))
+    seed = _seed_with_specs(AcceptanceCriterionSpec(description="ac", verify_command="exit 1"))
+    result = ACExecutionResult(ac_index=0, ac_content="ac", success=True)
+
+    gated = await executor._apply_verify_gate(
+        seed=seed, ac_index=0, result=result, session_id="s", execution_id="e"
+    )
+
+    assert gated.success is False
+    assert gated.outcome == ACExecutionOutcome.FAILED
+    assert "Verify gate failed" in (gated.error or "")
+    assert gated.atomic_verifier_verdict is not None
+    assert gated.atomic_verifier_verdict.failure_class == "EVIDENCE_MISSING"
+
+
+@pytest.mark.asyncio
+async def test_apply_verify_gate_contract_less_is_noop(tmp_path: Any) -> None:
+    """A description-only AC (no verify_command) is byte-identical to today."""
+    executor = _make_executor(working_directory=str(tmp_path))
+    seed = _seed_with_specs("plain string AC")
+    result = ACExecutionResult(ac_index=0, ac_content="plain string AC", success=True)
+
+    gated = await executor._apply_verify_gate(
+        seed=seed, ac_index=0, result=result, session_id="s", execution_id="e"
+    )
+
+    assert gated is result
+
+
+@pytest.mark.asyncio
+async def test_apply_verify_gate_disabled_is_noop(tmp_path: Any) -> None:
+    executor = _make_executor(working_directory=str(tmp_path), run_verify_commands=False)
+    seed = _seed_with_specs(AcceptanceCriterionSpec(description="ac", verify_command="exit 1"))
+    result = ACExecutionResult(ac_index=0, ac_content="ac", success=True)
+
+    gated = await executor._apply_verify_gate(
+        seed=seed, ac_index=0, result=result, session_id="s", execution_id="e"
+    )
+
+    assert gated is result
+
+
+@pytest.mark.asyncio
+async def test_apply_verify_gate_skips_already_failed(tmp_path: Any) -> None:
+    """No double-fail: an already-failed AC is not re-gated (one root cause)."""
+    executor = _make_executor(working_directory=str(tmp_path))
+    seed = _seed_with_specs(AcceptanceCriterionSpec(description="ac", verify_command="exit 1"))
+    result = ACExecutionResult(ac_index=0, ac_content="ac", success=False, error="already failed")
+
+    gated = await executor._apply_verify_gate(
+        seed=seed, ac_index=0, result=result, session_id="s", execution_id="e"
+    )
+
+    assert gated is result
+
+
+# ---------------------------------------------------------------------------
+# V3 retry — _run_batch_with_verify_and_retry
+# ---------------------------------------------------------------------------
+
+
+def _fail(ac_index: int, failure_class: str) -> ACExecutionResult:
+    return ACExecutionResult(
+        ac_index=ac_index,
+        ac_content="ac",
+        success=False,
+        error="boom",
+        outcome=ACExecutionOutcome.FAILED,
+        atomic_verifier_verdict=VerifierVerdict(
+            passed=False, reasons=("boom",), failure_class=failure_class
+        ),
+    )
+
+
+def _ok(ac_index: int) -> ACExecutionResult:
+    return ACExecutionResult(ac_index=ac_index, ac_content="ac", success=True)
+
+
+async def _run_retry(executor: ParallelACExecutor, seed: Seed) -> list[Any]:
+    return await executor._run_batch_with_verify_and_retry(
+        seed=seed,
+        batch_executable=[0],
+        session_id="s",
+        execution_id="e",
+        tools=[],
+        tool_catalog=None,
+        system_prompt="sys",
+        level_contexts=[],
+        ac_retry_attempts={0: 0},
+        execution_counters=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_retry_redispatches_and_exhausts(tmp_path: Any) -> None:
+    executor = _make_executor(
+        working_directory=str(tmp_path), run_verify_commands=False, ac_retry_attempts=2
+    )
+    seed = _seed_with_specs("ac")
+    ac_retry_attempts = {0: 0}
+    calls: list[list[int]] = []
+
+    async def fake_batch(**kwargs: Any) -> list[ACExecutionResult]:
+        calls.append(list(kwargs["batch_indices"]))
+        # Distinct classes each attempt so early-stop does not trigger.
+        cls = ["EVIDENCE_MISSING", "STALL", "SCOPE_CREEP"][len(calls) - 1]
+        return [_fail(0, cls)]
+
+    executor._execute_ac_batch = fake_batch  # type: ignore[method-assign]
+
+    results = await executor._run_batch_with_verify_and_retry(
+        seed=seed,
+        batch_executable=[0],
+        session_id="s",
+        execution_id="e",
+        tools=[],
+        tool_catalog=None,
+        system_prompt="sys",
+        level_contexts=[],
+        ac_retry_attempts=ac_retry_attempts,
+        execution_counters=None,
+    )
+
+    # initial + 2 retries = 3 dispatches; counter incremented to the limit.
+    assert calls == [[0], [0], [0]]
+    assert ac_retry_attempts[0] == 2
+    assert results[0].success is False
+
+
+@pytest.mark.asyncio
+async def test_retry_early_stop_on_identical_failure_class(tmp_path: Any) -> None:
+    executor = _make_executor(
+        working_directory=str(tmp_path), run_verify_commands=False, ac_retry_attempts=2
+    )
+    seed = _seed_with_specs("ac")
+    ac_retry_attempts = {0: 0}
+    calls: list[list[int]] = []
+
+    async def fake_batch(**kwargs: Any) -> list[ACExecutionResult]:
+        calls.append(list(kwargs["batch_indices"]))
+        return [_fail(0, "EVIDENCE_MISSING")]  # identical class every time
+
+    executor._execute_ac_batch = fake_batch  # type: ignore[method-assign]
+
+    await executor._run_batch_with_verify_and_retry(
+        seed=seed,
+        batch_executable=[0],
+        session_id="s",
+        execution_id="e",
+        tools=[],
+        tool_catalog=None,
+        system_prompt="sys",
+        level_contexts=[],
+        ac_retry_attempts=ac_retry_attempts,
+        execution_counters=None,
+    )
+
+    # Initial dispatch + a single retry that returns the identical class stops
+    # early rather than burning the last attempt (2 dispatches, not 3).
+    assert calls == [[0], [0]]
+    assert ac_retry_attempts[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_succeeds_before_dependents(tmp_path: Any) -> None:
+    executor = _make_executor(
+        working_directory=str(tmp_path), run_verify_commands=False, ac_retry_attempts=2
+    )
+    seed = _seed_with_specs("ac")
+    ac_retry_attempts = {0: 0}
+    calls: list[list[int]] = []
+
+    async def fake_batch(**kwargs: Any) -> list[ACExecutionResult]:
+        calls.append(list(kwargs["batch_indices"]))
+        return [_fail(0, "EVIDENCE_MISSING")] if len(calls) == 1 else [_ok(0)]
+
+    executor._execute_ac_batch = fake_batch  # type: ignore[method-assign]
+
+    results = await executor._run_batch_with_verify_and_retry(
+        seed=seed,
+        batch_executable=[0],
+        session_id="s",
+        execution_id="e",
+        tools=[],
+        tool_catalog=None,
+        system_prompt="sys",
+        level_contexts=[],
+        ac_retry_attempts=ac_retry_attempts,
+        execution_counters=None,
+    )
+
+    assert calls == [[0], [0]]
+    assert results[0].success is True
+
+
+@pytest.mark.asyncio
+async def test_no_retry_when_attempts_zero(tmp_path: Any) -> None:
+    executor = _make_executor(
+        working_directory=str(tmp_path), run_verify_commands=False, ac_retry_attempts=0
+    )
+    seed = _seed_with_specs("ac")
+    calls: list[list[int]] = []
+
+    async def fake_batch(**kwargs: Any) -> list[ACExecutionResult]:
+        calls.append(list(kwargs["batch_indices"]))
+        return [_fail(0, "EVIDENCE_MISSING")]
+
+    executor._execute_ac_batch = fake_batch  # type: ignore[method-assign]
+
+    await _run_retry(executor, seed)
+
+    assert calls == [[0]]
+
+
+# ---------------------------------------------------------------------------
+# V4 lateral directive — _build_ac_retry_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_retry_prompt_final_attempt_carries_lateral_directive() -> None:
+    executor = _make_executor()
+    result = _fail(0, "EVIDENCE_MISSING")
+
+    final = executor._build_ac_retry_prompt(
+        result=result, ac_content="build the thing", is_final_attempt=True
+    )
+    interim = executor._build_ac_retry_prompt(
+        result=result, ac_content="build the thing", is_final_attempt=False
+    )
+
+    assert "Change of Approach" in final
+    assert "EVIDENCE_MISSING" in final
+    assert "Change of Approach" not in interim
+
+
+# ---------------------------------------------------------------------------
+# V4 trust leaks — sibling flip gate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_compute_sibling_flip_gated_out_blocks_failing_contract(tmp_path: Any) -> None:
+    executor = _make_executor(working_directory=str(tmp_path))
+    seed = _seed_with_specs(
+        "sibling did work",
+        AcceptanceCriterionSpec(description="contract", verify_command="exit 1"),
+        AcceptanceCriterionSpec(description="passing", verify_command="exit 0"),
+        "plain",
+    )
+    level_results = [
+        ACExecutionResult(ac_index=0, ac_content="sibling did work", success=True),
+        ACExecutionResult(
+            ac_index=1, ac_content="contract", success=False, outcome=ACExecutionOutcome.FAILED
+        ),
+        ACExecutionResult(
+            ac_index=2, ac_content="passing", success=False, outcome=ACExecutionOutcome.FAILED
+        ),
+        ACExecutionResult(
+            ac_index=3, ac_content="plain", success=False, outcome=ACExecutionOutcome.FAILED
+        ),
+    ]
+
+    gated = await executor._compute_sibling_flip_gated_out(
+        seed=seed, level_results=level_results, session_id="s", execution_id="e"
+    )
+
+    # AC 1's verify fails → gated out; AC 2 passes → allowed; AC 3 has no
+    # contract → never gated.
+    assert gated == frozenset({1})
+
+
+def test_sibling_flip_respects_gated_out(tmp_path: Any) -> None:
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_hello_auto.py").write_text("def test_hello(): pass\n")
+    from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
+    from ouroboros.orchestrator.evidence_schema import EvidenceRecord
+
+    success = ACExecutionResult(
+        ac_index=0,
+        ac_content="`hello_auto.py` defines `hello_auto()`.",
+        success=True,
+        messages=(
+            AgentMessage(
+                type="tool_use",
+                content="write test",
+                tool_name="Write",
+                data={"tool_input": {"file_path": "tests/test_hello_auto.py"}},
+            ),
+        ),
+        typed_evidence=EvidenceRecord(data={"files_touched": ["tests/test_hello_auto.py"]}),
+        runtime_handle=RuntimeHandle(backend="codex_cli", cwd=str(tmp_path)),
+    )
+    failed = ACExecutionResult(
+        ac_index=1,
+        ac_content="`tests/test_hello_auto.py` exists.",
+        success=False,
+        error="not done separately",
+        outcome=ACExecutionOutcome.FAILED,
+    )
+
+    # Without gating, the failed AC is flipped to satisfied by sibling evidence.
+    _, _, _, open_results = _complete_sibling_acs_from_evidence(
+        level_results=[success, failed],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+    )
+    assert open_results[1].outcome == ACExecutionOutcome.SATISFIED_EXTERNALLY
+
+    # With AC 1 gated out (its own verify_command did not pass), it stays FAILED.
+    _, _, _, gated_results = _complete_sibling_acs_from_evidence(
+        level_results=[success, failed],
+        ac_statuses={0: "completed", 1: "failed"},
+        failed_indices={1},
+        completed_count=1,
+        level_success=1,
+        level_failed=1,
+        flip_gated_out=frozenset({1}),
+    )
+    assert gated_results[1].outcome == ACExecutionOutcome.FAILED
+
+
+# ---------------------------------------------------------------------------
+# V4 trust leaks — --skip-completed gate + verification_status stamp
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_skip_completed_stamps_assumed_for_contract_less(tmp_path: Any) -> None:
+    from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
+
+    seed = _seed_with_specs("plain AC")
+    executor = _make_executor(working_directory=str(tmp_path))
+    executor._execute_ac_batch = AsyncMock(return_value=[])  # type: ignore[method-assign]
+    graph = DependencyGraph(
+        nodes=(ACNode(index=0, content="plain AC", depends_on=()),),
+        execution_levels=((0,),),
+    )
+
+    result = await executor.execute_parallel(
+        seed=seed,
+        execution_plan=graph.to_execution_plan(),
+        session_id="s",
+        execution_id="e",
+        tools=["Read"],
+        tool_catalog=None,
+        system_prompt="sys",
+        externally_satisfied_acs={0: {"reason": "done manually"}},
+    )
+
+    assert result.externally_satisfied_count == 1
+    assert "verification_status=assumed" in result.results[0].final_message
+
+
+@pytest.mark.asyncio
+async def test_skip_completed_executes_when_verify_gate_fails(tmp_path: Any) -> None:
+    from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
+
+    seed = _seed_with_specs(
+        AcceptanceCriterionSpec(description="contract AC", verify_command="exit 1")
+    )
+    executor = _make_executor(working_directory=str(tmp_path))
+    dispatched: list[list[int]] = []
+
+    async def fake_batch(**kwargs: Any) -> list[ACExecutionResult]:
+        dispatched.append(list(kwargs["batch_indices"]))
+        return [ACExecutionResult(ac_index=0, ac_content="contract AC", success=True)]
+
+    executor._execute_ac_batch = fake_batch  # type: ignore[method-assign]
+    graph = DependencyGraph(
+        nodes=(ACNode(index=0, content="contract AC", depends_on=()),),
+        execution_levels=((0,),),
+    )
+
+    await executor.execute_parallel(
+        seed=seed,
+        execution_plan=graph.to_execution_plan(),
+        session_id="s",
+        execution_id="e",
+        tools=["Read"],
+        tool_catalog=None,
+        system_prompt="sys",
+        externally_satisfied_acs={0: {"reason": "claims done"}},
+    )
+
+    # The failing verify gate forced normal execution instead of skipping.
+    assert dispatched == [[0]]


### PR DESCRIPTION
## Summary

**Phase V of `docs/run-metaharness-plan-2026-07.md`** — the highest-impact fix from the run failure-mode audit: today the default (parallel) run path marks an AC complete on the worker's own word (`success = not message.is_error`), never retries a failed AC (`ac_retry_attempts` was a dead counter), and fences all stagnation/lateral recovery to the sequential runner. On hard domains and brownfield, workers "believe" they finished and nothing catches the false positive.

### 1 — AC success contract (`AcceptanceCriterionSpec`)
`acceptance_criteria` items become structured specs — `description` (mandatory) + optional `verify_command` / `expected_artifacts` / `output_assertion`. Bare-string ACs coerce forever; **description-only specs serialize back to bare strings so existing seed files round-trip byte-identically** (tested against a real fixture). `ac_text()` helper rippled across ~16 consumers with identical behavior for legacy data. seed-architect now emits per-AC contracts (`AC: <desc> | verify: … | artifacts: … | expect: …`, 2 few-shot examples); unparseable lines fall back to description-only — parsing never fails on missing contract fields.

### 2 — V1: orchestrator-run verify gate (default ON)
When an AC carries `verify_command`, the ORCHESTRATOR runs it (asyncio subprocess, workspace cwd, configurable 600s timeout) and requires exit 0 + `output_assertion` substring. Worker self-report becomes irrelevant. Gate failure → existing failure taxonomy (`EVIDENCE_MISSING`, no new codes) + `execution.verify.failed` event + command output tail in the failure reason. Already-failed ACs skip the gate — one failure event per root cause, no double-fail. Contract-less ACs byte-identical to today.

### 3 — V2/V3: per-AC retry with kill criteria
Non-stall failures re-dispatch up to `execution.ac_retry_attempts` (default 2) with an enriched prompt (failure class + error tail + verify output tail). Identical failure class on consecutive attempts → stop early. Final attempt injects a lateral change-of-approach directive (shared `resilience/lateral.py` helper, loop-independent). Retries complete within the level, so recovered ACs naturally unblock their dependents.

### 4 — V4: trust leaks closed
- Sibling-evidence flips: a FAILED AC with a `verify_command` can only be flipped to satisfied if its own gate passes now.
- `--skip-completed`: runs the gate when a contract exists (fail → execute normally); contract-less skips are stamped `verification_status=assumed`.

### 5 — fat-harness ON by default (user mandate), both paths
- CLI: fresh runs enforce typed evidence + verifier PASS unless the seed opts out with `execution_mode: legacy`.
- MCP (`execute_seed`/`start_execute_seed` — the primary `ooo run` surface): same resolution, same vocabulary. **Deliberate behavior change:** `_validate_fresh_execution_mode` re-admits `legacy` as the explicit opt-out (#978 P5 removed it when the default runner was observe-mode and the token was redundant; verify-by-default makes it meaningful again).
- Plugin dispatch (structurally cannot enforce): explicit `fat_harness` requests still hard-reject; the default case downgrades with a visible `fat_harness_downgraded: "plugin_dispatch_cannot_enforce"` meta note. Resume: persisted contract always wins; sessions without one resume ON unless the seed says `legacy`.
- `ParallelACExecutor` constructor defaults unchanged (False/0) — ~100 direct-construction tests rely on them and every production path passes flags explicitly from the resolvers; the mandated OUTCOME (fat-harness active on every real run) is delivered at the resolver layer.

Config: `execution.run_verify_commands: true`, `verify_command_timeout_seconds: 600`, `ac_retry_attempts: 2`.

## Testing
- 16 new executor tests (gate pass / exit-fail / assertion-mismatch, retry increment/exhaust/early-stop, lateral on final attempt, sibling gate, skip-completed stamp) + schema round-trip/coercion tests + 5 new MCP resolution tests (fresh default ON, legacy opt-out, plugin downgrade note, plugin explicit reject, resume persisted-False preserved).
- `ruff check` ✅ / `ruff format` ✅ / `mypy src/` ✅ (400 files, clean).
- Full `pytest tests/ --ignore=tests/e2e`: 11191 passed; the 17 failures are the pre-existing opencode/codex/plugin set, verified byte-identical on the base commit. Existing test edits are representation-only (`ac_text()` wrapping forced by the element-type change) or deliberate default-assertion updates for the mandated flips — documented per file in the commits.

Note: expect a small mechanical conflict with #1546 (cross-harness) in `parallel_executor.py`'s retry area — whichever merges second gets rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## R-run comparison

Substrate-only auto/ change: parameter plumbing / representation ripple only — the interview round loop, refiner, and grading mechanics are untouched, so there is no per-round comparison to capture (template-sanctioned explicit N/A).

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A | N/A | n/a |
| Per-round wall-clock (s/round) | N/A | N/A | n/a |
| Terminal reason                | N/A | N/A | n/a |
| EventStore event count         | N/A | N/A | n/a |

Budget compliance: [x] within 1.5× (no per-round cost path touched)