### PR TITLE
fix(mcp): close the remaining JobManager terminal-event race (zombie job without terminal state)

### DIFF
--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -449,6 +449,11 @@ class JobManager:
         coroutine ``close()`` cleanup.
         """
         cancel_context = False
+        # The terminal event the body intends to persist, captured before each
+        # append so the release-point backstop can replay the REAL payload
+        # (result_text / result_meta — e.g. chained_evaluate_job_id — matter to
+        # consumers) instead of a guard-status fallback if the append is lost.
+        intended_terminal: tuple[str, dict[str, Any]] | None = None
         try:
             await self.update_status(job_id, JobStatus.RUNNING, f"Running {job_type}")
 
@@ -484,28 +489,32 @@ class JobManager:
                             event_id=f"{_DRAIN_INTERRUPTED_EVENT_ID_PREFIX}{job_id}",
                         )
                     raise
+                cancelled_data = {
+                    "status": JobStatus.CANCELLED.value,
+                    "message": "Job cancelled",
+                }
+                intended_terminal = ("mcp.job.cancelled", cancelled_data)
                 await self._append_terminal_event_with_fallback(
                     "mcp.job.cancelled",
                     job_id,
-                    {
-                        "status": JobStatus.CANCELLED.value,
-                        "message": "Job cancelled",
-                    },
+                    cancelled_data,
                 )
                 raise
             except Exception as exc:
                 snapshot = await self.get_snapshot(job_id)
                 if snapshot.is_terminal:
                     return
+                failed_data = {
+                    "status": JobStatus.FAILED.value,
+                    "message": f"Job failed: {exc}",
+                    "error": str(exc),
+                    "is_error": True,
+                }
+                intended_terminal = ("mcp.job.failed", failed_data)
                 await self._append_terminal_event_with_fallback(
                     "mcp.job.failed",
                     job_id,
-                    {
-                        "status": JobStatus.FAILED.value,
-                        "message": f"Job failed: {exc}",
-                        "error": str(exc),
-                        "is_error": True,
-                    },
+                    failed_data,
                 )
             else:
                 snapshot = await self.get_snapshot(job_id)
@@ -547,22 +556,24 @@ class JobManager:
                             result_meta=result_meta if isinstance(result_meta, dict) else None,
                         )
                         return
+                terminal_data = {
+                    "status": terminal_status.value,
+                    "message": {
+                        JobStatus.COMPLETED: "Job complete",
+                        JobStatus.CANCELLED: "Job cancelled",
+                        JobStatus.INTERRUPTED: "Job interrupted",
+                        JobStatus.FAILED: "Job failed",
+                    }.get(terminal_status, "Job complete"),
+                    "result_text": getattr(result, "text_content", str(result))[:20_000],
+                    "result_meta": _safe_meta(getattr(result, "meta", {})),
+                    "result_payload": _safe_result_payload(result),
+                    "is_error": bool(getattr(result, "is_error", False)),
+                }
+                intended_terminal = (terminal_type, terminal_data)
                 await self._append_terminal_event_with_fallback(
                     terminal_type,
                     job_id,
-                    {
-                        "status": terminal_status.value,
-                        "message": {
-                            JobStatus.COMPLETED: "Job complete",
-                            JobStatus.CANCELLED: "Job cancelled",
-                            JobStatus.INTERRUPTED: "Job interrupted",
-                            JobStatus.FAILED: "Job failed",
-                        }.get(terminal_status, "Job complete"),
-                        "result_text": getattr(result, "text_content", str(result))[:20_000],
-                        "result_meta": _safe_meta(getattr(result, "meta", {})),
-                        "result_payload": _safe_result_payload(result),
-                        "is_error": bool(getattr(result, "is_error", False)),
-                    },
+                    terminal_data,
                 )
         except asyncio.CancelledError:
             # Cancellation can strike the terminal-writing logic itself (e.g. a
@@ -606,7 +617,11 @@ class JobManager:
             # legitimately deferred to a live drain holder) even if the rest of
             # the finally is torn down mid-flight.
             backstop = asyncio.create_task(
-                self._backstop_terminal_event(job_id, cancel_context=cancel_context)
+                self._backstop_terminal_event(
+                    job_id,
+                    cancel_context=cancel_context,
+                    intended_terminal=intended_terminal,
+                )
             )
             self._backstops[job_id] = backstop
             backstop.add_done_callback(
@@ -636,19 +651,43 @@ class JobManager:
             # running to completion on the loop.
             await asyncio.shield(backstop)
 
-    async def _backstop_terminal_event(self, job_id: str, *, cancel_context: bool) -> None:
+    async def _backstop_terminal_event(
+        self,
+        job_id: str,
+        *,
+        cancel_context: bool,
+        intended_terminal: tuple[str, dict[str, Any]] | None = None,
+    ) -> None:
         """Guarantee a terminal event exists after ``_run_job`` released a job.
 
         Runs as a detached task launched at the top of ``_run_job``'s
         ``finally`` so that cancellation of the job task cannot skip or
         interrupt it. No-ops once a terminal event is durably present (the
-        normal case) and respects drain semantics: when a live external holder
-        legitimately owns the job's terminal state, ``_terminal_guard_status``
-        returns ``None`` and this writes nothing. Never raises.
+        normal case). When the body's intended terminal event was lost, replay
+        the REAL payload (``intended_terminal``: result_text / result_meta —
+        e.g. ``chained_evaluate_job_id`` — matter to consumers) before falling
+        back to a guard-status diagnostic terminal. Respects drain semantics:
+        when a live external holder legitimately owns the job's terminal
+        state, ``_terminal_guard_status`` returns ``None`` and the fallback
+        writes nothing. Never raises.
         """
         try:
             if await self._job_has_persisted_terminal_event(job_id):
                 return
+            if intended_terminal is not None:
+                event_type, data = intended_terminal
+                try:
+                    await self._append_event(event_type, job_id, data)
+                except Exception:
+                    logger.warning(
+                        "mcp.job.backstop_intended_terminal_append_failed",
+                        extra={"job_id": job_id, "event_type": event_type},
+                        exc_info=True,
+                    )
+                else:
+                    return
+                if await self._job_has_persisted_terminal_event(job_id):
+                    return
             guard_status = await self._terminal_guard_status(job_id, cancel_context=cancel_context)
             if guard_status is None:
                 return

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -568,6 +568,47 @@ class JobManager:
                     await monitor
                 except asyncio.CancelledError:
                     pass
+            # Durability backstop for the residual #1566 zombie: the
+            # terminal-append helpers used in the try body
+            # (_append_terminal_event_with_fallback and
+            # _append_execution_completed_event_with_fallback, via
+            # _append_terminal_fallback_event) are BEST-EFFORT and SWALLOW
+            # persistence failures — when every append attempt raises they log
+            # and return normally. The body then completes with NO terminal
+            # event AND NO propagating exception, so neither the crash guard
+            # (except BaseException) nor the cancel guard (except CancelledError)
+            # fires, and the job is stranded RUNNING forever (persisted stream
+            # shows only created + running, exactly the CI diagnostics). This is
+            # the last point where this process still owns the job's tasks;
+            # guarantee a terminal row before releasing them.
+            await self._backstop_terminal_event(job_id, cancel_context=cancel_context)
+
+    async def _backstop_terminal_event(self, job_id: str, *, cancel_context: bool) -> None:
+        """Guarantee a terminal event exists after ``_run_job`` released a job.
+
+        No-ops once a terminal event is durably present (the normal case) and
+        respects drain semantics: when a live external holder legitimately owns
+        the job's terminal state, ``_terminal_guard_status`` returns ``None`` and
+        this writes nothing. Never raises — it runs inside ``_run_job``'s
+        ``finally`` and must not mask the job-task teardown.
+        """
+        try:
+            if await self._job_has_persisted_terminal_event(job_id):
+                return
+            guard_status = await self._terminal_guard_status(job_id, cancel_context=cancel_context)
+            if guard_status is None:
+                return
+            await self._ensure_terminal_event_best_effort(
+                job_id,
+                reason="terminal event missing after _run_job body released the job",
+                terminal_status=guard_status,
+            )
+        except Exception:
+            logger.error(
+                "mcp.job.backstop_terminal_failed",
+                extra={"job_id": job_id},
+                exc_info=True,
+            )
 
     async def _monitor_job(self, job_id: str) -> None:
         """Mirror linked execution/lineage progress into job updates."""

--- a/src/ouroboros/mcp/job_manager.py
+++ b/src/ouroboros/mcp/job_manager.py
@@ -115,6 +115,7 @@ _COMPLETED_EXECUTION_CANCEL_GRACE_SECONDS = 5.0
 _RECOVERED_COMPLETION_EVENT_ID_PREFIX = "mcp-job-recovered-completed-"
 _RECOVERED_FAILURE_EVENT_ID_PREFIX = "mcp-job-recovered-failed-"
 _RECOVERED_INTERRUPTED_EVENT_ID_PREFIX = "mcp-job-recovered-interrupted-"
+_STRANDED_INTERRUPTED_EVENT_ID_PREFIX = "mcp-job-stranded-interrupted-"
 _DRAIN_INTERRUPTED_EVENT_ID_PREFIX = "mcp-job-drain-interrupted-"
 _DRAIN_GRACE_SECONDS = 5.0
 _TERMINAL_APPEND_RETRY_DELAY_SECONDS = 0.05
@@ -270,6 +271,30 @@ def _orphaned_job_interrupted_event(job_id: str) -> BaseEvent:
     )
 
 
+def _stranded_job_interrupted_data() -> dict[str, Any]:
+    """Terminal payload for a job whose task was released without a terminal event."""
+    return {
+        "status": JobStatus.INTERRUPTED.value,
+        "message": "Job interrupted: job task released without persisting a terminal state",
+        "error": "Job task exited without persisting a terminal event",
+        "result_text": "Job task exited without persisting a terminal event",
+        "result_meta": {"interrupted_from_stranded_job_task": True},
+        "is_error": True,
+        "timestamp": datetime.now(UTC).isoformat(),
+    }
+
+
+def _stranded_job_interrupted_event(job_id: str) -> BaseEvent:
+    """Build the synthetic job-interrupted event for a stranded released job."""
+    return BaseEvent(
+        id=f"{_STRANDED_INTERRUPTED_EVENT_ID_PREFIX}{job_id}",
+        type="mcp.job.interrupted",
+        aggregate_type="job",
+        aggregate_id=job_id,
+        data=_stranded_job_interrupted_data(),
+    )
+
+
 def _snapshot_with_terminal_event(
     snapshot: JobSnapshot,
     event: BaseEvent,
@@ -306,6 +331,8 @@ class JobManager:
         self._tasks: dict[str, asyncio.Task[Any]] = {}
         self._runner_tasks: dict[str, asyncio.Task[Any]] = {}
         self._monitors: dict[str, asyncio.Task[None]] = {}
+        self._backstops: dict[str, asyncio.Task[None]] = {}
+        self._started_job_ids: set[str] = set()
         self._monitor_terminalized_jobs: set[str] = set()
         self._recovery_locks: dict[str, asyncio.Lock] = {}
         self._initialized = False
@@ -395,6 +422,13 @@ class JobManager:
         task = asyncio.create_task(self._run_job(job_id, job_type, runner_task))
         self._tasks[job_id] = task
         self._monitors[job_id] = asyncio.create_task(self._monitor_job(job_id))
+        # Registered synchronously with the task dicts above: marks THIS manager
+        # instance as the runner owner, so the in-process stranded-job
+        # reconciliation in get_snapshot only ever applies to jobs whose live
+        # tasks this instance owned and released (another instance in the same
+        # process cannot prove task liveness and must never terminalize live
+        # work).
+        self._started_job_ids.add(job_id)
 
         return await self.get_snapshot(job_id)
 
@@ -558,6 +592,27 @@ class JobManager:
                 )
             raise
         finally:
+            # Durability backstop for the residual #1566 zombie class: the
+            # terminal-append helpers used in the try body are best-effort and
+            # SWALLOW persistence failures, and every inline net above (the
+            # except guards and _ensure_terminal_event_best_effort) catches only
+            # Exception while awaiting — a late CancelledError landing on any of
+            # those awaits (or on the monitor await below) silently aborts the
+            # rest of this finally AFTER the pops. PR #1576's own CI run proved
+            # an inline backstop can be skipped exactly that way. Launch the
+            # backstop as a DETACHED task, synchronously, before anything else
+            # in this finally: no cancellation delivered to THIS task can reach
+            # it, so a terminal event is guaranteed to be persisted (or
+            # legitimately deferred to a live drain holder) even if the rest of
+            # the finally is torn down mid-flight.
+            backstop = asyncio.create_task(
+                self._backstop_terminal_event(job_id, cancel_context=cancel_context)
+            )
+            self._backstops[job_id] = backstop
+            backstop.add_done_callback(
+                lambda _task, _job_id=job_id: self._backstops.pop(_job_id, None)
+            )
+            backstop.add_done_callback(_consume_task_result)
             self._tasks.pop(job_id, None)
             self._runner_tasks.pop(job_id, None)
             self._monitor_terminalized_jobs.discard(job_id)
@@ -568,29 +623,28 @@ class JobManager:
                     await monitor
                 except asyncio.CancelledError:
                     pass
-            # Durability backstop for the residual #1566 zombie: the
-            # terminal-append helpers used in the try body
-            # (_append_terminal_event_with_fallback and
-            # _append_execution_completed_event_with_fallback, via
-            # _append_terminal_fallback_event) are BEST-EFFORT and SWALLOW
-            # persistence failures — when every append attempt raises they log
-            # and return normally. The body then completes with NO terminal
-            # event AND NO propagating exception, so neither the crash guard
-            # (except BaseException) nor the cancel guard (except CancelledError)
-            # fires, and the job is stranded RUNNING forever (persisted stream
-            # shows only created + running, exactly the CI diagnostics). This is
-            # the last point where this process still owns the job's tasks;
-            # guarantee a terminal row before releasing them.
-            await self._backstop_terminal_event(job_id, cancel_context=cancel_context)
+                except Exception:
+                    # A monitor that already crashed re-raises its failure here;
+                    # it must not abort the remainder of this finally.
+                    logger.debug(
+                        "mcp.job.monitor_finished_with_error",
+                        extra={"job_id": job_id},
+                        exc_info=True,
+                    )
+            # Normally the backstop finishes here; if THIS task is (re)cancelled
+            # during the wait, the shield lets the detached backstop keep
+            # running to completion on the loop.
+            await asyncio.shield(backstop)
 
     async def _backstop_terminal_event(self, job_id: str, *, cancel_context: bool) -> None:
         """Guarantee a terminal event exists after ``_run_job`` released a job.
 
