### PR TITLE
fix(brownfield): guarantee repo list visibility by ending turn before default selection

### DIFF
--- a/.claude-plugin/skills/brownfield/SKILL.md
+++ b/.claude-plugin/skills/brownfield/SKILL.md
@@ -33,8 +33,7 @@ Show scanning indicator:
   Scanning for Existing Projects...
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Looking for git repositories and worktrees under the scan root directory.
-Linked worktrees reported by discovered normal repo roots may also be registered, even outside the scan root directory.
+Looking for git repositories and worktrees up to two directories below the scan root.
 Local repos and repos with any remote name are eligible.
 This may take a moment...
 ```
@@ -55,7 +54,7 @@ stop with the MCP-not-available message instead of retrying the failing call.
    Tool: ouroboros_brownfield
    Arguments: { "action": "scan" }
    ```
-   This walks `scan_root` for valid seed repos/worktrees and registers them in DB. For each discovered normal repo root with a `.git` directory, Git-reported linked worktrees are also considered, even when they live outside `scan_root`. A linked worktree found under `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`. Existing defaults are preserved.
+   This walks `scan_root` (up to two directory levels deep) for valid seed repos/worktrees and registers them in DB. Each repo or worktree found directly by the walk is registered self-only — Git worktree families are not expanded, so worktrees outside the depth-bounded walk (e.g. under `.ouroboros/worktrees`) are not pulled in. Existing defaults are preserved.
 
 The scan response `text` already contains a pre-formatted numbered list with `[default]` markers. **Do NOT make any additional MCP calls to list or query repos.**
 
@@ -81,10 +80,9 @@ Then stop.
 ### Scan boundaries
 
 - The filesystem walk starts at `scan_root`; when omitted, `scan_root` defaults to the current user's home directory.
-- Repositories are only discovered directly by walking directories inside `scan_root`.
+- Repositories are discovered by walking directories inside `scan_root`, at most two levels deep (so `~/repo` and `~/group/repo` are found; deeper nesting is not).
 - Dot-prefixed directories and known noisy directories such as `node_modules` are not walked as seed locations.
-- Git worktrees are different: once a normal repo root with a `.git` directory is discovered, Ouroboros runs `git worktree list --porcelain` and may register those linked worktrees even if their paths are outside `scan_root`.
-- A linked worktree found inside `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`.
+- Both normal repos (`.git` directory) and linked worktrees (`.git` file) are registered when the walk reaches them. Git worktree families are NOT expanded — a worktree is only registered if the walk finds it directly, not because its main repo's Git metadata reports it.
 - Local repos, repos without remotes, and repos whose remotes are not named `origin` are all eligible.
 
 **Step 2: Default Selection**

--- a/.claude-plugin/skills/brownfield/SKILL.md
+++ b/.claude-plugin/skills/brownfield/SKILL.md
@@ -89,43 +89,41 @@ Then stop.
 
 **Step 2: Default Selection**
 
-**IMMEDIATELY after showing the list**, use `AskUserQuestion` with the current default numbers from the scan response.
+**Do NOT use `AskUserQuestion` for this selection.** Assistant text emitted
+between tool calls is not guaranteed to render, so a question dialog fired in
+the same turn can appear without the repo list the user needs to answer it.
+Option `preview` fields cannot hold the list either — the preview box has a
+fixed height and silently truncates long lists.
 
-**If defaults exist**, show them as the recommended option:
+Instead, **end the turn with the repo grid as the final message** and collect
+the selection as a plain chat reply. Immediately below the grid, append:
 
-```json
-{
-  "questions": [{
-    "question": "Which repos to set as default for interviews? Enter numbers like '6, 18, 19'.",
-    "header": "Default Repos",
-    "options": [
-      {"label": "<current default numbers> (Recommended)", "description": "<current default names>"},
-      {"label": "None", "description": "No default repos — interviews will run in greenfield mode"}
-    ],
-    "multiSelect": false
-  }]
-}
+**If defaults exist:**
+```
+Current defaults: <current default names> (numbers <current default numbers>)
+
+Reply with repo numbers to change defaults (e.g. "6, 18, 19"),
+"keep" to keep the current defaults, or "none" to clear them.
 ```
 
-**If no defaults exist**, do NOT show a "(Recommended)" option — offer "None" and "Select repos" instead:
+**If no defaults exist:**
+```
+No defaults set.
 
