### PR TITLE
fix(mcp): advisory fan-out re-entry — correlation contract + registry state dir (#1578 follow-up)

### DIFF
--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -54,7 +54,7 @@ from ouroboros.mcp.tools.subagent import (
     build_interview_subagent,
     dispatch_plugin_terminal,
     lateral_persona_panel_metadata_from_capability_definitions,
-    register_code_investigation_fanout,
+    register_question_advisory_fanout,
     resolve_subagent_dispatch,
     should_dispatch_via_plugin,
     stamp_fanout_meta,
@@ -718,9 +718,11 @@ def _attach_question_assist_requests(
     ``host_action=spawn_subagents`` cue for the host model to fan the advisory
     lanes out itself.
 
-    When ``fanout_registry`` is provided the code-investigation lane is
-    registered for result re-entry and its ``fanout_id`` is stamped as
-    ``question_advisory_fanout_id`` so a later
+    When ``fanout_registry`` is provided the advisory fan-out is registered for
+    result re-entry — keyed by ``context.lane_id`` with the emitted payloads'
+    lane ids as expected keys, matching the stamped
+    ``question_advisory_result_correlation_key`` — and its ``fanout_id`` is
+    stamped as ``question_advisory_fanout_id`` so a later
     ``ouroboros_submit_fanout_results`` submission can be matched. With no
     registry the emitted meta is byte-identical to the pre-registry contract.
     """
@@ -776,10 +778,17 @@ def _attach_question_assist_requests(
         correlation_key="context.lane_id",
     )
     if fanout_registry is not None:
-        meta["question_advisory_fanout_id"] = register_code_investigation_fanout(
+        # Register with the SAME contract this response stamps: the record's
+        # correlation key is ``context.lane_id`` and its expected keys are the
+        # lane ids carried on the emitted advisory payloads, so a host that
+        # follows the stamped ``question_advisory_result_correlation_key``
+        # round-trips through ``ouroboros_submit_fanout_results`` successfully
+        # (#1578 registered a ``code_facts`` code-investigation record here,
+        # which rejected contract-following submissions as a mismatch).
+        meta["question_advisory_fanout_id"] = register_question_advisory_fanout(
             fanout_registry,
             session_id=session_id,
-            request=code_request,
+            payloads=advisory_payloads,
         )
 
 
@@ -1660,6 +1669,21 @@ class InterviewHandler:
         if self.interview_engine is not None:
             return self.interview_engine.state_dir
         return self.data_dir or _DATA_DIR
+
+    def _resolved_fanout_registry(self) -> FanoutRegistry | None:
+        """Return the fan-out registry rooted under the handler's real data dir.
+
+        The server factory constructs the shared ``FanoutRegistry`` before the
+        interview state dir is known, so a default-located registry is re-rooted
+        onto ``resolved_state_dir()/fanout`` here — the same substrate interview
+        state JSON is written to. Explicitly-located registries (tests, custom
+        wiring) are left untouched, and since producers and the submit handler
+        share one instance, re-entry reads the same directory.
+        """
+        registry = self.fanout_registry
+        if registry is not None:
+            registry.rebase_default(self.resolved_state_dir() / "fanout")
+        return registry
 
     async def _emit_event(self, event: Any) -> None:
         """Emit event to store. Swallows errors to not break interview flow."""
@@ -2617,7 +2641,7 @@ class InterviewHandler:
                         ),
                         runtime_backend=self.agent_runtime_backend,
                         opencode_mode=self.opencode_mode,
-                        fanout_registry=self.fanout_registry,
+                        fanout_registry=self._resolved_fanout_registry(),
                     )
 
                 start_response_text = (
@@ -3151,7 +3175,7 @@ class InterviewHandler:
                         ),
                         runtime_backend=self.agent_runtime_backend,
                         opencode_mode=self.opencode_mode,
-                        fanout_registry=self.fanout_registry,
+                        fanout_registry=self._resolved_fanout_registry(),
                     )
 
                 resume_response_text = f"Session {session_id}\n\n{display_question}"
@@ -3394,7 +3418,7 @@ class InterviewHandler:
                 ),
                 runtime_backend=self.agent_runtime_backend,
                 opencode_mode=self.opencode_mode,
-                fanout_registry=self.fanout_registry,
+                fanout_registry=self._resolved_fanout_registry(),
             )
 
         if lateral_review_dispatch_meta is not None:

--- a/src/ouroboros/mcp/tools/subagent.py
+++ b/src/ouroboros/mcp/tools/subagent.py
@@ -155,6 +155,21 @@ def _payload_persona(payload: Mapping[str, Any]) -> str:
     return "unknown"
 
 
+def _payload_lane_id(payload: Mapping[str, Any]) -> str:
+    """Return the ``context.lane_id`` a fan-out payload correlates by, or ``""``.
+
+    Advisory lanes correlate by ``context.lane_id`` (their persona is absent on
+    some lanes, e.g. ``code_context`` / ``web_context``), so re-entry matches a
+    submitted result to its originating payload by this lane id.
+    """
+    context = payload.get("context")
+    if isinstance(context, Mapping):
+        lane_id = context.get("lane_id")
+        if lane_id:
+            return str(lane_id)
+    return ""
+
+
 def _response_text_json_payload(result: MCPToolResult) -> dict[str, Any] | None:
     text = result.text_content.strip()
     if not text or not text.startswith("{"):
@@ -2401,6 +2416,7 @@ _DEFAULT_FANOUT_DIR = Path.home() / ".ouroboros" / "data" / "fanout"
 # Fan-out re-entry kinds — each routes to one revived synthesizer.
 FANOUT_KIND_LATERAL_PERSONA_PANEL = "lateral_persona_panel"
 FANOUT_KIND_CODE_INVESTIGATION = "code_investigation"
+FANOUT_KIND_QUESTION_ADVISORY = "question_advisory"
 
 
 def _fanout_meta_key(prefix: str, key: str) -> str:
@@ -2554,7 +2570,10 @@ class FanoutRegistry:
     """File-backed store for pending fan-out expected-key state.
 
     Reuses the interview data directory as the persistence substrate (the same
-    place interview state JSON is written) rather than inventing a new layer.
+    place interview state JSON is written) rather than inventing a new layer:
+    handlers that know the resolved interview state dir thread it in via
+    :meth:`rebase_default`; until then the zero-arg default falls back to
+    ``~/.ouroboros/data/fanout``.
     Each record is a single ``{fanout_id}.json`` file. Writes are best-effort:
     a persistence failure degrades re-entry (submissions report the fan-out as
     unknown) but never breaks the fan-out request path.
@@ -2566,6 +2585,20 @@ class FanoutRegistry:
     @property
     def directory(self) -> Path:
         return self._dir
+
+    def rebase_default(self, directory: Path) -> None:
+        """Re-root a default-located registry onto the server's real data dir.
+
+        The zero-arg constructor falls back to ``~/.ouroboros/data/fanout``
+        because the server factory does not know the resolved interview state
+        dir at construction time. Handlers that DO know it (via
+        ``resolved_state_dir()``) call this to thread the actual data dir in.
+        A registry constructed with an explicit directory (e.g. tests injecting
+        ``tmp_path``) is never re-rooted, and because producer + submit handlers
+        share one registry instance, both sides observe the same directory.
+        """
+        if self._dir == _DEFAULT_FANOUT_DIR:
+            self._dir = directory
 
     def _path(self, fanout_id: str) -> Path:
         return self._dir / f"{fanout_id}.json"
@@ -2705,6 +2738,44 @@ def register_code_investigation_fanout(
     )
 
 
+def register_question_advisory_fanout(
+    registry: FanoutRegistry,
+    *,
+    session_id: str,
+    payloads: list[SubagentPayload],
+    correlation_key: str = "context.lane_id",
+    fanout_id: str | None = None,
+) -> str:
+    """Register an interview question-advisory fan-out for later result re-entry.
+
+    The advisory lanes are stamped to correlate by ``context.lane_id`` (a lane's
+    persona is absent on the ``code_context`` / ``web_context`` lanes), so the
+    expected keys are the lane ids carried on the emitted payloads — exactly the
+    keys the stamped ``question_advisory_result_correlation_key`` tells the host
+    to submit under. This is the invariant #1578 broke: the producer stamped
+    ``context.lane_id`` but registered a ``code_facts`` record, so a
+    contract-following host was rejected with ``correlation_mismatch``.
+
+    Advisory lanes have no gating synthesizer (each is independent advice to make
+    the human's answer easier), so submission routes to a deterministic
+    aggregation that returns the correlated lane outputs in dispatch order for
+    the host to synthesize.
+    """
+    expected_keys: list[str] = []
+    for payload in payloads:
+        lane_id = _payload_lane_id(payload.to_dict())
+        if lane_id and lane_id not in expected_keys:
+            expected_keys.append(lane_id)
+    return registry.register(
+        kind=FANOUT_KIND_QUESTION_ADVISORY,
+        session_id=session_id,
+        correlation_key=correlation_key,
+        expected_keys=expected_keys,
+        synthesizer_input={"lane_ids": list(expected_keys)},
+        fanout_id=fanout_id,
+    )
+
+
 def submit_fanout_results(
     registry: FanoutRegistry,
     *,
@@ -2788,6 +2859,25 @@ def submit_fanout_results(
             provided,
             _fanout_identity_synthesis,
         )
+        return {
+            "status": "complete",
+            "fanout_id": fanout_id,
+            "kind": record.kind,
+            "correlation_key": record.correlation_key,
+            "result": outcome,
+        }
+
+    if record.kind == FANOUT_KIND_QUESTION_ADVISORY:
+        # Advisory lanes are independent advice with no gating synthesizer, so
+        # aggregate the correlated outputs deterministically in dispatch (lane)
+        # order and hand them back for the host to synthesize.
+        lane_ids = record.synthesizer_input.get("lane_ids") or list(record.expected_keys)
+        aggregated = [
+            {"lane_id": lane_id, "output": provided[lane_id]}
+            for lane_id in lane_ids
+            if lane_id in provided
+        ]
+        outcome = _fanout_identity_synthesis(aggregated)
         return {
             "status": "complete",
             "fanout_id": fanout_id,

--- a/tests/unit/mcp/tools/test_fanout_core.py
+++ b/tests/unit/mcp/tools/test_fanout_core.py
@@ -11,12 +11,16 @@ Covers PR-J:
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 import pytest
 
 from ouroboros.backends.capabilities import SubagentDispatchMode
-from ouroboros.mcp.tools.authoring_handlers import _attach_question_assist_requests
+from ouroboros.mcp.tools.authoring_handlers import (
+    InterviewHandler,
+    _attach_question_assist_requests,
+)
 from ouroboros.mcp.tools.evaluation_handlers import (
     LateralThinkHandler,
     SubmitFanoutResultsHandler,
@@ -24,10 +28,12 @@ from ouroboros.mcp.tools.evaluation_handlers import (
 from ouroboros.mcp.tools.subagent import (
     FANOUT_KIND_CODE_INVESTIGATION,
     FANOUT_KIND_LATERAL_PERSONA_PANEL,
+    FANOUT_KIND_QUESTION_ADVISORY,
     FanoutRecord,
     FanoutRegistry,
     build_fanout_subagents,
     build_subagent_payload,
+    register_code_investigation_fanout,
     register_lateral_persona_fanout,
     stamp_fanout_meta,
     submit_fanout_results,
@@ -312,6 +318,10 @@ def _code_fact_output(session_id: str, question: str) -> dict[str, Any]:
 
 
 def test_submit_complete_code_investigation_routes_to_synthesizer(tmp_path: Any) -> None:
+    # The advisory producer no longer registers a code-investigation record
+    # (#1578 follow-up: it registered `code_facts` while stamping
+    # `context.lane_id`, so contract-following hosts were rejected). The
+    # code-investigation kind is now registered directly from its request.
     registry = FanoutRegistry(tmp_path)
     question = "Which manifest declares the package?"
     session_id = "sess-code"
@@ -324,9 +334,12 @@ def test_submit_complete_code_investigation_routes_to_synthesizer(tmp_path: Any)
         score=None,
         dispatch_mode=SubagentDispatchMode.HOST_DRIVEN,
         runtime_backend="codex",
-        fanout_registry=registry,
     )
-    fanout_id = meta["question_advisory_fanout_id"]
+    fanout_id = register_code_investigation_fanout(
+        registry,
+        session_id=session_id,
+        request=meta["code_investigation_request"],
+    )
     out = submit_fanout_results(
         registry,
         session_id=session_id,
@@ -340,6 +353,133 @@ def test_submit_complete_code_investigation_routes_to_synthesizer(tmp_path: Any)
     assert result["ready_for_synthesis"] is True
     assert result["ready_for_forward"] is True
     assert result["contract_violations"] == []
+
+
+# --------------------------------------------------------------------------- #
+# Advisory re-entry regression (#1578 follow-up): the STAMPED contract works
+# --------------------------------------------------------------------------- #
+
+
+def _resolve_correlated_key(payload: Mapping[str, Any], dotted_key: str) -> str:
+    """Resolve a payload's correlation value by walking the stamped dotted path."""
+    node: Any = payload
+    for part in dotted_key.split("."):
+        assert isinstance(node, Mapping), f"cannot traverse {dotted_key!r} at {part!r}"
+        node = node[part]
+    return str(node)
+
+
+def _emitted_advisory_contract(
+    registry: FanoutRegistry, session_id: str
+) -> tuple[str, str, list[str]]:
+    """Emit an advisory response and read the re-entry contract FROM its meta.
+
+    Returns ``(fanout_id, correlation_key, lane_keys)`` exactly as a
+    contract-following host would obtain them: the stamped fan-out id, the
+    stamped correlation key, and the per-lane keys resolved by walking that
+    dotted key against each emitted advisory payload.
+    """
+    meta: dict[str, Any] = {}
+    _attach_question_assist_requests(
+        meta,
+        session_id=session_id,
+        question="Which rollout strategy should we pick?",
+        phase="answer",
+        score=None,
+        dispatch_mode=SubagentDispatchMode.HOST_DRIVEN,
+        runtime_backend="codex",
+        fanout_registry=registry,
+    )
+    fanout_id = meta["question_advisory_fanout_id"]
+    correlation_key = meta["question_advisory_result_correlation_key"]
+    lane_keys = [
+        _resolve_correlated_key(payload, correlation_key)
+        for payload in meta["question_advisory_subagents"]
+    ]
+    assert lane_keys, "advisory fan-out emitted no lanes"
+    return fanout_id, correlation_key, lane_keys
+
+
+@pytest.mark.asyncio
+async def test_advisory_reentry_follows_stamped_meta_contract(tmp_path: Any) -> None:
+    """Regression (#1578): a host following the STAMPED contract must succeed.
+
+    The producer stamped ``question_advisory_result_correlation_key=
+    "context.lane_id"`` but registered a ``code_facts`` code-investigation
+    record, so submitting with the stamped key + per-lane keys was rejected
+    with ``correlation_mismatch``. Everything submitted here is read from the
+    emitted meta/payloads — nothing is hardcoded from server internals.
+    """
+    registry = FanoutRegistry(tmp_path)
+    session_id = "sess-advisory-contract"
+    fanout_id, correlation_key, lane_keys = _emitted_advisory_contract(registry, session_id)
+
+    submit = SubmitFanoutResultsHandler(fanout_registry=registry)
+    submit_result = await submit.handle(
+        {
+            "session_id": session_id,
+            "fanout_id": fanout_id,
+            "correlation_key": correlation_key,
+            "results": [{"key": key, "content": f"{key}-advice"} for key in lane_keys],
+        }
+    )
+    assert submit_result.is_ok, submit_result
+    out = submit_result.unwrap().meta
+    assert out["status"] == "complete"
+    assert out["kind"] == FANOUT_KIND_QUESTION_ADVISORY
+    assert out["correlation_key"] == correlation_key
+    aggregated = out["result"]["aggregated_outputs"]
+    assert [item["lane_id"] for item in aggregated] == lane_keys
+    assert [item["output"] for item in aggregated] == [f"{key}-advice" for key in lane_keys]
+
+
+@pytest.mark.asyncio
+async def test_advisory_reentry_partial_set_lists_missing_lane_ids(tmp_path: Any) -> None:
+    """Submitting a subset of the emitted lanes reports the missing lane ids."""
+    registry = FanoutRegistry(tmp_path)
+    session_id = "sess-advisory-partial"
+    fanout_id, correlation_key, lane_keys = _emitted_advisory_contract(registry, session_id)
+    assert len(lane_keys) > 1, "partial-set case needs multiple advisory lanes"
+
+    submit = SubmitFanoutResultsHandler(fanout_registry=registry)
+    submit_result = await submit.handle(
+        {
+            "session_id": session_id,
+            "fanout_id": fanout_id,
+            "correlation_key": correlation_key,
+            "results": [{"key": lane_keys[0], "content": f"{lane_keys[0]}-advice"}],
+        }
+    )
+    assert submit_result.is_ok, submit_result
+    out = submit_result.unwrap().meta
+    assert out["status"] == "partial"
+    assert out["missing_keys"] == lane_keys[1:]
+    assert out["received_keys"] == [lane_keys[0]]
+
+
+# --------------------------------------------------------------------------- #
+# Registry state-dir threading (#1578 follow-up, MEDIUM)
+# --------------------------------------------------------------------------- #
+
+
+def test_registry_rebase_default_moves_default_location_only(tmp_path: Any) -> None:
+    default_registry = FanoutRegistry()
+    default_registry.rebase_default(tmp_path / "fanout")
+    assert default_registry.directory == tmp_path / "fanout"
+    # A second rebase is a no-op: the registry is no longer default-located.
+    default_registry.rebase_default(tmp_path / "other")
+    assert default_registry.directory == tmp_path / "fanout"
+
+    explicit = FanoutRegistry(tmp_path / "explicit")
+    explicit.rebase_default(tmp_path / "fanout")
+    assert explicit.directory == tmp_path / "explicit"
+
+
+def test_interview_handler_threads_state_dir_into_registry(tmp_path: Any) -> None:
+    handler = InterviewHandler(data_dir=tmp_path, fanout_registry=FanoutRegistry())
+    registry = handler._resolved_fanout_registry()
+    assert registry is not None
+    assert registry.directory == tmp_path / "fanout"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Follow-up fixing the CHANGES_REQUESTED bot-review findings on already-merged #1578 (fan-out core + `submit_fanout_results` re-entry tool).

## BLOCKER — advisory correlation mismatch

**Before (#1578):** `_attach_question_assist_requests` stamped the advisory response with `question_advisory_result_correlation_key="context.lane_id"`, but registered the fan-out via `register_code_investigation_fanout(...)` — a record with `correlation_key="code_facts"` and expected key `code_facts`. Contract walkthrough for a host that follows the stamped meta:

1. Host reads `question_advisory_fanout_id` + `question_advisory_result_correlation_key` (`context.lane_id`) from the emitted meta.
2. Host resolves each advisory payload's `context.lane_id` (`code_context`, `web_context`, `ambiguity_contrarian`, ...) and spawns the lanes.
3. Host calls `ouroboros_submit_fanout_results(session_id, correlation_key="context.lane_id", results=[{key: <lane_id>, content}...], fanout_id=<stamped>)`.
4. Server loads the record → `record.correlation_key == "code_facts"` → **`correlation_mismatch` rejection**. Even bypassing that, expected key `code_facts` never matches lane ids → permanently `partial`. Advisory re-entry was unusable end-to-end.

**After:** the producer registers via a new `register_question_advisory_fanout` (mirrors the `register_lateral_persona_fanout` shape): `kind="question_advisory"`, `correlation_key="context.lane_id"`, expected keys = the actual lane ids read from the emitted advisory payloads. Step 4 now validates cleanly and routes to synthesis.

**Routing design:** the `synthesize_*` contracts were read first — `synthesize_code_investigation_when_complete` validates a code-fact answer contract and `continue_interview_after_lateral_persona_synthesis` orders persona entries; neither semantically fits independent advisory lanes. Per the finding's guidance ("if no synthesizer semantically fits advisory lanes — a deterministic aggregation that returns the correlated results"), the new `question_advisory` branch in `submit_fanout_results` deterministically aggregates `{lane_id, output}` pairs in dispatch (lane) order via the existing `_fanout_identity_synthesis`, returning them under `status="complete"` for the host to synthesize — consistent with the re-entry tool's no-LLM contract.

## MEDIUM — registry location

`FanoutRegistry`'s zero-arg default was hard-coded `~/.ouroboros/data/fanout` while its docstring claimed it reuses the interview data dir. Now `FanoutRegistry.rebase_default(dir)` re-roots a **default-located** registry, and `InterviewHandler._resolved_fanout_registry()` threads `resolved_state_dir() / "fanout"` (the same SSOT `_plugin_save_state` writes interview state under) into the shared instance at every producer call site. Explicitly-located registries (tests, custom wiring) are never re-rooted; the hard-coded default remains the fallback until a handler resolves the real dir. Producers and `SubmitFanoutResultsHandler` share one registry instance, so both sides observe the same directory.

## Tests

- `test_advisory_reentry_follows_stamped_meta_contract` — follows the emitted meta contract EXACTLY: reads `question_advisory_fanout_id`, `question_advisory_result_correlation_key`, and the per-lane keys by walking the stamped dotted path against each emitted payload, submits through the real `SubmitFanoutResultsHandler`, asserts `complete` + lane-ordered aggregation. This test fails with `correlation_mismatch` on the pre-fix code.
- `test_advisory_reentry_partial_set_lists_missing_lane_ids` — partial submission lists the missing lane ids.
- `test_registry_rebase_default_moves_default_location_only` + `test_interview_handler_threads_state_dir_into_registry` — state-dir threading.
- **#1578 byte-identical snapshot tests pass unmodified** (`test_advisory_producer_byte_identical_without_registry`, `test_advisory_registry_delta_is_exactly_fanout_id` — the delta is still exactly `question_advisory_fanout_id`; only the registration kind behind it changed, verified).
- One existing test necessarily changed: `test_submit_complete_code_investigation_routes_to_synthesizer` asserted the buggy behavior itself (submitting `code_facts` against the advisory-stamped fan-out). It now registers the code-investigation record directly via `register_code_investigation_fanout`, preserving its synthesizer-routing coverage without the broken producer coupling.

## Validation

- `ruff check` + `ruff format --check`: clean (1035 files)
- `mypy src/`: Success, 429 source files
- `pytest tests/ --ignore=tests/e2e --ignore=tests/unit/mcp --ignore=tests/integration/mcp -q`: **10197 passed, 6 failed, 5 skipped** — all 6 are the documented pre-existing failures (`test_surface` x4, `test_auto_runtime_dispatch` x2; codex-config-leak environment issue), unrelated to this change
- Targeted MCP test files (explicit, no dir runs): `test_fanout_core.py` **22 passed**; + the 13 authoring/interview handler test files: **147 passed** total

🤖 Generated with [Claude Code](https://claude.com/claude-code)