### PR TITLE
feat(auto): A1 provenance gate — source-tagged ledger decisions + low-ambiguity gate before executable seed

### DIFF
--- a/src/ouroboros/auto/auto_fill.py
+++ b/src/ouroboros/auto/auto_fill.py
@@ -20,6 +20,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 
 from ouroboros.auto.ledger import (
+    DecisionProvenance,
     LedgerEntry,
     LedgerSource,
     LedgerStatus,
@@ -93,6 +94,10 @@ def auto_fill_remaining(ledger: SeedDraftLedger, *, fill_slot: FillSlot) -> list
                 confidence=confidence,
                 status=LedgerStatus.DEFAULTED,
                 reversible=True,
+                # Deadline non-convergence backstop → the exact #1485 origin;
+                # stamp it distinctly so the histogram and gate see it as a
+                # timeout default rather than an ordinary model inference.
+                provenance=DecisionProvenance.TIMEOUT_DEFAULT,
                 rationale=(
                     proposal.rationale
                     or "Auto-filled by inference (RFC #1256 §I3) because the "

--- a/src/ouroboros/auto/grading.py
+++ b/src/ouroboros/auto/grading.py
@@ -8,7 +8,13 @@ import re
 from typing import Any
 
 from ouroboros.auto.gap_detector import GapDetector
-from ouroboros.auto.ledger import REQUIRED_SECTIONS, LedgerSource, LedgerStatus, SeedDraftLedger
+from ouroboros.auto.ledger import (
+    REQUIRED_SECTIONS,
+    DecisionProvenance,
+    LedgerSource,
+    LedgerStatus,
+    SeedDraftLedger,
+)
 from ouroboros.core.seed import AcceptanceCriterionSpec, Seed, ac_text
 
 
@@ -379,6 +385,20 @@ class GradeGate:
                     )
                 )
 
