### PR TITLE
feat(observability): report neutral execution frugality evidence

### DIFF
--- a/src/ouroboros/dashboard/board.py
+++ b/src/ouroboros/dashboard/board.py
@@ -19,6 +19,10 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
+from ouroboros.observability.frugality_retrospective import (
+    project_frugality_retrospective,
+)
+
 # Status columns, in board order. Node statuses map onto these directly
 # (verified distinct values: pending / executing / completed / failed); synonyms
 # from other emitters are normalized via ``_STATUS_ALIASES``.
@@ -340,6 +344,7 @@ def reduce_board(
         "provider": None,
         "total_tokens": 0.0,
         "frugality": None,
+        "frugality_retrospective": None,
     }
 
     for ev in events:
@@ -420,6 +425,11 @@ def reduce_board(
                 frugality["reason"] = str(reason)
             if frugality:
                 meta["frugality"] = frugality
+
+        elif event_type == "execution.frugality_retrospective.reported":
+            retrospective = project_frugality_retrospective(payload)
+            if retrospective is not None:
+                meta["frugality_retrospective"] = retrospective
 
         elif event_type == "workflow.progress.updated":
             if payload.get("completed_count") is not None:

--- a/src/ouroboros/dashboard_web/page.py
+++ b/src/ouroboros/dashboard_web/page.py
@@ -53,6 +53,7 @@ _PAGE_TEMPLATE = """<!doctype html>
   .tool { color: var(--executing); }
   .tok { color: var(--muted); }
   #m-frugality { color: var(--muted); }
+  #m-frugality-evidence { color: var(--muted); }
   .empty { color: var(--muted); font-size: 11px; padding: 8px 12px; }
   .st-pending  .col-head { color: var(--pending); }
   .st-executing .col-head { color: var(--executing); }
@@ -72,6 +73,7 @@ _PAGE_TEMPLATE = """<!doctype html>
   <span class="meta" id="m-phase"></span>
   <span class="meta" id="m-tokens"></span>
   <span class="meta" id="m-frugality"></span>
+  <span class="meta" id="m-frugality-evidence"></span>
   <div id="legend"></div>
 </header>
 <div id="board"></div>
@@ -113,6 +115,17 @@ function render(board) {
     ? "Frugality: " + fr.status
         + (fr.token_reduction_pct != null ? ` (${Number(fr.token_reduction_pct).toFixed(1)}% ↓)` : "")
         + (fr.reason ? " — " + String(fr.reason).slice(0, 80) : "")
+    : "";
+  const retro = meta.frugality_retrospective;
+  const retroParts = [];
+  if (retro && retro.retry_associated_attempts)
+    retroParts.push(`retry-associated ${fmtTokens(retro.retry_associated_tokens) || "0 tok"}`);
+  if (retro && retro.unaccepted_attempts)
+    retroParts.push(`unaccepted ${fmtTokens(retro.unaccepted_tokens) || "0 tok"}`);
+  if (retro)
+    retroParts.push(`coverage ${retro.measured_attempts} measured / ${retro.unknown_attempts} unknown / ${retro.invalid_attempts} invalid`);
+  document.getElementById("m-frugality-evidence").textContent = retro
+    ? "Evidence: " + retroParts.join(" · ")
     : "";
   // legend
   const legend = document.getElementById("legend");

--- a/src/ouroboros/dashboard_web/reader.py
+++ b/src/ouroboros/dashboard_web/reader.py
@@ -40,6 +40,7 @@ _RELEVANT_EVENT_TYPES: tuple[str, ...] = (
     "execution.ac.model_routed",
     "execution.ac.token_attribution.reported",
     "execution.frugality_proof.evaluated",
+    "execution.frugality_retrospective.reported",
 )
 
 

--- a/src/ouroboros/observability/frugality_retrospective.py
+++ b/src/ouroboros/observability/frugality_retrospective.py
@@ -1,0 +1,417 @@
+"""Neutral execution-finalized frugality evidence reporting.
+
+The v1 retrospective is deliberately evidence-only. It summarizes runtime token
+measurements associated with retries and latest unsuccessful AC outcomes, but it
+does not label either signal avoidable, non-contributory, or non-advancing spend.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from ouroboros.orchestrator.events import (
+    FRUGALITY_RETROSPECTIVE_EVENT_TYPE,
+    create_frugality_retrospective_event,
+)
+from ouroboros.orchestrator.evidence.common import (
+    event_data,
+    event_id,
+    event_type,
+    finite_number,
+    parse_retry_attempt,
+    parse_root_ac_index,
+    strict_bool,
+)
+from ouroboros.orchestrator.frugality_proof import (
+    EVENT_AC_OUTCOME_FINALIZED,
+    EVENT_DELIVER_VERDICT,
+    EVENT_EFFORT_ROUTED,
+    EVENT_MODEL_ROUTED,
+    EVENT_SHADOW_REPLAY,
+    EVENT_TOKEN_ATTRIBUTION,
+)
+
+if TYPE_CHECKING:
+    from ouroboros.persistence.event_store import EventStore
+
+RETROSPECTIVE_VERSION = "v1"
+RETROSPECTIVE_TRIGGER = "execution_finalized"
+HARD_FINAL_STATUSES = frozenset({"completed", "failed", "cancelled"})
+RETRY_ASSOCIATED_SPEND = "retry_associated_spend"
+UNACCEPTED_SPEND = "unaccepted_spend"
+_PROOF_EVENT_TYPE = "execution.frugality_proof.evaluated"
+_ATTEMPT_EVENT_TYPES = frozenset(
+    {
+        "execution.session.started",
+        "execution.session.resumed",
+        EVENT_EFFORT_ROUTED,
+        EVENT_MODEL_ROUTED,
+        EVENT_TOKEN_ATTRIBUTION,
+        EVENT_DELIVER_VERDICT,
+        EVENT_SHADOW_REPLAY,
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _AttemptKey:
+    unit_id: str
+    retry_attempt: int
+
+
+@dataclass(slots=True)
+class _AttemptEvidence:
+    root_ac_index: int | None = None
+    token_events: list[tuple[str | None, object]] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
+class _OutcomeEvidence:
+    root_ac_index: int
+    retry_attempt: int
+    success: bool
+    outcome: str
+    event_id: str | None
+
+
+def _non_empty_string(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def _unit_id(data: Mapping[str, object]) -> str | None:
+    return _non_empty_string(data.get("ac_id")) or _non_empty_string(data.get("node_id"))
+
+
+def _non_negative_int(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def _normalized_outcome(data: Mapping[str, object], *, success: bool) -> str | None:
+    raw = data.get("outcome")
+    if raw is None:
+        return "succeeded" if success else "failed"
+    return _non_empty_string(raw)
+
+
+def _attempt_key(data: Mapping[str, object]) -> _AttemptKey | None:
+    unit_id = _unit_id(data)
+    retry_attempt = parse_retry_attempt(data)
+    if unit_id is None or retry_attempt is None:
+        return None
+    return _AttemptKey(unit_id=unit_id, retry_attempt=retry_attempt)
+
+
+def _evidence_ids(values: Iterable[str | None]) -> list[str]:
+    return sorted({value for value in values if value})
+
+
+def _proof_reference(events: Iterable[object]) -> str | None:
+    for event in events:
+        if event_type(event) == _PROOF_EVENT_TYPE:
+            reference = event_id(event)
+            if reference is not None:
+                return reference
+    return None
+
+
+def build_frugality_retrospective(
+    events: Iterable[object],
+    *,
+    execution_id: str,
+    session_id: str,
+    terminal_status: str,
+) -> dict[str, Any] | None:
+    """Build the v1 evidence payload for one hard-finalized execution."""
+    if terminal_status not in HARD_FINAL_STATUSES:
+        return None
+
+    event_list = list(events)
+    attempts: dict[_AttemptKey, _AttemptEvidence] = {}
+    invalid_attempt_keys: set[_AttemptKey] = set()
+    anonymous_invalid_attempts: set[str] = set()
+    outcomes_by_root: dict[int, dict[int, list[_OutcomeEvidence]]] = {}
+    outcome_attempts_seen: dict[int, set[int]] = {}
+    invalid_outcome_attempts: set[tuple[int, int]] = set()
+    invalid_outcome_roots: set[int] = set()
+
+    for position, event in enumerate(event_list):
+        current_type = event_type(event)
+        data = event_data(event)
+        current_id = event_id(event)
+        invalid_identity = current_id or f"event-{position}"
+
+        if current_type in _ATTEMPT_EVENT_TYPES:
+            key = _attempt_key(data)
+            if key is None:
+                if current_type == EVENT_TOKEN_ATTRIBUTION or _unit_id(data) is not None:
+                    anonymous_invalid_attempts.add(invalid_identity)
+                continue
+            attempt = attempts.setdefault(key, _AttemptEvidence())
+            root_ac_index = parse_root_ac_index(data)
+            if root_ac_index is not None:
+                if attempt.root_ac_index is None:
+                    attempt.root_ac_index = root_ac_index
+                elif attempt.root_ac_index != root_ac_index:
+                    invalid_attempt_keys.add(key)
+            if current_type == EVENT_TOKEN_ATTRIBUTION:
+                attempt.token_events.append((current_id, data.get("token_spend")))
+            continue
+
+        if current_type != EVENT_AC_OUTCOME_FINALIZED:
+            continue
+
+        root_ac_index = parse_root_ac_index(data)
+        retry_attempt = parse_retry_attempt(data)
+        success = strict_bool(data.get("success"))
+        outcome = _normalized_outcome(data, success=success) if success is not None else None
+        if root_ac_index is None:
+            anonymous_invalid_attempts.add(invalid_identity)
+            continue
+        if retry_attempt is None:
+            invalid_outcome_roots.add(root_ac_index)
+            anonymous_invalid_attempts.add(invalid_identity)
+            continue
+        outcome_attempts_seen.setdefault(root_ac_index, set()).add(retry_attempt)
+        if success is None or outcome is None:
+            invalid_outcome_attempts.add((root_ac_index, retry_attempt))
+            continue
+        outcomes_by_root.setdefault(root_ac_index, {}).setdefault(retry_attempt, []).append(
+            _OutcomeEvidence(
+                root_ac_index=root_ac_index,
+                retry_attempt=retry_attempt,
+                success=success,
+                outcome=outcome,
+                event_id=current_id,
+            )
+        )
+
+    measured: dict[_AttemptKey, tuple[float, str | None]] = {}
+    unknown_attempt_keys: set[_AttemptKey] = set()
+    for key, attempt in attempts.items():
+        if key in invalid_attempt_keys:
+            continue
+        if not attempt.token_events:
+            unknown_attempt_keys.add(key)
+            continue
+        if len(attempt.token_events) > 1:
+            invalid_attempt_keys.add(key)
+            continue
+        token_event_id, raw_spend = attempt.token_events[0]
+        if raw_spend is None:
+            unknown_attempt_keys.add(key)
+            continue
+        spend = finite_number(raw_spend)
+        if spend is None or spend < 0:
+            invalid_attempt_keys.add(key)
+            continue
+        measured[key] = (spend, token_event_id)
+
+    latest_outcomes: dict[int, _OutcomeEvidence] = {}
+    for root_ac_index, attempts_seen in outcome_attempts_seen.items():
+        latest_attempt = max(attempts_seen)
+        records = outcomes_by_root.get(root_ac_index, {}).get(latest_attempt, [])
+        if (
+            root_ac_index in invalid_outcome_roots
+            or (root_ac_index, latest_attempt) in invalid_outcome_attempts
+            or len(records) != 1
+        ):
+            invalid_outcome_attempts.add((root_ac_index, latest_attempt))
+            continue
+        latest_outcomes[root_ac_index] = records[0]
+
+    retry_keys: set[_AttemptKey] = set()
+    retry_latest_attempts: list[int] = []
+    for unit_id in {key.unit_id for key in attempts}:
+        unit_attempts = [key for key in attempts if key.unit_id == unit_id]
+        latest_attempt = max(key.retry_attempt for key in unit_attempts)
+        contributing = {
+            key for key in unit_attempts if key.retry_attempt < latest_attempt and key in measured
+        }
+        if contributing:
+            retry_latest_attempts.append(latest_attempt)
+            retry_keys.update(contributing)
+
+    retry_token_spend = sum(measured[key][0] for key in retry_keys)
+    retry_event_ids = _evidence_ids(measured[key][1] for key in retry_keys)
+
+    unaccepted_roots = {
+        root_ac_index: outcome
+        for root_ac_index, outcome in latest_outcomes.items()
+        if not outcome.success
+    }
+    unaccepted_keys = {
+        key
+        for key, attempt in attempts.items()
+        if key in measured
+        and attempt.root_ac_index is not None
+        and attempt.root_ac_index in unaccepted_roots
+    }
+    unaccepted_token_spend = sum(measured[key][0] for key in unaccepted_keys)
+    unaccepted_event_ids = _evidence_ids(
+        [
+            *(measured[key][1] for key in unaccepted_keys),
+            *(outcome.event_id for outcome in unaccepted_roots.values()),
+        ]
+    )
+    outcome_labels = {outcome.outcome for outcome in unaccepted_roots.values()}
+    latest_outcome = (
+        next(iter(outcome_labels))
+        if len(outcome_labels) == 1
+        else ("mixed" if outcome_labels else None)
+    )
+
+    signals: list[dict[str, Any]] = []
+    if retry_keys:
+        signals.append(
+            {
+                "name": RETRY_ASSOCIATED_SPEND,
+                "token_spend": retry_token_spend,
+                "attempt_count": len(retry_keys),
+                "latest_attempt_index": max(retry_latest_attempts),
+                "evidence_event_ids": retry_event_ids,
+            }
+        )
+    if unaccepted_keys:
+        signals.append(
+            {
+                "name": UNACCEPTED_SPEND,
+                "token_spend": unaccepted_token_spend,
+                "attempt_count": len(unaccepted_keys),
+                "latest_outcome": latest_outcome,
+                "evidence_event_ids": unaccepted_event_ids,
+            }
+        )
+
+    invalid_count = (
+        len(invalid_attempt_keys) + len(anonymous_invalid_attempts) + len(invalid_outcome_attempts)
+    )
+    payload: dict[str, Any] = {
+        "execution_id": execution_id,
+        "session_id": session_id,
+        "retrospective_version": RETROSPECTIVE_VERSION,
+        "trigger": RETROSPECTIVE_TRIGGER,
+        "terminal_status": terminal_status,
+        "evidence_only": True,
+        "coverage": {
+            "measured_attempts": len(measured),
+            "unknown_attempts": len(unknown_attempt_keys),
+            "invalid_attempts": invalid_count,
+            "total_measured_tokens": sum(
+                (spend for spend, _event_id in measured.values()),
+                0.0,
+            ),
+        },
+        "evidence_signals": signals,
+    }
+    proof_reference = _proof_reference(event_list)
+    if proof_reference is not None:
+        payload["proof_reference"] = proof_reference
+    return payload
+
+
+async def report_frugality_retrospective(
+    event_store: EventStore,
+    *,
+    execution_id: str,
+    session_id: str,
+    terminal_status: str,
+) -> bool:
+    """Persist the report once for a hard-finalized execution.
+
+    ``paused`` returns before touching the EventStore, so it neither emits nor
+    consumes execution-scoped deduplication. The deterministic event id protects
+    against a concurrent duplicate append after the replay-based check.
+    """
+    if terminal_status not in HARD_FINAL_STATUSES:
+        return False
+    events = await event_store.query_execution_related_events(execution_id, limit=None)
+    if any(event_type(event) == FRUGALITY_RETROSPECTIVE_EVENT_TYPE for event in events):
+        return False
+    payload = build_frugality_retrospective(
+        events,
+        execution_id=execution_id,
+        session_id=session_id,
+        terminal_status=terminal_status,
+    )
+    if payload is None:
+        return False
+    await event_store.append(create_frugality_retrospective_event(execution_id, payload))
+    return True
+
+
+def project_frugality_retrospective(payload: Mapping[str, object]) -> dict[str, Any] | None:
+    """Validate and normalize the v1 payload for web/TUI read models."""
+    if (
+        payload.get("retrospective_version") != RETROSPECTIVE_VERSION
+        or payload.get("trigger") != RETROSPECTIVE_TRIGGER
+        or payload.get("terminal_status") not in HARD_FINAL_STATUSES
+        or strict_bool(payload.get("evidence_only")) is not True
+    ):
+        return None
+    coverage = payload.get("coverage")
+    signals = payload.get("evidence_signals")
+    if not isinstance(coverage, Mapping) or not isinstance(signals, (list, tuple)):
+        return None
+    measured_attempts = _non_negative_int(coverage.get("measured_attempts"))
+    unknown_attempts = _non_negative_int(coverage.get("unknown_attempts"))
+    invalid_attempts = _non_negative_int(coverage.get("invalid_attempts"))
+    total_measured_tokens = finite_number(coverage.get("total_measured_tokens"))
+    if (
+        measured_attempts is None
+        or unknown_attempts is None
+        or invalid_attempts is None
+        or total_measured_tokens is None
+        or total_measured_tokens < 0
+    ):
+        return None
+
+    projected_signals: dict[str, dict[str, Any]] = {}
+    for signal in signals:
+        if not isinstance(signal, Mapping):
+            return None
+        name = signal.get("name")
+        if name not in {RETRY_ASSOCIATED_SPEND, UNACCEPTED_SPEND}:
+            return None
+        normalized_name = str(name)
+        if normalized_name in projected_signals:
+            return None
+        token_spend = finite_number(signal.get("token_spend"))
+        attempt_count = _non_negative_int(signal.get("attempt_count"))
+        if token_spend is None or token_spend < 0 or attempt_count is None:
+            return None
+        projected_signals[normalized_name] = {
+            "token_spend": token_spend,
+            "attempt_count": attempt_count,
+        }
+
+    retry = projected_signals.get(RETRY_ASSOCIATED_SPEND, {})
+    unaccepted = projected_signals.get(UNACCEPTED_SPEND, {})
+    return {
+        "terminal_status": str(payload["terminal_status"]),
+        "measured_attempts": measured_attempts,
+        "unknown_attempts": unknown_attempts,
+        "invalid_attempts": invalid_attempts,
+        "total_measured_tokens": total_measured_tokens,
+        "retry_associated_tokens": retry.get("token_spend", 0.0),
+        "retry_associated_attempts": retry.get("attempt_count", 0),
+        "unaccepted_tokens": unaccepted.get("token_spend", 0.0),
+        "unaccepted_attempts": unaccepted.get("attempt_count", 0),
+    }
+
+
+__all__ = [
+    "HARD_FINAL_STATUSES",
+    "RETROSPECTIVE_TRIGGER",
+    "RETROSPECTIVE_VERSION",
+    "RETRY_ASSOCIATED_SPEND",
+    "UNACCEPTED_SPEND",
+    "build_frugality_retrospective",
+    "project_frugality_retrospective",
+    "report_frugality_retrospective",
+]

--- a/src/ouroboros/orchestrator/events.py
+++ b/src/ouroboros/orchestrator/events.py
@@ -21,10 +21,13 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from typing import Any
+from uuid import NAMESPACE_URL, uuid5
 
 from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator.capabilities import CapabilityDescriptor, CapabilityGraph
 from ouroboros.orchestrator.policy import PolicyContext, PolicyDecision
+
+FRUGALITY_RETROSPECTIVE_EVENT_TYPE = "execution.frugality_retrospective.reported"
 
 
 def create_session_started_event(
@@ -667,10 +670,30 @@ def create_execution_terminal_event(
     )
 
 
+def create_frugality_retrospective_event(
+    execution_id: str,
+    data: dict[str, Any],
+) -> BaseEvent:
+    """Create the deterministic v1 execution-finalized frugality evidence event."""
+    event_id = uuid5(
+        NAMESPACE_URL,
+        f"ouroboros:{FRUGALITY_RETROSPECTIVE_EVENT_TYPE}:v1:{execution_id}",
+    )
+    return BaseEvent(
+        id=str(event_id),
+        type=FRUGALITY_RETROSPECTIVE_EVENT_TYPE,
+        aggregate_type="execution",
+        aggregate_id=execution_id,
+        data=data,
+    )
+
+
 __all__ = [
+    "FRUGALITY_RETROSPECTIVE_EVENT_TYPE",
     "create_ac_stall_detected_event",
     "create_drift_measured_event",
     "create_execution_terminal_event",
+    "create_frugality_retrospective_event",
     "create_heartbeat_event",
     "create_mcp_tools_loaded_event",
     "create_policy_capabilities_evaluated_event",

--- a/src/ouroboros/orchestrator/evidence/common.py
+++ b/src/ouroboros/orchestrator/evidence/common.py
@@ -2,7 +2,77 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+import math
+
 _MAX_LEAF_RESULT_CHARS = 1200
+
+
+def finite_number(value: object) -> float | None:
+    """Return a finite numeric value, rejecting booleans and malformed inputs."""
+    if value is None or isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    try:
+        number = float(value)
+    except (OverflowError, TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def strict_bool(value: object) -> bool | None:
+    """Return a real boolean without applying truthiness coercion."""
+    return value if isinstance(value, bool) else None
+
+
+def event_type(event: object) -> str | None:
+    """Read an event type from mapping-style or object-style events."""
+    if isinstance(event, Mapping):
+        value = event.get("type") or event.get("event_type")
+    else:
+        value = getattr(event, "type", None) or getattr(event, "event_type", None)
+    return value if isinstance(value, str) else None
+
+
+def event_data(event: object) -> Mapping[str, object]:
+    """Read an event payload from mapping-style or object-style events."""
+    if isinstance(event, Mapping):
+        data = event.get("data") or event.get("payload") or {}
+    else:
+        data = getattr(event, "data", None) or getattr(event, "payload", None) or {}
+    return data if isinstance(data, Mapping) else {}
+
+
+def event_id(event: object) -> str | None:
+    """Read a non-empty event identifier from mapping- or object-style events."""
+    value = event.get("id") if isinstance(event, Mapping) else getattr(event, "id", None)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def execution_run_anchor(data: Mapping[str, object]) -> str | None:
+    """Return the persisted run anchor shared by execution evidence events."""
+    run = data.get("seed_run_id") or data.get("execution_id")
+    return str(run) if run is not None else None
+
+
+def parse_retry_attempt(data: Mapping[str, object]) -> int | None:
+    """Parse the required zero-based retry identity without defaulting missing data."""
+    if "retry_attempt" not in data:
+        return None
+    value = data.get("retry_attempt")
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        return None
+    return value
+
+
+def parse_root_ac_index(data: Mapping[str, object]) -> int | None:
+    """Return the first valid zero-based root AC index from the evidence aliases."""
+    for key in ("root_ac_index", "parent_ac_index", "ac_index"):
+        value = data.get(key)
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
+    return None
 
 
 def _flatten_evidence_values(value: object) -> tuple[str, ...]:

--- a/src/ouroboros/orchestrator/frugality_proof.py
+++ b/src/ouroboros/orchestrator/frugality_proof.py
@@ -40,36 +40,23 @@ from dataclasses import dataclass, field
 from enum import StrEnum
 import math
 
-
-def _finite_number(value: object) -> float | None:
-    """Return ``value`` as a finite float, or ``None`` if it is not a usable number.
-
-    Rejects ``None``, booleans (``True``/``False`` are ints in Python but are never
-    a valid token measurement), non-numeric types, and non-finite floats (NaN/inf).
-    The deterministic proof is fed by event payloads from not-yet-wired producers, so
-    a malformed measurement must be treated as *missing*, never silently trusted.
-    """
-    if value is None or isinstance(value, bool) or not isinstance(value, (int, float)):
-        return None
-    try:
-        f = float(value)
-    except (OverflowError, TypeError, ValueError):
-        return None
-    return f if math.isfinite(f) else None
-
-
-def _strict_bool(value: object) -> bool | None:
-    """Return ``value`` only if it is a real boolean, else ``None``.
-
-    Proof-admission flags (``is_decomposed_child``, ``decomposition_trustworthy``,
-    ``grounding_regression``) must never be derived via Python truthiness: a JSON
-    boolean deserializes to ``bool``, but a malformed string payload like
-    ``"false"`` would coerce to ``True`` under ``bool("false")`` and flip an
-    admission flag the wrong way. Anything that is not already a ``bool`` is treated
-    as unknown so the caller can fail safe (exclude the row) rather than admit it.
-    """
-    return value if isinstance(value, bool) else None
-
+from ouroboros.orchestrator.evidence.common import (
+    event_data as _event_data,
+)
+from ouroboros.orchestrator.evidence.common import (
+    event_type as _event_type,
+)
+from ouroboros.orchestrator.evidence.common import (
+    execution_run_anchor,
+    parse_retry_attempt,
+    parse_root_ac_index,
+)
+from ouroboros.orchestrator.evidence.common import (
+    finite_number as _finite_number,
+)
+from ouroboros.orchestrator.evidence.common import (
+    strict_bool as _strict_bool,
+)
 
 # -- Event-type contract the producers must emit -----------------------------
 EVENT_EFFORT_ROUTED = "execution.ac.effort_routed"
@@ -224,20 +211,6 @@ class ProofVerdict:
         return self.status is ProofStatus.PASS
 
 
-def _event_type(event: object) -> str | None:
-    if isinstance(event, Mapping):
-        return event.get("type") or event.get("event_type")
-    return getattr(event, "type", None) or getattr(event, "event_type", None)
-
-
-def _event_data(event: object) -> Mapping:
-    if isinstance(event, Mapping):
-        data = event.get("data") or event.get("payload") or {}
-    else:
-        data = getattr(event, "data", None) or getattr(event, "payload", None) or {}
-    return data if isinstance(data, Mapping) else {}
-
-
 def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
     """Join the per-axis events into one triad row per ``(run, ac_id)``.
 
@@ -269,30 +242,8 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
     ] = {}
     finalized_invalid: set[tuple[str | None, int]] = set()
 
-    def run_anchor(data: Mapping) -> str | None:
-        run = data.get("seed_run_id") or data.get("execution_id")
-        return str(run) if run is not None else None
-
-    def retry_attempt(data: Mapping) -> int | None:
-        # Retry identity is part of the proof schema, not an optional legacy
-        # convenience. Defaulting a missing field to attempt zero lets malformed
-        # events pair with a real final marker and manufacture a complete row.
-        if "retry_attempt" not in data:
-            return None
-        value = data.get("retry_attempt")
-        if isinstance(value, bool) or not isinstance(value, int) or value < 0:
-            return None
-        return value
-
-    def root_ac_index(data: Mapping) -> int | None:
-        for key in ("root_ac_index", "parent_ac_index", "ac_index"):
-            value = data.get(key)
-            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
-                return value
-        return None
-
     def merge_root(row: dict, data: Mapping) -> None:
-        observed = root_ac_index(data)
+        observed = parse_root_ac_index(data)
         if observed is None:
             return
         current = row.get("root_ac_index")
@@ -316,16 +267,16 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
         ac_id = data.get("ac_id")
         if not ac_id:
             return None
-        run_key = run_anchor(data)
+        run_key = execution_run_anchor(data)
         return acc.setdefault((run_key, str(ac_id)), {"ac_id": str(ac_id), "seed_run_id": run_key})
 
     for event in events:
         etype = _event_type(event)
         data = _event_data(event)
         if etype == EVENT_AC_OUTCOME_FINALIZED:
-            run_key = run_anchor(data)
-            root_index = root_ac_index(data)
-            attempt = retry_attempt(data)
+            run_key = execution_run_anchor(data)
+            root_index = parse_root_ac_index(data)
+            attempt = parse_retry_attempt(data)
             success = _strict_bool(data.get("success"))
             is_decomposed = _strict_bool(data.get("is_decomposed"))
             if root_index is None:
@@ -359,7 +310,7 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
                 continue
             merge_root(row, data)
             merge_decomposed(row, data)
-            attempt = retry_attempt(data)
+            attempt = parse_retry_attempt(data)
             if attempt is None:
                 row["model_invalid"] = True
                 continue
@@ -386,7 +337,7 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
             if row is None:
                 continue
             merge_root(row, data)
-            attempt = retry_attempt(data)
+            attempt = parse_retry_attempt(data)
             # One logical AC may emit one attribution event per retry/resume
             # attempt. Spend is cumulative across those attempts, and EventStore
             # query order is newest-first, so replacement would both undercount
@@ -411,7 +362,7 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
             if row is None:
                 continue
             merge_root(row, data)
-            attempt = retry_attempt(data)
+            attempt = parse_retry_attempt(data)
             verdict = data.get("traceguard_verdict")
             claim_rate = _finite_number(data.get("unsupported_claim_rate"))
             grounding = _strict_bool(data.get("grounding_regression"))
@@ -444,7 +395,7 @@ def assemble_triads(events: Iterable[object]) -> list[FrugalityTriadRow]:
             if row is None:
                 continue
             merge_root(row, data)
-            attempt = retry_attempt(data)
+            attempt = parse_retry_attempt(data)
             baseline = _finite_number(data.get("baseline_token_spend"))
             baseline_mode = data.get("baseline_mode")
             baseline_tier = data.get("baseline_tier")

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -893,6 +893,41 @@ class OrchestratorRunner:
                 error=str(exc),
             )
 
