### PR TITLE
feat(evolution): AC-scoped re-execution — grounded Wonder + Reflect AC patches

### DIFF
--- a/docs/rfc/reflect-grounded-elenchus-scoped-reexecution.md
+++ b/docs/rfc/reflect-grounded-elenchus-scoped-reexecution.md
@@ -1,0 +1,240 @@
+# RFC: Grounded Elenchus & Satisficing Delta — AC-Scoped Re-execution for the Reflect Layer
+
+Status: Draft
+Author: Ouroboros core
+Scope: `src/ouroboros/evolution/wonder.py`, `src/ouroboros/evolution/reflect.py`,
+`src/ouroboros/evolution/loop.py`, `src/ouroboros/mcp/server/adapter.py`
+
+## 1. Problem
+
+The Wonder → Reflect → Seed → Execute → Evaluate cycle re-derives and re-executes
+**everything** every generation:
+
+1. **Wonder questions are free-floating.** `WonderOutput.questions` are bare strings
+   (`wonder.py:49`) with no link to the acceptance criteria they challenge. "What did
+   we miss?" never says *where* we missed it.
+2. **Reflect rewrites the whole seed.** `ReflectOutput.refined_acs` is a full
+   replacement AC list (`reflect.py:64`), fed verbatim into
+   `SeedGenerator.generate_from_reflect` (`seed_generator.py:254`). Even when 9/10 ACs
+   passed, all 10 get re-derived by an LLM at temperature 0.5 — which also perturbs
+   their wording and breaks the positional AC identity that `RegressionDetector`
+   (`regression.py:67-72`) and the per-AC convergence gate rely on.
+3. **Execution re-runs every AC.** `_evolution_executor` (`adapter.py:1456`) calls
+   `OrchestratorRunner.execute_seed` without any scoping, so the parallel executor
+   spawns workers for all ACs each generation, including ones that already passed and
+   were not challenged by anything.
+
+Consequences observed in the field: heavy generations dominated by re-work of settled
+ACs, wording-drift-induced oscillation, and regression-gate noise.
+
+## 2. What already exists (borrow, don't port)
+
+The execution substrate for scoping is **already built and battle-tested**:
+
+- `OrchestratorRunner.execute_seed(..., externally_satisfied_acs: dict[int, dict[str, Any]])`
+  (`runner.py:2089-2132`) skips listed AC indices.
+- `ParallelACExecutor` handles them per-node (`parallel_executor.py:3899-3953`):
+  dependency validation still runs (a "satisfied" AC downstream of a failed dependency
+  is blocked, not skipped), and skipped ACs get
+  `ACExecutionOutcome.SATISFIED_EXTERNALLY` with `success=True`.
+- Reports count them as COMPLETED (`parallel_executor.py:2403-2409`), so the
+  mechanical evaluator (`adapter.py:1492-1500`) sees them as passing.
+- `ooo run --skip-completed` (`cli/commands/run.py:601-619`) is the existing consumer.
+
+The evolution loop simply never plumbs into it. That is the entire gap.
+
+## 3. Philosophy
+
+### Socrates — grounded elenchus
+An elenchus refutes a *specific* claim held by a *specific* interlocutor. A question
+that cannot name what it challenges is not yet a question — it is a mood. Every Wonder
+question must therefore be **grounded**: either it *challenges* named AC(s), or it
+names a *gap* (something the goal requires that no AC covers). A grounded challenge is
+the only licensed way to reopen a settled claim.
+
+### Herbert Simon — satisficing over nearly decomposable systems
+- **Satisficing:** an AC that passed evaluation is a satisficed commitment. Rational
+  agents with bounded resources do not re-derive satisficed commitments without
+  evidence (a regression or a grounded challenge).
+- **Near-decomposability** (*The Architecture of Complexity*): ACs are the subsystem
+  boundaries of the spec; intra-AC interactions dominate inter-AC ones. Local repair
+  of the failing subsystems beats global re-derivation.
+- **Means-ends analysis:** the agenda for generation N+1 is exactly the *difference*
+  between current state and goal state: failed ACs ∪ regressed ACs ∪ grounded
+  challenges ∪ gaps (as new ACs). Nothing else.
+
+Design rule that falls out: **the LLM proposes, deterministic code disposes.** LLM
+outputs are advisory; a deterministic backstop enforces the satisficing invariant
+(same pattern as the interview refiner's committed-decisions anchor that fixed
+oscillation in v0.42.4).
+
+## 4. Design
+
+### 4.1 `wonder.py` — GroundedQuestion
+
+```python
+class GroundedQuestion(BaseModel, frozen=True):
+    question: str
+    kind: Literal["challenge", "gap"] = "gap"
+    ac_indices: tuple[int, ...] = ()   # 0-based; required for kind="challenge"
+
+class WonderOutput(BaseModel, frozen=True):
+    questions: tuple[str, ...] = ...            # UNCHANGED (events/lineage compat)
+    grounded_questions: tuple[GroundedQuestion, ...] = ()   # NEW
+    ontology_tensions: tuple[str, ...] = ...
+    should_continue: bool = True
+    reasoning: str = ""
+```
+
+- System prompt (`_system_prompt`): each question must either cite the AC number(s) it
+  challenges (`"ac_refs": [2]`, 1-based in the JSON, converted to 0-based on parse) or
+  declare `"kind": "gap"`. Passing ACs may only be questioned with evidence from the
+  evaluation/execution output.
+- Parser: tolerant. If the LLM returns plain strings (legacy shape), fall back to a
+  deterministic regex over the question text (`\bAC\s*#?(\d+)\b`, case-insensitive):
+  any matches → `challenge` with those indices (out-of-range matches dropped; if none
+  remain in range → `gap`); no matches → `gap`. `questions` is always populated
+  (derived from grounded questions when the new shape parses) so existing events,
+  lineage records, and the repetitive-feedback convergence check are untouched.
+- The same regex fallback re-grounds questions restored from interrupted-generation
+  `partial_state` (which only persists strings, `loop.py:1403-1407`).
+
+### 4.2 `reflect.py` — ACPatch + deterministic satisficing backstop
+
+```python
+class ACPatch(BaseModel, frozen=True):
+    op: Literal["keep", "revise", "add"]
+    index: int | None = None      # required for keep/revise; None for add
+    content: str | None = None    # required for revise/add
+    reason: str = ""
+
+class ReflectOutput(BaseModel, frozen=True):
+    refined_goal: str
+    refined_constraints: tuple[str, ...] = ...
+    refined_acs: tuple[str, ...] = ...          # UNCHANGED — composed from patches
+    ac_patches: tuple[ACPatch, ...] = ()        # NEW
+    settled_ac_indices: tuple[int, ...] = ()    # NEW — indices in the NEW AC list
+    ontology_mutations: tuple[OntologyMutation, ...] = ...
+    reasoning: str = ""
+```
+
+- System prompt: Reflect now **patches** the AC list instead of rewriting it. Explicit
+  contract: an AC that passed and is not named by any grounded challenge and not
+  regressed MUST be `keep` (verbatim). Failed/challenged/regressed ACs may be
+  `revise`d. `gap` questions may become `add` patches. `remove` is NOT offered in v1
+  (see 4.5).
+- `reflect()` gains an optional `regression_report: RegressionReport | None = None`
+  parameter so the loop can pass the already-computed report (today Reflect recomputes
+  it internally for the prompt, `reflect.py:337-348`; reuse that when not supplied).
+- **Deterministic backstop** (`_apply_satisficing_backstop`), applied after parsing,
+  before composing `refined_acs`:
+  - Let `protected = {i : AC i passed in eval AND i not in challenged_indices AND
+    i not in regressed_indices}` (challenged from `wonder_output.grounded_questions`,
+    regressed from the regression report).
+  - Any LLM patch that revises a protected index is overridden to
+    `keep` (verbatim parent text), logged as `reflect.backstop.forced_keep`.
+  - Any index missing from the LLM's patches gets an implicit `keep`.
+  - Malformed/duplicate/out-of-range patches are dropped with a warning; the composed
+    list must contain every parent index exactly once (keeps/revises in place, adds
+    appended in order). Order stability preserves positional AC identity for
+    `RegressionDetector`.
+- **Legacy fallback:** if the LLM returns no `ac_patches` (old JSON shape), derive
+  patches by verbatim positional diff of `refined_acs` vs the parent ACs: identical
+  text at the same index → `keep`; different text → `revise`; extra tail entries →
+  `add`; a *shorter* list falls back to full-rewrite semantics (no settled indices)
+  rather than guessing at deletions. The backstop then applies on top. This means
+  scoping works even before any model has seen the new prompt.
+- `settled_ac_indices` = indices whose final op is `keep` AND whose AC passed in the
+  previous evaluation (kept-but-failing ACs must re-execute).
+
+### 4.3 `loop.py` — scoped execution plumbing
+
+In `_run_generation_phases`, Gen 2+ path:
+
+1. Compute `regression_report = RegressionDetector().detect(lineage)` once; pass it to
+   `reflect_engine.reflect(...)`.
+2. After seeding, when `self.config.scoped_reexecution` and `reflect_output` exists:
+
+```python
+settled = {
+    i: {"reason": "satisficed: passed in previous generation; not challenged or regressed"}
+    for i in reflect_output.settled_ac_indices
+}
+```
+
+3. `_call_executor` (`loop.py:1217-1231`) gains an `externally_satisfied_acs`
+   parameter, forwarded only when the wired executor accepts it (existing
+   `_callable_accepts_keyword` pattern) and non-empty. Resume paths that skip the
+   reflect phase but re-execute simply pass nothing (conservative full run).
+4. Config: `EvolutionaryLoopConfig.scoped_reexecution: bool = True`, overridable to
+   off via env `OUROBOROS_SCOPED_REEXECUTION=0` (read where the config is built in
+   `adapter.py:1756-1765`).
+
+### 4.4 `adapter.py` — executor forwarding
+
+`_evolution_executor` (`adapter.py:1456`) accepts
+`externally_satisfied_acs: dict[int, dict[str, Any]] | None = None` and forwards it to
+`evolution_runner.execute_seed(...)`. Four lines.
+
+### 4.5 Invariants & non-goals
+
+Invariants:
+- **A regressed AC is never settled.** Regression indices are subtracted before
+  settling.
+- **Trust but verify:** `_verify_spec_compliance` (`adapter.py:1529`) still runs
+  `SpecVerifier` over ALL assertions against the working tree every generation. A
+  stale "satisfied" claim flips to FAIL → regression gate (`convergence.py:139-154`)
+  blocks convergence → the AC is excluded from settling next generation. Skipping
+  execution never skips verification.
+- **Workspace continuity holds:** all generations execute in the same
+  `evolutionary_loop.get_project_dir()`, so previously-built artifacts persist and
+  skipping is sound.
+- **Positional identity is preserved:** keeps/revises stay at their index; adds
+  append. This *improves* on today, where full rewrites silently shuffle identity.
+
+Non-goals (v1):
+- `remove` op (index shifts would break positional AC history; deferred until stable
+  AC IDs / `AcceptanceCriterionSpec` land). An LLM-proposed `remove` is coerced to
+  `keep` with a warning.
+- Evaluator scoping (evaluation is cheap relative to execution and doubles as the
+  safety net).
+- Stable AC identity keys (separate workstream).
+
+### 4.6 Convergence interaction
+
+- All-pass tail generations become cheap: every AC settles, execution degenerates to a
+  near-noop verification report, and the loop spends its budget on ontology
+  convergence instead of redundant rebuilds.
+- The per-AC gate, eval gate, stagnation/oscillation detection are all unchanged —
+  they consume the same `EvaluationSummary`/ontology signals as before.
+
+## 5. Test plan
+
+New: `tests/unit/evolution/test_wonder_grounding.py`,
+`tests/unit/evolution/test_reflect_delta.py`, `tests/unit/evolution/test_scoped_reexecution.py`.
+
+1. **Wonder grounding:** new-shape parse (challenge + gap, 1-based→0-based); legacy
+   strings → regex fallback grounding; out-of-range refs dropped (all-dropped
+   challenge → gap); `questions` always populated.
+2. **Reflect delta:** patch parse; composition order (keep/revise in place, add
+   appended); backstop forces keep on passed+unchallenged+unregressed; challenged or
+   failed or regressed ACs may revise; kept-but-failed AC not settled; legacy
+   full-list fallback diff (identical→keep, changed→revise, longer→add,
+   shorter→full-rewrite semantics); malformed patches dropped, every parent index
+   present exactly once.
+3. **Loop scoping:** settled dict built and forwarded; executor without the kwarg →
+   not forwarded (signature guard); `scoped_reexecution=False` → not forwarded;
+   empty settled → not forwarded; regression exclusion end-to-end (AC passed gen N-1,
+   regressed gen N → executes in gen N+1).
+4. **Adapter:** `_evolution_executor` forwards the kwarg (extend
+   `tests/unit/mcp/server/test_adapter.py`).
+5. **Compat:** existing suites (`test_evolve_step.py`, `test_graceful_shutdown.py`,
+   `test_convergence.py`, `test_backend_drift.py`, `test_wonder_scope.py`) pass
+   unmodified — new fields all default-valued, `refined_acs`/`questions` semantics
+   unchanged.
+
+## 6. Rollout
+
+Single PR, default-on with `OUROBOROS_SCOPED_REEXECUTION=0` escape hatch. No event
+schema changes (new fields ride inside existing `reflect_output`/`wonder` payloads via
+pydantic defaults; old events replay fine because all new fields are optional).

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -58,11 +58,12 @@ from ouroboros.evolution.directive_mapping import (
 )
 from ouroboros.evolution.projector import LineageProjector
 from ouroboros.evolution.reflect import ReflectEngine, ReflectOutput
