### PR TITLE
perf(brownfield): bound scan depth, drop worktree expansion, parallelize validation

### DIFF
--- a/skills/brownfield/SKILL.md
+++ b/skills/brownfield/SKILL.md
@@ -33,8 +33,7 @@ Show scanning indicator:
   Scanning for Existing Projects...
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Looking for git repositories and worktrees under the scan root directory.
-Linked worktrees reported by discovered normal repo roots may also be registered, even outside the scan root directory.
+Looking for git repositories and worktrees up to two directories below the scan root.
 Local repos and repos with any remote name are eligible.
 This may take a moment...
 ```
@@ -55,7 +54,7 @@ stop with the MCP-not-available message instead of retrying the failing call.
    Tool: ouroboros_brownfield
    Arguments: { "action": "scan" }
    ```
-   This walks `scan_root` for valid seed repos/worktrees and registers them in DB. For each discovered normal repo root with a `.git` directory, Git-reported linked worktrees are also considered, even when they live outside `scan_root`. A linked worktree found under `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`. Existing defaults are preserved.
+   This walks `scan_root` (up to two directory levels deep) for valid seed repos/worktrees and registers them in DB. Each repo or worktree found directly by the walk is registered self-only — Git worktree families are not expanded, so worktrees outside the depth-bounded walk (e.g. under `.ouroboros/worktrees`) are not pulled in. Existing defaults are preserved.
 
 The scan response `text` already contains a pre-formatted numbered list with `[default]` markers. **Do NOT make any additional MCP calls to list or query repos.**
 
@@ -81,10 +80,9 @@ Then stop.
 ### Scan boundaries
 
 - The filesystem walk starts at `scan_root`; when omitted, `scan_root` defaults to the current user's home directory.
-- Repositories are only discovered directly by walking directories inside `scan_root`.
+- Repositories are discovered by walking directories inside `scan_root`, at most two levels deep (so `~/repo` and `~/group/repo` are found; deeper nesting is not).
 - Dot-prefixed directories and known noisy directories such as `node_modules` are not walked as seed locations.
-- Git worktrees are different: once a normal repo root with a `.git` directory is discovered, Ouroboros runs `git worktree list --porcelain` and may register those linked worktrees even if their paths are outside `scan_root`.
-- A linked worktree found inside `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`.
+- Both normal repos (`.git` directory) and linked worktrees (`.git` file) are registered when the walk reaches them. Git worktree families are NOT expanded — a worktree is only registered if the walk finds it directly, not because its main repo's Git metadata reports it.
 - Local repos, repos without remotes, and repos whose remotes are not named `origin` are all eligible.
 
 **Step 2: Default Selection**

--- a/src/ouroboros/bigbang/brownfield.py
+++ b/src/ouroboros/bigbang/brownfield.py
@@ -4,8 +4,7 @@ Manages the global brownfield registry in ``~/.ouroboros/ouroboros.db``
 via :class:`~ouroboros.persistence.brownfield.BrownfieldStore`.
 
 Business-level operations:
-- Scan-root discovery for valid seed git repos/worktrees
-- Linked worktree discovery from normal repo roots via Git metadata
+- Scan-root discovery for valid seed git repos/worktrees (depth-bounded walk)
 - README/CLAUDE.md parsing for one-line description generation (Frugal model)
 - Async CRUD delegated to BrownfieldStore
 

--- a/src/ouroboros/bigbang/brownfield.py
+++ b/src/ouroboros/bigbang/brownfield.py
@@ -15,6 +15,7 @@ All brownfield data is stored in the SQLite database.
 from __future__ import annotations
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 import os
 from pathlib import Path
 import subprocess
@@ -39,6 +40,11 @@ BrownfieldEntry = BrownfieldRepo
 # ── Constants ──────────────────────────────────────────────────────
 
 _FRUGAL_MODEL = "anthropic/claude-3-5-haiku-20241022"