+    async def _report_frugality_retrospective(
+        self,
+        *,
+        execution_id: str,
+        session_id: str,
+        terminal_status: str,
+    ) -> bool:
+        """Best-effort execution-finalized evidence reporting.
+
+        The reporter itself returns before querying on ``paused``. Keeping this
+        wrapper best-effort preserves the observability-only contract: persistence
+        or projection failures never change execution success, routing, or retry
+        behavior.
+        """
+        from ouroboros.observability.frugality_retrospective import (
+            report_frugality_retrospective,
+        )
+
+        try:
+            return await report_frugality_retrospective(
+                self._event_store,
+                execution_id=execution_id,
+                session_id=session_id,
+                terminal_status=terminal_status,
+            )
+        except Exception as exc:
+            log.warning(
+                "orchestrator.runner.frugality_retrospective.report_failed",
+                execution_id=execution_id,
+                session_id=session_id,
+                terminal_status=terminal_status,
+                error=str(exc),
+            )
+            return False
+
     async def _frugality_proof_cohort(
         self,
         execution_id: str,
@@ -3016,6 +3051,12 @@ class OrchestratorRunner:
                 )
             )
 
+        await self._report_frugality_retrospective(
+            execution_id=execution_id,
+            session_id=session_id,
+            terminal_status="cancelled",
+        )
+
         log.info(
             "orchestrator.runner.session_cancelled_directly",
             execution_id=execution_id,
@@ -3311,6 +3352,11 @@ class OrchestratorRunner:
                         messages_processed=messages_processed,
                     )
                 )
