### PR TITLE
fix(evaluation): apply reward-hacking veto after Stage 3 consensus approval (#1572 follow-up)

### DIFF
--- a/src/ouroboros/evaluation/pipeline.py
+++ b/src/ouroboros/evaluation/pipeline.py
@@ -240,16 +240,12 @@ class EvaluationPipeline:
                 )
 
         # No consensus triggered - approve based on Stage 2.
-        # The reward-hacking veto (REWARD_HACKING_VETO_THRESHOLD) blocks an
-        # otherwise-passing artifact only on a *high-confidence* gaming signal,
-        # so a merely uncertain evaluator never vetoes a genuine pass.
+        # The reward-hacking veto is applied uniformly in ``_build_result``
+        # (the single final gate), so it is intentionally NOT duplicated
+        # here — this branch only decides the Stage 2 pass conditions.
         final_approved = True
         if stage2_result:
-            final_approved = (
-                stage2_result.ac_compliance
-                and stage2_result.score >= 0.8
-                and stage2_result.reward_hacking_risk < REWARD_HACKING_VETO_THRESHOLD
-            )
+            final_approved = stage2_result.ac_compliance and stage2_result.score >= 0.8
 
         return self._build_result(
             context.execution_id,
@@ -281,6 +277,19 @@ class EvaluationPipeline:
         Returns:
             Result containing EvaluationResult
         """
+        # Single reward-hacking veto gate.  Applied here — the one place
+        # every approval source funnels through — so no approval branch
+        # (no-consensus Stage 2 pass OR Stage 3 consensus approval) can
+        # launder a high-confidence gaming signal.  The veto only flips
+        # approve→reject; it never rescues an already-rejected result, so
+        # consensus rejections stay rejections.
+        if (
+            final_approved
+            and stage2_result is not None
+            and stage2_result.reward_hacking_risk >= REWARD_HACKING_VETO_THRESHOLD
+        ):
+            final_approved = False
+
         # Calculate highest stage before creating immutable result
         highest_stage = 0
         if stage1_result is not None:

--- a/tests/unit/evaluation/test_pipeline_reward_hacking_veto.py
+++ b/tests/unit/evaluation/test_pipeline_reward_hacking_veto.py
@@ -16,10 +16,12 @@ from ouroboros.evaluation.models import (
     REWARD_HACKING_VETO_THRESHOLD,
     CheckResult,
     CheckType,
+    ConsensusResult,
     EvaluationContext,
     EvaluationResult,
     MechanicalResult,
     SemanticResult,
+    Vote,
 )
 from ouroboros.evaluation.pipeline import EvaluationPipeline, PipelineConfig
 
@@ -135,3 +137,90 @@ class TestFailureReasonSurface:
             final_approved=True,
         )
         assert result.failure_reason is None
+
+
+def _consensus_result(approved: bool) -> ConsensusResult:
+    return ConsensusResult(
+        approved=approved,
+        votes=(
+            Vote(model="m1", approved=approved, confidence=0.9, reasoning="ok"),
+            Vote(model="m2", approved=approved, confidence=0.8, reasoning="ok"),
+            Vote(model="m3", approved=not approved, confidence=0.6, reasoning="dissent"),
+        ),
+        majority_ratio=0.67 if approved else 0.33,
+    )
+
+
+def _consensus_context() -> EvaluationContext:
+    return EvaluationContext(
+        execution_id="veto-consensus-exec",
+        seed_id="seed-1",
+        current_ac="Test AC",
+        artifact="def f(): pass",
+        artifact_type="code",
+        goal="Test goal",
+        constraints=(),
+        trigger_consensus=True,
+    )
+
+
+async def _run_consensus(*, risk: float, consensus_approved: bool) -> EvaluationResult:
+    """Drive the real Stage 3 consensus approval path with mocked stages."""
+    pipeline = EvaluationPipeline(
+        AsyncMock(),
+        PipelineConfig(stage1_enabled=False, stage2_enabled=True, stage3_enabled=True),
+    )
+    with (
+        patch(
+            "ouroboros.evaluation.semantic.SemanticEvaluator.evaluate",
+            new_callable=AsyncMock,
+            return_value=Result.ok((_semantic(reward_hacking_risk=risk), [])),
+        ),
+        patch(
+            "ouroboros.evaluation.consensus.ConsensusEvaluator.evaluate",
+            new_callable=AsyncMock,
+            return_value=Result.ok((_consensus_result(consensus_approved), [])),
+        ),
+    ):
+        result = await pipeline.evaluate(_consensus_context())
+    assert result.is_ok
+    return result.value
+
+
+class TestConsensusApprovalVeto:
+    """The veto must apply after Stage 3 consensus approval, not only the
+    no-consensus branch (the #1572 consensus-bypass finding)."""
+
+    async def test_consensus_approval_is_vetoed_by_high_risk(self) -> None:
+        """trigger_consensus + approving Stage 3 + risk 0.95 → NOT approved."""
+        eval_result = await _run_consensus(risk=0.95, consensus_approved=True)
+
+        assert eval_result.stage3_result is not None
+        assert eval_result.stage3_result.approved is True  # consensus DID approve
+        assert eval_result.final_approved is False  # ...but the veto flipped it
+
+        reason = eval_result.failure_reason
+        assert reason is not None
+        assert "reward-hacking" in reason.lower()
+        assert "veto" in reason.lower()
+        assert "0.95" in reason
+
+    async def test_consensus_approval_stands_when_risk_low(self) -> None:
+        """Same consensus path but risk 0.0 → approved (unchanged behavior)."""
+        eval_result = await _run_consensus(risk=0.0, consensus_approved=True)
+
+        assert eval_result.stage3_result is not None
+        assert eval_result.final_approved is True
+        assert eval_result.failure_reason is None
+
+    async def test_consensus_rejection_stays_rejected(self) -> None:
+        """Consensus rejects + low risk → still rejected (veto never rescues)."""
+        eval_result = await _run_consensus(risk=0.0, consensus_approved=False)
+
+        assert eval_result.stage3_result is not None
+        assert eval_result.stage3_result.approved is False
+        assert eval_result.final_approved is False
+
+        reason = eval_result.failure_reason
+        assert reason is not None
+        assert "Stage 3 failed" in reason  # consensus rejection reason preserved


### PR DESCRIPTION
## Summary

Follow-up to the ouroboros-agent bot review on PR #1572 (CHANGES_REQUESTED, verified with a reproduction): the reward-hacking veto in `src/ouroboros/evaluation/pipeline.py` was applied **only** in the no-consensus Stage 2 approval branch. When Stage 3 consensus triggered and approved, the pipeline returned `_build_result(..., final_approved=stage3_result.approved)` directly — consensus could launder a high-risk artifact past the veto.

## Before / After

| Scenario | Before | After |
|---|---|---|
| No consensus, risk 0.95, Stage 2 passing | vetoed (`final_approved=False`) | vetoed (unchanged) |
| **Consensus approves, risk 0.95** | **`final_approved=True`, `failure_reason=None` (bypass)** | **`final_approved=False`, `failure_reason` = "Stage 2 veto: reward-hacking risk 0.95 >= 0.70 …"** |
| Consensus approves, risk < 0.7 | approved | approved (unchanged) |
| Consensus rejects, risk 0.0 | rejected | rejected — veto never flips reject→approve |

## Fix

Single final gate in `EvaluationPipeline._build_result` — the one place every approval source funnels through — instead of per-branch copies, so future approval branches can't reintroduce the bypass:

- If `final_approved` and `stage2_result.reward_hacking_risk >= REWARD_HACKING_VETO_THRESHOLD` → `final_approved = False`.
- The gate only flips approve→reject; a consensus rejection is untouched and `stage3_result` is still recorded on the result.
- The duplicated veto condition in the no-consensus branch is removed in favor of the gate.
- `failure_reason`: for the consensus-vetoed result, `stage3_result.approved` is True and Stage 2 was compliant, so both the pipeline's `_build_result` reason chain and `EvaluationResult.failure_reason` in `models.py` fall through to the existing veto branch — same explanation text as the no-consensus path, no new reason strings.

## Tests

New `TestConsensusApprovalVeto` in `tests/unit/evaluation/test_pipeline_reward_hacking_veto.py`, driving the real `pipeline.evaluate()` Stage 3 path with mocked stage evaluators:

- `trigger_consensus=True` + approving Stage 3 + risk 0.95 → NOT approved, `failure_reason` names the veto and surfaces 0.95
- Same path + risk 0.0 → approved, `failure_reason is None` (consensus path unchanged)
- Consensus rejects + risk 0.0 → still rejected, "Stage 3 failed" reason preserved

All 6 pre-existing tests in the file pass unmodified (the `risk < threshold` no-consensus behavior is proven unchanged).

## Validation

- `ruff check` / `ruff format --check`: clean
- `mypy src/`: no issues in 429 files
- `tests/unit/evaluation/`: **467 passed**
- Repo gate (`tests/` minus e2e/mcp): 9938 passed, 3 failed — all three are the known pre-existing `tests/unit/auto/test_surface.py` codex-config-leak failures, unrelated to this change; opencode tests deselected (known pre-existing failures that hang by spawning the real binary in this environment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)