### PR TITLE
feat(core): add structured acceptance criteria

### DIFF
--- a/src/ouroboros/agents/seed-architect.md
+++ b/src/ouroboros/agents/seed-architect.md
@@ -19,8 +19,8 @@ Example: "Python >= 3.12 | No external database | Must work offline"
 
 ### 3. ACCEPTANCE_CRITERIA
 Specific, measurable criteria for success.
-Format: pipe-separated list
-Example: "Tasks can be created | Tasks can be listed | Tasks persist to file"
+Format: one `AC:` line per criterion
+Example: "AC: Tasks can be created | verify: python -m pytest tests/test_tasks.py | artifacts: NONE | expect: created task"
 
 **Granularity contract (read carefully):**
 - Produce **3-7** acceptance criteria. Each criterion is **one independently valuable, user-visible outcome** — not an implementation step.
@@ -58,7 +58,9 @@ Provide your analysis in this exact structure:
 ```
 GOAL: <clear goal statement>
 CONSTRAINTS: <constraint 1> | <constraint 2> | ...
-ACCEPTANCE_CRITERIA: <criterion 1> | <criterion 2> | ...
+ACCEPTANCE_CRITERIA:
+AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
+AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
 ONTOLOGY_NAME: <name>
 ONTOLOGY_DESCRIPTION: <description>
 ONTOLOGY_FIELDS: <name>:<type>:<description> | ...
@@ -75,3 +77,11 @@ Weights should be between 0.0 and 1.0
 
 Be specific and concrete. Extract actual requirements from the conversation, not generic placeholders.
 For brownfield projects, ensure context references and patterns are extracted from the interview.
+
+Few-shot examples:
+
+```
+ACCEPTANCE_CRITERIA:
+AC: `python -m pytest tests/test_tasks.py` passes for task create/list flows | verify: python -m pytest tests/test_tasks.py | artifacts: NONE | expect: passed
+AC: README documents the CLI usage examples | verify: NONE | artifacts: README.md | expect: NONE
+```

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 import yaml
 
 from ouroboros.auto.interview_driver import InterviewBackend, InterviewTurn
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import Seed, ac_texts
 from ouroboros.mcp.errors import MCPServerError
 from ouroboros.mcp.job_manager import JobManager, JobStatus
 from ouroboros.mcp.tools.authoring_handlers import (
@@ -734,7 +734,7 @@ class HandlerEvaluator:
             )
 
         if seed.acceptance_criteria:
-            ac_lines = [f"- {ac}" for ac in seed.acceptance_criteria]
+            ac_lines = [f"- {ac}" for ac in ac_texts(seed.acceptance_criteria)]
             quality_bar = "The execution must satisfy all acceptance criteria:\n" + "\n".join(
                 ac_lines
             )

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import AcceptanceCriterionInput, Seed, ac_text
 
 _AUTO_WRAPPER_CRITERIA = frozenset(
     {
@@ -174,7 +174,10 @@ def normalize_execution_acceptance(seed: Seed) -> Seed:
     product requirements, only normalize the known hello_auto observation
     context.
     """
-    criteria = tuple(ac for ac in seed.acceptance_criteria if ac and ac.strip())
+    criteria_with_specs = tuple(
+        (ac, text) for ac in seed.acceptance_criteria if (text := ac_text(ac).strip())
+    )
+    criteria = tuple(text for _ac, text in criteria_with_specs)
     direction_context = "\n".join((seed.goal, *seed.constraints))
     if not criteria:
         return seed
@@ -199,9 +202,30 @@ def normalize_execution_acceptance(seed: Seed) -> Seed:
         return seed
     if filtered != criteria:
         data = normalized_seed.to_dict()
-        data["acceptance_criteria"] = list(filtered)
+        data["acceptance_criteria"] = list(
+            _restore_surviving_acceptance_specs(filtered, criteria_with_specs)
+        )
         normalized_seed = Seed.from_dict(data)
     return normalized_seed
+
+
+def _restore_surviving_acceptance_specs(
+    filtered: tuple[str, ...],
+    original: tuple[tuple[AcceptanceCriterionInput, str], ...],
+) -> tuple[AcceptanceCriterionInput, ...]:
+    """Keep structured contracts for criteria that survive normalization unchanged."""
+    original_by_text: dict[str, list[AcceptanceCriterionInput]] = {}
+    for criterion, text in original:
+        original_by_text.setdefault(text, []).append(criterion)
+
+    restored: list[AcceptanceCriterionInput] = []
+    for text in filtered:
+        matches = original_by_text.get(text)
+        if matches:
+            restored.append(matches.pop(0))
+        else:
+            restored.append(text)
+    return tuple(restored)
 
 
 def normalize_observation_execution_criteria(

--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from ouroboros.auto.gap_detector import GapDetector
 from ouroboros.auto.ledger import REQUIRED_SECTIONS, LedgerSource, LedgerStatus, SeedDraftLedger
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import AcceptanceCriterionSpec, Seed, ac_text
 
 
 class SeedGrade(StrEnum):
@@ -241,7 +241,8 @@ class GradeGate:
                     "Add observable acceptance criteria.",
                 )
             )
-        for index, criterion in enumerate(seed.acceptance_criteria):
+        for index, criterion_spec in enumerate(seed.acceptance_criteria):
+            criterion = ac_text(criterion_spec)
             if _is_vague(criterion):
                 findings.append(
                     GradeFinding(
@@ -252,14 +253,25 @@ class GradeGate:
                         "Replace with observable behavior or artifact.",
                     )
                 )
-            if not _is_observable(criterion):
+            if not _is_observable(criterion_spec):
                 findings.append(
                     GradeFinding(
-                        "untestable_acceptance_criteria",
-                        "high",
+                        (
+                            "missing_success_contract"
+                            if isinstance(criterion_spec, AcceptanceCriterionSpec)
+                            else "untestable_acceptance_criteria"
+                        ),
+                        (
+                            "medium"
+                            if isinstance(criterion_spec, AcceptanceCriterionSpec)
+                            else "high"
+                        ),
                         f"Acceptance criterion is not clearly observable: {criterion}",
                         f"acceptance_criteria[{index}]",
-                        "Mention command output, file/artifact, API response, or test result.",
+                        (
+                            "Add verify_command or expected_artifacts, or mention command "
+                            "output, file/artifact, API response, or test result."
+                        ),
                     )
                 )
 
@@ -476,7 +488,11 @@ def _is_vague(value: str) -> bool:
     return any(re.search(rf"\b{re.escape(term)}\b", lowered) for term in VAGUE_TERMS)
 
 
-def _is_observable(value: str) -> bool:
+def _is_observable(value: str | AcceptanceCriterionSpec) -> bool:
+    if isinstance(value, AcceptanceCriterionSpec):
+        if value.verify_command or value.expected_artifacts:
+            return True
+        value = value.description
     lowered = value.lower()
     if not any(hint in lowered for hint in _OBSERVABLE_HINTS):
         return False

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 from ouroboros.auto.grading import VAGUE_TERMS, SeedGrade
 from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import AcceptanceCriterionInput, Seed, ac_text
 
 
 def _review_accepts_closure_mode(review_callable: Callable[..., Any]) -> bool:
@@ -128,7 +128,7 @@ class SeedRepairer:
             )
 
         constraints = list(seed.constraints)
-        acceptance = list(seed.acceptance_criteria)
+        acceptance: list[AcceptanceCriterionInput] = list(seed.acceptance_criteria)
         goal = seed.goal
         applied: list[str] = []
         unresolved: list[ReviewFinding] = []
@@ -143,12 +143,16 @@ class SeedRepairer:
         for finding in review.findings:
             if finding.code in repairable_blocker_codes:
                 continue
-            if finding.code in {"vague_acceptance_criteria", "untestable_acceptance_criteria"}:
+            if finding.code in {
+                "missing_success_contract",
+                "vague_acceptance_criteria",
+                "untestable_acceptance_criteria",
+            }:
                 index = _target_index(finding.target)
                 if index is not None and index < len(acceptance):
                     if index not in repaired_acceptance_indices:
                         acceptance[index] = _observable_preserving_replacement(
-                            acceptance[index], index=index
+                            ac_text(acceptance[index]), index=index
                         )
                         repaired_acceptance_indices.add(index)
                 else:
@@ -185,8 +189,9 @@ class SeedRepairer:
         changed = bool(applied)
         updated_seed = seed
         if changed:
-            updated_seed = seed.model_copy(
-                update={
+            seed_data = seed.to_dict()
+            seed_data.update(
+                {
                     "goal": goal,
                     "constraints": tuple(dict.fromkeys(constraints)),
                     "acceptance_criteria": tuple(dict.fromkeys(acceptance)),
@@ -196,9 +201,10 @@ class SeedRepairer:
                             "created_at": datetime.now(UTC),
                             "parent_seed_id": seed.metadata.seed_id,
                         }
-                    ),
+                    ).model_dump(mode="json"),
                 }
             )
+            updated_seed = Seed.from_dict(seed_data)
         return RepairResult(
             changed=changed,
             seed=updated_seed,

--- a/src/ouroboros/auto/task_class_application.py
+++ b/src/ouroboros/auto/task_class_application.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from ouroboros.auto.task_classes import TASK_CLASS_CATALOG, TaskClass
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import Seed, ac_texts
 
 __all__ = [
     "AppliedTaskClassDefaults",
@@ -86,19 +86,21 @@ def apply_default_ac_template(seed: Seed, task_class: TaskClass) -> AppliedTaskC
     if _has_autoresearch_execution_contract(seed):
         return AppliedTaskClassDefaults(seed=seed, injected_ac=(), task_class=task_class)
 
-    existing = set(seed.acceptance_criteria)
+    existing = set(ac_texts(seed.acceptance_criteria))
     new_entries = tuple(item for item in template if item not in existing)
     if not new_entries:
         return AppliedTaskClassDefaults(seed=seed, injected_ac=(), task_class=task_class)
 
-    updated_ac = new_entries + tuple(seed.acceptance_criteria)
-    new_seed = seed.model_copy(update={"acceptance_criteria": updated_ac})
+    updated_ac = new_entries + seed.acceptance_criteria
+    seed_data = seed.to_dict()
+    seed_data["acceptance_criteria"] = updated_ac
+    new_seed = Seed.from_dict(seed_data)
     return AppliedTaskClassDefaults(seed=new_seed, injected_ac=new_entries, task_class=task_class)
 
 
 def _has_autoresearch_execution_contract(seed: Seed) -> bool:
     """Return True when an autoresearch plugin Seed already owns its AC surface."""
-    haystack = "\n".join((*seed.constraints, *seed.acceptance_criteria)).casefold()
+    haystack = "\n".join((*seed.constraints, *ac_texts(seed.acceptance_criteria))).casefold()
     return (
         "autoresearch" in haystack
         and "val_bpb" in haystack

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -29,6 +29,7 @@ from ouroboros.bigbang.interview import (
 from ouroboros.config import get_llm_model_for_role
 from ouroboros.core.errors import ProviderError, ValidationError
 from ouroboros.core.seed import (
+    AcceptanceCriterionSpec,
     BrownfieldContext,
     ContextReference,
     EvaluationPrinciple,
@@ -45,6 +46,63 @@ log = structlog.get_logger()
 
 EXTRACTION_TEMPERATURE = 0.2
 _MAX_EXTRACTION_RETRIES = 1
+_AC_CONTRACT_FIELD_RE = re.compile(r"\s\|\s*(verify|artifacts|expect)\s*:", re.IGNORECASE)
+
+
+def _parse_acceptance_criteria_contracts(
+    raw_value: object,
+) -> tuple[AcceptanceCriterionSpec | str, ...]:
+    """Parse legacy AC prose or structured AC success-contract lines."""
+    if isinstance(raw_value, list | tuple):
+        entries = tuple(str(item).strip() for item in raw_value if str(item).strip())
+    elif isinstance(raw_value, str):
+        text = raw_value.strip()
+        if not text:
+            return ()
+        if "\nAC:" in text or text.startswith("AC:"):
+            entries = tuple(line.strip() for line in text.splitlines() if line.strip())
+        else:
+            entries = tuple(item.strip() for item in text.split("|") if item.strip())
+    else:
+        return ()
+
+    parsed: list[AcceptanceCriterionSpec | str] = []
+    for entry in entries:
+        if not entry.startswith("AC:"):
+            parsed.append(entry)
+            continue
+        spec = _parse_acceptance_criterion_contract(entry)
+        parsed.append(spec if spec is not None else entry.removeprefix("AC:").strip())
+    return tuple(parsed)
+
+
+def _parse_acceptance_criterion_contract(line: str) -> AcceptanceCriterionSpec | None:
+    """Parse one structured AC line, falling back to description-only on gaps."""
+    if not line.startswith("AC:"):
+        return None
+    body = line.removeprefix("AC:").strip()
+    matches = tuple(_AC_CONTRACT_FIELD_RE.finditer(body))
+    description_end = matches[0].start() if matches else len(body)
+    description = body[:description_end].strip()
+    if not description:
+        return None
+    fields: dict[str, object] = {"description": description}
+    for index, match in enumerate(matches):
+        normalized_key = match.group(1).lower()
+        value_start = match.end()
+        value_end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        normalized_value = body[value_start:value_end].strip()
+        if not normalized_value or normalized_value.upper() == "NONE":
+            continue
+        if normalized_key == "verify":
+            fields["verify_command"] = normalized_value
+        elif normalized_key == "artifacts":
+            fields["expected_artifacts"] = tuple(
+                item.strip() for item in normalized_value.split(",") if item.strip()
+            )
+        elif normalized_key == "expect":
+            fields["output_assertion"] = normalized_value
+    return AcceptanceCriterionSpec.model_validate(fields)
 
 
 @dataclass
@@ -435,7 +493,9 @@ ACCEPTANCE_CRITERIA rule: produce 3-7 outcome-level criteria. Each is one indepe
 
 GOAL: <clear goal statement>
 CONSTRAINTS: <constraint 1> | <constraint 2> | ...
-ACCEPTANCE_CRITERIA: <criterion 1> | <criterion 2> | ...
+ACCEPTANCE_CRITERIA:
+AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
+AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
 ONTOLOGY_NAME: <name>
 ONTOLOGY_DESCRIPTION: <description>
 ONTOLOGY_FIELDS: <name>:<type>:<description> | ...
@@ -494,7 +554,9 @@ ACCEPTANCE_CRITERIA rule: produce 3-7 outcome-level criteria. Each is one indepe
 
 GOAL: <clear goal statement>
 CONSTRAINTS: <constraint 1> | <constraint 2> | ...
-ACCEPTANCE_CRITERIA: <criterion 1> | <criterion 2> | ...
+ACCEPTANCE_CRITERIA:
+AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
+AC: <description> | verify: <command or NONE> | artifacts: <comma-list or NONE> | expect: <output assertion or NONE>
 ONTOLOGY_NAME: <name>
 ONTOLOGY_DESCRIPTION: <description>
 ONTOLOGY_FIELDS: <name>:<type>:<description> | ...
@@ -560,17 +622,34 @@ PROJECT_TYPE: greenfield"""
         lines = cleaned.strip().split("\n")
         requirements: dict[str, Any] = {}
 
+        current_multiline_key: str | None = None
+        multiline_values: dict[str, list[str]] = {}
+
         for line in lines:
             line = line.strip()
             if not line:
                 continue
 
+            matched_prefix = False
             for prefix in self._KNOWN_PREFIXES:
                 if line.startswith(prefix):
                     key = prefix[:-1].lower()  # Remove colon and lowercase
                     value = line[len(prefix) :].strip()
-                    requirements[key] = value
+                    if key == "acceptance_criteria" and not value:
+                        current_multiline_key = key
+                        multiline_values.setdefault(key, [])
+                    else:
+                        requirements[key] = value
+                        current_multiline_key = None
+                    matched_prefix = True
                     break
+            if matched_prefix:
+                continue
+            if current_multiline_key == "acceptance_criteria" and line.startswith("AC:"):
+                multiline_values.setdefault(current_multiline_key, []).append(line)
+
+        if multiline_values.get("acceptance_criteria"):
+            requirements["acceptance_criteria"] = multiline_values["acceptance_criteria"]
 
         # Validate required fields
         required_fields = [
@@ -607,10 +686,10 @@ PROJECT_TYPE: greenfield"""
             )
 
         # Parse acceptance criteria
-        acceptance_criteria: tuple[str, ...] = ()
+        acceptance_criteria: tuple[AcceptanceCriterionSpec | str, ...] = ()
         if "acceptance_criteria" in requirements and requirements["acceptance_criteria"]:
-            acceptance_criteria = tuple(
-                c.strip() for c in requirements["acceptance_criteria"].split("|") if c.strip()
+            acceptance_criteria = _parse_acceptance_criteria_contracts(
+                requirements["acceptance_criteria"]
             )
 
         # Parse ontology fields

--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -26,6 +26,7 @@ from ouroboros.config.loader import get_config_dir, get_max_parallel_workers, lo
 from ouroboros.core.errors import ConfigError
 from ouroboros.core.project_paths import resolve_path_against_base, resolve_seed_project_path
 from ouroboros.core.security import InputValidator
+from ouroboros.core.seed import ac_texts
 from ouroboros.core.worktree import (
     TaskWorkspace,
     WorktreeError,
@@ -128,7 +129,7 @@ class AgentRuntimeBackend(str, Enum):  # noqa: UP042
 
 def _derive_quality_bar(seed: "Seed") -> str:
     """Derive a quality bar string from seed acceptance criteria."""
-    ac_lines = [f"- {ac}" for ac in seed.acceptance_criteria]
+    ac_lines = [f"- {ac}" for ac in ac_texts(seed.acceptance_criteria)]
     return "The execution must satisfy all acceptance criteria:\n" + "\n".join(ac_lines)
 
 

--- a/src/ouroboros/cli/commands/workflow_ir.py
+++ b/src/ouroboros/cli/commands/workflow_ir.py
@@ -74,12 +74,18 @@ def _normalize_seed_payload(raw: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
-def _normalize_criterion(item: Any) -> str:
-    if isinstance(item, dict) and isinstance(item.get("criterion"), str):
-        return item["criterion"]
+def _normalize_criterion(item: Any) -> str | dict[str, Any]:
+    if isinstance(item, dict):
+        if isinstance(item.get("criterion"), str):
+            return item["criterion"]
+        if isinstance(item.get("description"), str) or isinstance(item.get("content"), str):
+            return item
     if isinstance(item, str):
         return item
-    msg = "acceptance_criteria entries must be strings or {criterion: <text>} mappings"
+    msg = (
+        "acceptance_criteria entries must be strings or mappings with "
+        "description, content, or criterion text"
+    )
     raise ValueError(msg)
 
 

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -21,7 +21,7 @@ import math
 from typing import Any
 from uuid import uuid4
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
 
 
 class ExitCondition(BaseModel, frozen=True):
@@ -180,6 +180,81 @@ class SeedMetadata(BaseModel, frozen=True):
     recovery_reason: str | None = Field(default=None)
 
 
+class AcceptanceCriterionSpec(BaseModel, frozen=True):
+    """Structured success contract for one acceptance criterion."""
+
+    description: str
+    verify_command: str | None = Field(default=None)
+    expected_artifacts: tuple[str, ...] = Field(default_factory=tuple)
+    output_assertion: str | None = Field(default=None)
+
+    @field_validator("description", mode="before")
+    @classmethod
+    def _strip_description(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.strip()
+        return value
+
+    @field_validator("verify_command", "output_assertion", mode="before")
+    @classmethod
+    def _strip_optional_text(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped or stripped.upper() == "NONE":
+                return None
+            return stripped
+        return value
+
+    @field_validator("expected_artifacts", mode="before")
+    @classmethod
+    def _coerce_expected_artifacts(cls, value: Any) -> Any:
+        if value is None:
+            return ()
+        if isinstance(value, str):
+            if not value.strip() or value.strip().upper() == "NONE":
+                return ()
+            return tuple(item.strip() for item in value.split(",") if item.strip())
+        if isinstance(value, list | tuple | set):
+            return tuple(str(item).strip() for item in value if str(item).strip())
+        return value
+
+    @property
+    def has_success_contract(self) -> bool:
+        """Return True when explicit evidence fields are populated."""
+        return bool(self.verify_command or self.expected_artifacts or self.output_assertion)
+
+    def to_seed_value(self) -> str | dict[str, Any]:
+        """Return the stable persisted representation for this AC."""
+        if not self.has_success_contract:
+            return self.description
+        data: dict[str, Any] = {"description": self.description}
+        if self.verify_command:
+            data["verify_command"] = self.verify_command
+        if self.expected_artifacts:
+            data["expected_artifacts"] = list(self.expected_artifacts)
+        if self.output_assertion:
+            data["output_assertion"] = self.output_assertion
+        return data
+
+    def __str__(self) -> str:
+        return self.description
+
+
+AcceptanceCriterionInput = str | AcceptanceCriterionSpec
+
+
+def ac_text(criterion: AcceptanceCriterionInput) -> str:
+    """Return the human-readable description for an acceptance criterion."""
+    if isinstance(criterion, AcceptanceCriterionSpec):
+        return criterion.description
+    return str(criterion)
+
+
+def ac_texts(criteria: Any) -> tuple[str, ...]:
+    """Return AC descriptions while tolerating legacy string iterables."""
+    return tuple(ac_text(criterion) for criterion in criteria)
+
+
 class Seed(BaseModel, frozen=True):
     """Immutable specification for workflow execution.
 
@@ -253,7 +328,7 @@ class Seed(BaseModel, frozen=True):
         default_factory=tuple,
         description="Hard constraints that must be satisfied",
     )
-    acceptance_criteria: tuple[str, ...] = Field(
+    acceptance_criteria: tuple[AcceptanceCriterionSpec, ...] = Field(
         default_factory=tuple,
         description="Specific criteria for success evaluation",
     )
@@ -317,6 +392,42 @@ class Seed(BaseModel, frozen=True):
                 for index, item in enumerate(value, start=1)
             )
         return value
+
+    @field_validator("acceptance_criteria", mode="before")
+    @classmethod
+    def _coerce_acceptance_criteria(cls, value: Any) -> Any:
+        """Accept legacy string ACs and structured AC contracts."""
+        if value is None:
+            return ()
+        if isinstance(value, list | tuple):
+            normalized: list[Any] = []
+            for item in value:
+                if isinstance(item, str):
+                    normalized.append({"description": item})
+                    continue
+                if isinstance(item, dict) and "description" not in item:
+                    if isinstance(item.get("criterion"), str):
+                        normalized.append({**item, "description": item["criterion"]})
+                        continue
+                    if isinstance(item.get("content"), str):
+                        normalized.append({**item, "description": item["content"]})
+                        continue
+                normalized.append(item)
+            return tuple(normalized)
+        return value
+
+    @field_serializer("acceptance_criteria")
+    def _serialize_acceptance_criteria(
+        self,
+        value: tuple[AcceptanceCriterionInput, ...],
+    ) -> tuple[str | dict[str, Any], ...]:
+        """Persist description-only ACs in the legacy bare-string form."""
+        return tuple(
+            criterion.to_seed_value()
+            if isinstance(criterion, AcceptanceCriterionSpec)
+            else ac_text(criterion)
+            for criterion in value
+        )
 
     @model_validator(mode="after")
     def _validate_plugin_extra_fields(self) -> Seed:

--- a/src/ouroboros/core/seed_contract.py
+++ b/src/ouroboros/core/seed_contract.py
@@ -10,7 +10,13 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from ouroboros.core.seed import BrownfieldContext, EvaluationPrinciple, ExitCondition, Seed
+from ouroboros.core.seed import (
+    BrownfieldContext,
+    EvaluationPrinciple,
+    ExitCondition,
+    Seed,
+    ac_texts,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -56,7 +62,7 @@ class SeedContract:
         return cls(
             goal=seed.goal,
             task_type=seed.task_type,
-            acceptance_criteria=seed.acceptance_criteria,
+            acceptance_criteria=ac_texts(seed.acceptance_criteria),
             constraints=seed.constraints,
             ontology_lens=OntologyLens(
                 name=seed.ontology_schema.name,

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -18,12 +18,12 @@ import json
 import logging
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.lineage import EvaluationSummary, MutationAction, OntologyDelta, OntologyLineage
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import Seed, ac_texts
 from ouroboros.core.text import truncate_head_tail
 from ouroboros.core.types import Result
 from ouroboros.evolution.regression import RegressionDetector, RegressionReport
@@ -82,6 +82,13 @@ class ReflectOutput(BaseModel, frozen=True):
     settled_ac_indices: tuple[int, ...] = Field(default_factory=tuple)
     ontology_mutations: tuple[OntologyMutation, ...] = Field(default_factory=tuple)
     reasoning: str = ""
+
+    @field_validator("refined_acs", mode="before")
+    @classmethod
+    def _coerce_refined_acs(cls, value: object) -> object:
+        if isinstance(value, list | tuple):
+            return ac_texts(value)
+        return value
 
 
 def _parse_ac_patches(raw_patches: object) -> list[ACPatch]:
@@ -473,7 +480,7 @@ Guidelines:
         parts = ["## Current Seed"]
         parts.append(f"Goal: {seed.goal}")
         parts.append(f"Constraints: {list(seed.constraints)}")
-        parts.append(f"Acceptance Criteria: {list(seed.acceptance_criteria)}")
+        parts.append(f"Acceptance Criteria: {list(ac_texts(seed.acceptance_criteria))}")
 
         parts.append(f"\n## Ontology: {seed.ontology_schema.name}")
         parts.append(f"Description: {seed.ontology_schema.description}")
@@ -625,7 +632,7 @@ Guidelines:
                     )
                 )
 
-            parent_acs = tuple(current_seed.acceptance_criteria)
+            parent_acs = ac_texts(current_seed.acceptance_criteria)
             refined_acs, ac_patches, settled = self._compose_acs(
                 data,
                 parent_acs,

--- a/src/ouroboros/evolution/wonder.py
+++ b/src/ouroboros/evolution/wonder.py
@@ -22,7 +22,7 @@ from pydantic import BaseModel, Field
 from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.lineage import EvaluationSummary, OntologyLineage
-from ouroboros.core.seed import OntologySchema, Seed
+from ouroboros.core.seed import OntologySchema, Seed, ac_texts
 from ouroboros.core.text import truncate_head_tail
 from ouroboros.core.types import Result
 from ouroboros.evolution.regression import RegressionDetector
@@ -322,7 +322,7 @@ Focus on ONTOLOGICAL questions (what IS the thing?) not implementation questions
                     parts.append(f"  - {c}")
             if seed.acceptance_criteria:
                 parts.append(f"Acceptance Criteria: {len(seed.acceptance_criteria)}")
-                for i, ac in enumerate(seed.acceptance_criteria, 1):
+                for i, ac in enumerate(ac_texts(seed.acceptance_criteria), 1):
                     parts.append(f"  AC {i}: {ac}")
             parts.append("")
 

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 
 from ouroboros.config._model_defaults import DEFAULT_SONNET_MODEL
+from ouroboros.core.seed import ac_text, ac_texts
 from ouroboros.core.types import Result
 from ouroboros.events.io import new_call_id
 from ouroboros.events.io_recorder import IOJournalRecorder, use_io_journal_recorder
@@ -298,7 +299,9 @@ def _parse_legacy_execution_task_summary(artifact: str, seed: Any) -> Any | None
     task_results: list[TaskResult] = []
     for ac_num_str, status, description in task_line_matches:
         task_idx = int(ac_num_str) - 1
-        task_content = seed_acs[task_idx] if task_idx < len(seed_acs) else description.strip()
+        task_content = (
+            ac_text(seed_acs[task_idx]) if task_idx < len(seed_acs) else description.strip()
+        )
         completed = status in {"COMPLETED", "PASS"}
         task_results.append(
             TaskResult(
@@ -1564,7 +1567,7 @@ def create_ouroboros_server(
             return None
 
         # Extract assertions from ACs (cached by seed_id)
-        extract_result = await spec_extractor.extract(seed_id, seed_acs)
+        extract_result = await spec_extractor.extract(seed_id, ac_texts(seed_acs))
         if extract_result.is_err:
             log.warning("spec_verification.extraction_failed", error=str(extract_result.error))
             return None
@@ -1615,7 +1618,7 @@ def create_ouroboros_server(
         # Fallback: LLM-based evaluation when no structured AC results
         acs = getattr(seed, "acceptance_criteria", None)
         if acs:
-            current_ac = "\n".join(f"AC {i + 1}: {ac}" for i, ac in enumerate(acs))
+            current_ac = "\n".join(f"AC {i + 1}: {ac}" for i, ac in enumerate(ac_texts(acs)))
         else:
             current_ac = "Verify execution output meets requirements"
 

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -21,7 +21,7 @@ from ouroboros.backends import build_runtime_subagent_orchestration_contract
 from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
 from ouroboros.core.errors import ValidationError
 from ouroboros.core.project_paths import resolve_path_against_base, resolve_seed_project_path
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import Seed, ac_text
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.job_manager import JobLinks, JobManager
@@ -60,7 +60,11 @@ log = structlog.get_logger(__name__)
 
 
 def _seed_acceptance_criteria(seed: Seed) -> tuple[str, ...]:
-    return tuple(text.strip() for text in seed.acceptance_criteria if text and text.strip())
+    return tuple(
+        stripped
+        for criterion in seed.acceptance_criteria
+        if (stripped := ac_text(criterion).strip())
+    )
 
 
 async def _default_brownfield_project_dir() -> Path | None:
@@ -1236,7 +1240,7 @@ class ChecklistVerifyHandler:
             )
 
         acceptance_criteria = tuple(
-            text.strip() for text in seed.acceptance_criteria if text and text.strip()
+            text for criterion in seed.acceptance_criteria if (text := ac_text(criterion).strip())
         )
         if not acceptance_criteria:
             return Result.err(

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -19,7 +19,7 @@ from ouroboros.auto.checkpoint_commits import checkpoint_passed_ac
 from ouroboros.auto.state import AutoCommitPolicy, AutoPipelineState
 from ouroboros.config import get_runtime_controls_config
 from ouroboros.core.project_paths import resolve_path_against_base, resolve_seed_project_path
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import Seed, ac_texts
 from ouroboros.core.text import truncate_head_tail
 from ouroboros.core.types import Result
 from ouroboros.core.worktree import (
@@ -490,7 +490,7 @@ class EvolveStepHandler(BridgeAwareMixin):
             qa_handler = QAHandler()
             quality_bar = "Generation must improve upon previous generation."
             if initial_seed:
-                ac_lines = [f"- {ac}" for ac in initial_seed.acceptance_criteria]
+                ac_lines = [f"- {ac}" for ac in ac_texts(initial_seed.acceptance_criteria)]
                 quality_bar = "The execution must satisfy all acceptance criteria:\n" + "\n".join(
                     ac_lines
                 )

--- a/src/ouroboros/mcp/tools/execution_handlers.py
+++ b/src/ouroboros/mcp/tools/execution_handlers.py
@@ -23,7 +23,7 @@ from ouroboros.config.loader import get_auto_evaluate_enabled, get_max_parallel_
 from ouroboros.core.errors import ConfigError, ValidationError
 from ouroboros.core.project_paths import resolve_seed_project_path
 from ouroboros.core.security import InputValidator
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import Seed, ac_texts
 from ouroboros.core.types import Result
 from ouroboros.core.worktree import (
     TaskWorkspace,
@@ -1158,7 +1158,7 @@ class ExecuteSeedHandler(BridgeAwareMixin):
     @staticmethod
     def _derive_quality_bar(seed: Seed) -> str:
         """Derive a quality bar string from seed acceptance criteria."""
-        ac_lines = [f"- {ac}" for ac in seed.acceptance_criteria]
+        ac_lines = [f"- {ac}" for ac in ac_texts(seed.acceptance_criteria)]
         return "The execution must satisfy all acceptance criteria:\n" + "\n".join(ac_lines)
 
     @staticmethod
@@ -1343,7 +1343,9 @@ class StartExecuteSeedHandler:
             if isinstance(seed_dict, dict):
                 seed = Seed.from_dict(seed_dict)
                 acceptance_criteria = [
-                    text.strip() for text in seed.acceptance_criteria if text and text.strip()
+                    stripped
+                    for text in ac_texts(seed.acceptance_criteria)
+                    if (stripped := text.strip())
                 ]
                 if acceptance_criteria:
                     evaluation_arguments["acceptance_criteria"] = acceptance_criteria

--- a/src/ouroboros/orchestrator/dependency_analyzer.py
+++ b/src/ouroboros/orchestrator/dependency_analyzer.py
@@ -10,6 +10,7 @@ import re
 from typing import TYPE_CHECKING, Any
 
 from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
+from ouroboros.core.seed import AcceptanceCriterionInput, ac_text
 from ouroboros.core.types import Result
 from ouroboros.observability.logging import get_logger
 
@@ -385,7 +386,7 @@ class DependencyAnalyzer:
 
     async def analyze(
         self,
-        acceptance_criteria: Sequence[str] | Sequence[ACDependencySpec],
+        acceptance_criteria: Sequence[AcceptanceCriterionInput] | Sequence[ACDependencySpec],
     ) -> Result[DependencyGraph, DependencyAnalysisError]:
         """Analyze AC dependencies and return a graph with execution levels."""
         specs = self._normalize_specs(acceptance_criteria)
@@ -437,7 +438,7 @@ class DependencyAnalyzer:
 
     def _normalize_specs(
         self,
-        acceptance_criteria: Sequence[str] | Sequence[ACDependencySpec],
+        acceptance_criteria: Sequence[AcceptanceCriterionInput] | Sequence[ACDependencySpec],
     ) -> tuple[ACDependencySpec, ...]:
         specs: list[ACDependencySpec] = []
         for index, item in enumerate(acceptance_criteria):
@@ -453,7 +454,7 @@ class DependencyAnalyzer:
                     )
                 )
             else:
-                specs.append(ACDependencySpec(index=index, content=str(item)))
+                specs.append(ACDependencySpec(index=index, content=ac_text(item)))
         return tuple(specs)
 
     def _analyze_structured_dependencies(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -39,6 +39,7 @@ from typing import TYPE_CHECKING, Any
 import anyio
 from rich.console import Console
 
+from ouroboros.core.seed import ac_text
 from ouroboros.core.seed_contract_prompt import render_auto_recursion_guard
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.adapter import (
@@ -1606,7 +1607,7 @@ class ParallelACExecutor:
         """Execute one batch of stage-ready ACs using the shared worker pool."""
         batch_results: list[ACExecutionResult | BaseException] = [None] * len(batch_indices)
         sibling_acs: list[_SiblingACRef] = (
-            [(i, seed.acceptance_criteria[i]) for i in batch_indices]
+            [(i, ac_text(seed.acceptance_criteria[i])) for i in batch_indices]
             if len(batch_indices) > 1
             else []
         )
@@ -1616,7 +1617,7 @@ class ParallelACExecutor:
                 try:
                     batch_results[idx] = await self._execute_single_ac(
                         ac_index=ac_idx,
-                        ac_content=seed.acceptance_criteria[ac_idx],
+                        ac_content=ac_text(seed.acceptance_criteria[ac_idx]),
                         session_id=session_id,
                         tools=tools,
                         tool_catalog=tool_catalog,
@@ -1746,7 +1747,7 @@ class ParallelACExecutor:
                                 all_results.append(
                                     ACExecutionResult(
                                         ac_index=ac_idx,
-                                        ac_content=seed.acceptance_criteria[ac_idx],
+                                        ac_content=ac_text(seed.acceptance_criteria[ac_idx]),
                                         success=is_completed,
                                         final_message=(
                                             "[Restored from checkpoint]" if is_completed else ""
@@ -1791,7 +1792,7 @@ class ParallelACExecutor:
                 all_results.append(
                     ACExecutionResult(
                         ac_index=idx,
-                        ac_content=seed.acceptance_criteria[idx],
+                        ac_content=ac_text(seed.acceptance_criteria[idx]),
                         success=False,
                         error="Not included in dependency graph",
                         retry_attempt=ac_retry_attempts[idx],
@@ -1920,7 +1921,7 @@ class ParallelACExecutor:
 
                     satisfied_result = ACExecutionResult(
                         ac_index=ac_idx,
-                        ac_content=seed.acceptance_criteria[ac_idx],
+                        ac_content=ac_text(seed.acceptance_criteria[ac_idx]),
                         success=True,
                         final_message="\n".join(notes),
                         retry_attempt=ac_retry_attempts[ac_idx],
@@ -1943,7 +1944,7 @@ class ParallelACExecutor:
                 for ac_idx in blocked:
                     blocked_result = ACExecutionResult(
                         ac_index=ac_idx,
-                        ac_content=seed.acceptance_criteria[ac_idx],
+                        ac_content=ac_text(seed.acceptance_criteria[ac_idx]),
                         success=False,
                         error="Skipped: dependency failed",
                         retry_attempt=ac_retry_attempts[ac_idx],
@@ -2050,7 +2051,7 @@ class ParallelACExecutor:
                             error_msg = str(result)
                             ac_result = ACExecutionResult(
                                 ac_index=ac_idx,
-                                ac_content=seed.acceptance_criteria[ac_idx],
+                                ac_content=ac_text(seed.acceptance_criteria[ac_idx]),
                                 success=False,
                                 error=error_msg,
                                 retry_attempt=ac_retry_attempts[ac_idx],
@@ -2085,7 +2086,7 @@ class ParallelACExecutor:
                             )
                             ac_result = ACExecutionResult(
                                 ac_index=ac_idx,
-                                ac_content=seed.acceptance_criteria[ac_idx],
+                                ac_content=ac_text(seed.acceptance_criteria[ac_idx]),
                                 success=False,
                                 error=(f"Stalled (no activity for {STALL_TIMEOUT_SECONDS:.0f}s)"),
                                 retry_attempt=ac_retry_attempts[ac_idx],
@@ -4383,7 +4384,7 @@ Files present:
 
         # Build AC list for TUI
         acceptance_criteria = []
-        for i, ac_content in enumerate(seed.acceptance_criteria):
+        for i, ac_content in enumerate(ac_text(seed_ac) for seed_ac in seed.acceptance_criteria):
             status = ac_statuses.get(i, "pending")
             retry_attempt = (ac_retry_attempts or {}).get(i, 0)
             node_identity = ExecutionNodeIdentity.root(

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -37,6 +37,7 @@ from rich.text import Text
 from ouroboros.backends import backend_supports_tool_envelope
 from ouroboros.config import get_llm_model_for_role
 from ouroboros.core.errors import OuroborosError
+from ouroboros.core.seed import ac_text, ac_texts
 from ouroboros.core.seed_contract import SeedContract
 from ouroboros.core.seed_contract_prompt import (
     render_auto_recursion_guard,
@@ -339,7 +340,7 @@ def build_task_prompt(
     if strategy is None:
         strategy = get_strategy(seed.task_type)
 
-    ac_list = "\n".join(f"{i + 1}. {ac}" for i, ac in enumerate(seed.acceptance_criteria))
+    ac_list = "\n".join(f"{i + 1}. {ac}" for i, ac in enumerate(ac_texts(seed.acceptance_criteria)))
     suffix = strategy.get_task_prompt_suffix()
 
     return f"""Execute the following task according to the acceptance criteria:
@@ -2265,7 +2266,7 @@ class OrchestratorRunner:
             from ouroboros.orchestrator.workflow_state import WorkflowStateTracker
 
             state_tracker = WorkflowStateTracker(
-                acceptance_criteria=seed.acceptance_criteria,
+                acceptance_criteria=list(seed.acceptance_criteria),
                 goal=seed.goal,
                 session_id=tracker.session_id,
                 activity_map=strategy.get_activity_map(),
@@ -2840,7 +2841,7 @@ class OrchestratorRunner:
             self._console.print("\n[cyan]Preparing sequential AC execution plan...[/cyan]")
             dependency_graph = DependencyGraph(
                 nodes=tuple(
-                    ACNode(index=i, content=ac, depends_on=tuple(range(i)))
+                    ACNode(index=i, content=ac_text(ac), depends_on=tuple(range(i)))
                     for i, ac in enumerate(seed.acceptance_criteria)
                 ),
                 execution_levels=tuple((i,) for i in range(len(seed.acceptance_criteria))),
@@ -2861,7 +2862,7 @@ class OrchestratorRunner:
                 all_indices = tuple(range(len(seed.acceptance_criteria)))
                 dependency_graph = DependencyGraph(
                     nodes=tuple(
-                        ACNode(index=i, content=ac, depends_on=())
+                        ACNode(index=i, content=ac_text(ac), depends_on=())
                         for i, ac in enumerate(seed.acceptance_criteria)
                     ),
                     execution_levels=(all_indices,) if all_indices else (),
@@ -3261,7 +3262,7 @@ Note: This is a resumed session. Please continue from where execution was interr
 
             resume_strategy = get_strategy(seed.task_type)
             state_tracker = WorkflowStateTracker(
-                acceptance_criteria=seed.acceptance_criteria,
+                acceptance_criteria=list(seed.acceptance_criteria),
                 goal=seed.goal,
                 session_id=session_id,
                 activity_map=resume_strategy.get_activity_map(),

--- a/src/ouroboros/orchestrator/workflow_ir_adapter.py
+++ b/src/ouroboros/orchestrator/workflow_ir_adapter.py
@@ -11,7 +11,7 @@ from collections.abc import Iterable, Mapping
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import AcceptanceCriterionInput, Seed, ac_text
 from ouroboros.orchestrator.workflow_ir import (
     EdgeKind,
     NodeKind,
@@ -419,17 +419,12 @@ def _identifier_segment(value: str) -> str:
     return "u" + value.encode("utf-8").hex()
 
 
-def _normalize_acceptance_criteria(criteria: tuple[str, ...]) -> tuple[str, ...]:
+def _normalize_acceptance_criteria(
+    criteria: tuple[AcceptanceCriterionInput, ...],
+) -> tuple[str, ...]:
     normalized: list[str] = []
     for zero_based_index, criterion in enumerate(criteria):
-        if not isinstance(criterion, str):
-            msg = (
-                "Seed acceptance_criteria must contain only strings before the "
-                f"PlannedAC migration; item {zero_based_index + 1} is "
-                f"{type(criterion).__name__}"
-            )
-            raise ValueError(msg)
-        stripped = criterion.strip()
+        stripped = ac_text(criterion).strip()
         if not stripped:
             msg = f"Seed acceptance criterion {zero_based_index + 1} must be non-blank"
             raise ValueError(msg)

--- a/src/ouroboros/orchestrator/workflow_state.py
+++ b/src/ouroboros/orchestrator/workflow_state.py
@@ -25,6 +25,7 @@ from enum import Enum
 import re
 from typing import TYPE_CHECKING, Any
 
+from ouroboros.core.seed import AcceptanceCriterionInput, AcceptanceCriterionSpec, ac_text
 from ouroboros.mcp.types import MCPToolResult
 from ouroboros.orchestrator.mcp_tools import serialize_tool_result
 from ouroboros.orchestrator.runtime_message_projection import project_runtime_message
@@ -341,6 +342,7 @@ class AcceptanceCriterion:
 
     index: int
     content: str
+    spec: AcceptanceCriterionSpec | None = None
     status: ACStatus = ACStatus.PENDING
     retry_attempt: int = 0
     started_at: datetime | None = None
@@ -612,7 +614,7 @@ class WorkflowStateTracker:
 
     def __init__(
         self,
-        acceptance_criteria: list[str],
+        acceptance_criteria: list[AcceptanceCriterionInput],
         goal: str = "",
         session_id: str = "",
         activity_map: dict[str, ActivityType] | None = None,
@@ -631,7 +633,11 @@ class WorkflowStateTracker:
             session_id=session_id,
             goal=goal,
             acceptance_criteria=[
-                AcceptanceCriterion(index=i + 1, content=ac)
+                AcceptanceCriterion(
+                    index=i + 1,
+                    content=ac_text(ac),
+                    spec=ac if isinstance(ac, AcceptanceCriterionSpec) else None,
+                )
                 for i, ac in enumerate(acceptance_criteria)
             ],
         )

--- a/src/ouroboros/verification/extractor.py
+++ b/src/ouroboros/verification/extractor.py
@@ -15,6 +15,7 @@ import json
 import logging
 
 from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
+from ouroboros.core.seed import AcceptanceCriterionInput, ac_texts
 from ouroboros.core.types import Result
 from ouroboros.providers.base import (
     CompletionConfig,
@@ -85,7 +86,7 @@ class AssertionExtractor:
     async def extract(
         self,
         seed_id: str,
-        acceptance_criteria: tuple[str, ...] | list[str],
+        acceptance_criteria: tuple[AcceptanceCriterionInput, ...] | list[AcceptanceCriterionInput],
     ) -> Result[tuple[SpecAssertion, ...], str]:
         """Extract assertions from ACs.
 
@@ -100,11 +101,12 @@ class AssertionExtractor:
             logger.debug("AssertionExtractor cache hit: %s", seed_id)
             return Result.ok(self._cache[seed_id])
 
-        if not acceptance_criteria:
+        acceptance_texts = ac_texts(acceptance_criteria)
+        if not acceptance_texts:
             return Result.ok(())
 
         prompt = "Extract verifiable assertions from these acceptance criteria:\n\n"
-        for i, ac in enumerate(acceptance_criteria):
+        for i, ac in enumerate(acceptance_texts):
             prompt += f"AC {i} (index {i}): {ac}\n"
 
         messages = [
@@ -126,7 +128,7 @@ class AssertionExtractor:
             logger.warning("AssertionExtractor LLM failed: %s", result.error)
             return Result.err(f"Extraction failed: {result.error}")
 
-        assertions = self._parse_response(result.value.content, acceptance_criteria)
+        assertions = self._parse_response(result.value.content, acceptance_texts)
         self._cache[seed_id] = assertions
         # LRU eviction: remove oldest entry if cache exceeds max size
         while len(self._cache) > self.max_cache_size:
@@ -136,7 +138,7 @@ class AssertionExtractor:
     def _parse_response(
         self,
         content: str,
-        acceptance_criteria: tuple[str, ...] | list[str],
+        acceptance_criteria: tuple[str, ...],
     ) -> tuple[SpecAssertion, ...]:
         """Parse LLM response into SpecAssertions."""
         try:

--- a/tests/e2e/test_full_workflow.py
+++ b/tests/e2e/test_full_workflow.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import Seed, ac_text
 from ouroboros.orchestrator.adapter import AgentMessage
 from ouroboros.orchestrator.runner import (
     OrchestratorRunner,
@@ -98,7 +98,7 @@ class TestPromptBuilding:
         prompt = build_task_prompt(sample_seed)
 
         for criterion in sample_seed.acceptance_criteria:
-            assert criterion in prompt
+            assert ac_text(criterion) in prompt
 
     def test_task_prompt_numbers_criteria(self, sample_seed: Seed) -> None:
         """Test that task prompt numbers acceptance criteria."""

--- a/tests/fixtures/seeds/legacy-seed-minimal.json
+++ b/tests/fixtures/seeds/legacy-seed-minimal.json
@@ -1,0 +1,34 @@
+{
+  "acceptance_criteria": [
+    "CLI exits 0",
+    "Output contains greeting"
+  ],
+  "brownfield_context": {
+    "context_references": [],
+    "existing_dependencies": [],
+    "existing_patterns": [],
+    "project_type": "greenfield"
+  },
+  "constraints": [],
+  "evaluation_principles": [],
+  "exit_conditions": [],
+  "goal": "Build hello CLI",
+  "metadata": {
+    "ambiguity_score": 0.12,
+    "created_at": "2026-07-02T00:00:00Z",
+    "degraded": false,
+    "generation_mode": "normal",
+    "interview_id": null,
+    "parent_seed_id": null,
+    "recovery_reason": null,
+    "seed_id": "seed_legacy_json",
+    "unresolved_slots": [],
+    "version": "1.0.0"
+  },
+  "ontology_schema": {
+    "description": "Hello CLI domain",
+    "fields": [],
+    "name": "HelloCli"
+  },
+  "task_type": "code"
+}

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -13,16 +13,18 @@ _SINGLE_HELLO_AUTO_OBSERVATION_AC = (
 )
 
 from ouroboros.core.seed import (
+    AcceptanceCriterionSpec,
     EvaluationPrinciple,
     ExitCondition,
     OntologyField,
     OntologySchema,
     Seed,
     SeedMetadata,
+    ac_texts,
 )
 
 
-def _seed(*criteria: str) -> Seed:
+def _seed(*criteria: str | AcceptanceCriterionSpec) -> Seed:
     return Seed(
         goal="Verify ooo auto with a minimal coding task",
         constraints=("Only edit hello_auto.py and tests/test_hello_auto.py",),
@@ -58,7 +60,7 @@ def test_normalize_execution_acceptance_drops_auto_report_criteria() -> None:
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
+    assert ac_texts(normalized.acceptance_criteria) == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
 
 
 def test_normalize_execution_acceptance_preserves_requested_hello_auto_value() -> None:
@@ -83,7 +85,7 @@ def test_normalize_execution_acceptance_preserves_requested_hello_auto_value() -
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (
+    assert ac_texts(normalized.acceptance_criteria) == (
         "Create `hello_auto.py` and `tests/test_hello_auto.py` so "
         "`hello_auto() -> str` returns exactly `hello from ooo auto fresh`, "
         "the test imports `hello_auto` and asserts that exact value, and "
@@ -111,7 +113,7 @@ def test_normalize_execution_acceptance_reads_requested_value_from_constraints()
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (
+    assert ac_texts(normalized.acceptance_criteria) == (
         "Create `hello_auto.py` and `tests/test_hello_auto.py` so "
         "`hello_auto() -> str` returns exactly `hello from ooo auto fresh`, "
         "the test imports `hello_auto` and asserts that exact value, and "
@@ -137,7 +139,7 @@ def test_normalize_execution_acceptance_drops_observation_report_metadata() -> N
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
+    assert ac_texts(normalized.acceptance_criteria) == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
 
 
 def test_normalize_execution_acceptance_filters_latest_observation_prompt_metadata() -> None:
@@ -158,7 +160,7 @@ def test_normalize_execution_acceptance_filters_latest_observation_prompt_metada
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
+    assert ac_texts(normalized.acceptance_criteria) == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
 
 
 def test_normalize_execution_acceptance_preserves_non_equivalent_file_criteria() -> None:
@@ -175,11 +177,36 @@ def test_normalize_execution_acceptance_preserves_non_equivalent_file_criteria()
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (
+    assert ac_texts(normalized.acceptance_criteria) == (
         "`hello_auto.py` contains a module-level docstring.",
         "`tests/test_hello_auto.py` uses pytest.mark.smoke.",
         "pytest tests/test_hello_auto.py -q passes.",
     )
+
+
+def test_normalize_execution_acceptance_preserves_surviving_success_contracts() -> None:
+    spec = AcceptanceCriterionSpec(
+        description="`hello_auto.py` contains a module-level docstring.",
+        verify_command="uv run pytest tests/test_hello_auto.py",
+        expected_artifacts=("hello_auto.py",),
+    )
+    seed = _seed(
+        "`ooo auto` is dispatched through the installed Ouroboros MCP tool, not interpreted as plain text.",
+        spec,
+    ).model_copy(
+        update={
+            "goal": "Observation run: verify latest main Ouroboros ooo auto with hello_auto.py and tests/test_hello_auto.py via ouroboros_auto. hello_auto returns exactly hello from ooo auto."
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert len(normalized.acceptance_criteria) == 1
+    normalized_spec = normalized.acceptance_criteria[0]
+    assert isinstance(normalized_spec, AcceptanceCriterionSpec)
+    assert normalized_spec.description == spec.description
+    assert normalized_spec.verify_command == "uv run pytest tests/test_hello_auto.py"
+    assert normalized_spec.expected_artifacts == ("hello_auto.py",)
 
 
 def test_normalize_execution_acceptance_preserves_extra_hello_auto_requirements() -> None:
@@ -197,7 +224,7 @@ def test_normalize_execution_acceptance_preserves_extra_hello_auto_requirements(
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (
+    assert ac_texts(normalized.acceptance_criteria) == (
         _SINGLE_HELLO_AUTO_OBSERVATION_AC,
         "`hello_auto.py` contains a module-level docstring.",
         "`tests/test_hello_auto.py` uses pytest.mark.smoke.",
@@ -220,7 +247,7 @@ def test_normalize_execution_acceptance_preserves_real_product_lifecycle_criteri
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (
+    assert ac_texts(normalized.acceptance_criteria) == (
         "Implement a manual fallback mode for unavailable tools.",
         "Persist execution job status for resumed runs.",
         "Display progress accounting for every acceptance criterion.",
@@ -253,7 +280,7 @@ def test_normalize_execution_acceptance_unwraps_repaired_observation_criteria() 
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
+    assert ac_texts(normalized.acceptance_criteria) == (_SINGLE_HELLO_AUTO_OBSERVATION_AC,)
 
 
 def test_normalize_execution_acceptance_keeps_original_when_filter_would_empty() -> None:
@@ -273,7 +300,7 @@ def test_normalize_execution_acceptance_preserves_mixed_non_keyword_requirements
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (
+    assert ac_texts(normalized.acceptance_criteria) == (
         "`foo.py` exists.",
         "CLI exits 2 on invalid flags.",
         "HTTP 400 responses include a machine-readable error code.",
@@ -290,7 +317,7 @@ def test_normalize_execution_acceptance_preserves_expected_ooo_auto_output() -> 
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (
+    assert ac_texts(normalized.acceptance_criteria) == (
         "The command prints exactly `hello from ooo auto`.",
         "Manual fallback is not used.",
     )
@@ -308,7 +335,7 @@ def test_normalize_execution_acceptance_preserves_product_final_report_and_fallb
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (
+    assert ac_texts(normalized.acceptance_criteria) == (
         "Implement a manual fallback mode for offline users.",
         "The final report endpoint includes the session id field.",
         "The final report endpoint includes seed id and seed path.",
@@ -345,7 +372,7 @@ def test_normalize_execution_acceptance_drops_library_defaults_for_file_artifact
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (
+    assert ac_texts(normalized.acceptance_criteria) == (
         "pi_auto_smoke.txt exists at repository root.",
         "pi_auto_smoke.txt full content exactly pi-auto-ok followed by a newline.",
     )
@@ -370,7 +397,7 @@ def test_normalize_execution_acceptance_drops_wrapped_library_defaults_for_file_
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (
+    assert ac_texts(normalized.acceptance_criteria) == (
         "A command/API check returns stable observable output or artifacts proving the original requirement for pi_auto_smoke.txt exists at repository root.",
         "A command/API check returns stable observable output or artifacts proving the original requirement for pi_auto_smoke.txt full content exactly pi-auto-ok followed by a newline.",
     )
@@ -413,7 +440,7 @@ def test_normalize_execution_acceptance_canonicalizes_autoresearch_contract() ->
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert normalized.acceptance_criteria == (
+    assert ac_texts(normalized.acceptance_criteria) == (
         "The experiment ledger artifact contains a baseline entry written before any edit; it includes measured command `/usr/bin/time -l uv run train.py`, inner command, exit status, val_bpb, maximum resident set size bytes, and baseline status.",
         "The experiment ledger artifact contains at most two train.py-only experiment entries, each evaluated with the same measured command and timeout budget.",
         "The experiment ledger artifact contains sequential decision entries; each entry includes keep/revert status from the current best state, keeping strict val_bpb improvements and reverting ties, regressions, invalid runs, timeouts, crashes, missing metrics, missing memory, and unauthorized scope changes before the next attempt.",
@@ -463,12 +490,9 @@ def test_normalize_execution_acceptance_preserves_distinct_autoresearch_user_ac(
 
     normalized = normalize_execution_acceptance(seed)
 
-    assert "train.py must preserve the existing --device CLI flag behavior." in (
-        normalized.acceptance_criteria
-    )
-    assert "Final report must include the baseline val_bpb and memory." in (
-        normalized.acceptance_criteria
-    )
+    normalized_texts = ac_texts(normalized.acceptance_criteria)
+    assert "train.py must preserve the existing --device CLI flag behavior." in normalized_texts
+    assert "Final report must include the baseline val_bpb and memory." in normalized_texts
 
 
 def test_normalize_execution_acceptance_preserves_existing_autoresearch_runtime_context() -> None:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -25,6 +25,7 @@ from ouroboros.core.seed import (
     OntologySchema,
     Seed,
     SeedMetadata,
+    ac_text,
 )
 
 # The unsafe-context matcher / safe-default blocking machinery exercised here
@@ -1266,7 +1267,7 @@ def test_seed_repairer_rewrites_each_acceptance_criterion_once() -> None:
     result = SeedRepairer().repair_once(seed, review, ledger=ledger)
 
     assert result.changed
-    repaired_acceptance = result.seed.acceptance_criteria[0]
+    repaired_acceptance = ac_text(result.seed.acceptance_criteria[0])
     assert repaired_acceptance.count("original requirement for") == 1
     assert "The CLI" in repaired_acceptance
     assert "original requirement for A command/API check" not in repaired_acceptance
@@ -5635,7 +5636,7 @@ async def test_pipeline_normalizes_persisted_seed_artifact_on_resume(tmp_path) -
 
     assert result.status == "complete"
     resumed_seed = Seed.from_dict(state.seed_artifact)
-    criteria_text = "\n".join(resumed_seed.acceptance_criteria)
+    criteria_text = "\n".join(ac_text(item) for item in resumed_seed.acceptance_criteria)
     assert "Final report includes auto session id" not in criteria_text
     assert "CLI exits 2 on invalid flags" in criteria_text
 

--- a/tests/unit/auto/test_ledger_grading_answerer.py
+++ b/tests/unit/auto/test_ledger_grading_answerer.py
@@ -5,6 +5,7 @@ from ouroboros.auto.gap_detector import GapDetector
 from ouroboros.auto.grading import GradeGate, SeedGrade
 from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.core.seed import (
+    AcceptanceCriterionSpec,
     EvaluationPrinciple,
     ExitCondition,
     OntologyField,
@@ -39,7 +40,11 @@ def _fill_minimal_ready_ledger(ledger: SeedDraftLedger) -> None:
         )
 
 
-def _seed(*, ac: tuple[str, ...], goal: str = "Build a habit tracker") -> Seed:
+def _seed(
+    *,
+    ac: tuple[str | AcceptanceCriterionSpec, ...],
+    goal: str = "Build a habit tracker",
+) -> Seed:
     return Seed(
         goal=goal,
         constraints=("Use existing project patterns",),
@@ -291,9 +296,11 @@ def test_grade_gate_requires_observable_acceptance_behavior_not_keywords() -> No
 
     assert result.grade == SeedGrade.B
     assert not result.may_run
-    assert (
-        sum(1 for finding in result.findings if finding.code == "untestable_acceptance_criteria")
-        == 2
+    assert sum(1 for finding in result.findings if finding.code == "missing_success_contract") == 2
+    assert all(
+        finding.severity == "medium"
+        for finding in result.findings
+        if finding.code == "missing_success_contract"
     )
 
 
@@ -317,6 +324,47 @@ def test_grade_gate_accepts_coding_observation_run_acceptance_criteria() -> None
 
     assert result.grade == SeedGrade.A
     assert not any(finding.code == "untestable_acceptance_criteria" for finding in result.findings)
+    assert not any(finding.code == "missing_success_contract" for finding in result.findings)
+
+
+def test_grade_gate_accepts_verify_command_success_contract() -> None:
+    """A declared command contract is observable without prose heuristics."""
+    ledger = SeedDraftLedger.from_goal("Create hello_auto.py and verify it with pytest")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(
+        goal="Create hello_auto.py and verify it with pytest",
+        ac=(
+            AcceptanceCriterionSpec(
+                description="Hello behavior works",
+                verify_command="uv run pytest tests/test_hello_auto.py",
+            ),
+        ),
+    )
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.A
+    assert not any(finding.code == "missing_success_contract" for finding in result.findings)
+
+
+def test_grade_gate_accepts_expected_artifacts_success_contract() -> None:
+    """A declared artifact contract is observable without prose heuristics."""
+    ledger = SeedDraftLedger.from_goal("Create hello_auto.py")
+    _fill_minimal_ready_ledger(ledger)
+    seed = _seed(
+        goal="Create hello_auto.py",
+        ac=(
+            AcceptanceCriterionSpec(
+                description="Hello script exists",
+                expected_artifacts=("hello_auto.py",),
+            ),
+        ),
+    )
+
+    result = GradeGate().grade_seed(seed, ledger=ledger)
+
+    assert result.grade == SeedGrade.A
+    assert not any(finding.code == "missing_success_contract" for finding in result.findings)
 
 
 def test_grade_gate_rejects_vacuous_coding_command_acceptance_criteria() -> None:
@@ -336,10 +384,11 @@ def test_grade_gate_rejects_vacuous_coding_command_acceptance_criteria() -> None
 
     assert result.grade == SeedGrade.B
     assert not result.may_run
-    untestable = [
-        finding for finding in result.findings if finding.code == "untestable_acceptance_criteria"
+    missing_contract = [
+        finding for finding in result.findings if finding.code == "missing_success_contract"
     ]
-    assert [finding.target for finding in untestable] == [
+    assert [finding.severity for finding in missing_contract] == ["medium", "medium", "medium"]
+    assert [finding.target for finding in missing_contract] == [
         "acceptance_criteria[0]",
         "acceptance_criteria[1]",
         "acceptance_criteria[2]",
@@ -368,9 +417,7 @@ def test_grade_gate_rejects_vacuous_report_acceptance_criteria() -> None:
     assert result.grade == SeedGrade.B
     assert not result.may_run
     assert [
-        finding.target
-        for finding in result.findings
-        if finding.code == "untestable_acceptance_criteria"
+        finding.target for finding in result.findings if finding.code == "missing_success_contract"
     ] == [
         "acceptance_criteria[0]",
         "acceptance_criteria[1]",

--- a/tests/unit/auto/test_ledger_seed.py
+++ b/tests/unit/auto/test_ledger_seed.py
@@ -29,7 +29,7 @@ from ouroboros.auto.ledger_seed import (
     partial_seed_from_evidence,
     synthesize_seed_from_ledger,
 )
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import Seed, ac_texts
 
 
 def _populate_complete_ledger(goal: str = "Build a CLI tool that prints hello.") -> SeedDraftLedger:
@@ -296,7 +296,7 @@ class TestAcceptanceCriteriaNotExplodedOnSemicolons:
             "Tasks persist to a file; the data survives a process restart"
         )
         seed = synthesize_seed_from_ledger(ledger, interview_id="iv-semicolon")
-        assert seed.acceptance_criteria == (
+        assert ac_texts(seed.acceptance_criteria) == (
             "Tasks persist to a file; the data survives a process restart",
         )
 
@@ -305,7 +305,7 @@ class TestAcceptanceCriteriaNotExplodedOnSemicolons:
             "- Tasks can be created\n- Tasks can be listed\n- Tasks persist"
         )
         seed = synthesize_seed_from_ledger(ledger, interview_id="iv-bullets")
-        assert seed.acceptance_criteria == (
+        assert ac_texts(seed.acceptance_criteria) == (
             "Tasks can be created",
             "Tasks can be listed",
             "Tasks persist",
@@ -324,4 +324,4 @@ class TestAcceptanceCriteriaNotExplodedOnSemicolons:
             ),
         )
         seed = partial_seed_from_evidence(ledger, reason="interview_phase_deadline")
-        assert "API returns 200; payload is valid JSON" in seed.acceptance_criteria
+        assert "API returns 200; payload is valid JSON" in ac_texts(seed.acceptance_criteria)

--- a/tests/unit/auto/test_pipeline_evaluate.py
+++ b/tests/unit/auto/test_pipeline_evaluate.py
@@ -32,6 +32,7 @@ from ouroboros.core.seed import (
     OntologySchema,
     Seed,
     SeedMetadata,
+    ac_texts,
 )
 
 # ---------------------------------------------------------------------------
@@ -599,7 +600,7 @@ async def test_handler_evaluator_builds_quality_bar_from_seed_ac() -> None:
     args = stub.last_arguments
     assert args is not None
     # Quality bar must contain every acceptance criterion
-    for ac in seed.acceptance_criteria:
+    for ac in ac_texts(seed.acceptance_criteria):
         assert ac in args["quality_bar"]
     # Default arg shape
     assert args["artifact_type"] == "test_output"

--- a/tests/unit/auto/test_task_class_application.py
+++ b/tests/unit/auto/test_task_class_application.py
@@ -10,12 +10,14 @@ from ouroboros.auto.task_class_application import (
 )
 from ouroboros.auto.task_classes import TASK_CLASS_CATALOG, TaskClass
 from ouroboros.core.seed import (
+    AcceptanceCriterionSpec,
     EvaluationPrinciple,
     ExitCondition,
     OntologyField,
     OntologySchema,
     Seed,
     SeedMetadata,
+    ac_texts,
 )
 
 
@@ -56,7 +58,7 @@ def test_prepends_full_template_for_empty_user_ac() -> None:
     profile = TASK_CLASS_CATALOG[TaskClass.CLI]
     applied = apply_default_ac_template(seed, TaskClass.CLI)
     assert applied.injected_ac == profile.default_ac_template
-    assert applied.seed.acceptance_criteria == profile.default_ac_template
+    assert ac_texts(applied.seed.acceptance_criteria) == profile.default_ac_template
 
 
 def test_user_ac_appears_after_template_entries() -> None:
@@ -66,7 +68,7 @@ def test_user_ac_appears_after_template_entries() -> None:
     profile = TASK_CLASS_CATALOG[TaskClass.CLI]
     applied = apply_default_ac_template(seed, TaskClass.CLI)
     expected = profile.default_ac_template + ("Foo must do bar",)
-    assert applied.seed.acceptance_criteria == expected
+    assert ac_texts(applied.seed.acceptance_criteria) == expected
     # injected_ac carries only the entries this call added.
     assert applied.injected_ac == profile.default_ac_template
 
@@ -90,7 +92,7 @@ def test_autoresearch_execution_contract_skips_generic_template() -> None:
 
     assert applied.injected_ac == ()
     assert applied.seed is seed
-    assert not any("public API symbols" in item for item in seed.acceptance_criteria)
+    assert not any("public API symbols" in item for item in ac_texts(seed.acceptance_criteria))
 
 
 def test_generic_cli_execution_contract_still_gets_template() -> None:
@@ -118,8 +120,8 @@ def test_does_not_duplicate_when_user_already_supplied_one_template_entry() -> N
     seed = _seed(ac=(one_template_entry, "User-specific AC"))
     applied = apply_default_ac_template(seed, TaskClass.CLI)
     # The duplicate template entry is skipped; the rest is prepended.
-    assert one_template_entry in applied.seed.acceptance_criteria
-    assert applied.seed.acceptance_criteria.count(one_template_entry) == 1
+    assert one_template_entry in ac_texts(applied.seed.acceptance_criteria)
+    assert ac_texts(applied.seed.acceptance_criteria).count(one_template_entry) == 1
     assert one_template_entry not in applied.injected_ac
 
 
@@ -148,14 +150,14 @@ def test_each_task_class_has_a_nonempty_template() -> None:
 
 
 def test_seed_acceptance_criteria_type_preserved() -> None:
-    """``Seed.acceptance_criteria`` is ``tuple[str, ...]``; after
-    application, the type stays a tuple (pydantic ``frozen=True`` seed
-    can return a different container shape via ``model_copy`` if we
-    are not careful)."""
+    """Application preserves the tuple container and structured AC model."""
     seed = _seed(ac=("user-ac",))
     applied = apply_default_ac_template(seed, TaskClass.CLI)
     assert isinstance(applied.seed.acceptance_criteria, tuple)
-    assert all(isinstance(item, str) for item in applied.seed.acceptance_criteria)
+    assert all(
+        isinstance(item, AcceptanceCriterionSpec) for item in applied.seed.acceptance_criteria
+    )
+    assert ac_texts(applied.seed.acceptance_criteria)[-1] == "user-ac"
 
 
 def test_seed_is_frozen_after_application() -> None:

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -27,12 +27,14 @@ from ouroboros.bigbang.seed_generator import (
 from ouroboros.config.loader import get_clarification_model
 from ouroboros.core.errors import ProviderError, ValidationError
 from ouroboros.core.seed import (
+    AcceptanceCriterionSpec,
     EvaluationPrinciple,
     ExitCondition,
     OntologyField,
     OntologySchema,
     Seed,
     SeedMetadata,
+    ac_texts,
 )
 from ouroboros.core.types import Result
 from ouroboros.providers.base import CompletionResponse, UsageInfo
@@ -498,6 +500,51 @@ class TestSeedGeneratorExtraction:
 
             assert result.is_ok
             assert len(result.value.acceptance_criteria) == 2
+            assert ac_texts(result.value.acceptance_criteria) == (
+                "Tasks can be created",
+                "Tasks can be listed",
+            )
+
+    @pytest.mark.asyncio
+    async def test_generate_extracts_structured_acceptance_criteria_contracts(self) -> None:
+        """SeedGenerator extracts AC success contracts from multiline architect output."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        extraction_response = create_valid_extraction_response(
+            acceptance_criteria=(
+                "\n"
+                'AC: CLI lists tasks | verify: bash -lc "pytest -q | tee out.log" | '
+                "artifacts: tasks.json, logs/task.log | expect: No tasks\n"
+                "AC: Docs explain usage | verify: NONE | artifacts: README.md | expect: NONE\n"
+                "AC: Legacy line without contract"
+            )
+        )
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(extraction_response))
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, low_ambiguity)
+
+            assert result.is_ok
+            first, second, third = result.value.acceptance_criteria
+            assert isinstance(first, AcceptanceCriterionSpec)
+            assert first.description == "CLI lists tasks"
+            assert first.verify_command == 'bash -lc "pytest -q | tee out.log"'
+            assert first.expected_artifacts == ("tasks.json", "logs/task.log")
+            assert first.output_assertion == "No tasks"
+            assert second.description == "Docs explain usage"
+            assert second.verify_command is None
+            assert second.expected_artifacts == ("README.md",)
+            assert third.description == "Legacy line without contract"
+            assert third.verify_command is None
 
     @pytest.mark.asyncio
     async def test_generate_extracts_ontology_schema(self) -> None:
@@ -1066,6 +1113,19 @@ class TestAcceptanceCriteriaGranularityContract:
 
         assert "3-7" in prompt
         assert "implementation step" in prompt.lower()
+
+    def test_extraction_user_prompt_requests_structured_ac_contracts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=AsyncMock(),
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+            prompt = generator._build_extraction_user_prompt("Q: goal?\nA: build a thing")
+
+        assert "ACCEPTANCE_CRITERIA:\nAC:" in prompt
+        assert "verify: <command or NONE>" in prompt
+        assert "artifacts: <comma-list or NONE>" in prompt
+        assert "ACCEPTANCE_CRITERIA: <criterion 1> | <criterion 2>" not in prompt
 
     def test_seed_architect_agent_prompt_carries_granularity_contract(self) -> None:
         from ouroboros.agents.loader import load_agent_prompt

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -410,6 +410,10 @@ class TestWorkflowIRCommands:
                     "acceptance_criteria:",
                     "  - First criterion",
                     "  - criterion: Second criterion",
+                    "  - description: Structured criterion",
+                    "    verify_command: uv run pytest tests/unit/test_example.py",
+                    "    expected_artifacts:",
+                    "      - artifacts/example.txt",
                     "ontology_schema:",
                     "  name: WorkflowIR",
                     "  description: Workflow IR ontology",
@@ -438,7 +442,7 @@ class TestWorkflowIRCommands:
         assert result.exit_code == 0
         assert '"spec_id": "wfspec_seed_cli_ir"' in result.output
         assert '"ok": true' in result.output
-        assert '"acceptance_criteria_count": 2' in result.output
+        assert '"acceptance_criteria_count": 3' in result.output
 
     def test_workflow_ir_inspect_plain_text_reports_valid_projection(self, tmp_path: Path) -> None:
         seed_file = tmp_path / "seed.yaml"

--- a/tests/unit/core/test_seed.py
+++ b/tests/unit/core/test_seed.py
@@ -4,17 +4,21 @@ Tests the immutable Seed schema and related types.
 """
 
 from datetime import UTC, datetime
+import json
+from pathlib import Path
 
 from pydantic import ValidationError as PydanticValidationError
 import pytest
 
 from ouroboros.core.seed import (
+    AcceptanceCriterionSpec,
     EvaluationPrinciple,
     ExitCondition,
     OntologyField,
     OntologySchema,
     Seed,
     SeedMetadata,
+    ac_texts,
 )
 
 
@@ -349,9 +353,115 @@ class TestSeed:
         assert full_seed.goal.startswith("Build a CLI task management")
         assert len(full_seed.constraints) == 3
         assert len(full_seed.acceptance_criteria) == 4
+        assert ac_texts(full_seed.acceptance_criteria) == (
+            "Tasks can be created",
+            "Tasks can be listed",
+            "Tasks can be marked complete",
+            "Tasks can be grouped by project",
+        )
         assert len(full_seed.ontology_schema.fields) == 2
         assert len(full_seed.evaluation_principles) == 2
         assert len(full_seed.exit_conditions) == 1
+
+    def test_seed_coerces_string_acceptance_criteria(self) -> None:
+        """Legacy string ACs are lifted into structured specs."""
+        seed = Seed(
+            goal="Build a CLI task manager",
+            acceptance_criteria=("Tasks can be created",),
+            ontology_schema=OntologySchema(
+                name="TaskManager",
+                description="Task management domain",
+            ),
+            metadata=SeedMetadata(ambiguity_score=0.15),
+        )
+
+        assert isinstance(seed.acceptance_criteria[0], AcceptanceCriterionSpec)
+        assert seed.acceptance_criteria[0].description == "Tasks can be created"
+        assert seed.acceptance_criteria[0].verify_command is None
+        assert seed.acceptance_criteria[0].expected_artifacts == ()
+
+    def test_seed_acceptance_criterion_spec_fields_are_optional(self) -> None:
+        """Structured ACs can carry any subset of success-contract fields."""
+        seed = Seed(
+            goal="Build a CLI task manager",
+            acceptance_criteria=(
+                {
+                    "description": "Task list command exits 0",
+                    "verify_command": "uv run task list",
+                    "expected_artifacts": "tasks.json, logs/task.log",
+                    "output_assertion": "No tasks",
+                },
+                {"description": "Tasks can be created"},
+            ),
+            ontology_schema=OntologySchema(
+                name="TaskManager",
+                description="Task management domain",
+            ),
+            metadata=SeedMetadata(ambiguity_score=0.15),
+        )
+
+        first, second = seed.acceptance_criteria
+        assert first.verify_command == "uv run task list"
+        assert first.expected_artifacts == ("tasks.json", "logs/task.log")
+        assert first.output_assertion == "No tasks"
+        assert second.description == "Tasks can be created"
+        assert second.verify_command is None
+
+    def test_seed_acceptance_criteria_serialize_legacy_strings_stably(self) -> None:
+        """Description-only ACs dump back to bare strings."""
+        seed = Seed(
+            goal="Build a CLI task manager",
+            acceptance_criteria=(
+                "Tasks can be created",
+                AcceptanceCriterionSpec(description="Tasks can be listed"),
+            ),
+            ontology_schema=OntologySchema(
+                name="TaskManager",
+                description="Task management domain",
+            ),
+            metadata=SeedMetadata(ambiguity_score=0.15),
+        )
+
+        assert seed.to_dict()["acceptance_criteria"] == [
+            "Tasks can be created",
+            "Tasks can be listed",
+        ]
+
+    def test_seed_acceptance_criteria_serialize_structured_contract(self) -> None:
+        """Contract-bearing ACs dump only populated fields."""
+        seed = Seed(
+            goal="Build a CLI task manager",
+            acceptance_criteria=(
+                AcceptanceCriterionSpec(
+                    description="Task list command exits 0",
+                    verify_command="uv run task list",
+                    expected_artifacts=("tasks.json",),
+                ),
+            ),
+            ontology_schema=OntologySchema(
+                name="TaskManager",
+                description="Task management domain",
+            ),
+            metadata=SeedMetadata(ambiguity_score=0.15),
+        )
+
+        assert seed.to_dict()["acceptance_criteria"] == [
+            {
+                "description": "Task list command exits 0",
+                "expected_artifacts": ["tasks.json"],
+                "verify_command": "uv run task list",
+            }
+        ]
+
+    def test_legacy_seed_json_round_trips_byte_identically(self) -> None:
+        """An old bare-string seed fixture keeps identical JSON bytes after dump."""
+        fixture = Path(__file__).parents[2] / "fixtures" / "seeds" / "legacy-seed-minimal.json"
+        original = fixture.read_text()
+        seed = Seed.from_dict(json.loads(original))
+
+        round_tripped = json.dumps(seed.to_dict(), indent=2, sort_keys=True) + "\n"
+
+        assert round_tripped == original
 
     def test_seed_coerces_string_evaluation_principles(self) -> None:
         """Hand-written seed principle string lists are lifted into objects."""
@@ -430,7 +540,7 @@ class TestSeed:
         assert isinstance(seed_dict, dict)
         assert seed_dict["goal"] == full_seed.goal
         assert seed_dict["constraints"] == list(full_seed.constraints)
-        assert seed_dict["acceptance_criteria"] == list(full_seed.acceptance_criteria)
+        assert seed_dict["acceptance_criteria"] == list(ac_texts(full_seed.acceptance_criteria))
         assert seed_dict["ontology_schema"]["name"] == full_seed.ontology_schema.name
         assert seed_dict["metadata"]["ambiguity_score"] == full_seed.metadata.ambiguity_score
 

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -19,6 +19,7 @@ from ouroboros.core.seed import (
     OntologySchema,
     Seed,
     SeedMetadata,
+    ac_texts,
 )
 from ouroboros.core.types import Result
 from ouroboros.core.worktree import TaskWorkspace
@@ -127,7 +128,7 @@ class TestBuildSystemPrompt:
         task_prompt = build_task_prompt(sample_seed)
 
         assert "## Acceptance Criteria" not in system_prompt
-        for criterion in sample_seed.acceptance_criteria:
+        for criterion in ac_texts(sample_seed.acceptance_criteria):
             assert criterion not in system_prompt
             assert criterion in task_prompt
 

--- a/tests/unit/orchestrator/test_workflow_state.py
+++ b/tests/unit/orchestrator/test_workflow_state.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from ouroboros.core.seed import AcceptanceCriterionSpec
 from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
 from ouroboros.orchestrator.mcp_tools import normalize_runtime_tool_result
 from ouroboros.orchestrator.workflow_state import (
@@ -161,6 +162,23 @@ class TestWorkflowStateTracker:
         assert state.acceptance_criteria[0].content == "Users can create tasks"
         assert state.acceptance_criteria[0].index == 1
         assert all(ac.status == ACStatus.PENDING for ac in state.acceptance_criteria)
+
+    def test_init_preserves_acceptance_criterion_spec(self) -> None:
+        """Tracker stores display text and keeps the structured AC contract."""
+        spec = AcceptanceCriterionSpec(
+            description="Tests pass",
+            verify_command="uv run pytest tests/unit/test_app.py",
+        )
+
+        tracker = WorkflowStateTracker(
+            acceptance_criteria=[spec],
+            goal="Build a task manager",
+            session_id="test_session",
+        )
+
+        ac = tracker.state.acceptance_criteria[0]
+        assert ac.content == "Tests pass"
+        assert ac.spec == spec
 
     def test_process_message_updates_count(self, tracker: WorkflowStateTracker) -> None:
         """Test processing messages increments count."""


### PR DESCRIPTION
## Summary

- Introduces `AcceptanceCriterionSpec` so each Seed AC can carry an explicit success contract while legacy bare-string seeds keep loading and serializing unchanged.
- Threads AC descriptions safely through existing consumers and preserves the structured spec on workflow state for the follow-up executor work.
- Updates seed authoring, parsing, grading, and repair flow to understand `verify`, `artifacts`, and `expect` contract fields.

## Changes

- Core schema: `Seed.acceptance_criteria` now stores structured AC specs, with `ac_text(s)` helpers and legacy serialization for description-only ACs.
- Authoring/parser: seed architect prompts request structured AC contracts; parser supports missing fields and preserves shell commands containing pipes.
- Runtime consumers: orchestrator, MCP, CLI, evolution, verification, and auto paths use descriptions explicitly instead of assuming raw strings.
- Workflow handoff: `WorkflowState.AcceptanceCriterion` carries the original spec without changing current executor behavior.
- Grade gate: ACs with `verify_command` or `expected_artifacts` are observable; missing contracts emit `missing_success_contract` at MEDIUM for repair-loop feedback.

## PR-F Done checklist

- [x] Old seed JSON files load and round-trip byte-identically with a real fixture.
- [x] String AC and spec AC both validate; spec fields remain optional.
- [x] `grep -rn "acceptance_criteria" src/` reviewed: changed consumers no longer assume Seed AC items are plain strings.
- [x] Grading covers explicit `verify_command` observability and prose fallback with `missing_success_contract` MEDIUM.
- [x] Validation gate run.

## Verification

- 5/5 senior subagent approvals before PR: Hilbert, Copernicus, Aristotle, Locke, Boyle.
- `uv run ruff check .` passed.
- `uv run ruff format --check .` passed.
- `uv run mypy src/` passed.
- `uv run pytest tests/unit/core/test_seed.py tests/unit/bigbang/test_seed_generator.py tests/unit/cli/test_main.py::TestWorkflowIRCommands tests/unit/auto/test_ledger_grading_answerer.py tests/unit/auto/test_task_class_application.py tests/unit/orchestrator/test_workflow_state.py tests/unit/auto/test_execution_acceptance.py tests/unit/auto/test_ledger_seed.py tests/unit/auto/test_pipeline_evaluate.py tests/unit/auto/test_interview_pipeline.py -q` passed: 502 passed.
- `uv run pytest tests/unit/mcp/tools/test_checklist_verify.py tests/unit/mcp/server/test_adapter.py tests/unit/evolution -q` passed: 157 passed.
- `uv run pytest tests/unit/orchestrator -q` passed: 2314 passed, 1 skipped.
- `uv run pytest tests/ --ignore=tests/e2e -q` completed with known existing failures: 21 failed, 11184 passed, 5 skipped. Failures are in opencode/plugin runtime dispatch and config_tui order-dependent tests; this class was reproduced on a clean `origin/main` worktree at `e905a41c` before this PR-F change.

## R-run comparison

`OUROBOROS_RUN_CANONICAL=1 uv run pytest tests/canonical/ -k cli-todo -v` was attempted on this branch. The live canonical run did not produce product-complete timing metrics because it blocked at Seed QA after 5 attempts (`revise`, score `0.68`) before execution.

| Metric                         | Baseline (sha)                    | This PR (sha)                                             | Ratio |
|--------------------------------|-----------------------------------|-----------------------------------------------------------|-------|
| Rounds completed in 600 s      | N/A (no comparable completed run) | N/A (`74a9d769`; canonical blocked before completion)     | n/a   |
| Per-round wall-clock (s/round) | N/A (no comparable completed run) | N/A (`323.73s` wall-clock, no completed product run)      | n/a   |
| Terminal reason                | N/A (no comparable completed run) | blocked: Seed QA did not pass after 5 attempts            | n/a   |
| EventStore event count         | N/A (no comparable completed run) | N/A (canonical failed before product-complete metrics)    | n/a   |

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation /
[x] N/A (canonical run blocked before producing comparable R-run metrics)