+            await self._report_frugality_retrospective(
+                execution_id=execution_id,
+                session_id=session_id,
+                terminal_status=terminal_status.value,
+            )
             return Result.ok(
                 OrchestratorResult(
                     success=terminal_status == SessionStatus.COMPLETED,
@@ -3344,6 +3390,11 @@ class OrchestratorRunner:
                 error_message="Execution cancelled by external request",
                 messages_processed=messages_processed,
             )
+        )
+        await self._report_frugality_retrospective(
+            execution_id=execution_id,
+            session_id=session_id,
+            terminal_status="cancelled",
         )
 
         # Display cancellation notice
@@ -3985,6 +4036,12 @@ class OrchestratorRunner:
             # Deterministic frugality proof over this execution's per-AC triads.
             # Honestly INSUFFICIENT_DATA until the shadow-replay baseline exists.
             await self._evaluate_frugality_proof(exec_id)
+            if terminal_status in {"completed", "failed", "cancelled"}:
+                await self._report_frugality_retrospective(
+                    execution_id=exec_id,
+                    session_id=tracker.session_id,
+                    terminal_status=terminal_status,
+                )
 
             log.info(
                 "orchestrator.runner.execute_completed",
@@ -4060,6 +4117,11 @@ class OrchestratorRunner:
                     error_message=str(e),
                     messages_processed=messages_processed,
                 )
