### PR TITLE
docs: ratify Symposium as a deliberation contract

### DIFF
--- a/docs/agentos/issue-sequencing-graph.md
+++ b/docs/agentos/issue-sequencing-graph.md
@@ -4,6 +4,13 @@
 
 Snapshot: 2026-05-29 18:40 KST.
 
+Post-snapshot correction (2026-07-13): #813 remains the canonical open
+Symposium deliberation RFC. Issues #814-#819 are closed; #814, #815, #816, and
+#819 were folded into #813, while #817 and #818 closed separately. The canonical
+closeout contract is `docs/rfc/symposium-deliberation.md`. Any graph or table
+below that previously treated those child issues as active is superseded by this
+correction.
+
 This document is a point-in-time triage view for the AgentOS issue set. It is
 not a new source of truth. GitHub issues, especially #961 and #1256, remain the
 normative records. Use this page to see which recently merged PRs resolved
@@ -65,11 +72,11 @@ flowchart TD
     D --> I518["#518 AgentProcess lifecycle"]
     D --> I614["#614 external guidance contract"]
     D --> I615["#615 reasoning budget policy"]
-    D --> I813["#813 Symposium primitive"]
-    I813 --> I814["#814 verdict envelope"]
-    I813 --> I815["#815 stateful debate policy"]
-    I813 --> I816["#816 evaluate consensus migration"]
-    I813 --> I819["#819 persistent transcript"]
+    D --> I813["#813 open: Symposium deliberation RFC"]
+    I813 --> I814["#814 closed/folded: verdict envelope"]
+    I813 --> I815["#815 closed/folded: membership policy"]
+    I813 --> I816["#816 closed/folded: evaluate migration question"]
+    I813 --> I819["#819 closed/folded: transcript policy"]
     D --> I831["#831 interview MCP hang watchlist"]
     D --> I1139["#1139 Pi runtime bridge"]
     D --> I1239["#1239 reference-aware interviews"]
@@ -84,8 +91,8 @@ flowchart TD
     class LegendMeta,I961,I1157,I1256 meta
     class LegendOpen,I1254,I1258,I1170,I1263,I1234,I939 open
     class LegendMerged,A1282,B1260,B1281,B1284,B1286,B1289,B1290,C1276,C1277 merged
