### PR TITLE
refactor(backends): centralize factory dispatch registry

### DIFF
--- a/src/ouroboros/backends/__init__.py
+++ b/src/ouroboros/backends/__init__.py
@@ -23,17 +23,25 @@ from ouroboros.backends.capabilities import (
     runtime_backend_choices,
     soft_tool_enforcement_backends,
 )
+from ouroboros.backends.factory_registry import (
+    BackendFactorySpec,
+    backend_factory_specs,
+    get_backend_factory_spec,
+)
 
 __all__ = [
     "BackendCapability",
+    "BackendFactorySpec",
     "RuntimeSubagentOrchestrationContract",
     "SkillExecutionCapability",
     "SubagentDispatchMode",
     "SubagentSpawnTriggerMechanism",
     "ToolDiscoveryMechanism",
     "backend_supports_tool_envelope",
+    "backend_factory_specs",
     "build_runtime_subagent_orchestration_contract",
     "get_backend_capability",
+    "get_backend_factory_spec",
     "interview_driver_backend_choices",
     "llm_backend_choices",
     "resolve_backend_alias",

--- a/src/ouroboros/backends/factory_registry.py
+++ b/src/ouroboros/backends/factory_registry.py
@@ -1,0 +1,151 @@
+"""Shared backend-to-factory dispatch registry."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass(frozen=True, slots=True)
+class BackendFactorySpec:
+    """Factory dispatch metadata for one backend family."""
+
+    name: str
+    llm_backend: str | None = None
+    runtime_backend: str | None = None
+    llm_adapter_factory: str | None = None
+    agent_runtime_factory: str | None = None
+
+
+_FACTORY_SPECS: tuple[BackendFactorySpec, ...] = (
+    BackendFactorySpec(
+        name="claude",
+        llm_backend="claude_code",
+        runtime_backend="claude",
+        llm_adapter_factory="_create_claude_code_adapter",
+        agent_runtime_factory="_create_claude_runtime",
+    ),
+    BackendFactorySpec(
+        name="codex",
+        llm_backend="codex",
+        runtime_backend="codex",
+        llm_adapter_factory="_create_codex_adapter",
+        agent_runtime_factory="_create_codex_runtime",
+    ),
+    BackendFactorySpec(
+        name="codex_mcp",
+        runtime_backend="codex_mcp",
+        agent_runtime_factory="_create_codex_mcp_runtime",
+    ),
+    BackendFactorySpec(
+        name="claude_mcp",
+        runtime_backend="claude_mcp",
+        agent_runtime_factory="_create_claude_mcp_runtime",
+    ),
+    BackendFactorySpec(
+        name="copilot",
+        llm_backend="copilot",
+        runtime_backend="copilot",
+        llm_adapter_factory="_create_copilot_adapter",
+        agent_runtime_factory="_create_copilot_runtime",
+    ),
+    BackendFactorySpec(
+        name="gemini",
+        llm_backend="gemini",
+        runtime_backend="gemini",
+        llm_adapter_factory="_create_gemini_adapter",
+        agent_runtime_factory="_create_gemini_runtime",
+    ),
+    BackendFactorySpec(
+        name="hermes",
+        llm_backend="hermes",
+        runtime_backend="hermes",
+        llm_adapter_factory="_create_hermes_adapter",
+        agent_runtime_factory="_create_hermes_runtime",
+    ),
+    BackendFactorySpec(
+        name="kiro",
+        llm_backend="kiro",
+        runtime_backend="kiro",
+        llm_adapter_factory="_create_kiro_adapter",
+        agent_runtime_factory="_create_kiro_runtime",
+    ),
+    BackendFactorySpec(
+        name="opencode",
+        llm_backend="opencode",
+        runtime_backend="opencode",
+        llm_adapter_factory="_create_opencode_adapter",
+        agent_runtime_factory="_create_opencode_runtime",
+    ),
+    BackendFactorySpec(
+        name="goose",
+        llm_backend="goose",
+        runtime_backend="goose",
+        llm_adapter_factory="_create_goose_adapter",
+        agent_runtime_factory="_create_goose_runtime",
+    ),
+    BackendFactorySpec(
+        name="pi",
+        llm_backend="pi",
+        runtime_backend="pi",
+        llm_adapter_factory="_create_pi_adapter",
+        agent_runtime_factory="_create_pi_runtime",
+    ),
+    BackendFactorySpec(
+        name="gjc",
+        llm_backend="gjc",
+        runtime_backend="gjc",
+        llm_adapter_factory="_create_gjc_adapter",
+        agent_runtime_factory="_create_gjc_runtime",
+    ),
+    BackendFactorySpec(
+        name="antigravity",
+        runtime_backend="antigravity",
+        agent_runtime_factory="_create_antigravity_runtime",
+    ),
+    BackendFactorySpec(
+        name="grok",
+        runtime_backend="grok",
+        agent_runtime_factory="_create_grok_runtime",
+    ),
+    BackendFactorySpec(
+        name="ourocode",
+        llm_backend="ourocode",
+        llm_adapter_factory="_create_ourocode_adapter",
+    ),
+    BackendFactorySpec(
+        name="litellm",
+        llm_backend="litellm",
+        llm_adapter_factory="_create_litellm_adapter",
+    ),
+)
+
+_LLM_FACTORY_BY_BACKEND = {
+    spec.llm_backend: spec for spec in _FACTORY_SPECS if spec.llm_backend is not None
+}
+_RUNTIME_FACTORY_BY_BACKEND = {
+    spec.runtime_backend: spec for spec in _FACTORY_SPECS if spec.runtime_backend is not None
+}
+
+
+def get_backend_factory_spec(
+    backend: str,
+    *,
+    kind: Literal["llm", "runtime"],
+) -> BackendFactorySpec | None:
+    """Return factory metadata for a resolved backend name."""
+    if kind == "llm":
+        return _LLM_FACTORY_BY_BACKEND.get(backend)
+    return _RUNTIME_FACTORY_BY_BACKEND.get(backend)
+
+
+def backend_factory_specs() -> tuple[BackendFactorySpec, ...]:
+    """Return all factory dispatch specs."""
+    return _FACTORY_SPECS
+
+
+__all__ = [
+    "BackendFactorySpec",
+    "backend_factory_specs",
+    "get_backend_factory_spec",
+]

--- a/src/ouroboros/orchestrator/runtime_factory.py
+++ b/src/ouroboros/orchestrator/runtime_factory.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 
 from ouroboros.backends import resolve_runtime_backend_name, runtime_backend_choices
+from ouroboros.backends.factory_registry import get_backend_factory_spec
 from ouroboros.config import (
     get_agent_permission_mode,
     get_agent_runtime_backend,
@@ -27,6 +30,19 @@ from ouroboros.orchestrator.opencode_runtime import OpenCodeRuntime
 _SUPPORTED_BACKENDS = runtime_backend_choices()
 
 
+@dataclass(frozen=True, slots=True)
+class _AgentRuntimeRequest:
+    backend: str
+    permission_mode: str
+    model: str | None
+    cli_path: str | Path | None
+    cwd: str | Path | None
+    llm_backend: str
+    runtime_kwargs: dict[str, object] | None
+    startup_output_timeout_seconds: float | None
+    stdout_idle_timeout_seconds: float | None
+
+
 def resolve_agent_runtime_backend(backend: str | None = None) -> str:
     """Resolve and validate the orchestrator runtime backend name."""
     candidate = (backend or get_agent_runtime_backend()).strip().lower()
@@ -38,6 +54,199 @@ def resolve_agent_runtime_backend(backend: str | None = None) -> str:
             f"Supported backends: {', '.join(_SUPPORTED_BACKENDS)}"
         )
         raise ValueError(msg) from exc
+
+
+def _runtime_kwargs(request: _AgentRuntimeRequest) -> dict[str, object]:
+    if request.runtime_kwargs is None:
+        msg = f"Runtime kwargs were not prepared for backend: {request.backend}"
+        raise RuntimeError(msg)
+    return request.runtime_kwargs
+
+
+def _create_claude_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    return ClaudeAgentAdapter(
+        permission_mode=request.permission_mode,
+        model=request.model,
+        cwd=request.cwd,
+        cli_path=request.cli_path or get_cli_path(),
+    )
+
+
+def _create_codex_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    return CodexCliRuntime(
+        cli_path=request.cli_path or get_codex_cli_path(),
+        runtime_profile=get_runtime_profile(),
+        startup_output_timeout_seconds=request.startup_output_timeout_seconds,
+        stdout_idle_timeout_seconds=request.stdout_idle_timeout_seconds,
+        **_runtime_kwargs(request),
+    )
+
+
+def _create_codex_mcp_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    from ouroboros.config import get_native_session_index_enabled
+    from ouroboros.orchestrator.codex_mcp_runtime import build_codex_mcp_worker_runtime
+
+    return build_codex_mcp_worker_runtime(
+        cli_path=request.cli_path or get_codex_cli_path(),
+        cwd=request.cwd,
+        permission_mode=request.permission_mode,
+        model=request.model,
+        llm_backend=request.llm_backend,
+        # Dashboard is the default worker view; only dump workers into the
+        # Codex app's session list when the human explicitly opts in.
+        index_sessions=get_native_session_index_enabled(),
+    )
+
+
+def _create_claude_mcp_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    from ouroboros.config import get_native_session_index_enabled
+    from ouroboros.orchestrator.claude_worker_runtime import build_claude_worker_runtime
+
+    return build_claude_worker_runtime(
+        cli_path=request.cli_path or get_cli_path(),
+        cwd=request.cwd,
+        permission_mode=request.permission_mode,
+        model=request.model,
+        llm_backend=request.llm_backend,
+        # Dashboard is the default worker view; only persist (→ visible &
+        # resumable in /resume, with fork + --name) when the human opts in.
+        persist_sessions=get_native_session_index_enabled(),
+    )
+
+
+def _create_opencode_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    from ouroboros.config import get_opencode_cli_path
+
+    # OpenCodeRuntime is the SUBPROCESS orchestrator (`ouroboros run`).
+    # It shells out to `opencode run --pure` — no bridge plugin exists
+    # in that context.  Hardcode "subprocess" so handlers never emit
+    # dead _subagent envelopes, regardless of what config.yaml says.
+    # Plugin mode is exclusively an MCP-server concern (composition
+    # root in create_ouroboros_server reads config there).
+    return OpenCodeRuntime(
+        cli_path=request.cli_path or get_opencode_cli_path(),
+        opencode_mode="subprocess",
+        stdout_idle_timeout_seconds=(
+            request.stdout_idle_timeout_seconds
+            if request.stdout_idle_timeout_seconds is not None
+            else get_opencode_stdout_idle_timeout_seconds()
+        ),
+        **_runtime_kwargs(request),
+    )
+
+
+def _create_hermes_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    from ouroboros.orchestrator.hermes_runtime import HermesCliRuntime
+
+    return HermesCliRuntime(
+        cli_path=request.cli_path or get_hermes_cli_path(),
+        startup_output_timeout_seconds=request.startup_output_timeout_seconds,
+        stdout_idle_timeout_seconds=request.stdout_idle_timeout_seconds,
+        **_runtime_kwargs(request),
+    )
+
+
+def _create_gemini_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    from ouroboros.config import get_gemini_cli_path
+    from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
+
+    return GeminiCLIRuntime(
+        cli_path=request.cli_path or get_gemini_cli_path(),
+        **_runtime_kwargs(request),
+    )
+
+
+def _create_antigravity_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    from ouroboros.config import get_antigravity_cli_path
+    from ouroboros.orchestrator.antigravity_cli_runtime import AntigravityCLIRuntime
+
+    return AntigravityCLIRuntime(
+        cli_path=request.cli_path or get_antigravity_cli_path(),
+        **_runtime_kwargs(request),
+    )
+
+
+def _create_grok_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    from ouroboros.config import get_grok_cli_path
+    from ouroboros.orchestrator.grok_cli_runtime import GrokCliRuntime
+
+    return GrokCliRuntime(
+        cli_path=request.cli_path or get_grok_cli_path(),
+        startup_output_timeout_seconds=request.startup_output_timeout_seconds,
+        stdout_idle_timeout_seconds=request.stdout_idle_timeout_seconds,
+        **_runtime_kwargs(request),
+    )
+
+
+def _create_kiro_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    from ouroboros.orchestrator.kiro_adapter import KiroAgentAdapter
+
+    return KiroAgentAdapter(
+        cli_path=request.cli_path or get_kiro_cli_path(),
+        **_runtime_kwargs(request),
+    )
+
+
+def _create_copilot_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
+
+    return CopilotCliRuntime(
+        cli_path=request.cli_path or get_copilot_cli_path(),
+        runtime_profile=get_runtime_profile(),
+        **_runtime_kwargs(request),
+    )
+
+
+def _create_goose_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    from ouroboros.orchestrator.goose_runtime import GooseCliRuntime
+
+    return GooseCliRuntime(
+        cli_path=request.cli_path or get_goose_cli_path(),
+        startup_output_timeout_seconds=request.startup_output_timeout_seconds,
+        stdout_idle_timeout_seconds=request.stdout_idle_timeout_seconds,
+        **_runtime_kwargs(request),
+    )
+
+
+def _create_pi_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    from ouroboros.config import get_pi_cli_path
+    from ouroboros.orchestrator.pi_runtime import PiRuntime
+
+    return PiRuntime(
+        cli_path=request.cli_path or get_pi_cli_path(),
+        startup_output_timeout_seconds=request.startup_output_timeout_seconds,
+        stdout_idle_timeout_seconds=request.stdout_idle_timeout_seconds,
+        **_runtime_kwargs(request),
+    )
+
+
+def _create_gjc_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    from ouroboros.orchestrator.gjc_runtime import GjcRuntime
+
+    return GjcRuntime(
+        cli_path=request.cli_path or get_gjc_cli_path(),
+        startup_output_timeout_seconds=request.startup_output_timeout_seconds,
+        stdout_idle_timeout_seconds=request.stdout_idle_timeout_seconds,
+        **_runtime_kwargs(request),
+    )
+
+
+_AGENT_RUNTIME_FACTORIES: dict[str, Callable[[_AgentRuntimeRequest], AgentRuntime]] = {
+    "_create_claude_runtime": _create_claude_runtime,
+    "_create_codex_runtime": _create_codex_runtime,
+    "_create_codex_mcp_runtime": _create_codex_mcp_runtime,
+    "_create_claude_mcp_runtime": _create_claude_mcp_runtime,
+    "_create_opencode_runtime": _create_opencode_runtime,
+    "_create_hermes_runtime": _create_hermes_runtime,
+    "_create_gemini_runtime": _create_gemini_runtime,
+    "_create_antigravity_runtime": _create_antigravity_runtime,
+    "_create_grok_runtime": _create_grok_runtime,
+    "_create_kiro_runtime": _create_kiro_runtime,
+    "_create_copilot_runtime": _create_copilot_runtime,
+    "_create_goose_runtime": _create_goose_runtime,
+    "_create_pi_runtime": _create_pi_runtime,
+    "_create_gjc_runtime": _create_gjc_runtime,
+}
 
 
 def create_agent_runtime(
@@ -57,181 +266,41 @@ def create_agent_runtime(
         backend=resolved_backend
     )
     resolved_llm_backend = llm_backend or get_llm_backend()
-    if resolved_backend == "claude":
-        return ClaudeAgentAdapter(
-            permission_mode=resolved_permission_mode,
-            model=model,
-            cwd=cwd,
-            cli_path=cli_path or get_cli_path(),
-        )
-
-    runtime_kwargs = {
-        "permission_mode": resolved_permission_mode,
-        "model": model,
-        "cwd": cwd,
-        "skill_dispatcher": create_codex_command_dispatcher(
-            cwd=cwd,
-            runtime_backend=resolved_backend,
-            llm_backend=resolved_llm_backend,
-        ),
-        "llm_backend": resolved_llm_backend,
-    }
-    if resolved_backend == "codex":
-        return CodexCliRuntime(
-            cli_path=cli_path or get_codex_cli_path(),
-            runtime_profile=get_runtime_profile(),
-            startup_output_timeout_seconds=startup_output_timeout_seconds,
-            stdout_idle_timeout_seconds=stdout_idle_timeout_seconds,
-            **runtime_kwargs,
-        )
-
-    if resolved_backend == "codex_mcp":
-        # Leader-driven worker pool over `codex mcp-server` (codex/codex-reply).
-        # No skill_dispatcher / timeout knobs — the worker runtime is pure
-        # spawn/resume transport below the AgentRuntime seam.
-        from ouroboros.config import get_native_session_index_enabled
-        from ouroboros.orchestrator.codex_mcp_runtime import build_codex_mcp_worker_runtime
-
-        return build_codex_mcp_worker_runtime(
-            cli_path=cli_path or get_codex_cli_path(),
-            cwd=cwd,
-            permission_mode=resolved_permission_mode,
-            model=model,
-            llm_backend=resolved_llm_backend,
-            # Dashboard is the default worker view; only dump workers into the
-            # Codex app's session list when the human explicitly opts in.
-            index_sessions=get_native_session_index_enabled(),
-        )
-
-    if resolved_backend == "claude_mcp":
-        # Same worker pool, Claude transport (`claude -p --resume` stream-json) —
-        # proves the leader-driven seam is provider-neutral.
-        from ouroboros.config import get_native_session_index_enabled
-        from ouroboros.orchestrator.claude_worker_runtime import build_claude_worker_runtime
-
-        return build_claude_worker_runtime(
-            cli_path=cli_path or get_cli_path(),
-            cwd=cwd,
-            permission_mode=resolved_permission_mode,
-            model=model,
-            llm_backend=resolved_llm_backend,
-            # Dashboard is the default worker view; only persist (→ visible &
-            # resumable in /resume, with fork + --name) when the human opts in.
-            persist_sessions=get_native_session_index_enabled(),
-        )
-
-    if resolved_backend == "opencode":
-        from ouroboros.config import get_opencode_cli_path
-
-        # OpenCodeRuntime is the SUBPROCESS orchestrator (`ouroboros run`).
-        # It shells out to `opencode run --pure` — no bridge plugin exists
-        # in that context.  Hardcode "subprocess" so handlers never emit
-        # dead _subagent envelopes, regardless of what config.yaml says.
-        # Plugin mode is exclusively an MCP-server concern (composition
-        # root in create_ouroboros_server reads config there).
-        return OpenCodeRuntime(
-            cli_path=cli_path or get_opencode_cli_path(),
-            opencode_mode="subprocess",
-            stdout_idle_timeout_seconds=(
-                stdout_idle_timeout_seconds
-                if stdout_idle_timeout_seconds is not None
-                else get_opencode_stdout_idle_timeout_seconds()
+    runtime_kwargs = None
+    if resolved_backend != "claude":
+        runtime_kwargs = {
+            "permission_mode": resolved_permission_mode,
+            "model": model,
+            "cwd": cwd,
+            "skill_dispatcher": create_codex_command_dispatcher(
+                cwd=cwd,
+                runtime_backend=resolved_backend,
+                llm_backend=resolved_llm_backend,
             ),
-            **runtime_kwargs,
+            "llm_backend": resolved_llm_backend,
+        }
+
+    spec = get_backend_factory_spec(resolved_backend, kind="runtime")
+    if spec is None or spec.agent_runtime_factory is None:
+        msg = (
+            f"Unsupported orchestrator runtime backend: {resolved_backend}. "
+            f"Supported backends: {', '.join(_SUPPORTED_BACKENDS)}"
         )
-
-    if resolved_backend == "hermes":
-        from ouroboros.orchestrator.hermes_runtime import HermesCliRuntime
-
-        return HermesCliRuntime(
-            cli_path=cli_path or get_hermes_cli_path(),
+        raise ValueError(msg)
+    builder = _AGENT_RUNTIME_FACTORIES[spec.agent_runtime_factory]
+    return builder(
+        _AgentRuntimeRequest(
+            backend=resolved_backend,
+            permission_mode=resolved_permission_mode,
+            model=model,
+            cli_path=cli_path,
+            cwd=cwd,
+            llm_backend=resolved_llm_backend,
+            runtime_kwargs=runtime_kwargs,
             startup_output_timeout_seconds=startup_output_timeout_seconds,
             stdout_idle_timeout_seconds=stdout_idle_timeout_seconds,
-            **runtime_kwargs,
         )
-
-    if resolved_backend == "gemini":
-        from ouroboros.config import get_gemini_cli_path
-        from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
-
-        return GeminiCLIRuntime(
-            cli_path=cli_path or get_gemini_cli_path(),
-            **runtime_kwargs,
-        )
-
-    if resolved_backend == "antigravity":
-        from ouroboros.config import get_antigravity_cli_path
-        from ouroboros.orchestrator.antigravity_cli_runtime import AntigravityCLIRuntime
-
-        return AntigravityCLIRuntime(
-            cli_path=cli_path or get_antigravity_cli_path(),
-            **runtime_kwargs,
-        )
-
-    if resolved_backend == "grok":
-        from ouroboros.config import get_grok_cli_path
-        from ouroboros.orchestrator.grok_cli_runtime import GrokCliRuntime
-
-        return GrokCliRuntime(
-            cli_path=cli_path or get_grok_cli_path(),
-            startup_output_timeout_seconds=startup_output_timeout_seconds,
-            stdout_idle_timeout_seconds=stdout_idle_timeout_seconds,
-            **runtime_kwargs,
-        )
-
-    if resolved_backend == "kiro":
-        from ouroboros.orchestrator.kiro_adapter import KiroAgentAdapter
-
-        return KiroAgentAdapter(
-            cli_path=cli_path or get_kiro_cli_path(),
-            **runtime_kwargs,
-        )
-
-    if resolved_backend == "copilot":
-        from ouroboros.orchestrator.copilot_cli_runtime import CopilotCliRuntime
-
-        return CopilotCliRuntime(
-            cli_path=cli_path or get_copilot_cli_path(),
-            runtime_profile=get_runtime_profile(),
-            **runtime_kwargs,
-        )
-
-    if resolved_backend == "goose":
-        from ouroboros.orchestrator.goose_runtime import GooseCliRuntime
-
-        return GooseCliRuntime(
-            cli_path=cli_path or get_goose_cli_path(),
-            startup_output_timeout_seconds=startup_output_timeout_seconds,
-            stdout_idle_timeout_seconds=stdout_idle_timeout_seconds,
-            **runtime_kwargs,
-        )
-
-    if resolved_backend == "pi":
-        from ouroboros.config import get_pi_cli_path
-        from ouroboros.orchestrator.pi_runtime import PiRuntime
-
-        return PiRuntime(
-            cli_path=cli_path or get_pi_cli_path(),
-            startup_output_timeout_seconds=startup_output_timeout_seconds,
-            stdout_idle_timeout_seconds=stdout_idle_timeout_seconds,
-            **runtime_kwargs,
-        )
-
-    if resolved_backend == "gjc":
-        from ouroboros.orchestrator.gjc_runtime import GjcRuntime
-
-        return GjcRuntime(
-            cli_path=cli_path or get_gjc_cli_path(),
-            startup_output_timeout_seconds=startup_output_timeout_seconds,
-            stdout_idle_timeout_seconds=stdout_idle_timeout_seconds,
-            **runtime_kwargs,
-        )
-
-    msg = (
-        f"Unsupported orchestrator runtime backend: {resolved_backend}. "
-        f"Supported backends: {', '.join(_SUPPORTED_BACKENDS)}"
     )
-    raise ValueError(msg)
 
 
 __all__ = ["create_agent_runtime", "resolve_agent_runtime_backend"]

--- a/src/ouroboros/providers/factory.py
+++ b/src/ouroboros/providers/factory.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 import structlog
 
 from ouroboros.backends import resolve_llm_backend_name, soft_tool_enforcement_backends
+from ouroboros.backends.factory_registry import get_backend_factory_spec
 from ouroboros.config import (
     get_codex_cli_path,
     get_gemini_cli_path,
@@ -71,6 +73,22 @@ _LLM_USE_CASES = frozenset({"default", "interview"})
 _BACKENDS_WITH_SOFT_TOOL_ENFORCEMENT: frozenset[str] = soft_tool_enforcement_backends()
 
 
+@dataclass(frozen=True, slots=True)
+class _LLMAdapterRequest:
+    permission_mode: str
+    cli_path: str | Path | None
+    cwd: str | Path | None
+    allowed_tools: list[str] | None
+    max_turns: int
+    on_message: Callable[[str, str], None] | None
+    api_key: str | None
+    api_base: str | None
+    timeout: float | None
+    max_retries: int
+    io_recorder: IOJournalRecorder | None
+    strict_mcp_config: bool
+
+
 def resolve_llm_backend(backend: str | None = None) -> str:
     """Resolve and validate the LLM adapter backend name."""
     candidate = (backend or get_llm_backend()).strip().lower()
@@ -114,6 +132,194 @@ def resolve_llm_permission_mode(
         # CLI sandbox modes block LLM output entirely. Must bypass.
         return "bypassPermissions"
     return get_llm_permission_mode(backend=resolved)
+
+
+def _create_claude_code_adapter(request: _LLMAdapterRequest) -> LLMAdapter:
+    return ClaudeCodeAdapter(
+        permission_mode=request.permission_mode,
+        cli_path=request.cli_path,
+        cwd=request.cwd,
+        allowed_tools=request.allowed_tools,
+        max_turns=request.max_turns,
+        on_message=request.on_message,
+        timeout=request.timeout,
+        # Forwarded as-is.  The factory does NOT auto-derive
+        # ``strict_mcp_config`` from ``use_case`` because non-MCP
+        # interview entrypoints (CLI ``ooo init`` / ``ooo pm``) need
+        # to keep plugin and project ``.mcp.json`` servers reachable.
+        # Only the nested MCP-tool entrypoint
+        # (``InterviewHandler.handle`` in
+        # ``mcp/tools/authoring_handlers.py``) opts in.
+        strict_mcp_config=request.strict_mcp_config,
+    )
+
+
+def _create_codex_adapter(request: _LLMAdapterRequest) -> LLMAdapter:
+    return CodexCliLLMAdapter(
+        cli_path=request.cli_path or get_codex_cli_path(),
+        cwd=request.cwd,
+        permission_mode=request.permission_mode,
+        allowed_tools=request.allowed_tools,
+        max_turns=request.max_turns,
+        on_message=request.on_message,
+        timeout=request.timeout,
+        max_retries=request.max_retries,
+        runtime_profile=get_runtime_profile(),
+    )
+
+
+def _create_copilot_adapter(request: _LLMAdapterRequest) -> LLMAdapter:
+    from ouroboros.config import get_copilot_cli_path
+
+    return CopilotCliLLMAdapter(
+        cli_path=request.cli_path or get_copilot_cli_path(),
+        cwd=request.cwd,
+        permission_mode=request.permission_mode,
+        allowed_tools=request.allowed_tools,
+        max_turns=request.max_turns,
+        on_message=request.on_message,
+        timeout=request.timeout,
+        max_retries=request.max_retries,
+        runtime_profile=get_runtime_profile(),
+    )
+
+
+def _create_gemini_adapter(request: _LLMAdapterRequest) -> LLMAdapter:
+    return GeminiCLIAdapter(
+        cli_path=request.cli_path or get_gemini_cli_path(),
+        cwd=request.cwd,
+        max_turns=request.max_turns,
+        on_message=request.on_message,
+        timeout=request.timeout,
+        max_retries=request.max_retries,
+        allowed_tools=request.allowed_tools,
+    )
+
+
+def _create_opencode_adapter(request: _LLMAdapterRequest) -> LLMAdapter:
+    return OpenCodeLLMAdapter(
+        cli_path=request.cli_path,
+        cwd=request.cwd,
+        permission_mode=request.permission_mode,
+        allowed_tools=request.allowed_tools,
+        max_turns=request.max_turns,
+        on_message=request.on_message,
+        timeout=request.timeout,
+        max_retries=request.max_retries,
+    )
+
+
+def _create_hermes_adapter(request: _LLMAdapterRequest) -> LLMAdapter:
+    from ouroboros.providers.hermes_cli_adapter import HermesCliLLMAdapter
+
+    return HermesCliLLMAdapter(
+        cli_path=request.cli_path or get_hermes_cli_path(),
+        cwd=request.cwd,
+        allowed_tools=request.allowed_tools,
+        max_turns=request.max_turns,
+        on_message=request.on_message,
+        timeout=request.timeout,
+        max_retries=request.max_retries,
+    )
+
+
+def _create_goose_adapter(request: _LLMAdapterRequest) -> LLMAdapter:
+    return GooseCliLLMAdapter(
+        cli_path=request.cli_path or get_goose_cli_path(),
+        cwd=request.cwd,
+        permission_mode=request.permission_mode,
+        allowed_tools=request.allowed_tools,
+        max_turns=request.max_turns,
+        on_message=request.on_message,
+        timeout=request.timeout,
+        max_retries=request.max_retries,
+    )
+
+
+def _create_pi_adapter(request: _LLMAdapterRequest) -> LLMAdapter:
+    return PiLLMAdapter(
+        cli_path=request.cli_path or get_pi_cli_path(),
+        cwd=request.cwd,
+        permission_mode=request.permission_mode,
+        allowed_tools=request.allowed_tools,
+        max_turns=request.max_turns,
+        on_message=request.on_message,
+        timeout=request.timeout,
+        max_retries=request.max_retries,
+    )
+
+
+def _create_gjc_adapter(request: _LLMAdapterRequest) -> LLMAdapter:
+    return GjcLLMAdapter(
+        cli_path=request.cli_path or get_gjc_cli_path(),
+        cwd=request.cwd,
+        permission_mode=request.permission_mode,
+        allowed_tools=request.allowed_tools,
+        max_turns=request.max_turns,
+        on_message=request.on_message,
+        timeout=request.timeout,
+        max_retries=request.max_retries,
+    )
+
+
+def _create_ourocode_adapter(request: _LLMAdapterRequest) -> LLMAdapter:
+    return OurocodeLLMAdapter(
+        cli_path=request.cli_path or get_ourocode_cli_path(),
+        cwd=request.cwd,
+        timeout=request.timeout,
+        io_recorder=request.io_recorder,
+    )
+
+
+def _create_kiro_adapter(request: _LLMAdapterRequest) -> LLMAdapter:
+    from ouroboros.config import get_kiro_cli_path
+    from ouroboros.providers.kiro_adapter import KiroCodeAdapter
+
+    return KiroCodeAdapter(
+        cli_path=request.cli_path or get_kiro_cli_path(),
+        cwd=request.cwd,
+        allowed_tools=request.allowed_tools,
+        permission_mode=request.permission_mode,
+        max_turns=request.max_turns,
+        on_message=request.on_message,
+        timeout=request.timeout,
+        max_retries=request.max_retries,
+    )
+
+
+def _create_litellm_adapter(request: _LLMAdapterRequest) -> LLMAdapter:
+    try:
+        from ouroboros.providers.litellm_adapter import LiteLLMAdapter
+    except ImportError as exc:
+        msg = (
+            "litellm backend requested but litellm is not installed. "
+            "Install with: pip install 'ouroboros-ai[litellm]'"
+        )
+        raise RuntimeError(msg) from exc
+
+    return LiteLLMAdapter(
+        api_key=request.api_key,
+        api_base=request.api_base,
+        timeout=request.timeout,
+        max_retries=request.max_retries,
+        io_recorder=request.io_recorder,
+    )
+
+
+_LLM_ADAPTER_FACTORIES: dict[str, Callable[[_LLMAdapterRequest], LLMAdapter]] = {
+    "_create_claude_code_adapter": _create_claude_code_adapter,
+    "_create_codex_adapter": _create_codex_adapter,
+    "_create_copilot_adapter": _create_copilot_adapter,
+    "_create_gemini_adapter": _create_gemini_adapter,
+    "_create_opencode_adapter": _create_opencode_adapter,
+    "_create_hermes_adapter": _create_hermes_adapter,
+    "_create_goose_adapter": _create_goose_adapter,
+    "_create_pi_adapter": _create_pi_adapter,
+    "_create_gjc_adapter": _create_gjc_adapter,
+    "_create_ourocode_adapter": _create_ourocode_adapter,
+    "_create_kiro_adapter": _create_kiro_adapter,
+    "_create_litellm_adapter": _create_litellm_adapter,
+}
 
 
 def create_llm_adapter(
@@ -165,153 +371,26 @@ def create_llm_adapter(
             backend=resolved_backend,
             hint="Only LiteLLM and ourocode accept adapter-level IOJournalRecorder wiring.",
         )
-    if resolved_backend == "claude_code":
-        return ClaudeCodeAdapter(
+    spec = get_backend_factory_spec(resolved_backend, kind="llm")
+    if spec is None or spec.llm_adapter_factory is None:
+        msg = f"Unsupported LLM backend: {resolved_backend}"
+        raise ValueError(msg)
+    builder = _LLM_ADAPTER_FACTORIES[spec.llm_adapter_factory]
+    return builder(
+        _LLMAdapterRequest(
             permission_mode=resolved_permission_mode,
             cli_path=cli_path,
             cwd=cwd,
             allowed_tools=allowed_tools,
             max_turns=max_turns,
             on_message=on_message,
+            api_key=api_key,
+            api_base=api_base,
             timeout=timeout,
-            # Forwarded as-is.  The factory does NOT auto-derive
-            # ``strict_mcp_config`` from ``use_case`` because non-MCP
-            # interview entrypoints (CLI ``ooo init`` / ``ooo pm``) need
-            # to keep plugin and project ``.mcp.json`` servers reachable.
-            # Only the nested MCP-tool entrypoint
-            # (``InterviewHandler.handle`` in
-            # ``mcp/tools/authoring_handlers.py``) opts in.
+            max_retries=max_retries,
+            io_recorder=io_recorder,
             strict_mcp_config=strict_mcp_config,
         )
-    if resolved_backend == "codex":
-        return CodexCliLLMAdapter(
-            cli_path=cli_path or get_codex_cli_path(),
-            cwd=cwd,
-            permission_mode=resolved_permission_mode,
-            allowed_tools=allowed_tools,
-            max_turns=max_turns,
-            on_message=on_message,
-            timeout=timeout,
-            max_retries=max_retries,
-            runtime_profile=get_runtime_profile(),
-        )
-    if resolved_backend == "copilot":
-        from ouroboros.config import get_copilot_cli_path
-
-        return CopilotCliLLMAdapter(
-            cli_path=cli_path or get_copilot_cli_path(),
-            cwd=cwd,
-            permission_mode=resolved_permission_mode,
-            allowed_tools=allowed_tools,
-            max_turns=max_turns,
-            on_message=on_message,
-            timeout=timeout,
-            max_retries=max_retries,
-            runtime_profile=get_runtime_profile(),
-        )
-    if resolved_backend == "gemini":
-        return GeminiCLIAdapter(
-            cli_path=cli_path or get_gemini_cli_path(),
-            cwd=cwd,
-            max_turns=max_turns,
-            on_message=on_message,
-            timeout=timeout,
-            max_retries=max_retries,
-            allowed_tools=allowed_tools,
-        )
-    if resolved_backend == "opencode":
-        return OpenCodeLLMAdapter(
-            cli_path=cli_path,
-            cwd=cwd,
-            permission_mode=resolved_permission_mode,
-            allowed_tools=allowed_tools,
-            max_turns=max_turns,
-            on_message=on_message,
-            timeout=timeout,
-            max_retries=max_retries,
-        )
-    if resolved_backend == "hermes":
-        from ouroboros.providers.hermes_cli_adapter import HermesCliLLMAdapter
-
-        return HermesCliLLMAdapter(
-            cli_path=cli_path or get_hermes_cli_path(),
-            cwd=cwd,
-            allowed_tools=allowed_tools,
-            max_turns=max_turns,
-            on_message=on_message,
-            timeout=timeout,
-            max_retries=max_retries,
-        )
-    if resolved_backend == "goose":
-        return GooseCliLLMAdapter(
-            cli_path=cli_path or get_goose_cli_path(),
-            cwd=cwd,
-            permission_mode=resolved_permission_mode,
-            allowed_tools=allowed_tools,
-            max_turns=max_turns,
-            on_message=on_message,
-            timeout=timeout,
-            max_retries=max_retries,
-        )
-    if resolved_backend == "pi":
-        return PiLLMAdapter(
-            cli_path=cli_path or get_pi_cli_path(),
-            cwd=cwd,
-            permission_mode=resolved_permission_mode,
-            allowed_tools=allowed_tools,
-            max_turns=max_turns,
-            on_message=on_message,
-            timeout=timeout,
-            max_retries=max_retries,
-        )
-    if resolved_backend == "gjc":
-        return GjcLLMAdapter(
-            cli_path=cli_path or get_gjc_cli_path(),
-            cwd=cwd,
-            permission_mode=resolved_permission_mode,
-            allowed_tools=allowed_tools,
-            max_turns=max_turns,
-            on_message=on_message,
-            timeout=timeout,
-            max_retries=max_retries,
-        )
-    if resolved_backend == "ourocode":
-        return OurocodeLLMAdapter(
-            cli_path=cli_path or get_ourocode_cli_path(),
-            cwd=cwd,
-            timeout=timeout,
-            io_recorder=io_recorder,
-        )
-    if resolved_backend == "kiro":
-        from ouroboros.config import get_kiro_cli_path
-        from ouroboros.providers.kiro_adapter import KiroCodeAdapter
-
-        return KiroCodeAdapter(
-            cli_path=cli_path or get_kiro_cli_path(),
-            cwd=cwd,
-            allowed_tools=allowed_tools,
-            permission_mode=resolved_permission_mode,
-            max_turns=max_turns,
-            on_message=on_message,
-            timeout=timeout,
-            max_retries=max_retries,
-        )
-    # litellm is the fallback
-    try:
-        from ouroboros.providers.litellm_adapter import LiteLLMAdapter
-    except ImportError as exc:
-        msg = (
-            "litellm backend requested but litellm is not installed. "
-            "Install with: pip install 'ouroboros-ai[litellm]'"
-        )
-        raise RuntimeError(msg) from exc
-
-    return LiteLLMAdapter(
-        api_key=api_key,
-        api_base=api_base,
-        timeout=timeout,
-        max_retries=max_retries,
-        io_recorder=io_recorder,
     )
 
 

--- a/tests/unit/backends/test_factory_registry.py
+++ b/tests/unit/backends/test_factory_registry.py
@@ -1,0 +1,35 @@
+"""Tests for shared backend factory dispatch metadata."""
+
+from __future__ import annotations
+
+from ouroboros.backends import (
+    backend_factory_specs,
+    get_backend_factory_spec,
+    llm_backend_choices,
+    runtime_backend_choices,
+)
+
+
+def test_factory_registry_covers_every_backend_capability() -> None:
+    llm_factory_backends = {
+        spec.name for spec in backend_factory_specs() if spec.llm_adapter_factory is not None
+    }
+    runtime_factory_backends = {
+        spec.name for spec in backend_factory_specs() if spec.agent_runtime_factory is not None
+    }
+
+    assert set(llm_backend_choices()) <= llm_factory_backends
+    assert set(runtime_backend_choices()) <= runtime_factory_backends
+
+
+def test_factory_registry_resolves_factory_specific_backend_names() -> None:
+    assert (
+        get_backend_factory_spec("claude_code", kind="llm").llm_adapter_factory
+        == "_create_claude_code_adapter"
+    )
+    assert (
+        get_backend_factory_spec("claude", kind="runtime").agent_runtime_factory
+        == "_create_claude_runtime"
+    )
+    assert get_backend_factory_spec("litellm", kind="runtime") is None
+    assert get_backend_factory_spec("codex_mcp", kind="llm") is None


### PR DESCRIPTION
## Summary

- Adds a shared backend factory registry that maps canonical backend names to provider and orchestrator factory builders.
- Refactors `providers/factory.py` and `orchestrator/runtime_factory.py` to dispatch through the shared registry while keeping backend-specific constructor behavior local and patch-compatible.
- Adds registry coverage tests so every LLM/runtime-capable backend remains explicitly registered.

## Changes

- New `ouroboros.backends.factory_registry` defines factory metadata for LLM adapters and agent runtimes.
- Provider factory now resolves a backend, looks up the registry spec, and delegates to local per-backend builder functions.
- Runtime factory uses the same registry for agent runtime selection while preserving special cases such as OpenCode subprocess mode, worker runtimes, runtime profiles, stream timeouts, and lazy imports.
- Backends package exports the registry helpers for tests and future backend additions.

## R1 Done checklist

- [x] Twin backend factories now read one shared registry table for backend-to-factory dispatch.
- [x] Provider factory behavior is preserved for current LLM backends.
- [x] Orchestrator runtime factory behavior is preserved for current runtime backends.
- [x] New-backend coverage pins registry completeness for LLM/runtime-capable backends.
- [x] Validation gate run.

## Verification

- 5/5 senior subagent approvals before PR: Carson/Hilbert-R1, Sagan/Copernicus-R1, Herschel/Aristotle-R1, Poincare/Locke-R1, Pauli/Boyle-R1.
- `uv run ruff check .` passed.
- `uv run ruff format --check .` passed.
- `uv run mypy src/` passed.
- `uv run pytest tests/unit/backends tests/unit/providers tests/unit/orchestrator/test_runtime_factory.py tests/unit/orchestrator/test_gemini_cli_runtime.py tests/unit/orchestrator/test_antigravity_cli_runtime.py tests/unit/orchestrator/test_grok_cli_runtime.py tests/unit/orchestrator/test_copilot_cli_runtime.py tests/unit/orchestrator/test_pi_runtime.py -q` passed: 779 passed.
- `uv run pytest tests/ --ignore=tests/e2e -q` completed with known existing failures: 21 failed, 11175 passed, 5 skipped. Failures are the pre-existing opencode/plugin runtime dispatch and config_tui order-dependent group also observed before this track.