### PR TITLE
feat(providers): C4 native context channels — copilot instructions dir, claude --add-dir, per-run instruction files

### DIFF
--- a/src/ouroboros/copilot/cli_policy.py
+++ b/src/ouroboros/copilot/cli_policy.py
@@ -142,13 +142,21 @@ def build_copilot_child_env(
     max_depth: int = DEFAULT_MAX_OUROBOROS_DEPTH,
     child_session_env_keys: Sequence[str] = DEFAULT_COPILOT_CHILD_SESSION_ENV_KEYS,
     depth_error_factory: Callable[[int, int], Exception],
+    extra_instruction_dirs: Sequence[str] = (),
 ) -> dict[str, str]:
     """Build an isolated environment for nested Copilot subprocesses.
 
     Strips Ouroboros MCP discovery vars and Copilot session vars so the child
     starts as a clean one-shot process. Preserves ``GH_TOKEN`` /
     ``GITHUB_TOKEN`` because the child needs them to authenticate.
+
+    ``extra_instruction_dirs`` (C4 native context channel): additional
+    instruction directories (e.g. a directory holding the deterministic context
+    pack) appended to ``COPILOT_CUSTOM_INSTRUCTIONS_DIRS`` AFTER any
+    user-provided value and the setup-owned Ouroboros dir. Empty (the default)
+    is a byte-for-byte no-op — the env is identical to the pre-C4 build.
     """
+    extras = tuple(extra_instruction_dirs)
     return build_child_env(
         base_env=base_env,
         # Order preserved: Ouroboros markers, Copilot session keys, then the
@@ -162,20 +170,30 @@ def build_copilot_child_env(
         ),
         max_depth=max_depth,
         depth_error_factory=depth_error_factory,
-        post_build=_add_ouroboros_copilot_instruction_dir,
+        post_build=lambda env: _add_ouroboros_copilot_instruction_dir(env, extras),
     )
 
 
-def _add_ouroboros_copilot_instruction_dir(env: dict[str, str]) -> None:
-    """Ensure Copilot CLI sees the setup-owned Ouroboros AGENTS.md directory."""
+def _add_ouroboros_copilot_instruction_dir(
+    env: dict[str, str],
+    extra_instruction_dirs: Sequence[str] = (),
+) -> None:
+    """Ensure Copilot CLI sees the setup-owned Ouroboros AGENTS.md directory.
+
+    Extends (never replaces) any user-provided ``COPILOT_CUSTOM_INSTRUCTIONS_DIRS``:
+    the setup-owned dir is appended first, then each ``extra_instruction_dirs``
+    entry (C4 native context channel), skipping blanks and duplicates.
+    """
     from ouroboros.runtime_instruction_artifacts import copilot_instruction_dir
 
     instruction_dir = str(copilot_instruction_dir())
     key = "COPILOT_CUSTOM_INSTRUCTIONS_DIRS"
     existing = env.get(key, "")
     parts = [part.strip() for part in existing.split(",") if part.strip()]
-    if instruction_dir not in parts:
-        parts.append(instruction_dir)
+    for candidate in (instruction_dir, *extra_instruction_dirs):
+        candidate = (candidate or "").strip()
+        if candidate and candidate not in parts:
+            parts.append(candidate)
     env[key] = ",".join(parts)
 
 

--- a/src/ouroboros/orchestrator/claude_worker_runtime.py
+++ b/src/ouroboros/orchestrator/claude_worker_runtime.py
@@ -15,8 +15,10 @@ JSON ``session_id`` that is only diagnostic, not a valid future resume target.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Sequence
 import json
 import os
+from pathlib import Path
 from typing import Any
 
 from ouroboros.config import get_cli_path
@@ -47,6 +49,51 @@ _RECURSION_GUARD_DISALLOWED_TOOLS: tuple[str, ...] = (
     "mcp__plugin_ouroboros_ouroboros",
 )
 