-```json
-{
-  "questions": [{
-    "question": "Which repos to set as default for interviews? Enter numbers like '6, 18, 19'.",
-    "header": "Default Repos",
-    "options": [
-      {"label": "None", "description": "No default repos — interviews will run in greenfield mode"},
-      {"label": "Select repos", "description": "Type repo numbers to set as default"}
-    ],
-    "multiSelect": false
-  }]
-}
+Reply with repo numbers to set defaults (e.g. "6, 18, 19"),
+or "none" to run interviews in greenfield mode.
 ```
 
-The user can select the recommended defaults (if any), choose "None", or type custom numbers.
+Then **end the turn** — no tool calls after the grid.
 
-After the user responds, re-run `tool discovery query: "+ouroboros brownfield"`, then use ONE MCP call to update all defaults at once:
+On the next turn, parse the user's reply:
+
+- Numbers (any separator) → those indices
+- "keep" (defaults exist) → stop; no MCP call needed, confirm defaults unchanged
+- "none" → empty indices (clear all)
+- Anything else → ask again in plain text; do not guess
+
+Then re-run `tool discovery query: "+ouroboros brownfield"` and use ONE MCP call to update all defaults at once:
 
 ```
 Tool: ouroboros_brownfield
@@ -151,6 +149,12 @@ Or if "None" selected:
 ```
 No default repos set. Interviews will run in greenfield mode.
 You can set defaults anytime with: ooo brownfield
+```
+
+Or if "keep" selected:
+```
+Brownfield defaults unchanged.
+Defaults: <current default names>
 ```
 
 ---

--- a/.claude-plugin/skills/setup/SKILL.md
+++ b/.claude-plugin/skills/setup/SKILL.md
@@ -462,46 +462,43 @@ Include `*` markers for defaults exactly as they appear in the scan response. Do
 
 **If no repos found**, skip the default selection prompt and proceed to Step 6.
 
-**Default repo selection — IMMEDIATELY after showing the list:**
+**Default repo selection — end the turn with the list:**
 
-Use `AskUserQuestion` with the current default numbers from the scan response.
+**Do NOT use `AskUserQuestion` for this selection.** Assistant text emitted
+between tool calls is not guaranteed to render, so a question dialog fired in
+the same turn can appear without the repo list the user needs to answer it.
+Option `preview` fields cannot hold the list either — the preview box has a
+fixed height and silently truncates long lists.
 
-**If defaults exist**, show them as the recommended option:
+Instead, **end the turn with the repo grid as the final message** and collect
+the selection as a plain chat reply. Immediately below the grid, append:
 
-```json
-{
-  "questions": [{
-    "question": "Which repos to set as default for interviews? Enter numbers like '6, 18, 19'.",
-    "header": "Default Repos",
-    "options": [
-      {"label": "<current default numbers> (Recommended)", "description": "<current default names>"},
-      {"label": "None", "description": "Clear all defaults — interviews will run in greenfield mode"},
-      {"label": "Select repos", "description": "Type repo numbers to set as default"}
-    ],
-    "multiSelect": false
-  }]
-}
+**If defaults exist:**
+```
+Current defaults: <current default names> (numbers <current default numbers>)
+
+Reply with repo numbers to change defaults (e.g. "6, 18, 19"),
+"keep" to keep the current defaults, or "none" to clear them.
 ```
 
