### PR TITLE
feat(plugin): add bounded post-commit on_rewind observers

### DIFF
--- a/docs/rfc/plugin-rewind-hook-contract.md
+++ b/docs/rfc/plugin-rewind-hook-contract.md
@@ -1,0 +1,225 @@
+# Plugin `on_rewind` Hook Contract
+
+## 1. Status
+
+**Implemented for schema v0.6 under #1464.** This RFC is the canonical
+contract for observing a successful lineage rewind through the plugin
+firewall. It does not create a generic event bus, a plugin veto path, a second
+rewind implementation, or checkout authority.
+
+Schema v0.5 remains reserved for #1462's artifact-write contract. Because that
+slice was not present on the implementation baseline, #1464 introduces v0.6
+without modifying schemas v0.1 through v0.4 or claiming that v0.5 is released.
+
+## 2. Goals
+
+1. Keep `EvolutionaryLoop.rewind_to()` as the only primitive that truncates a
+   projected lineage and appends `lineage.rewound`.
+2. Route MCP and TUI rewind callers through that same commit boundary.
+3. Let an eligible installed plugin observe the committed rewind through a
+   bounded, read-only, fail-open hook.
+4. Preserve the committed result across catalog, trust, digest, subprocess,
+   timeout, and audit persistence failures.
+
+## 3. Canonical Commit Boundary
+
+`EvolutionaryLoop.rewind_to(lineage, generation_number)` owns validation,
+lineage truncation, event creation, and the single `EventStore.append()` call.
+It captures an immutable `CommittedRewindResult` containing:
+
+- `lineage`;
+- `lineage_id`;
+- `from_generation`;
+- `to_generation`;
+- `rewind_event_id`;
+- `rewind_occurred_at`.
+
+The optional observer runs only after the append succeeds. It receives a
+separate immutable `RewindObservationSnapshot` containing only the five scalar
+identity/generation fields. It never receives the lineage object, EventStore,
+loop, checkout handle, callback, or writable service.
+
+Invalid targets, no-op targets, and append failures return before observer
+dispatch. Observer exceptions are logged and the captured committed result is
+returned unchanged.
+
+## 4. Checkout Boundary
+
+Git checkout is caller-owned post-commit work.
+
+- TUI may check dirty state, resolve the generation tag, and run checkout only
+  after the canonical rewind succeeds.
+- `scripts/ralph-rewind.py` remains an MCP client and optional local checkout
+  owner.
+- The generation tag remains `ooo/{lineage_id}/gen_{to_generation}`.
+- Checkout failure may be reported as a partial client/UI outcome, but cannot
+  roll back or reclassify the persisted rewind.
+
+Checkout request/status, repository paths, dirty state, and workspace content
+are absent from the hook payload.
+
+## 5. Manifest Contract
+
+Only schema v0.6 accepts `on_rewind`. Every archived schema continues to
+reject it.
+
+An `on_rewind` declaration must satisfy all of the following:
+
+- `failure_policy = "fail_open"`;
+- `hooks[].permissions` contains `plugin:rewind:observe`;
+- top-level `permissions[]` contains the same scope with `required = true`;
+- the hook entrypoint is a command with the existing bounded timeout field.
+
+The runtime repeats these checks as defense in depth for programmatically
+constructed manifests.
+
+## 6. Payload Contract
+
+The hook receives deterministic compact JSON through
+`OUROBOROS_PLUGIN_REWIND_PAYLOAD`.
+
+| Field | Type | Contract |
+|---|---|---|
+| `rewind_contract_version` | string | Exactly `rewind.v1`. |
+| `rewind_event_id` | string | ID of the committed `lineage.rewound` event. |
+| `rewind_occurred_at` | string | RFC3339 UTC timestamp of that event. |
+| `lineage_id` | string | Rewound lineage aggregate ID. |
+| `from_generation` | integer | Generation before rewind. |
+| `to_generation` | integer | Retained generation. |
+| `correlation_id` | string | Exactly equal to `rewind_event_id` in v1. |
+
+Serialization uses sorted keys and compact separators. The final environment
+variable value is encoded as UTF-8 and must be at most 2,048 bytes. A
+serialization or size failure launches no hook and is isolated after commit.
+
+The payload excludes seed JSON, generation records, discarded-generation
+content, raw events, EventStore rows, checkout/workspace/repository data,
+credentials, and hook stdout/stderr.
+
+## 7. Audit Contract
+
+Schema v0.6 audit events contain exactly one subject:
+
+- `command`, for existing command lifecycle audit; or
+- `observation`, for rewind observation.
+
+Rewind events use:
+
+```json
+{
+  "kind": "rewind",
+  "id": "<rewind_event_id>",
+  "aggregate_type": "lineage",
+  "aggregate_id": "<lineage_id>"
+}
+```
+
+No synthetic command name is emitted. The dispatcher reuses
+`plugin.hook.invoked`, `plugin.hook.completed`, `plugin.hook.blocked`, and
+`plugin.hook.failed`.
+
+Rewind provenance is limited to string values for:
+
+- `correlation_id`;
+- `hook_name`;
+- `failure_policy`;
+- optional `reason`, `returncode`, `timeout_seconds`, `stdout_sha256`,
+  `stderr_sha256`, and `skipped_count`.
+
+Output digests are lowercase 64-character SHA-256 hex. Raw output is never
+persisted. Audit events flow through the shared typed `PluginLedgerAdapter`.
+Audit buffering or flush failure is fail-open and falls back to core logging
+without recursively calling the failed sink.
+
+## 8. Installed-Plugin Catalog
+
+Each committed rewind reads exactly one `Lockfile.read()` snapshot.
+
+- A missing lockfile is the normal no-observer case.
+- A corrupt or unreadable lockfile aborts only the observer phase.
+- Entries are visited by plugin name ascending.
+- Each manifest is loaded from its installed plugin home.
+- A corrupt manifest skips that entry and later entries continue.
+- Only schema v0.6 `on_rewind` declarations are selected.
+- Multiple hooks in one manifest preserve declaration order.
+
+The total order is plugin name then manifest hook index. Candidate values are
+immutable and contain only the validated manifest, plugin home, source subject,
+artifact digest, and declaration index needed by the firewall.
+
+There is no persistent subscriber list, lockfile polling, process-global
+registry, replay queue, or generic subscription API.
+
+## 9. Firewall And Trust
+
+The rewind dispatcher requires complete lockfile `source_type`,
+`source_identity`, and `artifact_digest` metadata. It does not use the legacy
+version-only fallback.
+
+Before launch, the firewall verifies:
+
+1. schema/hook/failure-policy/permission contract;
+2. eligible non-first-party lockfile source type;
+3. source type equality with the manifest;
+4. readable plugin home and current canonical tree digest;
+5. non-disabled install subject;
+6. exact trust record equality for version, source type, source identity, and
+   artifact digest;
+7. an exact trusted `plugin:rewind:observe` scope.
+
+Any failure records a bounded blocked/failed outcome when possible and launches
+no hook. Hook return code and output never become a rewind decision.
+
+## 10. Dispatch Budget
+
+One rewind observation phase has a fixed 5.0-second monotonic deadline. The
+deadline starts before payload/catalog work and also bounds digest/trust
+preflight plus audit flush. Each selected hook timeout is:
+
+```text
+min(manifest timeout, remaining global budget)
+```
+
+Quick failures continue to later candidates while time remains. At or after the
+deadline, no further candidate starts. Remaining candidates are skipped in
+deterministic order and the first skipped candidate records the total
+`skipped_count` with reason `dispatch_budget_exhausted`.
+
+Blocking filesystem work is isolated from the caller-facing async path. A
+timed-out worker may finish its current read in the background, but deadline
+checks after catalog/digest/trust work prevent a late hook launch, and its late
+audit writes are discarded.
+
+This is a bounded best-effort dispatch contract, not durable delivery or an
+at-most-once guarantee.
+
+## 11. Non-Goals And Claim Boundary
+
+- No generic `on_event` bus or subscriber registry.
+- No plugin-triggered rewind, retry, veto, cleanup, checkpoint, or checkout.
+- No raw EventStore or mutable lineage access.
+- No first-party/non-lockfile rewind observers.
+- No OS sandbox or malicious local-process containment claim.
+- No expected-head/CAS, idempotency key, cross-process duplicate prevention,
+  or at-most-once guarantee.
+
+`EventStore.append()` remains atomic for one insert, but concurrent callers may
+still commit semantically duplicate rewind events. Solving that requires a
+separate EventStore concurrency contract.
+
+## 12. Traceability
+
+| #1464 acceptance text | Contract section | Primary proof |
+|---|---|---|
+| Bounded plugin-visible payload | §6 | `test_rewind_dispatch.py`, golden payload fixture |
+| Hook cannot trigger rewind | §3, §11 | scalar-only observer API tests |
+| Permission and failure policy defined | §5 | v0.6 manifest schema matrix |
+| Hook failure cannot corrupt/mask rewind | §3, §7, §10 | loop failure injection and E2E tests |
+| Rewind works without plugin | §8 | no-plugin E2E baseline |
+
+## 13. Related Work
+
+- #1462: artifact/state hook dispatch; reserves schema v0.5.
+- #1463: typed read-only generic event observation; remains separate.
+- #1464: this harness-level rewind observation contract.
+- [`userlevel-plugins.md`](./userlevel-plugins.md): umbrella plugin contract.

--- a/docs/rfc/userlevel-plugins.md
+++ b/docs/rfc/userlevel-plugins.md
@@ -265,6 +265,11 @@ SHA. CI may surface drift as a warning until the schemas stabilize at v1;
 this is intentionally less strict than a hard error to keep bring-up
 smooth.
 
+Core-local schema v0.5 is reserved for #1462's artifact-write hook slice.
+Schema v0.6 implements #1464's observe-only `on_rewind` contract without
+modifying archived schemas; see
+[`plugin-rewind-hook-contract.md`](./plugin-rewind-hook-contract.md).
+
 ## Invocation Contract
 
 Every UserLevel plugin command flows through one wrapper —
@@ -337,6 +342,7 @@ the contract and keeps review scope small.
 | `after_artifact_write` | After artifact write completes | Observability | `fail_open` | `plugin:artifact:observe` | Deferred |
 | `on_error` | When the wrapper sees a plugin/runtime error | Observability / recovery hint | `fail_open`; MUST NOT mask the original error | `plugin:lifecycle:read` | **Included** |
 | `on_cancel` | When a plugin invocation is cancelled | Observability / cancellation summary | `fail_open`; MUST NOT perform cleanup side effects | `plugin:lifecycle:read` | **Included** |
