### PR TITLE
feat(evaluation): judge against declared AC contract + reward-hacking veto

### DIFF
--- a/src/ouroboros/evaluation/models.py
+++ b/src/ouroboros/evaluation/models.py
@@ -20,7 +20,16 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Any
 
+from ouroboros.core.seed import AcceptanceCriterionSpec
 from ouroboros.events.base import BaseEvent
+
+# Above this reward-hacking risk the final gate vetoes an otherwise-passing
+# artifact.  It is deliberately high (0.7): it only vetoes *high-confidence*
+# gaming signals so a nervous evaluator's mild suspicion never blocks a
+# genuine pass.  Defined here (not in pipeline.py) so the gate and the
+# ``EvaluationResult.failure_reason`` surface share one source of truth
+# without a models<->pipeline import cycle.  pipeline.py imports this.
+REWARD_HACKING_VETO_THRESHOLD = 0.7
 
 
 class VoterRole(StrEnum):
@@ -311,6 +320,11 @@ class EvaluationContext:
         execution_id: Unique identifier for the execution
         seed_id: Identifier of the seed being evaluated against
         current_ac: The acceptance criterion being evaluated
+        current_ac_spec: Structured success contract for ``current_ac`` when
+            the seed declared one (verify_command / expected_artifacts /
+            output_assertion).  ``None`` for bare-string ACs — the evaluator
+            then falls back to judging ``current_ac`` text alone (today's
+            behavior).
         artifact: The output artifact to evaluate
         artifact_type: Type of artifact (code, document, etc.)
         goal: Original goal from seed
@@ -322,6 +336,7 @@ class EvaluationContext:
     seed_id: str
     current_ac: str
     artifact: str
+    current_ac_spec: AcceptanceCriterionSpec | None = None
     artifact_type: str = "code"
     goal: str = ""
     constraints: tuple[str, ...] = ()
@@ -386,4 +401,14 @@ class EvaluationResult:
             )
         if self.stage2_result and not self.stage2_result.ac_compliance:
             return f"Stage 2 failed: AC non-compliance (score={self.stage2_result.score:.2f})"
+        if (
+            self.stage2_result
+            and self.stage2_result.reward_hacking_risk >= REWARD_HACKING_VETO_THRESHOLD
+        ):
+            return (
+                "Stage 2 veto: reward-hacking risk "
+                f"{self.stage2_result.reward_hacking_risk:.2f} >= "
+                f"{REWARD_HACKING_VETO_THRESHOLD:.2f} — artifact appears optimized to game the "
+                "evaluator rather than solve the real task"
+            )
         return "Unknown failure"

--- a/src/ouroboros/evaluation/pipeline.py
+++ b/src/ouroboros/evaluation/pipeline.py
@@ -18,6 +18,7 @@ from ouroboros.evaluation.mechanical import (
     MechanicalVerifier,
 )
 from ouroboros.evaluation.models import (
+    REWARD_HACKING_VETO_THRESHOLD,
     CheckType,
     EvaluationContext,
     EvaluationResult,
@@ -238,10 +239,17 @@ class EvaluationPipeline:
                     final_approved=stage3_result.approved,
                 )
 
-        # No consensus triggered - approve based on Stage 2
+        # No consensus triggered - approve based on Stage 2.
+        # The reward-hacking veto (REWARD_HACKING_VETO_THRESHOLD) blocks an
+        # otherwise-passing artifact only on a *high-confidence* gaming signal,
+        # so a merely uncertain evaluator never vetoes a genuine pass.
         final_approved = True
         if stage2_result:
-            final_approved = stage2_result.ac_compliance and stage2_result.score >= 0.8
+            final_approved = (
+                stage2_result.ac_compliance
+                and stage2_result.score >= 0.8
+                and stage2_result.reward_hacking_risk < REWARD_HACKING_VETO_THRESHOLD
+            )
 
         return self._build_result(
             context.execution_id,
@@ -298,6 +306,15 @@ class EvaluationPipeline:
             elif stage2_result and not stage2_result.ac_compliance:
                 failure_reason = (
                     f"Stage 2 failed: AC non-compliance (score={stage2_result.score:.2f})"
+                )
+            elif (
+                stage2_result and stage2_result.reward_hacking_risk >= REWARD_HACKING_VETO_THRESHOLD
+            ):
+                failure_reason = (
+                    "Stage 2 veto: reward-hacking risk "
+                    f"{stage2_result.reward_hacking_risk:.2f} >= "
+                    f"{REWARD_HACKING_VETO_THRESHOLD:.2f} — artifact appears optimized to game "
+                    "the evaluator rather than solve the real task"
                 )
             else:
                 failure_reason = "Unknown failure"

--- a/src/ouroboros/evaluation/semantic.py
+++ b/src/ouroboros/evaluation/semantic.py
@@ -122,6 +122,29 @@ def build_evaluation_prompt(context: EvaluationContext) -> str:
         else "None specified"
     )
 
