### PR TITLE
refactor(providers): share runtime stream helpers

### DIFF
--- a/src/ouroboros/providers/codex_cli_adapter.py
+++ b/src/ouroboros/providers/codex_cli_adapter.py
@@ -8,7 +8,7 @@ without requiring an API key.
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator, Callable
+from collections.abc import Awaitable, Callable
 import contextlib
 import json
 import os
@@ -41,11 +41,7 @@ from ouroboros.providers.base import (
     MessageRole,
     UsageInfo,
 )
-from ouroboros.providers.codex_cli_stream import (
-    collect_stream_lines,
-    iter_stream_lines,
-    terminate_process,
-)
+from ouroboros.providers.codex_cli_stream import RuntimeStreamMixin, collect_stream_lines
 from ouroboros.providers.profiles import resolve_completion_profile_result
 from ouroboros.providers.retry import TRANSIENT_ERROR_PATTERNS
 
@@ -84,7 +80,7 @@ _CODEX_PROVIDER_MARKERS = (
 _OPENAI_RESPONSES_ENDPOINT = "api.openai.com/v1/responses"
 
 
-class CodexCliLLMAdapter:
+class CodexCliLLMAdapter(RuntimeStreamMixin):
     """LLM adapter backed by local Codex CLI execution.
 
     Streaming progress callback contract (``on_message``):
@@ -115,6 +111,12 @@ class CodexCliLLMAdapter:
     _max_ouroboros_depth = DEFAULT_MAX_OUROBOROS_DEPTH
     _child_session_env_keys = DEFAULT_CODEX_CHILD_SESSION_ENV_KEYS
     _completion_profile_backend = "codex"
+
+    def _stream_provider_name(self) -> str:
+        return "codex_cli"
+
+    def _stream_line_collector(self) -> Callable[..., Awaitable[list[str]]]:
+        return collect_stream_lines
 
     def __init__(
         self,
@@ -740,30 +742,6 @@ class CodexCliLLMAdapter:
             )
             tool_info = self._format_tool_info("WebSearch", {"query": query})
             self._on_message("tool_started" if event_type == "item.started" else "tool", tool_info)
-
-    async def _iter_stream_lines(
-        self,
-        stream: asyncio.StreamReader | None,
-        *,
-        chunk_size: int = 16384,
-    ) -> AsyncIterator[str]:
-        """Yield decoded lines without relying on StreamReader.readline()."""
-        async for line in iter_stream_lines(stream, chunk_size=chunk_size):
-            yield line
-
-    async def _collect_stream_lines(
-        self,
-        stream: asyncio.StreamReader | None,
-    ) -> list[str]:
-        """Drain a subprocess stream without blocking stdout event parsing."""
-        return await collect_stream_lines(stream)
-
-    async def _terminate_process(self, process: Any) -> None:
-        """Best-effort subprocess shutdown used for timeouts and cancellation."""
-        await terminate_process(
-            process,
-            shutdown_timeout=self._process_shutdown_timeout_seconds,
-        )
 
     def _prompt_stdin_bytes(self, prompt: str) -> bytes | None:
         """Return bytes to write to process stdin for the prompt, if any."""

--- a/src/ouroboros/providers/codex_cli_stream.py
+++ b/src/ouroboros/providers/codex_cli_stream.py
@@ -389,7 +389,52 @@ async def terminate_process(
         await asyncio.wait_for(process.wait(), timeout=shutdown_timeout)
 
 
+class RuntimeStreamMixin:
+    """Shared stream/process helpers for CLI-backed completion adapters."""
+
+    _provider_name: str
+    _process_shutdown_timeout_seconds: float
+
+    def _stream_line_reader(self) -> Callable[..., AsyncIterator[str]]:
+        return iter_stream_lines
+
+    def _stream_line_collector(self) -> Callable[..., Awaitable[list[str]]]:
+        return collect_stream_lines
+
+    def _process_terminator(self) -> Callable[..., Awaitable[None]]:
+        return terminate_process
+
+    def _stream_provider_name(self) -> str:
+        return self._provider_name
+
+    async def _iter_stream_lines(
+        self,
+        stream: asyncio.StreamReader | None,
+        *,
+        chunk_size: int = 16384,
+    ) -> AsyncIterator[str]:
+        async for line in self._stream_line_reader()(
+            stream,
+            chunk_size=chunk_size,
+            provider=self._stream_provider_name(),
+        ):
+            yield line
+
+    async def _collect_stream_lines(
+        self,
+        stream: asyncio.StreamReader | None,
+    ) -> list[str]:
+        return await self._stream_line_collector()(stream, provider=self._stream_provider_name())
+
+    async def _terminate_process(self, process: Any) -> None:
+        await self._process_terminator()(
+            process,
+            shutdown_timeout=self._process_shutdown_timeout_seconds,
+        )
+
+
 __all__ = [
+    "RuntimeStreamMixin",
     "collect_stream_lines",
     "iter_runtime_stream_lines",
     "iter_stream_lines",

--- a/src/ouroboros/providers/copilot_cli_adapter.py
+++ b/src/ouroboros/providers/copilot_cli_adapter.py
@@ -21,7 +21,7 @@ subprocess teardown. Differences from Codex:
 from __future__ import annotations
 
 import asyncio
-from collections.abc import AsyncIterator, Callable
+from collections.abc import Callable
 import contextlib
 import json
 import os
@@ -54,11 +54,7 @@ from ouroboros.providers.base import (
     MessageRole,
     UsageInfo,
 )
-from ouroboros.providers.codex_cli_stream import (
-    collect_stream_lines,
-    iter_stream_lines,
-    terminate_process,
-)
+from ouroboros.providers.codex_cli_stream import RuntimeStreamMixin
 from ouroboros.providers.profiles import resolve_completion_profile_result
 
 log = structlog.get_logger()
@@ -139,7 +135,7 @@ _JSON_SCHEMA_DIRECTIVE_TEMPLATE = (
 )
 
 
-class CopilotCliLLMAdapter:
+class CopilotCliLLMAdapter(RuntimeStreamMixin):
     """LLM adapter backed by local GitHub Copilot CLI execution."""
 
     _provider_name = "copilot_cli"
@@ -567,29 +563,6 @@ class CopilotCliLLMAdapter:
                     continue
             content_lines.append(line)
         return "\n".join(content_lines or raw_json_content_lines)
-
-    # ------------------------------------------------------ stream/process io
-
-    async def _iter_stream_lines(
-        self,
-        stream: asyncio.StreamReader | None,
-        *,
-        chunk_size: int = 16384,
-    ) -> AsyncIterator[str]:
-        async for line in iter_stream_lines(stream, chunk_size=chunk_size, provider="copilot_cli"):
-            yield line
-
-    async def _collect_stream_lines(
-        self,
-        stream: asyncio.StreamReader | None,
-    ) -> list[str]:
-        return await collect_stream_lines(stream, provider="copilot_cli")
-
-    async def _terminate_process(self, process: Any) -> None:
-        await terminate_process(
-            process,
-            shutdown_timeout=self._process_shutdown_timeout_seconds,
-        )
 
     @staticmethod
     def _truncate_if_oversized(content: str, model: str) -> str:


### PR DESCRIPTION
## Summary

- Move duplicated CLI stream/process helper wrappers into `RuntimeStreamMixin` in `codex_cli_stream.py`.
- Have Codex and Copilot adapters inherit the shared helpers while keeping provider-specific metadata intact.
- Preserve the existing Codex `collect_stream_lines` monkeypatch path through a small collector hook.

## Changes

- Added `RuntimeStreamMixin` with shared `_iter_stream_lines`, `_collect_stream_lines`, and `_terminate_process` methods.
- Removed duplicate helper methods from `CodexCliLLMAdapter` and `CopilotCliLLMAdapter`.
- Added `_stream_provider_name()` so Codex-derived GJC/Pi/Goose keep legacy `codex_cli` stream error metadata while Copilot remains `copilot_cli`.

## Validation

- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run mypy src/`
- [x] `uv run pytest tests/unit/providers -q` (`565 passed`)
- [x] `uv run pytest tests/unit/orchestrator/test_codex_cli_runtime.py tests/unit/orchestrator/test_copilot_cli_runtime.py tests/unit/orchestrator/test_gjc_runtime.py tests/unit/orchestrator/test_pi_runtime.py tests/unit/orchestrator/test_goose_runtime.py -q` (`158 passed`)
- [x] Focused Codex/Copilot/GJC/Pi/Goose adapter+runtime slice after review fix (`262 passed`)
- [x] Hook probe: Codex/GJC/Pi/Goose stream provider = `codex_cli`; Copilot stream provider = `copilot_cli`
- [x] `uv run pytest tests/ --ignore=tests/e2e -q` reached `11177 passed, 5 skipped`; failed only the known pre-existing opencode/start_auto plugin runtime dispatch and lease group.

## Senior Subagent Approval

Pre-PR senior verification was completed before this PR was opened.

- [x] Jason: APPROVE
- [x] Confucius: APPROVE
- [x] Noether: APPROVE after requested metadata-preservation fix
- [x] Planck: APPROVE
- [x] Harvey: APPROVE

## Notes

The first review caught that GJC/Pi/Goose would have changed stream `ProviderError.provider` metadata from the inherited Codex default to their own provider names. The final commit fixes that with `_stream_provider_name()` and preserves the legacy `codex_cli` metadata for Codex-derived providers.