+| `on_rewind` | After a successful harness-level lineage rewind commit | Observability only | `fail_open` only | `plugin:rewind:observe` | **Included in schema v0.6** |
 
 `on_error` and `on_cancel` are the terminal-outcome subset of the v1 hook
 vocabulary, promoted out of the deferred bucket by Wave 1 PR E (#1131, refs
@@ -359,8 +365,12 @@ vocabulary:
   path.
 - `on_event`: too broad for v1. It risks turning the audit/event stream into a
   plugin message bus.
-- `on_rewind`: rewind semantics depend on replay/projection contracts that are
-  not yet stable.
+
+`on_rewind` is no longer part of the excluded set. It is promoted only in
+schema v0.6 through the canonical post-commit observer boundary documented in
+[`plugin-rewind-hook-contract.md`](./plugin-rewind-hook-contract.md). It does
+not participate in the command invocation ordering below and has no veto,
+cleanup, checkpoint, retry, or checkout authority.
 
 ### Hook ordering
 
@@ -377,6 +387,18 @@ plugin.completed | plugin.failed
 after_invocation hook(s)
 on_error hook(s), only for failed launched commands
 return InvocationResult
+```
+
+Harness-level rewind observation follows a separate order:
+
+```text
+validate target
+truncate projected lineage
+append lineage.rewound
+capture CommittedRewindResult
+dispatch eligible on_rewind observers (fail-open, five-second global budget)
+return the captured committed result
+caller-owned checkout, if requested
 ```
 
 `plugin.permission_used*` keeps the current v0 behavior: one event for each
@@ -587,6 +609,12 @@ core ledger writer accepts these events as-is, with any core-level envelope
 (e.g. ledger-internal sequence numbers) added at a layer **above** the
 schema's `additionalProperties: false` boundary. No silent field truncation
 or expansion is permitted; mismatches produce errors, not warnings.
+
+Schema v0.6 allows exactly one audit subject: the existing `command` subject
+or the new typed `observation` subject. `on_rewind` uses
+`observation.kind="rewind"` and never invents a command name. The exact
+subject and bounded provenance contract lives in
+[`plugin-rewind-hook-contract.md`](./plugin-rewind-hook-contract.md#7-audit-contract).
 
 **Bounded payloads — argv handling.** The "tokens, channel IDs, and
 free-form user messages are forbidden" rule applies to **plugin-defined
@@ -1014,6 +1042,9 @@ Sub-issues of #725, organized by phase:
 | 4 | #735 | CI lint guard preventing domain keywords from leaking into `ooo auto` |
 | Cross-repo | #736 | Schema vendoring strategy (vendor / submodule / PyPI) |
 | Cross-repo | #737 | `audit-event.schema.json` compatibility with core ledger writer |
+| Follow-up | #1462 | Artifact/state hook dispatch behind a write-side service boundary |
+| Follow-up | #1463 | Typed read-only generic `on_event` observation hook |
+| Follow-up | #1464 | Harness-level `on_rewind` observation hook |
 
 Contract repo issues at
 [Q00/ouroboros-plugins](https://github.com/Q00/ouroboros-plugins):

--- a/src/ouroboros/evolution/__init__.py
+++ b/src/ouroboros/evolution/__init__.py
@@ -23,6 +23,13 @@ from ouroboros.evolution.loop import (
 )
 from ouroboros.evolution.projector import LineageProjector
 from ouroboros.evolution.reflect import OntologyMutation, ReflectEngine, ReflectOutput
+from ouroboros.evolution.rewind import (
+    CommittedRewindResult,
+    NoOpRewindObserver,
+    RewindCommitter,
+    RewindObservationSnapshot,
+    RewindObserver,
+)
 from ouroboros.evolution.wonder import WonderEngine, WonderOutput
 
 __all__ = [
@@ -33,6 +40,11 @@ __all__ = [
     "GenerationResult",
     "StepAction",
     "StepResult",
+    "CommittedRewindResult",
+    "NoOpRewindObserver",
+    "RewindCommitter",
+    "RewindObservationSnapshot",
+    "RewindObserver",
     # Engines
     "WonderEngine",
     "ReflectEngine",

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -59,6 +59,11 @@ from ouroboros.evolution.directive_mapping import (
 from ouroboros.evolution.projector import LineageProjector
 from ouroboros.evolution.reflect import ReflectEngine, ReflectOutput
 from ouroboros.evolution.regression import RegressionDetector, RegressionReport
+from ouroboros.evolution.rewind import (
+    CommittedRewindResult,
+    NoOpRewindObserver,
+    RewindObserver,
+)
 from ouroboros.evolution.watchdog import (
     GenerationProgressWatchdog,
     GenerationWatchdogTimeout,
@@ -209,6 +214,7 @@ class EvolutionaryLoop:
         evaluator: Any | None = None,
         validator: Any | None = None,
         agent_process: AgentProcess | None = None,
+        rewind_observer: RewindObserver | None = None,
     ) -> None:
         self.event_store = event_store
         self.config = config or EvolutionaryLoopConfig()
@@ -218,6 +224,9 @@ class EvolutionaryLoop:
         self.executor = executor
         self.evaluator = evaluator
         self.validator = validator
+        self._rewind_observer = (
+            rewind_observer if rewind_observer is not None else NoOpRewindObserver()
+        )
         self._agent_process = agent_process or AgentProcess(event_store=event_store)
         self._project_dir_context: ContextVar[str | None] = ContextVar(
             "evolutionary_loop_project_dir",
@@ -1924,42 +1933,71 @@ class EvolutionaryLoop:
         self,
         lineage: OntologyLineage,
         generation_number: int,
-    ) -> Result[OntologyLineage, OuroborosError]:
+    ) -> Result[CommittedRewindResult, OuroborosError]:
         """Rewind lineage to a specific generation for re-evolution.
 
-        Emits a lineage.rewound event and returns truncated lineage.
+        The lineage event is committed before the optional observer runs. The
+        captured commit result is returned unchanged if observer dispatch fails.
 
         Args:
             lineage: Current lineage.
             generation_number: Generation to rewind to (inclusive).
 
         Returns:
-            Result containing truncated OntologyLineage.
+            Result containing the committed rewind identity and lineage.
         """
         try:
             from_gen = lineage.current_generation
+            if generation_number == from_gen:
+                return Result.err(
+                    OuroborosError(f"Already at generation {generation_number}, nothing to rewind")
+                )
             rewound = lineage.rewind_to(generation_number)
 
             from ouroboros.events.lineage import lineage_rewound
 
-            await self.event_store.append(
-                lineage_rewound(
-                    lineage.lineage_id,
-                    from_gen,
-                    generation_number,
-                )
+            rewind_event = lineage_rewound(
+                lineage.lineage_id,
+                from_gen,
+                generation_number,
             )
+        except ValueError as e:
+            return Result.err(OuroborosError(str(e)))
 
-            logger.info(
-                "evolution.rewound",
+        try:
+            await self.event_store.append(rewind_event)
+        except Exception as e:
+            return Result.err(OuroborosError(f"Failed to append rewind event: {e}"))
+
+        committed = CommittedRewindResult(
+            lineage=rewound,
+            lineage_id=lineage.lineage_id,
+            from_generation=from_gen,
+            to_generation=generation_number,
+            rewind_event_id=rewind_event.id,
+            rewind_occurred_at=rewind_event.timestamp,
+        )
+
+        logger.info(
+            "evolution.rewound",
+            extra={
+                "lineage_id": lineage.lineage_id,
+                "from": from_gen,
+                "to": generation_number,
+                "rewind_event_id": rewind_event.id,
+            },
+        )
+
+        try:
+            await self._rewind_observer.observe(committed.observation_snapshot())
+        except Exception as e:
+            logger.warning(
+                "evolution.rewind_observer_failed",
                 extra={
                     "lineage_id": lineage.lineage_id,
-                    "from": from_gen,
-                    "to": generation_number,
+                    "rewind_event_id": rewind_event.id,
+                    "error": str(e),
                 },
             )
 
-            return Result.ok(rewound)
-
-        except ValueError as e:
-            return Result.err(OuroborosError(str(e)))
+        return Result.ok(committed)

--- a/src/ouroboros/evolution/rewind.py
+++ b/src/ouroboros/evolution/rewind.py
@@ -1,0 +1,80 @@
+"""Typed boundary for committed lineage rewinds and post-commit observers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+
+from ouroboros.core.errors import OuroborosError
+from ouroboros.core.lineage import OntologyLineage
+from ouroboros.core.types import Result
+
+
+@dataclass(frozen=True, slots=True)
+class RewindObservationSnapshot:
+    """Scalar-only view of a committed rewind exposed to observers."""
+
+    lineage_id: str
+    from_generation: int
+    to_generation: int
+    rewind_event_id: str
+    rewind_occurred_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class CommittedRewindResult:
+    """Immutable caller-facing result captured before observer dispatch."""
+
+    lineage: OntologyLineage
+    lineage_id: str
+    from_generation: int
+    to_generation: int
+    rewind_event_id: str
+    rewind_occurred_at: datetime
+
+    def observation_snapshot(self) -> RewindObservationSnapshot:
+        """Return the least-privilege observer input for this commit."""
+        return RewindObservationSnapshot(
+            lineage_id=self.lineage_id,
+            from_generation=self.from_generation,
+            to_generation=self.to_generation,
+            rewind_event_id=self.rewind_event_id,
+            rewind_occurred_at=self.rewind_occurred_at,
+        )
+
+
+class RewindObserver(Protocol):
+    """Optional post-commit observer with no authority over rewind outcome."""
+
+    async def observe(self, snapshot: RewindObservationSnapshot) -> None:
+        """Observe an already committed rewind."""
+        ...
+
+
+class RewindCommitter(Protocol):
+    """Caller boundary for the canonical rewind commit primitive."""
+
+    async def rewind_to(
+        self,
+        lineage: OntologyLineage,
+        generation_number: int,
+    ) -> Result[CommittedRewindResult, OuroborosError]:
+        """Commit one lineage rewind through the canonical primitive."""
+        ...
+
+
+class NoOpRewindObserver:
+    """Default observer preserving rewind behavior when plugins are absent."""
+
+    async def observe(self, snapshot: RewindObservationSnapshot) -> None:  # noqa: ARG002
+        return None
+
+
+__all__ = [
+    "CommittedRewindResult",
+    "NoOpRewindObserver",
+    "RewindCommitter",
+    "RewindObservationSnapshot",
+    "RewindObserver",
+]

--- a/src/ouroboros/mcp/server/adapter.py
+++ b/src/ouroboros/mcp/server/adapter.py
@@ -1774,6 +1774,8 @@ def create_ouroboros_server(
 
     _scoped_reexecution_env = os.environ.get("OUROBOROS_SCOPED_REEXECUTION", "").strip().lower()
     _scoped_reexecution = _scoped_reexecution_env not in ("0", "false")
+    from ouroboros.plugin.rewind import build_lockfile_rewind_observer
+
     evolutionary_loop = EvolutionaryLoop(
         event_store=event_store,
         config=EvolutionaryLoopConfig(
@@ -1786,6 +1788,7 @@ def create_ouroboros_server(
         executor=_evolution_executor,
         evaluator=_evolution_evaluator,
         validator=_evolution_validator,
+        rewind_observer=build_lockfile_rewind_observer(event_store),
     )
     job_manager = JobManager(event_store)
 

--- a/src/ouroboros/mcp/tools/evolution_handlers.py
+++ b/src/ouroboros/mcp/tools/evolution_handlers.py
@@ -725,7 +725,8 @@ class EvolveRewindHandler:
                 )
             )
 
-        rewound_lineage = result.value
+        committed = result.value
+        rewound_lineage = committed.lineage
 
         # Get seed_json from the target generation if available
         target_gen = None
@@ -741,8 +742,8 @@ class EvolveRewindHandler:
         text = (
             f"## Rewind Complete\n\n"
             f"**Lineage**: {lineage_id}\n"
-            f"**From generation**: {from_gen}\n"
-            f"**To generation**: {to_generation}\n"
+            f"**From generation**: {committed.from_generation}\n"
+            f"**To generation**: {committed.to_generation}\n"
             f"**Status**: {rewound_lineage.status.value}\n"
             f"**Git tag**: `ooo/{lineage_id}/gen_{to_generation}`\n\n"
             f"Generations {to_generation + 1}–{from_gen} have been truncated.\n"
@@ -756,8 +757,12 @@ class EvolveRewindHandler:
                 is_error=False,
                 meta={
                     "lineage_id": lineage_id,
-                    "from_generation": from_gen,
-                    "to_generation": to_generation,
+                    "from_generation": committed.from_generation,
+                    "to_generation": committed.to_generation,
+                    "rewind_event_id": committed.rewind_event_id,
+                    "rewind_occurred_at": committed.rewind_occurred_at.isoformat().replace(
+                        "+00:00", "Z"
+                    ),
                 },
             )
         )

--- a/src/ouroboros/plugin/firewall.py
+++ b/src/ouroboros/plugin/firewall.py
@@ -36,6 +36,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 import hashlib
 import json
+import logging
 import os
 from pathlib import Path
 import re
@@ -54,6 +55,7 @@ from ouroboros.plugin.hooks import (
     HOOK_COMPLETED_EVENT,
     HOOK_FAILED_EVENT,
     HOOK_INVOKED_EVENT,
+    HOOK_REWIND_OBSERVE_SCOPE,
     HOOK_TOOL_INTERCEPT_BLOCKED_EVENT,
     HOOK_TOOL_INTERCEPT_COMPLETED_EVENT,
     HOOK_TOOL_INTERCEPT_REQUESTED_EVENT,
@@ -64,12 +66,15 @@ from ouroboros.plugin.hooks import (
     HookKind,
 )
 from ouroboros.plugin.manifest import HookSpec, PluginManifest
-from ouroboros.plugin.trust_store import TrustRecord
+from ouroboros.plugin.trust_store import TrustRecord, TrustStore
 from ouroboros.plugin.userlevel_registry import RegisteredProgram
 
 SCHEMA_VERSION = "0.1"
 HOOK_AUDIT_SCHEMA_VERSION = "0.3"
 DEFAULT_PLUGIN_INVOCATION_TIMEOUT_SECONDS = 300.0
+REWIND_HOOK_AUDIT_SCHEMA_VERSION = "0.6"
+
+logger = logging.getLogger(__name__)
 
 EventSink = Callable[[dict], None]
 ConfirmFn = Callable[[str], bool]
@@ -97,6 +102,15 @@ class InvocationResult:
     stderr_sha256: str | None = None
     stdout_bytes: bytes | None = None
     stderr_bytes: bytes | None = None
+    events: tuple[dict, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True)
+class RewindHookDispatchResult:
+    """Bounded outcome for one post-commit rewind hook candidate."""
+
+    status: Literal["completed", "blocked", "failed"]
+    reason: str | None = None
     events: tuple[dict, ...] = field(default_factory=tuple)
 
 
@@ -329,8 +343,432 @@ def _event_envelope(
     return event
 
 
+_REWIND_PROVENANCE_KEYS = frozenset(
+    {
+        "correlation_id",
+        "hook_name",
+        "failure_policy",
+        "reason",
+        "returncode",
+        "timeout_seconds",
+        "stdout_sha256",
+        "stderr_sha256",
+        "skipped_count",
+    }
+)
+
+
+def _rewind_event_envelope(
+    *,
+    event_type: str,
+    manifest: PluginManifest,
+    rewind_event_id: str,
+    lineage_id: str,
+    trust_state: str,
+    permissions_used: Iterable[str],
+    result: dict | None = None,
+    provenance: dict[str, str] | None = None,
+) -> dict:
+    """Build the truthful v0.6 observation audit subject for rewind hooks."""
+    final_provenance = dict(provenance or {})
+    unexpected = set(final_provenance).difference(_REWIND_PROVENANCE_KEYS)
+    if unexpected:
+        raise ValueError(f"unsupported rewind provenance keys: {sorted(unexpected)!r}")
+    event: dict = {
+        "schema_version": REWIND_HOOK_AUDIT_SCHEMA_VERSION,
+        "event_type": event_type,
+        "occurred_at": datetime.now(tz=UTC)
+        .isoformat(timespec="microseconds")
+        .replace("+00:00", "Z"),
+        "plugin": {
+            "name": manifest.name,
+            "version": manifest.version,
+            "source_type": _source_type_for_event(manifest),
+        },
+        "observation": {
+            "kind": "rewind",
+            "id": rewind_event_id,
+            "aggregate_type": "lineage",
+            "aggregate_id": lineage_id,
+        },
+        "trust_state": trust_state,
+        "capabilities_used": [],
+        "permissions_used": list(permissions_used),
+        "result": result or {"status": "success"},
+    }
+    if final_provenance:
+        event["provenance"] = final_provenance
+    return event
+
+
+def _coerce_rewind_output(value: object) -> bytes:
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        return value.encode("utf-8", errors="surrogateescape")
+    return b""
+
+
+def dispatch_rewind_hook(
+    *,
+    manifest: PluginManifest,
+    hook_index: int,
+    plugin_home: Path,
+    source_type: str,
+    source_identity: str,
+    artifact_digest: str,
+    trust_store: TrustStore,
+    rewind_event_id: str,
+    lineage_id: str,
+    payload_json: str,
+    timeout_seconds: float,
+    event_sink: EventSink,
+    subprocess_runner: Callable[..., subprocess.CompletedProcess] | None = None,
+    deadline: float | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+    skipped_count: int = 1,
+) -> RewindHookDispatchResult:
+    """Validate and launch one v0.6 post-commit rewind observer.
+
+    This helper has no return channel that can alter the committed rewind. Its
+    result is diagnostic only; every trust, digest, subprocess, and audit-sink
+    failure is contained to the observer phase.
+    """
+    emitted: list[dict] = []
+
+    def _emit(event: dict) -> None:
+        emitted.append(event)
+        try:
+            event_sink(event)
+        except Exception as exc:
+            logger.warning(
+                "plugin.rewind_audit_sink_failed",
+                extra={
+                    "plugin": manifest.name,
+                    "rewind_event_id": rewind_event_id,
+                    "error": str(exc),
+                },
+            )
+
+    def _finish(
+        *,
+        status: Literal["blocked", "failed"],
+        reason: str,
+        message: str,
+        trust_state: str = "blocked",
+        provenance: dict[str, str] | None = None,
+    ) -> RewindHookDispatchResult:
+        details = {
+            "correlation_id": rewind_event_id,
+            "hook_name": "on_rewind",
+            "failure_policy": "fail_open",
+            "reason": reason,
+            **(provenance or {}),
+        }
+        _emit(
+            _rewind_event_envelope(
+                event_type=HOOK_BLOCKED_EVENT if status == "blocked" else HOOK_FAILED_EVENT,
+                manifest=manifest,
+                rewind_event_id=rewind_event_id,
+                lineage_id=lineage_id,
+                trust_state=trust_state,
+                permissions_used=(HOOK_REWIND_OBSERVE_SCOPE,),
+                result={"status": status, "message": message},
+                provenance=details,
+            )
+        )
+        return RewindHookDispatchResult(status=status, reason=reason, events=tuple(emitted))
+
+    def _budget_exhausted() -> bool:
+        return deadline is not None and monotonic() >= deadline
+
+    def _finish_budget_exhausted() -> RewindHookDispatchResult:
+        emit_rewind_budget_exhausted(
+            manifest=manifest,
+            rewind_event_id=rewind_event_id,
+            lineage_id=lineage_id,
+            skipped_count=skipped_count,
+            event_sink=_emit,
+        )
+        return RewindHookDispatchResult(
+            status="blocked",
+            reason="dispatch_budget_exhausted",
+            events=tuple(emitted),
+        )
+
+    if _budget_exhausted():
+        return _finish_budget_exhausted()
+
+    try:
+        hook = manifest.hooks[hook_index]
+    except IndexError:
+        return _finish(
+            status="blocked",
+            reason="invalid_hook_index",
+            message="rewind hook declaration index is out of range",
+        )
+
+    required_rewind_permission = any(
+        permission.scope == HOOK_REWIND_OBSERVE_SCOPE and permission.required
+        for permission in manifest.permissions
+    )
+    if (
+        manifest.schema_version != REWIND_HOOK_AUDIT_SCHEMA_VERSION
+        or hook.name != HookKind.ON_REWIND.value
+        or hook.failure_policy != HookFailurePolicy.FAIL_OPEN.value
+        or hook.permissions != (HOOK_REWIND_OBSERVE_SCOPE,)
+        or not required_rewind_permission
+    ):
+        return _finish(
+            status="blocked",
+            reason="invalid_hook_contract",
+            message="rewind hook must be v0.6, fail_open, and hold required observe scope",
+        )
+
+    if not source_type or not source_identity or not artifact_digest:
+        return _finish(
+            status="blocked",
+            reason="incomplete_install_metadata",
+            message="rewind hooks require complete source and artifact metadata",
+        )
+    if source_type != manifest.source.type or source_type == "first_party":
+        return _finish(
+            status="blocked",
+            reason="install_subject_mismatch",
+            message="lockfile source type does not match an eligible installed plugin",
+        )
+
+    if _budget_exhausted():
+        return _finish_budget_exhausted()
+    try:
+        current_digest = canonical_tree_hash(plugin_home)
+    except (OSError, ValueError, EscapingSymlinkError, UnsupportedFileTypeError) as exc:
+        return _finish(
+            status="blocked",
+            reason="plugin_home_unreadable",
+            message=f"installed plugin bytes are unreadable: {type(exc).__name__}",
+        )
+    if _budget_exhausted():
+        return _finish_budget_exhausted()
+    if current_digest != artifact_digest:
+        return _finish(
+            status="blocked",
+            reason="artifact_digest_mismatch",
+            message="installed plugin bytes no longer match the lockfile digest",
+        )
+
+    if _budget_exhausted():
+        return _finish_budget_exhausted()
+    try:
+        is_disabled = trust_store.is_disabled_for_subject(
+            manifest.name,
+            source_type=source_type,
+            source_identity=source_identity,
+        )
+        trust_record = trust_store.read(manifest.name)
+    except (OSError, ValueError) as exc:
+        return _finish(
+            status="blocked",
+            reason="trust_state_unreadable",
+            message=f"plugin trust state is unreadable: {type(exc).__name__}",
+        )
+    if _budget_exhausted():
+        return _finish_budget_exhausted()
+    if is_disabled:
+        return _finish(
+            status="blocked",
+            reason="disabled",
+            message="plugin is disabled for this install subject",
+            trust_state="disabled",
+        )
+    if (
+        trust_record is None
+        or not trust_record.source_type
+        or not trust_record.source_identity
+        or not trust_record.artifact_digest
+        or trust_record.version != manifest.version
+        or trust_record.source_type != source_type
+        or trust_record.source_identity != source_identity
+        or trust_record.artifact_digest != artifact_digest
+    ):
+        return _finish(
+            status="blocked",
+            reason="trust_subject_mismatch",
+            message="plugin trust record does not match the complete install subject",
+        )
+    if not trust_record.has_scope(HOOK_REWIND_OBSERVE_SCOPE):
+        return _finish(
+            status="blocked",
+            reason="permission_not_trusted",
+            message="plugin:rewind:observe is not trusted for this install subject",
+        )
+
+    try:
+        hook_argv = shlex.split(hook.entrypoint.command)
+    except ValueError as exc:
+        return _finish(
+            status="failed",
+            reason="entrypoint_invalid",
+            message=f"hook entrypoint is not parseable: {exc}",
+            trust_state="trusted",
+            provenance={"timeout_seconds": f"{timeout_seconds:g}"},
+        )
+    if not hook_argv:
+        return _finish(
+            status="failed",
+            reason="entrypoint_invalid",
+            message="hook entrypoint command is empty after tokenization",
+            trust_state="trusted",
+            provenance={"timeout_seconds": f"{timeout_seconds:g}"},
+        )
+
+    effective_timeout = timeout_seconds
+    if deadline is not None:
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            return _finish_budget_exhausted()
+        effective_timeout = min(effective_timeout, remaining)
+
+    provenance = {
+        "correlation_id": rewind_event_id,
+        "hook_name": hook.name,
+        "failure_policy": hook.failure_policy,
+        "timeout_seconds": f"{effective_timeout:g}",
+    }
+    env = dict(os.environ)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["OUROBOROS_PLUGIN_HOME"] = str(plugin_home)
+    env["OUROBOROS_PLUGIN_REWIND_PAYLOAD"] = payload_json
+    if deadline is not None:
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            return _finish_budget_exhausted()
+        effective_timeout = min(effective_timeout, remaining)
+        provenance["timeout_seconds"] = f"{effective_timeout:g}"
+    _emit(
+        _rewind_event_envelope(
+            event_type=HOOK_INVOKED_EVENT,
+            manifest=manifest,
+            rewind_event_id=rewind_event_id,
+            lineage_id=lineage_id,
+            trust_state="trusted",
+            permissions_used=hook.permissions,
+            provenance=provenance,
+        )
+    )
+
+    runner = subprocess_runner or subprocess.run
+    try:
+        completed = runner(
+            hook_argv,
+            capture_output=True,
+            check=False,
+            timeout=effective_timeout,
+            cwd=str(plugin_home),
+            env=env,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return _finish(
+            status="failed",
+            reason="timeout",
+            message=f"on_rewind hook timed out after {effective_timeout:g}s",
+            trust_state="trusted",
+            provenance={
+                "timeout_seconds": f"{effective_timeout:g}",
+                "stdout_sha256": hashlib.sha256(_coerce_rewind_output(exc.stdout)).hexdigest(),
+                "stderr_sha256": hashlib.sha256(_coerce_rewind_output(exc.stderr)).hexdigest(),
+            },
+        )
+    except OSError as exc:
+        return _finish(
+            status="failed",
+            reason="startup_error",
+            message=f"on_rewind hook failed to start: {type(exc).__name__}",
+            trust_state="trusted",
+            provenance={"timeout_seconds": f"{effective_timeout:g}"},
+        )
+
+    stdout = _coerce_rewind_output(completed.stdout)
+    stderr = _coerce_rewind_output(completed.stderr)
+    run_provenance = {
+        **provenance,
+        "returncode": str(completed.returncode),
+        "stdout_sha256": hashlib.sha256(stdout).hexdigest(),
+        "stderr_sha256": hashlib.sha256(stderr).hexdigest(),
+    }
+    if completed.returncode != 0:
+        return _finish(
+            status="failed",
+            reason="nonzero_exit",
+            message=f"on_rewind hook exited with code {completed.returncode}",
+            trust_state="trusted",
+            provenance={
+                "timeout_seconds": f"{effective_timeout:g}",
+                "returncode": str(completed.returncode),
+                "stdout_sha256": run_provenance["stdout_sha256"],
+                "stderr_sha256": run_provenance["stderr_sha256"],
+            },
+        )
+
+    _emit(
+        _rewind_event_envelope(
+            event_type=HOOK_COMPLETED_EVENT,
+            manifest=manifest,
+            rewind_event_id=rewind_event_id,
+            lineage_id=lineage_id,
+            trust_state="trusted",
+            permissions_used=hook.permissions,
+            provenance=run_provenance,
+        )
+    )
+    return RewindHookDispatchResult(status="completed", events=tuple(emitted))
+
+
+def emit_rewind_budget_exhausted(
+    *,
+    manifest: PluginManifest,
+    rewind_event_id: str,
+    lineage_id: str,
+    skipped_count: int,
+    event_sink: EventSink,
+) -> RewindHookDispatchResult:
+    """Record deterministic skipping after the global rewind deadline."""
+    event = _rewind_event_envelope(
+        event_type=HOOK_BLOCKED_EVENT,
+        manifest=manifest,
+        rewind_event_id=rewind_event_id,
+        lineage_id=lineage_id,
+        trust_state="blocked",
+        permissions_used=(HOOK_REWIND_OBSERVE_SCOPE,),
+        result={"status": "blocked", "message": "rewind dispatch budget exhausted"},
+        provenance={
+            "correlation_id": rewind_event_id,
+            "hook_name": "on_rewind",
+            "failure_policy": "fail_open",
+            "reason": "dispatch_budget_exhausted",
+            "skipped_count": str(skipped_count),
+        },
+    )
+    try:
+        event_sink(event)
+    except Exception as exc:
+        logger.warning(
+            "plugin.rewind_audit_sink_failed",
+            extra={
+                "plugin": manifest.name,
+                "rewind_event_id": rewind_event_id,
+                "error": str(exc),
+            },
+        )
+    return RewindHookDispatchResult(
+        status="blocked",
+        reason="dispatch_budget_exhausted",
+        events=(event,),
+    )
+
+
 def _matching_hooks(manifest: PluginManifest, hook_kind: HookKind) -> tuple[HookSpec, ...]:
-    if manifest.schema_version not in {"0.3", "0.4"}:
+    if manifest.schema_version not in {"0.3", "0.4", "0.6"}:
         return ()
     return tuple(hook for hook in manifest.hooks if hook.name == hook_kind.value)
 
@@ -1524,7 +1962,7 @@ def _matching_tool_call_hooks(
     Tool-call hooks are a v0.4 vocabulary addition; v0.1/0.2/0.3 manifests
     never carry them, so any other schema version matches nothing.
     """
-    if manifest.schema_version != "0.4":
+    if manifest.schema_version not in {"0.4", "0.6"}:
         return ()
     return tuple(hook for hook in manifest.hooks if hook.name == hook_kind.value)
 
@@ -1940,9 +2378,12 @@ __all__ = [
     "ConfirmFn",
     "EventSink",
     "InvocationResult",
+    "RewindHookDispatchResult",
     "SCHEMA_VERSION",
     "ToolCallDecision",
     "dispatch_after_tool_call",
     "dispatch_before_tool_call",
+    "dispatch_rewind_hook",
+    "emit_rewind_budget_exhausted",
     "invoke_plugin",
 ]

--- a/src/ouroboros/plugin/hooks.py
+++ b/src/ouroboros/plugin/hooks.py
@@ -90,6 +90,12 @@ class HookKind(StrEnum):
     #: by the caller.
     AFTER_TOOL_CALL = "after_tool_call"
 
+    #: Harness-level lineage rewind observation hook. Promoted only for
+    #: schema v0.6; archived schemas continue rejecting the name. The source
+    #: rewind is already committed before this hook runs, so it is strictly
+    #: fail-open and carries no veto, retry, checkout, or mutation authority.
+    ON_REWIND = "on_rewind"
+
 
 class DeferredHookKind(StrEnum):
     """Hook names deferred to follow-up RFC slices.
@@ -155,7 +161,6 @@ class ExcludedHookKind(StrEnum):
     BEFORE_STATE_COMMIT = "before_state_commit"
     AFTER_STATE_COMMIT = "after_state_commit"
     ON_EVENT = "on_event"
-    ON_REWIND = "on_rewind"
 
 
 class HookFailurePolicy(StrEnum):
@@ -271,6 +276,15 @@ HOOK_TOOL_CALL_AUDIT_EVENTS: Final[frozenset[str]] = frozenset(
     }
 )
 
+#: Required permission for observing committed lineage rewinds. The scope
+#: must appear in both ``hooks[].permissions`` and top-level permissions with
+#: ``required=true`` before the lockfile-backed dispatcher may launch it.
+HOOK_REWIND_OBSERVE_SCOPE: Final[str] = "plugin:rewind:observe"
+
+#: Frozen v0.6 rewind hook family used by manifest and runtime dispatch.
+REWIND_HOOK_KINDS: Final[frozenset[HookKind]] = frozenset({HookKind.ON_REWIND})
+REWIND_HOOK_NAMES: Final[frozenset[str]] = frozenset(hook.value for hook in REWIND_HOOK_KINDS)
+
 
 def is_v1_hook_kind(value: str) -> bool:
     """Return True iff ``value`` names a hook included in v1.
@@ -366,6 +380,7 @@ __all__ = [
     "HOOK_LIFECYCLE_SCOPES",
     "HOOK_OUTCOME_AUDIT_EVENTS",
     "HOOK_RUNTIME_AUDIT_EVENTS",
+    "HOOK_REWIND_OBSERVE_SCOPE",
     "HOOK_TOOL_CALL_AUDIT_EVENTS",
     "HOOK_TOOL_CALL_SCOPES",
     "HOOK_TOOL_INTERCEPT_BLOCKED_EVENT",
@@ -374,6 +389,8 @@ __all__ = [
     "HOOK_TOOL_INTERCEPT_SCOPE",
     "HOOK_TOOL_OBSERVE_RECORDED_EVENT",
     "HOOK_TOOL_OBSERVE_SCOPE",
+    "REWIND_HOOK_KINDS",
+    "REWIND_HOOK_NAMES",
     "TERMINAL_DEFERRED_HOOK_KINDS",
     "TERMINAL_DEFERRED_HOOK_NAMES",
     "TERMINAL_OBSERVABILITY_HOOK_KINDS",

--- a/src/ouroboros/plugin/ledger_adapter.py
+++ b/src/ouroboros/plugin/ledger_adapter.py
@@ -25,18 +25,20 @@ This adapter:
     Production wires it to `EventStore.append`; tests can wire it to a
     list.
 
-This module deliberately does NOT import `persistence/event_store.py`
-or its async machinery. It speaks the envelope shape, not the store.
-The CLI (#731) is the integration point that takes a real EventStore
-async session and bridges to `append_fn`.
+The typed async adapter depends only on a narrow EventStore protocol, not the
+concrete persistence implementation. Callers retain construction and lifecycle
+ownership of the real store.
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
 import copy
+from datetime import datetime, timedelta
+from typing import Protocol
 import uuid
 
+from ouroboros.events.base import BaseEvent
 from ouroboros.plugin.hooks import HOOK_EVENT_TYPES, HOOK_TOOL_CALL_AUDIT_EVENTS
 
 PLUGIN_AGGREGATE_TYPE = "plugin"
@@ -170,10 +172,88 @@ def make_event_sink(
     return _sink
 
 
+class EventStoreLike(Protocol):
+    """Typed subset of EventStore required by plugin audit persistence."""
+
+    async def initialize(self) -> None: ...
+
+    async def append_batch(self, events: list[BaseEvent]) -> None: ...
+
+
+def plugin_event_to_base_event(
+    audit_event: dict,
+    *,
+    correlation_id: str,
+    aggregate_id: str | None = None,
+    envelope_id: str | None = None,
+) -> BaseEvent:
+    """Convert one schema-valid plugin audit event to a core event."""
+    envelope = wrap_plugin_event(
+        audit_event,
+        correlation_id=correlation_id,
+        aggregate_id=aggregate_id,
+        envelope_id=envelope_id,
+    )
+    timestamp = envelope["timestamp"]
+    if not isinstance(timestamp, str):
+        raise TypeError("plugin audit event occurred_at must be a string")
+    return BaseEvent(
+        id=envelope["id"],
+        type=envelope["event_type"],
+        timestamp=datetime.fromisoformat(timestamp.replace("Z", "+00:00")),
+        aggregate_type=envelope["aggregate_type"],
+        aggregate_id=envelope["aggregate_id"],
+        data=envelope["payload"],
+    )
+
+
+class PluginLedgerAdapter:
+    """Collect ordered audit events and flush them through ``append_batch``."""
+
+    def __init__(
+        self,
+        event_store: EventStoreLike,
+        *,
+        correlation_id: str,
+        aggregate_id: str | None = None,
+    ) -> None:
+        self._event_store = event_store
+        self._correlation_id = correlation_id
+        self._aggregate_id = aggregate_id
+        self._pending: list[BaseEvent] = []
+
+    @property
+    def pending_events(self) -> tuple[BaseEvent, ...]:
+        return tuple(self._pending)
+
+    def audit_sink(self, audit_event: dict) -> None:
+        event = plugin_event_to_base_event(
+            audit_event,
+            correlation_id=self._correlation_id,
+            aggregate_id=self._aggregate_id,
+        )
+        if self._pending and event.timestamp <= self._pending[-1].timestamp:
+            event = event.model_copy(
+                update={"timestamp": self._pending[-1].timestamp + timedelta(microseconds=1)}
+            )
+        self._pending.append(event)
+
+    async def flush(self) -> None:
+        if not self._pending:
+            return
+        await self._event_store.initialize()
+        batch = list(self._pending)
+        await self._event_store.append_batch(batch)
+        del self._pending[: len(batch)]
+
+
 __all__ = [
     "AUDIT_EVENT_TYPES",
+    "EventStoreLike",
     "PLUGIN_AGGREGATE_TYPE",
+    "PluginLedgerAdapter",
     "make_event_sink",
+    "plugin_event_to_base_event",
     "unwrap_plugin_event",
     "wrap_plugin_event",
 ]

--- a/src/ouroboros/plugin/manifest.py
+++ b/src/ouroboros/plugin/manifest.py
@@ -40,6 +40,7 @@ from ouroboros.plugin.hooks import (
     HOOK_LIFECYCLE_POLICY_SCOPE,
     HOOK_LIFECYCLE_READ_SCOPE,
     HOOK_LIFECYCLE_SCOPES,
+    HOOK_REWIND_OBSERVE_SCOPE,
     HOOK_TOOL_CALL_AUDIT_EVENTS,
     HOOK_TOOL_CALL_SCOPES,
     HOOK_TOOL_INTERCEPT_BLOCKED_EVENT,
@@ -75,8 +76,11 @@ except ImportError as exc:  # pragma: no cover
 # audit event names. Standalone dispatcher helpers exist in the firewall, but
 # production command invocation is wired through the tool-call
 # boundary; v0.4 manifests may declare these hooks, and they fire when
-# a tool-mediation caller invokes the helpers.
-SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("0.1", "0.2", "0.3", "0.4")
+# a tool-mediation caller invokes the helpers. Schema 0.5 is reserved by
+# #1462's artifact-hook contract and is intentionally absent until that slice
+# lands. v0.6 promotes the observe-only ``on_rewind`` hook without modifying
+# any archived schema.
+SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = ("0.1", "0.2", "0.3", "0.4", "0.6")
 
 # Source types whose `path` must be a sandboxed relative slug — no absolute
 # paths and no parent-directory traversal. `local_path` resolves relative to
@@ -208,7 +212,7 @@ class AuditSpec:
                     HOOK_FAILED_EVENT,
                 )
             )
-        if schema_version == "0.4":
+        if schema_version in {"0.4", "0.6"}:
             # v0.4 keeps the v0.3 hook event family and additively
             # reserves the four ``plugin.tool.*`` event names locked
             # in ``docs/rfc/plugin-tool-call-hook-contract.md`` § 6.
@@ -615,6 +619,14 @@ def _build_hook(
         schema_version=schema_version,
     )
 
+    _validate_rewind_hook_permission(
+        raw,
+        declared_required_permission_scopes=declared_required_permission_scopes,
+        hook_index=hook_index,
+        manifest_path=manifest_path,
+        schema_version=schema_version,
+    )
+
     for permission_index, scope in enumerate(raw.get("permissions", ())):
         if scope not in declared_permission_scopes:
             raise PluginManifestError(
@@ -658,7 +670,7 @@ def _validate_hook_lifecycle_permission(
     manifest_path: str | Path,
     schema_version: str,
 ) -> None:
-    """Require v0.3 / v0.4 lifecycle and tool-call hooks to declare required permissions.
+    """Require supported lifecycle and tool-call hooks to declare required permissions.
 
     ``plugin:lifecycle:read`` remains the permission boundary for
     observability hooks, and it must be a required top-level permission
@@ -681,12 +693,14 @@ def _validate_hook_lifecycle_permission(
     contract; JSON Schema cannot express that condition on a
     cross-referenced top-level array entry.
 
-    Enforce this only for the tightened v0.3 / v0.4 hook contract so
+    Enforce this only for the tightened v0.3 / v0.4 / v0.6 hook contract so
     supported v0.2 manifests keep their compatibility behavior until
     that schema version is retired deliberately.
     """
 
-    if schema_version not in {"0.3", "0.4"} or not is_v1_hook_kind(raw["name"]):
+    if schema_version not in {"0.3", "0.4", "0.6"} or not is_v1_hook_kind(raw["name"]):
+        return
+    if raw["name"] == HookKind.ON_REWIND.value:
         return
     if is_tool_call_hook_kind(raw["name"]):
         _validate_tool_call_hook_permission(
@@ -788,7 +802,7 @@ def _validate_tool_call_hook_permission(
     is sufficient for fail-open observation.
     """
 
-    if schema_version != "0.4":
+    if schema_version not in {"0.4", "0.6"}:
         return
     permissions = raw.get("permissions", ())
     declared_tool_scopes = HOOK_TOOL_CALL_SCOPES.intersection(permissions)
@@ -848,12 +862,50 @@ def _validate_tool_call_hook_permission(
     if HOOK_TOOL_INTERCEPT_SCOPE in declared_required_permission_scopes:
         return
     raise PluginManifestError(
-        "v0.4 fail_closed tool-call hook intercept permission must be required",
+        f"v{schema_version} fail_closed tool-call hook intercept permission must be required",
         path=str(manifest_path),
         json_pointer="/permissions",
         expected=f"top-level {HOOK_TOOL_INTERCEPT_SCOPE!r} permission with required=true",
         got=f"required permissions {sorted(declared_required_permission_scopes)!r}",
     )
+
+
+def _validate_rewind_hook_permission(
+    raw: dict[str, Any],
+    *,
+    declared_required_permission_scopes: frozenset[str],
+    hook_index: int,
+    manifest_path: str | Path,
+    schema_version: str,
+) -> None:
+    """Enforce the v0.6 observe-only rewind permission boundary."""
+    if schema_version != "0.6" or raw["name"] != HookKind.ON_REWIND.value:
+        return
+    permissions = raw.get("permissions", ())
+    if raw["failure_policy"] != HookFailurePolicy.FAIL_OPEN.value:
+        raise PluginManifestError(
+            "on_rewind hooks must use fail_open",
+            path=str(manifest_path),
+            json_pointer=f"/hooks/{hook_index}/failure_policy",
+            expected="'fail_open' for on_rewind hooks",
+            got=raw["failure_policy"],
+        )
+    if tuple(permissions) != (HOOK_REWIND_OBSERVE_SCOPE,):
+        raise PluginManifestError(
+            "v0.6 on_rewind hook must declare only plugin:rewind:observe",
+            path=str(manifest_path),
+            json_pointer=f"/hooks/{hook_index}/permissions",
+            expected=f"hooks[].permissions == [{HOOK_REWIND_OBSERVE_SCOPE!r}]",
+            got=permissions,
+        )
+    if HOOK_REWIND_OBSERVE_SCOPE not in declared_required_permission_scopes:
+        raise PluginManifestError(
+            "v0.6 on_rewind permission must be required",
+            path=str(manifest_path),
+            json_pointer="/permissions",
+            expected=(f"top-level {HOOK_REWIND_OBSERVE_SCOPE!r} permission with required=true"),
+            got=f"required permissions {sorted(declared_required_permission_scopes)!r}",
+        )
 
 
 def _validate_hook_name(
@@ -863,13 +915,13 @@ def _validate_hook_name(
     manifest_path: str | Path,
     schema_version: str,
 ) -> None:
-    """Reject v0.3 hook names that are not in the v1 vocabulary.
+    """Reject tightened-schema hook names outside the accepted vocabulary.
 
     v0.2 remains a supported manifest schema and its JSON Schema already
     defines the accepted hook-name enum for that version. Preserve that
     compatibility boundary here: v0.2 manifests keep their schema-level
-    contract, while v0.3 / v0.4 get the tightened v1-only Python guard.
-    v0.4 admits the tool-call hook family into the v1 vocabulary, so
+    contract, while v0.3 / v0.4 / v0.6 get the tightened Python guard.
+    v0.4 admits the tool-call hook family and v0.6 admits on_rewind, so
     ``is_v1_hook_kind`` returns True for those names; deferred and
     excluded names still reject identically.
     """
@@ -883,7 +935,7 @@ def _validate_hook_name(
             got=repr(name),
         )
 
-    if schema_version not in {"0.3", "0.4"} or is_v1_hook_kind(name):
+    if schema_version not in {"0.3", "0.4", "0.6"} or is_v1_hook_kind(name):
         return
 
     if is_deferred_hook_kind(name):
@@ -935,6 +987,7 @@ _OBSERVATION_ONLY_HOOK_NAMES: frozenset[str] = frozenset(
     {
         HookKind.AFTER_INVOCATION.value,
         HookKind.AFTER_TOOL_CALL.value,
+        HookKind.ON_REWIND.value,
         *TERMINAL_OBSERVABILITY_HOOK_NAMES,
     }
 )
@@ -948,7 +1001,7 @@ def _validate_after_invocation_policy(
     manifest_path: str | Path,
     schema_version: str,
 ) -> None:
-    """Keep v0.3 / v0.4 observation-only hooks from acquiring veto authority.
+    """Keep observation-only hooks from acquiring veto authority.
 
     v0.3 lifecycle permissions are read-only, so terminal observability
     hooks (``after_invocation`` plus the additive ``on_error`` /
@@ -963,7 +1016,7 @@ def _validate_after_invocation_policy(
     """
 
     if (
-        schema_version not in {"0.3", "0.4"}
+        schema_version not in {"0.3", "0.4", "0.6"}
         or hook_name not in _OBSERVATION_ONLY_HOOK_NAMES
         or failure_policy != HookFailurePolicy.FAIL_CLOSED.value
     ):
@@ -997,7 +1050,7 @@ def _validate_hook_audit_events(
     complete v0.3 lifecycle vocabulary.
     """
 
-    if schema_version not in {"0.3", "0.4"} or not audit_was_explicit:
+    if schema_version not in {"0.3", "0.4", "0.6"} or not audit_was_explicit:
         return
     required_events = set(AuditSpec.standard_four_events().events)
     if hooks:
@@ -1007,7 +1060,9 @@ def _validate_hook_audit_events(
     # AuditSpec.standard_events_for_schema("0.4"). Requiring them in an
     # explicit audit.events block keeps the helper-dispatch contract honest
     # without implying production ``invoke_plugin`` dispatch is wired.
-    if schema_version == "0.4" and any(is_tool_call_hook_kind(hook.name) for hook in hooks):
+    if schema_version in {"0.4", "0.6"} and any(
+        is_tool_call_hook_kind(hook.name) for hook in hooks
+    ):
         required_events.update(HOOK_TOOL_CALL_AUDIT_EVENTS)
     missing_events = required_events.difference(audit.events)
     if not missing_events:

--- a/src/ouroboros/plugin/rewind.py
+++ b/src/ouroboros/plugin/rewind.py
@@ -1,0 +1,367 @@
+"""Lockfile-backed post-commit rewind observation adapter."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC
+import json
+import logging
+import os
+from pathlib import Path
+import subprocess
+import threading
+import time
+
+from ouroboros.evolution.rewind import RewindObservationSnapshot
+from ouroboros.plugin.firewall import (
+    DEFAULT_PLUGIN_INVOCATION_TIMEOUT_SECONDS,
+    dispatch_rewind_hook,
+    emit_rewind_budget_exhausted,
+)
+from ouroboros.plugin.hooks import HookKind
+from ouroboros.plugin.ledger_adapter import EventStoreLike, PluginLedgerAdapter
+from ouroboros.plugin.lockfile import DEFAULT_LOCKFILE_PATH, Lockfile
+from ouroboros.plugin.manifest import PluginManifest, PluginManifestError, load_manifest
+from ouroboros.plugin.trust_store import DEFAULT_TRUST_ROOT, TrustStore
+
+logger = logging.getLogger(__name__)
+
+REWIND_CONTRACT_VERSION = "rewind.v1"
+REWIND_HOOK_SCHEMA_VERSION = "0.6"
+REWIND_PAYLOAD_ENV = "OUROBOROS_PLUGIN_REWIND_PAYLOAD"
+REWIND_PAYLOAD_MAX_BYTES = 2048
+REWIND_DISPATCH_BUDGET_SECONDS = 5.0
+
+
+@dataclass(frozen=True, slots=True)
+class RewindHookCandidate:
+    """Immutable installed-hook candidate selected from one lockfile snapshot."""
+
+    manifest: PluginManifest
+    plugin_home: Path
+    source_type: str
+    source_identity: str
+    artifact_digest: str
+    hook_index: int
+
+
+@dataclass(frozen=True, slots=True)
+class RewindCatalogIssue:
+    plugin_name: str
+    reason: str
+
+
+@dataclass(frozen=True, slots=True)
+class RewindCatalogSnapshot:
+    candidates: tuple[RewindHookCandidate, ...]
+    issues: tuple[RewindCatalogIssue, ...] = ()
+
+
+def build_rewind_payload(snapshot: RewindObservationSnapshot) -> str:
+    """Serialize exactly the seven public rewind.v1 payload fields."""
+    occurred_at = snapshot.rewind_occurred_at
+    if occurred_at.tzinfo is None:
+        raise ValueError("rewind_occurred_at must be timezone-aware")
+    occurred_at_text = (
+        occurred_at.astimezone(UTC).isoformat(timespec="microseconds").replace("+00:00", "Z")
+    )
+    payload = {
+        "rewind_contract_version": REWIND_CONTRACT_VERSION,
+        "rewind_event_id": snapshot.rewind_event_id,
+        "rewind_occurred_at": occurred_at_text,
+        "lineage_id": snapshot.lineage_id,
+        "from_generation": snapshot.from_generation,
+        "to_generation": snapshot.to_generation,
+        "correlation_id": snapshot.rewind_event_id,
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    if len(encoded) > REWIND_PAYLOAD_MAX_BYTES:
+        raise ValueError(
+            f"rewind payload is {len(encoded)} bytes; maximum is {REWIND_PAYLOAD_MAX_BYTES}"
+        )
+    return encoded.decode("utf-8")
+
+
+class RewindCatalog:
+    """Select v0.6 on_rewind declarations from one lockfile read."""
+
+    def __init__(
+        self,
+        lockfile: Lockfile,
+        *,
+        manifest_loader: Callable[[str | Path], PluginManifest] = load_manifest,
+    ) -> None:
+        self._lockfile = lockfile
+        self._manifest_loader = manifest_loader
+
+    def snapshot(self) -> RewindCatalogSnapshot:
+        entries = self._lockfile.read()
+        candidates: list[RewindHookCandidate] = []
+        issues: list[RewindCatalogIssue] = []
+        for plugin_name in sorted(entries):
+            entry = entries[plugin_name]
+            plugin_home = Path(entry.plugin_home).expanduser()
+            try:
+                manifest = self._manifest_loader(plugin_home / "ouroboros.plugin.json")
+            except (PluginManifestError, OSError, ValueError) as exc:
+                issues.append(
+                    RewindCatalogIssue(
+                        plugin_name=plugin_name,
+                        reason=f"manifest_unreadable:{type(exc).__name__}",
+                    )
+                )
+                continue
+            if manifest.name != plugin_name or manifest.version != entry.version:
+                issues.append(
+                    RewindCatalogIssue(
+                        plugin_name=plugin_name,
+                        reason="manifest_identity_mismatch",
+                    )
+                )
+                continue
+            if manifest.schema_version != REWIND_HOOK_SCHEMA_VERSION:
+                continue
+            for hook_index, hook in enumerate(manifest.hooks):
+                if hook.name != HookKind.ON_REWIND.value:
+                    continue
+                candidates.append(
+                    RewindHookCandidate(
+                        manifest=manifest,
+                        plugin_home=plugin_home,
+                        source_type=entry.source_type,
+                        source_identity=entry.source_identity,
+                        artifact_digest=entry.artifact_digest,
+                        hook_index=hook_index,
+                    )
+                )
+        return RewindCatalogSnapshot(
+            candidates=tuple(candidates),
+            issues=tuple(issues),
+        )
+
+
+class LockfileRewindObserver:
+    """Post-commit observer using installed manifests and the plugin firewall."""
+
+    def __init__(
+        self,
+        event_store: EventStoreLike,
+        *,
+        catalog: RewindCatalog,
+        trust_store: TrustStore,
+        subprocess_runner: Callable[..., subprocess.CompletedProcess] | None = None,
+        monotonic: Callable[[], float] = time.monotonic,
+        dispatch_budget_seconds: float = REWIND_DISPATCH_BUDGET_SECONDS,
+    ) -> None:
+        self._event_store = event_store
+        self._catalog = catalog
+        self._trust_store = trust_store
+        self._subprocess_runner = subprocess_runner
+        self._monotonic = monotonic
+        self._dispatch_budget_seconds = dispatch_budget_seconds
+
+    async def observe(self, snapshot: RewindObservationSnapshot) -> None:
+        deadline = self._monotonic() + self._dispatch_budget_seconds
+        try:
+            payload_json = build_rewind_payload(snapshot)
+            remaining = deadline - self._monotonic()
+            if remaining <= 0:
+                logger.warning(
+                    "plugin.rewind_dispatch_budget_exhausted",
+                    extra={"rewind_event_id": snapshot.rewind_event_id},
+                )
+                return
+            catalog_snapshot = await asyncio.wait_for(
+                asyncio.to_thread(self._catalog.snapshot),
+                timeout=remaining,
+            )
+        except TimeoutError:
+            logger.warning(
+                "plugin.rewind_catalog_budget_exhausted",
+                extra={"rewind_event_id": snapshot.rewind_event_id},
+            )
+            return
+        except Exception as exc:
+            logger.warning(
+                "plugin.rewind_observer_setup_failed",
+                extra={
+                    "rewind_event_id": snapshot.rewind_event_id,
+                    "error": str(exc),
+                },
+            )
+            return
+
+        for issue in catalog_snapshot.issues:
+            logger.warning(
+                "plugin.rewind_catalog_entry_skipped",
+                extra={"plugin": issue.plugin_name, "reason": issue.reason},
+            )
+
+        adapter = PluginLedgerAdapter(
+            self._event_store,
+            correlation_id=snapshot.rewind_event_id,
+        )
+        accept_audit = threading.Event()
+        accept_audit.set()
+        audit_lock = threading.Lock()
+
+        def _audit_sink(event: dict) -> None:
+            with audit_lock:
+                if not accept_audit.is_set():
+                    return
+                try:
+                    adapter.audit_sink(event)
+                except Exception as exc:
+                    logger.warning(
+                        "plugin.rewind_audit_buffer_failed",
+                        extra={
+                            "rewind_event_id": snapshot.rewind_event_id,
+                            "error": str(exc),
+                        },
+                    )
+
+        candidates = catalog_snapshot.candidates
+        for index, candidate in enumerate(candidates):
+            remaining = deadline - self._monotonic()
+            if remaining <= 0:
+                emit_rewind_budget_exhausted(
+                    manifest=candidate.manifest,
+                    rewind_event_id=snapshot.rewind_event_id,
+                    lineage_id=snapshot.lineage_id,
+                    skipped_count=len(candidates) - index,
+                    event_sink=_audit_sink,
+                )
+                break
+            hook = candidate.manifest.hooks[candidate.hook_index]
+            hook_timeout = float(hook.timeout_seconds or DEFAULT_PLUGIN_INVOCATION_TIMEOUT_SECONDS)
+            timeout_seconds = min(hook_timeout, remaining)
+            try:
+                dispatch_result = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        dispatch_rewind_hook,
+                        manifest=candidate.manifest,
+                        hook_index=candidate.hook_index,
+                        plugin_home=candidate.plugin_home,
+                        source_type=candidate.source_type,
+                        source_identity=candidate.source_identity,
+                        artifact_digest=candidate.artifact_digest,
+                        trust_store=self._trust_store,
+                        rewind_event_id=snapshot.rewind_event_id,
+                        lineage_id=snapshot.lineage_id,
+                        payload_json=payload_json,
+                        timeout_seconds=timeout_seconds,
+                        event_sink=_audit_sink,
+                        subprocess_runner=self._subprocess_runner,
+                        deadline=deadline,
+                        monotonic=self._monotonic,
+                        skipped_count=len(candidates) - index,
+                    ),
+                    timeout=remaining,
+                )
+            except TimeoutError:
+                with audit_lock:
+                    accept_audit.clear()
+                    emit_rewind_budget_exhausted(
+                        manifest=candidate.manifest,
+                        rewind_event_id=snapshot.rewind_event_id,
+                        lineage_id=snapshot.lineage_id,
+                        skipped_count=len(candidates) - index,
+                        event_sink=adapter.audit_sink,
+                    )
+                logger.warning(
+                    "plugin.rewind_dispatch_budget_exhausted",
+                    extra={
+                        "plugin": candidate.manifest.name,
+                        "rewind_event_id": snapshot.rewind_event_id,
+                    },
+                )
+                break
+            except Exception as exc:
+                logger.warning(
+                    "plugin.rewind_dispatch_failed",
+                    extra={
+                        "plugin": candidate.manifest.name,
+                        "rewind_event_id": snapshot.rewind_event_id,
+                        "error": str(exc),
+                    },
+                )
+            else:
+                if dispatch_result.reason == "dispatch_budget_exhausted":
+                    break
+
+        remaining = deadline - self._monotonic()
+        if remaining <= 0:
+            if adapter.pending_events:
+                logger.warning(
+                    "plugin.rewind_audit_flush_budget_exhausted",
+                    extra={
+                        "rewind_event_id": snapshot.rewind_event_id,
+                        "pending_events": len(adapter.pending_events),
+                    },
+                )
+            return
+        try:
+            await asyncio.wait_for(adapter.flush(), timeout=remaining)
+        except TimeoutError:
+            logger.warning(
+                "plugin.rewind_audit_flush_budget_exhausted",
+                extra={
+                    "rewind_event_id": snapshot.rewind_event_id,
+                    "pending_events": len(adapter.pending_events),
+                },
+            )
+        except Exception as exc:
+            logger.warning(
+                "plugin.rewind_audit_flush_failed",
+                extra={
+                    "rewind_event_id": snapshot.rewind_event_id,
+                    "error": str(exc),
+                },
+            )
+
+
+def build_lockfile_rewind_observer(
+    event_store: EventStoreLike,
+    *,
+    lockfile_path: Path | None = None,
+    trust_root: Path | None = None,
+) -> LockfileRewindObserver:
+    """Build the production observer from environment-aware plugin paths."""
+    resolved_lockfile = (
+        lockfile_path
+        or Path(
+            os.environ.get("OUROBOROS_PLUGIN_LOCKFILE", str(DEFAULT_LOCKFILE_PATH))
+        ).expanduser()
+    )
+    resolved_trust_root = (
+        trust_root
+        or Path(os.environ.get("OUROBOROS_PLUGIN_TRUST_ROOT", str(DEFAULT_TRUST_ROOT))).expanduser()
+    )
+    return LockfileRewindObserver(
+        event_store,
+        catalog=RewindCatalog(Lockfile(resolved_lockfile)),
+        trust_store=TrustStore(root=resolved_trust_root),
+    )
+
+
+__all__ = [
+    "LockfileRewindObserver",
+    "REWIND_CONTRACT_VERSION",
+    "REWIND_DISPATCH_BUDGET_SECONDS",
+    "REWIND_HOOK_SCHEMA_VERSION",
+    "REWIND_PAYLOAD_ENV",
+    "REWIND_PAYLOAD_MAX_BYTES",
+    "RewindCatalog",
+    "RewindCatalogIssue",
+    "RewindCatalogSnapshot",
+    "RewindHookCandidate",
+    "build_lockfile_rewind_observer",
+    "build_rewind_payload",
+]

--- a/src/ouroboros/plugin/schemas/0.6/_source.json
+++ b/src/ouroboros/plugin/schemas/0.6/_source.json
@@ -1,0 +1,18 @@
+{
+  "source": "Q00/ouroboros",
+  "purpose": "Local plugin manifest schema v0.6: promotes the observe-only on_rewind hook for Q00/ouroboros#1464 while leaving schema 0.5 reserved for #1462.",
+  "note": "Iterates on archived v0.4 without modifying it. Adds on_rewind, plugin:rewind:observe, fail_open-only validation, and an observation audit subject that is mutually exclusive with command. Generic lifecycle and tool-call hook contracts remain compatible.",
+  "local_extensions": {
+    "plugin.schema.json": [
+      "Bumped $id/title/schema_version const from 0.4 to 0.6; 0.5 remains reserved for #1462.",
+      "Added on_rewind to hooks[].name and plugin:rewind:observe to hooks[].permissions.",
+      "Constrained on_rewind to failure_policy='fail_open' and required the rewind observe scope in the hook declaration.",
+      "Preserved lifecycle/tool-call hooks and all archived v0.4 behavior."
+    ],
+    "audit-event.schema.json": [
+      "Added mutually exclusive command and observation subjects.",
+      "Defined observation.kind='rewind' with lineage aggregate identity.",
+      "Restricted rewind provenance to the bounded allowlist and SHA-256 digest shapes."
+    ]
+  }
+}

--- a/src/ouroboros/plugin/schemas/0.6/audit-event.schema.json
+++ b/src/ouroboros/plugin/schemas/0.6/audit-event.schema.json
@@ -1,0 +1,151 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Q00/ouroboros/schemas/local/0.6/audit-event.schema.json",
+  "title": "Ouroboros Plugin Audit Event (v0.6)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "event_type",
+    "occurred_at",
+    "plugin",
+    "trust_state",
+    "capabilities_used",
+    "permissions_used",
+    "result"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.6"
+    },
+    "event_type": {
+      "type": "string",
+      "enum": [
+        "plugin.discovered",
+        "plugin.installed",
+        "plugin.trusted",
+        "plugin.invoked",
+        "plugin.permission_used",
+        "plugin.completed",
+        "plugin.failed",
+        "plugin.hook.invoked",
+        "plugin.hook.completed",
+        "plugin.hook.blocked",
+        "plugin.hook.failed",
+        "plugin.tool.intercept.requested",
+        "plugin.tool.intercept.completed",
+        "plugin.tool.intercept.blocked",
+        "plugin.tool.observe.recorded"
+      ]
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "plugin": {
+      "type": "object",
+      "required": ["name", "version", "source_type"],
+      "additionalProperties": false,
+      "properties": {
+        "name": { "type": "string" },
+        "version": { "type": "string" },
+        "source_type": {
+          "type": "string",
+          "enum": ["local_path", "plugin_home", "first_party"]
+        }
+      }
+    },
+    "command": {
+      "type": "object",
+      "required": ["namespace", "name"],
+      "additionalProperties": false,
+      "properties": {
+        "namespace": { "type": "string" },
+        "name": { "type": "string" },
+        "argv": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "argv_summary": {
+          "type": "object",
+          "description": "Bounded fingerprint of argv added in step 1 of the audit-fidelity plan. Lets operators size the actual distribution before any cap is chosen and lets consumers correlate identical invocations by sha without dragging the full payload through the index. The argv field itself is unchanged in this step.",
+          "required": ["argc", "byte_length", "sha256"],
+          "additionalProperties": false,
+          "properties": {
+            "argc": { "type": "integer", "minimum": 0 },
+            "byte_length": { "type": "integer", "minimum": 0 },
+            "sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" }
+          }
+        }
+      }
+    },
+    "observation": {
+      "type": "object",
+      "required": ["kind", "id", "aggregate_type", "aggregate_id"],
+      "additionalProperties": false,
+      "properties": {
+        "kind": { "type": "string", "const": "rewind" },
+        "id": { "type": "string", "minLength": 1 },
+        "aggregate_type": { "type": "string", "const": "lineage" },
+        "aggregate_id": { "type": "string", "minLength": 1 }
+      }
+    },
+    "trust_state": {
+      "type": "string",
+      "enum": ["discovered", "installed", "trusted", "disabled", "blocked", "first_party"]
+    },
+    "capabilities_used": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "permissions_used": {
+      "type": "array",
+      "items": { "type": "string" }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "result": {
+      "type": "object",
+      "required": ["status"],
+      "additionalProperties": false,
+      "properties": {
+        "status": {
+          "type": "string",
+          "enum": ["success", "blocked", "failed", "trust_subject_changed"]
+        },
+        "message": { "type": "string" }
+      }
+    }
+  },
+  "oneOf": [
+    { "required": ["command"] },
+    { "required": ["observation"] }
+  ],
+  "allOf": [
+    {
+      "if": { "required": ["observation"] },
+      "then": {
+        "properties": {
+          "provenance": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "correlation_id": { "type": "string" },
+              "hook_name": { "type": "string", "const": "on_rewind" },
+              "failure_policy": { "type": "string", "const": "fail_open" },
+              "reason": { "type": "string" },
+              "returncode": { "type": "string", "pattern": "^-?[0-9]+$" },
+              "timeout_seconds": { "type": "string" },
+              "stdout_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+              "stderr_sha256": { "type": "string", "pattern": "^[0-9a-f]{64}$" },
+              "skipped_count": { "type": "string", "pattern": "^[0-9]+$" }
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/src/ouroboros/plugin/schemas/0.6/plugin.schema.json
+++ b/src/ouroboros/plugin/schemas/0.6/plugin.schema.json
@@ -1,0 +1,540 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Q00/ouroboros/schemas/local/0.6/plugin.schema.json",
+  "title": "Ouroboros Plugin Manifest (v0.6)",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "name",
+    "version",
+    "source",
+    "commands",
+    "capabilities",
+    "permissions",
+    "entrypoint"
+  ],
+  "additionalProperties": false,
+  "patternProperties": {
+    "^x-[a-z0-9][a-z0-9-]*$": {
+      "type": "object",
+      "description": "Namespaced extension metadata accepted for forward-compatible loaders."
+    }
+  },
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "const": "0.6"
+    },
+    "name": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+    },
+    "version": {
+      "type": "string",
+      "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+    },
+    "description": {
+      "type": "string",
+      "default": ""
+    },
+    "source": {
+      "type": "object",
+      "required": ["type"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["local_path", "plugin_home", "first_party"]
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "repository": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {"type": {"const": "local_path"}},
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["type", "path"]
+          }
+        },
+        {
+          "if": {
+            "properties": {"type": {"const": "plugin_home"}},
+            "required": ["type"]
+          },
+          "then": {
+            "required": ["type", "path"]
+          }
+        }
+      ]
+    },
+    "commands": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["namespace", "name", "summary", "usage", "risk"],
+        "additionalProperties": false,
+        "patternProperties": {
+          "^x-[a-z0-9][a-z0-9-]*$": {
+            "type": "object",
+            "description": "Namespaced command extension metadata accepted for forward-compatible loaders."
+          }
+        },
+        "properties": {
+          "namespace": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{1,62}[a-z0-9]$"
+          },
+          "name": {
+            "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]$"
+          },
+          "summary": {
+            "type": "string",
+            "minLength": 1
+          },
+          "usage": {
+            "type": "string",
+            "minLength": 1
+          },
+          "risk": {
+            "type": "string",
+            "enum": ["read_only", "write", "destructive"]
+          },
+          "requires_confirmation": {
+            "type": "boolean",
+            "default": false
+          },
+          "arguments": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["name", "type", "required"],
+              "additionalProperties": false,
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "pattern": "^[a-z][a-z0-9_-]*$"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": ["string", "boolean", "integer", "path", "url"]
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "permissions": {
+            "type": "array",
+            "description": "Command-specific permission scopes. Every scope must also be declared in top-level permissions[].scope so the core trust boundary remains authoritative.",
+            "items": {
+              "type": "string",
+              "pattern": "^[a-z][a-z0-9:-]*$"
+            },
+            "uniqueItems": true
+          },
+          "upstream": {
+            "type": "object",
+            "description": "Opaque upstream capability/source metadata for AgentOS assimilation. Preserved by loaders but not trusted for execution policy.",
+            "additionalProperties": true
+          },
+          "artifacts": {
+            "type": "object",
+            "description": "Opaque artifact contract hints for AgentOS assimilation. Preserved by loaders but not trusted for path authorization.",
+            "additionalProperties": true
+          },
+          "handoff": {
+            "type": "object",
+            "description": "Opaque handoff contract hints for AgentOS continuation. Preserved by loaders but not trusted for dispatch.",
+            "additionalProperties": true
+          },
+          "timeout_seconds": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 86400,
+            "description": "Command timeout hint in seconds; dispatchers may apply a stricter runtime cap."
+          },
+          "result_states": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["completed", "blocked", "failed", "cancelled"]
+            },
+            "uniqueItems": true,
+            "minItems": 1,
+            "description": "Declared terminal states the command adapter may emit."
+          },
+          "redaction": {
+            "type": "object",
+            "description": "Opaque redaction policy hints for produced artifacts/provenance.",
+            "additionalProperties": true
+          }
+        }
+      }
+    },
+    "capabilities": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "access"],
+        "additionalProperties": false,
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "seed",
+              "ledger",
+              "state",
+              "provenance",
+              "runtime",
+              "mcp",
+              "handoff",
+              "progress"
+            ]
+          },
+          "access": {
+            "type": "string",
+            "enum": ["read", "write", "execute", "attach"]
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "permissions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["scope", "risk", "required"],
+        "additionalProperties": false,
+        "properties": {
+          "scope": {
+            "type": "string",
+            "pattern": "^[a-z][a-z0-9_-]*(?::[a-z][a-z0-9_-]*){0,3}$"
+          },
+          "risk": {
+            "type": "string",
+            "enum": ["read_only", "write", "destructive"]
+          },
+          "required": {
+            "type": "boolean"
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "uniqueItems": true
+    },
+    "entrypoint": {
+      "type": "object",
+      "required": ["type", "command"],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "command"
+        },
+        "command": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "audit": {
+      "type": "object",
+      "required": ["events"],
+      "additionalProperties": false,
+      "default": {
+        "events": [
+          "plugin.invoked",
+          "plugin.permission_used",
+          "plugin.completed",
+          "plugin.failed",
+          "plugin.hook.invoked",
+          "plugin.hook.completed",
+          "plugin.hook.blocked",
+          "plugin.hook.failed",
+          "plugin.tool.intercept.requested",
+          "plugin.tool.intercept.completed",
+          "plugin.tool.intercept.blocked",
+          "plugin.tool.observe.recorded"
+        ]
+      },
+      "properties": {
+        "events": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "plugin.discovered",
+              "plugin.installed",
+              "plugin.trusted",
+              "plugin.invoked",
+              "plugin.permission_used",
+              "plugin.completed",
+              "plugin.failed",
+              "plugin.hook.invoked",
+              "plugin.hook.completed",
+              "plugin.hook.blocked",
+              "plugin.hook.failed",
+              "plugin.tool.intercept.requested",
+              "plugin.tool.intercept.completed",
+              "plugin.tool.intercept.blocked",
+              "plugin.tool.observe.recorded"
+            ]
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "hooks": {
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "object",
+        "required": ["name", "entrypoint", "failure_policy", "permissions"],
+        "additionalProperties": false,
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "name": {
+                  "const": "after_invocation"
+                }
+              },
+              "required": ["name"]
+            },
+            "then": {
+              "properties": {
+                "failure_policy": {
+                  "const": "fail_open"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "name": {
+                  "const": "on_error"
+                }
+              },
+              "required": ["name"]
+            },
+            "then": {
+              "properties": {
+                "failure_policy": {
+                  "const": "fail_open"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "name": {
+                  "const": "on_cancel"
+                }
+              },
+              "required": ["name"]
+            },
+            "then": {
+              "properties": {
+                "failure_policy": {
+                  "const": "fail_open"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "name": {
+                  "const": "after_tool_call"
+                }
+              },
+              "required": ["name"]
+            },
+            "then": {
+              "properties": {
+                "failure_policy": {
+                  "const": "fail_open"
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "name": {
+                  "enum": [
+                    "before_invocation",
+                    "after_invocation",
+                    "on_error",
+                    "on_cancel"
+                  ]
+                },
+                "failure_policy": {
+                  "const": "fail_closed"
+                }
+              },
+              "required": ["name", "failure_policy"]
+            },
+            "then": {
+              "properties": {
+                "permissions": {
+                  "contains": {
+                    "const": "plugin:lifecycle:policy"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "name": {
+                  "const": "before_tool_call"
+                },
+                "failure_policy": {
+                  "const": "fail_closed"
+                }
+              },
+              "required": ["name", "failure_policy"]
+            },
+            "then": {
+              "properties": {
+                "permissions": {
+                  "contains": {
+                    "const": "plugin:tool:intercept"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "if": {
+              "properties": {
+                "name": {
+                  "const": "on_rewind"
+                }
+              },
+              "required": ["name"]
+            },
+            "then": {
+              "properties": {
+                "failure_policy": {
+                  "const": "fail_open"
+                },
+                "permissions": {
+                  "const": ["plugin:rewind:observe"]
+                }
+              }
+            }
+          }
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "before_invocation",
+              "after_invocation",
+              "on_error",
+              "on_cancel",
+              "before_tool_call",
+              "after_tool_call",
+              "on_rewind"
+            ]
+          },
+          "description": {
+            "type": "string"
+          },
+          "entrypoint": {
+            "type": "object",
+            "required": ["type", "command"],
+            "additionalProperties": false,
+            "properties": {
+              "type": {
+                "type": "string",
+                "const": "command"
+              },
+              "command": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "permissions": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "plugin:lifecycle:read",
+                "plugin:lifecycle:policy",
+                "plugin:tool:intercept",
+                "plugin:tool:observe",
+                "plugin:rewind:observe"
+              ]
+            },
+            "anyOf": [
+              {
+                "contains": {
+                  "const": "plugin:lifecycle:read"
+                }
+              },
+              {
+                "contains": {
+                  "const": "plugin:lifecycle:policy"
+                }
+              },
+              {
+                "contains": {
+                  "const": "plugin:tool:intercept"
+                }
+              },
+              {
+                "contains": {
+                  "const": "plugin:tool:observe"
+                }
+              },
+              {
+                "contains": {
+                  "const": "plugin:rewind:observe"
+                }
+              }
+            ],
+            "uniqueItems": true,
+            "default": []
+          },
+          "timeout_seconds": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 300
+          },
+          "failure_policy": {
+            "type": "string",
+            "enum": ["fail_open", "fail_closed"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/ouroboros/tui/app.py
+++ b/src/ouroboros/tui/app.py
@@ -1051,7 +1051,21 @@ class OuroborosTUI(App[None]):
         self, message: LineageSelectorScreen.LineageSelected
     ) -> None:
         """Handle lineage selection and push the detail screen."""
-        self.push_screen(LineageDetailScreen(message.lineage, event_store=self._event_store))
+        assert self._event_store is not None
+        from ouroboros.evolution.loop import EvolutionaryLoop
+        from ouroboros.plugin.rewind import build_lockfile_rewind_observer
+
+        rewind_committer = EvolutionaryLoop(
+            self._event_store,
+            rewind_observer=build_lockfile_rewind_observer(self._event_store),
+        )
+        self.push_screen(
+            LineageDetailScreen(
+                message.lineage,
+                event_store=self._event_store,
+                rewind_committer=rewind_committer,
+            )
+        )
 
     def set_pause_callback(self, callback: Any) -> None:
         self._pause_callback = callback

--- a/src/ouroboros/tui/screens/lineage_detail.py
+++ b/src/ouroboros/tui/screens/lineage_detail.py
@@ -6,6 +6,7 @@ import asyncio
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from ouroboros.evolution.rewind import RewindCommitter
     from ouroboros.persistence.event_store import EventStore
 
 from textual.app import ComposeResult
@@ -21,7 +22,6 @@ from ouroboros.core.lineage import (
     OntologyLineage,
     RewindRecord,
 )
-from ouroboros.events.lineage import lineage_rewound
 from ouroboros.tui.screens.confirm_rewind import ConfirmRewindScreen
 from ouroboros.tui.widgets.lineage_tree import GenerationNodeSelected, LineageTreeWidget
 
@@ -356,6 +356,7 @@ class LineageDetailScreen(Screen[None]):
         lineage: OntologyLineage,
         *,
         event_store: EventStore | None = None,
+        rewind_committer: RewindCommitter | None = None,
         name: str | None = None,
         id: str | None = None,
         classes: str | None = None,
@@ -363,6 +364,11 @@ class LineageDetailScreen(Screen[None]):
         super().__init__(name=name, id=id, classes=classes)
         self._lineage = lineage
         self._event_store = event_store
+        if rewind_committer is None and event_store is not None:
+            from ouroboros.evolution.loop import EvolutionaryLoop
+
+            rewind_committer = EvolutionaryLoop(event_store)
+        self._rewind_committer = rewind_committer
         self._tree_widget: LineageTreeWidget | None = None
         self._detail_panel: GenerationDetailPanel | None = None
         self._selected_gen_num: int | None = None
@@ -466,8 +472,8 @@ class LineageDetailScreen(Screen[None]):
             self.notify("Select a generation first", severity="warning")
             return
 
-        if self._event_store is None:
-            self.notify("No event store available for rewind", severity="error")
+        if self._rewind_committer is None:
+            self.notify("No rewind committer available", severity="error")
             return
 
         if self._selected_gen_num >= self._lineage.current_generation:
@@ -494,22 +500,36 @@ class LineageDetailScreen(Screen[None]):
     async def _perform_rewind(self, to_generation: int) -> None:
         """Execute the rewind operation.
 
-        1. Emit lineage_rewound event
+        1. Commit through the canonical evolutionary-loop boundary
         2. Check git dirty state
         3. Check git tag exists
         4. Git checkout the target tag
         5. Notify and pop screen
         """
         lineage_id = self._lineage.lineage_id
-        from_gen = self._lineage.current_generation
 
-        # 1. Emit rewind event
+        # 1. Commit the lineage rewind. Observer dispatch, if configured, is
+        # post-commit and cannot change this result.
         try:
-            assert self._event_store is not None
-            await self._event_store.append(lineage_rewound(lineage_id, from_gen, to_generation))
+            assert self._rewind_committer is not None
+            rewind_result = await self._rewind_committer.rewind_to(
+                self._lineage,
+                to_generation,
+            )
         except Exception as e:
-            self.notify(f"Failed to emit rewind event: {e}", severity="error", markup=False)
+            self.notify(f"Failed to commit rewind: {e}", severity="error", markup=False)
             return
+        if rewind_result.is_err:
+            self.notify(
+                f"Failed to commit rewind: {rewind_result.error}",
+                severity="error",
+                markup=False,
+            )
+            return
+        committed = rewind_result.value
+        self._lineage = committed.lineage
+        lineage_id = committed.lineage_id
+        to_generation = committed.to_generation
 
         # 2. Check git dirty state
         tag_name = f"ooo/{lineage_id}/gen_{to_generation}"

--- a/tests/fixtures/plugin/rewind/audit-event-v0.6.json
+++ b/tests/fixtures/plugin/rewind/audit-event-v0.6.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "0.6",
+  "event_type": "plugin.hook.completed",
+  "occurred_at": "2026-07-13T06:00:01Z",
+  "plugin": {
+    "name": "rewind-observer",
+    "version": "1.0.0",
+    "source_type": "plugin_home"
+  },
+  "observation": {
+    "kind": "rewind",
+    "id": "event-1",
+    "aggregate_type": "lineage",
+    "aggregate_id": "lin-1"
+  },
+  "trust_state": "trusted",
+  "capabilities_used": [],
+  "permissions_used": ["plugin:rewind:observe"],
+  "provenance": {
+    "correlation_id": "event-1",
+    "hook_name": "on_rewind",
+    "failure_policy": "fail_open",
+    "returncode": "0",
+    "timeout_seconds": "5",
+    "stdout_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+  },
+  "result": {"status": "success"}
+}

--- a/tests/fixtures/plugin/rewind/payload-v1.json
+++ b/tests/fixtures/plugin/rewind/payload-v1.json
@@ -1,0 +1,1 @@
+{"correlation_id":"event-1","from_generation":3,"lineage_id":"lin-1","rewind_contract_version":"rewind.v1","rewind_event_id":"event-1","rewind_occurred_at":"2026-07-13T06:00:00.000000Z","to_generation":1}

--- a/tests/integration/plugin/test_rewind_e2e.py
+++ b/tests/integration/plugin/test_rewind_e2e.py
@@ -1,0 +1,179 @@
+"""End-to-end rewind observation through lockfile, firewall, and ledger."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+import shlex
+import sys
+
+import pytest
+
+from ouroboros.core.lineage import GenerationRecord, OntologyLineage
+from ouroboros.core.seed import OntologyField, OntologySchema
+from ouroboros.evolution.loop import EvolutionaryLoop
+from ouroboros.persistence.event_store import EventStore
+from ouroboros.plugin.digest import canonical_tree_hash
+from ouroboros.plugin.hooks import HOOK_REWIND_OBSERVE_SCOPE
+from ouroboros.plugin.lockfile import LockEntry, Lockfile
+from ouroboros.plugin.rewind import build_lockfile_rewind_observer
+from ouroboros.plugin.trust_store import TrustStore
+from tests.unit.plugin.test_manifest import REFERENCE_MANIFEST
+
+
+def _lineage() -> OntologyLineage:
+    ontology = OntologySchema(
+        name="Rewind",
+        description="Rewind E2E ontology",
+        fields=(OntologyField(name="id", field_type="string", description="ID"),),
+    )
+    return OntologyLineage(
+        lineage_id="lin-rewind-e2e",
+        goal="Exercise rewind observer",
+        generations=tuple(
+            GenerationRecord(
+                generation_number=number,
+                seed_id=f"seed-{number}",
+                ontology_snapshot=ontology,
+            )
+            for number in (1, 2, 3)
+        ),
+    )
+
+
+def _install_observer(tmp_path: Path) -> tuple[Path, Path, Path]:
+    plugin_home = tmp_path / "plugins" / "rewind-observer"
+    plugin_home.mkdir(parents=True)
+    payload_path = tmp_path / "observed-payload.json"
+    hook_path = plugin_home / "hook.py"
+    hook_path.write_text(
+        "from pathlib import Path\n"
+        "import os\n"
+        "import sys\n"
+        "Path(sys.argv[1]).write_text(os.environ['OUROBOROS_PLUGIN_REWIND_PAYLOAD'])\n"
+    )
+
+    manifest = deepcopy(REFERENCE_MANIFEST)
+    manifest.update(
+        {
+            "schema_version": "0.6",
+            "name": "rewind-observer",
+            "version": "1.0.0",
+            "source": {"type": "plugin_home", "path": "rewind-observer"},
+            "entrypoint": {"type": "command", "command": f"{sys.executable} hook.py"},
+            "hooks": [
+                {
+                    "name": "on_rewind",
+                    "entrypoint": {
+                        "type": "command",
+                        "command": (
+                            f"{shlex.quote(sys.executable)} hook.py "
+                            f"{shlex.quote(str(payload_path))}"
+                        ),
+                    },
+                    "permissions": [HOOK_REWIND_OBSERVE_SCOPE],
+                    "failure_policy": "fail_open",
+                    "timeout_seconds": 5,
+                }
+            ],
+        }
+    )
+    manifest["permissions"].append(
+        {
+            "scope": HOOK_REWIND_OBSERVE_SCOPE,
+            "risk": "read_only",
+            "required": True,
+            "reason": "Observe committed rewinds.",
+        }
+    )
+    (plugin_home / "ouroboros.plugin.json").write_text(json.dumps(manifest))
+
+    digest = canonical_tree_hash(plugin_home)
+    source_identity = "https://example.invalid/rewind-observer"
+    lockfile_path = tmp_path / "plugins.lock"
+    Lockfile(lockfile_path).add(
+        LockEntry(
+            name="rewind-observer",
+            version="1.0.0",
+            source_kind="git",
+            repository=source_identity,
+            git_sha="abc123",
+            manifest_checksum="sha256:manifest",
+            installed_at="2026-07-13T06:00:00Z",
+            plugin_home=str(plugin_home),
+            source_type="plugin_home",
+            source_identity=source_identity,
+            artifact_digest=digest,
+        )
+    )
+    trust_root = tmp_path / "trust"
+    TrustStore(root=trust_root).grant(
+        plugin="rewind-observer",
+        version="1.0.0",
+        scope=HOOK_REWIND_OBSERVE_SCOPE,
+        granted_by="user:test",
+        source_type="plugin_home",
+        source_identity=source_identity,
+        artifact_digest=digest,
+    )
+    return lockfile_path, trust_root, payload_path
+
+
+@pytest.mark.asyncio
+async def test_no_plugin_installed_preserves_rewind_baseline(tmp_path: Path) -> None:
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    observer = build_lockfile_rewind_observer(
+        store,
+        lockfile_path=tmp_path / "missing.lock",
+        trust_root=tmp_path / "trust",
+    )
+
+    result = await EvolutionaryLoop(store, rewind_observer=observer).rewind_to(_lineage(), 1)
+
+    assert result.is_ok
+    assert result.value.lineage.current_generation == 1
+    assert [event.type for event in await store.query_events(limit=10)] == ["lineage.rewound"]
+
+
+@pytest.mark.asyncio
+async def test_trusted_observer_runs_after_commit_and_persists_audit(tmp_path: Path) -> None:
+    lockfile_path, trust_root, payload_path = _install_observer(tmp_path)
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    observer = build_lockfile_rewind_observer(
+        store,
+        lockfile_path=lockfile_path,
+        trust_root=trust_root,
+    )
+
+    result = await EvolutionaryLoop(store, rewind_observer=observer).rewind_to(_lineage(), 1)
+
+    assert result.is_ok
+    payload = json.loads(payload_path.read_text())
+    assert payload == {
+        "rewind_contract_version": "rewind.v1",
+        "rewind_event_id": result.value.rewind_event_id,
+        "rewind_occurred_at": result.value.rewind_occurred_at.isoformat(
+            timespec="microseconds"
+        ).replace("+00:00", "Z"),
+        "lineage_id": "lin-rewind-e2e",
+        "from_generation": 3,
+        "to_generation": 1,
+        "correlation_id": result.value.rewind_event_id,
+    }
+
+    persisted = await store.query_events(limit=10)
+    assert [event.type for event in persisted] == [
+        "plugin.hook.completed",
+        "plugin.hook.invoked",
+        "lineage.rewound",
+    ]
+    assert persisted[0].data["observation"] == {
+        "kind": "rewind",
+        "id": result.value.rewind_event_id,
+        "aggregate_type": "lineage",
+        "aggregate_id": "lin-rewind-e2e",
+    }
+    assert all("command" not in event.data for event in persisted[:2])

--- a/tests/unit/evolution/test_rewind_commit.py
+++ b/tests/unit/evolution/test_rewind_commit.py
@@ -1,0 +1,145 @@
+"""Tests for the canonical committed-rewind boundary."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from ouroboros.core.lineage import GenerationRecord, OntologyLineage
+from ouroboros.core.seed import OntologyField, OntologySchema
+from ouroboros.events.base import BaseEvent
+from ouroboros.evolution.loop import EvolutionaryLoop
+from ouroboros.evolution.rewind import RewindObservationSnapshot
+
+
+def _lineage() -> OntologyLineage:
+    ontology = OntologySchema(
+        name="Rewind",
+        description="Rewind test ontology",
+        fields=(OntologyField(name="id", field_type="string", description="ID"),),
+    )
+    return OntologyLineage(
+        lineage_id="lin_rewind_commit",
+        goal="Test committed rewind",
+        generations=tuple(
+            GenerationRecord(
+                generation_number=number,
+                seed_id=f"seed-{number}",
+                ontology_snapshot=ontology,
+            )
+            for number in (1, 2, 3)
+        ),
+    )
+
+
+class _Store:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.events: list[BaseEvent] = []
+
+    async def append(self, event) -> None:
+        if self.fail:
+            raise RuntimeError("append unavailable")
+        self.events.append(event)
+
+
+class _Observer:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.snapshots: list[RewindObservationSnapshot] = []
+
+    async def observe(self, snapshot: RewindObservationSnapshot) -> None:
+        self.snapshots.append(snapshot)
+        if self.fail:
+            raise RuntimeError("observer unavailable")
+
+
+@pytest.mark.asyncio
+async def test_rewind_captures_exact_committed_event_identity() -> None:
+    store = _Store()
+    observer = _Observer()
+    loop = EvolutionaryLoop(store, rewind_observer=observer)  # type: ignore[arg-type]
+
+    result = await loop.rewind_to(_lineage(), 1)
+
+    assert result.is_ok
+    committed = result.value
+    assert len(store.events) == 1
+    persisted = store.events[0]
+    assert persisted.type == "lineage.rewound"
+    assert committed.rewind_event_id == persisted.id
+    assert committed.rewind_occurred_at == persisted.timestamp
+    assert committed.lineage.current_generation == 1
+    assert committed.from_generation == 3
+    assert committed.to_generation == 1
+    assert observer.snapshots == [committed.observation_snapshot()]
+    assert not hasattr(observer.snapshots[0], "lineage")
+
+
+@pytest.mark.asyncio
+async def test_observer_failure_cannot_change_committed_result() -> None:
+    store = _Store()
+    observer = _Observer(fail=True)
+    loop = EvolutionaryLoop(store, rewind_observer=observer)  # type: ignore[arg-type]
+
+    result = await loop.rewind_to(_lineage(), 2)
+
+    assert result.is_ok
+    assert result.value.rewind_event_id == store.events[0].id
+    assert result.value.lineage.current_generation == 2
+    assert len(observer.snapshots) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target", [0, 4])
+async def test_invalid_target_appends_nothing_and_skips_observer(target: int) -> None:
+    store = _Store()
+    observer = _Observer()
+    loop = EvolutionaryLoop(store, rewind_observer=observer)  # type: ignore[arg-type]
+
+    result = await loop.rewind_to(_lineage(), target)
+
+    assert result.is_err
+    assert store.events == []
+    assert observer.snapshots == []
+
+
+@pytest.mark.asyncio
+async def test_current_generation_appends_nothing_and_skips_observer() -> None:
+    store = _Store()
+    observer = _Observer()
+    loop = EvolutionaryLoop(store, rewind_observer=observer)  # type: ignore[arg-type]
+
+    result = await loop.rewind_to(_lineage(), 3)
+
+    assert result.is_err
+    assert "Already at generation 3" in str(result.error)
+    assert store.events == []
+    assert observer.snapshots == []
+
+
+@pytest.mark.asyncio
+async def test_append_failure_skips_observer() -> None:
+    store = _Store(fail=True)
+    observer = _Observer()
+    loop = EvolutionaryLoop(store, rewind_observer=observer)  # type: ignore[arg-type]
+
+    result = await loop.rewind_to(_lineage(), 1)
+
+    assert result.is_err
+    assert "Failed to append rewind event" in str(result.error)
+    assert observer.snapshots == []
+
+
+def test_observation_snapshot_is_immutable() -> None:
+    snapshot = RewindObservationSnapshot(
+        lineage_id="lin-1",
+        from_generation=3,
+        to_generation=1,
+        rewind_event_id="event-1",
+        rewind_occurred_at=_lineage().created_at,
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        snapshot.lineage_id = "mutated"  # type: ignore[misc]

--- a/tests/unit/plugin/test_hooks_contract.py
+++ b/tests/unit/plugin/test_hooks_contract.py
@@ -24,6 +24,7 @@ from ouroboros.plugin.hooks import (
     HOOK_FAILED_EVENT,
     HOOK_INVOKED_EVENT,
     HOOK_OUTCOME_AUDIT_EVENTS,
+    HOOK_REWIND_OBSERVE_SCOPE,
     HOOK_RUNTIME_AUDIT_EVENTS,
     TERMINAL_DEFERRED_HOOK_KINDS,
     TERMINAL_DEFERRED_HOOK_NAMES,
@@ -56,6 +57,7 @@ class TestHookKindEnumeration:
             "on_cancel",
             "before_tool_call",
             "after_tool_call",
+            "on_rewind",
         }
 
     def test_terminal_observability_hook_set_is_exact(self) -> None:
@@ -90,7 +92,6 @@ class TestHookKindEnumeration:
             "before_state_commit",
             "after_state_commit",
             "on_event",
-            "on_rewind",
         }
 
     def test_hook_sets_are_disjoint(self) -> None:
@@ -142,6 +143,7 @@ class TestRoutingHelpers:
         # Tool-call hooks were promoted into v1 by #939 PR F-1.
         assert is_v1_hook_kind("before_tool_call")
         assert is_v1_hook_kind("after_tool_call")
+        assert is_v1_hook_kind("on_rewind")
         assert not is_v1_hook_kind("on_event")
         assert not is_v1_hook_kind("before_artifact_write")
         assert not is_v1_hook_kind("unknown_hook")
@@ -177,7 +179,7 @@ class TestRoutingHelpers:
 
     def test_excluded_hook_kind_router(self) -> None:
         assert is_excluded_hook_kind("before_runtime_start")
-        assert is_excluded_hook_kind("on_rewind")
+        assert not is_excluded_hook_kind("on_rewind")
         assert not is_excluded_hook_kind("before_invocation")
         assert not is_excluded_hook_kind("before_tool_call")
 
@@ -186,6 +188,9 @@ class TestRoutingHelpers:
         assert not is_v1_hook_kind(unknown)
         assert not is_deferred_hook_kind(unknown)
         assert not is_excluded_hook_kind(unknown)
+
+    def test_rewind_permission_scope_is_stable(self) -> None:
+        assert HOOK_REWIND_OBSERVE_SCOPE == "plugin:rewind:observe"
 
 
 def test_hook_runtime_audit_event_contract_includes_invoked_and_completed() -> None:

--- a/tests/unit/plugin/test_ledger_adapter.py
+++ b/tests/unit/plugin/test_ledger_adapter.py
@@ -8,10 +8,13 @@ from pathlib import Path
 from jsonschema import Draft202012Validator
 import pytest
 
+from ouroboros.events.base import BaseEvent
 from ouroboros.plugin.ledger_adapter import (
     AUDIT_EVENT_TYPES,
     PLUGIN_AGGREGATE_TYPE,
+    PluginLedgerAdapter,
     make_event_sink,
+    plugin_event_to_base_event,
     unwrap_plugin_event,
     wrap_plugin_event,
 )
@@ -84,6 +87,44 @@ def test_wrap_basic_envelope() -> None:
     # payload contains the full audit event
     assert env["payload"]["schema_version"] == "0.1"
     assert env["payload"]["plugin"]["name"] == "github-pr-ops"
+
+
+def test_plugin_event_to_base_event_preserves_audit_subject() -> None:
+    audit_event = _audit_event("plugin.completed")
+
+    event = plugin_event_to_base_event(audit_event, correlation_id="corr-base")
+
+    assert event.type == "plugin.completed"
+    assert event.aggregate_type == "plugin"
+    assert event.aggregate_id == "corr-base"
+    assert event.data == audit_event
+
+
+@pytest.mark.asyncio
+async def test_plugin_ledger_adapter_flushes_ordered_batch() -> None:
+    class _Store:
+        def __init__(self) -> None:
+            self.initialized = False
+            self.batches: list[list[BaseEvent]] = []
+
+        async def initialize(self) -> None:
+            self.initialized = True
+
+        async def append_batch(self, events) -> None:
+            self.batches.append(list(events))
+
+    store = _Store()
+    adapter = PluginLedgerAdapter(store, correlation_id="corr-ledger")
+    adapter.audit_sink(_audit_event("plugin.invoked"))
+    adapter.audit_sink(_audit_event("plugin.completed"))
+
+    await adapter.flush()
+
+    assert store.initialized is True
+    assert [[event.type for event in batch] for batch in store.batches] == [
+        ["plugin.invoked", "plugin.completed"]
+    ]
+    assert adapter.pending_events == ()
 
 
 def test_wrap_does_not_mutate_input() -> None:

--- a/tests/unit/plugin/test_manifest_schema_0_6.py
+++ b/tests/unit/plugin/test_manifest_schema_0_6.py
@@ -1,0 +1,206 @@
+"""Schema and audit contract tests for the v0.6 on_rewind hook."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+import json
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+import pytest
+
+from ouroboros.plugin.hooks import HOOK_EVENT_TYPES, HOOK_REWIND_OBSERVE_SCOPE
+from ouroboros.plugin.manifest import (
+    SUPPORTED_SCHEMA_VERSIONS,
+    AuditSpec,
+    PluginManifestError,
+    load_manifest,
+)
+from tests.unit.plugin.test_manifest import REFERENCE_MANIFEST
+
+
+def _v06_manifest() -> dict:
+    payload = deepcopy(REFERENCE_MANIFEST)
+    payload["schema_version"] = "0.6"
+    payload["permissions"].append(
+        {
+            "scope": HOOK_REWIND_OBSERVE_SCOPE,
+            "risk": "read_only",
+            "required": True,
+            "reason": "Observe committed lineage rewinds.",
+        }
+    )
+    return payload
+
+
+def _rewind_hook() -> dict:
+    return {
+        "name": "on_rewind",
+        "description": "Observe a committed rewind.",
+        "entrypoint": {"type": "command", "command": "python -m hook rewind"},
+        "permissions": [HOOK_REWIND_OBSERVE_SCOPE],
+        "failure_policy": "fail_open",
+        "timeout_seconds": 5,
+    }
+
+
+def _write(tmp_path: Path, payload: dict) -> Path:
+    target = tmp_path / "ouroboros.plugin.json"
+    target.write_text(json.dumps(payload))
+    return target
+
+
+def _audit_schema() -> dict:
+    path = (
+        Path(__file__).resolve().parents[3]
+        / "src/ouroboros/plugin/schemas/0.6/audit-event.schema.json"
+    )
+    return json.loads(path.read_text())
+
+
+def _audit_event(*, observation: bool) -> dict:
+    event = {
+        "schema_version": "0.6",
+        "event_type": "plugin.hook.invoked" if observation else "plugin.invoked",
+        "occurred_at": "2026-07-13T06:00:00Z",
+        "plugin": {
+            "name": "rewind-observer",
+            "version": "1.0.0",
+            "source_type": "plugin_home",
+        },
+        "trust_state": "trusted",
+        "capabilities_used": [],
+        "permissions_used": [HOOK_REWIND_OBSERVE_SCOPE] if observation else [],
+        "result": {"status": "success"},
+    }
+    if observation:
+        event["observation"] = {
+            "kind": "rewind",
+            "id": "event-1",
+            "aggregate_type": "lineage",
+            "aggregate_id": "lin-1",
+        }
+        event["provenance"] = {
+            "correlation_id": "event-1",
+            "hook_name": "on_rewind",
+            "failure_policy": "fail_open",
+        }
+    else:
+        event["command"] = {"namespace": "rewind-observer", "name": "status"}
+    return event
+
+
+class TestV06Manifest:
+    def test_support_window_reserves_0_5_and_accepts_0_6(self) -> None:
+        assert "0.5" not in SUPPORTED_SCHEMA_VERSIONS
+        assert "0.6" in SUPPORTED_SCHEMA_VERSIONS
+
+    def test_on_rewind_fail_open_is_accepted(self, tmp_path: Path) -> None:
+        payload = _v06_manifest()
+        payload["hooks"] = [_rewind_hook()]
+
+        manifest = load_manifest(_write(tmp_path, payload))
+
+        assert manifest.schema_version == "0.6"
+        assert manifest.hooks[0].name == "on_rewind"
+        assert manifest.hooks[0].permissions == (HOOK_REWIND_OBSERVE_SCOPE,)
+
+    def test_fail_closed_is_rejected(self, tmp_path: Path) -> None:
+        payload = _v06_manifest()
+        payload["hooks"] = [_rewind_hook() | {"failure_policy": "fail_closed"}]
+
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+
+        assert exc_info.value.json_pointer == "/hooks/0/failure_policy"
+
+    def test_hook_permission_is_required(self, tmp_path: Path) -> None:
+        payload = _v06_manifest()
+        payload["hooks"] = [_rewind_hook() | {"permissions": []}]
+
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+
+        assert exc_info.value.json_pointer == "/hooks/0/permissions"
+
+    @pytest.mark.parametrize(
+        "extra_scope",
+        ["plugin:lifecycle:read", "plugin:tool:observe"],
+    )
+    def test_unrelated_hook_permission_is_rejected(self, tmp_path: Path, extra_scope: str) -> None:
+        payload = _v06_manifest()
+        payload["permissions"].append(
+            {
+                "scope": extra_scope,
+                "risk": "read_only",
+                "required": True,
+            }
+        )
+        payload["hooks"] = [
+            _rewind_hook() | {"permissions": [HOOK_REWIND_OBSERVE_SCOPE, extra_scope]}
+        ]
+
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+
+        assert exc_info.value.json_pointer == "/hooks/0/permissions"
+
+    def test_top_level_permission_must_be_required(self, tmp_path: Path) -> None:
+        payload = _v06_manifest()
+        payload["permissions"][-1]["required"] = False
+        payload["hooks"] = [_rewind_hook()]
+
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+
+        assert exc_info.value.json_pointer == "/permissions"
+
+    def test_v0_4_still_rejects_on_rewind(self, tmp_path: Path) -> None:
+        payload = _v06_manifest()
+        payload["schema_version"] = "0.4"
+        payload["hooks"] = [_rewind_hook()]
+
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+
+        assert exc_info.value.json_pointer == "/hooks/0/name"
+
+    def test_explicit_audit_requires_generic_hook_events(self, tmp_path: Path) -> None:
+        payload = _v06_manifest()
+        payload["hooks"] = [_rewind_hook()]
+        payload["audit"] = {"events": list(AuditSpec.standard_four_events().events)}
+
+        with pytest.raises(PluginManifestError) as exc_info:
+            load_manifest(_write(tmp_path, payload))
+
+        assert exc_info.value.json_pointer == "/audit/events"
+
+    def test_default_audit_contains_generic_hook_events(self) -> None:
+        assert set(AuditSpec.standard_events_for_schema("0.6").events) >= HOOK_EVENT_TYPES
+
+
+class TestV06AuditSubject:
+    def test_command_subject_remains_valid(self) -> None:
+        assert not list(
+            Draft202012Validator(_audit_schema()).iter_errors(_audit_event(observation=False))
+        )
+
+    def test_rewind_observation_subject_is_valid(self) -> None:
+        assert not list(
+            Draft202012Validator(_audit_schema()).iter_errors(_audit_event(observation=True))
+        )
+
+    def test_neither_subject_is_rejected(self) -> None:
+        event = _audit_event(observation=False)
+        event.pop("command")
+        assert list(Draft202012Validator(_audit_schema()).iter_errors(event))
+
+    def test_both_subjects_are_rejected(self) -> None:
+        event = _audit_event(observation=True)
+        event["command"] = {"namespace": "rewind-observer", "name": "status"}
+        assert list(Draft202012Validator(_audit_schema()).iter_errors(event))
+
+    def test_rewind_provenance_rejects_unbounded_keys(self) -> None:
+        event = _audit_event(observation=True)
+        event["provenance"]["stdout"] = "raw output"
+        assert list(Draft202012Validator(_audit_schema()).iter_errors(event))

--- a/tests/unit/plugin/test_rewind_catalog.py
+++ b/tests/unit/plugin/test_rewind_catalog.py
@@ -1,0 +1,144 @@
+"""Tests for one-shot installed-plugin rewind catalog selection."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from ouroboros.plugin.hooks import HOOK_REWIND_OBSERVE_SCOPE
+from ouroboros.plugin.lockfile import LockEntry
+from ouroboros.plugin.manifest import (
+    CommandSpec,
+    Entrypoint,
+    HookSpec,
+    Permission,
+    PluginManifest,
+    SourceSpec,
+)
+from ouroboros.plugin.rewind import RewindCatalog
+
+
+def _manifest(name: str, *, schema_version: str = "0.6", hooks: int = 1) -> PluginManifest:
+    return PluginManifest(
+        schema_version=schema_version,
+        name=name,
+        version="1.0.0",
+        source=SourceSpec(type="plugin_home", path=name),
+        commands=(
+            CommandSpec(
+                namespace=name,
+                name="status",
+                summary="Status",
+                usage=f"ooo {name} status",
+                risk="read_only",
+            ),
+        ),
+        capabilities=(),
+        permissions=(
+            Permission(
+                scope=HOOK_REWIND_OBSERVE_SCOPE,
+                risk="read_only",
+                required=True,
+            ),
+        ),
+        entrypoint=Entrypoint(type="command", command="python -m plugin"),
+        hooks=tuple(
+            HookSpec(
+                name="on_rewind",
+                entrypoint=Entrypoint(type="command", command=f"python -m hook {index}"),
+                failure_policy="fail_open",
+                timeout_seconds=5,
+                permissions=(HOOK_REWIND_OBSERVE_SCOPE,),
+            )
+            for index in range(hooks)
+        ),
+    )
+
+
+def _entry(name: str) -> LockEntry:
+    return LockEntry(
+        name=name,
+        version="1.0.0",
+        source_kind="git",
+        repository=f"https://example.invalid/{name}",
+        git_sha="abc123",
+        manifest_checksum="sha256:manifest",
+        installed_at="2026-07-13T06:00:00Z",
+        plugin_home=f"/plugins/{name}",
+        source_type="plugin_home",
+        source_identity=f"https://example.invalid/{name}",
+        artifact_digest="sha256:digest",
+    )
+
+
+class _Lockfile:
+    def __init__(self, entries: dict[str, LockEntry]) -> None:
+        self.entries = entries
+        self.read_count = 0
+
+    def read(self) -> dict[str, LockEntry]:
+        self.read_count += 1
+        return self.entries
+
+
+def test_catalog_reads_lockfile_once_and_orders_name_then_declaration() -> None:
+    lockfile = _Lockfile({"zulu": _entry("zulu"), "alpha": _entry("alpha")})
+    manifests = {"alpha": _manifest("alpha", hooks=2), "zulu": _manifest("zulu")}
+    catalog = RewindCatalog(
+        lockfile,  # type: ignore[arg-type]
+        manifest_loader=lambda path: manifests[Path(path).parent.name],
+    )
+
+    snapshot = catalog.snapshot()
+
+    assert lockfile.read_count == 1
+    assert [candidate.manifest.name for candidate in snapshot.candidates] == [
+        "alpha",
+        "alpha",
+        "zulu",
+    ]
+    assert [candidate.hook_index for candidate in snapshot.candidates] == [0, 1, 0]
+
+
+def test_catalog_skips_corrupt_manifest_and_continues() -> None:
+    lockfile = _Lockfile({"alpha": _entry("alpha"), "zulu": _entry("zulu")})
+
+    def _load(path: str | Path) -> PluginManifest:
+        if Path(path).parent.name == "alpha":
+            raise ValueError("corrupt manifest")
+        return _manifest("zulu")
+
+    snapshot = RewindCatalog(lockfile, manifest_loader=_load).snapshot()  # type: ignore[arg-type]
+
+    assert [candidate.manifest.name for candidate in snapshot.candidates] == ["zulu"]
+    assert snapshot.issues[0].plugin_name == "alpha"
+    assert snapshot.issues[0].reason == "manifest_unreadable:ValueError"
+
+
+def test_catalog_omits_archived_schema_and_missing_lockfile_entries() -> None:
+    empty = _Lockfile({})
+    assert RewindCatalog(empty).snapshot().candidates == ()  # type: ignore[arg-type]
+
+    old = _Lockfile({"alpha": _entry("alpha")})
+    snapshot = RewindCatalog(
+        old,  # type: ignore[arg-type]
+        manifest_loader=lambda _path: _manifest("alpha", schema_version="0.4"),
+    ).snapshot()
+    assert snapshot.candidates == ()
+
+
+def test_candidate_is_immutable() -> None:
+    lockfile = _Lockfile({"alpha": _entry("alpha")})
+    candidate = (
+        RewindCatalog(
+            lockfile,  # type: ignore[arg-type]
+            manifest_loader=lambda _path: _manifest("alpha"),
+        )
+        .snapshot()
+        .candidates[0]
+    )
+
+    with pytest.raises(FrozenInstanceError):
+        candidate.hook_index = 9  # type: ignore[misc]

--- a/tests/unit/plugin/test_rewind_dispatch.py
+++ b/tests/unit/plugin/test_rewind_dispatch.py
@@ -1,0 +1,610 @@
+"""Tests for bounded post-commit rewind plugin dispatch."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+import subprocess
+import time
+
+from jsonschema import Draft202012Validator
+import pytest
+
+from ouroboros.events.base import BaseEvent
+from ouroboros.evolution.rewind import RewindObservationSnapshot
+from ouroboros.plugin.digest import canonical_tree_hash
+from ouroboros.plugin.firewall import dispatch_rewind_hook, emit_rewind_budget_exhausted
+from ouroboros.plugin.hooks import HOOK_REWIND_OBSERVE_SCOPE
+from ouroboros.plugin.manifest import (
+    CommandSpec,
+    Entrypoint,
+    HookSpec,
+    Permission,
+    PluginManifest,
+    SourceSpec,
+)
+from ouroboros.plugin.rewind import (
+    REWIND_PAYLOAD_MAX_BYTES,
+    LockfileRewindObserver,
+    RewindCatalogSnapshot,
+    RewindHookCandidate,
+    build_rewind_payload,
+)
+from ouroboros.plugin.trust_store import TrustStore
+
+FIXTURE_ROOT = Path(__file__).resolve().parents[2] / "fixtures/plugin/rewind"
+AUDIT_SCHEMA = json.loads(
+    (
+        Path(__file__).resolve().parents[3]
+        / "src/ouroboros/plugin/schemas/0.6/audit-event.schema.json"
+    ).read_text()
+)
+AUDIT_VALIDATOR = Draft202012Validator(AUDIT_SCHEMA)
+
+
+def _snapshot(*, lineage_id: str = "lin-1") -> RewindObservationSnapshot:
+    return RewindObservationSnapshot(
+        lineage_id=lineage_id,
+        from_generation=3,
+        to_generation=1,
+        rewind_event_id="event-1",
+        rewind_occurred_at=datetime(2026, 7, 13, 6, 0, tzinfo=UTC),
+    )
+
+
+def _manifest(
+    name: str = "rewind-observer",
+    *,
+    command: str = "python -m hook rewind",
+    timeout_seconds: int = 10,
+) -> PluginManifest:
+    return PluginManifest(
+        schema_version="0.6",
+        name=name,
+        version="1.0.0",
+        source=SourceSpec(type="plugin_home", path=name),
+        commands=(
+            CommandSpec(
+                namespace=name,
+                name="status",
+                summary="Status",
+                usage=f"ooo {name} status",
+                risk="read_only",
+            ),
+        ),
+        capabilities=(),
+        permissions=(
+            Permission(
+                scope=HOOK_REWIND_OBSERVE_SCOPE,
+                risk="read_only",
+                required=True,
+            ),
+        ),
+        entrypoint=Entrypoint(type="command", command="python -m plugin"),
+        hooks=(
+            HookSpec(
+                name="on_rewind",
+                entrypoint=Entrypoint(type="command", command=command),
+                failure_policy="fail_open",
+                timeout_seconds=timeout_seconds,
+                permissions=(HOOK_REWIND_OBSERVE_SCOPE,),
+            ),
+        ),
+    )
+
+
+def _installed_subject(
+    tmp_path: Path,
+    manifest: PluginManifest,
+) -> tuple[Path, str, str, str, TrustStore]:
+    plugin_home = tmp_path / manifest.name
+    plugin_home.mkdir()
+    (plugin_home / "hook.py").write_text("print('hook')\n")
+    source_type = "plugin_home"
+    source_identity = f"https://example.invalid/{manifest.name}"
+    artifact_digest = canonical_tree_hash(plugin_home)
+    trust_store = TrustStore(root=tmp_path / "trust")
+    trust_store.grant(
+        plugin=manifest.name,
+        version=manifest.version,
+        scope=HOOK_REWIND_OBSERVE_SCOPE,
+        granted_by="user:test",
+        source_type=source_type,
+        source_identity=source_identity,
+        artifact_digest=artifact_digest,
+    )
+    return plugin_home, source_type, source_identity, artifact_digest, trust_store
+
+
+def _dispatch(
+    tmp_path: Path,
+    *,
+    manifest: PluginManifest | None = None,
+    runner=None,
+    sink=None,
+    source_identity_override: str | None = None,
+    digest_override: str | None = None,
+):
+    manifest = manifest or _manifest()
+    plugin_home, source_type, source_identity, artifact_digest, trust_store = _installed_subject(
+        tmp_path, manifest
+    )
+    events: list[dict] = []
+    result = dispatch_rewind_hook(
+        manifest=manifest,
+        hook_index=0,
+        plugin_home=plugin_home,
+        source_type=source_type,
+        source_identity=(
+            source_identity if source_identity_override is None else source_identity_override
+        ),
+        artifact_digest=artifact_digest if digest_override is None else digest_override,
+        trust_store=trust_store,
+        rewind_event_id="event-1",
+        lineage_id="lin-1",
+        payload_json=build_rewind_payload(_snapshot()),
+        timeout_seconds=5.0,
+        event_sink=sink or events.append,
+        subprocess_runner=runner,
+    )
+    return result, events, trust_store, plugin_home, source_identity
+
+
+def test_payload_matches_golden_and_contains_exact_fields() -> None:
+    payload = build_rewind_payload(_snapshot())
+    expected = (FIXTURE_ROOT / "payload-v1.json").read_text().strip()
+
+    assert payload == expected
+    assert set(json.loads(payload)) == {
+        "rewind_contract_version",
+        "rewind_event_id",
+        "rewind_occurred_at",
+        "lineage_id",
+        "from_generation",
+        "to_generation",
+        "correlation_id",
+    }
+    assert not any(
+        forbidden in payload
+        for forbidden in (
+            "seed_json",
+            "workspace",
+            "checkout",
+            "raw_event",
+            "event_store",
+            "stdout",
+            "stderr",
+            "token",
+            "credentials",
+        )
+    )
+
+
+def test_payload_accepts_exact_byte_limit_and_rejects_one_more() -> None:
+    empty_size = len(build_rewind_payload(_snapshot(lineage_id="")).encode("utf-8"))
+    exact_lineage_id = "x" * (REWIND_PAYLOAD_MAX_BYTES - empty_size)
+
+    exact = build_rewind_payload(_snapshot(lineage_id=exact_lineage_id))
+    assert len(exact.encode("utf-8")) == REWIND_PAYLOAD_MAX_BYTES
+
+    with pytest.raises(ValueError, match="maximum is 2048"):
+        build_rewind_payload(_snapshot(lineage_id=exact_lineage_id + "x"))
+
+
+def test_happy_path_launches_with_bounded_payload_and_truthful_audit(tmp_path: Path) -> None:
+    calls: list[dict] = []
+
+    def _runner(argv, **kwargs):
+        calls.append({"argv": argv, **kwargs})
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout="RAW_STDOUT_SENTINEL",
+            stderr="",
+        )
+
+    result, events, _, plugin_home, _ = _dispatch(tmp_path, runner=_runner)
+
+    assert result.status == "completed"
+    assert len(calls) == 1
+    assert calls[0]["cwd"] == str(plugin_home)
+    assert calls[0]["timeout"] == 5.0
+    assert calls[0]["env"]["OUROBOROS_PLUGIN_REWIND_PAYLOAD"] == build_rewind_payload(_snapshot())
+    assert [event["event_type"] for event in events] == [
+        "plugin.hook.invoked",
+        "plugin.hook.completed",
+    ]
+    assert all("observation" in event and "command" not in event for event in events)
+    assert all(not list(AUDIT_VALIDATOR.iter_errors(event)) for event in events)
+    assert "RAW_STDOUT_SENTINEL" not in json.dumps(events)
+    assert len(events[-1]["provenance"]["stdout_sha256"]) == 64
+
+
+@pytest.mark.parametrize(
+    ("source_identity", "digest", "reason"),
+    [
+        ("", None, "incomplete_install_metadata"),
+        (None, "", "incomplete_install_metadata"),
+        ("https://example.invalid/other", None, "trust_subject_mismatch"),
+        (None, "sha256:" + "0" * 64, "artifact_digest_mismatch"),
+    ],
+)
+def test_strict_install_subject_blocks_before_launch(
+    tmp_path: Path,
+    source_identity: str | None,
+    digest: str | None,
+    reason: str,
+) -> None:
+    calls: list[list[str]] = []
+
+    def _runner(argv, **_kwargs):
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    result, events, _, _, _ = _dispatch(
+        tmp_path,
+        runner=_runner,
+        source_identity_override=source_identity,
+        digest_override=digest,
+    )
+
+    assert result.status == "blocked"
+    assert calls == []
+    assert events[-1]["provenance"]["reason"] == reason
+
+
+def test_disabled_subject_blocks_before_launch(tmp_path: Path) -> None:
+    manifest = _manifest()
+    plugin_home, source_type, source_identity, digest, trust_store = _installed_subject(
+        tmp_path, manifest
+    )
+    trust_store.write_disable(
+        manifest.name,
+        source_type=source_type,
+        source_identity=source_identity,
+    )
+    calls: list[list[str]] = []
+    events: list[dict] = []
+
+    result = dispatch_rewind_hook(
+        manifest=manifest,
+        hook_index=0,
+        plugin_home=plugin_home,
+        source_type=source_type,
+        source_identity=source_identity,
+        artifact_digest=digest,
+        trust_store=trust_store,
+        rewind_event_id="event-1",
+        lineage_id="lin-1",
+        payload_json=build_rewind_payload(_snapshot()),
+        timeout_seconds=5.0,
+        event_sink=events.append,
+        subprocess_runner=lambda argv, **_kwargs: calls.append(argv),
+    )
+
+    assert result.status == "blocked"
+    assert calls == []
+    assert events[-1]["trust_state"] == "disabled"
+
+
+@pytest.mark.parametrize("failure", ["nonzero", "startup", "timeout"])
+def test_hook_process_failures_are_fail_open_and_digest_only(tmp_path: Path, failure: str) -> None:
+    if failure == "nonzero":
+
+        def runner(argv, **_kwargs):
+            return subprocess.CompletedProcess(
+                argv,
+                7,
+                stdout="secret stdout",
+                stderr="secret stderr",
+            )
+    elif failure == "startup":
+
+        def runner(argv, **_kwargs):
+            raise OSError("missing interpreter")
+    else:
+
+        def runner(argv, **_kwargs):
+            raise subprocess.TimeoutExpired(argv, 5, output=b"secret", stderr=b"private")
+
+    result, events, _, _, _ = _dispatch(tmp_path, runner=runner)
+
+    assert result.status == "failed"
+    assert events[-1]["event_type"] == "plugin.hook.failed"
+    serialized = json.dumps(events)
+    assert "secret stdout" not in serialized
+    assert "secret stderr" not in serialized
+    assert "private" not in serialized
+
+
+def test_audit_sink_failure_does_not_stop_hook(tmp_path: Path) -> None:
+    calls: list[list[str]] = []
+
+    def _runner(argv, **_kwargs):
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    result, _, _, _, _ = _dispatch(
+        tmp_path,
+        runner=_runner,
+        sink=lambda _event: (_ for _ in ()).throw(RuntimeError("sink down")),
+    )
+
+    assert result.status == "completed"
+    assert len(calls) == 1
+
+
+def test_programmatic_fail_closed_hook_is_defense_in_depth_blocked(tmp_path: Path) -> None:
+    manifest = _manifest()
+    invalid_hook = replace(manifest.hooks[0], failure_policy="fail_closed")
+    invalid_manifest = replace(manifest, hooks=(invalid_hook,))
+
+    result, events, _, _, _ = _dispatch(tmp_path, manifest=invalid_manifest)
+
+    assert result.status == "blocked"
+    assert events[-1]["provenance"]["reason"] == "invalid_hook_contract"
+
+
+class _Store:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.fail = fail
+        self.batches: list[list[BaseEvent]] = []
+
+    async def initialize(self) -> None:
+        return None
+
+    async def append_batch(self, events: list[BaseEvent]) -> None:
+        if self.fail:
+            raise RuntimeError("audit store down")
+        self.batches.append(list(events))
+
+
+class _Catalog:
+    def __init__(self, candidates: tuple[RewindHookCandidate, ...]) -> None:
+        self.candidates = candidates
+        self.calls = 0
+
+    def snapshot(self) -> RewindCatalogSnapshot:
+        self.calls += 1
+        return RewindCatalogSnapshot(candidates=self.candidates)
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.value = 0.0
+
+    def __call__(self) -> float:
+        return self.value
+
+
+def _candidate(tmp_path: Path, name: str) -> tuple[RewindHookCandidate, TrustStore]:
+    manifest = _manifest(name)
+    plugin_home, source_type, source_identity, digest, trust_store = _installed_subject(
+        tmp_path, manifest
+    )
+    return (
+        RewindHookCandidate(
+            manifest=manifest,
+            plugin_home=plugin_home,
+            source_type=source_type,
+            source_identity=source_identity,
+            artifact_digest=digest,
+            hook_index=0,
+        ),
+        trust_store,
+    )
+
+
+@pytest.mark.asyncio
+async def test_global_budget_skips_remaining_candidates_deterministically(
+    tmp_path: Path,
+) -> None:
+    first, trust_store = _candidate(tmp_path, "alpha-observer")
+    second_manifest = _manifest("zulu-observer")
+    second_home = tmp_path / second_manifest.name
+    second_home.mkdir()
+    (second_home / "hook.py").write_text("print('hook')\n")
+    second_identity = "https://example.invalid/zulu-observer"
+    second_digest = canonical_tree_hash(second_home)
+    trust_store.grant(
+        plugin=second_manifest.name,
+        version=second_manifest.version,
+        scope=HOOK_REWIND_OBSERVE_SCOPE,
+        granted_by="user:test",
+        source_type="plugin_home",
+        source_identity=second_identity,
+        artifact_digest=second_digest,
+    )
+    second = RewindHookCandidate(
+        manifest=second_manifest,
+        plugin_home=second_home,
+        source_type="plugin_home",
+        source_identity=second_identity,
+        artifact_digest=second_digest,
+        hook_index=0,
+    )
+    clock = _Clock()
+    calls: list[str] = []
+
+    def _runner(argv, **kwargs):
+        calls.append(Path(kwargs["cwd"]).name)
+        clock.value = 5.0
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    store = _Store()
+    catalog = _Catalog((first, second))
+    observer = LockfileRewindObserver(
+        store,
+        catalog=catalog,  # type: ignore[arg-type]
+        trust_store=trust_store,
+        subprocess_runner=_runner,
+        monotonic=clock,
+    )
+
+    await observer.observe(_snapshot())
+
+    assert catalog.calls == 1
+    assert calls == ["alpha-observer"]
+    assert store.batches == []
+
+
+def test_budget_exhaustion_event_records_total_skipped_count() -> None:
+    events: list[dict] = []
+
+    result = emit_rewind_budget_exhausted(
+        manifest=_manifest(),
+        rewind_event_id="event-1",
+        lineage_id="lin-1",
+        skipped_count=3,
+        event_sink=events.append,
+    )
+
+    assert result.reason == "dispatch_budget_exhausted"
+    assert events[-1]["provenance"] == {
+        "correlation_id": "event-1",
+        "hook_name": "on_rewind",
+        "failure_policy": "fail_open",
+        "reason": "dispatch_budget_exhausted",
+        "skipped_count": "3",
+    }
+
+
+@pytest.mark.asyncio
+async def test_remaining_timeout_is_clamped_after_prior_dispatch(tmp_path: Path) -> None:
+    first, trust_store = _candidate(tmp_path, "alpha-observer")
+    second_manifest = _manifest("zulu-observer")
+    second_home = tmp_path / second_manifest.name
+    second_home.mkdir()
+    (second_home / "hook.py").write_text("print('hook')\n")
+    second_identity = "https://example.invalid/zulu-observer"
+    second_digest = canonical_tree_hash(second_home)
+    trust_store.grant(
+        plugin=second_manifest.name,
+        version=second_manifest.version,
+        scope=HOOK_REWIND_OBSERVE_SCOPE,
+        granted_by="user:test",
+        source_type="plugin_home",
+        source_identity=second_identity,
+        artifact_digest=second_digest,
+    )
+    second = RewindHookCandidate(
+        manifest=second_manifest,
+        plugin_home=second_home,
+        source_type="plugin_home",
+        source_identity=second_identity,
+        artifact_digest=second_digest,
+        hook_index=0,
+    )
+    clock = _Clock()
+    timeouts: list[float] = []
+
+    def _runner(argv, **kwargs):
+        timeouts.append(kwargs["timeout"])
+        if len(timeouts) == 1:
+            clock.value = 4.9
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    observer = LockfileRewindObserver(
+        _Store(),
+        catalog=_Catalog((first, second)),  # type: ignore[arg-type]
+        trust_store=trust_store,
+        subprocess_runner=_runner,
+        monotonic=clock,
+    )
+
+    await observer.observe(_snapshot())
+
+    assert timeouts[0] == 5.0
+    assert timeouts[1] == pytest.approx(0.1)
+
+
+@pytest.mark.asyncio
+async def test_slow_catalog_cannot_delay_observer_past_global_budget() -> None:
+    class _SlowCatalog:
+        def snapshot(self) -> RewindCatalogSnapshot:
+            time.sleep(0.25)
+            return RewindCatalogSnapshot(candidates=())
+
+    observer = LockfileRewindObserver(
+        _Store(),
+        catalog=_SlowCatalog(),  # type: ignore[arg-type]
+        trust_store=TrustStore(),
+        dispatch_budget_seconds=0.03,
+    )
+
+    started = time.monotonic()
+    await observer.observe(_snapshot())
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 0.2
+    await asyncio.sleep(0.25)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("slow_stage", ["digest", "trust"])
+async def test_slow_prelaunch_work_cannot_start_hook_after_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    slow_stage: str,
+) -> None:
+    candidate, trust_store = _candidate(tmp_path, "alpha-observer")
+    calls: list[list[str]] = []
+
+    if slow_stage == "digest":
+
+        def _slow_digest(_plugin_home: Path) -> str:
+            time.sleep(0.25)
+            return candidate.artifact_digest
+
+        monkeypatch.setattr("ouroboros.plugin.firewall.canonical_tree_hash", _slow_digest)
+    else:
+        original_is_disabled = trust_store.is_disabled_for_subject
+
+        def _slow_is_disabled(*args, **kwargs) -> bool:
+            time.sleep(0.25)
+            return original_is_disabled(*args, **kwargs)
+
+        monkeypatch.setattr(trust_store, "is_disabled_for_subject", _slow_is_disabled)
+
+    def _runner(argv, **_kwargs):
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
+
+    observer = LockfileRewindObserver(
+        _Store(),
+        catalog=_Catalog((candidate,)),  # type: ignore[arg-type]
+        trust_store=trust_store,
+        subprocess_runner=_runner,
+        dispatch_budget_seconds=0.03,
+    )
+
+    started = time.monotonic()
+    await observer.observe(_snapshot())
+    elapsed = time.monotonic() - started
+    await asyncio.sleep(0.25)
+
+    assert elapsed < 0.2
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_audit_flush_failure_isolated_after_dispatch(tmp_path: Path) -> None:
+    candidate, trust_store = _candidate(tmp_path, "alpha-observer")
+    observer = LockfileRewindObserver(
+        _Store(fail=True),
+        catalog=_Catalog((candidate,)),  # type: ignore[arg-type]
+        trust_store=trust_store,
+        subprocess_runner=lambda argv, **_kwargs: subprocess.CompletedProcess(
+            argv, 0, stdout="", stderr=""
+        ),
+    )
+
+    await observer.observe(_snapshot())
+
+
+def test_golden_audit_fixture_validates_independently() -> None:
+    fixture = json.loads((FIXTURE_ROOT / "audit-event-v0.6.json").read_text())
+    assert not list(AUDIT_VALIDATOR.iter_errors(fixture))

--- a/tests/unit/test_evolve_rewind.py
+++ b/tests/unit/test_evolve_rewind.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 
+from ouroboros.core.lineage import LineageStatus
+from ouroboros.core.types import Result
+from ouroboros.evolution.rewind import CommittedRewindResult
 from ouroboros.mcp.tools.definitions import EvolveRewindHandler
 from ouroboros.mcp.types import ToolInputType
 
@@ -64,3 +69,52 @@ class TestEvolveRewindHandlerErrors:
         result = await handler.handle({"lineage_id": "lin_test", "to_generation": 1})
         assert result.is_err
         assert "EvolutionaryLoop not configured" in str(result.error)
+
+
+@pytest.mark.asyncio
+async def test_success_metadata_uses_committed_event_identity(monkeypatch) -> None:
+    from tests.unit.tui.test_lineage_viewer import make_lineage
+
+    lineage = make_lineage()
+    rewound = lineage.rewind_to(1).with_status(LineageStatus.ACTIVE)
+    occurred_at = datetime(2026, 7, 13, 6, 0, tzinfo=UTC)
+    committed = CommittedRewindResult(
+        lineage=rewound,
+        lineage_id=lineage.lineage_id,
+        from_generation=2,
+        to_generation=1,
+        rewind_event_id="rewind-event-1",
+        rewind_occurred_at=occurred_at,
+    )
+
+    class _Store:
+        async def initialize(self) -> None:
+            return None
+
+        async def replay_lineage(self, lineage_id: str):  # noqa: ARG002
+            return [object()]
+
+    class _Loop:
+        def __init__(self) -> None:
+            self.event_store = _Store()
+
+        async def rewind_to(self, current, target):  # noqa: ARG002
+            return Result.ok(committed)
+
+    class _Projector:
+        def project(self, events):  # noqa: ARG002
+            return lineage
+
+    monkeypatch.setattr("ouroboros.evolution.projector.LineageProjector", _Projector)
+    handler = EvolveRewindHandler(evolutionary_loop=_Loop())
+
+    result = await handler.handle({"lineage_id": lineage.lineage_id, "to_generation": 1})
+
+    assert result.is_ok
+    assert result.value.meta == {
+        "lineage_id": lineage.lineage_id,
+        "from_generation": 2,
+        "to_generation": 1,
+        "rewind_event_id": "rewind-event-1",
+        "rewind_occurred_at": "2026-07-13T06:00:00Z",
+    }

--- a/tests/unit/test_ralph_rewind.py
+++ b/tests/unit/test_ralph_rewind.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -17,6 +19,7 @@ sys.modules["ralph_rewind"] = _ralph_rewind
 _spec.loader.exec_module(_ralph_rewind)
 
 build_parser = _ralph_rewind.build_parser
+call_rewind = _ralph_rewind._call_rewind
 
 
 class TestRalphRewindParser:
@@ -76,3 +79,94 @@ class TestRalphRewindParser:
         parser = build_parser()
         with pytest.raises(SystemExit):
             parser.parse_args(["--lineage-id", "lin_test", "--to-generation", "abc"])
+
+
+def _args(*, checkout: bool = False) -> SimpleNamespace:
+    return SimpleNamespace(
+        lineage_id="lin_test",
+        to_generation=2,
+        git_checkout=checkout,
+    )
+
+
+def _tool_result(text: str | None, *, is_error: bool = False) -> SimpleNamespace:
+    content = [] if text is None else [SimpleNamespace(type="text", text=text)]
+    return SimpleNamespace(content=content, isError=is_error)
+
+
+class TestRalphRewindResponseContract:
+    @pytest.mark.asyncio
+    async def test_calls_rewind_once_with_exact_arguments(self) -> None:
+        session = SimpleNamespace(call_tool=AsyncMock(return_value=_tool_result("ok")))
+
+        result = await call_rewind(session, _args())
+
+        session.call_tool.assert_called_once_with(
+            "ouroboros_evolve_rewind",
+            {"lineage_id": "lin_test", "to_generation": 2},
+        )
+        assert result["error"] is None
+        assert result["git_checkout"] is False
+
+    @pytest.mark.asyncio
+    async def test_checkout_uses_generation_tag(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        session = SimpleNamespace(call_tool=AsyncMock(return_value=_tool_result("ok")))
+        run = Mock()
+        monkeypatch.setattr(_ralph_rewind.subprocess, "run", run)
+
+        result = await call_rewind(session, _args(checkout=True))
+
+        run.assert_called_once_with(
+            ["git", "checkout", "ooo/lin_test/gen_2"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        assert result["git_checkout"] is True
+
+    @pytest.mark.asyncio
+    async def test_checkout_failure_does_not_retry_rewind(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        session = SimpleNamespace(call_tool=AsyncMock(return_value=_tool_result("ok")))
+        monkeypatch.setattr(
+            _ralph_rewind.subprocess,
+            "run",
+            Mock(
+                side_effect=_ralph_rewind.subprocess.CalledProcessError(
+                    1,
+                    ["git", "checkout"],
+                    stderr="missing tag",
+                )
+            ),
+        )
+
+        result = await call_rewind(session, _args(checkout=True))
+
+        session.call_tool.assert_called_once()
+        assert result["git_checkout"] is False
+        assert result["error"] == "git checkout failed: missing tag"
+
+    @pytest.mark.asyncio
+    async def test_tool_error_preserves_error_shape(self) -> None:
+        session = SimpleNamespace(
+            call_tool=AsyncMock(return_value=_tool_result("rewind failed", is_error=True))
+        )
+
+        result = await call_rewind(session, _args())
+
+        assert result == {
+            "lineage_id": "lin_test",
+            "from_generation": None,
+            "to_generation": 2,
+            "git_checkout": False,
+            "error": "rewind failed",
+        }
+
+    @pytest.mark.asyncio
+    async def test_missing_text_preserves_error_shape(self) -> None:
+        session = SimpleNamespace(call_tool=AsyncMock(return_value=_tool_result(None)))
+
+        result = await call_rewind(session, _args())
+
+        assert result["error"] == "No text content in evolve_rewind response"

--- a/tests/unit/tui/test_lineage_viewer.py
+++ b/tests/unit/tui/test_lineage_viewer.py
@@ -11,6 +11,8 @@ Tests for:
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 
 from ouroboros.core.lineage import (
@@ -22,7 +24,9 @@ from ouroboros.core.lineage import (
     OntologyLineage,
 )
 from ouroboros.core.seed import OntologyField, OntologySchema
+from ouroboros.core.types import Result
 from ouroboros.events.base import BaseEvent
+from ouroboros.evolution.rewind import CommittedRewindResult
 from ouroboros.persistence.event_store import EventStore
 from ouroboros.tui.events import GenerationSelected, LineageSelected
 from ouroboros.tui.screens.lineage_detail import GenerationDetailPanel, LineageDetailScreen
@@ -421,3 +425,93 @@ class TestLineageDetailScreenRewind:
         mock_store = object()
         screen = LineageDetailScreen(lineage, event_store=mock_store)
         assert screen._event_store is mock_store
+
+    @pytest.mark.asyncio
+    async def test_perform_rewind_delegates_before_checkout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        lineage = make_lineage()
+        calls: list[tuple[OntologyLineage, int]] = []
+
+        class _Committer:
+            async def rewind_to(self, current: OntologyLineage, target: int):
+                calls.append((current, target))
+                return Result.ok(
+                    CommittedRewindResult(
+                        lineage=current.rewind_to(target),
+                        lineage_id=current.lineage_id,
+                        from_generation=current.current_generation,
+                        to_generation=target,
+                        rewind_event_id="rewind-tui-1",
+                        rewind_occurred_at=datetime(2026, 7, 13, tzinfo=UTC),
+                    )
+                )
+
+        class _Process:
+            returncode = 0
+
+            async def communicate(self):
+                return b"dirty\n", b""
+
+        class _App:
+            def __init__(self) -> None:
+                self.popped = False
+
+            def pop_screen(self) -> None:
+                self.popped = True
+
+        app = _App()
+        notifications: list[str] = []
+
+        async def _create_subprocess(*_args, **_kwargs):
+            return _Process()
+
+        def _get_app(_screen):
+            return app
+
+        def _notify(message, **_kwargs):
+            notifications.append(message)
+
+        monkeypatch.setattr(
+            "ouroboros.tui.screens.lineage_detail.asyncio.create_subprocess_exec",
+            _create_subprocess,
+        )
+        monkeypatch.setattr(LineageDetailScreen, "app", property(_get_app))
+        screen = LineageDetailScreen(lineage, rewind_committer=_Committer())
+        monkeypatch.setattr(screen, "notify", _notify)
+
+        await screen._perform_rewind(1)
+
+        assert calls == [(lineage, 1)]
+        assert screen._lineage.current_generation == 1
+        assert app.popped is True
+        assert any("working tree is dirty" in message for message in notifications)
+
+    @pytest.mark.asyncio
+    async def test_commit_failure_starts_no_checkout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from ouroboros.core.errors import OuroborosError
+
+        lineage = make_lineage()
+
+        class _Committer:
+            async def rewind_to(self, current, target):  # noqa: ARG002
+                return Result.err(OuroborosError("commit failed"))
+
+        async def _unexpected_subprocess(*args, **kwargs):
+            raise AssertionError("checkout must not start when commit fails")
+
+        notifications: list[str] = []
+
+        def _notify(message, **_kwargs):
+            notifications.append(message)
+
+        monkeypatch.setattr(
+            "ouroboros.tui.screens.lineage_detail.asyncio.create_subprocess_exec",
+            _unexpected_subprocess,
+        )
+        screen = LineageDetailScreen(lineage, rewind_committer=_Committer())
+        monkeypatch.setattr(screen, "notify", _notify)
+
+        await screen._perform_rewind(1)
+
+        assert notifications == ["Failed to commit rewind: commit failed"]


### PR DESCRIPTION
## Summary

- keep `EvolutionaryLoop.rewind_to()` as the sole truncate-and-append primitive and return an immutable committed rewind result
- route MCP and TUI rewinds through that boundary while leaving git checkout caller-owned
- add schema v0.6 `on_rewind` observers with exact `plugin:rewind:observe`, a seven-field 2,048-byte payload, strict trust/digest checks, and observation audit subjects
- enforce one lockfile snapshot and a single 5.0-second deadline across catalog, digest/trust preflight, subprocess execution, and audit flush
- persist fail-open hook audit through the typed plugin ledger adapter and document the complete contract/non-goals

## Contract

The hook runs only after `lineage.rewound` is committed. It receives a scalar-only snapshot and has no lineage/EventStore handle, veto, retry, cleanup, checkpoint, or checkout authority. Catalog, trust, digest, subprocess, timeout, and audit failures cannot change the captured rewind result.

Schema `0.5` remains reserved for #1462 on the current `upstream/main` baseline. If #1462 lands first, this PR must be rebased so schema `0.6` remains additive over the merged v0.5 contract.

## Validation

- related plugin/rewind/MCP/TUI/script and wheel suites: `613 passed, 2 skipped`
- full suite with the virtualenv `python` on `PATH`: `12187 passed, 7 skipped, 4 failed`
- all 4 full-suite failures reproduce on clean `upstream/main` and are outside this diff:
  - 2 Claude setup argument/idempotency assertions
  - 2 Codex runtime-profile fallback assertions
- `ruff check src tests scripts/ralph-rewind.py`: passed
- `ruff format --check src tests scripts/ralph-rewind.py`: passed
- `mypy src scripts/ralph-rewind.py`: passed (`437` source files)
- full tests-inclusive Mypy remains at the upstream baseline: `73 errors in 23 unrelated test files`
- independent verifier: PASS
- independent code review after deadline hardening: APPROVE
- independent architecture review: APPROVE

## Non-goals

- generic plugin event bus
- plugin-triggered rewind or checkout
- OS-level subprocess containment
- expected-head/CAS, idempotency, duplicate prevention, or at-most-once guarantees

Closes #1464
