### PR TITLE
fix(auto): run the trace-export filesystem tail on a daemon thread so abandoned writes cannot block CLI teardown (#1584 follow-up 2)

### DIFF
--- a/src/ouroboros/auto/trace_export.py
+++ b/src/ouroboros/auto/trace_export.py
@@ -29,8 +29,10 @@ Two entry points:
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 import json
 from pathlib import Path
+import threading
 from typing import TYPE_CHECKING, Any
 
 import structlog
@@ -108,19 +110,26 @@ _MAX_TEXT = 2000
 # Hard wall-clock bound on the *caller's wait* for the finalize trace
 # projection. The finalize hook awaits ``export_trace_from_state`` — up to two
 # unbounded ``event_store.query_events`` aggregate scans (cooperative awaits)
-# plus the filesystem tail, which runs off-loop in a worker thread via
-# ``asyncio.to_thread`` (see ``_write_trace_files``) — right before the
-# pipeline returns its already-computed terminal result. A slow or hung
-# EventStore / filesystem must never delay (or hang) a COMPLETE / BLOCKED /
-# FAILED return: trace generation is best-effort and cannot affect the run
-# outcome. On breach the caller stops waiting and the projection is dropped
-# like any other swallowed failure. Precisely: the deadline bounds only the
-# caller-visible wait — an abandoned worker thread may still finish its writes
-# (or stay wedged against the hung filesystem) in the background, which is the
-# standard, acceptable trade for best-effort observability. 30s is generous
-# for a healthy store yet keeps the terminal-return delay to a predictable
-# ceiling.
+# plus the filesystem tail, which runs off-loop on a dedicated **daemon**
+# thread (see ``_run_detached``) — right before the pipeline returns its
+# already-computed terminal result. A slow or hung EventStore / filesystem
+# must never delay (or hang) a COMPLETE / BLOCKED / FAILED return: trace
+# generation is best-effort and cannot affect the run outcome. On breach the
+# caller stops waiting and the projection is dropped like any other swallowed
+# failure. Precisely: the deadline bounds only the caller-visible wait — an
+# abandoned daemon thread may still finish its writes (or stay wedged against
+# the hung filesystem) in the background, possibly outliving the event loop
+# and running right up to process exit, where it is killed without being
+# joined. Torn/partial files from such a kill are harmless: the projection is
+# byte-idempotent, so any re-export deterministically overwrites them. That is
+# the standard, acceptable trade for best-effort observability. 30s is
+# generous for a healthy store yet keeps the terminal-return delay to a
+# predictable ceiling.
 TRACE_EXPORT_DEADLINE_SECONDS = 30.0
+
+# Name prefix for the detached write-phase threads — greppable in thread dumps
+# and asserted daemon in tests.
+_EXPORT_THREAD_NAME = "ooo-trace-export"
 
 
 def _clip(value: Any) -> Any:
@@ -488,6 +497,56 @@ def _resolve_out_root(state: AutoPipelineState, out_root: Path | None) -> Path:
     return base / ".ouroboros" / "traces" / state.auto_session_id
 
 
+async def _run_detached(fn: Callable[[], None]) -> None:
+    """Run blocking ``fn`` on a **daemon** thread; await its completion.
+
+    Why not ``asyncio.to_thread`` / ``ThreadPoolExecutor``: both run on
+    pool workers that are **joined at teardown** — ``asyncio.run()`` awaits
+    ``loop.shutdown_default_executor()`` and ``ThreadPoolExecutor`` workers
+    are non-daemon and joined via ``threading._register_atexit``. Either way,
+    a wedged filesystem write abandoned by our deadline would still block the
+    join, hanging the ``ooo auto`` CLI (which prints the terminal result only
+    *after* ``asyncio.run()`` returns) or process exit itself. A plain daemon
+    ``threading.Thread`` is never joined at exit, so abandonment truly
+    detaches: the caller resumes at the deadline and teardown stays unblocked.
+
+    Completion is bridged back via ``loop.call_soon_threadsafe`` resolving an
+    ``asyncio.Future``; an exception raised by ``fn`` propagates to the
+    awaiter unchanged (preserving the caller's best-effort except/log paths).
+    The bridge is guarded for late completion: if the future was already
+    abandoned (deadline / outer cancel) the result is dropped, and if the loop
+    is already closed the ``RuntimeError`` from ``call_soon_threadsafe`` is
+    swallowed — a post-teardown thread must never touch the dead loop.
+    """
+    loop = asyncio.get_running_loop()
+    future: asyncio.Future[None] = loop.create_future()
+
+    def _deliver(exc: BaseException | None) -> None:
+        if future.cancelled():
+            return
+        if exc is None:
+            future.set_result(None)
+        else:
+            future.set_exception(exc)
+
+    def _worker() -> None:
+        try:
+            fn()
+        except BaseException as exc:  # noqa: BLE001 - relayed to the awaiter
+            outcome_exc: BaseException | None = exc
+        else:
+            outcome_exc = None
+        try:
+            loop.call_soon_threadsafe(_deliver, outcome_exc)
+        except RuntimeError:
+            # Loop already closed: the wait was abandoned and the process is
+            # tearing down. There is nobody left to deliver to.
+            pass
+
+    threading.Thread(target=_worker, name=_EXPORT_THREAD_NAME, daemon=True).start()
+    await future
+
+
 def _write_trace_files(
     out_dir: Path,
     streams: dict[str, list[dict[str, Any]]],
@@ -497,12 +556,13 @@ def _write_trace_files(
     """Synchronous filesystem tail of the export: mkdir + every write.
 
     Deliberately a plain sync function with **no** await points, executed off
-    the event loop via ``asyncio.to_thread`` by :func:`export_trace_from_state`.
+    the event loop via :func:`_run_detached` by :func:`export_trace_from_state`.
     ``mkdir`` / ``write_text`` / ``unlink`` are blocking syscalls; run on the
     loop they would stall *every* coroutine — including the ``asyncio.wait_for``
     deadline in :func:`best_effort_export_trace`, which can only interrupt
-    cooperative awaits. In a worker thread, a hung or slow filesystem blocks
-    only that thread and the deadline still releases the caller.
+    cooperative awaits. On the detached daemon thread, a hung or slow
+    filesystem blocks only that thread; the deadline still releases the caller
+    and the thread never blocks loop or interpreter teardown.
     """
     out_dir.mkdir(parents=True, exist_ok=True)
     for filename, rows in streams.items():
@@ -532,9 +592,10 @@ async def export_trace_from_state(
     Idempotent: content is derived only from persisted state and stored
     events, so re-export is byte-identical.
 
-    The filesystem phase (:func:`_write_trace_files`) runs in a worker thread
-    via ``asyncio.to_thread`` so blocking syscalls never stall the event loop;
-    only the cooperative event queries and pure data-shaping run on the loop.
+    The filesystem phase (:func:`_write_trace_files`) runs on a detached
+    daemon thread (:func:`_run_detached`) so blocking syscalls never stall the
+    event loop — nor, if abandoned, loop/interpreter teardown; only the
+    cooperative event queries and pure data-shaping run on the loop.
     """
     aggregate_ids: tuple[str, ...] = tuple(
         agg for agg in (state.auto_session_id, state.interview_session_id) if agg
@@ -568,7 +629,7 @@ async def export_trace_from_state(
         DECISIONS_FILE: decision_lines,
         FLAGS_FILE: flag_lines,
     }
-    await asyncio.to_thread(_write_trace_files, out_dir, streams, outcome, summary_md)
+    await _run_detached(lambda: _write_trace_files(out_dir, streams, outcome, summary_md))
 
     log.info(
         "auto.trace_export.written",
@@ -623,22 +684,26 @@ async def best_effort_export_trace(
     The caller's wait is additionally **time-bounded** by
     :data:`TRACE_EXPORT_DEADLINE_SECONDS` via :func:`asyncio.wait_for`. For the
     bound to hold against *blocking* work — not just cooperative awaits — the
-    filesystem tail of the export runs in a worker thread
-    (``asyncio.to_thread`` in :func:`export_trace_from_state`); ``wait_for``
+    filesystem tail of the export runs on a detached **daemon** thread
+    (:func:`_run_detached` in :func:`export_trace_from_state`); ``wait_for``
     can only interrupt code that yields to the loop. The guarantee is therefore
     exactly this: the caller resumes within the deadline. On breach the wait is
     **abandoned**, surfacing as :class:`TimeoutError` and swallowed like any
-    other projection failure — while the abandoned worker thread may still
-    complete its writes (or stay wedged against a hung filesystem) in the
-    background. That is the standard trade for best-effort observability; the
-    trace may be partial or missing, the run outcome is unaffected.
+    other projection failure — while the abandoned daemon thread may still
+    complete its writes, stay wedged against the hung filesystem, or be killed
+    unjoined at process exit (daemon threads never block ``asyncio.run()``
+    teardown or interpreter shutdown, so the CLI's terminal print and process
+    exit stay unblocked). Writes torn by such an exit are harmless: the
+    projection is byte-idempotent and any re-export deterministically
+    overwrites them. That is the standard trade for best-effort observability;
+    the trace may be partial or missing, the run outcome is unaffected.
 
     Cancellation semantics follow the driver's established
     ``wait_for`` / ``CancelledError`` idiom: ``asyncio.wait_for`` converts its
     *own* timeout into ``TimeoutError``, so any :class:`asyncio.CancelledError`
     reaching this frame is a **genuine outer cancellation** (the pipeline task
     itself being torn down) — it is re-raised, never swallowed. An in-flight
-    worker thread is likewise abandoned on outer cancel.
+    daemon thread is likewise abandoned on outer cancel.
     """
     try:
         return await asyncio.wait_for(

--- a/tests/unit/auto/test_trace_export.py
+++ b/tests/unit/auto/test_trace_export.py
@@ -6,6 +6,7 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 import json
 from pathlib import Path
+import threading
 import time
 import types
 
@@ -485,6 +486,40 @@ async def test_pipeline_finalize_survives_blocking_filesystem(
 
     assert result.status == "complete"
     assert elapsed < 0.75  # returned at the deadline, not after the 1.0s stall
+
+
+def test_asyncio_run_teardown_not_blocked_by_wedged_write(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Regression for review 4642581190: asyncio.to_thread runs on the loop's
+    # DEFAULT executor, and asyncio.run() teardown awaits
+    # shutdown_default_executor(), which JOINS executor threads. An abandoned
+    # wedged write therefore hung the `ooo auto` CLI (cli/commands/auto.py
+    # prints the terminal result only AFTER asyncio.run() returns) even though
+    # the coroutine itself had already timed out cleanly. The write phase now
+    # runs on a plain daemon thread — never joined at teardown — so
+    # asyncio.run() must return promptly and simply abandon the wedged thread.
+    # Deliberately a SYNC test: it must own its asyncio.run() to exercise the
+    # exact teardown join the review flagged.
+    monkeypatch.setattr(trace_export, "TRACE_EXPORT_DEADLINE_SECONDS", 0.05)
+    _install_blocking_write_text(monkeypatch, block_seconds=3.0)
+    state = _terminal_state(tmp_path)
+    ledger = _populated_ledger()
+
+    start = time.monotonic()
+    result = asyncio.run(best_effort_export_trace(state, ledger, event_store=None))
+    elapsed = time.monotonic() - start
+
+    assert result is None  # deadline breach swallowed like any failure
+    # Wall-clock bound covers asyncio.run() INCLUDING loop teardown. With the
+    # executor-backed design the teardown join would pin elapsed >= 3.0s (the
+    # wedged write); the daemon-thread design returns at the ~0.05s deadline.
+    assert elapsed < 2.0
+    # The abandoned write-phase thread is still wedged past teardown and must
+    # be a daemon, i.e. it can never block interpreter exit either.
+    wedged = [t for t in threading.enumerate() if t.name == trace_export._EXPORT_THREAD_NAME]
+    assert wedged, "expected the abandoned export thread to still be alive"
+    assert all(t.daemon is True for t in wedged)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Second follow-up in the #1581 → #1584 → #1588 trace-export hardening chain, addressing the ouroboros-agent CHANGES_REQUESTED review [4642581190](https://github.com/Q00/ouroboros/pull/1584#pullrequestreview-4642581190) on the #1588 `asyncio.to_thread` design.

**The blocker (bot-reproduced).** `asyncio.to_thread` runs on the loop's *default executor*. On the direct CLI path, `ooo auto` wraps `_run_auto()` in `asyncio.run()` (`src/ouroboros/cli/commands/auto.py:294`) and prints the terminal result only *after* `asyncio.run()` returns (~:322). `asyncio.run()`'s teardown awaits `shutdown_default_executor()`, which **joins** executor threads. So when `best_effort_export_trace()` timed out and abandoned a wedged filesystem write, the coroutine returned fine — but the process then hung in executor shutdown before the user ever saw the terminal result. The bot reproduced this: `wait_for(asyncio.to_thread(time.sleep, 60), 0.05)` printed the timeout path, and the process did not exit within 3 s.

**The fix.**

- New `_run_detached(fn)` helper in `src/ouroboros/auto/trace_export.py`: spawns a plain `threading.Thread(..., daemon=True)` (named `ooo-trace-export`) for the filesystem tail and bridges completion back to the loop via `loop.call_soon_threadsafe` resolving an `asyncio.Future`; `export_trace_from_state()` awaits that future (still under the #1584 `wait_for` deadline). A daemon thread is never joined at exit, so abandonment truly detaches: `asyncio.run()` teardown and interpreter exit stay unblocked.
- **Not** `concurrent.futures.ThreadPoolExecutor` either: its workers are non-daemon and joined via `threading._register_atexit` — the same hang class the review flagged.
- **Closed-loop safety**: the thread's only loop interaction is the single `call_soon_threadsafe`, wrapped in `try/except RuntimeError` — a post-teardown completion is silently dropped; the thread never touches a dead loop. A late completion after deadline/cancel is likewise dropped via a `future.cancelled()` guard.
- **Exception propagation preserved**: an exception raised by `_write_trace_files` in the thread is relayed through the future to the awaiter unchanged, so the existing best-effort except/log paths behave exactly as today (verified by the untouched `test_best_effort_swallows_failure`).
- **Docstrings updated** for the new abandonment semantics: the abandoned daemon thread may still be running at process exit, where it is killed unjoined; writes torn by that are harmless because the projection is byte-idempotent — any re-export deterministically overwrites them.

**Scope.** Files touched: `src/ouroboros/auto/trace_export.py`, `tests/unit/auto/test_trace_export.py`. All existing tests kept unmodified; one process-exit-boundary regression test added.

## Test plan

- [x] New: `test_asyncio_run_teardown_not_blocked_by_wedged_write` — deliberately a **sync** test that owns its own `asyncio.run(...)`, exercising the exact teardown join the review flagged: with a `Path.write_text` wedged for 3.0 s and a 0.05 s deadline, `asyncio.run()` (including loop teardown) returns `None` in < 2.0 s wall-clock — under the `to_thread` design the executor join pins it ≥ 3.0 s, so this test fails on pre-fix code. It then asserts the abandoned `ooo-trace-export` thread is still alive past teardown with `thread.daemon is True`.
- [x] Corroborating signal: the file's suite wall-clock dropped from 2.75 s (#1588) to 0.87 s — the per-test executor joins of the wedged 1.0 s writers disappeared.
- [x] `uv run pytest tests/unit/auto/test_trace_export.py -q` → 15 passed (14 pre-existing kept byte-identical, + 1 new).
- [x] `uv run pytest tests/unit/auto/ -q` → 1272 passed, 4 failed (the documented pre-existing `test_surface` codex-config-leak set).
- [x] `uv run pytest tests/ --ignore=tests/e2e --ignore=tests/unit/mcp --ignore=tests/integration/mcp -q -k "not opencode"` → **9955 passed**, 4 skipped, 266 deselected, 4 failed — 3× `test_surface` (documented pre-existing codex-config-leak) + 1× `test_wheel_contains_profile_yamls` (transient sandbox DNS failure during `uv build`; passes on immediate rerun). opencode tests deselected: they spawn real `opencode` subprocesses that hang indefinitely in this environment (documented pre-existing failure category).
- [x] `uv run ruff check .` and `uv run ruff format --check .` clean.
- [x] `uv run mypy src/` clean (429 files).

## R-run comparison (required for `src/ouroboros/auto/` changes)

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [x] N/A — finalize-only change to how the trace-export write phase is threaded; no in-loop round code paths touched.

## Related issues

- Second follow-up to #1584 (chain: #1581 → #1584 → #1588); resolves [pullrequestreview-4642581190](https://github.com/Q00/ouroboros/pull/1584#pullrequestreview-4642581190)
- Refs #1256 (§I5), run-metaharness plan A2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