+# Cap on the number of ``--add-dir`` grants emitted for a worker so a seed with
+# many ``context_references`` cannot blow up the argv. The pack (C2) already
+# reaches the worker via the system prompt; ``--add-dir`` is the NATIVE channel
+# that additionally grants the worker filesystem READ access to referenced dirs
+# outside its cwd — a bounded optimization, not a correctness requirement.
+_MAX_ADD_DIRS = 8
+
+
+def _resolve_add_dirs(
+    context_reference_dirs: Sequence[str],
+    *,
+    cwd: str | None,
+) -> tuple[str, ...]:
+    """Return existing, deduped, absolute dirs for ``--add-dir`` (capped).
+
+    Best-effort and side-effect free: relative references are resolved against
+    ``cwd`` (the worker's repo root), non-directories and duplicates are
+    dropped, and the result is capped at :data:`_MAX_ADD_DIRS`. An empty input
+    yields an empty tuple so the caller emits no ``--add-dir`` flag at all
+    (byte-identical to the pre-C4 command).
+    """
+    base = Path(cwd) if cwd else None
+    resolved: list[str] = []
+    seen: set[str] = set()
+    for raw in context_reference_dirs:
+        candidate = (raw or "").strip()
+        if not candidate:
+            continue
+        path = Path(candidate).expanduser()
+        if not path.is_absolute() and base is not None:
+            path = base / path
+        try:
+            if not path.is_dir():
+                continue
+            key = str(path.resolve())
+        except OSError:
+            continue
+        if key in seen:
+            continue
+        seen.add(key)
+        resolved.append(key)
+        if len(resolved) >= _MAX_ADD_DIRS:
+            break
+    return tuple(resolved)
+
 
 class ClaudeWorkerTransport:
     """Spawn/resume a Claude worker session via ``claude -p ... --output-format json``."""
@@ -61,6 +108,7 @@ class ClaudeWorkerTransport:
         timeout: float | None = None,
         disallowed_tools: tuple[str, ...] = _RECURSION_GUARD_DISALLOWED_TOOLS,
         persist_sessions: bool = False,
+        context_reference_dirs: Sequence[str] = (),
     ) -> None:
         self._cli_path = cli_path or get_cli_path() or "claude"
         # Claude sessions are CWD-SCOPED: ``--resume`` finds a conversation only
@@ -79,6 +127,11 @@ class ClaudeWorkerTransport:
         # dashboard is the worker view instead. Opt in (native flag) to persist +
         # fork parent context + ``--name`` so a worker is openable/resumable natively.
         self._persist_sessions = persist_sessions
+        # NATIVE context channel (C4): grant the worker READ access to the
+        # seed's brownfield ``context_references`` dirs via ``--add-dir``.
+        # Resolved once against cwd (existing dirs only, deduped, capped) so the
+        # command builder just appends the flags. Empty ⇒ no ``--add-dir`` at all.
+        self._add_dirs = _resolve_add_dirs(context_reference_dirs, cwd=cwd)
 
     @staticmethod
     def _permission_args(permission_mode: str | None) -> list[str]:
@@ -97,6 +150,10 @@ class ClaudeWorkerTransport:
             # Space-separated list per `claude --disallowedTools` semantics; denies
             # the ouroboros MCP tools so the worker cannot re-enter the orchestrator.
             command.extend(["--disallowedTools", " ".join(self._disallowed_tools)])
+        for add_dir in self._add_dirs:
+            # Native passthrough grants read access to referenced brownfield
+            # dirs outside cwd. No-op when there are no context_references.
+            command.extend(["--add-dir", add_dir])
         if not self._persist_sessions:
             # Don't write a resumable session file → no /resume flooding.
             command.append("--no-session-persistence")
