### PR TITLE
fix(cli): auto waits for its run-handoff job instead of cancelling it on exit

### DIFF
--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -1497,6 +1497,33 @@ class AutoPipeline:
                     return await self._handoff_to_ralph(
                         state, ledger, seed, review, run_subagent=None
                     )
+                # Non-complete-product RUN resume with a persisted run handle.
+                # A persisted handle proves the execute job was *dispatched*,
+                # not that it reached terminal success (Q00/ouroboros#1590):
+                # the owning process may have exited (deadline/Ctrl-C/kill)
+                # leaving the job cancelled, or the run may have paused
+                # (usage-limit) or failed. Reconcile the owned job's terminal
+                # state before declaring COMPLETE so ``--resume`` cannot return
+                # a stale product-complete for an incomplete run. When no poll
+                # channel is available (plain-function run starter, pruned job,
+                # etc.) fall back to the historical "trust the handle" behavior
+                # so genuinely-complete sessions and legacy handles are
+                # unaffected.
+                run_verdict = (
+                    await _wait_owned_run_job_terminal(
+                        self.run_starter,
+                        state.job_id,
+                        timeout_seconds=self._deadline_capped_timeout(
+                            state, state.phase_timeout_seconds(AutoPhase.RUN)
+                        ),
+                    )
+                    if state.job_id
+                    else None
+                )
+                blocked = self._block_resume_if_run_not_successful(state, run_verdict)
+                if blocked is not None:
+                    self._save(state)
+                    return self._result(state, ledger, review=review, blocker=state.last_error)
                 state.transition(
                     AutoPhase.COMPLETE, "execution already started; using persisted run handle"
                 )
@@ -1850,6 +1877,49 @@ class AutoPipeline:
         )
         self._save(state)
         return self._result(state, ledger, blocker=state.last_error)
+
+    def _block_resume_if_run_not_successful(
+        self, state: AutoPipelineState, run_verdict: dict[str, Any] | None
+    ) -> bool | None:
+        """Block a non-complete-product RUN resume unless the owned job succeeded.
+
+        ``run_verdict`` is the owned execute job's terminal ``result_meta``
+        (from :func:`_wait_owned_run_job_terminal`), or ``None`` when no poll
+        channel was available. Returns ``True`` when the state was marked
+        BLOCKED (the run did not reach terminal success), or ``None`` to let the
+        caller proceed to COMPLETE.
+
+        Conservative on ambiguity: ``None`` verdict (unpollable / pruned /
+        plain-function starter) or a non-terminal ``running``/``queued`` status
+        preserves the historical "trust the persisted handle" behavior, so
+        genuinely-complete and legacy sessions are unaffected. Only an
+        *observed* non-success terminal (paused / failed / cancelled /
+        interrupted / unknown) blocks — resumably, via ``run_starter`` — so a
+        later ``--resume`` re-reconciles instead of returning stale COMPLETE.
+        """
+        if run_verdict is None:
+            return None
+        status = _optional_str(run_verdict.get("status"))
+        success = run_verdict.get("success")
+        if success is True or status == "completed":
+            return None
+        if status in {"running", "queued", "cancel_requested"}:
+            # Still in flight elsewhere — cannot prove failure; do not cancel or
+            # block a run another owner may still complete.
+            return None
+        if status == "paused":
+            state.mark_blocked(
+                "resumed run execution paused before completion; resume the "
+                "paused run before continuing",
+                tool_name="run_starter",
+            )
+            return True
+        detail = status or "unknown"
+        state.mark_blocked(
+            f"resumed run execution did not reach terminal success: {detail}",
+            tool_name="run_starter",
+        )
+        return True
 
     def _deadline_capped_timeout(self, state: AutoPipelineState, phase_timeout: float) -> float:
         """Return ``phase_timeout`` capped by the remaining pipeline deadline.

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -782,6 +782,41 @@ class AutoPipelineState:
         self.last_authoring_backend = None
         return True
 
+    def close_completed_run_handoff_as_failed(self, message: str) -> bool:
+        """Correct a prematurely-COMPLETE run handoff into a FAILED terminal.
+
+        Companion to :meth:`reopen_completed_run_handoff_to_run` for the
+        *genuine failure* case (the owned execute job reached a FAILED terminal
+        or reported ``success is False``). Unlike a paused / cancelled /
+        deadline outcome — which is resumable and re-opens to ``RUN`` — a
+        genuine failure must preserve a non-resumable failed terminal contract:
+        ``--resume`` must NOT retry it and must NOT report the run as complete.
+
+        Sets the phase directly to ``FAILED`` (``COMPLETE`` has no forward
+        transition edge, matching :meth:`reopen_completed_run_handoff_to_run`)
+        and sets ``last_tool_name = None`` so :meth:`resume_capability`
+        classifies the state as :attr:`AutoResumeCapability.NONE`
+        (``_recoverable_phase_for_tool(None)`` is ``None``). The run handles are
+        left intact for diagnostics. No-op (returns ``False``) unless the state
+        is currently ``COMPLETE``.
+        """
+        if self.phase is not AutoPhase.COMPLETE:
+            return False
+        now = utc_now_iso()
+        self.phase = AutoPhase.FAILED
+        self.phase_started_at = now
+        self.last_progress_at = now
+        self.updated_at = now
+        self.last_progress_message = message
+        self.last_error = message
+        self.last_error_code = None
+        # Intentionally not "run_starter": a genuine run failure is a terminal
+        # dead end, not a RUN-recoverable blocker, so resume_capability() must
+        # resolve to NONE rather than routing back into the RUN phase.
+        self.last_tool_name = None
+        self.last_authoring_backend = None
+        return True
+
     def is_terminal(self) -> bool:
         """Return True when the state cannot continue automatically."""
         return self.phase in TERMINAL_PHASES

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -747,6 +747,41 @@ class AutoPipelineState:
         self.last_tool_name = tool_name
         self.transition(AutoPhase.FAILED, message, error=message)
 
+    def reopen_completed_run_handoff_to_run(self, message: str) -> bool:
+        """Reopen a prematurely-COMPLETE run handoff back to the RUN phase.
+
+        ``AutoPipeline.run`` persists ``COMPLETE`` immediately after a run
+        handoff is *dispatched* (to avoid duplicate run starts on resume), but
+        that COMPLETE is not verified product completion. When a caller later
+        observes the execute job finish paused / unsuccessfully / cancelled (for
+        example the CLI in-process wait), the durable state must be corrected so
+        a later ``--resume`` reconciles the owned run job instead of returning
+        the stale COMPLETE (the ``pipeline.run`` COMPLETE fast-path returns
+        immediately for ``AutoPhase.COMPLETE``).
+
+        ``_ALLOWED_TRANSITIONS`` has no ``COMPLETE -> *`` edge by design — auto
+        never *advances* out of COMPLETE — so this corrective re-open sets the
+        phase directly rather than via :meth:`transition`. It is a no-op (returns
+        ``False``) unless the state is currently ``COMPLETE``; the run handles
+        (``job_id`` / ``execution_id`` / ``run_session_id``) and
+        ``run_handoff_status`` are left intact so the RUN-phase resume path can
+        reconcile the owned job. ``last_tool_name`` is set to ``"run_starter"``
+        so the state classifies as RUN-recoverable (resumable).
+        """
+        if self.phase is not AutoPhase.COMPLETE:
+            return False
+        now = utc_now_iso()
+        self.phase = AutoPhase.RUN
+        self.phase_started_at = now
+        self.last_progress_at = now
+        self.updated_at = now
+        self.last_progress_message = message
+        self.last_error = None
+        self.last_error_code = None
+        self.last_tool_name = "run_starter"
+        self.last_authoring_backend = None
+        return True
+
     def is_terminal(self) -> bool:
         """Return True when the state cannot continue automatically."""
         return self.phase in TERMINAL_PHASES

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -767,6 +767,16 @@ class AutoPipelineState:
         ``run_handoff_status`` are left intact so the RUN-phase resume path can
         reconcile the owned job. ``last_tool_name`` is set to ``"run_starter"``
         so the state classifies as RUN-recoverable (resumable).
+
+        The absolute pipeline deadline (``deadline_at`` / ``deadline_at_epoch``)
+        is CLEARED. The premature COMPLETE was often reached because the wait's
+        own deadline expired, so the persisted absolute deadline is already
+        past; leaving it would make ``--resume`` hit ``AutoPipeline.run``'s
+        deadline gate (which fires on an expired deadline BEFORE the RUN
+        reconciliation) and immediately re-block with ``pipeline_timeout`` —
+        turning the advertised resume into a dead end. Clearing both fields lets
+        ``AutoPipelineState.from_dict`` re-arm a fresh budget on the next load
+        (its non-terminal re-arm path), so a fresh resume gets a fresh deadline.
         """
         if self.phase is not AutoPhase.COMPLETE:
             return False
@@ -780,6 +790,8 @@ class AutoPipelineState:
         self.last_error_code = None
         self.last_tool_name = "run_starter"
         self.last_authoring_backend = None
+        self.deadline_at = None
+        self.deadline_at_epoch = None
         return True
 
     def close_completed_run_handoff_as_failed(self, message: str) -> bool:

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+from dataclasses import replace
 from enum import Enum
 import os
 from pathlib import Path
@@ -50,17 +52,25 @@ from ouroboros.auto.state import (
     AutoCommitPolicy,
     AutoPhase,
     AutoPipelineState,
+    AutoResumeCapability,
     AutoStore,
     parse_auto_worktree_policy,
     validate_complete_product_timeout,
 )
 from ouroboros.auto.worktree import ensure_auto_worktree, release_auto_worktree
 from ouroboros.cli.formatters import console
-from ouroboros.cli.formatters.panels import print_error, print_info, print_success
+from ouroboros.cli.formatters.panels import (
+    print_error,
+    print_info,
+    print_success,
+    print_warning,
+)
 from ouroboros.config import get_opencode_mode
+from ouroboros.mcp.job_manager import JobManager, JobSnapshot, JobStatus
 from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
 from ouroboros.mcp.tools.execution_handlers import ExecuteSeedHandler, StartExecuteSeedHandler
+from ouroboros.mcp.tools.job_handlers import JobResultHandler, JobWaitHandler
 from ouroboros.mcp.tools.qa import QAHandler
 from ouroboros.mcp.tools.ralph_handlers import RalphHandler
 from ouroboros.mcp.tools.subagent import should_dispatch_via_plugin