-    class LegendClosed,A920,A925,A960,B1257,C946,C956 closed
-    class LegendBacklog,I518,I614,I615,I813,I814,I815,I816,I819,I831,I1139,I1239 backlog
+    class LegendClosed,A920,A925,A960,B1257,C946,C956,I814,I815,I816,I819 closed
+    class LegendBacklog,I518,I614,I615,I813,I831,I1139,I1239 backlog
     class A,B,C,D track
 ```
 
@@ -202,11 +209,11 @@ uv run pytest tests/unit/auto/test_pipeline_partial_product_terminal.py \
 | #518 | D | Long-lived AgentProcess lifecycle design item. | Keep for later runtime lifecycle planning. |
 | #614 | D | External guidance contract design item. | Define project/user skill guidance boundaries. |
 | #615 | D | Runtime reasoning budget policy design item. | Define budget/cognitive-effort policy and enforcement surface. |
-| #813 | D | Symposium primitive RFC. | Pick naming/envelope/adoption plan before child migration. |
-| #814 | D | Child of Symposium-style dispatch direction. | Standardize verdict envelope after #813 direction. |
-| #815 | D | Debate-pool policy question. | Decide whether stateful agents may join debates. |
-| #816 | D | Needs-info migration from score average to debate. | Revisit after #813/#814 policy is accepted. |
-| #819 | D | Persistent transcript for multi-persona debate. | Revisit after the debate primitive is accepted. |
+| #813 | D | Open Symposium deliberation RFC. | Ratify `docs/rfc/symposium-deliberation.md`, refresh folded-history references, then close the issue. |
+| #814 | D | Closed/folded output-envelope design history. | Use `docs/rfc/verdict-envelope-v1.md`; open fresh adapter issues after #813 acceptance. |
+| #815 | D | Closed/folded membership-policy history. | Lateral remains stateless-only; named typed panels own stateful roles. |
+| #816 | D | Closed/folded evaluate-migration question. | Do not migrate execution without a reproduced failure and measurable success criterion. |
+| #819 | D | Closed/folded transcript-policy history. | V1 persistence stays off; any opt-in storage requires a fresh issue. |
 | #831 | D | Watchlist, not an active release blocker. #834/#837/#972 added contract hygiene and diagnostics, but the original trace likely crossed into Claude Code/SDK behavior. | Do not spend more harness-engineering effort unless it reproduces again on the supported MCP interview path; disclose or reopen as active only on a fresh failure. |
 | #1139 | D | Pi support via runtime bridge. | Keep as integration design work, separate from release readiness. |
 | #1239 | D | Reference-aware interview adapters RFC. | Define adapter/glossary provenance contract before implementation. |
@@ -225,6 +232,8 @@ uv run pytest tests/unit/auto/test_pipeline_partial_product_terminal.py \
    - Remaining #939 hook dispatch, permissions, and audit slices.
 5. Keep Track D as a deliberate design backlog. It should not block the current
    AgentOS release-readiness lane unless #961 reclassifies one of those issues.
+   Close #813 when the canonical Symposium RFC is ratified; do not revive its
+   folded child issue numbers for implementation.
    For #831 specifically, prefer watchlist/disclosure over more harness work
    unless a fresh supported-path hang reproduces.
 

--- a/docs/agentos/release-readiness.md
+++ b/docs/agentos/release-readiness.md
@@ -23,6 +23,12 @@ Snapshot used for this pass:
   available baseline is the local `main` snapshot above, where `origin/main`
   resolves to the same commit.
 
+Post-snapshot correction (2026-07-13): #813 is the only open canonical issue in
+the Symposium cluster. Issues #814-#819 are closed; #814, #815, #816, and #819
+were folded into #813, while #817 and #818 closed separately. References below
+that classified those children as open are superseded by this correction and
+the folded-history rows added in this update.
+
 ## Canonical Issue Review Method
 
 This pass reviewed the release-relevant canonical representatives rather than
@@ -34,7 +40,8 @@ duplicating #961 as implementation work. The relevant set is:
   #1170, #1234, #1254, #1256, #1263, #579, #637, #640, #673, #674, #678, #688,
   #692.
 - Linked current/future canonical issues: #518, #573, #575, #614, #615, #725,
-  #813, #814, #815, #816, #817, #818, #819, #831, #578, #1139, #1239.
+  #813, #831, #578, #1139, #1239.
+- Closed/folded deliberation history: #814, #815, #816, #817, #818, #819.
 
 For each issue, the tables below record current status, release impact, and
 release disposition. Closed or folded child issues are reviewed separately in
@@ -64,9 +71,9 @@ scan recorded for this snapshot.
 | Open Track C canonical representatives | #925, #939, #946, #960 | These are the open surviving AgentOS substrate surfaces: long-running runtime reliability, plugin permissions/audit, projection vocabulary, and HITL approval authority. |
 | `ooo auto` canonical authority | #772, #1157, #1170 | #772 is the older tactical epic, #1157 is the current `ooo auto` SSOT sibling to #961, and #1170 is the minimal canonical acceptance-test slice used as release evidence. |
 | `ooo auto` open child/follow-up issues | #1234, #1254, #1256, #1263, #579, #637, #640, #673, #674, #678, #688, #692 | These are the open child or follow-up items that can affect retry/resume truthfulness, mandatory MCP dispatch, provenance, packaged-skill integration, Product-or-Die policy, and product-completion claims. |
-| Linked open canonical/design issues | #518, #573, #575, #614, #615, #725, #813, #814, #815, #816, #817, #818, #819, #831, #578, #1139, #1239 | These are linked canonical or design issues that remain open but are not release-critical unless #961, #1157, or verification promotes a narrow failing slice. |
+| Linked open canonical/design issues | #518, #573, #575, #614, #615, #725, #813, #831, #578, #1139, #1239 | These are linked canonical or design issues that remain open but are not release-critical unless #961, #1157, or verification promotes a narrow failing slice. |
 
-Open issue count in this release-readiness inventory: 38, excluding PR gates
+Open issue count in this release-readiness inventory: 32, excluding PR gates
 and closed/folded issues. The direct live checks also showed #920 and #956 as
 closed even though they remain canonical historical representatives in #961, so
 they stay in the folded/evidence tables rather than the open enumeration above.
@@ -77,8 +84,8 @@ they stay in the folded/evidence tables rather than the open enumeration above.
 | #961 canonical Track C representatives | #830, #892, #920, #925, #939, #946, #956, #960 | Canonical AgentOS substrate surfaces from #961. Open representatives feed release slices; closed representatives provide verification context only. |
 | Open `ooo auto` authority and child/follow-up issues | #772, #1157, #1170, #1234, #1254, #1256, #1263, #579, #637, #640, #673, #674, #678, #688, #692 | Product and runtime-completion lane. Release triage prioritizes truthful resume/retry, mandatory MCP dispatch, grounding/provenance, and documented policy gates. |
 | Closed/folded `ooo auto` RFC authority | #809 | Strategic RFC context only; accepted work is represented by current `auto` code and open authority/child issues above. |
-| Other open linked canonical/design issues | #518, #573, #575, #614, #615, #725, #813, #814, #815, #816, #817, #818, #819, #831, #578, #1139, #1239 | Keep as current-next or design/future depending on release-path risk; do not promote broad design work unless #961 or a concrete regression requires it. |
-| Closed/folded Track C children from #961 | #921-#924, #930-#938, #940-#945, #947-#955, #957-#959, #963-#968 | Reviewed through #961 closure/fold table; each maps to an active home and creates no duplicate release work. |
+| Other open linked canonical/design issues | #518, #573, #575, #614, #615, #725, #813, #831, #578, #1139, #1239 | Keep as current-next or design/future depending on release-path risk; do not promote broad design work unless #961 or a concrete regression requires it. |
+| Closed/folded linked issues | #814-#819, #921-#924, #930-#938, #940-#945, #947-#955, #957-#959, #963-#968 | Reviewed through their canonical owners; each creates no duplicate release work. |
 
 ## Duplicate And Overlap Register
 
@@ -100,7 +107,7 @@ multiple issue numbers.
 | Plugin permission/audit contract vs plugin ecosystem management | #939 for release contract; #725 for ecosystem manager design | #934, #949 | Release readiness checks core plugin lifecycle, permission, hook, and audit invariants under #939. #725 remains a future UserLevel plugin-manager surface. |
 | HITL authority vs projection/plugin/pre-mutation safety | #960 | #942, #955, #958 | HITL WAIT/RESUME authority belongs to #960. Projection and plugin issues can expose or respect the state, but must not define new authority semantics. |
 | Runtime profile, guidance provenance, and effort policy | #573 for profile vocabulary; #614/#615 for future policy | #923 | #923 was folded into these design parents. Keep profile docs/tests separate from external-guidance and reasoning-budget policy work. |
-| Multi-agent deliberation and interview lateral-review backlog | #813-#819 as design backlog | #924, #817 | #924 folded into the debate backlog. #817 is the interview recovery/lateral-review member of that backlog, not a release blocker unless #961 or #1157 promotes it. |
+| Multi-agent deliberation and interview lateral-review RFC | #813 | #814-#819, #924 | #813 is the open RFC owner. The other issue numbers are closed/folded history and create no release implementation work. |
 | Backend/adapter expansion outside the AgentOS release core | Future integration owners | #1139, #1239, #692 | These are adjacent integration/product incidents, not duplicates of the AgentOS substrate gate. Keep them out of release-critical slices unless current docs or behavior depend on them. |
 
 Release triage rule: when a new failure appears in an overlap cluster, attach
@@ -142,7 +149,7 @@ edges. It separates three kinds of blockers:
 | #830/#978 -> verifier/evidence semantics | Evidence schema, retry routing, and TraceGuard-style acceptance semantics own verdict meaning. | #1234, #946 verdict display, #956 schema refs. | Code blocker if verifier tests fail | Projection and IR may reference evidence; they must not redefine acceptance policy. |
 | #960 -> HITL approval authority | WAIT/RESUME and approval authority must stay under the HITL contract. | #942, #955, #958, plugin/pre-mutation safety surfaces. | Code blocker if advertised HITL authority fails | Keep broader HITL persistence/resume as P1/P2 unless release docs over-promise it. |
 | #573/#614/#615 -> runtime policy vocabulary | Profile taxonomy, external guidance provenance, and reasoning-budget policy remain design gates. | #923 and future runtime policy work. | Policy/design blocker | Do not promote to release code work while locked docs/tests remain coherent. |
-| #813-#819 -> deliberation/lateral-review backlog | Symposium/debate/lateral-review work is not on the current AgentOS release path. | #924, #817. | Policy/design blocker | Keep as design backlog unless #961 or #1157 promotes a concrete advertised-path bug. |
+| #813 -> deliberation/lateral-review RFC | Symposium/debate/lateral-review work is not on the current AgentOS release path. | Closed history: #814-#819, #924. | Policy/design blocker | Keep #813 as the design owner until its RFC closes; folded issues create no release work. |
 | #1139/#1239/#692 -> adjacent integration/product incidents | Backend expansion, interview adapter enhancement, and Discord gateway incident work are outside the core release gate. | Related docs or future product slices only. | Scope dependency | Do not block AgentOS readiness unless current release docs or behavior depend on them. |
 
 ### Dependency rollup by release bucket
@@ -152,8 +159,8 @@ edges. It separates three kinds of blockers:
 | External gates | #961, #1279, #1280, #1258 | Only release-critical remaining blockers identified in this snapshot if verification passes. |
 | Independent current-next surfaces | #925, #939, #946, #960 | Can proceed independently; none should wait for `ooo auto` throughput or Product-or-Die policy decisions. |
 | `ooo auto` product chain | #1157, #1170, #1234, #1254, #579, #637, #640, #673, #674, #678, #688, #692 | Governed by #1157; #1258 blocks stronger throughput claims; #637 and #1170 become code blockers only on reproduced verification failure. |
-| Policy/design-wait items | #1256, #1263, #518, #573, #575, #614, #615, #725, #813, #814, #815, #816, #817, #818, #819, #578, #1139, #1239 | Do not consume release implementation time unless owners promote a narrow slice or verification shows current behavior regressed. |
-| Evidence-only folded items | #830, #892, #920, #956, #809, plus the closed/folded Track C issues enumerated in the folded table below | Create no new dependency edges; they point at their active homes in the folded table below. |
+| Policy/design-wait items | #1256, #1263, #518, #573, #575, #614, #615, #725, #813, #578, #1139, #1239 | Do not consume release implementation time unless owners promote a narrow slice or verification shows current behavior regressed. |
+| Evidence-only folded items | #814-#819, #830, #892, #920, #956, #809, plus the closed/folded linked issues enumerated below | Create no new dependency edges; they point at their active homes in the folded table below. |
 
 Release-blocking conclusion for this snapshot: no unresolved local code
 dependency is known after triage. The remaining release blockers are external
@@ -198,13 +205,8 @@ green and release notes avoid over-claiming unsupported behavior.
 | #614 | Out of release implementation scope as external-guidance provenance policy. | Non-blocking policy/design-wait unless owners make it a release claim. |
 | #615 | Out of release implementation scope as reasoning-budget policy design. | Non-blocking policy/design-wait until a verifiable release contract is accepted. |
 | #725 | Out of release implementation scope as UserLevel plugin-manager ecosystem work. | Non-blocking design/future while #939 covers the core plugin contract gate. |
-| #813 | Out of release implementation scope as multi-agent deliberation backlog. | Non-blocking design/future unless #961 or #1157 promotes a narrow slice. |
-| #814 | Out of release implementation scope as multi-agent deliberation backlog. | Non-blocking design/future unless #961 or #1157 promotes a narrow slice. |
-| #815 | Out of release implementation scope as multi-agent deliberation backlog. | Non-blocking design/future unless #961 or #1157 promotes a narrow slice. |
-| #816 | Out of release implementation scope as multi-agent deliberation backlog. | Non-blocking design/future unless #961 or #1157 promotes a narrow slice. |
-| #817 | Out of release implementation scope as interview stagnation/lateral-review enhancement. | Non-blocking design/future unless advertised interview milestone behavior depends on it. |
-| #818 | Out of release implementation scope as multi-agent deliberation backlog. | Non-blocking design/future unless #961 or #1157 promotes a narrow slice. |
-| #819 | Out of release implementation scope as multi-agent deliberation backlog. | Non-blocking design/future unless #961 or #1157 promotes a narrow slice. |
+| #813 | Out of release implementation scope as the open Symposium deliberation RFC. | Non-blocking design/future until its RFC closes. |
+| #814-#819 | Closed/folded deliberation and lateral-review history. | Evidence-only; create fresh issues for any accepted implementation slice. |
 | #831 | In scope as the concrete malformed-turn MCP interview risk under #925. | Non-blocking current-next while the affected path is verified or disclosed; blocking code gate if a supported path hangs or returns unrecoverable malformed state. |
 | #578 | Out of release implementation scope as unified watchdog-control design. | Non-blocking design/future while current directive/watchdog verification passes. |
 | #1139 | Out of release implementation scope as future backend support. | Non-blocking unless release docs claim that backend as supported. |
@@ -447,8 +449,8 @@ Canonical priority rollup:
 | P0 external gate | #961, #1279, #1280, #1258 |
 | P0 code gate | None identified in the local snapshot; promote any failed verification-pack item here. |
 | P1 current-next | #925, #939, #946, #960, #1157, #1170, #1234, #1254, #579, #637, #640, #673, #674, #678, #688, #692, #831 |
-| P2 design/future | #772, #1256, #1263, #518, #573, #575, #614, #615, #725, #813, #814, #815, #816, #817, #818, #819, #578, #1139, #1239 |
-| Done/folded | #830, #892, #920, #956, #809, #921-#924, #930-#938, #940-#945, #947-#955, #957-#959, #963-#968 |
+| P2 design/future | #772, #1256, #1263, #518, #573, #575, #614, #615, #725, #813, #578, #1139, #1239 |
+| Done/folded | #814-#819, #830, #892, #920, #956, #809, #921-#924, #930-#938, #940-#945, #947-#955, #957-#959, #963-#968 |
 
 ### Mutually Exclusive Issue Classification
 
@@ -462,12 +464,12 @@ an issue belong to multiple categories in this snapshot.
 | P0 external gate | #961, #1279, #1280, #1258 | 4 |
 | P0 code gate | None identified in the local snapshot | 0 |
 | P1 current-next | #925, #939, #946, #960, #1157, #1170, #1234, #1254, #579, #637, #640, #673, #674, #678, #688, #692, #831 | 17 |
-| P2 design/future | #772, #1256, #1263, #518, #573, #575, #614, #615, #725, #813, #814, #815, #816, #817, #818, #819, #578, #1139, #1239 | 19 |
-| Done/folded | #830, #892, #920, #956, #809, #921, #922, #923, #924, #930, #931, #932, #933, #934, #935, #936, #937, #938, #940, #941, #942, #943, #944, #945, #947, #948, #949, #950, #951, #952, #953, #954, #955, #957, #958, #959, #963, #964, #965, #966, #967, #968 | 42 |
+| P2 design/future | #772, #1256, #1263, #518, #573, #575, #614, #615, #725, #813, #578, #1139, #1239 | 13 |
+| Done/folded | #814, #815, #816, #817, #818, #819, #830, #892, #920, #956, #809, #921, #922, #923, #924, #930, #931, #932, #933, #934, #935, #936, #937, #938, #940, #941, #942, #943, #944, #945, #947, #948, #949, #950, #951, #952, #953, #954, #955, #957, #958, #959, #963, #964, #965, #966, #967, #968 | 48 |
 
-Classification invariant for this snapshot: the table assigns 82 total items
-with no duplicate assignments. The open issue inventory is 38 issues excluding
-PR gates and closed/folded issues; adding the 2 PR gates and 42 done/folded
+Classification invariant for this corrected snapshot: the table assigns 82 total items
+with no duplicate assignments. The open issue inventory is 32 issues excluding
+PR gates and closed/folded issues; adding the 2 PR gates and 48 done/folded
 items yields the 82-item release-readiness review set.
 
 ### Open Child / Canonical Classification Rationale
@@ -506,13 +508,7 @@ classification before tagging a release candidate.
 | #614 | P2 design/future | External guidance provenance is a policy/security design gate for future prompt guidance. | Promote only when owners make guidance provenance a release claim or current behavior depends on it. |
 | #615 | P2 design/future | Reasoning-budget policy is future runtime-cost governance, not a current code gate. | Promote only after policy acceptance defines a verifiable release contract. |
 | #725 | P2 design/future | UserLevel plugin manager expands ecosystem operations beyond the core #939 plugin contract. | Promote if #961 makes plugin-manager operations part of the release-supported surface. |
-| #813 | P2 design/future | Multi-agent deliberation backlog item outside the current AgentOS release path. | Promote only if #961 or #1157 selects a concrete deliberation slice. |
-| #814 | P2 design/future | Multi-agent deliberation backlog item outside the current AgentOS release path. | Promote only if #961 or #1157 selects a concrete deliberation slice. |
-| #815 | P2 design/future | Multi-agent deliberation backlog item outside the current AgentOS release path. | Promote only if #961 or #1157 selects a concrete deliberation slice. |
-| #816 | P2 design/future | Multi-agent deliberation backlog item outside the current AgentOS release path. | Promote only if #961 or #1157 selects a concrete deliberation slice. |
-| #817 | P2 design/future | Interview stagnation/lateral-review enhancement is useful UX/recovery work but not required for the current candidate. | Promote if an advertised interview milestone path depends on this enhancement. |
-| #818 | P2 design/future | Multi-agent deliberation backlog item outside the current AgentOS release path. | Promote only if #961 or #1157 selects a concrete deliberation slice. |
-| #819 | P2 design/future | Multi-agent deliberation backlog item outside the current AgentOS release path. | Promote only if #961 or #1157 selects a concrete deliberation slice. |
+| #813 | P2 design/future | Open Symposium deliberation RFC outside the current AgentOS release path. | Ratify `docs/rfc/symposium-deliberation.md`, close #813, and track accepted implementation slices in fresh issues. |
 | #831 | P1 current-next | Concrete malformed-turn MCP interview risk under #925; release-relevant for long-context MCP interview paths. | Promote to P0 code gate if the supported path hangs, returns malformed tool-use state, or cannot provide truthful recovery. |
 | #578 | P2 design/future | Unified watchdog controls are design context while current directive-mapping/runtime tests pass. | Promote if watchdog/directive verification regresses in a release-supported path. |
 | #1139 | P2 design/future | Future backend support is an optional integration surface, not a core AgentOS blocker. | Promote only if release docs claim this backend as supported. |
@@ -641,7 +637,7 @@ Current design-wait examples in this inventory:
 | #518, #575, #578 | Broader lifecycle, outbox, and watchdog-control design remains future work while current AgentProcess/watchdog verification passes. |
 | #573, #614, #615 | Runtime profile, external-guidance provenance, and reasoning-budget policy need accepted policy/design boundaries before release code slices. |
 | #725 | UserLevel plugin-manager work expands ecosystem management beyond the core #939 plugin contract gate. |
-| #813-#819 | Multi-agent deliberation and lateral-review backlog is not on the current AgentOS release path unless #961 or #1157 promotes a concrete bug. |
+| #813 | The open Symposium deliberation RFC is not on the current AgentOS release path. Closed issues #814-#819 are evidence-only history. |
 | #1139, #1239 | Future backend and interview-adapter enhancements are optional integration/product surfaces, not current release blockers. |
 
 ## Release-Critical Classification
@@ -724,13 +720,13 @@ reproduces the risk described in the rationale.
 | #614 | Non-critical | External guidance provenance is a future policy/security design gate. |
 | #615 | Non-critical | Reasoning-budget policy is future runtime policy work. |
 | #725 | Non-critical | UserLevel plugin manager is ecosystem roadmap work, separate from core plugin release contracts. |
-| #813 | Non-critical | Multi-agent deliberation backlog; not on the current AgentOS release path. |
-| #814 | Non-critical | Multi-agent deliberation backlog; not on the current AgentOS release path. |
-| #815 | Non-critical | Multi-agent deliberation backlog; not on the current AgentOS release path. |
-| #816 | Non-critical | Multi-agent deliberation backlog; not on the current AgentOS release path. |
-| #817 | Non-critical | Interview stagnation/lateral-review enhancement; not required unless advertised milestone behavior depends on it. |
-| #818 | Non-critical | Multi-agent deliberation backlog; not on the current AgentOS release path. |
-| #819 | Non-critical | Multi-agent deliberation backlog; not on the current AgentOS release path. |
+| #813 | Non-critical | Open Symposium deliberation RFC; not on the current AgentOS release path. |
+| #814 | Done/folded | Verdict-envelope design history folded into #813. |
+| #815 | Done/folded | Membership-policy design history folded into #813. |
+| #816 | Done/folded | Evaluate-migration design question folded into #813. |
+| #817 | Done/closed | Interview milestone lateral contract recorded separately. |
+| #818 | Done/closed | Inline-progress follow-up closed without release work. |
+| #819 | Done/folded | Transcript-policy design history folded into #813. |
 | #831 | Non-critical, conditional P0 if advertised path hangs | Malformed-turn MCP interview risk should be retested/disclosed, but is not a known current release blocker. |
 | #578 | Non-critical | Unified watchdog controls remain design context while current directive-mapping tests pass. |
 | #1139 | Non-critical | Future backend support, not a core AgentOS release blocker. |
@@ -738,7 +734,7 @@ reproduces the risk described in the rationale.
 | #921 | Non-critical | Closed/folded into active `ooo auto` authorities. |
 | #922 | Non-critical | Closed/folded into lifecycle/control parents. |
 | #923 | Non-critical | Closed/folded into runtime policy/design parents. |
-| #924 | Non-critical | Closed/folded into the multi-agent deliberation backlog. |
+| #924 | Non-critical | Closed/folded into the canonical #813 Symposium deliberation RFC. |
 | #930 | Non-critical | Closed/folded into #956 Workflow IR. |
 | #931 | Non-critical | Closed/folded into shipped #830 evidence substrate. |
 | #932 | Non-critical | Closed/folded into #946 projection readiness. |
@@ -789,8 +785,8 @@ candidate gate.
 | Conditional P0 code gate / P1 current-next | #946 | Projection/read-model work supports observability and recovery evidence. | Non-blocking while current projection docs/tests pass. Promote to P0 code gate only if release verification cannot reconstruct required Run/Stage/Step/Artifact/Verdict evidence. |
 | Conditional P0 code gate / P1 current-next | #960 | HITL approval authority is safety-relevant, but broader persistence/resume work is not fully advertised as release-complete. | Non-blocking with accurate docs. Promote to P0 code gate if release-supported approval, WAIT, or RESUME authority fails or docs over-claim unsupported behavior. |
 | Conditional P0 code gate / P1 current-next | #1157, #1170, #1234, #1254, #579, #637, #640, #673, #674, #678, #688, #692 | These are current `ooo auto` product, evidence, recovery, dispatch, provenance, and UX slices. | Non-blocking when documented gaps remain truthful and targeted verification passes. Promote the narrow failing child to P0 if canonical acceptance, mandatory MCP dispatch, EventStore provenance, resume/retry truthfulness, or packaged-skill controls regress. |
-| P2 design/future | #772, #1256, #1263, #518, #573, #575, #614, #615, #725, #813, #814, #815, #816, #817, #818, #819, #578, #1139, #1239 | These items either require product/architecture approval or expand future substrate, ecosystem, backend, policy, or deliberation capabilities beyond the current #961 candidate. | Not release-blocking unless #961 or an owner promotes a narrow release slice, or verification proves the current advertised behavior depends on the unresolved design. |
-| Done/folded evidence | #830, #892, #920, #956, #809, #921-#924, #930-#938, #940-#945, #947-#955, #957-#959, #963-#968 | These issues are closed, folded, or represented by active canonical owners and current tests/docs. | No direct release block. Use them as evidence/context only; reopen release work through the active owner or a reproduced candidate failure. |
+| P2 design/future | #772, #1256, #1263, #518, #573, #575, #614, #615, #725, #813, #578, #1139, #1239 | These items either require product/architecture approval or expand future substrate, ecosystem, backend, policy, or deliberation capabilities beyond the current #961 candidate. | Not release-blocking unless #961 or an owner promotes a narrow release slice, or verification proves the current advertised behavior depends on the unresolved design. |
+| Done/folded evidence | #814-#819, #830, #892, #920, #956, #809, #921-#924, #930-#938, #940-#945, #947-#955, #957-#959, #963-#968 | These issues are closed, folded, or represented by active canonical owners and current tests/docs. | No direct release block. Use them as evidence/context only; reopen release work through the active owner or a reproduced candidate failure. |
 
 ## Triage Summary: Owners And Next Actions
 
@@ -838,13 +834,13 @@ not create duplicate work.
 | #614 | Policy/security owner action: keep as future external guidance provenance design. |
 | #615 | Runtime policy owner action: keep as future reasoning-budget policy design. |
 | #725 | Plugin ecosystem owner action: keep as UserLevel plugin-manager roadmap work, separate from core plugin contract readiness. |
-| #813 | Design owner action: keep in the multi-agent deliberation backlog unless #961 or #1157 promotes it. |
-| #814 | Design owner action: keep in the multi-agent deliberation backlog unless #961 or #1157 promotes it. |
-| #815 | Design owner action: keep in the multi-agent deliberation backlog unless #961 or #1157 promotes it. |
-| #816 | Design owner action: keep in the multi-agent deliberation backlog unless #961 or #1157 promotes it. |
-| #817 | Interview UX/recovery owner action: keep as future stagnation/lateral-review work unless the advertised milestone path depends on it. |
-| #818 | Design owner action: keep in the multi-agent deliberation backlog unless #961 or #1157 promotes it. |
-| #819 | Design owner action: keep in the multi-agent deliberation backlog unless #961 or #1157 promotes it. |
+| #813 | Design owner action: ratify `docs/rfc/symposium-deliberation.md`, close #813, and open fresh issues for accepted implementation slices. |
+| #814 | No action; closed/folded verdict-envelope design history under #813. |
+| #815 | No action; closed/folded membership-policy design history under #813. |
+| #816 | No action; closed/folded evaluate-migration question under #813. |
+| #817 | No action; closed with the interview milestone lateral contract recorded in `docs/rfc/`. |
+| #818 | No action; closed without a release-critical implementation slice. |
+| #819 | No action; closed/folded transcript-policy design history under #813. |
 | #831 | Runtime UX owner action: retest or disclose the long-context MCP interview malformed-turn risk if that path remains in release scope. |
 | #578 | Runtime policy owner action: leave unified watchdog controls as design context while current directive mapping tests pass. |
 | #1139 | Integration owner action: keep as future backend support, not a core AgentOS release blocker. |
@@ -852,7 +848,7 @@ not create duplicate work.
 | #921 | No action; folded into #772 and #809. |
 | #922 | No action; folded into #518 and #575. |
 | #923 | No action; folded into #573, #614, and #615. |
-| #924 | No action; folded into #813-#819. |
+| #924 | No action; folded into the canonical #813 deliberation RFC. |
 | #930 | No action; folded into #956. |
 | #931 | No action; folded into shipped #830 substrate. |
 | #932 | No action; folded into #946. |
@@ -948,19 +944,13 @@ not create duplicate work.
 | #614 | Open external guidance contract design gate. | P2 design/future | Security/policy concern for future prompt guidance provenance; no release block for current local candidate. | Keep as policy/design. No local release code slice selected. |
 | #615 | Open reasoning budget / cognitive effort policy design gate. | P2 design/future | Runtime-cost policy concern for future agents; no release block for current candidate. | Keep as future runtime policy. No local release code slice selected. |
 | #725 | Open UserLevel plugin manager RFC/design parent. | P2 design/future | Plugin ecosystem readiness concern, separate from core plugin contract tests required for this release. | Related to plugin ecosystem operations, not core release readiness for this pass. |
-| #813 | Open/linked Symposium and debate design item. | P2 design/future | Multi-agent deliberation enhancement; no AgentOS release block unless #961 or #1157 promotes it to a concrete slice. | Keep in the design backlog. |
-| #814 | Open/linked Symposium and debate design item. | P2 design/future | Multi-agent deliberation enhancement; no AgentOS release block unless #961 or #1157 promotes it to a concrete slice. | Keep in the design backlog. |
-| #815 | Open/linked Symposium and debate design item. | P2 design/future | Multi-agent deliberation enhancement; no AgentOS release block unless #961 or #1157 promotes it to a concrete slice. | Keep in the design backlog. |
-| #816 | Open/linked Symposium and debate design item. | P2 design/future | Multi-agent deliberation enhancement; no AgentOS release block unless #961 or #1157 promotes it to a concrete slice. | Keep in the design backlog. |
-| #817 | Open/linked interview stagnation and lateral review design item. | P2 design/future | UX/recovery enhancement with existing advisory tests; no release block unless the affected interview milestone path is advertised as complete. | Keep in the design backlog. |
-| #818 | Open/linked Symposium and debate design item. | P2 design/future | Multi-agent deliberation enhancement; no AgentOS release block unless #961 or #1157 promotes it to a concrete slice. | Keep in the design backlog. |
-| #819 | Open/linked Symposium and debate design item. | P2 design/future | Multi-agent deliberation enhancement; no AgentOS release block unless #961 or #1157 promotes it to a concrete slice. | Keep in the design backlog. |
+| #813 | Open Symposium deliberation RFC. | P2 design/future | RFC closeout has no AgentOS release impact. | Ratify `docs/rfc/symposium-deliberation.md`, close #813, and use fresh issues for accepted implementation slices. |
 | #831 | Open MCP/interview malformed-turn UX bug referenced by #925. | P1 current-next | Runtime reliability and UX risk for long-context MCP interview paths; disclose or retest if that path is in release scope. | Document as the runtime reliability risk to revisit after release if the affected long-context MCP path remains in scope. |
 | #578 | Open RuntimeControls watchdog contract issue. | P2 design/future | Long-running stability context; current directive-mapping tests cover the release evidence slice. | Keep as design/future unless current watchdog/directive verification regresses. |
 | #1139 | Open future backend support item in the local inventory. | P2 design/future | Backend expansion only; no core AgentOS release block. | Integration enhancement, not a core AgentOS release blocker. |
 | #1239 | Open future interview adapter item in the local inventory. | P2 design/future | Interview adapter enhancement only; no release block for current candidate. | Product enhancement, not a release blocker. |
 
-### Closed/Folded Track C Issues From #961
+### Closed/Folded Linked Issues From #961
 
 These issues were reviewed through #961's closure table and should not create
 new release work. Their active home is the canonical representative listed in
@@ -968,10 +958,16 @@ new release work. Their active home is the canonical representative listed in
 
 | Issue | Current status | Priority | Release impact | Active home / disposition |
 | --- | --- | --- | --- | --- |
+| #814 | Closed/folded | Done/folded | No direct release impact; output-envelope design is preserved in `docs/rfc/verdict-envelope-v1.md`. | #813 Symposium deliberation RFC. |
+| #815 | Closed/folded | Done/folded | No direct release impact; membership policy is resolved by the #813 RFC. | #813 Symposium deliberation RFC. |
+| #816 | Closed/folded | Done/folded | No direct release impact; evaluate migration remains rejected without a separate evidence-backed issue. | #813 Symposium deliberation RFC. |
+| #817 | Closed | Done/folded | No direct release impact; the bounded interview milestone contract is recorded in `docs/rfc/interview-milestone-lateral-contract.md`. | Historical contract evidence. |
+| #818 | Closed | Done/folded | No direct release impact; no current release path depends on inline progress streaming. | Historical issue evidence. |
+| #819 | Closed/folded | Done/folded | No direct release impact; transcript persistence remains off by default in V1. | #813 Symposium deliberation RFC. |
 | #921 | Closed/folded | Done/folded | No direct release impact; covered by active `ooo auto` authorities. | #772 + #809 (`ooo auto` self-healing restatement). |
 | #922 | Closed/folded | Done/folded | No direct release impact; covered by lifecycle/control parents. | #518 + #575 (control/lifecycle restatement). |
 | #923 | Closed/folded | Done/folded | No direct release impact; covered by runtime policy/design parents. | #573 + #614 + #615 (runtime policy/replay input restatement). |
-| #924 | Closed/folded | Done/folded | No direct release impact; covered by the multi-agent deliberation design backlog. | #813-#819 (multi-agent deliberation restatement). |
+| #924 | Closed/folded | Done/folded | No direct release impact; covered by the canonical multi-agent deliberation RFC. | #813 (multi-agent deliberation restatement). |
 | #930 | Closed/folded | Done/folded | No direct release impact; Workflow IR evidence is under #956. | #956 (Workflow IR duplicate). |
 | #931 | Closed/folded | Done/folded | No direct release impact; typed evidence and retry routing are represented by shipped #830 substrate. | #830 typed evidence and retry routing already shipped. |
 | #932 | Closed/folded | Done/folded | No direct release impact; projection readiness is assessed through #946. | #946 RunSnapshot/safe-resume read model. |

--- a/docs/rfc/symposium-deliberation.md
+++ b/docs/rfc/symposium-deliberation.md
@@ -1,0 +1,240 @@
+# RFC: Symposium Deliberation Contract
+
+Issue: #813
+
+Status: Proposed closeout contract. This RFC resolves the design questions in
+#813 without changing runtime behavior.
+
+## Decision
+
+`Symposium` names a deliberation semantics layer. It does not rename or replace
+the generic subagent fan-out transport.
+
+The repository already has a transport contract in
+`src/ouroboros/mcp/tools/subagent.py`:
+
+- `build_fanout_subagents` builds independent payloads;
+- `stamp_fanout_meta` describes plugin-passive, host-driven, and sequential
+  dispatch;
+- `FanoutRegistry` records correlation state for result re-entry; and
+- `ouroboros_submit_fanout_results` returns correlated child outputs to the
+  caller.
+
+Those facilities answer how work is dispatched and correlated. Symposium
+answers a different set of questions: who participates, what they deliberate,
+how many rounds run, who synthesizes, and who owns the final decision.
+
+## Vocabulary
+
+| Term | Meaning | Current examples |
+| --- | --- | --- |
+| Fan-out transport | Dispatch and correlate N independent payloads. It defines no debate or verdict semantics. | `_subagents`, host-driven payloads, sequential payload processing |
+| Typed panel | N lanes with panel-specific outputs and deterministic aggregation or selection. Lanes do not become a general debate pool. | Interview question advisory, ambiguity scoring, question candidates, seed-closer tri-panel |
+| Symposium deliberation | Two or more members produce positions that may conflict, followed by an explicit synthesis and decision-ownership policy. | `ooo lateral` debate, Seed Reflect/user-adoption flow |
+| Evaluation consensus | Evaluation-specific voting or judgment over an artifact and acceptance contract. | `ConsensusEvaluator`, `DeliberativeConsensus` |
+
+These categories may share the fan-out transport without sharing semantics.
+Parallel execution alone does not make a surface a Symposium deliberation.
+
+## Canonical Request
+
+The semantic request is JSON-serializable:
+
+```json
+{
+  "schema_version": "symposium_request.v1",
+  "members": ["hacker", "architect"],
+  "topic": {
+    "problem_context": "The design has stalled.",
+    "current_approach": "Keep extending the current abstraction.",
+    "failed_attempts": ["Added another adapter layer"]
+  },
+  "rounds": 1,
+  "synthesis_mode": "host_recommendation",
+  "decision_owner": "user"
+}
+```
+
+### Field rules
+
+- `schema_version` is required and must be `symposium_request.v1`.
+- `members` is an ordered list of at least two unique member identifiers.
+  A single persona remains a solo lateral pass, not Symposium deliberation.
+- `topic.problem_context` and `topic.current_approach` are required non-empty
+  strings.
+- `topic.failed_attempts` is an optional ordered string list.
+- `rounds` is `1` or `2`; the default is `1`.
+- `rounds=2` runs one cross-attack round after the initial positions. It runs
+  only when the user or caller explicitly requests two rounds before dispatch.
+  V1 does not infer round escalation from free-text disagreement.
+- `synthesis_mode` is `host_recommendation` or `automatic_judge`.
+- `decision_owner` is `user` or `system`.
+- `synthesis_mode` and `decision_owner` are policy labels. They are not
+  transport keys and do not change `_subagents`, `dispatch_mode`,
+  `host_action`, or `result_correlation_key`.
+
+V1 supports these policy pairs:
+
+| Synthesis mode | Decision owner | Meaning |
+| --- | --- | --- |
+| `host_recommendation` | `user` | The host summarizes options, dissent, and a recommendation. The user owns the verdict. |
+| `automatic_judge` | `system` | A designated judge produces the terminal verdict under a subsystem-specific contract. |
+
+Other pairs require a later RFC revision.
+
+## Current Lateral Mapping
+
+`ouroboros_lateral_think` remains the current lateral prompt and dispatch
+surface. A future adoption slice maps its existing arguments without loss:
+
+| Current lateral input | Symposium request |
+| --- | --- |
+| `personas` | `members` |
+| `problem_context` | `topic.problem_context` |
+| `current_approach` | `topic.current_approach` |
+| `failed_attempts` | `topic.failed_attempts` |
+| `persona` | Solo lateral behavior; outside Symposium unless promoted to a request with at least two `members` |
+
+The current SKILL guidance may start a second cross-attack round when responses
+"diverge meaningfully." That heuristic is legacy, non-v1 behavior. This RFC
+does not change the SKILL. A fresh lateral-adoption issue must align the SKILL
+with the explicit `rounds` contract.
+
+## Canonical Result
+
+Symposium uses `VerdictEnvelopeV1` from
+`docs/rfc/verdict-envelope-v1.md`. It does not introduce another result
+envelope.
+
+For `host_recommendation + user`:
+
+- `status` is `DEFERRED`;
+- `verdict` is `null`;
+- `members` preserves request order;
+- `dissent` records material disagreements; and
+- a host recommendation, when present, belongs in
+  `metadata.recommendation`, not in `verdict`.
+
+For `automatic_judge + system`:
+
+- `status` is `PASS`, `FAIL`, or `BLOCKED` under the owning subsystem's
+  contract;
+- `verdict` contains the judge's synthesized conclusion; and
+- detailed votes or positions remain namespaced subsystem metadata.
+
+Current rendered text, `ConsensusResult`, `DeliberationResult`, Stage 3 events,
+and MCP metadata remain backward compatible until fresh adapter issues are
+implemented.
+
+## Membership Policy
+
+The `ooo lateral` debate pool remains the five stateless mindset personas:
+`hacker`, `researcher`, `simplifier`, `architect`, and `contrarian`.
+
+Stateful or workflow-owned roles do not join an ad hoc global debate pool in
+V1. They may participate in named typed panels only when that panel defines:
+
+- the role and required setup state;
+- the input and output schema;
+- whether the lane can vote or only advise;
+- side-effect and tool-call boundaries; and
+- deterministic aggregation or gating semantics.
+
+Allowing stateful roles to vote as generic Symposium members requires a later
+policy RFC.
+
+## Syntax Ownership
+
+Member and preset syntax stays at the SKILL/parser boundary:
+
+- `ooo lateral debate <p1> <p2> ...` remains the explicit member syntax;
+- `@all` remains an `unstuck` SKILL preset;
+- V1 does not add `+` member-join syntax because `+ouroboros lateral` is already
+  used as a tool-discovery cue; and
+- a shared parser is justified only after a second real grammar consumer needs
+  the same syntax.
+
+The transport layer receives normalized members and does not parse user-facing
+syntax.
+
+## Transcript Policy
+
+Transcript persistence is off by default in V1.
+
+- `transcript_ref` is `null` or absent when no transcript is persisted.
+- `FanoutRegistry` is correlation state, not transcript storage. It does not
+  satisfy replay, audit, privacy, or retrieval requirements.
+- A future opt-in implementation requires a fresh issue that defines project
+  locality, privacy/redaction, retention or TTL, purge behavior, and a retrieval
+  surface before storage code is added.
+
+## Adoption Matrix
+
+| Surface | Classification | Symposium action |
+| --- | --- | --- |
+| `ooo lateral` debate | Deliberation | V1 adoption target in a fresh issue |
+| Seed Reflect/user-adoption flow | Deliberation | Map to `host_recommendation + user`; no automatic verdict |
+| Interview milestone lateral review | Inherits lateral | Uses the lateral contract when it dispatches multiple personas |
+| Interview question advisory | Typed panel/fan-out | No Symposium adoption |
+| Ambiguity dimension panel | Typed panel/fan-out | No Symposium adoption |
+| Question candidate panel | Typed panel/fan-out | No Symposium adoption |
+| Seed-closer tri-panel | Typed panel/fan-out | No Symposium adoption |
+| `ConsensusEvaluator` | Voting consensus | Non-Symposium unless a later wrapper is justified |
+| `DeliberativeConsensus` | Existing standalone deliberation | Candidate for a result adapter only; no execution migration |
+| Auto single-persona lateral recovery | Solo lateral | Not Symposium |
+
+## Compatibility And Migration
+
+This RFC changes no runtime behavior.
+
+- Generic fan-out builders, dispatch metadata, and result re-entry remain the
+  transport source of truth.
+- `_subagent`, `_subagents`, host-driven payloads, sequential payloads, and the
+  lateral inline dispatch sentinel remain compatible.
+- `ConsensusResult`, `DeliberationResult`, Stage 3 events, and MCP rendered text
+  remain current public shapes until adapters are implemented.
+- Evaluation execution does not migrate to lateral debate. Any such proposal
+  must identify a reproducible failure in the current evaluator and a measurable
+  success criterion that justifies latency, cost, and reproducibility changes.
+
+## Fresh Follow-up Issues
+
+After this RFC is accepted, implementation work should be opened as new issues,
+not by reviving the folded issue numbers:
+
+1. Add the `VerdictEnvelopeV1` model/schema and compatibility adapters.
+2. Adopt the Symposium request/result contract in lateral debate, including
+   explicit round selection and synthesis emission.
+3. Add optional transcript storage and retrieval only after privacy, retention,
+   and purge policy is accepted.
+4. Add a `DeliberativeConsensus` output adapter if consumers need the standard
+   envelope.
+
+## Folded History
+
+Issues #814, #815, #816, and #819 were closed on 2026-06-07 and folded into
+#813. Issues #817 and #818 were also closed. They are design history and must
+not be treated as active implementation children.
+
+## Acceptance Criteria
+
+This RFC closes #813 when:
+
+1. `Symposium` is documented as deliberation semantics, not fan-out transport.
+2. The request schema, valid policy pairs, and current lateral mapping are
+   explicit.
+3. Round 2 is explicit-request-only in V1.
+4. `VerdictEnvelopeV1` is the only standard result envelope.
+5. The adoption matrix classifies current fan-out, panel, voting, and
+   deliberation surfaces.
+6. Membership, syntax, and transcript policies are explicit.
+7. Folded issues are historical and future implementation uses fresh issues.
+8. No runtime behavior or evaluation execution path is changed by this RFC.
+
+## Non-goals
+
+- Renaming or rewriting the generic fan-out transport.
+- Adding a global pool of stateful debate agents.
+- Migrating `evaluate` execution to Symposium without independent evidence.
+- Persisting transcripts in this RFC slice.
+- Replacing subsystem-specific detailed result models.

--- a/docs/rfc/verdict-envelope-v1.md
+++ b/docs/rfc/verdict-envelope-v1.md
@@ -1,9 +1,10 @@
 # Verdict Envelope v1
 
-Issue: #814
+Issue history: #814, closed and folded into #813 on 2026-06-07.
 
-Status: schema-first design RFC. This document fixes the multi-persona verdict
-output shape before subsystem adoption.
+Status: schema-first design RFC and output companion to
+`docs/rfc/symposium-deliberation.md`. This document fixes the multi-persona
+verdict output shape before subsystem adoption.
 
 ## Problem
 
@@ -42,7 +43,7 @@ or dataclass models in implementation PRs.
   ],
   "evidence_used": ["evt_123", "artifact_456"],
   "transcript_ref": "evt_transcript_789",
-  "follow_up_issue_refs": ["#1306"],
+  "follow_up_issue_refs": [],
   "metadata": {
     "source": "evaluation.stage3"
   }
@@ -60,7 +61,9 @@ Field rules:
 - `dissent` is optional and contains pairwise or topic-level disagreement.
 - `evidence_used` contains stable event IDs, artifact IDs, fact IDs, or handles
   that substantiate the verdict.
-- `transcript_ref` is optional until #819 provides durable transcript storage.
+- `transcript_ref` is optional and is `null` or absent by default. Any durable
+  transcript storage requires a fresh issue with explicit privacy, retention,
+  purge, and retrieval policy.
 - `follow_up_issue_refs` lists implementation issues opened from this design.
 - `metadata` is for subsystem-specific values that must not define verdict
   semantics.
@@ -78,19 +81,26 @@ Field rules:
 | MCP tool text outputs | `verdict` plus `metadata.rendered_text` | Text must stop being the semantic source of truth. |
 | MCP tool meta outputs | `metadata` | Existing meta can be preserved under namespaced keys. |
 
-## Follow-up Implementation Issues
+## Fresh Follow-up Implementation Issues
 
-- #814 follow-up A: add a shared `VerdictEnvelopeV1` model and JSON schema.
-- #814 follow-up B: adapt `ConsensusResult` / deliberative evaluation outputs
+- Add a shared `VerdictEnvelopeV1` model and JSON schema.
+- Adapt `ConsensusResult` / deliberative evaluation outputs
   to expose `VerdictEnvelopeV1`.
-- #814 follow-up C: emit `verdict_envelope` from Stage 3 evaluation events.
-- #814 follow-up D: add MCP tool result metadata for `verdict_envelope` while
+- Emit `verdict_envelope` from Stage 3 evaluation events.
+- Add MCP tool result metadata for `verdict_envelope` while
   preserving current rendered text for compatibility.
-- #1306: use typed verifier output and retry admission for TraceGuard-backed H1
-  deliver verdicts.
+
+These must be opened as fresh issues after #813 is accepted. The folded issue
+number #814 is historical and is not an active implementation tracker.
+
+## Existing Related History
+
+- #1306, now closed, tracked typed verifier output and retry admission for
+  TraceGuard-backed H1 deliver verdicts. It is evidence, not an active child of
+  #813 or #814.
 
 ## Non-goals
 
 - Do not require every user-facing response to auto-synthesize a verdict.
 - Do not replace subsystem-specific detailed result models.
-- Do not make transcript storage mandatory before #819.
+- Do not make transcript storage mandatory in V1.


### PR DESCRIPTION
## Summary

- Add `docs/rfc/symposium-deliberation.md` as the canonical #813 closeout contract.
- Define Symposium as deliberation semantics over the existing generic fan-out transport, with explicit request, result, membership, syntax, transcript, and adoption policies.
- Refresh the verdict-envelope RFC and AgentOS status documents so #814-#819 remain closed/folded history and future implementation uses fresh issues.
- Keep this PR documentation-only: no fan-out, lateral, SKILL, evaluation, or transcript runtime behavior changes.

## Test plan

- [x] `/Users/jh0927/ouroboros/.venv/bin/pytest tests/unit/mcp/tools/test_fanout_core.py tests/unit/mcp/tools/test_lateral_think_handler.py tests/unit/evaluation/test_consensus.py tests/unit/evaluation/test_models.py -q` — 104 passed
- [x] Parsed the JSON examples in both RFCs with `jq`
- [x] `git diff --check` and staged diff scope checks passed
- [x] Verified the commit contains only the four intended documentation files
- [ ] Full repository test suite not run because this PR changes documentation only

## Related issues

Closes #813