@@ -252,6 +309,7 @@ def build_claude_worker_runtime(
     model: str | None = None,
     llm_backend: str | None = None,
     persist_sessions: bool = False,
+    context_reference_dirs: Sequence[str] = (),
 ) -> LeaderDrivenWorkerRuntime:
     """Construct a leader-driven Claude worker runtime over ``claude -p --resume``.
 
@@ -259,10 +317,18 @@ def build_claude_worker_runtime(
     ``--no-session-persistence`` so they do not flood the human's ``/resume`` list.
     Opt in (native-session-index flag) to persist + fork parent context + ``--name``
     so a worker is openable/resumable in Claude natively.
+
+    ``context_reference_dirs`` (C4 native context channel): brownfield reference
+    directories the worker should be able to READ. Existing dirs are passed as
+    ``--add-dir`` grants (deduped, capped). Empty (the default) is a byte-for-byte
+    no-op — the worker command is identical to the pre-C4 invocation.
     """
     return LeaderDrivenWorkerRuntime(
         transport=ClaudeWorkerTransport(
-            cli_path=cli_path, cwd=cwd, persist_sessions=persist_sessions
+            cli_path=cli_path,
+            cwd=cwd,
+            persist_sessions=persist_sessions,
+            context_reference_dirs=context_reference_dirs,
         ),
         runtime_backend="claude_mcp",
         llm_backend=llm_backend or "claude",

--- a/tests/unit/copilot/test_cli_policy.py
+++ b/tests/unit/copilot/test_cli_policy.py
@@ -190,3 +190,44 @@ class TestBuildCopilotChildEnv:
             depth_error_factory=lambda depth, max_depth: RuntimeError(f"depth {depth}/{max_depth}"),
         )
         assert env["_OUROBOROS_DEPTH"] == "1"
+
+    def test_no_extra_dirs_is_identical_to_default(self, tmp_path: Path) -> None:
+        # C4 no-op contract: omitting extra_instruction_dirs must yield the exact
+        # same COPILOT_CUSTOM_INSTRUCTIONS_DIRS as the pre-C4 build.
+        base = {"COPILOT_CUSTOM_INSTRUCTIONS_DIRS": str(tmp_path / "user")}
+        default_env = build_copilot_child_env(
+            base_env=dict(base),
+            depth_error_factory=lambda depth, max_depth: RuntimeError(f"depth {depth}/{max_depth}"),
+        )
+        explicit_empty_env = build_copilot_child_env(
+            base_env=dict(base),
+            depth_error_factory=lambda depth, max_depth: RuntimeError(f"depth {depth}/{max_depth}"),
+            extra_instruction_dirs=(),
+        )
+        key = "COPILOT_CUSTOM_INSTRUCTIONS_DIRS"
+        assert default_env[key] == explicit_empty_env[key]
+
+    def test_extra_instruction_dirs_appended_after_setup_dir(self, tmp_path: Path) -> None:
+        user = str(tmp_path / "user")
+        pack_dir = str(tmp_path / "context-pack")
+        env = build_copilot_child_env(
+            base_env={"COPILOT_CUSTOM_INSTRUCTIONS_DIRS": user},
+            depth_error_factory=lambda depth, max_depth: RuntimeError(f"depth {depth}/{max_depth}"),
+            extra_instruction_dirs=[pack_dir],
+        )
+        parts = env["COPILOT_CUSTOM_INSTRUCTIONS_DIRS"].split(",")
+        # User value preserved first, setup-owned dir next, C4 extra dir last.
+        assert parts[0] == user
+        assert parts[-2].endswith(os.path.join(".copilot", "ouroboros-instructions"))
+        assert parts[-1] == pack_dir
+
+    def test_extra_instruction_dirs_deduped_and_blanks_skipped(self, tmp_path: Path) -> None:
+        pack_dir = str(tmp_path / "context-pack")
+        env = build_copilot_child_env(
+            base_env={"COPILOT_CUSTOM_INSTRUCTIONS_DIRS": pack_dir},
+            depth_error_factory=lambda depth, max_depth: RuntimeError(f"depth {depth}/{max_depth}"),
+            extra_instruction_dirs=["", "   ", pack_dir],
+        )
+        parts = env["COPILOT_CUSTOM_INSTRUCTIONS_DIRS"].split(",")
+        # pack_dir already present (user-provided) → not duplicated; blanks dropped.
+        assert parts.count(pack_dir) == 1

