### PR TITLE
test(plugin): stabilize rewind dispatch budget coverage

### DIFF
--- a/tests/unit/plugin/test_rewind_dispatch.py
+++ b/tests/unit/plugin/test_rewind_dispatch.py
@@ -504,7 +504,10 @@ async def test_remaining_timeout_is_clamped_after_prior_dispatch(tmp_path: Path)
     def _runner(argv, **kwargs):
         timeouts.append(kwargs["timeout"])
         if len(timeouts) == 1:
-            clock.value = 4.9
+            # Keep enough real wall-clock budget for the thread handoff while
+            # still proving that the second hook receives the remaining global
+            # budget instead of its full per-hook timeout.
+            clock.value = 3.0
         return subprocess.CompletedProcess(argv, 0, stdout="", stderr="")
 
     observer = LockfileRewindObserver(
@@ -518,7 +521,7 @@ async def test_remaining_timeout_is_clamped_after_prior_dispatch(tmp_path: Path)
     await observer.observe(_snapshot())
 
     assert timeouts[0] == 5.0
-    assert timeouts[1] == pytest.approx(0.1)
+    assert timeouts[1] == pytest.approx(2.0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Stabilizes the rewind dispatch timeout-clamping test under parallel CI.

The prior fixture left 0.1 seconds of synthetic budget after the first dispatch. The observer correctly enforces its global budget with a real wall-clock outer timeout, so a loaded CI worker could exhaust that remaining time before the second thread started. The test now leaves 2 seconds, still proving the second hook receives the remaining global budget rather than the full per-hook timeout.

## Verification

- Python 3.12 plugin rewind dispatch test file with xdist: 21 passed
- Failing test repeated 5 times with Python 3.12 and xdist: all passed
- Ruff check passed for the test file
- MyPy passed for src/ouroboros/plugin