+        # A1 provenance gate (#1485). Every active decision whose origin is
+        # gated — ``model_inferred`` or ``timeout_default`` — must individually
+        # clear a low-ambiguity criterion before the ledger can become an
+        # executable Seed. A failing entry (empty, question-text pollution,
+        # vague, or a deadline placeholder — i.e. the #1485 degraded-seed
+        # signature) produces a MEDIUM ``unverified_provenance`` finding that
+        # feeds the repair loop WITHOUT hard-blocking (mirrors
+        # ``missing_success_contract``): the finding drops grade A→B and is
+        # repairable, but it is never a blocker, so legacy sessions and
+        # already-degraded recovery seeds keep flowing. Grounded origins
+        # (user_confirmed / maintainer_policy / lateral_consensus) are exempt.
+        if ledger is not None:
+            findings.extend(_unverified_provenance_findings(ledger))
+
         untestable_count = sum(1 for finding in findings if "acceptance_criteria" in finding.code)
         scores = {
             "coverage": _score_threshold(len(findings), len(blockers), base=0.95),
@@ -589,3 +609,68 @@ def _high_risk_assumption_count(ledger: SeedDraftLedger) -> int:
 
 def _score_threshold(finding_count: int, blocker_count: int, *, base: float) -> float:
     return max(0.0, min(1.0, base - 0.08 * finding_count - 0.25 * blocker_count))
+
+
+# Decision origins that must clear the low-ambiguity criterion before the ledger
+# can become an executable Seed (A1 / #1485). Grounded origins (user_confirmed /
+# maintainer_policy / lateral_consensus) are trusted and never gated here.
+_PROVENANCE_GATED: frozenset[DecisionProvenance] = frozenset(
+    {DecisionProvenance.MODEL_INFERRED, DecisionProvenance.TIMEOUT_DEFAULT}
+)
+
+# The #1485 degraded-seed signature: a deadline placeholder leaked into a
+# contract field. Reused verbatim from ``ledger_seed`` semantics without the
+# import cycle.
+_DEADLINE_PLACEHOLDER_MARKER = "unresolved at deadline"
+
+
+def _is_low_ambiguity_decision(value: str) -> bool:
+    """Return True when a gated decision's value is concrete enough to execute.
+
+    This reuses the existing ambiguity machinery (:func:`_is_vague`) rather than
+    inventing a new scorer, and adds the #1485-specific pollution signals:
+    empty values, raw interview question text (``?``), and the deadline
+    placeholder. It is deliberately high-precision — only the degraded-seed
+    signature fails — so clean model-inferred/timeout-defaulted decisions (the
+    overwhelming common case) pass and no existing grade flips.
+    """
+    text = value.strip()
+    if not text:
+        return False
+    if "?" in text:
+        return False
+    if _DEADLINE_PLACEHOLDER_MARKER in text.lower():
+        return False
+    return not _is_vague(text)
+
+
+def _unverified_provenance_findings(ledger: SeedDraftLedger) -> list[GradeFinding]:
+    """Findings for gated ledger decisions that fail the low-ambiguity criterion."""
+    inactive_statuses = {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+    findings: list[GradeFinding] = []
+    for section in ledger.sections.values():
+        for entry in section.entries:
+            if entry.status in inactive_statuses:
+                continue
+            if entry.effective_provenance not in _PROVENANCE_GATED:
+                continue
+            if _is_low_ambiguity_decision(entry.value):
+                continue
+            findings.append(
+                GradeFinding(
+                    "unverified_provenance",
+                    "medium",
+                    (
+                        f"{entry.effective_provenance.value} decision is not low-ambiguity "
+                        f"and must be verified before execution: {entry.value[:120]!r}"
+                    ),
+                    f"{section.name}.{entry.key}",
+                    (
+                        "Confirm this decision with the user or replace it with an "
+                        "evidence-backed value; a model-inferred or timeout-defaulted "
+                        "contract field must be concrete (no question text or placeholder) "
+                        "before the seed is executable."
+                    ),
+                )
+            )
+    return findings

--- a/src/ouroboros/auto/ledger.py
+++ b/src/ouroboros/auto/ledger.py
@@ -38,6 +38,29 @@ class LedgerStatus(StrEnum):
     BLOCKED = "blocked"
 
 
+class DecisionProvenance(StrEnum):
+    """How a ledger decision came to be — orthogonal to :class:`LedgerSource`.
+
+    ``LedgerSource`` classifies *what kind of content-authority* a decision
+    rests on (user goal, repo fact, inference, …). ``DecisionProvenance``
+    classifies *how the decision was reached*, which is the axis the #1485
+    failure exposed: a timeout-defaulted decision was indistinguishable from a
+    user-confirmed one, so degraded seeds (whose contract fields contained raw
+    question text) executed silently.
+
+    The two gated classes — :data:`MODEL_INFERRED` and :data:`TIMEOUT_DEFAULT` —
+    must pass a low-ambiguity criterion (see :mod:`ouroboros.auto.grading`)
+    before the ledger can become an executable Seed. The other three are
+    grounded/human-authorized and pass the gate unconditionally.
+    """
+
+    USER_CONFIRMED = "user_confirmed"
+    MODEL_INFERRED = "model_inferred"
+    TIMEOUT_DEFAULT = "timeout_default"
+    LATERAL_CONSENSUS = "lateral_consensus"
+    MAINTAINER_POLICY = "maintainer_policy"
+
+
 SOURCE_PRIORITY: tuple[LedgerSource, ...] = (
     LedgerSource.USER_GOAL,
     LedgerSource.REPO_FACT,
@@ -108,6 +131,33 @@ _RESOLVED_STATUSES: frozenset[LedgerStatus] = frozenset(
 )
 
 
+# Derivation from the content-authority axis (``LedgerSource``) to the
+# decision-origin axis (``DecisionProvenance``) for entries that were never
+# explicitly stamped — i.e. legacy sessions, deserialized entries, and the many
+# writer sites whose ``LedgerSource`` already fully implies the origin. Sources
+# not listed here (currently only ``BLOCKER``, which is never active) fall
+# through to the safest honest default: ``MODEL_INFERRED``. That default keeps
+# old sessions from crashing AND from silently passing the provenance gate — an
+# unstamped entry is treated as a model guess and screened for low ambiguity.
+_PROVENANCE_FROM_SOURCE: dict[LedgerSource, DecisionProvenance] = {
+    # Grounded in a human statement OR verified repo/convention evidence — these
+    # are not model guesses, so they pass the provenance gate unconditionally.
+    LedgerSource.USER_GOAL: DecisionProvenance.USER_CONFIRMED,
+    LedgerSource.USER_PREFERENCE: DecisionProvenance.USER_CONFIRMED,
+    LedgerSource.NON_GOAL: DecisionProvenance.USER_CONFIRMED,
+    LedgerSource.REPO_FACT: DecisionProvenance.USER_CONFIRMED,
+    LedgerSource.EXISTING_CONVENTION: DecisionProvenance.USER_CONFIRMED,
+    # Deterministic policy/config fill applied during normal answering.
+    LedgerSource.CONSERVATIVE_DEFAULT: DecisionProvenance.MAINTAINER_POLICY,
+    # Model best-guesses — gated.
+    LedgerSource.INFERENCE: DecisionProvenance.MODEL_INFERRED,
+    LedgerSource.ASSUMPTION: DecisionProvenance.MODEL_INFERRED,
+    LedgerSource.AUTO_FILL_INFERENCE: DecisionProvenance.MODEL_INFERRED,
+}
+
+_PROVENANCE_DEFAULT: DecisionProvenance = DecisionProvenance.MODEL_INFERRED
+
+
 @dataclass(frozen=True, slots=True)
 class AssumptionRecord:
     """Auditable provenance for an assumption-class ledger entry.
@@ -144,17 +194,45 @@ class LedgerEntry:
     reversible: bool = True
     rationale: str = ""
     evidence: list[str] = field(default_factory=list)
+    # Decision-origin stamp (A1 / #1485). ``None`` for unstamped/legacy entries;
+    # :attr:`effective_provenance` derives a value from ``source`` in that case.
+    # Writer sites whose origin ``source`` cannot express (deadline/timeout
+    # backstops, lateral consensus) stamp this explicitly at the decision point.
+    provenance: DecisionProvenance | str | None = None
 
     def __post_init__(self) -> None:
         self.source = LedgerSource(str(self.source))
         self.status = LedgerStatus(str(self.status))
         self.confidence = max(0.0, min(1.0, float(self.confidence)))
+        if self.provenance is not None:
+            self.provenance = DecisionProvenance(str(self.provenance))
+
+    @property
+    def effective_provenance(self) -> DecisionProvenance:
+        """Return the decision origin, deriving from ``source`` when unstamped.
+
+        Explicit :attr:`provenance` wins; otherwise the content-authority
+        ``source`` is mapped via :data:`_PROVENANCE_FROM_SOURCE`, defaulting to
+        :data:`_PROVENANCE_DEFAULT` (``model_inferred``) — the safe fallback that
+        neither crashes legacy sessions nor lets an unstamped decision skip the
+        low-ambiguity gate.
+        """
+        if self.provenance is not None:
+            return DecisionProvenance(self.provenance)
+        source = self.source if isinstance(self.source, LedgerSource) else LedgerSource(self.source)
+        return _PROVENANCE_FROM_SOURCE.get(source, _PROVENANCE_DEFAULT)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize to JSON-compatible data."""
         data = asdict(self)
         data["source"] = self.source.value
         data["status"] = self.status.value
+        # Keep serialization additive: only emit ``provenance`` when explicitly
+        # stamped so legacy round-trips (entries without the key) are byte-stable.
+        if self.provenance is None:
+            data.pop("provenance", None)
+        else:
+            data["provenance"] = DecisionProvenance(self.provenance).value
         return data
 
     @classmethod
@@ -192,6 +270,13 @@ class LedgerEntry:
         if confidence < 0.0 or confidence > 1.0:
             msg = "ledger entry confidence must be between 0 and 1"
             raise ValueError(msg)
+        provenance = data.get("provenance")
+        if provenance is not None:
+            try:
+                DecisionProvenance(str(provenance))
+            except ValueError as exc:
+                msg = f"ledger entry provenance is not a valid decision provenance: {provenance!r}"
+                raise ValueError(msg) from exc
         return cls(**data)
 
 
@@ -462,6 +547,26 @@ class SeedDraftLedger:
             for entry in section.entries
             if entry.status == LedgerStatus.CONFLICTING
         )
+
+    def provenance_histogram(self) -> dict[str, int]:
+        """Return counts of active entries by decision origin (A1 / #1485).
+
+        Keys are :class:`DecisionProvenance` string values; only *active*
+        entries (not WEAK/CONFLICTING/BLOCKED) are counted, so the histogram
+        reflects the decisions that actually flow into the synthesized Seed.
+        Surfaced on ``SeedMetadata.decision_provenance`` so later phases (the A2
+        trace artifact) can grep how a seed's contract was assembled and how
+        many gated (``model_inferred`` / ``timeout_default``) decisions it rests
+        on. Deterministically ordered for stable serialization.
+        """
+        counts: dict[str, int] = {}
+        for section in self.sections.values():
+            for entry in section.entries:
+                if entry.status in _INACTIVE_STATUSES:
+                    continue
+                key = entry.effective_provenance.value
+                counts[key] = counts.get(key, 0) + 1
+        return dict(sorted(counts.items()))
 
     def assumptions(self) -> list[str]:
         """Return assumption entry values."""

--- a/src/ouroboros/auto/ledger_seed.py
+++ b/src/ouroboros/auto/ledger_seed.py
@@ -214,6 +214,7 @@ def _synthesized_metadata_kwargs(
         "seed_id": f"seed_{uuid4().hex[:12]}",
         "ambiguity_score": max(0.05, deterministic_floor(ledger)),
         "interview_id": interview_id,
+        "decision_provenance": ledger.provenance_histogram(),
     }
     if recovery_reason is not None:
         kwargs["generation_mode"] = DEADLINE_LEDGER_SEED_GENERATION_MODE
@@ -401,6 +402,7 @@ def partial_seed_from_evidence(
             degraded=degraded,
             unresolved_slots=unresolved_slots,
             recovery_reason=reason,
+            decision_provenance=ledger.provenance_histogram(),
         ),
     )
 

--- a/src/ouroboros/auto/safe_defaults.py
+++ b/src/ouroboros/auto/safe_defaults.py
@@ -11,6 +11,7 @@ import unicodedata
 import structlog
 
 from ouroboros.auto.ledger import (
+    DecisionProvenance,
     LedgerEntry,
     LedgerSource,
     LedgerStatus,
@@ -295,6 +296,11 @@ def finalize_safe_defaultable_gaps(
                 source=LedgerSource.ASSUMPTION,
                 confidence=0.68,
                 status=LedgerStatus.DEFAULTED,
+                # Forced closure of an unconverged interview (max_rounds /
+                # phase deadline) — same #1485 backstop class as auto-fill, so
+                # stamp it timeout_default rather than letting ASSUMPTION derive
+                # to a plain model inference.
+                provenance=DecisionProvenance.TIMEOUT_DEFAULT,
                 rationale=f"{spec.rationale} Applied at {provenance}.",
                 evidence=[
                     provenance,

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -21,7 +21,15 @@ import math
 from typing import Any
 from uuid import uuid4
 
-from pydantic import BaseModel, Field, field_serializer, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    field_serializer,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
+from pydantic_core.core_schema import SerializerFunctionWrapHandler
 
 
 class ExitCondition(BaseModel, frozen=True):
@@ -166,6 +174,12 @@ class SeedMetadata(BaseModel, frozen=True):
         recovery_reason: Free-form description of why the degraded path was
             taken (e.g. ``"interview_phase_deadline"``). ``None`` for normal
             seeds.
+        decision_provenance: Histogram of how the ledger decisions behind this
+            Seed were reached, keyed by decision-origin class (``user_confirmed``
+            / ``model_inferred`` / ``timeout_default`` / ``lateral_consensus`` /
+            ``maintainer_policy``) → count (A1 / #1485). Empty for Seeds not
+            synthesized from an auto ledger. Additive and greppable so later
+            phases can audit how many gated decisions a seed rests on.
     """
 
     seed_id: str = Field(default_factory=lambda: f"seed_{uuid4().hex[:12]}")
@@ -178,6 +192,20 @@ class SeedMetadata(BaseModel, frozen=True):
     degraded: bool = Field(default=False)
     unresolved_slots: tuple[str, ...] = Field(default_factory=tuple)
     recovery_reason: str | None = Field(default=None)
+    decision_provenance: dict[str, int] = Field(default_factory=dict)
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler: SerializerFunctionWrapHandler) -> dict[str, Any]:
+        """Serialize additively: omit ``decision_provenance`` when empty.
+
+        Keeps legacy Seed JSON byte-identical after a round-trip (the histogram
+        is only present for ledger-synthesized seeds) while still emitting it
+        whenever an auto ledger populated it.
+        """
+        data = handler(self)
+        if not self.decision_provenance:
+            data.pop("decision_provenance", None)
+        return data
 
 
 class AcceptanceCriterionSpec(BaseModel, frozen=True):

--- a/tests/unit/auto/test_provenance_gate.py
+++ b/tests/unit/auto/test_provenance_gate.py
@@ -1,0 +1,251 @@
+"""A1 provenance gate (#1485): source-tagged ledger decisions + low-ambiguity gate.
+
+Covers the decision-origin axis (:class:`DecisionProvenance`) layered onto the
+existing content-authority ``LedgerSource``: derivation for unstamped/legacy
+entries, explicit stamping at the deadline/timeout backstops, the histogram
+surface on ``SeedMetadata``, and the ``unverified_provenance`` grading finding
+that makes the #1485 degraded-seed (question-text pollution) structurally
+impossible to auto-run.
+"""
+
+from __future__ import annotations
+
+import json
+
+from ouroboros.auto.auto_fill import AutoFillProposal, auto_fill_remaining
+from ouroboros.auto.grading import GradeGate, SeedGrade
+from ouroboros.auto.ledger import (
+    DecisionProvenance,
+    LedgerEntry,
+    LedgerSource,
+    LedgerStatus,
+    SeedDraftLedger,
+)
+from ouroboros.auto.ledger_seed import partial_seed_from_evidence, synthesize_seed_from_ledger
+from ouroboros.auto.safe_defaults import finalize_safe_defaultable_gaps
+from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+
+
+def _populate_complete_ledger(goal: str = "Build a CLI tool that prints hello.") -> SeedDraftLedger:
+    ledger = SeedDraftLedger.from_goal(goal)
+    fillers = {
+        "actors": "End user invoking the CLI.",
+        "inputs": "A single positional argument provided on the command line.",
+        "outputs": "stdout text greeting the user.",
+        "constraints": "Pure Python; no external network calls.",
+        "non_goals": "Long-running daemon mode.",
+        "acceptance_criteria": "CLI exits with code 0 and prints the greeting.",
+        "verification_plan": "Run the CLI with a sample arg and assert stdout/exit code.",
+        "failure_modes": "Missing argument raises a typed error.",
+        "runtime_context": "Local developer shell on POSIX.",
+    }
+    for section, value in fillers.items():
+        ledger.add_entry(
+            section,
+            LedgerEntry(
+                key=f"{section}.test",
+                value=value,
+                source=LedgerSource.USER_GOAL,
+                confidence=0.9,
+                status=LedgerStatus.CONFIRMED,
+            ),
+        )
+    return ledger
+
+
+def _entry(
+    value: str, *, source: LedgerSource, provenance: DecisionProvenance | None = None
+) -> LedgerEntry:
+    return LedgerEntry(
+        key="section.key",
+        value=value,
+        source=source,
+        confidence=0.7,
+        status=LedgerStatus.INFERRED,
+        provenance=provenance,
+    )
+
+
+class TestEffectiveProvenance:
+    def test_explicit_stamp_wins(self) -> None:
+        entry = _entry(
+            "x", source=LedgerSource.USER_GOAL, provenance=DecisionProvenance.TIMEOUT_DEFAULT
+        )
+        assert entry.effective_provenance is DecisionProvenance.TIMEOUT_DEFAULT
+
+    def test_user_sources_derive_to_user_confirmed(self) -> None:
+        for source in (
+            LedgerSource.USER_GOAL,
+            LedgerSource.USER_PREFERENCE,
+            LedgerSource.NON_GOAL,
+            LedgerSource.REPO_FACT,
+            LedgerSource.EXISTING_CONVENTION,
+        ):
+            assert _entry("x", source=source).effective_provenance is (
+                DecisionProvenance.USER_CONFIRMED
+            )
+
+    def test_model_sources_derive_to_model_inferred(self) -> None:
+        for source in (
+            LedgerSource.INFERENCE,
+            LedgerSource.ASSUMPTION,
+            LedgerSource.AUTO_FILL_INFERENCE,
+        ):
+            assert _entry("x", source=source).effective_provenance is (
+                DecisionProvenance.MODEL_INFERRED
+            )
+
+    def test_conservative_default_derives_to_maintainer_policy(self) -> None:
+        assert _entry("x", source=LedgerSource.CONSERVATIVE_DEFAULT).effective_provenance is (
+            DecisionProvenance.MAINTAINER_POLICY
+        )
+
+    def test_unmapped_source_falls_back_to_model_inferred(self) -> None:
+        # BLOCKER has no derivation; the safe fallback keeps it gated, not exempt.
+        assert _entry("x", source=LedgerSource.BLOCKER).effective_provenance is (
+            DecisionProvenance.MODEL_INFERRED
+        )
+
+
+class TestLedgerEntrySerialization:
+    def test_legacy_entry_round_trips_without_provenance_key(self) -> None:
+        data = _entry("x", source=LedgerSource.USER_GOAL).to_dict()
+        assert "provenance" not in data
+        assert LedgerEntry.from_dict(data).provenance is None
+
+    def test_stamped_entry_round_trips(self) -> None:
+        data = _entry(
+            "x", source=LedgerSource.ASSUMPTION, provenance=DecisionProvenance.TIMEOUT_DEFAULT
+        ).to_dict()
+        assert data["provenance"] == "timeout_default"
+        assert LedgerEntry.from_dict(data).provenance is DecisionProvenance.TIMEOUT_DEFAULT
+
+    def test_invalid_provenance_rejected(self) -> None:
+        data = _entry("x", source=LedgerSource.USER_GOAL).to_dict()
+        data["provenance"] = "not_a_real_origin"
+        try:
+            LedgerEntry.from_dict(data)
+        except ValueError as exc:
+            assert "provenance" in str(exc)
+        else:  # pragma: no cover - defensive
+            raise AssertionError("expected ValueError for invalid provenance")
+
+
+class TestProvenanceHistogram:
+    def test_counts_active_entries_by_origin(self) -> None:
+        ledger = _populate_complete_ledger()
+        histogram = ledger.provenance_histogram()
+        # Every filler + goal echo is USER_GOAL-sourced -> user_confirmed.
+        assert histogram.get("user_confirmed", 0) >= 9
+        assert "model_inferred" not in histogram
+
+    def test_excludes_inactive_entries(self) -> None:
+        ledger = SeedDraftLedger.from_goal("Goal.")
+        ledger.add_entry(
+            "constraints",
+            LedgerEntry(
+                key="constraints.weak",
+                value="ignored",
+                source=LedgerSource.ASSUMPTION,
+                confidence=0.5,
+                status=LedgerStatus.WEAK,
+            ),
+        )
+        assert "model_inferred" not in ledger.provenance_histogram()
+
+
+class TestStampSites:
+    def test_auto_fill_stamps_timeout_default(self) -> None:
+        ledger = SeedDraftLedger.from_goal("Build a thing.")
+
+        def fill_slot(section: str, _ledger: SeedDraftLedger) -> AutoFillProposal:
+            return AutoFillProposal(value=f"Deadline default for {section}.", confidence=0.6)
+
+        auto_fill_remaining(ledger, fill_slot=fill_slot)
+        stamped = [
+            entry
+            for section in ledger.sections.values()
+            for entry in section.entries
+            if entry.provenance is DecisionProvenance.TIMEOUT_DEFAULT
+        ]
+        assert stamped, "auto-fill must stamp timeout_default"
+
+    def test_safe_default_finalization_stamps_timeout_default(self) -> None:
+        ledger = SeedDraftLedger.from_goal("Build a CLI that prints hello.")
+        finalize_safe_defaultable_gaps(
+            ledger, goal="Build a CLI that prints hello.", provenance="auto interview max_rounds=5"
+        )
+        stamped = [
+            entry
+            for section in ledger.sections.values()
+            for entry in section.entries
+            if entry.provenance is DecisionProvenance.TIMEOUT_DEFAULT
+        ]
+        assert stamped, "safe-default finalization must stamp timeout_default"
+
+
+class TestUnverifiedProvenanceGate:
+    def _ledger_with_gated_acceptance(self, value: str) -> SeedDraftLedger:
+        ledger = _populate_complete_ledger()
+        for entry in ledger.sections["acceptance_criteria"].entries:
+            entry.status = LedgerStatus.WEAK
+        ledger.add_entry(
+            "acceptance_criteria",
+            LedgerEntry(
+                key="acceptance_criteria.inferred",
+                value=value,
+                source=LedgerSource.INFERENCE,  # -> model_inferred, gated
+                confidence=0.7,
+                status=LedgerStatus.CONFIRMED,
+            ),
+        )
+        return ledger
+
+    def test_clean_model_inferred_entry_passes(self) -> None:
+        ledger = self._ledger_with_gated_acceptance(
+            "CLI exits with code 0 and prints the greeting to stdout."
+        )
+        seed = synthesize_seed_from_ledger(ledger)
+        result = GradeGate().grade_seed(seed, ledger=ledger)
+        assert not any(f.code == "unverified_provenance" for f in result.findings)
+
+    def test_question_text_pollution_produces_finding(self) -> None:
+        # The #1485 signature: raw interview question text in a contract field.
+        ledger = self._ledger_with_gated_acceptance(
+            "What should happen when the argument is missing?"
+        )
+        seed = synthesize_seed_from_ledger(ledger)
+        result = GradeGate().grade_seed(seed, ledger=ledger)
+        provenance_findings = [f for f in result.findings if f.code == "unverified_provenance"]
+        assert provenance_findings
+        assert provenance_findings[0].severity == "medium"
+        # Repairable finding, never a hard blocker -> feeds the repair loop.
+        assert result.can_repair
+        assert not any(b.code == "unverified_provenance" for b in result.blockers)
+        assert result.grade is not SeedGrade.A
+
+    def test_gate_inert_without_ledger(self) -> None:
+        # Legacy/direct grade_seed callers pass no ledger -> no provenance check.
+        seed = synthesize_seed_from_ledger(_populate_complete_ledger())
+        result = GradeGate().grade_seed(seed)
+        assert not any(f.code == "unverified_provenance" for f in result.findings)
+
+
+class TestSeedMetadataSurface:
+    def test_synthesized_seed_carries_histogram(self) -> None:
+        seed = synthesize_seed_from_ledger(_populate_complete_ledger())
+        assert seed.metadata.decision_provenance.get("user_confirmed", 0) >= 9
+
+    def test_partial_seed_carries_histogram(self) -> None:
+        ledger = SeedDraftLedger.from_goal("Build a CLI that prints hello.")
+        seed = partial_seed_from_evidence(ledger, reason="interview_phase_deadline")
+        assert seed.metadata.decision_provenance  # non-empty (goal + hydrated sections)
+
+    def test_empty_histogram_omitted_from_json(self) -> None:
+        seed = Seed(
+            goal="A bare seed with no ledger provenance.",
+            ontology_schema=OntologySchema(name="Bare", description="No ledger."),
+            metadata=SeedMetadata(ambiguity_score=0.15),
+        )
+        assert seed.metadata.decision_provenance == {}
+        assert "decision_provenance" not in json.dumps(seed.to_dict())


### PR DESCRIPTION
## What & why (A1 — Provenance gate)

Work order A1 from `docs/run-metaharness-plan-2026-07.md`. Tag every seed-ledger decision with *how it was reached* and refuse to make a seed executable when a `model_inferred` / `timeout_default` decision fails a low-ambiguity gate. This makes the **#1485** failure — `interview_phase_deadline` producing a degraded seed whose contract fields contained raw **question text** — structurally impossible to auto-run: a timeout-defaulted decision is no longer indistinguishable from a user-confirmed one, and a polluted one now produces a repair-loop finding instead of silently executing.

## Substrate reality (extend, don't rebuild)

`LedgerEntry` **already** carries `source: LedgerSource`, but that is a *content-authority* axis (`user_goal` / `repo_fact` / `inference` / `conservative_default` / …), not the decision-origin axis A1 specifies. So rather than overload `source`, this adds an **orthogonal** `DecisionProvenance` dimension with exactly the five values, and derives it from `source` for the many writer sites the source axis already implies. `committed_decisions` / the ledger entry model live exactly where the plan described (`auto/ledger.py`) — no substrate mismatch.

## Stamp-site inventory (every writer of committed decisions → the origin it now carries)

| Writer site | LedgerSource | Effective `DecisionProvenance` | How |
|---|---|---|---|
| `ledger.from_goal` / `_hydrate_explicit_goal_sections` (goal + explicit goal facts) | `USER_GOAL` / `NON_GOAL` | `user_confirmed` | derived |
| `answerer.py` user/preference/non-goal answers | `USER_GOAL` / `USER_PREFERENCE` / `NON_GOAL` | `user_confirmed` | derived |
| `answerer.py` repo/convention facts | `REPO_FACT` / `EXISTING_CONVENTION` | `user_confirmed` (grounded/verified) | derived |
| `answerer.py` conservative defaults | `CONSERVATIVE_DEFAULT` | `maintainer_policy` | derived |
| `answerer.py` assumptions/inference | `ASSUMPTION` / `INFERENCE` | `model_inferred` (**gated**) | derived |
| `auto_fill.py` deadline non-convergence auto-fill | `AUTO_FILL_INFERENCE` | `timeout_default` (**gated**) | **explicit stamp** |
| `safe_defaults.py` `finalize_safe_defaultable_gaps` (max_rounds/deadline forced closure) | `ASSUMPTION` | `timeout_default` (**gated**) | **explicit stamp** |
| `seed_repairer.py` MVP non-goal fill | `NON_GOAL` | `user_confirmed` | derived |
| legacy / deserialized / any unmapped source (e.g. `BLOCKER`) | — | `model_inferred` (**gated**) | safe fallback |

**Derivation vs explicit stamp:** origins `source` cannot express — the deadline/max_rounds backstops (the exact #1485 class) — are stamped `timeout_default` at the decision point. Everything else derives from `source`, so no churn across ~20 answerer construction sites. `effective_provenance` returns the explicit stamp when present, else the derived value.

**`lateral_consensus`:** the enum value exists for direct lateral→ledger injection. In the current auto pipeline the stagnation-lateral decision re-enters through the interview backend transcript and is re-graded by the answerer's routing, so it derives to `model_inferred` — i.e. it is still **gated** (safe: a lateral best-guess is screened for low ambiguity). No silent-pass path.

## Gate semantics

- **Where:** `GradeGate.grade_seed(seed, ledger=…)` — the actual executability gate (`grade_ledger` has no non-test caller; the pipeline gates on `grade_seed.may_run` via `SeedReviewer`).
- **What:** for each **active** ledger entry whose `effective_provenance ∈ {model_inferred, timeout_default}`, apply a low-ambiguity criterion. Failing entries emit finding code **`unverified_provenance`**, severity **MEDIUM**, in `findings` (not `blockers`) — exactly mirroring how `missing_success_contract` was added: drops grade A→B, `can_repair=True`, feeds the repair loop, **never hard-blocks**.
- **"Low-ambiguity" concretely:** reuses the existing ambiguity machinery (`_is_vague`) plus the #1485 pollution signature — a value is high-ambiguity (fails) iff it is empty, contains `?` (raw interview question text), contains the deadline placeholder, or trips `_is_vague`. Deliberately high-precision: clean model-inferred/timeout-defaulted decisions (the common case) pass, so no existing grade flips.

## Legacy-session behavior (zero regression)

- Unstamped/legacy/deserialized entries default `provenance=None` → `effective_provenance` derives `model_inferred` (the safest honest value): they are **screened, not exempt**, but clean values pass the high-precision check, so no finding.
- `grade_seed` with `ledger=None` (legacy/direct callers) runs **no** provenance check.
- `LedgerEntry.to_dict` omits `provenance` when unset; `SeedMetadata.decision_provenance` is omitted from JSON when empty → legacy Seed JSON round-trips **byte-identically** (fixes the one round-trip test that would otherwise have flipped).

## Surface (for A2)

`SeedMetadata.decision_provenance: dict[str,int]` — a histogram (`{user_confirmed: N, model_inferred: M, timeout_default: K, …}`) populated on both `synthesize_seed_from_ledger` and `partial_seed_from_evidence`, so the A2 trace artifact can grep how many gated decisions a seed rests on. Additive; omitted when empty.

## Validation

- `uv run ruff check .` ✅ · `uv run ruff format --check .` ✅ (1025 files) · `uv run mypy src/` ✅ (425 files)
- `tests/ --ignore e2e/mcp -q`: **10125 passed, 5 skipped, 6 failed** — the 6 failures are the pre-existing codex-config-leak set (`test_surface` ×4 + `test_auto_runtime_dispatch` ×2), verified identical on clean `origin/main` via `git stash`.
- New: `tests/unit/auto/test_provenance_gate.py` — **18 tests** (derivation, explicit-stamp-wins, legacy round-trip, invalid-value rejection, histogram, both stamp sites, gate fires on question-text / passes on clean / inert without ledger, metadata surface).

## Files changed

`src/ouroboros/auto/{ledger,grading,auto_fill,safe_defaults,ledger_seed}.py`, `src/ouroboros/core/seed.py`, `tests/unit/auto/test_provenance_gate.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## R-run comparison

Substrate-only PR: adds provenance tagging on existing ledger writes and a deterministic
(regex/string-check) grading pass — no LLM calls, no per-round loop changes. No per-round
comparison is applicable; cells filled `N/A` per the template's substrate-only rule.

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [x] N/A (substrate-only: deterministic gate, no round-loop impact)