-**If no defaults exist**, do NOT show a "(Recommended)" option — offer "None" and "Select repos" instead:
+**If no defaults exist:**
+```
+No defaults set.
 
-```json
-{
-  "questions": [{
-    "question": "Which repos to set as default for interviews? Enter numbers like '6, 18, 19'.",
-    "header": "Default Repos",
-    "options": [
-      {"label": "None", "description": "No default repos — interviews will run in greenfield mode"},
-      {"label": "Select repos", "description": "Type repo numbers to set as default"}
-    ],
-    "multiSelect": false
-  }]
-}
+Reply with repo numbers to set defaults (e.g. "6, 18, 19"),
+or "none" to run interviews in greenfield mode.
 ```
 
-The user can select the recommended defaults (if any), choose "None", or type custom numbers.
+Then **end the turn** — no tool calls after the grid.
 
-After the user responds, re-run `tool discovery query: "+ouroboros brownfield"`, then use ONE MCP call to update all defaults at once:
+On the next turn, parse the user's reply:
+
+- Numbers (any separator) → those indices
+- "keep" (defaults exist) → skip the MCP call, confirm defaults unchanged, proceed to Step 6
+- "none" → empty indices (clear all)
+- Anything else → ask again in plain text; do not guess
+
+Then re-run `tool discovery query: "+ouroboros brownfield"` and use ONE MCP call to update all defaults at once:
 
 ```
 Tool: ouroboros_brownfield
@@ -526,6 +523,12 @@ Or if "none" selected:
 ```
 No default repos set. interviews will run in greenfield mode.
 You can set defaults anytime by running ooo setup again.
+```
+
+Or if "keep" selected:
+```
+Brownfield defaults unchanged.
+Defaults: <current default names>
 ```
 
 ---

--- a/.claude-plugin/skills/setup/SKILL.md
+++ b/.claude-plugin/skills/setup/SKILL.md
@@ -413,8 +413,8 @@ Scan a root directory for existing git repositories and linked worktrees, then r
   Scanning for Existing Projects...
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Looking for git repositories and worktrees under the scan root directory.
-Linked worktrees reported by discovered normal repo roots may also be registered, even outside the scan root directory.
+Looking for git repositories and worktrees up to two directories below the scan root.
+Only repositories and worktrees reached directly by this depth-bounded walk are registered.
 Local repos and repos with any remote name are eligible.
 This may take a moment...
 ```
@@ -435,14 +435,14 @@ non-MCP setup fallback instead of retrying the failing call.
    Tool: ouroboros_brownfield
    Arguments: { "action": "scan" }
    ```
-   This walks `scan_root` for valid seed repos/worktrees and registers them in DB. For each discovered normal repo root with a `.git` directory, Git-reported linked worktrees are also considered, even when they live outside `scan_root`. A linked worktree found under `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`. Existing defaults are preserved.
+   This walks `scan_root` up to two directory levels deep for valid seed repos/worktrees and registers them in DB. Each repo or worktree reached directly by the walk is registered self-only. Git worktree families are not expanded, so main or sibling worktrees outside the depth-bounded walk are not pulled in. Existing defaults are preserved.
 
 **Scan boundaries:**
 - The filesystem walk starts at `scan_root`; when omitted, `scan_root` defaults to the current user's home directory.
-- Repositories are only discovered directly by walking directories inside `scan_root`.
+- Repositories are discovered directly by walking directories inside `scan_root`, at most two levels deep.
 - Dot-prefixed directories and known noisy directories such as `node_modules` are not walked as seed locations.
-- Git worktrees are different: once a normal repo root with a `.git` directory is discovered, Ouroboros runs `git worktree list --porcelain` and may register those linked worktrees even if their paths are outside `scan_root`.
-- A linked worktree found inside `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`.
+- Both normal repos with a `.git` directory and linked worktrees with a `.git` file are registered when the walk reaches them.
+- Git worktree families are not expanded. A worktree is registered only when the depth-bounded walk finds it directly.
 - Local repos, repos without remotes, and repos whose remotes are not named `origin` are all eligible.
 
 The scan response `text` already contains a pre-formatted numbered list with `[default]` markers. **Do NOT make any additional MCP calls to list or query repos.**

