### PR TITLE
refactor(providers): kill byte-identical duplication — JSONL parse + strip keys

### DIFF
--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -8,7 +8,6 @@ from collections.abc import AsyncIterator, Mapping
 import contextlib
 from dataclasses import replace
 from datetime import UTC, datetime
-import json
 import os
 from pathlib import Path
 import re
@@ -44,6 +43,7 @@ from ouroboros.orchestrator.adapter import (
 from ouroboros.providers.base import CompletionConfig
 from ouroboros.providers.codex_cli_stream import (
     iter_runtime_stream_lines,
+    parse_json_event,
     terminate_runtime_process,
 )
 from ouroboros.providers.profiles import resolve_completion_profile
@@ -1207,12 +1207,7 @@ class CodexCliRuntime:
 
     def _parse_json_event(self, line: str) -> dict[str, Any] | None:
         """Parse a JSONL event line, returning None for non-JSON output."""
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            return None
-
-        return event if isinstance(event, dict) else None
+        return parse_json_event(line)
 
     def _extract_event_session_id(self, event: Mapping[str, Any]) -> str | None:
         """Extract a backend-native session identifier from a runtime event."""

--- a/src/ouroboros/orchestrator/gemini_cli_runtime.py
+++ b/src/ouroboros/orchestrator/gemini_cli_runtime.py
@@ -31,7 +31,7 @@ from ouroboros.orchestrator.adapter import (
 )
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime, SkillDispatchHandler
 from ouroboros.providers.gemini_event_normalizer import GeminiEventNormalizer
-from ouroboros.runtime.child_env import build_child_env
+from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
 
 log = structlog.get_logger(__name__)
 
@@ -62,7 +62,7 @@ _MAX_OUROBOROS_DEPTH = 5
 # Child-env strip set for Gemini.  Gemini does NOT strip CLAUDECODE (unlike
 # codex/copilot/kiro) — preserve that divergence; only the Ouroboros markers
 # are removed.
-_CHILD_ENV_STRIP_KEYS = ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND")
+_CHILD_ENV_STRIP_KEYS = DEFAULT_OUROBOROS_STRIP_KEYS
 
 
 class GeminiCLIRuntime(CodexCliRuntime):

--- a/src/ouroboros/orchestrator/gjc_runtime.py
+++ b/src/ouroboros/orchestrator/gjc_runtime.py
@@ -26,6 +26,10 @@ from ouroboros.orchestrator.adapter import (
     TaskResult,
 )
 from ouroboros.orchestrator.skill_intercept import SkillInterceptor
+from ouroboros.providers.codex_cli_stream import (
+    malformed_event_message,
+    parse_json_event,
+)
 from ouroboros.providers.gjc_rpc_protocol import (
     SUPPORTED_EVENT_TYPES,
     GjcCommandError,
@@ -214,23 +218,15 @@ class GjcRuntime:
         return list(lines)
 
     def _parse_event(self, line: str) -> dict[str, Any]:
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError as exc:
-            raise MalformedGjcEvent(
-                message=self._malformed_event_message(line), provider=self._provider_name
-            ) from exc
-        if not isinstance(event, dict):
+        parsed = parse_json_event(line)
+        if parsed is None:
             raise MalformedGjcEvent(
                 message=self._malformed_event_message(line), provider=self._provider_name
             )
-        return event
+        return parsed
 
     def _malformed_event_message(self, line: str) -> str:
-        preview = line.strip()
-        if len(preview) > 240:
-            preview = f"{preview[:237]}..."
-        return f"Malformed {self._display_name} JSON event: {preview}"
+        return malformed_event_message(line, display_name=self._display_name)
 
     def _extract_content_delta(self, event: dict[str, Any]) -> str | None:
         if event.get("type") != "message_update":

--- a/src/ouroboros/orchestrator/grok_cli_runtime.py
+++ b/src/ouroboros/orchestrator/grok_cli_runtime.py
@@ -49,7 +49,7 @@ from ouroboros.orchestrator.adapter import (
 )
 from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime, SkillDispatchHandler
 from ouroboros.providers.gemini_event_normalizer import GeminiEventNormalizer
-from ouroboros.runtime.child_env import build_child_env
+from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
 
 log = structlog.get_logger(__name__)
 
@@ -65,7 +65,7 @@ _SENTINEL_MODEL = "default"
 
 #: Maximum Ouroboros nesting depth to prevent fork bombs.
 _MAX_OUROBOROS_DEPTH = 5
-_CHILD_ENV_STRIP_KEYS = ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND")
+_CHILD_ENV_STRIP_KEYS = DEFAULT_OUROBOROS_STRIP_KEYS
 
 
 class GrokCliRuntime(CodexCliRuntime):

--- a/src/ouroboros/orchestrator/hermes_runtime.py
+++ b/src/ouroboros/orchestrator/hermes_runtime.py
@@ -46,7 +46,7 @@ from ouroboros.router import (
     ResolveRequest,
     resolve_skill_dispatch,
 )
-from ouroboros.runtime.child_env import build_child_env
+from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
 
 log = get_logger(__name__)
 
@@ -58,7 +58,7 @@ _IDLE_TIMEOUT_ENV = "OUROBOROS_HERMES_IDLE_TIMEOUT_SECONDS"
 # Child-env strip set for Hermes.  Hermes does NOT strip CLAUDECODE (unlike
 # codex/copilot/kiro) — preserve that divergence; only the Ouroboros markers
 # are removed.
-_CHILD_ENV_STRIP_KEYS = ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND")
+_CHILD_ENV_STRIP_KEYS = DEFAULT_OUROBOROS_STRIP_KEYS
 
 
 def _resolve_timeout_override(

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -23,7 +23,6 @@ from collections.abc import AsyncIterator
 import contextlib
 from dataclasses import replace
 from datetime import UTC, datetime
-import json
 import math
 import os
 from pathlib import Path
@@ -52,6 +51,7 @@ from ouroboros.orchestrator.opencode_event_normalizer import (
 )
 from ouroboros.providers.codex_cli_stream import (
     iter_runtime_stream_lines,
+    parse_json_event,
     terminate_runtime_process,
 )
 from ouroboros.router import (
@@ -62,7 +62,7 @@ from ouroboros.router import (
     ResolveRequest,
     resolve_skill_dispatch,
 )
-from ouroboros.runtime.child_env import build_child_env
+from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
 
 log = get_logger(__name__)
 
@@ -71,7 +71,7 @@ _MAX_LINE_BUFFER_BYTES = 50 * 1024 * 1024  # 50 MB
 # Child-env strip set for OpenCode.  OpenCode does NOT strip CLAUDECODE (unlike
 # codex/copilot/kiro) — preserve that divergence; only the Ouroboros markers
 # are removed.
-_CHILD_ENV_STRIP_KEYS = ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND")
+_CHILD_ENV_STRIP_KEYS = DEFAULT_OUROBOROS_STRIP_KEYS
 
 _INTERVIEW_SESSION_METADATA_KEY = "ouroboros_interview_session_id"
 _STDOUT_IDLE_TIMEOUT_ENV = "OUROBOROS_OPENCODE_STDOUT_IDLE_TIMEOUT"
@@ -697,11 +697,7 @@ class OpenCodeRuntime:
             Parsed dict, or ``None`` if the line is not valid JSON
             or is not a dict.
         """
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            return None
-        return event if isinstance(event, dict) else None
+        return parse_json_event(line)
 
     def _extract_event_session_id(self, event: dict[str, Any]) -> str | None:
         """Extract the OpenCode session ID from a JSON event.

--- a/src/ouroboros/orchestrator/pi_runtime.py
+++ b/src/ouroboros/orchestrator/pi_runtime.py
@@ -12,7 +12,6 @@ import asyncio
 from collections import deque
 from collections.abc import AsyncIterator
 import contextlib
-import json
 import os
 from pathlib import Path
 import re
@@ -33,6 +32,8 @@ from ouroboros.orchestrator.adapter import (
 from ouroboros.orchestrator.skill_intercept import SkillInterceptor
 from ouroboros.providers.codex_cli_stream import (
     iter_runtime_stream_lines,
+    malformed_event_message,
+    parse_json_event,
     terminate_runtime_process,
 )
 
@@ -232,17 +233,10 @@ class PiRuntime:
     # -- Event parsing -----------------------------------------------------
 
     def _parse_event(self, line: str) -> dict[str, Any] | None:
-        try:
-            event = json.loads(line)
-        except json.JSONDecodeError:
-            return None
-        return event if isinstance(event, dict) else None
+        return parse_json_event(line)
 
     def _malformed_event_message(self, line: str) -> str:
-        preview = line.strip()
-        if len(preview) > 240:
-            preview = f"{preview[:237]}..."
-        return f"Malformed {self._display_name} JSON event: {preview}"
+        return malformed_event_message(line, display_name=self._display_name)
 
     def _extract_session_id(self, event: dict[str, Any]) -> str | None:
         """Extract session ID from the pi session header event."""

--- a/src/ouroboros/providers/codex_cli_stream.py
+++ b/src/ouroboros/providers/codex_cli_stream.py
@@ -15,6 +15,7 @@ import asyncio
 import codecs
 from collections.abc import AsyncIterator, Awaitable, Callable
 import contextlib
+import json
 import os
 import signal
 from typing import Any, Protocol
@@ -126,6 +127,33 @@ async def collect_stream_lines(
             )
         lines.append(line)
     return lines
+
+
+def parse_json_event(line: str) -> dict[str, Any] | None:
+    """Parse a JSONL event line into a dict, or ``None`` for non-JSON/non-dict.
+
+    Shared by the orchestrator CLI runtimes (codex, opencode, pi, gjc) whose
+    stdout is newline-delimited JSON.  Callers that must *raise* on malformed
+    output (e.g. gjc) wrap this at the call site:
+    ``if parse_json_event(line) is None: raise ...``.
+    """
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        return None
+    return event if isinstance(event, dict) else None
+
+
+def malformed_event_message(line: str, *, display_name: str) -> str:
+    """Build a bounded diagnostic message for a malformed JSONL event line.
+
+    Truncates the offending line to a 240-char preview so a pathological
+    stdout line cannot bloat logs or error payloads.
+    """
+    preview = line.strip()
+    if len(preview) > 240:
+        preview = f"{preview[:237]}..."
+    return f"Malformed {display_name} JSON event: {preview}"
 
 
 async def iter_runtime_stream_lines(
@@ -438,6 +466,8 @@ __all__ = [
     "collect_stream_lines",
     "iter_runtime_stream_lines",
     "iter_stream_lines",
+    "malformed_event_message",
+    "parse_json_event",
     "terminate_process",
     "terminate_runtime_process",
 ]

--- a/src/ouroboros/providers/gemini_cli_adapter.py
+++ b/src/ouroboros/providers/gemini_cli_adapter.py
@@ -50,7 +50,7 @@ from ouroboros.providers.base import (
 )
 from ouroboros.providers.codex_cli_stream import iter_stream_lines, terminate_process
 from ouroboros.providers.profiles import resolve_completion_profile_result
-from ouroboros.runtime.child_env import build_child_env
+from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
 
 log = structlog.get_logger()
 
@@ -82,7 +82,7 @@ _MAX_OUROBOROS_DEPTH = 5
 # Child-env strip set for Gemini.  Gemini does NOT strip CLAUDECODE (unlike
 # codex/copilot/kiro) — preserve that divergence; only the Ouroboros markers
 # are removed.
-_CHILD_ENV_STRIP_KEYS = ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND")
+_CHILD_ENV_STRIP_KEYS = DEFAULT_OUROBOROS_STRIP_KEYS
 
 
 class GeminiCLIAdapter:

--- a/src/ouroboros/providers/hermes_cli_adapter.py
+++ b/src/ouroboros/providers/hermes_cli_adapter.py
@@ -24,7 +24,7 @@ from ouroboros.providers.base import (
 )
 from ouroboros.providers.codex_cli_stream import terminate_process
 from ouroboros.providers.profiles import resolve_completion_profile_result
-from ouroboros.runtime.child_env import build_child_env
+from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
 
 log = structlog.get_logger()
 
@@ -34,7 +34,7 @@ _SAFE_MODEL_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_./:@-]+$")
 # Child-env strip set for Hermes.  Hermes does NOT strip CLAUDECODE (unlike
 # codex/copilot/kiro) — preserve that divergence; only the Ouroboros markers
 # are removed.
-_CHILD_ENV_STRIP_KEYS = ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND")
+_CHILD_ENV_STRIP_KEYS = DEFAULT_OUROBOROS_STRIP_KEYS
 
 
 class HermesCliLLMAdapter:

--- a/src/ouroboros/providers/opencode_adapter.py
+++ b/src/ouroboros/providers/opencode_adapter.py
@@ -61,7 +61,7 @@ from ouroboros.providers.codex_cli_stream import (
     terminate_process,
 )
 from ouroboros.providers.profiles import resolve_completion_profile_result
-from ouroboros.runtime.child_env import build_child_env
+from ouroboros.runtime.child_env import DEFAULT_OUROBOROS_STRIP_KEYS, build_child_env
 
 log = structlog.get_logger()
 
@@ -70,7 +70,7 @@ _MAX_OUROBOROS_DEPTH = 5
 # Child-env strip set for OpenCode.  OpenCode does NOT strip CLAUDECODE (unlike
 # codex/copilot/kiro) — preserve that divergence; only the Ouroboros markers
 # are removed.
-_CHILD_ENV_STRIP_KEYS = ("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND")
+_CHILD_ENV_STRIP_KEYS = DEFAULT_OUROBOROS_STRIP_KEYS
 
 _RETRYABLE_ERROR_PATTERNS = BASE_TRANSIENT_PATTERNS
 


### PR DESCRIPTION
Work order PR-B from `docs/master-roadmap-2026-07.md`. Pure deduplication of proven copy-paste sites; no behavior change. **Files located by symbol** — the roadmap's stale paths (`src/ouroboros/providers/*_runtime.py`) are actually `src/ouroboros/orchestrator/*_runtime.py`.

## Target 1 — `_compose_prompt` triplication → STOP (skipped, reported)

Per the Target 1 rule ("compare the three original bodies first; if any differs by more than docstring/whitespace, STOP and report the diff"), I diffed the three bodies. **They are NOT identical:**

- `orchestrator/codex_cli_runtime.py`: wraps system + tools in `<system-directive>` / `<tooling-guidance>` fences (the GPT-model fencing fix).
- `orchestrator/hermes_runtime.py` and `orchestrator/opencode_runtime.py`: use `## System Instructions` / `## Tooling Guidance` **markdown headings**.

The roadmap assumed all three were "identical except docstrings" — that assumption is stale. Copying codex's body verbatim into a shared helper and delegating all three would change hermes/opencode's emitted prompt string from `## System Instructions` to `<system-directive>` — a real behavior change, which violates the zero-behavior-change rule. **No `prompt_compose.py` created; the three methods are untouched.**

## Target 2 — JSONL event parsing quadruplication → DONE

Re-audited the four sites first (PR #1558 drift note): #1558 consolidated stream *reading* (`iter_runtime_stream_lines`) but left the JSON-event *parsing* duplicated. Work remained.

- Added `parse_json_event(line) -> dict | None` and `malformed_event_message(line, *, display_name) -> str` to the existing `providers/codex_cli_stream.py`.
  - Note: the roadmap's signature `malformed_event_message(line: str) -> str` omits the display name, but the original message is `f"Malformed {self._display_name} JSON event: ..."` — display name must be threaded to preserve output byte-for-byte, so it is a keyword-only param.
- Delegated all four: `codex_cli_runtime._parse_json_event`, `opencode_runtime._parse_json_event`, `pi_runtime._parse_event` (+ `_malformed_event_message`), `gjc_runtime._parse_event` (+ `_malformed_event_message`).
- **gjc keeps its raise semantics**: wrapped at the call site — `parsed = parse_json_event(line); if parsed is None: raise MalformedGjcEvent(...)`. Both original raise paths (JSONDecodeError, non-dict) collapse to the same `is None` raise with identical message/provider. (The only nuance is loss of `from exc` chaining on the decode path; the gjc test asserts on content/error_type, not `__cause__`, and this wrapping is exactly what the work order prescribed.)
- Dropped now-unused `import json` from codex/opencode/pi. gjc keeps it (`json.dumps`).
- `gemini_cli_runtime.py` left alone (normalizer path — out of scope).

## Target 3 — `_CHILD_ENV_STRIP_KEYS` duplication → DONE

Verified `DEFAULT_OUROBOROS_STRIP_KEYS` in `runtime/child_env.py` equals the local tuple exactly: `("OUROBOROS_AGENT_RUNTIME", "OUROBOROS_LLM_BACKEND")`. No file had extra keys → no STOP.

Grep found **7** duplicates (roadmap confirmed 3, said "there may be more — grep"): `providers/{opencode,gemini_cli,hermes_cli}_adapter.py` + `orchestrator/{hermes,grok_cli,opencode,gemini_cli}_runtime.py`. All aliased to the shared constant (`_CHILD_ENV_STRIP_KEYS = DEFAULT_OUROBOROS_STRIP_KEYS`), matching the existing repo idiom in `codex/cli_policy.py` and `copilot/cli_policy.py`. This kills the tuple re-declaration while preserving the per-runtime "does NOT strip CLAUDECODE" divergence comments and every call site (zero call-site churn).

## Done means
- [x] Zero behavior change (no test expectations edited)
- [x] The three original `_compose_prompt` bodies were diffed and found **NOT** identical → STOP reported (codex `<system-directive>` fencing vs hermes/opencode `## System Instructions` markdown)
- [x] gjc still raises on malformed events (`test_malformed_json_is_malformed_gjc_event` passes)
- [x] Validation gate passes

## Validation gate
- `uv run ruff check .` → All checks passed
- `uv run ruff format --check .` → 1019 files already formatted
- `uv run mypy src/` → Success: no issues found in 423 source files
- `uv run pytest tests/unit/providers/ tests/unit/orchestrator/ -q` → 2975 passed, 1 skipped
- `uv run pytest tests/unit/test_kiro_adapters.py tests/unit/copilot/test_cli_policy.py tests/unit/codex/test_cli_policy.py tests/unit/runtime/ -q` → 131 passed
- (SAFETY: did not run tests/unit/mcp, tests/integration/mcp, or tests/e2e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)