@@ -167,6 +177,20 @@ def auto_command(
     skip_run: Annotated[
         bool, typer.Option("--skip-run", help="Stop after A-grade Seed creation.")
     ] = False,
+    no_wait: Annotated[
+        bool,
+        typer.Option(
+            "--no-wait",
+            help=(
+                "Fire-and-forget: return as soon as the execute run-handoff job is "
+                "started instead of waiting for it to finish. WARNING: in direct CLI "
+                "mode the in-process job dies with the CLI, so detached execution does "
+                "NOT survive process exit unless a persistent owner (e.g. a running "
+                "'ouroboros mcp serve') holds it. Default off: auto waits for the run "
+                "job to reach a terminal state and reports the verdict."
+            ),
+        ),
+    ] = False,
     show_ledger: Annotated[
         bool, typer.Option("--show-ledger", help="Print assumptions and non-goals.")
     ] = False,
@@ -265,8 +289,10 @@ def auto_command(
 ) -> None:
     """Run an A-grade-gated auto pipeline.
 
-    The command returns execution IDs after the run starts; it does not wait
-    indefinitely for long-running execution completion.
+    By default the command waits for the execute run-handoff job to reach a
+    terminal state and reports the run verdict, because in direct CLI mode the
+    in-process job manager dies with the process and would otherwise cancel the
+    run on exit. Pass ``--no-wait`` to restore fire-and-forget behaviour.
     """
     if status:
         if not resume:
@@ -311,6 +337,7 @@ def auto_command(
                 commit_policy=commit_policy,
                 worktree_policy=worktree_policy,
                 progress_callback=_make_progress_renderer(quiet=quiet),
+                wait=not no_wait,
             )
         )
     except typer.Exit:
@@ -320,6 +347,13 @@ def auto_command(
         raise typer.Exit(1) from exc
 
     _print_result(result, show_ledger=show_ledger)
+    if no_wait and _is_run_handoff_only_completion(result) and result.job_id:
+        print_warning(
+            "Detached with --no-wait: the execute job runs in this CLI process only. "
+            "It will NOT survive process exit unless a persistent owner (e.g. a running "
+            "'ouroboros mcp serve') holds it. Re-run without --no-wait to wait for the "
+            f"run verdict, or track it with: ouroboros job wait {result.job_id}"
+        )
     if result.status in {"blocked", "failed"}:
         raise typer.Exit(1)
 
@@ -359,6 +393,7 @@ async def _run_auto(
     commit_policy: str | None = None,
     worktree_policy: str | None = None,
     progress_callback: AutoProgressCallback | None = None,
+    wait: bool = True,
 ) -> AutoPipelineResult:
     store = AutoStore()
     runtime_override = runtime
@@ -647,6 +682,19 @@ async def _run_auto(
     )
     try:
         result = await pipeline.run(state)
+        if wait and _is_run_handoff_only_completion(result) and result.job_id:
+            # Direct CLI mode has no long-lived owner for the in-process job:
+            # once _run_auto returns, ``asyncio.run`` teardown cancels the
+            # pending execute-job task (see mcp/job_manager.py drain docstring
+            # + the _run_job CancelledError handler), so the run would die at
+            # ~200ms without ever executing. Keep the event loop alive and
+            # stream the run to a terminal verdict before returning.
+            result = await _await_run_handoff_terminal(
+                result,
+                job_manager=getattr(start_execute, "_job_manager", None),
+                event_store=getattr(start_execute, "_event_store", None),
+                quiet=progress_callback is None,
+            )
     finally:
         release_auto_worktree(auto_workspace)
         await watchdog_event_store.close()
@@ -834,6 +882,133 @@ def _is_completed_ralph_product(result: AutoPipelineResult) -> bool:
 def _is_external_ralph_plugin_completion(result: AutoPipelineResult) -> bool:
     """True when auto is complete but product work lives in an OpenCode child."""
     return result.status == "complete" and result.ralph_dispatch_mode == "plugin"
+
+
+# Long-poll window (seconds) for each ``JobWaitHandler`` call while streaming
+# the run-handoff job to a terminal verdict. The handler returns early on any
+# AC/phase progress or terminal status, so this is only an upper bound on how
+# long a fully-idle poll blocks before we re-check the snapshot.
+_RUN_HANDOFF_WAIT_POLL_SECONDS = 5
+
+
+async def _cancel_run_handoff_job(job_manager: JobManager, job_id: str) -> None:
+    """Best-effort cancel of the in-process run job (Ctrl-C / teardown path)."""
+    cancel_job = getattr(job_manager, "cancel_job", None)
+    if cancel_job is None:
+        return
+    with contextlib.suppress(Exception):
+        await cancel_job(job_id)
+
+
+def _reconcile_run_handoff_result(
+    result: AutoPipelineResult, snapshot: JobSnapshot
+) -> AutoPipelineResult:
+    """Project a terminal execute-job snapshot back onto the auto result.
+
+    Mirrors ``mcp/tools/auto_handler._reconcile_execution_job_snapshot`` so the
+    CLI wait path and the MCP resume path report the same verdict, but reuses
+    the live job manager's snapshot instead of re-opening the event store.
+    """
+    status = result.status
+    blocker = result.blocker
+    resume_capability = result.resume_capability
+    if snapshot.status is JobStatus.COMPLETED:
+        status = "complete"
+        blocker = None
+        resume_capability = AutoResumeCapability.NONE
+    elif snapshot.status in {JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.INTERRUPTED}:
+        detail = snapshot.error or snapshot.result_text or snapshot.message
+        blocker = (
+            f"execution job {snapshot.status.value}: {detail}"
+            if detail
+            else f"execution job {snapshot.status.value}"
+        )
+        status = "failed" if snapshot.status is JobStatus.FAILED else "blocked"
+        resume_capability = AutoResumeCapability.NONE
+    else:
+        # Non-terminal snapshot (should not happen after a terminal wait): keep
+        # the handoff-only result intact and only surface the live status.
+        return replace(result, execution_job_status=snapshot.status.value)
+    return replace(
+        result,
+        status=status,
+        phase="complete" if status == "complete" else result.phase,
+        blocker=blocker,
+        resume_capability=resume_capability,
+        execution_job_status=snapshot.status.value,
+        execution_job_error=snapshot.error,
+        execution_job_message=snapshot.message,
+    )
+
+
+async def _await_run_handoff_terminal(
+    result: AutoPipelineResult,
+    *,
+    job_manager: JobManager | None,
+    event_store: EventStore | None,
+    quiet: bool,
+) -> AutoPipelineResult:
+    """Wait for the started execute job to finish, streaming run progress.
+
+    Returns the original ``result`` unchanged when there is nothing to wait on
+    (no job handle, or the job is not owned by this manager — e.g. a plugin
+    dispatch). Otherwise polls the live job manager to a terminal state, prints
+    the run receipt via the existing ``ouroboros_job_result`` renderer, and
+    reconciles the run verdict onto the returned result.
+    """
+    job_id = result.job_id
+    if not job_id or job_manager is None or event_store is None:
+        return result
+    try:
+        snapshot = await job_manager.get_snapshot(job_id)
+    except ValueError:
+        # Job handle not owned by this manager (e.g. plugin-mode dispatch):
+        # honestly leave the handoff-only result as-is for the caller to render.
+        return result
+
+    if not quiet:
+        print_info(
+            f"Waiting for run job {job_id} to finish (Ctrl-C to cancel the run and detach)..."
+        )
+    wait_handler = JobWaitHandler(job_manager=job_manager, event_store=event_store)
+    cursor = 0
+    last_line = ""
+    try:
+        while not snapshot.is_terminal:
+            wait_result = await wait_handler.handle(
+                {
+                    "job_id": job_id,
+                    "cursor": cursor,
+                    "timeout_seconds": _RUN_HANDOFF_WAIT_POLL_SECONDS,
+                    "view": "compact",
+                    "wait_for": "ac_change",
+                }
+            )
+            if wait_result.is_err:
+                break
+            value = wait_result.value
+            meta = value.meta or {}
+            with contextlib.suppress(TypeError, ValueError):
+                cursor = int(meta.get("cursor", cursor))
+            line = (value.text_content or "").strip()
+            if not quiet and meta.get("changed") and line and line != last_line:
+                last_line = line
+                console.print(rf"[dim]\[run][/] {_rich_escape(line)}")
+            if meta.get("is_terminal"):
+                break
+            snapshot = await job_manager.get_snapshot(job_id)
+    except (asyncio.CancelledError, KeyboardInterrupt):
+        await _cancel_run_handoff_job(job_manager, job_id)
+        print_warning(f"Interrupted — cancelled run job {job_id}")
+        raise
+
+    snapshot = await job_manager.get_snapshot(job_id)
+    if not quiet:
+        result_handler = JobResultHandler(job_manager=job_manager, event_store=event_store)
+        receipt = await result_handler.handle({"job_id": job_id})
+        if receipt.is_ok and receipt.value.text_content:
+            console.print(receipt.value.text_content)
+    return _reconcile_run_handoff_result(result, snapshot)
 
 
 def _print_detached_guidance(result: AutoPipelineResult) -> None:

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -900,22 +900,80 @@ async def _cancel_run_handoff_job(job_manager: JobManager, job_id: str) -> None:
         await cancel_job(job_id)
 
 
+_FAILED_RUN_META_STATUSES = frozenset({"failed", "cancelled", "interrupted"})
+
+
+def _run_meta_verdict(snapshot: JobSnapshot) -> tuple[str, bool | None]:
+    """Extract the execution-level (status, success) verdict from a job snapshot.
+
+    ``ExecuteSeedHandler`` maps the reconstructed session status into the tool
+    result meta (``_classify_synchronous_execution_status``): a PAUSED
+    execution — e.g. a usage-limit pause — completes the JOB with
+    ``result_meta={"status": "paused", "success": None}``. The job lifecycle
+    status alone is therefore not a run verdict. Mirrors the meta fallback of
+    ``auto/adapters._wait_for_job_terminal`` (``status`` defaults to the job's
+    own terminal status when the inner result did not provide one).
+    """
+    meta = snapshot.result_meta or {}
+    raw_status = meta.get("status")
+    status = (
+        raw_status.strip().lower()
+        if isinstance(raw_status, str) and raw_status.strip()
+        else snapshot.status.value
+    )
+    raw_success = meta.get("success")
+    success = raw_success if isinstance(raw_success, bool) else None
+    return status, success
+
+
 def _reconcile_run_handoff_result(
     result: AutoPipelineResult, snapshot: JobSnapshot
 ) -> AutoPipelineResult:
     """Project a terminal execute-job snapshot back onto the auto result.
 
-    Mirrors ``mcp/tools/auto_handler._reconcile_execution_job_snapshot`` so the
-    CLI wait path and the MCP resume path report the same verdict, but reuses
-    the live job manager's snapshot instead of re-opening the event store.
+    Mirrors ``mcp/tools/auto_handler._reconcile_execution_job_snapshot`` for
+    the job lifecycle, and the complete-product resume gate in
+    ``auto/pipeline.py`` (persisted-handle branch) for the execution-level
+    verdict carried in ``result_meta``: a COMPLETED job is only a successful
+    run when its meta confirms terminal success; ``status == "paused"`` keeps
+    the session resumable and never reports complete.
     """
     status = result.status
     blocker = result.blocker
     resume_capability = result.resume_capability
     if snapshot.status is JobStatus.COMPLETED:
-        status = "complete"
-        blocker = None
-        resume_capability = AutoResumeCapability.NONE
+        run_status, run_success = _run_meta_verdict(snapshot)
+        if run_status == "paused":
+            # The JOB completed but the EXECUTION paused (usage-limit etc.).
+            # Same contract as the pipeline's resume gate: block with resume
+            # guidance and keep the persisted run handle resumable.
+            status = "blocked"
+            blocker = (
+                "run execution paused before completion; resume the paused "
+                f"run before continuing (auto session {result.auto_session_id}, "
+                f"job {snapshot.job_id})"
+            )
+        elif run_success is False or run_status in _FAILED_RUN_META_STATUSES:
+            detail = snapshot.error or snapshot.result_text or snapshot.message
+            blocker = f"run execution finished unsuccessfully: {run_status}" + (
+                f" — {detail}" if detail else ""
+            )
+            status = "failed"
+            resume_capability = AutoResumeCapability.NONE
+        elif run_success is not True and run_status != "completed":
+            # Allowlist gate (pipeline parity): terminal job metadata without
+            # an explicit success signal is NOT evidence of run success.
+            status = "blocked"
+            blocker = (
+                "execution job completed without confirming terminal run "
+                f"success (status={run_status!r}, success={run_success!r}); "
+                "inspect the run before treating the product as complete "
+                f"(job {snapshot.job_id})"
+            )
+        else:
+            status = "complete"
+            blocker = None
+            resume_capability = AutoResumeCapability.NONE
     elif snapshot.status in {JobStatus.FAILED, JobStatus.CANCELLED, JobStatus.INTERRUPTED}:
         detail = snapshot.error or snapshot.result_text or snapshot.message
         blocker = (

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -956,6 +956,13 @@ def _reconcile_run_handoff_result(
     """
     status = result.status
     blocker = result.blocker
+    # Do NOT inherit ``result.resume_capability``: for a COMPLETE handoff the
+    # pipeline emits ``AutoResumeCapability.NONE`` (see
+    # ``AutoPipelineState.resume_capability()`` — COMPLETE -> NONE). Each branch
+    # below sets the capability explicitly so a blocked-but-resumable run
+    # (paused / unknown-success / deadline) is upgraded to RESUME regardless of
+    # the incoming COMPLETE->NONE, while genuine success stays NONE and genuine
+    # failure keeps NONE.
     resume_capability = result.resume_capability
     if snapshot.status is JobStatus.COMPLETED:
         run_status, run_success = _run_meta_verdict(snapshot)
@@ -964,6 +971,7 @@ def _reconcile_run_handoff_result(
             # Same contract as the pipeline's resume gate: block with resume
             # guidance and keep the persisted run handle resumable.
             status = "blocked"
+            resume_capability = AutoResumeCapability.RESUME
             blocker = (
                 "run execution paused before completion; resume the paused "
                 f"run before continuing (auto session {result.auto_session_id}, "
@@ -980,11 +988,12 @@ def _reconcile_run_handoff_result(
             # Allowlist gate (pipeline parity): terminal job metadata without
             # an explicit success signal is NOT evidence of run success.
             status = "blocked"
+            resume_capability = AutoResumeCapability.RESUME
             blocker = (
                 "execution job completed without confirming terminal run "
                 f"success (status={run_status!r}, success={run_success!r}); "
                 "inspect the run before treating the product as complete "
-                f"(job {snapshot.job_id})"
+                f"(auto session {result.auto_session_id}, job {snapshot.job_id})"
             )
         else:
             status = "complete"
@@ -997,8 +1006,14 @@ def _reconcile_run_handoff_result(
             if detail
             else f"execution job {snapshot.status.value}"
         )
-        status = "failed" if snapshot.status is JobStatus.FAILED else "blocked"
-        resume_capability = AutoResumeCapability.NONE
+        if snapshot.status is JobStatus.FAILED:
+            # Genuine failure: keep the failure (non-resumable) capability.
+            status = "failed"
+            resume_capability = AutoResumeCapability.NONE
+        else:
+            # Cancelled/interrupted mid-run is resumable, not a dead end.
+            status = "blocked"
+            resume_capability = AutoResumeCapability.RESUME
     else:
         # Non-terminal snapshot (should not happen after a terminal wait): keep
         # the handoff-only result intact and only surface the live status.
@@ -1027,11 +1042,14 @@ def _run_wait_deadline_result(
     """Bounded verdict for a run wait that exhausted the pipeline deadline.
 
     Same shape as the paused reconciliation: NOT complete, blocked with the
-    resume handle and guidance, resume capability preserved.
+    resume handle and guidance. ``resume_capability`` is set explicitly to
+    RESUME (not inherited): the incoming COMPLETE handoff result carries
+    ``AutoResumeCapability.NONE``, but a deadline-cancelled run IS resumable.
     """
     return replace(
         result,
         status="blocked",
+        resume_capability=AutoResumeCapability.RESUME,
         blocker=(
             "run wait deadline exhausted (top-level pipeline --timeout budget); "
             f"cancelled run job {snapshot.job_id}. The product run did NOT "

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -1170,7 +1170,8 @@ async def _await_run_handoff_terminal(
     )
     if not quiet:
         print_info(
-            f"Waiting for run job {job_id} to finish (Ctrl-C to cancel the run and detach)..."
+            f"Waiting for run job {job_id} to finish "
+            "(Ctrl-C cancels the run; resumable with ooo auto --resume)..."
         )
     wait_handler = JobWaitHandler(job_manager=job_manager, event_store=event_store)
     cursor = 0
@@ -1213,8 +1214,30 @@ async def _await_run_handoff_terminal(
                 break
             snapshot = await job_manager.get_snapshot(job_id)
     except (asyncio.CancelledError, KeyboardInterrupt):
+        # Interrupt cancels the run mid-flight — the same non-success boundary
+        # as the deadline/paused/terminal-failure paths. Correct the durable
+        # state FIRST (synchronous, so it always lands even if the cancel await
+        # below is itself interrupted) so a later ``ouroboros auto --resume``
+        # reconciles the cancelled run instead of returning the pipeline's
+        # premature COMPLETE. Best-effort: never let a persistence hiccup mask
+        # the operator's interrupt.
+        with contextlib.suppress(Exception):
+            interrupted_result = replace(
+                result,
+                status="blocked",
+                blocker=(
+                    f"run cancelled by interrupt; cancelled run job {job_id}. "
+                    "The product run did NOT complete. Resume with: "
+                    f"ouroboros auto --resume {result.auto_session_id}"
+                ),
+                resume_capability=AutoResumeCapability.RESUME,
+            )
+            _persist_resumable_run_verdict(interrupted_result, state, store)
         await _cancel_run_handoff_job(job_manager, job_id)
-        print_warning(f"Interrupted — cancelled run job {job_id}")
+        print_warning(
+            f"Interrupted — cancelled run job {job_id}. "
+            f"Resume with: ouroboros auto --resume {result.auto_session_id}"
+        )
         raise
 
     snapshot = await job_manager.get_snapshot(job_id)

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -8,6 +8,7 @@ from dataclasses import replace
 from enum import Enum
 import os
 from pathlib import Path
+import time
 from typing import Annotated
 
 from rich.markup import escape as _rich_escape
@@ -242,6 +243,9 @@ def auto_command(
                 "Top-level pipeline deadline in seconds. Defaults to "
                 f"{DEFAULT_PIPELINE_TIMEOUT_SECONDS:g}s (2h) for new sessions. "
                 f"Range: {MIN_PIPELINE_TIMEOUT_SECONDS:g}-{MAX_PIPELINE_TIMEOUT_SECONDS:g}. "
+                "The same deadline also bounds the default run-handoff wait: "
+                "on expiry the run job is cancelled cleanly and auto reports a "
+                "blocked (resumable) verdict. "
                 "On resume the deadline is preserved across process restarts; "
                 "passing --timeout on resume is rejected."
             ),
@@ -694,6 +698,13 @@ async def _run_auto(
                 job_manager=getattr(start_execute, "_job_manager", None),
                 event_store=getattr(start_execute, "_event_store", None),
                 quiet=progress_callback is None,
+                # Bound the wait by the SAME top-level pipeline deadline the
+                # CLI --timeout contract advertises: the pipeline consumed
+                # part of the budget, the wait gets the remainder. When the
+                # deadline was never armed (defensive), a fresh
+                # pipeline_timeout_seconds window applies — never unbounded.
+                deadline_at=state.deadline_at,
+                fallback_timeout_seconds=float(state.pipeline_timeout_seconds),
             )
     finally:
         release_auto_worktree(auto_workspace)
@@ -937,6 +948,11 @@ def _reconcile_run_handoff_result(
     verdict carried in ``result_meta``: a COMPLETED job is only a successful
     run when its meta confirms terminal success; ``status == "paused"`` keeps
     the session resumable and never reports complete.
+
+    TODO(Q00/ouroboros#1590): extract a shared job→auto-result reconciliation
+    helper with ``mcp/tools/auto_handler._reconcile_execution_job_snapshot``
+    instead of mirroring its semantics here (kept out of this PR to avoid
+    touching the MCP path).
     """
     status = result.status
     blocker = result.blocker
@@ -999,12 +1015,66 @@ def _reconcile_run_handoff_result(
     )
 
 
+# Grace window (seconds) after a deadline-driven cancel for the job's
+# CancelledError handler to persist its terminal ``mcp.job.cancelled`` event,
+# so the bounded verdict reports the post-cancel terminal status.
+_RUN_HANDOFF_CANCEL_GRACE_SECONDS = 5.0
+
+
+def _run_wait_deadline_result(
+    result: AutoPipelineResult, snapshot: JobSnapshot
+) -> AutoPipelineResult:
+    """Bounded verdict for a run wait that exhausted the pipeline deadline.
+
+    Same shape as the paused reconciliation: NOT complete, blocked with the
+    resume handle and guidance, resume capability preserved.
+    """
+    return replace(
+        result,
+        status="blocked",
+        blocker=(
+            "run wait deadline exhausted (top-level pipeline --timeout budget); "
+            f"cancelled run job {snapshot.job_id}. The product run did NOT "
+            "complete. Resume with: ouroboros auto --resume "
+            f"{result.auto_session_id}"
+        ),
+        execution_job_status=snapshot.status.value,
+        execution_job_error=snapshot.error,
+        execution_job_message=snapshot.message,
+    )
+
+
+async def _cancel_run_and_build_deadline_result(
+    result: AutoPipelineResult,
+    job_manager: JobManager,
+    job_id: str,
+    snapshot: JobSnapshot,
+) -> AutoPipelineResult:
+    """Cancel the run job on deadline expiry and return the bounded verdict."""
+    await _cancel_run_handoff_job(job_manager, job_id)
+    print_warning(
+        f"Run wait deadline reached — cancelled run job {job_id}. "
+        f"Resume with: ouroboros auto --resume {result.auto_session_id}"
+    )
+    # Short grace so the cancel lands as a terminal event before reporting.
+    grace_deadline = time.monotonic() + _RUN_HANDOFF_CANCEL_GRACE_SECONDS
+    with contextlib.suppress(Exception):
+        while time.monotonic() < grace_deadline:
+            snapshot = await job_manager.get_snapshot(job_id)
+            if snapshot.is_terminal:
+                break
+            await asyncio.sleep(0.05)
+    return _run_wait_deadline_result(result, snapshot)
+
+
 async def _await_run_handoff_terminal(
     result: AutoPipelineResult,
     *,
     job_manager: JobManager | None,
     event_store: EventStore | None,
     quiet: bool,
+    deadline_at: float | None = None,
+    fallback_timeout_seconds: float = DEFAULT_PIPELINE_TIMEOUT_SECONDS,
 ) -> AutoPipelineResult:
     """Wait for the started execute job to finish, streaming run progress.
 
@@ -1013,6 +1083,15 @@ async def _await_run_handoff_terminal(
     dispatch). Otherwise polls the live job manager to a terminal state, prints
     the run receipt via the existing ``ouroboros_job_result`` renderer, and
     reconciles the run verdict onto the returned result.
+
+    The wait is bounded by ``deadline_at`` — the pipeline's armed monotonic
+    deadline (``state.deadline_at``), i.e. the SAME budget the CLI's top-level
+    ``--timeout`` contract advertises; the pipeline consumed part of it and the
+    wait gets the remainder. When no deadline was armed (defensive), a fresh
+    ``fallback_timeout_seconds`` window (the pipeline's own default budget)
+    applies — the wait is never unbounded. On expiry the job is cancelled
+    cleanly via the existing cancel path and a bounded blocked/timeout verdict
+    is returned, mirroring the Ctrl-C semantics.
     """
     job_id = result.job_id
     if not job_id or job_manager is None or event_store is None:
@@ -1024,6 +1103,11 @@ async def _await_run_handoff_terminal(
         # honestly leave the handoff-only result as-is for the caller to render.
         return result
 
+    deadline = (
+        deadline_at
+        if deadline_at is not None
+        else time.monotonic() + max(0.0, fallback_timeout_seconds)
+    )
     if not quiet:
         print_info(
             f"Waiting for run job {job_id} to finish (Ctrl-C to cancel the run and detach)..."
@@ -1033,15 +1117,27 @@ async def _await_run_handoff_terminal(
     last_line = ""
     try:
         while not snapshot.is_terminal:
-            wait_result = await wait_handler.handle(
-                {
-                    "job_id": job_id,
-                    "cursor": cursor,
-                    "timeout_seconds": _RUN_HANDOFF_WAIT_POLL_SECONDS,
-                    "view": "compact",
-                    "wait_for": "ac_change",
-                }
-            )
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return await _cancel_run_and_build_deadline_result(
+                    result, job_manager, job_id, snapshot
+                )
+            try:
+                wait_result = await asyncio.wait_for(
+                    wait_handler.handle(
+                        {
+                            "job_id": job_id,
+                            "cursor": cursor,
+                            "timeout_seconds": _RUN_HANDOFF_WAIT_POLL_SECONDS,
+                            "view": "compact",
+                            "wait_for": "ac_change",
+                        }
+                    ),
+                    timeout=min(float(_RUN_HANDOFF_WAIT_POLL_SECONDS), remaining),
+                )
+            except TimeoutError:
+                # Poll window clipped by the deadline; loop re-checks it.
+                continue
             if wait_result.is_err:
                 break
             value = wait_result.value

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -705,6 +705,11 @@ async def _run_auto(
                 # pipeline_timeout_seconds window applies — never unbounded.
                 deadline_at=state.deadline_at,
                 fallback_timeout_seconds=float(state.pipeline_timeout_seconds),
+                # Correct the durable state (out of the pipeline's premature
+                # COMPLETE) on a non-success verdict so a later --resume
+                # reconciles the run instead of returning stale complete.
+                state=state,
+                store=store,
             )
     finally:
         release_auto_worktree(auto_workspace)
@@ -1085,6 +1090,36 @@ async def _cancel_run_and_build_deadline_result(
     return _run_wait_deadline_result(result, snapshot)
 
 
+def _persist_resumable_run_verdict(
+    result: AutoPipelineResult,
+    state: AutoPipelineState | None,
+    store: AutoStore | None,
+) -> AutoPipelineResult:
+    """Persist a non-success run verdict onto the durable auto state.
+
+    ``AutoPipeline.run`` saved the durable state as ``AutoPhase.COMPLETE`` when
+    the run handoff started. If the wait then observed the run finish paused /
+    unsuccessfully / deadline-cancelled, the in-memory ``result`` is corrected
+    but the DURABLE state is still COMPLETE — so a later plain
+    ``ouroboros auto --resume`` would hit the ``pipeline.run`` COMPLETE
+    fast-path and return the stale product-complete. Reopen the durable state
+    back to the RUN phase (and save via the same store the pipeline uses) so
+    ``--resume`` reconciles the owned run job instead. Genuine success stays
+    COMPLETE (no reopen). The in-memory ``resume_capability`` is then taken from
+    the durable state so it matches what ``--resume`` will actually do.
+    """
+    if result.status == "complete" or state is None:
+        return result
+    reopened = state.reopen_completed_run_handoff_to_run(
+        result.blocker or "run handoff started but not verified complete"
+    )
+    if not reopened:
+        return result
+    if store is not None:
+        store.save(state)
+    return replace(result, resume_capability=state.resume_capability())
+
+
 async def _await_run_handoff_terminal(
     result: AutoPipelineResult,
     *,
@@ -1093,6 +1128,8 @@ async def _await_run_handoff_terminal(
     quiet: bool,
     deadline_at: float | None = None,
     fallback_timeout_seconds: float = DEFAULT_PIPELINE_TIMEOUT_SECONDS,
+    state: AutoPipelineState | None = None,
+    store: AutoStore | None = None,
 ) -> AutoPipelineResult:
     """Wait for the started execute job to finish, streaming run progress.
 
@@ -1110,6 +1147,11 @@ async def _await_run_handoff_terminal(
     applies — the wait is never unbounded. On expiry the job is cancelled
     cleanly via the existing cancel path and a bounded blocked/timeout verdict
     is returned, mirroring the Ctrl-C semantics.
+
+    When ``state`` / ``store`` are provided, a non-success verdict also
+    corrects the DURABLE auto state (out of the pipeline's premature COMPLETE)
+    so a later ``--resume`` reconciles the run rather than returning stale
+    product-complete.
     """
     job_id = result.job_id
     if not job_id or job_manager is None or event_store is None:
@@ -1137,9 +1179,10 @@ async def _await_run_handoff_terminal(
         while not snapshot.is_terminal:
             remaining = deadline - time.monotonic()
             if remaining <= 0:
-                return await _cancel_run_and_build_deadline_result(
+                deadline_result = await _cancel_run_and_build_deadline_result(
                     result, job_manager, job_id, snapshot
                 )
+                return _persist_resumable_run_verdict(deadline_result, state, store)
             try:
                 wait_result = await asyncio.wait_for(
                     wait_handler.handle(
@@ -1180,7 +1223,8 @@ async def _await_run_handoff_terminal(
         receipt = await result_handler.handle({"job_id": job_id})
         if receipt.is_ok and receipt.value.text_content:
             console.print(receipt.value.text_content)
-    return _reconcile_run_handoff_result(result, snapshot)
+    reconciled = _reconcile_run_handoff_result(result, snapshot)
+    return _persist_resumable_run_verdict(reconciled, state, store)
 
 
 def _print_detached_guidance(result: AutoPipelineResult) -> None:

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -1098,26 +1098,50 @@ def _persist_resumable_run_verdict(
     """Persist a non-success run verdict onto the durable auto state.
 
     ``AutoPipeline.run`` saved the durable state as ``AutoPhase.COMPLETE`` when
-    the run handoff started. If the wait then observed the run finish paused /
-    unsuccessfully / deadline-cancelled, the in-memory ``result`` is corrected
-    but the DURABLE state is still COMPLETE — so a later plain
-    ``ouroboros auto --resume`` would hit the ``pipeline.run`` COMPLETE
-    fast-path and return the stale product-complete. Reopen the durable state
-    back to the RUN phase (and save via the same store the pipeline uses) so
-    ``--resume`` reconciles the owned run job instead. Genuine success stays
-    COMPLETE (no reopen). The in-memory ``resume_capability`` is then taken from
-    the durable state so it matches what ``--resume`` will actually do.
+    the run handoff started. If the wait then observed the run finish in a
+    non-success terminal, the in-memory ``result`` is corrected but the DURABLE
+    state is still COMPLETE — so a later plain ``ouroboros auto --resume`` would
+    hit the ``pipeline.run`` COMPLETE fast-path and return the stale
+    product-complete. Correct the durable state so the two disagree no more,
+    distinguishing the two kinds of non-success outcome:
+
+    * ``status == "blocked"`` — a *resumable* outcome (paused execution,
+      deadline-cancelled, interrupt-cancelled, cancelled/interrupted job, or an
+      unknown-success handle). Reopen the durable state to ``RUN`` so
+      ``--resume`` reconciles the owned job, and take the in-memory
+      ``resume_capability`` from the durable state (RESUME).
+    * ``status == "failed"`` — a *genuine* run failure (job ``FAILED`` /
+      ``success is False``). Preserve the failed terminal contract: persist a
+      durable ``FAILED`` phase (NOT reopened to RUN), and keep the reconciled
+      capability (``NONE``) — ``--resume`` must not retry an already-failed run.
+
+    Genuine success (``status == "complete"``) leaves the durable state
+    COMPLETE and is returned unchanged (fast-path intact).
     """
-    if result.status == "complete" or state is None:
+    if state is None:
         return result
-    reopened = state.reopen_completed_run_handoff_to_run(
-        result.blocker or "run handoff started but not verified complete"
-    )
-    if not reopened:
+    if result.status == "blocked":
+        reopened = state.reopen_completed_run_handoff_to_run(
+            result.blocker or "run handoff started but not verified complete"
+        )
+        if not reopened:
+            return result
+        if store is not None:
+            store.save(state)
+        return replace(result, resume_capability=state.resume_capability())
+    if result.status == "failed":
+        # Genuine failure: persist a durable FAILED terminal so --resume/--status
+        # never report success, but do NOT reopen to RUN and do NOT advertise
+        # resume — the reconciled NONE capability is authoritative for failures.
+        if (
+            state.close_completed_run_handoff_as_failed(
+                result.blocker or "run execution finished unsuccessfully"
+            )
+            and store is not None
+        ):
+            store.save(state)
         return result
-    if store is not None:
-        store.save(state)
-    return replace(result, resume_capability=state.resume_capability())
+    return result
 
 
 async def _await_run_handoff_terminal(

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2661,6 +2661,90 @@ async def test_run_resume_completes_when_owned_job_succeeded(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_resume_after_deadline_reopen_is_not_deadlined_out(tmp_path) -> None:
+    """A deadline-cancelled reopen-to-RUN must resume cleanly, not dead-end.
+
+    Q00/ouroboros#1590: the reopen clears the expired absolute deadline so
+    ``from_dict`` re-arms a fresh budget on load. Without it, ``--resume`` hits
+    the deadline gate (pipeline.run) and returns ``pipeline_timeout`` before the
+    RUN reconciliation ever runs — a dead-end resume promise. Here the reopened
+    state, saved and loaded through the store (as ``--resume`` does), resumes
+    into the owned-job reconciliation (paused → blocked) instead.
+    """
+    import time as time_module
+
+    from ouroboros.auto.interview_driver import FunctionInterviewBackend
+    from ouroboros.mcp.job_manager import JobManager
+    from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+    from ouroboros.persistence.event_store import EventStore
+
+    jobs = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(jobs)
+    store = AutoStore(tmp_path)
+    try:
+
+        async def _paused_runner() -> MCPToolResult:
+            return MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="PAUSED"),),
+                is_error=False,
+                meta={"status": "paused", "success": None},
+            )
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_paused_runner()
+        )
+
+        # Build the durable state exactly as the CLI leaves it after a
+        # deadline-cancelled wait: a COMPLETE handoff with an already-expired
+        # absolute deadline, then reopened to RUN (which clears the deadline).
+        state = _run_state_with_handle(tmp_path, started.job_id)
+        state.transition(AutoPhase.COMPLETE, "execution started for grade A Seed")
+        state.deadline_at = time_module.monotonic() - 100.0
+        state.deadline_at_epoch = time_module.time() - 100.0
+        assert state.is_deadline_expired()
+        assert state.reopen_completed_run_handoff_to_run("run cancelled by deadline")
+        assert state.deadline_at is None
+        store.save(state)
+
+        # Load fresh (as --resume): from_dict re-arms a fresh, non-expired budget.
+        loaded = store.load(state.auto_session_id)
+        assert loaded.phase is AutoPhase.RUN
+        assert loaded.deadline_at is not None and not loaded.is_deadline_expired()
+
+        async def _unused(*_a, **_k):  # noqa: ANN002, ANN003, ANN202
+            raise AssertionError("run resume should not restart interview/seed")
+
+        driver = AutoInterviewDriver(
+            FunctionInterviewBackend(_unused, _unused), store=AutoStore(tmp_path)
+        )
+        pipeline = AutoPipeline(
+            driver,
+            _unused,
+            run_starter=_run_starter_over_manager(manager),
+            store=AutoStore(tmp_path),
+        )
+
+        result = await pipeline.run(loaded)
+
+        # NOT the deadline dead-end — it reached the RUN reconciliation.
+        assert "pipeline_timeout" not in (result.blocker or "")
+        assert result.status == "blocked"
+        assert "paused" in (result.blocker or "")
+    finally:
+        tasks = [
+            *manager._tasks.values(),  # noqa: SLF001
+            *manager._runner_tasks.values(),  # noqa: SLF001
+            *manager._monitors.values(),  # noqa: SLF001
+        ]
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        await jobs.close()
+
+
+@pytest.mark.asyncio
 async def test_interview_driver_persists_blocker_ledger_entry(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("What API key should the workflow use?", "interview_1")

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -2514,6 +2514,152 @@ async def test_pipeline_resumes_run_with_persisted_handle_without_restarting(tmp
     assert result.job_id == "job_existing"
 
 
+def _run_state_with_handle(tmp_path, job_id: str) -> AutoPipelineState:
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.job_id = job_id
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    return state
+
+
+def _run_starter_over_manager(manager):  # noqa: ANN001, ANN202
+    """A run starter whose ``handler._job_manager`` exposes get_snapshot.
+
+    Matches the shape ``_wait_owned_run_job_terminal`` reads on the production
+    ``HandlerRunStarter`` (``adapter.handler._job_manager.get_snapshot``). The
+    persisted-handle RUN resume path reconciles the owned job and never invokes
+    the starter, so it does not need to be callable.
+    """
+    from types import SimpleNamespace
+
+    return SimpleNamespace(handler=SimpleNamespace(_job_manager=manager))
+
+
+@pytest.mark.asyncio
+async def test_run_resume_reconciles_owned_paused_job_to_blocked(tmp_path) -> None:
+    """Default RUN resume must not report COMPLETE when the owned job paused.
+
+    Q00/ouroboros#1590: a persisted run handle proves dispatch, not terminal
+    success. When the owned execute job finished paused, ``--resume`` must
+    reconcile the owned job and block (resumably) instead of returning a stale
+    product-complete off the handle alone.
+    """
+    from ouroboros.auto.interview_driver import FunctionInterviewBackend
+    from ouroboros.mcp.job_manager import JobManager
+    from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+    from ouroboros.persistence.event_store import EventStore
+
+    jobs = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(jobs)
+    try:
+
+        async def _paused_runner() -> MCPToolResult:
+            return MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="PAUSED"),),
+                is_error=False,
+                meta={"status": "paused", "success": None},
+            )
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_paused_runner()
+        )
+
+        async def _unused(*_a, **_k):  # noqa: ANN002, ANN003, ANN202
+            raise AssertionError("run resume should not restart interview/seed")
+
+        state = _run_state_with_handle(tmp_path, started.job_id)
+        driver = AutoInterviewDriver(
+            FunctionInterviewBackend(_unused, _unused), store=AutoStore(tmp_path)
+        )
+        pipeline = AutoPipeline(
+            driver,
+            _unused,
+            run_starter=_run_starter_over_manager(manager),
+            store=AutoStore(tmp_path),
+        )
+
+        result = await pipeline.run(state)
+
+        assert result.status != "complete"
+        assert result.status == "blocked"
+        assert "paused" in (result.blocker or "")
+        assert state.phase is AutoPhase.BLOCKED
+    finally:
+        tasks = [
+            *manager._tasks.values(),  # noqa: SLF001
+            *manager._runner_tasks.values(),  # noqa: SLF001
+            *manager._monitors.values(),  # noqa: SLF001
+        ]
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        await jobs.close()
+
+
+@pytest.mark.asyncio
+async def test_run_resume_completes_when_owned_job_succeeded(tmp_path) -> None:
+    """Default RUN resume still completes when the owned job reached success."""
+    from ouroboros.auto.interview_driver import FunctionInterviewBackend
+    from ouroboros.mcp.job_manager import JobManager
+    from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+    from ouroboros.persistence.event_store import EventStore
+
+    jobs = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(jobs)
+    try:
+
+        async def _ok_runner() -> MCPToolResult:
+            return MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="done"),),
+                is_error=False,
+                meta={"status": "completed", "success": True},
+            )
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_ok_runner()
+        )
+
+        async def _unused(*_a, **_k):  # noqa: ANN002, ANN003, ANN202
+            raise AssertionError("run resume should not restart interview/seed")
+
+        state = _run_state_with_handle(tmp_path, started.job_id)
+        driver = AutoInterviewDriver(
+            FunctionInterviewBackend(_unused, _unused), store=AutoStore(tmp_path)
+        )
+        pipeline = AutoPipeline(
+            driver,
+            _unused,
+            run_starter=_run_starter_over_manager(manager),
+            store=AutoStore(tmp_path),
+        )
+
+        result = await pipeline.run(state)
+
+        assert result.status == "complete"
+        assert state.phase is AutoPhase.COMPLETE
+    finally:
+        tasks = [
+            *manager._tasks.values(),  # noqa: SLF001
+            *manager._runner_tasks.values(),  # noqa: SLF001
+            *manager._monitors.values(),  # noqa: SLF001
+        ]
+        for task in tasks:
+            if not task.done():
+                task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        await jobs.close()
+
+
 @pytest.mark.asyncio
 async def test_interview_driver_persists_blocker_ledger_entry(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001

--- a/tests/unit/cli/test_auto_run_handoff_wait.py
+++ b/tests/unit/cli/test_auto_run_handoff_wait.py
@@ -18,7 +18,12 @@ from typer.testing import CliRunner
 
 from ouroboros.auto.handoff_contract import RUN_HANDOFF_STARTED_STATUS
 from ouroboros.auto.pipeline import AutoPipelineResult
-from ouroboros.auto.state import AutoResumeCapability
+from ouroboros.auto.state import (
+    AutoPhase,
+    AutoPipelineState,
+    AutoResumeCapability,
+    AutoStore,
+)
 from ouroboros.cli.commands import auto as auto_command
 from ouroboros.cli.commands.auto import _await_run_handoff_terminal
 from ouroboros.cli.main import app
@@ -146,6 +151,131 @@ async def test_wait_reflects_failed_run_job_verdict(tmp_path) -> None:
     finally:
         await _cancel_manager_tasks(manager)
         await store.close()
+
+
+def _completed_handoff_state(tmp_path, job_id: str) -> AutoPipelineState:
+    """Build the durable state exactly as ``AutoPipeline.run`` leaves it after a
+    run handoff: phase COMPLETE, with the persisted run handle."""
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    state.job_id = job_id
+    state.run_handoff_status = RUN_HANDOFF_STARTED_STATUS
+    # CREATED -> ... -> RUN -> COMPLETE, matching the pipeline's fresh path.
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.transition(AutoPhase.COMPLETE, "execution started for grade A Seed")
+    return state
+
+
+@pytest.mark.asyncio
+async def test_wait_blocked_verdict_persists_resumable_durable_state(tmp_path) -> None:
+    """A non-success wait verdict must correct the DURABLE state, not just memory.
+
+    The pipeline saved COMPLETE at handoff. After the wait observes a paused
+    run, a fresh load from the store (as a later ``ouroboros auto --resume``
+    would do) must NOT see COMPLETE/product-complete but a resumable state.
+    This is the durability the in-memory-only reconciliation could not provide.
+    """
+    jobs = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(jobs)
+    auto_store = AutoStore(tmp_path / "auto")
+    try:
+
+        async def _runner() -> MCPToolResult:
+            return MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="Seed Execution PAUSED"),),
+                is_error=False,
+                meta={"status": "paused", "success": None},
+            )
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_runner()
+        )
+        state = _completed_handoff_state(tmp_path, started.job_id)
+        auto_store.save(state)
+        # Durable state starts as COMPLETE (the stale, wrong verdict).
+        assert auto_store.load(state.auto_session_id).phase is AutoPhase.COMPLETE
+
+        result = AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            job_id=started.job_id,
+            run_handoff_status=RUN_HANDOFF_STARTED_STATUS,
+            resume_capability=AutoResumeCapability.NONE,
+        )
+
+        reconciled = await _await_run_handoff_terminal(
+            result,
+            job_manager=manager,
+            event_store=jobs,
+            quiet=True,
+            state=state,
+            store=auto_store,
+        )
+
+        # In-memory verdict is blocked + resumable.
+        assert reconciled.status == "blocked"
+        assert reconciled.resume_capability is AutoResumeCapability.RESUME
+
+        # DURABLE state, loaded fresh (new store instance) as --resume would:
+        # NOT COMPLETE, and classifies as resumable.
+        reloaded = AutoStore(tmp_path / "auto").load(state.auto_session_id)
+        assert reloaded.phase is not AutoPhase.COMPLETE
+        assert reloaded.phase is AutoPhase.RUN
+        assert reloaded.job_id == started.job_id
+        assert reloaded.resume_capability() is AutoResumeCapability.RESUME
+    finally:
+        await _cancel_manager_tasks(manager)
+        await jobs.close()
+
+
+@pytest.mark.asyncio
+async def test_wait_success_keeps_durable_state_complete(tmp_path) -> None:
+    """Genuine success must leave the durable state COMPLETE (fast-path intact)."""
+    jobs = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(jobs)
+    auto_store = AutoStore(tmp_path / "auto")
+    try:
+
+        async def _runner() -> MCPToolResult:
+            return MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="2/2 ACs satisfied"),),
+                is_error=False,
+                meta={"status": "completed", "success": True},
+            )
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_runner()
+        )
+        state = _completed_handoff_state(tmp_path, started.job_id)
+        auto_store.save(state)
+
+        result = AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            job_id=started.job_id,
+            run_handoff_status=RUN_HANDOFF_STARTED_STATUS,
+            resume_capability=AutoResumeCapability.NONE,
+        )
+
+        reconciled = await _await_run_handoff_terminal(
+            result,
+            job_manager=manager,
+            event_store=jobs,
+            quiet=True,
+            state=state,
+            store=auto_store,
+        )
+
+        assert reconciled.status == "complete"
+        reloaded = AutoStore(tmp_path / "auto").load(state.auto_session_id)
+        assert reloaded.phase is AutoPhase.COMPLETE
+    finally:
+        await _cancel_manager_tasks(manager)
+        await jobs.close()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_auto_run_handoff_wait.py
+++ b/tests/unit/cli/test_auto_run_handoff_wait.py
@@ -225,6 +225,96 @@ async def test_wait_completed_job_without_success_meta_is_not_complete(tmp_path)
         await store.close()
 
 