--- a/skills/brownfield/SKILL.md
+++ b/skills/brownfield/SKILL.md
@@ -87,43 +87,49 @@ Then stop.
 
 **Step 2: Default Selection**
 
-**IMMEDIATELY after showing the list**, use `AskUserQuestion` with the current default numbers from the scan response.
+**Do NOT use `AskUserQuestion` for this selection.** Two rendering constraints
+make it unusable here:
 
-**If defaults exist**, show them as the recommended option:
+- Assistant text emitted between tool calls (scan result → grid → question
+  dialog) is not guaranteed to render, so the user may face the dialog
+  without ever seeing the repo list.
+- Embedding the list in option `preview` fields does not work either — the
+  preview box has a fixed height and silently truncates long lists
+  ("N lines hidden"), and repo lists routinely exceed it.
 
-```json
-{
-  "questions": [{
-    "question": "Which repos to set as default for interviews? Enter numbers like '6, 18, 19'.",
-    "header": "Default Repos",
-    "options": [
-      {"label": "<current default numbers> (Recommended)", "description": "<current default names>"},
-      {"label": "None", "description": "No default repos — interviews will run in greenfield mode"}
-    ],
-    "multiSelect": false
-  }]
-}
+Instead, **end the turn with the repo grid as the final message** so its
+display is guaranteed, and collect the selection as a plain chat reply.
+
+Immediately below the grid (same message, same code block or right after it),
+append the selection prompt:
+
+**If defaults exist:**
+```
+Current defaults: <current default names> (numbers <current default numbers>)
+
+Reply with repo numbers to change defaults (e.g. "6, 18, 19"),
+"keep" to keep the current defaults, or "none" to clear them.
 ```
 
-**If no defaults exist**, do NOT show a "(Recommended)" option — offer "None" and "Select repos" instead:
+**If no defaults exist:**
+```
+No defaults set.
 
-```json
-{
-  "questions": [{
-    "question": "Which repos to set as default for interviews? Enter numbers like '6, 18, 19'.",
-    "header": "Default Repos",
-    "options": [
-      {"label": "None", "description": "No default repos — interviews will run in greenfield mode"},
-      {"label": "Select repos", "description": "Type repo numbers to set as default"}
-    ],
-    "multiSelect": false
-  }]
-}
+Reply with repo numbers to set defaults (e.g. "6, 18, 19"),
+or "none" to run interviews in greenfield mode.
 ```
 
-The user can select the recommended defaults (if any), choose "None", or type custom numbers.
+Then **end the turn** — no tool calls after the grid. The RFC #1392
+breadcrumb footer is still the last line of the message.
 
