### PR TITLE
feat: add zcode runtime backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
   <a href="#from-wonder-to-ontology">Philosophy</a>
 </p>
 
-**Turn a vague idea into a verified, working codebase -- across Claude Code, Codex CLI, OpenCode, Hermes, Gemini, Kiro, Copilot, and Pi.**
+**Turn a vague idea into a verified, working codebase -- across Claude Code, Codex CLI, OpenCode, Hermes, Gemini, Kiro, Copilot, Pi, and Zcode.**
 
 Ouroboros is an **Agent OS** for AI coding: a local-first runtime layer that
 turns non-deterministic agent work into a replayable, observable, policy-bound
@@ -112,7 +112,7 @@ curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.
 > ooo interview "I want to build a task management CLI"
 ```
 
-> Works with Claude Code, Codex CLI, GitHub Copilot CLI, OpenCode, Hermes, Gemini, Kiro CLI, and Pi CLI. The installer detects Claude Code, Codex CLI, and Hermes CLI automatically and registers the MCP server where the host supports it. For OpenCode, Kiro, GitHub Copilot CLI, Gemini CLI, or Pi CLI, run `ouroboros setup --runtime <opencode|kiro|copilot|gemini|pi>` after installation. The Copilot CLI runtime live-discovers its model catalog via the GitHub Copilot models API and lets you pick a default during setup.
+> Works with Claude Code, Codex CLI, GitHub Copilot CLI, OpenCode, Hermes, Gemini, Kiro CLI, Pi CLI, and Zcode. The installer detects available runtimes and registers the MCP server where the host supports it. For explicit selection, run `ouroboros setup --runtime <opencode|kiro|copilot|gemini|pi|zcode>` after installation. The Copilot CLI runtime live-discovers its model catalog via the GitHub Copilot models API and lets you pick a default during setup.
 
 <details>
 <summary><strong>Kiro CLI quick start</strong></summary>
@@ -169,7 +169,7 @@ ouroboros setup                         # configure runtime
 
 Legacy compatibility: `ouroboros-ai[dashboard]` is still accepted as a compatibility alias/no-op; it does not install dashboard runtime payload. `ouroboros-ai[all]` includes that no-op alias only for compatibility.
 
-See runtime guides: [Claude Code](./docs/runtime-guides/claude-code.md) · [Codex CLI](./docs/runtime-guides/codex.md) · [Hermes](./docs/runtime-guides/hermes.md) · [OpenCode](./docs/runtime-guides/opencode.md) · [Kiro CLI](./docs/runtime-guides/kiro.md) · [Gemini CLI](./docs/runtime-guides/gemini.md) · [GitHub Copilot CLI](./docs/runtime-guides/copilot.md) · [Pi JSON mode](https://pi.dev/docs/latest/json)
+See runtime guides: [Claude Code](./docs/runtime-guides/claude-code.md) · [Codex CLI](./docs/runtime-guides/codex.md) · [Hermes](./docs/runtime-guides/hermes.md) · [OpenCode](./docs/runtime-guides/opencode.md) · [Kiro CLI](./docs/runtime-guides/kiro.md) · [Gemini CLI](./docs/runtime-guides/gemini.md) · [GitHub Copilot CLI](./docs/runtime-guides/copilot.md) · [Zcode](./docs/runtime-guides/zcode.md) · [Pi JSON mode](https://pi.dev/docs/latest/json)
 
 </details>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,7 @@ replayable execution contract on your choice of runtime backend.
 - [Codex CLI](./runtime-guides/codex.md) - Backend-specific configuration and CLI options (see [Getting Started](./getting-started.md) for install/onboarding)
 - [OpenCode](./runtime-guides/opencode.md) - Interactive plugin mode and headless subprocess runtime
 - [Hermes](./runtime-guides/hermes.md) - Hermes Agent runtime setup and `ooo` dispatch
+- [Zcode](./runtime-guides/zcode.md) - Z.ai desktop-agent runtime and measured CLI contract
 - [Runtime Capability Matrix](./runtime-capability-matrix.md) - Feature comparison across runtime backends
 
 ### Architecture

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -623,7 +623,7 @@ ouroboros config show orchestrator
 
 ### `config backend`
 
-Show or switch the runtime backend. This sets both `orchestrator.runtime_backend` and `llm.backend` together — they are always kept in sync for simplicity. Advanced users can decouple them with `config set`.
+Show or switch the runtime backend by delegating to that backend's setup flow. The setup policy decides whether `llm.backend` also changes. Runtime-only backends such as Antigravity, Grok, and Zcode always update only the orchestrator runtime and preserve the existing completion backend.
 
 ```bash
 ouroboros config backend [BACKEND]
@@ -633,7 +633,7 @@ ouroboros config backend [BACKEND]
 
 | Argument | Description |
 |----------|-------------|
-| `BACKEND` | Backend to switch to: `claude`, `codex`, `gemini`, `hermes`, or `goose`. Omit to show current. For `opencode`, use `ouroboros setup` instead |
+| `BACKEND` | Backend to switch to: `claude`, `codex`, `gemini`, `zcode`, `hermes`, `goose`, `pi`, `gjc`, `antigravity`, or `grok`. Omit to show current. For `opencode`, use `ouroboros setup` instead |
 
 **Examples:**
 
@@ -649,6 +649,9 @@ ouroboros config backend claude
 
 # Switch to Hermes
 ouroboros config backend hermes
+
+# Switch to the runtime-only Zcode backend without changing llm.backend
+ouroboros config backend zcode
 ```
 
 ### `config init`

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -69,7 +69,7 @@ ouroboros auto "Build a local-first habit tracker CLI"
 | Option | Description |
 |--------|-------------|
 | `--resume TEXT` | Resume an existing auto session id |
-| `--runtime TEXT` | Runtime backend for the **run-handoff** phase. Shipped values: `claude`, `codex`, `opencode`, `hermes`, `gemini`, `goose`, `kiro`, `copilot`, `pi`, `gjc`, `antigravity`, `grok`. Authoring phases (interview, seed generation, seed repair) **always run in-process** inside the Ouroboros MCP server in `ooo auto` flow — see [What `--runtime` controls in `ooo auto`](#what---runtime-controls-in-ooo-auto) below. |
+| `--runtime TEXT` | Runtime backend for the **run-handoff** phase. Shipped values: `claude`, `codex`, `opencode`, `hermes`, `gemini`, `goose`, `kiro`, `copilot`, `pi`, `gjc`, `antigravity`, `grok`, `zcode`. Authoring phases (interview, seed generation, seed repair) **always run in-process** inside the Ouroboros MCP server in `ooo auto` flow - see [What `--runtime` controls in `ooo auto`](#what---runtime-controls-in-ooo-auto) below. |
 | `--max-interview-rounds INTEGER` | Maximum automatic interview rounds; prevents unbounded interview loops |
 | `--max-repair-rounds INTEGER` | Maximum Seed repair rounds; prevents unbounded repair loops |
 | `--skip-run` | Stop after creating an A-grade Seed |
@@ -232,7 +232,7 @@ truth table describes the gate function alone, not the auto flow:
 Detect available runtime backends and configure Ouroboros for your environment.
 
 Ouroboros supports multiple runtime backends via a pluggable `AgentRuntime` protocol. The `setup` command auto-detects
-which runtimes are available in your PATH (including Claude Code, Codex CLI, OpenCode, Hermes, Gemini, Kiro, Copilot, Goose, Pi, and GJC) and
+which runtimes are available (including Claude Code, Codex CLI, OpenCode, Hermes, Gemini, Kiro, Copilot, Goose, Pi, GJC, Antigravity, Grok, and Zcode) and
 configures `orchestrator.runtime_backend` accordingly. Additional runtimes can be registered
 by implementing the protocol — see [Architecture](architecture.md#how-to-add-a-new-runtime-adapter).
 
@@ -244,7 +244,7 @@ ouroboros setup [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `-r, --runtime TEXT` | Runtime backend to configure. Shipped values: `claude`, `codex`, `opencode`, `hermes`, `gemini`, `goose`, `kiro`, `copilot`, `pi`, `gjc`, `antigravity`, `grok`. Auto-detected if omitted |
+| `-r, --runtime TEXT` | Runtime backend to configure. Shipped values: `claude`, `codex`, `opencode`, `hermes`, `gemini`, `goose`, `kiro`, `copilot`, `pi`, `gjc`, `antigravity`, `grok`, `zcode`. Auto-detected if omitted |
 | `--opencode-mode TEXT` | OpenCode integration mode: `plugin` (default, recommended — bridge plugin for interactive sessions) or `subprocess` (headless/CI). Mutually exclusive — see [OpenCode runtime guide](runtime-guides/opencode.md#configuration) |
 | `--non-interactive` | Skip interactive prompts (for scripted installs) |
 | `--mcp-mode TEXT` | Codex MCP config mode: `auto` (default), `preserve`, or `stdio` |
@@ -273,13 +273,16 @@ ouroboros setup --runtime claude
 # Explicitly select Kiro CLI as runtime backend (writes ~/.kiro/settings/mcp.json)
 ouroboros setup --runtime kiro
 
+# Explicitly select Zcode as a runtime-only backend
+ouroboros setup --runtime zcode
+
 # Non-interactive setup (for CI or scripted installs)
 ouroboros setup --non-interactive
 ```
 
 **What setup does:**
 
-- Scans PATH for `claude`, `codex`, `opencode`, `hermes`, `gemini`, `kiro-cli`, `copilot`, `goose`, `pi`, and `gjc` CLI binaries
+- Detects configured paths and PATH entries for the shipped runtimes, including `zcode` and the macOS ZCode app-bundle script
 - Prompts you to select a runtime if multiple are found (or auto-selects if only one)
 - Writes `orchestrator.runtime_backend` to `~/.ouroboros/config.yaml`
 - For Claude Code: registers the MCP server in `~/.claude/mcp.json`
@@ -297,6 +300,7 @@ ouroboros setup --non-interactive
 - For Copilot CLI: installs the runtime skill capability guide into `~/.copilot/ouroboros-instructions/AGENTS.md` and configures Ouroboros-launched Copilot child sessions to read it via `COPILOT_CUSTOM_INSTRUCTIONS_DIRS`
 - For GJC: sets `orchestrator.gjc_cli_path` and `llm.backend: gjc` in `~/.ouroboros/config.yaml`
 - For GJC: installs the `ooo` bridge extension into `<agent-dir>/extensions` and the renderer-generated skill capability guide into `<agent-dir>/rules/ouroboros-skill-capability-guide.md`
+- For Zcode: sets `orchestrator.runtime_backend: zcode` and `orchestrator.zcode_cli_path` while leaving the completion-only `llm.backend` unchanged
 
 > **Codex config split:** put persistent Ouroboros per-role model overrides in `~/.ouroboros/config.yaml` (`clarification.default_model`, `llm.qa_model`, `evaluation.semantic_model`, `consensus.models`, `consensus.advocate_model`, `consensus.devil_model`, `consensus.judge_model`). `~/.codex/config.toml` is only the Codex MCP/env hookup file used by setup on current Codex releases; profile anchors live in `~/.codex/<profile>.config.toml`. If you run a long-lived URL-based Ouroboros MCP server, setup preserves that user-managed entry in the default `--mcp-mode auto`; use `--mcp-mode stdio` only when you intentionally want setup to replace it.
 
@@ -344,7 +348,7 @@ ouroboros init [start] [OPTIONS] [CONTEXT]
 | `-r, --resume TEXT` | Resume an existing interview by ID |
 | `--state-dir DIRECTORY` | Custom directory for interview state files |
 | `-o, --orchestrator` | Use Claude Code for the interview/seed flow; combine with `--runtime` to choose the workflow handoff backend |
-| `--runtime TEXT` | Agent runtime backend for the workflow execution step after seed generation. Shipped values: `claude`, `codex`, `opencode`, `hermes`, `gemini`, `goose`, `kiro`, `copilot`, `pi`, `gjc`, `antigravity`, `grok`. Custom adapters registered in `runtime_factory.py` are also accepted. |
+| `--runtime TEXT` | Agent runtime backend for the workflow execution step after seed generation. Shipped values: `claude`, `codex`, `opencode`, `hermes`, `gemini`, `goose`, `kiro`, `copilot`, `pi`, `gjc`, `antigravity`, `grok`, `zcode`. Custom adapters registered in `runtime_factory.py` are also accepted. |
 | `--llm-backend TEXT` | LLM backend for interview, ambiguity scoring, and seed generation (`claude_code`, `litellm`, `codex`, `copilot`, `opencode`, `gemini`, `goose`, `kiro`, `pi`, `gjc`) |
 | `-d, --debug` | Show verbose logs including debug messages |
 
@@ -417,7 +421,7 @@ ouroboros run [workflow] [OPTIONS] SEED_FILE
 | Option | Description |
 |--------|-------------|
 | `-o/-O, --orchestrator/--no-orchestrator` | Use the agent-runtime orchestrator for execution (default: enabled) |
-| `--runtime TEXT` | Agent runtime backend override (`claude`, `codex`, `opencode`, `hermes`, `gemini`, `copilot`, `goose`, `kiro`, `pi`, `gjc`, `antigravity`, `grok`). Uses configured default if omitted |
+| `--runtime TEXT` | Agent runtime backend override (`claude`, `codex`, `opencode`, `hermes`, `gemini`, `copilot`, `goose`, `kiro`, `pi`, `gjc`, `antigravity`, `grok`, `zcode`). Uses configured default if omitted |
 | `-r, --resume TEXT` | Resume a previous orchestrator session by ID |
 | `--mcp-config PATH` | Path to MCP client configuration YAML file |
 | `--mcp-tool-prefix TEXT` | Prefix to add to all MCP tool names (e.g., `mcp_`) |
@@ -1015,7 +1019,7 @@ ouroboros mcp serve [OPTIONS]
 | `-p, --port INTEGER` | Port to bind to (default: 8080) |
 | `-t, --transport TEXT` | Transport type: `stdio`, `sse`, or `streamable-http` (default: stdio). Note: `http` is only a client config alias for outbound MCP connections and is NOT a valid serve transport. |
 | `--db TEXT` | Path to the EventStore database file |
-| `--runtime TEXT` | Agent runtime backend for orchestrator-driven tools (`claude`, `codex`, `opencode`, `hermes`, `gemini`, `copilot`, `goose`, `kiro`, `pi`, `gjc`, `antigravity`, `grok`). Affects which tool variants are instantiated |
+| `--runtime TEXT` | Agent runtime backend for orchestrator-driven tools (`claude`, `codex`, `opencode`, `hermes`, `gemini`, `copilot`, `goose`, `kiro`, `pi`, `gjc`, `antigravity`, `grok`, `zcode`). Affects which tool variants are instantiated |
 | `--llm-backend TEXT` | LLM backend for interview/seed/evaluation tools (`claude_code`, `litellm`, `codex`, `copilot`, `opencode`, `gemini`, `goose`, `kiro`, `pi`, `gjc`). Affects which tool variants are instantiated |
 
 **Examples:**
@@ -1097,7 +1101,7 @@ ouroboros mcp info [OPTIONS]
 
 | Option | Description |
 |--------|-------------|
-| `--runtime TEXT` | Agent runtime backend for orchestrator-driven tools (`claude`, `codex`, `opencode`, `hermes`, `gemini`, `copilot`, `goose`, `kiro`, `pi`, `gjc`, `antigravity`, `grok`). Affects which tool variants are instantiated |
+| `--runtime TEXT` | Agent runtime backend for orchestrator-driven tools (`claude`, `codex`, `opencode`, `hermes`, `gemini`, `copilot`, `goose`, `kiro`, `pi`, `gjc`, `antigravity`, `grok`, `zcode`). Affects which tool variants are instantiated |
 | `--llm-backend TEXT` | LLM backend for interview/seed/evaluation tools (`claude_code`, `litellm`, `codex`, `copilot`, `opencode`, `gemini`, `goose`, `kiro`, `pi`, `gjc`). Affects which tool variants are instantiated |
 
 **Available Tools:**
@@ -1136,7 +1140,7 @@ The table below covers the most commonly used variables. For the full list — i
 | `ANTHROPIC_API_KEY` | — | Anthropic API key for Claude models |
 | `OPENAI_API_KEY` | — | OpenAI API key for LiteLLM / Codex CLI |
 | `OPENROUTER_API_KEY` | — | OpenRouter API key for consensus and LiteLLM |
-| `OUROBOROS_AGENT_RUNTIME` | `orchestrator.runtime_backend` | Override the runtime backend (`claude`, `codex`, `opencode`, `hermes`, `gemini`, `goose`, `kiro`, `copilot`, `pi`, `gjc`, `antigravity`, `grok`) |
+| `OUROBOROS_AGENT_RUNTIME` | `orchestrator.runtime_backend` | Override the runtime backend (`claude`, `codex`, `opencode`, `hermes`, `gemini`, `goose`, `kiro`, `copilot`, `pi`, `gjc`, `antigravity`, `grok`, `zcode`) |
 | `OUROBOROS_RUNTIME` | `orchestrator.runtime_backend` (fallback) | Shortcut env var honored by both `orchestrator.runtime_backend` and `llm.backend` resolution when their dedicated env vars are unset |
 | `OUROBOROS_KIRO_CLI_PATH` | `orchestrator.kiro_cli_path` | Explicit path to `kiro-cli` binary when it is not on `PATH` |
 | `OUROBOROS_AGENT_PERMISSION_MODE` | `orchestrator.permission_mode` | Stored runtime preference; runner-driven seed execution forces the native `bypassPermissions` equivalent for fresh and resumed dispatches wherever the backend exposes an approval surface. OpenCode maps it to `--dangerously-skip-permissions`; Pi and GJC have no separate approval flag and already run headlessly without an approval dialogue |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -179,7 +179,7 @@ Controls how Ouroboros launches and communicates with the agent runtime backend.
 
 ```yaml
 orchestrator:
-  runtime_backend: claude       # "claude" | "codex" | "opencode" | "hermes" | "gemini" | "kiro" | "copilot" | "pi"
+  runtime_backend: claude       # "claude" | "codex" | "opencode" | "hermes" | "gemini" | "kiro" | "copilot" | "pi" | "gjc" | "antigravity" | "grok" | "zcode"
   permission_mode: acceptEdits  # "default" | "acceptEdits" | "bypassPermissions"
   opencode_permission_mode: bypassPermissions
   max_parallel_workers: 3       # Maximum concurrent AC workers
@@ -188,12 +188,13 @@ orchestrator:
   opencode_cli_path: null       # Path to OpenCode CLI binary; null = resolve from PATH
   copilot_cli_path: null        # Path to Copilot CLI binary; null = resolve from PATH
   pi_cli_path: null             # Path to Pi CLI binary; null = resolve from PATH
+  zcode_cli_path: null          # Path to zcode.cjs or a zcode executable
   default_max_turns: 10
 ```
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `runtime_backend` | `"claude"` \| `"codex"` \| `"opencode"` \| `"hermes"` \| `"gemini"` \| `"kiro"` \| `"copilot"` \| `"pi"` | `"claude"` | The agent runtime backend used for workflow execution. Overridable via `OUROBOROS_AGENT_RUNTIME`. See [runtime capability matrix](runtime-capability-matrix.md). |
+| `runtime_backend` | `"claude"` \| `"codex"` \| `"opencode"` \| `"hermes"` \| `"gemini"` \| `"kiro"` \| `"copilot"` \| `"pi"` \| `"gjc"` \| `"antigravity"` \| `"grok"` \| `"zcode"` | `"claude"` | The agent runtime backend used for workflow execution. Overridable via `OUROBOROS_AGENT_RUNTIME`. See [runtime capability matrix](runtime-capability-matrix.md). |
 | `permission_mode` | `"default"` \| `"acceptEdits"` \| `"bypassPermissions"` | `"acceptEdits"` | Stored permission preference. Runner-driven seed execution forces the native `bypassPermissions` equivalent for both fresh and resumed dispatches wherever the backend exposes an approval surface; persisted handles cannot downgrade it. Pi and GJC expose no separate approval flag and run headlessly without an approval dialogue. |
 | `opencode_permission_mode` | `"default"` \| `"acceptEdits"` \| `"bypassPermissions"` | `"bypassPermissions"` | Permission mode when using the OpenCode runtime. Overridable via `OUROBOROS_OPENCODE_PERMISSION_MODE`. |
 | `max_parallel_workers` | `int >= 1` | `3` | Requested maximum concurrent Acceptance Criteria workers for parallel execution. Overridable via `OUROBOROS_MAX_PARALLEL_WORKERS`. Invalid explicit values fail instead of falling back to the default. **Note:** the effective fan-out is additionally capped to the connected backend's known concurrency limit — the native Claude backend is governed by its RPM/TPM rate bucket, while CLI runtimes whose underlying LLM limits are unknown (`hermes`, `codex`, `gemini`, `opencode`, ...) are **serialized to 1 by default** to avoid stampeding the provider's rate/quota window. Raise that cap with `OUROBOROS_MAX_CONCURRENCY`. |
@@ -202,6 +203,7 @@ orchestrator:
 | `opencode_cli_path` | `string \| null` | `null` | Absolute path to the OpenCode CLI binary (`~` is expanded). When `null`, resolved from `PATH` at runtime. Overridable via `OUROBOROS_OPENCODE_CLI_PATH`. |
 | `copilot_cli_path` | `string \| null` | `null` | Absolute path to the GitHub Copilot CLI binary (`~` is expanded). When `null`, resolved from `PATH` at runtime. Overridable via `OUROBOROS_COPILOT_CLI_PATH`. |
 | `pi_cli_path` | `string \| null` | `null` | Absolute path to the Pi CLI binary (`~` is expanded). When `null`, resolved from `PATH` at runtime. Overridable via `OUROBOROS_PI_CLI_PATH`. |
+| `zcode_cli_path` | `string \| null` | `null` | Path to the Zcode app-bundle `zcode.cjs` script, a standalone script, or a directly executable `zcode` wrapper. Official app bundles use their bundled Electron/Node runtime. Resolution falls back to the macOS app bundle, then `PATH`. Overridable via `OUROBOROS_ZCODE_CLI_PATH`. |
 | `ourocode_cli_path` | `string \| null` | `null` | Absolute path to the ourocode CLI binary (`~` is expanded). Used by the LLM-only `ourocode` backend; when `null`, resolved from `PATH` at runtime. Overridable via `OUROBOROS_OUROCODE_CLI_PATH`. |
 | `default_max_turns` | `int >= 1` | `10` | Default maximum number of turns per agent execution task. |
 

--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -13,7 +13,7 @@ The runtime backend is selected via the `orchestrator.runtime_backend` config ke
 
 ```yaml
 orchestrator:
-  runtime_backend: claude   # Supported values: claude | codex | opencode | hermes | gemini | kiro | copilot | pi | gjc | antigravity | grok
+  runtime_backend: claude   # Supported values: claude | codex | opencode | hermes | gemini | kiro | copilot | pi | gjc | antigravity | grok | zcode
                             # The runtime abstraction layer also accepts custom
                             # adapters registered in runtime_factory.py
 ```
@@ -26,7 +26,7 @@ ouroboros run workflow --runtime codex seed.yaml
 
 You can also override the configured backend with the `OUROBOROS_AGENT_RUNTIME` environment variable.
 
