### PR TITLE
docs(readme): align Korean runtime setup guidance

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -112,6 +112,22 @@ OUROBOROS_RUNTIME=kiro
 </details>
 
 <details>
+<summary><strong>GitHub Copilot CLI 빠른 시작</strong></summary>
+
+```bash
+gh auth login                                # 최초 1회 GitHub 인증(실시간 모델 검색에 사용)
+pipx install 'ouroboros-ai[mcp]'             # 또는: uv tool install 'ouroboros-ai[mcp]'
+ouroboros setup --runtime copilot            # 모델 실시간 검색 및 기본값 선택,
+                                             # ~/.copilot/mcp-config.json에 MCP 서버 등록
+```
+
+Copilot CLI 세션을 다시 시작한 뒤 세션 안에서 `ooo` 명령어를 사용합니다. 다른 설정에서 사용하는 하이픈 형식의 Anthropic 모델 ID(`claude-opus-4-6`)는 런타임에서 Copilot의 점 표기 형식(`claude-opus-4.6`)으로 자동 변환되므로, 백엔드를 전환해도 기존 설정을 그대로 사용할 수 있습니다.
+
+자세한 내용은 [GitHub Copilot CLI 런타임 가이드](./docs/runtime-guides/copilot.md)를 참고하세요.
+
+</details>
+
+<details>
 <summary><strong>다른 설치 방법</strong></summary>
 
 **Claude Code 플러그인만** (시스템 패키지 없이):

--- a/README.ko.md
+++ b/README.ko.md
@@ -92,13 +92,13 @@ curl -fsSL https://raw.githubusercontent.com/Q00/ouroboros/main/scripts/install.
 > ooo interview "I want to build a task management CLI"
 ```
 
-> Claude Code, Codex CLI, Kiro CLI 모두 지원합니다. 런타임 감지, MCP 서버 등록, 스킬 설치까지 자동으로 처리됩니다.
+> Claude Code, Codex CLI, GitHub Copilot CLI, OpenCode, Hermes, Gemini, Kiro CLI, Pi CLI를 지원합니다. 설치 프로그램은 Claude Code, Codex CLI, Hermes CLI를 자동으로 감지하고 호스트가 지원하는 경우 MCP 서버를 등록합니다. OpenCode, Kiro, GitHub Copilot CLI, Gemini CLI 또는 Pi CLI는 설치 후 `ouroboros setup --runtime <opencode|kiro|copilot|gemini|pi>`를 실행하세요. Copilot CLI 런타임은 GitHub Copilot models API를 통해 모델 카탈로그를 실시간으로 검색하고 설정 중 기본값을 선택할 수 있습니다.
 
 <details>
 <summary><strong>Kiro CLI 빠른 시작</strong></summary>
 
 ```bash
-pip install ouroboros-ai
+pip install 'ouroboros-ai[mcp,claude]'
 ouroboros setup            # Kiro CLI 감지 및 MCP 서버 등록
 ```
 


### PR DESCRIPTION
## Summary

- align the Korean Quick Start runtime list and setup guidance with the canonical English README
- install the quoted `ouroboros-ai[mcp,claude]` package spec in the Kiro quick start so the registered MCP server has its required dependencies

Fixes documentation severity: critical — the previous bare install omitted the optional MCP dependency required by the documented Kiro flow.

## Test plan

- [x] `git diff --check`
- [x] Cross-checked the runtime list and setup distinction against `README.md`
- [x] Cross-checked the Kiro package spec against `docs/runtime-guides/kiro.md` and `pyproject.toml`
- [x] Independent read-only review: CLEAR
- [x] Markdown-only change; no Python test, Ruff, or mypy surface changed

## Related issues

Follow-up to #1604