### PR TITLE
fix(auto): bound the trace export filesystem phase too — off-loop writes so the deadline holds (#1584 follow-up)

### DIFF
--- a/src/ouroboros/auto/trace_export.py
+++ b/src/ouroboros/auto/trace_export.py
@@ -105,15 +105,21 @@ _FLAG_MARKERS: tuple[str, ...] = (
 # passed straight through from event payloads.
 _MAX_TEXT = 2000
 
-# Hard wall-clock bound for the *finalize* trace projection. The finalize hook
-# awaits ``export_trace_from_state`` — which fans out to up to two unbounded
-# ``event_store.query_events`` aggregate scans plus filesystem writes — right
-# before the pipeline returns its already-computed terminal result. A slow or
-# hung EventStore / filesystem must never delay (or hang) a COMPLETE / BLOCKED
-# / FAILED return: trace generation is best-effort and cannot affect the run
-# outcome. This deadline caps the worst case; on breach the projection is
-# dropped like any other swallowed failure. 30s is generous for a healthy
-# store yet bounds the terminal-return delay to a predictable ceiling.
+# Hard wall-clock bound on the *caller's wait* for the finalize trace
+# projection. The finalize hook awaits ``export_trace_from_state`` — up to two
+# unbounded ``event_store.query_events`` aggregate scans (cooperative awaits)
+# plus the filesystem tail, which runs off-loop in a worker thread via
+# ``asyncio.to_thread`` (see ``_write_trace_files``) — right before the
+# pipeline returns its already-computed terminal result. A slow or hung
+# EventStore / filesystem must never delay (or hang) a COMPLETE / BLOCKED /
+# FAILED return: trace generation is best-effort and cannot affect the run
+# outcome. On breach the caller stops waiting and the projection is dropped
+# like any other swallowed failure. Precisely: the deadline bounds only the
+# caller-visible wait — an abandoned worker thread may still finish its writes
+# (or stay wedged against the hung filesystem) in the background, which is the
+# standard, acceptable trade for best-effort observability. 30s is generous
+# for a healthy store yet keeps the terminal-return delay to a predictable
+# ceiling.
 TRACE_EXPORT_DEADLINE_SECONDS = 30.0
 
 
@@ -482,6 +488,36 @@ def _resolve_out_root(state: AutoPipelineState, out_root: Path | None) -> Path:
     return base / ".ouroboros" / "traces" / state.auto_session_id
 
 
+def _write_trace_files(
+    out_dir: Path,
+    streams: dict[str, list[dict[str, Any]]],
+    outcome: dict[str, Any],
+    summary_md: str,
+) -> None:
+    """Synchronous filesystem tail of the export: mkdir + every write.
+
+    Deliberately a plain sync function with **no** await points, executed off
+    the event loop via ``asyncio.to_thread`` by :func:`export_trace_from_state`.
+    ``mkdir`` / ``write_text`` / ``unlink`` are blocking syscalls; run on the
+    loop they would stall *every* coroutine — including the ``asyncio.wait_for``
+    deadline in :func:`best_effort_export_trace`, which can only interrupt
+    cooperative awaits. In a worker thread, a hung or slow filesystem blocks
+    only that thread and the deadline still releases the caller.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for filename, rows in streams.items():
+        path = out_dir / filename
+        if rows:
+            _write_jsonl(path, rows)
+        else:
+            _remove_if_exists(path)
+    (out_dir / OUTCOME_FILE).write_text(
+        json.dumps(outcome, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out_dir / SUMMARY_FILE).write_text(summary_md, encoding="utf-8")
+
+
 async def export_trace_from_state(
     state: AutoPipelineState,
     ledger: SeedDraftLedger,
@@ -495,6 +531,10 @@ async def export_trace_from_state(
     and returns that directory. Empty streams omit (and clear any stale) file.
     Idempotent: content is derived only from persisted state and stored
     events, so re-export is byte-identical.
+
+    The filesystem phase (:func:`_write_trace_files`) runs in a worker thread
+    via ``asyncio.to_thread`` so blocking syscalls never stall the event loop;
+    only the cooperative event queries and pure data-shaping run on the loop.
     """
     aggregate_ids: tuple[str, ...] = tuple(
         agg for agg in (state.auto_session_id, state.interview_session_id) if agg
@@ -521,8 +561,6 @@ async def export_trace_from_state(
     summary_md = _build_summary_md(outcome, counts)
 
     out_dir = _resolve_out_root(state, out_root)
-    out_dir.mkdir(parents=True, exist_ok=True)
-
     streams: dict[str, list[dict[str, Any]]] = {
         QUESTIONS_FILE: question_lines,
         AMBIGUITY_FILE: ambiguity_lines,
@@ -530,18 +568,7 @@ async def export_trace_from_state(
         DECISIONS_FILE: decision_lines,
         FLAGS_FILE: flag_lines,
     }
-    for filename, rows in streams.items():
-        path = out_dir / filename
-        if rows:
-            _write_jsonl(path, rows)
-        else:
-            _remove_if_exists(path)
-
-    (out_dir / OUTCOME_FILE).write_text(
-        json.dumps(outcome, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-    (out_dir / SUMMARY_FILE).write_text(summary_md, encoding="utf-8")
+    await asyncio.to_thread(_write_trace_files, out_dir, streams, outcome, summary_md)
 
     log.info(
         "auto.trace_export.written",
@@ -593,17 +620,25 @@ async def best_effort_export_trace(
     Any failure — event-store query, filesystem, serialization — is logged and
     swallowed so trace generation cannot affect the auto pipeline's outcome.
 
-    The projection is additionally **time-bounded** by
-    :data:`TRACE_EXPORT_DEADLINE_SECONDS` via :func:`asyncio.wait_for`, so a
-    slow or hung EventStore / filesystem can drop the trace but never delay the
-    caller's terminal return past the deadline. A deadline breach surfaces as
-    :class:`TimeoutError` and is swallowed like any other projection failure.
+    The caller's wait is additionally **time-bounded** by
+    :data:`TRACE_EXPORT_DEADLINE_SECONDS` via :func:`asyncio.wait_for`. For the
+    bound to hold against *blocking* work — not just cooperative awaits — the
+    filesystem tail of the export runs in a worker thread
+    (``asyncio.to_thread`` in :func:`export_trace_from_state`); ``wait_for``
+    can only interrupt code that yields to the loop. The guarantee is therefore
+    exactly this: the caller resumes within the deadline. On breach the wait is
+    **abandoned**, surfacing as :class:`TimeoutError` and swallowed like any
+    other projection failure — while the abandoned worker thread may still
+    complete its writes (or stay wedged against a hung filesystem) in the
+    background. That is the standard trade for best-effort observability; the
+    trace may be partial or missing, the run outcome is unaffected.
 
     Cancellation semantics follow the driver's established
     ``wait_for`` / ``CancelledError`` idiom: ``asyncio.wait_for`` converts its
     *own* timeout into ``TimeoutError``, so any :class:`asyncio.CancelledError`
     reaching this frame is a **genuine outer cancellation** (the pipeline task
-    itself being torn down) — it is re-raised, never swallowed.
+    itself being torn down) — it is re-raised, never swallowed. An in-flight
+    worker thread is likewise abandoned on outer cancel.
     """
     try:
         return await asyncio.wait_for(

--- a/tests/unit/auto/test_trace_export.py
+++ b/tests/unit/auto/test_trace_export.py
@@ -412,6 +412,81 @@ async def test_outer_cancellation_propagates(
         await task
 
 
+def _install_blocking_write_text(monkeypatch: pytest.MonkeyPatch, *, block_seconds: float) -> None:
+    """Make the *first* ``Path.write_text`` a blocking synchronous stall.
+
+    Models a hung/slow filesystem during finalization. A plain ``time.sleep``
+    holds the calling OS thread without yielding to the event loop — exactly
+    the class of blocking syscall ``asyncio.wait_for`` cannot interrupt if it
+    runs on the loop. Only the first call blocks (then delegates to the real
+    method) so the abandoned worker thread drains within ``block_seconds``
+    instead of stacking one stall per written file.
+    """
+    real_write_text = Path.write_text
+    blocked = {"done": False}
+
+    def _blocking_write_text(self: Path, *args: object, **kwargs: object) -> int:
+        if not blocked["done"]:
+            blocked["done"] = True
+            time.sleep(block_seconds)
+        return real_write_text(self, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(Path, "write_text", _blocking_write_text)
+
+
+@pytest.mark.asyncio
+async def test_best_effort_bounded_when_filesystem_blocks(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression for review 4641826210 finding #1: `wait_for` only bounds
+    # cooperative awaits, so a *blocking synchronous* filesystem stall in the
+    # write phase used to freeze the loop past the deadline. With the
+    # filesystem tail off-loop (asyncio.to_thread), the caller must get its
+    # None back at the deadline while the stalled write is abandoned to the
+    # worker thread.
+    monkeypatch.setattr(trace_export, "TRACE_EXPORT_DEADLINE_SECONDS", 0.05)
+    _install_blocking_write_text(monkeypatch, block_seconds=1.0)
+    state = _terminal_state(tmp_path)
+    ledger = _populated_ledger()
+
+    start = time.monotonic()
+    result = await best_effort_export_trace(state, ledger, event_store=None)
+    elapsed = time.monotonic() - start
+
+    assert result is None  # deadline breach swallowed like any failure
+    # Returned at the ~0.05s deadline — NOT after the 1.0s blocking write. If
+    # the write ran on the loop the sleep would pin elapsed >= 1.0s.
+    assert elapsed < 0.75
+
+
+@pytest.mark.asyncio
+async def test_pipeline_finalize_survives_blocking_filesystem(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # The pipeline's already-computed terminal result must still return when
+    # finalization hits a blocking synchronous filesystem stall.
+    monkeypatch.setattr(trace_export, "TRACE_EXPORT_DEADLINE_SECONDS", 0.05)
+    _install_blocking_write_text(monkeypatch, block_seconds=1.0)
+    state = _terminal_state(tmp_path)
+    state.ledger = _populated_ledger().to_dict()
+    driver = types.SimpleNamespace(
+        event_store=_FakeEventStore(_events_for(state)), progress_callback=None
+    )
+    pipeline = AutoPipeline(
+        interview_driver=driver,  # type: ignore[arg-type]
+        seed_generator=lambda _sid: None,  # type: ignore[arg-type]
+    )
+
+    # The 5s guard is diagnostic only: the finalize deadline (0.05s), not this
+    # guard, is what must release the terminal return.
+    start = time.monotonic()
+    result = await asyncio.wait_for(pipeline.run(state), timeout=5.0)
+    elapsed = time.monotonic() - start
+
+    assert result.status == "complete"
+    assert elapsed < 0.75  # returned at the deadline, not after the 1.0s stall
+
+
 @pytest.mark.asyncio
 async def test_pipeline_finalize_writes_trace_once(tmp_path: Path) -> None:
     state = _terminal_state(tmp_path)


### PR DESCRIPTION
## Summary

Follow-up to #1584, addressing **finding #1 of the ouroboros-agent CHANGES_REQUESTED review [4641826210](https://github.com/Q00/ouroboros/pull/1584#pullrequestreview-4641826210)** (plus its non-blocking documentation note).

**The blocker.** #1584 wrapped the finalize trace export in `asyncio.wait_for(..., TRACE_EXPORT_DEADLINE_SECONDS)`, but `wait_for` only bounds the *cooperative async* portion. After the event queries, `export_trace_from_state()` performed synchronous `mkdir()` / `write_text()` / `unlink()` with no await points — a hung or slow filesystem blocks the event loop itself, so the deadline cannot fire and the terminal `AutoPipeline.run()` return is still delayed. The contract comment also overstated the guarantee.

**The fix.**

- Extracted the entire synchronous filesystem tail (mkdir + all stream/outcome/summary writes + stale-file clears) into a new plain-sync helper `_write_trace_files(...)`, and `export_trace_from_state()` now runs it off the event loop via `await asyncio.to_thread(...)`. The pure projection/data-shaping stays on the loop (it is trivial CPU work); the event queries were already cooperative awaits. With the blocking syscalls in a worker thread, `wait_for` can genuinely abandon the wait at the deadline.
- **Abandonment semantic, stated explicitly** (per the review's documentation note): the deadline bounds the *caller's* wait, nothing more. On breach — or on genuine outer cancellation — the in-flight worker thread is abandoned: it may still complete its writes, or stay wedged against the hung filesystem, in the background. That is the standard, acceptable trade for best-effort observability; the trace may be partial or missing, the run outcome is unaffected. This is now spelled out in the `TRACE_EXPORT_DEADLINE_SECONDS` comment, the `best_effort_export_trace` docstring, and the `_write_trace_files` docstring.
- Cancellation semantics from #1584 are unchanged: `wait_for` converts its own timeout into `TimeoutError` (logged, swallowed, `None`); a `CancelledError` reaching the guard is a genuine outer cancel and is re-raised.

**Scope.** Files touched: `src/ouroboros/auto/trace_export.py`, `tests/unit/auto/test_trace_export.py`. Existing tests unmodified; two regression tests added.

## Test plan

- [x] New: `test_best_effort_bounded_when_filesystem_blocks` — the bot-requested regression: `Path.write_text` monkeypatched to a `time.sleep(1.0)`-based synchronous stall (first call), deadline monkeypatched to 0.05 s → `best_effort_export_trace` returns `None` in < 0.75 s. If the writes ran on the loop, the sleep would pin elapsed ≥ 1.0 s, so this test fails on the pre-fix code.
- [x] New: `test_pipeline_finalize_survives_blocking_filesystem` — full `AutoPipeline.run()` with the same blocking-write stall still returns its terminal `complete` result in < 0.75 s (outer 5 s guard is diagnostic only).
- [x] `uv run pytest tests/unit/auto/test_trace_export.py -q` → 14 passed (12 pre-existing incl. #1584's three, + 2 new).
- [x] `uv run pytest tests/unit/auto/ -q` → 1271 passed, 4 failed — the four known pre-existing `test_surface` codex-config-leak failures (fail identically on `origin/main`).
- [x] `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/unit/mcp --ignore=tests/integration/mcp -q -k "not opencode"` → **9936 passed**, 4 skipped, 266 deselected, 7 failed — all pre-existing/environmental: 3× `test_surface` (documented codex-config-leak), 4× `config_tui/test_app.py` (an `antigravity` runtime-backend value leaked into shared config mid-run; these 4 pass in isolation on both this branch and `origin/main`, and this diff cannot reach config_tui). opencode tests deselected: they spawn real `opencode` subprocesses that hang indefinitely in this environment (documented pre-existing failure category).
- [x] `uv run ruff check .` and `uv run ruff format --check .` clean.
- [x] `uv run mypy src/` clean (429 files).

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [x] N/A — finalize-only change to the trace-export write phase; no in-loop round code paths touched.

## Related issues

- Follow-up to #1584 (itself a follow-up to #1581); resolves finding #1 of [pullrequestreview-4641826210](https://github.com/Q00/ouroboros/pull/1584#pullrequestreview-4641826210)
- Refs #1256 (§I5), run-metaharness plan A2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
