### PR TITLE
fix(orchestrator): stabilize Codex runtime identity and GPT-5.6 routing

### DIFF
--- a/src/ouroboros/backends/model_catalog.py
+++ b/src/ouroboros/backends/model_catalog.py
@@ -31,7 +31,7 @@ from ouroboros.backends.capabilities import (
     get_backend_capability,
     runtime_backend_choices,
 )
-from ouroboros.config._model_defaults import DEFAULT_OPUS_MODEL, DEFAULT_SONNET_MODEL
+import ouroboros.config._model_defaults as model_defaults
 
 # Backends whose runnable model is the CLI's own configured default rather
 # than a Claude model id. Mirrors the loader's sentinel frozensets
@@ -74,11 +74,11 @@ class BackendModelCatalog:
 
 
 # Hand-curated additions per backend, appended after the loader-mirroring
-# default entry. Keep entries verifiable: the codex ids below were confirmed
-# against a live `opencode models` listing of the OpenAI catalog.
+# default entry. Keep entries verifiable: the Codex ids below were confirmed
+# against live ChatGPT-account Codex CLI calls.
 _EXTRA_KNOWN_MODELS: dict[str, tuple[str, ...]] = {
     "claude": ("claude-haiku-4-5-20251001",),
-    "codex": ("gpt-5-codex", "gpt-5", "gpt-5-mini"),
+    "codex": model_defaults.DEFAULT_CODEX_TIER_MODELS,
     # Grok Build model slugs, after the CLI-owned "default" sentinel. Verified
     # against a live `grok models` listing (grok-build, grok-composer-2.5-fast).
     "grok": ("grok-build", "grok-composer-2.5-fast"),
@@ -145,7 +145,10 @@ def _build_catalogs() -> dict[str, BackendModelCatalog]:
         if name in _SENTINEL_MODEL_BACKENDS:
             models: tuple[str, ...] = (DEFAULT_MODEL_SENTINEL,)
         else:
-            models = (DEFAULT_OPUS_MODEL, DEFAULT_SONNET_MODEL)
+            models = (
+                model_defaults.DEFAULT_OPUS_MODEL,
+                model_defaults.DEFAULT_SONNET_MODEL,
+            )
         models = models + _EXTRA_KNOWN_MODELS.get(name, ())
         catalogs[name] = BackendModelCatalog(
             backend=name,

--- a/src/ouroboros/config/_model_defaults.py
+++ b/src/ouroboros/config/_model_defaults.py
@@ -1,4 +1,4 @@
-"""Single source of truth for default Claude model pins.
+"""Single source of truth for default Claude and Codex model pins.
 
 Every config default (Pydantic field defaults in :mod:`ouroboros.config.models`,
 the ``get_*_model`` fallbacks in :mod:`ouroboros.config.loader`, and the setup
@@ -39,6 +39,15 @@ DEFAULT_SONNET_MODEL = "claude-sonnet-4-6"
 # so decomposed leaves route here while top-level ACs keep the Sonnet default.
 # Anthropic-direct API id. Bump on each new Haiku release.
 DEFAULT_HAIKU_MODEL = "claude-haiku-4-5"
+
+DEFAULT_CODEX_LUNA_MODEL = "gpt-5.6-luna"
+DEFAULT_CODEX_TERRA_MODEL = "gpt-5.6-terra"
+DEFAULT_CODEX_SOL_MODEL = "gpt-5.6-sol"
+DEFAULT_CODEX_TIER_MODELS = (
+    DEFAULT_CODEX_LUNA_MODEL,
+    DEFAULT_CODEX_TERRA_MODEL,
+    DEFAULT_CODEX_SOL_MODEL,
+)
 
 # OpenRouter-routed Opus for the multi-provider consensus roster. This is the
 # OpenRouter slug (dotted ``claude-opus-4.8``), which differs from the
@@ -84,16 +93,20 @@ LEGACY_DEFAULT_MODELS: dict[str, tuple[str, ...]] = {
 # Verified against git history of ``ouroboros.config.models`` (the tier defaults
 # have only ever held these ids): openai frugal ``gpt-4o-mini`` -> standard
 # ``gpt-4o`` -> frontier ``o3`` became ``gpt-5.1-codex-mini`` / ``gpt-5-codex`` /
-# ``gpt-5.2``; anthropic frugal ``claude-3-5-haiku``, standard
+# ``gpt-5.2`` and then the current GPT-5.6 Luna/Terra/Sol family; anthropic
+# frugal ``claude-3-5-haiku``, standard
 # ``claude-sonnet-4-20250514``, frontier ``claude-opus-4-5-20251101`` (and the
 # later frontier ``claude-opus-4-6``) became the DEFAULT_*_MODEL pins. The google
 # tier ids (``gemini-2.0-flash`` / ``gemini-2.5-pro``) have never been bumped, so
 # they carry no entry and are preserved as-is.
 LEGACY_TIER_MODELS: dict[str, str] = {
     # openai (Codex CLI) tier ids
-    "gpt-4o-mini": "gpt-5.1-codex-mini",
-    "gpt-4o": "gpt-5-codex",
-    "o3": "gpt-5.2",
+    "gpt-4o-mini": DEFAULT_CODEX_LUNA_MODEL,
+    "gpt-5.1-codex-mini": DEFAULT_CODEX_LUNA_MODEL,
+    "gpt-4o": DEFAULT_CODEX_TERRA_MODEL,
+    "gpt-5-codex": DEFAULT_CODEX_TERRA_MODEL,
+    "o3": DEFAULT_CODEX_SOL_MODEL,
+    "gpt-5.2": DEFAULT_CODEX_SOL_MODEL,
     # anthropic tier ids
     "claude-3-5-haiku": DEFAULT_HAIKU_MODEL,
     "claude-sonnet-4-20250514": DEFAULT_SONNET_MODEL,
@@ -107,8 +120,11 @@ LEGACY_TIER_MODELS: dict[str, str] = {
 # preserved verbatim.
 LEGACY_TIER_MODEL_PROVIDERS: dict[str, str] = {
     "gpt-4o-mini": "openai",
+    "gpt-5.1-codex-mini": "openai",
     "gpt-4o": "openai",
+    "gpt-5-codex": "openai",
     "o3": "openai",
+    "gpt-5.2": "openai",
     "claude-3-5-haiku": "anthropic",
     "claude-sonnet-4-20250514": "anthropic",
     "claude-opus-4-5-20251101": "anthropic",

--- a/src/ouroboros/config/models.py
+++ b/src/ouroboros/config/models.py
@@ -27,6 +27,9 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field, field_validator
 
 from ouroboros.config._model_defaults import (
+    DEFAULT_CODEX_LUNA_MODEL,
+    DEFAULT_CODEX_SOL_MODEL,
+    DEFAULT_CODEX_TERRA_MODEL,
     DEFAULT_CONSENSUS_OPUS_MODEL,
     DEFAULT_HAIKU_MODEL,
     DEFAULT_OPUS_MODEL,
@@ -688,7 +691,7 @@ def get_default_config() -> OuroborosConfig:
                     cost_factor=1,
                     intelligence_range=(9, 11),
                     models=[
-                        ModelConfig(provider="openai", model="gpt-5.1-codex-mini"),
+                        ModelConfig(provider="openai", model=DEFAULT_CODEX_LUNA_MODEL),
                         ModelConfig(provider="google", model="gemini-2.0-flash"),
                         ModelConfig(provider="anthropic", model=DEFAULT_HAIKU_MODEL),
                     ],
@@ -698,7 +701,7 @@ def get_default_config() -> OuroborosConfig:
                     cost_factor=10,
                     intelligence_range=(14, 16),
                     models=[
-                        ModelConfig(provider="openai", model="gpt-5-codex"),
+                        ModelConfig(provider="openai", model=DEFAULT_CODEX_TERRA_MODEL),
                         ModelConfig(provider="anthropic", model=DEFAULT_SONNET_MODEL),
                         ModelConfig(provider="google", model="gemini-2.5-pro"),
                     ],
@@ -708,7 +711,7 @@ def get_default_config() -> OuroborosConfig:
                     cost_factor=30,
                     intelligence_range=(18, 20),
                     models=[
-                        ModelConfig(provider="openai", model="gpt-5.2"),
+                        ModelConfig(provider="openai", model=DEFAULT_CODEX_SOL_MODEL),
                         ModelConfig(provider="anthropic", model=DEFAULT_OPUS_MODEL),
                     ],
                     use_cases=["consensus", "lateral_thinking", "big_bang"],

--- a/src/ouroboros/config_tui/app.py
+++ b/src/ouroboros/config_tui/app.py
@@ -41,7 +41,13 @@ from ouroboros.backends.model_catalog import (
     refresh_models,
     uses_default_model_sentinel,
 )
-from ouroboros.config._model_defaults import DEFAULT_OPUS_MODEL, DEFAULT_SONNET_MODEL
+from ouroboros.config._model_defaults import (
+    DEFAULT_CODEX_LUNA_MODEL,
+    DEFAULT_CODEX_SOL_MODEL,
+    DEFAULT_CODEX_TERRA_MODEL,
+    DEFAULT_OPUS_MODEL,
+    DEFAULT_SONNET_MODEL,
+)
 from ouroboros.config.models import OuroborosConfig, get_config_dir
 from ouroboros.config_tui import persistence
 from ouroboros.config_tui.fields import (
@@ -69,9 +75,12 @@ SEARCH_THRESHOLD = 20
 # One-click model presets: per-backend picks, falling back to the backend's
 # catalog default where no differentiated tier exists (sentinel backends).
 PRESET_MODELS: dict[str, dict[str, str]] = {
-    "frugal": {"claude": "claude-haiku-4-5-20251001", "codex": "gpt-5-mini"},
-    "balanced": {"claude": DEFAULT_SONNET_MODEL, "codex": "gpt-5"},
-    "frontier": {"claude": DEFAULT_OPUS_MODEL, "codex": "gpt-5-codex"},
+    "frugal": {
+        "claude": "claude-haiku-4-5-20251001",
+        "codex": DEFAULT_CODEX_LUNA_MODEL,
+    },
+    "balanced": {"claude": DEFAULT_SONNET_MODEL, "codex": DEFAULT_CODEX_TERRA_MODEL},
+    "frontier": {"claude": DEFAULT_OPUS_MODEL, "codex": DEFAULT_CODEX_SOL_MODEL},
 }
 
 # One-click multi-LLM stage-routing presets: per-stage runtime backend picks

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -43,6 +43,7 @@ from ouroboros.orchestrator.adapter import (
     SubagentOrchestration,
     TaskResult,
 )
+from ouroboros.orchestrator.codex_config_fingerprint import fingerprint_codex_config_files
 from ouroboros.providers.base import CompletionConfig
 from ouroboros.providers.codex_cli_stream import (
     iter_runtime_stream_lines,
@@ -389,51 +390,7 @@ class CodexCliRuntime:
         return Path(configured).expanduser() if configured else Path.home() / ".codex"
 
     def _fingerprint_codex_config_files(self) -> str:
-        """Hash global Codex config and every profile-v2 TOML by name/content."""
-        codex_home = self._codex_home()
-        candidates: dict[str, Path] = {"config.toml": codex_home / "config.toml"}
-        try:
-            for path in codex_home.glob("*.config.toml"):
-                candidates[path.name] = path
-        except OSError as exc:
-            raise RuntimeError("Cannot inspect Codex profile configuration") from exc
-
-        digest = hashlib.sha256()
-        digest.update(b"ouroboros-codex-config-v1\0")
-        # CODEX_HOME also owns the session database used by ``codex exec
-        # resume``. Identical profile files under a different home must not
-        # authorize reconnecting a persisted thread id in another store.
-        digest.update(str(codex_home.resolve(strict=False)).encode("utf-8"))
-        digest.update(b"\0")
-        for name, path in sorted(candidates.items()):
-            digest.update(name.encode("utf-8", errors="surrogateescape"))
-            digest.update(b"\0")
-            try:
-                stat_result = path.lstat()
-            except FileNotFoundError:
-                digest.update(b"missing\0")
-                continue
-            except OSError as exc:
-                raise RuntimeError("Cannot inspect Codex profile configuration") from exc
-
-            if path.is_symlink():
-                try:
-                    digest.update(b"symlink\0")
-                    digest.update(os.readlink(path).encode("utf-8", errors="surrogateescape"))
-                    digest.update(b"\0")
-                except OSError as exc:
-                    raise RuntimeError("Cannot inspect Codex profile configuration") from exc
-            if not path.is_file():
-                digest.update(f"non-file:{stat_result.st_mode}\0".encode("ascii"))
-                continue
-            try:
-                with path.open("rb") as config_file:
-                    while chunk := config_file.read(64 * 1024):
-                        digest.update(chunk)
-            except OSError as exc:
-                raise RuntimeError("Cannot read Codex profile configuration") from exc
-            digest.update(b"\0")
-        return digest.hexdigest()
+        return fingerprint_codex_config_files(self._codex_home())
 
     def _assert_codex_config_files_unchanged(self) -> None:
         if self._runtime_backend != "codex":

--- a/src/ouroboros/orchestrator/codex_config_fingerprint.py
+++ b/src/ouroboros/orchestrator/codex_config_fingerprint.py
@@ -6,21 +6,7 @@ import json
 import os
 from pathlib import Path
 import tomllib
-from typing import Final, Protocol
-
-_GLOBAL_ROUTING_KEYS: Final[frozenset[str]] = frozenset(
-    {
-        "chatgpt_base_url",
-        "experimental_thread_config_endpoint",
-        "forced_chatgpt_workspace_id",
-        "forced_login_method",
-        "openai_base_url",
-        "oss_provider",
-        "profile",
-        "profiles",
-        "service_tier",
-    }
-)
+from typing import Protocol
 
 
 class _Digest(Protocol):
@@ -84,11 +70,12 @@ def _update_config_digest(
         raise CodexConfigFingerprintError("Cannot read Codex profile configuration") from exc
 
     if global_config:
-        config = {
-            key: value
-            for key, value in config.items()
-            if key.startswith("model") or key in _GLOBAL_ROUTING_KEYS
-        }
+        config.pop("projects", None)
+        hooks = config.get("hooks")
+        if isinstance(hooks, dict):
+            hooks.pop("state", None)
+            if not hooks:
+                config.pop("hooks")
     digest.update(
         json.dumps(
             config,

--- a/src/ouroboros/orchestrator/codex_config_fingerprint.py
+++ b/src/ouroboros/orchestrator/codex_config_fingerprint.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from datetime import date, datetime, time
+import hashlib
+import json
+import os
+from pathlib import Path
+import tomllib
+from typing import Final, Protocol
+
+_GLOBAL_ROUTING_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        "chatgpt_base_url",
+        "experimental_thread_config_endpoint",
+        "forced_chatgpt_workspace_id",
+        "forced_login_method",
+        "openai_base_url",
+        "oss_provider",
+        "profile",
+        "profiles",
+        "service_tier",
+    }
+)
+
+
+class _Digest(Protocol):
+    def update(self, data: bytes, /) -> None: ...
+
+
+class CodexConfigFingerprintError(RuntimeError):
+    pass
+
+
+def fingerprint_codex_config_files(codex_home: Path) -> str:
+    candidates: dict[str, Path] = {"config.toml": codex_home / "config.toml"}
+    try:
+        for path in codex_home.glob("*.config.toml"):
+            candidates[path.name] = path
+    except OSError as exc:
+        raise CodexConfigFingerprintError("Cannot inspect Codex profile configuration") from exc
+
+    digest = hashlib.sha256()
+    digest.update(b"ouroboros-codex-config-v2\0")
+    digest.update(str(codex_home.resolve(strict=False)).encode("utf-8"))
+    digest.update(b"\0")
+    for name, path in sorted(candidates.items()):
+        digest.update(name.encode("utf-8", errors="surrogateescape"))
+        digest.update(b"\0")
+        _update_config_digest(digest, path, global_config=name == "config.toml")
+    return digest.hexdigest()
+
+
+def _update_config_digest(
+    digest: _Digest,
+    path: Path,
+    *,
+    global_config: bool,
+) -> None:
+    try:
+        stat_result = path.lstat()
+    except FileNotFoundError:
+        digest.update(b"missing\0")
+        return
+    except OSError as exc:
+        raise CodexConfigFingerprintError("Cannot inspect Codex profile configuration") from exc
+
+    if path.is_symlink():
+        try:
+            digest.update(b"symlink\0")
+            digest.update(os.readlink(path).encode("utf-8", errors="surrogateescape"))
+            digest.update(b"\0")
+        except OSError as exc:
+            raise CodexConfigFingerprintError("Cannot inspect Codex profile configuration") from exc
+    if not path.is_file():
+        digest.update(f"non-file:{stat_result.st_mode}\0".encode("ascii"))
+        return
+
+    try:
+        with path.open("rb") as config_file:
+            config = tomllib.load(config_file)
+    except tomllib.TOMLDecodeError as exc:
+        raise CodexConfigFingerprintError("Cannot parse Codex profile configuration") from exc
+    except OSError as exc:
+        raise CodexConfigFingerprintError("Cannot read Codex profile configuration") from exc
+
+    if global_config:
+        config = {
+            key: value
+            for key, value in config.items()
+            if key.startswith("model") or key in _GLOBAL_ROUTING_KEYS
+        }
+    digest.update(
+        json.dumps(
+            config,
+            default=_serialize_toml_value,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    )
+    digest.update(b"\0")
+
+
+def _serialize_toml_value(value: date | datetime | time) -> dict[str, str]:
+    return {"toml_type": type(value).__name__, "value": value.isoformat()}

--- a/tests/unit/backends/test_model_catalog.py
+++ b/tests/unit/backends/test_model_catalog.py
@@ -36,7 +36,7 @@ def test_claude_catalog_lists_shipped_defaults_first() -> None:
 def test_codex_catalog_offers_known_models_after_sentinel() -> None:
     choices = mc.model_choices("codex")
     assert choices[0] == mc.DEFAULT_MODEL_SENTINEL
-    assert "gpt-5-codex" in choices
+    assert choices[1:4] == ("gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol")
 
 
 def test_default_model_sentinel_support_follows_backend_contract() -> None:

--- a/tests/unit/config_tui/test_app.py
+++ b/tests/unit/config_tui/test_app.py
@@ -19,12 +19,25 @@ from ouroboros.config_tui.app import (
     CUSTOM_SENTINEL,
     INHERIT_SENTINEL,
     INSTALL_REQUIRED_SUFFIX,
+    PRESET_MODELS,
     SEARCH_SENTINEL,
     ModelSearchScreen,
     SettingsApp,
 )
 from ouroboros.config_tui.fields import STAGE_MODEL_FIELDS
 from ouroboros.orchestrator_stage import Stage
+
+
+@pytest.mark.parametrize(
+    ("tier", "expected"),
+    [
+        ("frugal", "gpt-5.6-luna"),
+        ("balanced", "gpt-5.6-terra"),
+        ("frontier", "gpt-5.6-sol"),
+    ],
+)
+def test_codex_model_presets_use_5_6_family(tier: str, expected: str) -> None:
+    assert PRESET_MODELS[tier]["codex"] == expected
 
 
 @pytest.fixture

--- a/tests/unit/orchestrator/test_codex_cli_runtime.py
+++ b/tests/unit/orchestrator/test_codex_cli_runtime.py
@@ -288,6 +288,52 @@ class TestCodexCliRuntime:
         assert command.index("-C") < resume_index
         assert command[command.index("-C") + 1] == _EXPECTED_PROJECT_CWD
 
+    def test_build_command_allows_codex_managed_state_updates(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        codex_home = tmp_path / "codex-home"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text(
+            'model = "gpt-5.6-sol"\n\n[projects."/tmp/existing"]\ntrust_level = "trusted"\n',
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        runtime = CodexCliRuntime(cli_path="codex", cwd="/tmp/project")
+
+        config_path.write_text(
+            'model = "gpt-5.6-sol"\n'
+            '\n[projects."/tmp/existing"]\n'
+            'trust_level = "trusted"\n'
+            '\n[projects."/tmp/codex-relay-live-workspace-new"]\n'
+            'trust_level = "trusted"\n'
+            '\n[hooks.state."plugin:session_start:0"]\n'
+            'trusted_hash = "desktop-managed-state"\n',
+            encoding="utf-8",
+        )
+
+        command = runtime._build_command(output_last_message_path="/tmp/out.txt")
+
+        assert command[:2] == ["codex", "exec"]
+
+    def test_build_command_rejects_model_routing_config_updates(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        codex_home = tmp_path / "codex-home"
+        codex_home.mkdir()
+        config_path = codex_home / "config.toml"
+        config_path.write_text('model = "gpt-5.6-sol"\n', encoding="utf-8")
+        monkeypatch.setenv("CODEX_HOME", str(codex_home))
+        runtime = CodexCliRuntime(cli_path="codex", cwd="/tmp/project")
+        config_path.write_text('model = "gpt-5.6-terra"\n', encoding="utf-8")
+
+        with pytest.raises(RuntimeError, match="Codex configuration changed"):
+            runtime._build_command(output_last_message_path="/tmp/out.txt")
+
     def test_build_command_uses_profile_for_runtime_session_role(self) -> None:
         """Agent runtime sessions should resolve Codex profiles from session_role."""
         runtime_handle = RuntimeHandle(

--- a/tests/unit/orchestrator/test_codex_config_fingerprint.py
+++ b/tests/unit/orchestrator/test_codex_config_fingerprint.py
@@ -1,0 +1,70 @@
+from pathlib import Path
+
+import pytest
+
+from ouroboros.orchestrator.codex_config_fingerprint import (
+    fingerprint_codex_config_files,
+)
+
+
+@pytest.mark.parametrize(
+    ("initial_config", "updated_config"),
+    [
+        pytest.param(
+            '[mcp_servers.ouroboros]\ncommand = "/usr/local/bin/ouroboros"\n',
+            '[mcp_servers.ouroboros]\ncommand = "/tmp/replacement"\n',
+            id="mcp-command",
+        ),
+        pytest.param(
+            'sandbox_mode = "read-only"\n',
+            'sandbox_mode = "danger-full-access"\n',
+            id="sandbox-mode",
+        ),
+        pytest.param(
+            'approval_policy = "on-request"\n',
+            'approval_policy = "never"\n',
+            id="approval-policy",
+        ),
+    ],
+)
+def test_execution_setting_change_updates_fingerprint(
+    tmp_path: Path,
+    initial_config: str,
+    updated_config: str,
+) -> None:
+    # Given
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    config_path = codex_home / "config.toml"
+    config_path.write_text(initial_config, encoding="utf-8")
+    initial_fingerprint = fingerprint_codex_config_files(codex_home)
+
+    # When
+    config_path.write_text(updated_config, encoding="utf-8")
+
+    # Then
+    assert fingerprint_codex_config_files(codex_home) != initial_fingerprint
+
+
+def test_codex_managed_state_change_preserves_fingerprint(tmp_path: Path) -> None:
+    # Given
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir()
+    config_path = codex_home / "config.toml"
+    config_path.write_text(
+        '[projects."/tmp/existing"]\ntrust_level = "trusted"\n',
+        encoding="utf-8",
+    )
+    initial_fingerprint = fingerprint_codex_config_files(codex_home)
+
+    # When
+    config_path.write_text(
+        '[projects."/tmp/new"]\n'
+        'trust_level = "trusted"\n'
+        '\n[hooks.state."plugin:session_start:0"]\n'
+        'trusted_hash = "desktop-managed-state"\n',
+        encoding="utf-8",
+    )
+
+    # Then
+    assert fingerprint_codex_config_files(codex_home) == initial_fingerprint

--- a/tests/unit/orchestrator/test_model_routing.py
+++ b/tests/unit/orchestrator/test_model_routing.py
@@ -144,16 +144,16 @@ class TestBuildModelRouter:
         assert router is not None
         assert router.runtime_backend == "codex_cli"
         assert router.tier_models == {
-            "frugal": "gpt-5.1-codex-mini",
-            "standard": "gpt-5-codex",
-            "frontier": "gpt-5.2",
+            "frugal": "gpt-5.6-luna",
+            "standard": "gpt-5.6-terra",
+            "frontier": "gpt-5.6-sol",
         }
 
     def test_codex_mcp_backend_resolves_openai_tier_models(self) -> None:
         economics = get_default_config().economics
         router = build_model_router(economics, runtime_backend="codex_mcp")
         assert router is not None
-        assert router.tier_models["standard"] == "gpt-5-codex"
+        assert router.tier_models["standard"] == "gpt-5.6-terra"
 
     def test_gemini_backend_builds_google_router(self) -> None:
         # Gemini has no frontier google model in the default config, so only the
@@ -340,9 +340,36 @@ class TestLegacyTierModelNormalization:
         router = build_model_router(_legacy_persisted_economics(), runtime_backend="codex_cli")
         assert router is not None
         assert router.tier_models == {
-            "frugal": "gpt-5.1-codex-mini",
-            "standard": "gpt-5-codex",
-            "frontier": "gpt-5.2",
+            "frugal": "gpt-5.6-luna",
+            "standard": "gpt-5.6-terra",
+            "frontier": "gpt-5.6-sol",
+        }
+
+    def test_previous_codex_defaults_normalize_to_5_6_family(self) -> None:
+        economics = _economics(
+            tiers={
+                "frugal": TierConfig(
+                    cost_factor=1,
+                    models=[ModelConfig(provider="openai", model="gpt-5.1-codex-mini")],
+                ),
+                "standard": TierConfig(
+                    cost_factor=10,
+                    models=[ModelConfig(provider="openai", model="gpt-5-codex")],
+                ),
+                "frontier": TierConfig(
+                    cost_factor=30,
+                    models=[ModelConfig(provider="openai", model="gpt-5.2")],
+                ),
+            }
+        )
+
+        router = build_model_router(economics, runtime_backend="codex_cli")
+
+        assert router is not None
+        assert router.tier_models == {
+            "frugal": "gpt-5.6-luna",
+            "standard": "gpt-5.6-terra",
+            "frontier": "gpt-5.6-sol",
         }
 
     def test_legacy_opus_4_6_normalizes_to_current(self) -> None:
@@ -366,13 +393,13 @@ class TestLegacyTierModelNormalization:
             tiers={
                 "standard": TierConfig(
                     cost_factor=10,
-                    models=[ModelConfig(provider="openai", model="gpt-5.6-sol")],
+                    models=[ModelConfig(provider="openai", model="proxy-gpt-custom")],
                 ),
             }
         )
         router = build_model_router(economics, runtime_backend="codex_cli")
         assert router is not None
-        assert router.tier_models == {"standard": "gpt-5.6-sol"}
+        assert router.tier_models == {"standard": "proxy-gpt-custom"}
 
     def test_legacy_looking_id_under_other_provider_is_preserved(self) -> None:
         # This value was historically shipped only for OpenAI. Under Anthropic it


### PR DESCRIPTION
## Summary

Stabilize Codex-backed Ouroboros runs without weakening their execution identity:

- tolerate only Codex Desktop-managed project and hook state updates during an active runtime;
- continue failing closed when executable, security, model, provider, or profile settings change;
- route Codex worker tiers to the GPT-5.6 model family supported by ChatGPT-account Codex.

## Root cause

### Runtime identity

The Codex CLI runtime originally hashed `~/.codex/config.toml` byte-for-byte. Codex Desktop legitimately mutates `projects.*` trust state and `hooks.state.*` approval state, so those writes aborted active runs with `Codex configuration changed after runtime initialization`.

The global config also contains runtime-critical settings such as `[mcp_servers]`, `sandbox_mode`, and `approval_policy`. A safe canonicalization therefore cannot use a narrow routing-key allowlist: it must retain every setting except the two known Codex-managed state subtrees.

### Model routing

The shipped OpenAI tier ladder still selected `gpt-5.1-codex-mini`, `gpt-5-codex`, and `gpt-5.2`. ChatGPT-account Codex rejects those IDs with HTTP 400 before a worker starts, causing every retry to fail at model invocation.

## Changes

- Canonicalize the global Codex config by excluding only `projects.*` and `hooks.state.*` before hashing.
- Keep MCP server configuration, sandbox/approval policy, routing settings, all profile-v2 `*.config.toml` files, and the resolved `CODEX_HOME` in the runtime fingerprint.
- Add regression coverage proving MCP command, sandbox mode, and approval policy changes invalidate the fingerprint while Codex-managed state changes do not.
- Route Codex tiers as:
  - frugal → `gpt-5.6-luna`
  - standard → `gpt-5.6-terra`
  - frontier → `gpt-5.6-sol`
- Normalize previously shipped Codex tier defaults to the GPT-5.6 family while preserving explicit custom model IDs.
- Keep the backend model catalog and config TUI presets aligned with the runtime defaults.

## Verification

- [x] Full unit suite: `11812 passed, 2 skipped`
- [x] Review-focused suite: `287 passed`
- [x] `uv run ruff check src/ tests/`
- [x] `uv run ruff format --check src/ tests/`
- [x] `uv run mypy src/ouroboros` — 435 source files
- [x] `python3 scripts/check-auto-boundary.py`
- [x] No-excuse rules check for the changed files
- [x] Manual runtime QA: managed `projects`/`hooks.state` changes remain accepted; an MCP command change raises the restart-required runtime error
- [x] Routing red/green coverage: prior shipped defaults normalize to Luna/Terra/Sol; custom IDs remain unchanged
- [x] Real router driver resolves `codex_cli` to Luna/Terra/Sol
- [x] Authenticated Codex CLI calls to all three GPT-5.6 models return a non-empty response with exit code 0
- [x] GitHub Actions on the latest head: 10 checks passed

## Related issues

Refs #1600
