### PR TITLE
fix(orchestrator): ground contract-AC evaluation in authoritative execution, not transcript reconstruction

### DIFF
--- a/src/ouroboros/agents/seed-architect.md
+++ b/src/ouroboros/agents/seed-architect.md
@@ -22,6 +22,16 @@ Specific, measurable criteria for success.
 Format: one `AC:` line per criterion
 Example: "AC: Tasks can be created | verify: python -m pytest tests/test_tasks.py | artifacts: NONE | expect: created task"
 
+`verify` / `verify_command` semantics:
+- Use exactly one single-line shell command.
+- NEVER use heredoc or multiline shell syntax such as `<<`, `<<'PY'`, `cat <<EOF`, line-continuation scripts, or an unterminated command block. The AC contract format is one line, so multiline command bodies will be lost.
+- For Python snippets, use `python -c "..."` / `python3 -c "..."`; for longer checks, require a pytest-discoverable test artifact and use `python -m pytest -q`.
+
+`expect` / `output_assertion` semantics:
+- Use `expect` ONLY for a literal string that the verify command prints to stdout verbatim, such as `OK` or `5 passed`.
+- NEVER use a condition, status, or exit-code description such as `exit code 0`, `exit 0`, `returns 0`, `success`, `no errors`, `passed`, or `passes`.
+- If the command has no distinctive stdout literal to assert, write `expect: NONE`. Exit-code 0 is already verified separately by the runner.
+
 **Granularity contract (read carefully):**
 - Produce **3-7** acceptance criteria. Each criterion is **one independently valuable, user-visible outcome** — not an implementation step.
 - Do **NOT** pre-decompose criteria into executable sub-tasks. Splitting work into atomic units is the execution engine's job at runtime; doing it here multiplies token cost with no benefit.
@@ -82,6 +92,7 @@ Few-shot examples:
 
 ```
 ACCEPTANCE_CRITERIA:
-AC: `python -m pytest tests/test_tasks.py` passes for task create/list flows | verify: python -m pytest tests/test_tasks.py | artifacts: NONE | expect: passed
+AC: Task create/list flows pass automated verification | verify: python -m pytest tests/test_tasks.py -q && echo OK | artifacts: NONE | expect: OK
+AC: Greeting import check prints OK | verify: python -c "from hello import greet; assert greet('Alice') == 'Hello, Alice'; print('OK')" | artifacts: hello.py | expect: OK
 AC: README documents the CLI usage examples | verify: NONE | artifacts: README.md | expect: NONE
 ```

--- a/src/ouroboros/bigbang/seed_generator.py
+++ b/src/ouroboros/bigbang/seed_generator.py
@@ -47,6 +47,7 @@ log = structlog.get_logger()
 EXTRACTION_TEMPERATURE = 0.2
 _MAX_EXTRACTION_RETRIES = 1
 _AC_CONTRACT_FIELD_RE = re.compile(r"\s\|\s*(verify|artifacts|expect)\s*:", re.IGNORECASE)