+@pytest.mark.asyncio
+async def test_wait_deadline_cancels_wedged_job_and_reports_bounded_verdict(tmp_path) -> None:
+    """A never-terminal execute job must not outlive the pipeline deadline.
+
+    The default wait is bounded by the same top-level ``--timeout`` budget the
+    pipeline advertises: on expiry the job is cancelled cleanly (cancellation
+    event written) and the CLI reports blocked/timeout with the resume handle
+    preserved — never complete, never waiting past the bound.
+    """
+    import time as time_module
+
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(store)
+    try:
+        started_running = asyncio.Event()
+
+        async def _wedged_runner() -> MCPToolResult:
+            started_running.set()
+            await asyncio.sleep(3600)  # never terminates within the test
+            raise AssertionError("unreachable")
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_wedged_runner()
+        )
+        await asyncio.wait_for(started_running.wait(), timeout=5)
+        result = _handoff_only_result(started.job_id)
+
+        wait_started = time_module.monotonic()
+        reconciled = await asyncio.wait_for(
+            _await_run_handoff_terminal(
+                result,
+                job_manager=manager,
+                event_store=store,
+                quiet=True,
+                deadline_at=time_module.monotonic() + 0.5,
+            ),
+            # Outer guard: bound (0.5s) + cancel grace (5s) + margin. The wait
+            # must return on its own well within this.
+            timeout=15,
+        )
+        elapsed = time_module.monotonic() - wait_started
+
+        # Returned within the bound (deadline + cancel grace), not wedged.
+        assert elapsed < 10
+
+        # NOT complete: blocked/timeout verdict with resume guidance.
+        assert reconciled.status == "blocked"
+        assert reconciled.blocker is not None
+        assert "deadline" in reconciled.blocker
+        assert "--resume auto_wait" in reconciled.blocker
+        # Resume capability and the run handle are preserved.
+        assert reconciled.resume_capability is AutoResumeCapability.RESUME
+        assert reconciled.job_id == started.job_id
+
+        # The job was cancelled cleanly via the existing cancel path.
+        snapshot = await manager.get_snapshot(started.job_id)
+        assert snapshot.status in {JobStatus.CANCELLED, JobStatus.CANCEL_REQUESTED}
+        for _ in range(100):
+            snapshot = await manager.get_snapshot(started.job_id)
+            if snapshot.is_terminal:
+                break
+            await asyncio.sleep(0.05)
+        assert snapshot.status is JobStatus.CANCELLED
+        events, _cursor = await store.get_events_after("job", started.job_id, 0)
+        assert any(event.type == "mcp.job.cancelled" for event in events)
+    finally:
+        await _cancel_manager_tasks(manager)
+        await store.close()
+
+
+def test_deadline_blocked_result_exit_code_is_nonzero() -> None:
+    """CLI exit code is non-zero for the bounded deadline/blocked verdict."""
+    from dataclasses import replace as dc_replace
+
+    async def fake_run_auto(**_kwargs: object) -> AutoPipelineResult:
+        return dc_replace(
+            _handoff_only_result("job_wedged"),
+            status="blocked",
+            blocker="run wait deadline exhausted (top-level pipeline --timeout budget)",
+        )
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(auto_command, "_run_auto", fake_run_auto)
+        result = runner.invoke(app, ["auto", "safe wedged goal"])
+
+    assert result.exit_code == 1
+    output = _plain(result.output)
+    assert "deadline" in output
+
+
 def test_paused_run_exit_code_reflects_non_complete() -> None:
     """CLI exit code is non-zero when the waited run reconciles to paused/blocked."""
     from dataclasses import replace as dc_replace

