### PR TITLE
fix(core): honor worktree_cleanup policy and add ooo cleanup for auto-session residue

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -45,6 +45,7 @@ ouroboros [OPTIONS] COMMAND [ARGS]...
 | `run` | Execute Ouroboros workflows |
 | `qa` | Evaluate an artifact against a natural-language quality bar |
 | `cancel` | Cancel stuck or orphaned executions |
+| `cleanup` | Prune leftover auto-session worktrees, branches, locks, and state files |
 | `config` | Manage Ouroboros configuration (show, switch backend, set values) |
 | `uninstall` | Cleanly remove all Ouroboros configuration from your system |
 | `status` | Check Ouroboros system status |
@@ -516,6 +517,53 @@ ouroboros cancel execution --all
 # Cancel with a custom reason
 ouroboros cancel execution orch_abc123 --reason "Stuck for 2 hours"
 ```
+
+---
+
+## `ouroboros cleanup`
+
+Prune residue left behind by auto sessions: managed worktrees under the
+configured worktree root (default `~/.ouroboros/worktrees/`), their
+`ooo/auto_*` branches, stale task lock files, and orphaned session state files
+(`~/.ouroboros/data/auto_*.json`).
+
+```bash
+ouroboros cleanup [OPTIONS]
+```
+
+Safety rules:
+
+- Worktrees with a live (non-stale) lock are never touched — running sessions are safe.
+- Dirty worktrees are never removed, even with `--force`.
+- Branches are only deleted via safe `git branch -d` (fully merged); unmerged branches always survive.
+- Without `--force`, only worktrees whose branch is fully merged are removed.
+- State files are pruned only when the session is terminal and its worktree is gone (default: `complete` only).
+
+**Options:**
+
+| Option | Description |
+|--------|-------------|
+| `--dry-run` | Report what would be removed without removing anything |
+| `-f, --force` | Also remove clean worktrees whose branch is not merged yet (branch is kept) |
+| `--state-all` | Prune state files of `blocked`/`failed` sessions too (default: `complete` only) |
+
+**Examples:**
+
+```bash
+# See what would be cleaned up
+ouroboros cleanup --dry-run
+
+# Remove merged-and-clean auto worktrees, stale locks, completed session state
+ouroboros cleanup
+
+# Also drop clean-but-unmerged worktrees (their branches survive)
+ouroboros cleanup --force
+```
+
+Related: the `orchestrator.worktree_cleanup` config field (`keep` | `remove` |
+`prune-merged`, default `keep`) controls automatic cleanup when a session
+releases its worktree; `ooo cleanup` handles residue from sessions that ended
+before this policy existed, were cancelled, or ran with `keep`.
 
 ---
 

--- a/src/ouroboros/auto/worktree.py
+++ b/src/ouroboros/auto/worktree.py
@@ -7,7 +7,7 @@ from ouroboros.core.worktree import (
     TaskWorkspace,
     WorktreeError,
     is_git_repo,
-    release_lock,
+    release_task_workspace,
     restore_task_workspace,
 )
 
@@ -46,6 +46,5 @@ def ensure_auto_worktree(state: AutoPipelineState) -> TaskWorkspace | None:
 
 
 def release_auto_worktree(workspace: TaskWorkspace | None) -> None:
-    """Release the auto worktree lock if this process owns one."""
-    if workspace is not None:
-        release_lock(workspace.lock_path)
+    """Release the auto worktree and apply the configured cleanup policy."""
+    release_task_workspace(workspace)

--- a/src/ouroboros/cli/commands/cleanup.py
+++ b/src/ouroboros/cli/commands/cleanup.py
@@ -1,0 +1,214 @@
+"""Cleanup command for Ouroboros.
+
+Prunes residue left behind by auto sessions (issue #1560):
+
+- managed worktrees under the configured worktree root whose ``ooo/*`` branch
+  is fully merged and whose checkout is clean (``--force`` also removes clean
+  worktrees with unmerged branches, without force-deleting the branch)
+- the pruned worktrees' ``ooo/*`` branches (safe ``git branch -d`` only)
+- stale task lock files whose owning process is gone
+- state files (``~/.ouroboros/data/auto_*.json``) of completed sessions whose
+  worktree no longer exists (``--state-all`` extends this to blocked/failed
+  sessions)
+
+Never touches a worktree with a live (non-stale) lock or a dirty checkout.
+
+Usage:
+    ouroboros cleanup                # prune merged-and-clean auto worktrees
+    ouroboros cleanup --dry-run      # report what would be removed
+    ouroboros cleanup --force        # also remove clean-but-unmerged worktrees
+    ouroboros cleanup --state-all    # also prune blocked/failed session state
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from ouroboros.cli.formatters.panels import print_info, print_success, print_warning
+from ouroboros.core.worktree import (
+    TaskWorkspace,
+    WorktreeError,
+    cleanup_task_workspace,
+    discover_managed_workspaces,
+    lock_file_is_stale,
+    managed_worktree_root,
+)
+
+app = typer.Typer(
+    name="cleanup",
+    help="Prune leftover auto-session worktrees, branches, locks, and state files.",
+    invoke_without_command=True,
+)
+
+_TERMINAL_STATE_PHASES_DEFAULT = frozenset({"complete"})
+_TERMINAL_STATE_PHASES_ALL = frozenset({"complete", "blocked", "failed"})
+
+
+def _auto_data_root() -> Path:
+    return Path.home() / ".ouroboros" / "data"
+
+
+def _locks_root(workspaces_root: Path) -> Path:
+    return workspaces_root / ".locks"
+
+
+def _workspace_is_active(workspace: TaskWorkspace) -> bool:
+    """A workspace with a live (non-stale) lock belongs to a running session."""
+    lock_path = Path(workspace.lock_path)
+    return lock_path.exists() and not lock_file_is_stale(lock_path)
+
+
+def _prune_workspaces(
+    *,
+    policy: str,
+    dry_run: bool,
+) -> tuple[list[TaskWorkspace], list[TaskWorkspace], list[TaskWorkspace]]:
+    """Return (removed, skipped, failed) managed auto workspaces."""
+    removed: list[TaskWorkspace] = []
+    skipped: list[TaskWorkspace] = []
+    failed: list[TaskWorkspace] = []
+    for workspace in discover_managed_workspaces():
+        if not workspace.durable_id.startswith("auto_"):
+            skipped.append(workspace)
+            continue
+        if _workspace_is_active(workspace):
+            skipped.append(workspace)
+            continue
+        try:
+            if cleanup_task_workspace(workspace, policy=policy, dry_run=dry_run):
+                if not dry_run:
+                    Path(workspace.lock_path).unlink(missing_ok=True)
+                removed.append(workspace)
+            else:
+                skipped.append(workspace)
+        except WorktreeError:
+            failed.append(workspace)
+    return removed, skipped, failed
+
+
+def _prune_stale_locks(workspaces_root: Path, *, dry_run: bool) -> list[Path]:
+    """Remove stale lock files that no longer have a worktree directory."""
+    removed: list[Path] = []
+    locks_root = _locks_root(workspaces_root)
+    if not locks_root.is_dir():
+        return removed
+    for repo_dir in sorted(locks_root.iterdir()):
+        if not repo_dir.is_dir():
+            continue
+        for lock_path in sorted(repo_dir.glob("auto_*.json")):
+            worktree_dir = workspaces_root / repo_dir.name / lock_path.stem
+            if worktree_dir.exists():
+                continue
+            if not lock_file_is_stale(lock_path):
+                continue
+            if not dry_run:
+                lock_path.unlink(missing_ok=True)
+            removed.append(lock_path)
+    return removed
+
+
+def _state_phase(path: Path) -> str | None:
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    phase = raw.get("phase")
+    return phase if isinstance(phase, str) else None
+
+
+def _prune_state_files(
+    workspaces_root: Path,
+    *,
+    phases: frozenset[str],
+    dry_run: bool,
+) -> list[Path]:
+    """Remove terminal session state files whose worktree is gone."""
+    removed: list[Path] = []
+    data_root = _auto_data_root()
+    if not data_root.is_dir():
+        return removed
+    for state_path in sorted(data_root.glob("auto_*.json")):
+        phase = _state_phase(state_path)
+        if phase not in phases:
+            continue
+        session_id = state_path.stem
+        has_worktree = (
+            any(
+                (repo_dir / session_id).exists()
+                for repo_dir in workspaces_root.iterdir()
+                if repo_dir.is_dir() and repo_dir.name != ".locks"
+            )
+            if workspaces_root.is_dir()
+            else False
+        )
+        if has_worktree:
+            continue
+        if not dry_run:
+            state_path.unlink(missing_ok=True)
+        removed.append(state_path)
+    return removed
+
+
+@app.callback(invoke_without_command=True)
+def cleanup(
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="Report what would be removed without removing anything.",
+        ),
+    ] = False,
+    force: Annotated[
+        bool,
+        typer.Option(
+            "--force",
+            "-f",
+            help=(
+                "Also remove clean worktrees whose branch is not merged yet. "
+                "Unmerged branches themselves are kept."
+            ),
+        ),
+    ] = False,
+    state_all: Annotated[
+        bool,
+        typer.Option(
+            "--state-all",
+            help=(
+                "Prune state files of blocked/failed sessions too "
+                "(default prunes only completed sessions)."
+            ),
+        ),
+    ] = False,
+) -> None:
+    """Prune merged-and-clean auto worktrees, stale locks, and orphaned state."""
+    workspaces_root = managed_worktree_root()
+    policy = "remove" if force else "prune-merged"
+
+    removed, skipped, failed = _prune_workspaces(policy=policy, dry_run=dry_run)
+    stale_locks = _prune_stale_locks(workspaces_root, dry_run=dry_run)
+    phases = _TERMINAL_STATE_PHASES_ALL if state_all else _TERMINAL_STATE_PHASES_DEFAULT
+    state_files = _prune_state_files(workspaces_root, phases=phases, dry_run=dry_run)
+
+    verb = "Would remove" if dry_run else "Removed"
+    for workspace in removed:
+        print_info(f"{verb} worktree {workspace.worktree_path} (branch {workspace.branch})")
+    for lock_path in stale_locks:
+        print_info(f"{verb} stale lock {lock_path}")
+    for state_path in state_files:
+        print_info(f"{verb} session state {state_path}")
+    for workspace in failed:
+        print_warning(f"Could not clean {workspace.worktree_path} — see logs")
+
+    if not removed and not stale_locks and not state_files:
+        print_success("Nothing to clean up.")
+    else:
+        print_success(
+            f"{verb}: {len(removed)} worktree(s), {len(stale_locks)} stale lock(s), "
+            f"{len(state_files)} state file(s); skipped {len(skipped)} (active/dirty/unmerged)."
+        )

--- a/src/ouroboros/cli/main.py
+++ b/src/ouroboros/cli/main.py
@@ -24,6 +24,7 @@ from ouroboros import __version__
 from ouroboros.cli.commands import (
     auto,
     cancel,
+    cleanup,
     codex,
     config,
     detect,
@@ -98,6 +99,7 @@ app.add_typer(job.app, name="job")
 app.add_typer(config.app, name="config")
 app.add_typer(status.app, name="status")
 app.add_typer(cancel.app, name="cancel")
+app.add_typer(cleanup.app, name="cleanup")
 app.add_typer(codex.app, name="codex")
 app.add_typer(mcp.app, name="mcp")
 app.add_typer(setup.app, name="setup")

--- a/src/ouroboros/config/models.py
+++ b/src/ouroboros/config/models.py
@@ -506,7 +506,13 @@ class OrchestratorConfig(BaseModel, frozen=True):
         usage_limit_pause_hours: Default pause window for provider usage/quota limits
         use_worktrees: Whether mutating workflows run in dedicated git worktrees
         worktree_root: Root directory for managed task worktrees
-        worktree_cleanup: Cleanup policy for managed task worktrees
+        worktree_cleanup: Cleanup policy for managed task worktrees applied when
+            an auto session completes:
+            - ``keep`` (default): never remove anything (legacy behavior)
+            - ``prune-merged``: remove the worktree + ``ooo/*`` branch only when
+              the branch is fully merged and the worktree checkout is clean
+            - ``remove``: remove clean worktrees; delete the branch only when
+              Git accepts a safe merged-branch deletion
         worktree_lock_stale_after_minutes: Staleness threshold for task lock recovery
     """
 
@@ -569,7 +575,7 @@ class OrchestratorConfig(BaseModel, frozen=True):
     usage_limit_pause_hours: float = Field(default=5.0, gt=0.0)
     use_worktrees: bool = True
     worktree_root: str = "~/.ouroboros/worktrees"
-    worktree_cleanup: Literal["keep"] = "keep"
+    worktree_cleanup: Literal["keep", "remove", "prune-merged"] = "keep"
     worktree_lock_stale_after_minutes: int = Field(default=60, ge=1)
 
     @field_validator(

--- a/src/ouroboros/core/worktree.py
+++ b/src/ouroboros/core/worktree.py
@@ -12,10 +12,14 @@ import socket
 import subprocess
 from typing import Any
 
+import structlog
+
 from ouroboros.config.loader import load_config
 from ouroboros.config.models import OrchestratorConfig
 from ouroboros.core.errors import ConfigError, OuroborosError
 from ouroboros.core.file_lock import file_lock
+
+log = structlog.get_logger()
 
 
 class WorktreeError(OuroborosError):
@@ -107,6 +111,11 @@ def _worktrees_enabled() -> bool:
     return getattr(config, "use_worktrees", True)
 
 
+def _worktree_cleanup_policy() -> str:
+    config = _orchestrator_config()
+    return getattr(config, "worktree_cleanup", "keep")
+
+
 def _run_git_process(args: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
     try:
         return subprocess.run(
@@ -186,6 +195,25 @@ def _ensure_clean_checkout(repo_root: Path) -> None:
 
 def _checkout_is_dirty(repo_root: Path) -> bool:
     return bool(_run_git(["status", "--porcelain"], repo_root))
+
+
+def _branch_is_merged(repo_root: Path, branch: str) -> bool:
+    if not _branch_exists(repo_root, branch):
+        return True
+
+    result = _run_git_process(["merge-base", "--is-ancestor", branch, "HEAD"], repo_root)
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    raise WorktreeError(
+        "Git command failed: merge-base --is-ancestor",
+        details={
+            "branch": branch,
+            "stdout": result.stdout.strip(),
+            "stderr": result.stderr.strip(),
+        },
+    )
 
 
 def _list_worktrees(repo_root: Path) -> dict[str, dict[str, str]]:
@@ -395,6 +423,60 @@ def release_lock(lock_path: str) -> None:
             return
         if payload.get("pid") == os.getpid() and payload.get("host") == socket.gethostname():
             path.unlink(missing_ok=True)
+
+
+def cleanup_task_workspace(workspace: TaskWorkspace, *, policy: str | None = None) -> bool:
+    """Remove a managed task worktree according to the configured cleanup policy."""
+    selected_policy = policy or _worktree_cleanup_policy()
+    if selected_policy == "keep":
+        return False
+    if selected_policy not in {"remove", "prune-merged"}:
+        raise WorktreeError(
+            "Invalid task worktree cleanup policy",
+            details={"policy": selected_policy},
+        )
+
+    repo_root = Path(workspace.repo_root)
+    worktree_path = Path(workspace.worktree_path)
+    require_merged = selected_policy == "prune-merged"
+
+    if not worktree_path.exists():
+        if _branch_exists(repo_root, workspace.branch) and _branch_is_merged(
+            repo_root, workspace.branch
+        ):
+            _run_git(["branch", "-d", workspace.branch], repo_root)
+        return True
+
+    if _checkout_is_dirty(worktree_path):
+        return False
+    if require_merged and not _branch_is_merged(repo_root, workspace.branch):
+        return False
+
+    _run_git(["worktree", "remove", str(worktree_path)], repo_root)
+
+    if _branch_exists(repo_root, workspace.branch) and _branch_is_merged(
+        repo_root, workspace.branch
+    ):
+        _run_git(["branch", "-d", workspace.branch], repo_root)
+    return True
+
+
+def release_task_workspace(workspace: TaskWorkspace | None) -> None:
+    """Release a task workspace lock and best-effort configured cleanup."""
+    if workspace is None:
+        return
+    try:
+        cleanup_task_workspace(workspace)
+    except WorktreeError as exc:
+        log.warning(
+            "worktree.cleanup_failed",
+            durable_id=workspace.durable_id,
+            worktree_path=workspace.worktree_path,
+            branch=workspace.branch,
+            error=str(exc),
+        )
+    finally:
+        release_lock(workspace.lock_path)
 
 
 def prepare_task_workspace(

--- a/src/ouroboros/core/worktree.py
+++ b/src/ouroboros/core/worktree.py
@@ -450,6 +450,12 @@ def cleanup_task_workspace(
     require_merged = selected_policy == "prune-merged"
 
     if not worktree_path.exists():
+        if not dry_run:
+            # Drop any stale registration left in .git/worktrees when the
+            # directory was deleted externally; also required before a safe
+            # branch delete (git refuses to delete a branch a registered
+            # worktree still claims).
+            _run_git_process(["worktree", "prune"], repo_root)
         if _branch_exists(repo_root, workspace.branch) and _branch_is_merged(
             repo_root, workspace.branch
         ):

--- a/src/ouroboros/core/worktree.py
+++ b/src/ouroboros/core/worktree.py
@@ -425,8 +425,17 @@ def release_lock(lock_path: str) -> None:
             path.unlink(missing_ok=True)
 
 
-def cleanup_task_workspace(workspace: TaskWorkspace, *, policy: str | None = None) -> bool:
-    """Remove a managed task worktree according to the configured cleanup policy."""
+def cleanup_task_workspace(
+    workspace: TaskWorkspace,
+    *,
+    policy: str | None = None,
+    dry_run: bool = False,
+) -> bool:
+    """Remove a managed task worktree according to the configured cleanup policy.
+
+    With ``dry_run=True`` all safety checks run but nothing is mutated; the
+    return value still reports whether the workspace would be removed.
+    """
     selected_policy = policy or _worktree_cleanup_policy()
     if selected_policy == "keep":
         return False
@@ -444,13 +453,17 @@ def cleanup_task_workspace(workspace: TaskWorkspace, *, policy: str | None = Non
         if _branch_exists(repo_root, workspace.branch) and _branch_is_merged(
             repo_root, workspace.branch
         ):
-            _run_git(["branch", "-d", workspace.branch], repo_root)
+            if not dry_run:
+                _run_git(["branch", "-d", workspace.branch], repo_root)
         return True
 
     if _checkout_is_dirty(worktree_path):
         return False
     if require_merged and not _branch_is_merged(repo_root, workspace.branch):
         return False
+
+    if dry_run:
+        return True
 
     _run_git(["worktree", "remove", str(worktree_path)], repo_root)
 
@@ -477,6 +490,64 @@ def release_task_workspace(workspace: TaskWorkspace | None) -> None:
         )
     finally:
         release_lock(workspace.lock_path)
+
+
+def managed_worktree_root() -> Path:
+    """Return the configured root directory for managed task worktrees."""
+    return _worktree_root()
+
+
+def lock_file_is_stale(lock_path: str | Path) -> bool:
+    """Return True when a task lock file is stale, corrupt, or unreadable."""
+    path = Path(lock_path)
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return True
+    if not isinstance(payload, dict) or not payload:
+        return True
+    return _is_lock_stale(payload)
+
+
+def discover_managed_workspaces(root: Path | None = None) -> list[TaskWorkspace]:
+    """Enumerate managed task worktrees left on disk under the worktree root.
+
+    Reconstructs a ``TaskWorkspace`` for every ``<repo>/<durable_id>``
+    directory that still resolves to a git repository. Directories whose
+    parent repository has been deleted are skipped.
+    """
+    base = root if root is not None else _worktree_root()
+    workspaces: list[TaskWorkspace] = []
+    if not base.is_dir():
+        return workspaces
+    for repo_dir in sorted(base.iterdir()):
+        if not repo_dir.is_dir() or repo_dir.name == ".locks":
+            continue
+        for worktree_path in sorted(repo_dir.iterdir()):
+            if not worktree_path.is_dir():
+                continue
+            durable_id = worktree_path.name
+            try:
+                repo_root = _resolve_common_repo_root(worktree_path)
+                branch = _managed_branch_name(repo_root, durable_id)
+            except WorktreeError:
+                continue
+            if repo_root == worktree_path.resolve():
+                # Not a linked worktree (e.g. a stray standalone repo).
+                continue
+            workspaces.append(
+                TaskWorkspace(
+                    durable_id=durable_id,
+                    repo_root=str(repo_root),
+                    repo_name=repo_dir.name,
+                    original_cwd=str(repo_root),
+                    effective_cwd=str(worktree_path),
+                    worktree_path=str(worktree_path),
+                    branch=branch,
+                    lock_path=str(base / ".locks" / repo_dir.name / f"{durable_id}.json"),
+                )
+            )
+    return workspaces
 
 
 def prepare_task_workspace(

--- a/tests/unit/auto/test_auto_worktree.py
+++ b/tests/unit/auto/test_auto_worktree.py
@@ -4,6 +4,7 @@ import subprocess
 
 from ouroboros.auto.state import AutoPipelineState, AutoWorktreePolicy
 from ouroboros.auto.worktree import ensure_auto_worktree, release_auto_worktree
+from ouroboros.core.worktree import TaskWorkspace
 
 
 def _git(repo, *args: str) -> str:
@@ -81,3 +82,22 @@ def test_auto_policy_gracefully_skips_non_repo(tmp_path, monkeypatch) -> None:
     assert ensure_auto_worktree(state) is None
     assert state.managed_worktree is None
     assert state.cwd == str(tmp_path)
+
+
+def test_release_auto_worktree_delegates_to_task_workspace_release(monkeypatch) -> None:
+    workspace = TaskWorkspace(
+        durable_id="auto_test",
+        repo_root="/tmp/repo",
+        repo_name="repo",
+        original_cwd="/tmp/repo",
+        effective_cwd="/tmp/worktrees/repo/auto_test",
+        worktree_path="/tmp/worktrees/repo/auto_test",
+        branch="ooo/auto_test",
+        lock_path="/tmp/worktrees/.locks/repo/auto_test.json",
+    )
+    released = []
+    monkeypatch.setattr("ouroboros.auto.worktree.release_task_workspace", released.append)
+
+    release_auto_worktree(workspace)
+
+    assert released == [workspace]

--- a/tests/unit/cli/test_cleanup.py
+++ b/tests/unit/cli/test_cleanup.py
@@ -1,0 +1,214 @@
+"""Tests for the ``ouroboros cleanup`` command (issue #1560)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from ouroboros.cli.main import app
+from ouroboros.core.worktree import (
+    discover_managed_workspaces,
+    lock_file_is_stale,
+    prepare_task_workspace,
+    release_lock,
+)
+
+runner = CliRunner()
+
+
+def _git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True)
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "test@example.com")
+    _git(repo, "config", "user.name", "Test User")
+    (repo / "tracked.txt").write_text("initial\n", encoding="utf-8")
+    _git(repo, "add", "tracked.txt")
+    _git(repo, "commit", "-m", "initial")
+
+
+def _make_auto_workspace(repo_root: Path, worktree_root: Path, session_id: str):
+    with patch("ouroboros.core.worktree._worktree_root", return_value=worktree_root):
+        workspace = prepare_task_workspace(repo_root, session_id)
+    release_lock(workspace.lock_path)
+    return workspace
+
+
+class TestDiscoverManagedWorkspaces:
+    def test_discovers_leftover_auto_worktree(self, tmp_path: Path) -> None:
+        repo_root = tmp_path / "repo"
+        worktree_root = tmp_path / "worktrees"
+        _init_repo(repo_root)
+        workspace = _make_auto_workspace(repo_root, worktree_root, "auto_abc123def456")
+
+        found = discover_managed_workspaces(worktree_root)
+
+        assert len(found) == 1
+        assert found[0].durable_id == "auto_abc123def456"
+        assert found[0].branch == workspace.branch
+        assert Path(found[0].repo_root) == repo_root.resolve()
+
+    def test_skips_locks_dir_and_missing_root(self, tmp_path: Path) -> None:
+        assert discover_managed_workspaces(tmp_path / "nope") == []
+        root = tmp_path / "worktrees"
+        (root / ".locks" / "repo").mkdir(parents=True)
+        assert discover_managed_workspaces(root) == []
+
+
+class TestLockFileIsStale:
+    def test_missing_or_corrupt_lock_is_stale(self, tmp_path: Path) -> None:
+        assert lock_file_is_stale(tmp_path / "missing.json")
+        corrupt = tmp_path / "corrupt.json"
+        corrupt.write_text("{not json", encoding="utf-8")
+        assert lock_file_is_stale(corrupt)
+
+    def test_live_lock_is_not_stale(self, tmp_path: Path) -> None:
+        import os
+        import socket
+
+        lock = tmp_path / "live.json"
+        lock.write_text(
+            json.dumps({"pid": os.getpid(), "host": socket.gethostname()}),
+            encoding="utf-8",
+        )
+        assert not lock_file_is_stale(lock)
+
+
+class TestCleanupCommand:
+    def _run(self, worktree_root: Path, data_root: Path, *args: str):
+        with (
+            patch("ouroboros.core.worktree._worktree_root", return_value=worktree_root),
+            patch(
+                "ouroboros.cli.commands.cleanup.managed_worktree_root",
+                return_value=worktree_root,
+            ),
+            patch(
+                "ouroboros.cli.commands.cleanup._auto_data_root",
+                return_value=data_root,
+            ),
+        ):
+            return runner.invoke(app, ["cleanup", *args])
+
+    def test_removes_merged_clean_worktree_and_branch(self, tmp_path: Path) -> None:
+        repo_root = tmp_path / "repo"
+        worktree_root = tmp_path / "worktrees"
+        _init_repo(repo_root)
+        workspace = _make_auto_workspace(repo_root, worktree_root, "auto_merged111111")
+
+        result = self._run(worktree_root, tmp_path / "data")
+
+        assert result.exit_code == 0
+        assert not Path(workspace.worktree_path).exists()
+        assert workspace.branch not in _git(repo_root, "branch", "--list", workspace.branch)
+
+    def test_dry_run_removes_nothing(self, tmp_path: Path) -> None:
+        repo_root = tmp_path / "repo"
+        worktree_root = tmp_path / "worktrees"
+        _init_repo(repo_root)
+        workspace = _make_auto_workspace(repo_root, worktree_root, "auto_dryrun111111")
+
+        result = self._run(worktree_root, tmp_path / "data", "--dry-run")
+
+        assert result.exit_code == 0
+        assert "Would remove" in result.output
+        assert Path(workspace.worktree_path).exists()
+
+    def test_keeps_unmerged_worktree_unless_forced(self, tmp_path: Path) -> None:
+        repo_root = tmp_path / "repo"
+        worktree_root = tmp_path / "worktrees"
+        _init_repo(repo_root)
+        workspace = _make_auto_workspace(repo_root, worktree_root, "auto_unmerged1111")
+        worktree_path = Path(workspace.worktree_path)
+        (worktree_path / "feature.txt").write_text("feature\n", encoding="utf-8")
+        _git(worktree_path, "add", "feature.txt")
+        _git(worktree_path, "commit", "-m", "feature")
+
+        result = self._run(worktree_root, tmp_path / "data")
+        assert result.exit_code == 0
+        assert worktree_path.exists()
+
+        result = self._run(worktree_root, tmp_path / "data", "--force")
+        assert result.exit_code == 0
+        assert not worktree_path.exists()
+        # Unmerged branch survives even a forced worktree removal.
+        assert workspace.branch in _git(repo_root, "branch", "--list", workspace.branch)
+
+    def test_never_touches_dirty_worktree(self, tmp_path: Path) -> None:
+        repo_root = tmp_path / "repo"
+        worktree_root = tmp_path / "worktrees"
+        _init_repo(repo_root)
+        workspace = _make_auto_workspace(repo_root, worktree_root, "auto_dirty1111111")
+        worktree_path = Path(workspace.worktree_path)
+        (worktree_path / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+
+        result = self._run(worktree_root, tmp_path / "data", "--force")
+
+        assert result.exit_code == 0
+        assert worktree_path.exists()
+
+    def test_prunes_stale_lock_without_worktree(self, tmp_path: Path) -> None:
+        worktree_root = tmp_path / "worktrees"
+        lock_dir = worktree_root / ".locks" / "repo"
+        lock_dir.mkdir(parents=True)
+        stale_lock = lock_dir / "auto_gone11111111.json"
+        stale_lock.write_text(json.dumps({"pid": 1, "host": "nowhere"}), encoding="utf-8")
+
+        result = self._run(worktree_root, tmp_path / "data")
+
+        assert result.exit_code == 0
+        assert not stale_lock.exists()
+
+    def test_prunes_completed_state_without_worktree(self, tmp_path: Path) -> None:
+        worktree_root = tmp_path / "worktrees"
+        worktree_root.mkdir()
+        data_root = tmp_path / "data"
+        data_root.mkdir()
+        complete = data_root / "auto_done11111111.json"
+        complete.write_text(json.dumps({"phase": "complete"}), encoding="utf-8")
+        blocked = data_root / "auto_blocked111111.json"
+        blocked.write_text(json.dumps({"phase": "blocked"}), encoding="utf-8")
+        running = data_root / "auto_running111111.json"
+        running.write_text(json.dumps({"phase": "executing"}), encoding="utf-8")
+
+        result = self._run(worktree_root, data_root)
+        assert result.exit_code == 0
+        assert not complete.exists()
+        assert blocked.exists()
+        assert running.exists()
+
+        result = self._run(worktree_root, data_root, "--state-all")
+        assert result.exit_code == 0
+        assert not blocked.exists()
+        assert running.exists()
+
+    def test_keeps_state_of_session_with_live_worktree(self, tmp_path: Path) -> None:
+        repo_root = tmp_path / "repo"
+        worktree_root = tmp_path / "worktrees"
+        _init_repo(repo_root)
+        workspace = _make_auto_workspace(repo_root, worktree_root, "auto_live11111111")
+        worktree_path = Path(workspace.worktree_path)
+        (worktree_path / "wip.txt").write_text("wip\n", encoding="utf-8")  # dirty → kept
+
+        data_root = tmp_path / "data"
+        data_root.mkdir()
+        state = data_root / "auto_live11111111.json"
+        state.write_text(json.dumps({"phase": "complete"}), encoding="utf-8")
+
+        result = self._run(worktree_root, data_root)
+
+        assert result.exit_code == 0
+        assert state.exists()

--- a/tests/unit/config/test_models.py
+++ b/tests/unit/config/test_models.py
@@ -559,6 +559,17 @@ class TestOrchestratorConfig:
         with pytest.raises(ValidationError):
             OrchestratorConfig(usage_limit_pause_hours=0)
 
+    def test_orchestrator_config_accepts_worktree_cleanup_policies(self) -> None:
+        """Worktree cleanup policy accepts keep, remove, and prune-merged."""
+        for policy in ("keep", "remove", "prune-merged"):
+            config = OrchestratorConfig(worktree_cleanup=policy)
+            assert config.worktree_cleanup == policy
+
+    def test_orchestrator_config_rejects_unknown_worktree_cleanup_policy(self) -> None:
+        """Worktree cleanup policy rejects unknown values."""
+        with pytest.raises(ValidationError):
+            OrchestratorConfig(worktree_cleanup="delete")  # type: ignore[arg-type]
+
     def test_orchestrator_config_expands_codex_cli_path(self) -> None:
         """Expands ~ in codex_cli_path."""
         config = OrchestratorConfig(runtime_backend="codex", codex_cli_path="~/bin/codex")

--- a/tests/unit/core/test_worktree.py
+++ b/tests/unit/core/test_worktree.py
@@ -373,6 +373,32 @@ class TestWorktreeHardening:
         assert not Path(workspace.lock_path).exists()
         assert not _branch_exists(repo_root, workspace.branch)
 
+    def test_cleanup_prunes_stale_registration_when_directory_deleted_externally(
+        self, tmp_path: Path
+    ) -> None:
+        import shutil as _shutil
+
+        repo_root = tmp_path / "repo"
+        worktree_root = tmp_path / "worktrees"
+        self._init_repo(repo_root)
+
+        with patch("ouroboros.core.worktree._worktree_root", return_value=worktree_root):
+            workspace = prepare_task_workspace(repo_root, "orch_test_stale_reg")
+            release_lock(workspace.lock_path)
+            # Simulate external deletion: directory gone, .git/worktrees
+            # registration (and branch lock) left behind.
+            _shutil.rmtree(workspace.worktree_path)
+
+            removed = cleanup_task_workspace(workspace, policy="prune-merged")
+
+        assert removed is True
+        # Stale registration dropped and merged branch deleted despite the
+        # leftover .git/worktrees metadata.
+        assert workspace.worktree_path not in self._git(
+            repo_root, "worktree", "list", "--porcelain"
+        )
+        assert not _branch_exists(repo_root, workspace.branch)
+
     def test_prune_merged_policy_keeps_unmerged_worktree_branch_but_releases_lock(
         self, tmp_path: Path
     ) -> None:

--- a/tests/unit/core/test_worktree.py
+++ b/tests/unit/core/test_worktree.py
@@ -13,10 +13,12 @@ from ouroboros.core.worktree import (
     WorktreeError,
     _acquire_lock,
     _branch_exists,
+    cleanup_task_workspace,
     maybe_prepare_task_workspace,
     maybe_restore_task_workspace,
     prepare_task_workspace,
     release_lock,
+    release_task_workspace,
     restore_task_workspace,
 )
 
@@ -352,3 +354,84 @@ class TestWorktreeHardening:
         finally:
             if workspace is not None:
                 release_lock(workspace.lock_path)
+
+    def test_prune_merged_policy_removes_clean_worktree_branch_and_lock(
+        self, tmp_path: Path
+    ) -> None:
+        repo_root = tmp_path / "repo"
+        worktree_root = tmp_path / "worktrees"
+        self._init_repo(repo_root)
+
+        with (
+            patch("ouroboros.core.worktree._worktree_root", return_value=worktree_root),
+            patch("ouroboros.core.worktree._worktree_cleanup_policy", return_value="prune-merged"),
+        ):
+            workspace = prepare_task_workspace(repo_root, "orch_test_cleanup")
+            release_task_workspace(workspace)
+
+        assert not Path(workspace.worktree_path).exists()
+        assert not Path(workspace.lock_path).exists()
+        assert not _branch_exists(repo_root, workspace.branch)
+
+    def test_prune_merged_policy_keeps_unmerged_worktree_branch_but_releases_lock(
+        self, tmp_path: Path
+    ) -> None:
+        repo_root = tmp_path / "repo"
+        worktree_root = tmp_path / "worktrees"
+        self._init_repo(repo_root)
+
+        with (
+            patch("ouroboros.core.worktree._worktree_root", return_value=worktree_root),
+            patch("ouroboros.core.worktree._worktree_cleanup_policy", return_value="prune-merged"),
+        ):
+            workspace = prepare_task_workspace(repo_root, "orch_test_unmerged")
+            worktree_path = Path(workspace.worktree_path)
+            (worktree_path / "feature.txt").write_text("feature\n", encoding="utf-8")
+            self._git(worktree_path, "add", "feature.txt")
+            self._git(worktree_path, "commit", "-m", "feature")
+
+            release_task_workspace(workspace)
+
+        assert Path(workspace.worktree_path).exists()
+        assert not Path(workspace.lock_path).exists()
+        assert _branch_exists(repo_root, workspace.branch)
+
+    def test_remove_policy_removes_clean_unmerged_worktree_but_keeps_branch(
+        self, tmp_path: Path
+    ) -> None:
+        repo_root = tmp_path / "repo"
+        worktree_root = tmp_path / "worktrees"
+        self._init_repo(repo_root)
+
+        with patch("ouroboros.core.worktree._worktree_root", return_value=worktree_root):
+            workspace = prepare_task_workspace(repo_root, "orch_test_remove")
+            worktree_path = Path(workspace.worktree_path)
+            (worktree_path / "feature.txt").write_text("feature\n", encoding="utf-8")
+            self._git(worktree_path, "add", "feature.txt")
+            self._git(worktree_path, "commit", "-m", "feature")
+
+            removed = cleanup_task_workspace(workspace, policy="remove")
+            release_lock(workspace.lock_path)
+
+        assert removed is True
+        assert not Path(workspace.worktree_path).exists()
+        assert _branch_exists(repo_root, workspace.branch)
+
+    def test_remove_policy_keeps_dirty_worktree_but_releases_lock(self, tmp_path: Path) -> None:
+        repo_root = tmp_path / "repo"
+        worktree_root = tmp_path / "worktrees"
+        self._init_repo(repo_root)
+
+        with (
+            patch("ouroboros.core.worktree._worktree_root", return_value=worktree_root),
+            patch("ouroboros.core.worktree._worktree_cleanup_policy", return_value="remove"),
+        ):
+            workspace = prepare_task_workspace(repo_root, "orch_test_dirty_cleanup")
+            worktree_path = Path(workspace.worktree_path)
+            (worktree_path / "dirty.txt").write_text("dirty\n", encoding="utf-8")
+
+            release_task_workspace(workspace)
+
+        assert Path(workspace.worktree_path).exists()
+        assert not Path(workspace.lock_path).exists()
+        assert _branch_exists(repo_root, workspace.branch)


### PR DESCRIPTION
## Summary

Root cause (#1560): `worktree_cleanup` was typed `Literal["keep"]` and never read anywhere in the source — the config surface implied a cleanup policy that could not be configured and would not act. No teardown path existed at all (`core/worktree.py` exposes only create/restore/lock APIs), so every auto session leaked a worktree, an `ooo/auto_*` branch, a state file, and a lock file permanently.

- widen `worktree_cleanup` to `keep`, `remove`, and `prune-merged`
- add safe managed worktree cleanup on auto release while keeping `keep` as the default
- remove clean fully merged auto worktrees/branches for `prune-merged`; remove clean worktrees for `remove` without force-deleting unmerged branches
- cover config validation, core cleanup behavior, and the auto release wrapper

Closes #1560

## Tests
- `uv run pytest tests/unit/core/test_worktree.py tests/unit/auto/test_auto_worktree.py tests/unit/config/test_models.py`
- `uv run ruff check src/ouroboros/core/worktree.py src/ouroboros/auto/worktree.py src/ouroboros/config/models.py tests/unit/core/test_worktree.py tests/unit/auto/test_auto_worktree.py tests/unit/config/test_models.py`
- `uv run ruff format --check src/ouroboros/core/worktree.py src/ouroboros/auto/worktree.py src/ouroboros/config/models.py tests/unit/core/test_worktree.py tests/unit/auto/test_auto_worktree.py tests/unit/config/test_models.py`

## R-run comparison

This PR touches `src/ouroboros/auto/worktree.py` only to route final cleanup through the core worktree release helper. It does not change the auto pipeline round loop, prompt path, model calls, or per-round scheduling.

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation / [x] N/A (cleanup-finalizer-only auto wrapper change)
## Addendum: `ooo cleanup` command (second commit)

The config policy above only covers sessions that end after this change ships.
This commit adds the issue's "at minimum" ask — a manual prune path for residue
that already exists (or accumulates under the default `keep`):

- **`ooo cleanup`** removes managed auto worktrees whose `ooo/auto_*` branch is
  fully merged and whose checkout is clean, plus the merged branches
  (safe `git branch -d` only).
- **`--force`** also removes clean-but-unmerged worktrees; unmerged branches
  always survive.
- **Stale locks**: lock files with a dead owning process and no worktree are
  pruned.
- **Orphaned state files** (`~/.ouroboros/data/auto_*.json`): pruned when the
  session is terminal and its worktree is gone (`complete` by default;
  `--state-all` extends to `blocked`/`failed`).
- **`--dry-run`** reports without mutating (all safety checks still run via
  `cleanup_task_workspace(dry_run=True)`).

Safety rules: worktrees with a live (non-stale) lock are never touched; dirty
worktrees are never removed under any flag.

Supporting core additions: `discover_managed_workspaces()`,
`lock_file_is_stale()`, `managed_worktree_root()`, and a `dry_run` parameter on
`cleanup_task_workspace()`.

Docs: `docs/cli-reference.md` gains an `ouroboros cleanup` section
(per CONTRIBUTING "New Command or Flag Checklist"; `getting-started.md`
reviewed — no day-1 flow affected).

Tests: `tests/unit/cli/test_cleanup.py` (9 cases: merged/unmerged/dirty/dry-run
worktree pruning, stale-lock pruning, state-file phases, live-worktree guard).

### Addendum tests
- `uv run pytest tests/unit/ -q` — 10955 passed, 2 skipped, 1 failed (`uv build --wheel` DNS lookup in sandbox; network-dependent packaging test, unrelated)
- `uv run pytest tests/unit/cli/test_cleanup.py -q` — 11 passed
- `uv run ruff check src/ tests/` + `ruff format --check` clean
- `uv run mypy src/ouroboros` clean
- Live `ooo cleanup --dry-run` on this machine reported 25 prunable auto worktrees, mutated nothing