+    # Declared success contract (PR-H): when the seed attached a structured
+    # AcceptanceCriterionSpec carrying verify_command / expected_artifacts /
+    # output_assertion, surface it to the judge so it grades against the
+    # declared contract instead of the bare AC wording.  Bare-string ACs (no
+    # contract) render nothing here — identical to today's behavior.
+    spec = context.current_ac_spec
+    if spec is not None and spec.has_success_contract:
+        contract_lines = ["\n## DECLARED SUCCESS CONTRACT"]
+        if spec.verify_command:
+            contract_lines.append(f"- verify_command: {spec.verify_command}")
+        if spec.expected_artifacts:
+            artifacts = ", ".join(spec.expected_artifacts)
+            contract_lines.append(f"- expected_artifacts: {artifacts}")
+        if spec.output_assertion:
+            contract_lines.append(f"- output_assertion: {spec.output_assertion}")
+        contract_lines.append(
+            "The AC passes ONLY if the artifact demonstrates the declared contract "
+            "was met. Cite the evidence line."
+        )
+        contract_section = "\n".join(contract_lines)
+    else:
+        contract_section = ""
+
     has_files = context.artifact_bundle and context.artifact_bundle.files
 
     if has_files:
@@ -144,6 +167,7 @@ def build_evaluation_prompt(context: EvaluationContext) -> str:
 
 ## Acceptance Criterion
 {context.current_ac}
+{contract_section}
 
 ## Original Goal
 {context.goal if context.goal else "Not specified"}

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -21,7 +21,7 @@ from ouroboros.backends import build_runtime_subagent_orchestration_contract
 from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
 from ouroboros.core.errors import ValidationError
 from ouroboros.core.project_paths import resolve_path_against_base, resolve_seed_project_path
-from ouroboros.core.seed import Seed, ac_text
+from ouroboros.core.seed import AcceptanceCriterionSpec, Seed, ac_text
 from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.job_manager import JobLinks, JobManager
@@ -65,6 +65,30 @@ def _seed_acceptance_criteria(seed: Seed) -> tuple[str, ...]:
         for criterion in seed.acceptance_criteria
         if (stripped := ac_text(criterion).strip())
     )
+
+
+def _seed_ac_spec_map(seed: Seed | None) -> dict[str, AcceptanceCriterionSpec]:
+    """Map each AC description to its structured spec (PR-H).
+
+    Since PR-F, ``Seed.acceptance_criteria`` holds ``AcceptanceCriterionSpec``
+    objects.  Evaluation flows AC text (descriptions) around as bare strings,
+    so we key specs by their trimmed ``description`` to reattach the declared
+    success contract when building each ``EvaluationContext``.  Only specs
+    that actually carry a contract are included — bare-description ACs map to
+    nothing and the evaluator judges the AC text alone (today's behavior).
+    """
+    if seed is None:
+        return {}
+    spec_map: dict[str, AcceptanceCriterionSpec] = {}
+    for criterion in seed.acceptance_criteria:
+        if not isinstance(criterion, AcceptanceCriterionSpec):
+            continue
+        if not criterion.has_success_contract:
+            continue
+        key = criterion.description.strip()
+        if key:
+            spec_map.setdefault(key, criterion)
+    return spec_map
 
 
 async def _default_brownfield_project_dir() -> Path | None:
@@ -545,6 +569,7 @@ class EvaluateHandler:
                 if not acceptance_criteria:
                     acceptance_criteria = _seed_acceptance_criteria(seed)
             except (yaml.YAMLError, ValidationError, PydanticValidationError) as e:
+                # Seed failed to parse — leave seed as None; spec map stays empty.
                 log.warning("mcp.tool.evaluate.seed_parse_warning", error=str(e))
                 # Continue without seed data - not fatal
 
@@ -626,6 +651,11 @@ class EvaluateHandler:
                 if acceptance_criteria
                 else "Verify execution output meets requirements"
             )
+
+            # Reattach declared success contracts (PR-H): map AC text back to
+            # its structured spec so Stage 2 grades against verify_command /
+            # expected_artifacts / output_assertion, not the bare wording.
+            ac_spec_map = _seed_ac_spec_map(seed)
 
             # Evaluation reads multiple spec files (one Read call per AC).
             # Use a dedicated adapter with a higher turn budget — the shared
