### PR TITLE
perf(tests): stop real agent-CLI spawns in tests, parallelize CI with xdist

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run pytest with coverage
         run: |
-          uv run pytest tests/ --cov=src/ouroboros --cov-report=xml --cov-report=term-missing -v
+          uv run pytest tests/ -n 4 --cov=src/ouroboros --cov-report=xml --cov-report=term-missing -v
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ dev = [
     "pytest>=9.0.2",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.0.0",
+    "pytest-xdist>=3.6",
     "ruff>=0.14.11",
     "types-pyyaml>=6.0.12.20250915",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,9 @@
 
 import inspect
 import os
+import sys
 
+import pytest
 import pytest_asyncio
 
 # In CI, GITHUB_ACTIONS env var causes Typer to set force_terminal=True on
@@ -18,6 +20,39 @@ os.environ["_TYPER_FORCE_DISABLE_TERMINAL"] = "1"
 # effects, non-deterministic URL in responses). Force it OFF by default; tests that
 # exercise the wiring opt back in explicitly via monkeypatch + a mocked resolver.
 os.environ["OUROBOROS_DASHBOARD"] = "0"
+
+
+@pytest.fixture(autouse=True)
+def block_runner_real_llm_adapter(monkeypatch):
+    """Block execute_seed's dependency analysis from spawning real agent CLIs.
+
+    ``OrchestratorRunner._build_dependency_analyzer`` resolves an LLM adapter
+    from the adapter's ``llm_backend`` / the developer's real ~/.ouroboros
+    config, and if a matching CLI binary exists on the machine (claude,
+    opencode, ...) it spawns it for a REAL completion — with no timeout on
+    some backends. In tests this meant real API calls locally and a ~60s
+    hang per failure-path e2e test on CI.
+
+    Raising here routes the builder through its existing RuntimeError
+    fallback (structured-only ``DependencyAnalyzer()``), which is also the
+    effective CI behavior. Tests that exercise the builder itself patch
+    ``ouroboros.orchestrator.runner.create_llm_adapter`` inside the test
+    body; that patch is applied after this one and wins.
+
+    Gated on sys.modules so tests that never import the orchestrator don't
+    pay the import cost.
+    """
+    runner_mod = sys.modules.get("ouroboros.orchestrator.runner")
+    if runner_mod is not None:
+
+        def _blocked_create_llm_adapter(*_args, **_kwargs):
+            raise RuntimeError(
+                "create_llm_adapter blocked in tests: dependency analysis must not "
+                "spawn real agent CLIs (patch ouroboros.orchestrator.runner."
+                "create_llm_adapter to test the LLM path)"
+            )
+
+        monkeypatch.setattr(runner_mod, "create_llm_adapter", _blocked_create_llm_adapter)
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -284,6 +284,14 @@ class MockClaudeAgentAdapter:
     def permission_mode(self) -> str | None:
         return "default"
 
+    @property
+    def self_governs_rate_limit(self) -> bool:
+        # The real Claude adapter self-governs its RPM/TPM bucket, so the executor
+        # must not add a dispatch-level rate gate (mirrors adapter.py's
+        # self_governs_rate_limit = True). Without it, failure-path retries wait
+        # out 30s rate-limit backoffs.
+        return True
+
     def add_execution_sequence(self, messages: list[AgentMessage]) -> MockClaudeAgentAdapter:
         """Add a sequence of messages for a single execution."""
         self.message_sequences.append(messages)

--- a/tests/unit/cli/test_plugin_command_mutating.py
+++ b/tests/unit/cli/test_plugin_command_mutating.py
@@ -345,11 +345,21 @@ def test_add_duplicate_manifest_names_in_catalog_refused(runner: CliRunner, tmp_
         ],
     )
     assert result.exit_code == 1, result.output