--- a/tests/unit/cli/test_auto_run_handoff_wait.py
+++ b/tests/unit/cli/test_auto_run_handoff_wait.py
@@ -153,6 +153,66 @@ async def test_wait_reflects_failed_run_job_verdict(tmp_path) -> None:
         await store.close()
 
 
+@pytest.mark.asyncio
+async def test_wait_failed_run_preserves_failed_terminal_durably(tmp_path) -> None:
+    """A GENUINE failure must NOT be reopened to RUN / advertised as resumable.
+
+    Production-shaped: passes ``state`` AND ``store`` (unlike the in-memory-only
+    failed test above) so the durable-persistence path actually runs. A failed
+    execute job must (a) stay non-resumable (NONE), (b) NOT be reopened to RUN
+    in the durable store — it persists a FAILED terminal, and (c) a later
+    ``--resume`` preserves failed (never a retryable RUN), unlike the
+    paused/deadline/interrupt outcomes which SHOULD reopen to RUN.
+    """
+    jobs = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(jobs)
+    auto_store = AutoStore(tmp_path / "auto")
+    try:
+
+        async def _runner() -> MCPToolResult:
+            raise RuntimeError("boom in executor")
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_runner()
+        )
+        state = _completed_handoff_state(tmp_path, started.job_id)
+        auto_store.save(state)
+        assert auto_store.load(state.auto_session_id).phase is AutoPhase.COMPLETE
+
+        result = AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            job_id=started.job_id,
+            run_handoff_status=RUN_HANDOFF_STARTED_STATUS,
+            resume_capability=AutoResumeCapability.NONE,
+        )
+
+        reconciled = await _await_run_handoff_terminal(
+            result,
+            job_manager=manager,
+            event_store=jobs,
+            quiet=True,
+            state=state,
+            store=auto_store,
+        )
+
+        # (a) In-memory verdict stays failed + non-resumable.
+        assert reconciled.status == "failed"
+        assert reconciled.resume_capability is AutoResumeCapability.NONE
+
+        # (b) DURABLE state, loaded fresh: NOT reopened to RUN, and not COMPLETE.
+        reloaded = AutoStore(tmp_path / "auto").load(state.auto_session_id)
+        assert reloaded.phase is not AutoPhase.RUN
+        assert reloaded.phase is not AutoPhase.COMPLETE
+        assert reloaded.phase is AutoPhase.FAILED
+        # (c) --resume preserves failed, not retryable: capability is NONE.
+        assert reloaded.resume_capability() is AutoResumeCapability.NONE
+    finally:
+        await _cancel_manager_tasks(manager)
+        await jobs.close()
+
+
 def _completed_handoff_state(tmp_path, job_id: str) -> AutoPipelineState:
     """Build the durable state exactly as ``AutoPipeline.run`` leaves it after a
     run handoff: phase COMPLETE, with the persisted run handle."""