@@ -719,12 +749,14 @@ class EvaluateHandler:
                     pipeline=pipeline,
                     working_dir=working_dir,
                     executor_backend=executor_backend,
+                    ac_spec_map=ac_spec_map,
                 )
 
             context = EvaluationContext(
                 execution_id=session_id,
                 seed_id=seed_id,
                 current_ac=current_ac,
+                current_ac_spec=ac_spec_map.get(current_ac),
                 artifact=artifact,
                 artifact_type=artifact_type,
                 goal=goal,
@@ -832,6 +864,7 @@ class EvaluateHandler:
         pipeline: object,  # EvaluationPipeline — typed as object to avoid import cycle
         working_dir: Path,
         executor_backend: str | None = None,
+        ac_spec_map: dict[str, AcceptanceCriterionSpec] | None = None,
     ) -> Result[MCPToolResult, MCPServerError]:
         """Evaluate each AC individually and return an aggregated checklist (#366).
 
@@ -856,6 +889,8 @@ class EvaluateHandler:
             format_checklist,
         )
 
+        spec_map = ac_spec_map or {}
+
         log.info(
             "mcp.tool.evaluate.multi_ac_started",
             session_id=session_id,
@@ -867,6 +902,7 @@ class EvaluateHandler:
             execution_id=session_id,
             seed_id=seed_id,
             current_ac=acceptance_criteria[0],
+            current_ac_spec=spec_map.get(acceptance_criteria[0]),
             artifact=artifact,
             artifact_type=artifact_type,
             goal=goal,
@@ -895,6 +931,7 @@ class EvaluateHandler:
                 execution_id=session_id,
                 seed_id=seed_id,
                 current_ac=ac_text,
+                current_ac_spec=spec_map.get(ac_text),
                 artifact=artifact,
                 artifact_type=artifact_type,
                 goal=goal,

--- a/tests/unit/evaluation/test_pipeline_reward_hacking_veto.py
+++ b/tests/unit/evaluation/test_pipeline_reward_hacking_veto.py
@@ -1,0 +1,137 @@
+"""Pipeline-level tests for the reward-hacking veto gate (PR-H).
+
+The final Stage 2 approval gate now vetoes an otherwise-passing artifact when
+``reward_hacking_risk >= REWARD_HACKING_VETO_THRESHOLD`` (0.7).  These tests
+exercise the real ``EvaluationPipeline.evaluate()`` no-consensus path with a
+mocked semantic stage, plus the ``EvaluationResult.failure_reason`` surface
+that carries the veto explanation to the per-AC checklist.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from ouroboros.core.types import Result
+from ouroboros.evaluation.models import (
+    REWARD_HACKING_VETO_THRESHOLD,
+    CheckResult,
+    CheckType,
+    EvaluationContext,
+    EvaluationResult,
+    MechanicalResult,
+    SemanticResult,
+)
+from ouroboros.evaluation.pipeline import EvaluationPipeline, PipelineConfig
+
+
+def _make_context() -> EvaluationContext:
+    return EvaluationContext(
+        execution_id="veto-exec",
+        seed_id="seed-1",
+        current_ac="Test AC",
+        artifact="def f(): pass",
+        artifact_type="code",
+        goal="Test goal",
+        constraints=(),
+        trigger_consensus=False,
+    )
+
+
+def _passing_stage1() -> MechanicalResult:
+    return MechanicalResult(
+        passed=True,
+        checks=(CheckResult(check_type=CheckType.LINT, passed=True, message="ok"),),
+    )
+
+
+def _semantic(*, reward_hacking_risk: float) -> SemanticResult:
+    """A Stage 2 result that passes score + compliance, varying only risk."""
+    return SemanticResult(
+        score=0.95,
+        ac_compliance=True,
+        goal_alignment=0.9,
+        drift_score=0.1,
+        uncertainty=0.1,
+        reasoning="AC met",
+        reward_hacking_risk=reward_hacking_risk,
+    )
+
+
+def _make_pipeline() -> EvaluationPipeline:
+    # Stage 3 disabled so the no-consensus gate (the veto site) is exercised.
+    return EvaluationPipeline(AsyncMock(), PipelineConfig(stage3_enabled=False))
+
+
+async def _run_with_risk(risk: float) -> EvaluationResult:
+    pipeline = _make_pipeline()
+    with patch(
+        "ouroboros.evaluation.semantic.SemanticEvaluator.evaluate",
+        new_callable=AsyncMock,
+        return_value=Result.ok((_semantic(reward_hacking_risk=risk), [])),
+    ):
+        result = await pipeline.evaluate(_make_context(), stage1_result=_passing_stage1())
+    assert result.is_ok
+    return result.value
+
+
+class TestRewardHackingVeto:
+    async def test_high_risk_vetoes_passing_artifact(self) -> None:
+        """reward_hacking_risk=0.9 with a passing score is NOT approved."""
+        eval_result = await _run_with_risk(0.9)
+
+        assert eval_result.final_approved is False
+        # Stage 2 itself reported compliance + a high score — the block is the veto.
+        assert eval_result.stage2_result is not None
+        assert eval_result.stage2_result.ac_compliance is True
+        assert eval_result.stage2_result.score >= 0.8
+
+    async def test_veto_reason_explains_the_block(self) -> None:
+        """The failure reason must name the reward-hacking veto, not 'Unknown'."""
+        eval_result = await _run_with_risk(0.9)
+        reason = eval_result.failure_reason
+
+        assert reason is not None
+        assert "reward-hacking" in reason.lower()
+        assert "veto" in reason.lower()
+        assert "0.90" in reason  # the offending risk value is surfaced
+        assert reason != "Unknown failure"
+
+    async def test_zero_risk_is_approved(self) -> None:
+        """reward_hacking_risk=0.0 keeps today's behavior: approved."""
+        eval_result = await _run_with_risk(0.0)
+
+        assert eval_result.final_approved is True
+        assert eval_result.failure_reason is None
+
+    async def test_threshold_boundary_is_inclusive(self) -> None:
+        """risk == threshold vetoes; risk just below the threshold approves."""
+        vetoed = await _run_with_risk(REWARD_HACKING_VETO_THRESHOLD)
+        assert vetoed.final_approved is False
+
+        approved = await _run_with_risk(REWARD_HACKING_VETO_THRESHOLD - 0.01)
+        assert approved.final_approved is True
+
+
+class TestFailureReasonSurface:
+    """The EvaluationResult.failure_reason property is what ACCheckItem reads."""
+
+    def test_property_surfaces_veto_for_compliant_high_risk_result(self) -> None:
+        result = EvaluationResult(
+            execution_id="e1",
+            stage1_result=_passing_stage1(),
+            stage2_result=_semantic(reward_hacking_risk=0.85),
+            final_approved=False,
+        )
+        reason = result.failure_reason
+        assert reason is not None
+        assert "reward-hacking" in reason.lower()
+        assert "0.85" in reason
+
+    def test_property_returns_none_when_approved(self) -> None:
+        result = EvaluationResult(
+            execution_id="e1",
+            stage1_result=_passing_stage1(),
+            stage2_result=_semantic(reward_hacking_risk=0.85),
+            final_approved=True,
+        )
+        assert result.failure_reason is None