+from ouroboros.evolution.regression import RegressionDetector, RegressionReport
 from ouroboros.evolution.watchdog import (
     GenerationProgressWatchdog,
     GenerationWatchdogTimeout,
 )
-from ouroboros.evolution.wonder import WonderEngine, WonderOutput
+from ouroboros.evolution.wonder import WonderEngine, WonderOutput, ground_questions
 from ouroboros.observability.drift import DriftMeasuredEvent, DriftMeasurement
 from ouroboros.orchestrator.agent_process import AgentProcess, AgentProcessHandle
 from ouroboros.persistence.event_store import EventStore
@@ -90,6 +91,7 @@ class EvolutionaryLoopConfig:
     enable_oscillation_detection: bool = True
     eval_gate_enabled: bool = True
     eval_min_score: float = 0.7
+    scoped_reexecution: bool = True
 
     def __post_init__(self) -> None:
         """Map legacy generation_timeout_seconds onto no-progress detection."""
@@ -1220,6 +1222,7 @@ class EvolutionaryLoop:
         *,
         parallel: bool,
         execution_id: str | None,
+        externally_satisfied_acs: dict[int, dict[str, Any]] | None = None,
     ) -> Any:
         """Call the configured executor with optional execution_id support."""
         kwargs: dict[str, Any] = {"parallel": parallel}
@@ -1228,6 +1231,11 @@ class EvolutionaryLoop:
             "execution_id",
         ):
             kwargs["execution_id"] = execution_id
+        if externally_satisfied_acs and self._callable_accepts_keyword(
+            self.executor,
+            "externally_satisfied_acs",
+        ):
+            kwargs["externally_satisfied_acs"] = externally_satisfied_acs
         return await self.executor(seed, **kwargs)
 
     @staticmethod
@@ -1401,8 +1409,15 @@ class EvolutionaryLoop:
             if interrupted_gen and interrupted_gen.partial_state:
                 ps = interrupted_gen.partial_state
                 if _should_skip("wondering") and ps.get("wonder_questions"):
+                    # partial_state persists only plain strings — re-ground them
+                    # via the deterministic regex so a restored challenge is not
+                    # silently demoted to a gap (which would over-protect its AC).
+                    restored_questions = tuple(ps["wonder_questions"])
                     wonder_output = WonderOutput(
-                        questions=tuple(ps["wonder_questions"]),
+                        questions=restored_questions,
+                        grounded_questions=ground_questions(
+                            restored_questions, len(current_seed.acceptance_criteria)
+                        ),
                         should_continue=True,
                     )
                 if _should_skip("reflecting") and ps.get("reflect_output"):
@@ -1436,6 +1451,10 @@ class EvolutionaryLoop:
                 (g for g in reversed(lineage.generations) if g.phase == GenerationPhase.COMPLETED),
                 lineage.generations[-1],  # fallback if no completed gen exists
             )
+
+            # Compute regressions once and reuse for both Reflect's prompt and its
+            # deterministic satisficing backstop (a regressed AC is never settled).
+            regression_report: RegressionReport = RegressionDetector().detect(lineage)
 
             # Emit generation started
             await self.event_store.append(
@@ -1531,6 +1550,7 @@ class EvolutionaryLoop:
                         evaluation_summary=prev_gen.evaluation_summary,
                         wonder_output=wonder_output,
                         lineage=lineage,
+                        regression_report=regression_report,
                     )
 
                     if reflect_result.is_ok:
@@ -1695,11 +1715,31 @@ class EvolutionaryLoop:
                 extra={"generation": generation_number},
             )
         elif execute and self.executor:
+            # AC-scoped re-execution: skip ACs that satisficed last generation
+            # (passed AND not challenged AND not regressed). Only when Reflect ran
+            # fresh this invocation — resume paths pass nothing (conservative full
+            # run). Verification still runs over ALL ACs downstream.
+            externally_satisfied_acs: dict[int, dict[str, Any]] | None = None
+            if (
+                self.config.scoped_reexecution
+                and reflect_output is not None
+                and reflect_output.settled_ac_indices
+                and not _should_skip("reflecting")
+            ):
+                externally_satisfied_acs = {
+                    i: {
+                        "reason": (
+                            "satisficed: passed in previous generation; not challenged or regressed"
+                        )
+                    }
+                    for i in reflect_output.settled_ac_indices
+                }
             try:
                 exec_result = await self._call_executor(
                     current_seed,
                     parallel=parallel,
                     execution_id=execution_id,
+                    externally_satisfied_acs=externally_satisfied_acs,
                 )
                 if hasattr(exec_result, "is_ok") and exec_result.is_ok:
                     orch_result = exec_result.value

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -16,6 +16,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 import json
 import logging
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -25,7 +26,7 @@ from ouroboros.core.lineage import EvaluationSummary, MutationAction, OntologyDe
 from ouroboros.core.seed import Seed
 from ouroboros.core.text import truncate_head_tail
 from ouroboros.core.types import Result