-After the user responds, re-run `tool discovery query: "+ouroboros brownfield"`, then use ONE MCP call to update all defaults at once:
+On the next turn, parse the user's reply:
+
+- Numbers (any separator) → those indices
+- "keep" (defaults exist) → stop; no MCP call needed, confirm defaults unchanged
+- "none" → empty indices (clear all)
+- Anything else → ask again in plain text; do not guess
+
+Then re-run `tool discovery query: "+ouroboros brownfield"` and use ONE MCP call to update all defaults at once:
 
 ```
 Tool: ouroboros_brownfield
@@ -134,7 +140,7 @@ Example: if the user picks IDs 6, 18, 19 → `{ "action": "set_defaults", "indic
 
 This clears all existing defaults and sets the selected repos as default in one call.
 
-If "None" → `{ "action": "set_defaults", "indices": "" }` to clear all defaults.
+If "none" → `{ "action": "set_defaults", "indices": "" }` to clear all defaults.
 
 **Step 3: Confirmation**
 
@@ -145,10 +151,15 @@ Defaults: grape, podo-app, podo-backend
 These repos will be used as context in interviews.
 ```
 
-Or if "None" selected:
+Or if "none" selected:
 ```
 No default repos set. Interviews will run in greenfield mode.
 You can set defaults anytime with: ooo brownfield
+```
+
+Or if "keep" selected:
+```
+Defaults unchanged: <current default names>
 ```
 
 ---

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -462,46 +462,45 @@ Include `*` markers for defaults exactly as they appear in the scan response. Do
 
 **If no repos found**, skip the default selection prompt and proceed to Step 6.
 
-**Default repo selection — IMMEDIATELY after showing the list:**
+**Default repo selection — end the turn with the list:**
 
-Use `AskUserQuestion` with the current default numbers from the scan response.
+**Do NOT use `AskUserQuestion` for this selection.** Assistant text emitted
+between tool calls is not guaranteed to render, so a question dialog fired in
+the same turn can appear without the repo list the user needs to answer it.
+Option `preview` fields cannot hold the list either — the preview box has a
+fixed height and silently truncates long lists.
 
-**If defaults exist**, show them as the recommended option:
+Instead, **end the turn with the repo grid as the final message** so its
+display is guaranteed, and collect the selection as a plain chat reply.
 
-```json
-{
-  "questions": [{
-    "question": "Which repos to set as default for interviews? Enter numbers like '6, 18, 19'.",
-    "header": "Default Repos",
-    "options": [
-      {"label": "<current default numbers> (Recommended)", "description": "<current default names>"},
-      {"label": "None", "description": "Clear all defaults — interviews will run in greenfield mode"},
-      {"label": "Select repos", "description": "Type repo numbers to set as default"}
-    ],
-    "multiSelect": false
-  }]
-}
+Immediately below the grid, append the selection prompt:
+
+**If defaults exist:**
+```
+Current defaults: <current default names> (numbers <current default numbers>)
+
+Reply with repo numbers to change defaults (e.g. "6, 18, 19"),
+"keep" to keep the current defaults, or "none" to clear them.
 ```
 
-**If no defaults exist**, do NOT show a "(Recommended)" option — offer "None" and "Select repos" instead:
+**If no defaults exist:**
+```
+No defaults set.
 
-```json
-{
-  "questions": [{
-    "question": "Which repos to set as default for interviews? Enter numbers like '6, 18, 19'.",
-    "header": "Default Repos",
-    "options": [
-      {"label": "None", "description": "No default repos — interviews will run in greenfield mode"},
-      {"label": "Select repos", "description": "Type repo numbers to set as default"}
-    ],
-    "multiSelect": false
-  }]
-}
+Reply with repo numbers to set defaults (e.g. "6, 18, 19"),
+or "none" to run interviews in greenfield mode.
 ```
 
-The user can select the recommended defaults (if any), choose "None", or type custom numbers.
+Then **end the turn** — no tool calls after the grid.
 
-After the user responds, re-run `tool discovery query: "+ouroboros brownfield"`, then use ONE MCP call to update all defaults at once:
+On the next turn, parse the user's reply:
+
+- Numbers (any separator) → those indices
+- "keep" (defaults exist) → skip the MCP call, confirm defaults unchanged, proceed to Step 6
+- "none" → empty indices (clear all)
+- Anything else → ask again in plain text; do not guess
+
+Then re-run `tool discovery query: "+ouroboros brownfield"` and use ONE MCP call to update all defaults at once:
 
 ```
 Tool: ouroboros_brownfield

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -413,8 +413,8 @@ Scan a root directory for existing git repositories and linked worktrees, then r
   Scanning for Existing Projects...
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-Looking for git repositories and worktrees under the scan root directory.
-Linked worktrees reported by discovered normal repo roots may also be registered, even outside the scan root directory.
+Looking for git repositories and worktrees up to two directories below the scan root.
+Only repositories and worktrees reached directly by this depth-bounded walk are registered.
 Local repos and repos with any remote name are eligible.
 This may take a moment...
 ```
@@ -435,14 +435,14 @@ non-MCP setup fallback instead of retrying the failing call.
    Tool: ouroboros_brownfield
    Arguments: { "action": "scan" }
    ```
-   This walks `scan_root` for valid seed repos/worktrees and registers them in DB. For each discovered normal repo root with a `.git` directory, Git-reported linked worktrees are also considered, even when they live outside `scan_root`. A linked worktree found under `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`. Existing defaults are preserved.
+   This walks `scan_root` up to two directory levels deep for valid seed repos/worktrees and registers them in DB. Each repo or worktree reached directly by the walk is registered self-only. Git worktree families are not expanded, so main or sibling worktrees outside the depth-bounded walk are not pulled in. Existing defaults are preserved.
 
 **Scan boundaries:**
 - The filesystem walk starts at `scan_root`; when omitted, `scan_root` defaults to the current user's home directory.
-- Repositories are only discovered directly by walking directories inside `scan_root`.
+- Repositories are discovered directly by walking directories inside `scan_root`, at most two levels deep.
 - Dot-prefixed directories and known noisy directories such as `node_modules` are not walked as seed locations.
-- Git worktrees are different: once a normal repo root with a `.git` directory is discovered, Ouroboros runs `git worktree list --porcelain` and may register those linked worktrees even if their paths are outside `scan_root`.
-- A linked worktree found inside `scan_root` with a `.git` file is registered itself, but it is not used to register its main worktree or sibling worktrees outside `scan_root`.
+- Both normal repos with a `.git` directory and linked worktrees with a `.git` file are registered when the walk reaches them.
+- Git worktree families are not expanded. A worktree is registered only when the depth-bounded walk finds it directly.
 - Local repos, repos without remotes, and repos whose remotes are not named `origin` are all eligible.
 
 The scan response `text` already contains a pre-formatted numbered list with `[default]` markers. **Do NOT make any additional MCP calls to list or query repos.**

--- a/tests/unit/skills/test_skill_artifacts.py
+++ b/tests/unit/skills/test_skill_artifacts.py
@@ -120,6 +120,21 @@ def test_packaged_skills_gate_fallback_on_callability_not_empty_discovery() -> N
                 )
 
 