--- a/tests/unit/evaluation/test_semantic.py
+++ b/tests/unit/evaluation/test_semantic.py
@@ -103,6 +103,59 @@ class TestBuildEvaluationPrompt:
         assert "## Artifact Content" not in prompt
         assert "inline artifact text that should not be duplicated" not in prompt
 
+    def test_spec_with_contract_renders_contract_block(self) -> None:
+        """A spec-carrying AC renders the DECLARED SUCCESS CONTRACT block (PR-H)."""
+        from ouroboros.core.seed import AcceptanceCriterionSpec
+
+        context = EvaluationContext(
+            execution_id="exec-1",
+            seed_id="seed-1",
+            current_ac="CLI prints the version",
+            artifact="print('1.2.3')",
+            current_ac_spec=AcceptanceCriterionSpec(
+                description="CLI prints the version",
+                verify_command="mytool --version",
+                expected_artifacts=("mytool",),
+                output_assertion="stdout equals 1.2.3",
+            ),
+        )
+        prompt = build_evaluation_prompt(context)
+
+        assert "DECLARED SUCCESS CONTRACT" in prompt
+        assert "verify_command: mytool --version" in prompt
+        assert "expected_artifacts: mytool" in prompt
+        assert "output_assertion: stdout equals 1.2.3" in prompt
+        assert "The AC passes ONLY if the artifact demonstrates the declared contract" in prompt
+        assert "Cite the evidence line." in prompt
+
+    def test_bare_spec_without_contract_renders_no_contract_block(self) -> None:
+        """A description-only spec (no contract) leaves the prompt unchanged."""
+        from ouroboros.core.seed import AcceptanceCriterionSpec
+
+        context = EvaluationContext(
+            execution_id="exec-1",
+            seed_id="seed-1",
+            current_ac="User can login",
+            artifact="def login(): pass",
+            current_ac_spec=AcceptanceCriterionSpec(description="User can login"),
+        )
+        prompt = build_evaluation_prompt(context)
+
+        assert "DECLARED SUCCESS CONTRACT" not in prompt
+        assert "User can login" in prompt
+
+    def test_no_spec_renders_no_contract_block(self) -> None:
+        """When current_ac_spec is None the prompt has no contract block."""
+        context = EvaluationContext(
+            execution_id="exec-1",
+            seed_id="seed-1",
+            current_ac="User can login",
+            artifact="def login(): pass",
+        )
+        prompt = build_evaluation_prompt(context)
+
+        assert "DECLARED SUCCESS CONTRACT" not in prompt
+
 
 class TestParseSemanticResponse:
     """Tests for response parsing."""


