### PR TITLE
refactor(auto): split pipeline run phases

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -642,6 +642,40 @@ class AutoPipeline:
             self._save(state)
 
         review: SeedReview | None = None
+        interview_result = await self._run_interview_phase(state, ledger)
+        if interview_result is not None:
+            return interview_result
+
+        seed_result = await self._run_seed_phase(
+            state,
+            ledger,
+            resume_tool_name=resume_tool_name,
+        )
+        if isinstance(seed_result, AutoPipelineResult):
+            return seed_result
+        seed = seed_result
+
+        terminal_resume_result = await self._run_terminal_resume_phase(
+            state,
+            ledger,
+            seed,
+            review=review,
+        )
+        if terminal_resume_result is not None:
+            return terminal_resume_result
+
+        review_result = await self._run_review_phase(state, ledger, seed, review=review)
+        if isinstance(review_result, AutoPipelineResult):
+            return review_result
+        seed, review = review_result
+
+        return await self._run_execution_phase(state, ledger, seed, review=review)
+
+    async def _run_interview_phase(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+    ) -> AutoPipelineResult | None:
         # Q00/ouroboros#782 review-12 BLOCKING #1: same exception as the
         # early-return above — let RALPH_HANDOFF resume reach
         # ``_resume_ralph_handoff`` so an already-terminal Ralph job can be
@@ -787,6 +821,15 @@ class AutoPipeline:
             self._save(state)
             return self._result(state, ledger, blocker=state.last_error)
 
+        return None
+
+    async def _run_seed_phase(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        *,
+        resume_tool_name: str | None,
+    ) -> AutoPipelineResult | Seed:
         # Q00/ouroboros#782 review-12 BLOCKING #1: same exception — let
         # ``RALPH_HANDOFF`` resume reach ``_resume_ralph_handoff`` so the
         # poller can reconcile an already-terminal Ralph job.
@@ -971,6 +1014,16 @@ class AutoPipeline:
             self._save(state)
             return self._result(state, ledger, blocker=state.last_error)
 
+        return seed
+
+    async def _run_terminal_resume_phase(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        seed: Seed,
+        *,
+        review: SeedReview | None,
+    ) -> AutoPipelineResult | None:
         if state.phase == AutoPhase.RALPH_HANDOFF:
             if (
                 state.run_handoff_status == "ralph_retry_after_blocker"
@@ -1050,6 +1103,16 @@ class AutoPipeline:
                 run_subagent=None,
             )
 
+        return None
+
+    async def _run_review_phase(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        seed: Seed,
+        *,
+        review: SeedReview | None,
+    ) -> AutoPipelineResult | tuple[Seed, SeedReview | None]:
         if self._enforce_deadline(state):
             return self._result(state, ledger, blocker=state.last_error)
         if state.phase == AutoPhase.REVIEW:
@@ -1177,6 +1240,16 @@ class AutoPipeline:
                 self._save(state)
                 return self._result(state, ledger, review=review)
 
+        return seed, review
+
+    async def _run_execution_phase(
+        self,
+        state: AutoPipelineState,
+        ledger: SeedDraftLedger,
+        seed: Seed,
+        *,
+        review: SeedReview | None,
+    ) -> AutoPipelineResult:
         if self._enforce_deadline(state):
             return self._result(state, ledger, review=review, blocker=state.last_error)
         if state.phase == AutoPhase.RUN:


### PR DESCRIPTION
## Summary

- Split the large `AutoPipeline.run` body into explicit per-phase helpers while preserving the existing phase ordering and state transitions.
- Kept the refactor scoped to `src/ouroboros/auto/pipeline.py` with no test or behavior changes.
- `run()` now acts as the orchestration spine for interview, seed, terminal-resume, review, and execution phases.

## Changes

- Added `_run_interview_phase`, `_run_seed_phase`, `_run_terminal_resume_phase`, `_run_review_phase`, and `_run_execution_phase`.
- Preserved sensitive resume/deadline/Ralph/EVALUATE/UNSTUCK/RUN retry logic inside the extracted phase helpers.
- Reduced `AutoPipeline.run` from 1,204 lines to 193 lines; helpers remain class-level methods.

## Done means

- [x] `AutoPipeline.run` split into per-phase handlers following existing `_run_evaluate` / `_run_lateral` style
- [x] Watchdog, deadline, resume, and run-handoff semantics preserved
- [x] No tests modified
- [x] Branch starts from fresh `origin/main` and only changes `src/ouroboros/auto/pipeline.py`
- [x] Validation gate run

## Verification

- 5/5 senior subagent approvals before PR: Jason, Confucius, Noether, Planck, Harvey
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/`
- Targeted pipeline suite -> 348 passed
- `uv run pytest tests/unit/mcp/tools/test_auto_interview_construction.py -q` -> 40 passed
- Progress/probe/watchdog focused suite -> 29 passed
- `uv run pytest tests/unit/auto -q` -> 4 known pre-existing opencode dispatch failures, 1229 passed
- `uv run pytest tests/ --ignore=tests/e2e -q` -> 21 known pre-existing failures, 11173 passed, 5 skipped

## Notes

The full non-e2e failures match the known existing group reproduced on clean `origin/main`: opencode/plugin runtime dispatch, config_tui ordering/defaults, and start_auto plugin lease tests.

## R-run comparison

This is a pure structural refactor of `AutoPipeline.run`; no runtime behavior or tests were changed. A live canonical R-run was not captured for this refactor-only branch, so the comparison is explicitly marked N/A rather than implying measured throughput.

| Metric                         | Baseline (sha)                    | This PR (sha)                                      | Ratio |
|--------------------------------|-----------------------------------|----------------------------------------------------|-------|
| Rounds completed in 600 s      | N/A (refactor-only PR)            | N/A (`9504d1f0`; no live R-run captured)           | n/a   |
| Per-round wall-clock (s/round) | N/A (refactor-only PR)            | N/A (`9504d1f0`; no live R-run captured)           | n/a   |
| Terminal reason                | N/A (refactor-only PR)            | N/A (not executed; behavior covered by tests)      | n/a   |
| EventStore event count         | N/A (refactor-only PR)            | N/A (not executed; behavior covered by tests)      | n/a   |

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation /
[x] N/A (pure refactor; no live R-run metrics captured)