-    # Stable phrase the operator can grep for.
-    assert "duplicate `name`" in result.output
+    # The error is rendered through a force_terminal Rich Panel (80 cols),
+    # which emits ANSI codes and hard-wraps long lines. When tmp_path grows
+    # longer (e.g. the ``popen-gwN/`` segment under pytest-xdist workers) the
+    # wrap point shifts and splits a token across panel lines, so raw
+    # substring checks on ``result.output`` are brittle. Strip ANSI, then
+    # squash box borders and all whitespace/newlines so wrapped tokens rejoin.
+    import re
+
+    plain = re.sub(r"\x1b\[[0-9;]*m", "", result.output)
+    squashed = re.sub(r"[│╭╮╰╯─\s]+", "", plain)
+    # Stable phrase the operator can grep for (space vanishes when squashed).
+    assert "duplicate`name`" in squashed
     # Both colliding paths surfaced for remediation.
-    assert "github-pr-ops-a" in result.output
-    assert "github-pr-ops-b" in result.output
+    assert "github-pr-ops-a" in squashed
+    assert "github-pr-ops-b" in squashed
     # Crucially: nothing was installed.
     assert not paths["lockfile"].exists() or Lockfile(paths["lockfile"]).read() == {}
 

--- a/uv.lock
+++ b/uv.lock
@@ -593,6 +593,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "fastuuid"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1477,6 +1486,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
@@ -1517,6 +1527,7 @@ dev = [
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.6" },
     { name = "ruff", specifier = ">=0.14.11" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
@@ -1846,6 +1857,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **Tests were spawning real agent CLIs.** Any test driving `execute_seed` with ≥2 ACs hit `OrchestratorRunner._build_dependency_analyzer`, which resolves a real LLM adapter from the adapter's `llm_backend` / the developer's real `~/.ouroboros` config. On a machine with the binaries installed this meant real claude API calls per e2e test (~5–8s + cost) and a 12+ minute hang in `test_runner.py::test_execute_seed_success` on a real `opencode run` (that adapter defaults to **no timeout**). A root-conftest autouse guard now blocks `ouroboros.orchestrator.runner.create_llm_adapter`, routing the builder through its existing `RuntimeError` fallback (structured-only analysis — already the effective CI behavior). Builder-focused tests patch that same symbol inside their own `with patch(...)`, which applies after the guard and wins, so no test needed markers or edits.
- **The two slowest CI tests (63s each) were rate-limit backoff, not work.** `MockClaudeAgentAdapter` lacked the real Claude adapter's `self_governs_rate_limit = True`, so `_build_dispatch_rate_gate` armed an RPM/TPM gate from the built-in Anthropic ceilings and failure-path AC retries slept through 2×30s backoffs (`rate_limit.py` heartbeats). The mock now declares the flag, mirroring `adapter.py`.
- **CI now runs `pytest -n 4`** (pytest-xdist added to dev deps; ubuntu runners have 4 vCPUs; pytest-cov supports xdist natively). One brittle assertion is hardened for xdist: the duplicate-manifest error panel hard-wraps (module console is `Console(force_terminal=True)`, 80 cols), and xdist's `popen-gwN` tmp-path segment shifted the wrap point mid-token; the test now squashes box borders/ANSI before substring checks.

## Measured
| Scope | Before | After |
|---|---|---|
| `test_full_workflow.py` + `test_session_persistence.py` (local) | 123s | **2.8s** |
| Local subset (unit+integration+e2e, minus mcp) serial | 176s | — |
| Same subset with `-n 4` | — | **59s** |
| Slowest single CI test | 63s | sub-second |

## Checks passed
- [x] ruff lint
- [x] ruff format
- [x] mypy (changed files)
- [x] pytest: 3,659 passed on tests/e2e + tests/unit/cli + tests/unit/orchestrator; broader local run 10,340 passed. The only failures are 6 pre-existing local-config-leak tests (`test_surface` ×4, `test_auto_runtime_dispatch` ×2) — verified failing identically on clean `main`.
- [x] Verified with a subprocess-spy plugin that no claude/opencode processes are spawned by the suite after the change.

## Test plan
- `tests/unit/mcp` + `tests/integration/mcp` were not run locally (known constraint); **this PR's CI run is the first xdist pass over them** — watch for parallel-safety flakes there.
- Follow-up worth filing: production dependency-analysis LLM call has no timeout on some backends (opencode `timeout=None`), so a wedged CLI hangs `execute_seed` indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)