### PR TITLE
feat(orchestrator): V5 — transient-retry parity (goose/hermes) + effort defaults + leaf success-contract block

### DIFF
--- a/src/ouroboros/orchestrator/effort_routing.py
+++ b/src/ouroboros/orchestrator/effort_routing.py
@@ -22,12 +22,20 @@ from ouroboros.orchestrator.adapter import ParamSupport
 # Ordered weakest -> strongest. Shared vocabulary across the runtimes that expose
 # an effort knob (Claude Agent SDK: low/medium/high/xhigh/max; Codex
 # model_reasoning_effort: minimal/low/medium/high/xhigh). ``max`` is Claude-only
-# and deliberately omitted from the ladder used for the one-notch-lower rule so
-# the rule never depends on a level a CLI runtime cannot accept.
+# and deliberately omitted from the ladder used for the notch rules so they never
+# depend on a level a CLI runtime cannot accept.
 EFFORT_LADDER: tuple[str, ...] = ("minimal", "low", "medium", "high", "xhigh")
 
-# Default floor for the decomposed-child rule: never strip a unit below "low".
+# Default floor for the (legacy) one-notch-lower helper: never strip below "low".
 DEFAULT_EFFORT_FLOOR = "low"
+
+# Default ceiling for the retry raise rule: the strongest cross-runtime level.
+DEFAULT_EFFORT_CEILING = EFFORT_LADDER[-1]
+
+# Retry attempt at which a hard AC is escalated one notch. ``retry_attempt`` is 0
+# on the initial dispatch, 1 on the first retry, 2 on the second — so a hard AC
+# that has already burned one retry earns MORE reasoning, not less.
+EFFORT_RAISE_RETRY_THRESHOLD = 2
 
 # Effort modes recorded per unit so enforced rows can be told apart from advised
 # ones — the distinction the deterministic frugality proof depends on.
@@ -48,6 +56,22 @@ def lower_one_notch(level: str, *, floor: str = DEFAULT_EFFORT_FLOOR) -> str:
     floor_index = EFFORT_LADDER.index(floor) if floor in EFFORT_LADDER else 0
     current_index = EFFORT_LADDER.index(level)
     return EFFORT_LADDER[max(floor_index, current_index - 1)]
+
+
+def raise_one_notch(level: str, *, ceiling: str = DEFAULT_EFFORT_CEILING) -> str:
+    """Return ``level`` lifted one rung, never above ``ceiling``.
+
+    Unknown levels (not on :data:`EFFORT_LADDER`, e.g. Claude-only ``max``) are
+    returned unchanged — the caller chose a vocabulary this module does not model,
+    so it is not this function's place to silently rewrite it.
+    """
+    if level not in EFFORT_LADDER:
+        return level
+    ceiling_index = (
+        EFFORT_LADDER.index(ceiling) if ceiling in EFFORT_LADDER else len(EFFORT_LADDER) - 1
+    )
+    current_index = EFFORT_LADDER.index(level)
+    return EFFORT_LADDER[min(ceiling_index, current_index + 1)]
 
 
 @dataclass(frozen=True)
@@ -76,7 +100,8 @@ def decide_effort(
     *,
     base_effort: str | None,
     is_decomposed_child: bool,
-    floor: str = DEFAULT_EFFORT_FLOOR,
+    retry_attempt: int = 0,
+    ceiling: str = DEFAULT_EFFORT_CEILING,
     enforceable_levels: frozenset[str] | None = None,
 ) -> EffortDecision:
     """Decide the per-unit effort level and whether the runtime will enforce it.
@@ -86,9 +111,15 @@ def decide_effort(
             ``runtime.capabilities.reasoning_effort_support``.
         base_effort: The configured base level for full-strength units, or ``None``
             to leave effort routing dormant.
-        is_decomposed_child: Whether this unit is a verified-MECE child, which is
-            run one notch lower than its parent (the frugality hypothesis).
-        floor: The lowest level a child may be dropped to.
+        is_decomposed_child: Whether this unit is a verified-MECE child. Retained as
+            a first-class routing/proof flag, but **no longer lowers the level** (V5):
+            a harder decomposed child inherits the parent tier unchanged — it needs at
+            least as much reasoning as its parent, never less.
+        retry_attempt: Same-runtime retry index for this unit (0 on the initial
+            dispatch). From :data:`EFFORT_RAISE_RETRY_THRESHOLD` onward the level is
+            raised one notch (capped at ``ceiling``): a hard AC that keeps failing
+            earns MORE reasoning.
+        ceiling: The strongest level the retry raise may reach.
         enforceable_levels: The runtime's enforceable vocabulary
             (``capabilities.enforceable_reasoning_efforts``). When provided, a level
             outside it is recorded as *advised* even on a NATIVE runtime, because the
@@ -101,10 +132,18 @@ def decide_effort(
         enforces, so a silently-dropped or advised level can never be mistaken for an
         enforced one — exactly the property the proof's enforced rows rely on.
     """
+    # ``is_decomposed_child`` is intentionally not consulted for the level: V5
+    # stopped lowering decomposed children so they inherit the parent tier. It
+    # stays in the signature because live call sites pass it by keyword and the
+    # frugality proof still records it as an admission flag.
+    del is_decomposed_child
+
     if not base_effort:
         return EffortDecision(level=None, mode=EFFORT_MODE_NONE)
 
-    level = lower_one_notch(base_effort, floor=floor) if is_decomposed_child else base_effort
+    level = base_effort
+    if retry_attempt >= EFFORT_RAISE_RETRY_THRESHOLD:
+        level = raise_one_notch(level, ceiling=ceiling)
     enforces_level = enforceable_levels is None or level in enforceable_levels
     mode = (
         EFFORT_MODE_ENFORCED
@@ -119,7 +158,8 @@ def resolve_execute_effort(
     *,
     base_effort: str | None,
     is_decomposed_child: bool,
-    floor: str = DEFAULT_EFFORT_FLOOR,
+    retry_attempt: int = 0,
+    ceiling: str = DEFAULT_EFFORT_CEILING,
 ) -> tuple[EffortDecision, dict[str, str]]:
     """Decide effort for one ``execute_task`` call and build its kwargs.
 
@@ -129,6 +169,9 @@ def resolve_execute_effort(
     level, and returns the ``execute_task`` kwargs — which are **empty unless the
     runtime enforces effort**, so a runtime that does not accept the parameter is
     never handed it.
+
+    ``retry_attempt`` is forwarded so a hard AC on its second-or-later retry earns
+    one extra notch of reasoning (see :func:`decide_effort`).
 
     Returns:
         ``(decision, execute_kwargs)``. ``execute_kwargs`` is ``{"reasoning_effort":
@@ -147,7 +190,8 @@ def resolve_execute_effort(
         support,
         base_effort=base_effort,
         is_decomposed_child=is_decomposed_child,
-        floor=floor,
+        retry_attempt=retry_attempt,
+        ceiling=ceiling,
         enforceable_levels=enforceable_levels,
     )
     kwargs = {"reasoning_effort": decision.level} if decision.is_enforced else {}

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -296,6 +296,33 @@ def _missing_expected_artifacts(artifacts: tuple[str, ...], cwd: str) -> tuple[s
     return tuple(missing)
 
 
+def _build_success_contract_block(spec: AcceptanceCriterionSpec | None) -> str:
+    """Render the worker-facing SUCCESS CONTRACT block for an AC, or ``""``.
+
+    The parallel leaf dispatch builds its own prompt (it does not go through the
+    host ``build_execute_subagent`` VERIFY section, nor does the repo-level context
+    pack carry a *per-AC* contract), so a worker was never told the exact
+    verify_command / expected_artifacts / output_assertion the harness will grade
+    it against. When the AC's spec carries a contract, surface it verbatim so the
+    worker runs and reports the same evidence the verify gate checks. Contract-less
+    ACs return ``""`` — the prompt stays byte-identical to before.
+    """
+    if spec is None or not spec.has_success_contract:
+        return ""
+    lines = ["SUCCESS CONTRACT for this AC:"]
+    if spec.verify_command:
+        lines.append(f"- Run: {spec.verify_command} and report it in commands_run")
+    if spec.expected_artifacts:
+        lines.append(
+            "- Expected artifacts: "
+            + ", ".join(spec.expected_artifacts)
+            + " — report them in files_touched"
+        )
+    if spec.output_assertion:
+        lines.append(f"- Expected output: {spec.output_assertion}")
+    return "\n".join(lines)
+
+
 def _collect_decomposition_depth_warning_paths(
     result: ACExecutionResult,
     *,
@@ -1085,9 +1112,10 @@ class ParallelACExecutor:
         async def _run_ac(idx: int, ac_idx: int) -> None:
             async with self._semaphore:
                 try:
+                    ac_criterion = seed.acceptance_criteria[ac_idx]
                     batch_results[idx] = await self._execute_single_ac(
                         ac_index=ac_idx,
-                        ac_content=ac_text(seed.acceptance_criteria[ac_idx]),
+                        ac_content=ac_text(ac_criterion),
                         session_id=session_id,
                         tools=tools,
                         tool_catalog=tool_catalog,
@@ -1101,6 +1129,11 @@ class ParallelACExecutor:
                         execution_counters=execution_counters,
                         retry_prompt_extra=(retry_prompts or {}).get(ac_idx, ""),
                         same_runtime_budget_exhausted=same_runtime_budget_exhausted,
+                        ac_spec=(
+                            ac_criterion
+                            if isinstance(ac_criterion, AcceptanceCriterionSpec)
+                            else None
+                        ),
                     )
                 except BaseException as e:
                     # Never suppress anyio Cancelled — doing so breaks
@@ -1859,6 +1892,7 @@ class ParallelACExecutor:
         node_identity: ExecutionNodeIdentity | None = None,
         retry_prompt_extra: str = "",
         same_runtime_budget_exhausted: bool = True,
+        ac_spec: AcceptanceCriterionSpec | None = None,
     ) -> ACExecutionResult:
         """Execute a single AC via the sole recursive AC execution entry point.
 
@@ -1885,6 +1919,10 @@ class ParallelACExecutor:
                 call's stall retries) is spent — so the alternate harness never
                 pre-empts the configured same-runtime retries. The batch layer
                 sets it; direct/sub-AC callers default to ``True``.
+            ac_spec: The top-level AC's structured spec, when it carries a success
+                contract, so the atomic leaf prompt can surface it. Only the batch
+                layer passes it for top-level ACs; sub-AC recursion leaves it
+                ``None`` (a decomposed child has no spec-level contract of its own).
 
         Returns:
             ACExecutionResult for this AC.
@@ -2093,6 +2131,7 @@ class ParallelACExecutor:
             "parent_ac_index": parent_ac_index,
             "sub_ac_index": sub_ac_index,
             "node_identity": node_identity,
+            "ac_spec": ac_spec,
         }
         while True:
             atomic_result = await self._execute_atomic_ac(
@@ -2115,6 +2154,7 @@ class ParallelACExecutor:
                 parent_ac_index=parent_ac_index,
                 sub_ac_index=sub_ac_index,
                 node_identity=node_identity,
+                ac_spec=ac_spec,
             )
             if atomic_result.error != _STALL_SENTINEL:
                 if not atomic_result.success and same_runtime_budget_exhausted:
@@ -2828,6 +2868,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         tool_catalog: tuple[MCPToolDefinition, ...] | None = None,
         execution_counters: dict[str, int] | None = None,
         retry_prompt_extra: str = "",
+        ac_spec: AcceptanceCriterionSpec | None = None,
     ) -> ACExecutionResult:
         """Execute an atomic AC directly via Claude Agent.
 
@@ -2858,6 +2899,12 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
             level_contexts=level_contexts,
             sibling_acs=sibling_acs,
         )
+        # Surface this AC's success contract to the worker so it runs and reports
+        # the exact evidence the verify gate will grade. Empty for contract-less
+        # ACs → the prompt stays byte-identical to before.
+        contract_block = _build_success_contract_block(ac_spec)
+        if contract_block:
+            task_section = f"{task_section}\n\n{contract_block}"
         legacy_context_section = (
             ""
             if context_governance_audit is not None
@@ -3089,7 +3136,8 @@ Files present:
         await self._await_dispatch_rate_budget(prompt=prompt, system_prompt=system_prompt)
 
         # Lay the executor on the capability contract: decide the effort level for
-        # this unit (a decomposed child runs one notch lower) and classify how the
+        # this unit (a decomposed child inherits the parent tier unchanged; a hard AC
+        # on its second-or-later retry is raised one notch) and classify how the
         # chosen runtime will honor it from its declared capability — enforced via a
         # native knob, or advised. The level is passed to execute_task; an advised
         # runtime ignores it. Dormant by default (base effort None → level None).
@@ -3097,6 +3145,7 @@ Files present:
             self._adapter,
             base_effort=self._reasoning_effort,
             is_decomposed_child=is_sub_ac,
+            retry_attempt=retry_attempt,
         )
         if effort_decision.level is not None:
             log.debug(

--- a/src/ouroboros/providers/hermes_cli_adapter.py
+++ b/src/ouroboros/providers/hermes_cli_adapter.py
@@ -12,6 +12,7 @@ import structlog
 
 from ouroboros.config import get_hermes_cli_path
 from ouroboros.core.errors import ProviderError
+from ouroboros.core.retry import is_transient_error
 from ouroboros.core.security import MAX_LLM_RESPONSE_LENGTH, InputValidator
 from ouroboros.core.types import Result
 from ouroboros.orchestrator.hermes_runtime import _parse_quiet_output
@@ -116,8 +117,14 @@ class HermesCliLLMAdapter:
                 return result
 
             last_error = result.error
-            if attempt < self._max_retries - 1:
-                await asyncio.sleep(2**attempt)
+            # Retry only transient failures (429/529/overloaded/connection/
+            # timeout), reusing the shared providers/retry transient core the
+            # other CLI adapters classify against. A non-transient error (auth,
+            # not-found, empty response, non-transient exit) is terminal and is
+            # returned immediately instead of burning the retry budget.
+            if not is_transient_error(result.error.message) or attempt >= self._max_retries - 1:
+                return result
+            await asyncio.sleep(2**attempt)
 
         return Result.err(last_error or ProviderError(message="Max retries exceeded"))
 

--- a/tests/unit/orchestrator/test_effort_routed_event.py
+++ b/tests/unit/orchestrator/test_effort_routed_event.py
@@ -113,7 +113,7 @@ def _effort_events(events: list) -> list:
     return [e for e in events if getattr(e, "type", None) == "execution.ac.effort_routed"]
 
 
-async def _run_one_ac(executor: ParallelACExecutor, *, is_sub_ac: bool):
+async def _run_one_ac(executor: ParallelACExecutor, *, is_sub_ac: bool, retry_attempt: int = 0):
     return await executor._execute_atomic_ac(
         ac_index=1,
         ac_content="Implement a thing",
@@ -127,6 +127,7 @@ async def _run_one_ac(executor: ParallelACExecutor, *, is_sub_ac: bool):
         is_sub_ac=is_sub_ac,
         parent_ac_index=0 if is_sub_ac else None,
         sub_ac_index=0 if is_sub_ac else None,
+        retry_attempt=retry_attempt,
     )
 
 
@@ -153,7 +154,10 @@ async def test_enforced_runtime_emits_enforced_event_and_passes_kwarg() -> None:
 
 
 @pytest.mark.asyncio
-async def test_decomposed_child_runs_one_notch_lower() -> None:
+async def test_decomposed_child_inherits_parent_tier_unchanged() -> None:
+    # V5: a decomposed child no longer runs one notch lower — it inherits the
+    # parent tier unchanged. ``is_decomposed_child`` is still recorded as a proof
+    # flag, but the level is not dropped.
     store, events = _capturing_event_store()
     runtime = _EnforcedRuntime()
     executor = ParallelACExecutor(
@@ -167,9 +171,29 @@ async def test_decomposed_child_runs_one_notch_lower() -> None:
     await _run_one_ac(executor, is_sub_ac=True)
 
     routed = _effort_events(events)
-    assert routed[0].data["effort_level"] == "medium"  # high -> one notch lower
+    assert routed[0].data["effort_level"] == "high"  # inherited unchanged
     assert routed[0].data["is_decomposed_child"] is True
-    assert runtime.received_effort == "medium"
+    assert runtime.received_effort == "high"
+
+
+@pytest.mark.asyncio
+async def test_second_retry_raises_effort_one_notch() -> None:
+    # V5: a hard AC on its second retry earns MORE reasoning — one notch up.
+    store, events = _capturing_event_store()
+    runtime = _EnforcedRuntime()
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=store,
+        console=MagicMock(),
+        enable_decomposition=False,
+        reasoning_effort="medium",
+    )
+
+    await _run_one_ac(executor, is_sub_ac=False, retry_attempt=2)
+
+    routed = _effort_events(events)
+    assert routed[0].data["effort_level"] == "high"  # medium raised one notch
+    assert runtime.received_effort == "high"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_effort_routing.py
+++ b/tests/unit/orchestrator/test_effort_routing.py
@@ -10,6 +10,7 @@ from ouroboros.orchestrator.effort_routing import (
     EffortDecision,
     decide_effort,
     lower_one_notch,
+    raise_one_notch,
 )
 
 
@@ -34,6 +35,23 @@ class TestLowerOneNotch:
         assert EFFORT_LADDER.index("low") < EFFORT_LADDER.index("high")
 
 
+class TestRaiseOneNotch:
+    def test_lifts_one_rung(self) -> None:
+        assert raise_one_notch("low") == "medium"
+        assert raise_one_notch("medium") == "high"
+        assert raise_one_notch("high") == "xhigh"
+
+    def test_never_above_ceiling(self) -> None:
+        assert raise_one_notch("xhigh") == "xhigh"  # ladder top, cannot rise further
+        assert raise_one_notch("high", ceiling="high") == "high"
+        assert raise_one_notch("low", ceiling="medium") == "medium"
+
+    def test_unknown_level_passthrough(self) -> None:
+        # Claude-only 'max' is off the shared ladder and is returned unchanged.
+        assert raise_one_notch("max") == "max"
+        assert raise_one_notch("bananas") == "bananas"
+
+
 class TestDecideEffort:
     def test_dormant_when_no_base_effort(self) -> None:
         d = decide_effort(ParamSupport.NATIVE, base_effort=None, is_decomposed_child=True)
@@ -53,15 +71,45 @@ class TestDecideEffort:
         assert d.mode == "advised"
         assert d.is_enforced is False  # advised never counts as enforced
 
-    def test_decomposed_child_runs_one_notch_lower(self) -> None:
+    def test_decomposed_child_inherits_parent_tier_unchanged(self) -> None:
+        # V5: a decomposed child no longer runs one notch lower — a harder,
+        # verified-MECE child inherits the parent tier unchanged.
         parent = decide_effort(ParamSupport.NATIVE, base_effort="high", is_decomposed_child=False)
         child = decide_effort(ParamSupport.NATIVE, base_effort="high", is_decomposed_child=True)
         assert parent.level == "high"
-        assert child.level == "medium"
+        assert child.level == "high"
 
-    def test_child_respects_floor(self) -> None:
+    def test_child_at_low_base_also_inherits_unchanged(self) -> None:
         child = decide_effort(ParamSupport.NATIVE, base_effort="low", is_decomposed_child=True)
-        assert child.level == "low"  # floor=low, cannot drop further
+        assert child.level == "low"
+
+    def test_second_retry_raises_one_notch(self) -> None:
+        # retry_attempt: 0 initial, 1 first retry, 2 second retry -> raise.
+        initial = decide_effort(
+            ParamSupport.NATIVE, base_effort="medium", is_decomposed_child=False, retry_attempt=0
+        )
+        first = decide_effort(
+            ParamSupport.NATIVE, base_effort="medium", is_decomposed_child=False, retry_attempt=1
+        )
+        second = decide_effort(
+            ParamSupport.NATIVE, base_effort="medium", is_decomposed_child=False, retry_attempt=2
+        )
+        assert initial.level == "medium"
+        assert first.level == "medium"  # first retry does not raise yet
+        assert second.level == "high"  # second retry earns one extra notch
+
+    def test_retry_raise_caps_at_ladder_top(self) -> None:
+        d = decide_effort(
+            ParamSupport.NATIVE, base_effort="xhigh", is_decomposed_child=False, retry_attempt=3
+        )
+        assert d.level == "xhigh"  # already at the top, cannot rise further
+
+    def test_retry_raise_applies_to_decomposed_child_too(self) -> None:
+        # Children inherit the parent tier AND still earn the retry raise.
+        d = decide_effort(
+            ParamSupport.NATIVE, base_effort="low", is_decomposed_child=True, retry_attempt=2
+        )
+        assert d.level == "medium"
 
 
 class TestDecideEffortEnforceableLevels:
@@ -151,6 +199,18 @@ class TestResolveExecuteEffort:
         )
         assert decision.mode == "advised"
         assert kwargs == {}
+
+    def test_second_retry_raises_the_enforced_kwarg(self) -> None:
+        from ouroboros.orchestrator.effort_routing import resolve_execute_effort
+
+        decision, kwargs = resolve_execute_effort(
+            _Adapter(ParamSupport.NATIVE),
+            base_effort="medium",
+            is_decomposed_child=False,
+            retry_attempt=2,
+        )
+        assert decision.level == "high"
+        assert kwargs == {"reasoning_effort": "high"}
 
     def test_dormant_yields_no_kwarg(self) -> None:
         from ouroboros.orchestrator.effort_routing import resolve_execute_effort

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -17,6 +17,7 @@ from ouroboros.orchestrator.parallel_executor import (
     ACExecutionOutcome,
     ACExecutionResult,
     ParallelACExecutor,
+    _build_success_contract_block,
     _complete_sibling_acs_from_evidence,
 )
 from ouroboros.orchestrator.verifier import VerifierVerdict
@@ -779,3 +780,36 @@ async def test_skip_completed_gates_artifacts_only_contract(tmp_path: Any) -> No
     assert dispatched == []
     assert result.externally_satisfied_count == 1
     assert "verification_status=verified" in result.results[0].final_message
+
+
+class TestSuccessContractBlock:
+    """The worker-facing SUCCESS CONTRACT block surfaced in the leaf prompt."""
+
+    def test_none_spec_yields_empty_block(self) -> None:
+        assert _build_success_contract_block(None) == ""
+
+    def test_contract_less_spec_yields_empty_block(self) -> None:
+        spec = AcceptanceCriterionSpec(description="just a description")
+        assert _build_success_contract_block(spec) == ""
+
+    def test_full_contract_renders_all_three_lines(self) -> None:
+        spec = AcceptanceCriterionSpec(
+            description="build succeeds",
+            verify_command="make build",
+            expected_artifacts=("dist/app", "dist/app.map"),
+            output_assertion="BUILD OK",
+        )
+        block = _build_success_contract_block(spec)
+        assert block.startswith("SUCCESS CONTRACT for this AC:")
+        assert "- Run: make build and report it in commands_run" in block
+        assert (
+            "- Expected artifacts: dist/app, dist/app.map — report them in files_touched" in block
+        )
+        assert "- Expected output: BUILD OK" in block
+
+    def test_partial_contract_only_renders_present_fields(self) -> None:
+        spec = AcceptanceCriterionSpec(description="verify only", verify_command="pytest -q")
+        block = _build_success_contract_block(spec)
+        assert "- Run: pytest -q and report it in commands_run" in block
+        assert "Expected artifacts" not in block
+        assert "Expected output" not in block

--- a/tests/unit/providers/test_goose_cli_adapter.py
+++ b/tests/unit/providers/test_goose_cli_adapter.py
@@ -377,3 +377,73 @@ class TestGooseCliLLMAdapter:
             adapter = GooseCliLLMAdapter()
 
         assert adapter._cli_path == "/tmp/goose"
+
+
+class TestGooseTransientRetryParity:
+    """Goose inherits the shared transient-retry core from the Codex CLI adapter.
+
+    The parallel executor's cross-vendor recovery relies on every CLI adapter
+    retrying transient failures (429/529/overloaded/connection) while returning
+    terminal errors immediately. Goose gets this for free by subclassing
+    ``CodexCliLLMAdapter`` (whose ``complete`` loop classifies against
+    ``core.retry.is_transient_error``); these tests lock that parity in.
+    """
+
+    @pytest.mark.asyncio
+    async def test_transient_error_is_retried(self) -> None:
+        from ouroboros.core.errors import ProviderError
+        from ouroboros.core.types import Result
+        from ouroboros.providers.base import CompletionResponse
+
+        adapter = GooseCliLLMAdapter(cli_path="/bin/true", max_retries=3)
+        calls = {"n": 0}
+
+        async def fake_once(messages: Any, config: Any) -> Any:
+            calls["n"] += 1
+            if calls["n"] < 2:
+                return Result.err(
+                    ProviderError(
+                        message="overloaded_error: server overloaded", provider="goose_cli"
+                    )
+                )
+            return Result.ok(
+                CompletionResponse(
+                    content="ok",
+                    model="m",
+                    usage=None,
+                    finish_reason="stop",
+                    raw_response={},
+                )
+            )
+
+        with patch.object(adapter, "_complete_once", side_effect=fake_once), patch("asyncio.sleep"):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="hi")],
+                CompletionConfig(model="default"),
+            )
+
+        assert result.is_ok
+        assert calls["n"] == 2  # one transient retry, then success
+
+    @pytest.mark.asyncio
+    async def test_non_transient_error_is_not_retried(self) -> None:
+        from ouroboros.core.errors import ProviderError
+        from ouroboros.core.types import Result
+
+        adapter = GooseCliLLMAdapter(cli_path="/bin/true", max_retries=3)
+        calls = {"n": 0}
+
+        async def fake_once(messages: Any, config: Any) -> Any:
+            calls["n"] += 1
+            return Result.err(
+                ProviderError(message="authentication failed: bad key", provider="goose_cli")
+            )
+
+        with patch.object(adapter, "_complete_once", side_effect=fake_once), patch("asyncio.sleep"):
+            result = await adapter.complete(
+                [Message(role=MessageRole.USER, content="hi")],
+                CompletionConfig(model="default"),
+            )
+
+        assert result.is_err
+        assert calls["n"] == 1  # terminal error — no retry budget burned

--- a/tests/unit/providers/test_hermes_cli_adapter.py
+++ b/tests/unit/providers/test_hermes_cli_adapter.py
@@ -90,6 +90,85 @@ async def test_complete_returns_provider_error_on_nonzero_exit() -> None:
     assert "exited with code 2" in result.error.message
 
 
+@pytest.mark.asyncio
+async def test_complete_retries_only_transient_failures(monkeypatch: pytest.MonkeyPatch) -> None:
+    spawns: list[tuple[str, ...]] = []
+
+    async def _fake_exec(*cmd: str, **kwargs: object) -> _FakeProcess:
+        spawns.append(cmd)
+        # 503 is in the shared transient vocabulary -> retry-worthy.
+        return _FakeProcess(stderr="503 Service Unavailable", returncode=1)
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("ouroboros.providers.hermes_cli_adapter.asyncio.sleep", _no_sleep)
+    adapter = HermesCliLLMAdapter(cli_path="/usr/bin/hermes", max_retries=3)
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        result = await adapter.complete(
+            [Message(role=MessageRole.USER, content="Answer this")],
+            CompletionConfig(model="default"),
+        )
+
+    assert result.is_err
+    assert len(spawns) == 3  # transient error is retried up to the configured budget
+
+
+@pytest.mark.asyncio
+async def test_complete_does_not_retry_non_transient_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spawns: list[tuple[str, ...]] = []
+
+    async def _fake_exec(*cmd: str, **kwargs: object) -> _FakeProcess:
+        spawns.append(cmd)
+        return _FakeProcess(stderr="authentication failed: invalid api key", returncode=2)
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("ouroboros.providers.hermes_cli_adapter.asyncio.sleep", _no_sleep)
+    adapter = HermesCliLLMAdapter(cli_path="/usr/bin/hermes", max_retries=3)
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        result = await adapter.complete(
+            [Message(role=MessageRole.USER, content="Answer this")],
+            CompletionConfig(model="default"),
+        )
+
+    assert result.is_err
+    assert len(spawns) == 1  # non-transient error is terminal — no retry budget burned
+
+
+@pytest.mark.asyncio
+async def test_complete_recovers_after_transient_then_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    spawns: list[tuple[str, ...]] = []
+    outcomes = [
+        _FakeProcess(stderr="rate limit exceeded", returncode=1),
+        _FakeProcess(stdout="Recovered\nsession_id: 20260507_120000_abcdef\n"),
+    ]
+
+    async def _fake_exec(*cmd: str, **kwargs: object) -> _FakeProcess:
+        spawns.append(cmd)
+        return outcomes[len(spawns) - 1]
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr("ouroboros.providers.hermes_cli_adapter.asyncio.sleep", _no_sleep)
+    adapter = HermesCliLLMAdapter(cli_path="/usr/bin/hermes", max_retries=3)
+    with patch("asyncio.create_subprocess_exec", side_effect=_fake_exec):
+        result = await adapter.complete(
+            [Message(role=MessageRole.USER, content="Answer this")],
+            CompletionConfig(model="default"),
+        )
+
+    assert result.is_ok
+    assert result.value.content == "Recovered"
+    assert len(spawns) == 2  # one transient retry, then success
+
+
 def test_build_prompt_includes_tool_envelope() -> None:
     adapter = HermesCliLLMAdapter(
         cli_path=Path("/usr/bin/hermes"),


### PR DESCRIPTION
Work order **V5** from the approved run-metaharness plan (`docs/run-metaharness-plan-2026-07.md`). The small opportunistic remainder after Phase V (V1–V4, #1548). Three independent parts.

## Part 1 — Transient-retry parity for goose/hermes — DONE

- **Hermes** (`hermes_cli_adapter.py`): its `complete` loop retried **every** error blindly. Now it retries **only transient** failures, classified against the shared `core.retry.is_transient_error` (429/529/overloaded/connection/timeout) — the same core the other CLI adapters use. A non-transient error (auth, not-found, empty response, non-transient exit) is now terminal and returned immediately instead of burning the retry budget. Error semantics (ProviderError shapes) are unchanged.
- **Goose** (`goose_cli_adapter.py`): **no code change needed.** Audit + empirical probe show it already inherits the transient-retry loop from `CodexCliLLMAdapter.complete` (which classifies via `is_transient_error`). Probe result: a transient `overloaded_error` was retried (2 calls → success); a non-transient `authentication failed` was **not** retried (1 call). Parity locked in with tests rather than duplicated retry code (Zero-Refactor).

## Part 2 — Effort defaults — DONE

`effort_routing.py` (+ `parallel_executor.py` call site):
- **Stop lowering decomposed children.** `decide_effort` no longer drops a decomposed child one notch — a harder, verified-MECE child **inherits the parent tier unchanged**. `is_decomposed_child` stays in the signature as a first-class routing/proof flag (still recorded in the `effort_routed` event) but no longer alters the level.
- **Raise on the second retry.** New `raise_one_notch` + a `retry_attempt` param threaded through `resolve_execute_effort` → the executor dispatch. From the second retry onward (`retry_attempt >= 2`) the level is raised one notch, **capped at the ladder top (`xhigh`)**. Hard ACs get MORE reasoning, not less.

## Part 3 — Leaf-prompt SUCCESS CONTRACT block — DONE (audit verdict: MISSING → added)

**Audit:** the parallel leaf dispatch did **not** tell the worker its AC's success contract.
- `ac_content` comes from `ac_text(spec)`, which returns **`description` only** (`core/seed.py`).
- The repo **context pack** (`runner.py`) injects only *repo-level* verify commands into the system prompt — not this AC's `verify_command`/`expected_artifacts`/`output_assertion`.
- The `build_execute_subagent` **VERIFY** section is a *different* host-driven subagent path; the `parallel_executor` builds its own prompt directly and does not use it.

**Fix:** added `_build_success_contract_block(spec)` and threaded the top-level AC spec (`ac_spec`) through `_execute_single_ac` → `_execute_atomic_ac` (and into the cross-harness `alt_rerun_kwargs`). When the AC's spec carries a contract, the worker prompt now appends:

```
SUCCESS CONTRACT for this AC:
- Run: <verify_command> and report it in commands_run
- Expected artifacts: <list> — report them in files_touched
- Expected output: <output_assertion>
```

Only present fields are rendered. **Contract-less ACs (and sub-ACs, which have no spec-level contract) are byte-identical to before.**

## Intentional behavior change (test expectations updated)

The plan explicitly changes the decomposed-child effort rule, so two tests that asserted the **old** lower-child behavior were updated (not deleted):
- `test_effort_routing.py::test_decomposed_child_runs_one_notch_lower` → `..._inherits_parent_tier_unchanged` (child now `high`, was `medium`).
- `test_effort_routed_event.py::test_decomposed_child_runs_one_notch_lower` → `..._inherits_parent_tier_unchanged` (routed event `effort_level` now `high`).

## Tests added
- Effort: `raise_one_notch` (lift/ceiling/passthrough), child inherits unchanged, second-retry raise (unit + integration via `effort_routed` event), retry-raise caps at ladder top, `resolve_execute_effort` retry raise.
- Hermes: retries only transient, no retry on non-transient, recovers after transient-then-success.
- Goose: transient retried / non-transient not (inherited-parity lock-in).
- Contract block: none/contract-less → empty; full → all three lines; partial → only present fields.

## Validation
- `uv run ruff check .` — pass
- `uv run ruff format --check .` — pass
- `uv run mypy src/` — Success, no issues (423 files)
- `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/unit/mcp --ignore=tests/integration/mcp -q` — **10108 passed, 5 skipped, 6 failed**. The 6 failures (`test_surface.py`, `test_auto_runtime_dispatch.py`) are **pre-existing, environment-only**: a local codex-config leak making runtime-backend inference return `codex` instead of `opencode`. Verified they fail identically on a clean tree (stash + rerun) and none reference any file this PR touches.

Scope wall respected: only `goose_cli_adapter.py` (audited, unchanged), `hermes_cli_adapter.py`, `effort_routing.py`, `parallel_executor.py`, and their tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)