### PR TITLE
feat(mcp): generic interview fan-out core + ouroboros_submit_fanout_results re-entry tool

### DIFF
--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -210,6 +210,23 @@ MCP (question generator) ←→ You (answerer + router) ←→ User (human judgm
    subagent primitive at all (then use `sequential_fallback`).
    Preserve the original question text while advisory children run.
 
+   **Submitting fan-out results back (re-entry)**:
+   When the originating `meta` carries a `fanout_id` (e.g.
+   `meta.question_advisory_fanout_id`, or a `fanout_id` in a lateral persona
+   panel dispatch), after all advisory/persona subagents return, call
+   `ouroboros_submit_fanout_results` with:
+   - `fanout_id`: the stamped id from that meta,
+   - `correlation_key`: the stamped `result_correlation_key`
+     (`context.lane_id`, `context.persona`, or `code_facts`),
+   - `results`: one `{ "key": <correlation value>, "content": <child output> }`
+     per subagent, where `key` is that child's correlation value (its lane id,
+     persona, or `code_facts`).
+   A complete set returns the correlated synthesis to continue with; a partial
+   set returns `status="partial"` with `missing_keys` so you can resubmit the
+   remaining lanes. Sequential hosts submit after processing payloads
+   one-by-one — same tool, same contract. Continue the interview from the
+   returned synthesis; keep the user-facing question visible throughout.
+
    **Milestone lateral-review dispatch**:
    If an MCP response includes `meta.lateral_review_recommended=true`, treat it
    as a required lightweight subagent review for that turn. The interview just

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -47,14 +47,17 @@ from ouroboros.core.types import Result
 from ouroboros.mcp.errors import MCPServerError, MCPToolError
 from ouroboros.mcp.tools.subagent import (
     DELEGATED_TO_SUBAGENT,
+    FanoutRegistry,
     SubagentDispatchMode,
     build_generate_seed_subagent,
     build_interview_question_advisory_subagents,
     build_interview_subagent,
     dispatch_plugin_terminal,
     lateral_persona_panel_metadata_from_capability_definitions,
+    register_code_investigation_fanout,
     resolve_subagent_dispatch,
     should_dispatch_via_plugin,
+    stamp_fanout_meta,
 )
 from ouroboros.mcp.types import (
     ContentType,
@@ -705,6 +708,7 @@ def _attach_question_assist_requests(
     dispatch_mode: SubagentDispatchMode = SubagentDispatchMode.SEQUENTIAL,
     runtime_backend: str | None = None,
     opencode_mode: str | None = None,
+    fanout_registry: FanoutRegistry | None = None,
 ) -> None:
     """Attach code-fact and advisory fanout requests for a question turn.
 
@@ -713,6 +717,12 @@ def _attach_question_assist_requests(
     ``question_advisory_subagents``, so the response is stamped with an explicit
     ``host_action=spawn_subagents`` cue for the host model to fan the advisory
     lanes out itself.
+
+    When ``fanout_registry`` is provided the code-investigation lane is
+    registered for result re-entry and its ``fanout_id`` is stamped as
+    ``question_advisory_fanout_id`` so a later
+    ``ouroboros_submit_fanout_results`` submission can be matched. With no
+    registry the emitted meta is byte-identical to the pre-registry contract.
     """
     code_request = _build_code_investigation_request(
         session_id=session_id,
@@ -756,16 +766,21 @@ def _attach_question_assist_requests(
         opencode_mode=opencode_mode,
     )
     meta["subagent_orchestration_instruction"] = contract.runtime_instruction_handling
-    if dispatch_mode is SubagentDispatchMode.HOST_DRIVEN:
-        meta["question_advisory_dispatch_mode"] = "host_driven"
-        meta["question_advisory_host_action"] = "spawn_subagents"
-        # Advisory lanes are keyed by lane_id; their persona is absent on some
-        # lanes (code_context, web_context), so correlate by lane_id, not persona.
-        meta["question_advisory_result_correlation_key"] = "context.lane_id"
-    elif dispatch_mode is SubagentDispatchMode.SEQUENTIAL:
-        meta["question_advisory_dispatch_mode"] = "sequential"
-        meta["question_advisory_host_action"] = "process_payloads_sequentially"
-        meta["question_advisory_result_correlation_key"] = "context.lane_id"
+    # Advisory lanes are keyed by lane_id; their persona is absent on some
+    # lanes (code_context, web_context), so correlate by lane_id, not persona.
+    stamp_fanout_meta(
+        meta,
+        prefix="question_advisory",
+        dispatch_mode=dispatch_mode,
+        payloads=advisory_payloads,
+        correlation_key="context.lane_id",
+    )
+    if fanout_registry is not None:
+        meta["question_advisory_fanout_id"] = register_code_investigation_fanout(
+            fanout_registry,
+            session_id=session_id,
+            request=code_request,
+        )
 
 
 def _is_initial_context_length_guard_question(question: str) -> bool:
@@ -1594,6 +1609,7 @@ class InterviewHandler:
     agent_runtime_backend: str | None = field(default=None, repr=False)
     opencode_mode: str | None = field(default=None, repr=False)
     data_dir: Path | None = field(default=None, repr=False)
+    fanout_registry: FanoutRegistry | None = field(default=None, repr=False)
     suppress_tool_use_prompt_cues: bool = False
 
     def __post_init__(self) -> None:
@@ -2601,6 +2617,7 @@ class InterviewHandler:
                         ),
                         runtime_backend=self.agent_runtime_backend,
                         opencode_mode=self.opencode_mode,
+                        fanout_registry=self.fanout_registry,
                     )
 
                 start_response_text = (
@@ -3134,6 +3151,7 @@ class InterviewHandler:
                         ),
                         runtime_backend=self.agent_runtime_backend,
                         opencode_mode=self.opencode_mode,
+                        fanout_registry=self.fanout_registry,
                     )
 
                 resume_response_text = f"Session {session_id}\n\n{display_question}"
@@ -3376,6 +3394,7 @@ class InterviewHandler:
                 ),
                 runtime_backend=self.agent_runtime_backend,
                 opencode_mode=self.opencode_mode,
+                fanout_registry=self.fanout_registry,
             )
 
         if lateral_review_dispatch_meta is not None:

--- a/src/ouroboros/mcp/tools/definitions.py
+++ b/src/ouroboros/mcp/tools/definitions.py
@@ -34,6 +34,7 @@ from ouroboros.mcp.tools.evaluation_handlers import (
     LateralThinkHandler,
     MeasureDriftHandler,
     StartEvaluateHandler,
+    SubmitFanoutResultsHandler,
 )
 from ouroboros.mcp.tools.evolution_handlers import (
     EvolveRewindHandler,
@@ -60,6 +61,7 @@ from ouroboros.mcp.tools.query_handlers import (
     SessionStatusHandler,
 )
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler, StartRalphHandler
+from ouroboros.mcp.tools.subagent import FanoutRegistry
 
 if TYPE_CHECKING:
     from ouroboros.orchestrator.agent_runtime_context import AgentRuntimeContext
@@ -460,6 +462,9 @@ def get_ouroboros_tools(
     resolved_manager, resolved_prefix = _resolve_bridge_fields(
         context, mcp_manager, mcp_tool_prefix
     )
+    # One shared fan-out registry: interview/lateral producers register pending
+    # fan-outs into it, and the submit tool reads them back for synthesis.
+    fanout_registry = FanoutRegistry()
     execute_seed = ExecuteSeedHandler(
         agent_runtime_backend=runtime_backend,
         llm_backend=llm_backend,
@@ -479,6 +484,7 @@ def get_ouroboros_tools(
         llm_backend=llm_backend,
         agent_runtime_backend=runtime_backend,
         opencode_mode=opencode_mode,
+        fanout_registry=fanout_registry,
     )
     generate_seed = GenerateSeedHandler(
         llm_backend=llm_backend,
@@ -537,7 +543,9 @@ def get_ouroboros_tools(
         LateralThinkHandler(
             agent_runtime_backend=runtime_backend,
             opencode_mode=opencode_mode,
+            fanout_registry=fanout_registry,
         ),
+        SubmitFanoutResultsHandler(fanout_registry=fanout_registry),
         EvolveStepHandler(
             agent_runtime_backend=runtime_backend,
             opencode_mode=opencode_mode,

--- a/src/ouroboros/mcp/tools/evaluation_handlers.py
+++ b/src/ouroboros/mcp/tools/evaluation_handlers.py
@@ -30,9 +30,11 @@ from ouroboros.mcp.tools.bridge_mixin import BridgeAwareMixin
 from ouroboros.mcp.tools.subagent import (
     DELEGATED_TO_PLUGIN,
     DELEGATED_TO_SUBAGENT,
+    FanoutRegistry,
     build_evaluate_subagent,
     dispatch_plugin_terminal,
     should_dispatch_via_plugin,
+    submit_fanout_results,
 )
 from ouroboros.mcp.types import (
     ContentType,
@@ -1420,6 +1422,7 @@ class LateralThinkHandler(BridgeAwareMixin):
 
     agent_runtime_backend: str | None = field(default=None, repr=False)
     opencode_mode: str | None = field(default=None, repr=False)
+    fanout_registry: FanoutRegistry | None = field(default=None, repr=False)
 
     @property
     def definition(self) -> MCPToolDefinition:
@@ -1567,7 +1570,9 @@ class LateralThinkHandler(BridgeAwareMixin):
                 build_lateral_multi_subagent,
                 build_multi_subagent_result,
                 lateral_persona_panel_metadata_from_capability_definitions,
+                register_lateral_persona_fanout,
                 resolve_subagent_dispatch,
+                stamp_fanout_meta,
             )
 
             if explicit_list:
@@ -1693,7 +1698,6 @@ class LateralThinkHandler(BridgeAwareMixin):
             # machine-readable contract vocabulary, while preserving
             # ``inline_fallback`` as a legacy alias for older skill prose.
             host_driven = dispatch is SubagentDispatchMode.HOST_DRIVEN
-            dispatch_mode_value = "host_driven" if host_driven else "sequential"
             payload_dicts = [p.to_dict() for p in payloads]
             panel_metadata = lateral_persona_panel_metadata_from_capability_definitions()
             contract_backend = self.agent_runtime_backend
@@ -1705,17 +1709,29 @@ class LateralThinkHandler(BridgeAwareMixin):
                 opencode_mode=self.opencode_mode,
             )
             dispatch_record: dict[str, Any] = {
-                "dispatch_mode": dispatch_mode_value,
                 "persona_count": len(sections),
                 "payloads": payload_dicts,
-                "result_correlation_key": "context.persona",
                 "subagent_orchestration_instruction": contract.runtime_instruction_handling,
             }
-            if host_driven:
-                dispatch_record["host_action"] = "spawn_subagents"
-            else:
-                dispatch_record["host_action"] = "process_payloads_sequentially"
+            # Stamp the PR-C-standardized 3-mode contract (dispatch_mode /
+            # host_action / result_correlation_key) via the shared helper. Only
+            # HOST_DRIVEN and SEQUENTIAL reach here (PLUGIN_PASSIVE returned the
+            # ``_subagents`` envelope above), so a cue is always stamped.
+            stamp_fanout_meta(
+                dispatch_record,
+                prefix="",
+                dispatch_mode=dispatch,
+                payloads=payloads,
+                correlation_key="context.persona",
+            )
+            if not host_driven:
                 dispatch_record["legacy_dispatch_mode"] = "inline_fallback"
+            if self.fanout_registry is not None:
+                dispatch_record["fanout_id"] = register_lateral_persona_fanout(
+                    self.fanout_registry,
+                    session_id=str(arguments.get("session_id") or ""),
+                    payloads=payloads,
+                )
             dispatch_blob = json.dumps(dispatch_record)
             dispatch_b64 = base64.b64encode(dispatch_blob.encode("utf-8")).decode("ascii")
             host_banner = (
@@ -1891,6 +1907,128 @@ class LateralThinkHandler(BridgeAwareMixin):
                     tool_name="ouroboros_lateral_think",
                 )
             )
+
+
+@dataclass
+class SubmitFanoutResultsHandler:
+    """Handler for the ``ouroboros_submit_fanout_results`` re-entry tool.
+
+    After a host fans out a set of advisory/persona/investigation subagents
+    (declared by :func:`stamp_fanout_meta` with a stamped ``fanout_id``), it
+    submits the correlated child outputs back through this tool. The server
+    validates the expected keys against the persisted fan-out record and, when
+    complete, routes to the revived synthesizer for the record's kind, returning
+    the correlated synthesis for the host to continue with. Sequential hosts
+    submit after processing payloads one-by-one — same tool, same contract.
+    """
+
+    fanout_registry: FanoutRegistry | None = field(default=None, repr=False)
+
+    def __post_init__(self) -> None:
+        self._registry = self.fanout_registry or FanoutRegistry()
+
+    @property
+    def definition(self) -> MCPToolDefinition:
+        """Return the tool definition."""
+        return MCPToolDefinition(
+            name="ouroboros_submit_fanout_results",
+            description=(
+                "Submit correlated results from a subagent fan-out back to "
+                "Ouroboros. After spawning the advisory/persona/investigation "
+                "subagents declared by a prior tool's `meta` (which stamped a "
+                "`fanout_id` and a `result_correlation_key`), call this tool with "
+                "one {key, content} per child output — `key` is the value of the "
+                "correlation field for that child. A complete set returns the "
+                "synthesis to continue with; a partial set returns "
+                "`status=partial` with the missing keys so you can resubmit."
+            ),
+            parameters=(
+                MCPToolParameter(
+                    name="session_id",
+                    type=ToolInputType.STRING,
+                    description="Interview/lateral session id the fan-out belongs to.",
+                    required=False,
+                ),
+                MCPToolParameter(
+                    name="fanout_id",
+                    type=ToolInputType.STRING,
+                    description="The fanout_id stamped into the originating tool's meta.",
+                    required=True,
+                ),
+                MCPToolParameter(
+                    name="correlation_key",
+                    type=ToolInputType.STRING,
+                    description=(
+                        "The result_correlation_key from the originating meta "
+                        "(e.g. 'context.persona' or 'code_facts')."
+                    ),
+                    required=False,
+                ),
+                MCPToolParameter(
+                    name="results",
+                    type=ToolInputType.ARRAY,
+                    description=(
+                        "Correlated child outputs: a list of objects each with a "
+                        "'key' (the correlation value) and a 'content' (the child "
+                        "result, object or text)."
+                    ),
+                    required=True,
+                ),
+            ),
+        )
+
+    async def handle(
+        self,
+        arguments: dict[str, Any],
+    ) -> Result[MCPToolResult, MCPServerError]:
+        """Validate the submitted fan-out results and route them to synthesis."""
+        fanout_id = str(arguments.get("fanout_id") or "").strip()
+        if not fanout_id:
+            return Result.err(
+                MCPToolError(
+                    "fanout_id is required",
+                    tool_name="ouroboros_submit_fanout_results",
+                )
+            )
+
+        raw_results = arguments.get("results")
+        if not isinstance(raw_results, (list, tuple)):
+            return Result.err(
+                MCPToolError(
+                    "results must be a list of {key, content} objects",
+                    tool_name="ouroboros_submit_fanout_results",
+                )
+            )
+        results = [item for item in raw_results if isinstance(item, dict)]
+
+        outcome = submit_fanout_results(
+            self._registry,
+            session_id=str(arguments.get("session_id") or ""),
+            correlation_key=str(arguments.get("correlation_key") or ""),
+            results=results,
+            fanout_id=fanout_id,
+        )
+
+        if outcome.get("status") == "unknown_fanout_id":
+            return Result.err(
+                MCPToolError(
+                    str(outcome.get("error") or "unknown fanout_id"),
+                    tool_name="ouroboros_submit_fanout_results",
+                )
+            )
+
+        return Result.ok(
+            MCPToolResult(
+                content=(
+                    MCPContentItem(
+                        type=ContentType.TEXT,
+                        text=json.dumps(outcome, ensure_ascii=False, sort_keys=True),
+                    ),
+                ),
+                is_error=False,
+                meta=outcome,
+            )
+        )
 
 
 @dataclass

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -37,8 +37,10 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from functools import lru_cache
 import json
+from pathlib import Path
 import re
 from typing import Any
+from uuid import uuid4
 
 from jsonschema import Draft202012Validator
 import structlog
@@ -2296,3 +2298,435 @@ do not enqueue another background Ralph job."""
             max_total_seconds=max_total_seconds,
         ),
     )
+
+
+# ---------------------------------------------------------------------------
+# Generic interview fan-out core
+# ---------------------------------------------------------------------------
+#
+# Any interview/evaluation step can declare "fan these N prompts out and give
+# me correlated results back" with two primitives:
+#
+#   1. ``build_fanout_subagents`` — turn N request specs into SubagentPayloads.
+#   2. ``stamp_fanout_meta``      — stamp the PR-C-standardized 3-mode dispatch
+#      contract onto the response ``meta`` (the copy-pasted stamping the two
+#      legacy producers previously duplicated inline).
+#
+# Result re-entry (the host submitting the correlated child outputs back) is
+# served by ``FanoutRegistry`` + ``submit_fanout_results`` and the
+# ``ouroboros_submit_fanout_results`` MCP tool.
+
+# host_action cue keyed by inline dispatch mode. PLUGIN_PASSIVE is intentionally
+# absent: that surface consumes the ``_subagents`` bridge envelope built by
+# ``build_multi_subagent_result`` and stamps no host-action cue here.
+_FANOUT_HOST_ACTION_BY_MODE: dict[SubagentDispatchMode, str] = {
+    SubagentDispatchMode.HOST_DRIVEN: "spawn_subagents",
+    SubagentDispatchMode.SEQUENTIAL: "process_payloads_sequentially",
+}
+
+_DEFAULT_FANOUT_DIR = Path.home() / ".ouroboros" / "data" / "fanout"
+
+# Fan-out re-entry kinds — each routes to one revived synthesizer.
+FANOUT_KIND_LATERAL_PERSONA_PANEL = "lateral_persona_panel"
+FANOUT_KIND_CODE_INVESTIGATION = "code_investigation"
+
+
+def _fanout_meta_key(prefix: str, key: str) -> str:
+    """Prefix a fan-out meta key, or use it bare when no prefix is given."""
+    return f"{prefix}_{key}" if prefix else key
+
+
+def build_fanout_subagents(
+    requests: list[Mapping[str, Any]],
+    correlation_key: str,
+) -> list[SubagentPayload]:
+    """Build one SubagentPayload per fan-out request spec.
+
+    This is the generic, request-shaped builder that lets any interview step
+    declare a fan-out in one line, instead of copy-pasting a bespoke producer.
+    Each ``request`` is a mapping with the fields consumed by
+    :func:`build_subagent_payload` (``tool_name``, ``title``, ``prompt`` are
+    required; ``agent``, ``model``, ``context``, ``timeout`` are optional).
+
+    ``SubagentPayload.agent`` is an opaque runtime type — arbitrary values are
+    valid, so no ``.md`` role-stem validation is applied and ``context`` is not
+    clamped. The ``correlation_key`` (a dotted path such as ``context.lane_id``
+    or ``context.persona``) names the field the re-entry tool uses to match a
+    submitted result to its originating request; it is not mutated into the
+    payloads here, only carried alongside them by the caller/registry.
+
+    Args:
+        requests: Non-empty list of request specs.
+        correlation_key: Dotted path naming the result-correlation field.
+
+    Returns:
+        List of SubagentPayload, one per request (order preserved).
+
+    Raises:
+        ValueError: If ``requests`` is empty, ``correlation_key`` is blank, or
+            any request omits a required field.
+    """
+    if not requests:
+        raise ValueError("requests must not be empty")
+    if not correlation_key:
+        raise ValueError("correlation_key must not be empty")
+
+    payloads: list[SubagentPayload] = []
+    for index, request in enumerate(requests):
+        if not isinstance(request, Mapping):
+            raise ValueError(f"request[{index}] must be a mapping")
+        context = request.get("context")
+        payloads.append(
+            build_subagent_payload(
+                tool_name=str(request.get("tool_name") or ""),
+                title=str(request.get("title") or ""),
+                prompt=str(request.get("prompt") or ""),
+                agent=str(request.get("agent") or "general"),
+                model=request.get("model"),
+                context=dict(context) if isinstance(context, Mapping) else None,
+                timeout=request.get("timeout"),
+            )
+        )
+    return payloads
+
+
+def stamp_fanout_meta(
+    meta: dict[str, Any],
+    *,
+    prefix: str,
+    dispatch_mode: SubagentDispatchMode,
+    payloads: list[SubagentPayload],
+    correlation_key: str,
+) -> None:
+    """Stamp the standardized 3-mode fan-out dispatch contract onto ``meta``.
+
+    Single source of truth for the dispatch-mode stamping PR-C standardized and
+    that the two legacy producers (interview question advisory + lateral persona
+    panel) previously copy-pasted:
+
+    * ``HOST_DRIVEN``    → ``host_action = "spawn_subagents"``
+    * ``SEQUENTIAL``     → ``host_action = "process_payloads_sequentially"``
+    * ``PLUGIN_PASSIVE`` → no host-action cue (the bridge consumes the
+      ``_subagents`` envelope from :func:`build_multi_subagent_result`).
+
+    Keys are written as ``{prefix}_dispatch_mode`` / ``{prefix}_host_action`` /
+    ``{prefix}_result_correlation_key`` when ``prefix`` is non-empty, or as the
+    bare key names when ``prefix`` is empty. The emitted keys/values are
+    byte-identical to what the legacy producers stamped inline.
+
+    Args:
+        meta: Response meta dict, mutated in place.
+        prefix: Meta key namespace (``""`` for bare keys).
+        dispatch_mode: Resolved runtime dispatch mode.
+        payloads: The fan-out payloads (empty → no-op stamp).
+        correlation_key: Dotted path naming the result-correlation field.
+    """
+    if not payloads:
+        return
+    host_action = _FANOUT_HOST_ACTION_BY_MODE.get(dispatch_mode)
+    if host_action is None:
+        # PLUGIN_PASSIVE: the envelope path stamps no host-action cue here.
+        return
+    meta[_fanout_meta_key(prefix, "dispatch_mode")] = dispatch_mode.value
+    meta[_fanout_meta_key(prefix, "host_action")] = host_action
+    meta[_fanout_meta_key(prefix, "result_correlation_key")] = correlation_key
+
+
+# ---------------------------------------------------------------------------
+# Fan-out result re-entry: persisted expected-key state + synthesizer routing
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class FanoutRecord:
+    """Persisted fan-out request state, keyed by ``fanout_id``.
+
+    Survives across MCP calls so a later ``ouroboros_submit_fanout_results``
+    submission can validate its expected keys and route to the right revived
+    synthesizer. ``synthesizer_input`` carries exactly the non-output argument
+    each synthesizer needs: the orchestration ``entries`` list for a lateral
+    persona panel, or the ``request`` mapping for a code investigation.
+    """
+
+    fanout_id: str
+    kind: str
+    session_id: str
+    correlation_key: str
+    expected_keys: tuple[str, ...]
+    synthesizer_input: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "fanout_id": self.fanout_id,
+            "kind": self.kind,
+            "session_id": self.session_id,
+            "correlation_key": self.correlation_key,
+            "expected_keys": list(self.expected_keys),
+            "synthesizer_input": self.synthesizer_input,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> FanoutRecord:
+        raw_input = data.get("synthesizer_input")
+        return cls(
+            fanout_id=str(data["fanout_id"]),
+            kind=str(data["kind"]),
+            session_id=str(data.get("session_id") or ""),
+            correlation_key=str(data.get("correlation_key") or ""),
+            expected_keys=tuple(str(key) for key in data.get("expected_keys") or ()),
+            synthesizer_input=dict(raw_input) if isinstance(raw_input, Mapping) else {},
+        )
+
+
+class FanoutRegistry:
+    """File-backed store for pending fan-out expected-key state.
+
+    Reuses the interview data directory as the persistence substrate (the same
+    place interview state JSON is written) rather than inventing a new layer.
+    Each record is a single ``{fanout_id}.json`` file. Writes are best-effort:
+    a persistence failure degrades re-entry (submissions report the fan-out as
+    unknown) but never breaks the fan-out request path.
+    """
+
+    def __init__(self, directory: Path | None = None) -> None:
+        self._dir = directory or _DEFAULT_FANOUT_DIR
+
+    @property
+    def directory(self) -> Path:
+        return self._dir
+
+    def _path(self, fanout_id: str) -> Path:
+        return self._dir / f"{fanout_id}.json"
+
+    def register(
+        self,
+        *,
+        kind: str,
+        session_id: str,
+        correlation_key: str,
+        expected_keys: list[str],
+        synthesizer_input: dict[str, Any],
+        fanout_id: str | None = None,
+    ) -> str:
+        """Persist a fan-out record and return its ``fanout_id``.
+
+        A ``fanout_id`` is generated (uuid4-backed, deterministic-friendly when
+        supplied by the caller) and stamped into the returned value so the
+        producer can echo it into the emitted meta. Persistence is best-effort.
+        """
+        resolved_id = fanout_id or f"fanout_{uuid4().hex}"
+        record = FanoutRecord(
+            fanout_id=resolved_id,
+            kind=kind,
+            session_id=session_id,
+            correlation_key=correlation_key,
+            expected_keys=tuple(expected_keys),
+            synthesizer_input=synthesizer_input,
+        )
+        try:
+            self._dir.mkdir(parents=True, exist_ok=True)
+            self._path(resolved_id).write_text(
+                json.dumps(record.to_dict(), ensure_ascii=False),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            log.warning(
+                "fanout.registry.persist_failed",
+                fanout_id=resolved_id,
+                kind=kind,
+                error=str(exc),
+            )
+        return resolved_id
+
+    def load(self, fanout_id: str) -> FanoutRecord | None:
+        """Load a persisted fan-out record, or ``None`` if unknown/corrupt."""
+        try:
+            content = self._path(fanout_id).read_text(encoding="utf-8")
+        except OSError:
+            return None
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(data, Mapping):
+            return None
+        try:
+            return FanoutRecord.from_dict(data)
+        except (KeyError, TypeError, ValueError):
+            return None
+
+
+def _fanout_identity_synthesis(aggregated_outputs: list[Mapping[str, Any]]) -> dict[str, Any]:
+    """Server-side synthesizer: return the correlated outputs for the host.
+
+    The re-entry tool does not run an LLM. Its job is to give the host the
+    correlated child outputs back in dispatch order; the host performs the
+    actual synthesis. This identity synthesizer preserves that contract while
+    still exercising the revived synthesizer aggregation/ordering logic.
+    """
+    return {"aggregated_outputs": [dict(item) for item in aggregated_outputs]}
+
+
+def _fanout_identity_continuation(synthesis: Any) -> dict[str, Any]:
+    """Server-side interview continuation: signal readiness with the synthesis."""
+    return {"ready_to_continue": True, "synthesis": synthesis}
+
+
+def register_lateral_persona_fanout(
+    registry: FanoutRegistry,
+    *,
+    session_id: str,
+    payloads: list[SubagentPayload],
+    correlation_key: str = "context.persona",
+    fanout_id: str | None = None,
+) -> str:
+    """Register a lateral persona-panel fan-out for later result re-entry.
+
+    Expected keys are the payload personas (``context.persona``); the persisted
+    ``entries`` carry ``persona_id`` + ``execution_order`` so
+    :func:`synthesize_lateral_persona_panel_when_complete` can order and gate
+    the submitted outputs.
+    """
+    entries: list[dict[str, Any]] = []
+    expected_keys: list[str] = []
+    for index, payload in enumerate(payloads, start=1):
+        persona = _payload_persona(payload.to_dict())
+        expected_keys.append(persona)
+        entries.append({"persona_id": persona, "execution_order": index})
+    return registry.register(
+        kind=FANOUT_KIND_LATERAL_PERSONA_PANEL,
+        session_id=session_id,
+        correlation_key=correlation_key,
+        expected_keys=expected_keys,
+        synthesizer_input={"entries": entries},
+        fanout_id=fanout_id,
+    )
+
+
+def register_code_investigation_fanout(
+    registry: FanoutRegistry,
+    *,
+    session_id: str,
+    request: Mapping[str, Any],
+    correlation_key: str = "code_facts",
+    fanout_id: str | None = None,
+) -> str:
+    """Register a code-investigation fan-out for later result re-entry.
+
+    Expected keys default to the request's ``required_result_ids`` (or the
+    ``code_facts`` sentinel :func:`synthesize_code_investigation_when_complete`
+    assumes), and the full ``request`` is persisted so the synthesizer can
+    re-run its answer-contract validation on the submitted output.
+    """
+    required = request.get("required_result_ids")
+    if isinstance(required, (list, tuple)) and required:
+        expected_keys = [str(item) for item in required]
+    else:
+        expected_keys = ["code_facts"]
+    return registry.register(
+        kind=FANOUT_KIND_CODE_INVESTIGATION,
+        session_id=session_id,
+        correlation_key=correlation_key,
+        expected_keys=expected_keys,
+        synthesizer_input={"request": dict(request)},
+        fanout_id=fanout_id,
+    )
+
+
+def submit_fanout_results(
+    registry: FanoutRegistry,
+    *,
+    session_id: str,
+    correlation_key: str,
+    results: list[Mapping[str, Any]],
+    fanout_id: str,
+) -> dict[str, Any]:
+    """Validate + route a batch of correlated fan-out results back to synthesis.
+
+    Contract:
+
+    * Unknown ``fanout_id`` → ``status="unknown_fanout_id"`` (clean error).
+    * A ``session_id`` / ``correlation_key`` that disagrees with the persisted
+      record → ``status="correlation_mismatch"`` (clean error).
+    * Missing expected keys → ``status="partial"`` + ``missing_keys`` (the host
+      may resubmit with the remaining lanes).
+    * Complete set → route to the revived synthesizer for the record ``kind``
+      and return its structured outcome under ``status="complete"``.
+    """
+    record = registry.load(fanout_id)
+    if record is None:
+        return {
+            "status": "unknown_fanout_id",
+            "fanout_id": fanout_id,
+            "error": f"No pending fan-out is registered for fanout_id={fanout_id!r}.",
+        }
+    if record.session_id and session_id and record.session_id != session_id:
+        return {
+            "status": "correlation_mismatch",
+            "fanout_id": fanout_id,
+            "error": "session_id does not match the registered fan-out.",
+            "expected_session_id": record.session_id,
+        }
+    if record.correlation_key and correlation_key and record.correlation_key != correlation_key:
+        return {
+            "status": "correlation_mismatch",
+            "fanout_id": fanout_id,
+            "error": "correlation_key does not match the registered fan-out.",
+            "expected_correlation_key": record.correlation_key,
+        }
+
+    provided: dict[str, Any] = {}
+    for result in results:
+        key = result.get("key")
+        if key is None:
+            continue
+        provided[str(key)] = result.get("content")
+
+    missing_keys = [key for key in record.expected_keys if key not in provided]
+    if missing_keys:
+        return {
+            "status": "partial",
+            "fanout_id": fanout_id,
+            "kind": record.kind,
+            "missing_keys": missing_keys,
+            "received_keys": sorted(provided),
+            "expected_keys": list(record.expected_keys),
+        }
+
+    if record.kind == FANOUT_KIND_LATERAL_PERSONA_PANEL:
+        entries = record.synthesizer_input.get("entries") or []
+        outcome = continue_interview_after_lateral_persona_synthesis(
+            entries,
+            provided,
+            _fanout_identity_synthesis,
+            _fanout_identity_continuation,
+        )
+        return {
+            "status": "complete",
+            "fanout_id": fanout_id,
+            "kind": record.kind,
+            "correlation_key": record.correlation_key,
+            "result": outcome,
+        }
+
+    if record.kind == FANOUT_KIND_CODE_INVESTIGATION:
+        request = record.synthesizer_input.get("request") or {}
+        outcome = synthesize_code_investigation_when_complete(
+            request,
+            provided,
+            _fanout_identity_synthesis,
+        )
+        return {
+            "status": "complete",
+            "fanout_id": fanout_id,
+            "kind": record.kind,
+            "correlation_key": record.correlation_key,
+            "result": outcome,
+        }
+
+    return {
+        "status": "unknown_kind",
+        "fanout_id": fanout_id,
+        "kind": record.kind,
+        "error": f"No synthesizer is registered for fan-out kind={record.kind!r}.",
+    }

--- a/src/ouroboros/orchestrator/capabilities/tool_specs.py
+++ b/src/ouroboros/orchestrator/capabilities/tool_specs.py
@@ -785,6 +785,17 @@ _OUROBOROS_TOOL_CAPABILITY_SPECS: Mapping[str, _OuroborosToolCapabilitySpec] = {
         retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
         interrupt=_OUROBOROS_DEFAULT_INTERRUPT_METADATA,
     ),
+    "ouroboros_submit_fanout_results": _OuroborosToolCapabilitySpec(
+        # Re-entry synthesis is a read-only routing step: it reads persisted
+        # fan-out state and returns the correlated synthesis. The fan-out state
+        # write happens on the producer side, not here.
+        execution_mode="status",
+        companions=("ouroboros_interview", "ouroboros_lateral_think"),
+        side_effects=_OUROBOROS_SIDE_EFFECT_FREE_METADATA,
+        retry=_OUROBOROS_DEFAULT_RETRY_METADATA,
+        interrupt=_OUROBOROS_READ_ONLY_INTERRUPT_METADATA,
+        mutation_class=CapabilityMutationClass.READ_ONLY,
+    ),
     "ouroboros_evolve_step": _OuroborosToolCapabilitySpec(
         execution_mode="blocking",
         companions=(
@@ -963,6 +974,7 @@ _OUROBOROS_CANCEL_METADATA: Mapping[str, Mapping[str, Any]] = {
     "ouroboros_start_evolve_step": _OUROBOROS_BACKGROUND_JOB_CANCEL_METADATA,
     "ouroboros_start_execute_seed": _OUROBOROS_BACKGROUND_JOB_CANCEL_METADATA,
     "ouroboros_start_ralph": _OUROBOROS_BACKGROUND_JOB_CANCEL_METADATA,
+    "ouroboros_submit_fanout_results": _OUROBOROS_UNSUPPORTED_CANCEL_METADATA,
 }
 
 _OUROBOROS_BACKGROUND_BLOCKING_COMPANIONS: Mapping[str, str] = {

--- a/tests/unit/mcp/tools/test_definitions.py
+++ b/tests/unit/mcp/tools/test_definitions.py
@@ -1834,6 +1834,7 @@ class TestOuroborosTools:
         "ouroboros_start_evolve_step",
         "ouroboros_start_execute_seed",
         "ouroboros_start_ralph",
+        "ouroboros_submit_fanout_results",
     }
 
     def test_ouroboros_tools_contains_all_handlers(self) -> None:

--- a/tests/unit/mcp/tools/test_fanout_core.py
+++ b/tests/unit/mcp/tools/test_fanout_core.py
@@ -1,0 +1,404 @@
+"""Generic interview fan-out core + ``ouroboros_submit_fanout_results`` re-entry.
+
+Covers PR-J:
+- ``build_fanout_subagents`` generic builder,
+- ``stamp_fanout_meta`` 3-mode stamping (byte-identical to the legacy inline
+  producers),
+- ``FanoutRegistry`` persist/load,
+- ``submit_fanout_results`` routing (complete / partial / unknown / mismatch),
+- end-to-end producer -> registry -> submit for both revived synthesizer kinds.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ouroboros.backends.capabilities import SubagentDispatchMode
+from ouroboros.mcp.tools.authoring_handlers import _attach_question_assist_requests
+from ouroboros.mcp.tools.evaluation_handlers import (
+    LateralThinkHandler,
+    SubmitFanoutResultsHandler,
+)
+from ouroboros.mcp.tools.subagent import (
+    FANOUT_KIND_CODE_INVESTIGATION,
+    FANOUT_KIND_LATERAL_PERSONA_PANEL,
+    FanoutRecord,
+    FanoutRegistry,
+    build_fanout_subagents,
+    build_subagent_payload,
+    register_lateral_persona_fanout,
+    stamp_fanout_meta,
+    submit_fanout_results,
+)
+from ouroboros.orchestrator.capabilities import (
+    stable_code_investigation_question_identity,
+)
+
+# --------------------------------------------------------------------------- #
+# build_fanout_subagents
+# --------------------------------------------------------------------------- #
+
+
+def test_build_fanout_subagents_builds_one_payload_per_request() -> None:
+    requests = [
+        {"tool_name": "t", "title": "A", "prompt": "pa", "agent": "researcher"},
+        {"tool_name": "t", "title": "B", "prompt": "pb", "context": {"lane_id": "code"}},
+    ]
+    payloads = build_fanout_subagents(requests, "context.lane_id")
+    assert [p.title for p in payloads] == ["A", "B"]
+    assert payloads[0].agent == "researcher"
+    assert payloads[1].agent == "general"
+    assert payloads[1].context == {"lane_id": "code"}
+
+
+def test_build_fanout_subagents_rejects_empty_inputs() -> None:
+    with pytest.raises(ValueError, match="requests must not be empty"):
+        build_fanout_subagents([], "context.lane_id")
+    with pytest.raises(ValueError, match="correlation_key must not be empty"):
+        build_fanout_subagents([{"tool_name": "t", "title": "x", "prompt": "y"}], "")
+
+
+# --------------------------------------------------------------------------- #
+# stamp_fanout_meta (byte-identical 3-mode contract)
+# --------------------------------------------------------------------------- #
+
+
+def _payloads(n: int = 2) -> list[Any]:
+    return [build_subagent_payload(tool_name="t", title=f"T{i}", prompt=f"p{i}") for i in range(n)]
+
+
+def test_stamp_fanout_meta_host_driven_prefixed() -> None:
+    meta: dict[str, Any] = {}
+    stamp_fanout_meta(
+        meta,
+        prefix="question_advisory",
+        dispatch_mode=SubagentDispatchMode.HOST_DRIVEN,
+        payloads=_payloads(),
+        correlation_key="context.lane_id",
+    )
+    assert meta == {
+        "question_advisory_dispatch_mode": "host_driven",
+        "question_advisory_host_action": "spawn_subagents",
+        "question_advisory_result_correlation_key": "context.lane_id",
+    }
+
+
+def test_stamp_fanout_meta_sequential_bare() -> None:
+    meta: dict[str, Any] = {}
+    stamp_fanout_meta(
+        meta,
+        prefix="",
+        dispatch_mode=SubagentDispatchMode.SEQUENTIAL,
+        payloads=_payloads(),
+        correlation_key="context.persona",
+    )
+    assert meta == {
+        "dispatch_mode": "sequential",
+        "host_action": "process_payloads_sequentially",
+        "result_correlation_key": "context.persona",
+    }
+
+
+def test_stamp_fanout_meta_plugin_passive_stamps_nothing() -> None:
+    meta: dict[str, Any] = {}
+    stamp_fanout_meta(
+        meta,
+        prefix="question_advisory",
+        dispatch_mode=SubagentDispatchMode.PLUGIN_PASSIVE,
+        payloads=_payloads(),
+        correlation_key="context.lane_id",
+    )
+    assert meta == {}
+
+
+def test_stamp_fanout_meta_empty_payloads_is_noop() -> None:
+    meta: dict[str, Any] = {}
+    stamp_fanout_meta(
+        meta,
+        prefix="",
+        dispatch_mode=SubagentDispatchMode.HOST_DRIVEN,
+        payloads=[],
+        correlation_key="context.persona",
+    )
+    assert meta == {}
+
+
+# --------------------------------------------------------------------------- #
+# Byte-identical proof for the refactored advisory producer
+# --------------------------------------------------------------------------- #
+
+
+def _advisory_meta(dispatch_mode: SubagentDispatchMode, **kwargs: Any) -> dict[str, Any]:
+    meta: dict[str, Any] = {}
+    _attach_question_assist_requests(
+        meta,
+        session_id="sess-bytes",
+        question="What constraint remains?",
+        phase="answer",
+        score=None,
+        dispatch_mode=dispatch_mode,
+        runtime_backend="codex" if dispatch_mode is SubagentDispatchMode.HOST_DRIVEN else "gemini",
+        **kwargs,
+    )
+    return meta
+
+
+def test_advisory_producer_byte_identical_without_registry() -> None:
+    """No registry -> emitted fan-out meta is the exact pre-registry contract."""
+    host = _advisory_meta(SubagentDispatchMode.HOST_DRIVEN)
+    assert host["question_advisory_dispatch_mode"] == "host_driven"
+    assert host["question_advisory_host_action"] == "spawn_subagents"
+    assert host["question_advisory_result_correlation_key"] == "context.lane_id"
+    assert "question_advisory_fanout_id" not in host
+
+    seq = _advisory_meta(SubagentDispatchMode.SEQUENTIAL)
+    assert seq["question_advisory_dispatch_mode"] == "sequential"
+    assert seq["question_advisory_host_action"] == "process_payloads_sequentially"
+    assert seq["question_advisory_result_correlation_key"] == "context.lane_id"
+    assert "question_advisory_fanout_id" not in seq
+
+
+def test_advisory_registry_delta_is_exactly_fanout_id(tmp_path: Any) -> None:
+    """Adding a registry adds exactly one key: question_advisory_fanout_id."""
+    without = _advisory_meta(SubagentDispatchMode.HOST_DRIVEN)
+    registry = FanoutRegistry(tmp_path)
+    with_registry = _advisory_meta(SubagentDispatchMode.HOST_DRIVEN, fanout_registry=registry)
+    added = set(with_registry) - set(without)
+    assert added == {"question_advisory_fanout_id"}
+    # Every shared key is byte-identical.
+    for key in without:
+        assert with_registry[key] == without[key]
+
+
+# --------------------------------------------------------------------------- #
+# FanoutRegistry
+# --------------------------------------------------------------------------- #
+
+
+def test_registry_register_and_load_round_trip(tmp_path: Any) -> None:
+    registry = FanoutRegistry(tmp_path)
+    fanout_id = registry.register(
+        kind=FANOUT_KIND_LATERAL_PERSONA_PANEL,
+        session_id="s1",
+        correlation_key="context.persona",
+        expected_keys=["researcher", "contrarian"],
+        synthesizer_input={"entries": [{"persona_id": "researcher", "execution_order": 1}]},
+    )
+    assert fanout_id.startswith("fanout_")
+    loaded = registry.load(fanout_id)
+    assert isinstance(loaded, FanoutRecord)
+    assert loaded.kind == FANOUT_KIND_LATERAL_PERSONA_PANEL
+    assert loaded.expected_keys == ("researcher", "contrarian")
+
+
+def test_registry_load_unknown_returns_none(tmp_path: Any) -> None:
+    assert FanoutRegistry(tmp_path).load("nope") is None
+
+
+# --------------------------------------------------------------------------- #
+# submit_fanout_results routing
+# --------------------------------------------------------------------------- #
+
+
+def test_submit_unknown_fanout_id_is_clean_error(tmp_path: Any) -> None:
+    out = submit_fanout_results(
+        FanoutRegistry(tmp_path),
+        session_id="s",
+        correlation_key="context.persona",
+        results=[],
+        fanout_id="ghost",
+    )
+    assert out["status"] == "unknown_fanout_id"
+    assert "ghost" in out["error"]
+
+
+def test_submit_partial_lists_missing_keys(tmp_path: Any) -> None:
+    registry = FanoutRegistry(tmp_path)
+    payloads = [
+        build_subagent_payload(
+            tool_name="ouroboros_lateral_think",
+            title=f"L ({p})",
+            prompt="x",
+            agent=p,
+            context={"persona": p},
+        )
+        for p in ("researcher", "contrarian", "simplifier")
+    ]
+    fanout_id = register_lateral_persona_fanout(registry, session_id="s1", payloads=payloads)
+    out = submit_fanout_results(
+        registry,
+        session_id="s1",
+        correlation_key="context.persona",
+        results=[{"key": "researcher", "content": "found facts"}],
+        fanout_id=fanout_id,
+    )
+    assert out["status"] == "partial"
+    assert out["missing_keys"] == ["contrarian", "simplifier"]
+    assert out["received_keys"] == ["researcher"]
+
+
+def test_submit_correlation_mismatch(tmp_path: Any) -> None:
+    registry = FanoutRegistry(tmp_path)
+    payloads = [
+        build_subagent_payload(
+            tool_name="ouroboros_lateral_think",
+            title="L (researcher)",
+            prompt="x",
+            agent="researcher",
+            context={"persona": "researcher"},
+        )
+    ]
+    fanout_id = register_lateral_persona_fanout(registry, session_id="s1", payloads=payloads)
+    out = submit_fanout_results(
+        registry,
+        session_id="s1",
+        correlation_key="context.lane_id",  # wrong key
+        results=[{"key": "researcher", "content": "x"}],
+        fanout_id=fanout_id,
+    )
+    assert out["status"] == "correlation_mismatch"
+
+
+def test_submit_complete_lateral_panel_routes_to_synthesizer(tmp_path: Any) -> None:
+    registry = FanoutRegistry(tmp_path)
+    personas = ("researcher", "contrarian", "simplifier")
+    payloads = [
+        build_subagent_payload(
+            tool_name="ouroboros_lateral_think",
+            title=f"L ({p})",
+            prompt="x",
+            agent=p,
+            context={"persona": p},
+        )
+        for p in personas
+    ]
+    fanout_id = register_lateral_persona_fanout(registry, session_id="s1", payloads=payloads)
+    out = submit_fanout_results(
+        registry,
+        session_id="s1",
+        correlation_key="context.persona",
+        results=[{"key": p, "content": f"{p}-output"} for p in personas],
+        fanout_id=fanout_id,
+    )
+    assert out["status"] == "complete"
+    assert out["kind"] == FANOUT_KIND_LATERAL_PERSONA_PANEL
+    result = out["result"]
+    # continue_interview_after_lateral_persona_synthesis was exercised.
+    assert result["ready_for_synthesis"] is True
+    assert result["continued_interview"] is True
+    assert result["interview_continuation"]["ready_to_continue"] is True
+    agg = result["synthesis"]["aggregated_outputs"]
+    assert [item["persona_id"] for item in agg] == list(personas)
+
+
+def _code_fact_output(session_id: str, question: str) -> dict[str, Any]:
+    return {
+        "session_id": session_id,
+        "question_identity": stable_code_investigation_question_identity(question),
+        "answer_prefix": "[from-code][auto-confirmed]",
+        "answer_text": "pyproject.toml declares the package metadata.",
+        "confidence": "high_exact_match",
+        "evidence": [
+            {
+                "source": "pyproject.toml",
+                "locator": "project.name",
+                "claim": "The package name is declared in pyproject.toml.",
+            }
+        ],
+        "requires_user_confirmation": False,
+    }
+
+
+def test_submit_complete_code_investigation_routes_to_synthesizer(tmp_path: Any) -> None:
+    registry = FanoutRegistry(tmp_path)
+    question = "Which manifest declares the package?"
+    session_id = "sess-code"
+    meta: dict[str, Any] = {}
+    _attach_question_assist_requests(
+        meta,
+        session_id=session_id,
+        question=question,
+        phase="answer",
+        score=None,
+        dispatch_mode=SubagentDispatchMode.HOST_DRIVEN,
+        runtime_backend="codex",
+        fanout_registry=registry,
+    )
+    fanout_id = meta["question_advisory_fanout_id"]
+    out = submit_fanout_results(
+        registry,
+        session_id=session_id,
+        correlation_key="code_facts",
+        results=[{"key": "code_facts", "content": _code_fact_output(session_id, question)}],
+        fanout_id=fanout_id,
+    )
+    assert out["status"] == "complete"
+    assert out["kind"] == FANOUT_KIND_CODE_INVESTIGATION
+    result = out["result"]
+    assert result["ready_for_synthesis"] is True
+    assert result["ready_for_forward"] is True
+    assert result["contract_violations"] == []
+
+
+# --------------------------------------------------------------------------- #
+# Handler-level: lateral producer registers + submit tool re-entry
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_lateral_handler_registers_fanout_and_submit_tool_synthesizes(
+    tmp_path: Any,
+) -> None:
+    registry = FanoutRegistry(tmp_path)
+    handler = LateralThinkHandler(
+        agent_runtime_backend="gemini",  # -> SEQUENTIAL inline path
+        fanout_registry=registry,
+    )
+    personas = ["researcher", "contrarian", "simplifier"]
+    result = await handler.handle(
+        {
+            "problem_context": "stuck on a milestone question",
+            "current_approach": "keep asking the same thing",
+            "personas": personas,
+        }
+    )
+    assert result.is_ok, result
+    meta = result.unwrap().meta
+    fanout_id = meta["fanout_id"]
+    assert meta["host_action"] == "process_payloads_sequentially"
+
+    submit = SubmitFanoutResultsHandler(fanout_registry=registry)
+    submit_result = await submit.handle(
+        {
+            "correlation_key": "context.persona",
+            "fanout_id": fanout_id,
+            "results": [{"key": p, "content": f"{p}-out"} for p in personas],
+        }
+    )
+    assert submit_result.is_ok, submit_result
+    out = submit_result.unwrap().meta
+    assert out["status"] == "complete"
+    assert out["result"]["ready_for_synthesis"] is True
+
+
+@pytest.mark.asyncio
+async def test_lateral_handler_without_registry_stamps_no_fanout_id() -> None:
+    handler = LateralThinkHandler(agent_runtime_backend="gemini")
+    result = await handler.handle(
+        {
+            "problem_context": "stuck",
+            "current_approach": "same",
+            "personas": ["researcher", "contrarian"],
+        }
+    )
+    assert result.is_ok, result
+    assert "fanout_id" not in result.unwrap().meta
+
+
+@pytest.mark.asyncio
+async def test_submit_tool_requires_fanout_id() -> None:
+    submit = SubmitFanoutResultsHandler()
+    result = await submit.handle({"results": []})
+    assert result.is_err

--- a/tests/unit/mcp/tools/test_round5_fixes.py
+++ b/tests/unit/mcp/tools/test_round5_fixes.py
@@ -237,7 +237,7 @@ class TestGetOuroborosToolsPluginWiring:
 
         tools = get_ouroboros_tools()
         names = {tool.definition.name for tool in tools}
-        assert len(tools) == 29
+        assert len(tools) == 30
         assert "ouroboros_auto" in names
         assert "ouroboros_query_projection" in names
         assert "ouroboros_start_auto" in names

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -93,6 +93,7 @@ _EXPECTED_OUROBOROS_TOOL_EXECUTION_MODES = {
     "ouroboros_start_evolve_step": "background",
     "ouroboros_start_execute_seed": "background",
     "ouroboros_start_ralph": "background",
+    "ouroboros_submit_fanout_results": "status",
 }
 
 _VALID_OUROBOROS_TOOL_EXECUTION_MODES = frozenset(
@@ -215,6 +216,7 @@ _EXPECTED_OUROBOROS_REQUIRED_CONTEXT_KEYS = {
     "ouroboros_start_evolve_step": ("lineage_id",),
     "ouroboros_start_execute_seed": ("seed_content", "session_id"),
     "ouroboros_start_ralph": ("lineage_id",),
+    "ouroboros_submit_fanout_results": ("fanout_id", "results"),
 }
 
 _EXPECTED_OUROBOROS_TOOL_COMPANIONS = {
@@ -434,6 +436,10 @@ _EXPECTED_OUROBOROS_TOOL_COMPANIONS = {
         "ouroboros_evolve_rewind",
         "ouroboros_ralph",
     ),
+    "ouroboros_submit_fanout_results": (
+        "ouroboros_interview",
+        "ouroboros_lateral_think",
+    ),
 }
 
 _EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS = {
@@ -475,6 +481,7 @@ _EXPECTED_OUROBOROS_TOOL_SIDE_EFFECTS = {
     "ouroboros_start_evolve_step": ("workspace_write", "event_store_write"),
     "ouroboros_start_execute_seed": ("workspace_write", "event_store_write"),
     "ouroboros_start_ralph": ("workspace_write", "event_store_write"),
+    "ouroboros_submit_fanout_results": (),
 }
 
 _EXPECTED_MUTATION_TARGETS_BY_SIDE_EFFECT = {
@@ -782,6 +789,7 @@ _EXPECTED_READ_ONLY_OUROBOROS_TOOLS = {
     "ouroboros_query_events",
     "ouroboros_query_projection",
     "ouroboros_session_status",
+    "ouroboros_submit_fanout_results",
 }
 
 _EXPECTED_OUROBOROS_TOOL_RETRY = {
@@ -814,6 +822,7 @@ _EXPECTED_OUROBOROS_TOOL_RETRY = {
     "ouroboros_start_evolve_step": {"supported": True, "mode": "job_poll"},
     "ouroboros_start_execute_seed": {"supported": True, "mode": "job_poll"},
     "ouroboros_start_ralph": {"supported": True, "mode": "job_poll"},
+    "ouroboros_submit_fanout_results": {"supported": True, "mode": "handler_owned"},
 }
 
 _BACKGROUND_INTERRUPT = {
@@ -904,6 +913,7 @@ _EXPECTED_OUROBOROS_TOOL_INTERRUPT = {
     "ouroboros_start_evolve_step": _BACKGROUND_INTERRUPT,
     "ouroboros_start_execute_seed": _BACKGROUND_INTERRUPT,
     "ouroboros_start_ralph": _BACKGROUND_INTERRUPT,
+    "ouroboros_submit_fanout_results": _READ_ONLY_INTERRUPT,
 }
 
 _UNSUPPORTED_CANCEL = {
@@ -974,6 +984,7 @@ _EXPECTED_OUROBOROS_TOOL_CANCEL = {
     "ouroboros_start_evolve_step": _BACKGROUND_JOB_CANCEL,
     "ouroboros_start_execute_seed": _BACKGROUND_JOB_CANCEL,
     "ouroboros_start_ralph": _BACKGROUND_JOB_CANCEL,
+    "ouroboros_submit_fanout_results": _UNSUPPORTED_CANCEL,
 }
 
 _OUROBOROS_TOOL_CONTRACT_CASE_SETS = {
@@ -2811,6 +2822,7 @@ def test_read_only_query_status_projection_tools_have_non_mutating_interrupt_met
         "ouroboros_query_events",
         "ouroboros_query_projection",
         "ouroboros_session_status",
+        "ouroboros_submit_fanout_results",
     }
 
     assert expected_query_status_projection_tools == _EXPECTED_READ_ONLY_OUROBOROS_TOOLS
@@ -3242,6 +3254,7 @@ def test_non_cancel_ouroboros_owned_tools_explicitly_do_not_expose_cancel_semant
         "ouroboros_query_events",
         "ouroboros_query_projection",
         "ouroboros_session_status",
+        "ouroboros_submit_fanout_results",
     }
     assert cancel_capable_tools == {
         "ouroboros_cancel_execution",


### PR DESCRIPTION
## Work order: PR-J — generic interview fan-out core + result re-entry

Give ANY interview/evaluation step a one-liner to declare "fan these N prompts out and give me correlated results back." Two halves: a generic request builder + shared 3-mode stamping (replacing the copy-pasted producers), and a result re-entry MCP tool that revives the dead synthesis layer.

### Step 1 — Generic builder + shared stamping (`subagent.py`)
- **`build_fanout_subagents(requests, correlation_key)`** — turns N request specs into `SubagentPayload`s. `agent` stays opaque (no `.md` role-stem validation), `context` is not clamped.
- **`stamp_fanout_meta(meta, *, prefix, dispatch_mode, payloads, correlation_key)`** — single implementation of the PR-C-standardized 3-mode contract:
  - `HOST_DRIVEN` → `host_action="spawn_subagents"`
  - `SEQUENTIAL` → `host_action="process_payloads_sequentially"`
  - `PLUGIN_PASSIVE` → no cue (bridge consumes the `_subagents` envelope via `build_multi_subagent_result`)
- **Both legacy producers refactored onto it**: `_attach_question_assist_requests` (authoring) and the lateral_think multi-persona emission (evaluation). Emitted meta keys are **byte-identical** — a snapshot test asserts the without-registry meta is unchanged, and the registry-on delta is *exactly* one added `fanout_id` key.

### Step 2 — Re-entry tool `ouroboros_submit_fanout_results`
- **`FanoutRegistry`** persists `{expected_keys, fanout_id, kind, synthesizer_input}` as `{fanout_id}.json` under the interview data dir — reuses the existing state store, no new persistence layer. Producers stamp `fanout_id` into meta only when a registry is wired (kept off in direct-call tests → byte-identical).
- **`submit_fanout_results`** validates expected keys and routes:
  - complete set → the revived synthesizer for the record `kind` → correlated synthesis returned
  - partial set → `status="partial"` + `missing_keys` (host resubmits)
  - unknown `fanout_id` / session·correlation mismatch → clean error
- Routes to the **revived** synthesizers (`continue_interview_after_lateral_persona_synthesis` → which drives `synthesize_lateral_persona_panel_when_complete`; and `synthesize_code_investigation_when_complete`) — they now have **non-test consumers**.
- Registered in `get_ouroboros_tools` with capability + cancel metadata (read-only status tool). `skills/interview/SKILL.md` documents submit-then-continue for parallel and sequential hosts.

## How fanout state is persisted
`FanoutRegistry` (file-backed, `{fanout_id}.json` under `~/.ouroboros/data/fanout`, injectable for tests) — the same data-dir substrate the interview already uses for `_plugin_save_state`. Best-effort writes: a persistence failure degrades re-entry (submission reports the fan-out unknown) but never breaks the fan-out request path.

## Synthesizer contract notes
The submit tool runs no LLM; it passes identity aggregators so the revived synthesizers still exercise their ordering/gating/contract-validation logic and hand the host the correlated outputs to synthesize. `synthesize_code_investigation_when_complete` still re-runs its answer-contract validation on the submitted output (confirmation gating preserved).

## Done means
- [x] Both legacy producers emit byte-identical meta through the shared helpers (tests)
- [x] Submit tool: complete → synthesis; partial → `partial` + missing keys; unknown fanout_id → clean error (tests)
- [x] Dead synthesizers now have non-test consumers (`submit_fanout_results`)
- [x] Validation gate passes

## Validation
- `ruff check .` / `ruff format --check .` — clean
- `mypy src/` — Success, no issues in 425 files
- Main gate (`pytest tests/ --ignore=e2e --ignore=unit/mcp --ignore=integration/mcp`): **10128 passed, 6 failed** — the 6 are the documented pre-existing `test_surface` / `test_auto_runtime_dispatch` codex-config-leak failures, verified **identical on clean origin/main** via `git stash`.
- Targeted mcp files (run explicitly, never the full mcp dir): `test_lateral_think_handler`, `test_interview_lateral_review_advisory`, `test_interview_response_diagnostics`, `test_definitions`, `test_round5_fixes`, `test_capabilities`, and new `test_fanout_core` — **426 passed**.

## Files changed
- `src/ouroboros/mcp/tools/subagent.py` — fan-out core (builder, stamping, registry, submit routing, revived-synthesizer consumers)
- `src/ouroboros/mcp/tools/authoring_handlers.py` — advisory producer onto `stamp_fanout_meta` + opt-in re-entry
- `src/ouroboros/mcp/tools/evaluation_handlers.py` — lateral producer onto `stamp_fanout_meta` + `SubmitFanoutResultsHandler`
- `src/ouroboros/mcp/tools/definitions.py` — register submit tool, wire shared `FanoutRegistry`
- `src/ouroboros/orchestrator/capabilities/tool_specs.py` — capability + cancel metadata for the new tool
- `skills/interview/SKILL.md` — re-entry flow docs
- tests: new `test_fanout_core.py`; manifest updates in `test_capabilities.py`, `test_definitions.py`, `test_round5_fixes.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)