### PR TITLE
feat(setup): refresh installed artifacts for all detected runtimes on upgrade

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -598,18 +598,14 @@ else
   _info "No backend selected; skipping runtime setup."
 fi
 
-# Refresh Codex rules/skills whenever this machine appears to use Codex, even
-# if the preserved primary runtime is another backend. Setup already does this
-# for `--runtime codex`, but upgrades and `all` installs should not leave stale
-# ~/.codex artifacts behind.
-if [ -n "$OUROBOROS_SETUP_CMD" ] && {
-  [ "$RUNTIME" = "codex" ] ||
-    [ "$EXTRAS" = "[all]" ] ||
-    [ "$HAS_CODEX" = true ] ||
-    [ -d "$HOME/.codex" ]
-}; then
-  _info "Refreshing Codex rules and skills"
-  "$OUROBOROS_SETUP_CMD" codex refresh || _warn "Codex artifact refresh skipped; run: ouroboros codex refresh"
+# Refresh already-installed artifacts for every detected runtime, even those
+# that are not the preserved primary backend. Setup only wires the selected
+# runtime, so upgrades must not leave other runtimes' rules/skills/bridges
+# stale. `setup refresh` is presence-gated per artifact and never touches MCP
+# registrations or config.
+if [ -n "$OUROBOROS_SETUP_CMD" ]; then
+  _info "Refreshing runtime artifacts for detected runtimes"
+  "$OUROBOROS_SETUP_CMD" setup refresh || _warn "Artifact refresh skipped; run: ouroboros setup refresh"
 fi
 
 # 5. Claude Code integration (MCP + skills)
@@ -699,6 +695,8 @@ if command -v claude &>/dev/null; then
   claude plugin marketplace add Q00/ouroboros 2>/dev/null || true
   claude plugin marketplace update ouroboros 2>/dev/null || true
   if claude plugin install ouroboros@ouroboros 2>/dev/null; then
+    # `install` is a no-op for an already-installed plugin — `update` moves it to the latest version
+    claude plugin update ouroboros@ouroboros >/dev/null 2>&1 || true
     _ok "Skills installed"
   else
     _warn "Skills skipped. Manual install: claude plugin marketplace add Q00/ouroboros && claude plugin install ouroboros@ouroboros"

--- a/src/ouroboros/cli/commands/setup.py
+++ b/src/ouroboros/cli/commands/setup.py
@@ -3269,6 +3269,108 @@ def setup(
     console.print("  ouroboros run workflow seed.yaml\n")
 
 
+# ── Artifact refresh subcommand ──────────────────────────────────
+
+
+def _opencode_bridge_dest() -> Path:
+    plugin_dir = opencode_config_dir()
+    for part in _BRIDGE_PLUGIN_SUBDIR:
+        plugin_dir = plugin_dir / part
+    return plugin_dir / _BRIDGE_PLUGIN_FILENAME
+
+
+@app.command("refresh")
+def refresh_artifacts() -> None:
+    """Refresh installed Ouroboros artifacts for every detected runtime.
+
+    Rewrites rules, skills, bridges, and instruction guides that a previous
+    setup already installed — without changing MCP registrations, the runtime
+    selection, or ~/.ouroboros/config.yaml. Codex follows ``ouroboros codex
+    refresh`` semantics and refreshes whenever Codex is present; every other
+    artifact refreshes only when it already exists, so a deliberately removed
+    integration (e.g. OpenCode subprocess mode) is never resurrected.
+    """
+    from ouroboros.hermes.artifacts import HERMES_SKILL_CATEGORY, HERMES_SKILL_NAME
+    from ouroboros.runtime_instruction_artifacts import (
+        copilot_instruction_path,
+        gemini_instruction_path,
+        gjc_agent_dir,
+        gjc_instruction_path,
+        has_managed_section,
+        kiro_instruction_path,
+        opencode_instruction_path,
+    )
+
+    refreshed: list[str] = []
+
+    codex_dir = Path.home() / ".codex"
+    if codex_dir.exists() or shutil.which("codex"):
+        from ouroboros.codex import install_codex_artifacts
+
+        try:
+            result = install_codex_artifacts(codex_dir=codex_dir, prune=False)
+        except OSError as exc:
+            # One runtime failing must not leave the remaining ones stale.
+            print_warning(f"Could not refresh Codex artifacts: {exc}")
+        else:
+            print_success(f"Installed Codex rules → {result.rules_path}")
+            print_success(
+                f"Installed {len(result.skill_paths)} Codex skills → {codex_dir / 'skills'}"
+            )
+            refreshed.append("codex")
+
+    hermes_skill_dir = Path.home() / ".hermes" / "skills" / HERMES_SKILL_CATEGORY
+    if (hermes_skill_dir / HERMES_SKILL_NAME).exists():
+        try:
+            _install_hermes_artifacts()
+        except OSError as exc:
+            print_warning(f"Could not refresh Hermes artifacts: {exc}")
+        else:
+            refreshed.append("hermes")
+
+    opencode_dir = opencode_config_dir()
+    opencode_touched = False
+    if _opencode_bridge_dest().exists():
+        opencode_touched = _install_opencode_bridge_plugin()
+    if has_managed_section(opencode_instruction_path(opencode_dir)):
+        _install_runtime_instruction_artifact("opencode", config_dir=opencode_dir)
+        opencode_touched = True
+    if opencode_touched:
+        refreshed.append("opencode")
+
+    if has_managed_section(gemini_instruction_path()):
+        _install_runtime_instruction_artifact("gemini")
+        refreshed.append("gemini")
+
+    if kiro_instruction_path().exists():
+        _install_runtime_instruction_artifact("kiro")
+        refreshed.append("kiro")
+
+    if copilot_instruction_path().exists():
+        _install_runtime_instruction_artifact("copilot")
+        refreshed.append("copilot")
+
+    pi_bridge = Path.home() / ".pi" / "agent" / "extensions" / _PI_OOO_BRIDGE_FILENAME
+    if pi_bridge.exists():
+        if _install_pi_ooo_bridge():
+            refreshed.append("pi")
+
+    gjc_touched = False
+    gjc_bridge = gjc_agent_dir() / "extensions" / _GJC_OOO_BRIDGE_SUBDIR / _GJC_OOO_BRIDGE_FILENAME
+    if gjc_bridge.exists():
+        gjc_touched = _install_gjc_ooo_bridge()
+    if gjc_instruction_path().exists():
+        _install_runtime_instruction_artifact("gjc")
+        gjc_touched = True
+    if gjc_touched:
+        refreshed.append("gjc")
+
+    if refreshed:
+        print_success(f"Refreshed runtime artifacts: {', '.join(refreshed)}")
+    else:
+        print_info("No installed runtime artifacts found to refresh.")
+
+
 # ── Brownfield subcommands ───────────────────────────────────────
 
 

--- a/src/ouroboros/runtime_instruction_artifacts.py
+++ b/src/ouroboros/runtime_instruction_artifacts.py
@@ -66,6 +66,14 @@ def _upsert_marked_section(existing: str, section: str) -> str:
     return f"{base}\n\n{section}"
 
 
+def has_managed_section(path: str | Path) -> bool:
+    """Return True when *path* already contains the setup-managed guide section."""
+    try:
+        return _SECTION_START in Path(path).read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return False
+
+
 def _write_managed_section(path: Path, backend: str) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     existing = path.read_text(encoding="utf-8") if path.exists() else ""
@@ -203,6 +211,7 @@ __all__ = [
     "gemini_instruction_path",
     "gjc_agent_dir",
     "gjc_instruction_path",
+    "has_managed_section",
     "install_copilot_instruction_artifact",
     "install_gemini_instruction_artifact",
     "install_gjc_instruction_artifact",

--- a/tests/unit/cli/commands/test_setup_refresh.py
+++ b/tests/unit/cli/commands/test_setup_refresh.py
@@ -1,0 +1,153 @@
+"""Unit tests for `ouroboros setup refresh`.
+
+Refresh must rewrite only artifacts a previous setup already installed, and
+must never touch MCP registrations, runtime selection, or config.yaml — so an
+install.sh upgrade cannot resurrect a deliberately removed integration (e.g.
+OpenCode subprocess mode) or silently rewire a runtime the user never set up.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from ouroboros.cli.commands.setup import app
+from ouroboros.codex import CodexArtifactInstallResult
+from ouroboros.hermes.artifacts import HERMES_SKILL_CATEGORY, HERMES_SKILL_NAME
+from ouroboros.runtime_instruction_artifacts import (
+    _SECTION_END,
+    _SECTION_START,
+    GUIDE_FILENAME,
+)
+
+runner = CliRunner()
+
+
+def _managed_section_text() -> str:
+    return f"user text\n\n{_SECTION_START}\nold guide\n{_SECTION_END}\n"
+
+
+def _invoke_refresh(tmp_path: Path):
+    """Run `setup refresh` with home/config dirs redirected into tmp_path."""
+    with (
+        patch("pathlib.Path.home", return_value=tmp_path),
+        patch("shutil.which", return_value=None),
+        patch(
+            "ouroboros.cli.commands.setup.opencode_config_dir",
+            return_value=tmp_path / ".config" / "opencode",
+        ),
+    ):
+        return runner.invoke(app, ["refresh"])
+
+
+class TestSetupRefreshPresenceGating:
+    def test_no_artifacts_installed_refreshes_nothing(self, tmp_path: Path) -> None:
+        result = _invoke_refresh(tmp_path)
+
+        assert result.exit_code == 0
+        assert "No installed runtime artifacts found to refresh." in result.output
+        assert not (tmp_path / ".gemini").exists()
+        assert not (tmp_path / ".kiro").exists()
+        assert not (tmp_path / ".copilot").exists()
+        assert not (tmp_path / ".pi").exists()
+
+    def test_absent_bridge_is_not_resurrected(self, tmp_path: Path) -> None:
+        """Subprocess-mode opencode (bridge removed) must stay bridge-free."""
+        opencode_dir = tmp_path / ".config" / "opencode"
+        opencode_dir.mkdir(parents=True)
+        (opencode_dir / "opencode.json").write_text("{}", encoding="utf-8")
+
+        result = _invoke_refresh(tmp_path)
+
+        assert result.exit_code == 0
+        assert not (opencode_dir / "plugins").exists()
+
+    def test_instruction_file_without_managed_section_is_untouched(self, tmp_path: Path) -> None:
+        gemini_md = tmp_path / ".gemini" / "GEMINI.md"
+        gemini_md.parent.mkdir(parents=True)
+        gemini_md.write_text("my own notes\n", encoding="utf-8")
+
+        result = _invoke_refresh(tmp_path)
+
+        assert result.exit_code == 0
+        assert gemini_md.read_text(encoding="utf-8") == "my own notes\n"
+
+
+class TestSetupRefreshUpdatesInstalledArtifacts:
+    def test_refreshes_managed_gemini_section(self, tmp_path: Path) -> None:
+        gemini_md = tmp_path / ".gemini" / "GEMINI.md"
+        gemini_md.parent.mkdir(parents=True)
+        gemini_md.write_text(_managed_section_text(), encoding="utf-8")
+
+        result = _invoke_refresh(tmp_path)
+
+        assert result.exit_code == 0
+        refreshed = gemini_md.read_text(encoding="utf-8")
+        assert refreshed.startswith("user text")
+        assert _SECTION_START in refreshed
+        assert "old guide" not in refreshed
+        assert "gemini" in result.output
+
+    def test_refreshes_existing_kiro_guide(self, tmp_path: Path) -> None:
+        guide = tmp_path / ".kiro" / "steering" / GUIDE_FILENAME
+        guide.parent.mkdir(parents=True)
+        guide.write_text("stale\n", encoding="utf-8")
+
+        result = _invoke_refresh(tmp_path)
+
+        assert result.exit_code == 0
+        assert guide.read_text(encoding="utf-8") != "stale\n"
+
+    def test_refreshes_existing_hermes_skills(self, tmp_path: Path) -> None:
+        skill_dir = tmp_path / ".hermes" / "skills" / HERMES_SKILL_CATEGORY / HERMES_SKILL_NAME
+        skill_dir.mkdir(parents=True)
+
+        with patch("ouroboros.cli.commands.setup._install_hermes_artifacts") as mock_hermes:
+            result = _invoke_refresh(tmp_path)
+
+        assert result.exit_code == 0
+        mock_hermes.assert_called_once_with()
+        assert "hermes" in result.output
+
+    def test_refreshes_existing_pi_bridge(self, tmp_path: Path) -> None:
+        bridge = tmp_path / ".pi" / "agent" / "extensions" / "ouroboros-ooo-bridge.ts"
+        bridge.parent.mkdir(parents=True)
+        bridge.write_text("// stale bridge\n", encoding="utf-8")
+
+        result = _invoke_refresh(tmp_path)
+
+        assert result.exit_code == 0
+        assert bridge.read_text(encoding="utf-8") != "// stale bridge\n"
+
+    def test_codex_refreshes_when_codex_dir_exists(self, tmp_path: Path) -> None:
+        codex_dir = tmp_path / ".codex"
+        codex_dir.mkdir()
+        install_result = CodexArtifactInstallResult(
+            rules_path=codex_dir / "rules" / "ouroboros.md",
+            skill_paths=(codex_dir / "skills" / "ouroboros-run",),
+        )
+
+        with patch(
+            "ouroboros.codex.install_codex_artifacts", return_value=install_result
+        ) as mock_install:
+            result = _invoke_refresh(tmp_path)
+
+        assert result.exit_code == 0
+        mock_install.assert_called_once_with(codex_dir=codex_dir, prune=False)
+        assert "codex" in result.output
+
+
+class TestSetupRefreshDoesNotTouchConfig:
+    def test_never_writes_config_or_mcp_files(self, tmp_path: Path) -> None:
+        gemini_md = tmp_path / ".gemini" / "GEMINI.md"
+        gemini_md.parent.mkdir(parents=True)
+        gemini_md.write_text(_managed_section_text(), encoding="utf-8")
+
+        result = _invoke_refresh(tmp_path)
+
+        assert result.exit_code == 0
+        assert not (tmp_path / ".ouroboros" / "config.yaml").exists()
+        assert not (tmp_path / ".claude" / "mcp.json").exists()
+        assert not (tmp_path / ".codex" / "config.toml").exists()

--- a/tests/unit/scripts/test_install_runtime_selection.py
+++ b/tests/unit/scripts/test_install_runtime_selection.py
@@ -150,6 +150,7 @@ def test_preserves_opencode_backend_from_existing_config(tmp_path: Path) -> None
     assert (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines() == [
         "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0 --with textual==8.2.8 --with textual-serve==1.1.3",
         "ouroboros setup --runtime opencode --non-interactive",
+        "ouroboros setup refresh",
     ]
 
 
@@ -213,6 +214,7 @@ def test_explicit_pi_installs_base_and_runs_pi_setup(tmp_path: Path) -> None:
     assert calls == [
         "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0 --with textual==8.2.8 --with textual-serve==1.1.3",
         "ouroboros setup --runtime pi --non-interactive",
+        "ouroboros setup refresh",
     ]
 
 
@@ -494,10 +496,11 @@ def test_detects_pi_as_single_runtime_and_runs_pi_setup(tmp_path: Path) -> None:
     assert calls == [
         "uv tool install --upgrade --python >=3.12 . --with click>=8.1.0,<9.0.0 --with textual==8.2.8 --with textual-serve==1.1.3",
         "ouroboros setup --runtime pi --non-interactive",
+        "ouroboros setup refresh",
     ]
 
 
-def test_explicit_codex_refreshes_codex_artifacts(tmp_path: Path) -> None:
+def test_explicit_codex_refreshes_runtime_artifacts(tmp_path: Path) -> None:
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_INSTALL_RUNTIME": "codex"},
@@ -507,10 +510,10 @@ def test_explicit_codex_refreshes_codex_artifacts(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     calls = (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines()
     assert "ouroboros setup --runtime codex --non-interactive" in calls
-    assert "ouroboros codex refresh" in calls
+    assert "ouroboros setup refresh" in calls
 
 
-def test_preserved_non_codex_runtime_still_refreshes_codex_when_detected(tmp_path: Path) -> None:
+def test_preserved_non_codex_runtime_still_refreshes_runtime_artifacts(tmp_path: Path) -> None:
     config_dir = tmp_path / "home" / ".ouroboros"
     config_dir.mkdir(parents=True)
     (config_dir / "config.yaml").write_text(
@@ -526,7 +529,7 @@ def test_preserved_non_codex_runtime_still_refreshes_codex_when_detected(tmp_pat
     assert result.returncode == 0, result.stderr
     calls = (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines()
     assert "ouroboros setup --runtime opencode --non-interactive" in calls
-    assert "ouroboros codex refresh" in calls
+    assert "ouroboros setup refresh" in calls
 
 
 def test_preserved_codex_runtime_refreshes_claude_skills_when_detected(tmp_path: Path) -> None:
@@ -554,7 +557,7 @@ def test_preserved_codex_runtime_refreshes_claude_skills_when_detected(tmp_path:
     assert not (tmp_path / "home" / ".claude" / "mcp.json").exists()
 
 
-def test_all_runtime_install_refreshes_codex_artifacts(tmp_path: Path) -> None:
+def test_all_runtime_install_refreshes_runtime_artifacts(tmp_path: Path) -> None:
     result = _run_installer(
         tmp_path,
         env={"OUROBOROS_INSTALL_RUNTIME": "all"},
@@ -562,7 +565,7 @@ def test_all_runtime_install_refreshes_codex_artifacts(tmp_path: Path) -> None:
 
     assert result.returncode == 0, result.stderr
     calls = (tmp_path / "calls.log").read_text(encoding="utf-8").splitlines()
-    assert "ouroboros codex refresh" in calls
+    assert "ouroboros setup refresh" in calls
 
 
 def test_pypi_lookup_failure_stays_stable_only_for_remote_install(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- **Root cause chain**: `install.sh` upgraded the CLI but left everything else stale — `claude plugin install` is a no-op when the plugin is already installed (registry stayed pinned at 0.50.0 while the CLI moved to 0.50.4), and only Codex artifacts were refreshed on upgrade; every other non-primary runtime kept stale rules/skills/bridges until its setup was manually re-run.
- **New `ouroboros setup refresh`**: rewrites rules, skills, bridges, and instruction guides that a previous setup already installed — without touching MCP registrations, the runtime selection, or `~/.ouroboros/config.yaml`. install.sh replaces its Codex-only refresh block with this command and now runs `claude plugin update` right after `plugin install`.
- **Safety semantics**: presence-gated per artifact, so a deliberately removed integration (OpenCode subprocess mode removes the bridge plugin on purpose) is never resurrected and runtimes the user never set up stay untouched. Codex keeps `codex refresh` semantics (refresh whenever `~/.codex`/codex CLI is present), preserving install.sh's prior behavior. Per-runtime `OSError` handling so one failing runtime (e.g. the symlinked-path guard) doesn't leave the rest stale — caught live in a sandboxed-HOME smoke test on macOS `/var`.

## Checks passed
- [x] ruff lint
- [x] ruff format
- [x] mypy
- [x] pytest (444 passed: setup/codex/bridge/install.sh suites)

## Test plan
- New `tests/unit/cli/commands/test_setup_refresh.py` (9 tests): presence gating (nothing installed → nothing written; absent bridge not resurrected; unmanaged GEMINI.md untouched), refresh of installed artifacts (gemini managed section, kiro guide, hermes skills, pi bridge, codex `prune=False`), and config/MCP immutability.
- Updated `test_install_runtime_selection.py`: `ouroboros codex refresh` expectations → `ouroboros setup refresh`, including the exact-call-list assertions.
- End-to-end smoke test in a sandboxed `$HOME`: managed GEMINI.md section replaced, kiro guide + pi bridge rewritten, codex failure warned-and-continued, no `config.yaml`/`mcp.json` created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)