### PR TITLE
feat(auto): A2 interview trace artifact — greppable per-run projection over EventStore + ledger

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -66,6 +66,7 @@ from ouroboros.auto.state import (
     utc_now_iso,
 )
 from ouroboros.auto.task_class_application import apply_default_ac_template
+from ouroboros.auto.trace_export import best_effort_export_trace
 from ouroboros.core.seed import Seed
 from ouroboros.orchestrator.runtime_evidence import RuntimeEvidence
 from ouroboros.resilience.lateral import ThinkingPersona
@@ -477,8 +478,43 @@ class AutoPipeline:
     # of the ``probe_runner`` callback so multiple ``_result()`` returns
     # within a single run share the same evidence tuple.
     _last_probe_evidence: tuple[RuntimeEvidence, ...] = field(default=(), init=False, repr=False)
+    # A2 / run-metaharness trace artifact. ``run()`` recurses (resume paths do
+    # ``return await self.run(state)``); the depth counter fires the finalize
+    # trace export exactly once, at the outermost terminal return.
+    # ``_active_ledger`` is the live ledger the deepest ``_run_pipeline`` frame
+    # actually mutated, so the export projects the freshest decisions/history.
+    _run_depth: int = field(default=0, init=False, repr=False)
+    _active_ledger: SeedDraftLedger | None = field(default=None, init=False, repr=False)
 
     async def run(self, state: AutoPipelineState) -> AutoPipelineResult:
+        """Run the pipeline and, once at the outermost terminal, export a trace.
+
+        Thin re-entrancy-aware wrapper around :meth:`_run_pipeline`. The auto
+        pipeline recurses through ``run`` on resume boundaries; the depth
+        counter ensures the best-effort A2 interview-trace projection runs a
+        single time at the outermost frame when the session is terminal. The
+        export never raises into the run (see
+        :func:`ouroboros.auto.trace_export.best_effort_export_trace`).
+        """
+        self._run_depth += 1
+        try:
+            result = await self._run_pipeline(state)
+        finally:
+            self._run_depth -= 1
+        if self._run_depth == 0 and state.is_terminal():
+            await best_effort_export_trace(
+                state,
+                self._active_ledger
+                or (
+                    SeedDraftLedger.from_dict(state.ledger)
+                    if state.ledger
+                    else SeedDraftLedger.from_goal(state.goal)
+                ),
+                event_store=getattr(self.interview_driver, "event_store", None),
+            )
+        return result
+
+    async def _run_pipeline(self, state: AutoPipelineState) -> AutoPipelineResult:
         """Run a bounded auto pipeline using injected side-effecting dependencies."""
         self._last_emitted_phase = None
         self._last_emitted_grade = None
@@ -497,6 +533,9 @@ class AutoPipeline:
             if state.ledger
             else SeedDraftLedger.from_goal(state.goal)
         )
+        # A2 trace export: expose the live ledger to the outermost ``run()``
+        # wrapper so the finalize projection uses the freshest decisions.
+        self._active_ledger = ledger
         # L2-2 / #1172: wall-clock watchdog check.
         # Runs once per ``run()`` entry — both fresh sessions whose
         # ``created_at`` is too long ago (resume after budget elapsed)