-from ouroboros.evolution.regression import RegressionDetector
+from ouroboros.evolution.regression import RegressionDetector, RegressionReport
 from ouroboros.evolution.wonder import WonderOutput
 from ouroboros.providers.base import (
     CompletionConfig,
@@ -52,6 +53,21 @@ class OntologyMutation(BaseModel, frozen=True):
     reason: str = ""
 
 
+class ACPatch(BaseModel, frozen=True):
+    """A single delta against the parent AC list.
+
+    ``keep``/``revise`` target an existing parent AC by ``index`` (0-based);
+    ``add`` appends a new AC (``index`` is None). ``remove`` is not offered in
+    v1 — deleting an AC would shift positional identity that regression
+    detection and the per-AC gate depend on.
+    """
+
+    op: Literal["keep", "revise", "add"]
+    index: int | None = None
+    content: str | None = None
+    reason: str = ""
+
+
 class ReflectOutput(BaseModel, frozen=True):
     """Output of the Reflect phase -- feeds directly into SeedGenerator.
 
@@ -62,8 +78,137 @@ class ReflectOutput(BaseModel, frozen=True):
     refined_goal: str
     refined_constraints: tuple[str, ...] = Field(default_factory=tuple)
     refined_acs: tuple[str, ...] = Field(default_factory=tuple)
+    ac_patches: tuple[ACPatch, ...] = Field(default_factory=tuple)
+    settled_ac_indices: tuple[int, ...] = Field(default_factory=tuple)
     ontology_mutations: tuple[OntologyMutation, ...] = Field(default_factory=tuple)
     reasoning: str = ""
+
+
+def _parse_ac_patches(raw_patches: object) -> list[ACPatch]:
+    """Parse raw LLM patch objects, coercing unknown/``remove`` ops to keep."""
+    patches: list[ACPatch] = []
+    if not isinstance(raw_patches, list):
+        return patches
+    for item in raw_patches:
+        if not isinstance(item, dict):
+            continue
+        op = str(item.get("op", "")).lower()
+        if op not in ("keep", "revise", "add"):
+            logger.warning("reflect.patch.op_coerced_to_keep", extra={"op": op})
+            op = "keep"
+        raw_index = item.get("index")
+        index = (
+            raw_index if isinstance(raw_index, int) and not isinstance(raw_index, bool) else None
+        )
+        raw_content = item.get("content")
+        content = raw_content if isinstance(raw_content, str) else None
+        raw_reason = item.get("reason", "")
+        reason = raw_reason if isinstance(raw_reason, str) else ""
+        patches.append(ACPatch(op=op, index=index, content=content, reason=reason))
+    return patches
+
+
+def _derive_legacy_patches(
+    refined_acs: tuple[str, ...], parent_acs: tuple[str, ...]
+) -> list[ACPatch] | None:
+    """Derive patches from a full refined-AC list (old JSON shape).
+
+    Verbatim positional diff: identical text → keep, different → revise, extra
+    tail entries → add. A *shorter* list returns None to signal full-rewrite
+    semantics (the caller uses ``refined_acs`` as-is with no settled indices)
+    rather than guessing at deletions.
+    """
+    if len(refined_acs) < len(parent_acs):
+        return None
+    patches: list[ACPatch] = []
+    for i, parent_text in enumerate(parent_acs):
+        new_text = refined_acs[i]
+        if new_text == parent_text:
+            patches.append(ACPatch(op="keep", index=i))
+        else:
+            patches.append(ACPatch(op="revise", index=i, content=new_text))
+    for j in range(len(parent_acs), len(refined_acs)):
+        patches.append(ACPatch(op="add", content=refined_acs[j]))
+    return patches
+
+
+def _apply_satisficing_backstop(
+    parent_acs: tuple[str, ...],
+    patches: list[ACPatch],
+    protected: set[int],
+    passed_indices: set[int],
+) -> tuple[tuple[str, ...], tuple[ACPatch, ...], tuple[int, ...]]:
+    """Deterministically enforce the satisficing invariant.
+
+    The LLM proposes; this disposes. Protected indices (passed AND not
+    challenged AND not regressed) are forced to verbatim keep. Missing indices
+    keep implicitly. Malformed/duplicate/out-of-range patches are dropped so the
+    composed list holds every parent index exactly once (keeps/revises in place,
+    adds appended in order), preserving positional AC identity.
+
+    Returns ``(refined_acs, final_patches, settled_ac_indices)``.
+    """
+    n = len(parent_acs)
+    keep_revise: dict[int, ACPatch] = {}
+    adds: list[ACPatch] = []
+
+    for patch in patches:
+        if patch.op == "add":
+            if not patch.content:
+                logger.warning("reflect.patch.dropped", extra={"reason": "add_without_content"})
+                continue
+            adds.append(patch)
+            continue
+        # keep / revise must target a valid, not-yet-seen parent index.
+        if patch.index is None or not (0 <= patch.index < n):
+            logger.warning(
+                "reflect.patch.dropped",
+                extra={"reason": "index_out_of_range", "index": patch.index, "op": patch.op},
+            )
+            continue
+        if patch.op == "revise" and not patch.content:
+            logger.warning(
+                "reflect.patch.dropped",
+                extra={"reason": "revise_without_content", "index": patch.index},
+            )
+            continue
+        if patch.index in keep_revise:
+            logger.warning(
+                "reflect.patch.dropped", extra={"reason": "duplicate_index", "index": patch.index}
+            )
+            continue
+        keep_revise[patch.index] = patch
+
+    # Backstop: a protected AC may not be revised — force verbatim keep.
+    for i, patch in list(keep_revise.items()):
+        if i in protected and patch.op == "revise":
+            logger.info("reflect.backstop.forced_keep", extra={"index": i})
+            keep_revise[i] = ACPatch(
+                op="keep", index=i, reason="satisficing backstop: protected AC"
+            )
+
+    # Implicit keep for any parent index the LLM omitted.
+    for i in range(n):
+        if i not in keep_revise:
+            keep_revise[i] = ACPatch(op="keep", index=i, reason="implicit keep")
+
+    refined: list[str] = []
+    final_patches: list[ACPatch] = []
+    settled: list[int] = []
+    for i in range(n):
+        patch = keep_revise[i]
+        if patch.op == "keep":
+            refined.append(parent_acs[i])
+            if i in passed_indices:
+                settled.append(i)
+        else:
+            refined.append(patch.content or parent_acs[i])
+        final_patches.append(patch)
+    for add in adds:
+        refined.append(add.content or "")
+        final_patches.append(add)
+
+    return tuple(refined), tuple(final_patches), tuple(settled)
 
 
 @dataclass
@@ -191,6 +336,7 @@ class ReflectEngine:
         evaluation_summary: EvaluationSummary,
         wonder_output: WonderOutput,
         lineage: OntologyLineage,
+        regression_report: RegressionReport | None = None,
     ) -> Result[ReflectOutput, ProviderError]:
         """Reflect on execution results and propose evolution.
 
@@ -200,16 +346,23 @@ class ReflectEngine:
             evaluation_summary: How the execution was evaluated.
             wonder_output: What we still don't know (from WonderEngine).
             lineage: Full lineage for cross-generation context.
+            regression_report: Precomputed regressions (from the loop). When
+                None, computed once here and reused for both the prompt and the
+                satisficing backstop.
 
         Returns:
             Result containing ReflectOutput or ProviderError.
         """
+        if regression_report is None:
+            regression_report = RegressionDetector().detect(lineage)
+
         prompt = self._build_prompt(
             current_seed,
             execution_output,
             evaluation_summary,
             wonder_output,
             lineage,
+            regression_report,
         )
 
         messages = [
@@ -241,7 +394,13 @@ class ReflectEngine:
             },
         )
 
-        parsed = self._parse_response(raw_content, current_seed)
+        parsed = self._parse_response(
+            raw_content,
+            current_seed,
+            evaluation_summary,
+            wonder_output,
+            regression_report,
+        )
         if parsed is None:
             return Result.err(
                 ProviderError(
@@ -264,7 +423,11 @@ You must respond with a JSON object (no markdown, no code fences):
 {
     "refined_goal": "the goal, possibly refined based on what we learned",
     "refined_constraints": ["constraint 1", "constraint 2", ...],
-    "refined_acs": ["acceptance criterion 1", "criterion 2", ...],
+    "ac_patches": [
+        {"op": "keep", "index": 0, "reason": "passed, unchallenged"},
+        {"op": "revise", "index": 2, "content": "the corrected acceptance criterion", "reason": "failed / challenged"},
+        {"op": "add", "content": "a new acceptance criterion for an uncovered gap", "reason": "gap question"}
+    ],
     "ontology_mutations": [
         {"action": "add|modify|remove", "field_name": "name", "field_type": "type", "description": "desc", "reason": "why"},
         ...
@@ -272,12 +435,27 @@ You must respond with a JSON object (no markdown, no code fences):
     "reasoning": "explanation of why these changes are needed"
 }
 
+SATISFICING DELTA — patch the AC list, do NOT rewrite it:
+- The AC list is addressed by 0-based "index" against the CURRENT seed's ACs.
+- Emit ONE patch per current AC, plus "add" patches for new ACs.
+- "keep" (index only): an AC that PASSED evaluation AND is not named by any
+  grounded challenge AND is not regressed MUST be kept VERBATIM. Do not reword a
+  settled AC — rational agents with bounded resources do not re-derive satisficed
+  commitments without evidence. (A deterministic backstop will force-keep these
+  even if you try to revise them.)
+- "revise" (index + content): only for ACs that FAILED, were CHALLENGED by a
+  grounded Wonder question, or REGRESSED. Provide the full corrected AC text.
+- "add" (content only): for gap questions — something the goal requires that no
+  AC covers yet.
+- "remove" is NOT available in v1. Never delete an AC; it would break positional
+  AC identity.
+
 Guidelines:
 - If Wonder questions exist, you MUST propose at least one ontology_mutation that addresses them
 - If evaluation score >= 0.8 and approved, keep changes focused but still evolve the ontology based on Wonder insights
 - If evaluation score < 0.8 or not approved, propose more aggressive mutations to address failures
 - Each mutation must have a clear reason tied to evaluation findings or wonder questions
-- refined_acs should address the wonder questions and ontology tensions
+- Patches should address the wonder questions and ontology tensions
 - Do NOT change things that are working well -- only evolve what needs evolution
 - action must be exactly one of: "add", "modify", "remove"
 - An empty ontology_mutations list is ONLY acceptable when there are no Wonder questions
@@ -290,6 +468,7 @@ Guidelines:
         eval_summary: EvaluationSummary,
         wonder: WonderOutput,
         lineage: OntologyLineage,
+        regression_report: RegressionReport,
     ) -> str:
         parts = ["## Current Seed"]
         parts.append(f"Goal: {seed.goal}")
@@ -333,19 +512,27 @@ Guidelines:
                     f"\n  PRIORITY: Fix {len(failed_acs)} failing AC(s) while preserving passing ones."
                 )
 
-        # Regression context
-        if lineage and len(lineage.generations) >= 2:
-            report = RegressionDetector().detect(lineage)
-            if report.has_regressions:
-                parts.append(f"\n## REGRESSIONS ({len(report.regressions)})")
-                for reg in report.regressions:
-                    parts.append(
-                        f"  - AC {reg.ac_index + 1} (Gen {reg.passed_in_generation}→Gen {reg.failed_in_generation}): "
-                        f"{reg.ac_text}"
-                    )
+        # Regression context (precomputed once by the caller and reused here).
+        if regression_report.has_regressions:
+            parts.append(f"\n## REGRESSIONS ({len(regression_report.regressions)})")
+            for reg in regression_report.regressions:
                 parts.append(
-                    "  CRITICAL: These ACs previously passed. Preserve their behavior while fixing other issues."
+                    f"  - AC {reg.ac_index + 1} (Gen {reg.passed_in_generation}→Gen {reg.failed_in_generation}): "
+                    f"{reg.ac_text}"
                 )
+            parts.append(
+                "  CRITICAL: These ACs previously passed. Preserve their behavior while fixing other issues."
+            )
+
+        # Grounded challenges: which ACs a Wonder question explicitly reopened.
+        challenged: set[int] = set()
+        for gq in wonder.grounded_questions:
+            if gq.kind == "challenge":
+                challenged.update(gq.ac_indices)
+        if challenged:
+            challenged_labels = ", ".join(f"AC {i + 1}" for i in sorted(challenged))
+            parts.append(f"\n## Grounded Challenges (ACs reopened by Wonder): {challenged_labels}")
+            parts.append("  Only these passing ACs may be revised; keep all other passing ACs.")
 
         parts.append("\n## Wonder Questions (what we still don't know)")
         for q in wonder.questions:
@@ -399,10 +586,20 @@ Guidelines:
 
         return "\n".join(parts)
 
-    def _parse_response(self, content: str, current_seed: Seed) -> ReflectOutput | None:
+    def _parse_response(
+        self,
+        content: str,
+        current_seed: Seed,
+        evaluation_summary: EvaluationSummary,
+        wonder_output: WonderOutput,
+        regression_report: RegressionReport,
+    ) -> ReflectOutput | None:
         """Parse LLM response into ReflectOutput.
 
-        Returns None on parse failure so the caller can retry or propagate error.
+        Parses the AC delta (new ``ac_patches`` shape or legacy full-list diff),
+        then applies the deterministic satisficing backstop before composing the
+        final ``refined_acs``. Returns None on JSON parse failure so the caller
+        can retry or propagate error.
         """
         try:
             cleaned = content.strip()
@@ -428,12 +625,23 @@ Guidelines:
                     )
                 )
 
+            parent_acs = tuple(current_seed.acceptance_criteria)
+            refined_acs, ac_patches, settled = self._compose_acs(
+                data,
+                parent_acs,
+                evaluation_summary,
+                wonder_output,
+                regression_report,
+            )
+
             return ReflectOutput(
                 refined_goal=data.get("refined_goal", current_seed.goal),
                 refined_constraints=tuple(
                     data.get("refined_constraints", list(current_seed.constraints))
                 ),
-                refined_acs=tuple(data.get("refined_acs", list(current_seed.acceptance_criteria))),
+                refined_acs=refined_acs,
+                ac_patches=ac_patches,
+                settled_ac_indices=settled,
                 ontology_mutations=tuple(mutations),
                 reasoning=data.get("reasoning", ""),
             )
@@ -446,6 +654,44 @@ Guidelines:
                 },
             )
             return None
+
+    @staticmethod
+    def _compose_acs(
+        data: dict[str, object],
+        parent_acs: tuple[str, ...],
+        evaluation_summary: EvaluationSummary,
+        wonder_output: WonderOutput,
+        regression_report: RegressionReport,
+    ) -> tuple[tuple[str, ...], tuple[ACPatch, ...], tuple[int, ...]]:
+        """Compose the next AC list from LLM patches under the satisficing backstop."""
+        passed_indices = {ac.ac_index for ac in evaluation_summary.ac_results if ac.passed}
+        challenged: set[int] = set()
+        for gq in wonder_output.grounded_questions:
+            if gq.kind == "challenge":
+                challenged.update(gq.ac_indices)
+        regressed = set(regression_report.regressed_ac_indices)
+        protected = {
+            i
+            for i in passed_indices
+            if 0 <= i < len(parent_acs) and i not in challenged and i not in regressed
+        }
+        # Invariant: a regressed AC is never settled, even if kept — subtract it
+        # from the settleable set before the backstop decides settling.
+        settleable = passed_indices - regressed
+
+        raw_patches = data.get("ac_patches")
+        if isinstance(raw_patches, list) and raw_patches:
+            patches = _parse_ac_patches(raw_patches)
+            return _apply_satisficing_backstop(parent_acs, patches, protected, settleable)
+
+        # Legacy full-list shape: derive patches by positional diff.
+        llm_refined_acs: tuple[str, ...] = tuple(data.get("refined_acs", list(parent_acs)))  # type: ignore[arg-type]
+        legacy_patches = _derive_legacy_patches(llm_refined_acs, parent_acs)
+        if legacy_patches is None:
+            # Shorter list → full-rewrite semantics: use the LLM list as-is with
+            # no settled indices and no patches (do not guess at deletions).
+            return llm_refined_acs, (), ()
+        return _apply_satisficing_backstop(parent_acs, legacy_patches, protected, settleable)
 
 
 def _adapter_rebuild_kwargs(adapter: LLMAdapter) -> dict[str, object]:

--- a/src/ouroboros/evolution/wonder.py
+++ b/src/ouroboros/evolution/wonder.py
@@ -10,10 +10,12 @@ The WonderEngine asks: "Given what we learned, what do we still not know?"
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 import json
 import logging
+import re
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -39,6 +41,56 @@ def get_wonder_model(backend: str | None = None) -> str:
     return get_llm_model_for_role("wonder", backend=backend)
 
 
+# Deterministic fallback for grounding free-floating question strings to ACs.
+# Matches "AC 2", "AC#2", "ac 3" — the 1-based AC number the question challenges.
+_AC_REF_PATTERN = re.compile(r"\bAC\s*#?(\d+)\b", re.IGNORECASE)
+
+
+class GroundedQuestion(BaseModel, frozen=True):
+    """A Wonder question tied to what it challenges.
+
+    A grounded elenchus refutes a *specific* claim: either it challenges named
+    acceptance criteria (``kind="challenge"`` with 0-based ``ac_indices``) or it
+    names a gap the goal requires but no AC covers (``kind="gap"``).
+    """
+
+    question: str
+    kind: Literal["challenge", "gap"] = "gap"
+    ac_indices: tuple[int, ...] = ()
+
+
+def _ground_ac_indices(refs: Iterable[object], total_acs: int | None) -> tuple[int, ...]:
+    """Convert 1-based AC refs to deduped, in-range 0-based indices."""
+    seen: list[int] = []
+    for ref in refs:
+        try:
+            idx = int(ref) - 1  # type: ignore[call-overload]
+        except (TypeError, ValueError):
+            continue
+        if idx < 0:
+            continue
+        if total_acs is not None and idx >= total_acs:
+            continue
+        if idx not in seen:
+            seen.append(idx)
+    return tuple(seen)
+
+
+def ground_question_text(text: str, total_acs: int | None) -> GroundedQuestion:
+    """Ground a plain question string via the deterministic AC-ref regex."""
+    indices = _ground_ac_indices(_AC_REF_PATTERN.findall(text), total_acs)
+    if indices:
+        return GroundedQuestion(question=text, kind="challenge", ac_indices=indices)
+    return GroundedQuestion(question=text, kind="gap")
+
+
+def ground_questions(
+    questions: Iterable[str], total_acs: int | None
+) -> tuple[GroundedQuestion, ...]:
+    """Ground a sequence of plain question strings (legacy/partial-state path)."""
+    return tuple(ground_question_text(q, total_acs) for q in questions)
+
+
 class WonderOutput(BaseModel, frozen=True):
     """Output of the Wonder phase.
 
@@ -47,6 +99,7 @@ class WonderOutput(BaseModel, frozen=True):
     """
 
     questions: tuple[str, ...] = Field(default_factory=tuple)
+    grounded_questions: tuple[GroundedQuestion, ...] = Field(default_factory=tuple)
     ontology_tensions: tuple[str, ...] = Field(default_factory=tuple)
     should_continue: bool = True
     reasoning: str = ""
@@ -213,11 +266,24 @@ not just asking "what went wrong" but "what assumptions are we making?"
 
 You must respond with a JSON object (no markdown, no code fences):
 {
-    "questions": ["question 1", "question 2", ...],
+    "questions": [
+        {"question": "Why does the OAuth flow assume a single provider?", "ac_refs": [2]},
+        {"question": "What handles token refresh — no AC covers it?", "kind": "gap"}
+    ],
     "ontology_tensions": ["tension 1", "tension 2", ...],
     "should_continue": true/false,
     "reasoning": "explanation of your analysis"
 }
+
+GROUNDED ELENCHUS — every question must name what it challenges:
+- A question that challenges existing acceptance criteria MUST cite them with
+  "ac_refs": [<1-based AC number(s)>]. A challenge is the only licensed way to
+  reopen a settled (passing) claim, so only challenge a PASSING AC when you have
+  concrete evidence from the evaluation or execution output that it is wrong.
+- A question about something the goal requires but NO AC covers MUST declare
+  "kind": "gap" (no ac_refs). Gaps may become new ACs downstream.
+- A question that is neither grounded in an AC nor a real gap is not a question —
+  it is a mood. Do not emit it.
 
 Guidelines:
 - questions: What gaps remain? What assumptions haven't been tested?
@@ -335,6 +401,7 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
 
     def _parse_response(self, content: str, seed: Seed | None = None) -> WonderOutput:
         """Parse LLM response into WonderOutput."""
+        total_acs = len(seed.acceptance_criteria) if seed else None
         try:
             # Strip markdown fences if present
             cleaned = content.strip()
@@ -343,8 +410,12 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
                 cleaned = "\n".join(lines[1:-1])
 
             data = json.loads(cleaned)
+            grounded = self._parse_grounded_questions(data.get("questions", []), total_acs)
             return WonderOutput(
-                questions=tuple(data.get("questions", [])),
+                # ``questions`` stays a flat string tuple for events, lineage, and
+                # the repetitive-feedback convergence check (unchanged contract).
+                questions=tuple(gq.question for gq in grounded),
+                grounded_questions=grounded,
                 ontology_tensions=tuple(data.get("ontology_tensions", [])),
                 should_continue=data.get("should_continue", True),
                 reasoning=data.get("reasoning", ""),
@@ -352,12 +423,47 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
         except (json.JSONDecodeError, KeyError, TypeError) as e:
             logger.warning("Failed to parse WonderEngine response: %s", e)
             scope_hint = f" for goal: {seed.goal}" if seed else ""
+            fallback = f"What assumptions remain untested{scope_hint}?"
             return WonderOutput(
-                questions=(f"What assumptions remain untested{scope_hint}?",),
+                questions=(fallback,),
+                grounded_questions=(GroundedQuestion(question=fallback, kind="gap"),),
                 ontology_tensions=(),
                 should_continue=True,
                 reasoning=f"Parse error, using seed-scoped fallback: {e}",
             )
+
+    @staticmethod
+    def _parse_grounded_questions(
+        raw_questions: object, total_acs: int | None
+    ) -> tuple[GroundedQuestion, ...]:
+        """Parse the ``questions`` payload, tolerating new and legacy shapes.
+
+        New shape: list of objects carrying ``ac_refs`` (1-based) or
+        ``kind="gap"``. Legacy shape: list of plain strings, grounded via the
+        deterministic AC-ref regex.
+        """
+        if not isinstance(raw_questions, list):
+            return ()
+        grounded: list[GroundedQuestion] = []
+        for item in raw_questions:
+            if isinstance(item, str):
+                grounded.append(ground_question_text(item, total_acs))
+            elif isinstance(item, dict):
+                text = item.get("question") or item.get("text")
+                if not isinstance(text, str) or not text:
+                    continue
+                refs = item.get("ac_refs")
+                if isinstance(refs, (list, tuple)) and refs:
+                    indices = _ground_ac_indices(refs, total_acs)
+                    if indices:
+                        grounded.append(
+                            GroundedQuestion(question=text, kind="challenge", ac_indices=indices)
+                        )
+                        continue
+                # No usable refs (or all out of range): fall back to regex on the
+                # text, then treat as a gap.
+                grounded.append(ground_question_text(text, total_acs))
+        return tuple(grounded)
 
     def _degraded_output(
         self,
@@ -395,6 +501,8 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
 
         return WonderOutput(
             questions=tuple(questions),
+            # Heuristic questions have no AC evidence to challenge, so they are gaps.
+            grounded_questions=tuple(GroundedQuestion(question=q, kind="gap") for q in questions),
             ontology_tensions=tuple(tensions),
             should_continue=should_continue,
             reasoning="Degraded mode: LLM unavailable, using heuristic questions"

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1471,6 +1471,7 @@ def create_ouroboros_server(
         *,
         parallel: bool = True,
         execution_id: str | None = None,
+        externally_satisfied_acs: dict[int, dict[str, Any]] | None = None,
     ) -> Any:
         await _ensure_evolution_store_initialized()
         task_cwd = evolutionary_loop.get_project_dir()
@@ -1500,6 +1501,7 @@ def create_ouroboros_server(
             seed=seed,
             execution_id=execution_id,
             parallel=parallel,
+            externally_satisfied_acs=externally_satisfied_acs,
         )
 
     def _evaluate_mechanically(artifact: str, seed: Any) -> EvaluationSummary | None:
@@ -1766,9 +1768,14 @@ def create_ouroboros_server(
             f"Remaining: {', '.join(remaining[:5])}"
         )
 
+    _scoped_reexecution_env = os.environ.get("OUROBOROS_SCOPED_REEXECUTION", "").strip().lower()
+    _scoped_reexecution = _scoped_reexecution_env not in ("0", "false")
     evolutionary_loop = EvolutionaryLoop(
         event_store=event_store,
-        config=EvolutionaryLoopConfig(runtime_controls=get_runtime_controls_config()),
+        config=EvolutionaryLoopConfig(
+            runtime_controls=get_runtime_controls_config(),
+            scoped_reexecution=_scoped_reexecution,
+        ),
         wonder_engine=wonder_engine,
         reflect_engine=reflect_engine,
         seed_generator=seed_generator,

--- a/tests/unit/evolution/test_reflect_delta.py
+++ b/tests/unit/evolution/test_reflect_delta.py
@@ -1,0 +1,321 @@
+"""Tests for the satisficing delta — ACPatch composition and backstop.
+
+Covers RFC §5.2: patch parse; composition order (keep/revise in place, add
+appended); backstop forces keep on passed+unchallenged+unregressed; challenged
+or failed or regressed ACs may revise; kept-but-failed AC not settled; legacy
+full-list fallback diff (identical→keep, changed→revise, longer→add,
+shorter→full-rewrite semantics); malformed patches dropped, every parent index
+present exactly once.
+"""
+
+from __future__ import annotations
+
+import json
+
+from ouroboros.core.lineage import ACResult, EvaluationSummary
+from ouroboros.core.seed import OntologyField, OntologySchema, Seed, SeedMetadata
+from ouroboros.evolution.reflect import (
+    ACPatch,
+    ReflectEngine,
+    _apply_satisficing_backstop,
+    _derive_legacy_patches,
+    _parse_ac_patches,
+)
+from ouroboros.evolution.regression import ACRegression, RegressionReport
+from ouroboros.evolution.wonder import GroundedQuestion, WonderOutput
+
+PARENT_ACS = ("AC zero", "AC one", "AC two")
+
+
+def _seed(acs: tuple[str, ...] = PARENT_ACS) -> Seed:
+    return Seed(
+        metadata=SeedMetadata(ambiguity_score=0.1),
+        goal="Build a thing",
+        constraints=("c1",),
+        acceptance_criteria=acs,
+        ontology_schema=OntologySchema(
+            name="o",
+            description="d",
+            fields=(OntologyField(name="f", field_type="entity", description="a field"),),
+        ),
+    )
+
+
+def _summary(passed: dict[int, bool]) -> EvaluationSummary:
+    return EvaluationSummary(
+        final_approved=all(passed.values()),
+        highest_stage_passed=2,
+        score=0.8,
+        ac_results=tuple(
+            ACResult(ac_index=i, ac_content=PARENT_ACS[i], passed=p) for i, p in passed.items()
+        ),
+    )
+
+
+def _wonder(challenge_indices: tuple[int, ...] = ()) -> WonderOutput:
+    grounded = ()
+    if challenge_indices:
+        grounded = (
+            GroundedQuestion(question="challenge", kind="challenge", ac_indices=challenge_indices),
+        )
+    return WonderOutput(questions=("q",), grounded_questions=grounded)
+
+
+def _regression(indices: tuple[int, ...] = ()) -> RegressionReport:
+    regs = tuple(
+        ACRegression(
+            ac_index=i,
+            ac_text=PARENT_ACS[i],
+            passed_in_generation=1,
+            failed_in_generation=2,
+        )
+        for i in indices
+    )
+    return RegressionReport(regressions=regs)
+
+
+def _compose(
+    data: dict,
+    parent: tuple[str, ...] = PARENT_ACS,
+    passed: dict[int, bool] | None = None,
+    challenge: tuple[int, ...] = (),
+    regressed: tuple[int, ...] = (),
+) -> tuple[tuple[str, ...], tuple[ACPatch, ...], tuple[int, ...]]:
+    if passed is None:
+        passed = {0: True, 1: True, 2: True}
+    return ReflectEngine._compose_acs(
+        data, parent, _summary(passed), _wonder(challenge), _regression(regressed)
+    )
+
+
+class TestPatchParse:
+    def test_parses_keep_revise_add(self) -> None:
+        patches = _parse_ac_patches(
+            [
+                {"op": "keep", "index": 0},
+                {"op": "revise", "index": 1, "content": "new"},
+                {"op": "add", "content": "extra"},
+            ]
+        )
+        assert [p.op for p in patches] == ["keep", "revise", "add"]
+        assert patches[1].content == "new"
+        assert patches[2].index is None
+
+    def test_remove_coerced_to_keep(self) -> None:
+        patches = _parse_ac_patches([{"op": "remove", "index": 1}])
+        assert patches[0].op == "keep"
+        assert patches[0].index == 1
+
+    def test_unknown_op_coerced_to_keep(self) -> None:
+        patches = _parse_ac_patches([{"op": "frobnicate", "index": 0}])
+        assert patches[0].op == "keep"
+
+    def test_non_dict_items_skipped(self) -> None:
+        patches = _parse_ac_patches(["nonsense", 42, {"op": "keep", "index": 0}])
+        assert len(patches) == 1
+
+    def test_bool_index_rejected(self) -> None:
+        # True is an int subclass; must not be treated as index 1.
+        patches = _parse_ac_patches([{"op": "keep", "index": True}])
+        assert patches[0].index is None
+
+
+class TestComposition:
+    def test_keep_revise_in_place_add_appended(self) -> None:
+        data = {
+            "ac_patches": [
+                {"op": "keep", "index": 0},
+                {"op": "revise", "index": 1, "content": "revised one"},
+                {"op": "keep", "index": 2},
+                {"op": "add", "content": "brand new"},
+            ]
+        }
+        # AC 1 challenged so revise is allowed
+        refined, patches, settled = _compose(data, challenge=(1,))
+        assert refined == ("AC zero", "revised one", "AC two", "brand new")
+
+    def test_every_parent_index_present_exactly_once(self) -> None:
+        # LLM omits index 2 entirely — implicit keep must fill it.
+        data = {"ac_patches": [{"op": "keep", "index": 0}, {"op": "keep", "index": 1}]}
+        refined, patches, _ = _compose(data)
+        keep_revise_indices = [p.index for p in patches if p.op in ("keep", "revise")]
+        assert sorted(keep_revise_indices) == [0, 1, 2]
+        assert len(refined) == 3
+
+    def test_add_content_missing_dropped(self) -> None:
+        data = {"ac_patches": [{"op": "add"}]}  # no content
+        refined, patches, _ = _compose(data)
+        # only the 3 implicit keeps remain
+        assert len(refined) == 3
+        assert all(p.op == "keep" for p in patches)
+
+
+class TestSatisficingBackstop:
+    def test_forces_keep_on_protected(self) -> None:
+        # AC 0 passed, unchallenged, unregressed → protected. LLM tries to revise.
+        patches = [ACPatch(op="revise", index=0, content="sneaky rewrite")]
+        refined, final, settled = _apply_satisficing_backstop(
+            PARENT_ACS, patches, protected={0}, passed_indices={0, 1, 2}
+        )
+        assert refined[0] == "AC zero"  # verbatim, not the rewrite
+        assert final[0].op == "keep"
+        assert 0 in settled
+
+    def test_challenged_ac_may_revise(self) -> None:
+        # AC 1 passed but challenged → NOT protected → revise honored.
+        refined, _, settled = _compose(
+            {"ac_patches": [{"op": "revise", "index": 1, "content": "challenged fix"}]},
+            challenge=(1,),
+        )
+        assert refined[1] == "challenged fix"
+        assert 1 not in settled  # revised, not kept
+
+    def test_failed_ac_may_revise(self) -> None:
+        refined, _, settled = _compose(
+            {"ac_patches": [{"op": "revise", "index": 2, "content": "fix failed"}]},
+            passed={0: True, 1: True, 2: False},
+        )
+        assert refined[2] == "fix failed"
+        assert 2 not in settled
+
+    def test_regressed_ac_may_revise(self) -> None:
+        # AC 1 passed this eval but regression report flags it → not protected.
+        refined, _, settled = _compose(
+            {"ac_patches": [{"op": "revise", "index": 1, "content": "regression fix"}]},
+            regressed=(1,),
+        )
+        assert refined[1] == "regression fix"
+        assert 1 not in settled
+
+    def test_regressed_ac_never_settled_even_if_kept(self) -> None:
+        # Passed this eval + kept, but regressed → excluded from settling.
+        _, _, settled = _compose(
+            {"ac_patches": [{"op": "keep", "index": 1}]},
+            regressed=(1,),
+        )
+        assert 1 not in settled
+
+
+class TestSettledIndices:
+    def test_kept_passing_acs_are_settled(self) -> None:
+        _, _, settled = _compose(
+            {"ac_patches": [{"op": "keep", "index": 0}, {"op": "keep", "index": 1}]}
+        )
+        # index 2 implicitly kept; all passed → all settled
+        assert set(settled) == {0, 1, 2}
+
+    def test_kept_but_failed_ac_not_settled(self) -> None:
+        _, _, settled = _compose(
+            {"ac_patches": [{"op": "keep", "index": 2}]},
+            passed={0: True, 1: True, 2: False},
+        )
+        assert 2 not in settled
+        assert set(settled) == {0, 1}
+
+
+class TestLegacyFallbackDiff:
+    def test_identical_keep_changed_revise_longer_add(self) -> None:
+        # No ac_patches key → legacy diff of refined_acs vs parent.
+        data = {"refined_acs": ["AC zero", "CHANGED one", "AC two", "NEW three"]}
+        # AC 1 challenged so its revise survives the backstop
+        refined, patches, settled = _compose(data, challenge=(1,))
+        assert refined == ("AC zero", "CHANGED one", "AC two", "NEW three")
+        ops = [p.op for p in patches]
+        assert ops == ["keep", "revise", "keep", "add"]
+        assert set(settled) == {0, 2}  # kept + passed; index 1 revised
+
+    def test_shorter_list_full_rewrite_semantics(self) -> None:
+        data = {"refined_acs": ["only one"]}
+        refined, patches, settled = _compose(data)
+        assert refined == ("only one",)
+        assert patches == ()
+        assert settled == ()
+
+    def test_derive_legacy_patches_shorter_returns_none(self) -> None:
+        assert _derive_legacy_patches(("a",), ("a", "b", "c")) is None
+
+    def test_derive_legacy_patches_equal_lengths(self) -> None:
+        patches = _derive_legacy_patches(("a", "X"), ("a", "b"))
+        assert patches is not None
+        assert patches[0].op == "keep"
+        assert patches[1].op == "revise"
+        assert patches[1].content == "X"
+
+
+class TestMalformedPatches:
+    def test_out_of_range_and_duplicate_dropped(self) -> None:
+        patches = [
+            ACPatch(op="keep", index=0),
+            ACPatch(op="keep", index=0),  # duplicate
+            ACPatch(op="revise", index=99, content="x"),  # out of range
+            ACPatch(op="revise", index=None, content="y"),  # no index
+        ]
+        refined, final, _ = _apply_satisficing_backstop(
+            PARENT_ACS, patches, protected=set(), passed_indices=set()
+        )
+        # every parent index present exactly once
+        assert len(refined) == 3
+        indices = sorted(p.index for p in final if p.index is not None)
+        assert indices == [0, 1, 2]
+
+    def test_revise_without_content_dropped_then_implicit_keep(self) -> None:
+        patches = [ACPatch(op="revise", index=0, content=None)]
+        refined, final, _ = _apply_satisficing_backstop(
+            PARENT_ACS, patches, protected=set(), passed_indices=set()
+        )
+        assert refined[0] == "AC zero"  # implicit keep filled it
+        assert final[0].op == "keep"
+
+
+class TestReflectEndToEnd:
+    async def test_reflect_composes_from_patches(self) -> None:
+        response = json.dumps(
+            {
+                "refined_goal": "Build a thing better",
+                "refined_constraints": ["c1"],
+                "ac_patches": [
+                    {"op": "keep", "index": 0},
+                    {"op": "revise", "index": 1, "content": "fixed AC one"},
+                    {"op": "keep", "index": 2},
+                ],
+                "ontology_mutations": [],
+                "reasoning": "r",
+            }
+        )
+        adapter = _FakeAdapter(response)
+        engine = ReflectEngine(llm_adapter=adapter, model="test")
+
+        from ouroboros.core.lineage import OntologyLineage
+
+        result = await engine.reflect(
+            current_seed=_seed(),
+            execution_output="out",
+            evaluation_summary=_summary({0: True, 1: True, 2: True}),
+            wonder_output=_wonder(challenge_indices=(1,)),
+            lineage=OntologyLineage(lineage_id="l", goal="Build a thing"),
+        )
+
+        assert result.is_ok
+        out = result.value
+        assert out.refined_acs == ("AC zero", "fixed AC one", "AC two")
+        assert 0 in out.settled_ac_indices
+        assert 2 in out.settled_ac_indices
+        assert 1 not in out.settled_ac_indices
+
+
+class _FakeAdapter:
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self._max_turns = 1
+
+    async def complete(self, messages, config):  # type: ignore[no-untyped-def]
+        from ouroboros.core.types import Result
+        from ouroboros.providers.base import CompletionResponse, UsageInfo
+
+        return Result.ok(
+            CompletionResponse(
+                content=self.content,
+                model=config.model,
+                usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+        )

--- a/tests/unit/evolution/test_scoped_reexecution.py
+++ b/tests/unit/evolution/test_scoped_reexecution.py
@@ -1,0 +1,345 @@
+"""Tests for AC-scoped re-execution plumbing in the evolutionary loop.
+
+Covers RFC §5.3: settled dict built and forwarded; executor without the kwarg →
+not forwarded (signature guard); ``scoped_reexecution=False`` → not forwarded;
+empty settled → not forwarded; regression exclusion end-to-end (AC passed gen
+N-1, regressed gen N → executes in gen N+1).
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from ouroboros.core.lineage import (
+    ACResult,
+    EvaluationSummary,
+    GenerationPhase,
+    GenerationRecord,
+    OntologyLineage,
+)
+from ouroboros.core.seed import (
+    EvaluationPrinciple,
+    ExitCondition,
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+from ouroboros.core.types import Result
+from ouroboros.evolution.loop import EvolutionaryLoop, EvolutionaryLoopConfig
+from ouroboros.evolution.reflect import ReflectEngine, ReflectOutput
+from ouroboros.evolution.wonder import WonderOutput
+from ouroboros.providers.base import CompletionResponse, UsageInfo
+
+
+async def _store() -> object:
+    from ouroboros.persistence.event_store import EventStore
+
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    return store
+
+
+def _seed(acs: tuple[str, ...] = ("AC0", "AC1"), seed_id: str = "seed_1") -> Seed:
+    return Seed(
+        goal="Build a thing",
+        task_type="code",
+        constraints=("c1",),
+        acceptance_criteria=acs,
+        ontology_schema=OntologySchema(
+            name="o",
+            description="d",
+            fields=(OntologyField(name="f", field_type="entity", description="a field"),),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="completeness", description="done", weight=1.0),
+        ),
+        exit_conditions=(ExitCondition(name="done", description="d", evaluation_criteria="100%"),),
+        metadata=SeedMetadata(seed_id=seed_id, ambiguity_score=0.1),
+    )
+
+
+def _eval(passed: dict[int, bool], acs: tuple[str, ...] = ("AC0", "AC1")) -> EvaluationSummary:
+    return EvaluationSummary(
+        final_approved=all(passed.values()),
+        highest_stage_passed=2,
+        score=0.8,
+        ac_results=tuple(
+            ACResult(ac_index=i, ac_content=acs[i], passed=p) for i, p in passed.items()
+        ),
+    )
+
+
+def _gen(number: int, seed: Seed, eval_summary: EvaluationSummary) -> GenerationRecord:
+    return GenerationRecord(
+        generation_number=number,
+        seed_id=seed.metadata.seed_id,
+        ontology_snapshot=seed.ontology_schema,
+        evaluation_summary=eval_summary,
+        phase=GenerationPhase.COMPLETED,
+        execution_output="prev output",
+        seed_json=json.dumps(seed.to_dict()),
+    )
+
+
+class _CaptureExecutor:
+    """Executor spy that records the externally_satisfied_acs it was passed."""
+
+    def __init__(self, accept_kwarg: bool = True) -> None:
+        self.accept_kwarg = accept_kwarg
+        self.captured: dict[int, dict[str, object]] | None = None
+        self.called = False
+
+    async def __call__(self, seed, **kwargs):  # type: ignore[no-untyped-def]
+        self.called = True
+        self.captured = kwargs.get("externally_satisfied_acs")
+        return Result.ok(SimpleNamespace(final_message="done", summary={}))
+
+
+# A spy with an explicit signature so _callable_accepts_keyword can introspect it.
+async def _executor_with_kwarg(
+    seed, *, parallel=True, execution_id=None, externally_satisfied_acs=None
+):  # type: ignore[no-untyped-def]
+    _executor_with_kwarg.captured = externally_satisfied_acs  # type: ignore[attr-defined]
+    return Result.ok(SimpleNamespace(final_message="done", summary={}))
+
+
+async def _executor_without_kwarg(seed, *, parallel=True, execution_id=None):  # type: ignore[no-untyped-def]
+    _executor_without_kwarg.called = True  # type: ignore[attr-defined]
+    return Result.ok(SimpleNamespace(final_message="done", summary={}))
+
+
+class TestCallExecutorGuard:
+    async def test_forwards_when_executor_accepts_kwarg(self) -> None:
+        store = await _store()
+        loop = EvolutionaryLoop(event_store=store, executor=_executor_with_kwarg)
+        _executor_with_kwarg.captured = "unset"  # type: ignore[attr-defined]
+
+        await loop._call_executor(
+            _seed(),
+            parallel=True,
+            execution_id=None,
+            externally_satisfied_acs={0: {"reason": "x"}},
+        )
+        assert _executor_with_kwarg.captured == {0: {"reason": "x"}}  # type: ignore[attr-defined]
+
+    async def test_signature_guard_skips_unaccepting_executor(self) -> None:
+        store = await _store()
+        loop = EvolutionaryLoop(event_store=store, executor=_executor_without_kwarg)
+        _executor_without_kwarg.called = False  # type: ignore[attr-defined]
+
+        # Must not raise even though we pass a settled dict.
+        await loop._call_executor(
+            _seed(),
+            parallel=True,
+            execution_id=None,
+            externally_satisfied_acs={0: {"reason": "x"}},
+        )
+        assert _executor_without_kwarg.called is True  # type: ignore[attr-defined]
+
+    async def test_empty_settled_not_forwarded(self) -> None:
+        store = await _store()
+        loop = EvolutionaryLoop(event_store=store, executor=_executor_with_kwarg)
+        _executor_with_kwarg.captured = "unset"  # type: ignore[attr-defined]
+
+        await loop._call_executor(
+            _seed(),
+            parallel=True,
+            execution_id=None,
+            externally_satisfied_acs={},
+        )
+        # Falsy dict → not forwarded → default None seen by executor.
+        assert _executor_with_kwarg.captured is None  # type: ignore[attr-defined]
+
+
+class TestConfig:
+    def test_scoped_reexecution_defaults_true(self) -> None:
+        assert EvolutionaryLoopConfig().scoped_reexecution is True
+
+    def test_scoped_reexecution_can_disable(self) -> None:
+        assert EvolutionaryLoopConfig(scoped_reexecution=False).scoped_reexecution is False
+
+
+def _make_loop_for_gen2(
+    store, executor: _CaptureExecutor, config: EvolutionaryLoopConfig, settled: tuple[int, ...]
+) -> EvolutionaryLoop:
+    seed_v1 = _seed()
+    new_seed = _seed(seed_id="seed_2")
+
+    wonder_engine = MagicMock()
+    wonder_engine.wonder = AsyncMock(
+        return_value=Result.ok(
+            WonderOutput(questions=("q",), grounded_questions=(), should_continue=True)
+        )
+    )
+    reflect_engine = MagicMock()
+    reflect_engine.reflect = AsyncMock(
+        return_value=Result.ok(
+            ReflectOutput(
+                refined_goal=seed_v1.goal,
+                refined_constraints=seed_v1.constraints,
+                refined_acs=seed_v1.acceptance_criteria,
+                settled_ac_indices=settled,
+                ontology_mutations=(),
+                reasoning="r",
+            )
+        )
+    )
+    seed_generator = MagicMock()
+    seed_generator.generate_from_reflect = MagicMock(return_value=Result.ok(new_seed))
+    evaluator = AsyncMock(return_value=Result.ok(_eval({0: True, 1: True})))
+
+    return EvolutionaryLoop(
+        event_store=store,
+        config=config,
+        wonder_engine=wonder_engine,
+        reflect_engine=reflect_engine,
+        seed_generator=seed_generator,
+        executor=executor,
+        evaluator=evaluator,
+    )
+
+
+class TestScopedForwardingIntegration:
+    async def test_settled_dict_built_and_forwarded(self) -> None:
+        store = await _store()
+        seed_v1 = _seed()
+        lineage = OntologyLineage(
+            lineage_id="lin_forward",
+            goal=seed_v1.goal,
+            generations=(_gen(1, seed_v1, _eval({0: True, 1: True})),),
+        )
+        executor = _CaptureExecutor()
+        loop = _make_loop_for_gen2(store, executor, EvolutionaryLoopConfig(), settled=(0, 1))
+
+        result = await loop._run_generation(
+            lineage=lineage, generation_number=2, current_seed=seed_v1
+        )
+        assert result.is_ok
+        assert executor.captured is not None
+        assert set(executor.captured.keys()) == {0, 1}
+        assert "satisficed" in executor.captured[0]["reason"]
+
+    async def test_config_off_not_forwarded(self) -> None:
+        store = await _store()
+        seed_v1 = _seed()
+        lineage = OntologyLineage(
+            lineage_id="lin_off",
+            goal=seed_v1.goal,
+            generations=(_gen(1, seed_v1, _eval({0: True, 1: True})),),
+        )
+        executor = _CaptureExecutor()
+        loop = _make_loop_for_gen2(
+            store, executor, EvolutionaryLoopConfig(scoped_reexecution=False), settled=(0, 1)
+        )
+
+        result = await loop._run_generation(
+            lineage=lineage, generation_number=2, current_seed=seed_v1
+        )
+        assert result.is_ok
+        assert executor.called is True
+        assert executor.captured is None
+
+    async def test_empty_settled_not_forwarded_integration(self) -> None:
+        store = await _store()
+        seed_v1 = _seed()
+        lineage = OntologyLineage(
+            lineage_id="lin_empty",
+            goal=seed_v1.goal,
+            generations=(_gen(1, seed_v1, _eval({0: True, 1: True})),),
+        )
+        executor = _CaptureExecutor()
+        loop = _make_loop_for_gen2(store, executor, EvolutionaryLoopConfig(), settled=())
+
+        result = await loop._run_generation(
+            lineage=lineage, generation_number=2, current_seed=seed_v1
+        )
+        assert result.is_ok
+        assert executor.called is True
+        assert executor.captured is None
+
+
+class TestRegressionExclusionEndToEnd:
+    async def test_regressed_ac_re_executes_next_generation(self) -> None:
+        """AC1 passes gen1, regresses gen2 → not settled → executes gen3.
+
+        Uses the real ReflectEngine so the satisficing backstop computes settled
+        indices from evaluation + regression, exercising the full path.
+        """
+        store = await _store()
+        seed_v1 = _seed()
+
+        # Gen1: both pass. Gen2: AC0 passes, AC1 regresses.
+        lineage = OntologyLineage(
+            lineage_id="lin_regress",
+            goal=seed_v1.goal,
+            generations=(
+                _gen(1, seed_v1, _eval({0: True, 1: True})),
+                _gen(2, seed_v1, _eval({0: True, 1: False})),
+            ),
+        )
+
+        # Real Wonder-less path: mock wonder to a no-challenge gap question.
+        wonder_engine = MagicMock()
+        wonder_engine.wonder = AsyncMock(
+            return_value=Result.ok(
+                WonderOutput(questions=("gap q",), grounded_questions=(), should_continue=True)
+            )
+        )
+
+        # Real reflect engine; fake adapter returns keep-0, revise-1 (fix the fail).
+        reflect_response = json.dumps(
+            {
+                "refined_goal": seed_v1.goal,
+                "refined_constraints": ["c1"],
+                "ac_patches": [
+                    {"op": "keep", "index": 0},
+                    {"op": "revise", "index": 1, "content": "AC1 fixed"},
+                ],
+                "ontology_mutations": [],
+                "reasoning": "fix regression",
+            }
+        )
+        reflect_engine = ReflectEngine(llm_adapter=_FakeAdapter(reflect_response), model="test")
+
+        new_seed = _seed(acs=("AC0", "AC1 fixed"), seed_id="seed_3")
+        seed_generator = MagicMock()
+        seed_generator.generate_from_reflect = MagicMock(return_value=Result.ok(new_seed))
+        evaluator = AsyncMock(return_value=Result.ok(_eval({0: True, 1: True})))
+
+        executor = _CaptureExecutor()
+        loop = EvolutionaryLoop(
+            event_store=store,
+            config=EvolutionaryLoopConfig(),
+            wonder_engine=wonder_engine,
+            reflect_engine=reflect_engine,
+            seed_generator=seed_generator,
+            executor=executor,
+            evaluator=evaluator,
+        )
+
+        result = await loop._run_generation(
+            lineage=lineage, generation_number=3, current_seed=seed_v1
+        )
+        assert result.is_ok
+        # AC0 kept + passed → settled (skipped). AC1 failed/regressed → executes.
+        assert executor.captured is not None
+        assert set(executor.captured.keys()) == {0}
+        assert 1 not in executor.captured
+
+
+class _FakeAdapter:
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self._max_turns = 1
+
+    async def complete(self, messages, config):  # type: ignore[no-untyped-def]
+        return Result.ok(
+            CompletionResponse(
+                content=self.content,
+                model=config.model,
+                usage=UsageInfo(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+        )

--- a/tests/unit/evolution/test_wonder_grounding.py
+++ b/tests/unit/evolution/test_wonder_grounding.py
@@ -1,0 +1,178 @@
+"""Tests for grounded elenchus — Wonder question → AC grounding.
+
+Covers RFC §5.1: new-shape parse (challenge + gap, 1-based→0-based); legacy
+strings → deterministic regex fallback; out-of-range refs dropped (all-dropped
+challenge → gap); ``questions`` always populated from grounded questions.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock
+
+from ouroboros.core.seed import (
+    OntologyField,
+    OntologySchema,
+    Seed,
+    SeedMetadata,
+)
+from ouroboros.evolution.wonder import (
+    GroundedQuestion,
+    WonderEngine,
+    ground_question_text,
+    ground_questions,
+)
+
+_ONTOLOGY = OntologySchema(
+    name="login",
+    description="Login system ontology",
+    fields=(OntologyField(name="user", field_type="entity", description="A user"),),
+)
+
+
+def _seed(num_acs: int = 3) -> Seed:
+    return Seed(
+        metadata=SeedMetadata(ambiguity_score=0.1),
+        goal="Build a login system",
+        constraints=("Must use OAuth",),
+        acceptance_criteria=tuple(f"AC number {i}" for i in range(1, num_acs + 1)),
+        ontology_schema=_ONTOLOGY,
+    )
+
+
+def _engine() -> WonderEngine:
+    return WonderEngine(llm_adapter=AsyncMock(), model="test")
+
+
+class TestNewShapeParse:
+    def test_challenge_refs_convert_one_based_to_zero_based(self) -> None:
+        content = json.dumps(
+            {
+                "questions": [
+                    {"question": "Why does AC 2 assume a single provider?", "ac_refs": [2]},
+                    {"question": "What handles token refresh?", "kind": "gap"},
+                ],
+                "should_continue": True,
+            }
+        )
+        out = _engine()._parse_response(content, _seed(3))
+
+        assert len(out.grounded_questions) == 2
+        challenge, gap = out.grounded_questions
+        assert challenge.kind == "challenge"
+        assert challenge.ac_indices == (1,)  # 1-based 2 → 0-based 1
+        assert gap.kind == "gap"
+        assert gap.ac_indices == ()
+
+    def test_multiple_refs_deduped_and_sorted_in_order(self) -> None:
+        content = json.dumps(
+            {"questions": [{"question": "AC 1 and AC 3 conflict", "ac_refs": [3, 1, 3]}]}
+        )
+        out = _engine()._parse_response(content, _seed(3))
+
+        gq = out.grounded_questions[0]
+        assert gq.kind == "challenge"
+        assert gq.ac_indices == (2, 0)  # order preserved, deduped
+
+    def test_questions_field_populated_from_grounded(self) -> None:
+        content = json.dumps(
+            {
+                "questions": [
+                    {"question": "Challenge one", "ac_refs": [1]},
+                    {"question": "Gap two", "kind": "gap"},
+                ]
+            }
+        )
+        out = _engine()._parse_response(content, _seed(2))
+
+        assert out.questions == ("Challenge one", "Gap two")
+
+
+class TestLegacyStringFallback:
+    def test_plain_string_with_ac_ref_grounds_to_challenge(self) -> None:
+        content = json.dumps({"questions": ["Why did AC 2 regress in this build?"]})
+        out = _engine()._parse_response(content, _seed(3))
+
+        gq = out.grounded_questions[0]
+        assert gq.kind == "challenge"
+        assert gq.ac_indices == (1,)
+
+    def test_plain_string_without_ac_ref_is_gap(self) -> None:
+        content = json.dumps({"questions": ["What about rate limiting entirely?"]})
+        out = _engine()._parse_response(content, _seed(3))
+
+        gq = out.grounded_questions[0]
+        assert gq.kind == "gap"
+        assert gq.ac_indices == ()
+
+    def test_regex_is_case_insensitive_and_hash_tolerant(self) -> None:
+        assert ground_question_text("ac#2 is wrong", 3).ac_indices == (1,)
+        assert ground_question_text("AC 3 broke", 3).ac_indices == (2,)
+        assert ground_question_text("Ac1 fails", 3).ac_indices == (0,)
+
+    def test_ground_questions_helper_batches(self) -> None:
+        grounded = ground_questions(["AC 1 broke", "generic gap"], 3)
+        assert grounded[0].kind == "challenge"
+        assert grounded[1].kind == "gap"
+
+
+class TestOutOfRangeDropped:
+    def test_out_of_range_ref_dropped_and_all_dropped_becomes_gap(self) -> None:
+        # AC 9 does not exist in a 3-AC seed → dropped → no valid refs → gap.
+        content = json.dumps({"questions": [{"question": "AC 9?", "ac_refs": [9]}]})
+        out = _engine()._parse_response(content, _seed(3))
+
+        gq = out.grounded_questions[0]
+        assert gq.kind == "gap"
+        assert gq.ac_indices == ()
+
+    def test_partial_out_of_range_keeps_valid_refs(self) -> None:
+        content = json.dumps({"questions": [{"question": "AC 1 and AC 9", "ac_refs": [1, 9]}]})
+        out = _engine()._parse_response(content, _seed(3))
+
+        gq = out.grounded_questions[0]
+        assert gq.kind == "challenge"
+        assert gq.ac_indices == (0,)
+
+    def test_legacy_string_out_of_range_ref_dropped(self) -> None:
+        content = json.dumps({"questions": ["AC 42 is suspicious"]})
+        out = _engine()._parse_response(content, _seed(3))
+
+        assert out.grounded_questions[0].kind == "gap"
+
+    def test_no_seed_means_no_range_check(self) -> None:
+        # Without a seed we cannot know the AC count; refs are kept as-is.
+        out = ground_question_text("AC 5 is odd", None)
+        assert out.kind == "challenge"
+        assert out.ac_indices == (4,)
+
+
+class TestFallbackPathsPopulateGrounded:
+    def test_parse_error_fallback_is_gap(self) -> None:
+        out = _engine()._parse_response("not json", _seed(2))
+        assert len(out.grounded_questions) == 1
+        assert out.grounded_questions[0].kind == "gap"
+        assert out.grounded_questions[0].question == out.questions[0]
+
+    def test_degraded_output_populates_grounded_gaps(self) -> None:
+        from ouroboros.core.lineage import EvaluationSummary
+
+        seed = _seed(2)
+        summary = EvaluationSummary(
+            final_approved=False,
+            highest_stage_passed=2,
+            score=0.4,
+            drift_score=0.6,
+            failure_reason="1/2 ACs failed",
+        )
+        out = _engine()._degraded_output(summary, seed.ontology_schema, seed)
+
+        assert len(out.grounded_questions) == len(out.questions)
+        assert all(gq.kind == "gap" for gq in out.grounded_questions)
+
+
+class TestGroundedQuestionModel:
+    def test_frozen_and_defaults(self) -> None:
+        gq = GroundedQuestion(question="q")
+        assert gq.kind == "gap"
+        assert gq.ac_indices == ()


### PR DESCRIPTION
## Summary

- The Wonder → Reflect → Seed → Execute cycle re-derived and **re-executed every AC each generation**, even when 9/10 had already passed — making reflect-driven evolution far heavier than it needs to be.
- This PR grounds the philosophy layer in **Socrates (grounded elenchus)** and **Herbert Simon (satisficing over nearly decomposable systems)**: a Wonder question must name what it challenges, a passed-and-unchallenged AC is a satisficed commitment that is kept verbatim and skipped, and the next generation's agenda is exactly the difference set — failed ∪ challenged ∪ regressed ∪ new-gap ACs.
- Execution scoping reuses the **existing `externally_satisfied_acs` substrate** (`--skip-completed` path in `OrchestratorRunner.execute_seed` / parallel executor) — no new execution machinery.

Design doc: `docs/rfc/reflect-grounded-elenchus-scoped-reexecution.md`

## Changes

**Wonder (`evolution/wonder.py`)**
- New `GroundedQuestion` (kind `challenge` with 0-based `ac_indices`, or `gap`) and `WonderOutput.grounded_questions`.
- Prompt requires `"ac_refs": [1-based]` or `"kind": "gap"` per question; parser tolerates the legacy plain-string shape and grounds it via a deterministic `AC N` regex (also used to re-ground questions restored from interrupted-generation partial state).
- `questions` stays a flat string tuple — events, lineage, and the repetitive-feedback convergence check are unchanged.

**Reflect (`evolution/reflect.py`)**
- New `ACPatch` (`keep`/`revise`/`add`; `remove` deliberately not offered — it would shift the positional AC identity that regression detection depends on) and `ReflectOutput.ac_patches` + `settled_ac_indices`; `refined_acs` is now composed from patches, so `SeedGenerator.generate_from_reflect` is untouched.
- **Deterministic satisficing backstop**: an AC that passed ∧ was not challenged ∧ did not regress is force-kept verbatim even if the LLM tries to reword it (same anchoring principle that fixed interview-refiner oscillation in v0.42.4). Missing indices keep implicitly; malformed/duplicate/out-of-range patches are dropped; every parent index appears exactly once.
- Legacy full-list responses are diffed positionally into patches (shorter list → full-rewrite semantics, no settling), so scoping works even with old-shape model output.
- `reflect()` takes an optional precomputed `regression_report` (loop computes it once for prompt + backstop).

**Loop (`evolution/loop.py`) & MCP adapter**
- Settled ACs are forwarded to the executor as `externally_satisfied_acs` (signature-guarded, only when non-empty, never on interrupted-resume paths); `_evolution_executor` forwards it to `execute_seed`.
- `EvolutionaryLoopConfig.scoped_reexecution` (default **on**), env escape hatch `OUROBOROS_SCOPED_REEXECUTION=0`.

**Tests** — 3 new suites (grounding parse/regex fallback/out-of-range, patch composition/backstop/settling/legacy diff, loop forwarding/config gates/regression-exclusion end-to-end).

## Notes

- **Safety invariants:** a regressed AC is never settled; `SpecVerifier` still verifies ALL assertions against the working tree every generation, so a stale "satisfied" claim flips to FAIL, the regression gate blocks convergence, and the AC re-executes next generation. Dependency validation still blocks a "satisfied" AC downstream of a failed dependency (existing executor behavior).
- All-pass tail generations become near-noops on the execution side — the loop spends its budget on ontology convergence instead of redundant rebuilds.
- Verified: ruff/format/mypy clean; `tests/unit` green except 11 pre-existing failures (config-leak/env + untracked local files), confirmed identical with this change stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)