+            )
+            await self._report_frugality_retrospective(
+                execution_id=exec_id,
+                session_id=tracker.session_id,
+                terminal_status="failed",
             )
 
             return Result.err(
@@ -4402,6 +4464,12 @@ class OrchestratorRunner:
         # Deterministic frugality proof over this execution's per-AC triads.
         # Honestly INSUFFICIENT_DATA until the shadow-replay baseline exists.
         await self._evaluate_frugality_proof(exec_id)
+        if terminal_status in {"completed", "failed", "cancelled"}:
+            await self._report_frugality_retrospective(
+                execution_id=exec_id,
+                session_id=tracker.session_id,
+                terminal_status=terminal_status,
+            )
 
         log.info(
             "orchestrator.runner.parallel_completed",
@@ -4841,6 +4909,12 @@ Note: This is a resumed session. Please continue from where execution was interr
             # Deterministic frugality proof over this execution's per-AC triads.
             # Honestly INSUFFICIENT_DATA until the shadow-replay baseline exists.
             await self._evaluate_frugality_proof(tracker.execution_id)
+            if terminal_status in {"completed", "failed", "cancelled"}:
+                await self._report_frugality_retrospective(
+                    execution_id=tracker.execution_id,
+                    session_id=session_id,
+                    terminal_status=terminal_status,
+                )
 
             log.info(
                 "orchestrator.runner.resume_completed",
@@ -4888,6 +4962,11 @@ Note: This is a resumed session. Please continue from where execution was interr
                     status="failed",
                     error_message=str(e),
                 )
+            )
+            await self._report_frugality_retrospective(
+                execution_id=tracker.execution_id,
+                session_id=session_id,
+                terminal_status="failed",
             )
 
             return Result.err(

--- a/src/ouroboros/tui/app.py
+++ b/src/ouroboros/tui/app.py
@@ -27,6 +27,7 @@ from ouroboros.tui.events import (
     DriftUpdated,
     ExecutionUpdated,
     FrugalityProofEvaluated,
+    FrugalityRetrospectiveReported,
     LogMessage,
     PauseRequested,
     PhaseChanged,
@@ -37,6 +38,7 @@ from ouroboros.tui.events import (
     TUIState,
     WorkflowProgressUpdated,
     create_message_from_event,
+    format_frugality_retrospective_summary,
     format_frugality_summary,
 )
 from ouroboros.tui.screens import (
@@ -576,6 +578,8 @@ class OuroborosTUI(App[None]):
         self._state.tokens_by_node.clear()
         self._state.run_total_tokens = 0.0
         self._state.frugality_summary = None
+        self._state.frugality_retrospective = None
+        self._state.frugality_retrospective_summary = None
         self._state.add_log("info", "tui.main", f"Monitoring execution: {execution_id}")
         # Forward to logs screen
         try:
@@ -768,6 +772,18 @@ class OuroborosTUI(App[None]):
                 message.status, message.token_reduction_pct
             )
         self._forward_to_dashboard("on_frugality_proof_evaluated", message)
+
+    def on_frugality_retrospective_reported(
+        self,
+        message: FrugalityRetrospectiveReported,
+    ) -> None:
+        """Fold the execution-finalized evidence report once for live display."""
+        if self._state.frugality_retrospective is None:
+            self._state.frugality_retrospective = dict(message.summary)
+            self._state.frugality_retrospective_summary = format_frugality_retrospective_summary(
+                message.summary
+            )
+        self._forward_to_dashboard("on_frugality_retrospective_reported", message)
 
     def on_workflow_progress_updated(self, message: WorkflowProgressUpdated) -> None:
         # Update state with AC tree from workflow progress (smart merge)

--- a/src/ouroboros/tui/events.py
+++ b/src/ouroboros/tui/events.py
@@ -23,6 +23,10 @@ from typing import TYPE_CHECKING, Any
 
 from textual.message import Message
 
+from ouroboros.observability.frugality_retrospective import (
+    project_frugality_retrospective,
+)
+
 if TYPE_CHECKING:
     from ouroboros.events.base import BaseEvent
 
@@ -629,6 +633,15 @@ class FrugalityProofEvaluated(Message):
         self.reason = reason
 
 
+class FrugalityRetrospectiveReported(Message):
+    """Neutral execution-finalized frugality evidence summary."""
+
+    def __init__(self, execution_id: str, summary: dict[str, Any]) -> None:
+        super().__init__()
+        self.execution_id = execution_id
+        self.summary = dict(summary)
+
+
 # =============================================================================
 # Event Subscription State
 # =============================================================================
@@ -693,6 +706,8 @@ class TUIState:
     tokens_by_node: dict[str, float] = field(default_factory=dict)
     run_total_tokens: float = 0.0
     frugality_summary: str | None = None
+    frugality_retrospective: dict[str, Any] | None = None
+    frugality_retrospective_summary: str | None = None
 
     # P1: Tool/thinking tracking for dashboard
     active_tools: dict[str, dict[str, str]] = field(default_factory=dict)
@@ -1036,6 +1051,20 @@ def create_message_from_event(event: BaseEvent) -> Message | None:
             reason=data.get("reason") if isinstance(data.get("reason"), str) else "",
         )
 
+    elif event_type == "execution.frugality_retrospective.reported":
+        summary = project_frugality_retrospective(data)
+        if summary is None:
+            return None
+        execution_id = data.get("execution_id")
+        return FrugalityRetrospectiveReported(
+            execution_id=(
+                execution_id
+                if isinstance(execution_id, str) and execution_id
+                else event.aggregate_id
+            ),
+            summary=summary,
+        )
+
     # Return None for unhandled event types
     return None
 
@@ -1069,6 +1098,33 @@ def format_frugality_summary(
     return f"⚖ {label}"
 
 
+def _format_evidence_tokens(value: object) -> str:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return "0 tok"
+    tokens = float(value)
+    if tokens >= 1000:
+        return f"{tokens / 1000:.1f}".rstrip("0").rstrip(".") + "k tok"
+    return f"{tokens:.0f} tok"
+
+
+def format_frugality_retrospective_summary(summary: dict[str, Any]) -> str:
+    """Return one neutral evidence line for the execution-finalized report."""
+    parts: list[str] = []
+    if summary.get("retry_associated_attempts"):
+        parts.append(
+            "retry-associated " + _format_evidence_tokens(summary.get("retry_associated_tokens"))
+        )
+    if summary.get("unaccepted_attempts"):
+        parts.append("unaccepted " + _format_evidence_tokens(summary.get("unaccepted_tokens")))
+    parts.append(
+        "coverage "
+        f"{summary.get('measured_attempts', 0)} measured/"
+        f"{summary.get('unknown_attempts', 0)} unknown/"
+        f"{summary.get('invalid_attempts', 0)} invalid"
+    )
+    return "Evidence: " + " | ".join(parts)
+
+
 __all__ = [
     "ACModelRouted",
     "ACTokenAttribution",
@@ -1078,6 +1134,7 @@ __all__ = [
     "DriftUpdated",
     "ExecutionUpdated",
     "FrugalityProofEvaluated",
+    "FrugalityRetrospectiveReported",
     "GenerationSelected",
     "LineageSelected",
     "LogMessage",
@@ -1092,5 +1149,6 @@ __all__ = [
     "ToolCallStarted",
     "WorkflowProgressUpdated",
     "create_message_from_event",
+    "format_frugality_retrospective_summary",
     "format_frugality_summary",
 ]

--- a/src/ouroboros/tui/screens/dashboard_v3.py
+++ b/src/ouroboros/tui/screens/dashboard_v3.py
@@ -48,6 +48,7 @@ from ouroboros.tui.events import (
     DriftUpdated,
     ExecutionUpdated,
     FrugalityProofEvaluated,
+    FrugalityRetrospectiveReported,
     ParallelBatchCompleted,
     ParallelBatchStarted,
     PauseRequested,
@@ -57,6 +58,7 @@ from ouroboros.tui.events import (
     ToolCallCompleted,
     ToolCallStarted,
     WorkflowProgressUpdated,
+    format_frugality_retrospective_summary,
     format_frugality_summary,
 )
 
@@ -846,27 +848,47 @@ class DashboardScreenV3(Screen[None]):
                 self._phase_bar.progress_text = "  ".join(parts) + verdict
 
     def _frugality_verdict_suffix(self) -> str:
-        """Return the ``⚖`` frugality verdict already on the bar, as an appendable suffix.
-
-        Lets a live progress refresh rebuild the counter without dropping a
-        run-end verdict that landed earlier (the ``⚖`` glyph marks its start).
-        """
-        if self._phase_bar is None:
+        """Return the run-end proof and retrospective summaries as one suffix."""
+        if self._state is None:
             return ""
-        current = self._phase_bar.progress_text
-        marker = current.find("⚖")
-        return f"  {current[marker:]}" if marker >= 0 else ""
+        summaries = [
+            self._state.frugality_summary,
+            self._state.frugality_retrospective_summary,
+        ]
+        rendered = [summary for summary in summaries if summary]
+        return f"  {'  '.join(rendered)}" if rendered else ""
+
+    @staticmethod
+    def _strip_frugality_suffix(value: str) -> str:
+        markers = [
+            position for marker in ("⚖", "Evidence:") if (position := value.find(marker)) >= 0
+        ]
+        return value[: min(markers)].rstrip() if markers else value.rstrip()
 
     def on_frugality_proof_evaluated(self, message: FrugalityProofEvaluated) -> None:
         """Append the one-line run-end frugality verdict to the phase bar."""
         if self._phase_bar is None:
             return
         line = format_frugality_summary(message.status, message.token_reduction_pct)
-        base = self._phase_bar.progress_text
-        marker = base.find("⚖")
-        if marker >= 0:
-            base = base[:marker].rstrip()
-        self._phase_bar.progress_text = f"{base}  {line}" if base else line
+        base = self._strip_frugality_suffix(self._phase_bar.progress_text)
+        retrospective = (
+            self._state.frugality_retrospective_summary if self._state is not None else None
+        )
+        suffix = "  ".join(item for item in (line, retrospective) if item)
+        self._phase_bar.progress_text = f"{base}  {suffix}" if base else suffix
+
+    def on_frugality_retrospective_reported(
+        self,
+        message: FrugalityRetrospectiveReported,
+    ) -> None:
+        """Append the neutral execution-finalized evidence line to the phase bar."""
+        if self._phase_bar is None:
+            return
+        line = format_frugality_retrospective_summary(message.summary)
+        base = self._strip_frugality_suffix(self._phase_bar.progress_text)
+        proof = self._state.frugality_summary if self._state is not None else None
+        suffix = "  ".join(item for item in (proof, line) if item)
+        self._phase_bar.progress_text = f"{base}  {suffix}" if base else suffix
 
     def on_subtask_updated(self, message: SubtaskUpdated) -> None:
         """Handle sub-task updates.

--- a/tests/unit/dashboard/test_board_shared.py
+++ b/tests/unit/dashboard/test_board_shared.py
@@ -19,6 +19,10 @@ from ouroboros.dashboard.board import (
 )
 from ouroboros.events.base import BaseEvent
 from ouroboros.tui.app import OuroborosTUI
+from ouroboros.tui.events import (
+    FrugalityRetrospectiveReported,
+    create_message_from_event,
+)
 
 # A fixed, mixed-provider run: a run-level backend (claude) plus one worker that
 # ran on codex_cli. ac_1 must resolve to its per-worker provider; ac_2 has no
@@ -255,6 +259,50 @@ class TestTelemetryFoldAgreement:
         assert ledger.model_by_node == {}
         assert ledger.tokens_by_node == {}
         assert ledger.total_tokens == 0.0
+
+    def test_web_reduce_and_tui_incremental_fold_agree_on_retrospective(self) -> None:
+        payload = {
+            "execution_id": "exec_1",
+            "session_id": "sess_1",
+            "retrospective_version": "v1",
+            "trigger": "execution_finalized",
+            "terminal_status": "completed",
+            "evidence_only": True,
+            "coverage": {
+                "measured_attempts": 2,
+                "unknown_attempts": 1,
+                "invalid_attempts": 0,
+                "total_measured_tokens": 150.0,
+            },
+            "evidence_signals": [
+                {
+                    "name": "retry_associated_spend",
+                    "token_spend": 100.0,
+                    "attempt_count": 1,
+                }
+            ],
+        }
+        board = reduce_board(
+            [
+                {
+                    "event_type": "execution.frugality_retrospective.reported",
+                    "payload": payload,
+                }
+            ],
+            execution_id="exec_1",
+        )
+        event = BaseEvent(
+            type="execution.frugality_retrospective.reported",
+            aggregate_type="execution",
+            aggregate_id="exec_1",
+            data=payload,
+        )
+        message = create_message_from_event(event)
+        assert isinstance(message, FrugalityRetrospectiveReported)
+        app = OuroborosTUI(execution_id="exec_1")
+        app.on_frugality_retrospective_reported(message)
+
+        assert app.state.frugality_retrospective == board["meta"]["frugality_retrospective"]
 
 
 class TestProviderIdentityReachesTui:

--- a/tests/unit/dashboard_web/test_kanban.py
+++ b/tests/unit/dashboard_web/test_kanban.py
@@ -335,6 +335,66 @@ class TestFrugalityTelemetry:
         )
         assert board["meta"]["frugality"] == {"status": "proven", "reason": "ok"}
 
+    def test_frugality_retrospective_summary_reaches_meta(self) -> None:
+        board = reduce_board(
+            [
+                _ev(
+                    "execution.frugality_retrospective.reported",
+                    retrospective_version="v1",
+                    trigger="execution_finalized",
+                    terminal_status="failed",
+                    evidence_only=True,
+                    coverage={
+                        "measured_attempts": 3,
+                        "unknown_attempts": 1,
+                        "invalid_attempts": 0,
+                        "total_measured_tokens": 250.0,
+                    },
+                    evidence_signals=[
+                        {
+                            "name": "retry_associated_spend",
+                            "token_spend": 100.0,
+                            "attempt_count": 1,
+                        },
+                        {
+                            "name": "unaccepted_spend",
+                            "token_spend": 150.0,
+                            "attempt_count": 2,
+                        },
+                    ],
+                )
+            ]
+        )
+
+        assert board["meta"]["frugality_retrospective"] == {
+            "terminal_status": "failed",
+            "measured_attempts": 3,
+            "unknown_attempts": 1,
+            "invalid_attempts": 0,
+            "total_measured_tokens": 250.0,
+            "retry_associated_tokens": 100.0,
+            "retry_associated_attempts": 1,
+            "unaccepted_tokens": 150.0,
+            "unaccepted_attempts": 2,
+        }
+
+    def test_frugality_retrospective_malformed_payload_is_omitted(self) -> None:
+        board = reduce_board(
+            [
+                _ev(
+                    "execution.frugality_retrospective.reported",
+                    retrospective_version="v1",
+                    trigger="execution_finalized",
+                    terminal_status="paused",
+                    evidence_only=True,
+                    coverage={},
+                    evidence_signals=[],
+                )
+            ]
+        )
+
+        assert board["meta"]["frugality_retrospective"] is None
+
 
 class TestToolAndMeta:
     def test_tool_activity_attached_to_node(self) -> None:

--- a/tests/unit/dashboard_web/test_page.py
+++ b/tests/unit/dashboard_web/test_page.py
@@ -31,8 +31,12 @@ class TestLivePage:
         assert "fmtTokens" in INDEX_HTML
         assert "m-tokens" in INDEX_HTML
         assert "m-frugality" in INDEX_HTML
+        assert "m-frugality-evidence" in INDEX_HTML
         assert "c.model_tier" in INDEX_HTML
         assert "Frugality:" in INDEX_HTML
+        assert "retry-associated" in INDEX_HTML
+        assert "unaccepted" in INDEX_HTML
+        assert "coverage" in INDEX_HTML
 
     def test_index_html_polls_for_pending_run(self) -> None:
         # The daemon base URL is published before a run exists (auto flow links it
@@ -105,7 +109,19 @@ class TestStaticSnapshot:
 
     def test_static_snapshot_inlines_telemetry_fields(self) -> None:
         board = {
-            "meta": {"total_tokens": 1500.0, "frugality": {"status": "proven", "reason": "ok"}},
+            "meta": {
+                "total_tokens": 1500.0,
+                "frugality": {"status": "proven", "reason": "ok"},
+                "frugality_retrospective": {
+                    "measured_attempts": 2,
+                    "unknown_attempts": 0,
+                    "invalid_attempts": 0,
+                    "retry_associated_tokens": 500.0,
+                    "retry_associated_attempts": 1,
+                    "unaccepted_tokens": 0.0,
+                    "unaccepted_attempts": 0,
+                },
+            },
             "columns": {
                 "pending": [],
                 "executing": [
@@ -127,3 +143,5 @@ class TestStaticSnapshot:
         assert "model_tier" in html and "frugal" in html
         assert "1500" in html
         assert "proven" in html
+        assert "frugality_retrospective" in html
+        assert "retry_associated_tokens" in html

--- a/tests/unit/dashboard_web/test_reader_readonly_uri.py
+++ b/tests/unit/dashboard_web/test_reader_readonly_uri.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import sqlite3
 
-from ouroboros.dashboard_web.reader import _connect_readonly
+from ouroboros.dashboard_web.reader import _RELEVANT_EVENT_TYPES, _connect_readonly
 
 
 def _make_db(path) -> None:
@@ -47,3 +47,7 @@ def test_readonly_connect_is_actually_read_only(tmp_path) -> None:
         assert with_error
     finally:
         conn.close()
+
+
+def test_reader_includes_execution_frugality_retrospective() -> None:
+    assert "execution.frugality_retrospective.reported" in _RELEVANT_EVENT_TYPES

--- a/tests/unit/observability/test_frugality_retrospective.py
+++ b/tests/unit/observability/test_frugality_retrospective.py
@@ -1,0 +1,423 @@
+"""Execution-finalized frugality evidence reporting."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.observability.frugality_retrospective import (
+    RETRY_ASSOCIATED_SPEND,
+    UNACCEPTED_SPEND,
+    build_frugality_retrospective,
+    project_frugality_retrospective,
+    report_frugality_retrospective,
+)
+from ouroboros.orchestrator.events import (
+    FRUGALITY_RETROSPECTIVE_EVENT_TYPE,
+    create_frugality_retrospective_event,
+)
+from ouroboros.orchestrator.frugality_proof import (
+    EVENT_AC_OUTCOME_FINALIZED,
+    EVENT_MODEL_ROUTED,
+    EVENT_TOKEN_ATTRIBUTION,
+)
+from ouroboros.persistence.event_store import EventStore
+
+
+def _event(event_type: str, event_id: str, **data: Any) -> BaseEvent:
+    return BaseEvent(
+        id=event_id,
+        type=event_type,
+        aggregate_type="execution",
+        aggregate_id="exec-1",
+        data=data,
+    )
+
+
+def _token(
+    ac_id: str,
+    attempt: int,
+    spend: object = 10.0,
+    *,
+    root_ac_index: int = 0,
+    event_id: str | None = None,
+) -> BaseEvent:
+    data: dict[str, Any] = {
+        "execution_id": "exec-1",
+        "ac_id": ac_id,
+        "root_ac_index": root_ac_index,
+        "retry_attempt": attempt,
+        "token_spend": spend,
+    }
+    return _event(EVENT_TOKEN_ATTRIBUTION, event_id or f"tok-{ac_id}-{attempt}", **data)
+
+
+def _outcome(
+    attempt: int,
+    success: object,
+    *,
+    root_ac_index: int = 0,
+    outcome: object = "succeeded",
+    event_id: str | None = None,
+) -> BaseEvent:
+    return _event(
+        EVENT_AC_OUTCOME_FINALIZED,
+        event_id or f"out-{root_ac_index}-{attempt}",
+        execution_id="exec-1",
+        root_ac_index=root_ac_index,
+        retry_attempt=attempt,
+        success=success,
+        outcome=outcome,
+    )
+
+
+def _signal(report: dict[str, Any], name: str) -> dict[str, Any] | None:
+    return next((item for item in report["evidence_signals"] if item["name"] == name), None)
+
+
+class TestBuildFrugalityRetrospective:
+    @pytest.mark.parametrize("status", ["completed", "failed", "cancelled"])
+    def test_hard_final_statuses_emit_the_required_v1_envelope(self, status: str) -> None:
+        report = build_frugality_retrospective(
+            [],
+            execution_id="exec-1",
+            session_id="sess-1",
+            terminal_status=status,
+        )
+
+        assert report == {
+            "execution_id": "exec-1",
+            "session_id": "sess-1",
+            "retrospective_version": "v1",
+            "trigger": "execution_finalized",
+            "terminal_status": status,
+            "evidence_only": True,
+            "coverage": {
+                "measured_attempts": 0,
+                "unknown_attempts": 0,
+                "invalid_attempts": 0,
+                "total_measured_tokens": 0.0,
+            },
+            "evidence_signals": [],
+        }
+
+    def test_paused_is_not_a_reportable_terminal_status(self) -> None:
+        assert (
+            build_frugality_retrospective(
+                [],
+                execution_id="exec-1",
+                session_id="sess-1",
+                terminal_status="paused",
+            )
+            is None
+        )
+
+    def test_final_success_reports_retry_associated_spend_only(self) -> None:
+        report = build_frugality_retrospective(
+            [
+                _token("ac-1", 0, 100.0),
+                _outcome(0, False, outcome="failed"),
+                _token("ac-1", 1, 50.0),
+                _outcome(1, True, outcome="succeeded"),
+            ],
+            execution_id="exec-1",
+            session_id="sess-1",
+            terminal_status="completed",
+        )
+
+        assert report is not None
+        assert report["coverage"] == {
+            "measured_attempts": 2,
+            "unknown_attempts": 0,
+            "invalid_attempts": 0,
+            "total_measured_tokens": 150.0,
+        }
+        assert _signal(report, RETRY_ASSOCIATED_SPEND) == {
+            "name": RETRY_ASSOCIATED_SPEND,
+            "token_spend": 100.0,
+            "attempt_count": 1,
+            "latest_attempt_index": 1,
+            "evidence_event_ids": ["tok-ac-1-0"],
+        }
+        assert _signal(report, UNACCEPTED_SPEND) is None
+
+    def test_final_failure_reports_unaccepted_spend_without_calling_it_waste(self) -> None:
+        report = build_frugality_retrospective(
+            [
+                _token("ac-1", 0, 100.0),
+                _outcome(0, False, outcome="failed"),
+                _token("ac-1", 1, 50.0),
+                _outcome(1, False, outcome="failed"),
+            ],
+            execution_id="exec-1",
+            session_id="sess-1",
+            terminal_status="failed",
+        )
+
+        assert report is not None
+        unaccepted = _signal(report, UNACCEPTED_SPEND)
+        assert unaccepted == {
+            "name": UNACCEPTED_SPEND,
+            "token_spend": 150.0,
+            "attempt_count": 2,
+            "latest_outcome": "failed",
+            "evidence_event_ids": ["out-0-1", "tok-ac-1-0", "tok-ac-1-1"],
+        }
+        assert "waste" not in str(report).lower()
+        assert "guardrail" not in str(report).lower()
+
+    def test_successful_first_attempt_has_no_evidence_signal(self) -> None:
+        report = build_frugality_retrospective(
+            [_token("ac-1", 0, 25.0), _outcome(0, True)],
+            execution_id="exec-1",
+            session_id="sess-1",
+            terminal_status="completed",
+        )
+
+        assert report is not None
+        assert report["evidence_signals"] == []
+
+    def test_coverage_separates_measured_unknown_and_invalid_attempts(self) -> None:
+        missing_spend = _token("ac-missing", 0)
+        missing_spend.data.pop("token_spend")
+        report = build_frugality_retrospective(
+            [
+                _token("ac-measured", 0, 10.0),
+                _event(
+                    EVENT_MODEL_ROUTED,
+                    "model-unknown",
+                    ac_id="ac-unknown",
+                    root_ac_index=1,
+                    retry_attempt=0,
+                ),
+                missing_spend,
+                _token("ac-invalid", 0, "not-a-number"),
+                _event(
+                    EVENT_TOKEN_ATTRIBUTION,
+                    "tok-bad-attempt",
+                    ac_id="ac-bad-attempt",
+                    retry_attempt="0",
+                    token_spend=5.0,
+                ),
+            ],
+            execution_id="exec-1",
+            session_id="sess-1",
+            terminal_status="completed",
+        )
+
+        assert report is not None
+        assert report["coverage"] == {
+            "measured_attempts": 1,
+            "unknown_attempts": 2,
+            "invalid_attempts": 2,
+            "total_measured_tokens": 10.0,
+        }
+
+    @pytest.mark.parametrize("spend", [-1.0, float("nan"), float("inf"), True, "10"])
+    def test_malformed_token_spend_is_invalid_and_never_fabricates_spend(
+        self, spend: object
+    ) -> None:
+        report = build_frugality_retrospective(
+            [_token("ac-1", 0, spend)],
+            execution_id="exec-1",
+            session_id="sess-1",
+            terminal_status="failed",
+        )
+
+        assert report is not None
+        assert report["coverage"]["invalid_attempts"] == 1
+        assert report["coverage"]["total_measured_tokens"] == 0
+        assert report["evidence_signals"] == []
+
+    def test_malformed_latest_outcome_fails_closed_without_falling_back(self) -> None:
+        report = build_frugality_retrospective(
+            [
+                _token("ac-1", 0, 10.0),
+                _outcome(0, False, outcome="failed"),
+                _token("ac-1", 1, 20.0),
+                _outcome(1, "false", outcome="failed"),
+            ],
+            execution_id="exec-1",
+            session_id="sess-1",
+            terminal_status="failed",
+        )
+
+        assert report is not None
+        assert report["coverage"]["invalid_attempts"] == 1
+        assert _signal(report, UNACCEPTED_SPEND) is None
+
+    def test_proof_reference_is_optional_and_never_gates_emission(self) -> None:
+        absent = build_frugality_retrospective(
+            [],
+            execution_id="exec-1",
+            session_id="sess-1",
+            terminal_status="completed",
+        )
+        insufficient = build_frugality_retrospective(
+            [
+                _event(
+                    "execution.frugality_proof.evaluated",
+                    "proof-insufficient",
+                    status="insufficient_data",
+                )
+            ],
+            execution_id="exec-1",
+            session_id="sess-1",
+            terminal_status="completed",
+        )
+
+        assert absent is not None and "proof_reference" not in absent
+        assert insufficient is not None
+        assert insufficient["proof_reference"] == "proof-insufficient"
+
+
+class _MemoryStore:
+    def __init__(self, events: list[BaseEvent] | None = None) -> None:
+        self.events = list(events or [])
+        self.query_calls = 0
+
+    async def query_execution_related_events(
+        self,
+        execution_id: str,
+        event_type: str | None = None,
+        limit: int | None = 50,
+    ) -> list[BaseEvent]:
+        del execution_id, limit
+        self.query_calls += 1
+        events = self.events
+        if event_type is not None:
+            events = [event for event in events if event.type == event_type]
+        return list(reversed(events))
+
+    async def append(self, event: BaseEvent) -> None:
+        self.events.append(event)
+
+
+class TestReportFrugalityRetrospective:
+    @pytest.mark.asyncio
+    async def test_pause_resume_same_execution_emits_once_at_hard_finalization(self) -> None:
+        store = _MemoryStore([_token("ac-1", 0, 10.0), _outcome(0, True)])
+
+        paused = await report_frugality_retrospective(
+            store,
+            execution_id="exec-1",
+            session_id="sess-1",
+            terminal_status="paused",
+        )
+        completed = await report_frugality_retrospective(
+            store,
+            execution_id="exec-1",
+            session_id="sess-1",
+            terminal_status="completed",
+        )
+        duplicate = await report_frugality_retrospective(
+            store,
+            execution_id="exec-1",
+            session_id="sess-1",
+            terminal_status="completed",
+        )
+
+        assert paused is False
+        assert store.query_calls == 2
+        assert completed is True
+        assert duplicate is False
+        emitted = [
+            event for event in store.events if event.type == FRUGALITY_RETROSPECTIVE_EVENT_TYPE
+        ]
+        assert len(emitted) == 1
+
+    def test_event_id_is_deterministic_per_execution_and_version(self) -> None:
+        data = {
+            "execution_id": "exec-1",
+            "session_id": "sess-1",
+            "retrospective_version": "v1",
+        }
+        first = create_frugality_retrospective_event("exec-1", data)
+        second = create_frugality_retrospective_event("exec-1", data)
+
+        assert first.id == second.id
+        assert first.aggregate_type == "execution"
+        assert first.aggregate_id == "exec-1"
+
+    @pytest.mark.asyncio
+    async def test_event_store_replay_reconstructs_the_same_payload(self) -> None:
+        store = EventStore("sqlite+aiosqlite:///:memory:")
+        await store.initialize()
+        try:
+            token = _token("ac-1", 0, 25.0)
+            outcome = _outcome(0, True)
+            await store.append(token)
+            await store.append(outcome)
+
+            emitted = await report_frugality_retrospective(
+                store,
+                execution_id="exec-1",
+                session_id="sess-1",
+                terminal_status="completed",
+            )
+            replayed = await store.replay("execution", "exec-1")
+        finally:
+            await store.close()
+
+        assert emitted is True
+        report = next(
+            event for event in replayed if event.type == FRUGALITY_RETROSPECTIVE_EVENT_TYPE
+        )
+        expected = build_frugality_retrospective(
+            [outcome, token],
+            execution_id="exec-1",
+            session_id="sess-1",
+            terminal_status="completed",
+        )
+        assert report.data == expected
+
+
+class TestProjectFrugalityRetrospective:
+    def test_projection_normalizes_the_shared_web_tui_shape(self) -> None:
+        report = build_frugality_retrospective(
+            [
+                _token("ac-1", 0, 100.0),
+                _outcome(0, False, outcome="failed"),
+                _token("ac-1", 1, 50.0),
+                _outcome(1, False, outcome="failed"),
+            ],
+            execution_id="exec-1",
+            session_id="sess-1",
+            terminal_status="failed",
+        )
+
+        assert report is not None
+        assert project_frugality_retrospective(report) == {
+            "terminal_status": "failed",
+            "measured_attempts": 2,
+            "unknown_attempts": 0,
+            "invalid_attempts": 0,
+            "total_measured_tokens": 150.0,
+            "retry_associated_tokens": 100.0,
+            "retry_associated_attempts": 1,
+            "unaccepted_tokens": 150.0,
+            "unaccepted_attempts": 2,
+        }
+
+    def test_projection_rejects_non_evidence_or_malformed_payloads(self) -> None:
+        assert project_frugality_retrospective({"evidence_only": False}) is None
+        assert (
+            project_frugality_retrospective(
+                {
+                    "retrospective_version": "v1",
+                    "trigger": "execution_finalized",
+                    "terminal_status": "completed",
+                    "evidence_only": True,
+                    "coverage": {
+                        "measured_attempts": 1,
+                        "unknown_attempts": 0,
+                        "invalid_attempts": 0,
+                        "total_measured_tokens": float("nan"),
+                    },
+                    "evidence_signals": [],
+                }
+            )
+            is None
+        )

--- a/tests/unit/orchestrator/test_frugality_producers.py
+++ b/tests/unit/orchestrator/test_frugality_producers.py
@@ -1563,6 +1563,11 @@ class TestLiveRunPathsTriggerProof:
                 _FakeParallelExecutor,
             ),
             patch.object(runner, "_evaluate_frugality_proof", AsyncMock()) as proof,
+            patch.object(
+                runner,
+                "_report_frugality_retrospective",
+                AsyncMock(return_value=True),
+            ) as retrospective,
         ):
             result = await runner._execute_parallel(
                 seed=seed,
@@ -1577,3 +1582,8 @@ class TestLiveRunPathsTriggerProof:
         assert result.is_ok
         # The proof was evaluated for THIS execution after the terminal event.
         proof.assert_awaited_once_with("exec_parallel")
+        retrospective.assert_awaited_once_with(
+            execution_id="exec_parallel",
+            session_id=tracker.session_id,
+            terminal_status="completed",
+        )

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -1162,6 +1162,11 @@ class TestOrchestratorRunner:
             patch.object(runner, "_unregister_session"),
             patch.object(runner._session_repo, "mark_paused", mark_paused),
             patch.object(runner._session_repo, "mark_failed", mark_failed),
+            patch.object(
+                runner,
+                "_report_frugality_retrospective",
+                AsyncMock(return_value=False),
+            ) as retrospective,
         ):
             result = await runner.execute_precreated_session(
                 seed=sample_seed,
@@ -1188,6 +1193,7 @@ class TestOrchestratorRunner:
         assert terminal.data["status"] == "paused"
         assert terminal.data["pause_seconds"] == 18000
         assert terminal.data["pause_kind"] == "usage_limit"
+        retrospective.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_execute_seed_exception_marks_session_failed(
@@ -1545,6 +1551,11 @@ class TestOrchestratorRunner:
                 "mark_failed",
                 AsyncMock(return_value=Result.ok(None)),
             ) as mark_failed,
+            patch.object(
+                runner,
+                "_report_frugality_retrospective",
+                AsyncMock(return_value=False),
+            ) as retrospective,
         ):
             result = await runner.resume_session("sess_resume", sample_seed)
 
@@ -1553,6 +1564,7 @@ class TestOrchestratorRunner:
         assert result.value.final_message == "Codex rejected the resume command"
         mark_paused.assert_awaited_once()
         mark_failed.assert_not_called()
+        retrospective.assert_not_awaited()
 
     def test_recoverable_failure_ignores_ordinary_429(
         self,

--- a/tests/unit/tui/test_app.py
+++ b/tests/unit/tui/test_app.py
@@ -18,6 +18,7 @@ from ouroboros.tui.events import (
     DriftUpdated,
     ExecutionUpdated,
     FrugalityProofEvaluated,
+    FrugalityRetrospectiveReported,
     PauseRequested,
     PhaseChanged,
     ResumeRequested,
@@ -317,6 +318,38 @@ class TestOuroborosTUIMessageHandlers:
             FrugalityProofEvaluated(status="fail_no_frugality", token_reduction_pct=None, reason="")
         )
         assert app.state.frugality_summary == "⚖ frugal −20% tok"
+
+    def test_on_frugality_retrospective_reported_sets_neutral_summary_once(self) -> None:
+        app = OuroborosTUI()
+        summary = {
+            "terminal_status": "failed",
+            "measured_attempts": 3,
+            "unknown_attempts": 1,
+            "invalid_attempts": 0,
+            "total_measured_tokens": 250.0,
+            "retry_associated_tokens": 100.0,
+            "retry_associated_attempts": 1,
+            "unaccepted_tokens": 150.0,
+            "unaccepted_attempts": 2,
+        }
+
+        app.on_frugality_retrospective_reported(
+            FrugalityRetrospectiveReported(execution_id="exec_1", summary=summary)
+        )
+
+        assert app.state.frugality_retrospective == summary
+        assert app.state.frugality_retrospective_summary == (
+            "Evidence: retry-associated 100 tok | unaccepted 150 tok | "
+            "coverage 3 measured/1 unknown/0 invalid"
+        )
+
+        app.on_frugality_retrospective_reported(
+            FrugalityRetrospectiveReported(
+                execution_id="exec_1",
+                summary={**summary, "measured_attempts": 999},
+            )
+        )
+        assert app.state.frugality_retrospective == summary
 
     def test_apply_provider_tags_stamps_frugality_telemetry_onto_tree(self) -> None:
         """Folded tier/model/tokens are stamped onto the AC tree node for rendering."""

--- a/tests/unit/tui/test_events.py
+++ b/tests/unit/tui/test_events.py
@@ -13,6 +13,7 @@ from ouroboros.tui.events import (
     DriftUpdated,
     ExecutionUpdated,
     FrugalityProofEvaluated,
+    FrugalityRetrospectiveReported,
     LogMessage,
     PauseRequested,
     PhaseChanged,
@@ -21,6 +22,7 @@ from ouroboros.tui.events import (
     TUIState,
     WorkflowProgressUpdated,
     create_message_from_event,
+    format_frugality_retrospective_summary,
     format_frugality_summary,
 )
 
@@ -875,6 +877,62 @@ class TestFrugalityTelemetryEvents:
 
         assert create_message_from_event(event) is None
 
+    def test_frugality_retrospective_event(self) -> None:
+        event = BaseEvent(
+            type="execution.frugality_retrospective.reported",
+            aggregate_type="execution",
+            aggregate_id="exec_123",
+            data={
+                "execution_id": "exec_123",
+                "retrospective_version": "v1",
+                "trigger": "execution_finalized",
+                "terminal_status": "failed",
+                "evidence_only": True,
+                "coverage": {
+                    "measured_attempts": 3,
+                    "unknown_attempts": 1,
+                    "invalid_attempts": 0,
+                    "total_measured_tokens": 250.0,
+                },
+                "evidence_signals": [
+                    {
+                        "name": "retry_associated_spend",
+                        "token_spend": 100.0,
+                        "attempt_count": 1,
+                    },
+                    {
+                        "name": "unaccepted_spend",
+                        "token_spend": 150.0,
+                        "attempt_count": 2,
+                    },
+                ],
+            },
+        )
+
+        msg = create_message_from_event(event)
+
+        assert isinstance(msg, FrugalityRetrospectiveReported)
+        assert msg.execution_id == "exec_123"
+        assert msg.summary["retry_associated_tokens"] == 100.0
+        assert msg.summary["unaccepted_tokens"] == 150.0
+
+    def test_frugality_retrospective_malformed_event_returns_none(self) -> None:
+        event = BaseEvent(
+            type="execution.frugality_retrospective.reported",
+            aggregate_type="execution",
+            aggregate_id="exec_123",
+            data={
+                "retrospective_version": "v1",
+                "trigger": "execution_finalized",
+                "terminal_status": "paused",
+                "evidence_only": True,
+                "coverage": {},
+                "evidence_signals": [],
+            },
+        )
+
+        assert create_message_from_event(event) is None
+
     def test_format_frugality_summary_pass_includes_reduction(self) -> None:
         """A PASS verdict shows the token reduction percentage."""
         assert format_frugality_summary("pass", 18.0) == "⚖ frugal −18% tok"
@@ -882,3 +940,23 @@ class TestFrugalityTelemetryEvents:
     def test_format_frugality_summary_non_pass_omits_percentage(self) -> None:
         """A non-PASS verdict is a bare labelled line, no percentage."""
         assert format_frugality_summary("fail_no_frugality", None) == "⚖ no savings"
+
+    def test_format_frugality_retrospective_summary_is_neutral(self) -> None:
+        line = format_frugality_retrospective_summary(
+            {
+                "retry_associated_tokens": 1200.0,
+                "retry_associated_attempts": 1,
+                "unaccepted_tokens": 500.0,
+                "unaccepted_attempts": 1,
+                "measured_attempts": 3,
+                "unknown_attempts": 1,
+                "invalid_attempts": 0,
+            }
+        )
+
+        assert line == (
+            "Evidence: retry-associated 1.2k tok | unaccepted 500 tok | "
+            "coverage 3 measured/1 unknown/0 invalid"
+        )
+        assert "waste" not in line.lower()
+        assert "avoidable" not in line.lower()

--- a/tests/unit/tui/test_screens.py
+++ b/tests/unit/tui/test_screens.py
@@ -2,10 +2,37 @@
 
 from datetime import UTC, datetime
 
-from ouroboros.tui.events import TUIState
+from ouroboros.tui.events import FrugalityRetrospectiveReported, TUIState
+from ouroboros.tui.screens.dashboard_v3 import DashboardScreenV3, DoubleDiamondBar
 from ouroboros.tui.screens.debug import DebugScreen, JsonViewer, StateInspector
 from ouroboros.tui.screens.execution import ExecutionScreen, PhaseOutputPanel
 from ouroboros.tui.screens.logs import LogEntry, LogFilterBar, LogsScreen
+
+
+class TestDashboardFrugalityRetrospective:
+    def test_retrospective_is_visible_in_phase_bar(self) -> None:
+        state = TUIState(frugality_summary="⚖ insufficient data")
+        screen = DashboardScreenV3(state)
+        screen._phase_bar = DoubleDiamondBar()
+        screen._phase_bar.progress_text = "[2/2 AC]"
+        message = FrugalityRetrospectiveReported(
+            execution_id="exec_1",
+            summary={
+                "retry_associated_tokens": 100.0,
+                "retry_associated_attempts": 1,
+                "unaccepted_tokens": 50.0,
+                "unaccepted_attempts": 1,
+                "measured_attempts": 2,
+                "unknown_attempts": 0,
+                "invalid_attempts": 0,
+            },
+        )
+
+        screen.on_frugality_retrospective_reported(message)
+
+        assert "⚖ insufficient data" in screen._phase_bar.progress_text
+        assert "Evidence: retry-associated 100 tok" in screen._phase_bar.progress_text
+        assert "unaccepted 50 tok" in screen._phase_bar.progress_text
 
 
 class TestPhaseOutputPanel:


### PR DESCRIPTION
## Summary

Adds an EventStore-backed frugality retrospective that is emitted only after hard execution finalization. It reuses the canonical per-AC token attribution stream, reports neutral evidence with explicit coverage, and exposes one validated projection in the Python TUI and web dashboard.

This intentionally does not add per-stage spend, USD conversion, avoidable-waste claims, or guardrail generation because current `main` does not have authoritative stage coverage or progress attribution for those claims.

## Finalization and evidence contract

- Emits `execution.frugality_retrospective.reported` for `completed`, `failed`, and `cancelled`.
- Returns before EventStore access for `paused`, so the same `execution_id` can emit after resume and hard finalization.
- Deduplicates through replay plus a deterministic UUID5 event id.
- Defines `retry_associated_spend` as measured spend from superseded attempts when a later attempt exists.
- Defines `unaccepted_spend` as measured spend under roots whose latest valid outcome is unsuccessful.
- Reports measured, unknown, and invalid attempt coverage plus total measured tokens and evidence event ids.
- Treats frugality-proof provenance as optional and non-gating.
- Leaves the existing proof gate, drift retrospective, and lifecycle stage taxonomy unchanged.

## Related draft

PR #1610 was generated independently for the same issue after the current-main analysis comment. This PR leaves it untouched and differs by enforcing deterministic execution-scoped dedupe, testing pause/resume and failure/cancellation paths, sharing one strict web/TUI projection contract, and carrying evidence provenance plus total measured-token coverage.

## Test plan

- [x] Changed-surface suite: `369 passed, 1 skipped`
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [x] `uv run mypy src/` (`435` source files)
- [x] CI-isolated full suite: `12162 passed, 5 skipped`
- [x] Independent code review and architecture review: no blocking findings

## Deferred follow-ups

- Coverage-aware stage-spend projection over `llm.call.returned` / `IOJournalRecorder`
- Guardrail learning after a verified non-advancing attribution contract exists
- Project-scoped cross-run recall after stable project identity exists
- Optional native Rust/SLT TUI parity

## Related issues

Refs #1396
Related: #1610
