### PR TITLE
fix(auto): bound the finalize trace export so a hung store cannot delay terminal results (#1581 follow-up)

### DIFF
--- a/src/ouroboros/auto/trace_export.py
+++ b/src/ouroboros/auto/trace_export.py
@@ -28,6 +28,7 @@ Two entry points:
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -103,6 +104,17 @@ _FLAG_MARKERS: tuple[str, ...] = (
 # trace file. The ledger already truncates its own text; this bounds anything
 # passed straight through from event payloads.
 _MAX_TEXT = 2000
+
+# Hard wall-clock bound for the *finalize* trace projection. The finalize hook
+# awaits ``export_trace_from_state`` — which fans out to up to two unbounded
+# ``event_store.query_events`` aggregate scans plus filesystem writes — right
+# before the pipeline returns its already-computed terminal result. A slow or
+# hung EventStore / filesystem must never delay (or hang) a COMPLETE / BLOCKED
+# / FAILED return: trace generation is best-effort and cannot affect the run
+# outcome. This deadline caps the worst case; on breach the projection is
+# dropped like any other swallowed failure. 30s is generous for a healthy
+# store yet bounds the terminal-return delay to a predictable ceiling.
+TRACE_EXPORT_DEADLINE_SECONDS = 30.0
 
 
 def _clip(value: Any) -> Any:
@@ -580,14 +592,41 @@ async def best_effort_export_trace(
 
     Any failure — event-store query, filesystem, serialization — is logged and
     swallowed so trace generation cannot affect the auto pipeline's outcome.
+
+    The projection is additionally **time-bounded** by
+    :data:`TRACE_EXPORT_DEADLINE_SECONDS` via :func:`asyncio.wait_for`, so a
+    slow or hung EventStore / filesystem can drop the trace but never delay the
+    caller's terminal return past the deadline. A deadline breach surfaces as
+    :class:`TimeoutError` and is swallowed like any other projection failure.
+
+    Cancellation semantics follow the driver's established
+    ``wait_for`` / ``CancelledError`` idiom: ``asyncio.wait_for`` converts its
+    *own* timeout into ``TimeoutError``, so any :class:`asyncio.CancelledError`
+    reaching this frame is a **genuine outer cancellation** (the pipeline task
+    itself being torn down) — it is re-raised, never swallowed.
     """
     try:
-        return await export_trace_from_state(
-            state,
-            ledger,
-            event_store=event_store,
-            out_root=out_root,
+        return await asyncio.wait_for(
+            export_trace_from_state(
+                state,
+                ledger,
+                event_store=event_store,
+                out_root=out_root,
+            ),
+            timeout=TRACE_EXPORT_DEADLINE_SECONDS,
         )
+    except TimeoutError:
+        # Our own deadline fired: the export overran the best-effort budget.
+        log.warning(
+            "auto.trace_export.deadline_exceeded",
+            auto_session_id=getattr(state, "auto_session_id", None),
+            deadline_seconds=TRACE_EXPORT_DEADLINE_SECONDS,
+        )
+        return None
+    except asyncio.CancelledError:
+        # Genuine outer cancellation — the pipeline task is being cancelled.
+        # Never swallow: propagate so cancellation semantics are preserved.
+        raise
     except Exception as exc:  # noqa: BLE001 - best-effort by contract
         log.warning(
             "auto.trace_export.failed",

--- a/tests/unit/auto/test_trace_export.py
+++ b/tests/unit/auto/test_trace_export.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 import json
 from pathlib import Path
+import time
 import types
 
 import pytest
 
+from ouroboros.auto import trace_export
 from ouroboros.auto.ledger import (
     DecisionProvenance,
     LedgerEntry,
@@ -316,6 +319,97 @@ async def test_best_effort_swallows_failure(tmp_path: Path) -> None:
 
     result = await best_effort_export_trace(state, ledger, event_store=None)
     assert result is None  # swallowed, no raise
+
+
+class _HangingEventStore:
+    """EventStore stand-in whose ``query_events`` never returns.
+
+    Models a slow / hung store or a blocked filesystem behind the projection:
+    once the export enters the query it stays there until the awaiting frame is
+    cancelled (by the finalize deadline or by an outer cancel).
+    """
+
+    def __init__(self) -> None:
+        # Set the instant we enter the query so a test can deterministically
+        # cancel *after* the export is genuinely blocked inside the store.
+        self.entered = asyncio.Event()
+
+    async def query_events(
+        self,
+        aggregate_id: str | None = None,
+        event_type: str | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> list[BaseEvent]:
+        self.entered.set()
+        await asyncio.Event().wait()  # never resolves
+        return []  # pragma: no cover - unreachable
+
+
+@pytest.mark.asyncio
+async def test_best_effort_bounded_by_deadline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A hung store must not pin the finalize hook: the export is dropped once
+    # the (monkeypatched-small) deadline fires, and None is returned promptly.
+    monkeypatch.setattr(trace_export, "TRACE_EXPORT_DEADLINE_SECONDS", 0.05)
+    state = _terminal_state(tmp_path)
+    ledger = _populated_ledger()
+    store = _HangingEventStore()
+
+    start = time.monotonic()
+    result = await best_effort_export_trace(state, ledger, event_store=store)
+    elapsed = time.monotonic() - start
+
+    assert result is None  # deadline breach swallowed like any failure
+    assert elapsed < 2.0  # bounded well under the hung store's forever-await
+    # Projection aborted mid-query, so no trace files were materialized.
+    out_dir = tmp_path / ".ouroboros" / "traces" / state.auto_session_id
+    assert not (out_dir / "outcome.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_pipeline_finalize_survives_hung_store(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The pipeline's already-computed terminal result must still return even if
+    # the finalize trace export hangs on a wedged store.
+    monkeypatch.setattr(trace_export, "TRACE_EXPORT_DEADLINE_SECONDS", 0.05)
+    state = _terminal_state(tmp_path)
+    state.ledger = _populated_ledger().to_dict()
+    store = _HangingEventStore()
+    driver = types.SimpleNamespace(event_store=store, progress_callback=None)
+    pipeline = AutoPipeline(
+        interview_driver=driver,  # type: ignore[arg-type]
+        seed_generator=lambda _sid: None,  # type: ignore[arg-type]
+    )
+
+    # An unbounded finalize would hang here forever; the 5s guard proves the
+    # deadline (not the guard) is what releases the terminal return.
+    result = await asyncio.wait_for(pipeline.run(state), timeout=5.0)
+
+    assert result.status == "complete"
+    out_dir = tmp_path / ".ouroboros" / "traces" / state.auto_session_id
+    assert not (out_dir / "outcome.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_outer_cancellation_propagates(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A genuine *outer* cancel (pipeline task torn down) must surface as
+    # CancelledError — never swallowed by the best-effort guard. Keep the
+    # deadline long so the timeout path cannot fire before we cancel.
+    monkeypatch.setattr(trace_export, "TRACE_EXPORT_DEADLINE_SECONDS", 30.0)
+    state = _terminal_state(tmp_path)
+    ledger = _populated_ledger()
+    store = _HangingEventStore()
+
+    task = asyncio.ensure_future(best_effort_export_trace(state, ledger, event_store=store))
+    await store.entered.wait()  # cancel only once genuinely blocked in-query
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Follow-up to #1581, addressing the CHANGES_REQUESTED blocker raised in both ouroboros-agent bot reviews on that PR ([review 4638127324](https://github.com/Q00/ouroboros/pull/1581#pullrequestreview-4638127324), [review 4638263222](https://github.com/Q00/ouroboros/pull/1581#pullrequestreview-4638263222)).

**The blocker.** `AutoPipeline.run()` (the finalize wrapper) awaits `best_effort_export_trace()` right before returning the already-computed COMPLETE/BLOCKED/FAILED result. Exceptions were swallowed, but the export was not *time*-bounded: it awaits `export_trace_from_state()` → up to two unbounded `event_store.query_events(...)` aggregate scans plus filesystem writes. A slow or hung EventStore/filesystem could delay — or hang forever — the pipeline's terminal return, violating the stated best-effort contract that trace generation cannot affect the run outcome.

**The fix.** Bound the export with a hard deadline inside `best_effort_export_trace` itself, so every caller inherits the bound:

- New module-level constant `TRACE_EXPORT_DEADLINE_SECONDS = 30.0` in `src/ouroboros/auto/trace_export.py`, with a comment explaining the contract.
- The inner `export_trace_from_state(...)` await is wrapped in `asyncio.wait_for(..., timeout=TRACE_EXPORT_DEADLINE_SECONDS)`. A deadline breach surfaces as `TimeoutError` and is logged (`auto.trace_export.deadline_exceeded`) and swallowed (return `None`) — exactly like any other best-effort projection failure.
- **Cancellation semantics** follow the codebase's established `wait_for`/`CancelledError` idiom (see `interview_driver.py`'s narrowed-catch rationale and `adapters.py`): `asyncio.wait_for` converts its *own* timeout into `TimeoutError`, so any `asyncio.CancelledError` reaching this frame is a **genuine outer cancellation** (the pipeline task itself being torn down) and is re-raised, never swallowed. Timeout → swallow; outer cancel → propagate.

**Bound, not decouple.** The reviewers asked to "bound or decouple" the export. This PR keeps the export awaited (bounded) rather than detaching it as a fire-and-forget task: a detached task can outlive the event loop at CLI exit (dropped writes, "task was destroyed but it is pending" noise), while the 30 s bound satisfies the contract with the simpler, safer option — the terminal return is now delayed by at most a fixed, auditable ceiling and by nothing in the failure case.

**Scope.** Only the finalize export path is bounded; no in-loop behavior changes. Files touched: `src/ouroboros/auto/trace_export.py`, `tests/unit/auto/test_trace_export.py`. Existing tests unmodified.

## Test plan

- [x] New: `test_best_effort_bounded_by_deadline` — a never-returning fake `query_events` + monkeypatched 0.05 s deadline → `best_effort_export_trace` returns `None` promptly (asserted well under the hung store's forever-await), no partial trace files.
- [x] New: `test_pipeline_finalize_survives_hung_store` — full `AutoPipeline.run()` over the hung store still returns its terminal result under an outer 5 s guard.
- [x] New: `test_outer_cancellation_propagates` — cancelling the task running the export (deadline kept long so the timeout path cannot win) raises `CancelledError` out; the cancel fires only after the export is provably blocked inside the store query.
- [x] `uv run pytest tests/unit/auto/test_trace_export.py -q` → 12 passed (9 pre-existing + 3 new).
- [x] `uv run pytest tests/unit/auto/ -q` → 1269 passed, 4 failed — all four are the known pre-existing `test_surface` codex-config-leak failures, confirmed failing identically on `origin/main` with this change stashed.
- [x] `uv run ruff check .` and `uv run ruff format --check .` clean.
- [x] `uv run mypy src/` clean (429 files).

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [x] N/A — finalize-only bound on the trace-export hook; no per-round code path changes.

## Related issues

- Follow-up to #1581 (A2 interview trace artifact); resolves the time-bounding blocker from both ouroboros-agent CHANGES_REQUESTED reviews: [pullrequestreview-4638127324](https://github.com/Q00/ouroboros/pull/1581#pullrequestreview-4638127324), [pullrequestreview-4638263222](https://github.com/Q00/ouroboros/pull/1581#pullrequestreview-4638263222)
- Refs #1256 (§I5), run-metaharness plan A2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
