### PR TITLE
fix(cli): ooo seed/interview commands + auto run-wait trusts durable execution terminal

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ tui = ["textual==8.2.7", "textual-serve==1.1.3"]
 all = ["ouroboros-ai[claude,copilot,litellm,mcp,tui,dashboard]"]
 
 [project.scripts]
+ooo = "ouroboros.cli.main:app"
 ouroboros = "ouroboros.cli.main:app"
 
 [build-system]

--- a/src/ouroboros/auto/adapters.py
+++ b/src/ouroboros/auto/adapters.py
@@ -815,8 +815,11 @@ class HandlerSeedQAEvaluator:
         quality_bar = (
             "The Seed must be ready for autonomous execution before run starts. "
             "It must preserve the interview/ledger intent, have ambiguity_score <= 0.20, "
-            "contain concrete acceptance criteria, include constraints/non-goals/runtime "
-            "context, and avoid unsupported assumptions or missing requirements."
+            "contain concrete acceptance criteria, and preserve constraints, non-goals, "
+            "and runtime context in executable Seed surfaces. The Seed schema has no "
+            "top-level non_goals/runtime_context fields; constraints, ontology fields, "
+            "brownfield_context, or acceptance criteria are valid preservation surfaces. "
+            "Avoid unsupported assumptions or missing requirements."
         )
         result = await self.qa_handler.handle(
             {

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4999,7 +4999,10 @@ def _normalized_seed_qa_feedback(qa_result: EvaluateResult) -> tuple[str, ...]:
     if "ambiguity_score" in lowered:
         repairs.append("Seed metadata must satisfy the readiness gate: ambiguity_score <= 0.20.")
     if "non_goals" in lowered or "non-goals" in lowered or "runtime_context" in lowered:
-        repairs.append("Preserve ledger non-goals and runtime context in executable Seed surfaces.")
+        repairs.append(
+            "Preserve ledger non-goals and runtime context in executable Seed surfaces; "
+            "use constraints prefixed with `Non-goal:` and explicit runtime constraints or ontology fields."
+        )
     if "polluted" in lowered or "diagnostic" in lowered or "lateral repair" in lowered:
         repairs.append(
             "Constraints must contain only actionable product/runtime constraints; omit QA or lateral diagnostic prose."

--- a/src/ouroboros/cli/commands/__init__.py
+++ b/src/ouroboros/cli/commands/__init__.py
@@ -2,6 +2,7 @@
 
 This module contains the command group implementations:
 - init: Start interactive interview
+- seed: Generate Seed specifications from interviews
 - run: Execute workflows
 - config: Manage configuration
 - status: Check system status

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -919,6 +919,62 @@ async def _cancel_run_handoff_job(job_manager: JobManager, job_id: str) -> None:
 _FAILED_RUN_META_STATUSES = frozenset({"failed", "cancelled", "interrupted"})
 
 
+async def _linked_execution_completed_result(
+    result: AutoPipelineResult,
+    event_store: EventStore,
+) -> AutoPipelineResult | None:
+    """Return a successful run verdict from durable linked execution evidence.
+
+    Direct CLI ``ooo auto`` waits on the in-process execute job so the process
+    does not exit before the run finishes. In practice a runtime subprocess can
+    outlive the already-emitted source-of-truth ``execution.terminal`` event
+    (for example a Codex child that keeps the job task open after all ACs
+    completed). When the execution terminal says completed, prefer that durable
+    fact over cancelling the live job at the wait deadline.
+    """
+    execution_id = result.execution_id
+    if not execution_id:
+        return None
+
+    terminal_events = await event_store.query_events(
+        aggregate_id=execution_id,
+        event_type="execution.terminal",
+        limit=1,
+    )
+    if not terminal_events or terminal_events[0].data.get("status") != "completed":
+        return None
+
+    message = "Execution complete"
+    workflow_events = await event_store.query_events(
+        aggregate_id=execution_id,
+        event_type="workflow.progress.updated",
+        limit=1,
+    )
+    if workflow_events:
+        data = workflow_events[0].data
+        completed = data.get("completed_count")
+        total = data.get("total_count")
+        if (
+            isinstance(completed, int)
+            and isinstance(total, int)
+            and total > 0
+            and completed >= total
+        ):
+            message = f"Execution complete: {completed}/{total} ACs completed"
+
+    return replace(
+        result,
+        status="complete",
+        phase="complete",
+        blocker=None,
+        resume_capability=AutoResumeCapability.NONE,
+        execution_job_status=JobStatus.COMPLETED.value,
+        execution_job_error=None,
+        execution_job_message=message,
+        run_handoff_status="completed",
+    )
+
+
 def _run_meta_verdict(snapshot: JobSnapshot) -> tuple[str, bool | None]:
     """Extract the execution-level (status, success) verdict from a job snapshot.
 
@@ -1202,8 +1258,14 @@ async def _await_run_handoff_terminal(
     last_line = ""
     try:
         while not snapshot.is_terminal:
+            linked_completed = await _linked_execution_completed_result(result, event_store)
+            if linked_completed is not None:
+                return _persist_resumable_run_verdict(linked_completed, state, store)
             remaining = deadline - time.monotonic()
             if remaining <= 0:
+                linked_completed = await _linked_execution_completed_result(result, event_store)
+                if linked_completed is not None:
+                    return _persist_resumable_run_verdict(linked_completed, state, store)
                 deadline_result = await _cancel_run_and_build_deadline_result(
                     result, job_manager, job_id, snapshot
                 )
@@ -1263,6 +1325,10 @@ async def _await_run_handoff_terminal(
             f"Resume with: ouroboros auto --resume {result.auto_session_id}"
         )
         raise
+
+    linked_completed = await _linked_execution_completed_result(result, event_store)
+    if linked_completed is not None:
+        return _persist_resumable_run_verdict(linked_completed, state, store)
 
     snapshot = await job_manager.get_snapshot(job_id)
     if not quiet:

--- a/src/ouroboros/cli/commands/plugin.py
+++ b/src/ouroboros/cli/commands/plugin.py
@@ -1186,7 +1186,7 @@ def list_command(
 # command namespace. The reserved set is the union of:
 #   - first-party UserLevel programs (`auto`, `run`, `pm`, `plugin`,
 #     `init`, `cancel`, `codex`, `config`, `detect`, `mcp`, `setup`,
-#     `status`, `tui`, `resume`, `uninstall`),
+#     `status`, `tui`, `resume`, `uninstall`, `interview`, `seed`),
 #   - top-level `ooo` built-ins / aliases that are not first-party
 #     programs (`help`, `version`, `monitor`).
 #
@@ -1200,6 +1200,8 @@ _RESERVED_TOP_LEVEL_NAMES: frozenset[str] = frozenset(
         # First-party UserLevel programs
         "auto",
         "init",
+        "interview",
+        "seed",
         "run",
         "config",
         "status",

--- a/src/ouroboros/cli/commands/seed.py
+++ b/src/ouroboros/cli/commands/seed.py
@@ -1,0 +1,99 @@
+"""Seed command for generating a Seed from a completed interview."""
+
+import asyncio
+from pathlib import Path
+from typing import Annotated
+
+import typer
+
+from ouroboros.bigbang.interview import InterviewEngine, InterviewStatus
+from ouroboros.cli.commands.init import LLMBackend, _generate_seed_from_interview, _get_adapter
+from ouroboros.cli.formatters.panels import print_error, print_info
+from ouroboros.config import get_clarification_model
+
+
+def seed_command(
+    session_id: Annotated[
+        str,
+        typer.Argument(help="Interview session ID to crystallize into a Seed."),
+    ],
+    state_dir: Annotated[
+        Path | None,
+        typer.Option(
+            "--state-dir",
+            help="Custom directory for interview state files.",
+            exists=True,
+            file_okay=False,
+            dir_okay=True,
+        ),
+    ] = None,
+    llm_backend: Annotated[
+        LLMBackend | None,
+        typer.Option(
+            "--llm-backend",
+            help=(
+                "LLM backend for ambiguity scoring and seed generation "
+                "(claude_code, litellm, codex, copilot, opencode, gemini, goose, kiro, or pi)."
+            ),
+            case_sensitive=False,
+        ),
+    ] = None,
+) -> None:
+    """Generate a Seed YAML specification from an interview session."""
+    try:
+        asyncio.run(
+            _run_seed_generation(
+                session_id,
+                state_dir=state_dir,
+                llm_backend=llm_backend.value if llm_backend else None,
+            )
+        )
+    except KeyboardInterrupt:
+        print_info("Seed generation interrupted.")
+        raise typer.Exit(code=0)
+    except typer.Exit:
+        raise
+    except Exception as exc:
+        print_error(f"Seed generation failed: {exc}")
+        raise typer.Exit(code=1)
+
+
+async def _run_seed_generation(
+    session_id: str,
+    *,
+    state_dir: Path | None = None,
+    llm_backend: str | None = None,
+) -> Path:
+    """Load an interview and run the existing seed generation path."""
+    llm_adapter = _get_adapter(
+        use_orchestrator=False,
+        backend=llm_backend,
+        for_interview=False,
+    )
+    engine = InterviewEngine(
+        llm_adapter=llm_adapter,
+        state_dir=state_dir or Path.home() / ".ouroboros" / "data",
+        model=get_clarification_model(llm_backend),
+    )
+
+    state_result = await engine.load_state(session_id)
+    if state_result.is_err:
+        print_error(f"Failed to load interview: {state_result.error.message}")
+        raise typer.Exit(code=1)
+
+    state = state_result.value
+    if state.status != InterviewStatus.COMPLETED:
+        print_error(
+            f"Interview {session_id} is {state.status}; complete it with "
+            f"`ooo interview --resume {session_id}` before generating a Seed."
+        )
+        raise typer.Exit(code=1)
+
+    seed_path, result = await _generate_seed_from_interview(state, llm_adapter, llm_backend)
+    if seed_path is None:
+        raise typer.Exit(code=1)
+
+    return seed_path
+
+
+__all__ = ["seed_command", "_run_seed_generation"]

--- a/src/ouroboros/cli/main.py
+++ b/src/ouroboros/cli/main.py
@@ -38,6 +38,7 @@ from ouroboros.cli.commands import (
     qa,
     resume,
     run,
+    seed,
     setup,
     status,
     tui,
@@ -95,6 +96,10 @@ app.command(
     ),
 )(auto.auto_command)
 app.add_typer(init.app, name="init")
+app.add_typer(init.app, name="interview")
+app.command(name="seed", help="Generate a Seed YAML specification from an interview.")(
+    seed.seed_command
+)
 app.add_typer(run.app, name="run")
 app.add_typer(job.app, name="job")
 app.add_typer(harness.app, name="harness")

--- a/tests/unit/cli/test_auto_run_handoff_wait.py
+++ b/tests/unit/cli/test_auto_run_handoff_wait.py
@@ -27,7 +27,8 @@ from ouroboros.auto.state import (
 from ouroboros.cli.commands import auto as auto_command
 from ouroboros.cli.commands.auto import _await_run_handoff_terminal
 from ouroboros.cli.main import app
-from ouroboros.mcp.job_manager import JobManager, JobStatus
+from ouroboros.events.base import BaseEvent
+from ouroboros.mcp.job_manager import JobLinks, JobManager, JobStatus
 from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
 from ouroboros.persistence.event_store import EventStore
 
@@ -558,6 +559,79 @@ async def test_wait_completed_job_without_success_meta_is_not_complete(tmp_path)
         assert "without confirming terminal run success" in reconciled.blocker
         # Upgraded from the NONE input — allowlist-blocked runs are resumable.
         assert reconciled.resume_capability is AutoResumeCapability.RESUME
+    finally:
+        await _cancel_manager_tasks(manager)
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_wait_prefers_linked_execution_terminal_over_live_wedged_job(
+    tmp_path,
+) -> None:
+    """Durable execution success must win over a live job task stuck open.
+
+    Live ``ooo auto`` can observe all ACs completed and an ``execution.terminal``
+    success while the underlying runtime subprocess still keeps the job task
+    open. The wait path must not cancel that product at the deadline.
+    """
+    import time as time_module
+
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(store)
+    try:
+        started_running = asyncio.Event()
+
+        async def _wedged_runner() -> MCPToolResult:
+            started_running.set()
+            await asyncio.sleep(3600)
+            raise AssertionError("unreachable")
+
+        started = await manager.start_job(
+            job_type="execute",
+            initial_message="queued",
+            runner=_wedged_runner(),
+            links=JobLinks(session_id="orch_wait", execution_id="exec_wait"),
+        )
+        await asyncio.wait_for(started_running.wait(), timeout=5)
+
+        await store.append(
+            BaseEvent(
+                type="workflow.progress.updated",
+                aggregate_type="execution",
+                aggregate_id="exec_wait",
+                data={"completed_count": 3, "total_count": 3},
+            )
+        )
+        await store.append(
+            BaseEvent(
+                type="execution.terminal",
+                aggregate_type="execution",
+                aggregate_id="exec_wait",
+                data={"status": "completed", "session_id": "orch_wait"},
+            )
+        )
+
+        reconciled = await asyncio.wait_for(
+            _await_run_handoff_terminal(
+                _handoff_only_result(started.job_id),
+                job_manager=manager,
+                event_store=store,
+                quiet=True,
+                deadline_at=time_module.monotonic() + 0.1,
+            ),
+            timeout=5,
+        )
+
+        assert reconciled.status == "complete"
+        assert reconciled.execution_job_status == JobStatus.COMPLETED.value
+        assert reconciled.execution_job_message == "Execution complete: 3/3 ACs completed"
+        assert reconciled.run_handoff_status == "completed"
+        assert reconciled.resume_capability is AutoResumeCapability.NONE
+
+        snapshot = await manager.get_snapshot(started.job_id)
+        assert snapshot.status is JobStatus.RUNNING
+        events, _cursor = await store.get_events_after("job", started.job_id, 0)
+        assert not any(event.type == "mcp.job.cancelled" for event in events)
     finally:
         await _cancel_manager_tasks(manager)
         await store.close()

--- a/tests/unit/cli/test_main.py
+++ b/tests/unit/cli/test_main.py
@@ -70,6 +70,18 @@ class TestCommandGroups:
         assert result.exit_code == 0
         assert "Check Ouroboros system status" in result.output
 
+    def test_interview_alias_registered(self) -> None:
+        """Test that interview is registered as a top-level init alias."""
+        result = runner.invoke(app, ["interview", "--help"])
+        assert result.exit_code == 0
+        assert "Start interactive interview" in result.output
+
+    def test_seed_command_registered(self) -> None:
+        """Test that seed command is registered."""
+        result = runner.invoke(app, ["seed", "--help"])
+        assert result.exit_code == 0
+        assert "Seed" in result.output
+
 
 class TestRunCommands:
     """Tests for run command group."""


### PR DESCRIPTION
## Summary
CLI + auto run-wait robustness so a direct `ooo auto` reliably reports a completed product. Companion to #1592 (evidence-gate grounding); independent of it (both branch from `origin/main`).

### What changed
1. **auto run-wait trusts the durable execution terminal.** New `_linked_execution_completed_result`: when the run-handoff wait would hit its deadline but the durable `execution.terminal` event already carries `status=completed` (the source of truth, emitted only when every AC actually succeeded in the fat-harness path), trust that over cancelling the still-live job. A codex `codex exec` child can keep the in-process job task open after all ACs finished; without this the wait mis-cancelled a genuinely finished run as deadline-blocked. Genuine success stays durably COMPLETE via `_persist_resumable_run_verdict` — the #1590 paused/failed reopen-to-RUN contract is untouched (only `blocked`/`failed` mutate durable state; `complete` is returned unchanged).
2. **`ooo seed <SESSION_ID>`** — crystallize a completed interview into a Seed from the CLI, reusing the existing `_generate_seed_from_interview` path (with a COMPLETED-interview guard). **`ooo interview`** alias for `init`. **`ooo`** console-script entry point in `pyproject.toml`. Reserved-name sets updated so plugin passthrough does not shadow them.
3. **Seed-QA quality bar** no longer demands non-existent top-level `non_goals`/`runtime_context` fields (those intents live in `constraints`/ontology), reducing false Seed-QA rejections during `ooo auto`.

### Validation
- `ruff check .` / `ruff format --check .` / `mypy src/` — clean (430 source files)
- Isolated PR tests: `test_main.py` + `test_auto_run_handoff_wait.py` → **58 passed** (incl. `test_wait_prefers_linked_execution_terminal_over_live_wedged_job` and the alias/seed-command registration tests)
- Live (real codex): fresh `ooo auto ... --timeout 1200` → **4/4, complete_verified**; `ooo seed <interview_id>` produced a real Seed.

## R-run comparison

Substrate/CLI-only change: the auto edits touch the CLI run-wait reconciliation and a Seed-QA prompt string; no per-cycle interview/execution loop cost changes. No comparison is applicable; cells are `N/A` per the template's substrate-only rule.

| Metric                         | Baseline (sha)        | This PR (sha)         | Ratio    |
|--------------------------------|-----------------------|-----------------------|----------|
| Rounds completed in 600 s      | N/A                   | N/A                   | n/a      |
| Per-round wall-clock (s/round) | N/A                   | N/A                   | n/a      |
| Terminal reason                | N/A                   | N/A                   | n/a      |
| EventStore event count         | N/A                   | N/A                   | n/a      |

Budget compliance: [x] N/A (CLI/prompt-only; no round-loop cost change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)