+def test_brownfield_default_selection_ends_turn_in_every_skill_bundle() -> None:
+    """All shipped host bundles must render the repo list before selection."""
+    repo_root = Path(__file__).resolve().parents[3]
+
+    for root in (repo_root / "skills", repo_root / ".claude-plugin" / "skills"):
+        for skill in ("brownfield", "setup"):
+            text = (root / skill / "SKILL.md").read_text(encoding="utf-8")
+            compact = " ".join(text.split())
+            assert "Do NOT use `AskUserQuestion` for this selection" in text
+            assert "end the turn with the repo grid as the final message" in compact
+            assert '"keep" to keep the current defaults' in compact
+            assert "IMMEDIATELY after showing the list" not in text
+            assert "Default repo selection — IMMEDIATELY" not in text
+
+
 def test_background_skills_delegate_one_exclusive_job_observer() -> None:
     """Run/auto should free the main session when native child sessions exist."""
     repo_root = Path(__file__).resolve().parents[3]

--- a/tests/unit/skills/test_skill_artifacts.py
+++ b/tests/unit/skills/test_skill_artifacts.py
@@ -135,6 +135,41 @@ def test_brownfield_default_selection_ends_turn_in_every_skill_bundle() -> None:
             assert "Default repo selection — IMMEDIATELY" not in text
 
 