--- a/tests/unit/cli/test_auto_run_handoff_wait.py
+++ b/tests/unit/cli/test_auto_run_handoff_wait.py
@@ -232,6 +232,71 @@ async def test_wait_blocked_verdict_persists_resumable_durable_state(tmp_path) -
 
 
 @pytest.mark.asyncio
+async def test_wait_interrupt_persists_resumable_durable_state(tmp_path) -> None:
+    """An operator interrupt mid-wait must correct the DURABLE state too.
+
+    Cancelling the wait cancels the execute job; the durable auto session must
+    NOT be left as COMPLETE (which would make a later ``ooo auto --resume``
+    report success for a run that was actually cancelled). Same durability
+    proof shape as the deadline/paused tests: load fresh from the store and
+    assert not COMPLETE / resumable.
+    """
+    jobs = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(jobs)
+    auto_store = AutoStore(tmp_path / "auto")
+    try:
+        started_running = asyncio.Event()
+
+        async def _wedged_runner() -> MCPToolResult:
+            started_running.set()
+            await asyncio.sleep(3600)  # never terminates
+            raise AssertionError("unreachable")
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_wedged_runner()
+        )
+        await asyncio.wait_for(started_running.wait(), timeout=5)
+        state = _completed_handoff_state(tmp_path, started.job_id)
+        auto_store.save(state)
+        assert auto_store.load(state.auto_session_id).phase is AutoPhase.COMPLETE
+
+        result = AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            job_id=started.job_id,
+            run_handoff_status=RUN_HANDOFF_STARTED_STATUS,
+            resume_capability=AutoResumeCapability.NONE,
+        )
+
+        wait_task = asyncio.create_task(
+            _await_run_handoff_terminal(
+                result,
+                job_manager=manager,
+                event_store=jobs,
+                quiet=True,
+                state=state,
+                store=auto_store,
+            )
+        )
+        # Let the wait enter its poll loop, then deliver the interrupt.
+        await asyncio.sleep(0.2)
+        wait_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await wait_task
+
+        # DURABLE state, loaded fresh as --resume would: NOT COMPLETE, resumable.
+        reloaded = AutoStore(tmp_path / "auto").load(state.auto_session_id)
+        assert reloaded.phase is not AutoPhase.COMPLETE
+        assert reloaded.phase is AutoPhase.RUN
+        assert reloaded.job_id == started.job_id
+        assert reloaded.resume_capability() is AutoResumeCapability.RESUME
+    finally:
+        await _cancel_manager_tasks(manager)
+        await jobs.close()
+
+
+@pytest.mark.asyncio
 async def test_wait_success_keeps_durable_state_complete(tmp_path) -> None:
     """Genuine success must leave the durable state COMPLETE (fast-path intact)."""
     jobs = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")

