### PR TITLE
fix(test): loosen CI-flaky wall-clock deadline in run-evaluate chaining test

### DIFF
--- a/tests/unit/mcp/tools/test_run_evaluate_chaining.py
+++ b/tests/unit/mcp/tools/test_run_evaluate_chaining.py
@@ -36,7 +36,10 @@ async def event_store():
 
 
 async def _wait_terminal(job_manager: JobManager, job_id: str) -> JobSnapshot:
-    deadline = time.monotonic() + 15.0
+    # 15s was too tight for loaded/shared CI runners (observed intermittent
+    # timeouts on GitHub Actions despite the awaited work completing in <1s
+    # locally); 60s gives ample headroom without weakening the assertion.
+    deadline = time.monotonic() + 60.0
     while time.monotonic() < deadline:
         snapshot = await job_manager.get_snapshot(job_id)
         if snapshot.is_terminal:
@@ -54,7 +57,7 @@ async def _wait_terminal(job_manager: JobManager, job_id: str) -> JobSnapshot:
 
 
 async def _wait_for_call(calls: list[Any]) -> None:
-    deadline = time.monotonic() + 15.0
+    deadline = time.monotonic() + 60.0
     while time.monotonic() < deadline:
         if calls:
             return


### PR DESCRIPTION
## Summary
- `test_run_evaluate_chaining.py`'s `_wait_terminal`/`_wait_for_call` polling helpers used a 15s wall-clock deadline that intermittently timed out on GitHub Actions shared runners (observed 6/6 CI test failures during a recent bulk-merge session were this exact test)
- The awaited background job consistently completes in <1s locally across 15+ repro attempts (full suite, with/without `--cov`, py3.12/3.13/3.14) — confirms a CI-scheduling flake, not a functional regression
- Bump both deadlines to 60s to give ample headroom without weakening the assertion

## Test plan
- [x] `uv run ruff check` / `ruff format --check` pass
- [x] `uv run pytest tests/unit/mcp/tools/test_run_evaluate_chaining.py -q` passes locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)