--- a/tests/unit/orchestrator/test_claude_worker_runtime.py
+++ b/tests/unit/orchestrator/test_claude_worker_runtime.py
@@ -189,6 +189,77 @@ class TestForkAndLabelSpawnOptIn:
         assert command[command.index("--name") + 1] == "ooo: ship it"
 
 
+class TestContextReferenceAddDirs:
+    """C4 native context channel: existing context_references dirs become
+    ``--add-dir`` grants (deduped, cap 8). Absent ⇒ byte-identical to pre-C4."""
+
+    def test_no_add_dir_flag_when_no_references(self) -> None:
+        transport = ClaudeWorkerTransport(cli_path="claude", cwd="/tmp")
+        assert "--add-dir" not in transport._base_command(cwd="/tmp")
+
+    def test_existing_dirs_become_add_dir_grants(self, tmp_path) -> None:
+        d1 = tmp_path / "pkg-a"
+        d2 = tmp_path / "pkg-b"
+        d1.mkdir()
+        d2.mkdir()
+        transport = ClaudeWorkerTransport(
+            cli_path="claude",
+            cwd=str(tmp_path),
+            context_reference_dirs=[str(d1), str(d2)],
+        )
+        command = transport._base_command(cwd=str(tmp_path))
+        add_dir_values = [command[i + 1] for i, tok in enumerate(command) if tok == "--add-dir"]
+        assert add_dir_values == [str(d1.resolve()), str(d2.resolve())]
+
+    def test_nonexistent_dirs_and_files_are_skipped(self, tmp_path) -> None:
+        real = tmp_path / "real"
+        real.mkdir()
+        a_file = tmp_path / "notes.md"
+        a_file.write_text("x", encoding="utf-8")
+        transport = ClaudeWorkerTransport(
+            cli_path="claude",
+            cwd=str(tmp_path),
+            context_reference_dirs=[str(real), str(tmp_path / "missing"), str(a_file)],
+        )
+        command = transport._base_command(cwd=str(tmp_path))
+        add_dir_values = [command[i + 1] for i, tok in enumerate(command) if tok == "--add-dir"]
+        assert add_dir_values == [str(real.resolve())]
+
+    def test_relative_reference_resolves_against_cwd(self, tmp_path) -> None:
+        (tmp_path / "sub").mkdir()
+        transport = ClaudeWorkerTransport(
+            cli_path="claude",
+            cwd=str(tmp_path),
+            context_reference_dirs=["sub"],
+        )
+        command = transport._base_command(cwd=str(tmp_path))
+        assert command[command.index("--add-dir") + 1] == str((tmp_path / "sub").resolve())
+
+    def test_duplicates_deduped_and_capped(self, tmp_path) -> None:
+        dirs: list[str] = []
+        for i in range(12):
+            d = tmp_path / f"d{i}"
+            d.mkdir()
+            dirs.append(str(d))
+        # Feed a duplicate of the first plus 12 uniques; expect the 8-cap to hold.
+        transport = ClaudeWorkerTransport(
+            cli_path="claude",
+            cwd=str(tmp_path),
+            context_reference_dirs=[dirs[0], *dirs],
+        )
+        command = transport._base_command(cwd=str(tmp_path))
+        add_dir_values = [command[i + 1] for i, tok in enumerate(command) if tok == "--add-dir"]
+        assert len(add_dir_values) == 8
+        assert add_dir_values == [str((tmp_path / f"d{i}").resolve()) for i in range(8)]
+
+    def test_factory_threads_context_reference_dirs(self, tmp_path) -> None:
+        d = tmp_path / "ref"
+        d.mkdir()
+        rt = build_claude_worker_runtime(cwd=str(tmp_path), context_reference_dirs=[str(d)])
+        command = rt._transport._base_command(cwd=str(tmp_path))
+        assert command[command.index("--add-dir") + 1] == str(d.resolve())
+
+
 class TestRecursionHardening:
     """The claude worker must deny ouroboros tools + set the depth guard, while
     preserving native passthrough of every other MCP server."""