--- a/tests/unit/cli/test_auto_run_handoff_wait.py
+++ b/tests/unit/cli/test_auto_run_handoff_wait.py
@@ -1,0 +1,217 @@
+"""Tests for the direct ``ouroboros auto`` run-handoff wait behaviour.
+
+Regression coverage for the live smoke-test bug where a direct CLI
+``ouroboros auto`` started the execute run-handoff as a detached in-process
+job and then exited, so ``asyncio.run`` teardown cancelled the job at ~200ms
+and the seed was never executed. The fix makes the CLI wait for the job to
+reach a terminal state (default) and reconciles the run verdict onto the
+result, while ``--no-wait`` preserves fire-and-forget detach behaviour.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+
+import pytest
+from typer.testing import CliRunner
+
+from ouroboros.auto.handoff_contract import RUN_HANDOFF_STARTED_STATUS
+from ouroboros.auto.pipeline import AutoPipelineResult
+from ouroboros.auto.state import AutoResumeCapability
+from ouroboros.cli.commands import auto as auto_command
+from ouroboros.cli.commands.auto import _await_run_handoff_terminal
+from ouroboros.cli.main import app
+from ouroboros.mcp.job_manager import JobManager, JobStatus
+from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+from ouroboros.persistence.event_store import EventStore
+
+runner = CliRunner()
+
+
+def _plain(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+async def _cancel_manager_tasks(manager: JobManager) -> None:
+    tasks = [
+        *manager._tasks.values(),  # noqa: SLF001
+        *manager._runner_tasks.values(),  # noqa: SLF001
+        *manager._monitors.values(),  # noqa: SLF001
+    ]
+    for task in tasks:
+        if not task.done():
+            task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def _handoff_only_result(job_id: str) -> AutoPipelineResult:
+    """A COMPLETE-but-handoff-only result, the state the wait path acts on."""
+    return AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_wait",
+        phase="complete",
+        grade="A",
+        seed_path="/tmp/seed.yaml",
+        job_id=job_id,
+        execution_id="exec_wait",
+        run_session_id="orch_wait",
+        run_handoff_status=RUN_HANDOFF_STARTED_STATUS,
+        resume_capability=AutoResumeCapability.RESUME,
+    )
+
+
+def _terminal_run_result() -> MCPToolResult:
+    return MCPToolResult(
+        content=(MCPContentItem(type=ContentType.TEXT, text="run receipt: 2/2 ACs satisfied"),),
+        is_error=False,
+        meta={"status": "completed", "success": True},
+    )
+
+
+@pytest.mark.asyncio
+async def test_wait_drives_run_job_to_completion_without_cancellation(tmp_path) -> None:
+    """A fast completing job is awaited to COMPLETED — never cancelled on exit."""
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(store)
+    try:
+
+        async def _runner() -> MCPToolResult:
+            return _terminal_run_result()
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_runner()
+        )
+        result = _handoff_only_result(started.job_id)
+
+        reconciled = await _await_run_handoff_terminal(
+            result,
+            job_manager=manager,
+            event_store=store,
+            quiet=True,
+        )
+
+        # Run verdict is projected onto the auto result.
+        assert reconciled.status == "complete"
+        assert reconciled.execution_job_status == JobStatus.COMPLETED.value
+        assert reconciled.resume_capability is AutoResumeCapability.NONE
+
+        # The job reached a genuine COMPLETED terminal, not CANCELLED.
+        snapshot = await manager.get_snapshot(started.job_id)
+        assert snapshot.status is JobStatus.COMPLETED
+
+        # No cancellation event was ever written for this job.
+        events, _cursor = await store.get_events_after("job", started.job_id, 0)
+        assert not any(event.type == "mcp.job.cancelled" for event in events)
+    finally:
+        await _cancel_manager_tasks(manager)
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_wait_reflects_failed_run_job_verdict(tmp_path) -> None:
+    """A failing run job flips the auto result to ``failed`` so exit code is 1."""
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(store)
+    try:
+
+        async def _runner() -> MCPToolResult:
+            raise RuntimeError("boom in executor")
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_runner()
+        )
+        result = _handoff_only_result(started.job_id)
+
+        reconciled = await _await_run_handoff_terminal(
+            result,
+            job_manager=manager,
+            event_store=store,
+            quiet=True,
+        )
+
+        assert reconciled.status == "failed"
+        assert reconciled.execution_job_status == JobStatus.FAILED.value
+        assert reconciled.blocker and "boom in executor" in reconciled.blocker
+    finally:
+        await _cancel_manager_tasks(manager)
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_wait_is_noop_when_job_not_owned(tmp_path) -> None:
+    """An unknown/plugin-dispatch job handle leaves the result untouched."""
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(store)
+    try:
+        result = _handoff_only_result("job_not_in_this_manager")
+        reconciled = await _await_run_handoff_terminal(
+            result,
+            job_manager=manager,
+            event_store=store,
+            quiet=True,
+        )
+        assert reconciled is result
+    finally:
+        await _cancel_manager_tasks(manager)
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_wait_is_noop_without_job_handle(tmp_path) -> None:
+    """No job_id (plugin dispatch) => nothing to wait on, result unchanged."""
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(store)
+    try:
+        result = AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_wait",
+            phase="complete",
+            run_handoff_status=RUN_HANDOFF_STARTED_STATUS,
+        )
+        reconciled = await _await_run_handoff_terminal(
+            result,
+            job_manager=manager,
+            event_store=store,
+            quiet=True,
+        )
+        assert reconciled is result
+    finally:
+        await _cancel_manager_tasks(manager)
+        await store.close()
+
+
+def test_default_cli_invocation_requests_wait() -> None:
+    """Without --no-wait, the CLI asks ``_run_auto`` to wait for the run job."""
+    captured: dict[str, object] = {}
+
+    async def fake_run_auto(**kwargs: object) -> AutoPipelineResult:
+        captured.update(kwargs)
+        return _handoff_only_result("job_default")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(auto_command, "_run_auto", fake_run_auto)
+        result = runner.invoke(app, ["auto", "safe wait goal"])
+
+    assert result.exit_code == 0
+    assert captured["wait"] is True
+
+
+def test_no_wait_flag_detaches_and_prints_honest_notice() -> None:
+    """--no-wait passes wait=False and warns the run won't survive exit."""
+    captured: dict[str, object] = {}
+
+    async def fake_run_auto(**kwargs: object) -> AutoPipelineResult:
+        captured.update(kwargs)
+        return _handoff_only_result("job_detached")
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(auto_command, "_run_auto", fake_run_auto)
+        result = runner.invoke(app, ["auto", "safe detach goal", "--no-wait"])
+
+    assert result.exit_code == 0
+    assert captured["wait"] is False
+    output = _plain(result.output)
+    assert "will NOT survive process exit" in output
+    assert "job_detached" in output

--- a/tests/unit/cli/test_auto_run_handoff_wait.py
+++ b/tests/unit/cli/test_auto_run_handoff_wait.py
@@ -47,7 +47,14 @@ async def _cancel_manager_tasks(manager: JobManager) -> None:
 
 
 def _handoff_only_result(job_id: str) -> AutoPipelineResult:
-    """A COMPLETE-but-handoff-only result, the state the wait path acts on."""
+    """A COMPLETE-but-handoff-only result, the state the wait path acts on.
+
+    Matches what ``AutoPipeline._result()`` actually emits for a COMPLETE
+    handoff: ``resume_capability=AutoResumeCapability.NONE`` (because
+    ``AutoPipelineState.resume_capability()`` maps COMPLETE -> NONE). The wait
+    reconciliation must therefore *upgrade* a blocked-but-resumable outcome to
+    RESUME explicitly — it cannot inherit RESUME from the input.
+    """
     return AutoPipelineResult(
         status="complete",
         auto_session_id="auto_wait",
@@ -58,7 +65,7 @@ def _handoff_only_result(job_id: str) -> AutoPipelineResult:
         execution_id="exec_wait",
         run_session_id="orch_wait",
         run_handoff_status=RUN_HANDOFF_STARTED_STATUS,
-        resume_capability=AutoResumeCapability.RESUME,
+        resume_capability=AutoResumeCapability.NONE,
     )
 
 
@@ -134,6 +141,8 @@ async def test_wait_reflects_failed_run_job_verdict(tmp_path) -> None:
         assert reconciled.status == "failed"
         assert reconciled.execution_job_status == JobStatus.FAILED.value
         assert reconciled.blocker and "boom in executor" in reconciled.blocker
+        # Genuine failure keeps the non-resumable capability (NOT upgraded).
+        assert reconciled.resume_capability is AutoResumeCapability.NONE
     finally:
         await _cancel_manager_tasks(manager)
         await store.close()
@@ -164,6 +173,9 @@ async def test_wait_paused_run_is_not_complete_and_stays_resumable(tmp_path) -> 
             job_type="execute", initial_message="queued", runner=_runner()
         )
         result = _handoff_only_result(started.job_id)
+        # Production input: a COMPLETE handoff carries NONE, so a passing
+        # RESUME assertion below proves an explicit upgrade, not inheritance.
+        assert result.resume_capability is AutoResumeCapability.NONE
 
         reconciled = await _await_run_handoff_terminal(
             result,
@@ -180,7 +192,7 @@ async def test_wait_paused_run_is_not_complete_and_stays_resumable(tmp_path) -> 
         # NOT successful completion.
         assert reconciled.status == "blocked"
         assert reconciled.blocker is not None and "paused" in reconciled.blocker
-        # Resume capability and the run handle are preserved.
+        # Upgraded to RESUME (from the NONE input) with the run handle intact.
         assert reconciled.resume_capability is AutoResumeCapability.RESUME
         assert reconciled.job_id == started.job_id
         assert reconciled.execution_id == "exec_wait"
@@ -208,6 +220,7 @@ async def test_wait_completed_job_without_success_meta_is_not_complete(tmp_path)
             job_type="execute", initial_message="queued", runner=_runner()
         )
         result = _handoff_only_result(started.job_id)
