### PR TITLE
fix(orchestrator): delegate contract commands to verify gate

### DIFF
--- a/src/ouroboros/orchestrator/atomic_prompt_builder.py
+++ b/src/ouroboros/orchestrator/atomic_prompt_builder.py
@@ -45,7 +45,10 @@ def _build_success_contract_block(spec: AcceptanceCriterionSpec | None) -> str:
         return ""
     lines = ["SUCCESS CONTRACT for this AC:"]
     if spec.verify_command:
-        lines.append(f"- Run: {spec.verify_command} and report it in commands_run")
+        lines.append(
+            f"- Run locally before completion: {spec.verify_command}. "
+            "The verify gate re-runs it and records authoritative evidence."
+        )
     if spec.expected_artifacts:
         lines.append(
             "- Expected artifacts: "

--- a/src/ouroboros/orchestrator/evidence/ac_classification.py
+++ b/src/ouroboros/orchestrator/evidence/ac_classification.py
@@ -270,12 +270,13 @@ def _effective_evidence_schema_for_ac(
     """Return the active evidence schema for one atomic AC dispatch.
 
     ``has_success_contract`` is True when the AC declares a ``verify_command``.
-    For such ACs ``tests_passed`` is dropped from the required evidence set: the
-    orchestrator itself runs the declared command via ``_run_ac_verify_gate``
-    (real subprocess, real exit code + output_assertion), which is an
-    authoritative, non-fabricatable check — strictly stronger than reconstructing
-    "did a test pass" from the worker's transcript. Legacy ACs (no
-    ``verify_command``) keep ``tests_passed`` required and verified as before.
+    When the verify gate is active, such ACs drop ``commands_run`` and
+    ``tests_passed`` from the required evidence set: the orchestrator itself runs
+    the declared command via ``_run_ac_verify_gate`` (real subprocess, real exit
+    code + output_assertion), which is an authoritative, non-fabricatable check —
+    strictly stronger than reconstructing command execution or "did a test pass"
+    from the worker's transcript. Legacy ACs (no ``verify_command``) keep both
+    fields required and verified as before.
 
     ``has_expected_artifacts`` is True when the AC declares filesystem artifacts.
     For contract ACs that also declare artifacts, ``files_touched`` is likewise
@@ -284,22 +285,23 @@ def _effective_evidence_schema_for_ac(
     there is no filesystem oracle to replace it.
 
     ``verify_gate_active`` is True only when the orchestrator verify gate is
-    actually enabled (``run_verify_commands``). Delegation of ``tests_passed`` /
-    ``files_touched`` to the gate is *only* valid when the gate will run. When an
-    operator disables verify commands, the gate that would replace the transcript
-    check never fires (``_apply_verify_gate`` returns early), so we retain the
-    transcript-backed evidence — the pre-delegation behavior — as a fail-safe.
-    The default is ``False`` so we never delegate unless explicitly told the gate
-    is active. The content-based ``_is_validation_only_ac`` /
-    ``_is_documentation_only_ac`` drops are unaffected — those are not gate
-    delegations.
+    actually enabled (``run_verify_commands``). Delegation of ``commands_run``,
+    ``tests_passed``, and ``files_touched`` to the gate is *only* valid when the
+    gate will run. When an operator disables verify commands, the gate that would
+    replace the transcript check never fires (``_apply_verify_gate`` returns
+    early), so we retain the transcript-backed evidence — the pre-delegation
+    behavior — as a fail-safe. The default is ``False`` so we never delegate
+    unless explicitly told the gate is active. The content-based
+    ``_is_validation_only_ac`` / ``_is_documentation_only_ac`` drops are
+    unaffected — those are not gate delegations.
     """
     schema = profile.evidence_schema
     if _is_validation_only_ac(ac_content) and "files_touched" in schema.required:
         schema = _drop_required_evidence_field(schema, "files_touched")
     elif _is_documentation_only_ac(ac_content) and "tests_passed" in schema.required:
         schema = _drop_required_evidence_field(schema, "tests_passed")
-    if has_success_contract and verify_gate_active and "tests_passed" in schema.required:
+    if has_success_contract and verify_gate_active:
+        schema = _drop_required_evidence_field(schema, "commands_run")
         schema = _drop_required_evidence_field(schema, "tests_passed")
     if (
         has_success_contract

--- a/src/ouroboros/orchestrator/evidence/verification.py
+++ b/src/ouroboros/orchestrator/evidence/verification.py
@@ -39,11 +39,12 @@ def _verify_atomic_evidence_against_runtime_messages(
     accepted evidence cannot be supported only by the leaf's self-report.
 
     ``has_success_contract`` (the AC declares a ``verify_command``) drops
-    ``tests_passed`` from the required set, and contract ACs with declared
-    artifacts also drop ``files_touched`` — but only when ``verify_gate_active``
-    (``run_verify_commands`` is enabled) so the orchestrator's authoritative
-    ``_run_ac_verify_gate`` execution actually runs to replace those checks. With
-    the gate disabled the transcript-backed evidence is retained.
+    ``commands_run`` and ``tests_passed`` from the required set, and contract
+    ACs with declared artifacts also drop ``files_touched`` — but only when
+    ``verify_gate_active`` (``run_verify_commands`` is enabled) so the
+    orchestrator's authoritative ``_run_ac_verify_gate`` execution actually runs
+    to replace those checks. With the gate disabled the transcript-backed evidence
+    is retained.
     """
     support_messages = tuple(messages[:-1] if messages and messages[-1].is_final else messages)
     if not support_messages:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -3812,8 +3812,8 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
 
             duration = (datetime.now(UTC) - start_time).total_seconds()
 
-            # A contract-carrying AC (declares verify_command) delegates its
-            # tests_passed check to the orchestrator's authoritative
+            # A contract-carrying AC (declares verify_command) delegates
+            # commands_run and tests_passed to the orchestrator's authoritative
             # _run_ac_verify_gate. When it also declares expected_artifacts,
             # files_touched is delegated to that gate's filesystem oracle too
             # (see _effective_evidence_schema_for_ac).
@@ -3823,10 +3823,11 @@ Respond with either "ATOMIC" or the JSON array only, nothing else.
             has_expected_artifacts = isinstance(ac_spec, AcceptanceCriterionSpec) and bool(
                 ac_spec.expected_artifacts
             )
-            # Delegating tests_passed/files_touched to _run_ac_verify_gate is only
-            # valid when that gate actually runs. _apply_verify_gate returns early
-            # when run_verify_commands is disabled, so with the gate off we must
-            # retain the transcript-backed evidence rather than drop it.
+            # Delegating commands_run/tests_passed/files_touched to
+            # _run_ac_verify_gate is only valid when that gate actually runs.
+            # _apply_verify_gate returns early when run_verify_commands is disabled,
+            # so with the gate off we must retain the transcript-backed evidence
+            # rather than drop it.
             verify_gate_active = self._run_verify_commands
             typed_evidence, typed_validation, typed_error = self._observe_atomic_typed_evidence(
                 ac_content=ac_content,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -2003,38 +2003,32 @@ def test_correlated_tool_result_name_requires_one_exact_call_id_match() -> None:
     )
 
 
-def test_effective_schema_drops_tests_passed_for_contract_ac() -> None:
-    """A declared verify_command drops tests_passed from the required evidence set."""
+def test_effective_schema_delegates_contract_command_evidence() -> None:
+    """An active contract gate replaces transcript command and test evidence."""
     profile = load_profile("code")
-    assert "tests_passed" in profile.evidence_schema.required
 
-    legacy = _effective_evidence_schema_for_ac(profile, "Implement the module.")
-    assert "tests_passed" in legacy.required
-
-    contract = _effective_evidence_schema_for_ac(
+    schema = _effective_evidence_schema_for_ac(
         profile,
         "Implement the module.",
         has_success_contract=True,
         verify_gate_active=True,
     )
-    assert "tests_passed" not in contract.required
-    # Without declared expected_artifacts, there is no filesystem oracle for
-    # files_touched, so it stays transcript-gated.
-    assert "files_touched" in contract.required
-    assert "commands_run" in contract.required
 
-    artifact_contract = _effective_evidence_schema_for_ac(
+    assert schema.required == ("files_touched",)
+
+    artifact_schema = _effective_evidence_schema_for_ac(
         profile,
         "Implement the module.",
         has_success_contract=True,
         has_expected_artifacts=True,
         verify_gate_active=True,
     )
-    assert artifact_contract.required == ("commands_run",)
+
+    assert artifact_schema.required == ()
 
 
-def test_legacy_ac_keeps_files_touched_required_even_with_expected_artifacts_flag() -> None:
-    """Expected artifacts only delegate files_touched when a verify command is present."""
+def test_legacy_ac_keeps_transcript_backed_evidence() -> None:
+    """Legacy ACs retain every transcript-backed required evidence field."""
     profile = load_profile("code")
 
     schema = _effective_evidence_schema_for_ac(
@@ -2044,18 +2038,11 @@ def test_legacy_ac_keeps_files_touched_required_even_with_expected_artifacts_fla
         has_expected_artifacts=True,
     )
 
-    assert "files_touched" in schema.required
-    assert "tests_passed" in schema.required
+    assert schema.required == ("files_touched", "commands_run", "tests_passed")
 
 
-def test_contract_ac_retains_evidence_when_verify_gate_inactive() -> None:
-    """With the verify gate disabled there is no oracle to delegate to.
-
-    ``_apply_verify_gate`` returns early when ``run_verify_commands`` is False, so
-    dropping ``tests_passed`` / ``files_touched`` would leave a contract AC with an
-    unbacked, self-reported artifact and no check. The fail-safe default retains
-    the transcript-backed evidence.
-    """
+def test_contract_ac_retains_transcript_backed_evidence_when_verify_gate_inactive() -> None:
+    """A disabled contract gate cannot replace transcript-backed evidence."""
     profile = load_profile("code")
 
     schema = _effective_evidence_schema_for_ac(
@@ -2066,13 +2053,11 @@ def test_contract_ac_retains_evidence_when_verify_gate_inactive() -> None:
         verify_gate_active=False,
     )
 
-    assert "files_touched" in schema.required
-    assert "tests_passed" in schema.required
-    assert "commands_run" in schema.required
+    assert schema.required == ("files_touched", "commands_run", "tests_passed")
 
 
-def test_contract_ac_drops_delegated_fields_only_when_verify_gate_active() -> None:
-    """The delegation drop fires only once the verify gate is confirmed active."""
+def test_contract_ac_with_artifacts_delegates_all_evidence_when_verify_gate_active() -> None:
+    """An active contract gate replaces all evidence when it checks artifacts too."""
     profile = load_profile("code")
 
     schema = _effective_evidence_schema_for_ac(
@@ -2083,16 +2068,14 @@ def test_contract_ac_drops_delegated_fields_only_when_verify_gate_active() -> No
         verify_gate_active=True,
     )
 
-    assert schema.required == ("commands_run",)
+    assert schema.required == ()
 
 
-def test_contract_ac_verifier_delegates_tests_passed() -> None:
-    """Contract AC: the transcript verifier does not gate tests_passed at all.
+def test_contract_ac_verifier_delegates_command_evidence() -> None:
+    """Contract ACs do not transcript-gate commands_run or tests_passed.
 
-    Only files_touched + commands_run are checked; the tests_passed check is
-    delegated to the orchestrator verify-gate. Evidence with no tests_passed field
-    still passes the transcript verifier, so worker sample-input variance in the
-    verification command is irrelevant here.
+    Only files_touched is checked without expected artifacts; command execution and
+    test success are delegated to the orchestrator verify gate.
     """
     executor = _file_scope_executor("/private/tmp/ooo-repro-blos")
     verdict = executor._verify_atomic_evidence_against_runtime_messages(
@@ -2110,8 +2093,8 @@ def test_contract_ac_verifier_delegates_tests_passed() -> None:
     assert verdict.passed is True, verdict.reasons
 
 
-def test_contract_ac_with_expected_artifacts_verifier_delegates_files_touched() -> None:
-    """Contract AC artifacts are verified by the filesystem gate, not transcript claims."""
+def test_contract_ac_with_expected_artifacts_verifier_delegates_all_evidence() -> None:
+    """Contract AC artifacts and command execution are verified by the gate."""
     executor = _file_scope_executor("/private/tmp/ooo-repro-blos")
     verdict = executor._verify_atomic_evidence_against_runtime_messages(
         messages=_greeting_repro_messages("/private/tmp/ooo-repro-blos/hello.py"),
@@ -4798,13 +4781,12 @@ class TestParallelACExecutor:
         assert evidence_event.data["verifier_ran"] is False
 
     @pytest.mark.asyncio
-    async def test_contract_ac_with_artifacts_accepts_unbacked_files_touched_claim(
+    async def test_contract_ac_with_artifacts_ignores_transcript_claims(
         self,
         tmp_path,
     ) -> None:
-        """A contract AC delegates artifact proof to the verify gate filesystem oracle."""
+        """The verify gate owns artifact and command proof for contract ACs."""
         command = "python -c \"print('OK')\""
-        command_json = command.replace("\\", "\\\\").replace('"', '\\"')
         (tmp_path / "hello.py").write_text(
             "def greet(name):\n    return f'Hello, {name}'\n",
             encoding="utf-8",
@@ -4815,7 +4797,7 @@ class TestParallelACExecutor:
             "```json\n"
             "{"
             '"files_touched":["not-backed-by-transcript.py"],'
-            f'"commands_run":["{command_json}"]'
+            '"commands_run":0'
             "}\n"
             "```",
             native_session_id="codex-session-contract-artifact-delegation",
@@ -4859,19 +4841,22 @@ class TestParallelACExecutor:
         assert result.success is True
         assert result.error is None
         assert result.typed_evidence is not None
-        assert result.typed_evidence.data == {"commands_run": [command]}
+        assert result.typed_evidence.data == {}
         assert runtime.last_prompt is not None
-        assert "directly (commands_run)" in runtime.last_prompt
+        assert "directly (commands_run)" not in runtime.last_prompt
         assert "ensure they exist in the workspace" in runtime.last_prompt
         evidence_event = next(
             event
             for event in appended_events
             if event.type == "execution.ac.typed_evidence.observed"
         )
-        assert evidence_event.data["required_fields"] == ["commands_run"]
+        assert evidence_event.data["required_fields"] == []
         assert evidence_event.data["typed_evidence_valid"] is True
         assert evidence_event.data["verifier_passed"] is True
-        assert evidence_event.data["ignored_out_of_scope_evidence_fields"] == ["files_touched"]
+        assert evidence_event.data["ignored_out_of_scope_evidence_fields"] == [
+            "files_touched",
+            "commands_run",
+        ]
 
     @pytest.mark.asyncio
     async def test_contract_ac_missing_artifact_rejected_when_verify_gate_disabled(
@@ -4881,10 +4866,10 @@ class TestParallelACExecutor:
         """Reproduced blocker: with the verify gate off, delegation must not fire.
 
         ``run_verify_commands=False`` makes ``_apply_verify_gate`` return early, so
-        the filesystem oracle never checks ``expected_artifacts``. If the schema
-        still dropped ``files_touched``/``tests_passed``, a contract AC could
-        complete with only ``commands_run`` evidence and no artifact on disk. The
-        verify-gate-active guard keeps those fields required (transcript-backed),
+        neither the filesystem oracle nor command exit status verifies the contract.
+        If the schema still dropped ``commands_run``/``tests_passed``/``files_touched``,
+        a contract AC could complete without transcript-backed evidence or an
+        artifact on disk. The verify-gate-active guard keeps those fields required,
         so the worker's self-reported evidence fails and the AC is not accepted.
         """
         command = "python -c \"print('OK')\""
@@ -4939,8 +4924,9 @@ class TestParallelACExecutor:
             for event in appended_events
             if event.type == "execution.ac.typed_evidence.observed"
         )
-        # files_touched/tests_passed remain required because the gate is off.
+        # files_touched, commands_run, and tests_passed remain required because the gate is off.
         assert "files_touched" in evidence_event.data["required_fields"]
+        assert "commands_run" in evidence_event.data["required_fields"]
         assert "tests_passed" in evidence_event.data["required_fields"]
         assert evidence_event.data["typed_evidence_valid"] is False
 

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1148,7 +1148,11 @@ class TestSuccessContractBlock:
         )
         block = _build_success_contract_block(spec)
         assert block.startswith("SUCCESS CONTRACT for this AC:")
-        assert "- Run: make build and report it in commands_run" in block
+        assert (
+            "- Run locally before completion: make build. "
+            "The verify gate re-runs it and records authoritative evidence."
+            in block
+        )
         assert (
             "- Expected artifacts: dist/app, dist/app.map — ensure they exist in the workspace"
             in block
@@ -1158,6 +1162,10 @@ class TestSuccessContractBlock:
     def test_partial_contract_only_renders_present_fields(self) -> None:
         spec = AcceptanceCriterionSpec(description="verify only", verify_command="pytest -q")
         block = _build_success_contract_block(spec)
-        assert "- Run: pytest -q and report it in commands_run" in block
+        assert (
+            "- Run locally before completion: pytest -q. "
+            "The verify gate re-runs it and records authoritative evidence."
+            in block
+        )
         assert "Expected artifacts" not in block
         assert "Expected output" not in block

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1150,8 +1150,7 @@ class TestSuccessContractBlock:
         assert block.startswith("SUCCESS CONTRACT for this AC:")
         assert (
             "- Run locally before completion: make build. "
-            "The verify gate re-runs it and records authoritative evidence."
-            in block
+            "The verify gate re-runs it and records authoritative evidence." in block
         )
         assert (
             "- Expected artifacts: dist/app, dist/app.map — ensure they exist in the workspace"
@@ -1164,8 +1163,7 @@ class TestSuccessContractBlock:
         block = _build_success_contract_block(spec)
         assert (
             "- Run locally before completion: pytest -q. "
-            "The verify gate re-runs it and records authoritative evidence."
-            in block
+            "The verify gate re-runs it and records authoritative evidence." in block
         )
         assert "Expected artifacts" not in block
         assert "Expected output" not in block


### PR DESCRIPTION
## Summary

- delegate `commands_run` and `tests_passed` transcript evidence to the authoritative verify gate only for contract-carrying ACs when that gate is active
- preserve fail-closed transcript requirements for legacy ACs and `run_verify_commands=False`
- cover exact required-field tuples, malformed `commands_run: 0`, prompt scoping, and emitted evidence metadata

The orchestrator already executes the declared `verify_command` and gates on its real exit status, so requiring the worker to reconstruct the same command from its transcript was redundant and caused valid Codex runs to waste retries.

## Test plan

- [x] Focused contract/legacy/verify-gate selection: `9 passed, 260 deselected`
- [x] `uv run --python 3.13 pytest tests/unit/orchestrator/test_parallel_executor.py -q`: `269 passed`
- [x] `uv run --python 3.13 pytest tests/unit/orchestrator/ -q`: `2807 passed, 2 skipped`
- [x] Ruff check and format check on all three changed files
- [x] mypy on both changed source files
- [x] `git diff --check`
- [x] Independent read-only review: CLEAR
- [ ] Full `tests/unit/` run did not complete within the 300s local limit; it reached 49%. The only two observed failures were in `tests/unit/cli/test_setup.py` and were reproduced unchanged on unmodified `main` in the same checkout environment.

## Related issues

Fixes #1594