+_UNSUPPORTED_VERIFY_HEREDOC_RE = re.compile(r"<<-?\s*['\"]?[A-Za-z_][\w-]*['\"]?")
 
 
 def _parse_acceptance_criteria_contracts(
@@ -103,6 +104,32 @@ def _parse_acceptance_criterion_contract(line: str) -> AcceptanceCriterionSpec |
         elif normalized_key == "expect":
             fields["output_assertion"] = normalized_value
     return AcceptanceCriterionSpec.model_validate(fields)
+
+
+def _unsupported_verify_command_reason(command: str) -> str | None:
+    if "\n" in command or "\r" in command:
+        return "verify_command must be a single-line command"
+    if _UNSUPPORTED_VERIFY_HEREDOC_RE.search(command):
+        return "verify_command uses heredoc/multiline shell syntax; use python -c or pytest instead"
+    return None
+
+
+def _validate_acceptance_criteria_contract_lines(lines: object) -> None:
+    if not isinstance(lines, list | tuple):
+        return
+    for index, raw_line in enumerate(lines, start=1):
+        line = str(raw_line).strip()
+        if not line.startswith("AC:"):
+            continue
+        spec = _parse_acceptance_criterion_contract(line)
+        if spec is None or not spec.verify_command:
+            continue
+        reason = _unsupported_verify_command_reason(spec.verify_command)
+        if reason:
+            raise ValueError(
+                f"Unsupported verify_command in acceptance criterion {index}: {reason}. "
+                "The Seed AC format is one line; use a complete single-line command."
+            )
 
 
 @dataclass
@@ -508,6 +535,8 @@ Please try again. Extract requirements from this interview:
 You MUST respond with ONLY the following format, one field per line, no other text:
 
 ACCEPTANCE_CRITERIA rule: produce 3-7 outcome-level criteria. Each is one independently valuable, user-visible outcome — NOT an implementation step. Do not pre-decompose into sub-tasks; the execution engine splits work at runtime.
+ACCEPTANCE_CRITERIA verify rule: `verify` must be one complete single-line shell command. Never use heredoc or multiline syntax (`<<`, `<<'PY'`, `cat <<EOF`, line-continuation scripts); use `python -c "..."`, `python3 -c "..."`, or `python -m pytest -q` instead.
+ACCEPTANCE_CRITERIA expect rule: `expect` is ONLY a literal string printed verbatim in stdout, such as `OK` or `5 passed`. Use `expect: NONE` for exit-code/status conditions like `exit code 0`, `success`, `passed`, or `no errors`; exit-code 0 is already verified separately.
 
 GOAL: <clear goal statement>
 CONSTRAINTS: <constraint 1> | <constraint 2> | ...
@@ -605,6 +634,8 @@ EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
 Respond ONLY with the structured format below. Do NOT add explanations, questions, commentary, or prose. Do NOT wrap in markdown code blocks.
 
 ACCEPTANCE_CRITERIA rule: produce 3-7 outcome-level criteria. Each is one independently valuable, user-visible outcome — NOT an implementation step. Do not pre-decompose into sub-tasks; the execution engine splits work at runtime. If you would list more than 7, merge criteria that share a user-visible outcome before responding. An AC that is a sub-step of a sibling AC is a defect, as severe as a missing requirement.
+ACCEPTANCE_CRITERIA verify rule: `verify` must be one complete single-line shell command. Never use heredoc or multiline syntax (`<<`, `<<'PY'`, `cat <<EOF`, line-continuation scripts); use `python -c "..."`, `python3 -c "..."`, or `python -m pytest -q` instead.
+ACCEPTANCE_CRITERIA expect rule: `expect` is ONLY a literal string printed verbatim in stdout, such as `OK` or `5 passed`. Use `expect: NONE` for exit-code/status conditions like `exit code 0`, `success`, `passed`, or `no errors`; exit-code 0 is already verified separately.
 
 GOAL: <clear goal statement>
 CONSTRAINTS: <constraint 1> | <constraint 2> | ...
@@ -704,6 +735,7 @@ EXIT_CONDITIONS: <name>:<description>:<criteria> | ...
 
         if multiline_values.get("acceptance_criteria"):
             requirements["acceptance_criteria"] = multiline_values["acceptance_criteria"]
+            _validate_acceptance_criteria_contract_lines(requirements["acceptance_criteria"])
 
         # Validate required fields
         required_fields = [

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 import math
+import re
 from typing import Any
 from uuid import uuid4
 
@@ -30,6 +31,11 @@ from pydantic import (
     model_validator,
 )
 from pydantic_core.core_schema import SerializerFunctionWrapHandler
+
+_OUTPUT_ASSERTION_CONDITION_RE = re.compile(
+    r"^(?:exit\s*(?:code|status)?\s*0|returns?\s*0|success|succeeds|passed|passes|ok exit|no errors?)$",
+    re.IGNORECASE,
+)
 
 
 class ExitCondition(BaseModel, frozen=True):
@@ -223,12 +229,24 @@ class AcceptanceCriterionSpec(BaseModel, frozen=True):
             return value.strip()
         return value
 
-    @field_validator("verify_command", "output_assertion", mode="before")
+    @field_validator("verify_command", mode="before")
     @classmethod
     def _strip_optional_text(cls, value: Any) -> Any:
         if isinstance(value, str):
             stripped = value.strip()
             if not stripped or stripped.upper() == "NONE":
+                return None
+            return stripped
+        return value
+
+    @field_validator("output_assertion", mode="before")
+    @classmethod
+    def _normalize_output_assertion(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped or stripped.upper() == "NONE":
+                return None
+            if _OUTPUT_ASSERTION_CONDITION_RE.fullmatch(stripped):
                 return None
             return stripped
         return value

--- a/src/ouroboros/orchestrator/atomic_prompt_builder.py
+++ b/src/ouroboros/orchestrator/atomic_prompt_builder.py
@@ -50,7 +50,7 @@ def _build_success_contract_block(spec: AcceptanceCriterionSpec | None) -> str:
         lines.append(
             "- Expected artifacts: "
             + ", ".join(spec.expected_artifacts)
-            + " — report them in files_touched"
+            + " — ensure they exist in the workspace"
         )
     if spec.output_assertion:
         lines.append(f"- Expected output: {spec.output_assertion}")
@@ -207,8 +207,17 @@ class AtomicPromptBuilder:
             file_listing = "(unable to list)"
 
         if executor._fat_harness_mode and executor._execution_profile is not None:
+            has_success_contract = isinstance(ac_spec, AcceptanceCriterionSpec) and bool(
+                ac_spec.verify_command
+            )
+            has_expected_artifacts = isinstance(ac_spec, AcceptanceCriterionSpec) and bool(
+                ac_spec.expected_artifacts
+            )
             effective_schema = _effective_evidence_schema_for_ac(
-                executor._execution_profile, ac_content
+                executor._execution_profile,
+                ac_content,
+                has_success_contract=has_success_contract,
+                has_expected_artifacts=has_expected_artifacts,
             )
             required_fields = ", ".join(effective_schema.required)
             doc_only_note = ""

--- a/src/ouroboros/orchestrator/atomic_prompt_builder.py
+++ b/src/ouroboros/orchestrator/atomic_prompt_builder.py
@@ -213,11 +213,16 @@ class AtomicPromptBuilder:
             has_expected_artifacts = isinstance(ac_spec, AcceptanceCriterionSpec) and bool(
                 ac_spec.expected_artifacts
             )
+            # Only delegate tests_passed/files_touched to the verify gate when it
+            # will actually run; with run_verify_commands off the worker's
+            # displayed required-fields must still list them.
+            verify_gate_active = executor._run_verify_commands
             effective_schema = _effective_evidence_schema_for_ac(
                 executor._execution_profile,
                 ac_content,
                 has_success_contract=has_success_contract,
                 has_expected_artifacts=has_expected_artifacts,
+                verify_gate_active=verify_gate_active,
             )
             required_fields = ", ".join(effective_schema.required)
             doc_only_note = ""

--- a/src/ouroboros/orchestrator/evidence/ac_classification.py
+++ b/src/ouroboros/orchestrator/evidence/ac_classification.py
@@ -265,6 +265,7 @@ def _effective_evidence_schema_for_ac(
     *,
     has_success_contract: bool = False,
     has_expected_artifacts: bool = False,
+    verify_gate_active: bool = False,
 ) -> EvidenceSchema:
     """Return the active evidence schema for one atomic AC dispatch.
 
@@ -281,15 +282,31 @@ def _effective_evidence_schema_for_ac(
     delegated to the verify gate's real filesystem existence check. Contract ACs
     without artifacts keep transcript-backed ``files_touched`` evidence because
     there is no filesystem oracle to replace it.
+
+    ``verify_gate_active`` is True only when the orchestrator verify gate is
+    actually enabled (``run_verify_commands``). Delegation of ``tests_passed`` /
+    ``files_touched`` to the gate is *only* valid when the gate will run. When an
+    operator disables verify commands, the gate that would replace the transcript
+    check never fires (``_apply_verify_gate`` returns early), so we retain the
+    transcript-backed evidence — the pre-delegation behavior — as a fail-safe.
+    The default is ``False`` so we never delegate unless explicitly told the gate
+    is active. The content-based ``_is_validation_only_ac`` /
+    ``_is_documentation_only_ac`` drops are unaffected — those are not gate
+    delegations.
     """
     schema = profile.evidence_schema
     if _is_validation_only_ac(ac_content) and "files_touched" in schema.required:
         schema = _drop_required_evidence_field(schema, "files_touched")
     elif _is_documentation_only_ac(ac_content) and "tests_passed" in schema.required:
         schema = _drop_required_evidence_field(schema, "tests_passed")
-    if has_success_contract and "tests_passed" in schema.required:
+    if has_success_contract and verify_gate_active and "tests_passed" in schema.required:
         schema = _drop_required_evidence_field(schema, "tests_passed")
-    if has_success_contract and has_expected_artifacts and "files_touched" in schema.required:
+    if (
+        has_success_contract
+        and has_expected_artifacts
+        and verify_gate_active
+        and "files_touched" in schema.required
+    ):
         schema = _drop_required_evidence_field(schema, "files_touched")
     return schema
 
@@ -301,6 +318,7 @@ def _out_of_scope_evidence_fields_for_ac(
     *,
     has_success_contract: bool = False,
     has_expected_artifacts: bool = False,
+    verify_gate_active: bool = False,
 ) -> tuple[str, ...]:
     """Return non-empty evidence fields excluded by the AC-specific schema."""
     if record is None:
@@ -310,6 +328,7 @@ def _out_of_scope_evidence_fields_for_ac(
         ac_content,
         has_success_contract=has_success_contract,
         has_expected_artifacts=has_expected_artifacts,
+        verify_gate_active=verify_gate_active,
     )
     required_fields = set(effective_schema.required)
     return tuple(
@@ -326,6 +345,7 @@ def _out_of_scope_evidence_values_for_ac(
     *,
     has_success_contract: bool = False,
     has_expected_artifacts: bool = False,
+    verify_gate_active: bool = False,
 ) -> dict[str, Any]:
     """Return out-of-scope evidence values retained for audit metadata only."""
     if record is None:
@@ -336,6 +356,7 @@ def _out_of_scope_evidence_values_for_ac(
         record,
         has_success_contract=has_success_contract,
         has_expected_artifacts=has_expected_artifacts,
+        verify_gate_active=verify_gate_active,
     )
     return {field: record.data[field] for field in fields if field in record.data}
 
@@ -347,6 +368,7 @@ def _scoped_evidence_record_for_ac(
     *,
     has_success_contract: bool = False,
     has_expected_artifacts: bool = False,
+    verify_gate_active: bool = False,
 ) -> EvidenceRecord:
     """Return only evidence fields inside the AC-specific schema."""
     effective_schema = _effective_evidence_schema_for_ac(
@@ -354,6 +376,7 @@ def _scoped_evidence_record_for_ac(
         ac_content,
         has_success_contract=has_success_contract,
         has_expected_artifacts=has_expected_artifacts,
+        verify_gate_active=verify_gate_active,
     )
     allowed_fields = set(effective_schema.required)
     return EvidenceRecord(

--- a/src/ouroboros/orchestrator/evidence/ac_classification.py
+++ b/src/ouroboros/orchestrator/evidence/ac_classification.py
@@ -264,6 +264,7 @@ def _effective_evidence_schema_for_ac(
     ac_content: str,
     *,
     has_success_contract: bool = False,
+    has_expected_artifacts: bool = False,
 ) -> EvidenceSchema:
     """Return the active evidence schema for one atomic AC dispatch.
 
@@ -274,6 +275,12 @@ def _effective_evidence_schema_for_ac(
     authoritative, non-fabricatable check — strictly stronger than reconstructing
     "did a test pass" from the worker's transcript. Legacy ACs (no
     ``verify_command``) keep ``tests_passed`` required and verified as before.
+
+    ``has_expected_artifacts`` is True when the AC declares filesystem artifacts.
+    For contract ACs that also declare artifacts, ``files_touched`` is likewise
+    delegated to the verify gate's real filesystem existence check. Contract ACs
+    without artifacts keep transcript-backed ``files_touched`` evidence because
+    there is no filesystem oracle to replace it.
     """
     schema = profile.evidence_schema
     if _is_validation_only_ac(ac_content) and "files_touched" in schema.required:
@@ -282,6 +289,8 @@ def _effective_evidence_schema_for_ac(
         schema = _drop_required_evidence_field(schema, "tests_passed")
     if has_success_contract and "tests_passed" in schema.required:
         schema = _drop_required_evidence_field(schema, "tests_passed")
+    if has_success_contract and has_expected_artifacts and "files_touched" in schema.required:
+        schema = _drop_required_evidence_field(schema, "files_touched")
     return schema
 
 
@@ -291,12 +300,16 @@ def _out_of_scope_evidence_fields_for_ac(
     record: EvidenceRecord | None,
     *,
     has_success_contract: bool = False,
+    has_expected_artifacts: bool = False,
 ) -> tuple[str, ...]:
     """Return non-empty evidence fields excluded by the AC-specific schema."""
     if record is None:
         return ()
     effective_schema = _effective_evidence_schema_for_ac(
-        profile, ac_content, has_success_contract=has_success_contract
+        profile,
+        ac_content,
+        has_success_contract=has_success_contract,
+        has_expected_artifacts=has_expected_artifacts,
     )
     required_fields = set(effective_schema.required)
     return tuple(
@@ -312,12 +325,17 @@ def _out_of_scope_evidence_values_for_ac(
     record: EvidenceRecord | None,
     *,
     has_success_contract: bool = False,
+    has_expected_artifacts: bool = False,
 ) -> dict[str, Any]:
     """Return out-of-scope evidence values retained for audit metadata only."""
     if record is None:
         return {}
     fields = _out_of_scope_evidence_fields_for_ac(
-        profile, ac_content, record, has_success_contract=has_success_contract
+        profile,
+        ac_content,
+        record,
+        has_success_contract=has_success_contract,
+        has_expected_artifacts=has_expected_artifacts,
     )
     return {field: record.data[field] for field in fields if field in record.data}
 
@@ -328,10 +346,14 @@ def _scoped_evidence_record_for_ac(
     record: EvidenceRecord,
     *,
     has_success_contract: bool = False,
+    has_expected_artifacts: bool = False,
 ) -> EvidenceRecord:
     """Return only evidence fields inside the AC-specific schema."""
     effective_schema = _effective_evidence_schema_for_ac(
-        profile, ac_content, has_success_contract=has_success_contract
+        profile,
+        ac_content,
+        has_success_contract=has_success_contract,
+        has_expected_artifacts=has_expected_artifacts,
     )
     allowed_fields = set(effective_schema.required)
     return EvidenceRecord(

--- a/src/ouroboros/orchestrator/evidence/verification.py
+++ b/src/ouroboros/orchestrator/evidence/verification.py
@@ -31,6 +31,7 @@ def _verify_atomic_evidence_against_runtime_messages(
     adapter_working_directory: str | None,
     has_success_contract: bool = False,
     has_expected_artifacts: bool = False,
+    verify_gate_active: bool = False,
 ) -> VerifierVerdict:
     """Verify leaf evidence is backed by runtime transcript events.
 
@@ -39,8 +40,10 @@ def _verify_atomic_evidence_against_runtime_messages(
 
     ``has_success_contract`` (the AC declares a ``verify_command``) drops
     ``tests_passed`` from the required set, and contract ACs with declared
-    artifacts also drop ``files_touched``. Both checks are delegated to the
-    orchestrator's authoritative ``_run_ac_verify_gate`` execution.
+    artifacts also drop ``files_touched`` — but only when ``verify_gate_active``
+    (``run_verify_commands`` is enabled) so the orchestrator's authoritative
+    ``_run_ac_verify_gate`` execution actually runs to replace those checks. With
+    the gate disabled the transcript-backed evidence is retained.
     """
     support_messages = tuple(messages[:-1] if messages and messages[-1].is_final else messages)
     if not support_messages:
@@ -65,6 +68,7 @@ def _verify_atomic_evidence_against_runtime_messages(
         ac_content,
         has_success_contract=has_success_contract,
         has_expected_artifacts=has_expected_artifacts,
+        verify_gate_active=verify_gate_active,
     )
     required_fields = set(effective_schema.required)
     fields_to_verify = list(effective_schema.required)

--- a/src/ouroboros/orchestrator/evidence/verification.py
+++ b/src/ouroboros/orchestrator/evidence/verification.py
@@ -30,6 +30,7 @@ def _verify_atomic_evidence_against_runtime_messages(
     task_cwd: str | None,
     adapter_working_directory: str | None,
     has_success_contract: bool = False,
+    has_expected_artifacts: bool = False,
 ) -> VerifierVerdict:
     """Verify leaf evidence is backed by runtime transcript events.
 
@@ -37,7 +38,8 @@ def _verify_atomic_evidence_against_runtime_messages(
     accepted evidence cannot be supported only by the leaf's self-report.
 
     ``has_success_contract`` (the AC declares a ``verify_command``) drops
-    ``tests_passed`` from the required set — that check is delegated to the
+    ``tests_passed`` from the required set, and contract ACs with declared
+    artifacts also drop ``files_touched``. Both checks are delegated to the
     orchestrator's authoritative ``_run_ac_verify_gate`` execution.
     """
     support_messages = tuple(messages[:-1] if messages and messages[-1].is_final else messages)
@@ -59,7 +61,10 @@ def _verify_atomic_evidence_against_runtime_messages(
         )
     )
     effective_schema = _effective_evidence_schema_for_ac(
-        execution_profile, ac_content, has_success_contract=has_success_contract
+        execution_profile,
+        ac_content,
+        has_success_contract=has_success_contract,
+        has_expected_artifacts=has_expected_artifacts,
     )
     required_fields = set(effective_schema.required)
     fields_to_verify = list(effective_schema.required)

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -3058,12 +3058,18 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
             has_expected_artifacts = isinstance(ac_spec, AcceptanceCriterionSpec) and bool(
                 ac_spec.expected_artifacts
             )
+            # Delegating tests_passed/files_touched to _run_ac_verify_gate is only
+            # valid when that gate actually runs. _apply_verify_gate returns early
+            # when run_verify_commands is disabled, so with the gate off we must
+            # retain the transcript-backed evidence rather than drop it.
+            verify_gate_active = self._run_verify_commands
             typed_evidence, typed_validation, typed_error = self._observe_atomic_typed_evidence(
                 ac_content=ac_content,
                 final_message=final_message,
                 success=success,
                 has_success_contract=has_success_contract,
                 has_expected_artifacts=has_expected_artifacts,
+                verify_gate_active=verify_gate_active,
             )
             verifier_verdict = self._run_atomic_verifier_pass(
                 ac_content=ac_content,
@@ -3074,6 +3080,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 typed_validation=typed_validation,
                 has_success_contract=has_success_contract,
                 has_expected_artifacts=has_expected_artifacts,
+                verify_gate_active=verify_gate_active,
             )
             fat_harness_error = self._fat_harness_acceptance_error(
                 runtime_success=success,
@@ -3135,6 +3142,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 enforcement_error=fat_harness_error,
                 has_success_contract=has_success_contract,
                 has_expected_artifacts=has_expected_artifacts,
+                verify_gate_active=verify_gate_active,
             )
             await self._emit_ac_runtime_event(
                 event_type=(
@@ -3162,6 +3170,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                     typed_evidence,
                     has_success_contract=has_success_contract,
                     has_expected_artifacts=has_expected_artifacts,
+                    verify_gate_active=verify_gate_active,
                 )
 
             log.info(
@@ -3259,6 +3268,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         success: bool,
         has_success_contract: bool = False,
         has_expected_artifacts: bool = False,
+        verify_gate_active: bool = False,
     ) -> tuple[EvidenceRecord | None, ValidationResult | None, str | None]:
         """Parse and validate typed evidence at the atomic AC acceptance boundary.
 
@@ -3277,6 +3287,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 ac_content,
                 has_success_contract=has_success_contract,
                 has_expected_artifacts=has_expected_artifacts,
+                verify_gate_active=verify_gate_active,
             )
             validation = validate_evidence(
                 _profile_with_evidence_schema(self._execution_profile, effective_schema),
@@ -3803,6 +3814,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         typed_validation: ValidationResult | None,
         has_success_contract: bool = False,
         has_expected_artifacts: bool = False,
+        verify_gate_active: bool = False,
     ) -> VerifierVerdict | None:
         """Run the separate verifier pass once typed evidence is schema-valid."""
         if (
@@ -3822,6 +3834,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 ac_content,
                 has_success_contract=has_success_contract,
                 has_expected_artifacts=has_expected_artifacts,
+                verify_gate_active=verify_gate_active,
             )
             effective_profile = _profile_with_evidence_schema(
                 self._execution_profile, effective_schema
@@ -3832,6 +3845,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 typed_evidence,
                 has_success_contract=has_success_contract,
                 has_expected_artifacts=has_expected_artifacts,
+                verify_gate_active=verify_gate_active,
             )
             verdict = (
                 verifier(
@@ -3847,6 +3861,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                     ac_content=ac_content,
                     has_success_contract=has_success_contract,
                     has_expected_artifacts=has_expected_artifacts,
+                    verify_gate_active=verify_gate_active,
                 )
             )
         except VerifierContractError:
@@ -3866,6 +3881,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         ac_content: str,
         has_success_contract: bool = False,
         has_expected_artifacts: bool = False,
+        verify_gate_active: bool = False,
     ) -> VerifierVerdict:
         return _verify_atomic_evidence_against_runtime_messages(
             messages=messages,
@@ -3876,6 +3892,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
             adapter_working_directory=self._adapter.working_directory,
             has_success_contract=has_success_contract,
             has_expected_artifacts=has_expected_artifacts,
+            verify_gate_active=verify_gate_active,
         )
 
     async def _emit_atomic_typed_evidence_event(
@@ -3892,6 +3909,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         enforcement_error: str | None = None,
         has_success_contract: bool = False,
         has_expected_artifacts: bool = False,
+        verify_gate_active: bool = False,
     ) -> None:
         """Persist typed-evidence metadata for atomic AC completion."""
         if self._execution_profile is None:
@@ -3910,6 +3928,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                     ac_content,
                     has_success_contract=has_success_contract,
                     has_expected_artifacts=has_expected_artifacts,
+                    verify_gate_active=verify_gate_active,
                 ).required
             ),
             "observe_only": not self._fat_harness_mode,
@@ -3937,6 +3956,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                     typed_evidence,
                     has_success_contract=has_success_contract,
                     has_expected_artifacts=has_expected_artifacts,
+                    verify_gate_active=verify_gate_active,
                 )
             )
             data["ignored_out_of_scope_evidence"] = _out_of_scope_evidence_values_for_ac(
@@ -3945,6 +3965,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 typed_evidence,
                 has_success_contract=has_success_contract,
                 has_expected_artifacts=has_expected_artifacts,
+                verify_gate_active=verify_gate_active,
             )
         if typed_validation is not None:
             data["missing_fields"] = list(typed_validation.missing_fields)

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -3049,16 +3049,21 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
 
             # A contract-carrying AC (declares verify_command) delegates its
             # tests_passed check to the orchestrator's authoritative
-            # _run_ac_verify_gate, so tests_passed is dropped from the required
-            # evidence gated here (see _effective_evidence_schema_for_ac).
+            # _run_ac_verify_gate. When it also declares expected_artifacts,
+            # files_touched is delegated to that gate's filesystem oracle too
+            # (see _effective_evidence_schema_for_ac).
             has_success_contract = isinstance(ac_spec, AcceptanceCriterionSpec) and bool(
                 ac_spec.verify_command
+            )
+            has_expected_artifacts = isinstance(ac_spec, AcceptanceCriterionSpec) and bool(
+                ac_spec.expected_artifacts
             )
             typed_evidence, typed_validation, typed_error = self._observe_atomic_typed_evidence(
                 ac_content=ac_content,
                 final_message=final_message,
                 success=success,
                 has_success_contract=has_success_contract,
+                has_expected_artifacts=has_expected_artifacts,
             )
             verifier_verdict = self._run_atomic_verifier_pass(
                 ac_content=ac_content,
@@ -3068,6 +3073,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 typed_evidence=typed_evidence,
                 typed_validation=typed_validation,
                 has_success_contract=has_success_contract,
+                has_expected_artifacts=has_expected_artifacts,
             )
             fat_harness_error = self._fat_harness_acceptance_error(
                 runtime_success=success,
@@ -3128,6 +3134,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 verifier_verdict=verifier_verdict,
                 enforcement_error=fat_harness_error,
                 has_success_contract=has_success_contract,
+                has_expected_artifacts=has_expected_artifacts,
             )
             await self._emit_ac_runtime_event(
                 event_type=(
@@ -3154,6 +3161,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                     ac_content,
                     typed_evidence,
                     has_success_contract=has_success_contract,
+                    has_expected_artifacts=has_expected_artifacts,
                 )
 
             log.info(
@@ -3250,6 +3258,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         final_message: str,
         success: bool,
         has_success_contract: bool = False,
+        has_expected_artifacts: bool = False,
     ) -> tuple[EvidenceRecord | None, ValidationResult | None, str | None]:
         """Parse and validate typed evidence at the atomic AC acceptance boundary.
 
@@ -3267,6 +3276,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 self._execution_profile,
                 ac_content,
                 has_success_contract=has_success_contract,
+                has_expected_artifacts=has_expected_artifacts,
             )
             validation = validate_evidence(
                 _profile_with_evidence_schema(self._execution_profile, effective_schema),
@@ -3792,6 +3802,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         typed_evidence: EvidenceRecord | None,
         typed_validation: ValidationResult | None,
         has_success_contract: bool = False,
+        has_expected_artifacts: bool = False,
     ) -> VerifierVerdict | None:
         """Run the separate verifier pass once typed evidence is schema-valid."""
         if (
@@ -3807,7 +3818,10 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         verifier = self._atomic_verifier
         try:
             effective_schema = _effective_evidence_schema_for_ac(
-                self._execution_profile, ac_content, has_success_contract=has_success_contract
+                self._execution_profile,
+                ac_content,
+                has_success_contract=has_success_contract,
+                has_expected_artifacts=has_expected_artifacts,
             )
             effective_profile = _profile_with_evidence_schema(
                 self._execution_profile, effective_schema
@@ -3817,6 +3831,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 ac_content,
                 typed_evidence,
                 has_success_contract=has_success_contract,
+                has_expected_artifacts=has_expected_artifacts,
             )
             verdict = (
                 verifier(
@@ -3831,6 +3846,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                     typed_evidence=scoped_evidence,
                     ac_content=ac_content,
                     has_success_contract=has_success_contract,
+                    has_expected_artifacts=has_expected_artifacts,
                 )
             )
         except VerifierContractError:
@@ -3849,6 +3865,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         typed_evidence: EvidenceRecord,
         ac_content: str,
         has_success_contract: bool = False,
+        has_expected_artifacts: bool = False,
     ) -> VerifierVerdict:
         return _verify_atomic_evidence_against_runtime_messages(
             messages=messages,
@@ -3858,6 +3875,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
             task_cwd=self._task_cwd,
             adapter_working_directory=self._adapter.working_directory,
             has_success_contract=has_success_contract,
+            has_expected_artifacts=has_expected_artifacts,
         )
 
     async def _emit_atomic_typed_evidence_event(
@@ -3873,6 +3891,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
         verifier_verdict: VerifierVerdict | None = None,
         enforcement_error: str | None = None,
         has_success_contract: bool = False,
+        has_expected_artifacts: bool = False,
     ) -> None:
         """Persist typed-evidence metadata for atomic AC completion."""
         if self._execution_profile is None:
@@ -3890,6 +3909,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                     self._execution_profile,
                     ac_content,
                     has_success_contract=has_success_contract,
+                    has_expected_artifacts=has_expected_artifacts,
                 ).required
             ),
             "observe_only": not self._fat_harness_mode,
@@ -3916,6 +3936,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                     ac_content,
                     typed_evidence,
                     has_success_contract=has_success_contract,
+                    has_expected_artifacts=has_expected_artifacts,
                 )
             )
             data["ignored_out_of_scope_evidence"] = _out_of_scope_evidence_values_for_ac(
@@ -3923,6 +3944,7 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
                 ac_content,
                 typed_evidence,
                 has_success_contract=has_success_contract,
+                has_expected_artifacts=has_expected_artifacts,
             )
         if typed_validation is not None:
             data["missing_fields"] = list(typed_validation.missing_fields)

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -547,6 +547,91 @@ class TestSeedGeneratorExtraction:
             assert third.verify_command is None
 
     @pytest.mark.asyncio
+    async def test_generate_normalizes_output_assertion_condition_phrases(self) -> None:
+        """Generated contract assertions must be literal stdout, not status prose."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        extraction_response = create_valid_extraction_response(
+            acceptance_criteria=(
+                "\n"
+                "AC: CLI exits successfully | verify: python -m app | artifacts: NONE | "
+                "expect: exit code 0\n"
+                "AC: Test summary is visible | verify: pytest -q | artifacts: NONE | "
+                "expect: 5 passed\n"
+            )
+        )
+        mock_adapter.complete = AsyncMock(
+            return_value=Result.ok(create_mock_completion_response(extraction_response))
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, low_ambiguity)
+
+            assert result.is_ok
+            first, second = result.value.acceptance_criteria
+            assert isinstance(first, AcceptanceCriterionSpec)
+            assert first.output_assertion is None
+            assert first.to_seed_value() == {
+                "description": "CLI exits successfully",
+                "verify_command": "python -m app",
+            }
+            assert isinstance(second, AcceptanceCriterionSpec)
+            assert second.output_assertion == "5 passed"
+
+    @pytest.mark.asyncio
+    async def test_generate_retries_when_verify_command_uses_heredoc(self) -> None:
+        """Single-line AC contracts must reject heredoc commands before Seed build."""
+        mock_adapter = AsyncMock()
+        state = create_interview_state_with_rounds()
+        low_ambiguity = create_low_ambiguity_score()
+
+        bad_response = create_valid_extraction_response(
+            acceptance_criteria=(
+                "\n"
+                "AC: Import check prints OK | verify: python - <<'PY' | "
+                "artifacts: hello.py | expect: OK\n"
+            )
+        )
+        repaired_response = create_valid_extraction_response(
+            acceptance_criteria=(
+                "\n"
+                "AC: Import check prints OK | "
+                'verify: python -c "from hello import greet; '
+                "assert greet('Alice') == 'Hello, Alice'; print('OK')\" | "
+                "artifacts: hello.py | expect: OK\n"
+            )
+        )
+        mock_adapter.complete = AsyncMock(
+            side_effect=[
+                Result.ok(create_mock_completion_response(bad_response)),
+                Result.ok(create_mock_completion_response(repaired_response)),
+            ]
+        )
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            generator = SeedGenerator(
+                llm_adapter=mock_adapter,
+                output_dir=Path(tmp_dir) / "seeds",
+            )
+
+            result = await generator.generate(state, low_ambiguity)
+
+            assert result.is_ok
+            assert mock_adapter.complete.await_count == 2
+            (criterion,) = result.value.acceptance_criteria
+            assert isinstance(criterion, AcceptanceCriterionSpec)
+            assert criterion.verify_command is not None
+            assert "<<'PY'" not in criterion.verify_command
+            assert "python -c" in criterion.verify_command
+
+    @pytest.mark.asyncio
     async def test_generate_extracts_ontology_schema(self) -> None:
         """SeedGenerator extracts ontology schema with fields."""
         mock_adapter = AsyncMock()
@@ -1125,6 +1210,8 @@ class TestAcceptanceCriteriaGranularityContract:
         assert "ACCEPTANCE_CRITERIA:\nAC:" in prompt
         assert "verify: <command or NONE>" in prompt
         assert "artifacts: <comma-list or NONE>" in prompt
+        assert "heredoc" in prompt.lower()
+        assert "python -c" in prompt
         assert "ACCEPTANCE_CRITERIA: <criterion 1> | <criterion 2>" not in prompt
 
     def test_seed_architect_agent_prompt_carries_granularity_contract(self) -> None:
@@ -1133,3 +1220,5 @@ class TestAcceptanceCriteriaGranularityContract:
         system_prompt = load_agent_prompt("seed-architect")
         assert "3-7" in system_prompt
         assert "sub-step of a sibling" in system_prompt.lower()
+        assert "heredoc" in system_prompt.lower()
+        assert "python -c" in system_prompt

--- a/tests/unit/core/test_seed.py
+++ b/tests/unit/core/test_seed.py
@@ -407,6 +407,49 @@ class TestSeed:
         assert second.description == "Tasks can be created"
         assert second.verify_command is None
 
+    def test_output_assertion_normalizes_exit_status_conditions_to_none(self) -> None:
+        """Exit-code success phrases are redundant with verify_command exit status."""
+        for phrase in (
+            "exit code 0",
+            "exit status 0",
+            "exit 0",
+            "returns 0",
+            "return 0",
+            "success",
+            "succeeds",
+            "passed",
+            "passes",
+            "ok exit",
+            "no error",
+            "no errors",
+        ):
+            spec = AcceptanceCriterionSpec(
+                description="Command exits successfully",
+                verify_command="python -c 'pass'",
+                output_assertion=phrase,
+            )
+            assert spec.output_assertion is None
+            assert spec.to_seed_value() == {
+                "description": "Command exits successfully",
+                "verify_command": "python -c 'pass'",
+            }
+
+    def test_output_assertion_preserves_distinctive_stdout_literals(self) -> None:
+        """Real stdout literals survive normalization."""
+        ok = AcceptanceCriterionSpec(
+            description="Command prints OK",
+            verify_command="python -c \"print('OK')\"",
+            output_assertion="OK",
+        )
+        pytest_literal = AcceptanceCriterionSpec(
+            description="Pytest summary is asserted",
+            verify_command="pytest -q",
+            output_assertion="5 passed",
+        )
+
+        assert ok.output_assertion == "OK"
+        assert pytest_literal.output_assertion == "5 passed"
+
     def test_seed_acceptance_criteria_serialize_legacy_strings_stably(self) -> None:
         """Description-only ACs dump back to bare strings."""
         seed = Seed(

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1480,6 +1480,7 @@ def test_atomic_verifier_accepts_relative_claim_against_absolute_transcript_with
         ),
         ac_content=_GREETING_AC,
         has_success_contract=True,
+        verify_gate_active=True,
     )
 
     assert verdict.passed is True, verdict.reasons
@@ -1528,6 +1529,7 @@ def test_atomic_verifier_accepts_symlinked_cwd_against_resolved_transcript_path(
         ),
         ac_content=_GREETING_AC,
         has_success_contract=True,
+        verify_gate_active=True,
     )
     assert verdict.passed is True, verdict.reasons
 
@@ -1696,7 +1698,10 @@ def test_effective_schema_drops_tests_passed_for_contract_ac() -> None:
     assert "tests_passed" in legacy.required
 
     contract = _effective_evidence_schema_for_ac(
-        profile, "Implement the module.", has_success_contract=True
+        profile,
+        "Implement the module.",
+        has_success_contract=True,
+        verify_gate_active=True,
     )
     assert "tests_passed" not in contract.required
     # Without declared expected_artifacts, there is no filesystem oracle for
@@ -1709,6 +1714,7 @@ def test_effective_schema_drops_tests_passed_for_contract_ac() -> None:
         "Implement the module.",
         has_success_contract=True,
         has_expected_artifacts=True,
+        verify_gate_active=True,
     )
     assert artifact_contract.required == ("commands_run",)
 
@@ -1726,6 +1732,44 @@ def test_legacy_ac_keeps_files_touched_required_even_with_expected_artifacts_fla
 
     assert "files_touched" in schema.required
     assert "tests_passed" in schema.required
+
+
+def test_contract_ac_retains_evidence_when_verify_gate_inactive() -> None:
+    """With the verify gate disabled there is no oracle to delegate to.
+
+    ``_apply_verify_gate`` returns early when ``run_verify_commands`` is False, so
+    dropping ``tests_passed`` / ``files_touched`` would leave a contract AC with an
+    unbacked, self-reported artifact and no check. The fail-safe default retains
+    the transcript-backed evidence.
+    """
+    profile = load_profile("code")
+
+    schema = _effective_evidence_schema_for_ac(
+        profile,
+        "Implement the module.",
+        has_success_contract=True,
+        has_expected_artifacts=True,
+        verify_gate_active=False,
+    )
+
+    assert "files_touched" in schema.required
+    assert "tests_passed" in schema.required
+    assert "commands_run" in schema.required
+
+
+def test_contract_ac_drops_delegated_fields_only_when_verify_gate_active() -> None:
+    """The delegation drop fires only once the verify gate is confirmed active."""
+    profile = load_profile("code")
+
+    schema = _effective_evidence_schema_for_ac(
+        profile,
+        "Implement the module.",
+        has_success_contract=True,
+        has_expected_artifacts=True,
+        verify_gate_active=True,
+    )
+
+    assert schema.required == ("commands_run",)
 
 
 def test_contract_ac_verifier_delegates_tests_passed() -> None:
@@ -1747,6 +1791,7 @@ def test_contract_ac_verifier_delegates_tests_passed() -> None:
         ),
         ac_content=_GREETING_AC,
         has_success_contract=True,
+        verify_gate_active=True,
     )
     assert verdict.passed is True, verdict.reasons
 
@@ -1765,6 +1810,7 @@ def test_contract_ac_with_expected_artifacts_verifier_delegates_files_touched() 
         ac_content=_GREETING_AC,
         has_success_contract=True,
         has_expected_artifacts=True,
+        verify_gate_active=True,
     )
 
     assert verdict.passed is True, verdict.reasons
@@ -4502,6 +4548,77 @@ class TestParallelACExecutor:
         assert evidence_event.data["typed_evidence_valid"] is True
         assert evidence_event.data["verifier_passed"] is True
         assert evidence_event.data["ignored_out_of_scope_evidence_fields"] == ["files_touched"]
+
+    @pytest.mark.asyncio
+    async def test_contract_ac_missing_artifact_rejected_when_verify_gate_disabled(
+        self,
+        tmp_path,
+    ) -> None:
+        """Reproduced blocker: with the verify gate off, delegation must not fire.
+
+        ``run_verify_commands=False`` makes ``_apply_verify_gate`` return early, so
+        the filesystem oracle never checks ``expected_artifacts``. If the schema
+        still dropped ``files_touched``/``tests_passed``, a contract AC could
+        complete with only ``commands_run`` evidence and no artifact on disk. The
+        verify-gate-active guard keeps those fields required (transcript-backed),
+        so the worker's self-reported evidence fails and the AC is not accepted.
+        """
+        command = "python -c \"print('OK')\""
+        command_json = command.replace("\\", "\\\\").replace('"', '\\"')
+        # Deliberately do NOT write hello.py: the artifact is missing on disk.
+        event_store, appended_events = _make_replaying_event_store()
+        runtime = _FinalMessageRuntime(
+            f'Done.\n```json\n{{"commands_run":["{command_json}"]}}\n```',
+            native_session_id="codex-session-verify-gate-off-missing-artifact",
+            support_messages=(
+                AgentMessage(
+                    type="assistant",
+                    content=f"Calling tool: Bash: {command}",
+                    tool_name="Bash",
+                    data={"tool_input": {"command": command}},
+                ),
+            ),
+            cwd=str(tmp_path),
+        )
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            run_verify_commands=False,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content=_GREETING_AC,
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+            ac_spec=AcceptanceCriterionSpec(
+                description=_GREETING_AC,
+                verify_command=command,
+                expected_artifacts=("hello.py",),
+            ),
+        )
+
+        assert result.success is False
+        assert result.error is not None
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        # files_touched/tests_passed remain required because the gate is off.
+        assert "files_touched" in evidence_event.data["required_fields"]
+        assert "tests_passed" in evidence_event.data["required_fields"]
+        assert evidence_event.data["typed_evidence_valid"] is False
 
     @pytest.mark.asyncio
     async def test_fat_harness_mode_rejects_missing_typed_evidence(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1699,9 +1699,33 @@ def test_effective_schema_drops_tests_passed_for_contract_ac() -> None:
         profile, "Implement the module.", has_success_contract=True
     )
     assert "tests_passed" not in contract.required
-    # files_touched + commands_run stay gated by the transcript verifier.
+    # Without declared expected_artifacts, there is no filesystem oracle for
+    # files_touched, so it stays transcript-gated.
     assert "files_touched" in contract.required
     assert "commands_run" in contract.required
+
+    artifact_contract = _effective_evidence_schema_for_ac(
+        profile,
+        "Implement the module.",
+        has_success_contract=True,
+        has_expected_artifacts=True,
+    )
+    assert artifact_contract.required == ("commands_run",)
+
+
+def test_legacy_ac_keeps_files_touched_required_even_with_expected_artifacts_flag() -> None:
+    """Expected artifacts only delegate files_touched when a verify command is present."""
+    profile = load_profile("code")
+
+    schema = _effective_evidence_schema_for_ac(
+        profile,
+        "Implement the module.",
+        has_success_contract=False,
+        has_expected_artifacts=True,
+    )
+
+    assert "files_touched" in schema.required
+    assert "tests_passed" in schema.required
 
 
 def test_contract_ac_verifier_delegates_tests_passed() -> None:
@@ -1724,6 +1748,25 @@ def test_contract_ac_verifier_delegates_tests_passed() -> None:
         ac_content=_GREETING_AC,
         has_success_contract=True,
     )
+    assert verdict.passed is True, verdict.reasons
+
+
+def test_contract_ac_with_expected_artifacts_verifier_delegates_files_touched() -> None:
+    """Contract AC artifacts are verified by the filesystem gate, not transcript claims."""
+    executor = _file_scope_executor("/private/tmp/ooo-repro-blos")
+    verdict = executor._verify_atomic_evidence_against_runtime_messages(
+        messages=_greeting_repro_messages("/private/tmp/ooo-repro-blos/hello.py"),
+        typed_evidence=EvidenceRecord(
+            data={
+                "files_touched": ["not-backed-by-transcript.py"],
+                "commands_run": [_GREETING_INNER_COMMAND],
+            }
+        ),
+        ac_content=_GREETING_AC,
+        has_success_contract=True,
+        has_expected_artifacts=True,
+    )
+
     assert verdict.passed is True, verdict.reasons
 
 
@@ -4383,6 +4426,82 @@ class TestParallelACExecutor:
             "tests_passed",
         ]
         assert evidence_event.data["verifier_ran"] is False
+
+    @pytest.mark.asyncio
+    async def test_contract_ac_with_artifacts_accepts_unbacked_files_touched_claim(
+        self,
+        tmp_path,
+    ) -> None:
+        """A contract AC delegates artifact proof to the verify gate filesystem oracle."""
+        command = "python -c \"print('OK')\""
+        command_json = command.replace("\\", "\\\\").replace('"', '\\"')
+        (tmp_path / "hello.py").write_text(
+            "def greet(name):\n    return f'Hello, {name}'\n",
+            encoding="utf-8",
+        )
+        event_store, appended_events = _make_replaying_event_store()
+        runtime = _FinalMessageRuntime(
+            "Done.\n"
+            "```json\n"
+            "{"
+            '"files_touched":["not-backed-by-transcript.py"],'
+            f'"commands_run":["{command_json}"]'
+            "}\n"
+            "```",
+            native_session_id="codex-session-contract-artifact-delegation",
+            support_messages=(
+                AgentMessage(
+                    type="assistant",
+                    content=f"Calling tool: Bash: {command}",
+                    tool_name="Bash",
+                    data={"tool_input": {"command": command}},
+                ),
+            ),
+            cwd=str(tmp_path),
+        )
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            execution_profile=load_profile("code"),
+            fat_harness_mode=True,
+            task_cwd=str(tmp_path),
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content=_GREETING_AC,
+            session_id="orch_123",
+            tools=["Read", "Edit", "Bash"],
+            tool_catalog=(MCPToolDefinition(name="Read", description="Read a file."),),
+            system_prompt="system",
+            seed_goal="Ship the feature",
+            depth=0,
+            start_time=datetime.now(UTC),
+            ac_spec=AcceptanceCriterionSpec(
+                description=_GREETING_AC,
+                verify_command=command,
+                expected_artifacts=("hello.py",),
+            ),
+        )
+
+        assert result.success is True
+        assert result.error is None
+        assert result.typed_evidence is not None
+        assert result.typed_evidence.data == {"commands_run": [command]}
+        assert runtime.last_prompt is not None
+        assert "directly (commands_run)" in runtime.last_prompt
+        assert "ensure they exist in the workspace" in runtime.last_prompt
+        evidence_event = next(
+            event
+            for event in appended_events
+            if event.type == "execution.ac.typed_evidence.observed"
+        )
+        assert evidence_event.data["required_fields"] == ["commands_run"]
+        assert evidence_event.data["typed_evidence_valid"] is True
+        assert evidence_event.data["verifier_passed"] is True
+        assert evidence_event.data["ignored_out_of_scope_evidence_fields"] == ["files_touched"]
 
     @pytest.mark.asyncio
     async def test_fat_harness_mode_rejects_missing_typed_evidence(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -107,6 +107,24 @@ async def test_verify_gate_output_assertion_match_and_mismatch(tmp_path: Any) ->
     assert "output_assertion" in (mismatch.reason or "")
 
 
+@pytest.mark.asyncio
+async def test_verify_gate_ignores_normalized_exit_code_output_assertion(
+    tmp_path: Any,
+) -> None:
+    executor = _make_executor(working_directory=str(tmp_path))
+    spec = AcceptanceCriterionSpec(
+        description="exit code is already enforced by verify_command",
+        verify_command="exit 0",
+        output_assertion="exit code 0",
+    )
+
+    assert spec.output_assertion is None
+    outcome = await executor._run_ac_verify_gate(spec=spec, cwd=str(tmp_path))
+
+    assert outcome.passed is True
+    assert outcome.reason is None
+
+
 # ---------------------------------------------------------------------------
 # V1 gate integration — _apply_verify_gate
 # ---------------------------------------------------------------------------
@@ -803,7 +821,8 @@ class TestSuccessContractBlock:
         assert block.startswith("SUCCESS CONTRACT for this AC:")
         assert "- Run: make build and report it in commands_run" in block
         assert (
-            "- Expected artifacts: dist/app, dist/app.map — report them in files_touched" in block
+            "- Expected artifacts: dist/app, dist/app.map — ensure they exist in the workspace"
+            in block
         )
         assert "- Expected output: BUILD OK" in block
 


### PR DESCRIPTION
## Summary
Completes the #1591 architecture pivot: for a **contract-carrying AC** (its spec declares a `verify_command`), the fat-harness stops reconstructing evidence from the worker transcript and defers to the orchestrator's own authoritative checks. This closes the release blocker where a correct `ooo run` / `ooo auto` on the **codex** backend was rejected as `FABRICATION_SUSPECTED` even though the produced code was correct.

### What changed
1. **`files_touched` → filesystem oracle.** When a contract AC also declares `expected_artifacts`, `files_touched` is dropped from the fat-harness required-evidence set (mirroring #1591's `tests_passed` drop). The verify-gate's `_missing_expected_artifacts` (real `os.path.exists` check in the run workspace) is the oracle — so it no longer matters whether the worker wrote files via a structured `Edit` event or a bash heredoc / `apply_patch`. Contract ACs **without** `expected_artifacts` keep transcript-backed `files_touched` (no filesystem oracle to delegate to). Strictly stronger than transcript reconstruction.
2. **`output_assertion` normalization.** Condition / exit-code phrases (`exit code 0`, `exit 0`, `returns 0`, `success`, `passed`, `no errors`, …) are normalized to `None` via a `fullmatch` validator, so a redundant, impossible-to-satisfy assertion no longer strands a correct run. Only literal stdout (`OK`, `5 passed`) survives. Exit-code 0 is already gated by `verify_command`'s own exit status.
3. **Seed authoring.** `seed-architect` now emits single-line verify commands and literal-only `expect` values; seed generation rejects heredoc/multiline `verify_command` and retries the extraction.

### Anti-fabrication is preserved / strengthened
Dropping `files_touched` only removes a *self-reported* evidence check. The authoritative `_apply_verify_gate` → `_run_ac_verify_gate` runs on **all** completion paths (initial dispatch, same-runtime retry, alt-harness redispatch) and independently flips `result.success = False` when a declared artifact is missing on disk or the `verify_command` exits non-zero. A worker cannot pass by touching nothing.

### Validation
- `ruff check .` / `ruff format --check .` / `mypy src/` — clean (429 source files)
- Isolated PR tests: `test_seed.py` + `test_seed_generator.py` + `test_parallel_executor.py` + `test_parallel_executor_verify_by_default.py` → **383 passed**
- Live (real codex backend, full working tree): `ooo run workflow ...` **3/3**; fresh `ooo auto ... --timeout 1200` **4/4, Artifact state: complete_verified**; run/auto event DB shows **0** occurrences of `unsupported evidence claims` / `output_assertion ... not found` / `Fat-harness verifier failed`.

### Scope
Evidence-gate + seed-authoring correctness only. CLI aliases, the `ooo seed` command, the auto run-wait reconciliation, and the Seed-QA prompt refinements ship in a companion PR. Does not touch `src/ouroboros/auto/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)