### PR TITLE
fix(cli): validate harness run_id before filesystem resolution — close path traversal (#1582 follow-up)

### DIFF
--- a/src/ouroboros/cli/commands/harness.py
+++ b/src/ouroboros/cli/commands/harness.py
@@ -82,11 +82,36 @@ def _default_db_path() -> Path:
 
 
 def _auto_store(data_root: Path | None) -> AutoStore:
-    return AutoStore(root=data_root) if data_root is not None else AutoStore()
+    return AutoStore(root=data_root.expanduser()) if data_root is not None else AutoStore()
 
 
 def _trace_dir(traces_root: Path, run_id: str) -> Path:
     return traces_root / run_id
+
+
+# Run ids are auto session ids: ``auto_<uuid4().hex[:12]>`` (see
+# :class:`ouroboros.auto.state.AutoPipelineState`) and A2 keys every trace
+# directory by exactly that id. The real id is therefore ``auto_`` + 12 hex
+# chars — a strict subset of the conservative single-segment allowlist below.
+# We enforce the *allowlist* rather than the exact ``auto_<hex>`` shape so that
+# any exporter-written directory name (and the ids used in tests, e.g.
+# ``auto_ondemand``) still resolves, while a caller can never break out of
+# ``--traces-root``: the pattern admits only ``[A-Za-z0-9._-]`` — which forbids
+# every path separator (``/``, ``\``, ``os.sep``), drive/colon prefixes, and
+# whitespace — and we additionally reject any ``..`` parent reference and the
+# empty string. This runs BEFORE any filesystem lookup.
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _is_valid_run_id(run_id: str) -> bool:
+    """Return ``True`` only for a safe single-segment auto session id.
+
+    Rejects the empty string, any ``..`` parent reference, and anything outside
+    the conservative allowlist (which already excludes absolute paths and every
+    path separator). Deliberately conservative: the real id shape
+    (``auto_<hex12>``) is a strict subset of what this accepts.
+    """
+    return bool(run_id) and ".." not in run_id and _RUN_ID_RE.fullmatch(run_id) is not None
 
 
 def _is_exported(trace_dir: Path) -> bool:
@@ -249,11 +274,27 @@ def _ensure_trace(
 ) -> Path | None:
     """Resolve a run's trace dir, projecting on-demand when not yet exported.
 
-    Filesystem first: an already-exported trace is returned untouched. When
-    missing, fall back to A2's :func:`export_interview_trace`. Returns ``None``
-    when the run can be neither found on disk nor projected from state.
+    Validation first: a caller-controlled ``run_id`` is checked against the
+    conservative allowlist BEFORE any filesystem lookup, so an absolute or
+    ``../`` id can never reach :func:`_trace_dir`. Filesystem next: an
+    already-exported trace is returned untouched. When missing, fall back to
+    A2's :func:`export_interview_trace`. Returns ``None`` when the run is
+    invalid, cannot be found on disk, or cannot be projected from state — all
+    funnel into the caller's single clean "run not found" error (no info leak).
     """
+    if not _is_valid_run_id(run_id):
+        return None
     trace_dir = _trace_dir(traces_root, run_id)
+    # Defense in depth: the built dir must resolve strictly inside traces_root.
+    # (``resolve()`` collapses any symlink/relative component the allowlist did
+    # not catch.) A violation is treated exactly like an unknown run.
+    try:
+        resolved_root = traces_root.resolve()
+        resolved_dir = trace_dir.resolve()
+    except OSError:
+        return None
+    if not resolved_dir.is_relative_to(resolved_root):
+        return None
     if _is_exported(trace_dir):
         return trace_dir
     return asyncio.run(
@@ -316,9 +357,9 @@ def _resolve_roots(
     data_root: Path | None,
     db_path: Path | None,
 ) -> tuple[Path, AutoStore, Path]:
-    root = traces_root if traces_root is not None else _default_traces_root()
+    root = (traces_root if traces_root is not None else _default_traces_root()).expanduser()
     store = _auto_store(data_root)
-    db = db_path if db_path is not None else _default_db_path()
+    db = (db_path if db_path is not None else _default_db_path()).expanduser()
     return root, store, db
 
 
@@ -336,7 +377,7 @@ def list_runs(
     wall-clock at render), export status, terminal phase / grade, final
     ambiguity, and a provenance-histogram digest.
     """
-    root = traces_root if traces_root is not None else _default_traces_root()
+    root = (traces_root if traces_root is not None else _default_traces_root()).expanduser()
     store = _auto_store(data_root)
 
     exported: set[str] = set()
@@ -653,7 +694,7 @@ def frontier(
         raise typer.Exit(EXIT_UNKNOWN)
 
     extractor, ascending, _description = _FRONTIER_METRICS[metric]
-    root = traces_root if traces_root is not None else _default_traces_root()
+    root = (traces_root if traces_root is not None else _default_traces_root()).expanduser()
 
     traced: list[str] = []
     if root.is_dir():

--- a/tests/unit/cli/test_harness.py
+++ b/tests/unit/cli/test_harness.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from ouroboros.auto.state import AutoPipelineState, AutoStore
@@ -414,3 +415,163 @@ def test_frontier_no_traces(tmp_path: Path) -> None:
     )
     assert result.exit_code == 0
     assert "No traced runs found." in result.output
+
+
+# --------------------------------------------------------------------------- #
+# run_id path-traversal boundary (security regression, #1582 bot finding)     #
+# --------------------------------------------------------------------------- #
+# The bot reproduced: ``harness show <abs-path> --traces-root <root>`` served
+# an *outside* directory's summary.md (exit 0) because ``traces_root / run_id``
+# was computed before any validation — an absolute run_id ignores --traces-root
+# and a ``../`` run_id escapes it. These tests pin the fix: a caller-controlled
+# run_id must be validated (and the resolved dir confined under traces_root)
+# BEFORE any filesystem lookup, funnelling into the clean "run not found" path.
+
+# A distinctive marker planted in a fully-exported trace sitting OUTSIDE the
+# --traces-root the CLI is pointed at. If any subcommand ever serves it, the
+# boundary has been breached.
+_OUTSIDE_SUMMARY_MARKER = "Interview trace — outside"
+_OUTSIDE_QUESTION_MARKER = "OUTSIDE_SECRET_QUESTION"
+
+
+def _setup_boundary(tmp_path: Path) -> Path:
+    """Create a real traces_root plus an exported trace just outside it.
+
+    Layout::
+
+        tmp_path/traces/auto_legit/   # a valid in-root trace
+        tmp_path/outside/             # exported, but NOT under traces_root
+
+    Returns the traces_root the CLI will be pointed at.
+    """
+    traces_root = tmp_path / "traces"
+    traces_root.mkdir(parents=True)
+    _write_trace(traces_root, "auto_legit")
+    # The escape target: a complete, greppable trace outside traces_root.
+    _write_trace(tmp_path, "outside", questions=[_OUTSIDE_QUESTION_MARKER])
+    return traces_root
+
+
+def _attack_run_ids(tmp_path: Path) -> dict[str, str]:
+    """Malicious run ids that all target ``tmp_path/outside`` (or any escape)."""
+    return {
+        # Absolute path ignores --traces-root entirely (the bot's repro).
+        "absolute": str(tmp_path / "outside"),
+        # ``..`` climbs out of traces_root back to tmp_path/outside.
+        "parent_traversal": "../outside",
+        # Any path separator must be rejected outright.
+        "separator": "sub/outside",
+    }
+
+
+def _assert_no_outside_leak(output: str) -> None:
+    assert _OUTSIDE_SUMMARY_MARKER not in output
+    assert _OUTSIDE_QUESTION_MARKER not in output
+
+
+@pytest.mark.parametrize("attack", ["absolute", "parent_traversal", "separator"])
+def test_show_rejects_out_of_root_run_id(tmp_path: Path, attack: str) -> None:
+    traces_root = _setup_boundary(tmp_path)
+    run_id = _attack_run_ids(tmp_path)[attack]
+
+    result = runner.invoke(
+        app,
+        [
+            "harness",
+            "show",
+            run_id,
+            "--traces-root",
+            str(traces_root),
+            "--data-root",
+            str(tmp_path / "data"),
+            "--db-path",
+            str(tmp_path / "absent.db"),
+        ],
+    )
+
+    assert result.exit_code != 0, result.output
+    _assert_no_outside_leak(result.output)
+
+
+@pytest.mark.parametrize("attack", ["absolute", "parent_traversal", "separator"])
+def test_trace_rejects_out_of_root_run_id(tmp_path: Path, attack: str) -> None:
+    traces_root = _setup_boundary(tmp_path)
+    run_id = _attack_run_ids(tmp_path)[attack]
+
+    result = runner.invoke(
+        app,
+        [
+            "harness",
+            "trace",
+            run_id,
+            "--grep",
+            _OUTSIDE_QUESTION_MARKER,
+            "--traces-root",
+            str(traces_root),
+            "--data-root",
+            str(tmp_path / "data"),
+            "--db-path",
+            str(tmp_path / "absent.db"),
+        ],
+    )
+
+    assert result.exit_code != 0, result.output
+    _assert_no_outside_leak(result.output)
+
+
+@pytest.mark.parametrize("attack", ["absolute", "parent_traversal", "separator"])
+def test_diff_rejects_out_of_root_run_id(tmp_path: Path, attack: str) -> None:
+    traces_root = _setup_boundary(tmp_path)
+    run_id = _attack_run_ids(tmp_path)[attack]
+
+    result = runner.invoke(
+        app,
+        [
+            "harness",
+            "diff",
+            run_id,
+            "auto_legit",  # a valid in-root run for the B slot
+            "--traces-root",
+            str(traces_root),
+            "--data-root",
+            str(tmp_path / "data"),
+            "--db-path",
+            str(tmp_path / "absent.db"),
+        ],
+    )
+
+    assert result.exit_code != 0, result.output
+    _assert_no_outside_leak(result.output)
+    # It must error before rendering anything (no partial diff of the escape).
+    assert "# diff" not in result.output
+
+
+def test_show_valid_run_id_still_works(tmp_path: Path) -> None:
+    traces_root = _setup_boundary(tmp_path)
+    result = runner.invoke(
+        app,
+        ["harness", "show", "auto_legit", "--traces-root", str(traces_root)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "Interview trace — auto_legit" in result.output
+
+
+def test_trace_valid_run_id_still_works(tmp_path: Path) -> None:
+    traces_root = _setup_boundary(tmp_path)
+    result = runner.invoke(
+        app,
+        ["harness", "trace", "auto_legit", "--grep", "goal", "--traces-root", str(traces_root)],
+    )
+    assert result.exit_code == 0, result.output
+    assert f"{QUESTIONS_FILE}:" in result.output
+
+
+def test_diff_valid_run_ids_still_work(tmp_path: Path) -> None:
+    traces_root = _setup_boundary(tmp_path)
+    _write_trace(traces_root, "auto_legit2", grade="B")
+    result = runner.invoke(
+        app,
+        ["harness", "diff", "auto_legit", "auto_legit2", "--traces-root", str(traces_root)],
+    )
+    assert result.exit_code == 0, result.output
+    assert "# diff A=auto_legit B=auto_legit2" in result.output


### PR DESCRIPTION
## What

Follow-up to #1582, fixing the SECURITY blocker from the ouroboros-agent bot review (CHANGES_REQUESTED): `ooo harness show/trace/diff` accepted a caller-controlled `run_id` and built `traces_root / run_id` **before any validation**.

**Bot's reproduction (confirmed locally before the fix):**

```
harness show /tmp/.../outside --traces-root /tmp/.../traces
```

printed the *outside* directory's `summary.md` and exited 0 — an absolute `run_id` ignores `--traces-root` entirely, and a `../` run_id escapes it. Any directory containing an `outcome.json` was served. AutoStore's own id validation only ran on the not-yet-exported fallback path, never on the filesystem-first path.

## Boundary rule

Run ids are auto session ids — `auto_<uuid4().hex[:12]>` (`AutoPipelineState.auto_session_id`, `src/ouroboros/auto/state.py:450`) — and A2 keys every trace directory by exactly that id. The new `_is_valid_run_id()` in `harness.py` enforces, **before any filesystem lookup**, in the one shared resolver (`_ensure_trace`) used by `show`, `trace`, and `diff`:

1. **Allowlist**: `^[A-Za-z0-9._-]+$` — a conservative single-segment superset of the real `auto_<hex12>` shape. Forbids every path separator (`/`, `\`, `os.sep`), drive/colon prefixes, and whitespace; an absolute path can therefore never match.
2. **Explicit rejects**: empty string and any `..` parent reference.
3. **Defense in depth**: the built dir is `resolve()`d and must satisfy `Path.is_relative_to(traces_root.resolve())` — catches anything the allowlist could ever miss (e.g. symlinked components).

A violation funnels into the *existing* clean error path — the same `print_error` + exit 2 (`EXIT_UNKNOWN`) as an unknown run — so nothing about outside paths is leaked. (`list` and `frontier` never resolve caller ids; they only enumerate directory names under the root.)

Also addressed the bot's low-priority note: `~` is now expanded (`Path.expanduser()`) for user-supplied `--traces-root` / `--data-root` / `--db-path` — one-liners in `_resolve_roots` / `list` / `frontier` / `_auto_store`.

## Tests

`tests/unit/cli/test_harness.py` (existing tests untouched — diff is purely additive):

- `show` / `trace` / `diff` × {absolute run_id, `../` traversal, separator-containing id}: assert **non-zero exit** and that the outside trace's summary/question markers are **never printed** (9 parametrized cases).
- Valid-id happy paths for all three subcommands still pass.

## Validation

- `ruff check` + `ruff format --check`: clean
- `mypy src/`: clean (429 files)
- `pytest tests/unit/cli/test_harness.py`: **24 passed**
- Full gate (`tests/` minus e2e / unit/mcp / integration/mcp), run under an isolated `$HOME` to cut the known user-config leak that spawns real backend binaries: **10215 passed, 5 skipped, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)