+def test_brownfield_scan_contract_matches_runtime_in_every_skill_bundle() -> None:
+    """All shipped host bundles must describe the depth-bounded, self-only scan.
+
+    ``scan_home_for_repos()`` walks ``scan_root`` at most two levels deep and
+    registers each candidate self-only — it never expands Git worktree families
+    via ``git worktree list``. Skill instructions in both ``skills/`` and
+    ``.claude-plugin/skills/`` must not advertise the retired outside-root
+    worktree-expansion behavior.
+    """
+    repo_root = Path(__file__).resolve().parents[3]
+    stale_phrases = (
+        "even outside the scan root directory",
+        "even when they live outside `scan_root`",
+        "even if their paths are outside `scan_root`",
+        "git worktree list --porcelain",
+    )
+
+    for root in (repo_root / "skills", repo_root / ".claude-plugin" / "skills"):
+        for skill in ("brownfield", "setup"):
+            skill_path = root / skill / "SKILL.md"
+            text = skill_path.read_text(encoding="utf-8")
+            compact = " ".join(text.split())
+            for phrase in stale_phrases:
+                assert phrase not in compact, (
+                    f"{skill_path}: stale worktree-expansion scan contract `{phrase}` — "
+                    "the runtime scan is depth-bounded and registers repos self-only"
+                )
+            assert "Git worktree families are not expanded" in compact.replace(
+                "families are NOT expanded", "families are not expanded"
+            ), f"{skill_path}: missing self-only scan contract statement"
+            assert "two" in compact and "level" in compact, (
+                f"{skill_path}: missing depth-bounded (two-level) scan description"
+            )
+
+
 def test_background_skills_delegate_one_exclusive_job_observer() -> None:
     """Run/auto should free the main session when native child sessions exist."""
     repo_root = Path(__file__).resolve().parents[3]


### PR DESCRIPTION
## Purpose

The default-repo selection flow in `ooo brownfield` (and setup Step 5) was unusable: the "Default Repos" dialog appeared without the numbered repo list the user needs to answer it. The grid was emitted as assistant text *between* two tool calls (scan → grid → `AskUserQuestion`), and the host UI does not guarantee rendering of inter-tool-call text. This PR restructures the flow so list visibility is guaranteed before any selection is requested.

## Changes (with intent)

- `skills/brownfield/SKILL.md` Step 2: replaced the `AskUserQuestion` dialog with a **turn-boundary pattern** — the repo grid plus a plain-text selection prompt ("numbers / keep / none") is now the final message of the turn. Intent: turn-final text is the only rendering-guaranteed surface in the host UI.
- Added explicit next-turn reply parsing rules (numbers → indices, "keep" → no-op, "none" → clear, anything else → re-ask, never guess) followed by the single `set_defaults` MCP call. Intent: keep exactly one MCP write and remove the dead-end "Select repos" option that collected no numbers and forced an extra round-trip.
- `skills/setup/SKILL.md` Step 5: applied the same pattern ("keep" proceeds to Step 6). Intent: the flaw was a copy of the same block; fixing only one file would leave the two flows divergent.
- Documented both rendering constraints inside the skill bodies (inter-tool-call text may not render; option `preview` boxes truncate). Intent: prevent the dialog pattern from being reintroduced by a future edit that only reads the skill file.
- Added a "keep" confirmation message case in Step 3. Intent: every reply branch now has a defined user-visible outcome.
- **Non-goal: embedding the repo list in `AskUserQuestion` option `preview` fields.** Verified live with a 68-repo scan — the preview box is fixed-height, non-scrollable, and silently truncates ("9 lines hidden"). The absence of any dialog here is a decision, not an omission.
- **Non-goal: changing `ouroboros_brownfield` server behavior.** The scan/set_defaults contracts and response format are untouched; the defect was purely in skill presentation sequencing.
- **Trade-off:** the structured option dialog (arrow-key selection) is given up in exchange for guaranteed list visibility. Free-text replies need parsing, which is why the parse rules are specified in the skill rather than left to the model.

## Success criteria

Running `ooo brownfield` shows the full numbered repo list on screen before any selection is requested, and one chat reply completes the default update.

- [ ] After scan, the repo grid + selection prompt is the final message of its turn, with no tool call after it
- [ ] Replying with numbers (e.g. "2, 3, 7") produces exactly one `set_defaults` call and a confirmation listing the chosen repos
- [ ] "none" clears all defaults; "keep" (when defaults exist) makes no MCP call and confirms defaults unchanged
- [ ] No `AskUserQuestion` dialog appears anywhere in the brownfield/setup default-repo selection
- [ ] `pytest tests/unit/orchestrator/test_skill_tool_mapping.py tests/unit/test_codex_artifacts.py` passes (47 tests)