### PR DESCRIPTION
## What / Why (per step)

PR-H from the 2026-07 master roadmap. Stage 2 (semantic) evaluation only ever saw the bare AC text, and `reward_hacking_risk` was scored but never acted on (write-only). This PR feeds the declared success contract to the judge and makes the risk signal a real gate.

**1. `models.py` — context field + threshold + failure surface**
- `EvaluationContext.current_ac_spec: AcceptanceCriterionSpec | None = None`.
- New module-level `REWARD_HACKING_VETO_THRESHOLD = 0.7`, defined here (not pipeline.py) so the gate *and* the `EvaluationResult.failure_reason` property share one SSOT without a models↔pipeline import cycle; `pipeline.py` imports it. Comment notes it only vetoes high-confidence gaming signals.
- Extended `EvaluationResult.failure_reason` with a reward-hacking branch.

**2. `semantic.py` — DECLARED SUCCESS CONTRACT block**
- When `current_ac_spec.has_success_contract` is true, renders a block listing `verify_command` / `expected_artifacts` / `output_assertion` and instructs: "The AC passes ONLY if the artifact demonstrates the declared contract was met. Cite the evidence line." Bare-string / no-contract ACs render nothing — prompt is byte-identical to today apart from a blank line.

**3. `pipeline.py` — gate wiring**
- No-consensus gate: `final_approved = ac_compliance and score >= 0.8 and reward_hacking_risk < REWARD_HACKING_VETO_THRESHOLD`.
- `_build_result` mirrors the veto reason for the pipeline-completed event.

**4. `evaluation_handlers.py` — thread specs into the loop**
- `_seed_ac_spec_map(seed)` maps each AC `description` back to its `AcceptanceCriterionSpec` (only specs carrying a contract). Threaded into the single-AC context and both `_handle_multi_ac` contexts via `current_ac_spec=spec_map.get(...)`. Bare-string ACs / no seed → `None` → unchanged behavior.

### Where the veto reason surfaces
`EvaluationResult.failure_reason` (models.py). `evaluation/checklist.py::_derive_failure_reason` reads exactly this property, so `ACCheckItem.failure_reason` carries the veto text unchanged (checklist.py untouched). Text: `Stage 2 veto: reward-hacking risk 0.90 >= 0.70 — artifact appears optimized to game the evaluator rather than solve the real task`.

## Done means
- [x] Spec-carrying AC renders the contract block in the Stage 2 prompt (test on prompt construction, no live LLM) — `test_semantic.py::test_spec_with_contract_renders_contract_block`
- [x] `reward_hacking_risk=0.9` with passing score → NOT approved, reason explains the veto — `test_pipeline_reward_hacking_veto.py`
- [x] `reward_hacking_risk=0.0` → behavior identical to today (existing tests unmodified) — `test_zero_risk_is_approved` + untouched existing pipeline/semantic tests
- [x] Validation gate passes

## Validation
- `ruff check .` / `ruff format --check .` — clean (1020 files)
- `mypy src/` — Success, no issues in 423 files
- `pytest tests/ --ignore=tests/e2e --ignore=tests/unit/mcp --ignore=tests/integration/mcp` — 10100 passed, 5 skipped, 6 failed. All 6 failures are pre-existing (`test_surface.py` / `test_auto_runtime_dispatch.py` opencode-vs-codex config leak); confirmed they fail identically on clean `origin/main`.
- Relevant MCP handler files run individually (not the full dir, per safety rule): `test_evaluate_multi_ac.py`, `test_checklist_verify.py`, `test_run_evaluate_chaining.py` — 40 passed.

## Files changed
- `src/ouroboros/evaluation/models.py`
- `src/ouroboros/evaluation/semantic.py`
- `src/ouroboros/evaluation/pipeline.py`
- `src/ouroboros/mcp/tools/evaluation_handlers.py`
- `tests/unit/evaluation/test_semantic.py` (added contract-block tests)
- `tests/unit/evaluation/test_pipeline_reward_hacking_veto.py` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)