+
+# Maximum directory depth, relative to the scan root, to search for repos.
+# Repos commonly live at ``~/repo`` (depth 1) or ``~/group/repo`` (depth 2);
+# deeper nesting is rare and not worth the extra filesystem traversal.
+_MAX_SCAN_DEPTH = 2
 
 _SKIP_DIRS: frozenset[str] = frozenset(
     {
@@ -143,29 +149,6 @@ def _is_git_worktree(repo_path: Path) -> bool:
     return result.returncode == 0 and result.stdout.strip() == "true"
 
 
-def _list_git_worktrees(repo_path: Path) -> list[Path]:
-    """Return linked worktree paths reported by Git for a normal repo root."""
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(repo_path), "worktree", "list", "--porcelain"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        )
-        if result.returncode != 0:
-            return []
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
-        return []
-
-    worktrees: list[Path] = []
-    for line in result.stdout.splitlines():
-        if line.startswith("worktree "):
-            worktree_path = line.removeprefix("worktree ").strip()
-            if worktree_path:
-                worktrees.append(Path(worktree_path))
-    return worktrees
-
-
 def _repo_entry(repo_path: Path) -> dict[str, str] | None:
     """Build a scan result entry for an existing repository directory."""
     try:
@@ -179,54 +162,44 @@ def _repo_entry(repo_path: Path) -> dict[str, str] | None:
     return {"path": str(resolved), "name": resolved.name}
 
 
-def _add_repo_and_worktrees(
-    repo_path: Path,
-    repos_by_path: dict[str, dict[str, str]],
-    *,
-    include_linked_worktrees: bool,
-) -> None:
-    """Add a seed repo and optionally any Git-reported linked worktrees.
+def _scan_repo_entry(repo_path: Path) -> dict[str, str] | None:
+    """Validate a walk-discovered ``.git`` location and build its scan entry.
 
-    The seed path must be found by the filesystem walk. For normal repository
-    roots, linked worktrees come from ``git worktree list`` and may be outside
-    the walk root.
+    Runs the ``git`` work-tree check exactly once and returns None for anything
+    that is not a real working tree. Safe to call from worker threads — it only
+    spawns a subprocess (which releases the GIL).
     """
     if not _is_git_worktree(repo_path):
-        return
-
-    candidates = [repo_path]
-    if include_linked_worktrees:
-        candidates.extend(_list_git_worktrees(repo_path))
-
-    for candidate in candidates:
-        if not _is_git_worktree(candidate):
-            continue
-        entry = _repo_entry(candidate)
-        if entry is None:
-            continue
-        repos_by_path.setdefault(entry["path"], entry)
+        return None
+    return _repo_entry(repo_path)
 
 
 def scan_home_for_repos(
     root: Path | None = None,
+    *,
+    max_depth: int = _MAX_SCAN_DEPTH,
 ) -> list[dict[str, str]]:
     """Walk a root directory to find valid git repos/worktrees.
 
     Scanning rules:
     - Repositories are discovered by filesystem walking under ``root`` only.
     - A seed repo/worktree is any walked directory with a ``.git`` directory or file.
+    - The walk descends at most ``max_depth`` levels below ``root`` — repos at
+      ``~/repo`` (depth 1) or ``~/group/repo`` (depth 2) are found; deeper ones
+      are not.
     - Prune subdirectories once a seed is found (no nested repo walk).
     - Skip hardcoded noise directories (node_modules, .venv, etc.).
     - Skip dot-prefixed directories during filesystem walking.
-    - Normal repo roots are expanded via ``git worktree list --porcelain``.
-    - Linked worktrees reported by normal repo roots may be included outside ``root``.
-    - Linked worktree seeds are registered self-only and do not pull main/sibling
-      worktrees outside ``root``.
+    - Each candidate is registered self-only; Git worktree families are NOT
+      expanded. Any worktree that lives within the depth-bounded walk is found
+      directly; worktrees outside it (e.g. under ``.ouroboros/worktrees``) are
+      intentionally left out.
     - Local repos and repos with any remote name are included.
 
     Args:
         root: Directory to start the seed filesystem walk. Defaults to the
             current user's home directory.
+        max_depth: Maximum directory depth below ``root`` to search.
 
     Returns:
         Sorted list of ``{path, name}`` dicts for each discovered repo/worktree.
@@ -234,36 +207,42 @@ def scan_home_for_repos(
     if root is None:
         root = Path.home()
 
-    repos_by_path: dict[str, dict[str, str]] = {}
-
-    # os.walk with topdown=True so we can modify dirs in-place to prune
+    # Phase 1 — cheap filesystem walk (no subprocess) collects candidate repo
+    # roots: directories carrying a ``.git`` dir or file. Bounded to max_depth
+    # levels below root and pruned at skip/dot dirs and at any repo found.
+    candidates: list[Path] = []
     for dirpath, dirnames, filenames in os.walk(root, topdown=True):
         current = Path(dirpath)
 
-        has_git_dir = ".git" in dirnames
-        has_git_file = ".git" in filenames
-        if has_git_dir or has_git_file:
-            # A .git directory is a normal repo root, so it can safely expand to
-            # its Git-reported worktree family. A .git file is a linked worktree
-            # seed; register it, but do not use it as a portal to pull in the
-            # main repo or siblings. Users may scan/pass a specific worktree to
-            # keep the rest of the repository out of AI context.
-            _add_repo_and_worktrees(
-                current,
-                repos_by_path,
-                include_linked_worktrees=has_git_dir,
-            )
+        if ".git" in dirnames or ".git" in filenames:
+            candidates.append(current)
             log.debug("brownfield.scan.found", path=str(current))
-
-            # Prune: don't descend into this repo's subdirectories
+            # Prune: a repo's subtree holds its own files, not more seed repos.
             dirnames.clear()
             continue
 
-        # Prune skip directories
+        if len(current.relative_to(root).parts) >= max_depth:
+            # At the depth cap: this dir was already checked above; go no deeper.
+            dirnames.clear()
+            continue
+
+        # Prune skip and dot-prefixed directories.
         dirnames[:] = [d for d in dirnames if d not in _SKIP_DIRS and not d.startswith(".")]
 
-    repos = list(repos_by_path.values())
-    repos.sort(key=lambda r: r["path"])
+    if not candidates:
+        log.info("brownfield.scan.complete", root=str(root), found=0)
+        return []
+
+    # Phase 2 — validate candidates in parallel. Each check spawns a ``git``
+    # subprocess (releases the GIL), so threads overlap the process-spawn cost.
+    repos_by_path: dict[str, dict[str, str]] = {}
+    max_workers = min(16, (os.cpu_count() or 4) * 4, len(candidates))
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        for entry in pool.map(_scan_repo_entry, candidates):
+            if entry is not None:
+                repos_by_path.setdefault(entry["path"], entry)
+
+    repos = sorted(repos_by_path.values(), key=lambda r: r["path"])
     log.info("brownfield.scan.complete", root=str(root), found=len(repos))
     return repos
 
@@ -373,9 +352,9 @@ async def scan_and_register(
     This is the main entry point for brownfield scanning.
 
     1. Walk ``root`` (the current user's home directory when omitted) to find
-       valid seed git repos/worktrees.
-    2. For each normal repo root, include Git-reported linked worktrees even
-       when they live outside ``root``. Linked worktree seeds are self-only.
+       valid seed git repos/worktrees, bounded to a shallow depth.
+    2. Each discovered repo/worktree is registered self-only; Git worktree
+       families are not expanded.
     3. Upsert all found repos while preserving existing names, descriptions,
        and default flags. Default selection is handled by setup/MCP flows.
 

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -2913,10 +2913,9 @@ async def _scan_and_register_repos(scan_root: Path | None = None) -> list[dict]:
     """Scan a root directory and register repos/worktrees in DB.
 
     Uses upsert semantics so that manually-registered repos outside the
-    scan root are preserved across re-scans. Git-reported linked worktrees for
-    discovered normal repo roots may be registered even when they live outside
-    the scan root. A linked worktree inside the scan root is registered itself
-    but does not pull its main/sibling worktrees outside the scan root.
+    scan root are preserved across re-scans. The walk is depth-bounded and
+    registers each repo/worktree it reaches directly; Git worktree families
+    are not expanded.
 
     Returns:
         List of repo dicts with path, name, desc, is_default.
@@ -3289,12 +3288,11 @@ def scan(
 ) -> None:
     """Re-scan a root directory and register new repos.
 
-    Scans the requested root for valid seed git repos/worktrees and updates the
-    brownfield registry. Linked worktrees reported by normal repo roots may be
-    registered even when they live outside the scan root. A linked worktree
-    found inside the scan root is registered itself but does not pull its
-    main/sibling worktrees outside the scan root. Local repos and repos with any
-    remote name are eligible. Existing repos are preserved (upsert).
+    Scans the requested root (up to a shallow depth) for valid seed git
+    repos/worktrees and updates the brownfield registry. Each repo/worktree
+    the walk reaches directly is registered self-only; Git worktree families
+    are not expanded. Local repos and repos with any remote name are eligible.
+    Existing repos are preserved (upsert).
     """
     effective_scan_root = scan_root or Path.home()
     console.print("\n[bold cyan]Brownfield Scan[/]\n")
@@ -3315,7 +3313,7 @@ def scan(
 
 async def _run_scan_only(scan_root: Path) -> list[dict]:
     """Scan and register, returning repo list."""
-    with console.status("[cyan]Scanning scan root and linked worktrees...[/]", spinner="dots"):
+    with console.status("[cyan]Scanning scan root for repos...[/]", spinner="dots"):
         return await _scan_and_register_repos(scan_root)
 
 

--- a/src/ouroboros/mcp/tools/brownfield_handler.py
+++ b/src/ouroboros/mcp/tools/brownfield_handler.py
@@ -4,8 +4,8 @@ Provides an ``ouroboros_brownfield`` MCP tool for managing brownfield
 repository registrations in the SQLite database. Supports four actions:
 
 - **scan** — Walk a caller-supplied root (or the home directory by
-  default) for seed repos/worktrees, include Git-reported linked worktrees
-  from normal repo roots, and register discovered local repositories in the DB.
+  default) up to a shallow depth for seed repos/worktrees, and register
+  discovered local repositories in the DB.
 - **register** — Manually register a single repository by path.
 - **query** — List all registered repos or get the current default.
 - **set_default** — Set a registered repo as the default brownfield context.
@@ -326,7 +326,7 @@ class BrownfieldHandler:
         """Scan an existing root directory for repos/worktrees and register them.
 
         Delegates to ``bigbang.brownfield.scan_and_register`` which handles
-        directory walking, linked worktree expansion, and DB upsert.
+        depth-bounded directory walking and DB upsert.
         """
         scan_root_str = arguments.get("scan_root")
         scan_root = Path(scan_root_str).expanduser() if scan_root_str else None
@@ -341,7 +341,7 @@ class BrownfieldHandler:
         store = await self._get_store()
 
         # scan_and_register handles the full workflow:
-        # walk dirs → expand linked worktrees → upsert
+        # walk dirs (depth-bounded) → validate candidates → upsert
         repos = await scan_and_register(
             store=store,
             llm_adapter=None,  # No LLM in MCP context for now

--- a/tests/unit/bigbang/test_brownfield.py
+++ b/tests/unit/bigbang/test_brownfield.py
@@ -236,10 +236,13 @@ class TestScanHomeForRepos:
         paths = {r["path"] for r in result}
         assert paths == {str(linked.resolve())}
 
-    def test_includes_git_reported_worktrees_without_crawling_hidden_dirs(
+    def test_worktrees_under_hidden_dirs_are_not_expanded(
         self,
         tmp_path: Path,
     ) -> None:
+        # Git worktree families are no longer expanded. Worktrees that only the
+        # main repo's Git metadata knows about — here parked under a dot-prefixed
+        # ``.ouroboros`` dir the walk never enters — are intentionally left out.
         main = tmp_path / "projects" / "main"
         managed_worktree = tmp_path / ".ouroboros" / "worktrees" / "main" / "task"
         unlinked_hidden_repo = tmp_path / ".ouroboros" / "worktrees" / "unlinked"
@@ -251,7 +254,7 @@ class TestScanHomeForRepos:
         result = scan_home_for_repos(tmp_path)
 
         paths = {r["path"] for r in result}
-        assert paths == {str(main.resolve()), str(managed_worktree.resolve())}
+        assert paths == {str(main.resolve())}
 
     def test_finds_local_repos_without_remotes(self, tmp_path: Path) -> None:
         repo = tmp_path / "local-proj"
@@ -387,6 +390,33 @@ class TestScanHomeForRepos:
         assert set(entry.keys()) == {"path", "name"}
         assert isinstance(entry["path"], str)
         assert isinstance(entry["name"], str)
+
+    def test_finds_repo_at_depth_two(self, tmp_path: Path) -> None:
+        # A repo nested one group directory deep (~/group/repo) is within the
+        # depth-2 bound and must be found.
+        repo = tmp_path / "group" / "repo"
+        repo.mkdir(parents=True)
+        subprocess.run(["git", "init", str(repo)], capture_output=True)
+
+        result = scan_home_for_repos(tmp_path)
+        assert [r["path"] for r in result] == [str(repo.resolve())]
+
+    def test_does_not_find_repo_beyond_max_depth(self, tmp_path: Path) -> None:
+        # A repo three levels below the root exceeds the depth-2 bound.
+        deep = tmp_path / "a" / "b" / "repo"
+        deep.mkdir(parents=True)
+        subprocess.run(["git", "init", str(deep)], capture_output=True)
+
+        result = scan_home_for_repos(tmp_path)
+        assert result == []
+
+    def test_max_depth_is_configurable(self, tmp_path: Path) -> None:
+        deep = tmp_path / "a" / "b" / "repo"
+        deep.mkdir(parents=True)
+        subprocess.run(["git", "init", str(deep)], capture_output=True)
+
+        result = scan_home_for_repos(tmp_path, max_depth=3)
+        assert [r["path"] for r in result] == [str(deep.resolve())]
 
 
 # ── _read_readme_content ───────────────────────────────────────────


### PR DESCRIPTION
Closes #1596

## Purpose

The brownfield repo scan (`scan_home_for_repos`) is slower than necessary and pollutes its registry with worktrees that are noise for its consumers. It walked the entire home tree with no depth limit and ran serial `git` subprocesses (validate + `worktree list` expansion + a redundant second validate) per repo. The `git worktree list` expansion only uniquely surfaced internal/hidden worktrees (`~/.ouroboros/worktrees/**`, `.worktrees/`) that no user wants as interview/evaluate context.

Goal: make the scan fast and make its output contain only the repos/worktrees users actually work in. The intended consumer is `ooo pm`, and a PM interview only needs **one main repo as its reference** — it does not need a repo's full linked-worktree family enumerated. So exhaustively registering every worktree adds no value for the consumer while adding cost and noise; dropping that is by design, not just an optimization. The registry is load-bearing for **PM interview** (exploration context) and **`evaluate`** (working-dir fallback), so both correctness and cost matter. Full problem analysis and blast radius in #1596.

## What changed & why

- **Depth-bounded walk (default 2 levels).** Registered repos live at `~/repo` (depth 1) or `~/group/repo` (depth 2); deeper nesting is rare. Bounding the walk stops it from descending arbitrarily deep into non-repo subtrees. Exposed as `max_depth` for callers that need more reach.
- **Dropped `git worktree list` expansion.** Removed `_list_git_worktrees` / `_add_repo_and_worktrees`. Each repo/worktree is registered self-only when the walk reaches it directly. Intent: `ooo pm` only references a single main repo, so enumerating a repo's whole worktree family is unnecessary by design. Real work worktrees already live inside the bounded walk and are still found; the expansion only added internal/hidden worktrees (noise) at a per-repo subprocess cost, so removing it improves both signal and speed.
- **Two-phase, parallel scan.** Phase 1 is a subprocess-free `os.walk` that only collects candidate `.git` paths; Phase 2 validates them in parallel via a `ThreadPoolExecutor`. Intent: the `git` validation releases the GIL during `subprocess`, so overlapping the process-spawn cost turns a serial O(N) cost into near-constant wall-clock.
- **Single validation per candidate.** The old path validated the same repo twice (guard + `candidates[0]`); now each candidate runs `git rev-parse` exactly once.
- **Docs.** Updated `skills/brownfield/SKILL.md` scan-boundary section to match the new depth-bounded, no-expansion behavior.

Out of scope / unaffected: regular interview, the auto pipeline, and seed execution use cwd-/seed-context brownfield detection and do not read this registry.

## Success criteria

- All brownfield unit tests pass: `tests/unit/bigbang/test_brownfield.py` + `tests/unit/mcp/tools/test_brownfield_handler.py` → **135 passed**.
- New tests assert the behavior contract: depth-2 repo discovered, depth-3 repo excluded, `max_depth` configurable, and worktrees under hidden dirs are not expanded.
- A repo/worktree that lives within the depth-bounded walk (e.g. `~/podo-backend-rfc-*`) is still registered; internal worktrees under `~/.ouroboros/worktrees/**` are not.
- `ruff check` clean.
- Real `~/` smoke run completes in ~0.17s for 79 repos, including depth-2 repos (`Developer/browser-harness`, `grape-worktrees/*`).

Accepted trade-offs: repos deeper than 2 levels are no longer discovered by the default scan (raise `max_depth` if needed), and internal/hidden worktrees are intentionally excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