-        No-ops once a terminal event is durably present (the normal case) and
-        respects drain semantics: when a live external holder legitimately owns
-        the job's terminal state, ``_terminal_guard_status`` returns ``None`` and
-        this writes nothing. Never raises — it runs inside ``_run_job``'s
-        ``finally`` and must not mask the job-task teardown.
+        Runs as a detached task launched at the top of ``_run_job``'s
+        ``finally`` so that cancellation of the job task cannot skip or
+        interrupt it. No-ops once a terminal event is durably present (the
+        normal case) and respects drain semantics: when a live external holder
+        legitimately owns the job's terminal state, ``_terminal_guard_status``
+        returns ``None`` and this writes nothing. Never raises.
         """
         try:
             if await self._job_has_persisted_terminal_event(job_id):
@@ -1289,11 +1343,12 @@ class JobManager:
         )
         owner_pid, owner_start_time = _read_owner_identity(created.data)
         snapshot = await self._recover_linked_execution_terminal_snapshot(snapshot)
-        return await self._reconcile_orphaned_job_snapshot(
+        snapshot = await self._reconcile_orphaned_job_snapshot(
             snapshot,
             owner_pid=owner_pid,
             owner_start_time=owner_start_time,
         )
+        return await self._reconcile_stranded_started_job_snapshot(snapshot)
 
     async def _recover_linked_execution_terminal_snapshot(
         self, snapshot: JobSnapshot
@@ -1497,6 +1552,79 @@ class JobManager:
             event_id=event_id,
         )
         return True
+
+    async def _reconcile_stranded_started_job_snapshot(self, snapshot: JobSnapshot) -> JobSnapshot:
+        """Terminalize a job THIS manager started whose tasks are gone with no terminal event.
+
+        Second net behind the ``_run_job`` release-point backstop — and the
+        reason a stranded in-process job used to stay RUNNING through thousands
+        of ``get_snapshot`` polls: both restart-oriented reconcilers are
+        structurally inapplicable in-process.
+        :meth:`_recover_linked_execution_terminal_snapshot` needs
+        ``execution.terminal`` evidence and
+        :meth:`_reconcile_orphaned_job_snapshot` needs a provably dead owner,
+        while an in-process zombie has a live owner and may have no execution
+        evidence at all.
+
+        Scoped to ``_started_job_ids`` so only the manager instance that owned
+        (and released) the runner tasks ever self-heals a job — another
+        instance in the same process cannot prove task liveness and must never
+        terminalize live work. Defers while the job's release-point backstop is
+        still pending, while draining (drain owns those semantics), and while a
+        live linked-session holder is the progress authority (it surfaces
+        ``execution.terminal`` evidence the linked-execution reconciler
+        materializes).
+        """
+        if (
+            snapshot.is_terminal
+            or snapshot.status == JobStatus.CANCEL_REQUESTED
+            or snapshot.job_id not in self._started_job_ids
+            or self.has_live_job_task(snapshot.job_id)
+            or snapshot.job_id in self._backstops
+            or self._draining
+        ):
+            return snapshot
+        if snapshot.links.session_id is not None and is_holder_alive(snapshot.links.session_id):
+            return snapshot
+
+        if getattr(self._event_store, "_read_only", False):
+            event = _stranded_job_interrupted_event(snapshot.job_id)
+            return _snapshot_with_terminal_event(snapshot, event, snapshot.cursor)
+
+        lock = self._recovery_locks.setdefault(snapshot.job_id, asyncio.Lock())
+        async with lock:
+            events, cursor = await self._event_store.get_events_after(
+                "job", snapshot.job_id, last_row_id=0
+            )
+            existing_terminal = _latest_job_terminal_event(events)
+            if existing_terminal is not None:
+                return _snapshot_with_terminal_event(snapshot, existing_terminal, cursor)
+            latest_status_event = _latest_job_status_event(events)
+            if (
+                latest_status_event is not None
+                and latest_status_event.data.get("status") == JobStatus.CANCEL_REQUESTED.value
+            ):
+                return _snapshot_with_status_event(snapshot, latest_status_event, cursor)
+            try:
+                await self._append_event(
+                    "mcp.job.interrupted",
+                    snapshot.job_id,
+                    _stranded_job_interrupted_data(),
+                    event_id=f"{_STRANDED_INTERRUPTED_EVENT_ID_PREFIX}{snapshot.job_id}",
+                )
+            except PersistenceError:
+                events, cursor = await self._event_store.get_events_after(
+                    "job", snapshot.job_id, last_row_id=0
+                )
+                existing_terminal = _latest_job_terminal_event(events)
+                if existing_terminal is not None:
+                    return _snapshot_with_terminal_event(snapshot, existing_terminal, cursor)
+                raise
+            events, cursor = await self._event_store.get_events_after(
+                "job", snapshot.job_id, last_row_id=0
+            )
+            latest = events[-1]
+        return _snapshot_with_terminal_event(snapshot, latest, cursor)
 
     async def wait_for_change(
         self,
@@ -1913,6 +2041,7 @@ class JobManager:
             self._monitors.pop(job_id, None)
             self._recovery_locks.pop(job_id, None)
             self._monitor_terminalized_jobs.discard(job_id)
+            self._started_job_ids.discard(job_id)
         return len(expired)
 
     async def _append_event(

--- a/src/ouroboros/persistence/event_store.py
+++ b/src/ouroboros/persistence/event_store.py
@@ -11,8 +11,10 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 import logging
 from pathlib import Path
+import sqlite3
 from typing import TYPE_CHECKING, Any
 from urllib.parse import unquote
+from uuid import uuid4
 
 from sqlalchemy import and_, event, func, or_, select, text
 from sqlalchemy.exc import OperationalError
@@ -20,7 +22,7 @@ from sqlalchemy.exc import OperationalError
 if TYPE_CHECKING:
     from ouroboros.orchestrator.workflow_lifecycle import WorkflowLifecycleEvent
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
-from sqlalchemy.pool import StaticPool
+from sqlalchemy.pool import AsyncAdaptedQueuePool
 
 from ouroboros.core.errors import PersistenceError
 from ouroboros.events.base import BaseEvent
@@ -152,6 +154,9 @@ class EventStore:
             database_url = self._coerce_to_readonly_url(database_url)
         self._database_url = database_url
         self._engine: AsyncEngine | None = None
+        # Anchor connection for process-shared in-memory databases (memdb VFS):
+        # the database lives as long as at least one connection holds it open.
+        self._memory_keepalive: sqlite3.Connection | None = None
 
     @staticmethod
     def _coerce_to_readonly_url(database_url: str) -> str:
@@ -250,9 +255,10 @@ class EventStore:
                 ``read_only=True`` skip schema creation and all others create
                 it, preserving the prior default behaviour.
 
-        For aiosqlite, uses StaticPool (default) which maintains a single
-        connection. This avoids connection accumulation while supporting
-        :memory: databases in tests.
+        For aiosqlite ``:memory:`` databases, backs the store with SQLite's
+        process-shared in-memory VFS (``memdb``): pooled connections join one
+        shared database with normal connection-scoped transactions, and a
+        keepalive connection anchors the database's lifetime.
         """
         if create_schema is None:
             create_schema = not self._read_only