--- a/src/ouroboros/auto/trace_export.py
+++ b/src/ouroboros/auto/trace_export.py
@@ -1,0 +1,597 @@
+"""Greppable per-run interview trace artifact (A2 / run-metaharness plan).
+
+This module is a **projection**, not a store. It reads from two durable
+sources that already exist by the time an ``ooo auto`` run finalizes:
+
+* the auto :class:`~ouroboros.auto.ledger.SeedDraftLedger` — question history,
+  every decided contract field with its ``source`` / ``status`` /
+  ``provenance`` (A1 / #1579), and the decision-origin histogram; and
+* the :class:`~ouroboros.persistence.event_store.EventStore` — the interview
+  event stream (ambiguity-score trajectory, lateral advisories, and the
+  timeout / fallback / degraded lifecycle events the driver appends).
+
+The projection writes plain, grep-able files under
+``<cwd>/.ouroboros/traces/<run_id>/`` (``run_id`` == ``auto_session_id``):
+one JSONL file per stream plus a human ``summary.md``. Empty streams omit
+their file. Every JSONL line is self-describing via a ``type`` field and is
+derived purely from persisted state + stored events (no wall-clock stamps),
+so re-export is **byte-idempotent**: it overwrites deterministically.
+
+Two entry points:
+
+* :func:`export_interview_trace` — manual / A3-CLI entry that loads a past
+  run from :class:`~ouroboros.auto.state.AutoStore` + the EventStore and
+  projects it. Callable for any ``run_id`` whose state is persisted.
+* :func:`best_effort_export_trace` — the pipeline-finalize hook. Wrapped so
+  a projection failure only logs and never raises into the run.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from ouroboros.auto.ledger import (
+    DecisionProvenance,
+    LedgerStatus,
+    SeedDraftLedger,
+)
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from ouroboros.auto.state import AutoPipelineState, AutoStore
+    from ouroboros.persistence.event_store import EventStore
+
+log = structlog.get_logger(__name__)
+
+# --- stream filenames (stable public contract for A3 / grep tooling) --------
+QUESTIONS_FILE = "questions.jsonl"
+AMBIGUITY_FILE = "ambiguity.jsonl"
+LATERAL_FILE = "lateral.jsonl"
+DECISIONS_FILE = "decisions.jsonl"
+FLAGS_FILE = "flags.jsonl"
+OUTCOME_FILE = "outcome.json"
+SUMMARY_FILE = "summary.md"
+
+_ALL_STREAM_FILES: tuple[str, ...] = (
+    QUESTIONS_FILE,
+    AMBIGUITY_FILE,
+    LATERAL_FILE,
+    DECISIONS_FILE,
+    FLAGS_FILE,
+    OUTCOME_FILE,
+    SUMMARY_FILE,
+)
+
+# Entry statuses that mean a decision was *superseded / unresolved* — the
+# "rejected" half of promoted-vs-rejected. Mirrors ``ledger._INACTIVE_STATUSES``.
+_REJECTED_STATUSES: frozenset[LedgerStatus] = frozenset(
+    {LedgerStatus.WEAK, LedgerStatus.CONFLICTING, LedgerStatus.BLOCKED}
+)
+
+# Decision origins that must pass the A1 low-ambiguity gate before executing.
+_GATED_PROVENANCE: frozenset[DecisionProvenance] = frozenset(
+    {DecisionProvenance.MODEL_INFERRED, DecisionProvenance.TIMEOUT_DEFAULT}
+)
+
+# Event-type substrings that classify an event into the ``lateral`` stream.
+_LATERAL_MARKERS: tuple[str, ...] = ("lateral", "unstuck", "stagnation")
+
+# Event-type substrings that classify an event into the ``flags`` stream —
+# timeout / fallback / degraded lifecycle signals worth an audit line.
+_FLAG_MARKERS: tuple[str, ...] = (
+    "timeout",
+    "timed_out",
+    "fallback",
+    "failed",
+    "deadline",
+    "degraded",
+    "safe_default",
+    "closure",
+    "blocked",
+    "intent_guard",
+    "parent_handoff",
+    "nonclosure",
+    "synthesis_failed",
+    "persistence_probe",
+    "unsafe",
+)
+
+# Cap projected string payloads so a runaway answer/decision cannot bloat a
+# trace file. The ledger already truncates its own text; this bounds anything
+# passed straight through from event payloads.
+_MAX_TEXT = 2000
+
+
+def _clip(value: Any) -> Any:
+    if isinstance(value, str) and len(value) > _MAX_TEXT:
+        return value[: _MAX_TEXT - 15].rstrip() + " ... (truncated)"
+    return value
+
+
+def _clip_data(data: dict[str, Any]) -> dict[str, Any]:
+    return {key: _clip(val) for key, val in data.items()}
+
+
+def _event_iso(event: Any) -> str | None:
+    ts = getattr(event, "timestamp", None)
+    if ts is None:
+        return None
+    isoformat = getattr(ts, "isoformat", None)
+    return isoformat() if callable(isoformat) else str(ts)
+
+
+async def _gather_events(
+    event_store: EventStore | None,
+    aggregate_ids: tuple[str, ...],
+) -> list[Any]:
+    """Return stored events for ``aggregate_ids`` ordered oldest-first.
+
+    Best-effort: any per-aggregate query failure is swallowed so a partial
+    event stream still produces a partial trace instead of no trace.
+    """
+    if event_store is None:
+        return []
+    collected: list[Any] = []
+    for aggregate_id in aggregate_ids:
+        if not aggregate_id:
+            continue
+        try:
+            events = await event_store.query_events(aggregate_id=aggregate_id, limit=2000)
+        except Exception as exc:  # pragma: no cover - defensive; store may be closed
+            log.warning(
+                "auto.trace_export.event_query_failed",
+                aggregate_id=aggregate_id,
+                error=str(exc),
+            )
+            continue
+        collected.extend(events)
+    # ``query_events`` returns newest-first; a stable ascending sort by
+    # timestamp gives a readable, deterministic trajectory.
+    collected.sort(key=lambda e: (getattr(e, "timestamp", None) is None, _event_iso(e) or ""))
+    return collected
+
+
+def _classify_event(event_type: str) -> str:
+    """Route an event type to a stream: ``lateral`` | ``flag`` | ``other``.
+
+    Ambiguity classification is handled separately (payload-driven) so an
+    event carrying an ``ambiguity_score`` lands in the ambiguity stream
+    regardless of its type name.
+    """
+    lowered = event_type.lower()
+    if any(marker in lowered for marker in _LATERAL_MARKERS):
+        return "lateral"
+    if any(marker in lowered for marker in _FLAG_MARKERS):
+        return "flag"
+    return "other"
+
+
+def _build_question_lines(
+    ledger: SeedDraftLedger,
+    events: list[Any],
+) -> list[dict[str, Any]]:
+    lines: list[dict[str, Any]] = []
+    for index, qa in enumerate(ledger.question_history, start=1):
+        lines.append(
+            {
+                "type": "question",
+                "round": index,
+                "question": _clip(qa.get("question", "")),
+                "answer": _clip(qa.get("answer", "")),
+            }
+        )
+    # Enrich with event-store response records (the true round numbers, and the
+    # only Q/A surface for cross-provider runs whose ledger history is sparse).
+    for event in events:
+        if getattr(event, "type", "") != "interview.response.recorded":
+            continue
+        data = getattr(event, "data", {}) or {}
+        lines.append(
+            {
+                "type": "response_event",
+                "round": data.get("round_number"),
+                "question_preview": _clip(data.get("question_preview", "")),
+                "response_preview": _clip(data.get("response_preview", "")),
+                "at": _event_iso(event),
+            }
+        )
+    return lines
+
+
+def _build_ambiguity_lines(events: list[Any]) -> list[dict[str, Any]]:
+    lines: list[dict[str, Any]] = []
+    for event in events:
+        data = getattr(event, "data", {}) or {}
+        if "ambiguity_score" not in data:
+            continue
+        lines.append(
+            {
+                "type": "ambiguity",
+                "event": getattr(event, "type", ""),
+                "at": _event_iso(event),
+                "round": data.get("round_number"),
+                "ambiguity_score": data.get("ambiguity_score"),
+                "data": _clip_data(data),
+            }
+        )
+    return lines
+
+
+def _build_lateral_lines(
+    state: AutoPipelineState,
+    events: list[Any],
+) -> list[dict[str, Any]]:
+    lines: list[dict[str, Any]] = []
+    for event in events:
+        data = getattr(event, "data", {}) or {}
+        if "ambiguity_score" in data:
+            # Already captured as an ambiguity trajectory point.
+            continue
+        if _classify_event(getattr(event, "type", "")) != "lateral":
+            continue
+        lines.append(
+            {
+                "type": "lateral",
+                "event": getattr(event, "type", ""),
+                "at": _event_iso(event),
+                "data": _clip_data(data),
+            }
+        )
+    if state.last_lateral_persona or state.last_lateral_text:
+        lines.append(
+            {
+                "type": "lateral_final",
+                "persona": state.last_lateral_persona,
+                "approach_summary": _clip(state.last_lateral_approach_summary or ""),
+                "text": _clip(state.last_lateral_text or ""),
+            }
+        )
+    return lines
+
+
+def _build_decision_lines(ledger: SeedDraftLedger) -> list[dict[str, Any]]:
+    lines: list[dict[str, Any]] = []
+    for section_name, section in ledger.sections.items():
+        for entry in section.entries:
+            status = entry.status
+            status_value = status.value if isinstance(status, LedgerStatus) else str(status)
+            source = entry.source
+            source_value = getattr(source, "value", None) or str(source)
+            provenance = entry.effective_provenance
+            promoted = status not in _REJECTED_STATUSES
+            lines.append(
+                {
+                    "type": "decision",
+                    "section": section_name,
+                    "key": entry.key,
+                    "value": _clip(entry.value),
+                    "source": source_value,
+                    "provenance": provenance.value,
+                    "status": status_value,
+                    "promoted": promoted,
+                    "gated": provenance in _GATED_PROVENANCE,
+                    "confidence": entry.confidence,
+                }
+            )
+    return lines
+
+
+def _build_flag_lines(
+    state: AutoPipelineState,
+    ledger: SeedDraftLedger,
+    events: list[Any],
+) -> list[dict[str, Any]]:
+    lines: list[dict[str, Any]] = []
+    for event in events:
+        data = getattr(event, "data", {}) or {}
+        if "ambiguity_score" in data:
+            continue
+        event_type = getattr(event, "type", "")
+        classification = _classify_event(event_type)
+        if classification != "flag":
+            continue
+        lines.append(
+            {
+                "type": "event_flag",
+                "event": event_type,
+                "at": _event_iso(event),
+                "data": _clip_data(data),
+            }
+        )
+    # Derived state flags — the durable end-of-run signals that are not
+    # individual events.
+    lines.append({"type": "state_flag", "kind": "terminal_phase", "value": state.phase.value})
+    if state.interview_closure_mode:
+        lines.append(
+            {
+                "type": "state_flag",
+                "kind": "interview_closure_mode",
+                "value": state.interview_closure_mode,
+            }
+        )
+    seed_meta = _seed_metadata(state)
+    if seed_meta.get("degraded"):
+        lines.append(
+            {
+                "type": "state_flag",
+                "kind": "degraded_seed",
+                "value": True,
+                "recovery_reason": seed_meta.get("recovery_reason"),
+                "unresolved_slots": list(seed_meta.get("unresolved_slots", ()) or ()),
+            }
+        )
+    if state.last_error:
+        lines.append(
+            {
+                "type": "state_flag",
+                "kind": "blocker",
+                "value": _clip(state.last_error),
+                "stop_reason_code": state.last_error_code,
+            }
+        )
+    open_gaps = ledger.open_gaps()
+    if open_gaps:
+        lines.append({"type": "state_flag", "kind": "open_gaps", "value": list(open_gaps)})
+    return lines
+
+
+def _seed_metadata(state: AutoPipelineState) -> dict[str, Any]:
+    artifact = state.seed_artifact or {}
+    if not isinstance(artifact, dict):
+        return {}
+    meta = artifact.get("metadata", {})
+    return meta if isinstance(meta, dict) else {}
+
+
+def _gate_findings(state: AutoPipelineState) -> list[dict[str, Any]]:
+    findings: list[dict[str, Any]] = []
+    for finding in state.findings:
+        if isinstance(finding, dict):
+            findings.append(finding)
+    return findings
+
+
+def _build_outcome(
+    state: AutoPipelineState,
+    ledger: SeedDraftLedger,
+    counts: dict[str, int],
+) -> dict[str, Any]:
+    seed_meta = _seed_metadata(state)
+    findings = _gate_findings(state)
+    return {
+        "run_id": state.auto_session_id,
+        "auto_session_id": state.auto_session_id,
+        "status": state.phase.value,
+        "phase": state.phase.value,
+        "grade": state.last_grade,
+        "seed_id": state.seed_id,
+        "seed_path": state.seed_path,
+        "seed_origin": state.seed_origin.value,
+        "interview_session_id": state.interview_session_id,
+        "interview_closure_mode": state.interview_closure_mode,
+        "qa": {
+            "verdict": state.last_qa_verdict,
+            "score": state.last_qa_score,
+            "passed": state.last_qa_passed,
+            "differences": list(state.last_qa_differences),
+            "suggestions": list(state.last_qa_suggestions),
+        },
+        "provenance_histogram": ledger.provenance_histogram(),
+        "seed_decision_provenance": seed_meta.get("decision_provenance", {}),
+        "gate_findings": findings,
+        "unverified_provenance_findings": [
+            f for f in findings if f.get("code") == "unverified_provenance"
+        ],
+        "assumptions": [_clip(v) for v in ledger.assumptions()],
+        "non_goals": [_clip(v) for v in ledger.non_goals()],
+        "open_gaps": ledger.open_gaps(),
+        "blocker": _clip(state.last_error) if state.last_error else None,
+        "stop_reason_code": state.last_error_code,
+        "degraded": bool(seed_meta.get("degraded")),
+        "counts": counts,
+    }
+
+
+def _build_summary_md(outcome: dict[str, Any], counts: dict[str, int]) -> str:
+    lines: list[str] = []
+    lines.append(f"# Interview trace — {outcome['run_id']}")
+    lines.append("")
+    lines.append(f"- Status: **{outcome['status']}**")
+    lines.append(f"- Grade: {outcome['grade'] or 'n/a'}")
+    lines.append(f"- Seed: {outcome['seed_id'] or 'n/a'} (origin: {outcome['seed_origin']})")
+    if outcome["interview_closure_mode"]:
+        lines.append(f"- Interview closure mode: {outcome['interview_closure_mode']}")
+    qa = outcome["qa"]
+    if qa["verdict"] is not None or qa["score"] is not None:
+        lines.append(
+            f"- Evaluate/QA: verdict={qa['verdict'] or 'n/a'} "
+            f"score={qa['score'] if qa['score'] is not None else 'n/a'} "
+            f"passed={qa['passed']}"
+        )
+    if outcome["blocker"]:
+        lines.append(f"- Blocker: {outcome['blocker']}")
+    lines.append("")
+    lines.append("## Counts")
+    lines.append("")
+    lines.append(f"- Questions: {counts['questions']}")
+    lines.append(
+        f"- Decisions: {counts['decisions']} "
+        f"(promoted {counts['promoted']}, rejected {counts['rejected']}, "
+        f"gated {counts['gated']})"
+    )
+    lines.append(f"- Ambiguity points: {counts['ambiguity']}")
+    lines.append(f"- Lateral records: {counts['lateral']}")
+    lines.append(f"- Flags: {counts['flags']}")
+    lines.append("")
+    lines.append("## Decision provenance histogram")
+    lines.append("")
+    histogram = outcome["provenance_histogram"]
+    if histogram:
+        for provenance, count in histogram.items():
+            lines.append(f"- {provenance}: {count}")
+    else:
+        lines.append("- (none)")
+    unverified = outcome["unverified_provenance_findings"]
+    if unverified:
+        lines.append("")
+        lines.append("## Unverified provenance findings (gate)")
+        lines.append("")
+        for finding in unverified:
+            lines.append(f"- {finding.get('target', '')}: {finding.get('message', '')}")
+    if outcome["open_gaps"]:
+        lines.append("")
+        lines.append("## Open gaps")
+        lines.append("")
+        for gap in outcome["open_gaps"]:
+            lines.append(f"- {gap}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+    payload = "\n".join(json.dumps(row, ensure_ascii=False, sort_keys=True) for row in rows)
+    path.write_text(payload + "\n", encoding="utf-8")
+
+
+def _remove_if_exists(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _resolve_out_root(state: AutoPipelineState, out_root: Path | None) -> Path:
+    if out_root is not None:
+        return Path(out_root)
+    base = Path(state.cwd).expanduser() if state.cwd else Path.cwd()
+    return base / ".ouroboros" / "traces" / state.auto_session_id
+
+
+async def export_trace_from_state(
+    state: AutoPipelineState,
+    ledger: SeedDraftLedger,
+    *,
+    event_store: EventStore | None,
+    out_root: Path | None = None,
+) -> Path:
+    """Project a completed run's state + ledger + events into trace files.
+
+    Writes into ``out_root`` (default ``<cwd>/.ouroboros/traces/<run_id>/``)
+    and returns that directory. Empty streams omit (and clear any stale) file.
+    Idempotent: content is derived only from persisted state and stored
+    events, so re-export is byte-identical.
+    """
+    aggregate_ids: tuple[str, ...] = tuple(
+        agg for agg in (state.auto_session_id, state.interview_session_id) if agg
+    )
+    events = await _gather_events(event_store, aggregate_ids)
+
+    question_lines = _build_question_lines(ledger, events)
+    ambiguity_lines = _build_ambiguity_lines(events)
+    lateral_lines = _build_lateral_lines(state, events)
+    decision_lines = _build_decision_lines(ledger)
+    flag_lines = _build_flag_lines(state, ledger, events)
+
+    counts = {
+        "questions": len(question_lines),
+        "decisions": len(decision_lines),
+        "promoted": sum(1 for line in decision_lines if line["promoted"]),
+        "rejected": sum(1 for line in decision_lines if not line["promoted"]),
+        "gated": sum(1 for line in decision_lines if line["gated"]),
+        "ambiguity": len(ambiguity_lines),
+        "lateral": len(lateral_lines),
+        "flags": len(flag_lines),
+    }
+    outcome = _build_outcome(state, ledger, counts)
+    summary_md = _build_summary_md(outcome, counts)
+
+    out_dir = _resolve_out_root(state, out_root)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    streams: dict[str, list[dict[str, Any]]] = {
+        QUESTIONS_FILE: question_lines,
+        AMBIGUITY_FILE: ambiguity_lines,
+        LATERAL_FILE: lateral_lines,
+        DECISIONS_FILE: decision_lines,
+        FLAGS_FILE: flag_lines,
+    }
+    for filename, rows in streams.items():
+        path = out_dir / filename
+        if rows:
+            _write_jsonl(path, rows)
+        else:
+            _remove_if_exists(path)
+
+    (out_dir / OUTCOME_FILE).write_text(
+        json.dumps(outcome, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / SUMMARY_FILE).write_text(summary_md, encoding="utf-8")
+
+    log.info(
+        "auto.trace_export.written",
+        auto_session_id=state.auto_session_id,
+        out_dir=str(out_dir),
+        **counts,
+    )
+    return out_dir
+
+
+async def export_interview_trace(
+    run_id: str,
+    *,
+    auto_store: AutoStore,
+    event_store: EventStore | None,
+    out_root: Path | None = None,
+) -> Path | None:
+    """Manual / A3-CLI entry: project a *past* run from persisted state.
+
+    Loads ``run_id`` from ``auto_store`` (raising :class:`ValueError` for an
+    unknown or corrupt session, matching :meth:`AutoStore.load`), reconstructs
+    its ledger, and delegates to :func:`export_trace_from_state`. Returns the
+    trace directory, or ``None`` if the persisted state carries no ledger and
+    no goal to seed one from.
+    """
+    state = auto_store.load(run_id)
+    ledger = (
+        SeedDraftLedger.from_dict(state.ledger)
+        if state.ledger
+        else SeedDraftLedger.from_goal(state.goal)
+    )
+    return await export_trace_from_state(
+        state,
+        ledger,
+        event_store=event_store,
+        out_root=out_root,
+    )
+
+
+async def best_effort_export_trace(
+    state: AutoPipelineState,
+    ledger: SeedDraftLedger,
+    *,
+    event_store: EventStore | None,
+    out_root: Path | None = None,
+) -> Path | None:
+    """Pipeline-finalize hook: export the trace, never raising into the run.
+
+    Any failure — event-store query, filesystem, serialization — is logged and
+    swallowed so trace generation cannot affect the auto pipeline's outcome.
+    """
+    try:
+        return await export_trace_from_state(
+            state,
+            ledger,
+            event_store=event_store,
+            out_root=out_root,
+        )
+    except Exception as exc:  # noqa: BLE001 - best-effort by contract
+        log.warning(
+            "auto.trace_export.failed",
+            auto_session_id=getattr(state, "auto_session_id", None),
+            error=str(exc),
+        )
+        return None

--- a/tests/unit/auto/test_trace_export.py
+++ b/tests/unit/auto/test_trace_export.py
@@ -1,0 +1,338 @@
+"""A2 interview-trace projection over EventStore + auto ledger."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+import json
+from pathlib import Path
+import types
+
+import pytest
+
+from ouroboros.auto.ledger import (
+    DecisionProvenance,
+    LedgerEntry,
+    LedgerSource,
+    LedgerStatus,
+    SeedDraftLedger,
+)
+from ouroboros.auto.pipeline import AutoPipeline
+from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
+from ouroboros.auto.trace_export import (
+    best_effort_export_trace,
+    export_interview_trace,
+    export_trace_from_state,
+)
+from ouroboros.events.base import BaseEvent
+
+_BASE_TS = datetime(2026, 7, 7, 12, 0, 0, tzinfo=UTC)
+
+
+class _FakeEventStore:
+    """Minimal EventStore stand-in exposing ``query_events`` newest-first."""
+
+    def __init__(self, events: list[BaseEvent], *, raise_on: str | None = None) -> None:
+        self._events = events
+        self._raise_on = raise_on
+
+    async def query_events(
+        self,
+        aggregate_id: str | None = None,
+        event_type: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[BaseEvent]:
+        if self._raise_on is not None and aggregate_id == self._raise_on:
+            raise RuntimeError("boom")
+        rows = [e for e in self._events if aggregate_id is None or e.aggregate_id == aggregate_id]
+        # Real store returns newest-first; the projection re-sorts ascending.
+        return sorted(rows, key=lambda e: e.timestamp, reverse=True)
+
+
+def _event(offset: int, event_type: str, aggregate_id: str, data: dict) -> BaseEvent:
+    return BaseEvent(
+        type=event_type,
+        timestamp=_BASE_TS + timedelta(seconds=offset),
+        aggregate_type="interview",
+        aggregate_id=aggregate_id,
+        data=data,
+    )
+
+
+def _populated_ledger() -> SeedDraftLedger:
+    ledger = SeedDraftLedger.from_goal("build a widget")
+    ledger.record_qa("What runtime?", "python 3.12")
+    ledger.record_qa("What output format?", "json")
+    # Promoted, evidence-backed decision.
+    ledger.add_entry(
+        "outputs",
+        LedgerEntry(
+            key="outputs.format",
+            value="json lines",
+            source=LedgerSource.USER_PREFERENCE,
+            confidence=0.9,
+            status=LedgerStatus.CONFIRMED,
+        ),
+    )
+    # Promoted but gated (timeout-defaulted) decision.
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.latency",
+            value="best effort",
+            source=LedgerSource.CONSERVATIVE_DEFAULT,
+            confidence=0.5,
+            status=LedgerStatus.DEFAULTED,
+            provenance=DecisionProvenance.TIMEOUT_DEFAULT,
+        ),
+    )
+    # Rejected (superseded) decision.
+    ledger.add_entry(
+        "constraints",
+        LedgerEntry(
+            key="constraints.old",
+            value="stale",
+            source=LedgerSource.INFERENCE,
+            confidence=0.3,
+            status=LedgerStatus.WEAK,
+        ),
+    )
+    return ledger
+
+
+def _terminal_state(tmp_path: Path) -> AutoPipelineState:
+    state = AutoPipelineState(goal="build a widget", cwd=str(tmp_path))
+    state.interview_session_id = "int_abc"
+    state.phase = AutoPhase.COMPLETE
+    state.last_grade = "A"
+    state.seed_id = "seed_xyz"
+    state.interview_closure_mode = "ledger_only"
+    state.last_qa_verdict = "pass"
+    state.last_qa_score = 0.95
+    state.last_qa_passed = True
+    return state
+
+
+def _events_for(state: AutoPipelineState) -> list[BaseEvent]:
+    aid = state.auto_session_id
+    iid = state.interview_session_id or ""
+    return [
+        _event(
+            0,
+            "interview.response.recorded",
+            iid,
+            {
+                "round_number": 1,
+                "question_preview": "What runtime?",
+                "response_preview": "python 3.12",
+            },
+        ),
+        _event(
+            1,
+            "interview.lateral_review.recommended",
+            iid,
+            {"ambiguity_score": 0.6, "round_number": 1, "from_milestone": "a", "to_milestone": "b"},
+        ),
+        _event(
+            2,
+            "interview.lateral_review.recommended",
+            iid,
+            {"ambiguity_score": 0.3, "round_number": 2},
+        ),
+        _event(
+            3,
+            "auto.interview.stagnation.lateral_invoked",
+            aid,
+            {"persona": "contrarian", "directive": "decide the CSV dialect"},
+        ),
+        _event(
+            4,
+            "auto.interview.backend_start_failed_ledger_fallback",
+            aid,
+            {"reason": "provider down"},
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_export_produces_all_streams(tmp_path: Path) -> None:
+    state = _terminal_state(tmp_path)
+    ledger = _populated_ledger()
+    store = _FakeEventStore(_events_for(state))
+
+    out_dir = await export_trace_from_state(state, ledger, event_store=store)
+
+    assert out_dir == tmp_path / ".ouroboros" / "traces" / state.auto_session_id
+    files = {p.name for p in out_dir.iterdir()}
+    assert {
+        "questions.jsonl",
+        "ambiguity.jsonl",
+        "lateral.jsonl",
+        "decisions.jsonl",
+        "flags.jsonl",
+        "outcome.json",
+        "summary.md",
+    } <= files
+
+    # questions: two ledger Q/A lines + one response_event line.
+    q_lines = [json.loads(x) for x in (out_dir / "questions.jsonl").read_text().splitlines()]
+    assert [ln["type"] for ln in q_lines].count("question") == 2
+    assert any(ln["type"] == "response_event" and ln["round"] == 1 for ln in q_lines)
+
+    # ambiguity trajectory ascending in time.
+    amb = [json.loads(x) for x in (out_dir / "ambiguity.jsonl").read_text().splitlines()]
+    assert [ln["ambiguity_score"] for ln in amb] == [0.6, 0.3]
+
+    # lateral: the stagnation event + the persona directive survive.
+    lat = (out_dir / "lateral.jsonl").read_text()
+    assert "contrarian" in lat and "decide the CSV dialect" in lat
+
+
+@pytest.mark.asyncio
+async def test_decisions_promoted_rejected_and_gated(tmp_path: Path) -> None:
+    state = _terminal_state(tmp_path)
+    ledger = _populated_ledger()
+
+    out_dir = await export_trace_from_state(state, ledger, event_store=None)
+
+    decisions = [json.loads(x) for x in (out_dir / "decisions.jsonl").read_text().splitlines()]
+    by_key = {d["key"]: d for d in decisions}
+    assert by_key["outputs.format"]["promoted"] is True
+    assert by_key["outputs.format"]["gated"] is False
+    assert by_key["constraints.latency"]["promoted"] is True
+    assert by_key["constraints.latency"]["provenance"] == "timeout_default"
+    assert by_key["constraints.latency"]["gated"] is True
+    assert by_key["constraints.old"]["promoted"] is False
+
+
+@pytest.mark.asyncio
+async def test_outcome_surfaces_histogram_and_gate_findings(tmp_path: Path) -> None:
+    state = _terminal_state(tmp_path)
+    state.findings = [
+        {
+            "code": "unverified_provenance",
+            "severity": "medium",
+            "message": "gated decision not verified",
+            "target": "constraints.latency",
+            "repair_instruction": "confirm",
+        },
+        {
+            "code": "other",
+            "severity": "low",
+            "message": "x",
+            "target": "",
+            "repair_instruction": "",
+        },
+    ]
+    ledger = _populated_ledger()
+
+    out_dir = await export_trace_from_state(state, ledger, event_store=None)
+    outcome = json.loads((out_dir / "outcome.json").read_text())
+
+    assert outcome["run_id"] == state.auto_session_id
+    assert outcome["grade"] == "A"
+    assert outcome["qa"]["verdict"] == "pass"
+    assert outcome["provenance_histogram"].get("timeout_default") == 1
+    assert len(outcome["unverified_provenance_findings"]) == 1
+    assert outcome["counts"]["decisions"] == len(
+        (out_dir / "decisions.jsonl").read_text().splitlines()
+    )
+    # summary.md mentions the histogram + gate finding.
+    summary = (out_dir / "summary.md").read_text()
+    assert "timeout_default" in summary
+    assert "constraints.latency" in summary
+
+
+@pytest.mark.asyncio
+async def test_empty_streams_are_omitted_and_cleared(tmp_path: Path) -> None:
+    state = _terminal_state(tmp_path)
+    ledger = SeedDraftLedger.from_goal("build a widget")  # no decisions beyond goal echo
+
+    out_dir = await export_trace_from_state(state, ledger, event_store=None)
+    # No events → no ambiguity/lateral files.
+    assert not (out_dir / "ambiguity.jsonl").exists()
+    assert not (out_dir / "lateral.jsonl").exists()
+
+    # Re-export with a stale ambiguity file present → it is cleared.
+    (out_dir / "ambiguity.jsonl").write_text("stale\n")
+    await export_trace_from_state(state, ledger, event_store=None)
+    assert not (out_dir / "ambiguity.jsonl").exists()
+
+
+@pytest.mark.asyncio
+async def test_reexport_is_byte_idempotent(tmp_path: Path) -> None:
+    state = _terminal_state(tmp_path)
+    ledger = _populated_ledger()
+    store = _FakeEventStore(_events_for(state))
+
+    out_dir = await export_trace_from_state(state, ledger, event_store=store)
+    first = {p.name: p.read_bytes() for p in out_dir.iterdir()}
+    await export_trace_from_state(state, ledger, event_store=store)
+    second = {p.name: p.read_bytes() for p in out_dir.iterdir()}
+
+    assert first == second
+
+
+@pytest.mark.asyncio
+async def test_export_interview_trace_from_store(tmp_path: Path) -> None:
+    store_dir = tmp_path / "data"
+    auto_store = AutoStore(store_dir)
+    state = _terminal_state(tmp_path)
+    state.ledger = _populated_ledger().to_dict()
+    auto_store.save(state)
+
+    event_store = _FakeEventStore(_events_for(state))
+    out_dir = await export_interview_trace(
+        state.auto_session_id, auto_store=auto_store, event_store=event_store
+    )
+
+    assert out_dir is not None
+    decisions = (out_dir / "decisions.jsonl").read_text()
+    assert "outputs.format" in decisions
+
+
+@pytest.mark.asyncio
+async def test_gather_swallows_per_aggregate_query_error(tmp_path: Path) -> None:
+    state = _terminal_state(tmp_path)
+    ledger = _populated_ledger()
+    # Raise for the interview aggregate; auto aggregate still projects.
+    store = _FakeEventStore(_events_for(state), raise_on=state.interview_session_id)
+
+    out_dir = await export_trace_from_state(state, ledger, event_store=store)
+    # Still wrote files despite the interview-aggregate query failure.
+    assert (out_dir / "decisions.jsonl").exists()
+    lat = (out_dir / "lateral.jsonl").read_text()
+    assert "contrarian" in lat  # auto-aggregate lateral event survived
+
+
+@pytest.mark.asyncio
+async def test_best_effort_swallows_failure(tmp_path: Path) -> None:
+    # cwd points at an existing *file*, so mkdir(parents=True) raises.
+    blocker_file = tmp_path / "not_a_dir"
+    blocker_file.write_text("x")
+    state = AutoPipelineState(goal="g", cwd=str(blocker_file))
+    state.phase = AutoPhase.COMPLETE
+    ledger = SeedDraftLedger.from_goal("g")
+
+    result = await best_effort_export_trace(state, ledger, event_store=None)
+    assert result is None  # swallowed, no raise
+
+
+@pytest.mark.asyncio
+async def test_pipeline_finalize_writes_trace_once(tmp_path: Path) -> None:
+    state = _terminal_state(tmp_path)
+    state.ledger = _populated_ledger().to_dict()
+    event_store = _FakeEventStore(_events_for(state))
+    driver = types.SimpleNamespace(event_store=event_store, progress_callback=None)
+    pipeline = AutoPipeline(
+        interview_driver=driver,  # type: ignore[arg-type]
+        seed_generator=lambda _sid: None,  # type: ignore[arg-type]
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete"
+    out_dir = tmp_path / ".ouroboros" / "traces" / state.auto_session_id
+    assert (out_dir / "outcome.json").exists()
+    outcome = json.loads((out_dir / "outcome.json").read_text())
+    assert outcome["status"] == "complete"


### PR DESCRIPTION
## What & why

**A2 — Interview trace artifact** (run-metaharness plan, Phase A). Per interview run, emit a grep-able export of what actually happened: questions, answers, ambiguity-score trajectory, lateral results, timeout/fallback/degraded flags, promoted-vs-rejected decisions (with their A1 provenance), and the evaluate/QA outcome.

This is a **projection, not a store**. It reads the two durable sources that already exist by the time an `ooo auto` run finalizes — the auto `SeedDraftLedger` (question history + every decided contract field with `source`/`status`/`provenance`, A1 #1579) and the `EventStore` (interview event stream: ambiguity trajectory, lateral advisories, lifecycle flags) — and writes plain files under the project working dir. No new store, no event-schema changes.

## Module + export API

`src/ouroboros/auto/trace_export.py`:

- `async export_trace_from_state(state, ledger, *, event_store, out_root=None) -> Path` — core projection.
- `async export_interview_trace(run_id, *, auto_store, event_store, out_root=None) -> Path | None` — **manual / A3-CLI entry**: loads a past run from `AutoStore` + EventStore and projects it. Importable and cleanly callable; A3 wraps this. (A3 CLI itself is intentionally NOT built here.)
- `async best_effort_export_trace(state, ledger, *, event_store, out_root=None) -> Path | None` — the pipeline finalize hook; logs and swallows any failure so trace generation has **zero impact on the run**.

## File schema (`<cwd>/.ouroboros/traces/<run_id>/`, run_id == auto_session_id)

One JSONL file per stream (each line self-describing via `type`) plus a human digest. Empty streams omit their file.

| File | Lines |
|------|-------|
| `questions.jsonl` | `question` (round, question, answer from ledger history) + `response_event` (event-store round records) |
| `ambiguity.jsonl` | per-event `ambiguity_score` trajectory (round, from/to milestone), time-ascending |
| `lateral.jsonl` | `lateral` events (persona, directive, outcome) + `lateral_final` from state |
| `decisions.jsonl` | `decision` per ledger entry: section, key, value, source, **provenance**, status, **promoted** (active) vs rejected, **gated** (model_inferred/timeout_default) |
| `flags.jsonl` | `event_flag` (timeout/fallback/degraded/safe_default/…) + `state_flag` (terminal_phase, closure_mode, degraded_seed, blocker, open_gaps) |
| `outcome.json` | run_id, status, grade, seed_id, qa verdict/score/passed, **provenance_histogram**, seed `decision_provenance`, **unverified_provenance** gate findings, assumptions/non_goals/open_gaps, counts |
| `summary.md` | compact human digest: status/grade/QA, counts, provenance histogram, gate findings, open gaps |

Surfaces the A1 provenance work end-to-end: per-decision `provenance`/`gated`, the `provenance_histogram`, and `unverified_provenance` MEDIUM findings — the greppable audit trail A1 made possible.

## Trigger wiring

`AutoPipeline.run` is now a thin re-entrancy-aware wrapper around the (renamed) `_run_pipeline`. The auto pipeline recurses through `run` on resume boundaries (`return await self.run(state)`); a depth counter fires the best-effort export **exactly once**, at the outermost terminal (`COMPLETE`/`BLOCKED`/`FAILED`) return, projecting the freshest live ledger (`_active_ledger`). The manual `export_interview_trace` covers any past run_id from persisted state.

## Idempotency

Content is derived **only** from persisted state + stored events — no wall-clock stamps. Re-export overwrites **byte-identically**; empty streams unlink any stale file. Verified by `test_reexport_is_byte_idempotent`.

## R-run comparison (required for `src/ouroboros/auto/` changes)

Substrate/observability-only: the export runs **once at finalize** (behind a best-effort wrapper) and does **no per-round work** — the interview/round loop is untouched. Round wall-clock cost is therefore unchanged and there is no round-loop comparison to capture.

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Justification: finalize-only best-effort export; no new per-round code path, no event-schema change, no new store.

## Validation

- `uv run ruff check .` — All checks passed
- `uv run ruff format --check .` — 1030 files already formatted
- `uv run mypy src/` — Success: no issues found in 428 source files
- `uv run pytest tests/unit/auto/test_trace_export.py -q` — 9 passed
- `uv run pytest tests/unit/auto/ -q` — 1266 passed, 4 failed; the 4 (`test_surface.py` `test_auto_handler_*` / `test_cli_resume_infers_opencode`) are the **pre-existing codex-config-leak** failures — verified identical on clean `origin/main` via `git stash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