### PR DESCRIPTION
## What & why

Work order **C4** (Phase C follow-ups) from `docs/run-metaharness-plan-2026-07.md`.
C2 (#1544) already delivers the deterministic context pack to **every** runtime via
the composed system prompt. C4 adds the **native** channel each runtime prefers so the
pack (or the seed's `context_references`) also arrives the way that runtime consumes it.
Every channel is bounded and a **byte-identical no-op when unfed** (existing tests
unmodified prove it).

## Per-channel outcome

### ✅ copilot — DONE (`copilot/cli_policy.py`)
`build_copilot_child_env` gains optional `extra_instruction_dirs`, appended to
`COPILOT_CUSTOM_INSTRUCTIONS_DIRS` **after** any user-provided value and the
setup-owned Ouroboros dir (dedupe, blanks skipped, user values never replaced —
"extend, don't replace"). Empty default → env identical to the pre-C4 build.

### ✅ claude worker — DONE (`orchestrator/claude_worker_runtime.py`)
`ClaudeWorkerTransport` / `build_claude_worker_runtime` gain optional
`context_reference_dirs`. Existing directories become `--add-dir` grants in the worker
command (relative refs resolved against cwd; **existing dirs only**; deduped; **capped
at 8**). Empty default → no `--add-dir` at all (identical to the pre-C4 invocation).
This is the one thing the system-prompt pack cannot do: grant the worker filesystem
**read access** to referenced dirs outside its cwd.

### ⛔ opencode / gemini / kiro — SKIPPED (substrate divergence, per plan's skip clause)
The `opencode_instruction_path` / `gemini_instruction_path` / `kiro_instruction_path`
helpers point at **global, setup-owned** files (`~/.gemini/GEMINI.md`, config-dir
`AGENTS.md`, `~/.kiro/steering/…`) installed **once at setup** (`cli/commands/setup.py`).
These runtimes have **no per-run instruction-file consumption path** — they deliver the
context pack **inline via `system_prompt`** (already covered by C2). Writing a per-run
pack into those global files would pollute cross-project state and break the
byte-identical no-op contract — i.e. inventing a new mechanism, which the work order
explicitly forbids ("If a runtime … has NO existing instruction-artifact consumption
path, skip it and note why"). No files touched for these three.

## Scope note (honest)
The pack and `seed.context_references` are produced **upstream** (`runner.build_system_prompt`
holds `repo_root` and builds the pack; the `Seed` holds `context_references`). The two
shipped channels add the native-channel **seam** at the builder layer, gated behind an
optional param that defaults to a no-op — consistent with the work order's explicit
no-op contract. Threading the upstream data into `create_agent_runtime` /
`runtime_factory` / the copilot runtime's `_build_child_env` is a separate concern
outside this work order's scope wall and is a natural follow-up.

## Validation
- `uv run ruff check .` → **All checks passed**
- `uv run ruff format --check .` → **1035 files already formatted**
- `uv run mypy src/` → **Success: no issues found in 429 source files**
- Targeted + full blast-radius suites (no xdist): **all green**
  - `tests/unit/copilot/test_cli_policy.py`, `tests/unit/orchestrator/test_claude_worker_runtime.py`,
    `test_runtime_factory.py`, `test_copilot_cli_runtime.py`,
    `tests/unit/providers/test_copilot_cli_adapter.py`, `tests/unit/test_runtime_instruction_artifacts.py`
    → **241 passed** combined; new per-channel tests included, existing tests unmodified.

## Files changed
- `src/ouroboros/copilot/cli_policy.py`
- `src/ouroboros/orchestrator/claude_worker_runtime.py`
- `tests/unit/copilot/test_cli_policy.py`
- `tests/unit/orchestrator/test_claude_worker_runtime.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)