@@ -276,16 +282,54 @@ class EventStore:
                 "echo": False,
                 "connect_args": connect_args,
             }
+            engine_url = self._database_url
             if self._database_url.endswith("/:memory:"):
-                # SQLite in-memory databases are scoped to the DB-API
-                # connection.  Without a StaticPool, concurrent async tasks can
-                # observe a fresh connection that has not run create_all(),
-                # producing intermittent "no such table: events" failures in
-                # watchdog cancellation paths.
-                engine_kwargs["poolclass"] = StaticPool
+                # A plain ``:memory:`` SQLite database is scoped to ONE DB-API
+                # connection, which is fundamentally unsafe under concurrent
+                # async use:
+                #
+                # - StaticPool (used previously) hands the same connection to
+                #   CONCURRENT ``engine.begin()`` blocks with no mutual
+                #   exclusion. SQLite transactions are connection-scoped, so a
+                #   concurrent block exiting via exception (e.g. a monitor task
+                #   cancelled mid-SELECT) issues a ROLLBACK that silently
+                #   discards another task's uncommitted INSERT — whose own
+                #   COMMIT then no-ops (sqlite3 commit with no active
+                #   transaction) and append() reports success while the event
+                #   vanishes. That silent append-void is the mechanism behind
+                #   the #1566 / PR #1576 CI zombie jobs.
+                # - ANY single-connection pool additionally loses the entire
+                #   database when asyncio cancellation invalidates the pooled
+                #   connection: the replacement connection is a fresh empty DB
+                #   ("no such table: events").
+                #
+                # Fix: back ``:memory:`` stores with SQLite's process-shared
+                # in-memory VFS (``memdb``, SQLite >= 3.36). Every pooled
+                # connection then joins the SAME in-memory database with normal
+                # connection-scoped transactions (no interleaving) and the
+                # database survives connection invalidation; a keepalive
+                # connection anchors its lifetime. Each store instance gets a
+                # unique name, preserving the "one ``:memory:`` store == one
+                # private database" semantics.
+                if sqlite3.sqlite_version_info >= (3, 36):
+                    shared_name = f"/ouroboros-mem-{uuid4().hex}"
+                    engine_url = f"sqlite+aiosqlite:///file:{shared_name}?vfs=memdb&uri=true"
+                    self._memory_keepalive = sqlite3.connect(
+                        f"file:{shared_name}?vfs=memdb",
+                        uri=True,
+                        check_same_thread=False,
+                    )
+                else:  # pragma: no cover - ancient SQLite fallback
+                    # Serialized one-connection pool: keeps the shared
+                    # connection AND makes checkouts mutually exclusive so
+                    # transactions cannot interleave (closes the append-void);
+                    # cancellation-invalidation remains a residual risk here.
+                    engine_kwargs["poolclass"] = AsyncAdaptedQueuePool
+                    engine_kwargs["pool_size"] = 1
+                    engine_kwargs["max_overflow"] = 0
 
             self._engine = create_async_engine(
-                self._database_url,
+                engine_url,
                 **engine_kwargs,
             )
 