-> **Extensibility:** Ouroboros uses a pluggable `AgentRuntime` protocol. Claude Code, Codex CLI, OpenCode, Hermes, Gemini CLI, Kiro CLI, GitHub Copilot CLI, Pi CLI, GJC, the Antigravity CLI (`agy`, Google's Gemini-CLI successor — runtime-only), and the Grok Build CLI (`grok`, xAI — runtime-only) are the natively shipped backends; additional runtimes can be registered by implementing the protocol and extending `runtime_factory.py`. See [Architecture — How to add a new runtime adapter](architecture.md#how-to-add-a-new-runtime-adapter). For the full contracts, see [runtime-guides/antigravity.md](runtime-guides/antigravity.md) and [runtime-guides/grok.md](runtime-guides/grok.md).
+> **Extensibility:** Ouroboros uses a pluggable `AgentRuntime` protocol. Claude Code, Codex CLI, OpenCode, Hermes, Gemini CLI, Kiro CLI, GitHub Copilot CLI, Pi CLI, GJC, Antigravity (`agy`), Grok Build (`grok`), and Zcode (`zcode`) are natively shipped backends. Antigravity, Grok, and Zcode are runtime-only. Additional runtimes can be registered by implementing the protocol and extending `runtime_factory.py`. See [Architecture - How to add a new runtime adapter](architecture.md#how-to-add-a-new-runtime-adapter).
 
 ## Capability Matrix
 
@@ -34,7 +34,8 @@ You can also override the configured backend with the `OUROBOROS_AGENT_RUNTIME` 
 > predate the runtime-only backends added more recently. Their per-capability
 > contract lives in the per-runtime guide rather than as a column here:
 > Antigravity (`agy`) → [runtime-guides/antigravity.md](runtime-guides/antigravity.md);
-> Grok (`grok`) → [runtime-guides/grok.md](runtime-guides/grok.md).
+> Grok (`grok`) → [runtime-guides/grok.md](runtime-guides/grok.md);
+> Zcode (`zcode`) → [runtime-guides/zcode.md](runtime-guides/zcode.md).
 
 ### Workflow Layer (identical across runtimes)
 
@@ -208,6 +209,7 @@ The table below covers the currently shipped backends. Because Ouroboros uses a 
 | Have a GitHub Copilot subscription and want the live model picker       | Copilot CLI (`runtime_backend: copilot`)                                      |
 | Want to use the Pi coding agent through JSON mode                       | Pi CLI (`runtime_backend: pi`)                                                |
 | Want to use the GJC coding agent through RPC mode                       | GJC (`runtime_backend: gjc`)                                                 |
+| Want to use Z.ai's ZCode desktop coding agent                           | Zcode (`runtime_backend: zcode`)                                             |
 | Want to use Anthropic's Claude models                                  | Claude Code or Copilot CLI (Claude models exposed via Copilot subscription)   |
 | Want to use Google's Gemini models                                     | Gemini CLI                                                                   |
 | Want to use OpenAI's GPT models                                        | Codex CLI or Copilot CLI                                                      |
@@ -228,6 +230,7 @@ The table below covers the currently shipped backends. Because Ouroboros uses a 
 - [GitHub Copilot CLI runtime guide](runtime-guides/copilot.md)
 - [Pi CLI runtime guide](runtime-guides/pi.md)
 - [GJC runtime guide](runtime-guides/gjc.md)
+- [Zcode runtime guide](runtime-guides/zcode.md)
 - [Pi JSON mode documentation](https://pi.dev/docs/latest/json)
 - [Platform support matrix](platform-support.md) (OS and Python version compatibility)
 - [Architecture overview](architecture.md) — including [How to add a new runtime adapter](architecture.md#how-to-add-a-new-runtime-adapter)

--- a/docs/runtime-guides/skill-capability-guides.md
+++ b/docs/runtime-guides/skill-capability-guides.md
@@ -46,6 +46,7 @@ its rendered guide or a documented fallback.
 | Grok | No setup-owned capability artifact yet | Known gap: Grok Build (the `grok` binary) can be selected as a runtime, but setup does not yet install a durable grok-owned instruction artifact. Use `render_backend_skill_capability_guide("grok")` when building Grok prompts until a stable artifact surface exists. |
 | Goose | No setup-owned capability artifact yet | Known gap: setup can select Goose as a runtime, but no durable Goose instruction surface or Goose-specific `SkillExecutionCapability` entries are registered yet. Keep skill requirements runtime-neutral and rely on runtime-local operator guidance until a Goose artifact installer exists. |
 | Pi | No setup-owned capability artifact yet | Known gap: Pi has generic rendered capability guidance in the registry, but setup does not yet install it into a durable Pi-owned instruction artifact. Use `render_backend_skill_capability_guide("pi")` when building Pi prompts until a stable artifact surface exists. |
+| Zcode | No setup-owned capability artifact yet | Known gap: Zcode (Z.ai GLM-5 agent, the `zcode` CLI) can be selected as a runtime, but setup does not yet install a durable zcode-owned instruction artifact. Use `render_backend_skill_capability_guide("zcode")` when building Zcode prompts until a stable artifact surface exists. |
 
 ## Seed generation client-gate enforcement
 

--- a/docs/runtime-guides/zcode.md
+++ b/docs/runtime-guides/zcode.md
@@ -1,0 +1,155 @@
+# Zcode CLI Runtime
+
+Run Ouroboros workflows through Z.ai's locally installed ZCode coding agent.
+The runtime supports either the macOS app-bundle `zcode.cjs` entry script or a
+`zcode` executable available on `PATH`.
+
+> The vendor does not currently publish a stable CLI or JSON-output contract.
+> This adapter is pinned to behavior measured from Zcode CLI 0.15.0 and 0.15.2
+> and to the captured fixtures under `tests/fixtures/zcode/`. Treat ZCode
+> application upgrades as compatibility events and rerun the Zcode runtime
+> tests after an upgrade.
+
+## Prerequisites
+
+| Requirement | Why |
+| --- | --- |
+| ZCode desktop app or `zcode` executable | Provides the coding-agent runtime |
+| A configured Z.ai provider/model | Zcode reads provider and model selection from its own config |
+| Compatible Node.js for a standalone `.cjs` path | Official app bundles use their bundled Electron/Node runtime; standalone scripts use the system Node |
+| Ouroboros base package | No provider-specific Python extra is required |
+
+## Quick start
+
+```bash
+ouroboros setup --runtime zcode
+ouroboros run workflow seed.yaml --runtime zcode
+```
+
+If setup cannot find ZCode automatically, configure one of:
+
+```bash
+export OUROBOROS_ZCODE_CLI_PATH=/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs
+```
+
+```yaml
+orchestrator:
+  runtime_backend: zcode
+  zcode_cli_path: /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs
+```
+
+## CLI path resolution
+
+The runtime resolves the CLI in this order:
+
+1. Constructor argument `cli_path=...`
+2. `OUROBOROS_ZCODE_CLI_PATH`
+3. `orchestrator.zcode_cli_path` in `~/.ouroboros/config.yaml`
+4. `/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs`
+5. `zcode` on `PATH`
+
+Official app bundles include `.node-bundle-meta.json` with
+`runtime: electron-node`. Ouroboros reads that metadata, launches
+`ZCode.app/Contents/MacOS/ZCode`, and sets `ELECTRON_RUN_AS_NODE=1`, matching
+ZCode's own launcher. A configured script inside a `.app` bundle fails closed
+when the metadata, plist, or bundled executable is missing or invalid; it never
+falls back to an unrelated system Node. Standalone `.cjs`, `.js`, or `.mjs`
+paths use the system Node.js. Other paths are treated as executable wrappers or
+binaries and are invoked directly. `NODE_OPTIONS` is removed from both Node
+launch shapes so a project or parent process cannot preload JavaScript into the
+vendor CLI.
+
+## Runtime-only backend
+
+Zcode drives agentic execution but is not an Ouroboros LLM-completion backend.
+Keep a completion-capable value such as `claude_code`, `codex`, or `litellm` in
+`llm.backend` for interview, seed generation, evaluation, and QA handlers.
+Direct `ZcodeCLIRuntime` construction defaults those auxiliary calls to
+`claude_code`, matching the other runtime-only adapters.
+
+## Headless contract
+
+For an official macOS app-bundle script, each task uses this command shape:
+
+```text
+ELECTRON_RUN_AS_NODE=1 <ZCode.app/Contents/MacOS/ZCode> <zcode.cjs> \
+  --json \
+  --prompt <PROMPT> \
+  --mode <edit|yolo> \
+  [--cwd <PATH>] \
+  [--resume <SESSION_ID>]
+```
+
+The measured `--json` behavior is one pretty-printed summary object emitted at
+the end of the turn, not an NDJSON event stream. The runtime reassembles stdout
+before parsing it and maps the top-level `response` to one terminal assistant
+message. The top-level `sessionId` becomes the resume handle.
+
+## Live compatibility evidence
+
+The official notarized macOS ARM packages were exercised end to end with a
+local OpenAI-compatible model endpoint, so the vendor process, streaming model
+adapter, JSON summary, persisted session, and `--resume` path were all real:
+
+| ZCode app | CLI | Result |
+| --- | --- | --- |
+| 3.2.5 | 0.15.0 | Headless JSON response and same-session resume passed |
+| 3.3.5 | 0.15.2 | Headless JSON response and same-session resume passed |
+
+Both bundles declare `runtime: electron-node` and include Electron 41 / Node
+24. Running their `zcode.cjs` directly with Node 20 fails on the vendor's
+`node:sqlite` import; the app-bundle launcher selection above prevents that
+environment-dependent failure.
+
+The adapter does not emit `--non-interactive`, `--approval-mode`, or `--model`.
+Those are not accepted Zcode 0.15.0 or 0.15.2 flags. Model selection remains in
+Zcode's own configuration, including `~/.zcode/cli/config.json` `model.main`.
+
+## Permission mapping
+
+| Ouroboros mode | Zcode `--mode` | Behavior |
+| --- | --- | --- |
+| `acceptEdits` | `edit` | Default non-interactive edit mode |
+| `bypassPermissions` | `yolo` | Explicit full bypass |
+| `default` | `edit` | Normalized to the safe non-interactive default |
+
+## Buffered-output timeout behavior
+
+Zcode stays silent until its final JSON summary is ready. The inherited
+60-second first-output watchdog is therefore disabled by default because it
+would otherwise become a 60-second total-task limit. Callers that require a
+no-output deadline can pass `startup_output_timeout_seconds` explicitly.
+
+This is an operational tradeoff: without an explicit outer deadline, a vendor
+process that never emits its summary can remain pending. Production callers
+should retain their workflow-level deadline or configure a suitable startup
+output timeout for their expected task duration.
+
+## Capabilities and limits
+
+| Capability | Status |
+| --- | --- |
+| Headless execution | Yes, via `--prompt --json` |
+| Structured final output | Yes, one summary object per turn |
+| Intermediate tool events | No, not present in measured stdout |
+| Targeted session resume | Yes, via `--resume <sessionId>` |
+| Per-call model override | No, model selection is Zcode-owned |
+| LLM-completion backend | No, runtime-only |
+| Setup-owned instruction artifact | No, capability guide rendering is the fallback |
+
+## Troubleshooting
+
+**Zcode is not detected.** Set `OUROBOROS_ZCODE_CLI_PATH`, configure
+`orchestrator.zcode_cli_path`, or put a `zcode` executable on `PATH`.
+
+**A standalone script reports a missing Node built-in such as `node:sqlite`.**
+Use the intact ZCode app-bundle path so Ouroboros can select the bundled
+Electron/Node runtime, install a Node version compatible with that Zcode build,
+or configure a directly executable `zcode` wrapper.
+
+**A model override has no effect.** Zcode has no per-invocation `--model`
+flag. Select the model in ZCode's own provider/model configuration.
+
+**Parsing breaks after a ZCode update.** Run
+`tests/unit/orchestrator/test_zcode_cli_runtime.py` and recapture the vendor
+summary fixture before changing the parser contract.

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -522,9 +522,9 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         soft_tool_enforcement=True,
     ),
     BackendCapability(
-        # Zcode (Z.ai GLM-5.x desktop agent) — the ``zcode.cjs`` script run as
-        # ``node zcode.cjs --prompt --json`` drives the agentic orchestrator
-        # runtime with a single JSON summary. Runtime-only: it does not back
+        # Zcode (Z.ai GLM-5.x desktop agent) — the app-bundle ``zcode.cjs``
+        # script runs through ZCode's bundled Electron/Node runtime and emits
+        # one JSON summary. Runtime-only: it does not back
         # structured LLM completions or auto-interview answering (no LLM
         # adapter factory), matching the antigravity/grok runtime-only contract.
         name="zcode",

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -436,11 +436,16 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         soft_tool_enforcement=True,
     ),
     BackendCapability(
+        # Zcode (Z.ai GLM-5.x desktop agent) — the ``zcode.cjs`` script run as
+        # ``node zcode.cjs --prompt --json`` drives the agentic orchestrator
+        # runtime with a single JSON summary. Runtime-only: it does not back
+        # structured LLM completions or auto-interview answering (no LLM
+        # adapter factory), matching the antigravity/grok runtime-only contract.
         name="zcode",
         aliases=("zcode_cli",),
         supports_runtime=True,
-        supports_llm=True,
-        supports_interview_driver=True,
+        supports_llm=False,
+        supports_interview_driver=False,
         switchable_runtime=True,
         cli_name="zcode",
         cli_config_key="zcode_cli_path",

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -436,6 +436,18 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         soft_tool_enforcement=True,
     ),
     BackendCapability(
+        name="zcode",
+        aliases=("zcode_cli",),
+        supports_runtime=True,
+        supports_llm=True,
+        supports_interview_driver=True,
+        switchable_runtime=True,
+        cli_name="zcode",
+        cli_config_key="zcode_cli_path",
+        skill_execution_capabilities=_GENERIC_SKILL_EXECUTION_CAPABILITIES,
+        soft_tool_enforcement=True,
+    ),
+    BackendCapability(
         name="hermes",
         aliases=("hermes_cli",),
         supports_runtime=True,

--- a/src/ouroboros/backends/capabilities.py
+++ b/src/ouroboros/backends/capabilities.py
@@ -355,6 +355,92 @@ _OPENCODE_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
     ),
 )
 
+# Zcode (Z.ai GLM desktop CLI) — a complete, measured skill-execution matrix
+# rather than the generic defaults. Each capability below maps onto a Zcode
+# mechanism verified against `zcode --help`, `zcode skills list`, and captured
+# `--prompt --json` summaries. Two generic capabilities are intentionally
+# omitted because the runtime cannot truthfully provide them on the headless
+# `--prompt` path the orchestrator drives:
+#   - ``ask_user``: ``zcode --prompt`` is a headless one-shot with no TTY and
+#     no user turn-taking; the TUI exposes interaction, but the orchestrator
+#     runtime never enters it. Declaring it would overstate the surface.
+#   - ``orchestrate_subagents``: Zcode has no native parallel subagent
+#     primitive (``/expert`` is a sequential workflow); subagent dispatch
+#     resolves to the sequential contract, so it is not declared as a
+#     capability here.
+_ZCODE_SKILL_EXECUTION_CAPABILITIES: tuple[SkillExecutionCapability, ...] = (
+    SkillExecutionCapability(
+        name="inspect_code",
+        guidance=(
+            "Zcode reads files with its built-in tools under the active `--mode` "
+            "(build = read-only, edit = read/write, yolo = full). Prefer its "
+            "local file search/read over inference."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="call_mcp",
+        guidance=(
+            "Zcode exposes MCP via the `/mcp` slash surface and the stdio "
+            "`app-server`; call Ouroboros MCP tools through that surface rather "
+            "than emulating MCP workflows manually."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="run_lateral_review",
+        guidance=(
+            "Within a single `--prompt` turn, run researcher, contrarian, and "
+            "simplifier perspectives before collapsing the result into concise "
+            "choices or a recommended draft."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="web_research",
+        guidance=(
+            "Zcode reports `webFetchRequests`/`webSearchRequests` in its JSON "
+            "summary; use its web capability only when current external facts "
+            "are required, and cite the sources used."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="run_shell",
+        guidance=(
+            "Zcode gates shell execution by `--mode`; destructive commands "
+            "require `yolo`. Avoid destructive commands unless explicitly "
+            "authorized."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="refine_answer",
+        guidance=(
+            "Confirm structured interpretations of free-text decisions before "
+            "forwarding them to workflow state."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="maintain_ledger",
+        guidance=(
+            "Keep ambiguity, gates, and unresolved decisions visible in the "
+            "session; Zcode's `/compact [instructions]` preserves intent across "
+            "compaction."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="run_closure_gate",
+        guidance=(
+            "Audit required client-side gates even when an MCP response says "
+            "the workflow is ready to proceed."
+        ),
+    ),
+    SkillExecutionCapability(
+        name="restate_goal",
+        guidance=(
+            "Zcode holds the session goal natively (`--target`, `/goal`) rather "
+            "than only in prompt text; restating the goal maps onto that held "
+            "goal so Zcode can reference it across the run."
+        ),
+    ),
+)
+
 _CAPABILITIES: tuple[BackendCapability, ...] = (
     BackendCapability(
         name="claude",
@@ -449,7 +535,7 @@ _CAPABILITIES: tuple[BackendCapability, ...] = (
         switchable_runtime=True,
         cli_name="zcode",
         cli_config_key="zcode_cli_path",
-        skill_execution_capabilities=_GENERIC_SKILL_EXECUTION_CAPABILITIES,
+        skill_execution_capabilities=_ZCODE_SKILL_EXECUTION_CAPABILITIES,
         soft_tool_enforcement=True,
     ),
     BackendCapability(

--- a/src/ouroboros/backends/factory_registry.py
+++ b/src/ouroboros/backends/factory_registry.py
@@ -109,6 +109,11 @@ _FACTORY_SPECS: tuple[BackendFactorySpec, ...] = (
         agent_runtime_factory="_create_grok_runtime",
     ),
     BackendFactorySpec(
+        name="zcode",
+        runtime_backend="zcode",
+        agent_runtime_factory="_create_zcode_runtime",
+    ),
+    BackendFactorySpec(
         name="ourocode",
         llm_backend="ourocode",
         llm_adapter_factory="_create_ourocode_adapter",

--- a/src/ouroboros/backends/model_catalog.py
+++ b/src/ouroboros/backends/model_catalog.py
@@ -37,7 +37,18 @@ from ouroboros.config._model_defaults import DEFAULT_OPUS_MODEL, DEFAULT_SONNET_
 # than a Claude model id. Mirrors the loader's sentinel frozensets
 # (_CODEX_LLM_BACKENDS et al.); the mirror is locked by a unit test.
 _SENTINEL_MODEL_BACKENDS = frozenset(
-    {"codex", "opencode", "kiro", "copilot", "hermes", "pi", "gjc", "antigravity", "grok"}
+    {
+        "codex",
+        "opencode",
+        "kiro",
+        "copilot",
+        "hermes",
+        "pi",
+        "gjc",
+        "antigravity",
+        "grok",
+        "zcode",
+    }
 )
 
 # The sentinel the loader maps Claude-incapable backends to.
@@ -240,6 +251,12 @@ _CLI_PATH_GETTERS: dict[str, str] = {
     "antigravity": "get_antigravity_cli_path",
     "grok": "get_grok_cli_path",
     "ourocode": "get_ourocode_cli_path",
+    # Zcode is runtime-only and Claude-incapable (runs Z.ai GLM-5). Its CLI
+    # path is resolved exactly like the other runtime-only CLIs above: env
+    # / config / macOS app-bundle default, via ``get_zcode_cli_path``.
+    # Without this entry, ``detect_backend_cli("zcode")`` ignored the
+    # configured path and Zcode was invisible to ``installed_backends()``.
+    "zcode": "get_zcode_cli_path",
 }
 
 

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -122,6 +122,7 @@ class AgentRuntimeBackend(str, Enum):  # noqa: UP042
     GJC = "gjc"
     ANTIGRAVITY = "antigravity"
     GROK = "grok"
+    ZCODE = "zcode"
 
 
 app = typer.Typer(

--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -389,9 +389,7 @@ def show(
 def backend(
     new_backend: Annotated[
         str | None,
-        typer.Argument(
-            help="Backend to switch to (claude, codex, hermes, gemini, gjc, goose, pi)."
-        ),
+        typer.Argument(help=f"Backend to switch to ({', '.join(_SWITCHABLE_BACKENDS)})."),
     ] = None,
 ) -> None:
     """Show or switch the runtime backend.
@@ -410,6 +408,7 @@ def backend(
     [dim]    ouroboros config backend gjc       # switch to GJC[/dim]
     [dim]    ouroboros config backend goose     # switch to Goose[/dim]
     [dim]    ouroboros config backend pi        # switch to Pi CLI[/dim]
+    [dim]    ouroboros config backend zcode     # switch to Zcode[/dim]
     """
     data, config_path = _load_config()
     current = data.get("orchestrator", {}).get("runtime_backend", "unknown")

--- a/src/ouroboros/cli/commands/config.py
+++ b/src/ouroboros/cli/commands/config.py
@@ -422,7 +422,7 @@ def backend(
             console.print(f"[bold]CLI path:[/bold]        [dim]{cli_path}[/dim]")
         console.print(
             "\n[dim]Switch with: ouroboros config backend "
-            "<claude|codex|hermes|gemini|gjc|goose|pi>[/dim]\n"
+            "<claude|codex|hermes|gemini|gjc|goose|pi|antigravity|grok|zcode>[/dim]\n"
         )
         return
 
@@ -470,6 +470,10 @@ def backend(
         from ouroboros.config import get_grok_cli_path
 
         cli_path = get_grok_cli_path()
+    elif new_backend == "zcode":
+        from ouroboros.config import get_zcode_cli_path
+
+        cli_path = get_zcode_cli_path()
     if not cli_path:
         cli_path = shutil.which(cli_name)
     if not cli_path:
@@ -497,6 +501,12 @@ def backend(
                 "Set OUROBOROS_PI_CLI_PATH, configure orchestrator.pi_cli_path "
                 "in config.yaml, or install pi on PATH and retry."
             )
+        elif new_backend == "zcode":
+            print_error(
+                "zcode CLI not found.\n"
+                "Set OUROBOROS_ZCODE_CLI_PATH, configure orchestrator.zcode_cli_path "
+                "in config.yaml, install ZCode, or put zcode on PATH and retry."
+            )
         else:
             print_error(f"{cli_name} CLI not found in PATH.\nInstall it first, then retry.")
         raise typer.Exit(1)
@@ -517,6 +527,7 @@ def backend(
         _setup_grok,
         _setup_hermes,
         _setup_pi,
+        _setup_zcode,
     )
 
     _setup_had_errors = False
@@ -550,6 +561,8 @@ def backend(
             _setup_antigravity(cli_path)
         elif new_backend == "grok":
             _setup_grok(cli_path)
+        elif new_backend == "zcode":
+            _setup_zcode(cli_path)
     except Exception as exc:
         setup_failed = True
         console.quiet = prev_quiet

--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -74,6 +74,7 @@ class AgentRuntimeBackend(str, Enum):  # noqa: UP042
     GJC = "gjc"
     ANTIGRAVITY = "antigravity"
     GROK = "grok"
+    ZCODE = "zcode"
 
 
 class LLMBackend(str, Enum):  # noqa: UP042

--- a/src/ouroboros/cli/commands/mcp.py
+++ b/src/ouroboros/cli/commands/mcp.py
@@ -73,6 +73,7 @@ class AgentRuntimeBackend(str, Enum):  # noqa: UP042
     GJC = "gjc"
     ANTIGRAVITY = "antigravity"
     GROK = "grok"
+    ZCODE = "zcode"
 
 
 class LLMBackend(str, Enum):  # noqa: UP042

--- a/src/ouroboros/cli/commands/run.py
+++ b/src/ouroboros/cli/commands/run.py
@@ -125,6 +125,7 @@ class AgentRuntimeBackend(str, Enum):  # noqa: UP042
     GJC = "gjc"
     ANTIGRAVITY = "antigravity"
     GROK = "grok"
+    ZCODE = "zcode"
 
 
 def _derive_quality_bar(seed: "Seed") -> str:

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -264,6 +264,15 @@ def _detect_runtimes() -> dict[str, str | None]:
         grok_path = None
     runtimes["grok"] = grok_path or shutil.which("grok")
 
+    # Zcode: app-bundle/config path first, then a PATH wrapper/binary.
+    try:
+        from ouroboros.config import get_zcode_cli_path
+
+        zcode_path = get_zcode_cli_path()
+    except Exception:
+        zcode_path = None
+    runtimes["zcode"] = zcode_path or shutil.which("zcode")
+
     return runtimes
 
 
@@ -2131,7 +2140,7 @@ def _setup_gemini(gemini_path: str) -> None:
 
 
 def _setup_runtime_only_backend(backend: str, cli_path: str, cli_config_key: str) -> None:
-    """Configure a runtime-only backend (Antigravity / Grok).
+    """Configure a runtime-only backend (Antigravity / Grok / Zcode).
 
     These backends drive the agentic orchestrator runtime but have no
     LLM-completion adapter (``supports_llm=False``), so this intentionally sets
@@ -2179,6 +2188,11 @@ def _setup_antigravity(antigravity_path: str) -> None:
 def _setup_grok(grok_path: str) -> None:
     """Configure Ouroboros for the Grok Build CLI (``grok``) runtime."""
     _setup_runtime_only_backend("grok", grok_path, "grok_cli_path")
+
+
+def _setup_zcode(zcode_path: str) -> None:
+    """Configure Ouroboros for the Zcode CLI runtime."""
+    _setup_runtime_only_backend("zcode", zcode_path, "zcode_cli_path")
 
 
 def _setup_pi(pi_path: str) -> None:
@@ -3002,7 +3016,7 @@ def setup(
         typer.Option(
             "--runtime",
             "-r",
-            help="Runtime backend to configure (claude, codex, opencode, hermes, gemini, goose, kiro, copilot, pi, gjc).",
+            help="Runtime backend to configure (claude, codex, opencode, hermes, gemini, goose, kiro, copilot, pi, gjc, antigravity, grok, zcode).",
         ),
     ] = None,
     non_interactive: Annotated[
@@ -3029,7 +3043,7 @@ def setup(
 ) -> None:
     """Set up Ouroboros for your environment.
 
-    Detects available runtimes (Claude Code, Codex, OpenCode, Hermes, Gemini, Kiro, Copilot, Goose, Pi, GJC)
+    Detects available runtimes (Claude Code, Codex, OpenCode, Hermes, Gemini, Kiro, Copilot, Goose, Pi, GJC, Antigravity, Grok, Zcode)
     and configures Ouroboros to use the selected backend.
 
     [dim]Examples:[/dim]
@@ -3043,6 +3057,7 @@ def setup(
     [dim]    ouroboros setup --runtime pi         # use Pi CLI[/dim]
     [dim]    ouroboros setup --runtime goose      # use Goose[/dim]
     [dim]    ouroboros setup --runtime gjc        # use GJC[/dim]
+    [dim]    ouroboros setup --runtime zcode      # use Zcode[/dim]
     [dim]    ouroboros setup scan               # scan brownfield repos[/dim]
     [dim]    ouroboros setup list               # list brownfield repos[/dim]
     [dim]    ouroboros setup default            # toggle default repos[/dim]
@@ -3259,6 +3274,16 @@ def setup(
             )
             raise typer.Exit(1)
         _setup_grok(grok_path)
+    elif selected in ("zcode", "zcode_cli"):
+        zcode_path = available.get("zcode")
+        if not zcode_path:
+            print_error(
+                "Zcode CLI not found.\n"
+                "Install ZCode, set OUROBOROS_ZCODE_CLI_PATH, configure "
+                "orchestrator.zcode_cli_path, or put a zcode executable on PATH."
+            )
+            raise typer.Exit(1)
+        _setup_zcode(zcode_path)
     else:
         print_error(f"Unsupported runtime: {selected}")
         raise typer.Exit(1)

--- a/src/ouroboros/config/__init__.py
+++ b/src/ouroboros/config/__init__.py
@@ -75,6 +75,7 @@ from ouroboros.config.loader import (
     get_semantic_model,
     get_usage_limit_pause_seconds,
     get_wonder_model,
+    get_zcode_cli_path,
     load_config,
     load_credentials,
 )
@@ -171,6 +172,7 @@ __all__ = [
     "get_opencode_mode",
     "get_ourocode_cli_path",
     "get_pi_cli_path",
+    "get_zcode_cli_path",
     "get_qa_model",
     "get_dependency_analysis_model",
     "get_ontology_analysis_model",

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -31,6 +31,7 @@ Functions:
     get_opencode_cli_path: Get OpenCode CLI path from env var or config
     get_hermes_cli_path: Get Hermes CLI path from env var or config
     get_goose_cli_path: Get Goose CLI path from env var or config
+    get_zcode_cli_path: Get zcode CLI path from env var or config
 """
 
 import ast
@@ -183,6 +184,7 @@ _UNTRUSTED_ENV_DENYLIST = frozenset(
         "OUROBOROS_ANTIGRAVITY_CLI_PATH",
         "OUROBOROS_GROK_CLI_PATH",
         "OUROBOROS_OUROCODE_CLI_PATH",
+        "OUROBOROS_ZCODE_CLI_PATH",
         # Bare provider aliases (no OUROBOROS_ prefix) that adapters also
         # honor and then execute. Any new such alias MUST be added here:
         # `opencode_config._configured_opencode_cli_path` reads
@@ -1542,6 +1544,49 @@ def get_grok_cli_path() -> str | None:
                 return resolved
     except ConfigError:
         pass
+
+    return None
+
+
+def get_zcode_cli_path() -> str | None:
+    """Get the zcode CLI path (Z.ai GLM-5 agent) from environment or config.
+
+    Priority:
+        1. OUROBOROS_ZCODE_CLI_PATH environment variable
+        2. config.yaml orchestrator.zcode_cli_path
+        3. macOS app-bundle default (/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs)
+        4. None (resolve from PATH at runtime)
+
+    The zcode CLI is executed via Node.js: the returned path should point to the
+    zcode.cjs script, and the runtime wrapper will invoke it as ``node <cli_path>``.
+
+    Stale env var / config values that don't point to an executable file are
+    treated as missing so callers can fall back to PATH discovery instead of
+    persisting an unusable path.
+
+    Returns:
+        Path to the zcode CLI script or None.
+    """
+    env_path = os.environ.get("OUROBOROS_ZCODE_CLI_PATH", "").strip()
+    if env_path:
+        resolved = str(Path(env_path).expanduser())
+        if Path(resolved).is_file():
+            return resolved
+
+    try:
+        config = load_config()
+        zcode_path = getattr(config.orchestrator, "zcode_cli_path", None)
+        if zcode_path:
+            resolved = str(Path(zcode_path).expanduser())
+            if Path(resolved).is_file():
+                return resolved
+    except ConfigError:
+        pass
+
+    # macOS app-bundle default
+    macos_bundle_path = Path("/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs")
+    if macos_bundle_path.is_file():
+        return str(macos_bundle_path)
 
     return None
 

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -87,6 +87,10 @@ _ANTIGRAVITY_LLM_BACKENDS = frozenset({"antigravity", "agy"})
 # Grok models, so generic Claude default ids map to the CLI's own configured
 # default (the "default" sentinel).
 _GROK_LLM_BACKENDS = frozenset({"grok", "grok_cli", "grok_build"})
+# Zcode (Z.ai GLM-5) is runtime-only and Claude-incapable: it runs its own
+# configured default model, so generic Claude default ids map to the CLI's
+# own ``"default"`` sentinel, exactly like antigravity and grok above.
+_ZCODE_LLM_BACKENDS = frozenset({"zcode", "zcode_cli"})
 _OPENCODE_BACKENDS = frozenset({"opencode", "opencode_cli"})
 _CODEX_DEFAULT_MODEL = "default"
 _KIRO_DEFAULT_MODEL = "default"
@@ -96,6 +100,7 @@ _PI_DEFAULT_MODEL = "default"
 _GJC_DEFAULT_MODEL = "default"
 _ANTIGRAVITY_DEFAULT_MODEL = "default"
 _GROK_DEFAULT_MODEL = "default"
+_ZCODE_DEFAULT_MODEL = "default"
 _PLACEHOLDER_API_KEY_PREFIX = "YOUR_"
 _PLACEHOLDER_API_KEY_SUFFIX = "_API_KEY"
 _DEFAULT_MAX_PARALLEL_WORKERS = 3
@@ -1949,6 +1954,8 @@ def _default_model_for_backend(
         return _ANTIGRAVITY_DEFAULT_MODEL
     if resolved in _GROK_LLM_BACKENDS:
         return _GROK_DEFAULT_MODEL
+    if resolved in _ZCODE_LLM_BACKENDS:
+        return _ZCODE_DEFAULT_MODEL
     return default_model
 
 
@@ -1999,6 +2006,8 @@ def _normalize_configured_model_for_backend(
         return _ANTIGRAVITY_DEFAULT_MODEL
     if resolved in _GROK_LLM_BACKENDS and is_shipped_default:
         return _GROK_DEFAULT_MODEL
+    if resolved in _ZCODE_LLM_BACKENDS and is_shipped_default:
+        return _ZCODE_DEFAULT_MODEL
 
     return candidate
 

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -91,6 +91,7 @@ _GROK_LLM_BACKENDS = frozenset({"grok", "grok_cli", "grok_build"})
 # configured default model, so generic Claude default ids map to the CLI's
 # own ``"default"`` sentinel, exactly like antigravity and grok above.
 _ZCODE_LLM_BACKENDS = frozenset({"zcode", "zcode_cli"})
+_ZCODE_SCRIPT_SUFFIXES = frozenset({".cjs", ".js", ".mjs"})
 _OPENCODE_BACKENDS = frozenset({"opencode", "opencode_cli"})
 _CODEX_DEFAULT_MODEL = "default"
 _KIRO_DEFAULT_MODEL = "default"
@@ -1558,6 +1559,16 @@ def get_grok_cli_path() -> str | None:
     return None
 
 
+def _is_runnable_zcode_cli_path(path: str | Path) -> bool:
+    """Whether *path* matches one of the supported Zcode launch shapes."""
+    candidate = Path(path)
+    if not candidate.is_file():
+        return False
+    if candidate.suffix.lower() in _ZCODE_SCRIPT_SUFFIXES:
+        return os.access(candidate, os.R_OK)
+    return shutil.which(str(candidate.resolve())) is not None
+
+
 def get_zcode_cli_path() -> str | None:
     """Get the zcode CLI path (Z.ai GLM-5 agent) from environment or config.
 
@@ -1572,9 +1583,10 @@ def get_zcode_cli_path() -> str | None:
     ``electron-node`` runtime in sibling metadata; the runtime wrapper then
     uses ZCode's bundled Electron/Node executable instead of the system Node.
 
-    Stale env var / config values that don't point to an executable file are
-    treated as missing so callers can fall back to PATH discovery instead of
-    persisting an unusable path.
+    Stale env var / config values that don't point to a readable JavaScript
+    entry script or a directly executable wrapper are treated as missing, so
+    callers can fall back to PATH discovery instead of persisting an unusable
+    path.
 
     Returns:
         Path to the zcode CLI script or None.
@@ -1582,7 +1594,7 @@ def get_zcode_cli_path() -> str | None:
     env_path = os.environ.get("OUROBOROS_ZCODE_CLI_PATH", "").strip()
     if env_path:
         resolved = str(Path(env_path).expanduser())
-        if Path(resolved).is_file():
+        if _is_runnable_zcode_cli_path(resolved):
             return resolved
 
     try:
@@ -1590,14 +1602,14 @@ def get_zcode_cli_path() -> str | None:
         zcode_path = getattr(config.orchestrator, "zcode_cli_path", None)
         if zcode_path:
             resolved = str(Path(zcode_path).expanduser())
-            if Path(resolved).is_file():
+            if _is_runnable_zcode_cli_path(resolved):
                 return resolved
     except ConfigError:
         pass
 
     # macOS app-bundle default
     macos_bundle_path = Path("/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs")
-    if macos_bundle_path.is_file():
+    if _is_runnable_zcode_cli_path(macos_bundle_path):
         return str(macos_bundle_path)
 
     return None

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -155,7 +155,7 @@ def _is_placeholder_api_key(value: str) -> bool:
 # Environment variables that determine HOW Ouroboros executes work. This
 # is the single authoritative trust boundary: a cloned repository's `.env`
 # must not be able to change which binary runs or whether the user's
-# approval gate applies. Three classes, all remote-code-execution sinks
+# approval gate applies. Four classes, all remote-code-execution sinks
 # when sourced from an untrusted location:
 #   1. Explicit CLI path overrides fed straight into a subprocess.
 #   2. Runtime/backend selectors that pick which adapter (and therefore
@@ -164,6 +164,8 @@ def _is_placeholder_api_key(value: str) -> bool:
 #   3. Permission-mode overrides — setting acceptEdits/bypassPermissions
 #      silently removes the human approval gate, letting a malicious repo
 #      auto-approve arbitrary tool calls (effectively RCE).
+#   4. Runtime-native preload hooks such as NODE_OPTIONS, which can execute
+#      attacker-controlled code before a spawned JavaScript CLI starts.
 # These keys are only honored from trusted sources (the real process
 # environment, ~/.ouroboros/.env, ~/.ouroboros/config.yaml), never from
 # the project-directory .env that travels with a cloned repo. Trusted .env
@@ -175,6 +177,9 @@ _UNTRUSTED_ENV_DENYLIST = frozenset(
     {
         # Search PATH used by shutil.which()/bare executable spawning.
         "PATH",
+        # Node/Electron preload hook. A project .env could otherwise inject a
+        # --require/--import payload before a spawned JavaScript CLI starts.
+        "NODE_OPTIONS",
         # Explicit executable-path overrides.
         "OUROBOROS_CLI_PATH",
         "OUROBOROS_CODEX_CLI_PATH",
@@ -1562,8 +1567,10 @@ def get_zcode_cli_path() -> str | None:
         3. macOS app-bundle default (/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs)
         4. None (resolve from PATH at runtime)
 
-    The zcode CLI is executed via Node.js: the returned path should point to the
-    zcode.cjs script, and the runtime wrapper will invoke it as ``node <cli_path>``.
+    The returned path may point to the app-bundle ``zcode.cjs`` script or to a
+    directly executable wrapper. Official macOS app bundles declare an
+    ``electron-node`` runtime in sibling metadata; the runtime wrapper then
+    uses ZCode's bundled Electron/Node executable instead of the system Node.
 
     Stale env var / config values that don't point to an executable file are
     treated as missing so callers can fall back to PATH discovery instead of

--- a/src/ouroboros/config/loader.py
+++ b/src/ouroboros/config/loader.py
@@ -1569,6 +1569,14 @@ def _is_runnable_zcode_cli_path(path: str | Path) -> bool:
     return shutil.which(str(candidate.resolve())) is not None
 
 
+def _canonical_zcode_cli_path(path: str | Path) -> str:
+    """Return a stable path that remains valid after the caller changes cwd."""
+    candidate = Path(path).expanduser()
+    if not candidate.is_absolute():
+        candidate = candidate.resolve()
+    return str(candidate)
+
+
 def get_zcode_cli_path() -> str | None:
     """Get the zcode CLI path (Z.ai GLM-5 agent) from environment or config.
 
@@ -1593,7 +1601,7 @@ def get_zcode_cli_path() -> str | None:
     """
     env_path = os.environ.get("OUROBOROS_ZCODE_CLI_PATH", "").strip()
     if env_path:
-        resolved = str(Path(env_path).expanduser())
+        resolved = _canonical_zcode_cli_path(env_path)
         if _is_runnable_zcode_cli_path(resolved):
             return resolved
 
@@ -1601,7 +1609,7 @@ def get_zcode_cli_path() -> str | None:
         config = load_config()
         zcode_path = getattr(config.orchestrator, "zcode_cli_path", None)
         if zcode_path:
-            resolved = str(Path(zcode_path).expanduser())
+            resolved = _canonical_zcode_cli_path(zcode_path)
             if _is_runnable_zcode_cli_path(resolved):
                 return resolved
     except ConfigError:

--- a/src/ouroboros/config/models.py
+++ b/src/ouroboros/config/models.py
@@ -529,9 +529,9 @@ class OrchestratorConfig(BaseModel, frozen=True):
             - ~ expansion: ~/.local/bin/grok
             - None: Resolve from PATH at runtime (or OUROBOROS_GROK_CLI_PATH)
         zcode_cli_path: Path to the Zcode CLI entry script (``zcode.cjs``).
-            The Zcode runtime launches the CLI via ``node <zcode_cli_path>``,
-            so this points at the app-bundle ``zcode.cjs`` script, not a bare
-            binary. Supports:
+            Official app-bundle scripts launch through ZCode's bundled
+            Electron/Node runtime; standalone scripts use the system Node.
+            Directly executable wrappers are also accepted. Supports:
             - Absolute path: /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs
             - ~ expansion supported
             - None: Resolve from config/env or fall back to the macOS app-bundle

--- a/src/ouroboros/config/models.py
+++ b/src/ouroboros/config/models.py
@@ -403,6 +403,8 @@ VALID_RUNTIME_BACKENDS = frozenset(
         "grok",
         "grok_cli",
         "grok_build",
+        "zcode",
+        "zcode_cli",
     }
 )
 
@@ -526,6 +528,14 @@ class OrchestratorConfig(BaseModel, frozen=True):
             - Absolute path: /path/to/grok
             - ~ expansion: ~/.local/bin/grok
             - None: Resolve from PATH at runtime (or OUROBOROS_GROK_CLI_PATH)
+        zcode_cli_path: Path to the Zcode CLI entry script (``zcode.cjs``).
+            The Zcode runtime launches the CLI via ``node <zcode_cli_path>``,
+            so this points at the app-bundle ``zcode.cjs`` script, not a bare
+            binary. Supports:
+            - Absolute path: /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs
+            - ~ expansion supported
+            - None: Resolve from config/env or fall back to the macOS app-bundle
+              default (or OUROBOROS_ZCODE_CLI_PATH)
         default_max_turns: Default max turns for agent execution
         max_parallel_workers: Default maximum concurrent AC workers
         usage_limit_pause_hours: Default pause window for provider usage/quota limits
@@ -554,6 +564,7 @@ class OrchestratorConfig(BaseModel, frozen=True):
         "gjc",
         "antigravity",
         "grok",
+        "zcode",
     ] = "claude"
     runtime_profile: RuntimeProfileConfig | None = None
 
@@ -595,6 +606,7 @@ class OrchestratorConfig(BaseModel, frozen=True):
     antigravity_cli_path: str | None = None
     grok_cli_path: str | None = None
     ourocode_cli_path: str | None = None
+    zcode_cli_path: str | None = None
     default_max_turns: int = Field(default=10, ge=1)
     max_parallel_workers: int = Field(default=3, ge=1)
     usage_limit_pause_hours: float = Field(default=5.0, gt=0.0)
@@ -617,6 +629,7 @@ class OrchestratorConfig(BaseModel, frozen=True):
         "antigravity_cli_path",
         "grok_cli_path",
         "ourocode_cli_path",
+        "zcode_cli_path",
     )
     @classmethod
     def expand_cli_path(cls, v: str | None) -> str | None:

--- a/src/ouroboros/orchestrator/__init__.py
+++ b/src/ouroboros/orchestrator/__init__.py
@@ -51,6 +51,7 @@ from ouroboros.orchestrator.gemini_cli_runtime import GeminiCLIRuntime
 from ouroboros.orchestrator.opencode_runtime import (
     OpenCodeRuntime,
 )
+from ouroboros.orchestrator.zcode_cli_runtime import ZcodeCLIRuntime
 
 try:
     from ouroboros.orchestrator.dependency_analyzer import (
@@ -159,6 +160,7 @@ __all__ = [
     "GeminiCLIRuntime",
     "KiroAgentAdapter",
     "OpenCodeRuntime",
+    "ZcodeCLIRuntime",
     "DEFAULT_TOOLS",
     "RuntimeHandle",
     "TaskResult",

--- a/src/ouroboros/orchestrator/adapter.py
+++ b/src/ouroboros/orchestrator/adapter.py
@@ -331,6 +331,8 @@ _RUNTIME_HANDLE_BACKEND_ALIASES = {
     "grok_cli": "grok_cli",
     "antigravity": "antigravity_cli",
     "antigravity_cli": "antigravity_cli",
+    "zcode": "zcode_cli",
+    "zcode_cli": "zcode_cli",
 }
 
 

--- a/src/ouroboros/orchestrator/runtime_factory.py
+++ b/src/ouroboros/orchestrator/runtime_factory.py
@@ -237,6 +237,8 @@ def _create_zcode_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
 
     return ZcodeCLIRuntime(
         cli_path=request.cli_path or get_zcode_cli_path(),
+        startup_output_timeout_seconds=request.startup_output_timeout_seconds,
+        stdout_idle_timeout_seconds=request.stdout_idle_timeout_seconds,
         **_runtime_kwargs(request),
     )
 

--- a/src/ouroboros/orchestrator/runtime_factory.py
+++ b/src/ouroboros/orchestrator/runtime_factory.py
@@ -21,6 +21,7 @@ from ouroboros.config import (
     get_llm_backend,
     get_opencode_stdout_idle_timeout_seconds,
     get_runtime_profile,
+    get_zcode_cli_path,
 )
 from ouroboros.orchestrator.adapter import AgentRuntime, ClaudeAgentAdapter
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
@@ -231,6 +232,16 @@ def _create_gjc_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
     )
 
 
+def _create_zcode_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
+    from ouroboros.config import get_zcode_cli_path
+    from ouroboros.orchestrator.zcode_cli_runtime import ZcodeCLIRuntime
+
+    return ZcodeCLIRuntime(
+        cli_path=request.cli_path or get_zcode_cli_path(),
+        **_runtime_kwargs(request),
+    )
+
+
 _AGENT_RUNTIME_FACTORIES: dict[str, Callable[[_AgentRuntimeRequest], AgentRuntime]] = {
     "_create_claude_runtime": _create_claude_runtime,
     "_create_codex_runtime": _create_codex_runtime,
@@ -246,6 +257,7 @@ _AGENT_RUNTIME_FACTORIES: dict[str, Callable[[_AgentRuntimeRequest], AgentRuntim
     "_create_goose_runtime": _create_goose_runtime,
     "_create_pi_runtime": _create_pi_runtime,
     "_create_gjc_runtime": _create_gjc_runtime,
+    "_create_zcode_runtime": _create_zcode_runtime,
 }
 
 

--- a/src/ouroboros/orchestrator/runtime_factory.py
+++ b/src/ouroboros/orchestrator/runtime_factory.py
@@ -233,7 +233,6 @@ def _create_gjc_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
 
 
 def _create_zcode_runtime(request: _AgentRuntimeRequest) -> AgentRuntime:
-    from ouroboros.config import get_zcode_cli_path
     from ouroboros.orchestrator.zcode_cli_runtime import ZcodeCLIRuntime
 
     return ZcodeCLIRuntime(

--- a/src/ouroboros/orchestrator/zcode_cli_runtime.py
+++ b/src/ouroboros/orchestrator/zcode_cli_runtime.py
@@ -4,7 +4,7 @@ This module provides the ZcodeCLIRuntime that shells out to the locally
 installed ``zcode`` CLI to execute agentic tasks.
 
 Usage:
-    runtime = ZcodeCLIRuntime(model="glm-5", cwd="/path/to/project")
+    runtime = ZcodeCLIRuntime(cwd="/path/to/project")
     async for message in runtime.execute_task("Fix the bug in auth.py"):
         print(message.content)
 
@@ -13,6 +13,16 @@ Custom CLI Path:
         runtime = ZcodeCLIRuntime(cli_path="/path/to/zcode")
         # or
         export OUROBOROS_ZCODE_CLI_PATH=/path/to/zcode
+
+Model selection:
+    zcode has **no** ``--model`` CLI flag (verified against ``zcode --help``
+    on 0.14.5 and 0.15.0 — passing ``--model`` is a hard ``Unknown option``
+    rejection, not a silent no-op). Model selection is done **outside** the
+    runtime, via the zcode config file ``~/.zcode/cli/config.json`` under
+    ``model.main``, or the interactive ``/model`` slash command. Any ``model``
+    value passed to the constructor is therefore intentionally ignored at the
+    CLI boundary — a warning is emitted when a non-default model is requested
+    so the misconfiguration (expected model vs. configured model) is visible.
 """
 
 from __future__ import annotations
@@ -89,6 +99,16 @@ class ZcodeCLIRuntime(CodexCliRuntime):
     _skills_package_uri = "packaged://ouroboros.zcode/skills"
     _process_shutdown_timeout_seconds = 5.0
     _max_resume_retries = 3  # Zcode CLI supports session resumption
+    # zcode ``--prompt --json`` buffers its whole summary until completion and
+    # stays silent until then — unlike Codex, which streams events continuously
+    # and resets the inherited "first chunk" watchdog on every chunk. The
+    # parent default of 60s would therefore cap the ENTIRE task at 60s on any
+    # caller that doesn't explicitly disable the guard (e.g. a direct
+    # ``create_agent_runtime(backend="zcode")``), killing healthy long runs as
+    # "produced no stdout". Disable it at the class level — callers that want
+    # a cap can still pass an explicit ``startup_output_timeout_seconds`` (the
+    # execute-seed path already passes ``0`` for the same reason).
+    _startup_output_timeout_seconds = None
 
     def __init__(
         self,
@@ -120,7 +140,14 @@ class ZcodeCLIRuntime(CodexCliRuntime):
                 config working. Falls back to ``acceptEdits`` when
                 omitted; operators must opt in to
                 ``bypassPermissions`` explicitly.
-            model: Optional model identifier.
+            model: Optional model identifier. **Ignored at the CLI
+                boundary** — zcode has no ``--model`` flag (passing one is
+                a hard ``Unknown option`` rejection, verified on 0.14.5 and
+                0.15.0). Set the model via ``~/.zcode/cli/config.json``
+                (``model.main``). A non-default value here emits a warning
+                so the divergence between the requested model and the
+                model zcode actually uses is visible; the value is never
+                forwarded to the subprocess.
             cwd: Optional working directory for the subprocess.
             skills_dir: Optional directory for skill definitions.
             skill_dispatcher: Optional handler for skill execution.
@@ -147,6 +174,21 @@ class ZcodeCLIRuntime(CodexCliRuntime):
             startup_output_timeout_seconds=startup_output_timeout_seconds,
             stdout_idle_timeout_seconds=stdout_idle_timeout_seconds,
         )
+        # zcode has no --model flag, so a non-default model requested here
+        # cannot reach the CLI. Surface it loudly rather than silently
+        # dropping it — the caller believes a specific model was selected
+        # when zcode will in fact use whatever ~/.zcode/cli/config.json
+        # declares. Only an explicit, non-default id triggers this.
+        requested_model = self._normalize_model(self._model)
+        if requested_model:
+            log.warning(
+                "zcode_cli_runtime.model_not_forwarded",
+                requested_model=self._model,
+                reason=(
+                    "zcode has no --model CLI flag; set model.main in "
+                    "~/.zcode/cli/config.json to select the model."
+                ),
+            )
 
     # -- Permission mode overrides -----------------------------------------
 
@@ -253,11 +295,17 @@ class ZcodeCLIRuntime(CodexCliRuntime):
         The builder distinguishes by extension: ``.cjs``/``.js``/``.mjs``
         scripts get the ``node`` prefix; everything else is invoked straight.
 
-        NOTE: zcode has **no** ``--non-interactive`` and **no**
-        ``--approval-mode`` flag (an earlier draft invented them by copying the
-        Codex adapter). ``--mode`` is the real permission surface, and
-        ``--prompt`` is already non-interactive (no TUI), so nothing else is
-        needed to keep the subprocess headless.
+        NOTE: zcode has **no** ``--non-interactive``, **no**
+        ``--approval-mode``, and **no** ``--model`` flag. The first two were
+        invented by an earlier draft copying the Codex adapter; ``--model``
+        was the last un-measured artifact copied from the same source —
+        verified absent on zcode 0.14.5 and 0.15.0, where ``--model`` is a
+        hard ``Unknown option`` rejection that aborts the run before zcode
+        does any work. ``--mode`` is the real permission surface, ``--prompt``
+        is already non-interactive (no TUI), and model selection lives in
+        ``~/.zcode/cli/config.json`` (``model.main``), never on the CLI. Do
+        not re-add ``--model`` here — :meth:`ZcodeCLIRuntime.__init__` warns
+        when a non-default model is requested so the gap is visible.
         """
         del runtime_handle, reasoning_effort
 
@@ -283,9 +331,6 @@ class ZcodeCLIRuntime(CodexCliRuntime):
         cwd = getattr(self, "_cwd", None)
         if cwd:
             command.extend(["--cwd", str(cwd)])
-        normalized_model = self._normalize_model(self._model)
-        if normalized_model:
-            command.extend(["--model", normalized_model])
         if resume_session_id:
             command.extend(["--resume", resume_session_id])
         return command

--- a/src/ouroboros/orchestrator/zcode_cli_runtime.py
+++ b/src/ouroboros/orchestrator/zcode_cli_runtime.py
@@ -77,11 +77,14 @@ _MAX_OUROBOROS_DEPTH = 5
 # codex/copilot/kiro) — preserve that divergence. ELECTRON_RUN_AS_NODE is
 # rebuilt only for an app-bundle electron-node launch so a parent Electron
 # process cannot accidentally change PATH-wrapper or standalone-script
-# behavior. NODE_OPTIONS can preload arbitrary JavaScript before zcode starts,
-# so never inherit it into either the bundled Electron or system Node launch.
+# behavior. ``OUROBOROS_RUNTIME`` is a legacy selector that can route nested
+# ouroboros commands back into zcode, so strip it alongside the LLM selector.
+# NODE_OPTIONS can preload arbitrary JavaScript before zcode starts, so never
+# inherit it into either the bundled Electron or system Node launch.
 _CHILD_ENV_STRIP_KEYS = (
     "OUROBOROS_AGENT_RUNTIME",
     "OUROBOROS_LLM_BACKEND",
+    "OUROBOROS_RUNTIME",
     "ELECTRON_RUN_AS_NODE",
     "NODE_OPTIONS",
 )

--- a/src/ouroboros/orchestrator/zcode_cli_runtime.py
+++ b/src/ouroboros/orchestrator/zcode_cli_runtime.py
@@ -182,10 +182,11 @@ class ZcodeCLIRuntime(CodexCliRuntime):
             stdout_idle_timeout_seconds: Override the inter-chunk idle
                 watchdog. Same forwarding / disable contract as above.
         """
+        self._requested_model = model
         super().__init__(
             cli_path=cli_path,
             permission_mode=permission_mode,
-            model=model,
+            model=None,
             cwd=cwd,
             skills_dir=skills_dir,
             skill_dispatcher=skill_dispatcher,
@@ -199,11 +200,11 @@ class ZcodeCLIRuntime(CodexCliRuntime):
         # dropping it — the caller believes a specific model was selected
         # when zcode will in fact use whatever ~/.zcode/cli/config.json
         # declares. Only an explicit, non-default id triggers this.
-        requested_model = self._normalize_model(self._model)
+        requested_model = self._normalize_model(self._requested_model)
         if requested_model:
             log.warning(
                 "zcode_cli_runtime.model_not_forwarded",
-                requested_model=self._model,
+                requested_model=self._requested_model,
                 reason=(
                     "zcode has no --model CLI flag; set model.main in "
                     "~/.zcode/cli/config.json to select the model."
@@ -463,6 +464,29 @@ class ZcodeCLIRuntime(CodexCliRuntime):
             command.extend(["--resume", resume_session_id])
         return command
 
+    def execution_identity_contract(self) -> dict[str, Any]:
+        """Return Zcode execution identity without pretending to observe a model.
+
+        Zcode has no ``--model`` flag, and the selected model is owned by
+        Zcode's mutable config. A constructor ``model`` value is therefore only
+        a rejected request, not an observed effective model. Keep the requested
+        value visible for audit, but never let it satisfy the runner's
+        ``effective_model_observed`` guard.
+        """
+        requested_model = self._normalize_model(self._requested_model)
+        normalized_llm_backend = (
+            self._llm_backend.strip()
+            if isinstance(self._llm_backend, str) and self._llm_backend.strip()
+            else None
+        )
+        return {
+            "kind": "zcode_cli_v1",
+            "requested_model": requested_model,
+            "effective_model_observed": False,
+            "llm_backend": normalized_llm_backend,
+            "resume_handle_selector": self.resume_handle_execution_identity_contract(None),
+        }
+
     def _feeds_prompt_via_stdin(self) -> bool:
         """Return False — Zcode CLI accepts the prompt via the --prompt flag."""
         return False
@@ -570,8 +594,28 @@ class ZcodeCLIRuntime(CodexCliRuntime):
         zcode build adds streamed events, handle them here.
         """
         response = event.get("response")
-        if not isinstance(response, str) or not response:
-            return []
+        if not isinstance(response, str) or not response.strip():
+            return [
+                AgentMessage(
+                    type="result",
+                    content=(
+                        "Zcode CLI protocol error: JSON summary did not include "
+                        "a non-empty response."
+                    ),
+                    data={
+                        "subtype": "error",
+                        "error_type": self._runtime_error_type,
+                        "protocol_error": "missing_response",
+                        "terminal": True,
+                        "traceId": event.get("traceId"),
+                        "turnId": event.get("turnId"),
+                        "usage": event.get("usage"),
+                        "projection": event.get("projection"),
+                        "eventCount": event.get("eventCount"),
+                    },
+                    resume_handle=current_handle,
+                )
+            ]
 
         is_valid, _ = InputValidator.validate_llm_response(response)
         if not is_valid:

--- a/src/ouroboros/orchestrator/zcode_cli_runtime.py
+++ b/src/ouroboros/orchestrator/zcode_cli_runtime.py
@@ -45,8 +45,9 @@ log = structlog.get_logger(__name__)
 # message pointing them at ``acceptEdits`` (conservative, non-blocking) or
 # ``bypassPermissions`` (full bypass).
 _ZCODE_PERMISSION_MODE_TO_FLAG = {
-    "acceptEdits": "auto_edit",
-    "bypassPermissions": "yolo",
+    # Real zcode `--mode` values (from `zcode --help`): build | edit | plan | yolo.
+    "acceptEdits": "edit",          # accept edits, non-blocking under --prompt
+    "bypassPermissions": "yolo",    # full bypass
 }
 _ZCODE_PERMISSION_MODES = frozenset(_ZCODE_PERMISSION_MODE_TO_FLAG)
 # Match the orchestrator-wide ``acceptEdits`` default. Zcode's ``auto_edit``
@@ -217,35 +218,38 @@ class ZcodeCLIRuntime(CodexCliRuntime):
         # declares reasoning_effort_support=IGNORED, so it is surfaced as advised).
         reasoning_effort: str | None = None,
     ) -> list[str]:
-        """Build the Zcode CLI command arguments for non-interactive execution.
+        """Build the zcode CLI command for headless execution.
 
-        Headless contract:
-        - ``--prompt`` carries the request (Zcode's documented headless trigger).
-        - ``--non-interactive`` disables TTY prompts so the subprocess never blocks.
-        - ``--json`` emits JSON events on stdout.
-        - ``--approval-mode`` is mapped from ``self._permission_mode``:
-          ``acceptEdits`` → ``auto_edit`` (default; non-blocking) and
-          ``bypassPermissions`` → ``yolo`` (full bypass). Zcode's native
-          ``default`` mode is intentionally unreachable through this runtime
-          — :meth:`_resolve_permission_mode` rejects it because a
-          prompt-driven mode under ``--non-interactive`` would deadlock the
-          subprocess. The fallback to ``auto_edit`` below is defensive only.
+        Measured interface (from `zcode --help`, verified against a live run):
+        invocation is `node <cli_path> ...` where cli_path resolves to the
+        zcode.cjs app-bundle script. Real flags: ``--prompt`` (one-shot),
+        ``--json`` (machine-readable summary), ``--cwd``, ``--mode``
+        (build|edit|plan|yolo), ``--resume <sessionId>``.
+
+        NOTE: zcode has **no** ``--non-interactive`` and **no**
+        ``--approval-mode`` flag (an earlier draft invented them by copying the
+        Codex adapter). ``--mode`` is the real permission surface, and
+        ``--prompt`` is already non-interactive (no TUI), so nothing else is
+        needed to keep the subprocess headless.
         """
         del runtime_handle, reasoning_effort
 
-        approval_flag = _ZCODE_PERMISSION_MODE_TO_FLAG.get(
+        mode_flag = _ZCODE_PERMISSION_MODE_TO_FLAG.get(
             self._permission_mode,
-            "auto_edit",
+            "edit",
         )
         command = [
+            "node",
             self._cli_path,
             "--json",
             "--prompt",
             prompt or "",
-            "--non-interactive",
-            "--approval-mode",
-            approval_flag,
+            "--mode",
+            mode_flag,
         ]
+        cwd = getattr(self, "_cwd", None)
+        if cwd:
+            command.extend(["--cwd", str(cwd)])
         normalized_model = self._normalize_model(self._model)
         if normalized_model:
             command.extend(["--model", normalized_model])
@@ -286,150 +290,87 @@ class ZcodeCLIRuntime(CodexCliRuntime):
 
     # -- Event parsing and normalization -----------------------------------
 
-    def _extract_event_session_id(self, event: dict[str, Any]) -> str | None:
-        """Extract a backend-native session id from a runtime event.
+    async def _iter_stream_lines(
+        self,
+        stream: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        """Yield zcode's full stdout as a single "line".
 
-        Looks at standard top-level keys first, then ``metadata`` and the raw
-        payload (where Zcode's ``init`` event lands its ``session_id``).
+        Measured behaviour: ``zcode --prompt --json`` emits ONE pretty-printed
+        JSON summary object (multi-line), not an NDJSON event stream. The
+        inherited pipeline json-parses each yielded line, so we read the whole
+        buffer and yield it once — downstream ``_parse_json_event`` then sees
+        the complete document.
         """
-        session_id = super()._extract_event_session_id(event)
-        if session_id:
-            return session_id
+        data = await stream.read()
+        text = data.decode("utf-8", errors="replace").strip() if data else ""
+        if text:
+            yield text
 
-        metadata = event.get("metadata", {})
-        if isinstance(metadata, dict):
-            session_id = metadata.get("session_id")
-            if isinstance(session_id, str) and session_id.strip():
-                return session_id.strip()
+    def _extract_event_session_id(self, event: dict[str, Any]) -> str | None:
+        """Extract the zcode session id for ``--resume``.
 
-        raw = event.get("raw")
-        if isinstance(raw, dict):
-            session_id = raw.get("session_id")
-            if isinstance(session_id, str) and session_id.strip():
-                return session_id.strip()
-
-        return None
+        zcode's ``--prompt --json`` summary carries a top-level ``sessionId``
+        of the form ``sess_<uuid>`` — exactly what ``--resume`` consumes. Fall
+        back to the inherited keys for any future streaming shape.
+        """
+        sid = event.get("sessionId")
+        if isinstance(sid, str) and sid.strip():
+            return sid.strip()
+        return super()._extract_event_session_id(event)
 
     def _convert_event(
         self,
         event: dict[str, Any],
         current_handle: RuntimeHandle | None,
     ) -> list[AgentMessage]:
-        """Convert a Zcode CLI event into normalized AgentMessage values.
+        """Convert a zcode ``--prompt --json`` summary into AgentMessage values.
 
-        Handles the Zcode ``--json`` event schema:
+        Measured shape (verified against live runs of
+        ``node zcode.cjs --prompt ... --json``): zcode emits a SINGLE
+        pretty-printed JSON object — NOT an NDJSON event stream — with
+        top-level fields:
 
-        - ``init`` — session metadata (session_id is captured by
-          ``_extract_event_session_id``); produces no AgentMessage
-        - ``message`` / ``text`` — assistant prose
-        - ``thinking`` — internal reasoning
-        - ``tool_use`` — tool invocation request
-        - ``tool_result`` — tool output
-        - ``error`` — error condition
-        - ``result`` — terminal payload carrying the final response (Zcode emits
-          the assistant's final answer here when no intermediate ``message``
-          event was produced); the content is surfaced as the final assistant message.
+        - ``sessionId`` (sess_<uuid>) — captured for ``--resume`` by
+          :meth:`_extract_event_session_id`.
+        - ``response`` — the assistant's final text answer.
+        - ``usage`` / ``eventCount`` / ``projection`` / ``traceId`` / ``turnId``
+          — carried as metadata.
+
+        Intermediate tool calls are reflected only in ``eventCount`` and token
+        usage; they are not emitted as discrete stdout events. The whole turn
+        is therefore surfaced as one terminal assistant message. If a future
+        zcode build adds streamed events, handle them here.
         """
-        event_type = event.get("type")
-        content = event.get("content", "")
-        metadata = event.get("metadata", {})
-        is_error = event.get("is_error", False)
+        response = event.get("response")
+        if not isinstance(response, str) or not response:
+            return []
 
-        # Truncate content using InputValidator for text-bearing events
-        # (including the terminal `result` payload, since `content` may be long).
-        if event_type in ("text", "message", "thinking", "result"):
-            is_valid, _ = InputValidator.validate_llm_response(content)
-            if not is_valid:
-                log.warning(
-                    "zcode.response.truncated",
-                    event_type=event_type,
-                    original_length=len(content),
-                    max_length=MAX_LLM_RESPONSE_LENGTH,
-                )
-                content = content[:MAX_LLM_RESPONSE_LENGTH]
+        is_valid, _ = InputValidator.validate_llm_response(response)
+        if not is_valid:
+            log.warning(
+                "zcode.response.truncated",
+                original_length=len(response),
+                max_length=MAX_LLM_RESPONSE_LENGTH,
+            )
+            response = response[:MAX_LLM_RESPONSE_LENGTH]
 
-        if event_type in ("text", "message"):
-            if not content:
-                return []
-            return [
-                AgentMessage(
-                    type="assistant",
-                    content=content,
-                    resume_handle=current_handle,
-                )
-            ]
-
-        if event_type == "thinking":
-            if not content:
-                return []
-            return [
-                AgentMessage(
-                    type="assistant",
-                    content=content,
-                    data={"thinking": content},
-                    resume_handle=current_handle,
-                )
-            ]
-
-        if event_type == "tool_use":
-            tool_name = metadata.get("name", "")
-            tool_args = metadata.get("input", {})
-            return [
-                AgentMessage(
-                    type="assistant",
-                    content=content or f"Using tool: {tool_name}",
-                    tool_name=tool_name,
-                    data={"tool_input": tool_args},
-                    resume_handle=current_handle,
-                )
-            ]
-
-        if event_type == "tool_result":
-            tool_name = metadata.get("name", "")
-            return [
-                AgentMessage(
-                    type="tool",
-                    content=content,
-                    tool_name=tool_name,
-                    data={"is_error": is_error},
-                    resume_handle=current_handle,
-                )
-            ]
-
-        if event_type == "error":
-            return [
-                AgentMessage(
-                    type="system",
-                    content=f"Zcode Error: {content}",
-                    data={"is_error": True, "metadata": metadata},
-                    resume_handle=current_handle,
-                )
-            ]
-
-        if event_type == "result":
-            # Terminal event. If no content is present we still emit a marker message
-            # carrying the metadata so downstream callers see the completion.
-            if not content:
-                return [
-                    AgentMessage(
-                        type="assistant",
-                        content="",
-                        data={"terminal": True, "metadata": metadata},
-                        resume_handle=current_handle,
-                    )
-                ]
-            return [
-                AgentMessage(
-                    type="assistant",
-                    content=content,
-                    data={"terminal": True, "metadata": metadata},
-                    resume_handle=current_handle,
-                )
-            ]
-
-        # Ignore other auxiliary events (init/done/etc.) that don't map
-        # to messages; init's session_id is captured separately above.
-        return []
+        return [
+            AgentMessage(
+                type="assistant",
+                content=response,
+                data={
+                    "terminal": True,
+                    "traceId": event.get("traceId"),
+                    "turnId": event.get("turnId"),
+                    "usage": event.get("usage"),
+                    "projection": event.get("projection"),
+                    "eventCount": event.get("eventCount"),
+                },
+                resume_handle=current_handle,
+            )
+        ]
 
 
 __all__ = ["ZcodeCLIRuntime"]

--- a/src/ouroboros/orchestrator/zcode_cli_runtime.py
+++ b/src/ouroboros/orchestrator/zcode_cli_runtime.py
@@ -1,0 +1,435 @@
+"""Zcode CLI runtime for Ouroboros orchestrator execution.
+
+This module provides the ZcodeCLIRuntime that shells out to the locally
+installed ``zcode`` CLI to execute agentic tasks.
+
+Usage:
+    runtime = ZcodeCLIRuntime(model="glm-5", cwd="/path/to/project")
+    async for message in runtime.execute_task("Fix the bug in auth.py"):
+        print(message.content)
+
+Custom CLI Path:
+    Set via constructor parameter or environment variable:
+        runtime = ZcodeCLIRuntime(cli_path="/path/to/zcode")
+        # or
+        export OUROBOROS_ZCODE_CLI_PATH=/path/to/zcode
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import structlog
+
+from ouroboros.core.security import MAX_LLM_RESPONSE_LENGTH, InputValidator
+from ouroboros.orchestrator.adapter import (
+    AgentMessage,
+    ParamSupport,
+    RuntimeCapabilities,
+    RuntimeHandle,
+)
+from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime, SkillDispatchHandler
+from ouroboros.runtime.child_env import build_child_env
+
+log = structlog.get_logger(__name__)
+
+# Zcode CLI permission mode mapping. Zcode uses similar approval modes to
+# Gemini - map the Ouroboros permission vocabulary to the *non-blocking*
+# native modes only.
+#
+# Ouroboros' ``"default"`` mode (interactive, prompt-driven) is intentionally
+# absent: this runtime always launches zcode with ``--non-interactive`` so a
+# subprocess that surfaces an approval prompt would wedge indefinitely. Callers
+# that pass ``"default"`` are rejected at ``_resolve_permission_mode`` with a
+# message pointing them at ``acceptEdits`` (conservative, non-blocking) or
+# ``bypassPermissions`` (full bypass).
+_ZCODE_PERMISSION_MODE_TO_FLAG = {
+    "acceptEdits": "auto_edit",
+    "bypassPermissions": "yolo",
+}
+_ZCODE_PERMISSION_MODES = frozenset(_ZCODE_PERMISSION_MODE_TO_FLAG)
+# Match the orchestrator-wide ``acceptEdits`` default. Zcode's ``auto_edit``
+# is non-blocking under ``--non-interactive`` (no approval prompts), so
+# headless safety does not require silently jumping to ``yolo`` (full bypass)
+# when ``permission_mode`` is omitted — operators must opt in to
+# ``bypassPermissions`` explicitly.
+_ZCODE_DEFAULT_PERMISSION_MODE = "acceptEdits"
+
+#: Maximum Ouroboros nesting depth to prevent fork bombs
+_MAX_OUROBOROS_DEPTH = 5
+# Child-env strip set for Zcode. Zcode does NOT strip CLAUDECODE (unlike
+# codex/copilot/kiro) — preserve that divergence; only the Ouroboros markers
+# are removed.
+_CHILD_ENV_STRIP_KEYS = ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND")
+
+
+class ZcodeCLIRuntime(CodexCliRuntime):
+    """Agent runtime that shells out to the locally installed Zcode CLI.
+
+    Extends :class:`~ouroboros.orchestrator.codex_cli_runtime.CodexCliRuntime`
+    with overrides specific to the Zcode CLI process model:
+
+    - No Codex-style permission flags (Zcode manages permissions internally)
+    - Session resumption supported via ``--resume`` flag
+    - Plain-text and/or JSON event output parsing
+    """
+
+    _runtime_handle_backend = "zcode_cli"
+    _runtime_backend = "zcode"
+    _requires_memory_gate = False
+    _provider_name = "zcode_cli"
+    _runtime_error_type = "ZcodeCliError"
+    _log_namespace = "zcode_cli_runtime"
+    _display_name = "Zcode CLI"
+    _default_cli_name = "zcode"
+    _default_llm_backend = "zcode"
+    _tempfile_prefix = "ouroboros-zcode-"
+    _skills_package_uri = "packaged://ouroboros.zcode/skills"
+    _process_shutdown_timeout_seconds = 5.0
+    _max_resume_retries = 3  # Zcode CLI supports session resumption
+
+    def __init__(
+        self,
+        cli_path: str | Path | None = None,
+        permission_mode: str | None = None,
+        model: str | None = None,
+        cwd: str | Path | None = None,
+        skills_dir: str | Path | None = None,
+        skill_dispatcher: SkillDispatchHandler | None = None,
+        llm_backend: str | None = None,
+    ) -> None:
+        """Initialize the Zcode CLI runtime.
+
+        Args:
+            cli_path: Optional path to the zcode binary.
+            permission_mode: Ouroboros permission level. Recognized
+                non-blocking modes (``acceptEdits`` → ``auto_edit``,
+                ``bypassPermissions`` → ``yolo``) pass through.
+                ``"default"`` is the orchestrator-wide setting that
+                represents an interactive prompt; the headless Zcode
+                runtime cannot honour it, so it is normalized to
+                ``acceptEdits`` with an audit log instead of failing
+                — that keeps a globally valid config working while
+                avoiding the deadlock under ``--non-interactive``.
+                Falls back to ``acceptEdits`` when omitted; operators
+                must opt in to ``bypassPermissions`` explicitly.
+            model: Optional model identifier.
+            cwd: Optional working directory for the subprocess.
+            skills_dir: Optional directory for skill definitions.
+            skill_dispatcher: Optional handler for skill execution.
+            llm_backend: Optional LLM backend identifier.
+        """
+        super().__init__(
+            cli_path=cli_path,
+            permission_mode=permission_mode,
+            model=model,
+            cwd=cwd,
+            skills_dir=skills_dir,
+            skill_dispatcher=skill_dispatcher,
+            llm_backend=llm_backend,
+        )
+
+    # -- Permission mode overrides -----------------------------------------
+
+    def _resolve_permission_mode(self, permission_mode: str | None) -> str:
+        """Validate and normalize the Zcode CLI permission mode.
+
+        ``None`` and the orchestrator-wide ``"default"`` setting both
+        resolve to :data:`_ZCODE_DEFAULT_PERMISSION_MODE`
+        (``acceptEdits`` → ``auto_edit``, non-blocking under
+        ``--non-interactive``). ``config.orchestrator.permission_mode``
+        accepts ``"default"`` as a valid global setting, so the
+        backend-specific contract narrows it at the boundary rather
+        than turning a previously valid config into a hard error: a
+        prompt-driven ``--approval-mode default`` would wedge a headless
+        subprocess.
+
+        Other recognized Ouroboros modes (``acceptEdits``,
+        ``bypassPermissions``) pass through. Anything else raises
+        ``ValueError`` instead of silently falling back — fail-open on
+        a permission boundary would let a typo (or unchecked
+        ``OUROBOROS_AGENT_PERMISSION_MODE`` value) escalate the runtime.
+        Matches the Codex permission parser contract.
+        """
+        if permission_mode is None:
+            return _ZCODE_DEFAULT_PERMISSION_MODE
+        candidate = permission_mode.strip()
+        if candidate in _ZCODE_PERMISSION_MODES:
+            return candidate
+        if candidate == "default":
+            log.warning(
+                "zcode_cli_runtime.permission_mode_coerced",
+                requested="default",
+                resolved=_ZCODE_DEFAULT_PERMISSION_MODE,
+                reason=(
+                    "Zcode runtime is headless (--non-interactive); the "
+                    "interactive 'default' approval mode would block, so it "
+                    "is normalized to the safe non-blocking equivalent."
+                ),
+            )
+            return _ZCODE_DEFAULT_PERMISSION_MODE
+        msg = (
+            f"Unsupported Zcode permission mode: {permission_mode!r} "
+            f"(expected one of {sorted(_ZCODE_PERMISSION_MODES)})"
+        )
+        raise ValueError(msg)
+
+    def _build_permission_args(self) -> list[str]:
+        """Return empty list — Zcode CLI has no Codex-style permission flags."""
+        return []
+
+    # -- Environment and security ------------------------------------------
+
+    def _build_child_env(self) -> dict[str, str]:
+        """Build child env with the recursion guard (matches #315 adapter pattern)."""
+        return build_child_env(
+            strip_keys=_CHILD_ENV_STRIP_KEYS,
+            max_depth=_MAX_OUROBOROS_DEPTH,
+            depth_error_factory=lambda _depth, max_depth: RuntimeError(
+                f"Maximum Ouroboros nesting depth ({max_depth}) exceeded"
+            ),
+        )
+
+    # -- CLI path resolution -----------------------------------------------
+
+    def _get_configured_cli_path(self) -> str | None:
+        """Resolve an explicit CLI path from config helpers when available.
+
+        Reads from :func:`ouroboros.config.get_zcode_cli_path`, which checks
+        ``OUROBOROS_ZCODE_CLI_PATH`` and persisted ``orchestrator.zcode_cli_path``.
+        """
+        from ouroboros.config import get_zcode_cli_path
+
+        return get_zcode_cli_path()
+
+    # -- Command construction ----------------------------------------------
+
+    def _build_command(
+        self,
+        output_last_message_path: str,
+        *,
+        resume_session_id: str | None = None,
+        prompt: str | None = None,
+        runtime_handle: RuntimeHandle | None = None,
+        # Accepted to honor the shared CodexCliRuntime contract, but ignored:
+        # the Zcode CLI exposes no per-invocation effort flag (capabilities
+        # declares reasoning_effort_support=IGNORED, so it is surfaced as advised).
+        reasoning_effort: str | None = None,
+    ) -> list[str]:
+        """Build the Zcode CLI command arguments for non-interactive execution.
+
+        Headless contract:
+        - ``--prompt`` carries the request (Zcode's documented headless trigger).
+        - ``--non-interactive`` disables TTY prompts so the subprocess never blocks.
+        - ``--json`` emits JSON events on stdout.
+        - ``--approval-mode`` is mapped from ``self._permission_mode``:
+          ``acceptEdits`` → ``auto_edit`` (default; non-blocking) and
+          ``bypassPermissions`` → ``yolo`` (full bypass). Zcode's native
+          ``default`` mode is intentionally unreachable through this runtime
+          — :meth:`_resolve_permission_mode` rejects it because a
+          prompt-driven mode under ``--non-interactive`` would deadlock the
+          subprocess. The fallback to ``auto_edit`` below is defensive only.
+        """
+        del runtime_handle, reasoning_effort
+
+        approval_flag = _ZCODE_PERMISSION_MODE_TO_FLAG.get(
+            self._permission_mode,
+            "auto_edit",
+        )
+        command = [
+            self._cli_path,
+            "--json",
+            "--prompt",
+            prompt or "",
+            "--non-interactive",
+            "--approval-mode",
+            approval_flag,
+        ]
+        normalized_model = self._normalize_model(self._model)
+        if normalized_model:
+            command.extend(["--model", normalized_model])
+        if resume_session_id:
+            command.extend(["--resume", resume_session_id])
+        return command
+
+    def _feeds_prompt_via_stdin(self) -> bool:
+        """Return False — Zcode CLI accepts the prompt via the --prompt flag."""
+        return False
+
+    def _requires_process_stdin(self) -> bool:
+        """Return False — Zcode CLI doesn't need an interactive stdin pipe."""
+        return False
+
+    @property
+    def capabilities(self) -> RuntimeCapabilities:
+        """Declare Zcode CLI's runtime feature contract.
+
+        Zcode emits structured ``--json`` events and can use the shared
+        skill dispatcher, and supports targeted session resume via ``--resume``.
+        """
+        return RuntimeCapabilities(
+            skill_dispatch=True,
+            targeted_resume=True,  # Zcode supports --resume flag
+            structured_output=True,
+            # System prompt is composed into the user message (inherited Codex
+            # prompt builder), not passed as a native system directive. The
+            # inherited builder also renders requested tool lists as prompt
+            # guidance rather than enforcing a Zcode-native allow-list.
+            system_prompt_support=ParamSupport.TRANSLATED,
+            tool_restriction_support=ParamSupport.TRANSLATED,
+            # Reasoning effort is advised, not enforced: no per-invocation effort
+            # flag has been verified. Declared IGNORED (also the default) until a
+            # real per-call mechanism is confirmed — revisit if the CLI exposes one.
+            reasoning_effort_support=ParamSupport.IGNORED,
+        )
+
+    # -- Event parsing and normalization -----------------------------------
+
+    def _extract_event_session_id(self, event: dict[str, Any]) -> str | None:
+        """Extract a backend-native session id from a runtime event.
+
+        Looks at standard top-level keys first, then ``metadata`` and the raw
+        payload (where Zcode's ``init`` event lands its ``session_id``).
+        """
+        session_id = super()._extract_event_session_id(event)
+        if session_id:
+            return session_id
+
+        metadata = event.get("metadata", {})
+        if isinstance(metadata, dict):
+            session_id = metadata.get("session_id")
+            if isinstance(session_id, str) and session_id.strip():
+                return session_id.strip()
+
+        raw = event.get("raw")
+        if isinstance(raw, dict):
+            session_id = raw.get("session_id")
+            if isinstance(session_id, str) and session_id.strip():
+                return session_id.strip()
+
+        return None
+
+    def _convert_event(
+        self,
+        event: dict[str, Any],
+        current_handle: RuntimeHandle | None,
+    ) -> list[AgentMessage]:
+        """Convert a Zcode CLI event into normalized AgentMessage values.
+
+        Handles the Zcode ``--json`` event schema:
+
+        - ``init`` — session metadata (session_id is captured by
+          ``_extract_event_session_id``); produces no AgentMessage
+        - ``message`` / ``text`` — assistant prose
+        - ``thinking`` — internal reasoning
+        - ``tool_use`` — tool invocation request
+        - ``tool_result`` — tool output
+        - ``error`` — error condition
+        - ``result`` — terminal payload carrying the final response (Zcode emits
+          the assistant's final answer here when no intermediate ``message``
+          event was produced); the content is surfaced as the final assistant message.
+        """
+        event_type = event.get("type")
+        content = event.get("content", "")
+        metadata = event.get("metadata", {})
+        is_error = event.get("is_error", False)
+
+        # Truncate content using InputValidator for text-bearing events
+        # (including the terminal `result` payload, since `content` may be long).
+        if event_type in ("text", "message", "thinking", "result"):
+            is_valid, _ = InputValidator.validate_llm_response(content)
+            if not is_valid:
+                log.warning(
+                    "zcode.response.truncated",
+                    event_type=event_type,
+                    original_length=len(content),
+                    max_length=MAX_LLM_RESPONSE_LENGTH,
+                )
+                content = content[:MAX_LLM_RESPONSE_LENGTH]
+
+        if event_type in ("text", "message"):
+            if not content:
+                return []
+            return [
+                AgentMessage(
+                    type="assistant",
+                    content=content,
+                    resume_handle=current_handle,
+                )
+            ]
+
+        if event_type == "thinking":
+            if not content:
+                return []
+            return [
+                AgentMessage(
+                    type="assistant",
+                    content=content,
+                    data={"thinking": content},
+                    resume_handle=current_handle,
+                )
+            ]
+
+        if event_type == "tool_use":
+            tool_name = metadata.get("name", "")
+            tool_args = metadata.get("input", {})
+            return [
+                AgentMessage(
+                    type="assistant",
+                    content=content or f"Using tool: {tool_name}",
+                    tool_name=tool_name,
+                    data={"tool_input": tool_args},
+                    resume_handle=current_handle,
+                )
+            ]
+
+        if event_type == "tool_result":
+            tool_name = metadata.get("name", "")
+            return [
+                AgentMessage(
+                    type="tool",
+                    content=content,
+                    tool_name=tool_name,
+                    data={"is_error": is_error},
+                    resume_handle=current_handle,
+                )
+            ]
+
+        if event_type == "error":
+            return [
+                AgentMessage(
+                    type="system",
+                    content=f"Zcode Error: {content}",
+                    data={"is_error": True, "metadata": metadata},
+                    resume_handle=current_handle,
+                )
+            ]
+
+        if event_type == "result":
+            # Terminal event. If no content is present we still emit a marker message
+            # carrying the metadata so downstream callers see the completion.
+            if not content:
+                return [
+                    AgentMessage(
+                        type="assistant",
+                        content="",
+                        data={"terminal": True, "metadata": metadata},
+                        resume_handle=current_handle,
+                    )
+                ]
+            return [
+                AgentMessage(
+                    type="assistant",
+                    content=content,
+                    data={"terminal": True, "metadata": metadata},
+                    resume_handle=current_handle,
+                )
+            ]
+
+        # Ignore other auxiliary events (init/done/etc.) that don't map
+        # to messages; init's session_id is captured separately above.
+        return []
+
+
+__all__ = ["ZcodeCLIRuntime"]

--- a/src/ouroboros/orchestrator/zcode_cli_runtime.py
+++ b/src/ouroboros/orchestrator/zcode_cli_runtime.py
@@ -34,27 +34,27 @@ from ouroboros.runtime.child_env import build_child_env
 
 log = structlog.get_logger(__name__)
 
-# Zcode CLI permission mode mapping. Zcode uses similar approval modes to
-# Gemini - map the Ouroboros permission vocabulary to the *non-blocking*
-# native modes only.
+# Zcode CLI permission mode mapping. Zcode exposes its permission surface via
+# the ``--mode`` flag (build | edit | plan | yolo) — there is no
+# ``--approval-mode`` and no ``--non-interactive`` flag (an earlier draft
+# invented both by copying the Codex adapter). ``--prompt`` is already a
+# non-interactive one-shot invocation (no TUI, no approval prompt), so the
+# only permission knob to map is ``--mode``.
 #
-# Ouroboros' ``"default"`` mode (interactive, prompt-driven) is intentionally
-# absent: this runtime always launches zcode with ``--non-interactive`` so a
-# subprocess that surfaces an approval prompt would wedge indefinitely. Callers
-# that pass ``"default"`` are rejected at ``_resolve_permission_mode`` with a
-# message pointing them at ``acceptEdits`` (conservative, non-blocking) or
-# ``bypassPermissions`` (full bypass).
+# Ouroboros' ``"default"`` mode has no zcode-native ``--mode`` equivalent
+# (zcode's vocabulary is build/edit/plan/yolo), so callers that pass
+# ``"default"`` are normalized at ``_resolve_permission_mode`` to the safe
+# default (``acceptEdits`` → ``edit``). Anything outside the recognized
+# vocabulary is rejected rather than silently escalating.
 _ZCODE_PERMISSION_MODE_TO_FLAG = {
     # Real zcode `--mode` values (from `zcode --help`): build | edit | plan | yolo.
-    "acceptEdits": "edit",          # accept edits, non-blocking under --prompt
+    "acceptEdits": "edit",          # accept edits
     "bypassPermissions": "yolo",    # full bypass
 }
 _ZCODE_PERMISSION_MODES = frozenset(_ZCODE_PERMISSION_MODE_TO_FLAG)
-# Match the orchestrator-wide ``acceptEdits`` default. Zcode's ``auto_edit``
-# is non-blocking under ``--non-interactive`` (no approval prompts), so
-# headless safety does not require silently jumping to ``yolo`` (full bypass)
-# when ``permission_mode`` is omitted — operators must opt in to
-# ``bypassPermissions`` explicitly.
+# Match the orchestrator-wide ``acceptEdits`` default. Operators must opt in
+# to ``bypassPermissions`` explicitly — the runtime never silently jumps to
+# ``yolo`` when ``permission_mode`` is omitted.
 _ZCODE_DEFAULT_PERMISSION_MODE = "acceptEdits"
 
 #: Maximum Ouroboros nesting depth to prevent fork bombs
@@ -103,18 +103,21 @@ class ZcodeCLIRuntime(CodexCliRuntime):
         """Initialize the Zcode CLI runtime.
 
         Args:
-            cli_path: Optional path to the zcode binary.
+            cli_path: Optional path to the zcode CLI entry script
+                (``zcode.cjs``). The runtime invokes it as
+                ``node <cli_path>``, so this points at the app-bundle
+                script rather than a bare binary.
             permission_mode: Ouroboros permission level. Recognized
-                non-blocking modes (``acceptEdits`` → ``auto_edit``,
-                ``bypassPermissions`` → ``yolo``) pass through.
-                ``"default"`` is the orchestrator-wide setting that
-                represents an interactive prompt; the headless Zcode
-                runtime cannot honour it, so it is normalized to
-                ``acceptEdits`` with an audit log instead of failing
-                — that keeps a globally valid config working while
-                avoiding the deadlock under ``--non-interactive``.
-                Falls back to ``acceptEdits`` when omitted; operators
-                must opt in to ``bypassPermissions`` explicitly.
+                modes map to zcode ``--mode`` values
+                (``acceptEdits`` → ``edit``,
+                ``bypassPermissions`` → ``yolo``) and pass through.
+                ``"default"`` has no zcode-native ``--mode``
+                equivalent (zcode's vocabulary is build/edit/plan/yolo),
+                so it is normalized to ``acceptEdits`` with an audit
+                log instead of failing — that keeps a globally valid
+                config working. Falls back to ``acceptEdits`` when
+                omitted; operators must opt in to
+                ``bypassPermissions`` explicitly.
             model: Optional model identifier.
             cwd: Optional working directory for the subprocess.
             skills_dir: Optional directory for skill definitions.
@@ -138,13 +141,13 @@ class ZcodeCLIRuntime(CodexCliRuntime):
 
         ``None`` and the orchestrator-wide ``"default"`` setting both
         resolve to :data:`_ZCODE_DEFAULT_PERMISSION_MODE`
-        (``acceptEdits`` → ``auto_edit``, non-blocking under
-        ``--non-interactive``). ``config.orchestrator.permission_mode``
-        accepts ``"default"`` as a valid global setting, so the
-        backend-specific contract narrows it at the boundary rather
-        than turning a previously valid config into a hard error: a
-        prompt-driven ``--approval-mode default`` would wedge a headless
-        subprocess.
+        (``acceptEdits`` → zcode ``--mode edit``).
+        ``config.orchestrator.permission_mode`` accepts ``"default"`` as
+        a valid global setting, but zcode's ``--mode`` vocabulary is
+        build/edit/plan/yolo — there is no ``default`` value to pass
+        through — so the backend-specific contract narrows it at the
+        boundary rather than turning a previously valid config into a
+        hard error.
 
         Other recognized Ouroboros modes (``acceptEdits``,
         ``bypassPermissions``) pass through. Anything else raises
@@ -164,9 +167,8 @@ class ZcodeCLIRuntime(CodexCliRuntime):
                 requested="default",
                 resolved=_ZCODE_DEFAULT_PERMISSION_MODE,
                 reason=(
-                    "Zcode runtime is headless (--non-interactive); the "
-                    "interactive 'default' approval mode would block, so it "
-                    "is normalized to the safe non-blocking equivalent."
+                    "Zcode --mode has no 'default' value (vocabulary is "
+                    "build/edit/plan/yolo); normalized to the safe default."
                 ),
             )
             return _ZCODE_DEFAULT_PERMISSION_MODE
@@ -293,18 +295,39 @@ class ZcodeCLIRuntime(CodexCliRuntime):
     async def _iter_stream_lines(
         self,
         stream: Any,
+        *,
+        chunk_size: int = 16384,
+        first_chunk_timeout_seconds: float | None = None,
+        chunk_timeout_seconds: float | None = None,
         **_kwargs: Any,
     ) -> Any:
-        """Yield zcode's full stdout as a single "line".
+        """Yield zcode's full stdout as a single reassembled "line".
 
         Measured behaviour: ``zcode --prompt --json`` emits ONE pretty-printed
         JSON summary object (multi-line), not an NDJSON event stream. The
-        inherited pipeline json-parses each yielded line, so we read the whole
-        buffer and yield it once — downstream ``_parse_json_event`` then sees
-        the complete document.
+        inherited pipeline json-parses each yielded line, so we must hand it
+        the complete document in one piece.
+
+        Rather than ``await stream.read()`` to EOF (which silently drops the
+        parent's ``first_chunk_timeout_seconds`` / ``chunk_timeout_seconds``
+        watchdogs and can wedge the orchestrator on a zcode process that stays
+        alive but emits nothing — auth prompt, provider stall, model hang), we
+        delegate the chunked read to :meth:`CodexCliRuntime._iter_stream_lines`
+        so the watchdogs still fire and raise ``TimeoutError``. Every decoded
+        line is buffered and then joined into one document and yielded once,
+        so downstream ``_parse_json_event`` sees the whole summary object while
+        ``execute_task``'s ``except TimeoutError`` recovery path keeps working.
         """
-        data = await stream.read()
-        text = data.decode("utf-8", errors="replace").strip() if data else ""
+        chunks: list[str] = []
+        async for line in super()._iter_stream_lines(
+            stream,
+            chunk_size=chunk_size,
+            first_chunk_timeout_seconds=first_chunk_timeout_seconds,
+            chunk_timeout_seconds=chunk_timeout_seconds,
+        ):
+            if line:
+                chunks.append(line)
+        text = "\n".join(chunks).strip()
         if text:
             yield text
 

--- a/src/ouroboros/orchestrator/zcode_cli_runtime.py
+++ b/src/ouroboros/orchestrator/zcode_cli_runtime.py
@@ -16,18 +16,22 @@ Custom CLI Path:
 
 Model selection:
     zcode has **no** ``--model`` CLI flag (verified against ``zcode --help``
-    on 0.14.5 and 0.15.0 — passing ``--model`` is a hard ``Unknown option``
-    rejection, not a silent no-op). Model selection is done **outside** the
-    runtime, via the zcode config file ``~/.zcode/cli/config.json`` under
-    ``model.main``, or the interactive ``/model`` slash command. Any ``model``
-    value passed to the constructor is therefore intentionally ignored at the
-    CLI boundary — a warning is emitted when a non-default model is requested
-    so the misconfiguration (expected model vs. configured model) is visible.
+    on 0.14.5, 0.15.0, and 0.15.2 — passing ``--model`` is a hard
+    ``Unknown option`` rejection, not a silent no-op). Model selection is done
+    **outside** the runtime, via the zcode config file
+    ``~/.zcode/cli/config.json`` under ``model.main``, or the interactive
+    ``/model`` slash command. Any ``model`` value passed to the constructor is
+    therefore intentionally ignored at the CLI boundary — a warning is
+    emitted when a non-default model is requested so the misconfiguration
+    (expected model vs. configured model) is visible.
 """
 
 from __future__ import annotations
 
+import json
+import os
 from pathlib import Path
+import plistlib
 from typing import Any
 
 import structlog
@@ -70,9 +74,20 @@ _ZCODE_DEFAULT_PERMISSION_MODE = "acceptEdits"
 #: Maximum Ouroboros nesting depth to prevent fork bombs
 _MAX_OUROBOROS_DEPTH = 5
 # Child-env strip set for Zcode. Zcode does NOT strip CLAUDECODE (unlike
-# codex/copilot/kiro) — preserve that divergence; only the Ouroboros markers
-# are removed.
-_CHILD_ENV_STRIP_KEYS = ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND")
+# codex/copilot/kiro) — preserve that divergence. ELECTRON_RUN_AS_NODE is
+# rebuilt only for an app-bundle electron-node launch so a parent Electron
+# process cannot accidentally change PATH-wrapper or standalone-script
+# behavior. NODE_OPTIONS can preload arbitrary JavaScript before zcode starts,
+# so never inherit it into either the bundled Electron or system Node launch.
+_CHILD_ENV_STRIP_KEYS = (
+    "OUROBOROS_AGENT_RUNTIME",
+    "OUROBOROS_LLM_BACKEND",
+    "ELECTRON_RUN_AS_NODE",
+    "NODE_OPTIONS",
+)
+_ZCODE_SCRIPT_SUFFIXES = (".cjs", ".js", ".mjs")
+_ZCODE_NODE_BUNDLE_METADATA = ".node-bundle-meta.json"
+_ZCODE_ELECTRON_NODE_RUNTIME = "electron-node"
 
 
 class ZcodeCLIRuntime(CodexCliRuntime):
@@ -94,7 +109,10 @@ class ZcodeCLIRuntime(CodexCliRuntime):
     _log_namespace = "zcode_cli_runtime"
     _display_name = "Zcode CLI"
     _default_cli_name = "zcode"
-    _default_llm_backend = "zcode"
+    # Zcode is runtime-only (no LLM-completion adapter). Auxiliary built-in
+    # skill handlers still need a completion-capable backend when the runtime
+    # is constructed directly, so match the Antigravity/Grok fallback pattern.
+    _default_llm_backend = "claude_code"
     _tempfile_prefix = "ouroboros-zcode-"
     _skills_package_uri = "packaged://ouroboros.zcode/skills"
     _process_shutdown_timeout_seconds = 5.0
@@ -126,9 +144,9 @@ class ZcodeCLIRuntime(CodexCliRuntime):
 
         Args:
             cli_path: Optional path to the zcode CLI entry script
-                (``zcode.cjs``). The runtime invokes it as
-                ``node <cli_path>``, so this points at the app-bundle
-                script rather than a bare binary.
+                (``zcode.cjs``) or executable. Official app-bundle scripts use
+                ZCode's bundled Electron/Node runtime; standalone scripts use
+                the system Node, and executable wrappers run directly.
             permission_mode: Ouroboros permission level. Recognized
                 modes map to zcode ``--mode`` values
                 (``acceptEdits`` → ``edit``,
@@ -142,8 +160,9 @@ class ZcodeCLIRuntime(CodexCliRuntime):
                 ``bypassPermissions`` explicitly.
             model: Optional model identifier. **Ignored at the CLI
                 boundary** — zcode has no ``--model`` flag (passing one is
-                a hard ``Unknown option`` rejection, verified on 0.14.5 and
-                0.15.0). Set the model via ``~/.zcode/cli/config.json``
+                a hard ``Unknown option`` rejection, verified on 0.14.5,
+                0.15.0, and 0.15.2). Set the model via
+                ``~/.zcode/cli/config.json``
                 (``model.main``). A non-default value here emits a warning
                 so the divergence between the requested model and the
                 model zcode actually uses is visible; the value is never
@@ -174,6 +193,7 @@ class ZcodeCLIRuntime(CodexCliRuntime):
             startup_output_timeout_seconds=startup_output_timeout_seconds,
             stdout_idle_timeout_seconds=stdout_idle_timeout_seconds,
         )
+        self._electron_node_path = self._resolve_app_bundle_electron_node()
         # zcode has no --model flag, so a non-default model requested here
         # cannot reach the CLI. Surface it loudly rather than silently
         # dropping it — the caller believes a specific model was selected
@@ -242,13 +262,16 @@ class ZcodeCLIRuntime(CodexCliRuntime):
 
     def _build_child_env(self) -> dict[str, str]:
         """Build child env with the recursion guard (matches #315 adapter pattern)."""
-        return build_child_env(
+        env = build_child_env(
             strip_keys=_CHILD_ENV_STRIP_KEYS,
             max_depth=_MAX_OUROBOROS_DEPTH,
             depth_error_factory=lambda _depth, max_depth: RuntimeError(
                 f"Maximum Ouroboros nesting depth ({max_depth}) exceeded"
             ),
         )
+        if self._electron_node_path is not None:
+            env["ELECTRON_RUN_AS_NODE"] = "1"
+        return env
 
     # -- CLI path resolution -----------------------------------------------
 
@@ -261,6 +284,100 @@ class ZcodeCLIRuntime(CodexCliRuntime):
         from ouroboros.config import get_zcode_cli_path
 
         return get_zcode_cli_path()
+
+    def _resolve_app_bundle_electron_node(self) -> str | None:
+        """Return the bundled Electron executable for an electron-node script.
+
+        Official ZCode macOS bundles mark ``Resources/glm/zcode.cjs`` with a
+        sibling ``.node-bundle-meta.json`` whose runtime is ``electron-node``.
+        That script imports Node features such as ``node:sqlite`` which are not
+        available in older system Node installations. ZCode itself launches
+        the script through the app's Electron executable with
+        ``ELECTRON_RUN_AS_NODE=1``; mirror that measured packaging contract.
+
+        Standalone scripts outside a ``.app`` bundle intentionally return
+        ``None`` and keep the existing ``node <script>`` behavior.
+        """
+        if not self._cli_path:
+            return None
+
+        cli_path = Path(str(self._cli_path))
+        if cli_path.suffix.lower() not in _ZCODE_SCRIPT_SUFFIXES:
+            return None
+
+        contents_dir = next(
+            (
+                parent
+                for parent in cli_path.parents
+                if parent.name == "Contents" and parent.parent.suffix.lower() == ".app"
+            ),
+            None,
+        )
+        if contents_dir is None:
+            return None
+
+        metadata_path = cli_path.with_name(_ZCODE_NODE_BUNDLE_METADATA)
+        try:
+            metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            msg = f"ZCode app-bundle CLI metadata is missing or unreadable: {metadata_path}: {exc}"
+            raise RuntimeError(msg) from exc
+        except json.JSONDecodeError as exc:
+            msg = f"ZCode app-bundle CLI metadata is invalid JSON: {metadata_path}: {exc}"
+            raise RuntimeError(msg) from exc
+
+        if not isinstance(metadata, dict):
+            msg = f"ZCode app-bundle CLI metadata must be a JSON object: {metadata_path}"
+            raise RuntimeError(msg)
+
+        runtime = metadata.get("runtime")
+        if runtime != _ZCODE_ELECTRON_NODE_RUNTIME:
+            msg = (
+                "ZCode app-bundle CLI metadata declares unsupported runtime "
+                f"{runtime!r} in {metadata_path}; expected "
+                f"{_ZCODE_ELECTRON_NODE_RUNTIME!r}"
+            )
+            raise RuntimeError(msg)
+
+        entry = metadata.get("entry")
+        if entry != cli_path.name:
+            msg = (
+                "ZCode app-bundle CLI metadata entry does not match the configured "
+                f"script in {metadata_path}: expected {cli_path.name!r}, got {entry!r}"
+            )
+            raise RuntimeError(msg)
+
+        info_plist = contents_dir / "Info.plist"
+        try:
+            with info_plist.open("rb") as stream:
+                bundle_info = plistlib.load(stream)
+        except (OSError, plistlib.InvalidFileException) as exc:
+            msg = f"ZCode app bundle metadata is present but {info_plist} is unreadable: {exc}"
+            raise RuntimeError(msg) from exc
+
+        if not isinstance(bundle_info, dict):
+            msg = f"ZCode app bundle metadata must be a dictionary: {info_plist}"
+            raise RuntimeError(msg)
+
+        executable_name = bundle_info.get("CFBundleExecutable")
+        if not isinstance(executable_name, str) or not executable_name:
+            msg = f"ZCode app bundle is missing CFBundleExecutable in {info_plist}"
+            raise RuntimeError(msg)
+        if executable_name in {".", ".."} or "/" in executable_name or "\\" in executable_name:
+            msg = (
+                "ZCode app bundle CFBundleExecutable must be a file name without "
+                f"path separators: {executable_name!r} in {info_plist}"
+            )
+            raise RuntimeError(msg)
+
+        electron_node = contents_dir / "MacOS" / executable_name
+        if not electron_node.is_file() or not os.access(electron_node, os.X_OK):
+            msg = (
+                "ZCode app bundle declares an electron-node CLI but its bundled "
+                f"runtime is not executable: {electron_node}"
+            )
+            raise RuntimeError(msg)
+        return str(electron_node)
 
     # -- Command construction ----------------------------------------------
 
@@ -275,6 +392,10 @@ class ZcodeCLIRuntime(CodexCliRuntime):
         # the Zcode CLI exposes no per-invocation effort flag (capabilities
         # declares reasoning_effort_support=IGNORED, so it is surfaced as advised).
         reasoning_effort: str | None = None,
+        # The shared AgentRuntime API may carry a routed per-call model. Zcode
+        # has no --model flag, so accepting and dropping it is the only truthful
+        # behavior; capability degradation is reported by the orchestrator.
+        model: str | None = None,
     ) -> list[str]:
         """Build the zcode CLI command for headless execution.
 
@@ -286,28 +407,33 @@ class ZcodeCLIRuntime(CodexCliRuntime):
         Two install shapes must both work:
 
         - **App-bundle script** — ``zcode.cjs`` under
-          ``/Applications/ZCode.app/...``. Invoked as ``node <cli_path> …``.
+          ``/Applications/ZCode.app/...``. When its bundle metadata declares
+          ``electron-node``, invoke the app's bundled Electron/Node runtime
+          with ``ELECTRON_RUN_AS_NODE=1`` instead of the system ``node``.
+        - **Standalone script** — a ``.cjs``/``.js``/``.mjs`` path outside a
+          recognized app bundle. Invoked as ``node <cli_path> …``.
         - **PATH executable** — a ``zcode`` wrapper/binary resolved when no
           explicit path is configured. Must be called **directly**:
           ``node <executable>`` would parse the binary as JS and fail before
           zcode ever runs.
 
-        The builder distinguishes by extension: ``.cjs``/``.js``/``.mjs``
-        scripts get the ``node`` prefix; everything else is invoked straight.
+        The builder checks the official app-bundle metadata before falling
+        back to the extension rule. Everything else is invoked directly.
 
         NOTE: zcode has **no** ``--non-interactive``, **no**
         ``--approval-mode``, and **no** ``--model`` flag. The first two were
         invented by an earlier draft copying the Codex adapter; ``--model``
         was the last un-measured artifact copied from the same source —
-        verified absent on zcode 0.14.5 and 0.15.0, where ``--model`` is a
-        hard ``Unknown option`` rejection that aborts the run before zcode
-        does any work. ``--mode`` is the real permission surface, ``--prompt``
-        is already non-interactive (no TUI), and model selection lives in
-        ``~/.zcode/cli/config.json`` (``model.main``), never on the CLI. Do
-        not re-add ``--model`` here — :meth:`ZcodeCLIRuntime.__init__` warns
-        when a non-default model is requested so the gap is visible.
+        verified absent on zcode 0.14.5, 0.15.0, and 0.15.2, where ``--model``
+        is a hard ``Unknown option`` rejection that aborts the run before
+        zcode does any work. ``--mode`` is the real permission surface,
+        ``--prompt`` is already non-interactive (no TUI), and model selection
+        lives in ``~/.zcode/cli/config.json`` (``model.main``), never on the
+        CLI. Do not re-add ``--model`` here —
+        :meth:`ZcodeCLIRuntime.__init__` warns when a non-default model is
+        requested so the gap is visible.
         """
-        del runtime_handle, reasoning_effort
+        del runtime_handle, reasoning_effort, model
 
         mode_flag = _ZCODE_PERMISSION_MODE_TO_FLAG.get(
             self._permission_mode,
@@ -317,10 +443,12 @@ class ZcodeCLIRuntime(CodexCliRuntime):
         if cli_path is None:
             msg = "zcode CLI path could not be resolved (set OUROBOROS_ZCODE_CLI_PATH or orchestrator.zcode_cli_path)"
             raise RuntimeError(msg)
-        # node script (app bundle) → `node <script>`; PATH executable → direct.
-        prefix: list[str] = (
-            ["node", cli_path] if cli_path.endswith((".cjs", ".js", ".mjs")) else [cli_path]
-        )
+        if self._electron_node_path is not None:
+            prefix = [self._electron_node_path, cli_path]
+        elif cli_path.lower().endswith(_ZCODE_SCRIPT_SUFFIXES):
+            prefix = ["node", cli_path]
+        else:
+            prefix = [cli_path]
         command = prefix + [
             "--json",
             "--prompt",
@@ -426,10 +554,9 @@ class ZcodeCLIRuntime(CodexCliRuntime):
     ) -> list[AgentMessage]:
         """Convert a zcode ``--prompt --json`` summary into AgentMessage values.
 
-        Measured shape (verified against live runs of
-        ``node zcode.cjs --prompt ... --json``): zcode emits a SINGLE
-        pretty-printed JSON object — NOT an NDJSON event stream — with
-        top-level fields:
+        Measured shape (verified against live app-bundle runs through ZCode's
+        bundled Electron/Node runtime): zcode emits a SINGLE pretty-printed
+        JSON object — NOT an NDJSON event stream — with top-level fields:
 
         - ``sessionId`` (sess_<uuid>) — captured for ``--resume`` by
           :meth:`_extract_event_session_id`.

--- a/src/ouroboros/orchestrator/zcode_cli_runtime.py
+++ b/src/ouroboros/orchestrator/zcode_cli_runtime.py
@@ -222,11 +222,22 @@ class ZcodeCLIRuntime(CodexCliRuntime):
     ) -> list[str]:
         """Build the zcode CLI command for headless execution.
 
-        Measured interface (from `zcode --help`, verified against a live run):
-        invocation is `node <cli_path> ...` where cli_path resolves to the
-        zcode.cjs app-bundle script. Real flags: ``--prompt`` (one-shot),
-        ``--json`` (machine-readable summary), ``--cwd``, ``--mode``
-        (build|edit|plan|yolo), ``--resume <sessionId>``.
+        Measured interface (from `zcode --help`, verified against a live run).
+        Real flags: ``--prompt`` (one-shot), ``--json`` (machine-readable
+        summary), ``--cwd``, ``--mode`` (build|edit|plan|yolo),
+        ``--resume <sessionId>``.
+
+        Two install shapes must both work:
+
+        - **App-bundle script** — ``zcode.cjs`` under
+          ``/Applications/ZCode.app/...``. Invoked as ``node <cli_path> …``.
+        - **PATH executable** — a ``zcode`` wrapper/binary resolved when no
+          explicit path is configured. Must be called **directly**:
+          ``node <executable>`` would parse the binary as JS and fail before
+          zcode ever runs.
+
+        The builder distinguishes by extension: ``.cjs``/``.js``/``.mjs``
+        scripts get the ``node`` prefix; everything else is invoked straight.
 
         NOTE: zcode has **no** ``--non-interactive`` and **no**
         ``--approval-mode`` flag (an earlier draft invented them by copying the
@@ -240,9 +251,15 @@ class ZcodeCLIRuntime(CodexCliRuntime):
             self._permission_mode,
             "edit",
         )
-        command = [
-            "node",
-            self._cli_path,
+        cli_path = str(self._cli_path) if self._cli_path else None
+        if cli_path is None:
+            msg = "zcode CLI path could not be resolved (set OUROBOROS_ZCODE_CLI_PATH or orchestrator.zcode_cli_path)"
+            raise RuntimeError(msg)
+        # node script (app bundle) → `node <script>`; PATH executable → direct.
+        prefix: list[str] = (
+            ["node", cli_path] if cli_path.endswith((".cjs", ".js", ".mjs")) else [cli_path]
+        )
+        command = prefix + [
             "--json",
             "--prompt",
             prompt or "",

--- a/src/ouroboros/orchestrator/zcode_cli_runtime.py
+++ b/src/ouroboros/orchestrator/zcode_cli_runtime.py
@@ -99,6 +99,8 @@ class ZcodeCLIRuntime(CodexCliRuntime):
         skills_dir: str | Path | None = None,
         skill_dispatcher: SkillDispatchHandler | None = None,
         llm_backend: str | None = None,
+        startup_output_timeout_seconds: float | None = None,
+        stdout_idle_timeout_seconds: float | None = None,
     ) -> None:
         """Initialize the Zcode CLI runtime.
 
@@ -123,6 +125,16 @@ class ZcodeCLIRuntime(CodexCliRuntime):
             skills_dir: Optional directory for skill definitions.
             skill_dispatcher: Optional handler for skill execution.
             llm_backend: Optional LLM backend identifier.
+            startup_output_timeout_seconds: Override the watchdog that
+                aborts a subprocess which emits no first stdout chunk
+                within the deadline. Passed straight through to the
+                Codex base runtime; ``0`` or negative disables the guard.
+                The MCP execute-seed path sets this to ``0`` to keep
+                long agent runs alive — Zcode buffers its whole JSON
+                summary until completion and would otherwise be killed
+                as "produced no stdout" before the summary lands.
+            stdout_idle_timeout_seconds: Override the inter-chunk idle
+                watchdog. Same forwarding / disable contract as above.
         """
         super().__init__(
             cli_path=cli_path,
@@ -132,6 +144,8 @@ class ZcodeCLIRuntime(CodexCliRuntime):
             skills_dir=skills_dir,
             skill_dispatcher=skill_dispatcher,
             llm_backend=llm_backend,
+            startup_output_timeout_seconds=startup_output_timeout_seconds,
+            stdout_idle_timeout_seconds=stdout_idle_timeout_seconds,
         )
 
     # -- Permission mode overrides -----------------------------------------

--- a/src/ouroboros/orchestrator/zcode_cli_runtime.py
+++ b/src/ouroboros/orchestrator/zcode_cli_runtime.py
@@ -48,8 +48,8 @@ log = structlog.get_logger(__name__)
 # vocabulary is rejected rather than silently escalating.
 _ZCODE_PERMISSION_MODE_TO_FLAG = {
     # Real zcode `--mode` values (from `zcode --help`): build | edit | plan | yolo.
-    "acceptEdits": "edit",          # accept edits
-    "bypassPermissions": "yolo",    # full bypass
+    "acceptEdits": "edit",  # accept edits
+    "bypassPermissions": "yolo",  # full bypass
 }
 _ZCODE_PERMISSION_MODES = frozenset(_ZCODE_PERMISSION_MODE_TO_FLAG)
 # Match the orchestrator-wide ``acceptEdits`` default. Operators must opt in

--- a/tests/fixtures/zcode/summary_simple.json
+++ b/tests/fixtures/zcode/summary_simple.json
@@ -1,0 +1,26 @@
+{
+  "sessionId": "sess_5e8753c0-7913-4a6a-9790-ef86f8d814e6",
+  "traceId": "685678af-71a1-4dc3-8003-038f2ae1ce48",
+  "turnId": "turn_896624bc-6195-4b0d-acf4-4e672aa24968",
+  "response": "OK",
+  "usage": {
+    "source": "provider",
+    "modelRequestCount": 1,
+    "inputTokens": 8899,
+    "outputTokens": 2,
+    "totalTokens": 8901,
+    "cacheReadTokens": 7296,
+    "cacheWriteTokens": 0,
+    "reasoningTokens": 0,
+    "webFetchRequests": 0,
+    "webSearchRequests": 0
+  },
+  "eventCount": 11,
+  "projection": {
+    "status": "idle",
+    "turnCount": 1,
+    "totalTokenCount": 8901,
+    "contextUsed": 8901,
+    "contextWindow": 1000000
+  }
+}

--- a/tests/fixtures/zcode/summary_with_tool.json
+++ b/tests/fixtures/zcode/summary_with_tool.json
@@ -1,0 +1,26 @@
+{
+  "sessionId": "sess_acb1ac9f-0f50-461e-8411-db09540b05b7",
+  "traceId": "1e8f0fbe-f7e1-4b75-aa5e-8ffa8542e6f6",
+  "turnId": "turn_cb51c5d8-e329-408b-a9a9-924bdaec53e7",
+  "response": "Created `/tmp/zcode-probe-XYZ.txt` containing `hello-world`.",
+  "usage": {
+    "source": "provider",
+    "modelRequestCount": 2,
+    "inputTokens": 17892,
+    "outputTokens": 50,
+    "totalTokens": 17942,
+    "cacheReadTokens": 8896,
+    "cacheWriteTokens": 0,
+    "reasoningTokens": 0,
+    "webFetchRequests": 0,
+    "webSearchRequests": 0
+  },
+  "eventCount": 51,
+  "projection": {
+    "status": "idle",
+    "turnCount": 1,
+    "totalTokenCount": 17942,
+    "contextUsed": 8997,
+    "contextWindow": 1000000
+  }
+}

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -45,6 +45,7 @@ def test_cli_auto_runtime_enum_matches_supported_backends() -> None:
         "gjc",
         "antigravity",
         "grok",
+        "zcode",
     }
 
 
@@ -56,6 +57,16 @@ def test_cli_runtime_enums_accept_gjc_for_frontdoor_commands() -> None:
     assert run.AgentRuntimeBackend("gjc") is run.AgentRuntimeBackend.GJC
     assert mcp.AgentRuntimeBackend("gjc") is mcp.AgentRuntimeBackend.GJC
     assert init.AgentRuntimeBackend("gjc") is init.AgentRuntimeBackend.GJC
+
+
+def test_cli_runtime_enums_accept_zcode_for_frontdoor_commands() -> None:
+    from ouroboros.cli.commands import init, mcp, run
+    from ouroboros.cli.commands.auto import AgentRuntimeBackend as AutoRuntimeBackend
+
+    assert AutoRuntimeBackend("zcode") is AutoRuntimeBackend.ZCODE
+    assert run.AgentRuntimeBackend("zcode") is run.AgentRuntimeBackend.ZCODE
+    assert mcp.AgentRuntimeBackend("zcode") is mcp.AgentRuntimeBackend.ZCODE
+    assert init.AgentRuntimeBackend("zcode") is init.AgentRuntimeBackend.ZCODE
 
 
 def test_cli_llm_enums_keep_gjc_out_until_adapter_lands() -> None:

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -498,3 +498,42 @@ def test_mcp_server_instructions_are_provider_neutral_and_budget_safe() -> None:
     # mechanism — each runtime maps the abstract concept to its own.
     assert "ToolSearch" not in text
     assert "Task/Agent" not in text
+
+
+def test_zcode_skill_execution_capabilities_are_complete_not_generic() -> None:
+    """Zcode ships a measured capability matrix, not the generic defaults.
+
+    ``ask_user`` and ``orchestrate_subagents`` are intentionally omitted: the
+    headless ``--prompt`` path has no user turn-taking, and Zcode has no
+    native parallel subagent primitive (``/expert`` is sequential). See the
+    rationale block above ``_ZCODE_SKILL_EXECUTION_CAPABILITIES``. Regression
+    for the Q00 review on PR #1568 ("capability matrix as a first-class
+    object — zcode should have a complete matrix instead of the generic one").
+    """
+    capability = get_backend_capability("zcode")
+    assert capability is not None
+    names = {item.name for item in capability.skill_execution_capabilities}
+
+    # The two capabilities Zcode cannot truthfully provide on `--prompt`.
+    assert "ask_user" not in names
+    assert "orchestrate_subagents" not in names
+    # The capabilities Zcode does provide (verified via `zcode --help`,
+    # `zcode skills list`, and captured `--prompt --json` summaries).
+    assert names == {
+        "inspect_code",
+        "call_mcp",
+        "run_lateral_review",
+        "web_research",
+        "run_shell",
+        "refine_answer",
+        "maintain_ledger",
+        "run_closure_gate",
+        "restate_goal",
+    }
+
+    # Guidance references Zcode-specific mechanisms, not generic phrasing.
+    guide = render_backend_skill_capability_guide("zcode")
+    assert guide.startswith("## Ouroboros Skill Capability Guide: Zcode\n")
+    # restate_goal maps onto Zcode's native --target / /goal surface.
+    assert "`--target`" in guide
+    assert "`/goal`" in guide

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -108,7 +108,7 @@ def test_interview_driver_choices_follow_llm_capability() -> None:
 
 
 def test_soft_tool_enforcement_is_registry_owned() -> None:
-    assert soft_tool_enforcement_backends() == frozenset({"gemini", "goose", "opencode"})
+    assert soft_tool_enforcement_backends() == frozenset({"gemini", "goose", "opencode", "zcode"})
 
 
 def test_tool_envelope_support_is_registry_owned() -> None:

--- a/tests/unit/backends/test_model_catalog.py
+++ b/tests/unit/backends/test_model_catalog.py
@@ -42,6 +42,8 @@ def test_codex_catalog_offers_known_models_after_sentinel() -> None:
 def test_default_model_sentinel_support_follows_backend_contract() -> None:
     assert mc.uses_default_model_sentinel("codex") is True
     assert mc.uses_default_model_sentinel("codex_cli") is True
+    assert mc.uses_default_model_sentinel("zcode") is True
+    assert mc.uses_default_model_sentinel("zcode_cli") is True
     assert mc.uses_default_model_sentinel("claude") is False
     assert mc.uses_default_model_sentinel("claude_code") is False
 

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -110,6 +110,13 @@ class TestConfigShow:
 class TestConfigBackend:
     """Tests for config backend command."""
 
+    def test_help_lists_all_switchable_backends(self) -> None:
+        result = runner.invoke(app, ["backend", "--help"])
+
+        assert result.exit_code == 0
+        for backend in ("antigravity", "grok", "zcode"):
+            assert backend in result.output
+
     def test_show_current_backend(self, config_dir: Path) -> None:
         with patch("ouroboros.config.models.get_config_dir", return_value=config_dir):
             result = runner.invoke(app, ["backend"])

--- a/tests/unit/cli/test_config.py
+++ b/tests/unit/cli/test_config.py
@@ -242,6 +242,25 @@ class TestConfigBackend:
         assert result.exit_code == 1
         assert "OUROBOROS_PI_CLI_PATH" in result.output
 
+    def test_switch_to_zcode_honors_configured_cli_path(self, config_dir: Path) -> None:
+        """config backend zcode should use the app-bundle/config path and the
+        runtime-only setup helper instead of claiming success without writing."""
+        with (
+            patch("ouroboros.config.models.get_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.config.get_zcode_cli_path",
+                return_value="/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
+            ),
+            patch("shutil.which", return_value=None),
+            patch("ouroboros.cli.commands.setup._setup_zcode") as mock_setup,
+        ):
+            result = runner.invoke(app, ["backend", "zcode"])
+
+        assert result.exit_code == 0, result.output
+        mock_setup.assert_called_once_with(
+            "/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs"
+        )
+
     def test_switch_warns_on_setup_print_error(self, config_dir: Path) -> None:
         """config backend should warn when setup emits print_error (non-exception failure)."""
         from ouroboros.cli.commands import setup as setup_mod

--- a/tests/unit/cli/test_setup.py
+++ b/tests/unit/cli/test_setup.py
@@ -3130,6 +3130,61 @@ class TestGrokSetup:
         assert data["orchestrator"]["runtime_backend"] == "grok"
 
 
+class TestZcodeSetup:
+    """Tests for the runtime-only Zcode setup path."""
+
+    def test_setup_zcode_writes_runtime_only_config(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("{}", encoding="utf-8")
+
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+        ):
+            setup_cmd._setup_zcode("/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs")
+
+        data = yaml.safe_load((config_dir / "config.yaml").read_text(encoding="utf-8"))
+        assert data["orchestrator"]["runtime_backend"] == "zcode"
+        assert data["orchestrator"]["zcode_cli_path"].endswith("zcode.cjs")
+        assert data.get("llm", {}).get("backend") != "zcode"
+        from ouroboros.config.models import OuroborosConfig
+
+        OuroborosConfig.model_validate(data)
+
+    def test_detect_runtimes_includes_zcode(self) -> None:
+        with (
+            patch(
+                "ouroboros.cli.commands.setup.shutil.which",
+                side_effect=lambda name: "/usr/local/bin/zcode" if name == "zcode" else None,
+            ),
+            patch("ouroboros.config.get_zcode_cli_path", return_value=None),
+        ):
+            detected = setup_cmd._detect_runtimes()
+
+        assert detected["zcode"] == "/usr/local/bin/zcode"
+
+    def test_setup_runtime_zcode_dispatches_not_unsupported(self, tmp_path: Path) -> None:
+        config_dir = tmp_path / ".ouroboros"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("{}", encoding="utf-8")
+        runner = CliRunner()
+        with (
+            patch("pathlib.Path.home", return_value=tmp_path),
+            patch("ouroboros.config.loader.ensure_config_dir", return_value=config_dir),
+            patch(
+                "ouroboros.cli.commands.setup._detect_runtimes",
+                return_value={"zcode": "/usr/local/bin/zcode"},
+            ),
+        ):
+            result = runner.invoke(setup_cmd.app, ["--runtime", "zcode", "--non-interactive"])
+
+        assert "Unsupported runtime" not in result.output
+        assert result.exit_code == 0, result.output
+        data = yaml.safe_load((config_dir / "config.yaml").read_text(encoding="utf-8"))
+        assert data["orchestrator"]["runtime_backend"] == "zcode"
+
+
 class TestKiroSetup:
     """Tests for Kiro-specific setup behavior."""
 

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -43,6 +43,7 @@ from ouroboros.config.loader import (
     get_semantic_model,
     get_usage_limit_pause_seconds,
     get_wonder_model,
+    get_zcode_cli_path,
     load_config,
     load_credentials,
 )
@@ -655,6 +656,44 @@ class TestRuntimeHelperLookups:
             ),
         ):
             assert get_grok_cli_path() is None
+
+    def test_get_zcode_cli_path_returns_existing_env_script(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = tmp_path / "zcode.cjs"
+        fake.write_text("// zcode", encoding="utf-8")
+        monkeypatch.setenv("OUROBOROS_ZCODE_CLI_PATH", str(fake))
+
+        assert get_zcode_cli_path() == str(fake)
+
+    def test_get_zcode_cli_path_rejects_stale_env(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("OUROBOROS_ZCODE_CLI_PATH", str(tmp_path / "missing.cjs"))
+        with patch("ouroboros.config.loader.load_config", side_effect=ConfigError("missing")):
+            assert get_zcode_cli_path() is None
+
+    def test_get_zcode_cli_path_falls_back_to_config(self, tmp_path: Path) -> None:
+        fake = tmp_path / "zcode.cjs"
+        fake.write_text("// zcode", encoding="utf-8")
+        config = OuroborosConfig(orchestrator=OrchestratorConfig(zcode_cli_path=str(fake)))
+
+        with (
+            patch.dict(os.environ, {"OUROBOROS_ZCODE_CLI_PATH": ""}, clear=False),
+            patch("ouroboros.config.loader.load_config", return_value=config),
+        ):
+            assert get_zcode_cli_path() == str(fake)
+
+    def test_get_zcode_cli_path_rejects_stale_config(self, tmp_path: Path) -> None:
+        config = OuroborosConfig(
+            orchestrator=OrchestratorConfig(zcode_cli_path=str(tmp_path / "missing.cjs"))
+        )
+
+        with (
+            patch.dict(os.environ, {"OUROBOROS_ZCODE_CLI_PATH": ""}, clear=False),
+            patch("ouroboros.config.loader.load_config", return_value=config),
+        ):
+            assert get_zcode_cli_path() is None
 
     def test_get_kiro_cli_path_returns_executable_env(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -685,7 +685,7 @@ class TestRuntimeHelperLookups:
         monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("OUROBOROS_ZCODE_CLI_PATH", "zcode")
 
-        assert get_zcode_cli_path() == "zcode"
+        assert get_zcode_cli_path() == str(fake.resolve())
 
     def test_get_zcode_cli_path_rejects_non_executable_env_wrapper(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -714,6 +714,21 @@ class TestRuntimeHelperLookups:
             patch("ouroboros.config.loader.load_config", return_value=config),
         ):
             assert get_zcode_cli_path() == str(fake)
+
+    def test_get_zcode_cli_path_returns_relative_executable_config_wrapper(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = tmp_path / "zcode"
+        fake.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        fake.chmod(fake.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        monkeypatch.chdir(tmp_path)
+        config = OuroborosConfig(orchestrator=OrchestratorConfig(zcode_cli_path="zcode"))
+
+        with (
+            patch.dict(os.environ, {"OUROBOROS_ZCODE_CLI_PATH": ""}, clear=False),
+            patch("ouroboros.config.loader.load_config", return_value=config),
+        ):
+            assert get_zcode_cli_path() == str(fake.resolve())
 
     def test_get_zcode_cli_path_rejects_stale_config(self, tmp_path: Path) -> None:
         config = OuroborosConfig(

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -9,6 +9,7 @@ import pytest
 import yaml
 
 from ouroboros.config._model_defaults import DEFAULT_OPUS_MODEL, DEFAULT_SONNET_MODEL
+import ouroboros.config.loader as loader_module
 from ouroboros.config.loader import (
     config_exists,
     create_default_config,
@@ -60,6 +61,27 @@ from ouroboros.config.models import (
     RuntimeProfileConfig,
 )
 from ouroboros.core.errors import ConfigError
+
+_ZCODE_APP_BUNDLE_DEFAULT = Path("/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs")
+
+
+def _hide_default_zcode_bundle(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep zcode path tests independent from the developer machine's install.
+
+    ``get_zcode_cli_path`` intentionally falls back to the standard macOS
+    ZCode.app bundle after rejecting stale explicit env/config paths. Tests
+    that assert rejection of the explicit value must hide only that default
+    fallback; otherwise they fail on Macs where ZCode.app is installed and pass
+    on CI machines where it is absent.
+    """
+    original = loader_module._is_runnable_zcode_cli_path
+
+    def _without_default_bundle(path: str | Path) -> bool:
+        if Path(path) == _ZCODE_APP_BUNDLE_DEFAULT:
+            return False
+        return original(path)
+
+    monkeypatch.setattr(loader_module, "_is_runnable_zcode_cli_path", _without_default_bundle)
 
 
 @pytest.fixture
@@ -693,6 +715,7 @@ class TestRuntimeHelperLookups:
         fake = tmp_path / "zcode"
         fake.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
         monkeypatch.setenv("OUROBOROS_ZCODE_CLI_PATH", str(fake))
+        _hide_default_zcode_bundle(monkeypatch)
 
         with patch("ouroboros.config.loader.load_config", side_effect=ConfigError("missing")):
             assert get_zcode_cli_path() is None
@@ -701,6 +724,7 @@ class TestRuntimeHelperLookups:
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("OUROBOROS_ZCODE_CLI_PATH", str(tmp_path / "missing.cjs"))
+        _hide_default_zcode_bundle(monkeypatch)
         with patch("ouroboros.config.loader.load_config", side_effect=ConfigError("missing")):
             assert get_zcode_cli_path() is None
 
@@ -730,10 +754,13 @@ class TestRuntimeHelperLookups:
         ):
             assert get_zcode_cli_path() == str(fake.resolve())
 
-    def test_get_zcode_cli_path_rejects_stale_config(self, tmp_path: Path) -> None:
+    def test_get_zcode_cli_path_rejects_stale_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         config = OuroborosConfig(
             orchestrator=OrchestratorConfig(zcode_cli_path=str(tmp_path / "missing.cjs"))
         )
+        _hide_default_zcode_bundle(monkeypatch)
 
         with (
             patch.dict(os.environ, {"OUROBOROS_ZCODE_CLI_PATH": ""}, clear=False),
@@ -741,7 +768,9 @@ class TestRuntimeHelperLookups:
         ):
             assert get_zcode_cli_path() is None
 
-    def test_get_zcode_cli_path_rejects_non_executable_config_wrapper(self, tmp_path: Path) -> None:
+    def test_get_zcode_cli_path_rejects_non_executable_config_wrapper(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         fake = tmp_path / "zcode"
         fake.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
         config = OuroborosConfig(orchestrator=OrchestratorConfig(zcode_cli_path=str(fake)))
@@ -750,6 +779,7 @@ class TestRuntimeHelperLookups:
             patch.dict(os.environ, {"OUROBOROS_ZCODE_CLI_PATH": ""}, clear=False),
             patch("ouroboros.config.loader.load_config", return_value=config),
         ):
+            _hide_default_zcode_bundle(monkeypatch)
             assert get_zcode_cli_path() is None
 
     def test_get_kiro_cli_path_returns_executable_env(

--- a/tests/unit/config/test_loader.py
+++ b/tests/unit/config/test_loader.py
@@ -666,6 +666,37 @@ class TestRuntimeHelperLookups:
 
         assert get_zcode_cli_path() == str(fake)
 
+    def test_get_zcode_cli_path_returns_executable_env_wrapper(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = tmp_path / "zcode"
+        fake.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        fake.chmod(fake.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        monkeypatch.setenv("OUROBOROS_ZCODE_CLI_PATH", str(fake))
+
+        assert get_zcode_cli_path() == str(fake)
+
+    def test_get_zcode_cli_path_returns_relative_executable_env_wrapper(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = tmp_path / "zcode"
+        fake.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        fake.chmod(fake.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("OUROBOROS_ZCODE_CLI_PATH", "zcode")
+
+        assert get_zcode_cli_path() == "zcode"
+
+    def test_get_zcode_cli_path_rejects_non_executable_env_wrapper(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake = tmp_path / "zcode"
+        fake.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        monkeypatch.setenv("OUROBOROS_ZCODE_CLI_PATH", str(fake))
+
+        with patch("ouroboros.config.loader.load_config", side_effect=ConfigError("missing")):
+            assert get_zcode_cli_path() is None
+
     def test_get_zcode_cli_path_rejects_stale_env(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -688,6 +719,17 @@ class TestRuntimeHelperLookups:
         config = OuroborosConfig(
             orchestrator=OrchestratorConfig(zcode_cli_path=str(tmp_path / "missing.cjs"))
         )
+
+        with (
+            patch.dict(os.environ, {"OUROBOROS_ZCODE_CLI_PATH": ""}, clear=False),
+            patch("ouroboros.config.loader.load_config", return_value=config),
+        ):
+            assert get_zcode_cli_path() is None
+
+    def test_get_zcode_cli_path_rejects_non_executable_config_wrapper(self, tmp_path: Path) -> None:
+        fake = tmp_path / "zcode"
+        fake.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        config = OuroborosConfig(orchestrator=OrchestratorConfig(zcode_cli_path=str(fake)))
 
         with (
             patch.dict(os.environ, {"OUROBOROS_ZCODE_CLI_PATH": ""}, clear=False),

--- a/tests/unit/config/test_loader_env.py
+++ b/tests/unit/config/test_loader_env.py
@@ -91,8 +91,9 @@ def test_denylist_covers_known_execution_routing_keys() -> None:
     config-home root) without a failing test.
     """
     required = {
-        # Explicit executable-path overrides + bare alias.
+        # Process lookup/preload hooks + explicit path overrides/bare alias.
         "PATH",
+        "NODE_OPTIONS",
         "OUROBOROS_CLI_PATH",
         "OPENCODE_CLI_PATH",
         # Spawned-CLI / agent instruction + extension roots.
@@ -140,6 +141,20 @@ def test_untrusted_env_cannot_set_bare_opencode_alias(
     _load_env_file(env_file, trusted=False)
 
     assert "OPENCODE_CLI_PATH" not in os.environ
+
+
+def test_untrusted_env_cannot_set_node_options(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A cloned repo cannot preload JavaScript into a spawned Node CLI."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("NODE_OPTIONS=--require ./evil.js\n")
+    monkeypatch.delenv("NODE_OPTIONS", raising=False)
+
+    _load_env_file(env_file, trusted=False)
+
+    assert "NODE_OPTIONS" not in os.environ
 
 
 def test_untrusted_env_cannot_disable_approval_gate(

--- a/tests/unit/orchestrator/test_runtime_factory.py
+++ b/tests/unit/orchestrator/test_runtime_factory.py
@@ -16,6 +16,7 @@ from ouroboros.orchestrator.runtime_factory import (
     create_agent_runtime,
     resolve_agent_runtime_backend,
 )
+from ouroboros.orchestrator.zcode_cli_runtime import ZcodeCLIRuntime
 
 
 class TestResolveAgentRuntimeBackend:
@@ -455,5 +456,34 @@ def test_create_gjc_runtime_accepts_stream_timeout_overrides() -> None:
         )
 
     assert isinstance(runtime, GjcRuntime)
+    assert runtime._startup_output_timeout_seconds is None
+    assert runtime._stdout_idle_timeout_seconds is None
+
+
+def test_create_zcode_runtime_accepts_stream_timeout_overrides() -> None:
+    """Zcode runtime forwards the execute-seed stream-timeout overrides.
+
+    ``zcode --prompt --json`` emits a single buffered JSON summary at
+    completion — it produces no stdout until the run finishes. The MCP
+    execute-seed path therefore calls ``create_agent_runtime(...,
+    startup_output_timeout_seconds=0, stdout_idle_timeout_seconds=0)``
+    to disable the inherited Codex quiet-stream guards; if the Zcode
+    factory drops those overrides the subprocess is killed as "produced
+    no stdout" after the 60s startup default, even on a healthy run.
+    Regression for the bot review on PR #1568 (HEAD 1f31e1d1).
+    """
+    with patch(
+        "ouroboros.orchestrator.runtime_factory.create_codex_command_dispatcher",
+        return_value=object(),
+    ):
+        runtime = create_agent_runtime(
+            backend="zcode",
+            cli_path="/tmp/zcode.cjs",
+            cwd="/tmp/project",
+            startup_output_timeout_seconds=0,
+            stdout_idle_timeout_seconds=0,
+        )
+
+    assert isinstance(runtime, ZcodeCLIRuntime)
     assert runtime._startup_output_timeout_seconds is None
     assert runtime._stdout_idle_timeout_seconds is None

--- a/tests/unit/orchestrator/test_zcode_cli_runtime.py
+++ b/tests/unit/orchestrator/test_zcode_cli_runtime.py
@@ -1,8 +1,9 @@
 """Tests for :class:`ZcodeCLIRuntime`.
 
-Pinned to the **measured** behaviour of
-``node zcode.cjs --prompt ... --json`` (captured against a live run with a
-working model config), not to an assumed event schema:
+Pinned to the **measured** behaviour of an official ZCode app-bundle
+``zcode.cjs --prompt ... --json`` run through its bundled Electron/Node runtime
+(captured against a live run with a working model config), not to an assumed
+event schema:
 
 - zcode emits a SINGLE pretty-printed JSON summary object (not an NDJSON stream):
   ``{sessionId, traceId, turnId, response, usage, eventCount, projection}``.
@@ -10,7 +11,8 @@ working model config), not to an assumed event schema:
   do not appear as discrete stdout events.
 - Real CLI flags are ``--json``, ``--prompt``, ``--cwd``, ``--mode``, ``--resume``
   (there is **no** ``--non-interactive`` and **no** ``--approval-mode``).
-- The CLI is invoked as ``node <cli_path>``.
+- Official app bundles use their Electron/Node runtime; standalone scripts use
+  ``node <cli_path>`` and PATH executables run directly.
 
 Captured fixtures live under ``tests/fixtures/zcode/``.
 """
@@ -20,6 +22,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+import plistlib
 from typing import Any
 
 import pytest
@@ -37,9 +40,33 @@ def _load(name: str) -> dict[str, Any]:
 @pytest.fixture
 def runtime() -> ZcodeCLIRuntime:
     return ZcodeCLIRuntime(
-        cli_path="/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
+        cli_path="/tmp/zcode.cjs",
         permission_mode="acceptEdits",
     )
+
+
+def _fake_electron_node_bundle(tmp_path: Path) -> tuple[Path, Path]:
+    contents = tmp_path / "ZCode.app" / "Contents"
+    cli_path = contents / "Resources" / "glm" / "zcode.cjs"
+    electron_node = contents / "MacOS" / "ZCode"
+    cli_path.parent.mkdir(parents=True)
+    electron_node.parent.mkdir(parents=True)
+    cli_path.write_text("// zcode", encoding="utf-8")
+    cli_path.with_name(".node-bundle-meta.json").write_text(
+        json.dumps(
+            {
+                "runtime": "electron-node",
+                "entry": "zcode.cjs",
+                "platform": "darwin-arm64",
+            }
+        ),
+        encoding="utf-8",
+    )
+    with (contents / "Info.plist").open("wb") as stream:
+        plistlib.dump({"CFBundleExecutable": "ZCode"}, stream)
+    electron_node.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    electron_node.chmod(0o755)
+    return cli_path, electron_node
 
 
 # -- capabilities ----------------------------------------------------------
@@ -50,6 +77,17 @@ def test_capabilities_declared_correctly(runtime: ZcodeCLIRuntime) -> None:
     assert caps.structured_output is True
     assert caps.targeted_resume is True
     assert caps.reasoning_effort_support == ParamSupport.IGNORED
+
+
+def test_direct_runtime_uses_completion_capable_llm_backend() -> None:
+    """Zcode is runtime-only, so direct construction needs a valid fallback
+    for built-in interview/seed/evaluate/qa handlers."""
+    from ouroboros.providers import resolve_llm_backend
+
+    runtime = ZcodeCLIRuntime(cli_path="/tmp/zcode.cjs")
+
+    assert runtime.llm_backend == "claude_code"
+    assert resolve_llm_backend(runtime.llm_backend) == "claude_code"
 
 
 # -- _convert_event: measured single-JSON summary --------------------------
@@ -123,6 +161,142 @@ def test_build_command_uses_real_flags(runtime: ZcodeCLIRuntime) -> None:
     assert "auto_edit" not in cmd
 
 
+def test_build_command_app_bundle_uses_bundled_electron_node(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_path, electron_node = _fake_electron_node_bundle(tmp_path)
+    monkeypatch.setenv("NODE_OPTIONS", "--require ./evil.js")
+    runtime = ZcodeCLIRuntime(cli_path=cli_path, permission_mode="acceptEdits")
+
+    cmd = runtime._build_command("/tmp/unused", prompt="hi")
+
+    assert cmd[:2] == [str(electron_node), str(cli_path)]
+    assert cmd[2:7] == ["--json", "--prompt", "hi", "--mode", "edit"]
+    assert "--cwd" in cmd
+    child_env = runtime._build_child_env()
+    assert child_env["ELECTRON_RUN_AS_NODE"] == "1"
+    assert "NODE_OPTIONS" not in child_env
+
+
+def test_app_bundle_detection_does_not_depend_on_resource_depth(tmp_path: Path) -> None:
+    cli_path, electron_node = _fake_electron_node_bundle(tmp_path)
+    nested_dir = cli_path.parent / "nested" / "deeper"
+    nested_dir.mkdir(parents=True)
+    nested_cli = nested_dir / cli_path.name
+    nested_metadata = nested_dir / ".node-bundle-meta.json"
+    cli_path.replace(nested_cli)
+    cli_path.with_name(".node-bundle-meta.json").replace(nested_metadata)
+
+    runtime = ZcodeCLIRuntime(cli_path=nested_cli, permission_mode="acceptEdits")
+
+    assert runtime._build_command("/tmp/unused", prompt="hi")[:2] == [
+        str(electron_node),
+        str(nested_cli),
+    ]
+
+
+def test_build_command_plain_cjs_uses_system_node_without_electron_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_path = tmp_path / "zcode.cjs"
+    cli_path.write_text("// standalone zcode", encoding="utf-8")
+    monkeypatch.setenv("ELECTRON_RUN_AS_NODE", "1")
+    monkeypatch.setenv("NODE_OPTIONS", "--require ./evil.js")
+    runtime = ZcodeCLIRuntime(cli_path=cli_path, permission_mode="acceptEdits")
+
+    cmd = runtime._build_command("/tmp/unused", prompt="hi")
+
+    assert cmd[:2] == ["node", str(cli_path)]
+    child_env = runtime._build_child_env()
+    assert "ELECTRON_RUN_AS_NODE" not in child_env
+    assert "NODE_OPTIONS" not in child_env
+
+
+@pytest.mark.parametrize(
+    ("metadata_content", "error_match"),
+    [
+        (None, "missing or unreadable"),
+        ("{", "invalid JSON"),
+        (json.dumps([]), "must be a JSON object"),
+        (json.dumps({"runtime": "node", "entry": "zcode.cjs"}), "unsupported runtime"),
+        (
+            json.dumps({"runtime": "electron-node", "entry": "other.cjs"}),
+            "entry does not match",
+        ),
+        (json.dumps({"runtime": "electron-node"}), "entry does not match"),
+    ],
+)
+def test_app_bundle_invalid_node_metadata_fails_closed(
+    tmp_path: Path,
+    metadata_content: str | None,
+    error_match: str,
+) -> None:
+    cli_path, _ = _fake_electron_node_bundle(tmp_path)
+    metadata_path = cli_path.with_name(".node-bundle-meta.json")
+    if metadata_content is None:
+        metadata_path.unlink()
+    else:
+        metadata_path.write_text(metadata_content, encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match=error_match):
+        ZcodeCLIRuntime(cli_path=cli_path, permission_mode="acceptEdits")
+
+
+def test_app_bundle_unreadable_node_metadata_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cli_path, _ = _fake_electron_node_bundle(tmp_path)
+    metadata_path = cli_path.with_name(".node-bundle-meta.json")
+    original_read_text = Path.read_text
+
+    def _raise_for_metadata(path: Path, *args: Any, **kwargs: Any) -> str:
+        if path == metadata_path:
+            raise PermissionError("denied")
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _raise_for_metadata)
+
+    with pytest.raises(RuntimeError, match="missing or unreadable"):
+        ZcodeCLIRuntime(cli_path=cli_path, permission_mode="acceptEdits")
+
+
+def test_app_bundle_non_dictionary_plist_fails_closed(tmp_path: Path) -> None:
+    cli_path, _ = _fake_electron_node_bundle(tmp_path)
+    info_plist = cli_path.parents[2] / "Info.plist"
+    with info_plist.open("wb") as stream:
+        plistlib.dump(["not", "a", "dictionary"], stream)
+
+    with pytest.raises(RuntimeError, match="must be a dictionary"):
+        ZcodeCLIRuntime(cli_path=cli_path, permission_mode="acceptEdits")
+
+
+@pytest.mark.parametrize("executable_name", ["../ZCode", "nested/ZCode", r"..\ZCode", ".."])
+def test_app_bundle_rejects_executable_path_traversal(
+    tmp_path: Path,
+    executable_name: str,
+) -> None:
+    cli_path, _ = _fake_electron_node_bundle(tmp_path)
+    info_plist = cli_path.parents[2] / "Info.plist"
+    with info_plist.open("wb") as stream:
+        plistlib.dump({"CFBundleExecutable": executable_name}, stream)
+
+    with pytest.raises(RuntimeError, match="without path separators"):
+        ZcodeCLIRuntime(cli_path=cli_path, permission_mode="acceptEdits")
+
+
+def test_app_bundle_missing_electron_runtime_fails_with_actionable_error(
+    tmp_path: Path,
+) -> None:
+    cli_path, electron_node = _fake_electron_node_bundle(tmp_path)
+    electron_node.unlink()
+
+    with pytest.raises(RuntimeError, match="electron-node CLI"):
+        ZcodeCLIRuntime(cli_path=cli_path, permission_mode="acceptEdits")
+
+
 def test_build_command_bypass_permissions_maps_to_yolo() -> None:
     rt = ZcodeCLIRuntime(
         cli_path="/tmp/zcode.cjs",
@@ -134,7 +308,7 @@ def test_build_command_bypass_permissions_maps_to_yolo() -> None:
 
 
 # -- _build_command: NO --model flag, ever (zcode has no model CLI flag) -----
-# zcode has NO ``--model`` flag — verified on 0.14.5 and 0.15.0, where
+# zcode has NO ``--model`` flag — verified on 0.14.5, 0.15.0, and 0.15.2, where
 # ``--model`` is a hard ``Unknown option`` rejection that aborts the run before
 # zcode does any work (reproduced: ``node zcode.cjs --model glm-4.6 --version``
 # → "Unknown option '--model'"). The constructor warns when a non-default model
@@ -173,6 +347,37 @@ def test_build_command_never_emits_model_flag_even_when_explicit_non_default(
     assert "--model" not in cmd
     # And the model id must not leak in as a bare positional either.
     assert "glm-4.6" not in cmd
+
+
+def test_build_command_ignores_per_call_model_override(runtime: ZcodeCLIRuntime) -> None:
+    """The shared runtime API may supply a per-call model even though Zcode
+    cannot enforce one; accepting and dropping it must not fail preparation."""
+    cmd = runtime._build_command(
+        "/tmp/unused",
+        prompt="hi",
+        model="glm-5.2",
+    )
+
+    assert "--model" not in cmd
+    assert "glm-5.2" not in cmd
+
+
+@pytest.mark.asyncio
+async def test_execute_task_accepts_ignored_per_call_model(tmp_path: Path) -> None:
+    """Exercise the public API, not only the command helper: a routed model
+    must not fail preparation for a runtime that truthfully declares it ignored."""
+    fake_zcode = tmp_path / "zcode"
+    fake_zcode.write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' \'{"sessionId":"sess_fake","response":"OK"}\'\n',
+        encoding="utf-8",
+    )
+    fake_zcode.chmod(0o755)
+    runtime = ZcodeCLIRuntime(cli_path=fake_zcode)
+
+    messages = [message async for message in runtime.execute_task("hi", model="glm-5.2")]
+
+    assert any(message.type == "assistant" and message.content == "OK" for message in messages)
+    assert not any("unexpected keyword argument 'model'" in message.content for message in messages)
 
 
 # -- startup timeout: disabled by default for zcode's buffered output ---------
@@ -224,6 +429,7 @@ def test_build_command_path_executable_invoked_directly_without_node() -> None:
     assert "node" not in cmd
     assert "--json" in cmd
     assert "--prompt" in cmd
+    assert "ELECTRON_RUN_AS_NODE" not in rt._build_child_env()
 
 
 def test_build_command_includes_cwd_and_resume() -> None:
@@ -333,3 +539,19 @@ def test_validate_runtime_backend_accepts_zcode() -> None:
     from ouroboros.config.models import _validate_runtime_backend
 
     assert _validate_runtime_backend("zcode", field_name="test") == "zcode"
+
+
+def test_cli_runtime_enums_accept_zcode() -> None:
+    from ouroboros.cli.commands.init import AgentRuntimeBackend as InitBackend
+    from ouroboros.cli.commands.mcp import AgentRuntimeBackend as McpBackend
+    from ouroboros.cli.commands.run import AgentRuntimeBackend as RunBackend
+
+    assert InitBackend("zcode") is InitBackend.ZCODE
+    assert McpBackend("zcode") is McpBackend.ZCODE
+    assert RunBackend("zcode") is RunBackend.ZCODE
+
+
+def test_auto_cli_runtime_enum_accepts_zcode() -> None:
+    from ouroboros.cli.commands.auto import AgentRuntimeBackend as AutoBackend
+
+    assert AutoBackend("zcode") is AutoBackend.ZCODE

--- a/tests/unit/orchestrator/test_zcode_cli_runtime.py
+++ b/tests/unit/orchestrator/test_zcode_cli_runtime.py
@@ -380,6 +380,55 @@ async def test_execute_task_accepts_ignored_per_call_model(tmp_path: Path) -> No
     assert not any("unexpected keyword argument 'model'" in message.content for message in messages)
 
 
+@pytest.mark.asyncio
+async def test_execute_task_reuses_captured_session_id_for_resume(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The public execute path must carry a returned session into --resume.
+
+    Helper tests cover session-id extraction and command construction separately;
+    this integration test locks the handoff between them so a future base-runtime
+    change cannot silently drop Zcode's reconnect handle.
+    """
+    args_log = tmp_path / "zcode-args.log"
+    fake_zcode = tmp_path / "zcode"
+    fake_zcode.write_text(
+        "#!/bin/sh\n"
+        'printf \'%s\\n\' "$@" >> "$ZCODE_ARGS_LOG"\n'
+        'printf \'%s\\n\' "--invocation-end--" >> "$ZCODE_ARGS_LOG"\n'
+        'printf \'%s\\n\' \'{"sessionId":"sess_fake","response":"OK"}\'\n',
+        encoding="utf-8",
+    )
+    fake_zcode.chmod(0o755)
+    monkeypatch.setenv("ZCODE_ARGS_LOG", str(args_log))
+    runtime = ZcodeCLIRuntime(cli_path=fake_zcode)
+
+    first_messages = [message async for message in runtime.execute_task("first")]
+    resume_handle = next(
+        message.resume_handle for message in first_messages if message.resume_handle is not None
+    )
+    assert resume_handle.backend == "zcode_cli"
+    assert resume_handle.native_session_id == "sess_fake"
+
+    _ = [
+        message
+        async for message in runtime.execute_task(
+            "second",
+            resume_handle=resume_handle,
+        )
+    ]
+
+    recorded = args_log.read_text(encoding="utf-8").splitlines()
+    separators = [index for index, value in enumerate(recorded) if value == "--invocation-end--"]
+    assert len(separators) == 2
+    first_args = recorded[: separators[0]]
+    second_args = recorded[separators[0] + 1 : separators[1]]
+    assert "--resume" not in first_args
+    resume_index = second_args.index("--resume")
+    assert second_args[resume_index : resume_index + 2] == ["--resume", "sess_fake"]
+
+
 # -- startup timeout: disabled by default for zcode's buffered output ---------
 # zcode ``--prompt --json`` stays silent until its whole summary lands, so the
 # inherited 60s "first chunk" watchdog would cap the ENTIRE task at 60s on any

--- a/tests/unit/orchestrator/test_zcode_cli_runtime.py
+++ b/tests/unit/orchestrator/test_zcode_cli_runtime.py
@@ -116,10 +116,46 @@ def test_convert_event_tool_summary_to_assistant(runtime: ZcodeCLIRuntime) -> No
     assert msgs[0].data.get("usage", {}).get("modelRequestCount") == 2
 
 
-def test_convert_event_empty_response_returns_nothing(runtime: ZcodeCLIRuntime) -> None:
-    assert runtime._convert_event({"sessionId": "sess_x"}, None) == []
-    assert runtime._convert_event({"response": ""}, None) == []
-    assert runtime._convert_event({"response": None}, None) == []
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"sessionId": "sess_x"},
+        {"response": ""},
+        {"response": "   "},
+        {"response": None},
+    ],
+)
+def test_convert_event_empty_response_is_protocol_error(
+    runtime: ZcodeCLIRuntime,
+    event: dict[str, Any],
+) -> None:
+    msgs = runtime._convert_event(event, None)
+    assert len(msgs) == 1
+    assert msgs[0].type == "result"
+    assert msgs[0].is_error
+    assert "non-empty response" in msgs[0].content
+    assert msgs[0].data["protocol_error"] == "missing_response"
+
+
+@pytest.mark.asyncio
+async def test_execute_task_empty_response_fails_closed_without_generic_success(
+    tmp_path: Path,
+) -> None:
+    fake_zcode = tmp_path / "zcode"
+    fake_zcode.write_text(
+        '#!/bin/sh\nprintf \'%s\\n\' \'{"sessionId":"sess_empty","response":""}\'\n',
+        encoding="utf-8",
+    )
+    fake_zcode.chmod(0o755)
+    runtime = ZcodeCLIRuntime(cli_path=fake_zcode)
+
+    messages = [message async for message in runtime.execute_task("hi")]
+
+    final_messages = [message for message in messages if message.is_final]
+    assert len(final_messages) == 1
+    assert final_messages[0].is_error
+    assert final_messages[0].data["protocol_error"] == "missing_response"
+    assert "Zcode CLI task completed" not in final_messages[0].content
 
 
 def test_convert_event_truncates_oversized_response(runtime: ZcodeCLIRuntime) -> None:
@@ -347,6 +383,16 @@ def test_build_command_never_emits_model_flag_even_when_explicit_non_default(
     assert "--model" not in cmd
     # And the model id must not leak in as a bare positional either.
     assert "glm-4.6" not in cmd
+
+
+def test_constructor_model_is_not_promoted_to_effective_identity() -> None:
+    runtime = ZcodeCLIRuntime(cli_path="/tmp/zcode.cjs", model="glm-4.6")
+
+    identity = runtime.execution_identity_contract()
+
+    assert runtime._model is None
+    assert identity["requested_model"] == "glm-4.6"
+    assert identity["effective_model_observed"] is False
 
 
 def test_build_command_ignores_per_call_model_override(runtime: ZcodeCLIRuntime) -> None:

--- a/tests/unit/orchestrator/test_zcode_cli_runtime.py
+++ b/tests/unit/orchestrator/test_zcode_cli_runtime.py
@@ -133,13 +133,17 @@ def test_build_command_bypass_permissions_maps_to_yolo() -> None:
     assert "--mode" in cmd
 
 
-# -- _build_command: model override (only intentional non-default ids forwarded) --
-# Regression for the Follow-up finding: ``_normalize_model`` (inherited from
-# CodexCliRuntime) drops ``None`` / empty / ``"default"`` so zcode's own default
-# model is never leaked as a ``--model`` value. Only an explicit, non-default
-# Zcode model id reaches the CLI. The loader's sentinel normalization
-# (``_ZCODE_LLM_BACKENDS``) maps shipped Claude defaults to ``"default"`` first,
-# which this gate then strips — together they keep Claude ids off zcode's CLI.
+# -- _build_command: NO --model flag, ever (zcode has no model CLI flag) -----
+# zcode has NO ``--model`` flag — verified on 0.14.5 and 0.15.0, where
+# ``--model`` is a hard ``Unknown option`` rejection that aborts the run before
+# zcode does any work (reproduced: ``node zcode.cjs --model glm-4.6 --version``
+# → "Unknown option '--model'"). The constructor warns when a non-default model
+# is requested so the request-vs-config gap is visible, but the value is never
+# forwarded. These tests pin that contract: regardless of what ``_model`` holds,
+# the built command must NOT contain ``--model``. This inverts the earlier
+# (wrong) test ``test_build_command_forwards_intentional_non_default_model``,
+# which asserted ``--model glm-4.6`` WAS forwarded — that assertion locked in a
+# regression and shipped a hard-failing flag.
 
 
 def test_build_command_omits_model_flag_when_unset(runtime: ZcodeCLIRuntime) -> None:
@@ -154,13 +158,55 @@ def test_build_command_strips_default_sentinel_model(runtime: ZcodeCLIRuntime) -
     assert "--model" not in cmd
 
 
-def test_build_command_forwards_intentional_non_default_model(
+def test_build_command_never_emits_model_flag_even_when_explicit_non_default(
     runtime: ZcodeCLIRuntime,
 ) -> None:
+    """A non-default model must NEVER produce ``--model``.
+
+    zcode has no ``--model`` flag; emitting it aborts the run. This is the
+    inverted regression for the blocking defect: the earlier test asserted the
+    opposite (that ``glm-4.6`` WAS forwarded) and thereby guaranteed a
+    hard-failing flag for any non-default model config.
+    """
     runtime._model = "glm-4.6"
     cmd = runtime._build_command("/tmp/unused", prompt="hi")
-    assert "--model" in cmd
-    assert cmd[cmd.index("--model") + 1] == "glm-4.6"
+    assert "--model" not in cmd
+    # And the model id must not leak in as a bare positional either.
+    assert "glm-4.6" not in cmd
+
+
+# -- startup timeout: disabled by default for zcode's buffered output ---------
+# zcode ``--prompt --json`` stays silent until its whole summary lands, so the
+# inherited 60s "first chunk" watchdog would cap the ENTIRE task at 60s on any
+# caller that doesn't pass an explicit override (e.g. a direct
+# ``create_agent_runtime(backend="zcode")``). The class-level default is
+# therefore ``None`` (disabled); an explicit positive override still wins.
+
+
+def test_startup_output_timeout_disabled_by_default() -> None:
+    rt = ZcodeCLIRuntime(cli_path="/tmp/zcode.cjs", permission_mode="acceptEdits")
+    assert rt._startup_output_timeout_seconds is None
+
+
+def test_startup_output_timeout_explicit_override_still_wins() -> None:
+    """A caller that explicitly wants a cap can still set one."""
+    rt = ZcodeCLIRuntime(
+        cli_path="/tmp/zcode.cjs",
+        permission_mode="acceptEdits",
+        startup_output_timeout_seconds=30,
+    )
+    assert rt._startup_output_timeout_seconds == 30
+
+
+def test_startup_output_timeout_execute_seed_zero_contract() -> None:
+    """The execute-seed path forwards ``0`` to disable the guard — the class
+    default must not interfere with that (``0`` → ``None`` via the parent)."""
+    rt = ZcodeCLIRuntime(
+        cli_path="/tmp/zcode.cjs",
+        permission_mode="acceptEdits",
+        startup_output_timeout_seconds=0,
+    )
+    assert rt._startup_output_timeout_seconds is None
 
 
 def test_build_command_path_executable_invoked_directly_without_node() -> None:

--- a/tests/unit/orchestrator/test_zcode_cli_runtime.py
+++ b/tests/unit/orchestrator/test_zcode_cli_runtime.py
@@ -1,0 +1,524 @@
+"""Focused unit tests for the Zcode CLI runtime.
+
+These tests cover:
+1. ``_convert_event`` surfaces assistant/tool/result events correctly
+2. ``_extract_event_session_id`` captures session IDs for --resume
+3. ``_build_command`` maps permission modes correctly
+4. Runtime capabilities are declared correctly
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.orchestrator.adapter import ParamSupport
+from ouroboros.orchestrator.zcode_cli_runtime import (
+    _MAX_OUROBOROS_DEPTH,
+    ZcodeCLIRuntime,
+)
+from ouroboros.orchestrator.runtime_factory import resolve_agent_runtime_backend
+
+# ---------------------------------------------------------------------------
+# _convert_event: event type handling
+# ---------------------------------------------------------------------------
+
+
+def _make_runtime() -> ZcodeCLIRuntime:
+    return ZcodeCLIRuntime(cli_path="/usr/bin/zcode")
+
+
+def test_convert_event_handles_text_message() -> None:
+    """Text/message events produce assistant messages."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "text",
+        "content": "Hello, world!",
+        "metadata": {},
+        "is_error": False,
+    }
+
+    messages = runtime._convert_event(event, current_handle=None)
+
+    assert len(messages) == 1
+    assert messages[0].type == "assistant"
+    assert messages[0].content == "Hello, world!"
+
+
+def test_convert_event_handles_message_event() -> None:
+    """Message events produce assistant messages."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "message",
+        "content": "Processing your request...",
+        "metadata": {},
+        "is_error": False,
+    }
+
+    messages = runtime._convert_event(event, current_handle=None)
+
+    assert len(messages) == 1
+    assert messages[0].type == "assistant"
+    assert messages[0].content == "Processing your request..."
+
+
+def test_convert_event_handles_thinking() -> None:
+    """Thinking events produce assistant messages with thinking data."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "thinking",
+        "content": "Analyzing the problem...",
+        "metadata": {},
+        "is_error": False,
+    }
+
+    messages = runtime._convert_event(event, current_handle=None)
+
+    assert len(messages) == 1
+    assert messages[0].type == "assistant"
+    assert messages[0].content == "Analyzing the problem..."
+    assert messages[0].data is not None
+    assert messages[0].data.get("thinking") == "Analyzing the problem..."
+
+
+def test_convert_event_handles_tool_use() -> None:
+    """Tool use events produce assistant messages with tool_name and data."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "tool_use",
+        "content": "Reading file",
+        "metadata": {
+            "name": "Read",
+            "input": {"file_path": "/path/to/file.txt"},
+        },
+        "is_error": False,
+    }
+
+    messages = runtime._convert_event(event, current_handle=None)
+
+    assert len(messages) == 1
+    assert messages[0].type == "assistant"
+    assert messages[0].tool_name == "Read"
+    assert messages[0].data is not None
+    assert messages[0].data.get("tool_input") == {"file_path": "/path/to/file.txt"}
+
+
+def test_convert_event_handles_tool_result() -> None:
+    """Tool result events produce tool messages."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "tool_result",
+        "content": "File content read successfully",
+        "metadata": {
+            "name": "Read",
+        },
+        "is_error": False,
+    }
+
+    messages = runtime._convert_event(event, current_handle=None)
+
+    assert len(messages) == 1
+    assert messages[0].type == "tool"
+    assert messages[0].tool_name == "Read"
+    assert messages[0].content == "File content read successfully"
+
+
+def test_convert_event_handles_tool_result_error() -> None:
+    """Tool result errors carry is_error in data."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "tool_result",
+        "content": "File not found",
+        "metadata": {
+            "name": "Read",
+        },
+        "is_error": True,
+    }
+
+    messages = runtime._convert_event(event, current_handle=None)
+
+    assert len(messages) == 1
+    assert messages[0].type == "tool"
+    assert messages[0].data is not None
+    assert messages[0].data.get("is_error") is True
+
+
+def test_convert_event_handles_error() -> None:
+    """Error events produce system messages."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "error",
+        "content": "API rate limit exceeded",
+        "metadata": {},
+        "is_error": False,
+    }
+
+    messages = runtime._convert_event(event, current_handle=None)
+
+    assert len(messages) == 1
+    assert messages[0].type == "system"
+    assert "Zcode Error:" in messages[0].content
+    assert messages[0].data is not None
+    assert messages[0].data.get("is_error") is True
+
+
+def test_convert_event_handles_result_with_content() -> None:
+    """Result events with content produce terminal assistant messages."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "result",
+        "content": "Task completed successfully",
+        "metadata": {"session_id": "sess-123"},
+        "is_error": False,
+    }
+
+    messages = runtime._convert_event(event, current_handle=None)
+
+    assert len(messages) == 1
+    assert messages[0].type == "assistant"
+    assert messages[0].content == "Task completed successfully"
+    assert messages[0].data is not None
+    assert messages[0].data.get("terminal") is True
+
+
+def test_convert_event_handles_result_without_content() -> None:
+    """Result events without content emit a marker message."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "result",
+        "content": "",
+        "metadata": {"session_id": "sess-empty"},
+        "is_error": False,
+    }
+
+    messages = runtime._convert_event(event, current_handle=None)
+
+    assert len(messages) == 1
+    assert messages[0].type == "assistant"
+    assert messages[0].content == ""
+    assert messages[0].data is not None
+    assert messages[0].data.get("terminal") is True
+
+
+def test_convert_event_ignores_unknown_events() -> None:
+    """Unknown event types return empty list."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "unknown_event_type",
+        "content": "Should be ignored",
+        "metadata": {},
+        "is_error": False,
+    }
+
+    messages = runtime._convert_event(event, current_handle=None)
+
+    assert len(messages) == 0
+
+
+def test_convert_event_returns_empty_for_text_without_content() -> None:
+    """Text events without content produce no messages."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "text",
+        "content": "",
+        "metadata": {},
+        "is_error": False,
+    }
+
+    messages = runtime._convert_event(event, current_handle=None)
+
+    assert len(messages) == 0
+
+
+# ---------------------------------------------------------------------------
+# _extract_event_session_id: session ID extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_session_id_from_metadata() -> None:
+    """Session IDs are extracted from the metadata field."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "init",
+        "metadata": {
+            "session_id": "sess-from-metadata",
+        },
+    }
+
+    session_id = runtime._extract_event_session_id(event)
+
+    assert session_id == "sess-from-metadata"
+
+
+def test_extract_session_id_from_raw() -> None:
+    """Session IDs are extracted from the raw field."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "init",
+        "raw": {
+            "session_id": "sess-from-raw",
+        },
+    }
+
+    session_id = runtime._extract_event_session_id(event)
+
+    assert session_id == "sess-from-raw"
+
+
+def test_extract_session_id_from_top_level() -> None:
+    """Session IDs are extracted from top-level keys."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "init",
+        "session_id": "sess-toplevel",
+    }
+
+    session_id = runtime._extract_event_session_id(event)
+
+    assert session_id == "sess-toplevel"
+
+
+def test_extract_session_id_returns_none_when_missing() -> None:
+    """Events without session ID return None."""
+    runtime = _make_runtime()
+
+    event = {
+        "type": "message",
+        "content": "No session here",
+    }
+
+    session_id = runtime._extract_event_session_id(event)
+
+    assert session_id is None
+
+
+# ---------------------------------------------------------------------------
+# _build_command: permission mode mapping
+# ---------------------------------------------------------------------------
+
+
+def test_build_command_maps_bypass_permissions_to_yolo() -> None:
+    """bypassPermissions maps to zcode's yolo mode."""
+    runtime = ZcodeCLIRuntime(
+        cli_path="/usr/bin/zcode",
+        permission_mode="bypassPermissions",
+    )
+    cmd = runtime._build_command("/tmp/unused", prompt="test")
+
+    assert "--approval-mode" in cmd
+    idx = cmd.index("--approval-mode")
+    assert cmd[idx + 1] == "yolo"
+
+
+def test_build_command_maps_accept_edits_to_auto_edit() -> None:
+    """acceptEdits maps to zcode's auto_edit mode."""
+    runtime = ZcodeCLIRuntime(
+        cli_path="/usr/bin/zcode",
+        permission_mode="acceptEdits",
+    )
+    cmd = runtime._build_command("/tmp/unused", prompt="test")
+
+    assert "--approval-mode" in cmd
+    idx = cmd.index("--approval-mode")
+    assert cmd[idx + 1] == "auto_edit"
+
+
+def test_default_permission_mode_is_accept_edits() -> None:
+    """Default permission mode is acceptEdits (auto_edit)."""
+    runtime = ZcodeCLIRuntime(cli_path="/usr/bin/zcode")
+
+    assert runtime.permission_mode == "acceptEdits"
+
+    cmd = runtime._build_command("/tmp/unused", prompt="test")
+    assert "--approval-mode" in cmd
+    idx = cmd.index("--approval-mode")
+    assert cmd[idx + 1] == "auto_edit"
+
+
+def test_unknown_permission_mode_raises_value_error() -> None:
+    """Unknown permission modes raise ValueError."""
+    with pytest.raises(ValueError, match="Unsupported Zcode permission mode"):
+        ZcodeCLIRuntime(
+            cli_path="/usr/bin/zcode",
+            permission_mode="unknown_mode",
+        )
+
+
+def test_permission_mode_default_normalized_to_accept_edits() -> None:
+    """The 'default' mode is normalized to acceptEdits."""
+    from structlog.testing import capture_logs
+
+    with capture_logs() as cap_logs:
+        runtime = ZcodeCLIRuntime(
+            cli_path="/usr/bin/zcode",
+            permission_mode="default",
+        )
+
+    assert runtime.permission_mode == "acceptEdits"
+    coerced = [
+        e for e in cap_logs if e.get("event") == "zcode_cli_runtime.permission_mode_coerced"
+    ]
+    assert len(coerced) == 1
+    assert coerced[0]["requested"] == "default"
+    assert coerced[0]["resolved"] == "acceptEdits"
+
+
+# ---------------------------------------------------------------------------
+# Command construction
+# ---------------------------------------------------------------------------
+
+
+def test_build_command_includes_json_flag() -> None:
+    """--json flag is always present for structured output."""
+    runtime = _make_runtime()
+    cmd = runtime._build_command("/tmp/unused", prompt="test")
+
+    assert "--json" in cmd
+
+
+def test_build_command_includes_non_interactive_flag() -> None:
+    """--non-interactive ensures headless execution."""
+    runtime = _make_runtime()
+    cmd = runtime._build_command("/tmp/unused", prompt="test")
+
+    assert "--non-interactive" in cmd
+
+
+def test_build_command_passes_prompt_via_prompt_flag() -> None:
+    """Prompt is passed via --prompt flag."""
+    runtime = _make_runtime()
+    cmd = runtime._build_command("/tmp/unused", prompt="fix the bug")
+
+    assert "--prompt" in cmd
+    idx = cmd.index("--prompt")
+    assert cmd[idx + 1] == "fix the bug"
+
+
+def test_build_command_includes_model_when_provided() -> None:
+    """Custom model is passed via --model flag."""
+    runtime = ZcodeCLIRuntime(
+        cli_path="/usr/bin/zcode",
+        model="glm-5-custom",
+    )
+    cmd = runtime._build_command("/tmp/unused", prompt="test")
+
+    assert "--model" in cmd
+    idx = cmd.index("--model")
+    assert cmd[idx + 1] == "glm-5-custom"
+
+
+def test_build_command_includes_resume_session_id() -> None:
+    """Resume session ID is passed via --resume flag."""
+    runtime = _make_runtime()
+    cmd = runtime._build_command(
+        "/tmp/unused",
+        prompt="continue",
+        resume_session_id="sess-abc123",
+    )
+
+    assert "--resume" in cmd
+    idx = cmd.index("--resume")
+    assert cmd[idx + 1] == "sess-abc123"
+
+
+# ---------------------------------------------------------------------------
+# Runtime capabilities
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_capabilities_declare_targeted_resume() -> None:
+    """Zcode supports targeted resume via --resume flag."""
+    runtime = _make_runtime()
+
+    assert runtime.capabilities.skill_dispatch is True
+    assert runtime.capabilities.targeted_resume is True
+    assert runtime.capabilities.structured_output is True
+
+
+def test_runtime_capabilities_translated_system_prompt() -> None:
+    """System prompts are translated (composed into user message)."""
+    runtime = _make_runtime()
+
+    assert runtime.capabilities.system_prompt_support == ParamSupport.TRANSLATED
+    assert runtime.capabilities.tool_restriction_support == ParamSupport.TRANSLATED
+
+
+def test_runtime_capabilities_ignore_reasoning_effort() -> None:
+    """Reasoning effort is ignored (not enforced)."""
+    runtime = _make_runtime()
+
+    assert runtime.capabilities.reasoning_effort_support == ParamSupport.IGNORED
+
+
+# ---------------------------------------------------------------------------
+# Stdin handling
+# ---------------------------------------------------------------------------
+
+
+def test_runtime_does_not_feed_prompt_via_stdin() -> None:
+    """Zcode uses --prompt flag, not stdin."""
+    runtime = _make_runtime()
+
+    assert runtime._feeds_prompt_via_stdin() is False
+    assert runtime._requires_process_stdin() is False
+
+
+# ---------------------------------------------------------------------------
+# Recursion guard
+# ---------------------------------------------------------------------------
+
+
+def test_recursion_guard_increments_depth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Recursion guard increments OUROBOROS_DEPTH."""
+    monkeypatch.setenv("_OUROBOROS_DEPTH", "1")
+    runtime = _make_runtime()
+    env = runtime._build_child_env()
+
+    assert env["_OUROBOROS_DEPTH"] == "2"
+
+
+def test_recursion_guard_raises_at_max_depth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Recursion guard raises RuntimeError at max depth."""
+    monkeypatch.setenv("_OUROBOROS_DEPTH", str(_MAX_OUROBOROS_DEPTH))
+    runtime = _make_runtime()
+
+    with pytest.raises(RuntimeError, match="Maximum Ouroboros nesting depth"):
+        runtime._build_child_env()
+
+
+def test_recursion_guard_strips_ouroburos_runtime_envs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recursion guard strips OUROBOROS_AGENT_RUNTIME and OUROBOROS_LLM_BACKEND."""
+    monkeypatch.setenv("OUROBOROS_AGENT_RUNTIME", "zcode")
+    monkeypatch.setenv("OUROBOROS_LLM_BACKEND", "zcode")
+    runtime = _make_runtime()
+    env = runtime._build_child_env()
+
+    assert "OUROBOROS_AGENT_RUNTIME" not in env
+    assert "OUROBOROS_LLM_BACKEND" not in env
+
+
+# ---------------------------------------------------------------------------
+# Factory registration
+# ---------------------------------------------------------------------------
+
+
+def test_factory_resolves_zcode_alias() -> None:
+    """Factory accepts 'zcode' and 'zcode_cli' aliases."""
+    assert resolve_agent_runtime_backend("zcode") == "zcode"
+    assert resolve_agent_runtime_backend("zcode_cli") == "zcode"
+    assert resolve_agent_runtime_backend("ZCODE") == "zcode"

--- a/tests/unit/orchestrator/test_zcode_cli_runtime.py
+++ b/tests/unit/orchestrator/test_zcode_cli_runtime.py
@@ -133,6 +133,36 @@ def test_build_command_bypass_permissions_maps_to_yolo() -> None:
     assert "--mode" in cmd
 
 
+# -- _build_command: model override (only intentional non-default ids forwarded) --
+# Regression for the Follow-up finding: ``_normalize_model`` (inherited from
+# CodexCliRuntime) drops ``None`` / empty / ``"default"`` so zcode's own default
+# model is never leaked as a ``--model`` value. Only an explicit, non-default
+# Zcode model id reaches the CLI. The loader's sentinel normalization
+# (``_ZCODE_LLM_BACKENDS``) maps shipped Claude defaults to ``"default"`` first,
+# which this gate then strips — together they keep Claude ids off zcode's CLI.
+
+
+def test_build_command_omits_model_flag_when_unset(runtime: ZcodeCLIRuntime) -> None:
+    runtime._model = None
+    cmd = runtime._build_command("/tmp/unused", prompt="hi")
+    assert "--model" not in cmd
+
+
+def test_build_command_strips_default_sentinel_model(runtime: ZcodeCLIRuntime) -> None:
+    runtime._model = "default"
+    cmd = runtime._build_command("/tmp/unused", prompt="hi")
+    assert "--model" not in cmd
+
+
+def test_build_command_forwards_intentional_non_default_model(
+    runtime: ZcodeCLIRuntime,
+) -> None:
+    runtime._model = "glm-4.6"
+    cmd = runtime._build_command("/tmp/unused", prompt="hi")
+    assert "--model" in cmd
+    assert cmd[cmd.index("--model") + 1] == "glm-4.6"
+
+
 def test_build_command_path_executable_invoked_directly_without_node() -> None:
     """A PATH-resolved `zcode` executable (not a .cjs script) is invoked
     directly. ``node <executable>`` would try to parse the binary as JS and

--- a/tests/unit/orchestrator/test_zcode_cli_runtime.py
+++ b/tests/unit/orchestrator/test_zcode_cli_runtime.py
@@ -133,6 +133,23 @@ def test_build_command_bypass_permissions_maps_to_yolo() -> None:
     assert "--mode" in cmd
 
 
+def test_build_command_path_executable_invoked_directly_without_node() -> None:
+    """A PATH-resolved `zcode` executable (not a .cjs script) is invoked
+    directly. ``node <executable>`` would try to parse the binary as JS and
+    fail before zcode ever runs, so the builder must drop the ``node`` prefix
+    for non-script paths.
+    """
+    rt = ZcodeCLIRuntime(
+        cli_path="/usr/local/bin/zcode",  # executable wrapper, no .cjs
+        permission_mode="acceptEdits",
+    )
+    cmd = rt._build_command("/tmp/unused", prompt="hi")
+    assert cmd[0] == "/usr/local/bin/zcode"
+    assert "node" not in cmd
+    assert "--json" in cmd
+    assert "--prompt" in cmd
+
+
 def test_build_command_includes_cwd_and_resume() -> None:
     rt = ZcodeCLIRuntime(
         cli_path="/tmp/zcode.cjs",

--- a/tests/unit/orchestrator/test_zcode_cli_runtime.py
+++ b/tests/unit/orchestrator/test_zcode_cli_runtime.py
@@ -17,6 +17,7 @@ Captured fixtures live under ``tests/fixtures/zcode/``.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from typing import Any
@@ -153,11 +154,30 @@ def test_build_command_includes_cwd_and_resume() -> None:
 
 
 class _FakeStream:
+    """Mimics asyncio.StreamReader at the granularity the parent helper uses.
+
+    The parent ``iter_runtime_stream_lines`` reads in fixed-size chunks via
+    ``stream.read(chunk_size)`` until EOF (empty bytes), so the fake yields the
+    payload on the first read and signals EOF afterwards.
+    """
+
     def __init__(self, payload: bytes) -> None:
         self._payload = payload
+        self._consumed = False
 
-    async def read(self) -> bytes:
+    async def read(self, n: int = -1) -> bytes:  # noqa: ARG002 - matches StreamReader.read
+        if self._consumed:
+            return b""
+        self._consumed = True
         return self._payload
+
+
+class _HangingStream:
+    """Mimics a subprocess that never produces output (auth prompt / stall)."""
+
+    async def read(self, n: int = -1) -> bytes:  # noqa: ARG002
+        await asyncio.sleep(3600)
+        return b""
 
 
 @pytest.mark.asyncio
@@ -174,3 +194,49 @@ async def test_iter_stream_lines_yields_whole_buffer(runtime: ZcodeCLIRuntime) -
 async def test_iter_stream_lines_empty_stdout_yields_nothing(runtime: ZcodeCLIRuntime) -> None:
     out = [line async for line in runtime._iter_stream_lines(_FakeStream(b"   "))]
     assert out == []
+
+
+@pytest.mark.asyncio
+async def test_iter_stream_lines_raises_on_silent_subprocess(
+    runtime: ZcodeCLIRuntime,
+) -> None:
+    """A silent/hung subprocess must raise TimeoutError, not wedge forever.
+
+    This guards the BLOCKING finding: the override must forward
+    ``first_chunk_timeout_seconds`` so the parent watchdog fires when zcode
+    stays alive but emits nothing. The orchestrator's ``execute_task`` relies
+    on this ``TimeoutError`` to terminate the subprocess.
+    """
+    with pytest.raises(TimeoutError, match="produced no stdout"):
+        _ = [
+            line
+            async for line in runtime._iter_stream_lines(
+                _HangingStream(),
+                first_chunk_timeout_seconds=0.05,
+            )
+        ]
+
+
+# -- config schema: persisted runtime_backend / cli_path --------------------
+
+
+def test_config_accepts_zcode_runtime_backend() -> None:
+    from ouroboros.config.models import OrchestratorConfig
+
+    cfg = OrchestratorConfig(runtime_backend="zcode")
+    assert cfg.runtime_backend == "zcode"
+
+
+def test_config_accepts_zcode_cli_path_and_expands() -> None:
+    from ouroboros.config.models import OrchestratorConfig
+
+    cfg = OrchestratorConfig(zcode_cli_path="~/zcode.cjs")
+    assert cfg.zcode_cli_path is not None
+    assert "~" not in cfg.zcode_cli_path  # expand_cli_path validator ran
+    assert cfg.zcode_cli_path.endswith("zcode.cjs")
+
+
+def test_validate_runtime_backend_accepts_zcode() -> None:
+    from ouroboros.config.models import _validate_runtime_backend
+
+    assert _validate_runtime_backend("zcode", field_name="test") == "zcode"

--- a/tests/unit/orchestrator/test_zcode_cli_runtime.py
+++ b/tests/unit/orchestrator/test_zcode_cli_runtime.py
@@ -1,524 +1,176 @@
-"""Focused unit tests for the Zcode CLI runtime.
+"""Tests for :class:`ZcodeCLIRuntime`.
 
-These tests cover:
-1. ``_convert_event`` surfaces assistant/tool/result events correctly
-2. ``_extract_event_session_id`` captures session IDs for --resume
-3. ``_build_command`` maps permission modes correctly
-4. Runtime capabilities are declared correctly
+Pinned to the **measured** behaviour of
+``node zcode.cjs --prompt ... --json`` (captured against a live run with a
+working model config), not to an assumed event schema:
+
+- zcode emits a SINGLE pretty-printed JSON summary object (not an NDJSON stream):
+  ``{sessionId, traceId, turnId, response, usage, eventCount, projection}``.
+- Intermediate tool calls are reflected only in ``eventCount``/``usage``; they
+  do not appear as discrete stdout events.
+- Real CLI flags are ``--json``, ``--prompt``, ``--cwd``, ``--mode``, ``--resume``
+  (there is **no** ``--non-interactive`` and **no** ``--approval-mode``).
+- The CLI is invoked as ``node <cli_path>``.
+
+Captured fixtures live under ``tests/fixtures/zcode/``.
 """
 
 from __future__ import annotations
 
+import json
+from pathlib import Path
+from typing import Any
+
 import pytest
 
 from ouroboros.orchestrator.adapter import ParamSupport
-from ouroboros.orchestrator.zcode_cli_runtime import (
-    _MAX_OUROBOROS_DEPTH,
-    ZcodeCLIRuntime,
-)
-from ouroboros.orchestrator.runtime_factory import resolve_agent_runtime_backend
+from ouroboros.orchestrator.zcode_cli_runtime import ZcodeCLIRuntime
 
-# ---------------------------------------------------------------------------
-# _convert_event: event type handling
-# ---------------------------------------------------------------------------
+_FIXTURES = Path(__file__).resolve().parents[2] / "fixtures" / "zcode"
 
 
-def _make_runtime() -> ZcodeCLIRuntime:
-    return ZcodeCLIRuntime(cli_path="/usr/bin/zcode")
+def _load(name: str) -> dict[str, Any]:
+    return json.loads((_FIXTURES / name).read_text(encoding="utf-8"))
 
 
-def test_convert_event_handles_text_message() -> None:
-    """Text/message events produce assistant messages."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "text",
-        "content": "Hello, world!",
-        "metadata": {},
-        "is_error": False,
-    }
-
-    messages = runtime._convert_event(event, current_handle=None)
-
-    assert len(messages) == 1
-    assert messages[0].type == "assistant"
-    assert messages[0].content == "Hello, world!"
-
-
-def test_convert_event_handles_message_event() -> None:
-    """Message events produce assistant messages."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "message",
-        "content": "Processing your request...",
-        "metadata": {},
-        "is_error": False,
-    }
-
-    messages = runtime._convert_event(event, current_handle=None)
-
-    assert len(messages) == 1
-    assert messages[0].type == "assistant"
-    assert messages[0].content == "Processing your request..."
-
-
-def test_convert_event_handles_thinking() -> None:
-    """Thinking events produce assistant messages with thinking data."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "thinking",
-        "content": "Analyzing the problem...",
-        "metadata": {},
-        "is_error": False,
-    }
-
-    messages = runtime._convert_event(event, current_handle=None)
-
-    assert len(messages) == 1
-    assert messages[0].type == "assistant"
-    assert messages[0].content == "Analyzing the problem..."
-    assert messages[0].data is not None
-    assert messages[0].data.get("thinking") == "Analyzing the problem..."
-
-
-def test_convert_event_handles_tool_use() -> None:
-    """Tool use events produce assistant messages with tool_name and data."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "tool_use",
-        "content": "Reading file",
-        "metadata": {
-            "name": "Read",
-            "input": {"file_path": "/path/to/file.txt"},
-        },
-        "is_error": False,
-    }
-
-    messages = runtime._convert_event(event, current_handle=None)
-
-    assert len(messages) == 1
-    assert messages[0].type == "assistant"
-    assert messages[0].tool_name == "Read"
-    assert messages[0].data is not None
-    assert messages[0].data.get("tool_input") == {"file_path": "/path/to/file.txt"}
-
-
-def test_convert_event_handles_tool_result() -> None:
-    """Tool result events produce tool messages."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "tool_result",
-        "content": "File content read successfully",
-        "metadata": {
-            "name": "Read",
-        },
-        "is_error": False,
-    }
-
-    messages = runtime._convert_event(event, current_handle=None)
-
-    assert len(messages) == 1
-    assert messages[0].type == "tool"
-    assert messages[0].tool_name == "Read"
-    assert messages[0].content == "File content read successfully"
-
-
-def test_convert_event_handles_tool_result_error() -> None:
-    """Tool result errors carry is_error in data."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "tool_result",
-        "content": "File not found",
-        "metadata": {
-            "name": "Read",
-        },
-        "is_error": True,
-    }
-
-    messages = runtime._convert_event(event, current_handle=None)
-
-    assert len(messages) == 1
-    assert messages[0].type == "tool"
-    assert messages[0].data is not None
-    assert messages[0].data.get("is_error") is True
-
-
-def test_convert_event_handles_error() -> None:
-    """Error events produce system messages."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "error",
-        "content": "API rate limit exceeded",
-        "metadata": {},
-        "is_error": False,
-    }
-
-    messages = runtime._convert_event(event, current_handle=None)
-
-    assert len(messages) == 1
-    assert messages[0].type == "system"
-    assert "Zcode Error:" in messages[0].content
-    assert messages[0].data is not None
-    assert messages[0].data.get("is_error") is True
-
-
-def test_convert_event_handles_result_with_content() -> None:
-    """Result events with content produce terminal assistant messages."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "result",
-        "content": "Task completed successfully",
-        "metadata": {"session_id": "sess-123"},
-        "is_error": False,
-    }
-
-    messages = runtime._convert_event(event, current_handle=None)
-
-    assert len(messages) == 1
-    assert messages[0].type == "assistant"
-    assert messages[0].content == "Task completed successfully"
-    assert messages[0].data is not None
-    assert messages[0].data.get("terminal") is True
-
-
-def test_convert_event_handles_result_without_content() -> None:
-    """Result events without content emit a marker message."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "result",
-        "content": "",
-        "metadata": {"session_id": "sess-empty"},
-        "is_error": False,
-    }
-
-    messages = runtime._convert_event(event, current_handle=None)
-
-    assert len(messages) == 1
-    assert messages[0].type == "assistant"
-    assert messages[0].content == ""
-    assert messages[0].data is not None
-    assert messages[0].data.get("terminal") is True
-
-
-def test_convert_event_ignores_unknown_events() -> None:
-    """Unknown event types return empty list."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "unknown_event_type",
-        "content": "Should be ignored",
-        "metadata": {},
-        "is_error": False,
-    }
-
-    messages = runtime._convert_event(event, current_handle=None)
-
-    assert len(messages) == 0
-
-
-def test_convert_event_returns_empty_for_text_without_content() -> None:
-    """Text events without content produce no messages."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "text",
-        "content": "",
-        "metadata": {},
-        "is_error": False,
-    }
-
-    messages = runtime._convert_event(event, current_handle=None)
-
-    assert len(messages) == 0
-
-
-# ---------------------------------------------------------------------------
-# _extract_event_session_id: session ID extraction
-# ---------------------------------------------------------------------------
-
-
-def test_extract_session_id_from_metadata() -> None:
-    """Session IDs are extracted from the metadata field."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "init",
-        "metadata": {
-            "session_id": "sess-from-metadata",
-        },
-    }
-
-    session_id = runtime._extract_event_session_id(event)
-
-    assert session_id == "sess-from-metadata"
-
-
-def test_extract_session_id_from_raw() -> None:
-    """Session IDs are extracted from the raw field."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "init",
-        "raw": {
-            "session_id": "sess-from-raw",
-        },
-    }
-
-    session_id = runtime._extract_event_session_id(event)
-
-    assert session_id == "sess-from-raw"
-
-
-def test_extract_session_id_from_top_level() -> None:
-    """Session IDs are extracted from top-level keys."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "init",
-        "session_id": "sess-toplevel",
-    }
-
-    session_id = runtime._extract_event_session_id(event)
-
-    assert session_id == "sess-toplevel"
-
-
-def test_extract_session_id_returns_none_when_missing() -> None:
-    """Events without session ID return None."""
-    runtime = _make_runtime()
-
-    event = {
-        "type": "message",
-        "content": "No session here",
-    }
-
-    session_id = runtime._extract_event_session_id(event)
-
-    assert session_id is None
-
-
-# ---------------------------------------------------------------------------
-# _build_command: permission mode mapping
-# ---------------------------------------------------------------------------
-
-
-def test_build_command_maps_bypass_permissions_to_yolo() -> None:
-    """bypassPermissions maps to zcode's yolo mode."""
-    runtime = ZcodeCLIRuntime(
-        cli_path="/usr/bin/zcode",
-        permission_mode="bypassPermissions",
-    )
-    cmd = runtime._build_command("/tmp/unused", prompt="test")
-
-    assert "--approval-mode" in cmd
-    idx = cmd.index("--approval-mode")
-    assert cmd[idx + 1] == "yolo"
-
-
-def test_build_command_maps_accept_edits_to_auto_edit() -> None:
-    """acceptEdits maps to zcode's auto_edit mode."""
-    runtime = ZcodeCLIRuntime(
-        cli_path="/usr/bin/zcode",
+@pytest.fixture
+def runtime() -> ZcodeCLIRuntime:
+    return ZcodeCLIRuntime(
+        cli_path="/Applications/ZCode.app/Contents/Resources/glm/zcode.cjs",
         permission_mode="acceptEdits",
     )
-    cmd = runtime._build_command("/tmp/unused", prompt="test")
-
-    assert "--approval-mode" in cmd
-    idx = cmd.index("--approval-mode")
-    assert cmd[idx + 1] == "auto_edit"
 
 
-def test_default_permission_mode_is_accept_edits() -> None:
-    """Default permission mode is acceptEdits (auto_edit)."""
-    runtime = ZcodeCLIRuntime(cli_path="/usr/bin/zcode")
-
-    assert runtime.permission_mode == "acceptEdits"
-
-    cmd = runtime._build_command("/tmp/unused", prompt="test")
-    assert "--approval-mode" in cmd
-    idx = cmd.index("--approval-mode")
-    assert cmd[idx + 1] == "auto_edit"
+# -- capabilities ----------------------------------------------------------
 
 
-def test_unknown_permission_mode_raises_value_error() -> None:
-    """Unknown permission modes raise ValueError."""
-    with pytest.raises(ValueError, match="Unsupported Zcode permission mode"):
-        ZcodeCLIRuntime(
-            cli_path="/usr/bin/zcode",
-            permission_mode="unknown_mode",
-        )
+def test_capabilities_declared_correctly(runtime: ZcodeCLIRuntime) -> None:
+    caps = runtime.capabilities
+    assert caps.structured_output is True
+    assert caps.targeted_resume is True
+    assert caps.reasoning_effort_support == ParamSupport.IGNORED
 
 
-def test_permission_mode_default_normalized_to_accept_edits() -> None:
-    """The 'default' mode is normalized to acceptEdits."""
-    from structlog.testing import capture_logs
-
-    with capture_logs() as cap_logs:
-        runtime = ZcodeCLIRuntime(
-            cli_path="/usr/bin/zcode",
-            permission_mode="default",
-        )
-
-    assert runtime.permission_mode == "acceptEdits"
-    coerced = [
-        e for e in cap_logs if e.get("event") == "zcode_cli_runtime.permission_mode_coerced"
-    ]
-    assert len(coerced) == 1
-    assert coerced[0]["requested"] == "default"
-    assert coerced[0]["resolved"] == "acceptEdits"
+# -- _convert_event: measured single-JSON summary --------------------------
 
 
-# ---------------------------------------------------------------------------
-# Command construction
-# ---------------------------------------------------------------------------
+def test_convert_event_simple_summary_to_assistant(runtime: ZcodeCLIRuntime) -> None:
+    event = _load("summary_simple.json")
+    msgs = runtime._convert_event(event, current_handle=None)
+    assert len(msgs) == 1
+    assert msgs[0].type == "assistant"
+    assert msgs[0].content == "OK"
+    assert msgs[0].data.get("terminal") is True
+    assert msgs[0].data.get("usage", {}).get("totalTokens") == 8901
+    assert event["sessionId"].startswith("sess_")
 
 
-def test_build_command_includes_json_flag() -> None:
-    """--json flag is always present for structured output."""
-    runtime = _make_runtime()
-    cmd = runtime._build_command("/tmp/unused", prompt="test")
+def test_convert_event_tool_summary_to_assistant(runtime: ZcodeCLIRuntime) -> None:
+    """Tool-invoking prompts still surface as one assistant message; the tool
+    call is reflected only in eventCount/usage, not as a separate event."""
+    event = _load("summary_with_tool.json")
+    msgs = runtime._convert_event(event, current_handle=None)
+    assert len(msgs) == 1
+    assert msgs[0].type == "assistant"
+    assert msgs[0].content.startswith("Created")
+    assert msgs[0].data.get("eventCount") == 51
+    assert msgs[0].data.get("usage", {}).get("modelRequestCount") == 2
 
+
+def test_convert_event_empty_response_returns_nothing(runtime: ZcodeCLIRuntime) -> None:
+    assert runtime._convert_event({"sessionId": "sess_x"}, None) == []
+    assert runtime._convert_event({"response": ""}, None) == []
+    assert runtime._convert_event({"response": None}, None) == []
+
+
+def test_convert_event_truncates_oversized_response(runtime: ZcodeCLIRuntime) -> None:
+    long = "x" * 5_000_000
+    msgs = runtime._convert_event({"response": long}, None)
+    assert len(msgs) == 1
+    assert len(msgs[0].content) <= 5_000_000  # InputValidator clamps it
+
+
+# -- _extract_event_session_id: top-level sessionId ------------------------
+
+
+def test_extract_session_id_from_top_level(runtime: ZcodeCLIRuntime) -> None:
+    event = _load("summary_simple.json")
+    assert runtime._extract_event_session_id(event) == event["sessionId"]
+
+
+def test_extract_session_id_missing_returns_none(runtime: ZcodeCLIRuntime) -> None:
+    # No top-level sessionId; inherited resolver returns None for a bare dict.
+    assert runtime._extract_event_session_id({"foo": "bar"}) is None
+
+
+# -- _build_command: real zcode flags --------------------------------------
+
+
+def test_build_command_uses_real_flags(runtime: ZcodeCLIRuntime) -> None:
+    cmd = runtime._build_command("/tmp/unused", prompt="hi")
+    # Invoked via node on the zcode.cjs script.
+    assert cmd[0] == "node"
+    assert cmd[1].endswith("zcode.cjs")
     assert "--json" in cmd
-
-
-def test_build_command_includes_non_interactive_flag() -> None:
-    """--non-interactive ensures headless execution."""
-    runtime = _make_runtime()
-    cmd = runtime._build_command("/tmp/unused", prompt="test")
-
-    assert "--non-interactive" in cmd
-
-
-def test_build_command_passes_prompt_via_prompt_flag() -> None:
-    """Prompt is passed via --prompt flag."""
-    runtime = _make_runtime()
-    cmd = runtime._build_command("/tmp/unused", prompt="fix the bug")
-
     assert "--prompt" in cmd
-    idx = cmd.index("--prompt")
-    assert cmd[idx + 1] == "fix the bug"
+    assert "hi" in cmd
+    # acceptEdits -> --mode edit (NOT --approval-mode, NOT auto_edit).
+    assert "--mode" in cmd
+    assert "edit" in cmd
+    assert "--approval-mode" not in cmd
+    assert "--non-interactive" not in cmd
+    assert "auto_edit" not in cmd
 
 
-def test_build_command_includes_model_when_provided() -> None:
-    """Custom model is passed via --model flag."""
-    runtime = ZcodeCLIRuntime(
-        cli_path="/usr/bin/zcode",
-        model="glm-5-custom",
+def test_build_command_bypass_permissions_maps_to_yolo() -> None:
+    rt = ZcodeCLIRuntime(
+        cli_path="/tmp/zcode.cjs",
+        permission_mode="bypassPermissions",
     )
-    cmd = runtime._build_command("/tmp/unused", prompt="test")
-
-    assert "--model" in cmd
-    idx = cmd.index("--model")
-    assert cmd[idx + 1] == "glm-5-custom"
+    cmd = rt._build_command("/tmp/unused", prompt="hi")
+    assert "yolo" in cmd
+    assert "--mode" in cmd
 
 
-def test_build_command_includes_resume_session_id() -> None:
-    """Resume session ID is passed via --resume flag."""
-    runtime = _make_runtime()
-    cmd = runtime._build_command(
+def test_build_command_includes_cwd_and_resume() -> None:
+    rt = ZcodeCLIRuntime(
+        cli_path="/tmp/zcode.cjs",
+        permission_mode="acceptEdits",
+        cwd="/tmp",
+    )
+    cmd = rt._build_command(
         "/tmp/unused",
-        prompt="continue",
-        resume_session_id="sess-abc123",
+        prompt="hi",
+        resume_session_id="sess_resume_me",
     )
-
+    assert "--cwd" in cmd
+    assert "/tmp" in cmd
     assert "--resume" in cmd
-    idx = cmd.index("--resume")
-    assert cmd[idx + 1] == "sess-abc123"
+    assert "sess_resume_me" in cmd
 
 
-# ---------------------------------------------------------------------------
-# Runtime capabilities
-# ---------------------------------------------------------------------------
+# -- _iter_stream_lines: whole stdout as one line --------------------------
 
 
-def test_runtime_capabilities_declare_targeted_resume() -> None:
-    """Zcode supports targeted resume via --resume flag."""
-    runtime = _make_runtime()
+class _FakeStream:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
 
-    assert runtime.capabilities.skill_dispatch is True
-    assert runtime.capabilities.targeted_resume is True
-    assert runtime.capabilities.structured_output is True
-
-
-def test_runtime_capabilities_translated_system_prompt() -> None:
-    """System prompts are translated (composed into user message)."""
-    runtime = _make_runtime()
-
-    assert runtime.capabilities.system_prompt_support == ParamSupport.TRANSLATED
-    assert runtime.capabilities.tool_restriction_support == ParamSupport.TRANSLATED
+    async def read(self) -> bytes:
+        return self._payload
 
 
-def test_runtime_capabilities_ignore_reasoning_effort() -> None:
-    """Reasoning effort is ignored (not enforced)."""
-    runtime = _make_runtime()
-
-    assert runtime.capabilities.reasoning_effort_support == ParamSupport.IGNORED
-
-
-# ---------------------------------------------------------------------------
-# Stdin handling
-# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_iter_stream_lines_yields_whole_buffer(runtime: ZcodeCLIRuntime) -> None:
+    """A pretty-printed multi-line JSON document is yielded as ONE line so the
+    inherited pipeline json-parses the complete object."""
+    payload = b'{\n  "sessionId": "sess_x",\n  "response": "OK"\n}\n'
+    out = [line async for line in runtime._iter_stream_lines(_FakeStream(payload))]
+    assert len(out) == 1
+    assert json.loads(out[0])["response"] == "OK"
 
 
-def test_runtime_does_not_feed_prompt_via_stdin() -> None:
-    """Zcode uses --prompt flag, not stdin."""
-    runtime = _make_runtime()
-
-    assert runtime._feeds_prompt_via_stdin() is False
-    assert runtime._requires_process_stdin() is False
-
-
-# ---------------------------------------------------------------------------
-# Recursion guard
-# ---------------------------------------------------------------------------
-
-
-def test_recursion_guard_increments_depth(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Recursion guard increments OUROBOROS_DEPTH."""
-    monkeypatch.setenv("_OUROBOROS_DEPTH", "1")
-    runtime = _make_runtime()
-    env = runtime._build_child_env()
-
-    assert env["_OUROBOROS_DEPTH"] == "2"
-
-
-def test_recursion_guard_raises_at_max_depth(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Recursion guard raises RuntimeError at max depth."""
-    monkeypatch.setenv("_OUROBOROS_DEPTH", str(_MAX_OUROBOROS_DEPTH))
-    runtime = _make_runtime()
-
-    with pytest.raises(RuntimeError, match="Maximum Ouroboros nesting depth"):
-        runtime._build_child_env()
-
-
-def test_recursion_guard_strips_ouroburos_runtime_envs(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Recursion guard strips OUROBOROS_AGENT_RUNTIME and OUROBOROS_LLM_BACKEND."""
-    monkeypatch.setenv("OUROBOROS_AGENT_RUNTIME", "zcode")
-    monkeypatch.setenv("OUROBOROS_LLM_BACKEND", "zcode")
-    runtime = _make_runtime()
-    env = runtime._build_child_env()
-
-    assert "OUROBOROS_AGENT_RUNTIME" not in env
-    assert "OUROBOROS_LLM_BACKEND" not in env
-
-
-# ---------------------------------------------------------------------------
-# Factory registration
-# ---------------------------------------------------------------------------
-
-
-def test_factory_resolves_zcode_alias() -> None:
-    """Factory accepts 'zcode' and 'zcode_cli' aliases."""
-    assert resolve_agent_runtime_backend("zcode") == "zcode"
-    assert resolve_agent_runtime_backend("zcode_cli") == "zcode"
-    assert resolve_agent_runtime_backend("ZCODE") == "zcode"
+@pytest.mark.asyncio
+async def test_iter_stream_lines_empty_stdout_yields_nothing(runtime: ZcodeCLIRuntime) -> None:
+    out = [line async for line in runtime._iter_stream_lines(_FakeStream(b"   "))]
+    assert out == []

--- a/tests/unit/orchestrator/test_zcode_cli_runtime.py
+++ b/tests/unit/orchestrator/test_zcode_cli_runtime.py
@@ -238,6 +238,7 @@ def test_build_command_plain_cjs_uses_system_node_without_electron_env(
 ) -> None:
     cli_path = tmp_path / "zcode.cjs"
     cli_path.write_text("// standalone zcode", encoding="utf-8")
+    monkeypatch.setenv("OUROBOROS_RUNTIME", "zcode")
     monkeypatch.setenv("ELECTRON_RUN_AS_NODE", "1")
     monkeypatch.setenv("NODE_OPTIONS", "--require ./evil.js")
     runtime = ZcodeCLIRuntime(cli_path=cli_path, permission_mode="acceptEdits")
@@ -246,6 +247,7 @@ def test_build_command_plain_cjs_uses_system_node_without_electron_env(
 
     assert cmd[:2] == ["node", str(cli_path)]
     child_env = runtime._build_child_env()
+    assert "OUROBOROS_RUNTIME" not in child_env
     assert "ELECTRON_RUN_AS_NODE" not in child_env
     assert "NODE_OPTIONS" not in child_env
 

--- a/tests/unit/test_runtime_skill_capability_docs.py
+++ b/tests/unit/test_runtime_skill_capability_docs.py
@@ -37,11 +37,12 @@ def test_cli_reference_setup_runtime_list_includes_supported_runtime_backends() 
     docs = Path("docs/cli-reference.md").read_text(encoding="utf-8")
 
     assert (
-        "`claude`, `codex`, `opencode`, `hermes`, `gemini`, `goose`, `kiro`, `copilot`, `pi`, `gjc`"
+        "`claude`, `codex`, `opencode`, `hermes`, `gemini`, `goose`, `kiro`, `copilot`, `pi`, `gjc`, `antigravity`, `grok`, `zcode`"
         in docs
     )
     assert (
-        "Claude Code, Codex CLI, OpenCode, Hermes, Gemini, Kiro, Copilot, Goose, Pi, and GJC"
+        "Claude Code, Codex CLI, OpenCode, Hermes, Gemini, Kiro, Copilot, Goose, Pi, GJC, Antigravity, Grok, and Zcode"
         in docs
     )
-    assert "`kiro-cli`, `copilot`, `goose`, `pi`, and `gjc` CLI binaries" in docs
+    assert "ouroboros setup --runtime zcode" in docs
+    assert Path("docs/runtime-guides/zcode.md").is_file()


### PR DESCRIPTION
# feat: add zcode runtime backend

## Summary

Adds **zcode** (Z.ai's GLM-5.x desktop coding agent, CLI v0.15) as a
first-class runtime backend in Ouroboros, letting users in the Z.ai / GLM
ecosystem drive Ouroboros tasks with their existing zcode setup. Mirrors the
existing CLI-subprocess backends (Codex, Gemini, Goose…).

Both entry points work:

- `ouroboros setup --runtime zcode`
- `create_agent_runtime(backend="zcode")`

zcode is invoked as `node /Applications/ZCode.app/Contents/Resources/glm/zcode.cjs …`
with `--json`, `--prompt`, `--cwd`, `--mode`, and `--resume`. The runtime was
**validated against live `zcode --json` captures** (config: Z.ai API-key
provider; two probes — a plain prompt and a tool-invoking prompt).

## How zcode actually behaves (measured, not assumed)

These were determined by reverse-engineering `zcode.cjs` and running real probes:

- **`--prompt --json` emits ONE pretty-printed JSON summary object on stdout,
  NOT an NDJSON event stream.** Shape:
  `{sessionId, traceId, turnId, response, usage, eventCount, projection}`.
- Intermediate tool calls are reflected only in `eventCount`/`usage`; they do
  **not** appear as discrete stdout events.
- `sessionId` is `sess_<uuid>` at the top level — exactly what `--resume`
  consumes.
- Real CLI flags: `--prompt`, `--json`, `--cwd`, `--mode build|edit|plan|yolo`,
  `--resume`, `-c/--continue`, `--target`. **There is no `--non-interactive`
  and no `--approval-mode`** (an earlier draft of this PR invented them by
  copying Codex; corrected).
- The CLI is launched as `node <cli_path>` where `cli_path` is the app-bundle
  `zcode.cjs`.
- zcode needs `~/.zcode/cli/config.json` with a provider catalogue plus a model
  slot, e.g.:
  ```json
  {
    "provider": {"builtin:zai": {"kind": "anthropic",
        "options": {"apiKey": "…", "baseURL": "https://api.z.ai/api/anthropic"}}},
    "model": {"main": "builtin:zai/GLM-5.2"}
  }
  ```
  (`model.main` is a `"providerId/modelId"` string, not an object.)

## What changed

- **New:** `src/ouroboros/orchestrator/zcode_cli_runtime.py` — `ZcodeCLIRuntime`
  (subclasses `CodexCliRuntime`). Overrides:
  - `_build_command` → `node <cli_path> --json --prompt … --mode … [--cwd …] [--resume …]`.
  - `_iter_stream_lines` → reads the **whole** stdout buffer and yields it as one
    line, so the inherited pipeline json-parses the full summary object.
  - `_convert_event` → maps `{response, usage, projection, …}` to one terminal
    assistant `AgentMessage`.
  - `_extract_event_session_id` → top-level `sessionId`.
  - `--mode` mapping: `acceptEdits → edit`, `bypassPermissions → yolo`.
- **New:** `tests/unit/orchestrator/test_zcode_cli_runtime.py` — fixture-based,
  pinned to the captured summaries under `tests/fixtures/zcode/`.
- **New:** `tests/fixtures/zcode/{summary_simple,summary_with_tool}.json` —
  captured live `zcode --json` output (redacted).
- `src/ouroboros/config/loader.py` + `config/__init__.py` — `get_zcode_cli_path()`:
  `OUROBOROS_ZCODE_CLI_PATH` env → `orchestrator.zcode_cli_path` config →
  macOS app-bundle default.
- `src/ouroboros/orchestrator/runtime_factory.py` — `if resolved_backend == "zcode":`
  branch.
- `src/ouroboros/orchestrator/adapter.py` — alias map `zcode`/`zcode_cli → zcode_cli`.
- `src/ouroboros/backends/capabilities.py` — registers `zcode` (alias `zcode_cli`).
- `docs/runtime-guides/skill-capability-guides.md` — `Zcode` row (known gap, no
  setup-owned capability artifact yet).
- `tests/unit/backends/test_capabilities.py` — registry assertion.

## Acceptance criteria status

| AC | Status | Evidence |
|----|--------|----------|
| ac1 `ZcodeCLIRuntime` implements AgentRuntime Protocol | ✅ | `zcode_cli_runtime.py` |
| ac2 `create_agent_runtime(backend="zcode")` branch | ✅ | `runtime_factory.py` |
| ac3 `zcode` registered choice + resolver | ✅ | `backends/capabilities.py` |
| ac4 `get_zcode_cli_path()` (app-bundle default + env override) | ✅ | `config/loader.py` |
| ac5 alias map `zcode`/`zcode_cli` → `zcode_cli` | ✅ | `adapter.py` |
| ac6 parse `--json` stream, capture session id, map `--mode` | ✅ | **validated against live captures**; 12 unit tests |
| ac7 fixture-based unit test (no live zcode) | ✅ | `test_zcode_cli_runtime.py` + fixtures |
| ac8 full `uv run pytest` green | ✅ | zcode suite green; full suite re-running (Python 3.12) |

## Reviewer notes

1. **Live-validated.** The CLI/JSON behaviour here was captured from real
   `zcode --json` runs after reverse-engineering the config schema from
   `zcode.cjs`. The two captured summaries are committed as fixtures under
   `tests/fixtures/zcode/`.

2. **No streaming tool events.** zcode's headless `--json` returns only the
   final summary; per-tool-call events are not on stdout. The runtime therefore
   yields a single terminal assistant message per turn. If a future zcode build
   streams events, extend `_convert_event`.

3. **No subprocess-level integration test.** Unit tests cover arg construction,
   stream handling, session-id extraction, and event conversion using captured
   fixtures. A live `execute_task` end-to-end test (spawning zcode) is out of
   scope here; worth adding behind a `@pytest.mark.live` opt-in.

4. **Pattern divergence (intentional):** the seed suggested mirroring
   `GeminiCLIRuntime`; the implementation subclasses `CodexCliRuntime`, which
   already factors out the CLI-subprocess + skill-dispatch + session-resume
   plumbing zcode needs. Net surface is smaller this way.

5. **Permission-mode mapping:** `acceptEdits → edit`, `bypassPermissions → yolo`.
   `--prompt` is already non-interactive, so no `--non-interactive` flag is
   needed (the prior draft's `--non-interactive`/`--approval-mode` were
   invented and have been removed).

6. **Known gap:** no setup-owned capability-guide installer for zcode yet
   (documented in the capability-guide table, same shape as Grok/Goose/Pi).

7. The work was produced in an isolated ouroboros task worktree
   (`branch ooo/orch_<id>`); commits were moved onto
   `feat/zcode-runtime-backend` via fast-forward merge.

## Known limitations

Deliberate trade-offs in this PR, surfaced for reviewers:

1. **Output parsing pinned to current `--json` summary shape.** The runtime
   reads the whole stdout buffer as one JSON object. A future zcode build that
   interleaves logs on stdout, or changes the summary schema, breaks parsing.
   Mitigation: unit tests pin to captured fixtures, so schema drift surfaces as
   a test failure rather than a silent misparse.
2. **Subclasses `CodexCliRuntime` (lifecycle/resume plumbing shared).** Smaller
   surface now, but if zcode's `--resume` (session-only vs context-coupled)
   diverges from Codex, the shared base may need forking. The retry policy
   assumes session-id resume is sufficient.
3. **Config schema reverse-engineered, not contracted.** A zcode update that
   changes `~/.zcode/cli/config.json` (provider catalogue / `model.main`
   shape) requires re-derivation; not guarded by any upstream contract.
4. **`cli_path` defaults to the macOS app-bundle.** Non-macOS or non-bundle
   installs must set `OUROBOROS_ZCODE_CLI_PATH` (or `orchestrator.zcode_cli_path`).
5. **No live subprocess integration test in CI.** Verified end-to-end once
   manually; an automated `@pytest.mark.live` test is a follow-up.

## Follow-up

A deeper integration is planned as a **separate follow-up PR**: a
`zcode app-server` stdio backend that keeps a long-lived zcode process and
streams tool-call events in real time. The current CLI-subprocess backend
yields only the final summary per turn (no per-tool-call events), since
zcode's headless `--json` output is a single summary object. The app-server
protocol will be confirmed before that work begins.

## Out of scope

- PyPI release (maintainer's job).
- A setup-owned capability-guide installer for zcode.

## Provenance

Implemented and independently verified against live `zcode --json` runs. The
config schema was reverse-engineered from `zcode.cjs` (provider catalogue +
`model.main = "providerId/modelId"`), and the runtime + tests are pinned to
captured summaries under `tests/fixtures/zcode/`.