+        assert result.resume_capability is AutoResumeCapability.NONE
 
         reconciled = await _await_run_handoff_terminal(
             result,
@@ -219,6 +232,7 @@ async def test_wait_completed_job_without_success_meta_is_not_complete(tmp_path)
         assert reconciled.status == "blocked"
         assert reconciled.blocker is not None
         assert "without confirming terminal run success" in reconciled.blocker
+        # Upgraded from the NONE input — allowlist-blocked runs are resumable.
         assert reconciled.resume_capability is AutoResumeCapability.RESUME
     finally:
         await _cancel_manager_tasks(manager)
@@ -251,6 +265,7 @@ async def test_wait_deadline_cancels_wedged_job_and_reports_bounded_verdict(tmp_
         )
         await asyncio.wait_for(started_running.wait(), timeout=5)
         result = _handoff_only_result(started.job_id)
+        assert result.resume_capability is AutoResumeCapability.NONE
 
         wait_started = time_module.monotonic()
         reconciled = await asyncio.wait_for(
@@ -275,7 +290,7 @@ async def test_wait_deadline_cancels_wedged_job_and_reports_bounded_verdict(tmp_
         assert reconciled.blocker is not None
         assert "deadline" in reconciled.blocker
         assert "--resume auto_wait" in reconciled.blocker
-        # Resume capability and the run handle are preserved.
+        # Upgraded from the NONE input — a deadline-cancelled run is resumable.
         assert reconciled.resume_capability is AutoResumeCapability.RESUME
         assert reconciled.job_id == started.job_id
 

--- a/tests/unit/cli/test_auto_run_handoff_wait.py
+++ b/tests/unit/cli/test_auto_run_handoff_wait.py
@@ -292,6 +292,75 @@ async def test_wait_blocked_verdict_persists_resumable_durable_state(tmp_path) -
 
 
 @pytest.mark.asyncio
+async def test_wait_deadline_reopen_rearms_deadline_so_resume_is_not_dead_end(tmp_path) -> None:
+    """A deadline-cancelled reopen must not leave an expired deadline behind.
+
+    Otherwise a later ``ouroboros auto --resume`` hits ``AutoPipeline.run``'s
+    deadline gate (which fires on an expired deadline BEFORE the RUN
+    reconciliation) and is immediately re-blocked with ``pipeline_timeout`` —
+    the advertised resume would be a dead end. The reopen clears the absolute
+    deadline so a fresh load re-arms a fresh budget that is NOT already expired.
+    """
+    import time as time_module
+
+    jobs = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(jobs)
+    auto_store = AutoStore(tmp_path / "auto")
+    try:
+        started_running = asyncio.Event()
+
+        async def _wedged_runner() -> MCPToolResult:
+            started_running.set()
+            await asyncio.sleep(3600)  # never terminates
+            raise AssertionError("unreachable")
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_wedged_runner()
+        )
+        await asyncio.wait_for(started_running.wait(), timeout=5)
+        state = _completed_handoff_state(tmp_path, started.job_id)
+        # Mimic the pipeline: an armed absolute deadline that is already expired.
+        state.deadline_at = time_module.monotonic() - 100.0
+        state.deadline_at_epoch = time_module.time() - 100.0
+        assert state.is_deadline_expired()
+        auto_store.save(state)
+
+        result = AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            job_id=started.job_id,
+            run_handoff_status=RUN_HANDOFF_STARTED_STATUS,
+            resume_capability=AutoResumeCapability.NONE,
+        )
+
+        reconciled = await asyncio.wait_for(
+            _await_run_handoff_terminal(
+                result,
+                job_manager=manager,
+                event_store=jobs,
+                quiet=True,
+                deadline_at=time_module.monotonic() + 0.5,
+                state=state,
+                store=auto_store,
+            ),
+            timeout=15,
+        )
+        assert reconciled.status == "blocked"
+
+        # DURABLE state, loaded fresh as --resume would: RUN + a FRESH deadline
+        # that is NOT already expired, so the resume-time deadline gate passes.
+        reloaded = AutoStore(tmp_path / "auto").load(state.auto_session_id)
+        assert reloaded.phase is AutoPhase.RUN
+        assert reloaded.deadline_at is not None
+        assert not reloaded.is_deadline_expired()
+        assert reloaded.resume_capability() is AutoResumeCapability.RESUME
+    finally:
+        await _cancel_manager_tasks(manager)
+        await jobs.close()
+
+
+@pytest.mark.asyncio
 async def test_wait_interrupt_persists_resumable_durable_state(tmp_path) -> None:
     """An operator interrupt mid-wait must correct the DURABLE state too.
 

--- a/tests/unit/cli/test_auto_run_handoff_wait.py
+++ b/tests/unit/cli/test_auto_run_handoff_wait.py
@@ -140,6 +140,112 @@ async def test_wait_reflects_failed_run_job_verdict(tmp_path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_wait_paused_run_is_not_complete_and_stays_resumable(tmp_path) -> None:
+    """JobStatus.COMPLETED + result_meta status 'paused' must NOT read as success.
+
+    ``ExecuteSeedHandler`` maps ``SessionStatus.PAUSED`` (e.g. usage-limit
+    pause) to a job result of ``status="paused", success=None`` while the JOB
+    itself completes. The complete-product resume gate blocks paused runs; the
+    CLI wait path must preserve that contract: paused surfaces as blocked with
+    the run handle and resume capability preserved — never complete.
+    """
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(store)
+    try:
+
+        async def _runner() -> MCPToolResult:
+            return MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="Seed Execution PAUSED"),),
+                is_error=False,
+                meta={"status": "paused", "success": None},
+            )
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_runner()
+        )
+        result = _handoff_only_result(started.job_id)
+
+        reconciled = await _await_run_handoff_terminal(
+            result,
+            job_manager=manager,
+            event_store=store,
+            quiet=True,
+        )
+
+        # The JOB reached COMPLETED, but the EXECUTION paused.
+        snapshot = await manager.get_snapshot(started.job_id)
+        assert snapshot.status is JobStatus.COMPLETED
+        assert snapshot.result_meta.get("status") == "paused"
+
+        # NOT successful completion.
+        assert reconciled.status == "blocked"
+        assert reconciled.blocker is not None and "paused" in reconciled.blocker
+        # Resume capability and the run handle are preserved.
+        assert reconciled.resume_capability is AutoResumeCapability.RESUME
+        assert reconciled.job_id == started.job_id
+        assert reconciled.execution_id == "exec_wait"
+        assert reconciled.run_session_id == "orch_wait"
+    finally:
+        await _cancel_manager_tasks(manager)
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_wait_completed_job_without_success_meta_is_not_complete(tmp_path) -> None:
+    """Allowlist parity: unknown terminal meta must not pass as run success."""
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(store)
+    try:
+
+        async def _runner() -> MCPToolResult:
+            return MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="weird terminal"),),
+                is_error=False,
+                meta={"status": "unknown"},
+            )
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_runner()
+        )
+        result = _handoff_only_result(started.job_id)
+
+        reconciled = await _await_run_handoff_terminal(
+            result,
+            job_manager=manager,
+            event_store=store,
+            quiet=True,
+        )
+
+        assert reconciled.status == "blocked"
+        assert reconciled.blocker is not None
+        assert "without confirming terminal run success" in reconciled.blocker
+        assert reconciled.resume_capability is AutoResumeCapability.RESUME
+    finally:
+        await _cancel_manager_tasks(manager)
+        await store.close()
+
+
+def test_paused_run_exit_code_reflects_non_complete() -> None:
+    """CLI exit code is non-zero when the waited run reconciles to paused/blocked."""
+    from dataclasses import replace as dc_replace
+
+    async def fake_run_auto(**_kwargs: object) -> AutoPipelineResult:
+        return dc_replace(
+            _handoff_only_result("job_paused"),
+            status="blocked",
+            blocker="run execution paused before completion; resume the paused run",
+        )
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(auto_command, "_run_auto", fake_run_auto)
+        result = runner.invoke(app, ["auto", "safe paused goal"])
+
+    assert result.exit_code == 1
+    output = _plain(result.output)
+    assert "paused" in output
+
+
+@pytest.mark.asyncio
 async def test_wait_is_noop_when_job_not_owned(tmp_path) -> None:
     """An unknown/plugin-dispatch job handle leaves the result untouched."""
     store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")


### PR DESCRIPTION
## Summary

Live smoke testing on `main` found that a direct CLI `ouroboros auto "<goal>"` drove interview→seed→grade successfully, then started the execute phase as a **detached** in-process `JobManager` job and exited — printing `run_handoff_started` / "not verified complete; execution is still external/pending". Because the `JobManager` lives in the dying process, `asyncio.run` teardown cancelled the job almost immediately (observed: `job_3ce3660f6503` created → CANCELLED in ~200ms). Net effect: a single CLI `ouroboros auto` invocation **never actually executed the seed**.

## Confirmed cancel mechanism

- `src/ouroboros/cli/commands/auto.py:294` — `asyncio.run(_run_auto(...))`. When `_run_auto` returns, the event loop is torn down.
- `src/ouroboros/mcp/job_manager.py:1963-1971` (`drain` docstring, authoritative): *"Called by the serve shutdown path... Without an explicit drain, job tasks are killed by `asyncio.run` teardown after `EventStore.close()`..."*. The CLI path has **no** `drain()` call (that is serve-only).
- `src/ouroboros/mcp/job_manager.py:496-499` — the `_run_job` `CancelledError` handler persists `mcp.job.cancelled` when not draining, so the teardown cancel lands as a plain `CANCELLED` terminal.

## Fix

Scope: `src/ouroboros/cli/commands/auto.py` + tests only (no `auto/` or `job_manager.py` semantic changes).

1. **Default: wait for the run job.** After the handoff starts (`_is_run_handoff_only_completion` + a `job_id`), `_run_auto` keeps the event loop alive and awaits the execute job to a terminal state using the **live** `StartExecuteSeedHandler._job_manager` (the one that owns the running task). Progress is streamed via the existing `JobWaitHandler` (`ouroboros_job_wait`) renderer and the terminal receipt via `JobResultHandler` (`ouroboros_job_result`) — no new renderer invented. The terminal snapshot is reconciled onto `AutoPipelineResult` (mirrors `mcp/tools/auto_handler._reconcile_execution_job_snapshot`), so the final output shows a real completed/failed verdict and the exit code reflects the run result.
2. **`--no-wait`** restores fire-and-forget. No pre-existing detach flag existed for this path (`--skip-run` stops before the run; `--complete-product` already runs synchronously), so `--no-wait` is new. It prints an honest notice that CLI-mode execution does **not** survive process exit unless a persistent owner (e.g. a running `ouroboros mcp serve`) holds it, and points at `ouroboros job wait <id>`.
3. **Bounded wait.** No artificial cap (a real run takes minutes); each poll long-polls up to 5s then re-checks. `Ctrl-C`/`CancelledError` during the wait cancels the job cleanly via the existing `JobManager.cancel_job` path and prints an interrupt notice.
4. **Zero change to the MCP/server auto path.** The wait is gated inside the CLI `_run_auto` only.

## MCP-path note

The MCP `ouroboros_start_auto` path was never affected: its server process is long-lived, so the background execute job keeps running and is reconciled to a terminal status on resume via `_reconcile_execution_job_snapshot`. That long-lived owner is exactly why this bug was invisible outside direct CLI mode.

## Tests

New `tests/unit/cli/test_auto_run_handoff_wait.py` (6 tests):
- wait drives a fast job to `COMPLETED` and reconciles `status=complete` — asserts **no `mcp.job.cancelled` event** is written (the regression).
- a failing run job flips the result to `failed` (exit code reflects run result).
- no-op when the job handle is unknown / absent (plugin dispatch).
- default CLI invocation requests `wait=True`; `--no-wait` passes `wait=False` and prints the honest detach notice.

## Validation

- `uv run ruff check .` + `ruff format --check .` — clean.
- `uv run mypy src/` — clean (429 files).
- `uv run pytest tests/unit/cli tests/unit/auto` (excl. mcp) — **2346 passed**; the only 6 failures are the pre-existing codex-config-leak cases in `test_surface` / `test_auto_runtime_dispatch` (confirmed failing on clean `origin/main`, unrelated to this change).
- New auto CLI wait tests: **6 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## R-run comparison (required for `src/ouroboros/auto/` changes)

This change is a resume-path correctness fix (durable state reconciliation on
run handoff); it does not alter the auto convergence loop's per-cycle cost.
No per-cycle comparison applies, so every cell is filled explicitly as N/A.

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |
