### PR TITLE
feat(conductor): define active-conductor control contracts

### DIFF
--- a/docs/active-conductor/architecture.md
+++ b/docs/active-conductor/architecture.md
@@ -1,0 +1,193 @@
+# Active Conductor Architecture
+
+> Generated: 2026-07-12
+> Approach: staged, event-authoritative successor recovery
+
+## Overview
+
+The active conductor extends the delegated observer without taking its cursor.
+The server converts authoritative durable events into bounded relay envelopes.
+The observer relays those envelopes, and the main host session verifies and
+selects a safe action. Recovery, artifact, routing, and specification mutation is
+allowed only after engine recovery is closed and always creates a successor
+rather than racing the current worker. Bounded user-intent messages use the
+separate safe-boundary control path below.
+
+## System diagram
+
+```text
+┌──────────────────── engine-owned ────────────────────┐
+│ worker -> retry -> effort/model raise -> alt harness │
+└──────────────────────────┬────────────────────────────┘
+                           │ durable events
+                           v
+                  ┌───────────────────┐
+                  │ attention         │
+                  │ classifier        │
+                  └─────────┬─────────┘
+                            │ meta.relay_events
+                            v
+                  ┌───────────────────┐
+                  │ read-only observer│ owns cursor
+                  └─────────┬─────────┘
+                            │ sparse relay
+                            v
+┌──────────────────────────────────────────────────────┐
+│ main conductor                                       │
+│ VERIFY child -> DECIDE -> LOG -> ACT successor       │
+│ user intent -> TARGET -> MESSAGE -> ASSURE delivery  │
+└──────────────────────────────────────────────────────┘
+                            │ guarded session command
+                            v
+                  ┌───────────────────┐
+                  │ durable mailbox   │
+                  │ + capability gate │
+                  └─────────┬─────────┘
+                            │ runtime-specific control
+                            v
+                  ┌───────────────────┐
+                  │ owned AC session  │
+                  │ safe boundary     │
+                  └───────────────────┘
+```
+
+## Components
+
+| Component | Responsibility | Primary location |
+|---|---|---|
+| Efficiency preference | Resolve, persist, and forward actuation/assurance modes | execute/auto MCP handlers, execution contract, Auto state |
+| Briefing producers | Emit resolved run configuration, staged plan, phase, and discovery summaries | runner, dependency planner, execution event emitter |
+| Semantic AC identity | Assign and preserve stable criterion identity | `core/seed.py`, Seed generation/evolution paths |
+| Recovery sensor | Prove all engine recovery is closed | `orchestrator/parallel_executor.py` |
+| Routing/verdict identity | Supply escalation evidence and stable AC lineage | `orchestrator/execution_event_emitter.py` |
+| Seed-QA sensor | Emit a typed exhausted-gate event | `auto/pipeline.py` |
+| Attention classifier | Join event history and create bounded relay envelopes | `mcp/tools/job_handlers.py` |
+| Observer contract | Request linked attention-aware waits | `mcp/tools/job_observer.py` |
+| Decision recorder | Persist selected and terminal decision events | new MCP handler + event module |
+| Successor directive | Persist non-relaxing corrective context | evolution/Ralph handlers and loop |
+| Host playbook | VERIFY, DECIDE, LOG, ACT | root/package skills and Codex artifact |
+| Session-attempt projection | Resolve live logical scope/attempt to its owned runtime handle without accepting native IDs as caller authority | `orchestrator/synapse.py` + runtime lifecycle events |
+| Synapse command | Validate SessionSignal authority, target generation, capability, fallback, and idempotency | `mcp/tools/synapse_handler.py` + MCP composition root |
+| Synapse mailbox | Persist requested/accepted/queued/delivering/applied/rejected/uncertain/completed delivery state | `core/session_signal*`, `events/session_signal.py`, `orchestrator/synapse.py` |
+| Runtime signal adapter | Apply after-turn delivery, checkpoint redirect, or owned replacement only where the harness can enforce it | optional worker transport/session-control protocol |
+
+## Data flow
+
+1. The engine completes its retry and alternate-harness policy.
+2. A producer emits authoritative sensor events.
+3. `ouroboros_job_wait` reads linked streams with one global cursor.
+4. The classifier performs any required full-history join and emits bounded
+   `relay_events`.
+5. The observer forwards only classified phase/progress/attention/terminal events.
+6. The main conductor spawns one read-only verifier for attention evidence.
+7. The conductor selects an ordered action and logs intent.
+8. Read-only actions may run immediately. Mutation requires closed ownership.
+9. A successful mutation starts a bounded successor and logs its receipt.
+
+Before step 1, `run`/`auto` resolves the user-facing efficiency choice into a
+persisted `efficiency_mode` plus `frugality_assurance` contract. Every successor
+inherits that contract unless the user starts a new successor with an explicit
+override.
+
+The proactive UX uses the same flow without invoking conductor judgment:
+configuration, plan, phase/discovery, level, model, and harness events are reduced
+into sparse `phase_changed`/`progress_advanced` relay envelopes. Only
+`attention_required` enters VERIFY/DECIDE.
+
+Updated user intent follows a reverse, cursor-independent command path:
+
+1. The main conductor calls `ouroboros_session_signal_targets` for the observed
+   execution and maps the human's wording to the most relevant live AC content.
+2. If candidates remain genuinely tied, the conductor asks one short question
+   in the active conversation language; it never asks the human for internal IDs.
+3. The conductor copies the selected exact scope/attempt guards into
+   `ouroboros_session_signal`, which persists `requested` before validation.
+4. The server validates execution/attempt guards, source authority, content
+   bounds, and runtime control capabilities.
+5. The mailbox records `accepted` and `queued`, including requested and effective
+   mode when an explicit fallback is used.
+6. The owning runtime claims the signal with `delivering`, applies it at its
+   declared boundary, and emits `applied` plus `completed`, or emits `rejected`.
+   A crash after claim but before provider acknowledgement emits terminal
+   `delivery_uncertain` and suppresses automatic retry.
+7. For `inform`, the same native session runs one reply turn with `tools=[]` and
+   stores only a bounded, secret-filtered reply in `completed`. A runtime that
+   cannot enforce the empty catalog surfaces that parameter degradation instead
+   of claiming a native no-tools guarantee.
+8. The existing observer relays the status; the main session explains the proven
+   state naturally in the active conversation language.
+
+The existing `ControlBus` may fan out a message inside one runtime process, but
+it is not the durable or cross-runtime transport. EventStore-backed mailbox
+state remains authoritative across process boundaries and restarts.
+
+## Key decisions
+
+| Decision | Rationale |
+|---|---|
+| Dedicated recovery-exhausted event | Retry counters cannot represent early stop and alternate-harness closure safely. |
+| New attention wake mode | `raw` is noisy while `ac_change` misses semantic events. |
+| Discriminated action menu | VERIFY and user escalation are not MCP tool calls. |
+| Successor-only recovery/artifact mutation | Prevents token duplication and races with deterministic recovery. |
+| Stable semantic AC identity | Runtime session IDs and AC list positions cannot form a streak across evolution. |
+| Separate intent/outcome audit | Failed and declined conductor choices remain visible. |
+| Non-relaxing corrective directive | Autonomy must not silently weaken the user's contract. |
+| Separate actuation from assurance | Lower-cost routing can save tokens, while strict proof may spend extra tokens. |
+| Reuse #1601/#1602 telemetry | The main session, TUI, and Web must agree on progressive routing, current model, and token totals. |
+| Plan event plus live level events | Users need the whole schedule once and the current stage as it changes. |
+| Bounded discovery summaries | Helpful visibility without leaking noisy raw tool streams or chain-of-thought. |
+| Signal delivery separate from redirect | Background advice, after-turn delivery, checkpoint redirect, and replacement have different safety and capability semantics. |
+| Logical attempt addressing | Native session IDs are transport metadata; execution + scope + attempt guards prevent stale cross-run delivery. |
+| Acknowledged application | Queued delivery is useful but does not prove that the worker changed course. |
+| Explicit hard replacement | Aborting owned work may discard tool progress and therefore requires user authority. |
+| Shared contract for spec changes | A changed goal or AC cannot be injected into one worker while peers continue on an older Seed version. |
+
+## Compatibility
+
+- Preserve `recommended_host_action="spawn_observer_session"`.
+- Add, rather than replace, `meta.relay_events` and plural per-event menus.
+- Keep legacy `raw`, `ac_change`, `phase_change`, and `terminal` waits.
+- Leave OpenCode plugin mode unchanged.
+- Update both root `skills/` and packaged/plugin skill copies in the same slice.
+- Render efficiency choices in the conversation language; keep persisted enum
+  values language-neutral.
+- Add session-control capabilities without changing existing runtime behavior;
+  unsupported transports advertise false and use explicit follow-up/rejection.
+- Preserve current resume handles. Checkpoint redirect is an optional capability, not a
+  reinterpretation of `targeted_resume`.
+- `ouroboros_session_signal` is registered because leader-driven resumable
+  runtimes now implement tested `after_turn` delivery and application
+  acknowledgement. Other modes remain capability-gated.
+
+## Testing strategy
+
+- Pure table-driven classifier tests for every trigger and malformed payload.
+- Job-wait wake, cursor paging, timeout, and no-skip tests.
+- Producer tests for exactly-once recovery exhaustion and stable AC identity.
+- Negative tests proving intermediate retries never authorize mutation.
+- Skill artifact tests for observer/verifier separation and mode policy.
+- End-to-end tests for logged successor dispatch, idempotency, and budget exhaustion.
+- Start/resume tests for efficiency mapping, Auto forwarding, English canonical
+  host guidance, and strict-proof opt-in.
+- Reducer agreement tests proving main-session routing/token summaries match the
+  #1602 TUI/Web projections.
+- Plan/level/discovery deduplication and on-demand AC assurance tests.
+- Session-message state-machine, idempotency, stale-attempt, priority, expiry,
+  uncertain-delivery, payload-bound, and secret-filter tests.
+- Runtime contract tests distinguishing resume, after-turn delivery, checkpoint redirect,
+  owned abort, and replacement resume.
+- End-to-end assurance tests proving `queued` is never rendered as `applied` and
+  explicit fallback names the effective mode.
+
+## Integration with #1601 and #1602
+
+- #1601 changes model escalation from one fixed notch to progressive routing.
+  Active Conductor must consume the final event shape after that PR lands and
+  announce each actual route change rather than calculate an expected tier in the
+  host.
+- #1602 exposes model/tier/token telemetry through TUI/Web related-event queries
+  and shared reducers. Main-session briefing should reuse those event semantics
+  and, where practical, shared projection helpers instead of building a separate
+  token/model accounting path.
+- Neither PR currently provides execution-plan or semantic Discover events; those
+  remain explicit Active Conductor producer work.

--- a/docs/active-conductor/architecture.md
+++ b/docs/active-conductor/architecture.md
@@ -2,6 +2,9 @@
 
 > Generated: 2026-07-12
 > Approach: staged, event-authoritative successor recovery
+> Availability: this document describes the complete stacked target. The first
+> contract layer provides only core/event contracts; MCP registration, runtime
+> capability opt-ins, and delivery acknowledgement arrive in later layers.
 
 ## Overview
 
@@ -94,7 +97,9 @@ configuration, plan, phase/discovery, level, model, and harness events are reduc
 into sparse `phase_changed`/`progress_advanced` relay envelopes. Only
 `attention_required` enters VERIFY/DECIDE.
 
-Updated user intent follows a reverse, cursor-independent command path:
+In the complete stack, updated user intent follows a reverse,
+cursor-independent command path. These commands are not public or callable from
+the contract layer alone:
 
 1. The main conductor calls `ouroboros_session_signal_targets` for the observed
    execution and maps the human's wording to the most relevant live AC content.
@@ -155,8 +160,9 @@ state remains authoritative across process boundaries and restarts.
   unsupported transports advertise false and use explicit follow-up/rejection.
 - Preserve current resume handles. Checkpoint redirect is an optional capability, not a
   reinterpretation of `targeted_resume`.
-- `ouroboros_session_signal` is registered because leader-driven resumable
-  runtimes now implement tested `after_turn` delivery and application
+- The contract layer leaves `ouroboros_session_signal` unregistered and every
+  runtime capability false. A later host layer registers it only after the
+  runtime layer supplies tested `after_turn` delivery and application
   acknowledgement. Other modes remain capability-gated.
 
 ## Testing strategy

--- a/docs/active-conductor/implementation-plan.md
+++ b/docs/active-conductor/implementation-plan.md
@@ -1,0 +1,284 @@
+# Active Conductor Implementation Plan
+
+> Generated: 2026-07-12
+> Status: S0-S4 implementation and final validation complete
+
+## Delivery strategy
+
+Implement as five reviewable slices. Do not combine host autonomy with the first
+sensor/relay change.
+
+## S0 — sensor closure
+
+### Changes
+
+- Add `execution.ac.recovery_exhausted` and emit it exactly once after retry and
+  alternate-harness paths close.
+- Add `efficiency_mode` (`adaptive`, `quality_first`) and
+  `frugality_assurance` (`off`, `observe`, `strict`) to execute and Auto start
+  contracts.
+- Persist resolved preferences in the execution contract and `AutoPipelineState`;
+  forward them through Auto RUN/Ralph handoffs and restore them on resume.
+- Emit `execution.run.configuration_resolved` before AC dispatch.
+- Emit `execution.plan.created` after dependency analysis with total levels,
+  bounded AC summaries, dependency stages, and the first scheduled level.
+- Emit bounded `execution.ac.phase_changed` and
+  `execution.ac.discovery.updated` events with material-change deduplication.
+- Add optional `semantic_ac_key` to `AcceptanceCriterionSpec`, including additive
+  serialization, deterministic legacy materialization, and successor propagation.
+- Add `semantic_ac_key`, `base_model_tier`, `escalation_retry_threshold`, and
+  `model_escalated` to relevant execution events.
+- Add `semantic_ac_key` to deliver-verdict events.
+- Emit `auto.seed_qa.blocked` for exhausted non-passing QA gates.
+- Define bounded event schemas/constants and event documentation.
+
+### Tests
+
+- configured retry exhaustion;
+- repeated-failure early stop below the numeric retry cap;
+- alternate-harness success/failure;
+- model escalation at and below threshold;
+- semantic key creation and propagation through retry/decomposition/evolution;
+- replacement criteria receive a new key while preserved criteria retain theirs;
+- Seed-QA pass, repair, transient error, and exhausted block.
+- efficiency default mapping, explicit override, persistence, forwarding, and
+  resume immutability;
+- strict assurance never arms shadow replay without explicit authorization and
+  required safety attestations.
+- run configuration and plan events precede level 1 dispatch;
+- discovery events are bounded, phase-honest, and suppress raw tool activity;
+- #1601 progressive route events and #1602 token/model projections remain the
+  authoritative source for main-session summaries.
+
+### Exit gate
+
+No host behavior changes. Producers alone prove all attention preconditions.
+
+## S1 — attention classification and observer relay
+
+### Changes
+
+- Add `attention_or_ac_change` to `ouroboros_job_wait`.
+- Add `stream="linked"` to the observer wait template.
+- Add pure classifier helpers over raw `BaseEvent` data.
+- Add bounded `meta.relay_events` and discriminated action menus.
+- Add proactive briefing subtypes for run configuration, discovery, execution
+  plan, level, AC routing, harness changes, and AC verification.
+- Perform a terminal full-history scan before final observer completion.
+- Preserve cursor page boundaries and legacy wait modes.
+
+### Tests
+
+- one table row per trigger;
+- no action menu on phase/progress;
+- unrelated linked event does not wake;
+- attention event wakes immediately;
+- malformed evidence fails closed;
+- terminal scan finds late frugality evidence;
+- proactive event cadence and material deduplication;
+- plan briefing contains total levels and first scheduled ACs;
+- route/harness messages emit on initial/current change only;
+- bounded pages do not skip or duplicate events;
+- legacy observer contract remains compatible.
+
+### Exit gate
+
+Observer can reliably relay attention, but menus advertise only read-only actions
+and user escalation.
+
+## S2 — host conductor playbook
+
+### Changes
+
+- Update `skills/run`, `skills/auto`, and `skills/ralph`.
+- Update packaged/plugin copies used by supported hosts.
+- Update `src/ouroboros/codex/ouroboros.md` and runtime guides.
+- Specify one exclusive observer and at most one short-lived verifier.
+- Implement VERIFY → DECIDE behavior and current-turn schema reload.
+- Add English canonical pre-start efficiency guidance when neither an explicit
+  argument nor a remembered preference exists; describe user outcomes rather
+  than MCP internals and let the host phrase them naturally in the active
+  conversation language.
+- Add English canonical host guidance for start accepted, Discover targets, plan
+  ready, level start/completion, current model/harness, escalation, AC assurance,
+  and terminal summary.
+- Tell the user at start that they can ask about any AC or continue other work.
+- Keep ACT non-mutating until S3 tools are present.
+
+### Tests
+
+- skill artifact contract across every packaged copy;
+- no action without a menu;
+- no ACT without verifier support;
+- no duplicate polling owner;
+- `run` user escalation vs Auto/Ralph deterministic policy;
+- OpenCode plugin behavior unchanged;
+- language-neutral persisted enums and artifact tests for the English canonical
+  host contract;
+- on-demand AC assurance view never advances the observer cursor;
+- main-session model/tier/token output agrees with #1602 TUI/Web reducers;
+- #1601 progressive escalation and existing alt-harness events produce friendly
+  one-time change notices.
+
+### Exit gate
+
+The main session owns judgment and can verify/surface actionable attention without
+changing execution state.
+
+## S3 — audited successor recovery
+
+### Changes
+
+- Add `ouroboros_record_conductor_decision` with idempotent selected/outcome events.
+- Add optional persisted `conductor_directive` support to evolution and Ralph.
+- Wire run-mode successor execution with explicit approval for spec changes.
+- Wire one bounded Auto/Ralph successor for non-relaxing directives.
+- Add conductor successor budgets and user escalation on exhaustion.
+- Expand action menus only when the corresponding tools are registered.
+
+### Tests
+
+- selected/completed/failed/declined decision audit;
+- idempotent repeated decision submission;
+- rejected-reason directive propagation;
+- preserved goal/AC/non-goal invariants;
+- closed-ownership enforcement;
+- successor tier override creates a new execution;
+- autonomous budget exhaustion;
+- action failure is logged and not silently retried.
+
+### Exit gate
+
+All revised RFC acceptance criteria pass, including bounded Auto/Ralph successor
+recovery and run-mode approval.
+
+## S4 — Ouroboros Synapse
+
+The clean-room contract, lifecycle events, replay projection, exact-attempt live
+hub, durable queue admission, target-discovery and delivery MCP handlers,
+observer relay, same-session `inform`, leader-driven `after_turn`, priority,
+expiry, and restart recovery are implemented. Checkpoint `redirect` and hard
+`replace` remain capability-disabled because no runtime has supplied the needed
+live-boundary proof.
+
+### Changes
+
+- Add optional runtime signal capabilities distinct from `targeted_resume`:
+  inform delivery, background reply, after-turn delivery, checkpoint redirect,
+  owned-turn abort, and
+  resumable replacement.
+- Add a live session-attempt projection keyed by `execution_id`,
+  `session_scope_id`, and `session_attempt_id`; keep native session IDs internal
+  to the resolved runtime handle.
+- Add bounded event factories and a durable mailbox for:
+  `control.session.signal.requested`, `accepted`, `queued`, `delivering`,
+  `applied`, `rejected`, `delivery_uncertain`, and `completed`.
+- Add `ouroboros_session_signal` with `inform`, `after_turn`, `redirect`, and
+  `replace`, plus an explicit `fallback_mode`, expiry, reason, source,
+  generation guards, and idempotency key.
+- Implement same-session `inform` replies with an explicit `tools=[]` request and
+  `after_turn` on transports that can safely resume after the current turn.
+  Surface parameter degradation where an empty catalog is not natively
+  enforceable. Do not advertise checkpoint redirect for that behavior.
+- Extend supported live transports with checkpoint redirect only where an
+  application acknowledgement can be produced.
+- Wire `replace` only where Ouroboros owns cancellation and can prove
+  terminalization before resume/restart; require explicit user approval.
+- Route changed goals, ACs, constraints, and non-goals through an approval-bound
+  shared successor/replacement contract rather than redirecting one live worker.
+- Link delivery lifecycle events to the owning job so the existing observer
+  relays requested/effective mode and queued/delivering/applied/rejected state.
+- Update `run`/`auto` host playbooks to map user refinements to affected ACs,
+  explain the proposed target/mode, preserve unaffected work, and render delivery
+  assurance in the conversation language.
+
+### Tests
+
+- exact target, stale attempt, wrong execution, terminal session, and expiry;
+- at-most-once request and replay-safe mailbox consumption;
+- restart replay of still-queued signals and terminal `delivery_uncertain` for a
+  signal that was claimed before process loss;
+- provider-acknowledgement crash windows terminate as `delivery_uncertain`
+  without automatic resend;
+- user > conductor > worker priority with no lower-priority supersession;
+- bounded text, secret filtering, digest audit, and no raw transcript storage;
+- queued versus applied acknowledgement and bounded background reply;
+- explicit `redirect -> after_turn` fallback with effective-mode disclosure;
+- unsupported redirect with no fallback fails closed;
+- replace approval validation plus capability-disabled rejection until an owned
+  cancellation, terminalization, and replacement-resume proof exists;
+- runtime capability matrices for Codex, Claude SDK/workers, OpenCode, Goose,
+  Pi, and unsupported harnesses;
+- no duplicate observer cursor and English canonical delivery-state guidance;
+- unaffected parallel AC sessions continue while one exact target receives an
+  `inform` or `after_turn` signal.
+
+### Exit gate
+
+The main session can deliver updated user intent to an exact AC session with
+auditable, capability-truthful semantics. It never reports a safe interrupt,
+application, or hard replacement that the runtime did not acknowledge.
+
+### Final validation
+
+- Complete automated suite: `12,263 passed, 5 skipped`.
+- Ruff lint/format: clean; Mypy: clean across 444 source files.
+- Live same-native-session `inform`: Codex CLI, Claude Agent SDK, persisted
+  Claude worker, OpenCode, Goose, and Pi.
+- Explicit `redirect -> after_turn` fallback: Pi.
+- Truthful unsupported path: Hermes requested → rejected with every
+  SessionSignal capability disabled.
+- Deterministic manual persistence harness: consumption expiry, source-priority
+  supersession, queued restart replay, and delivering restart uncertainty.
+
+## Review checkpoints
+
+After each slice:
+
+1. run targeted unit tests;
+2. run formatting and type checks for changed modules;
+3. review event backward compatibility and payload bounds;
+4. verify no unrelated skill/package copy drift;
+5. update the RFC status only for the completed slice.
+
+## Primary risks
+
+| Risk | Mitigation |
+|---|---|
+| Duplicate recovery-exhausted events | Deterministic event ID/idempotency key per execution + semantic AC key. |
+| Cursor skips from linked streams | Reuse the existing bounded global-rowid page boundary. |
+| Conductor races active recovery | Server validates authoritative ownership closure before mutation. |
+| Dynamic prompt payload growth | Strict reason/count/length bounds and argument digests in audit events. |
+| Skill behavior differs by host | Test root and packaged copies from one canonical contract. |
+| Autonomous spec weakening | Persisted directive is additive and invariant-checked before successor start. |
+| “Efficiency proof” costs more than it saves | Keep strict assurance/shadow replay as a separate explicit opt-in. |
+| Auto loses the user's start preference | Persist in Auto state and assert forwarding/resume contracts. |
+| Main/TUI/Web disagree about current model | Reuse #1602 event semantics and shared projection helpers. |
+| Discover becomes a noisy activity feed | Emit bounded semantic summaries only on material change. |
+| Plan briefing arrives after work starts | Persist `execution.plan.created` before level 1 dispatch and test event order. |
+| Resume is mistaken for checkpoint redirect | Model the capabilities separately and require an `applied` acknowledgement. |
+| Intent reaches a newer retry or successor | Require execution + scope + attempt guards and reject stale targets. |
+| Lower-priority automation overrides the user | Persist source priority and serialize unapplied messages per target. |
+| Hard abort loses completed work | Require explicit approval, terminalization proof, and a replacement receipt. |
+| Main session overstates delivery | Host UX is driven by durable queued/delivering/applied/rejected events, not MCP call success prose. |
+| One AC receives a new spec while peers use the old Seed | Reject live redirect and create one approval-bound shared successor contract. |
+
+## Merge prerequisites
+
+- #1601 and #1602 are present on main. Keep progressive escalation as the only
+  routing semantics supported.
+- Reuse #1602 related-event delivery and projection patterns; do not
+  duplicate token aggregation or latest-route selection.
+- Keep the RFC/plan changes isolated from the open PR code until both merge or
+  explicitly coordinate a stacked branch.
+
+## Proposed implementation order
+
+1. S0 sensor closure
+2. S1 attention relay
+3. S2 host playbook
+4. S3 audited successor recovery
+5. S4 Ouroboros Synapse
+
+The remaining gate is full regression plus repeated live runtime proof against
+the completed implementation.

--- a/docs/active-conductor/implementation-plan.md
+++ b/docs/active-conductor/implementation-plan.md
@@ -1,7 +1,8 @@
 # Active Conductor Implementation Plan
 
 > Generated: 2026-07-12
-> Status: S0-S4 implementation and final validation complete
+> Status: Stacked implementation plan. Availability is established per slice;
+> the contract foundation lands before the runtime and host layers.
 
 ## Delivery strategy
 

--- a/docs/active-conductor/requirements.md
+++ b/docs/active-conductor/requirements.md
@@ -1,0 +1,124 @@
+# Active Conductor Requirements
+
+> Generated: 2026-07-12
+> Status: Clarified for planning
+
+## Original request
+
+> "Review the Active Conductor RFC; I want to implement it."
+>
+> "Revise the RFC and prepare the plan before implementation."
+>
+> "Use an original name instead of IRC and implement it from a clean-room specification."
+
+## Goal
+
+Revise the Active Conductor RFC so every promised trigger, relay event, host
+decision, and corrective action is implementable against an explicit durable
+contract. Produce an implementation plan before changing runtime behavior.
+
+## Scope
+
+Included:
+
+- authoritative recovery, model escalation, deliver-verdict, Seed-QA, frugality,
+  and stagnation sensor contracts;
+- `ouroboros_job_wait` attention classification and observer wake behavior;
+- structured host action menus;
+- `run`, `auto`, and `ralph` conductor playbooks;
+- conductor decision logging;
+- bounded successor executions or generations after engine recovery closes;
+- start-time efficiency choice for `run` and `auto`, described in user-facing
+  outcome language;
+- persisted frugality assurance preference across Auto handoff and resume;
+- proactive start, Discover, execution-plan, routing, level, and AC assurance
+  briefings from English canonical host guidance;
+- on-demand per-AC assurance inspection without duplicate polling;
+- Ouroboros Synapse: capability-aware SessionSignal delivery and intent redirect for the
+  provider-native AC sessions Ouroboros already owns;
+- durable requested/accepted/queued/delivering/applied/rejected/uncertain/
+  completed delivery audit and main-session assurance;
+- root and packaged skill consistency, including Codex instructions.
+
+Excluded:
+
+- direct in-flight artifact mutation or concurrent targeted redispatch;
+- live model-tier pinning of an active worker;
+- MCP server push or a long-lived conductor/notification daemon; short-lived
+  per-job worker ownership is allowed where the accepting stdio MCP process
+  cannot survive the run it starts;
+- OpenCode plugin-mode changes;
+- automatic relaxation of user-approved goals or acceptance criteria;
+- provider-independent hard preemption or a general-purpose chat service.
+
+## Constraints
+
+- The observer remains the exclusive `job_wait` cursor owner.
+- The conductor never duplicates engine-owned retry, effort/model escalation, or
+  alternate-harness redispatch.
+- Recovery, artifact, routing, and specification mutations require authoritative
+  `engine_ownership.state="closed"`; bounded SessionSignals use the separate
+  capability and authority contract.
+- VERIFY is performed by one short-lived read-only host subagent.
+- Hosts without a verifier primitive must not ACT.
+- Dynamic corrective inputs must be explicit in the action schema.
+- Decision and evidence payloads are bounded and auditable.
+- Strict frugality proof may add cost and therefore requires explicit consent.
+- Progress UX must describe meaningful user-level state, not raw tool activity.
+- Runtime resumability must not be treated as proof of checkpoint redirect support.
+- SessionSignals require execution and attempt guards, bounded payloads,
+  idempotency, and an applied acknowledgement before adoption is claimed.
+- User intent outranks conductor/worker messages; spec-changing messages and
+  hard replacement require explicit user authority.
+- Host guidance is authored once in English. The host phrases it naturally in
+  the user's current conversation language; persisted event values stay stable.
+- A non-plugin Start* receipt is not accepted until a cross-turn worker owns the
+  durable job identity; the stdio MCP process is never the lifetime guarantee.
+
+## Success criteria
+
+- The revised RFC has no references to nonexistent events or tools without also
+  defining the slice that creates them.
+- All attention triggers have durable, machine-readable evidence.
+- The relay can wake on attention without waking on every raw event.
+- Host instructions distinguish observer, verifier, conductor, and worker roles.
+- Recovery/artifact mutation happens only as a bounded successor after recovery
+  closure; active-session control changes future decisions only at proven safe
+  boundaries.
+- Every conductor decision, including refusal or failure, is logged.
+- Implementation can be delivered as independently testable S0-S4 slices.
+- The main session discovers live AC content, selects the affected session from
+  the human's natural-language intent without exposing internal IDs, and
+  truthfully distinguishes queued, safely applied, deferred, rejected, and
+  explicitly aborted delivery.
+- Unsupported redirect degrades only through a declared fallback and never
+  silently claims that an interrupt occurred.
+- Ending the accepting main turn does not interrupt run/auto/evaluate/evolve/
+  Ralph work. A confirmed observer provides live relays; without one, the host
+  says so and catches up from durable events on the next parent turn.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Can the conductor directly mutate an active AC's artifacts or routing? | No; only a successor after engine ownership closes. |
+| Is model tier changed in flight? | No; it is a successor-run tier override. |
+| How is retry exhaustion detected? | A dedicated `execution.ac.recovery_exhausted` event. |
+| How are rejected verdicts grouped? | `(lineage_id or root_job_id, semantic_ac_key)`. |
+| Is VERIFY an MCP tool action? | No; the action menu discriminates host-native verification from MCP calls. |
+| Can Auto/Ralph act autonomously? | Yes, only for bounded non-relaxing successors. |
+| What happens without host subagents? | Surface attention and stop before ACT. |
+| How does efficiency mode map to frugality? | `adaptive` defaults to lightweight `observe`; `quality_first` defaults to `off`. |
+| Does efficiency mode enable shadow replay? | No; strict baseline proof is a separate explicit opt-in. |
+| How is the choice presented? | From English canonical guidance, phrased naturally in the user's current conversation language before start when no preference is known. |
+| When does the main session first speak? | Immediately after start acceptance, then after configuration and plan resolution. |
+| How are model/harness details phrased? | As current state with changes announced, because retries may progressively escalate or switch harnesses. |
+| What does Discover reveal? | A bounded summary of targets and purpose, not raw commands, file reads, or reasoning. |
+| What plan detail is guaranteed? | Total ACs/levels, parallelizable groups, dependencies, and first scheduled ACs. |
+| What is this subsystem called? | **Ouroboros Synapse**; each directed unit is a `SessionSignal`. |
+| What is the clean-room boundary? | Implement only this RFC's behavior; do not copy external source, protocols, names, prompts, or registries. |
+| What is the default intent-change behavior? | `redirect` at a runtime-declared checkpoint, with explicit `after_turn` fallback when requested. |
+| Can the conductor hard-stop an AC on its own? | No. `replace` requires explicit user approval and runtime support. |
+| How is a target protected from stale delivery? | Scope ID + unique attempt ID + expected execution ID + idempotency key. |
+| What if the runtime cannot redirect? | Report the limitation and apply only the declared fallback or reject the signal. |
+| Can a changed Seed/AC be redirected into one worker? | No. It requires an approved shared successor/replacement contract for all affected ACs. |

--- a/docs/active-conductor/synapse-clean-room-spec.md
+++ b/docs/active-conductor/synapse-clean-room-spec.md
@@ -1,7 +1,9 @@
 # Ouroboros Synapse Clean-Room Specification
 
 > Generated: 2026-07-12
-> Status: Implementation input
+> Status: Normative input for a stacked delivery. The contract layer implements
+> only the core/event items identified below; runtime and host availability
+> requires the later stack layers.
 > Source boundary: this document and Ouroboros repository contracts only
 
 ## Purpose
@@ -35,7 +37,7 @@ The following are original Ouroboros terms:
 
 ## Scope
 
-Implemented:
+Implemented in the contract layer:
 
 - validated immutable `SessionSignal` contract;
 - exact execution/scope/attempt target identity;
@@ -46,6 +48,10 @@ Implemented:
 - deterministic lifecycle projection;
 - idempotency identity and legal state-transition checks;
 - capability fields that default to unsupported;
+
+Implemented by the later runtime and host stack layers, and therefore not
+claimed as available from the contract layer alone:
+
 - exact-attempt EventStore target resolution and durable queue admission;
 - public discovery/delivery MCP schemas, validation, and composition-root registration;
 - in-process exact-attempt hub and tested leader-driven plus persisted

--- a/docs/active-conductor/synapse-clean-room-spec.md
+++ b/docs/active-conductor/synapse-clean-room-spec.md
@@ -1,0 +1,269 @@
+# Ouroboros Synapse Clean-Room Specification
+
+> Generated: 2026-07-12
+> Status: Implementation input
+> Source boundary: this document and Ouroboros repository contracts only
+
+## Purpose
+
+Ouroboros Synapse delivers one bounded intent signal from the main conductor to
+one exact AC runtime attempt. It records whether the signal was requested,
+accepted, queued, claimed for delivery, applied, rejected, completed, or left
+uncertain across a provider acknowledgement boundary.
+
+Synapse complements the observer path:
+
+```text
+AC runtime ── durable events ──> observer ──> main conductor
+AC runtime <── SessionSignal ─── Synapse <── main conductor
+```
+
+## Clean-room rules
+
+Implementation uses only this behavior specification and existing Ouroboros
+abstractions. It must not copy or translate another framework's source code,
+protocol layout, type names, event names, prompts, registry, or UI transcript
+format.
+
+The following are original Ouroboros terms:
+
+- subsystem: `Synapse`
+- directed unit: `SessionSignal`
+- command: `ouroboros_session_signal`
+- delivery modes: `inform`, `after_turn`, `redirect`, `replace`
+- runtime capability: `SessionSignalCapabilities`
+
+## Scope
+
+Implemented:
+
+- validated immutable `SessionSignal` contract;
+- exact execution/scope/attempt target identity;
+- bounded message, reason, and identifier fields;
+- expiry and approval-receipt validation;
+- requested/effective mode resolution against runtime capabilities;
+- durable lifecycle event factories;
+- deterministic lifecycle projection;
+- idempotency identity and legal state-transition checks;
+- capability fields that default to unsupported;
+- exact-attempt EventStore target resolution and durable queue admission;
+- public discovery/delivery MCP schemas, validation, and composition-root registration;
+- in-process exact-attempt hub and tested leader-driven plus persisted
+  `codex_cli` delivery;
+- same-session `inform` replies with an explicit `tools=[]` request, plus
+  additive `after_turn` delivery; runtimes surface degradation when they cannot
+  enforce an empty tool catalog natively;
+- durable `delivering` state before provider handoff;
+- user > conductor > worker pending-signal priority;
+- expiry checks at admission, replay, and consumption;
+- queued replay after restart and terminal uncertainty for a previously claimed
+  signal;
+- bounded, secret-filtered replies in completed events.
+
+Capability-disabled until runtime proof exists:
+
+- checkpoint hooks inside an active provider turn;
+- owned process abort and replacement resume.
+
+## Vocabulary
+
+### Modes
+
+| Mode | Semantics | May be fallback |
+|---|---|---|
+| `inform` | Deliver contextual information without claiming execution redirection. | no |
+| `after_turn` | Apply after the current worker turn finishes and before the next turn begins. | yes |
+| `redirect` | Apply at a runtime-declared checkpoint before the next model/tool decision. | no |
+| `replace` | Abort owned activity and start a replacement turn or session. | no |
+
+### Sources
+
+Priority is deterministic:
+
+1. `user`
+2. `conductor`
+3. `worker`
+
+A lower-priority signal cannot supersede an unapplied higher-priority signal for
+the same session attempt.
+
+### Lifecycle states
+
+```text
+requested
+  ├─> rejected
+  └─> accepted ─> queued
+                  ├─> delivering ─> applied ─> completed
+                  │               ├─> rejected
+                  │               └─> delivery_uncertain
+                  ├─> applied ─> completed
+                  ├─> rejected
+                  └─> delivery_uncertain
+```
+
+Terminal states are `rejected`, `completed`, and `delivery_uncertain`.
+`applied` is not terminal because an optional acknowledgement or bounded reply
+may still complete the signal.
+
+## SessionSignal contract
+
+Required fields:
+
+- `signal_id`
+- `target_session_scope_id`
+- `target_session_attempt_id`
+- `expected_execution_id`
+- `mode`
+- `message`
+- `source`
+- `reason`
+- `idempotency_key`
+
+Optional fields:
+
+- `fallback_mode` — only `after_turn`, and only when requested mode is `redirect`;
+- `expires_at` — timezone-aware UTC timestamp;
+- `user_approval_event_id` — required for `replace`;
+- `expected_contract_version` — required when a future signal references a
+  versioned shared execution contract.
+
+## Bounds
+
+| Field | Maximum |
+|---|---:|
+| `signal_id` | 160 UTF-8 bytes |
+| scope/attempt/execution/idempotency identifiers | 256 UTF-8 bytes each |
+| `message` | 8,192 UTF-8 bytes |
+| `reason` | 1,000 UTF-8 bytes |
+| approval event ID | 256 UTF-8 bytes |
+
+Values are stripped before validation. Empty strings, control-only text, and
+oversized values fail closed. The persisted event payload stores bounded text
+and a SHA-256 message digest. It never stores raw transcripts or tool output.
+
+## Identity invariants
+
+- `target_session_attempt_id` identifies one implementation attempt, not merely
+  a resumable provider session.
+- `expected_execution_id` prevents a signal from crossing into a successor run.
+- The server resolves provider-native session IDs; callers cannot supply them as
+  routing authority.
+- An expired, terminal, replaced, or mismatched target is rejected.
+- `idempotency_key` identifies one effective signal within the exact target
+  attempt.
+
+## Capability resolution
+
+`SessionSignalCapabilities` contains independent booleans:
+
+- `background_reply`
+- `inform_delivery`
+- `after_turn_delivery`
+- `checkpoint_redirect`
+- `owned_turn_abort`
+- `replacement_resume`
+
+All fields default to `False`. Existing `targeted_resume=True` does not imply any
+Synapse capability. A runtime opts in only after its exact resume transport is
+tested.
+
+The currently proven same-session `inform_delivery`, `background_reply`, and
+`after_turn_delivery` transports are:
+
+| Runtime | Resume proof | Synapse status |
+|---|---|---|
+| `codex_cli` | persisted Codex thread ID | enabled |
+| `claude` | Claude Agent SDK native session ID | enabled |
+| `claude_mcp` | persisted worker session only | enabled only when persistence is configured |
+| `opencode` | `opencode run --session <id>` | enabled |
+| `goose` | stable generated session name plus `--resume` | enabled |
+| `pi` | exact project session ID via `--session` | enabled |
+| `hermes_cli` | CLI advertises `--resume`, but the installed live probe did not persist the emitted session into its resumable store | disabled |
+
+Provider credentials and a valid model remain deployment prerequisites. A
+configured transport failure becomes an ordinary runtime error; capability
+declaration means the adapter preserves and targets the native session when the
+provider itself is operational.
+
+The human never supplies scope or attempt IDs. The main session calls
+`ouroboros_session_signal_targets` with the observed execution ID, semantically
+matches natural-language intent to live AC content, and copies the selected
+logical guards into the delivery command. It asks only for genuine semantic
+ties and never exposes provider-native session IDs.
+
+Resolution rules:
+
+1. `inform` requires `inform_delivery`; a returned reply requires
+   `background_reply` and is always bounded.
+2. `after_turn` requires `after_turn_delivery`.
+3. `redirect` requires `checkpoint_redirect`.
+4. A `redirect` request may resolve to effective mode `after_turn` only when
+   `fallback_mode=after_turn` and the runtime supports it.
+5. `replace` requires both `owned_turn_abort` and `replacement_resume`, plus a
+   non-empty user approval event ID.
+6. Unsupported modes are rejected; capability resolution never silently
+   upgrades or downgrades.
+
+## Lifecycle event contract
+
+Event namespace:
+
+- `control.session.signal.requested`
+- `control.session.signal.accepted`
+- `control.session.signal.queued`
+- `control.session.signal.delivering`
+- `control.session.signal.applied`
+- `control.session.signal.rejected`
+- `control.session.signal.delivery_uncertain`
+- `control.session.signal.completed`
+
+All events:
+
+- aggregate by `("session_signal", signal_id)`;
+- carry schema version, exact target identity, source, requested mode,
+  idempotency key, message digest, and bounded reason;
+- include `effective_mode` after acceptance;
+- may include `job_id`, `session_id`, and runtime backend as bounded correlation
+  metadata;
+- never include provider payloads, raw prompts, transcripts, or tool output.
+
+## Delivery acknowledgement
+
+`queued` proves only that Ouroboros durably owns pending delivery.
+`delivering` proves only that the owning runtime claimed the signal before the
+provider boundary; it still does not prove application.
+`applied` requires a runtime or checkpoint acknowledgement that the signal
+entered the target context.
+
+If Ouroboros may have handed the signal to a provider but cannot prove whether
+the provider accepted it, the state becomes `delivery_uncertain`. That state is
+terminal for automatic delivery; operators may inspect the target, but Synapse
+does not resend automatically.
+
+## Specification-changing intent
+
+Live signals are additive implementation guidance or read-only information.
+A change to the approved goal, ACs, constraints, or non-goals cannot be delivered
+as `inform`, `after_turn`, or `redirect`.
+
+Such a change requires:
+
+1. an explicit user approval receipt;
+2. a new shared contract version;
+3. one successor or replacement plan covering every affected AC.
+
+## Acceptance criteria
+
+1. Every invalid or oversized contract fails before an event is created.
+2. Capability resolution is deterministic and table-tested.
+3. `redirect` falls back only to an explicitly requested `after_turn` mode.
+4. `replace` requires both runtime capabilities and user approval.
+5. Legal lifecycle transitions are deterministic; illegal transitions fail.
+6. Event payloads are bounded, digest-bearing, and free of raw provider data.
+7. Idempotency identity includes exact execution, scope, attempt, and key.
+8. Existing runtimes remain behaviorally unchanged because all Synapse
+   capabilities default to unsupported.
+9. A queued signal is replayed after restart, while a previously delivering
+   signal becomes terminal `delivery_uncertain` and is never blindly resent.
+10. `inform` runs without tools in the same native session and persists only a
+    bounded, secret-filtered reply.

--- a/docs/rfc/active-conductor.md
+++ b/docs/rfc/active-conductor.md
@@ -1,170 +1,993 @@
 # RFC — Active conductor: judgment on the event-driven main session
 
-> Status: Proposed
-> Scope: `ooo run`, `ooo auto`, `ooo ralph` host skills; MCP attention classification
-> Builds on: [delegated-job-observer](delegated-job-observer.md), [frugality-proof-producers](frugality-proof-producers.md)
+> Status: Proposed — Synapse contract foundation implemented (2026-07-12)
+> Scope: `ooo run`, `ooo auto`, `ooo ralph` host skills; MCP attention
+> classification; conductor decision audit; post-recovery successor dispatch;
+> capability-aware Ouroboros Synapse control
+> Builds on: [delegated-job-observer](delegated-job-observer.md),
+> [frugality-proof-producers](frugality-proof-producers.md)
 
 ## Problem
 
-#1599 (delegated-job-observer) made the main session event-driven. An observer
-child owns the `job_wait` cursor exclusively and relays only four categories to
-the parent — `phase_changed`, `progress_advanced`, `attention_required`,
-`terminal` (`mcp/tools/job_observer.py:58-61`). By design the parent's declared
-`main_session_policy` is `start_and_on_demand_only`
-(`mcp/tools/job_observer.py:53`): it is a passive spectator.
+#1599 made background-job observation event-driven: one read-only child owns the
+`job_wait` cursor and relays sparse progress, attention, and terminal messages to
+the main session. That split correctly moved polling out of the expensive main
+context, but it left semantic judgment unowned.
 
-That is the right split for *observation*, but it left *judgment* unowned. When
-an AC fails after retry exhaustion, a TraceGuard deliver verdict rejects the same
-lineage repeatedly, or the frugality proof returns a FAIL status, nothing with
-semantic judgment reacts. The engine's deterministic recovery is the ceiling:
-reasoning-effort raise at `EFFORT_RAISE_RETRY_THRESHOLD = 2`
-(`orchestrator/effort_routing.py:38`), and one model-tier raise applied once at or
-after the configured escalation retry threshold (`orchestrator/model_routing.py`,
-`raise_one_notch`). Later retries recompute from the same starting tier rather than
-climbing repeatedly: a normal decomposed child moves `frugal -> standard`, while a
-normal top-level AC moves `standard -> frontier`. Once the configured retry budget,
-including that stronger-model attempt where available, is exhausted, the run simply
-reports failure. The proven pattern for lifting that ceiling is a conductor main
-loop: woken by events, it re-verifies claims against ground truth and issues
-corrective, context-rich directives to workers.
+The engine already owns deterministic recovery: configured AC retries,
+reasoning-effort escalation, one-notch model escalation, and alternate-harness
+redispatch. Once that recovery is exhausted, however, no component verifies the
+failure against ground truth, decides whether the specification or approach is
+wrong, and starts a bounded corrective successor.
+
+The first RFC draft assumed that the existing event and MCP surfaces were already
+sufficient. The implementation audit found six contract gaps:
+
+1. The observer waits with `wait_for="ac_change"` and does not request the linked
+   event stream, so deliver verdicts and frugality events cannot wake it.
+2. `execution.ac.outcome_finalized` is emitted after intermediate attempts as well
+   as final attempts. It does not prove that retry and alternate-harness ownership
+   is closed.
+3. Model-routing events do not explicitly record whether an escalation occurred,
+   and deliver-verdict events have no lineage-stable semantic AC identity.
+4. Seed-QA blocking mutates Auto state but emits no dedicated gate-block event.
+5. No public MCP surface exists for conductor decision logging, corrective
+   directives, targeted in-flight tier pinning, or spec amendment.
+6. Ouroboros can observe and resume provider-native worker sessions, but it has
+   no durable, capability-aware mailbox for applying updated user intent to a
+   specific live session. The existing `ControlBus` is explicitly in-process
+   only and cannot by itself redirect a worker owned by another runtime process.
+
+The active conductor must close these gaps without racing the recovery already
+owned by the engine, and without claiming that every runtime can interrupt an
+in-flight turn.
 
 ## Decision
 
-Make the main session an **active conductor** in three layers, preserving the
-observer split — the observer owns the cursor; the conductor owns judgment. The
-conductor never re-drives what the engine already retries.
+Make the main session an **active conductor** while preserving exclusive observer
+cursor ownership:
 
-### L1 — server: attention classification with action menus
+```text
+engine/workers  -> durable sensor events
+                      |
+job observer    -> classified relay event
+                      |
+main conductor  -> VERIFY -> DECIDE -> LOG -> ACT
+                                             |
+                              bounded successor execution/generation
+```
 
-The MCP job event summarizer classifies events into `attention_required` for a
-fixed set of judgment-demanding conditions, and embeds a
-`recommended_host_actions` menu on each such event. This generalizes the
-existing singular `recommended_host_action="spawn_observer_session"`
-(`mcp/tools/job_observer.py:32`) into an ordered list of concrete MCP tool-call
-templates — structured meta the host executes verbatim, never prose the host
-must reconstruct. This is the same SOL-compatibility rationale the observer RFC
-gives: tool names and arguments live in MCP meta so the orchestrating model does
-not rebuild them from surrounding skill prose, and one explicit act replaces a
-multi-turn reconstruction.
+The observer owns polling. The main session owns judgment. The engine continues
+to own every retry and redispatch inside the active job.
 
-Attention triggers (all sensed from events already emitted on this branch):
+The conductor MUST NOT directly mutate artifacts, change routing, or redispatch
+an active AC. A mutating recovery action is valid only when
+`engine_ownership.state == "closed"`. Corrective work is a successor execution or
+successor evolution generation, never a concurrent second driver of the current
+AC.
 
-| Trigger | Source event | Sensed field |
+Updated user intent is a separate control-plane input. It may be queued for a
+specific active session and applied only through a runtime-declared safe boundary.
+This does not authorize concurrent redispatch or silent specification changes.
+
+## Layer 0 — authoritative sensor contract
+
+Attention classification must consume durable facts, not infer retry state from
+counter values or prose.
+
+### Recovery exhaustion
+
+Emit exactly one `execution.ac.recovery_exhausted` event for each root AC that
+remains failed after every engine-owned path has closed.
+
+Required data:
+
+```json
+{
+  "execution_id": "exec_...",
+  "session_id": "orch_...",
+  "root_ac_index": 2,
+  "semantic_ac_key": "ac_...",
+  "retry_attempt": 2,
+  "configured_retry_attempts": 2,
+  "retry_termination_reason": "budget_exhausted",
+  "alternate_redispatch_status": "failed",
+  "last_failure_class": "verify_command_failed",
+  "success": false
+}
+```
+
+`retry_termination_reason` is one of:
+
+- `budget_exhausted`
+- `repeated_failure_early_stop`
+- `alternate_harness_exhausted`
+- `not_retryable`
+
+`alternate_redispatch_status` is one of:
+
+- `not_eligible`
+- `not_attempted`
+- `succeeded`
+- `failed`
+
+This event is the authoritative proof that the conductor may consider a
+successor. `execution.ac.outcome_finalized` remains attempt-level telemetry and
+MUST NOT independently trigger a mutating conductor action.
+
+### Model escalation evidence
+
+Extend `execution.ac.model_routed` with:
+
+- `semantic_ac_key`
+- `base_model_tier`
+- `escalation_retry_threshold`
+- `model_escalated: bool`
+
+An escalation-failed trigger requires a matching
+`execution.ac.recovery_exhausted` event and the latest routed event with
+`model_escalated=true`. Reaching `frontier` alone is not evidence of exhaustion.
+
+### Deliver-verdict lineage
+
+Add an optional `semantic_ac_key` to `AcceptanceCriterionSpec`, and extend
+`execution.ac.deliver_verdict` with the resolved key. The key is assigned when an
+acceptance criterion is created and is preserved through retries, decomposition,
+and evolution successors. A genuinely new or semantically replaced criterion
+receives a new key. Legacy criteria without a key receive a deterministic key at
+Seed materialization and persist it in the next structured Seed representation.
+
+A rejected streak is counted by `(judgment_scope_id, semantic_ac_key)`, where
+`judgment_scope_id` is the evolution lineage when one exists and otherwise the
+root background job. Runtime session ID and list position are not valid lineage
+identities.
+
+The event keeps the full `rejected_reasons`; classification and verification must
+not depend on the truncated human-readable event detail.
+
+### Seed-QA gate
+
+Emit `auto.seed_qa.blocked` whenever the Seed-QA repair budget closes without a
+passing verdict.
+
+Required data:
+
+- `auto_session_id`
+- `seed_id`
+- `attempts`
+- `verdict`
+- `score`
+- `differences`
+- `suggestions`
+- `reason`
+
+Transient evaluator errors and timeouts remain ordinary Auto blockers and use a
+different trigger code from a genuine non-passing Seed-QA verdict.
+
+### Frugality and stagnation
+
+Reuse the existing events:
+
+- `execution.frugality_proof.evaluated`
+- `lineage.stagnated`
+
+The terminal job response performs a final full-history classification scan so a
+frugality event emitted during runner teardown is not lost when the observer
+fetches the terminal result.
+
+## Layer 1 — job-wait attention relay
+
+### Wake contract
+
+The observer wait template uses:
+
+```json
+{
+  "tool": "ouroboros_job_wait",
+  "arguments": {
+    "job_id": "job_...",
+    "cursor": 0,
+    "timeout_seconds": 180,
+    "view": "summary",
+    "stream": "linked",
+    "wait_for": "attention_or_ac_change"
+  }
+}
+```
+
+`attention_or_ac_change` wakes on:
+
+- meaningful AC/Sub-AC/phase progress;
+- a newly classified attention event;
+- terminal job state;
+- timeout.
+
+It does not wake on unrelated raw linked events or unchanged heartbeats.
+
+### Relay envelope
+
+`ouroboros_job_wait` adds `meta.relay_events`, ordered by durable event position.
+Each item uses this discriminated envelope:
+
+```json
+{
+  "id": "attention_...",
+  "kind": "attention_required",
+  "trigger": "ac_recovery_exhausted",
+  "scope": {
+    "job_id": "job_...",
+    "execution_id": "exec_...",
+    "session_id": "orch_...",
+    "lineage_id": null,
+    "semantic_ac_key": "ac_..."
+  },
+  "engine_ownership": {
+    "state": "closed",
+    "evidence_event_ids": ["event_..."]
+  },
+  "evidence": {
+    "reason": "verify_command_failed",
+    "rejected_reasons": []
+  },
+  "recommended_host_actions": [
+    {
+      "kind": "host_verify",
+      "action": "spawn_read_only_verifier",
+      "arguments": {
+        "evidence_event_ids": ["event_..."],
+        "workspace_policy": "read_only"
+      },
+      "effect": "read_only",
+      "rationale": "Confirm the failure against durable evidence and disk state."
+    }
+  ]
+}
+```
+
+Valid `kind` values remain:
+
+- `phase_changed`
+- `progress_advanced`
+- `attention_required`
+- `terminal`
+
+Only `attention_required` carries `engine_ownership`, `evidence`, and
+`recommended_host_actions`. Progress and phase events MUST NOT carry action
+menus.
+
+### Attention triggers
+
+| Trigger code | Durable evidence | Mutation eligibility |
 |---|---|---|
-| AC terminal failure after retry exhaustion | latest failed `execution.ac.outcome_finalized` plus terminal execution state | `success=false`, `retry_attempt`, and no further engine-owned retry/redispatch |
-| One-notch model escalation attempted and still failing | `execution.ac.model_routed` + matching `execution.ac.outcome_finalized` | `retry_attempt` at/above the resolved escalation threshold, raised `model_tier`, `success=false` |
-| deliver_verdict rejected streak (≥2 for one AC lineage) | `execution.ac.deliver_verdict` | `rejected_reasons`, `traceguard_verdict` (`execution_event_emitter.py:434-467`) |
-| Frugality proof FAIL | `execution.frugality_proof.evaluated` | `status` ∈ `fail_grounding_regression`, `fail_no_frugality` (`runner.py:871`, `frugality_proof.py:80-81`) |
-| Seed-QA blocked | seed-QA gate block event | gate status |
-| Stagnation | progress-stall signal | unchanged progress across bounded window |
+| `ac_recovery_exhausted` | `execution.ac.recovery_exhausted` | ownership closed |
+| `model_escalation_failed` | recovery exhausted + latest `model_escalated=true` | ownership closed |
+| `deliver_verdict_rejected_streak` | at least two rejected verdicts for one `(judgment_scope_id, semantic_ac_key)` | verify immediately; mutate only after ownership closes |
+| `frugality_grounding_regression` | proof status `fail_grounding_regression` | successor only |
+| `frugality_no_savings` | proof status `fail_no_frugality` | successor only |
+| `seed_qa_blocked` | `auto.seed_qa.blocked` | successor/resume only |
+| `lineage_stagnated` | `lineage.stagnated` | successor generation only |
 
-Each `recommended_host_actions` entry is a template of `{tool, arguments,
-rationale}` drawn from the conductor control surface (below). The menu is
-*ordered by minimal intervention* — verify-only first, spec-changing last.
-Non-attention events carry no menu.
+If a rejected streak is observed while engine ownership is still active, the
+menu contains only read-only verification and defer/escalation actions. No
+redispatch template is emitted until ownership is closed.
 
-### L2 — skill: triage playbook
+### Action menu schema
 
-`run`, `auto`, and `ralph` SKILL.md gain a conductor section executed on each
-relayed `attention_required` event. Four steps:
+VERIFY is a host-native operation, while ACT may be an MCP tool call. The menu
+therefore uses a discriminator instead of pretending every action is an
+`ouroboros_*` tool:
 
-1. **VERIFY** — never act on a worker's claim alone. Spawn one cheap, read-only
-   host subagent (the host-native Agent tool, the only surface with inline
-   visibility) to check actual state: the files on disk, the `deliver_verdict`
-   `rejected_reasons`, the `frugality_proof.evaluated` `reason`. The worker
-   reports what it believes; the conductor confirms against ground truth.
-2. **DECIDE** — the minimal intervention that unblocks. Prefer the earliest
-   entry in `recommended_host_actions` that the verification supports.
-3. **ACT** via the MCP control surface: `ouroboros_lateral_think` injection, a
-   spec amendment + redispatch, a model-tier pin, `ouroboros_cancel_execution`,
-   or explicit user escalation.
-4. **LOG** the decision as an event so the intervention trail is auditable
-   alongside the run's own events.
+```json
+{
+  "kind": "host_verify",
+  "action": "spawn_read_only_verifier",
+  "arguments": {
+    "evidence_event_ids": ["event_..."],
+    "workspace_policy": "read_only"
+  },
+  "effect": "read_only",
+  "rationale": "Confirm the reported failure against durable evidence and disk state."
+}
+```
 
-Non-attention events: no action, no tokens. S2 is inert without S1 — with no
-`recommended_host_actions` on the relayed event, the playbook has nothing to
-triage.
+```json
+{
+  "kind": "mcp_tool",
+  "tool": "ouroboros_lateral_think",
+  "arguments": {
+    "problem_context": "...",
+    "current_approach": "..."
+  },
+  "required_host_inputs": [],
+  "effect": "read_only",
+  "rationale": "Generate a bounded alternative before changing the specification."
+}
+```
 
-### L3 — autonomy loop (auto/ralph only)
+```json
+{
+  "kind": "user_escalation",
+  "action": "request_spec_change_approval",
+  "arguments": {
+    "decision_scope": "acceptance_criteria"
+  },
+  "effect": "spec_changing",
+  "rationale": "The proposed successor changes the user-approved contract."
+}
+```
 
-In `auto` and `ralph` the playbook may ACT without user confirmation on
-deterministic triggers. Example: a repeated deliver-verdict rejection — the
-conductor reads the event's `rejected_reasons`, composes a corrective
-instruction naming the unsupported claims, and injects it into the next
-`ouroboros_evolve_step` / redispatch. `ooo run` is interactive: it stops at
-user escalation for anything spec-changing, and only auto-acts on
-non-spec-changing unblocks (e.g. a tier pin).
+Menus are ordered by minimum intervention:
 
-## Division of labor (hard rule)
+1. host verification;
+2. read-only MCP analysis;
+3. non-spec-changing successor action;
+4. spec-changing successor action or user escalation.
 
-Deterministic recovery belongs to the engine and stays there — retries,
-reasoning-effort raise (`effort_routing.py`), model-tier escalation
-(`model_routing.py`). The conductor owns only what the engine cannot:
+An MCP menu entry MUST name a registered tool and contain all server-known
+arguments. Values that require conductor judgment are declared in
+`required_host_inputs`; the host fills only those named fields after VERIFY.
+This replaces the unimplementable requirement that every dynamic corrective
+argument be executable verbatim before verification has happened.
 
-- semantic interpretation of **why** something keeps failing;
-- spec-level amendments;
-- goal-drift judgment;
-- user escalation.
+The initial observer handoff retains the singular
+`recommended_host_action="spawn_observer_session"` for backward compatibility.
+Per-event menus use the plural `recommended_host_actions` field.
 
-The conductor never re-drives an AC the engine is still retrying. Double-driving
-burns tokens and races the engine's own escalation ladder. The conductor engages
-only *after* the configured retry budget is closed and no engine-owned
-same-runtime or alternate-harness redispatch remains. Reaching `frontier` is
-neither required nor sufficient: a decomposed child normally exhausts its single
-raise at `standard`, while a top-level AC may reach `frontier` before its retry
-budget is closed.
+## Layer 2 — host conductor playbook
+
+`run`, `auto`, and `ralph` execute the following playbook only for a relayed
+`attention_required` event with a non-empty action menu.
+
+1. **VERIFY** — spawn exactly one additional, short-lived, cheap, read-only host
+   subagent. It checks the named durable evidence and actual files. It does not
+   own the observer cursor and does not edit the workspace.
+2. **DECIDE** — choose the earliest menu entry supported by verification. Reject
+   an action whose preconditions or required inputs cannot be established.
+3. **LOG INTENT** — record the selected action before mutation.
+4. **ACT** — reload the selected MCP tool schema in the current turn and call it.
+   Mutating actions require `engine_ownership.state="closed"`.
+5. **LOG OUTCOME** — record completed, failed, or declined status with the action
+   receipt or user decision.
+
+Non-attention events consume no conductor reasoning. If the host cannot spawn a
+read-only verifier, it surfaces the attention event and does not ACT.
+
+If the decision-log/control tools are not registered yet, the host completes
+VERIFY and DECIDE, surfaces the verified recommendation, and stops. It does not
+simulate LOG or ACT from prose.
+
+The observer remains the exclusive polling owner throughout this playbook.
+
+## Layer 3 — decision log and successor recovery
+
+### Decision audit surface
+
+Add `ouroboros_record_conductor_decision`, which appends versioned events keyed by
+an idempotent `decision_id`:
+
+- `conductor.decision.selected`
+- `conductor.decision.completed`
+- `conductor.decision.failed`
+- `conductor.decision.declined`
+
+The record includes attention event ID, evidence event IDs, verification summary,
+selected action/effect, arguments digest, actor mode (`run`, `auto`, `ralph`), and
+result receipt where applicable. It never stores secrets or unbounded raw model
+output.
+
+### Corrective directive
+
+Extend the evolution/Ralph start surfaces with an optional
+`conductor_directive` object:
+
+```json
+{
+  "source_attention_event_id": "attention_...",
+  "instruction": "Support the rejected claims with repository evidence or remove them.",
+  "rejected_reasons": ["..."],
+  "preserve_goal": true,
+  "preserve_acceptance_criteria": true
+}
+```
+
+The directive is persisted before successor dispatch and becomes an additive,
+non-relaxing constraint. It cannot silently weaken the goal, delete an acceptance
+criterion, or rewrite user-owned non-goals.
+
+### Mode policy
+
+- `ooo run` is interactive. It may automatically perform read-only analysis and
+  non-spec-changing successor parameter changes. Any amended Seed or acceptance
+  contract requires explicit user approval.
+- `ooo auto` may autonomously start one bounded successor when the verified
+  directive is non-relaxing and the menu marks the action deterministic.
+- `ooo ralph` may autonomously start a successor generation with a non-relaxing
+  directive after its current Ralph job is terminal. It does not inject into a
+  generation already running.
+
+A model-tier change is a **successor-run tier override**, not an in-flight pin.
+The action menu must use that wording and must identify the new execution it will
+start.
+
+Autonomous conductor actions have a separate bounded budget. Default: one
+mutating successor per attention event and no more than two conductor-created
+successors per root job. Exhaustion becomes user escalation.
+
+## Start-time efficiency and frugality preference
+
+`ooo run` and `ooo auto` expose a friendly start-time efficiency choice. The
+prompt is rendered in the user's conversation language and describes the outcome,
+not internal MCP or environment-variable names.
+
+If the user has not supplied an explicit argument or saved preference, the host
+asks once:
+
+> Use efficiency mode for this run? It starts suitable ACs on lower-cost models
+> and automatically raises capability when recovery requires it.
+
+The public execution preference is:
+
+- `efficiency_mode="adaptive"` — efficiency ON; use tier routing, child lowering,
+  and retry escalation;
+- `efficiency_mode="quality_first"` — efficiency OFF; do not lower decomposed
+  children for cost and do not generate frugality attention.
+
+Efficiency actuation and proof strength are separate internally because proving
+savings can itself spend additional tokens:
+
+- `frugality_assurance="off"` — no frugality verdict or conductor attention;
+- `frugality_assurance="observe"` — lightweight routing/token/grounding telemetry
+  and best-effort proof; this is the default when efficiency is adaptive;
+- `frugality_assurance="strict"` — explicitly authorized baseline comparison.
+  It may arm shadow replay only when isolation and decomposition attestations are
+  satisfied. It MUST NOT be enabled implicitly because it can increase cost.
+
+Default mapping:
+
+| Efficiency choice | Frugality assurance | Shadow replay |
+|---|---|---|
+| `adaptive` | `observe` | off |
+| `quality_first` | `off` | off |
+
+An explicit advanced `frugality_assurance` value overrides the mapping. An
+explicit `model_tier` chooses the starting tier but does not silently enable
+strict proof.
+
+The resolved preference is persisted in the execution contract. Auto also stores
+it in `AutoPipelineState` and forwards it through RUN and Ralph successors.
+Resume restores the original preference; changing it starts a new successor
+contract rather than mutating an active or historical run.
+
+When assurance is `off`, frugality events may remain as internal low-cost
+telemetry where already unavoidable, but the classifier suppresses frugality
+attention and the user-facing result makes no savings claim. In `observe` mode,
+`insufficient_data` is reported only in the final assurance summary, not as an
+attention blocker.
+
+## Proactive run briefing UX
+
+The active conductor is responsible for the user's understanding from the moment
+`run` or `auto` starts, not only when something fails. MCP calls, cursors, raw
+events, and internal handler names remain implementation details.
+
+All host guidance is canonical English. The host phrases those facts naturally
+in the user's current conversation language. Persisted event codes and enum
+values remain language-neutral.
+
+### Progressive disclosure
+
+The main session proactively communicates these milestones:
+
+1. **Start accepted** — goal/Seed summary, efficiency choice, planned primary
+   harness/runtime, model-routing policy, and what happens next.
+2. **Discovering** — which bounded repository areas, artifacts, or contracts are
+   currently being inspected and why.
+3. **Execution plan ready** — total AC count, total serial/parallel levels,
+   dependency shape, and the ACs scheduled first.
+4. **AC dispatch** — the current model, tier, enforcement mode, and harness for
+   each newly active AC.
+5. **Meaningful change** — model escalation, harness redispatch, level advance,
+   AC verification, or attention-required judgment.
+6. **Terminal assurance** — per-AC outcome, verification evidence, model/harness
+   history, token summary when enabled, and remaining risk.
+
+The start message explicitly tells the user that the main conversation remains
+available: they may ask about any AC, request more detail, or continue unrelated
+work while the observer watches execution.
+
+### Briefing sensor contract
+
+Add `execution.run.configuration_resolved` after runtime and economic preferences
+are resolved but before AC dispatch.
+
+Required data:
+
+- `execution_id`, `session_id`
+- `efficiency_mode`, `frugality_assurance`
+- `primary_runtime_backend`
+- `primary_harness_label`
+- `model_routing_enabled`
+- `requested_model_tier`
+- `starting_model_tier` and `starting_model` when already resolvable
+- `progressive_escalation_enabled`
+- `alternate_harness_enabled`
+
+Add `execution.plan.created` after dependency analysis and before level 1 starts.
+
+Required data:
+
+```json
+{
+  "execution_id": "exec_...",
+  "total_acs": 5,
+  "total_levels": 3,
+  "parallelizable": true,
+  "levels": [
+    {
+      "level": 1,
+      "ac_indices": [0, 2],
+      "ac_summaries": ["...", "..."],
+      "depends_on_levels": []
+    }
+  ],
+  "first_level": 1,
+  "first_ac_indices": [0, 2]
+}
+```
+
+Reuse `execution.decomposition.level_started` and
+`execution.decomposition.level_completed` for live level transitions. The plan
+event describes the whole schedule once; level events describe what is happening
+now.
+
+### Discover visibility
+
+The current workflow progress projection defaults to broad phase labels and does
+not reliably describe what a worker is inspecting. Add bounded semantic events:
+
+- `execution.ac.phase_changed`
+- `execution.ac.discovery.updated`
+
+`execution.ac.phase_changed` uses the stable phase vocabulary:
+
+- `discover`
+- `plan`
+- `implement`
+- `verify`
+- `deliver`
+
+`execution.ac.discovery.updated` contains:
+
+- `semantic_ac_key`, `ac_index`
+- `targets`: at most five bounded paths, symbols, tests, or document labels
+- `purpose`: one short sentence
+- `source`: `structured_worker` or `deterministic_tool_classifier`
+
+The event is emitted only when the target set or purpose materially changes. It
+must not relay every file read, search query, command, thinking fragment, or raw
+tool output.
+
+If the runtime cannot provide structured phases, a deterministic classifier may
+derive them from tool categories: read-only repository inspection → `discover`,
+write/edit → `implement`, test/check commands → `verify`, and final evidence
+assembly → `deliver`. Ambiguous activity remains `unknown` rather than being
+presented as a confident claim.
+
+### Current model and harness
+
+After #1601, model escalation may climb progressively on later retries. The main
+session therefore says **currently running with**, never **this run uses one fixed
+model**.
+
+After #1602, reuse the same authoritative events used by TUI/Web:
+
+- `execution.ac.model_routed` for current model/tier/mode;
+- `execution.ac.token_attribution.reported` for bounded spend summaries;
+- `execution.frugality_proof.evaluated` for the terminal assurance verdict.
+
+Reuse `execution.ac.alt_harness_redispatched` to announce a harness change with
+its from/to backend and reason. The main session posts the initial route once and
+then only meaningful changes: a stronger tier/model, a different harness, or a
+new retry attempt. It does not repeat unchanged routing events.
+
+### Relay subtypes and message policy
+
+Proactive briefings use existing relay `kind` values with structured `subtype`:
+
+- `progress_advanced / run_configuration`
+- `phase_changed / ac_phase`
+- `progress_advanced / discovery_summary`
+- `progress_advanced / execution_plan`
+- `progress_advanced / level_started`
+- `progress_advanced / ac_routing`
+- `progress_advanced / harness_changed`
+- `progress_advanced / ac_verified`
+
+Default cadence:
+
+- start configuration: once;
+- plan summary: once;
+- discovery: only on material target change;
+- level start/completion: once per level;
+- model/harness: initial dispatch and changes only;
+- AC completion: once with compact evidence;
+- raw logs and unchanged heartbeats: never.
+
+The user can request an on-demand AC assurance view at any time. That view shows
+the selected AC's purpose, dependencies, current phase, current model/harness,
+retry history, verified evidence, and blocker without taking observer cursor
+ownership.
+
+## Ouroboros Synapse — inter-session intent control
+
+### Clean-room boundary
+
+Synapse is an Ouroboros-native control plane designed from this RFC's behavioral
+requirements. Implementations MUST NOT copy another agent framework's source,
+wire protocol, type names, event names, prompts, or registry design. Comparative
+research is treated only as evidence that asynchronous messaging and execution
+redirection are distinct problems.
+
+The subsystem name is **Ouroboros Synapse**. A single directed unit is a
+`SessionSignal`. Synapse carries intent from the main conductor to one exact AC
+session attempt and reports the proven delivery state back through durable
+events. It is not a chat network.
+
+### Control modes
+
+Inter-session signaling and execution redirection use one audited surface with
+distinct modes:
+
+| Mode | Meaning | Default authority |
+|---|---|---|
+| `inform` | Deliver bounded context or advice; an optional no-tools/background reply may be returned when supported. | user or conductor |
+| `after_turn` | Queue the signal for the next worker turn after the current turn completes. | user or conductor |
+| `redirect` | Apply updated intent before the next model/tool decision at a runtime-declared checkpoint. | user; conductor only for non-relaxing directives |
+| `replace` | Abort owned runtime activity, persist the interruption, then resume or restart with replacement intent. | explicit user approval only |
+
+`redirect` is the preferred interrupt behavior because it preserves completed tool
+work and avoids pretending that a provider token stream can be spliced
+arbitrarily. If the target runtime cannot redirect, the signal may fall back to
+`after_turn` only when that fallback is explicit in the command. Otherwise it is
+rejected. `replace` is never an implicit fallback.
+
+### Addressing and capability contract
+
+The logical target is an Ouroboros runtime session, not merely a provider-native
+session ID. Every request carries all of:
+
+- `target_session_scope_id` — stable AC/session identity;
+- `target_session_attempt_id` — unique implementation attempt;
+- `expected_execution_id` — generation guard against delivery to a later run;
+- `idempotency_key` — at-most-once command identity.
+
+The server resolves the current runtime handle internally. Native session IDs
+are audit metadata, not user-supplied routing authority. A stale, terminal, or
+mismatched target fails closed.
+
+The human never supplies these logical IDs either. The main session obtains the
+current `execution_id` from the run/auto start or observer contract, calls
+`ouroboros_session_signal_targets`, and semantically matches the human's wording
+against each live target's AC content, display path, and current activity. One
+candidate may be selected directly. With multiple candidates, the conductor
+selects only when one is materially more relevant and asks a short question in
+the active conversation language only for a genuine tie. Exact scope and attempt IDs are copied from the
+selected discovery result, never invented or requested from the human.
+
+Each runtime advertises an explicit control capability matrix:
+
+- background reply support;
+- inform delivery support;
+- after-turn delivery support;
+- checkpoint redirect support;
+- owned-turn abort support;
+- resumable replacement support.
+
+Capabilities describe what the active transport can enforce now. Session
+resumability alone does not imply checkpoint redirect, and the in-process `ControlBus`
+does not imply cross-runtime delivery.
+
+### MCP command and durable lifecycle
+
+Add the read-only discovery command `ouroboros_session_signal_targets`:
+
+```json
+{
+  "execution_id": "exec_abc"
+}
+```
+
+It returns only currently registered attempts for that execution, including AC
+content and logical scope/attempt guards. It never exposes provider-native
+session IDs and does not choose a target on behalf of the main model.
+
+Add the delivery command `ouroboros_session_signal`:
+
+```json
+{
+  "target_session_scope_id": "exec_abc_ac_2",
+  "target_session_attempt_id": "exec_abc_ac_2_attempt_1",
+  "expected_execution_id": "exec_abc",
+  "mode": "redirect",
+  "fallback_mode": "after_turn",
+  "message": "Apply the refined requirement while preserving the approved ACs.",
+  "source": "user",
+  "reason": "The user refined the desired interaction.",
+  "user_approval_event_id": null,
+  "idempotency_key": "msg_...",
+  "expires_at": "2026-07-12T15:00:00Z"
+}
+```
+
+The command appends a durable state machine:
+
+- `control.session.signal.requested`
+- `control.session.signal.accepted`
+- `control.session.signal.queued`
+- `control.session.signal.delivering`
+- `control.session.signal.applied`
+- `control.session.signal.rejected`
+- `control.session.signal.delivery_uncertain`
+- `control.session.signal.completed`
+
+`accepted` records the validated target, requested/effective mode, capabilities,
+and any explicit fallback. `queued` proves durable ownership of pending delivery.
+`delivering` records that the owning runtime claimed the signal immediately
+before provider handoff; it does not prove application.
+`applied` requires a runtime or checkpoint acknowledgement that the instruction
+entered the target context. `completed` may include a bounded acknowledgement or
+side-channel reply, but never an unbounded transcript. A tool success response
+that only means "queued" MUST NOT be presented as "already applied".
+If a process fails after handing the message to a provider but before recording
+acknowledgement, `delivery_uncertain` is terminal for automatic delivery. The
+system does not blindly retry a possibly applied instruction.
+
+On restart, still-queued signals are reconstructed into the exact live target's
+queue. A signal whose last durable state is `delivering` is never replayed; it is
+closed as `delivery_uncertain`. Expiry is checked again when the runtime consumes
+the signal, not only when it was admitted.
+
+The event stream is linked to the owning job and execution so the exclusive job
+observer can relay delivery status without giving the main session another
+cursor. The direct MCP call does not read or advance the observer cursor.
+
+### Ordering, authority, and safety
+
+- User-authored intent outranks conductor and worker messages. A lower-priority
+  message cannot supersede an unapplied user message for the same target. Source
+  attribution is resolved from the command path and approval receipt; it is not
+  inferred from prose inside `message`.
+- Messages are bounded, secret-filtered, and contain no raw transcript or tool
+  output. The persisted audit stores a digest plus bounded user-visible text.
+- A signal that changes the approved goal, ACs, constraints, or non-goals is not
+  accepted as `inform`, `after_turn`, or `redirect`. It requires an explicit user
+  approval receipt and an approval-bound successor or `replace`
+  contract so every affected AC shares one new specification version.
+- Delivery is at most once per idempotency key. Runtime acknowledgement and
+  mailbox consumption are replay-safe.
+- Expired messages and messages targeting a replaced attempt are rejected, not
+  silently redirected.
+- If safe application cannot be proven, the conductor reports `queued`,
+  `deferred`, or `rejected`; it never claims the AC changed course.
+
+### User assurance
+
+Canonical host guidance is written in English and the host phrases it naturally
+in the user's current conversation language. The facts must preserve actual
+delivery semantics. Example canonical messages:
+
+- "The request is durably queued for AC 3 and has not been applied yet."
+- "This runtime cannot redirect at a live checkpoint, so the explicit
+  after-turn fallback will apply after the current turn."
+- "AC 3 was replaced by another attempt, so the request was rejected."
+- "Delivery crossed the provider boundary without acknowledgement; Synapse will
+  not resend it automatically."
+- "Stopping and replacing the current execution requires explicit approval."
+
+When the user refines intent in the main conversation, the conductor identifies
+the affected AC session through discovery, explains the selected AC and
+effective mode, then issues only the authorized message. The user is never asked
+for internal IDs. Unaffected ACs continue normally.
+
+## Division of labor
+
+Engine-owned:
+
+- same-runtime retries;
+- effort and model escalation;
+- alternate-harness redispatch;
+- active job cancellation and terminalization;
+- runtime-specific safe-boundary acknowledgement and owned-turn abort;
+
+Conductor-owned:
+
+- verification of reported claims against ground truth;
+- semantic interpretation of repeated failure;
+- non-relaxing corrective directives;
+- successor execution/generation selection;
+- spec-change approval and user escalation;
+- decision audit;
+- mapping updated user intent to affected AC sessions;
+- capability-aware message mode selection and truthful delivery assurance.
+
+`frontier` tier is neither required nor sufficient for conductor engagement.
+Only authoritative recovery closure permits mutation.
 
 ## Frugality coupling
 
-The conductor is the most expensive context in the system, so the design spends
-it only at attention moments — never on `phase_changed` / `progress_advanced`
-heartbeats. Verification is delegated to cheap read-only subagents, not done in
-the conductor's own context. The event vocabulary shipped on this branch is
-precisely the conductor's sensor suite:
+The main conductor wakes only for classified attention. Phase changes, progress,
+raw events, and heartbeats remain in the observer context. Verification is
+delegated to one cheap read-only child, and action menus carry bounded evidence
+instead of requiring the conductor to replay the complete event history.
 
-- `execution.ac.model_routed` (`model_tier`, `retry_attempt`)
-- `execution.ac.token_attribution.reported`
-  (`frugality_proof.py:66`, `EVENT_TOKEN_ATTRIBUTION`)
-- `execution.ac.deliver_verdict`
-  (`frugality_proof.py:67`, `EVENT_DELIVER_VERDICT`; `rejected_reasons`)
-- `execution.frugality_proof.evaluated` (`status`, `reason`)
+The classifier may query complete history server-side, but each relay envelope is
+bounded:
 
-No new sensor is invented — the conductor reads what the frugality machine
-already produces.
+- at most 10 evidence event IDs;
+- at most 10 rejected reasons, each length-limited;
+- no raw tool output;
+- no unbounded file content or model transcript.
 
 ## Non-goals
 
-- No MCP server push. The observer still long-polls (`job_wait`); the conductor
-  reacts to relayed events, not to a pushed stream.
-- No new daemon. The conductor is the existing main session, not a process.
-- No change to OpenCode plugin mode — execution there belongs to a plugin child
-  and returns no pollable job ID, so there is no observer/conductor split to add.
-- No conductor writes into the active run workspace without the overlap check
-  the observer RFC already defines. Verification subagents are read-only.
+- No MCP server push; the observer still long-polls.
+- No long-lived conductor or notification daemon; the conductor is the existing
+  main session. A detached per-job worker may own execution because an stdio MCP
+  process is scoped to one client turn and cannot be the durability boundary.
+- No duplicate polling or cursor ownership in the main session.
+- No direct in-flight artifact mutation, targeted concurrent redispatch, or live
+  tier pin. Checkpoint intent redirection is the only active-session control
+  introduced here.
+- No OpenCode plugin-mode conductor in this RFC.
+- No verifier writes to the active workspace.
+- No automatic weakening of user-approved goals, ACs, constraints, or non-goals.
+- No provider-independent promise of arbitrary token-stream preemption.
+- No general-purpose peer chat network, channel membership, or transcript sync.
 
 ## Implementation slices
 
-- **S1** — attention classification + `recommended_host_actions` in the job
-  event summarizer (server). Independently shippable and testable against the
-  fixed event contract above.
-- **S2** — the conductor playbook sections in `run`/`auto`/`ralph` SKILL.md.
-  Inert without S1.
-- **S3** — `auto`/`ralph` autonomous triggers + the decision-log event.
+### S0 — sensor closure
 
-Each slice ships independently.
+- emit `execution.ac.recovery_exhausted`;
+- add model escalation fields and `semantic_ac_key`;
+- emit `auto.seed_qa.blocked`;
+- add and persist resolved efficiency/frugality execution preferences;
+- emit run configuration, execution plan, AC phase, and bounded discovery events;
+- guarantee terminal full-history visibility.
+
+S0 changes no host behavior.
+
+### S1 — attention relay
+
+- add `attention_or_ac_change`;
+- request `stream="linked"` in observer contracts;
+- classify bounded `meta.relay_events`;
+- add ordered, discriminated action menus;
+- retain observer protocol backward compatibility.
+
+S1 may initially advertise only read-only actions and user escalation.
+
+### S2 — active host playbook
+
+- update root and packaged `run`/`auto`/`ralph` skills;
+- update Codex host instructions;
+- preserve exactly one observer plus at most one short-lived verifier;
+- implement VERIFY → DECIDE → LOG → ACT behavior;
+- keep OpenCode plugin mode unchanged.
+
+S2 remains non-mutating until S3 tools are registered.
+
+### S3 — audited successor recovery
+
+- add `ouroboros_record_conductor_decision`;
+- add persisted `conductor_directive` support to evolution/Ralph successors;
+- add bounded autonomous successor budgets for Auto/Ralph;
+- implement run-mode user approval for spec-changing successors.
+
+### S4 — Ouroboros Synapse
+
+- add runtime control capabilities and a live session-attempt projection;
+- add the durable SessionSignal state machine and idempotent mailbox;
+- add `ouroboros_session_signal` with explicit fallback semantics;
+- implement `inform`/`after_turn` first, then runtime-specific checkpoint
+  `redirect` and explicitly approved `replace` where enforceable;
+- relay requested/effective mode and applied/rejected status through the existing
+  observer;
+- update English canonical `run`/`auto` guidance so the main session targets affected ACs and
+  guarantees only the delivery state actually proven.
+
+Current `after_turn` capability matrix:
+
+| Runtime | State | Evidence boundary |
+|---|---|---|
+| persisted Codex CLI | enabled | same persisted thread |
+| Claude Agent SDK | enabled | same native SDK session |
+| persisted Claude MCP worker | enabled | same persisted worker session |
+| OpenCode CLI | enabled | same OpenCode session ID |
+| Goose CLI | enabled | same stable session name with explicit resume |
+| Pi CLI | enabled | same exact project session ID |
+| Hermes CLI | disabled | emitted ID was not resumable in the installed live probe |
+
+This table is capability evidence, not provider availability. Missing
+credentials, an invalid model, or an unhealthy upstream still fails as a runtime
+error. `targeted_resume=True` without a successful same-session proof never opens
+Synapse admission.
+
+Each slice is independently shippable and has no hidden dependency on host prose.
 
 ## Acceptance criteria
 
-1. The summarizer emits `attention_required` with a non-empty
-   `recommended_host_actions` menu for each L1 trigger, and no menu on
-   `phase_changed` / `progress_advanced`.
-2. `recommended_host_actions` entries are structured `{tool, arguments,
-   rationale}` templates using real `ouroboros_*` tool names — no prose.
-3. The playbook VERIFYs via a read-only host subagent before any ACT, and never
-   acts on a worker claim alone.
-4. The conductor never redispatches an AC while the engine still owns a configured
-   retry, the one-notch effort/model raise, or an alternate-harness redispatch.
-5. In `auto`/`ralph` a repeated `deliver_verdict` rejection produces a corrective
-   injection composed from `rejected_reasons`; in `ooo run` a spec-changing
-   intervention stops at user escalation.
-6. Every conductor decision is logged as an event.
+1. Every trigger in the attention table has authoritative durable evidence; no
+   trigger depends on parsing human-readable event detail.
+2. `attention_or_ac_change` wakes for attention, meaningful progress, terminal,
+   or timeout, but not unrelated raw events.
+3. `meta.relay_events` carries bounded structured evidence. Only
+   `attention_required` carries a non-empty action menu.
+4. MCP action entries name registered tools. Dynamic host-supplied values are
+   explicitly listed in `required_host_inputs`.
+5. VERIFY uses one read-only host subagent before any ACT. Hosts without that
+   primitive surface the event and do not mutate.
+6. No recovery, artifact, routing, or specification mutation is offered or
+   executed unless authoritative engine ownership is closed. Active-session
+   messages follow the separate capability and authority rules in this RFC.
+7. Intermediate `outcome_finalized` events, reaching `frontier`, or an unchanged
+   polling window cannot independently authorize redispatch.
+8. A repeated rejected verdict is grouped by
+   `(judgment_scope_id, semantic_ac_key)` and produces a corrective directive
+   containing the bounded `rejected_reasons`.
+9. `ooo run` requests approval for spec-changing successors; `auto` and `ralph`
+   may only auto-run bounded non-relaxing successors.
+10. Every conductor decision has selected and terminal audit events, including
+    declined and failed actions.
+11. Observer cursor ownership remains exclusive and OpenCode plugin behavior is
+    unchanged.
+12. Root skills, packaged skill copies, Codex instructions, runtime guides, and
+    artifact contract tests remain coherent.
+13. `run` and `auto` accept and persist `efficiency_mode` and
+    `frugality_assurance`; Auto forwards the resolved values to RUN/Ralph.
+14. Start UX presents the choice in the user's conversation language and never
+    exposes MCP polling, environment variables, or internal routing vocabulary as
+    the primary explanation.
+15. Strict assurance and shadow replay require explicit authorization. Efficiency
+    mode alone never enables extra-cost baseline execution.
+16. The main session proactively emits start, discovery, plan, routing,
+    level, AC-verification, and terminal-assurance briefings without exposing MCP
+    mechanics or raw logs. Guidance is canonical English and is phrased naturally
+    in the active conversation language.
+17. The plan briefing names total levels and the first scheduled ACs before level
+    1 execution begins.
+18. Model and harness wording is current-state based. Progressive escalation and
+    alternate-harness changes are announced once when they occur.
+19. Discovery summaries are bounded, materially deduplicated, and honest about
+    unknown activity; they never forward raw tool calls or model reasoning.
+20. On-demand AC assurance inspection does not acquire or advance the observer
+    job cursor.
+21. SessionSignal commands require stable scope, attempt, and execution guards;
+    stale or terminal targets fail closed.
+22. `inform`, `after_turn`, `redirect`, and `replace` have distinct
+    capability and authority checks. No runtime is credited with redirect merely
+    because it can resume a session.
+23. A successful command distinguishes `queued` from `applied`; the main session
+    never reports intent adoption without an application acknowledgement.
+24. Unsupported redirect falls back only to the explicitly requested mode and
+    reports the effective mode. Hard abort is never an implicit fallback.
+25. User messages outrank conductor/worker messages, and specification-changing
+    content requires explicit user confirmation.
+26. SessionSignal delivery is bounded, secret-filtered, idempotent, replay-safe,
+    and auditable from request through completion or rejection.
+27. Session-control relay events use the existing exclusive observer cursor;
+    direct message commands never create a second polling owner.
+28. Runtime-specific tests prove safe-boundary behavior, abort ownership, and
+    truthful degradation for every supported harness.
+29. Ambiguous provider delivery becomes `delivery_uncertain` and is not
+    automatically retried or reported as applied.
+30. Specification-changing intent cannot be injected into only one live AC; it
+    creates an approval-bound shared successor/replacement contract for every
+    affected AC.
+31. Every non-plugin Start* acceptance is owned by a process whose lifetime is
+    independent of the accepting stdio MCP turn. Parent shutdown cannot create
+    `mcp.job.interrupted`; a later controller can observe and cancel the owner
+    through durable state.
+32. When no real host observer is available, the main session does not claim
+    proactive observation. The durable worker continues, and a later parent
+    turn can catch up the same linked events and terminal result.

--- a/src/ouroboros/core/__init__.py
+++ b/src/ouroboros/core/__init__.py
@@ -19,6 +19,57 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     # Control-plane directive vocabulary and contract
     "ControlContract": ("ouroboros.core.control_contract", "ControlContract"),
     "Directive": ("ouroboros.core.directive", "Directive"),
+    # Active Conductor decision and successor contracts
+    "ConductorActorMode": ("ouroboros.core.conductor", "ConductorActorMode"),
+    "ConductorDecisionPhase": (
+        "ouroboros.core.conductor",
+        "ConductorDecisionPhase",
+    ),
+    "ConductorDirective": ("ouroboros.core.conductor", "ConductorDirective"),
+    "ConductorEffect": ("ouroboros.core.conductor", "ConductorEffect"),
+    "EngineOwnershipState": (
+        "ouroboros.core.conductor",
+        "EngineOwnershipState",
+    ),
+    # Execution preferences
+    "EfficiencyMode": ("ouroboros.core.execution_preferences", "EfficiencyMode"),
+    "FrugalityAssurance": (
+        "ouroboros.core.execution_preferences",
+        "FrugalityAssurance",
+    ),
+    "ResolvedExecutionPreferences": (
+        "ouroboros.core.execution_preferences",
+        "ResolvedExecutionPreferences",
+    ),
+    "resolve_execution_preferences": (
+        "ouroboros.core.execution_preferences",
+        "resolve_execution_preferences",
+    ),
+    # Ouroboros Synapse
+    "SessionSignal": ("ouroboros.core.session_signal", "SessionSignal"),
+    "SessionSignalCapabilities": (
+        "ouroboros.core.session_signal",
+        "SessionSignalCapabilities",
+    ),
+    "SessionSignalCapabilityError": (
+        "ouroboros.core.session_signal",
+        "SessionSignalCapabilityError",
+    ),
+    "SessionSignalContractEffect": (
+        "ouroboros.core.session_signal",
+        "SessionSignalContractEffect",
+    ),
+    "SessionSignalMode": ("ouroboros.core.session_signal", "SessionSignalMode"),
+    "SessionSignalSource": ("ouroboros.core.session_signal", "SessionSignalSource"),
+    "SessionSignalState": ("ouroboros.core.session_signal", "SessionSignalState"),
+    "resolve_session_signal_mode": (
+        "ouroboros.core.session_signal",
+        "resolve_session_signal_mode",
+    ),
+    "derive_session_signal_id": (
+        "ouroboros.core.session_signal",
+        "derive_session_signal_id",
+    ),
     # Errors
     "OuroborosError": ("ouroboros.core.errors", "OuroborosError"),
     "ProviderError": ("ouroboros.core.errors", "ProviderError"),
@@ -32,6 +83,7 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "OntologyField": ("ouroboros.core.seed", "OntologyField"),
     "EvaluationPrinciple": ("ouroboros.core.seed", "EvaluationPrinciple"),
     "ExitCondition": ("ouroboros.core.seed", "ExitCondition"),
+    "derive_semantic_ac_key": ("ouroboros.core.seed", "derive_semantic_ac_key"),
     "OntologyConcept": ("ouroboros.core.seed_contract", "OntologyConcept"),
     "OntologyLens": ("ouroboros.core.seed_contract", "OntologyLens"),
     "SeedContract": ("ouroboros.core.seed_contract", "SeedContract"),

--- a/src/ouroboros/core/conductor.py
+++ b/src/ouroboros/core/conductor.py
@@ -1,0 +1,318 @@
+"""Bounded contracts for Active Conductor decisions and successor directives."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+import hashlib
+import json
+import re
+from typing import Any
+import unicodedata
+
+CONDUCTOR_SCHEMA_VERSION = 1
+MAX_DECISION_ID_BYTES = 160
+MAX_EVENT_ID_BYTES = 256
+MAX_ACTION_BYTES = 160
+MAX_VERIFICATION_SUMMARY_BYTES = 2_000
+MAX_DIRECTIVE_INSTRUCTION_BYTES = 2_000
+MAX_REJECTED_REASON_BYTES = 500
+MAX_REJECTED_REASONS = 10
+MAX_RECEIPT_BYTES = 1_000
+
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]{12,}"),
+    re.compile(r"\bsk-(?:ant-|or-)?[a-zA-Z0-9_-]{16,}"),
+    re.compile(r"\bAIza[a-zA-Z0-9_-]{20,}"),
+    re.compile(
+        r"(?i)\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|password|"
+        r"client[_-]?secret)\b\s*[:=]\s*[^\s,;]{8,}"
+    ),
+)
+
+
+class ConductorActorMode(StrEnum):
+    """Host policy that selected a conductor decision."""
+
+    RUN = "run"
+    AUTO = "auto"
+    RALPH = "ralph"
+
+
+class ConductorDecisionPhase(StrEnum):
+    """Durable phases of one conductor decision aggregate."""
+
+    SELECTED = "selected"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    DECLINED = "declined"
+
+    @property
+    def is_terminal(self) -> bool:
+        return self is not ConductorDecisionPhase.SELECTED
+
+
+class ConductorEffect(StrEnum):
+    """Mutation class used for authority and ownership checks."""
+
+    READ_ONLY = "read_only"
+    SUCCESSOR_ONLY = "successor_only"
+    SPECIFICATION_CHANGE = "specification_change"
+    USER_ESCALATION = "user_escalation"
+
+    @property
+    def mutates(self) -> bool:
+        return self in {
+            ConductorEffect.SUCCESSOR_ONLY,
+            ConductorEffect.SPECIFICATION_CHANGE,
+        }
+
+
+class EngineOwnershipState(StrEnum):
+    """Authoritative ownership state supplied by the attention envelope."""
+
+    ACTIVE = "active"
+    CLOSED = "closed"
+    UNKNOWN = "unknown"
+
+
+def _visible(value: str) -> bool:
+    return any(
+        not char.isspace() and not unicodedata.category(char).startswith("C") for char in value
+    )
+
+
+def bounded_conductor_text(
+    name: str,
+    value: str,
+    *,
+    max_bytes: int,
+    reject_secrets: bool = True,
+) -> str:
+    """Normalize one conductor text field and fail closed on unsafe content."""
+    if not isinstance(value, str):
+        raise TypeError(f"Conductor {name} must be a string")
+    normalized = value.strip()
+    if not normalized or not _visible(normalized):
+        raise ValueError(f"Conductor {name} must contain visible text")
+    if len(normalized.encode("utf-8")) > max_bytes:
+        raise ValueError(f"Conductor {name} exceeds {max_bytes} UTF-8 bytes")
+    if reject_secrets and any(pattern.search(normalized) for pattern in _SECRET_PATTERNS):
+        raise ValueError(f"Conductor {name} must not contain secret-shaped content")
+    return normalized
+
+
+def bounded_conductor_optional_text(
+    name: str,
+    value: str | None,
+    *,
+    max_bytes: int,
+    reject_secrets: bool = True,
+) -> str | None:
+    if value is None:
+        return None
+    return bounded_conductor_text(
+        name,
+        value,
+        max_bytes=max_bytes,
+        reject_secrets=reject_secrets,
+    )
+
+
+def stable_payload_digest(value: object) -> str:
+    """Return a deterministic SHA-256 digest without persisting the payload."""
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class ConductorDirective:
+    """Additive corrective context for a successor run or generation."""
+
+    source_attention_event_id: str
+    instruction: str
+    rejected_reasons: tuple[str, ...] = ()
+    preserve_goal: bool = True
+    preserve_acceptance_criteria: bool = True
+    preserve_constraints: bool = True
+    preserve_non_goals: bool = True
+    deterministic: bool = False
+    user_approval_event_id: str | None = None
+    schema_version: int = CONDUCTOR_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version < 1:
+            raise ValueError("ConductorDirective schema_version must be >= 1")
+        object.__setattr__(
+            self,
+            "source_attention_event_id",
+            bounded_conductor_text(
+                "source_attention_event_id",
+                self.source_attention_event_id,
+                max_bytes=MAX_EVENT_ID_BYTES,
+                reject_secrets=False,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "instruction",
+            bounded_conductor_text(
+                "instruction",
+                self.instruction,
+                max_bytes=MAX_DIRECTIVE_INSTRUCTION_BYTES,
+            ),
+        )
+        if len(self.rejected_reasons) > MAX_REJECTED_REASONS:
+            raise ValueError(
+                f"ConductorDirective rejected_reasons exceeds {MAX_REJECTED_REASONS} items"
+            )
+        normalized_reasons = tuple(
+            bounded_conductor_text(
+                f"rejected_reasons[{index}]",
+                reason,
+                max_bytes=MAX_REJECTED_REASON_BYTES,
+            )
+            for index, reason in enumerate(self.rejected_reasons)
+        )
+        object.__setattr__(self, "rejected_reasons", normalized_reasons)
+        for field_name in (
+            "preserve_goal",
+            "preserve_acceptance_criteria",
+            "preserve_constraints",
+            "preserve_non_goals",
+            "deterministic",
+        ):
+            if not isinstance(getattr(self, field_name), bool):
+                raise TypeError(f"ConductorDirective {field_name} must be a boolean")
+        object.__setattr__(
+            self,
+            "user_approval_event_id",
+            bounded_conductor_optional_text(
+                "user_approval_event_id",
+                self.user_approval_event_id,
+                max_bytes=MAX_EVENT_ID_BYTES,
+                reject_secrets=False,
+            ),
+        )
+        if not self.is_non_relaxing and self.user_approval_event_id is None:
+            raise ValueError(
+                "A specification-changing ConductorDirective requires user_approval_event_id"
+            )
+
+    @property
+    def is_non_relaxing(self) -> bool:
+        """Return whether every approved direction field must be preserved."""
+        return all(
+            (
+                self.preserve_goal,
+                self.preserve_acceptance_criteria,
+                self.preserve_constraints,
+                self.preserve_non_goals,
+            )
+        )
+
+    @property
+    def digest(self) -> str:
+        return stable_payload_digest(self.to_event_data())
+
+    def validate_actor_policy(self, actor_mode: ConductorActorMode) -> None:
+        """Prevent autonomous Auto/Ralph from weakening the approved contract."""
+        if actor_mode in {ConductorActorMode.AUTO, ConductorActorMode.RALPH} and not (
+            self.is_non_relaxing and self.deterministic
+        ):
+            raise ValueError(
+                "Auto/Ralph conductor successors require a deterministic non-relaxing directive"
+            )
+
+    def to_event_data(self) -> dict[str, object]:
+        data: dict[str, object] = {
+            "schema_version": self.schema_version,
+            "source_attention_event_id": self.source_attention_event_id,
+            "instruction": self.instruction,
+            "rejected_reasons": list(self.rejected_reasons),
+            "preserve_goal": self.preserve_goal,
+            "preserve_acceptance_criteria": self.preserve_acceptance_criteria,
+            "preserve_constraints": self.preserve_constraints,
+            "preserve_non_goals": self.preserve_non_goals,
+            "deterministic": self.deterministic,
+            "is_non_relaxing": self.is_non_relaxing,
+        }
+        if self.user_approval_event_id is not None:
+            data["user_approval_event_id"] = self.user_approval_event_id
+        return data
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, Any]) -> ConductorDirective:
+        if not isinstance(value, Mapping):
+            raise TypeError("conductor_directive must be an object")
+        raw_reasons = value.get("rejected_reasons", ())
+        if raw_reasons is None:
+            raw_reasons = ()
+        if not isinstance(raw_reasons, list | tuple):
+            raise TypeError("conductor_directive.rejected_reasons must be an array")
+        return cls(
+            source_attention_event_id=value.get("source_attention_event_id", ""),
+            instruction=value.get("instruction", ""),
+            rejected_reasons=tuple(raw_reasons),
+            preserve_goal=value.get("preserve_goal", True),
+            preserve_acceptance_criteria=value.get("preserve_acceptance_criteria", True),
+            preserve_constraints=value.get("preserve_constraints", True),
+            preserve_non_goals=value.get("preserve_non_goals", True),
+            deterministic=value.get("deterministic", False),
+            user_approval_event_id=value.get("user_approval_event_id"),
+            schema_version=value.get("schema_version", CONDUCTOR_SCHEMA_VERSION),
+        )
+
+
+def validate_conductor_successor_authorization(
+    selected_data: Mapping[str, Any],
+    *,
+    directive: ConductorDirective,
+    predecessor_execution_id: str,
+) -> ConductorActorMode:
+    """Validate one selected decision before successor dispatch."""
+    if selected_data.get("engine_ownership_state") != EngineOwnershipState.CLOSED.value:
+        raise ValueError("Conductor successor dispatch requires closed engine ownership")
+    if selected_data.get("selected_effect") not in {
+        ConductorEffect.SUCCESSOR_ONLY.value,
+        ConductorEffect.SPECIFICATION_CHANGE.value,
+    }:
+        raise ValueError("Selected conductor decision does not authorize a successor")
+    if selected_data.get("predecessor_execution_id") != predecessor_execution_id:
+        raise ValueError("predecessor_execution_id does not match the selected conductor decision")
+    if selected_data.get("conductor_directive_digest") != directive.digest:
+        raise ValueError("conductor_directive does not match the selected conductor decision")
+    actor_mode = ConductorActorMode(str(selected_data.get("actor_mode")))
+    directive.validate_actor_policy(actor_mode)
+    if not directive.is_non_relaxing:
+        if selected_data.get("selected_effect") != ConductorEffect.SPECIFICATION_CHANGE.value:
+            raise ValueError("A relaxing directive requires a specification_change decision")
+        if selected_data.get("user_approval_event_id") != directive.user_approval_event_id:
+            raise ValueError("Successor user approval does not match the selected decision")
+    return actor_mode
+
+
+__all__ = [
+    "CONDUCTOR_SCHEMA_VERSION",
+    "MAX_ACTION_BYTES",
+    "MAX_DECISION_ID_BYTES",
+    "MAX_EVENT_ID_BYTES",
+    "MAX_RECEIPT_BYTES",
+    "MAX_VERIFICATION_SUMMARY_BYTES",
+    "ConductorActorMode",
+    "ConductorDecisionPhase",
+    "ConductorDirective",
+    "ConductorEffect",
+    "EngineOwnershipState",
+    "bounded_conductor_optional_text",
+    "bounded_conductor_text",
+    "stable_payload_digest",
+    "validate_conductor_successor_authorization",
+]

--- a/src/ouroboros/core/execution_preferences.py
+++ b/src/ouroboros/core/execution_preferences.py
@@ -1,0 +1,133 @@
+"""Stable execution-efficiency preferences shared by run and Auto.
+
+The public vocabulary is deliberately small and language-neutral. Hosts may
+explain the choice in the user's conversation language, while persisted state
+and MCP contracts keep these enum values stable across resume and successor
+handoffs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+
+class EfficiencyMode(StrEnum):
+    """How aggressively a run may use lower-cost execution tiers."""
+
+    ADAPTIVE = "adaptive"
+    QUALITY_FIRST = "quality_first"
+
+
+class FrugalityAssurance(StrEnum):
+    """Strength of cost/grounding assurance requested for a run."""
+
+    OFF = "off"
+    OBSERVE = "observe"
+    STRICT = "strict"
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedExecutionPreferences:
+    """Canonical execution preferences after applying the public defaults."""
+
+    efficiency_mode: EfficiencyMode
+    frugality_assurance: FrugalityAssurance
+    frugality_assurance_explicit: bool = False
+
+    @property
+    def child_model_lowering_enabled(self) -> bool:
+        """Whether decomposition may start children below the parent tier."""
+        return self.efficiency_mode is EfficiencyMode.ADAPTIVE
+
+    @property
+    def frugality_attention_enabled(self) -> bool:
+        """Whether frugality verdicts may become user-facing attention."""
+        return self.frugality_assurance is not FrugalityAssurance.OFF
+
+    @property
+    def strict_baseline_authorized(self) -> bool:
+        """Whether the user explicitly authorized potentially costly proof."""
+        return (
+            self.frugality_assurance is FrugalityAssurance.STRICT
+            and self.frugality_assurance_explicit
+        )
+
+    def to_contract_data(self) -> dict[str, object]:
+        """Serialize the durable, language-neutral execution contract."""
+        return {
+            "efficiency_mode": self.efficiency_mode.value,
+            "frugality_assurance": self.frugality_assurance.value,
+            "frugality_assurance_explicit": self.frugality_assurance_explicit,
+        }
+
+
+def resolve_execution_preferences(
+    efficiency_mode: str | EfficiencyMode | None,
+    frugality_assurance: str | FrugalityAssurance | None,
+) -> ResolvedExecutionPreferences:
+    """Resolve public values and their safe default coupling.
+
+    Adaptive execution defaults to lightweight observation. Quality-first
+    execution disables frugality attention by default. Strict assurance never
+    appears implicitly because it may authorize extra-cost baseline work.
+    """
+    resolved_efficiency = (
+        efficiency_mode
+        if isinstance(efficiency_mode, EfficiencyMode)
+        else EfficiencyMode(efficiency_mode or EfficiencyMode.ADAPTIVE.value)
+    )
+    assurance_explicit = frugality_assurance is not None
+    if isinstance(frugality_assurance, FrugalityAssurance):
+        resolved_assurance = frugality_assurance
+    elif isinstance(frugality_assurance, str):
+        resolved_assurance = FrugalityAssurance(frugality_assurance)
+    else:
+        resolved_assurance = (
+            FrugalityAssurance.OBSERVE
+            if resolved_efficiency is EfficiencyMode.ADAPTIVE
+            else FrugalityAssurance.OFF
+        )
+    return ResolvedExecutionPreferences(
+        efficiency_mode=resolved_efficiency,
+        frugality_assurance=resolved_assurance,
+        frugality_assurance_explicit=assurance_explicit,
+    )
+
+
+def execution_preferences_from_contract(
+    value: object,
+) -> ResolvedExecutionPreferences | None:
+    """Parse a persisted preference object, failing closed on malformed data."""
+    if not isinstance(value, dict):
+        return None
+    if set(value) != {
+        "efficiency_mode",
+        "frugality_assurance",
+        "frugality_assurance_explicit",
+    }:
+        return None
+    explicit = value.get("frugality_assurance_explicit")
+    if not isinstance(explicit, bool):
+        return None
+    try:
+        resolved = resolve_execution_preferences(
+            value.get("efficiency_mode"),
+            value.get("frugality_assurance"),
+        )
+    except (TypeError, ValueError):
+        return None
+    return ResolvedExecutionPreferences(
+        efficiency_mode=resolved.efficiency_mode,
+        frugality_assurance=resolved.frugality_assurance,
+        frugality_assurance_explicit=explicit,
+    )
+
+
+__all__ = [
+    "EfficiencyMode",
+    "FrugalityAssurance",
+    "ResolvedExecutionPreferences",
+    "execution_preferences_from_contract",
+    "resolve_execution_preferences",
+]

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -17,6 +17,8 @@ This module defines:
 from __future__ import annotations
 
 from datetime import UTC, datetime
+import hashlib
+import json
 import math
 import re
 from typing import Any
@@ -31,6 +33,8 @@ from pydantic import (
     model_validator,
 )
 from pydantic_core.core_schema import SerializerFunctionWrapHandler
+
+from ouroboros.core.conductor import ConductorDirective
 
 _OUTPUT_ASSERTION_CONDITION_RE = re.compile(
     r"^(?:exit\s*(?:code|status)?\s*0|returns?\s*0|success|succeeds|passed|passes|ok exit|no errors?)$",
@@ -218,6 +222,7 @@ class AcceptanceCriterionSpec(BaseModel, frozen=True):
     """Structured success contract for one acceptance criterion."""
 
     description: str
+    semantic_ac_key: str | None = Field(default=None, pattern=r"^ac_[a-f0-9]{16}$")
     verify_command: str | None = Field(default=None)
     expected_artifacts: tuple[str, ...] = Field(default_factory=tuple)
     output_assertion: str | None = Field(default=None)
@@ -269,11 +274,19 @@ class AcceptanceCriterionSpec(BaseModel, frozen=True):
         """Return True when explicit evidence fields are populated."""
         return bool(self.verify_command or self.expected_artifacts or self.output_assertion)
 
+    def with_materialized_semantic_key(self) -> AcceptanceCriterionSpec:
+        """Return this criterion with a deterministic legacy semantic identity."""
+        if self.semantic_ac_key is not None:
+            return self
+        return self.model_copy(update={"semantic_ac_key": derive_semantic_ac_key(self)})
+
     def to_seed_value(self) -> str | dict[str, Any]:
         """Return the stable persisted representation for this AC."""
-        if not self.has_success_contract:
+        if not self.has_success_contract and self.semantic_ac_key is None:
             return self.description
         data: dict[str, Any] = {"description": self.description}
+        if self.semantic_ac_key:
+            data["semantic_ac_key"] = self.semantic_ac_key
         if self.verify_command:
             data["verify_command"] = self.verify_command
         if self.expected_artifacts:
@@ -287,6 +300,32 @@ class AcceptanceCriterionSpec(BaseModel, frozen=True):
 
 
 AcceptanceCriterionInput = str | AcceptanceCriterionSpec
+
+
+def derive_semantic_ac_key(criterion: AcceptanceCriterionInput) -> str:
+    """Derive a stable semantic identity for a legacy or newly created AC.
+
+    The digest intentionally excludes list position, runtime/session identity,
+    and volatile Seed metadata. Preserved structured criteria keep their
+    explicit key across retries and successors; a semantically replaced
+    criterion gets a new key when materialized from its changed contract.
+    """
+    if isinstance(criterion, AcceptanceCriterionSpec):
+        payload = {
+            "description": criterion.description,
+            "verify_command": criterion.verify_command,
+            "expected_artifacts": list(criterion.expected_artifacts),
+            "output_assertion": criterion.output_assertion,
+        }
+    else:
+        payload = {"description": str(criterion).strip()}
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+    return f"ac_{hashlib.sha256(encoded).hexdigest()[:16]}"
 
 
 def ac_text(criterion: AcceptanceCriterionInput) -> str:
@@ -478,10 +517,24 @@ class Seed(BaseModel, frozen=True):
     @model_validator(mode="after")
     def _validate_plugin_extra_fields(self) -> Seed:
         """Keep plugin-owned extra fields safe for Seed persistence paths."""
+        materialized_criteria = tuple(
+            criterion.with_materialized_semantic_key()
+            if isinstance(criterion, AcceptanceCriterionSpec)
+            else AcceptanceCriterionSpec(
+                description=ac_text(criterion),
+                semantic_ac_key=derive_semantic_ac_key(criterion),
+            )
+            for criterion in self.acceptance_criteria
+        )
+        object.__setattr__(self, "acceptance_criteria", materialized_criteria)
         frozen_extra: dict[str, Any] = {}
         for key, value in (self.model_extra or {}).items():
             if not isinstance(key, str):
                 raise ValueError("Seed extra field keys must be strings")
+            if key == "conductor_directive":
+                if not isinstance(value, dict):
+                    raise ValueError("Seed conductor_directive must be a structured object")
+                value = ConductorDirective.from_mapping(value).to_event_data()
             frozen_extra[key] = _freeze_seed_extra_value(value, path=key)
         object.__setattr__(self, "__pydantic_extra__", _FrozenDict(frozen_extra))
         return self

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -506,7 +506,7 @@ class Seed(BaseModel, frozen=True):
         self,
         value: tuple[AcceptanceCriterionInput, ...],
     ) -> tuple[str | dict[str, Any], ...]:
-        """Persist description-only ACs in the legacy bare-string form."""
+        """Persist materialized AC contracts, retaining legacy fallback handling."""
         return tuple(
             criterion.to_seed_value()
             if isinstance(criterion, AcceptanceCriterionSpec)

--- a/src/ouroboros/core/session_signal.py
+++ b/src/ouroboros/core/session_signal.py
@@ -1,0 +1,438 @@
+"""Ouroboros Synapse contracts for directed AC-session intent signals.
+
+This module is transport-neutral.  It defines the immutable signal, runtime
+capabilities, capability resolution, and lifecycle vocabulary used by later MCP
+and worker-runtime integrations.  All capabilities default to unsupported so
+adding the contract cannot change existing runtime behaviour.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+import hashlib
+import re
+import unicodedata
+
+SESSION_SIGNAL_SCHEMA_VERSION = 1
+
+MAX_SIGNAL_ID_BYTES = 160
+MAX_TARGET_ID_BYTES = 256
+MAX_MESSAGE_BYTES = 8_192
+MAX_REASON_BYTES = 1_000
+MAX_REPLY_BYTES = 1_000
+MAX_APPROVAL_ID_BYTES = 256
+
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"(?i)\bbearer\s+[a-z0-9._~+/=-]{12,}"),
+    re.compile(r"\bsk-(?:ant-|or-)?[a-zA-Z0-9_-]{16,}"),
+    re.compile(r"\bAIza[a-zA-Z0-9_-]{20,}"),
+    re.compile(
+        r"(?i)\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|password|"
+        r"client[_-]?secret)\b\s*[:=]\s*[^\s,;]{8,}"
+    ),
+)
+
+
+class SessionSignalMode(StrEnum):
+    """How a signal may affect the addressed runtime attempt."""
+
+    INFORM = "inform"
+    AFTER_TURN = "after_turn"
+    REDIRECT = "redirect"
+    REPLACE = "replace"
+
+
+class SessionSignalContractEffect(StrEnum):
+    """Whether the message preserves or changes the shared execution contract."""
+
+    ADDITIVE = "additive"
+    SPECIFICATION_CHANGE = "specification_change"
+
+
+class SessionSignalSource(StrEnum):
+    """Audited origin of a signal, ordered by authority."""
+
+    USER = "user"
+    CONDUCTOR = "conductor"
+    WORKER = "worker"
+
+    @property
+    def priority(self) -> int:
+        """Return a larger number for a more authoritative source."""
+        return {
+            SessionSignalSource.USER: 3,
+            SessionSignalSource.CONDUCTOR: 2,
+            SessionSignalSource.WORKER: 1,
+        }[self]
+
+
+class SessionSignalState(StrEnum):
+    """Durable lifecycle states for one signal aggregate."""
+
+    REQUESTED = "requested"
+    ACCEPTED = "accepted"
+    QUEUED = "queued"
+    DELIVERING = "delivering"
+    APPLIED = "applied"
+    REJECTED = "rejected"
+    DELIVERY_UNCERTAIN = "delivery_uncertain"
+    COMPLETED = "completed"
+
+    @property
+    def is_terminal(self) -> bool:
+        return self in {
+            SessionSignalState.REJECTED,
+            SessionSignalState.DELIVERY_UNCERTAIN,
+            SessionSignalState.COMPLETED,
+        }
+
+
+class SessionSignalCapabilityError(ValueError):
+    """Raised when a runtime cannot enforce the requested signal mode."""
+
+
+@dataclass(frozen=True, slots=True)
+class SessionSignalCapabilities:
+    """Independent runtime abilities used by Synapse mode resolution."""
+
+    inform_delivery: bool = False
+    background_reply: bool = False
+    after_turn_delivery: bool = False
+    checkpoint_redirect: bool = False
+    owned_turn_abort: bool = False
+    replacement_resume: bool = False
+
+    def to_event_data(self) -> dict[str, bool]:
+        """Return a stable JSON-safe capability snapshot."""
+        return {
+            "inform_delivery": self.inform_delivery,
+            "background_reply": self.background_reply,
+            "after_turn_delivery": self.after_turn_delivery,
+            "checkpoint_redirect": self.checkpoint_redirect,
+            "owned_turn_abort": self.owned_turn_abort,
+            "replacement_resume": self.replacement_resume,
+        }
+
+
+def _has_visible_text(value: str) -> bool:
+    return any(
+        not char.isspace() and not unicodedata.category(char).startswith("C") for char in value
+    )
+
+
+def _bounded_text(name: str, value: str, *, max_bytes: int) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"SessionSignal {name} must be a string")
+    normalized = value.strip()
+    if not normalized or not _has_visible_text(normalized):
+        raise ValueError(f"SessionSignal {name} must contain visible text")
+    if len(normalized.encode("utf-8")) > max_bytes:
+        raise ValueError(f"SessionSignal {name} exceeds {max_bytes} UTF-8 bytes")
+    return normalized
+
+
+def _reject_secret_shaped_text(name: str, value: str) -> None:
+    if session_signal_text_contains_secret(value):
+        raise ValueError(f"SessionSignal {name} must not contain secret-shaped content")
+
+
+def session_signal_text_contains_secret(value: str) -> bool:
+    """Return whether bounded text resembles a credential or bearer secret."""
+    if not isinstance(value, str):
+        raise TypeError("SessionSignal secret inspection requires a string")
+    return any(pattern.search(value) for pattern in _SECRET_PATTERNS)
+
+
+def bounded_session_signal_reply(value: str) -> str:
+    """Return one safe, bounded AC-to-main reply without persisting transcripts."""
+    normalized = _bounded_text("reply", value, max_bytes=max(MAX_REPLY_BYTES, len(value.encode())))
+    if session_signal_text_contains_secret(normalized):
+        return "[Reply omitted because it contained secret-shaped content.]"
+    encoded = normalized.encode("utf-8")
+    if len(encoded) <= MAX_REPLY_BYTES:
+        return normalized
+    suffix = "…"
+    budget = MAX_REPLY_BYTES - len(suffix.encode("utf-8"))
+    truncated = encoded[:budget]
+    while truncated:
+        try:
+            return f"{truncated.decode('utf-8')}{suffix}"
+        except UnicodeDecodeError:
+            truncated = truncated[:-1]
+    return suffix
+
+
+@dataclass(frozen=True, slots=True)
+class SessionSignal:
+    """Validated intent signal addressed to one exact AC runtime attempt."""
+
+    signal_id: str
+    target_session_scope_id: str
+    target_session_attempt_id: str
+    expected_execution_id: str
+    mode: SessionSignalMode
+    message: str
+    source: SessionSignalSource
+    reason: str
+    idempotency_key: str
+    contract_effect: SessionSignalContractEffect = SessionSignalContractEffect.ADDITIVE
+    fallback_mode: SessionSignalMode | None = None
+    expires_at: datetime | None = None
+    user_approval_event_id: str | None = None
+    expected_contract_version: int | None = None
+    schema_version: int = SESSION_SIGNAL_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        if self.schema_version < 1:
+            raise ValueError("SessionSignal schema_version must be >= 1")
+        if not isinstance(self.mode, SessionSignalMode):
+            raise TypeError("SessionSignal mode must be a SessionSignalMode")
+        if not isinstance(self.source, SessionSignalSource):
+            raise TypeError("SessionSignal source must be a SessionSignalSource")
+        if not isinstance(self.contract_effect, SessionSignalContractEffect):
+            raise TypeError("SessionSignal contract_effect must be a SessionSignalContractEffect")
+
+        bounded_fields = {
+            "signal_id": (self.signal_id, MAX_SIGNAL_ID_BYTES),
+            "target_session_scope_id": (self.target_session_scope_id, MAX_TARGET_ID_BYTES),
+            "target_session_attempt_id": (self.target_session_attempt_id, MAX_TARGET_ID_BYTES),
+            "expected_execution_id": (self.expected_execution_id, MAX_TARGET_ID_BYTES),
+            "message": (self.message, MAX_MESSAGE_BYTES),
+            "reason": (self.reason, MAX_REASON_BYTES),
+            "idempotency_key": (self.idempotency_key, MAX_TARGET_ID_BYTES),
+        }
+        for name, (value, max_bytes) in bounded_fields.items():
+            object.__setattr__(self, name, _bounded_text(name, value, max_bytes=max_bytes))
+
+        _reject_secret_shaped_text("message", self.message)
+        _reject_secret_shaped_text("reason", self.reason)
+
+        if self.fallback_mode is not None:
+            if not isinstance(self.fallback_mode, SessionSignalMode):
+                raise TypeError("SessionSignal fallback_mode must be a SessionSignalMode")
+            if self.mode is not SessionSignalMode.REDIRECT:
+                raise ValueError("SessionSignal fallback_mode is valid only for redirect")
+            if self.fallback_mode is not SessionSignalMode.AFTER_TURN:
+                raise ValueError("SessionSignal redirect fallback must be after_turn")
+
+        if self.expires_at is not None:
+            if self.expires_at.tzinfo is None or self.expires_at.utcoffset() is None:
+                raise ValueError("SessionSignal expires_at must be timezone-aware")
+            object.__setattr__(self, "expires_at", self.expires_at.astimezone(UTC))
+
+        if self.user_approval_event_id is not None:
+            object.__setattr__(
+                self,
+                "user_approval_event_id",
+                _bounded_text(
+                    "user_approval_event_id",
+                    self.user_approval_event_id,
+                    max_bytes=MAX_APPROVAL_ID_BYTES,
+                ),
+            )
+        if self.mode is SessionSignalMode.REPLACE and self.user_approval_event_id is None:
+            raise ValueError("SessionSignal replace requires user_approval_event_id")
+        if (
+            self.contract_effect is SessionSignalContractEffect.SPECIFICATION_CHANGE
+            and self.user_approval_event_id is None
+        ):
+            raise ValueError("SessionSignal specification_change requires user_approval_event_id")
+
+        if self.expected_contract_version is not None and self.expected_contract_version < 1:
+            raise ValueError("SessionSignal expected_contract_version must be >= 1")
+
+    @property
+    def message_digest(self) -> str:
+        """Return the stable SHA-256 digest used in every lifecycle event."""
+        return hashlib.sha256(self.message.encode("utf-8")).hexdigest()
+
+    @property
+    def effective_idempotency_key(self) -> tuple[str, str, str, str]:
+        """Return the exact-attempt idempotency identity."""
+        return (
+            self.expected_execution_id,
+            self.target_session_scope_id,
+            self.target_session_attempt_id,
+            self.idempotency_key,
+        )
+
+    def is_expired(self, *, at: datetime | None = None) -> bool:
+        """Return whether this signal is expired at a timezone-aware instant."""
+        if self.expires_at is None:
+            return False
+        reference = at or datetime.now(UTC)
+        if reference.tzinfo is None or reference.utcoffset() is None:
+            raise ValueError("SessionSignal expiry reference must be timezone-aware")
+        return reference.astimezone(UTC) >= self.expires_at
+
+    def to_event_data(self, *, include_message: bool = False) -> dict[str, object]:
+        """Serialize the bounded transport-neutral signal metadata."""
+        data: dict[str, object] = {
+            "schema_version": self.schema_version,
+            "signal_id": self.signal_id,
+            "target_session_scope_id": self.target_session_scope_id,
+            "target_session_attempt_id": self.target_session_attempt_id,
+            "expected_execution_id": self.expected_execution_id,
+            # Correlation alias consumed by EventStore related-event queries and
+            # the existing job observer. It is not a second authority field.
+            "execution_id": self.expected_execution_id,
+            "requested_mode": self.mode.value,
+            "contract_effect": self.contract_effect.value,
+            "source": self.source.value,
+            "reason": self.reason,
+            "idempotency_key": self.idempotency_key,
+            "message_digest": self.message_digest,
+        }
+        if include_message:
+            data["message"] = self.message
+        if self.fallback_mode is not None:
+            data["fallback_mode"] = self.fallback_mode.value
+        if self.expires_at is not None:
+            data["expires_at"] = self.expires_at.isoformat()
+        if self.user_approval_event_id is not None:
+            data["user_approval_event_id"] = self.user_approval_event_id
+        if self.expected_contract_version is not None:
+            data["expected_contract_version"] = self.expected_contract_version
+        return data
+
+    @classmethod
+    def from_event_data(cls, data: dict[str, object]) -> SessionSignal:
+        """Reconstruct one validated signal from its durable requested event."""
+
+        def required_text(name: str) -> str:
+            value = data.get(name)
+            if not isinstance(value, str) or not value.strip():
+                raise ValueError(f"SessionSignal event requires non-empty {name}")
+            return value
+
+        raw_expires_at = data.get("expires_at")
+        expires_at: datetime | None = None
+        if raw_expires_at is not None:
+            if not isinstance(raw_expires_at, str):
+                raise ValueError("SessionSignal event expires_at must be a string")
+            expires_at = datetime.fromisoformat(
+                f"{raw_expires_at[:-1]}+00:00" if raw_expires_at.endswith("Z") else raw_expires_at
+            )
+        raw_fallback = data.get("fallback_mode")
+        fallback_mode = SessionSignalMode(raw_fallback) if isinstance(raw_fallback, str) else None
+        raw_contract_version = data.get("expected_contract_version")
+        if raw_contract_version is not None and (
+            isinstance(raw_contract_version, bool) or not isinstance(raw_contract_version, int)
+        ):
+            raise ValueError("SessionSignal event expected_contract_version must be an integer")
+        raw_schema_version = data.get("schema_version", SESSION_SIGNAL_SCHEMA_VERSION)
+        if isinstance(raw_schema_version, bool) or not isinstance(raw_schema_version, int):
+            raise ValueError("SessionSignal event schema_version must be an integer")
+        return cls(
+            signal_id=required_text("signal_id"),
+            target_session_scope_id=required_text("target_session_scope_id"),
+            target_session_attempt_id=required_text("target_session_attempt_id"),
+            expected_execution_id=required_text("expected_execution_id"),
+            mode=SessionSignalMode(required_text("requested_mode")),
+            message=required_text("message"),
+            source=SessionSignalSource(required_text("source")),
+            reason=required_text("reason"),
+            idempotency_key=required_text("idempotency_key"),
+            contract_effect=SessionSignalContractEffect(
+                str(data.get("contract_effect", SessionSignalContractEffect.ADDITIVE.value))
+            ),
+            fallback_mode=fallback_mode,
+            expires_at=expires_at,
+            user_approval_event_id=(
+                str(data["user_approval_event_id"])
+                if isinstance(data.get("user_approval_event_id"), str)
+                else None
+            ),
+            expected_contract_version=raw_contract_version,
+            schema_version=raw_schema_version,
+        )
+
+
+def resolve_session_signal_mode(
+    signal: SessionSignal,
+    capabilities: SessionSignalCapabilities,
+) -> SessionSignalMode:
+    """Resolve an enforceable effective mode or fail closed."""
+    if not isinstance(capabilities, SessionSignalCapabilities):
+        raise TypeError("capabilities must be SessionSignalCapabilities")
+
+    if signal.mode is SessionSignalMode.INFORM:
+        if capabilities.inform_delivery:
+            return SessionSignalMode.INFORM
+        raise SessionSignalCapabilityError("runtime does not support inform delivery")
+
+    if signal.mode is SessionSignalMode.AFTER_TURN:
+        if capabilities.after_turn_delivery:
+            return SessionSignalMode.AFTER_TURN
+        raise SessionSignalCapabilityError("runtime does not support after_turn delivery")
+
+    if signal.mode is SessionSignalMode.REDIRECT:
+        if capabilities.checkpoint_redirect:
+            return SessionSignalMode.REDIRECT
+        if (
+            signal.fallback_mode is SessionSignalMode.AFTER_TURN
+            and capabilities.after_turn_delivery
+        ):
+            return SessionSignalMode.AFTER_TURN
+        raise SessionSignalCapabilityError("runtime does not support checkpoint redirect")
+
+    if signal.mode is SessionSignalMode.REPLACE:
+        if capabilities.owned_turn_abort and capabilities.replacement_resume:
+            return SessionSignalMode.REPLACE
+        raise SessionSignalCapabilityError("runtime cannot abort and resume a replacement")
+
+    raise SessionSignalCapabilityError(f"unsupported SessionSignal mode: {signal.mode}")
+
+
+def derive_session_signal_id(
+    *,
+    expected_execution_id: str,
+    target_session_scope_id: str,
+    target_session_attempt_id: str,
+    idempotency_key: str,
+) -> str:
+    """Derive a stable public signal ID from the exact idempotency identity."""
+    parts = (
+        _bounded_text(
+            "expected_execution_id",
+            expected_execution_id,
+            max_bytes=MAX_TARGET_ID_BYTES,
+        ),
+        _bounded_text(
+            "target_session_scope_id",
+            target_session_scope_id,
+            max_bytes=MAX_TARGET_ID_BYTES,
+        ),
+        _bounded_text(
+            "target_session_attempt_id",
+            target_session_attempt_id,
+            max_bytes=MAX_TARGET_ID_BYTES,
+        ),
+        _bounded_text("idempotency_key", idempotency_key, max_bytes=MAX_TARGET_ID_BYTES),
+    )
+    digest = hashlib.sha256("\x1f".join(parts).encode("utf-8")).hexdigest()
+    return f"sig_{digest[:24]}"
+
+
+__all__ = [
+    "MAX_APPROVAL_ID_BYTES",
+    "MAX_MESSAGE_BYTES",
+    "MAX_REASON_BYTES",
+    "MAX_REPLY_BYTES",
+    "MAX_SIGNAL_ID_BYTES",
+    "MAX_TARGET_ID_BYTES",
+    "SESSION_SIGNAL_SCHEMA_VERSION",
+    "SessionSignal",
+    "SessionSignalCapabilities",
+    "SessionSignalCapabilityError",
+    "SessionSignalContractEffect",
+    "SessionSignalMode",
+    "SessionSignalSource",
+    "SessionSignalState",
+    "derive_session_signal_id",
+    "bounded_session_signal_reply",
+    "resolve_session_signal_mode",
+    "session_signal_text_contains_secret",
+]

--- a/src/ouroboros/core/session_signal_projection.py
+++ b/src/ouroboros/core/session_signal_projection.py
@@ -1,0 +1,222 @@
+"""Deterministic lifecycle projection for Ouroboros Synapse events."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from ouroboros.core.session_signal import (
+    SessionSignalContractEffect,
+    SessionSignalMode,
+    SessionSignalSource,
+    SessionSignalState,
+)
+from ouroboros.events.base import BaseEvent
+
+_EVENT_PREFIX = "control.session.signal."
+_ALLOWED_TRANSITIONS: dict[SessionSignalState | None, frozenset[SessionSignalState]] = {
+    None: frozenset({SessionSignalState.REQUESTED}),
+    SessionSignalState.REQUESTED: frozenset(
+        {SessionSignalState.ACCEPTED, SessionSignalState.REJECTED}
+    ),
+    SessionSignalState.ACCEPTED: frozenset(
+        {SessionSignalState.QUEUED, SessionSignalState.REJECTED}
+    ),
+    SessionSignalState.QUEUED: frozenset(
+        {
+            SessionSignalState.DELIVERING,
+            SessionSignalState.APPLIED,
+            SessionSignalState.REJECTED,
+            SessionSignalState.DELIVERY_UNCERTAIN,
+        }
+    ),
+    SessionSignalState.DELIVERING: frozenset(
+        {
+            SessionSignalState.APPLIED,
+            SessionSignalState.REJECTED,
+            SessionSignalState.DELIVERY_UNCERTAIN,
+        }
+    ),
+    SessionSignalState.APPLIED: frozenset({SessionSignalState.COMPLETED}),
+    SessionSignalState.REJECTED: frozenset(),
+    SessionSignalState.DELIVERY_UNCERTAIN: frozenset(),
+    SessionSignalState.COMPLETED: frozenset(),
+}
+
+_IDENTITY_FIELDS = (
+    "signal_id",
+    "target_session_scope_id",
+    "target_session_attempt_id",
+    "expected_execution_id",
+    "requested_mode",
+    "source",
+    "idempotency_key",
+    "message_digest",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SessionSignalProjection:
+    """Replay result for one exact SessionSignal aggregate."""
+
+    signal_id: str
+    target_session_scope_id: str
+    target_session_attempt_id: str
+    expected_execution_id: str
+    requested_mode: SessionSignalMode
+    effective_mode: SessionSignalMode | None
+    source: SessionSignalSource
+    idempotency_key: str
+    message_digest: str
+    state: SessionSignalState
+    event_ids: tuple[str, ...]
+    contract_effect: SessionSignalContractEffect = SessionSignalContractEffect.ADDITIVE
+    acknowledgement: str | None = None
+    summary: str | None = None
+    reply: str | None = None
+
+    @property
+    def is_terminal(self) -> bool:
+        return self.state.is_terminal
+
+    @property
+    def effective_idempotency_key(self) -> tuple[str, str, str, str]:
+        return (
+            self.expected_execution_id,
+            self.target_session_scope_id,
+            self.target_session_attempt_id,
+            self.idempotency_key,
+        )
+
+
+def _state_for_event(event: BaseEvent) -> SessionSignalState:
+    if not event.type.startswith(_EVENT_PREFIX):
+        raise ValueError(f"Not a SessionSignal event: {event.type}")
+    raw_state = event.type.removeprefix(_EVENT_PREFIX)
+    try:
+        state = SessionSignalState(raw_state)
+    except ValueError as exc:
+        raise ValueError(f"Unknown SessionSignal event state: {raw_state}") from exc
+    if event.data.get("state") != state.value:
+        raise ValueError("SessionSignal event type/state mismatch")
+    if event.data.get("is_terminal") is not state.is_terminal:
+        raise ValueError("SessionSignal event terminality mismatch")
+    return state
+
+
+def _required_string(data: dict[str, object], name: str) -> str:
+    value = data.get(name)
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"SessionSignal event requires non-empty {name}")
+    return value
+
+
+def project_session_signal(events: Iterable[BaseEvent]) -> SessionSignalProjection:
+    """Replay an ordered event sequence and reject illegal or divergent state."""
+    identity: dict[str, str] | None = None
+    state: SessionSignalState | None = None
+    effective_mode: SessionSignalMode | None = None
+    contract_effect: SessionSignalContractEffect | None = None
+    acknowledgement: str | None = None
+    summary: str | None = None
+    reply: str | None = None
+    event_ids: list[str] = []
+    seen_event_ids: set[str] = set()
+    aggregate_id: str | None = None
+
+    for event in events:
+        if event.id in seen_event_ids:
+            continue
+        seen_event_ids.add(event.id)
+
+        if event.aggregate_type != "session_signal":
+            raise ValueError("SessionSignal events must aggregate by session_signal")
+        if aggregate_id is None:
+            aggregate_id = event.aggregate_id
+        elif event.aggregate_id != aggregate_id:
+            raise ValueError("Cannot project multiple SessionSignal aggregates together")
+
+        next_state = _state_for_event(event)
+        if next_state not in _ALLOWED_TRANSITIONS[state]:
+            previous = state.value if state is not None else "<none>"
+            raise ValueError(f"Illegal SessionSignal transition: {previous} -> {next_state.value}")
+
+        current_identity = {name: _required_string(event.data, name) for name in _IDENTITY_FIELDS}
+        if identity is None:
+            identity = current_identity
+        elif current_identity != identity:
+            raise ValueError("SessionSignal identity changed within one aggregate")
+        if identity["signal_id"] != event.aggregate_id:
+            raise ValueError("SessionSignal payload signal_id must match aggregate_id")
+
+        current_contract_effect = SessionSignalContractEffect(
+            str(event.data.get("contract_effect", SessionSignalContractEffect.ADDITIVE.value))
+        )
+        if contract_effect is None:
+            contract_effect = current_contract_effect
+        elif current_contract_effect is not contract_effect:
+            raise ValueError("SessionSignal contract_effect changed within one aggregate")
+
+        raw_effective_mode = event.data.get("effective_mode")
+        if raw_effective_mode is not None:
+            if not isinstance(raw_effective_mode, str):
+                raise ValueError("SessionSignal effective_mode must be a string")
+            current_effective_mode = SessionSignalMode(raw_effective_mode)
+            if effective_mode is None:
+                effective_mode = current_effective_mode
+            elif current_effective_mode is not effective_mode:
+                raise ValueError("SessionSignal effective_mode changed after acceptance")
+        elif next_state not in {SessionSignalState.REQUESTED, SessionSignalState.REJECTED}:
+            raise ValueError(f"SessionSignal {next_state.value} requires effective_mode")
+
+        state = next_state
+        raw_acknowledgement = event.data.get("acknowledgement")
+        if isinstance(raw_acknowledgement, str):
+            acknowledgement = raw_acknowledgement
+        raw_summary = event.data.get("summary")
+        if isinstance(raw_summary, str):
+            summary = raw_summary
+        raw_reply = event.data.get("reply")
+        if isinstance(raw_reply, str):
+            reply = raw_reply
+        event_ids.append(event.id)
+
+    if identity is None or state is None:
+        raise ValueError("Cannot project an empty SessionSignal event sequence")
+
+    return SessionSignalProjection(
+        signal_id=identity["signal_id"],
+        target_session_scope_id=identity["target_session_scope_id"],
+        target_session_attempt_id=identity["target_session_attempt_id"],
+        expected_execution_id=identity["expected_execution_id"],
+        requested_mode=SessionSignalMode(identity["requested_mode"]),
+        effective_mode=effective_mode,
+        source=SessionSignalSource(identity["source"]),
+        idempotency_key=identity["idempotency_key"],
+        message_digest=identity["message_digest"],
+        state=state,
+        event_ids=tuple(event_ids),
+        contract_effect=contract_effect or SessionSignalContractEffect.ADDITIVE,
+        acknowledgement=acknowledgement,
+        summary=summary,
+        reply=reply,
+    )
+
+
+def can_supersede_session_signal(
+    pending_source: SessionSignalSource,
+    incoming_source: SessionSignalSource,
+) -> bool:
+    """Return whether incoming authority is at least as strong as pending authority."""
+    if not isinstance(pending_source, SessionSignalSource):
+        raise TypeError("pending_source must be SessionSignalSource")
+    if not isinstance(incoming_source, SessionSignalSource):
+        raise TypeError("incoming_source must be SessionSignalSource")
+    return incoming_source.priority >= pending_source.priority
+
+
+__all__ = [
+    "SessionSignalProjection",
+    "can_supersede_session_signal",
+    "project_session_signal",
+]

--- a/src/ouroboros/events/conductor.py
+++ b/src/ouroboros/events/conductor.py
@@ -1,0 +1,238 @@
+"""Durable Active Conductor decision audit events."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+from ouroboros.core.conductor import (
+    CONDUCTOR_SCHEMA_VERSION,
+    MAX_ACTION_BYTES,
+    MAX_DECISION_ID_BYTES,
+    MAX_EVENT_ID_BYTES,
+    MAX_RECEIPT_BYTES,
+    MAX_VERIFICATION_SUMMARY_BYTES,
+    ConductorActorMode,
+    ConductorDecisionPhase,
+    ConductorDirective,
+    ConductorEffect,
+    EngineOwnershipState,
+    bounded_conductor_optional_text,
+    bounded_conductor_text,
+    stable_payload_digest,
+)
+from ouroboros.events.base import BaseEvent
+
+MAX_EVIDENCE_EVENT_IDS = 10
+
+
+def _event_ids(values: Sequence[str]) -> list[str]:
+    if len(values) > MAX_EVIDENCE_EVENT_IDS:
+        raise ValueError(f"evidence_event_ids exceeds {MAX_EVIDENCE_EVENT_IDS} items")
+    return list(
+        dict.fromkeys(
+            bounded_conductor_text(
+                f"evidence_event_ids[{index}]",
+                value,
+                max_bytes=MAX_EVENT_ID_BYTES,
+                reject_secrets=False,
+            )
+            for index, value in enumerate(values)
+        )
+    )
+
+
+def create_conductor_decision_selected_event(
+    *,
+    decision_id: str,
+    attention_event_id: str,
+    evidence_event_ids: Sequence[str],
+    verification_summary: str,
+    selected_action: str,
+    selected_effect: ConductorEffect,
+    actor_mode: ConductorActorMode,
+    engine_ownership_state: EngineOwnershipState,
+    action_arguments: object | None,
+    root_job_id: str | None,
+    predecessor_execution_id: str | None,
+    conductor_directive: ConductorDirective | None,
+    user_approval_event_id: str | None,
+) -> BaseEvent:
+    normalized_decision_id = bounded_conductor_text(
+        "decision_id",
+        decision_id,
+        max_bytes=MAX_DECISION_ID_BYTES,
+        reject_secrets=False,
+    )
+    normalized_attention = bounded_conductor_text(
+        "attention_event_id",
+        attention_event_id,
+        max_bytes=MAX_EVENT_ID_BYTES,
+        reject_secrets=False,
+    )
+    normalized_action = bounded_conductor_text(
+        "selected_action",
+        selected_action,
+        max_bytes=MAX_ACTION_BYTES,
+        reject_secrets=False,
+    )
+    normalized_root_job = bounded_conductor_optional_text(
+        "root_job_id",
+        root_job_id,
+        max_bytes=MAX_EVENT_ID_BYTES,
+        reject_secrets=False,
+    )
+    normalized_approval = bounded_conductor_optional_text(
+        "user_approval_event_id",
+        user_approval_event_id,
+        max_bytes=MAX_EVENT_ID_BYTES,
+        reject_secrets=False,
+    )
+    normalized_predecessor = bounded_conductor_optional_text(
+        "predecessor_execution_id",
+        predecessor_execution_id,
+        max_bytes=MAX_EVENT_ID_BYTES,
+        reject_secrets=False,
+    )
+    data: dict[str, Any] = {
+        "schema_version": CONDUCTOR_SCHEMA_VERSION,
+        "decision_id": normalized_decision_id,
+        "phase": ConductorDecisionPhase.SELECTED.value,
+        "attention_event_id": normalized_attention,
+        "evidence_event_ids": _event_ids(evidence_event_ids),
+        "verification_summary": bounded_conductor_text(
+            "verification_summary",
+            verification_summary,
+            max_bytes=MAX_VERIFICATION_SUMMARY_BYTES,
+        ),
+        "selected_action": normalized_action,
+        "selected_effect": selected_effect.value,
+        "actor_mode": actor_mode.value,
+        "engine_ownership_state": engine_ownership_state.value,
+        "arguments_digest": stable_payload_digest(action_arguments or {}),
+        "arguments_keys": (
+            sorted(str(key)[:80] for key in action_arguments)[:20]
+            if isinstance(action_arguments, dict)
+            else []
+        ),
+        "mutating": selected_effect.mutates,
+    }
+    if normalized_root_job is not None:
+        data["root_job_id"] = normalized_root_job
+    if normalized_predecessor is not None:
+        data["predecessor_execution_id"] = normalized_predecessor
+    if normalized_approval is not None:
+        data["user_approval_event_id"] = normalized_approval
+    if conductor_directive is not None:
+        data["conductor_directive"] = conductor_directive.to_event_data()
+        data["conductor_directive_digest"] = conductor_directive.digest
+    data["selection_digest"] = stable_payload_digest(data)
+    return BaseEvent(
+        type="conductor.decision.selected",
+        aggregate_type="conductor_decision",
+        aggregate_id=normalized_decision_id,
+        data=data,
+    )
+
+
+def create_conductor_decision_terminal_event(
+    *,
+    decision_id: str,
+    phase: ConductorDecisionPhase,
+    result_receipt: str | None = None,
+    successor_execution_id: str | None = None,
+) -> BaseEvent:
+    if not phase.is_terminal:
+        raise ValueError("terminal conductor event requires completed, failed, or declined phase")
+    normalized_decision_id = bounded_conductor_text(
+        "decision_id",
+        decision_id,
+        max_bytes=MAX_DECISION_ID_BYTES,
+        reject_secrets=False,
+    )
+    normalized_receipt = bounded_conductor_optional_text(
+        "result_receipt",
+        result_receipt,
+        max_bytes=MAX_RECEIPT_BYTES,
+    )
+    if normalized_receipt is None:
+        raise ValueError(f"conductor decision {phase.value} requires result_receipt")
+    normalized_successor = bounded_conductor_optional_text(
+        "successor_execution_id",
+        successor_execution_id,
+        max_bytes=MAX_EVENT_ID_BYTES,
+        reject_secrets=False,
+    )
+    data: dict[str, Any] = {
+        "schema_version": CONDUCTOR_SCHEMA_VERSION,
+        "decision_id": normalized_decision_id,
+        "phase": phase.value,
+        "result_receipt": normalized_receipt,
+    }
+    if normalized_successor is not None:
+        data["successor_execution_id"] = normalized_successor
+    data["outcome_digest"] = stable_payload_digest(data)
+    return BaseEvent(
+        type=f"conductor.decision.{phase.value}",
+        aggregate_type="conductor_decision",
+        aggregate_id=normalized_decision_id,
+        data=data,
+    )
+
+
+def create_conductor_directive_attached_event(
+    *,
+    decision_id: str,
+    target_type: str,
+    target_id: str,
+    predecessor_execution_id: str,
+    directive: ConductorDirective,
+) -> BaseEvent:
+    """Record that a selected directive was attached before successor dispatch."""
+    normalized_decision_id = bounded_conductor_text(
+        "decision_id",
+        decision_id,
+        max_bytes=MAX_DECISION_ID_BYTES,
+        reject_secrets=False,
+    )
+    normalized_target_type = bounded_conductor_text(
+        "target_type",
+        target_type,
+        max_bytes=80,
+        reject_secrets=False,
+    )
+    normalized_target_id = bounded_conductor_text(
+        "target_id",
+        target_id,
+        max_bytes=MAX_EVENT_ID_BYTES,
+        reject_secrets=False,
+    )
+    normalized_predecessor = bounded_conductor_text(
+        "predecessor_execution_id",
+        predecessor_execution_id,
+        max_bytes=MAX_EVENT_ID_BYTES,
+        reject_secrets=False,
+    )
+    return BaseEvent(
+        type="conductor.directive.attached",
+        aggregate_type=normalized_target_type,
+        aggregate_id=normalized_target_id,
+        data={
+            "schema_version": CONDUCTOR_SCHEMA_VERSION,
+            "decision_id": normalized_decision_id,
+            "target_type": normalized_target_type,
+            "target_id": normalized_target_id,
+            "predecessor_execution_id": normalized_predecessor,
+            "source_attention_event_id": directive.source_attention_event_id,
+            "conductor_directive": directive.to_event_data(),
+            "conductor_directive_digest": directive.digest,
+        },
+    )
+
+
+__all__ = [
+    "MAX_EVIDENCE_EVENT_IDS",
+    "create_conductor_decision_selected_event",
+    "create_conductor_decision_terminal_event",
+    "create_conductor_directive_attached_event",
+]

--- a/src/ouroboros/events/session_signal.py
+++ b/src/ouroboros/events/session_signal.py
@@ -1,0 +1,274 @@
+"""Durable lifecycle events for Ouroboros Synapse SessionSignals."""
+
+from __future__ import annotations
+
+from typing import Any, Final
+
+from ouroboros.core.session_signal import (
+    SessionSignal,
+    SessionSignalCapabilities,
+    SessionSignalMode,
+    SessionSignalState,
+    bounded_session_signal_reply,
+)
+from ouroboros.events.base import BaseEvent
+
+SESSION_SIGNAL_EVENT_PREFIX: Final[str] = "control.session.signal."
+SESSION_SIGNAL_EVENT_TYPES: Final[dict[SessionSignalState, str]] = {
+    state: f"{SESSION_SIGNAL_EVENT_PREFIX}{state.value}" for state in SessionSignalState
+}
+
+_MAX_EVENT_TEXT_BYTES = 1_000
+_MAX_CORRELATION_BYTES = 256
+
+
+def _bounded_optional(name: str, value: str | None, *, max_bytes: int) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError(f"SessionSignal event {name} must be a string")
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"SessionSignal event {name} must be non-empty")
+    if len(normalized.encode("utf-8")) > max_bytes:
+        raise ValueError(f"SessionSignal event {name} exceeds {max_bytes} UTF-8 bytes")
+    return normalized
+
+
+def _create_signal_event(
+    signal: SessionSignal,
+    state: SessionSignalState,
+    *,
+    effective_mode: SessionSignalMode | None = None,
+    include_message: bool = False,
+    job_id: str | None = None,
+    orchestrator_session_id: str | None = None,
+    runtime_backend: str | None = None,
+    extra: dict[str, Any] | None = None,
+) -> BaseEvent:
+    if not isinstance(state, SessionSignalState):
+        raise TypeError("state must be a SessionSignalState")
+    if effective_mode is not None and not isinstance(effective_mode, SessionSignalMode):
+        raise TypeError("effective_mode must be a SessionSignalMode")
+
+    data = signal.to_event_data(include_message=include_message)
+    data["state"] = state.value
+    data["is_terminal"] = state.is_terminal
+    if effective_mode is not None:
+        data["effective_mode"] = effective_mode.value
+
+    bounded_correlations = {
+        "job_id": _bounded_optional("job_id", job_id, max_bytes=_MAX_CORRELATION_BYTES),
+        "orchestrator_session_id": _bounded_optional(
+            "orchestrator_session_id",
+            orchestrator_session_id,
+            max_bytes=_MAX_CORRELATION_BYTES,
+        ),
+        "runtime_backend": _bounded_optional(
+            "runtime_backend",
+            runtime_backend,
+            max_bytes=_MAX_CORRELATION_BYTES,
+        ),
+    }
+    data.update({key: value for key, value in bounded_correlations.items() if value is not None})
+    if extra:
+        data.update(extra)
+
+    return BaseEvent(
+        type=SESSION_SIGNAL_EVENT_TYPES[state],
+        aggregate_type="session_signal",
+        aggregate_id=signal.signal_id,
+        data=data,
+    )
+
+
+def create_session_signal_requested_event(
+    signal: SessionSignal,
+    *,
+    job_id: str | None = None,
+    orchestrator_session_id: str | None = None,
+) -> BaseEvent:
+    """Record the original bounded signal before target/capability validation."""
+    return _create_signal_event(
+        signal,
+        SessionSignalState.REQUESTED,
+        include_message=True,
+        job_id=job_id,
+        orchestrator_session_id=orchestrator_session_id,
+    )
+
+
+def create_session_signal_accepted_event(
+    signal: SessionSignal,
+    *,
+    effective_mode: SessionSignalMode,
+    capabilities: SessionSignalCapabilities,
+    runtime_backend: str | None = None,
+    job_id: str | None = None,
+    orchestrator_session_id: str | None = None,
+) -> BaseEvent:
+    """Record validated addressing and the enforceable effective mode."""
+    return _create_signal_event(
+        signal,
+        SessionSignalState.ACCEPTED,
+        effective_mode=effective_mode,
+        runtime_backend=runtime_backend,
+        job_id=job_id,
+        orchestrator_session_id=orchestrator_session_id,
+        extra={"capabilities": capabilities.to_event_data()},
+    )
+
+
+def create_session_signal_queued_event(
+    signal: SessionSignal,
+    *,
+    effective_mode: SessionSignalMode,
+    runtime_backend: str | None = None,
+    job_id: str | None = None,
+    orchestrator_session_id: str | None = None,
+) -> BaseEvent:
+    """Record that Synapse durably owns pending delivery."""
+    return _create_signal_event(
+        signal,
+        SessionSignalState.QUEUED,
+        effective_mode=effective_mode,
+        runtime_backend=runtime_backend,
+        job_id=job_id,
+        orchestrator_session_id=orchestrator_session_id,
+    )
+
+
+def create_session_signal_delivery_started_event(
+    signal: SessionSignal,
+    *,
+    effective_mode: SessionSignalMode,
+    runtime_backend: str | None = None,
+    job_id: str | None = None,
+    orchestrator_session_id: str | None = None,
+) -> BaseEvent:
+    """Record the at-most-once provider-delivery claim before handoff."""
+    return _create_signal_event(
+        signal,
+        SessionSignalState.DELIVERING,
+        effective_mode=effective_mode,
+        runtime_backend=runtime_backend,
+        job_id=job_id,
+        orchestrator_session_id=orchestrator_session_id,
+        extra={"automatic_retry_allowed": False},
+    )
+
+
+def create_session_signal_applied_event(
+    signal: SessionSignal,
+    *,
+    effective_mode: SessionSignalMode,
+    acknowledgement: str,
+    runtime_backend: str | None = None,
+    job_id: str | None = None,
+    orchestrator_session_id: str | None = None,
+) -> BaseEvent:
+    """Record a runtime/checkpoint acknowledgement of context application."""
+    bounded = _bounded_optional(
+        "acknowledgement",
+        acknowledgement,
+        max_bytes=_MAX_EVENT_TEXT_BYTES,
+    )
+    assert bounded is not None
+    return _create_signal_event(
+        signal,
+        SessionSignalState.APPLIED,
+        effective_mode=effective_mode,
+        runtime_backend=runtime_backend,
+        job_id=job_id,
+        orchestrator_session_id=orchestrator_session_id,
+        extra={"acknowledgement": bounded},
+    )
+
+
+def create_session_signal_rejected_event(
+    signal: SessionSignal,
+    *,
+    rejection_code: str,
+    detail: str,
+    effective_mode: SessionSignalMode | None = None,
+    runtime_backend: str | None = None,
+    job_id: str | None = None,
+    orchestrator_session_id: str | None = None,
+) -> BaseEvent:
+    """Record a fail-closed validation or pre-application rejection."""
+    code = _bounded_optional("rejection_code", rejection_code, max_bytes=128)
+    bounded_detail = _bounded_optional("detail", detail, max_bytes=_MAX_EVENT_TEXT_BYTES)
+    assert code is not None and bounded_detail is not None
+    return _create_signal_event(
+        signal,
+        SessionSignalState.REJECTED,
+        effective_mode=effective_mode,
+        runtime_backend=runtime_backend,
+        job_id=job_id,
+        orchestrator_session_id=orchestrator_session_id,
+        extra={"rejection_code": code, "detail": bounded_detail},
+    )
+
+
+def create_session_signal_delivery_uncertain_event(
+    signal: SessionSignal,
+    *,
+    effective_mode: SessionSignalMode,
+    detail: str,
+    runtime_backend: str | None = None,
+    job_id: str | None = None,
+    orchestrator_session_id: str | None = None,
+) -> BaseEvent:
+    """Record an ambiguous provider acknowledgement boundary without retrying."""
+    bounded_detail = _bounded_optional("detail", detail, max_bytes=_MAX_EVENT_TEXT_BYTES)
+    assert bounded_detail is not None
+    return _create_signal_event(
+        signal,
+        SessionSignalState.DELIVERY_UNCERTAIN,
+        effective_mode=effective_mode,
+        runtime_backend=runtime_backend,
+        job_id=job_id,
+        orchestrator_session_id=orchestrator_session_id,
+        extra={"detail": bounded_detail, "automatic_retry_allowed": False},
+    )
+
+
+def create_session_signal_completed_event(
+    signal: SessionSignal,
+    *,
+    effective_mode: SessionSignalMode,
+    summary: str,
+    reply: str | None = None,
+    runtime_backend: str | None = None,
+    job_id: str | None = None,
+    orchestrator_session_id: str | None = None,
+) -> BaseEvent:
+    """Record terminal completion with a bounded acknowledgement summary."""
+    bounded_summary = _bounded_optional("summary", summary, max_bytes=_MAX_EVENT_TEXT_BYTES)
+    assert bounded_summary is not None
+    extra = {"summary": bounded_summary}
+    if reply is not None:
+        extra["reply"] = bounded_session_signal_reply(reply)
+    return _create_signal_event(
+        signal,
+        SessionSignalState.COMPLETED,
+        effective_mode=effective_mode,
+        runtime_backend=runtime_backend,
+        job_id=job_id,
+        orchestrator_session_id=orchestrator_session_id,
+        extra=extra,
+    )
+
+
+__all__ = [
+    "SESSION_SIGNAL_EVENT_PREFIX",
+    "SESSION_SIGNAL_EVENT_TYPES",
+    "create_session_signal_accepted_event",
+    "create_session_signal_applied_event",
+    "create_session_signal_completed_event",
+    "create_session_signal_delivery_started_event",
+    "create_session_signal_delivery_uncertain_event",
+    "create_session_signal_queued_event",
+    "create_session_signal_rejected_event",
+    "create_session_signal_requested_event",
+]

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -35,7 +35,7 @@ from ouroboros.core.lineage import (
     OntologyDelta,
     OntologyLineage,
 )
-from ouroboros.core.seed import Seed, ac_texts
+from ouroboros.core.seed import Seed
 from ouroboros.core.types import Result
 from ouroboros.events.control import create_control_directive_emitted_event
 from ouroboros.events.lineage import (
@@ -90,9 +90,10 @@ def _conductor_preservation_error(
     changed: list[str] = []
     if directive.preserve_goal and approved.goal != successor.goal:
         changed.append("goal")
-    if directive.preserve_acceptance_criteria and ac_texts(
-        approved.acceptance_criteria
-    ) != ac_texts(successor.acceptance_criteria):
+    if (
+        directive.preserve_acceptance_criteria
+        and approved.acceptance_criteria != successor.acceptance_criteria
+    ):
         changed.append("acceptance_criteria")
     if directive.preserve_constraints and approved.constraints != successor.constraints:
         changed.append("constraints")
@@ -1722,6 +1723,22 @@ class EvolutionaryLoop:
                                 "conductor_directive": conductor_directive.to_event_data(),
                             }
                         )
+
+                    preservation_error = _conductor_preservation_error(
+                        current_seed,
+                        new_seed,
+                        conductor_directive,
+                    )
+                    if preservation_error is not None:
+                        await self.event_store.append(
+                            lineage_generation_failed(
+                                lineage.lineage_id,
+                                generation_number,
+                                "conductor_preservation",
+                                preservation_error,
+                            )
+                        )
+                        return Result.err(OuroborosError(preservation_error))
 
                     # Compute ontology delta
                     ontology_delta = OntologyDelta.compute(

--- a/src/ouroboros/evolution/loop.py
+++ b/src/ouroboros/evolution/loop.py
@@ -25,6 +25,7 @@ import signal
 from typing import Any
 
 from ouroboros.config.models import RuntimeControlsConfig
+from ouroboros.core.conductor import ConductorDirective
 from ouroboros.core.errors import OuroborosError
 from ouroboros.core.lineage import (
     EvaluationSummary,
@@ -34,7 +35,7 @@ from ouroboros.core.lineage import (
     OntologyDelta,
     OntologyLineage,
 )
-from ouroboros.core.seed import Seed
+from ouroboros.core.seed import Seed, ac_texts
 from ouroboros.core.types import Result
 from ouroboros.events.control import create_control_directive_emitted_event
 from ouroboros.events.lineage import (
@@ -76,6 +77,32 @@ def _default_runtime_controls() -> RuntimeControlsConfig:
     from ouroboros.config.loader import get_runtime_controls_config
 
     return get_runtime_controls_config()
+
+
+def _conductor_preservation_error(
+    approved: Seed,
+    successor: Seed,
+    directive: ConductorDirective | None,
+) -> str | None:
+    """Return a fail-closed invariant error for an unauthorized direction change."""
+    if directive is None:
+        return None
+    changed: list[str] = []
+    if directive.preserve_goal and approved.goal != successor.goal:
+        changed.append("goal")
+    if directive.preserve_acceptance_criteria and ac_texts(
+        approved.acceptance_criteria
+    ) != ac_texts(successor.acceptance_criteria):
+        changed.append("acceptance_criteria")
+    if directive.preserve_constraints and approved.constraints != successor.constraints:
+        changed.append("constraints")
+    if directive.preserve_non_goals and approved.to_dict().get(
+        "non_goals"
+    ) != successor.to_dict().get("non_goals"):
+        changed.append("non_goals")
+    if not changed:
+        return None
+    return "Conductor successor changed preserved direction fields: " + ", ".join(changed)
 
 
 @dataclass
@@ -656,6 +683,7 @@ class EvolutionaryLoop:
         initial_seed: Seed | None = None,
         execute: bool = True,
         parallel: bool = True,
+        conductor_directive: ConductorDirective | None = None,
     ) -> Result[StepResult, OuroborosError]:
         """Run exactly one generation of the evolutionary loop.
 
@@ -807,6 +835,15 @@ class EvolutionaryLoop:
             else:
                 return Result.err(OuroborosError("Events exist but no completed generations found"))
 
+        approved_seed = current_seed
+        if conductor_directive is not None:
+            current_seed = Seed.from_dict(
+                {
+                    **current_seed.to_dict(),
+                    "conductor_directive": conductor_directive.to_event_data(),
+                }
+            )
+
         # Step 2: Run one generation wrapped in AgentProcess for pause/cancel/replay
         # primitives. State reconstruction above is outside the process boundary
         # so that replays start with a clean slate.
@@ -865,6 +902,7 @@ class EvolutionaryLoop:
                     parallel=parallel,
                     resume_after_phase=resume_after_phase,
                     agent_process_handle=handle,
+                    conductor_directive=conductor_directive,
                 )
             finally:
                 self._uninstall_sigint_handler()
@@ -944,6 +982,23 @@ class EvolutionaryLoop:
                 return
 
             result = gen_result.value
+
+            preservation_error = _conductor_preservation_error(
+                approved_seed,
+                result.seed,
+                conductor_directive,
+            )
+            if preservation_error is not None:
+                await self.event_store.append(
+                    lineage_generation_failed(
+                        lineage.lineage_id,
+                        generation_number,
+                        "conductor_preservation",
+                        preservation_error,
+                    )
+                )
+                container.result = Result.err(OuroborosError(preservation_error))
+                return
 
             # After generation work has returned a completed result, finish
             # durable lineage/post-processing writes without another
@@ -1131,6 +1186,7 @@ class EvolutionaryLoop:
         resume_after_phase: str | None = None,
         execution_id: str | None = None,
         agent_process_handle: AgentProcessHandle | None = None,
+        conductor_directive: ConductorDirective | None = None,
     ) -> Result[GenerationResult, OuroborosError]:
         """Run a single generation within the loop.
 
@@ -1151,6 +1207,7 @@ class EvolutionaryLoop:
                 resume_after_phase=resume_after_phase,
                 execution_id=execution_id,
                 agent_process_handle=agent_process_handle,
+                conductor_directive=conductor_directive,
             )
         except asyncio.CancelledError:
             # MCP transport disconnect, timeout, or external task cancellation.
@@ -1185,6 +1242,7 @@ class EvolutionaryLoop:
         parallel: bool = True,
         resume_after_phase: str | None = None,
         agent_process_handle: AgentProcessHandle | None = None,
+        conductor_directive: ConductorDirective | None = None,
     ) -> Result[GenerationResult, OuroborosError]:
         """Run one generation under progress-aware liveness controls."""
         execution_id = self._generation_execution_id(lineage.lineage_id, generation_number)
@@ -1206,6 +1264,7 @@ class EvolutionaryLoop:
                     resume_after_phase=resume_after_phase,
                     execution_id=execution_id,
                     agent_process_handle=agent_process_handle,
+                    conductor_directive=conductor_directive,
                 )
             )
         except GenerationWatchdogTimeout as exc:
@@ -1366,6 +1425,7 @@ class EvolutionaryLoop:
         resume_after_phase: str | None = None,
         execution_id: str | None = None,
         agent_process_handle: AgentProcessHandle | None = None,
+        conductor_directive: ConductorDirective | None = None,
     ) -> Result[GenerationResult, OuroborosError]:
         """Inner implementation of _run_generation with all phase logic.
 
@@ -1551,6 +1611,7 @@ class EvolutionaryLoop:
                         wonder_output=wonder_output,
                         lineage=lineage,
                         regression_report=regression_report,
+                        conductor_directive=conductor_directive,
                     )
 
                     if reflect_result.is_ok:
@@ -1654,6 +1715,13 @@ class EvolutionaryLoop:
                             OuroborosError(f"Seed generation failed: {seed_result.error}")
                         )
                     new_seed = seed_result.value
+                    if conductor_directive is not None:
+                        new_seed = Seed.from_dict(
+                            {
+                                **new_seed.to_dict(),
+                                "conductor_directive": conductor_directive.to_event_data(),
+                            }
+                        )
 
                     # Compute ontology delta
                     ontology_delta = OntologyDelta.compute(

--- a/src/ouroboros/evolution/reflect.py
+++ b/src/ouroboros/evolution/reflect.py
@@ -21,6 +21,7 @@ from typing import Literal
 from pydantic import BaseModel, Field, field_validator
 
 from ouroboros.config import get_llm_backend_for_role, get_llm_model_for_role
+from ouroboros.core.conductor import ConductorDirective
 from ouroboros.core.errors import ProviderError
 from ouroboros.core.lineage import EvaluationSummary, MutationAction, OntologyDelta, OntologyLineage
 from ouroboros.core.seed import Seed, ac_texts
@@ -344,6 +345,7 @@ class ReflectEngine:
         wonder_output: WonderOutput,
         lineage: OntologyLineage,
         regression_report: RegressionReport | None = None,
+        conductor_directive: ConductorDirective | None = None,
     ) -> Result[ReflectOutput, ProviderError]:
         """Reflect on execution results and propose evolution.
 
@@ -370,6 +372,7 @@ class ReflectEngine:
             wonder_output,
             lineage,
             regression_report,
+            conductor_directive,
         )
 
         messages = [
@@ -476,11 +479,31 @@ Guidelines:
         wonder: WonderOutput,
         lineage: OntologyLineage,
         regression_report: RegressionReport,
+        conductor_directive: ConductorDirective | None = None,
     ) -> str:
         parts = ["## Current Seed"]
         parts.append(f"Goal: {seed.goal}")
         parts.append(f"Constraints: {list(seed.constraints)}")
         parts.append(f"Acceptance Criteria: {list(ac_texts(seed.acceptance_criteria))}")
+
+        if conductor_directive is not None:
+            parts.append("\n## Active Conductor Successor Directive")
+            parts.append(f"Instruction: {conductor_directive.instruction}")
+            if conductor_directive.rejected_reasons:
+                parts.append("Rejected evidence reasons:")
+                parts.extend(f"  - {reason}" for reason in conductor_directive.rejected_reasons)
+            parts.append(
+                "Preserve approved direction exactly where these flags are true: "
+                f"goal={conductor_directive.preserve_goal}, "
+                "acceptance_criteria="
+                f"{conductor_directive.preserve_acceptance_criteria}, "
+                f"constraints={conductor_directive.preserve_constraints}, "
+                f"non_goals={conductor_directive.preserve_non_goals}."
+            )
+            parts.append(
+                "Use the directive to correct implementation or evidence. Do not relax a "
+                "preserved field to make evaluation easier."
+            )
 
         parts.append(f"\n## Ontology: {seed.ontology_schema.name}")
         parts.append(f"Description: {seed.ontology_schema.description}")

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1243,7 +1243,9 @@ async def test_pipeline_repairs_b_seed_to_a_and_starts_run(tmp_path) -> None:
     # prepended to the Seed before the repairer runs, so the *user*
     # entry is no longer at index [0]; locate it by content instead.
     repaired_entries = [
-        item for item in state.seed_artifact["acceptance_criteria"] if "The CLI" in item
+        item.get("description", "") if isinstance(item, dict) else item
+        for item in state.seed_artifact["acceptance_criteria"]
+        if "The CLI" in (item.get("description", "") if isinstance(item, dict) else item)
     ]
     assert repaired_entries, "expected to find the repaired user-supplied CLI AC"
     repaired_acceptance = repaired_entries[0]

--- a/tests/unit/auto/test_pipeline_task_class_envelope.py
+++ b/tests/unit/auto/test_pipeline_task_class_envelope.py
@@ -204,13 +204,16 @@ async def test_envelope_carries_active_task_class_on_single_match(tmp_path) -> N
 
     assert result.active_task_class == TaskClass.CLI.value
     ac = state.seed_artifact["acceptance_criteria"]
+    ac_descriptions = [
+        item.get("description", "") if isinstance(item, dict) else item for item in ac
+    ]
     # Template entries are prepended in order.
     for index, expected in enumerate(profile.default_ac_template):
-        assert ac[index] == expected, (
+        assert ac_descriptions[index] == expected, (
             f"AC[{index}] should be the L1-d-prepended template entry; got {ac[index]!r}"
         )
     # The user's original AC remains present after the template.
-    assert "`habit list` prints stable stdout containing created habits" in ac
+    assert "`habit list` prints stable stdout containing created habits" in ac_descriptions
 
 
 @pytest.mark.asyncio
@@ -246,12 +249,15 @@ async def test_envelope_leaves_active_task_class_none_when_unmatched(tmp_path) -
 
     assert result.active_task_class is None
     ac = state.seed_artifact["acceptance_criteria"]
+    ac_descriptions = [
+        item.get("description", "") if isinstance(item, dict) else item for item in ac
+    ]
     library_template_entries = TASK_CLASS_CATALOG[TaskClass.LIBRARY].default_ac_template
     for template_entry in library_template_entries:
-        assert template_entry not in ac, (
+        assert template_entry not in ac_descriptions, (
             f"unmatched inference must not inject library template entry: {template_entry!r}"
         )
-    assert any("Changed behavior" in item and "tests" in item for item in ac)
+    assert any("Changed behavior" in item and "tests" in item for item in ac_descriptions)
 
 
 @pytest.mark.asyncio
@@ -292,11 +298,14 @@ async def test_envelope_leaves_active_task_class_none_when_ambiguous(tmp_path) -
 
     assert result.active_task_class is None
     ac = state.seed_artifact["acceptance_criteria"]
+    ac_descriptions = [
+        item.get("description", "") if isinstance(item, dict) else item for item in ac
+    ]
     # No catalog templates were injected — user AC stays as-is (plus
     # any normalization the existing pipeline applies, but the
     # template entries from L1-d.CLI are not added).
     cli_template_entries = TASK_CLASS_CATALOG[TaskClass.CLI].default_ac_template
     for template_entry in cli_template_entries:
-        assert template_entry not in ac, (
+        assert template_entry not in ac_descriptions, (
             f"ambiguous inference must not inject CLI template entry: {template_entry!r}"
         )

--- a/tests/unit/bigbang/test_seed_generator.py
+++ b/tests/unit/bigbang/test_seed_generator.py
@@ -580,6 +580,7 @@ class TestSeedGeneratorExtraction:
             assert first.output_assertion is None
             assert first.to_seed_value() == {
                 "description": "CLI exits successfully",
+                "semantic_ac_key": first.semantic_ac_key,
                 "verify_command": "python -m app",
             }
             assert isinstance(second, AcceptanceCriterionSpec)

--- a/tests/unit/core/test_conductor.py
+++ b/tests/unit/core/test_conductor.py
@@ -1,0 +1,135 @@
+"""Active Conductor bounded contract tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.core.conductor import (
+    ConductorActorMode,
+    ConductorDirective,
+    validate_conductor_successor_authorization,
+)
+from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+from ouroboros.evolution.loop import _conductor_preservation_error
+
+
+def test_non_relaxing_directive_is_bounded_and_digest_stable() -> None:
+    directive = ConductorDirective(
+        source_attention_event_id="attention_1",
+        instruction="Support the rejected claim with repository evidence.",
+        rejected_reasons=("The cited file was not observed.",),
+        deterministic=True,
+    )
+
+    assert directive.is_non_relaxing is True
+    assert directive.digest == ConductorDirective.from_mapping(directive.to_event_data()).digest
+    directive.validate_actor_policy(ConductorActorMode.AUTO)
+
+
+def test_auto_rejects_non_deterministic_or_relaxing_directive() -> None:
+    non_deterministic = ConductorDirective(
+        source_attention_event_id="attention_1",
+        instruction="Try a different implementation approach.",
+    )
+    relaxing = ConductorDirective(
+        source_attention_event_id="attention_1",
+        instruction="Replace the acceptance criteria after approval.",
+        preserve_acceptance_criteria=False,
+        deterministic=True,
+        user_approval_event_id="approval_1",
+    )
+
+    with pytest.raises(ValueError, match="deterministic non-relaxing"):
+        non_deterministic.validate_actor_policy(ConductorActorMode.AUTO)
+    with pytest.raises(ValueError, match="deterministic non-relaxing"):
+        relaxing.validate_actor_policy(ConductorActorMode.RALPH)
+    relaxing.validate_actor_policy(ConductorActorMode.RUN)
+
+
+def test_specification_change_requires_user_approval() -> None:
+    with pytest.raises(ValueError, match="requires user_approval_event_id"):
+        ConductorDirective(
+            source_attention_event_id="attention_1",
+            instruction="Replace one acceptance criterion.",
+            preserve_acceptance_criteria=False,
+            deterministic=True,
+        )
+
+
+def test_directive_rejects_secret_shaped_content() -> None:
+    with pytest.raises(ValueError, match="secret-shaped"):
+        ConductorDirective(
+            source_attention_event_id="attention_1",
+            instruction="Use api_key=super-secret-token-value in the successor.",
+            deterministic=True,
+        )
+
+
+def test_successor_authorization_rejects_mismatched_predecessor_or_directive() -> None:
+    directive = ConductorDirective(
+        source_attention_event_id="attention_1",
+        instruction="Correct the rejected evidence without weakening the AC.",
+        deterministic=True,
+    )
+    selected = {
+        "engine_ownership_state": "closed",
+        "selected_effect": "successor_only",
+        "predecessor_execution_id": "exec_predecessor",
+        "conductor_directive_digest": directive.digest,
+        "actor_mode": "auto",
+    }
+
+    assert (
+        validate_conductor_successor_authorization(
+            selected,
+            directive=directive,
+            predecessor_execution_id="exec_predecessor",
+        )
+        is ConductorActorMode.AUTO
+    )
+    with pytest.raises(ValueError, match="predecessor_execution_id"):
+        validate_conductor_successor_authorization(
+            selected,
+            directive=directive,
+            predecessor_execution_id="exec_other",
+        )
+    changed = ConductorDirective(
+        source_attention_event_id="attention_1",
+        instruction="Use a different correction.",
+        deterministic=True,
+    )
+    with pytest.raises(ValueError, match="conductor_directive"):
+        validate_conductor_successor_authorization(
+            selected,
+            directive=changed,
+            predecessor_execution_id="exec_predecessor",
+        )
+
+
+def test_evolution_preservation_gate_names_every_unauthorized_direction_change() -> None:
+    approved = Seed(
+        goal="Keep the approved goal",
+        constraints=("Keep the compatibility contract",),
+        acceptance_criteria=("The behavior remains verified",),
+        ontology_schema=OntologySchema(name="Test", description="Test"),
+        metadata=SeedMetadata(ambiguity_score=0.1),
+    )
+    successor = approved.model_copy(
+        update={
+            "goal": "Changed goal",
+            "constraints": ("Changed constraint",),
+            "acceptance_criteria": ("Changed criterion",),
+        }
+    )
+    directive = ConductorDirective(
+        source_attention_event_id="attention_1",
+        instruction="Correct evidence only.",
+        deterministic=True,
+    )
+
+    error = _conductor_preservation_error(approved, successor, directive)
+
+    assert error is not None
+    assert "goal" in error
+    assert "acceptance_criteria" in error
+    assert "constraints" in error

--- a/tests/unit/core/test_conductor.py
+++ b/tests/unit/core/test_conductor.py
@@ -9,7 +9,7 @@ from ouroboros.core.conductor import (
     ConductorDirective,
     validate_conductor_successor_authorization,
 )
-from ouroboros.core.seed import OntologySchema, Seed, SeedMetadata
+from ouroboros.core.seed import AcceptanceCriterionSpec, OntologySchema, Seed, SeedMetadata
 from ouroboros.evolution.loop import _conductor_preservation_error
 
 
@@ -133,3 +133,45 @@ def test_evolution_preservation_gate_names_every_unauthorized_direction_change()
     assert "goal" in error
     assert "acceptance_criteria" in error
     assert "constraints" in error
+
+
+@pytest.mark.parametrize(
+    "contract_update",
+    [
+        {"verify_command": "pytest tests/changed -q"},
+        {"expected_artifacts": ("changed-report.json",)},
+        {"output_assertion": "changed output"},
+        {"semantic_ac_key": "ac_ffffffffffffffff"},
+    ],
+)
+def test_evolution_preservation_gate_compares_full_structured_ac_contract(
+    contract_update: dict[str, object],
+) -> None:
+    approved = Seed(
+        goal="Keep the approved goal",
+        constraints=("Keep the compatibility contract",),
+        acceptance_criteria=(
+            AcceptanceCriterionSpec(
+                description="The behavior remains verified",
+                verify_command="pytest tests/original -q",
+                expected_artifacts=("original-report.json",),
+                output_assertion="original output",
+            ),
+        ),
+        ontology_schema=OntologySchema(name="Test", description="Test"),
+        metadata=SeedMetadata(ambiguity_score=0.1),
+    )
+    approved_ac = approved.acceptance_criteria[0]
+    assert isinstance(approved_ac, AcceptanceCriterionSpec)
+    successor_ac = approved_ac.model_copy(update=contract_update)
+    successor = approved.model_copy(update={"acceptance_criteria": (successor_ac,)})
+    directive = ConductorDirective(
+        source_attention_event_id="attention_1",
+        instruction="Correct evidence only.",
+        deterministic=True,
+    )
+
+    error = _conductor_preservation_error(approved, successor, directive)
+
+    assert error is not None
+    assert "acceptance_criteria" in error

--- a/tests/unit/core/test_execution_preferences.py
+++ b/tests/unit/core/test_execution_preferences.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.core.execution_preferences import (
+    EfficiencyMode,
+    FrugalityAssurance,
+    execution_preferences_from_contract,
+    resolve_execution_preferences,
+)
+
+
+@pytest.mark.parametrize(
+    ("efficiency", "expected_assurance"),
+    [
+        ("adaptive", FrugalityAssurance.OBSERVE),
+        ("quality_first", FrugalityAssurance.OFF),
+    ],
+)
+def test_default_assurance_mapping(
+    efficiency: str,
+    expected_assurance: FrugalityAssurance,
+) -> None:
+    resolved = resolve_execution_preferences(efficiency, None)
+
+    assert resolved.efficiency_mode is EfficiencyMode(efficiency)
+    assert resolved.frugality_assurance is expected_assurance
+    assert resolved.frugality_assurance_explicit is False
+    assert resolved.strict_baseline_authorized is False
+
+
+def test_strict_requires_explicit_value() -> None:
+    resolved = resolve_execution_preferences("adaptive", "strict")
+
+    assert resolved.strict_baseline_authorized is True
+
+
+def test_contract_round_trip_and_malformed_rejection() -> None:
+    resolved = resolve_execution_preferences("quality_first", "observe")
+
+    assert execution_preferences_from_contract(resolved.to_contract_data()) == resolved
+    assert execution_preferences_from_contract({"efficiency_mode": "adaptive"}) is None

--- a/tests/unit/core/test_seed.py
+++ b/tests/unit/core/test_seed.py
@@ -450,8 +450,8 @@ class TestSeed:
         assert ok.output_assertion == "OK"
         assert pytest_literal.output_assertion == "5 passed"
 
-    def test_seed_acceptance_criteria_serialize_legacy_strings_stably(self) -> None:
-        """Description-only ACs dump back to bare strings."""
+    def test_seed_acceptance_criteria_materialize_semantic_keys(self) -> None:
+        """Legacy description-only ACs gain deterministic persisted identities."""
         seed = Seed(
             goal="Build a CLI task manager",
             acceptance_criteria=(
@@ -465,10 +465,13 @@ class TestSeed:
             metadata=SeedMetadata(ambiguity_score=0.15),
         )
 
-        assert seed.to_dict()["acceptance_criteria"] == [
+        serialized = seed.to_dict()["acceptance_criteria"]
+        assert [item["description"] for item in serialized] == [
             "Tasks can be created",
             "Tasks can be listed",
         ]
+        assert all(item["semantic_ac_key"].startswith("ac_") for item in serialized)
+        assert Seed.from_dict(seed.to_dict()).to_dict() == seed.to_dict()
 
     def test_seed_acceptance_criteria_serialize_structured_contract(self) -> None:
         """Contract-bearing ACs dump only populated fields."""
@@ -492,19 +495,25 @@ class TestSeed:
             {
                 "description": "Task list command exits 0",
                 "expected_artifacts": ["tasks.json"],
+                "semantic_ac_key": seed.acceptance_criteria[0].semantic_ac_key,
                 "verify_command": "uv run task list",
             }
         ]
 
-    def test_legacy_seed_json_round_trips_byte_identically(self) -> None:
-        """An old bare-string seed fixture keeps identical JSON bytes after dump."""
+    def test_legacy_seed_json_materializes_semantic_keys_once(self) -> None:
+        """An old bare-string fixture upgrades once and is then stable."""
         fixture = Path(__file__).parents[2] / "fixtures" / "seeds" / "legacy-seed-minimal.json"
         original = fixture.read_text()
         seed = Seed.from_dict(json.loads(original))
 
         round_tripped = json.dumps(seed.to_dict(), indent=2, sort_keys=True) + "\n"
 
-        assert round_tripped == original
+        assert round_tripped != original
+        assert all(
+            item["semantic_ac_key"].startswith("ac_")
+            for item in seed.to_dict()["acceptance_criteria"]
+        )
+        assert Seed.from_dict(json.loads(round_tripped)).to_dict() == seed.to_dict()
 
     def test_seed_coerces_string_evaluation_principles(self) -> None:
         """Hand-written seed principle string lists are lifted into objects."""
@@ -583,7 +592,17 @@ class TestSeed:
         assert isinstance(seed_dict, dict)
         assert seed_dict["goal"] == full_seed.goal
         assert seed_dict["constraints"] == list(full_seed.constraints)
-        assert seed_dict["acceptance_criteria"] == list(ac_texts(full_seed.acceptance_criteria))
+        assert [item["description"] for item in seed_dict["acceptance_criteria"]] == list(
+            ac_texts(full_seed.acceptance_criteria)
+        )
+        assert all(
+            item["semantic_ac_key"] == criterion.semantic_ac_key
+            for item, criterion in zip(
+                seed_dict["acceptance_criteria"],
+                full_seed.acceptance_criteria,
+                strict=True,
+            )
+        )
         assert seed_dict["ontology_schema"]["name"] == full_seed.ontology_schema.name
         assert seed_dict["metadata"]["ambiguity_score"] == full_seed.metadata.ambiguity_score
 

--- a/tests/unit/core/test_session_signal.py
+++ b/tests/unit/core/test_session_signal.py
@@ -1,0 +1,228 @@
+"""Unit tests for the clean-room Ouroboros Synapse contract."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from ouroboros.core import SessionSignal as CoreSessionSignal
+from ouroboros.core.session_signal import (
+    MAX_MESSAGE_BYTES,
+    MAX_REPLY_BYTES,
+    SESSION_SIGNAL_SCHEMA_VERSION,
+    SessionSignal,
+    SessionSignalCapabilities,
+    SessionSignalCapabilityError,
+    SessionSignalContractEffect,
+    SessionSignalMode,
+    SessionSignalSource,
+    bounded_session_signal_reply,
+    resolve_session_signal_mode,
+)
+
+
+def _signal(**overrides: object) -> SessionSignal:
+    values: dict[str, object] = {
+        "signal_id": "sig_1",
+        "target_session_scope_id": "exec_1_ac_2",
+        "target_session_attempt_id": "exec_1_ac_2_attempt_1",
+        "expected_execution_id": "exec_1",
+        "mode": SessionSignalMode.REDIRECT,
+        "fallback_mode": SessionSignalMode.AFTER_TURN,
+        "message": "Preserve the approved AC and use the clarified interaction.",
+        "source": SessionSignalSource.USER,
+        "reason": "The user clarified implementation intent.",
+        "idempotency_key": "turn_7_ac_2",
+    }
+    values.update(overrides)
+    return SessionSignal(**values)  # type: ignore[arg-type]
+
+
+class TestSessionSignalValidation:
+    def test_minimal_signal_has_stable_digest_and_identity(self) -> None:
+        signal = _signal()
+
+        assert signal.schema_version == SESSION_SIGNAL_SCHEMA_VERSION
+        assert len(signal.message_digest) == 64
+        assert signal.effective_idempotency_key == (
+            "exec_1",
+            "exec_1_ac_2",
+            "exec_1_ac_2_attempt_1",
+            "turn_7_ac_2",
+        )
+
+    @pytest.mark.parametrize(
+        "field",
+        [
+            "signal_id",
+            "target_session_scope_id",
+            "target_session_attempt_id",
+            "expected_execution_id",
+            "message",
+            "reason",
+            "idempotency_key",
+        ],
+    )
+    def test_blank_required_text_is_rejected(self, field: str) -> None:
+        with pytest.raises(ValueError, match=field):
+            _signal(**{field: " \n\t "})
+
+    def test_control_only_text_is_rejected(self) -> None:
+        with pytest.raises(ValueError, match="visible text"):
+            _signal(message="\u0000\u0001")
+
+    def test_utf8_byte_bound_is_enforced(self) -> None:
+        oversized = "€" * ((MAX_MESSAGE_BYTES // 3) + 1)
+
+        with pytest.raises(ValueError, match="8192 UTF-8 bytes"):
+            _signal(message=oversized)
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "Use Bearer abcdefghijklmnopqrstuvwxyz for the request",
+            "Use sk-abcdefghijklmnopqrstuvwxyz123456",
+            "password=super-secret-value",
+        ],
+    )
+    def test_secret_shaped_content_is_rejected(self, message: str) -> None:
+        with pytest.raises(ValueError, match="secret-shaped"):
+            _signal(message=message)
+
+    def test_only_redirect_accepts_after_turn_fallback(self) -> None:
+        with pytest.raises(ValueError, match="valid only for redirect"):
+            _signal(mode=SessionSignalMode.INFORM, fallback_mode=SessionSignalMode.AFTER_TURN)
+
+        with pytest.raises(ValueError, match="must be after_turn"):
+            _signal(mode=SessionSignalMode.REDIRECT, fallback_mode=SessionSignalMode.INFORM)
+
+    def test_replace_requires_user_approval(self) -> None:
+        with pytest.raises(ValueError, match="user_approval_event_id"):
+            _signal(mode=SessionSignalMode.REPLACE, fallback_mode=None)
+
+        approved = _signal(
+            mode=SessionSignalMode.REPLACE,
+            fallback_mode=None,
+            user_approval_event_id="hitl_evt_1",
+        )
+        assert approved.user_approval_event_id == "hitl_evt_1"
+
+    def test_specification_change_requires_approval_and_round_trips_event_data(self) -> None:
+        with pytest.raises(ValueError, match="specification_change"):
+            _signal(contract_effect=SessionSignalContractEffect.SPECIFICATION_CHANGE)
+
+        signal = _signal(
+            contract_effect=SessionSignalContractEffect.SPECIFICATION_CHANGE,
+            user_approval_event_id="approval_1",
+        )
+        restored = SessionSignal.from_event_data(signal.to_event_data(include_message=True))
+
+        assert restored == signal
+
+    def test_runtime_reply_is_secret_filtered_and_utf8_bounded(self) -> None:
+        assert bounded_session_signal_reply("password=super-secret-value") == (
+            "[Reply omitted because it contained secret-shaped content.]"
+        )
+        reply = bounded_session_signal_reply("€" * 1_000)
+        assert len(reply.encode("utf-8")) <= MAX_REPLY_BYTES
+        assert reply.endswith("…")
+
+    def test_expiry_is_timezone_aware_and_normalized(self) -> None:
+        with pytest.raises(ValueError, match="timezone-aware"):
+            _signal(expires_at=datetime(2026, 7, 12, 12, 0, 0))
+
+        expires = datetime.now(UTC) + timedelta(minutes=1)
+        signal = _signal(expires_at=expires)
+        assert signal.is_expired(at=expires - timedelta(seconds=1)) is False
+        assert signal.is_expired(at=expires) is True
+
+    def test_requested_event_data_includes_message_only_when_requested(self) -> None:
+        signal = _signal()
+
+        assert "message" not in signal.to_event_data()
+        assert signal.to_event_data(include_message=True)["message"] == signal.message
+
+
+class TestSessionSignalCapabilityResolution:
+    def test_all_capabilities_default_to_unsupported(self) -> None:
+        capabilities = SessionSignalCapabilities()
+
+        assert capabilities.to_event_data() == {
+            "inform_delivery": False,
+            "background_reply": False,
+            "after_turn_delivery": False,
+            "checkpoint_redirect": False,
+            "owned_turn_abort": False,
+            "replacement_resume": False,
+        }
+
+    def test_inform_requires_its_own_capability(self) -> None:
+        signal = _signal(mode=SessionSignalMode.INFORM, fallback_mode=None)
+
+        with pytest.raises(SessionSignalCapabilityError, match="inform"):
+            resolve_session_signal_mode(signal, SessionSignalCapabilities())
+
+        assert (
+            resolve_session_signal_mode(
+                signal,
+                SessionSignalCapabilities(inform_delivery=True),
+            )
+            is SessionSignalMode.INFORM
+        )
+
+    def test_redirect_is_used_when_supported(self) -> None:
+        effective = resolve_session_signal_mode(
+            _signal(),
+            SessionSignalCapabilities(
+                checkpoint_redirect=True,
+                after_turn_delivery=True,
+            ),
+        )
+
+        assert effective is SessionSignalMode.REDIRECT
+
+    def test_redirect_falls_back_only_when_explicit(self) -> None:
+        capabilities = SessionSignalCapabilities(after_turn_delivery=True)
+
+        assert resolve_session_signal_mode(_signal(), capabilities) is SessionSignalMode.AFTER_TURN
+        with pytest.raises(SessionSignalCapabilityError, match="checkpoint redirect"):
+            resolve_session_signal_mode(
+                replace(_signal(), fallback_mode=None),
+                capabilities,
+            )
+
+    def test_after_turn_is_not_inferred_from_targeted_resume(self) -> None:
+        signal = _signal(mode=SessionSignalMode.AFTER_TURN, fallback_mode=None)
+
+        with pytest.raises(SessionSignalCapabilityError, match="after_turn"):
+            resolve_session_signal_mode(signal, SessionSignalCapabilities())
+
+    def test_replace_requires_abort_and_resume(self) -> None:
+        signal = _signal(
+            mode=SessionSignalMode.REPLACE,
+            fallback_mode=None,
+            user_approval_event_id="hitl_evt_1",
+        )
+
+        with pytest.raises(SessionSignalCapabilityError, match="abort and resume"):
+            resolve_session_signal_mode(
+                signal,
+                SessionSignalCapabilities(owned_turn_abort=True),
+            )
+
+        assert (
+            resolve_session_signal_mode(
+                signal,
+                SessionSignalCapabilities(
+                    owned_turn_abort=True,
+                    replacement_resume=True,
+                ),
+            )
+            is SessionSignalMode.REPLACE
+        )
+
+
+def test_session_signal_is_reexported_from_core() -> None:
+    assert CoreSessionSignal is SessionSignal

--- a/tests/unit/core/test_session_signal_projection.py
+++ b/tests/unit/core/test_session_signal_projection.py
@@ -1,0 +1,210 @@
+"""Replay and authority tests for the Synapse lifecycle projection."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.core.session_signal import (
+    SessionSignal,
+    SessionSignalCapabilities,
+    SessionSignalMode,
+    SessionSignalSource,
+    SessionSignalState,
+)
+from ouroboros.core.session_signal_projection import (
+    can_supersede_session_signal,
+    project_session_signal,
+)
+from ouroboros.events.session_signal import (
+    create_session_signal_accepted_event,
+    create_session_signal_applied_event,
+    create_session_signal_completed_event,
+    create_session_signal_delivery_started_event,
+    create_session_signal_delivery_uncertain_event,
+    create_session_signal_queued_event,
+    create_session_signal_rejected_event,
+    create_session_signal_requested_event,
+)
+
+
+def _signal() -> SessionSignal:
+    return SessionSignal(
+        signal_id="sig_1",
+        target_session_scope_id="scope_1",
+        target_session_attempt_id="scope_1_attempt_1",
+        expected_execution_id="exec_1",
+        mode=SessionSignalMode.REDIRECT,
+        fallback_mode=SessionSignalMode.AFTER_TURN,
+        message="Apply the clarified local intent.",
+        source=SessionSignalSource.USER,
+        reason="User clarification.",
+        idempotency_key="intent_1",
+    )
+
+
+def _accepted_flow() -> tuple[SessionSignal, list]:
+    signal = _signal()
+    events = [
+        create_session_signal_requested_event(signal),
+        create_session_signal_accepted_event(
+            signal,
+            effective_mode=SessionSignalMode.REDIRECT,
+            capabilities=SessionSignalCapabilities(checkpoint_redirect=True),
+        ),
+        create_session_signal_queued_event(
+            signal,
+            effective_mode=SessionSignalMode.REDIRECT,
+        ),
+    ]
+    return signal, events
+
+
+def test_happy_path_projects_to_completed() -> None:
+    signal, events = _accepted_flow()
+    events.extend(
+        [
+            create_session_signal_applied_event(
+                signal,
+                effective_mode=SessionSignalMode.REDIRECT,
+                acknowledgement="checkpoint:next_decision",
+            ),
+            create_session_signal_completed_event(
+                signal,
+                effective_mode=SessionSignalMode.REDIRECT,
+                summary="Redirect acknowledged.",
+            ),
+        ]
+    )
+
+    projection = project_session_signal(events)
+
+    assert projection.state is SessionSignalState.COMPLETED
+
+
+def test_delivery_claim_and_bounded_reply_are_projected() -> None:
+    signal, events = _accepted_flow()
+    events.extend(
+        [
+            create_session_signal_delivery_started_event(
+                signal,
+                effective_mode=SessionSignalMode.REDIRECT,
+            ),
+            create_session_signal_applied_event(
+                signal,
+                effective_mode=SessionSignalMode.REDIRECT,
+                acknowledgement="checkpoint:next_decision",
+            ),
+            create_session_signal_completed_event(
+                signal,
+                effective_mode=SessionSignalMode.REDIRECT,
+                summary="Redirect acknowledged.",
+                reply="The affected assertion is now passing.",
+            ),
+        ]
+    )
+
+    projection = project_session_signal(events)
+
+    assert projection.state is SessionSignalState.COMPLETED
+    assert projection.acknowledgement == "checkpoint:next_decision"
+    assert projection.summary == "Redirect acknowledged."
+    assert projection.reply == "The affected assertion is now passing."
+    assert projection.is_terminal is True
+    assert projection.effective_mode is SessionSignalMode.REDIRECT
+    assert projection.effective_idempotency_key == (
+        "exec_1",
+        "scope_1",
+        "scope_1_attempt_1",
+        "intent_1",
+    )
+
+
+def test_requested_can_fail_closed_without_effective_mode() -> None:
+    signal = _signal()
+    projection = project_session_signal(
+        [
+            create_session_signal_requested_event(signal),
+            create_session_signal_rejected_event(
+                signal,
+                rejection_code="stale_attempt",
+                detail="Attempt replaced.",
+            ),
+        ]
+    )
+
+    assert projection.state is SessionSignalState.REJECTED
+    assert projection.effective_mode is None
+
+
+def test_queued_can_end_delivery_uncertain() -> None:
+    signal, events = _accepted_flow()
+    events.append(
+        create_session_signal_delivery_uncertain_event(
+            signal,
+            effective_mode=SessionSignalMode.REDIRECT,
+            detail="Acknowledgement boundary was lost.",
+        )
+    )
+
+    assert project_session_signal(events).state is SessionSignalState.DELIVERY_UNCERTAIN
+
+
+def test_illegal_transition_is_rejected() -> None:
+    signal = _signal()
+    with pytest.raises(ValueError, match="requested -> completed"):
+        project_session_signal(
+            [
+                create_session_signal_requested_event(signal),
+                create_session_signal_completed_event(
+                    signal,
+                    effective_mode=SessionSignalMode.REDIRECT,
+                    summary="Impossible.",
+                ),
+            ]
+        )
+
+
+def test_identity_drift_is_rejected() -> None:
+    signal, events = _accepted_flow()
+    drifted = events[-1].model_copy(
+        update={"data": {**events[-1].data, "expected_execution_id": "exec_2"}}
+    )
+
+    with pytest.raises(ValueError, match="identity changed"):
+        project_session_signal([events[0], events[1], drifted])
+
+
+def test_duplicate_event_id_is_idempotently_ignored() -> None:
+    _signal_value, events = _accepted_flow()
+    projection = project_session_signal([events[0], events[0], events[1], events[2]])
+
+    assert projection.state is SessionSignalState.QUEUED
+    assert projection.event_ids == tuple(event.id for event in events)
+
+
+def test_effective_mode_cannot_change_after_acceptance() -> None:
+    signal, events = _accepted_flow()
+    changed = create_session_signal_queued_event(
+        signal,
+        effective_mode=SessionSignalMode.AFTER_TURN,
+    )
+
+    with pytest.raises(ValueError, match="effective_mode changed"):
+        project_session_signal([events[0], events[1], changed])
+
+
+@pytest.mark.parametrize(
+    ("pending", "incoming", "expected"),
+    [
+        (SessionSignalSource.USER, SessionSignalSource.CONDUCTOR, False),
+        (SessionSignalSource.USER, SessionSignalSource.USER, True),
+        (SessionSignalSource.WORKER, SessionSignalSource.CONDUCTOR, True),
+        (SessionSignalSource.CONDUCTOR, SessionSignalSource.USER, True),
+    ],
+)
+def test_source_authority_is_deterministic(
+    pending: SessionSignalSource,
+    incoming: SessionSignalSource,
+    expected: bool,
+) -> None:
+    assert can_supersede_session_signal(pending, incoming) is expected

--- a/tests/unit/events/test_session_signal_events.py
+++ b/tests/unit/events/test_session_signal_events.py
@@ -1,0 +1,139 @@
+"""Event-contract tests for Ouroboros Synapse."""
+
+from __future__ import annotations
+
+import pytest
+
+from ouroboros.core.session_signal import (
+    SessionSignal,
+    SessionSignalCapabilities,
+    SessionSignalMode,
+    SessionSignalSource,
+)
+from ouroboros.events.session_signal import (
+    create_session_signal_accepted_event,
+    create_session_signal_applied_event,
+    create_session_signal_completed_event,
+    create_session_signal_delivery_started_event,
+    create_session_signal_delivery_uncertain_event,
+    create_session_signal_queued_event,
+    create_session_signal_rejected_event,
+    create_session_signal_requested_event,
+)
+
+
+def _signal() -> SessionSignal:
+    return SessionSignal(
+        signal_id="sig_1",
+        target_session_scope_id="exec_1_ac_2",
+        target_session_attempt_id="exec_1_ac_2_attempt_1",
+        expected_execution_id="exec_1",
+        mode=SessionSignalMode.REDIRECT,
+        fallback_mode=SessionSignalMode.AFTER_TURN,
+        message="Use the clarified interaction while preserving the AC.",
+        source=SessionSignalSource.USER,
+        reason="User clarification.",
+        idempotency_key="turn_7_ac_2",
+    )
+
+
+def test_requested_event_is_bounded_signal_aggregate() -> None:
+    signal = _signal()
+    event = create_session_signal_requested_event(
+        signal,
+        job_id="job_1",
+        orchestrator_session_id="orch_1",
+    )
+
+    assert event.type == "control.session.signal.requested"
+    assert event.aggregate_type == "session_signal"
+    assert event.aggregate_id == "sig_1"
+    assert event.data["state"] == "requested"
+    assert event.data["is_terminal"] is False
+    assert event.data["message"] == signal.message
+    assert event.data["message_digest"] == signal.message_digest
+    assert event.data["job_id"] == "job_1"
+    assert "raw_payload" not in event.data
+
+
+def test_accepted_event_records_effective_mode_and_capability_snapshot() -> None:
+    event = create_session_signal_accepted_event(
+        _signal(),
+        effective_mode=SessionSignalMode.AFTER_TURN,
+        capabilities=SessionSignalCapabilities(after_turn_delivery=True),
+        runtime_backend="codex_mcp",
+    )
+
+    assert event.data["effective_mode"] == "after_turn"
+    assert event.data["capabilities"]["after_turn_delivery"] is True
+    assert event.data["capabilities"]["checkpoint_redirect"] is False
+    assert event.data["runtime_backend"] == "codex_mcp"
+    assert "message" not in event.data
+
+
+def test_queued_does_not_claim_application() -> None:
+    event = create_session_signal_queued_event(
+        _signal(),
+        effective_mode=SessionSignalMode.AFTER_TURN,
+    )
+
+    assert event.type.endswith(".queued")
+    assert event.data["state"] == "queued"
+    assert "acknowledgement" not in event.data
+
+
+def test_delivery_started_is_non_terminal_and_disables_automatic_retry() -> None:
+    event = create_session_signal_delivery_started_event(
+        _signal(),
+        effective_mode=SessionSignalMode.AFTER_TURN,
+    )
+
+    assert event.type.endswith(".delivering")
+    assert event.data["is_terminal"] is False
+    assert event.data["automatic_retry_allowed"] is False
+
+
+def test_applied_and_completed_have_distinct_terminality() -> None:
+    signal = _signal()
+    applied = create_session_signal_applied_event(
+        signal,
+        effective_mode=SessionSignalMode.REDIRECT,
+        acknowledgement="checkpoint:before_next_model_decision",
+    )
+    completed = create_session_signal_completed_event(
+        signal,
+        effective_mode=SessionSignalMode.REDIRECT,
+        summary="The target acknowledged the redirect.",
+        reply="The confirmation copy was updated.",
+    )
+
+    assert applied.data["is_terminal"] is False
+    assert completed.data["is_terminal"] is True
+    assert completed.data["reply"] == "The confirmation copy was updated."
+
+
+def test_rejected_and_uncertain_are_terminal() -> None:
+    signal = _signal()
+    rejected = create_session_signal_rejected_event(
+        signal,
+        rejection_code="stale_attempt",
+        detail="The target attempt has already been replaced.",
+    )
+    uncertain = create_session_signal_delivery_uncertain_event(
+        signal,
+        effective_mode=SessionSignalMode.REDIRECT,
+        detail="Provider acknowledgement was lost during process exit.",
+    )
+
+    assert rejected.data["is_terminal"] is True
+    assert uncertain.data["is_terminal"] is True
+    assert uncertain.data["automatic_retry_allowed"] is False
+
+
+def test_event_detail_bounds_fail_closed() -> None:
+    with pytest.raises(ValueError, match="1000 UTF-8 bytes"):
+        create_session_signal_rejected_event(
+            _signal(),
+            rejection_code="invalid",
+            detail="€" * 334,
+        )

--- a/tests/unit/evolution/test_scoped_reexecution.py
+++ b/tests/unit/evolution/test_scoped_reexecution.py
@@ -12,6 +12,7 @@ import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+from ouroboros.core.conductor import ConductorDirective
 from ouroboros.core.lineage import (
     ACResult,
     EvaluationSummary,
@@ -203,6 +204,40 @@ def _make_loop_for_gen2(
 
 
 class TestScopedForwardingIntegration:
+    async def test_conductor_preservation_blocks_executor_before_side_effects(self) -> None:
+        store = await _store()
+        seed_v1 = _seed()
+        lineage = OntologyLineage(
+            lineage_id="lin_conductor_preservation",
+            goal=seed_v1.goal,
+            generations=(_gen(1, seed_v1, _eval({0: True, 1: True})),),
+        )
+        executor = _CaptureExecutor()
+        loop = _make_loop_for_gen2(store, executor, EvolutionaryLoopConfig(), settled=())
+        weakened_seed = _seed(seed_id="seed_weakened").model_copy(
+            update={"goal": "Replace the approved goal"}
+        )
+        loop.seed_generator.generate_from_reflect = MagicMock(return_value=Result.ok(weakened_seed))
+        directive = ConductorDirective(
+            source_attention_event_id="attention_1",
+            instruction="Correct evidence without changing approved direction.",
+            deterministic=True,
+        )
+
+        result = await loop._run_generation(
+            lineage=lineage,
+            generation_number=2,
+            current_seed=seed_v1,
+            conductor_directive=directive,
+        )
+
+        assert result.is_err
+        assert "changed preserved direction fields: goal" in str(result.error)
+        assert executor.called is False
+        events = await store.replay_lineage(lineage.lineage_id)
+        failure = [event for event in events if event.type == "lineage.generation.failed"][-1]
+        assert failure.data["phase"] == "conductor_preservation"
+
     async def test_settled_dict_built_and_forwarded(self) -> None:
         store = await _store()
         seed_v1 = _seed()


### PR DESCRIPTION
## Stack: Active Conductor + Synapse (1/3)

> Review and merge this PR first. Later layers build on these contracts.

| Order | PR | Scope |
|---|---|---|
| 1 | This PR | Contracts, RFC, and successor safeguards |
| 2 | [#1619](https://github.com/Q00/ouroboros/pull/1619) | Synapse runtime delivery |
| 3 | [#1620](https://github.com/Q00/ouroboros/pull/1620) | Durable MCP host and main-session UX |

## Summary

- Define bounded Active Conductor decisions, successor directives, and execution-efficiency preferences.
- Add stable semantic AC identities plus the durable, replay-safe `SessionSignal` lifecycle.
- Make the RFC, requirements, architecture, implementation plan, and clean-room Synapse specification the normative review boundary.

## Review guide

1. Start with `docs/active-conductor/requirements.md` and `docs/rfc/active-conductor.md` for authority and UX constraints.
2. Review `core/conductor.py` and `core/execution_preferences.py` for decision, ownership, and frugality rules.
3. Review `core/session_signal*.py` and `events/session_signal.py` for bounds, capability gating, transitions, and replay semantics.
4. Finish with `core/seed.py` and `evolution/` for semantic AC identity and non-relaxing successor enforcement.

## Test evidence

- Full suite at this stack layer: **12,188 passed, 5 skipped**
- Ruff check and format check: passed
- Mypy: **440 source files**, no issues
- `git diff --check`: passed