@@ -1377,6 +1421,13 @@ class EventStore:
             await self.checkpoint_wal()
             await self._engine.dispose()
             self._engine = None
+        if self._memory_keepalive is not None:
+            # Release the shared in-memory database anchor last so pooled
+            # connections never observe the database disappearing mid-dispose.
+            try:
+                self._memory_keepalive.close()
+            finally:
+                self._memory_keepalive = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -352,6 +352,85 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
+    async def test_run_job_never_strands_running_when_all_terminal_appends_fail(
+        self, tmp_path
+    ) -> None:
+        """Residual #1566 zombie: when EVERY terminal append (the primary
+        completed AND the FAILED fallback) fails, the best-effort helpers
+        swallow the error and ``_run_job`` returns normally with no terminal
+        event and no exception — stranding the job RUNNING forever. The
+        finally-block durability backstop must still persist a terminal state.
+
+        Fails on main (job never leaves RUNNING); passes with the backstop.
+        """
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+
+        _terminal_types = {
+            "mcp.job.completed",
+            "mcp.job.failed",
+            "mcp.job.cancelled",
+            "mcp.job.interrupted",
+        }
+
+        try:
+            original_append_event = manager._append_event
+            failed_terminal_appends = 0
+
+            async def _fail_every_terminal_append_except_backstop(
+                event_type: str, job_id: str, data: dict, **kwargs
+            ) -> None:
+                nonlocal failed_terminal_appends
+                result_meta = data.get("result_meta")
+                # The finally-block backstop is the ONLY terminal writer allowed
+                # through — it is distinguished by the ``ensure_reason`` sentinel
+                # that _ensure_terminal_event_best_effort stamps. Everything the
+                # try body attempts (completed + fallback FAILED) fails, exactly
+                # like a store under sustained "database is locked" pressure.
+                is_backstop = isinstance(result_meta, dict) and "ensure_reason" in result_meta
+                if event_type in _terminal_types and not is_backstop:
+                    failed_terminal_appends += 1
+                    raise PersistenceError(
+                        "synthetic sustained terminal append failure", operation="insert"
+                    )
+                await original_append_event(event_type, job_id, data, **kwargs)
+
+            manager._append_event = _fail_every_terminal_append_except_backstop
+
+            async def _runner() -> MCPToolResult:
+                return MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="runner ok"),),
+                    is_error=False,
+                )
+
+            started = await manager.start_job(
+                job_type="test",
+                initial_message="queued",
+                runner=_runner(),
+            )
+
+            snapshot = await _wait_for_job_status(
+                manager, started.job_id, JobStatus.FAILED, timeout=2.0
+            )
+
+            # The try body burned its primary + fallback terminal appends...
+            assert failed_terminal_appends >= 2
+            # ...and yet the job is terminal, persisted by the finally backstop.
+            assert snapshot.status is JobStatus.FAILED
+            assert snapshot.result_meta.get("ensure_reason")
+            assert snapshot.result_meta.get("terminal_append_failed") is True
+            assert snapshot.message == "Job terminalized by last-resort guard"
+
+            # Durable across a fresh manager (no live tasks): the terminal row
+            # is genuinely persisted, not an in-memory recovery artifact.
+            recovered = JobManager(store)
+            recovered_snapshot = await recovered.get_snapshot(started.job_id)
+            assert recovered_snapshot.status is JobStatus.FAILED
+        finally:
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_runner_success_transient_append_failure_recovers_original_completed(
         self, tmp_path
     ) -> None:

--- a/tests/unit/mcp/test_job_manager.py
+++ b/tests/unit/mcp/test_job_manager.py
@@ -431,6 +431,137 @@ class TestJobManager:
             await _cancel_manager_tasks(manager)
             await store.close()
 
+    async def test_hostile_repeated_cancellation_cannot_strand_job_without_terminal_event(
+        self, tmp_path
+    ) -> None:
+        """PR #1576's own CI run refuted the inline-backstop theory: every
+        inline net in ``_run_job`` (the except guards, the ensure helper, an
+        inline finally backstop) awaits while catching only ``Exception``, so a
+        fresh CancelledError delivered at EVERY await point silently defeats
+        them all — the finally pops the tasks and nothing is persisted. The
+        detached release-point backstop must survive that hostile interleaving.
+
+        Fails before the detached backstop (job stranded RUNNING); passes with it.
+        """
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+
+        release = asyncio.Event()
+
+        async def _runner() -> MCPToolResult:
+            await release.wait()
+            return MCPToolResult()
+
+        try:
+            started = await manager.start_job(
+                job_type="test",
+                initial_message="queued",
+                runner=_runner(),
+            )
+            await _wait_for_job_status(manager, started.job_id, JobStatus.RUNNING, timeout=2.0)
+
+            task = manager._tasks[started.job_id]
+            # Hostile canceller: deliver a fresh CancelledError at every await
+            # point until the job task dies. Each cancel() re-arms delivery at
+            # the task's next suspension, so no inline except/finally net can
+            # complete an awaited persistence step.
+            while not task.done():
+                task.cancel()
+                await asyncio.sleep(0)
+            assert started.job_id not in manager._tasks
+
+            deadline = asyncio.get_running_loop().time() + 2.0
+            snapshot = await manager.get_snapshot(started.job_id)
+            while not snapshot.is_terminal and asyncio.get_running_loop().time() < deadline:
+                await asyncio.sleep(0.01)
+                snapshot = await manager.get_snapshot(started.job_id)
+
+            assert snapshot.is_terminal, f"job stranded in {snapshot.status}"
+            # Written by the detached backstop with cancel semantics — the
+            # hostile interleaving is a cancellation, not a failure.
+            assert snapshot.status is JobStatus.CANCELLED
+        finally:
+            release.set()
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
+    async def test_stranded_started_job_is_reconciled_by_get_snapshot(self, tmp_path) -> None:
+        """Exact CI signature of the #1566/#1576 zombie: the job task fully
+        released (tasks popped, stream = created+running, nothing raised) —
+        modeled by silently dropping every terminal append while the job task
+        lives, a superset of any silent-loss mechanism. The in-process
+        stranded-job net in get_snapshot must terminalize it on the next poll.
+
+        Fails without the net (RUNNING forever: the linked-execution reconciler
+        has no execution.terminal evidence and the dead-owner reconciler sees a
+        live owner); passes with it.
+        """
+        store = _build_store(tmp_path)
+        manager = JobManager(store)
+        await store.initialize()
+
+        _terminal_types = {
+            "mcp.job.completed",
+            "mcp.job.failed",
+            "mcp.job.cancelled",
+            "mcp.job.interrupted",
+        }
+        dropping = True
+        original_append_event = manager._append_event
+
+        async def _drop_terminal_appends(
+            event_type: str, job_id: str, data: dict, **kwargs
+        ) -> None:
+            if dropping and event_type in _terminal_types:
+                return  # silently lost: no event persisted, no exception raised
+            await original_append_event(event_type, job_id, data, **kwargs)
+
+        manager._append_event = _drop_terminal_appends
+
+        try:
+            started = await manager.start_job(
+                job_type="test",
+                initial_message="queued",
+                runner=_ok_runner(),
+            )
+            job_task = manager._tasks.get(started.job_id)
+            if job_task is not None:
+                await asyncio.wait({job_task}, timeout=2.0)
+            # Let the detached release-point backstop finish too (its appends
+            # are also dropped) so the loss is total, like the CI capture.
+            deadline = asyncio.get_running_loop().time() + 2.0
+            while (
+                getattr(manager, "_backstops", {}) and asyncio.get_running_loop().time() < deadline
+            ):
+                await asyncio.sleep(0)
+
+            # The CI signature: tasks released, no terminal event persisted.
+            assert started.job_id not in manager._tasks
+            assert started.job_id not in manager._runner_tasks
+            events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
+            assert events
+            assert all(e.type in {"mcp.job.created", "mcp.job.updated"} for e in events)
+
+            dropping = False
+            deadline = asyncio.get_running_loop().time() + 2.0
+            snapshot = await manager.get_snapshot(started.job_id)
+            while not snapshot.is_terminal and asyncio.get_running_loop().time() < deadline:
+                await asyncio.sleep(0.01)
+                snapshot = await manager.get_snapshot(started.job_id)
+
+            assert snapshot.status is JobStatus.INTERRUPTED, f"job stranded in {snapshot.status}"
+            assert snapshot.result_meta.get("interrupted_from_stranded_job_task") is True
+
+            # Durable and idempotent: one terminal event, visible to a fresh manager.
+            recovered = JobManager(store)
+            assert (await recovered.get_snapshot(started.job_id)).status is JobStatus.INTERRUPTED
+            events, _ = await store.get_events_after("job", started.job_id, last_row_id=0)
+            assert sum(1 for e in events if e.type == "mcp.job.interrupted") == 1
+        finally:
+            await _cancel_manager_tasks(manager)
+            await store.close()
+
     async def test_runner_success_transient_append_failure_recovers_original_completed(
         self, tmp_path
     ) -> None:

--- a/tests/unit/mcp/tools/test_run_evaluate_chaining.py
+++ b/tests/unit/mcp/tools/test_run_evaluate_chaining.py
@@ -56,15 +56,49 @@ async def _wait_terminal(job_manager: JobManager, job_id: str) -> JobSnapshot:
         else:
             await asyncio.sleep(0.01)
     diagnostics = _diagnose_stuck_job(job_manager, job_id)
-    try:
-        events, cursor = await job_manager._event_store.get_events_after("job", job_id, 0)
-        stream = "\n".join(
-            f"  {e.timestamp} {e.type} id={e.id} status={e.data.get('status')}" for e in events
-        )
-        diagnostics += f"\npersisted job events (cursor={cursor}):\n{stream or '  <empty stream>'}"
-    except Exception as exc:
-        diagnostics += f"\n<event stream unavailable: {exc!r}>"
+    diagnostics += "\n" + await _dump_all_job_streams(job_manager)
     raise AssertionError(f"job {job_id} did not reach a terminal state\n{diagnostics}")
+
+
+async def _dump_all_job_streams(job_manager: JobManager) -> str:
+    """Dump every persisted job stream plus store/manager state (#1566 insurance).
+
+    The append-void class of this flake (silently lost terminal events) is only
+    diagnosable from the FULL persisted picture: the run job's stream, the
+    chained evaluate job's stream, and the store connection/pool state.
+    """
+    lines: list[str] = ["--- all persisted job streams ---"]
+    store = job_manager._event_store
+    try:
+        created_events = await store.query_events(event_type="mcp.job.created", limit=50)
+        for job_id in [e.aggregate_id for e in created_events]:
+            try:
+                events, cursor = await store.get_events_after("job", job_id, 0)
+            except Exception as exc:  # noqa: BLE001 - diagnostics must not mask failures
+                lines.append(f"job {job_id}: <stream unavailable: {exc!r}>")
+                continue
+            lines.append(f"job {job_id} (cursor={cursor}):")
+            for e in events:
+                meta = e.data.get("result_meta")
+                meta_keys = sorted(meta) if isinstance(meta, dict) else meta
+                lines.append(
+                    f"  {e.timestamp} {e.type} id={e.id} "
+                    f"status={e.data.get('status')} meta_keys={meta_keys}"
+                )
+    except Exception as exc:  # noqa: BLE001
+        lines.append(f"<job discovery unavailable: {exc!r}>")
+    try:
+        engine = store._engine
+        lines.append(f"engine pool: {engine.pool.status() if engine is not None else '<none>'}")
+    except Exception as exc:  # noqa: BLE001
+        lines.append(f"<pool status unavailable: {exc!r}>")
+    lines.append(f"manager tasks={sorted(job_manager._tasks)}")
+    lines.append(f"manager runner_tasks={sorted(job_manager._runner_tasks)}")
+    lines.append(f"manager backstops={sorted(getattr(job_manager, '_backstops', {}))}")
+    lines.append(
+        f"manager started_job_ids={sorted(getattr(job_manager, '_started_job_ids', set()))}"
+    )
+    return "\n".join(lines)
 
 
 def _diagnose_stuck_job(job_manager: JobManager, job_id: str) -> str:
@@ -203,7 +237,14 @@ async def test_successful_run_enqueues_chained_evaluate_job(
 
     snapshot = await _wait_terminal(job_manager, started.value.meta["job_id"])
 
-    assert snapshot.status == JobStatus.COMPLETED
+    if snapshot.status != JobStatus.COMPLETED:
+        # Self-explaining flake diagnostics (#1566): a non-COMPLETED terminal
+        # here has historically meant a silently lost terminal append; dump
+        # the full persisted picture for both jobs plus store state.
+        raise AssertionError(
+            f"expected COMPLETED, got {snapshot.status} "
+            f"(result_meta={snapshot.result_meta})\n" + await _dump_all_job_streams(job_manager)
+        )
     assert snapshot.result_meta["success"] is True
     evaluation_job_id = snapshot.result_meta["chained_evaluate_job_id"]
     assert isinstance(evaluation_job_id, str)

--- a/tests/unit/mcp/tools/test_run_evaluate_chaining.py
+++ b/tests/unit/mcp/tools/test_run_evaluate_chaining.py
@@ -226,6 +226,97 @@ async def test_successful_run_enqueues_chained_evaluate_job(
     assert "execution artifact" in evaluate_calls[0]["arguments"]["artifact"]
 
 
+async def test_run_job_stranded_without_terminal_event_still_terminalizes(
+    event_store,
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression for this file's own CI flake signature (#1566 / PR #1576):
+    the run job's task is fully released — job task AND runner task popped,
+    persisted stream = created + running only — with no terminal event and no
+    log. Whatever silently defeats the inline guards (modeled here by dropping
+    every terminal append for the run job while its task lives), the run job
+    must still reach a terminal state instead of zombying for the full wait
+    deadline: first via the detached release-point backstop, and failing that
+    via the get_snapshot in-process stranded-job net.
+    """
+    monkeypatch.setattr(execution_handlers, "get_auto_evaluate_enabled", lambda: True)
+
+    class FakeEvaluateHandler:
+        def __init__(self, **kwargs: Any) -> None:
+            self.kwargs = kwargs
+
+        async def handle(self, arguments: dict[str, Any]) -> Result[MCPToolResult, Any]:
+            return Result.ok(
+                MCPToolResult(
+                    content=(MCPContentItem(type=ContentType.TEXT, text="approved"),),
+                    is_error=False,
+                    meta={"final_approved": True, "session_id": arguments["session_id"]},
+                )
+            )
+
+    monkeypatch.setattr(evaluation_handlers, "EvaluateHandler", FakeEvaluateHandler)
+
+    job_manager = JobManager(event_store)
+    handler = StartExecuteSeedHandler(
+        execute_handler=_SuccessfulExecuteHandler(text="execution artifact"),  # type: ignore[arg-type]
+        event_store=event_store,
+        job_manager=job_manager,
+    )
+
+    _terminal_types = {
+        "mcp.job.completed",
+        "mcp.job.failed",
+        "mcp.job.cancelled",
+        "mcp.job.interrupted",
+    }
+    # Identify the run job from its created event (allocated before handle()
+    # returns) and drop its terminal appends while the drop flag is on. The
+    # chained evaluate job is untouched.
+    target: dict[str, str | None] = {"job_id": None}
+    dropping = {"on": True}
+    original_append_event = job_manager._append_event
+
+    async def _drop_run_job_terminal_appends(
+        event_type: str, job_id: str, data: dict, **kwargs: Any
+    ) -> None:
+        if event_type == "mcp.job.created" and data.get("job_type") == "execute_seed":
+            target["job_id"] = job_id
+        if dropping["on"] and job_id == target["job_id"] and event_type in _terminal_types:
+            return  # silently lost, like the CI capture: no event, no exception
+        await original_append_event(event_type, job_id, data, **kwargs)
+
+    job_manager._append_event = _drop_run_job_terminal_appends
+
+    started = await handler.handle({"seed_content": "goal: stranded\n", "cwd": str(tmp_path)})
+    assert started.is_ok
+    run_job_id = started.value.meta["job_id"]
+    assert target["job_id"] == run_job_id
+
+    # Wait for the run job's tasks to be fully released and its detached
+    # backstop (whose appends are also dropped) to finish: the CI signature.
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline and (
+        run_job_id in job_manager._tasks or getattr(job_manager, "_backstops", {})
+    ):
+        await asyncio.sleep(0.01)
+    assert run_job_id not in job_manager._tasks
+    assert run_job_id not in job_manager._runner_tasks
+    events, _ = await event_store.get_events_after("job", run_job_id, 0)
+    assert all(e.type in {"mcp.job.created", "mcp.job.updated"} for e in events)
+
+    # From here the store is healthy again; the job must terminalize promptly
+    # instead of zombying for the full 60s wait deadline.
+    dropping["on"] = False
+    deadline = time.monotonic() + 5.0
+    snapshot = await job_manager.get_snapshot(run_job_id)
+    while not snapshot.is_terminal and time.monotonic() < deadline:
+        await asyncio.sleep(0.01)
+        snapshot = await job_manager.get_snapshot(run_job_id)
+    assert snapshot.is_terminal, f"run job stranded in {snapshot.status}"
+    assert snapshot.result_meta.get("interrupted_from_stranded_job_task") is True
+
+
 async def test_chained_evaluate_uses_execution_worktree_when_present(
     event_store,
     tmp_path,

--- a/tests/unit/persistence/test_event_store.py
+++ b/tests/unit/persistence/test_event_store.py
@@ -73,6 +73,64 @@ class TestEventStoreInitialization:
         assert len(events) == 5
         await store.close()
 
+    async def test_memory_store_concurrent_rollback_cannot_void_append(self, monkeypatch) -> None:
+        """The #1566/#1576 CI append-void, reproduced deterministically.
+
+        StaticPool handed the SAME aiosqlite connection to concurrent
+        ``engine.begin()`` blocks with no exclusivity. SQLite transactions are
+        connection-scoped, so a concurrent block exiting via exception (e.g. a
+        cancelled monitor mid-SELECT) issued a ROLLBACK that discarded another
+        task's uncommitted INSERT — whose own COMMIT then no-oped and append()
+        reported success while the event vanished (no exception, no log).
+
+        A slowed commit widens the INSERT→COMMIT window like a loaded CI
+        runner. With the memdb-backed store each block runs on its OWN
+        connection, so the failing block's rollback cannot touch the append's
+        transaction.
+
+        Fails on StaticPool (0 events persisted despite successful append);
+        passes with the process-shared memdb-backed store.
+        """
+        import contextlib
+
+        import aiosqlite
+
+        store = EventStore("sqlite+aiosqlite:///:memory:")
+        await store.initialize()
+
+        commit_delay = 0.1
+        orig_commit = aiosqlite.Connection.commit
+
+        async def slow_commit(self):
+            await asyncio.sleep(commit_delay)
+            return await orig_commit(self)
+
+        monkeypatch.setattr(aiosqlite.Connection, "commit", slow_commit)
+
+        event = BaseEvent(
+            type="test.event.created",
+            aggregate_type="test",
+            aggregate_id="void",
+            data={},
+        )
+
+        async def concurrent_failing_block() -> None:
+            # Land between the append's INSERT and its COMMIT.
+            await asyncio.sleep(commit_delay / 2)
+            with contextlib.suppress(RuntimeError):
+                async with store._engine.begin():
+                    raise RuntimeError("simulated cancelled concurrent block")
+
+        await asyncio.gather(store.append(event), concurrent_failing_block())
+        monkeypatch.setattr(aiosqlite.Connection, "commit", orig_commit)
+
+        events = await store.replay("test", "void")
+        assert len(events) == 1, (
+            "append() reported success but the event vanished (silent rollback "
+            "by a concurrent transaction sharing the :memory: connection)"
+        )
+        await store.close()
+
 
 class TestEventStoreAppend:
     """Test EventStore.append() method."""


### PR DESCRIPTION
## Status

Three commits, each driven by CI evidence from the previous one:

1. `90bf1738` — swallowed-append hardening + inline backstop. **Refuted as the primary mechanism** by this PR's own CI (job 85408070770): the flake reproduced with the backstop in the branch, no log line.
2. `f72cf8e4` — cancellation-proof detached backstop + in-process stranded-job reconciler in `get_snapshot`. **Changed the failure mode** (CI job 85415178221): the job now terminalizes, but as INTERRUPTED while the runner returned SUCCESS — proving both terminal appends *silently vanished* while a later append succeeded.
3. `8f96188d` — the actual root cause, found and **reproduced deterministically**: a silent append-void in `EventStore` for `:memory:` databases.

## Root cause: the `:memory:` append-void (src/ouroboros/persistence/event_store.py)

`EventStore` used **StaticPool** for `sqlite+aiosqlite:///:memory:` (the chaining test fixture's store). StaticPool hands the **same aiosqlite connection to concurrent `engine.begin()` blocks with no mutual exclusion**. SQLite transactions are connection-scoped, so:

```
task A (append terminal event):   INSERT (implicit BEGIN) ........... COMMIT → no-op!
task B (monitor cancelled          |                          |
        mid-SELECT poll):          |   exception → ROLLBACK ──┘  ← discards A's INSERT
result: append() returns SUCCESS; no exception; no log; event GONE
```

sqlite3 `commit()` with no active transaction is a **no-op**, so task A's append reports success. In this test two jobs (run + chained evaluate), two monitors, and agent-process lifecycle appends all share one connection; `_run_job`'s finally cancels monitors mid-poll, so ROLLBACKs land inside other tasks' INSERT→COMMIT windows. On a loaded CI runner the congested aiosqlite worker-thread queue stretches those windows to many ms.

Evidence:
- **Deterministic repro**: slow the commit 100ms, run one `append()` concurrently with one failing `engine.begin()` block → `append returned SUCCESS, persisted rows: 0`. Committed as `test_memory_store_concurrent_rollback_cannot_void_append` (fails on StaticPool, passes with the fix).
- **Stress repro of the actual CI failures**: with random 2-40ms aiosqlite latency injected (simulating a loaded runner), the chaining test fails **2/15** locally on StaticPool with the exact CI signatures — including round 3's `INTERRUPTED != COMPLETED`.
- **Why only this test**: it is the only job-manager test on a `:memory:` store (`test_run_evaluate_chaining.py:34`); the rest use file-backed stores with per-connection pools. **Why round 2/3's raw CI log shows no captured log section**: nothing ever raised.
- Full trace of the earlier theories is preserved in the commit messages; both were real defense-in-depth gaps but not the void itself.

## Why not just serialize the one connection

A one-connection exclusive pool closes the interleaving but stress testing exposed the second `:memory:` hazard: **asyncio cancellation invalidates the pooled connection**, and its replacement is a fresh empty database (`no such table: events` — 3/100 under stress). A plain `:memory:` database cannot survive the loss of its only connection, period.

## Fix (commit 3)

Back `:memory:` stores with SQLite's **process-shared in-memory VFS (`memdb`, SQLite ≥ 3.36)**, unique name per store instance, plus a keepalive anchor connection:
- pooled connections join ONE shared database with normal connection-scoped transactions → interleaving impossible;
- the database **survives connection invalidation**;
- `:memory:`-store semantics preserved (one store instance == one private DB; `sqlite_path()` still `None`);
- ancient-SQLite fallback: serialized one-connection queue pool.

**Stress result: 100/100 green** with injected latency (vs 3/100 serialized pool, 2/15 StaticPool).

## Defense-in-depth kept from commits 1-2 (all still tested)

- Detached, cancellation-proof release-point backstop in `_run_job`'s finally — now **replays the body's real intended terminal event** (result_text / result_meta incl. `chained_evaluate_job_id`) before any guard-status fallback.
- In-process stranded-job reconciler in `get_snapshot` (scoped to jobs this manager instance started; defers to drain/live holders) — the second net that converted round 2's 60s zombie into round 3's visible wrong-status, and remains the safety net for any future silent loss.
- Swallowed-append last-resort guard (commit 1).

## Diagnostics insurance

The chaining test's failure paths now dump **every persisted job stream** (run + chained evaluate, with result_meta keys), engine pool status, and manager task/backstop state — any residual flake will name its own mechanism.

## Done evidence

- `ruff check` / `ruff format --check`: clean; `mypy src/`: 423 files, no issues
- persistence + job manager + drain + chaining suites: **293 passed**
- chaining test plain 30× loop: 0 failures; **jittered 100× loop: 0 failures**
- new regression tests verified to fail on the code they target (git stash)
- `pytest tests/ --ignore e2e --ignore unit/mcp --ignore integration/mcp`: **10101 passed**, only the documented pre-existing codex-config-leak failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)