### PR TITLE
fix codex auto recovery harness

### DIFF
--- a/docs/superpowers/plans/2026-07-17-codex-auto-static-tool-recovery.md
+++ b/docs/superpowers/plans/2026-07-17-codex-auto-static-tool-recovery.md
@@ -1,0 +1,92 @@
+# Codex Auto Static Tool Recovery Implementation Plan
+
+**Goal:** Let an already-open Codex session whose static tool snapshot missed a late Ouroboros MCP registration run the official Auto pipeline without duplicate dispatch, false completion, detached foreground work, or preference drift.
+
+**Root cause:** Codex takes a static tool snapshot when a thread starts. If Ouroboros is registered or refreshed after that snapshot, the current thread cannot call `ouroboros_start_auto` even though the configured MCP server and CLI are healthy. The official foreground CLI is therefore the only in-scope recovery surface for that already-open thread, but its run-handoff boundary must first fail closed.
+
+**Architecture:** Keep native MCP as branch one. Branch two is allowed only when the full required native tool set is demonstrably absent before any native dispatch attempt. Branch two invokes the official foreground `ouroboros auto` command exactly once, never `--no-wait`, and requires a durable `auto_session_id` plus a terminal success or resumable non-zero verdict. Direct CLI state remains RUN/nonterminal while an owned execution job is pending; only authoritative `status=completed` plus `success=true`, or a separately validated durable execution terminal, may promote it to COMPLETE.
+
+## Invariants
+
+- Discovery precedes dispatch. Required native tools are `ouroboros_start_auto`, `ouroboros_job_wait`, and `ouroboros_job_result`.
+- If native start was invoked, timed out, or returned an ambiguous transport outcome, CLI fallback is forbidden; reconcile the possible native run instead.
+- CLI recovery is one foreground process and one fresh Auto request, marked with `--codex-recovery`. A user-supplied `--no-wait` is rejected.
+- Fresh recovery preserves goal as one argv element, resolved cwd, `--runtime codex`, max rounds, skip/complete flags, timeout translation (`pipeline_timeout_seconds` -> `--timeout`), and resolved efficiency/frugality preferences.
+- Resume recovery is `ouroboros auto --resume <auto_session_id>` plus presentation-only flags. It must not resend goal, runtime, preferences, timeout, or fresh-only options.
+- Resume rejects preference overrides before saving; persisted state must remain byte-for-byte unchanged.
+- Foreground missing ownership, unknown handles, waiter errors, nonterminal snapshots, or detached results are blocked/non-zero and resumable when a durable handle exists.
+- A completed job is successful only when its execution metadata says `status=completed` and `success is True`, or durable linked execution evidence independently proves completion.
+- Fresh direct CLI state is persisted and prints machine-readable `auto_session_id=<id>` before long-running interview/model work.
+- Direct CLI handoff remains durable RUN/pending until positive terminal execution evidence. Abrupt process loss cannot leave a handoff-only session as COMPLETE.
+- No manual repository work may be presented as an Auto run.
+
+## Task 1 — RED: foreground durability and verdicts
+
+**Files:** `tests/unit/cli/test_auto_run_handoff_wait.py`, `tests/unit/cli/test_auto_command.py`, and focused pipeline tests when required.
+
+- Add RED cases for missing manager/store ownership, unknown job, waiter error, nonterminal/detached return, and non-zero CLI exit.
+- Add RED cases for `meta={}`, `status=completed` without `success=true`, malformed success/status, and explicit success.
+- Add RED state assertions proving a direct foreground handoff is persisted as RUN before waiting and becomes COMPLETE only after terminal success.
+- Add graceful-cancel and subprocess abrupt-termination coverage around handoff persistence; resume must reconcile the same handle and never start a duplicate.
+- Add a concurrent resume/recovery assertion that one persisted Auto idempotency key yields at most one run handoff.
+
+## Task 2 — GREEN: direct CLI state machine
+
+**Files:** `src/ouroboros/auto/pipeline.py`, `src/ouroboros/cli/commands/auto.py`, `src/ouroboros/auto/state.py` only if state helpers are needed.
+
+- Add a direct-foreground policy to `AutoPipeline`: after an owned non-complete-product handoff, persist RUN/pending and return the handle rather than prematurely persisting COMPLETE.
+- Make the CLI waiter recognize that pending result and fail closed when it cannot prove ownership or terminal success.
+- Persist COMPLETE after positive terminal evidence; persist RUN/BLOCKED or FAILED on every other verdict.
+- Tighten `_run_meta_verdict` and reconciliation to require both completed status and explicit true success unless durable execution events prove success.
+- Emit and persist the Auto session id before constructing or invoking long-running handlers.
+
+## Task 3 — RED/GREEN: preference and argv parity
+
+**Files:** `src/ouroboros/cli/commands/auto.py`, `tests/unit/cli/test_auto_command.py`, `tests/unit/auto/test_surface.py`.
+
+- Add `--efficiency-mode adaptive|quality_first` and `--frugality-assurance off|observe|strict` to direct CLI.
+- Test defaults and every resolver combination: default adaptive/observe, adaptive/observe, quality_first/off, explicit quality_first/observe, and explicit strict.
+- Test invalid values, Typer forwarding, AutoStore round-trip, status/result rendering, and resume override rejection with unchanged persisted bytes.
+- Preserve existing max-round increase behavior, but recovery documentation must use the immutable minimal resume command.
+
+## Task 4 — RED/GREEN: ordered recovery contract
+
+**Files:** `skills/auto/SKILL.md`, `src/ouroboros/codex/ouroboros.md`, `tests/unit/test_codex_artifacts.py`, `tests/unit/auto/test_surface.py`.
+
+- Replace token-presence assertions with an ordered decision matrix: discovery, full native set, native branch, no-fallback-after-attempt, then absent-before-dispatch CLI branch.
+- Lock distinct fresh and resume templates; forbid mutable resume args and executable `--no-wait` examples.
+- Require active cwd resolution and argv-safe invocation without shell-concatenating the goal.
+- Require CLI capability verification; if required options are unavailable, fail closed rather than silently dropping them.
+- Keep the manual-emulation prohibition and narrow the old unconditional-stop language to attempted/uncertain native dispatch.
+
+## Task 5 — verification, active artifact refresh, and review
+
+- Run focused RED/GREEN tests after each behavior slice, then the complete CLI/Auto/Codex artifact regression.
+- Run a controlled recovery smoke proving: native wins; absent-before-dispatch chooses CLI once; preferences persist; foreground reaches terminal success; blocked paths exit non-zero and are resumable; abrupt restart reuses the same handle; no orphaned process remains.
+- The owner-approved patch includes a bounded refresh of the active Codex rule/skill artifacts only. Resolve the active `CODEX_HOME`; refresh only copies owned by that home and the canonical `~/.codex/skills` source. Do not mutate a second home without proving it is active.
+- Verify source, installed rule, and installed skill using semantic assertions and SHA-256 hashes. This is artifact synchronization, not a tool install/update.
+- Run completion GPT-5.6 Pro insane-review with RED/GREEN output, smoke receipts, hashes, dirty classification, and cleanup evidence. Apply all non-gated findings and repeat until no actionable blocker remains.
+- Update the bounded Hanoa handoff/service-impact card only if the actual changed paths meet the common-service routing trigger. Commit/push remain owner-gated.
+
+## Acceptance Matrix
+
+1. Native tool set available -> native starter exactly once; CLI never.
+2. Deferred discovery succeeds -> native starter exactly once.
+3. Required native tool absent before dispatch -> CLI exactly once.
+4. Native attempted with ambiguous outcome -> CLI never.
+5. User `--no-wait` -> rejected before start.
+6. Fresh argv parity includes goal, cwd, runtime, preferences, timeout, bounds, skip/complete.
+7. Shell metacharacters remain one unchanged goal argument.
+8. Resume uses only the session handle and presentation-only flags.
+9. Every preference resolver combination round-trips through AutoStore.
+10. Resume preference rejection leaves the persisted file unchanged.
+11. Missing/unowned job manager -> blocked/non-zero.
+12. Waiter error -> blocked/non-zero.
+13. Completed job with empty metadata -> not success.
+14. `status=completed` without `success=true` -> not success.
+15. Detached/nonterminal -> not successful foreground completion.
+16. Graceful or abrupt loss around handoff persistence cannot leave false COMPLETE.
+17. Resume reconciles the existing handle and does not dispatch a duplicate.
+18. Concurrent recovery/resume produces at most one run handoff.
+19. Installed rule and skill expose the same ordered contract.
+20. End-to-end controlled recovery exits only on genuine terminal success or an honest resumable blocker, with no orphan process.

--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -1,18 +1,6 @@
 ---
 name: auto
 description: "Automatically converge from goal to A-grade Seed and execute it"
-mcp_tool: ouroboros_start_auto
-mcp_args:
-  goal: "$goal"
-  resume: "$resume"
-  cwd: "$CWD"
-  max_interview_rounds: "$max_interview_rounds"
-  max_repair_rounds: "$max_repair_rounds"
-  skip_run: "$skip_run"
-  complete_product: "$complete_product"
-  pipeline_timeout_seconds: "$pipeline_timeout_seconds"
-  efficiency_mode: "$efficiency_mode"
-  frugality_assurance: "$frugality_assurance"
 ---
 
 # /ouroboros:auto
@@ -21,18 +9,55 @@ Run the full-quality auto pipeline from a single task description.
 
 ## Dispatch requirement
 
-This skill must be executed by invoking MCP tool `ouroboros_start_auto`. Do not
-manually inspect repositories, run shell commands, query GitHub, edit files, or
-otherwise emulate the auto pipeline as a substitute. Full auto runs routinely
-exceed interactive MCP tool-call timeouts, so the background starter is the
-supported default: it returns `job_id` and `auto_session_id` quickly. Retain
-both. When `response.meta.job_observer` is present, delegate its read-only
-wait/result contract to exactly one independent child session. The main session
-keeps only start and explicit on-demand status responsibility.
+### Required native tool set
 
-If `ouroboros_start_auto` is unavailable, or if any required job polling/result
-MCP tool is unavailable, stop and report that the required MCP tool is
-unavailable. A manual fallback is not an `ooo auto` run.
+Before dispatch, inspect the current host tool snapshot for the full set:
+`ouroboros_start_auto`, `ouroboros_job_wait`, and `ouroboros_job_result`.
+Discovery must finish before any start attempt. The prohibition is explicit:
+manual repository work is not an `ooo auto` run and must never be used to
+emulate this pipeline.
+
+### Native MCP branch
+
+When the full required native tool set is present, invoke
+`ouroboros_start_auto`. Full auto runs routinely exceed interactive MCP
+tool-call timeouts, so the background starter is the supported default: it
+returns `job_id` and `auto_session_id` quickly. Retain both. When
+`response.meta.job_observer` is present, delegate its read-only wait/result
+contract to exactly one independent child session. The main session keeps only
+start and explicit on-demand status responsibility.
+
+Once `ouroboros_start_auto` has been invoked, CLI fallback is forbidden. This
+includes a timeout, disconnect, or ambiguous transport outcome: reconcile the
+possible native run through its durable handles and native status surfaces.
+Never start a fresh CLI Auto request after an attempted native dispatch.
+
+### Official foreground CLI recovery
+
+Use this branch only when at least one required native tool is demonstrably
+absent before any native dispatch attempt in the current host snapshot. This is
+an official Auto entrypoint, not manual emulation:
+
+1. Verify `ouroboros auto --help` exposes `--runtime`, `--timeout`,
+   `--efficiency-mode`, `--frugality-assurance`, and
+   `--codex-recovery`. Fail closed if any required option is absent.
+2. Resolve the task's working directory explicitly and launch one retained
+   foreground process there. Pass the goal as one argv element; never build a
+   shell-concatenated command string.
+3. For a fresh run, invoke `ouroboros auto <goal> --runtime codex
+   --codex-recovery` and add the translated bounds, `--skip-run`,
+   `--complete-product`, `--timeout`, `--efficiency-mode`, and
+   `--frugality-assurance` arguments that apply; never add `--no-wait`.
+4. Capture the early `auto_session_id=<id>` line. Keep the same foreground
+   process until it returns verified terminal success or a non-zero resumable
+   blocker.
+5. Resume only with `ouroboros auto --resume <auto_session_id>
+   --codex-recovery`. Do not pass goal, runtime, preferences,
+   timeout, bounds, skip/complete, or other fresh-start options on resume.
+
+If foreground recovery returns detached/nonterminal work, loses job ownership,
+or cannot prove execution success, report the resumable blocker and non-zero
+outcome. Do not present it as completion.
 
 If a started auto job later returns `detached`, `blocked`, `failed`, or another
 auto-session status, report that auto-session status and the tool's blocker.
@@ -60,7 +85,9 @@ ooo auto "Build a local-first habit tracker CLI" --complete-product
 
 ## CLI flag → MCP arg translation
 
-When the user types `ooo auto` with CLI-style flags inside chat, translate to MCP arguments before invoking `ouroboros_start_auto`:
+When the full required native tool set was discovered and the native MCP branch
+was selected, translate CLI-style chat flags to the following
+`ouroboros_start_auto` arguments:
 
 | CLI flag | MCP arg | Type |
 |----------|---------|------|

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -291,6 +291,8 @@ class AutoPipelineResult:
     auto_session_id: str
     phase: str
     grade: str | None = None
+    required_grade: str = "A"
+    skip_run: bool = False
     seed_path: str | None = None
     seed_origin: str = SeedOrigin.NONE.value
     interview_session_id: str | None = None
@@ -300,6 +302,8 @@ class AutoPipelineResult:
     execution_job_status: str | None = None
     execution_job_error: str | None = None
     execution_job_message: str | None = None
+    execution_run_status: str | None = None
+    execution_run_success: bool | None = None
     run_subagent: dict[str, Any] | None = None
     current_round: int = 0
     pending_question: str | None = None
@@ -394,6 +398,11 @@ class AutoPipelineResult:
     # not mistaken for verified completion. Values are intentionally stringly
     # typed for stable CLI/MCP wire compatibility.
     artifact_state: str | None = None
+    # Issued only by the direct CLI after it validates the result together
+    # with the persisted state.  Consumers must not infer recovery success
+    # from a handleless result shape.
+    seed_receipt_validated: bool = False
+    recovery_terminal_proof: bool = False
 
 
 @dataclass(slots=True)
@@ -436,6 +445,14 @@ class AutoPipeline:
     # the legacy guidance-only behavior.
     ralph_resumer: RalphStarter | None = None
     complete_product: bool = False
+    # Direct foreground CLI owns the in-process execute job and must keep the
+    # durable Auto state non-terminal until its waiter proves the execution
+    # reached terminal success. MCP/background callers keep the historical
+    # handoff-completes-pipeline behavior by leaving this disabled.
+    foreground_run_wait: bool = False
+    # Codex foreground recovery applies its proof gate outside the pipeline.
+    # Defer FINAL_ONLY checkpointing until that gate accepts the envelope.
+    defer_final_checkpoint: bool = False
     # RFC #809 Phase 2.1 — when set AND ``complete_product`` is True, the
     # pipeline inserts an EVALUATE phase between the Ralph terminal verdict
     # and the COMPLETE transition. The evaluator grades the Ralph artifact
@@ -1377,6 +1394,7 @@ class AutoPipeline:
                             )
                         run_status_resume = _optional_str(terminal_run_meta.get("status"))
                         run_success_resume = terminal_run_meta.get("success")
+                        run_job_status_resume = _optional_str(terminal_run_meta.get("_job_status"))
                         failed_run_statuses = {"failed", "cancelled", "interrupted"}
                         if run_success_resume is False or (
                             run_status_resume in failed_run_statuses
@@ -1437,7 +1455,11 @@ class AutoPipeline:
                         # handoff just like the unreconcilable cases
                         # above so a malformed or unfamiliar snapshot
                         # cannot pass the gate by omission.
-                        if run_success_resume is not True and run_status_resume != "completed":
+                        if not (
+                            run_job_status_resume == "completed"
+                            and run_status_resume == "completed"
+                            and run_success_resume is True
+                        ):
                             state.mark_blocked(
                                 "Cannot resume complete-product Ralph handoff: "
                                 "owned run job snapshot did not confirm terminal "
@@ -1455,6 +1477,9 @@ class AutoPipeline:
                                 blocker=state.last_error,
                                 run_subagent=None,
                             )
+                        state.run_terminal_job_status = run_job_status_resume
+                        state.run_terminal_status = run_status_resume
+                        state.run_terminal_success = True
                     else:
                         # Synchronous starters
                         # (``HandlerSynchronousRunStarter``) return
@@ -1520,12 +1545,21 @@ class AutoPipeline:
                         ),
                     )
                     if state.job_id
-                    else None
+                    else {
+                        "status": "unowned",
+                        "success": None,
+                        "error": (
+                            "persisted execution/session handle has no owned job snapshot channel"
+                        ),
+                    }
                 )
                 blocked = self._block_resume_if_run_not_successful(state, run_verdict)
                 if blocked is not None:
                     self._save(state)
                     return self._result(state, ledger, review=review, blocker=state.last_error)
+                state.run_terminal_job_status = _optional_str(run_verdict.get("_job_status"))
+                state.run_terminal_status = _optional_str(run_verdict.get("status"))
+                state.run_terminal_success = True
                 state.transition(
                     AutoPhase.COMPLETE, "execution already started; using persisted run handle"
                 )
@@ -1734,11 +1768,28 @@ class AutoPipeline:
                     state.run_handoff_status = RUN_HANDOFF_STARTED_STATUS
                     state.run_handoff_guidance = None
                     run_success = run_meta.get("success")
-                    if (
-                        self.complete_product
-                        and bool(getattr(self.run_starter, "synchronous_execution", False))
-                        and run_success is True
+                    run_status = _optional_str(run_meta.get("status"))
+                    synchronous_complete_product = self.complete_product and bool(
+                        getattr(self.run_starter, "synchronous_execution", False)
+                    )
+                    if synchronous_complete_product and not (
+                        run_status == "completed" and run_success is True
                     ):
+                        state.mark_blocked(
+                            "synchronous complete-product execution did not confirm "
+                            "terminal success "
+                            f"(status={run_status!r}, success={run_success!r})",
+                            tool_name="run_starter",
+                        )
+                        self._save(state)
+                        return self._result(
+                            state,
+                            ledger,
+                            review=review,
+                            blocker=state.last_error,
+                            run_subagent=run_subagent,
+                        )
+                    if synchronous_complete_product:
                         if state.is_deadline_expired() and not (
                             _allows_synchronous_completion_grace(run_meta)
                             and _within_synchronous_completion_grace(state)
@@ -1753,6 +1804,9 @@ class AutoPipeline:
                                 )
                         state.run_handoff_status = "completed"
                         state.run_handoff_guidance = None
+                        state.run_terminal_job_status = "completed"
+                        state.run_terminal_status = run_status
+                        state.run_terminal_success = True
                         # RFC #1256 §I4 (#1254): emit the typed
                         # ``auto.product.emitted`` terminal for the synchronous
                         # complete-product success path — the branch
@@ -1798,6 +1852,18 @@ class AutoPipeline:
                             )
                         return await self._handoff_to_ralph(
                             state, ledger, seed, review, run_subagent
+                        )
+                    if self.foreground_run_wait:
+                        # The execute job is only dispatched, not completed.
+                        # Persist RUN + the stable handles before returning to
+                        # the foreground waiter so SIGKILL/power loss cannot
+                        # leave a handoff-only session as durable COMPLETE.
+                        self._save(state)
+                        return self._result(
+                            state,
+                            ledger,
+                            review=review,
+                            run_subagent=run_subagent,
                         )
                     state.transition(
                         AutoPhase.COMPLETE,
@@ -1891,23 +1957,15 @@ class AutoPipeline:
         BLOCKED (the run did not reach terminal success), or ``None`` to let the
         caller proceed to COMPLETE.
 
-        Conservative on ambiguity: ``None`` verdict (unpollable / pruned /
-        plain-function starter) or a non-terminal ``running``/``queued`` status
-        preserves the historical "trust the persisted handle" behavior, so
-        genuinely-complete and legacy sessions are unaffected. Only an
-        *observed* non-success terminal (paused / failed / cancelled /
-        interrupted / unknown) blocks — resumably, via ``run_starter`` — so a
-        later ``--resume`` re-reconciles instead of returning stale COMPLETE.
+        Fail closed on ambiguity. A persisted handle proves dispatch only;
+        completion requires an owned snapshot whose execution metadata says
+        both ``status == "completed"`` and ``success is True``.
         """
-        if run_verdict is None:
-            return None
-        status = _optional_str(run_verdict.get("status"))
-        success = run_verdict.get("success")
-        if success is True or status == "completed":
-            return None
-        if status in {"running", "queued", "cancel_requested"}:
-            # Still in flight elsewhere — cannot prove failure; do not cancel or
-            # block a run another owner may still complete.
+        verdict = run_verdict if isinstance(run_verdict, dict) else {}
+        status = _optional_str(verdict.get("status"))
+        success = verdict.get("success")
+        job_status = _optional_str(verdict.get("_job_status"))
+        if job_status == "completed" and status == "completed" and success is True:
             return None
         if status == "paused":
             state.mark_blocked(
@@ -1917,8 +1975,10 @@ class AutoPipeline:
             )
             return True
         detail = status or "unknown"
+        error = _optional_str(verdict.get("error"))
+        suffix = f" ({error})" if error else ""
         state.mark_blocked(
-            f"resumed run execution did not reach terminal success: {detail}",
+            f"resumed run execution did not reach terminal success: {detail}{suffix}",
             tool_name="run_starter",
         )
         return True
@@ -4290,7 +4350,7 @@ class AutoPipeline:
         run_subagent: dict[str, Any] | None = None,
         status_override: str | None = None,
     ) -> AutoPipelineResult:
-        if state.phase == AutoPhase.COMPLETE:
+        if state.phase == AutoPhase.COMPLETE and not self.defer_final_checkpoint:
             self._checkpoint_final_commit(state)
         summary = ledger.summary()
         ledger_provenance = {
@@ -4326,17 +4386,34 @@ class AutoPipeline:
             partial_product=partial_product,
             product_verified=_has_verified_product_completion(state),
         )
+        skip_run_artifact_verified = bool(
+            state.skip_run
+            and state.phase is AutoPhase.COMPLETE
+            and not partial_product
+            and not any((state.execution_id, state.job_id, state.run_session_id))
+            and not any((state.ralph_job_id, state.ralph_lineage_id))
+            and _grade_meets_required(state.last_grade, state.required_grade)
+            and state.seed_path
+            and state.seed_artifact
+        )
+        if skip_run_artifact_verified:
+            artifact_state = "complete_verified"
         return AutoPipelineResult(
             status=result_status,
             auto_session_id=state.auto_session_id,
             phase=state.phase.value,
             grade=review.grade_result.grade.value if review else state.last_grade,
+            required_grade=state.required_grade,
+            skip_run=state.skip_run,
             seed_path=state.seed_path,
             seed_origin=state.seed_origin.value,
             interview_session_id=state.interview_session_id,
             execution_id=state.execution_id,
             job_id=state.job_id,
             run_session_id=state.run_session_id,
+            execution_job_status=state.run_terminal_job_status,
+            execution_run_status=state.run_terminal_status,
+            execution_run_success=state.run_terminal_success,
             run_subagent=run_subagent or state.run_subagent or None,
             current_round=state.current_round,
             pending_question=state.pending_question,
@@ -4596,9 +4673,9 @@ def _artifact_state_for_result(
             return "complete_unverified"
         if product_verified:
             return "complete_verified"
-        if run_handoff_status == RUN_HANDOFF_STARTED_STATUS:
-            return "complete_unverified"
-        return "complete_verified"
+        if run_handoff_status == "completed":
+            return "complete_verified"
+        return "complete_unverified"
     if phase in {AutoPhase.BLOCKED, AutoPhase.FAILED}:
         return "partial_artifact_generated" if has_generated_artifact else phase.value
     return "artifact_in_progress" if has_generated_artifact else "not_generated"
@@ -5121,23 +5198,43 @@ async def _wait_owned_run_job_terminal(
     job_manager = getattr(handler, "_job_manager", None)
     get_snapshot = getattr(job_manager, "get_snapshot", None)
     if get_snapshot is None:
-        return None
+        return {
+            "status": "unowned",
+            "success": None,
+            "error": "owned run job snapshot API is unavailable",
+        }
     loop = asyncio.get_running_loop()
     deadline = loop.time() + max(0.0, timeout_seconds)
     while True:
         try:
             snapshot = await get_snapshot(job_id)
-        except Exception:
-            return None
+        except Exception as exc:
+            return {
+                "status": "snapshot_error",
+                "success": None,
+                "error": f"run job snapshot failed: {exc}",
+            }
         if getattr(snapshot, "is_terminal", False):
-            meta = dict(getattr(snapshot, "result_meta", None) or {})
-            status = getattr(getattr(snapshot, "status", None), "value", None)
-            if isinstance(status, str):
-                meta.setdefault("status", status)
+            raw_meta = getattr(snapshot, "result_meta", None)
+            if not isinstance(raw_meta, dict):
+                return {
+                    "status": "malformed",
+                    "success": None,
+                    "error": "terminal run job result_meta is not an object",
+                }
+            meta = dict(raw_meta)
+            lifecycle_status = getattr(getattr(snapshot, "status", None), "value", None)
+            if isinstance(lifecycle_status, str):
+                meta["_job_status"] = lifecycle_status
             return meta
         remaining = deadline - loop.time()
         if remaining <= 0:
-            return {"status": "running"}
+            lifecycle_status = getattr(getattr(snapshot, "status", None), "value", None)
+            return {
+                "status": lifecycle_status if isinstance(lifecycle_status, str) else "running",
+                "success": None,
+                "error": "owned run job did not reach terminal success before timeout",
+            }
         await asyncio.sleep(min(0.1, remaining))
 
 

--- a/src/ouroboros/auto/state.py
+++ b/src/ouroboros/auto/state.py
@@ -18,6 +18,43 @@ from ouroboros.auto.recovery_plan import AutoRecoveryPlan
 _LOGGER = logging.getLogger(__name__)
 
 
+def _durable_replace(source: Path, destination: Path) -> None:
+    """Atomically replace ``destination`` with write-through semantics."""
+    if os.name != "nt":
+        source.replace(destination)
+        return
+
+    # Windows cannot fsync a directory handle through ``os.open``. A
+    # MOVEFILE_WRITE_THROUGH rename is the platform-equivalent durability
+    # boundary: the call returns only after the move reaches stable storage.
+    import ctypes
+
+    move_file_ex = ctypes.windll.kernel32.MoveFileExW
+    move_file_ex.argtypes = (ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32)
+    move_file_ex.restype = ctypes.c_int
+    movefile_replace_existing = 0x1
+    movefile_write_through = 0x8
+    if not move_file_ex(
+        str(source),
+        str(destination),
+        movefile_replace_existing | movefile_write_through,
+    ):
+        raise ctypes.WinError()
+
+
+def _fsync_directory(path: Path) -> None:
+    """Persist the containing-directory entry after an atomic replacement."""
+    if os.name == "nt":
+        # ``_durable_replace`` already used MOVEFILE_WRITE_THROUGH. Windows
+        # rejects FlushFileBuffers on ordinary directory handles.
+        return
+    directory_fd = os.open(path, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
 class AutoPhase(StrEnum):
     """Closed set of phases for auto-mode resume and stall handling."""
 
@@ -482,6 +519,12 @@ class AutoPipelineState:
     run_start_attempted: bool = False
     run_handoff_status: str | None = None
     run_handoff_guidance: str | None = None
+    # Durable proof written only after the owned execution reaches the exact
+    # lifecycle+execution success conjunction. Legacy sessions default to
+    # unknown and therefore fail closed in Codex recovery.
+    run_terminal_job_status: str | None = None
+    run_terminal_status: str | None = None
+    run_terminal_success: bool | None = None
     attached_run_handle: str | None = None
     attached_run_source: str | None = None
     attached_at: str | None = None
@@ -1056,6 +1099,9 @@ class AutoPipelineState:
         payload.setdefault("max_repair_rounds", 5)
         payload.setdefault("run_handoff_status", None)
         payload.setdefault("run_handoff_guidance", None)
+        payload.setdefault("run_terminal_job_status", None)
+        payload.setdefault("run_terminal_status", None)
+        payload.setdefault("run_terminal_success", None)
         payload.setdefault("attached_run_handle", None)
         payload.setdefault("attached_run_source", None)
         payload.setdefault("attached_at", None)
@@ -1461,6 +1507,8 @@ class AutoPipelineState:
             "run_session_id",
             "run_handoff_status",
             "run_handoff_guidance",
+            "run_terminal_job_status",
+            "run_terminal_status",
             "attached_run_handle",
             "attached_run_source",
             "attached_at",
@@ -1492,6 +1540,10 @@ class AutoPipelineState:
             if not value.strip():
                 msg = f"{field_name} must be a non-empty string or null"
                 raise ValueError(msg)
+        if self.run_terminal_success is not None and not isinstance(
+            self.run_terminal_success, bool
+        ):
+            raise ValueError("run_terminal_success must be a boolean or null")
         for field_name in (
             "interview_completed",
             "skip_run",
@@ -1544,12 +1596,27 @@ class AutoStore:
         state._validate_loaded()
         self.root.mkdir(parents=True, exist_ok=True)
         path = self.path_for(state.auto_session_id)
-        tmp_path = path.with_suffix(".json.tmp")
-        tmp_path.write_text(
-            json.dumps(state.to_dict(), ensure_ascii=False, indent=2), encoding="utf-8"
-        )
-        tmp_path.replace(path)
+        # A fixed ``.json.tmp`` name lets concurrent processes overwrite or
+        # replace each other's staging file. Unique staging keeps each atomic
+        # write self-contained; session-level read/modify/dispatch operations
+        # are serialized separately by ``session_lock``.
+        tmp_path = path.with_name(f".{path.name}.{os.getpid()}.{uuid4().hex}.tmp")
+        try:
+            with tmp_path.open("w", encoding="utf-8") as handle:
+                handle.write(json.dumps(state.to_dict(), ensure_ascii=False, indent=2))
+                handle.flush()
+                os.fsync(handle.fileno())
+            _durable_replace(tmp_path, path)
+            _fsync_directory(path.parent)
+        finally:
+            tmp_path.unlink(missing_ok=True)
         return path
+
+    def session_lock(self, auto_session_id: str):  # noqa: ANN201
+        """Return an exclusive cross-process lease for one Auto session."""
+        from ouroboros.core.file_lock import file_lock
+
+        return file_lock(self.path_for(auto_session_id), exclusive=True)
 
     def load(self, auto_session_id: str) -> AutoPipelineState:
         """Load a state record or raise an actionable error."""

--- a/src/ouroboros/cli/commands/auto.py
+++ b/src/ouroboros/cli/commands/auto.py
@@ -67,6 +67,12 @@ from ouroboros.cli.formatters.panels import (
     print_warning,
 )
 from ouroboros.config import get_opencode_mode
+from ouroboros.core.execution_preferences import (
+    EfficiencyMode,
+    FrugalityAssurance,
+    resolve_execution_preferences,
+)
+from ouroboros.core.seed import Seed
 from ouroboros.mcp.job_manager import JobManager, JobSnapshot, JobStatus
 from ouroboros.mcp.tools.authoring_handlers import GenerateSeedHandler, InterviewHandler
 from ouroboros.mcp.tools.evaluation_handlers import LateralThinkHandler
@@ -178,6 +184,22 @@ def auto_command(
     skip_run: Annotated[
         bool, typer.Option("--skip-run", help="Stop after A-grade Seed creation.")
     ] = False,
+    efficiency_mode: Annotated[
+        EfficiencyMode | None,
+        typer.Option(
+            "--efficiency-mode",
+            help="Execution policy: adaptive or quality_first. Immutable on resume.",
+            case_sensitive=False,
+        ),
+    ] = None,
+    frugality_assurance: Annotated[
+        FrugalityAssurance | None,
+        typer.Option(
+            "--frugality-assurance",
+            help="Cost/grounding assurance: off, observe, or strict. Immutable on resume.",
+            case_sensitive=False,
+        ),
+    ] = None,
     no_wait: Annotated[
         bool,
         typer.Option(
@@ -189,6 +211,16 @@ def auto_command(
                 "NOT survive process exit unless a persistent owner (e.g. a running "
                 "'ouroboros mcp serve') holds it. Default off: auto waits for the run "
                 "job to reach a terminal state and reports the verdict."
+            ),
+        ),
+    ] = False,
+    codex_static_tool_recovery: Annotated[
+        bool,
+        typer.Option(
+            "--codex-recovery",
+            help=(
+                "Fail-closed foreground recovery for a Codex thread whose static "
+                "MCP tool snapshot omitted Auto tools."
             ),
         ),
     ] = False,
@@ -298,6 +330,38 @@ def auto_command(
     in-process job manager dies with the process and would otherwise cancel the
     run on exit. Pass ``--no-wait`` to restore fire-and-forget behaviour.
     """
+    if codex_static_tool_recovery and no_wait:
+        print_error("--codex-recovery cannot be combined with --no-wait")
+        raise typer.Exit(1)
+    if codex_static_tool_recovery and resume:
+        try:
+            _validate_codex_recovery_resume_arguments(
+                goal=goal,
+                runtime=runtime,
+                max_interview_rounds=max_interview_rounds,
+                max_repair_rounds=max_repair_rounds,
+                skip_run=skip_run,
+                efficiency_mode=efficiency_mode,
+                frugality_assurance=frugality_assurance,
+                attach_execution=attach_execution,
+                attach_job=attach_job,
+                attach_session=attach_session,
+                attach_source=attach_source,
+                reconcile_run=reconcile_run,
+                reconcile_source=reconcile_source,
+                pipeline_timeout_seconds=timeout,
+                complete_product=complete_product,
+                domain=domain,
+                commit_policy=commit_policy,
+                worktree_policy=worktree_policy,
+            )
+        except ValueError as exc:
+            print_error(str(exc))
+            raise typer.Exit(1) from exc
+    if codex_static_tool_recovery and not resume and runtime is not AgentRuntimeBackend.CODEX:
+        print_error("--codex-recovery requires --runtime codex on a fresh start")
+        raise typer.Exit(1)
+
     if status:
         if not resume:
             print_error("--status requires --resume auto_<id>")
@@ -320,35 +384,56 @@ def auto_command(
             f"{MAX_PIPELINE_TIMEOUT_SECONDS:g} seconds"
         )
         raise typer.Exit(1)
+    resume_lock = AutoStore().session_lock(resume) if resume else contextlib.nullcontext()
     try:
-        result = asyncio.run(
-            _run_auto(
-                goal=goal,
-                resume=resume,
-                runtime=runtime.value if runtime else None,
-                max_interview_rounds=max_interview_rounds,
-                max_repair_rounds=max_repair_rounds,
-                skip_run=skip_run,
-                attach_execution=attach_execution,
-                attach_job=attach_job,
-                attach_session=attach_session,
-                attach_source=attach_source,
-                reconcile_run=reconcile_run,
-                reconcile_source=reconcile_source,
-                pipeline_timeout_seconds=timeout,
-                complete_product=complete_product,
-                domain=domain,
-                commit_policy=commit_policy,
-                worktree_policy=worktree_policy,
-                progress_callback=_make_progress_renderer(quiet=quiet),
-                wait=not no_wait,
+        with resume_lock:
+            result = asyncio.run(
+                _run_auto(
+                    goal=goal,
+                    resume=resume,
+                    runtime=runtime.value if runtime else None,
+                    max_interview_rounds=max_interview_rounds,
+                    max_repair_rounds=max_repair_rounds,
+                    skip_run=skip_run,
+                    efficiency_mode=(efficiency_mode.value if efficiency_mode else None),
+                    frugality_assurance=(
+                        frugality_assurance.value if frugality_assurance else None
+                    ),
+                    attach_execution=attach_execution,
+                    attach_job=attach_job,
+                    attach_session=attach_session,
+                    attach_source=attach_source,
+                    reconcile_run=reconcile_run,
+                    reconcile_source=reconcile_source,
+                    pipeline_timeout_seconds=timeout,
+                    complete_product=complete_product,
+                    domain=domain,
+                    commit_policy=commit_policy,
+                    worktree_policy=worktree_policy,
+                    progress_callback=_make_progress_renderer(quiet=quiet),
+                    wait=not no_wait,
+                    codex_recovery=codex_static_tool_recovery,
+                )
             )
-        )
     except typer.Exit:
         raise
     except Exception as exc:
         print_error(f"Auto pipeline failed: {exc}")
         raise typer.Exit(1) from exc
+
+    recovery_unverified = codex_static_tool_recovery and not (
+        _codex_recovery_result_has_terminal_proof(result)
+    )
+    if recovery_unverified:
+        blocker = result.blocker or (
+            "Codex recovery did not prove terminal completion; persisted or "
+            "returned execution evidence is missing, pending, or contradictory"
+        )
+        _print_result(
+            replace(result, status="blocked", blocker=blocker),
+            show_ledger=show_ledger,
+        )
+        raise typer.Exit(1)
 
     _print_result(result, show_ledger=show_ledger)
     if no_wait and _is_run_handoff_only_completion(result) and result.job_id:
@@ -365,8 +450,6 @@ def auto_command(
 def _safe_default_cwd() -> Path:
     """Return a safe default cwd without silently retargeting projects."""
     cwd = Path.cwd()
-    if cwd == Path("/"):
-        return Path.home()
     if not os.access(cwd, os.W_OK | os.X_OK):
         msg = f"current working directory is not writable/searchable: {cwd}"
         raise ValueError(msg)
@@ -377,6 +460,151 @@ _DEFAULT_MAX_INTERVIEW_ROUNDS = 50
 _DEFAULT_MAX_REPAIR_ROUNDS = 5
 
 
+def _validate_codex_recovery_resume_arguments(
+    *,
+    goal: str | None,
+    runtime: object | None,
+    max_interview_rounds: int | None,
+    max_repair_rounds: int | None,
+    skip_run: bool,
+    efficiency_mode: object | None,
+    frugality_assurance: object | None,
+    attach_execution: str | None,
+    attach_job: str | None,
+    attach_session: str | None,
+    attach_source: str | None,
+    reconcile_run: bool,
+    reconcile_source: str | None,
+    pipeline_timeout_seconds: float | None,
+    complete_product: bool,
+    domain: str | None,
+    commit_policy: str | None,
+    worktree_policy: str | None,
+) -> None:
+    """Reject every mutating option on a fail-closed recovery resume."""
+    supplied = {
+        "goal": bool(goal and goal.strip()),
+        "runtime": runtime is not None,
+        "max_interview_rounds": max_interview_rounds is not None,
+        "max_repair_rounds": max_repair_rounds is not None,
+        "skip_run": skip_run,
+        "efficiency_mode": efficiency_mode is not None,
+        "frugality_assurance": frugality_assurance is not None,
+        "attach_execution": attach_execution is not None,
+        "attach_job": attach_job is not None,
+        "attach_session": attach_session is not None,
+        "attach_source": attach_source is not None,
+        "reconcile_run": reconcile_run,
+        "reconcile_source": reconcile_source is not None,
+        "timeout": pipeline_timeout_seconds is not None,
+        "complete_product": complete_product,
+        "domain": domain is not None,
+        "commit_policy": commit_policy is not None,
+        "worktree_policy": worktree_policy is not None,
+    }
+    invalid = [name for name, present in supplied.items() if present]
+    if invalid:
+        raise ValueError(
+            "--codex-recovery --resume is immutable; remove fresh-start or "
+            f"mutation arguments: {', '.join(invalid)}"
+        )
+
+
+def _codex_recovery_state_has_terminal_proof(state: AutoPipelineState) -> bool:
+    """Return whether a persisted COMPLETE state is safe to replay as success."""
+    if state.phase is not AutoPhase.COMPLETE or state.last_error:
+        return False
+    handles = any((state.job_id, state.execution_id, state.run_session_id))
+    ralph_handles = any((state.ralph_job_id, state.ralph_lineage_id))
+    if state.skip_run:
+        return bool(
+            not handles
+            and not ralph_handles
+            and _codex_recovery_grade_meets_required(state.last_grade, state.required_grade)
+            and _codex_recovery_seed_receipt_is_valid(state)
+        )
+    if state.run_handoff_status == "completed":
+        return bool(
+            handles
+            and state.run_terminal_job_status == "completed"
+            and state.run_terminal_status == "completed"
+            and state.run_terminal_success is True
+        )
+    ralph_verified = (
+        state.complete_product
+        and state.ralph_dispatch_mode != "plugin"
+        and (
+            state.last_qa_passed is True
+            or (state.ralph_job_status == "completed" and state.ralph_stop_reason == "qa passed")
+        )
+    )
+    return bool(ralph_verified)
+
+
+def _codex_recovery_grade_meets_required(actual: str | None, required: str) -> bool:
+    """Return whether ``actual`` satisfies the persisted recovery grade floor."""
+    rank = {"A": 0, "B": 1, "C": 2}
+    return actual in rank and required in rank and rank[actual] <= rank[required]
+
+
+def _codex_recovery_seed_receipt_is_valid(state: AutoPipelineState) -> bool:
+    """Validate that state and the durable Seed file describe the same Seed."""
+    if not state.seed_path or not state.seed_artifact:
+        return False
+    try:
+        state_seed = Seed.from_dict(state.seed_artifact)
+        disk_seed = load_seed(state.seed_path)
+    except (OSError, RuntimeError, TypeError, ValueError):
+        return False
+    return disk_seed.to_dict() == state_seed.to_dict()
+
+
+def _codex_recovery_state_result_has_terminal_proof(
+    state: AutoPipelineState,
+    result: AutoPipelineResult,
+) -> bool:
+    """Validate one terminal against both durable state and result envelope."""
+    if not _codex_recovery_state_has_terminal_proof(state):
+        return False
+    if (
+        result.status != "complete"
+        or result.blocker
+        or result.partial_product
+        or result.artifact_state in {"complete_unverified", "partial_artifact_generated"}
+    ):
+        return False
+
+    result_handles = any((result.job_id, result.execution_id, result.run_session_id))
+    result_ralph_handles = any((result.ralph_job_id, result.ralph_lineage_id))
+    if state.skip_run:
+        return bool(
+            result.skip_run
+            and not result_handles
+            and not result_ralph_handles
+            and result.seed_path == state.seed_path
+            and _codex_recovery_grade_meets_required(result.grade, state.required_grade)
+            and _codex_recovery_seed_receipt_is_valid(state)
+        )
+
+    if state.run_handoff_status == "completed":
+        return bool(
+            result_handles
+            and result.job_id == state.job_id
+            and result.execution_id == state.execution_id
+            and result.run_session_id == state.run_session_id
+            and result.run_handoff_status == "completed"
+            and result.execution_job_status == "completed"
+            and result.execution_run_status == "completed"
+            and result.execution_run_success is True
+        )
+    return bool(_is_completed_ralph_product(result))
+
+
+def _codex_recovery_result_has_terminal_proof(result: AutoPipelineResult) -> bool:
+    """Accept only proof issued by ``_run_auto`` from state plus result."""
+    return result.recovery_terminal_proof is True
+
+
 async def _run_auto(
     *,
     goal: str | None,
@@ -385,6 +613,8 @@ async def _run_auto(
     max_interview_rounds: int | None,
     max_repair_rounds: int | None,
     skip_run: bool,
+    efficiency_mode: str | None = None,
+    frugality_assurance: str | None = None,
     attach_execution: str | None = None,
     attach_job: str | None = None,
     attach_session: str | None = None,
@@ -398,6 +628,7 @@ async def _run_auto(
     worktree_policy: str | None = None,
     progress_callback: AutoProgressCallback | None = None,
     wait: bool = True,
+    codex_recovery: bool = False,
 ) -> AutoPipelineResult:
     store = AutoStore()
     runtime_override = runtime
@@ -410,18 +641,53 @@ async def _run_auto(
         raise ValueError("--attach-execution/--attach-job/--attach-session require --resume")
     if reconcile_run and not resume:
         raise ValueError("--reconcile-run requires --resume")
+    if codex_recovery and resume:
+        _validate_codex_recovery_resume_arguments(
+            goal=goal,
+            runtime=runtime,
+            max_interview_rounds=max_interview_rounds,
+            max_repair_rounds=max_repair_rounds,
+            skip_run=skip_run,
+            efficiency_mode=efficiency_mode,
+            frugality_assurance=frugality_assurance,
+            attach_execution=attach_execution,
+            attach_job=attach_job,
+            attach_session=attach_session,
+            attach_source=attach_source,
+            reconcile_run=reconcile_run,
+            reconcile_source=reconcile_source,
+            pipeline_timeout_seconds=pipeline_timeout_seconds,
+            complete_product=complete_product,
+            domain=domain,
+            commit_policy=commit_policy,
+            worktree_policy=worktree_policy,
+        )
     validate_complete_product_timeout(
         complete_product=complete_product and not bool(resume),
         pipeline_timeout_seconds=pipeline_timeout_seconds,
         option_name="--timeout",
     )
     if resume:
+        if efficiency_mode is not None or frugality_assurance is not None:
+            raise ValueError(
+                "efficiency_mode and frugality_assurance cannot be changed on resume; "
+                "start a new successor execution for an intentional change"
+            )
         if pipeline_timeout_seconds is not None:
             raise ValueError(
                 "--timeout cannot be changed on resume; the original deadline "
                 "is preserved across process restarts"
             )
         state = store.load(resume)
+        if (
+            codex_recovery
+            and state.phase is AutoPhase.COMPLETE
+            and not _codex_recovery_state_has_terminal_proof(state)
+        ):
+            raise ValueError(
+                "Codex recovery refused an unverified persisted COMPLETE state; "
+                "terminal execution proof is missing or contradictory"
+            )
         persisted_runtime = state.runtime_backend
         if persisted_runtime is None and state.opencode_mode is not None:
             persisted_runtime = "opencode"
@@ -479,6 +745,13 @@ async def _run_auto(
         if max_repair_rounds is None:
             max_repair_rounds = _DEFAULT_MAX_REPAIR_ROUNDS
         state = AutoPipelineState(goal=goal.strip(), cwd=str(_safe_default_cwd()))
+        preferences = resolve_execution_preferences(
+            efficiency_mode,
+            frugality_assurance,
+        )
+        state.efficiency_mode = preferences.efficiency_mode.value
+        state.frugality_assurance = preferences.frugality_assurance.value
+        state.frugality_assurance_explicit = preferences.frugality_assurance_explicit
         state.runtime_backend = runtime
         state.skip_run = skip_run
         state.max_interview_rounds = max_interview_rounds
@@ -558,6 +831,12 @@ async def _run_auto(
             )
             raise ValueError(msg)
         state.provenance = incoming_provenance
+
+    if not resume:
+        # Publish the recovery handle before any long-running model/runtime
+        # construction. This line is intentionally machine-parseable.
+        store.save(state)
+        console.print(f"auto_session_id={state.auto_session_id}")
 
     auto_workspace = ensure_auto_worktree(state)
 
@@ -678,6 +957,8 @@ async def _run_auto(
         ralph_starter=ralph_starter,
         ralph_resumer=ralph_resumer,
         complete_product=complete_product,
+        foreground_run_wait=wait,
+        defer_final_checkpoint=codex_recovery,
         seed_qa_evaluator=HandlerSeedQAEvaluator(seed_qa),
         lateral_thinker=lateral_thinker,
         progress_callback=progress_callback,
@@ -711,6 +992,23 @@ async def _run_auto(
                 state=state,
                 store=store,
             )
+        if codex_recovery:
+            receipt_validated = bool(
+                state.skip_run and _codex_recovery_seed_receipt_is_valid(state)
+            )
+            terminal_proof = _codex_recovery_state_result_has_terminal_proof(state, result)
+            result = replace(
+                result,
+                required_grade=state.required_grade,
+                skip_run=state.skip_run,
+                seed_receipt_validated=receipt_validated,
+                recovery_terminal_proof=terminal_proof,
+            )
+            if terminal_proof:
+                # The pipeline deferred FINAL_ONLY specifically so this side
+                # effect occurs only after the same state+result proof used by
+                # the CLI renderer.
+                pipeline._checkpoint_final_commit(state)  # noqa: SLF001
     finally:
         release_auto_worktree(auto_workspace)
         await watchdog_event_store.close()
@@ -800,6 +1098,9 @@ def _print_status(state: AutoPipelineState) -> None:
     authoring, run_label = _format_runtime_labels(state.runtime_backend, state.opencode_mode)
     console.print(f"Authoring backend: [bold]{authoring}[/]")
     console.print(f"Run backend: [bold]{run_label}[/]")
+    assurance_suffix = " (explicit)" if state.frugality_assurance_explicit else ""
+    console.print(f"Efficiency mode: [bold]{state.efficiency_mode}[/]")
+    console.print(f"Frugality assurance: [bold]{state.frugality_assurance}[/]{assurance_suffix}")
     invoked_by = state.invoked_by()
     if invoked_by != "direct":
         source = (state.provenance or {}).get("source", "unknown")
@@ -878,7 +1179,7 @@ def _is_run_handoff_only_completion(result: AutoPipelineResult) -> bool:
     starts on resume, but it is not verified product completion yet.
     """
     return (
-        result.status == "complete"
+        result.status in {"complete", AutoPhase.RUN.value}
         and result.run_handoff_status == RUN_HANDOFF_STARTED_STATUS
         and result.execution_job_status != "completed"
         and not result.ralph_job_id
@@ -969,6 +1270,8 @@ async def _linked_execution_completed_result(
         blocker=None,
         resume_capability=AutoResumeCapability.NONE,
         execution_job_status=JobStatus.COMPLETED.value,
+        execution_run_status="completed",
+        execution_run_success=True,
         execution_job_error=None,
         execution_job_message=message,
         run_handoff_status="completed",
@@ -982,17 +1285,13 @@ def _run_meta_verdict(snapshot: JobSnapshot) -> tuple[str, bool | None]:
     result meta (``_classify_synchronous_execution_status``): a PAUSED
     execution — e.g. a usage-limit pause — completes the JOB with
     ``result_meta={"status": "paused", "success": None}``. The job lifecycle
-    status alone is therefore not a run verdict. Mirrors the meta fallback of
-    ``auto/adapters._wait_for_job_terminal`` (``status`` defaults to the job's
-    own terminal status when the inner result did not provide one).
+    status alone is therefore not a run verdict. Missing or malformed execution
+    metadata stays unknown and cannot inherit the job's ``completed`` status.
     """
-    meta = snapshot.result_meta or {}
+    raw_meta = snapshot.result_meta
+    meta = raw_meta if isinstance(raw_meta, dict) else {}
     raw_status = meta.get("status")
-    status = (
-        raw_status.strip().lower()
-        if isinstance(raw_status, str) and raw_status.strip()
-        else snapshot.status.value
-    )
+    status = raw_status.strip().lower() if isinstance(raw_status, str) else ""
     raw_success = meta.get("success")
     success = raw_success if isinstance(raw_success, bool) else None
     return status, success
@@ -1007,8 +1306,9 @@ def _reconcile_run_handoff_result(
     the job lifecycle, and the complete-product resume gate in
     ``auto/pipeline.py`` (persisted-handle branch) for the execution-level
     verdict carried in ``result_meta``: a COMPLETED job is only a successful
-    run when its meta confirms terminal success; ``status == "paused"`` keeps
-    the session resumable and never reports complete.
+    run when its meta confirms both ``status == "completed"`` and
+    ``success is True``; ``status == "paused"`` keeps the session resumable and
+    never reports complete.
 
     TODO(Q00/ouroboros#1590): extract a shared job→auto-result reconciliation
     helper with ``mcp/tools/auto_handler._reconcile_execution_job_snapshot``
@@ -1025,6 +1325,8 @@ def _reconcile_run_handoff_result(
     # the incoming COMPLETE->NONE, while genuine success stays NONE and genuine
     # failure keeps NONE.
     resume_capability = result.resume_capability
+    run_status = ""
+    run_success: bool | None = None
     if snapshot.status is JobStatus.COMPLETED:
         run_status, run_success = _run_meta_verdict(snapshot)
         if run_status == "paused":
@@ -1045,7 +1347,7 @@ def _reconcile_run_handoff_result(
             )
             status = "failed"
             resume_capability = AutoResumeCapability.NONE
-        elif run_success is not True and run_status != "completed":
+        elif not (run_status == "completed" and run_success is True):
             # Allowlist gate (pipeline parity): terminal job metadata without
             # an explicit success signal is NOT evidence of run success.
             status = "blocked"
@@ -1076,18 +1378,29 @@ def _reconcile_run_handoff_result(
             status = "blocked"
             resume_capability = AutoResumeCapability.RESUME
     else:
-        # Non-terminal snapshot (should not happen after a terminal wait): keep
-        # the handoff-only result intact and only surface the live status.
-        return replace(result, execution_job_status=snapshot.status.value)
+        return replace(
+            result,
+            status="blocked",
+            blocker=(
+                "foreground run wait ended before a terminal execution verdict "
+                f"(job {snapshot.job_id}, status={snapshot.status.value}); resume "
+                f"with: ouroboros auto --resume {result.auto_session_id}"
+            ),
+            resume_capability=AutoResumeCapability.RESUME,
+            execution_job_status=snapshot.status.value,
+        )
     return replace(
         result,
         status=status,
         phase="complete" if status == "complete" else result.phase,
         blocker=blocker,
         resume_capability=resume_capability,
+        run_handoff_status=("completed" if status == "complete" else result.run_handoff_status),
         execution_job_status=snapshot.status.value,
         execution_job_error=snapshot.error,
         execution_job_message=snapshot.message,
+        execution_run_status=run_status or None,
+        execution_run_success=run_success,
     )
 
 
@@ -1176,12 +1489,30 @@ def _persist_resumable_run_verdict(
     """
     if state is None:
         return result
+    if result.status == "complete":
+        if state.phase is AutoPhase.RUN:
+            state.run_handoff_status = "completed"
+            state.run_handoff_guidance = None
+            state.run_terminal_job_status = result.execution_job_status
+            state.run_terminal_status = result.execution_run_status
+            state.run_terminal_success = result.execution_run_success
+            state.transition(AutoPhase.COMPLETE, "foreground execution reached terminal success")
+            if store is not None:
+                store.save(state)
+        return result
     if result.status == "blocked":
         reopened = state.reopen_completed_run_handoff_to_run(
             result.blocker or "run handoff started but not verified complete"
         )
         if not reopened:
-            return result
+            if state.phase is not AutoPhase.RUN:
+                return result
+            # The pipeline now persists foreground handoffs in RUN already.
+            # Preserve the structured transport/nonterminal blocker without
+            # converting the durable session to a false terminal phase.
+            state.last_error = result.blocker
+            state.last_tool_name = "run_starter"
+            state.run_handoff_guidance = result.blocker
         if store is not None:
             store.save(state)
         return replace(result, resume_capability=state.resume_capability())
@@ -1189,12 +1520,12 @@ def _persist_resumable_run_verdict(
         # Genuine failure: persist a durable FAILED terminal so --resume/--status
         # never report success, but do NOT reopen to RUN and do NOT advertise
         # resume — the reconciled NONE capability is authoritative for failures.
-        if (
-            state.close_completed_run_handoff_as_failed(
-                result.blocker or "run execution finished unsuccessfully"
-            )
-            and store is not None
-        ):
+        message = result.blocker or "run execution finished unsuccessfully"
+        changed = state.close_completed_run_handoff_as_failed(message)
+        if state.phase is AutoPhase.RUN:
+            state.mark_failed(message)
+            changed = True
+        if changed and store is not None:
             store.save(state)
         return result
     return result
@@ -1234,14 +1565,52 @@ async def _await_run_handoff_terminal(
     product-complete.
     """
     job_id = result.job_id
-    if not job_id or job_manager is None or event_store is None:
-        return result
+    if not job_id:
+        blocked = replace(
+            result,
+            status="blocked",
+            blocker=(
+                "foreground run handoff returned no durable job handle; "
+                "refusing to claim completion"
+            ),
+            resume_capability=AutoResumeCapability.NONE,
+        )
+        return _persist_resumable_run_verdict(blocked, state, store)
+    if job_manager is None or event_store is None:
+        blocked = replace(
+            result,
+            status="blocked",
+            blocker=(
+                f"foreground run job {job_id} has no owning manager/event store; "
+                f"resume with: ouroboros auto --resume {result.auto_session_id}"
+            ),
+            resume_capability=AutoResumeCapability.RESUME,
+        )
+        return _persist_resumable_run_verdict(blocked, state, store)
     try:
         snapshot = await job_manager.get_snapshot(job_id)
     except ValueError:
-        # Job handle not owned by this manager (e.g. plugin-mode dispatch):
-        # honestly leave the handoff-only result as-is for the caller to render.
-        return result
+        blocked = replace(
+            result,
+            status="blocked",
+            blocker=(
+                f"foreground run job {job_id} is not owned by this manager; "
+                f"resume with: ouroboros auto --resume {result.auto_session_id}"
+            ),
+            resume_capability=AutoResumeCapability.RESUME,
+        )
+        return _persist_resumable_run_verdict(blocked, state, store)
+    except Exception as exc:
+        blocked = replace(
+            result,
+            status="blocked",
+            blocker=(
+                f"foreground run transport failed while loading job {job_id}: {exc}; "
+                f"resume with: ouroboros auto --resume {result.auto_session_id}"
+            ),
+            resume_capability=AutoResumeCapability.RESUME,
+        )
+        return _persist_resumable_run_verdict(blocked, state, store)
 
     deadline = (
         deadline_at
@@ -1287,7 +1656,16 @@ async def _await_run_handoff_terminal(
                 # Poll window clipped by the deadline; loop re-checks it.
                 continue
             if wait_result.is_err:
-                break
+                blocked = replace(
+                    result,
+                    status="blocked",
+                    blocker=(
+                        f"foreground run waiter failed for job {job_id}; resume with: "
+                        f"ouroboros auto --resume {result.auto_session_id}"
+                    ),
+                    resume_capability=AutoResumeCapability.RESUME,
+                )
+                return _persist_resumable_run_verdict(blocked, state, store)
             value = wait_result.value
             meta = value.meta or {}
             with contextlib.suppress(TypeError, ValueError):
@@ -1325,17 +1703,40 @@ async def _await_run_handoff_terminal(
             f"Resume with: ouroboros auto --resume {result.auto_session_id}"
         )
         raise
+    except Exception as exc:
+        blocked = replace(
+            result,
+            status="blocked",
+            blocker=(
+                f"foreground run transport failed while waiting for job {job_id}: {exc}; "
+                f"resume with: ouroboros auto --resume {result.auto_session_id}"
+            ),
+            resume_capability=AutoResumeCapability.RESUME,
+        )
+        return _persist_resumable_run_verdict(blocked, state, store)
 
-    linked_completed = await _linked_execution_completed_result(result, event_store)
-    if linked_completed is not None:
-        return _persist_resumable_run_verdict(linked_completed, state, store)
+    try:
+        linked_completed = await _linked_execution_completed_result(result, event_store)
+        if linked_completed is not None:
+            return _persist_resumable_run_verdict(linked_completed, state, store)
 
-    snapshot = await job_manager.get_snapshot(job_id)
-    if not quiet:
-        result_handler = JobResultHandler(job_manager=job_manager, event_store=event_store)
-        receipt = await result_handler.handle({"job_id": job_id})
-        if receipt.is_ok and receipt.value.text_content:
-            console.print(receipt.value.text_content)
+        snapshot = await job_manager.get_snapshot(job_id)
+        if not quiet:
+            result_handler = JobResultHandler(job_manager=job_manager, event_store=event_store)
+            receipt = await result_handler.handle({"job_id": job_id})
+            if receipt.is_ok and receipt.value.text_content:
+                console.print(receipt.value.text_content)
+    except Exception as exc:
+        blocked = replace(
+            result,
+            status="blocked",
+            blocker=(
+                f"foreground run transport failed while reconciling job {job_id}: {exc}; "
+                f"resume with: ouroboros auto --resume {result.auto_session_id}"
+            ),
+            resume_capability=AutoResumeCapability.RESUME,
+        )
+        return _persist_resumable_run_verdict(blocked, state, store)
     reconciled = _reconcile_run_handoff_result(result, snapshot)
     return _persist_resumable_run_verdict(reconciled, state, store)
 
@@ -1396,6 +1797,8 @@ def _print_result(result: AutoPipelineResult, *, show_ledger: bool) -> None:
     authoring, run_label = _format_runtime_labels(result.runtime_backend, result.opencode_mode)
     console.print(f"Authoring backend: [bold]{authoring}[/]")
     console.print(f"Run backend: [bold]{run_label}[/]")
+    console.print(f"Efficiency mode: [bold]{result.efficiency_mode}[/]")
+    console.print(f"Frugality assurance: [bold]{result.frugality_assurance}[/]")
     if result.invoked_by != "direct":
         source = (result.provenance or {}).get("source", "unknown")
         console.print(f"Invoked by: [bold]{result.invoked_by}[/] (source={_rich_escape(source)})")

--- a/src/ouroboros/cli/commands/codex.py
+++ b/src/ouroboros/cli/commands/codex.py
@@ -36,6 +36,17 @@ _REQUIRED_CODEX_AUTO_TOOLS = frozenset(
 )
 _MCP_PROTOCOL_VERSION = "2024-11-05"
 _MCP_STDERR_TAIL_BYTES = 8192
+_REQUIRED_AUTO_SKILL_CONTRACT = (
+    "### Required native tool set",
+    "ouroboros_start_auto",
+    "ouroboros_job_wait",
+    "ouroboros_job_result",
+    "### Native MCP branch",
+    "### Official foreground CLI recovery",
+    "`ouroboros auto --help`",
+    "`--codex-recovery`",
+    "CLI fallback is forbidden",
+)
 
 
 class _StdioMcpFramingMismatch(RuntimeError):
@@ -107,8 +118,9 @@ def doctor(
 
     print_success(
         "Codex ooo auto dispatch: OK\n"
-        "- rule maps `ooo auto` to `ouroboros_start_auto`\n"
-        "- auto skill declares MCP dispatch through `ouroboros_start_auto`\n"
+        "- rule maps `ooo auto` to the ordered Auto dispatch matrix\n"
+        "- auto skill discovers the native tool set before choosing native MCP or CLI recovery\n"
+        "- auto skill has no unconditional static `mcp_tool` binding\n"
         "- live MCP auto workflow includes job status/wait/result tools when probed\n"
         "- Codex config contains an `ouroboros` MCP server entry"
         + ("\n- live stdio initialize/list_tools exposes required auto tools" if live_mcp else ""),
@@ -137,8 +149,14 @@ def _check_auto_dispatch_surface(codex_dir: Path, *, live_mcp: bool = False) -> 
         failures.append(f"missing auto skill file: {skill_path}")
     else:
         skill = _read_codex_text(skill_path, "auto skill", failures)
-        if skill is not None and "mcp_tool: ouroboros_start_auto" not in skill:
-            failures.append("auto skill does not declare `mcp_tool: ouroboros_start_auto`")
+        if skill is not None and any(
+            line.strip().startswith("mcp_tool:") for line in skill.splitlines()
+        ):
+            failures.append("auto skill must not declare a static `mcp_tool` binding")
+        if skill is not None and any(
+            fragment not in skill for fragment in _REQUIRED_AUTO_SKILL_CONTRACT
+        ):
+            failures.append("auto skill is missing the ordered native/CLI recovery contract")
         if skill is not None and (
             "manual" not in skill.lower() or "unavailable" not in skill.lower()
         ):

--- a/src/ouroboros/codex/ouroboros.md
+++ b/src/ouroboros/codex/ouroboros.md
@@ -4,8 +4,10 @@ Use Ouroboros commands when the user is asking to clarify requirements, generate
 
 ## CRITICAL: MCP Tool Routing
 
-When the user types `ooo <command>`, you MUST call the corresponding MCP tool.
-Do NOT interpret `ooo` commands as natural language. ALWAYS route to the MCP tool.
+For `ooo` commands other than `ooo auto`, call the corresponding MCP tool.
+`ooo auto` is the explicit exception: route it through the ordered Auto
+dispatch decision matrix below because a static host snapshot may omit one or
+more required native tools. Do not interpret these commands as ordinary prose.
 
 | User Input | MCP Tool to Call |
 |-----------|-----------------|
@@ -13,14 +15,12 @@ Do NOT interpret `ooo` commands as natural language. ALWAYS route to the MCP too
 | `ooo interview "<answer>"` (follow-up) | `ouroboros_interview` with `answer` and `session_id` |
 | `ooo seed [session_id]` | `ouroboros_generate_seed` |
 | `ooo run <seed.yaml>` | `ouroboros_start_execute_seed` with `seed_path` |
-| `ooo auto ...` | `ouroboros_start_auto` with the resolved `goal` / `resume` / option arguments |
+| `ooo auto ...` | Use the ordered Auto dispatch decision matrix below |
 | `ooo status [session_id]` | `ouroboros_session_status` |
 | `ooo evaluate <session_id>` | `ouroboros_evaluate` |
 | `ooo evolve ...` | `ouroboros_evolve_step` |
 | `ooo cancel [execution_id]` | `ouroboros_cancel_execution` |
 | `ooo unstuck` / `ooo lateral` | `ouroboros_lateral_think` |
-
-If `ouroboros_start_auto` is unavailable, stop and report that the MCP dispatch surface is broken. Do not manually emulate `ooo auto` with ordinary shell, GitHub, or coding work.
 
 ## Natural Language Mapping
 
@@ -37,9 +37,18 @@ For natural-language requests, map to the corresponding MCP tool:
 A-grade review/repair, and execution handoff. Do not emulate it with manual
 shell, repository, or GitHub work.
 
-If a user input starts with `ooo auto`, call `ouroboros_start_auto`. Full auto
-runs routinely exceed interactive MCP tool-call timeouts, so the background
-starter is the supported default. It returns `job_id` and `auto_session_id`
+### Required native tool set
+
+Before dispatch, inspect the current host snapshot for
+`ouroboros_start_auto`, `ouroboros_job_wait`, and `ouroboros_job_result`.
+Complete discovery before making any start call.
+
+### Native MCP branch
+
+When the full required native tool set is present before any start attempt,
+call `ouroboros_start_auto`. Full auto runs routinely exceed interactive MCP
+tool-call timeouts, so the background starter is the supported default. It
+returns `job_id` and `auto_session_id`
 quickly; report both briefly, retain the `job_id` plus latest cursor, and keep
 monitoring ownership inside the agent UX. When the response includes
 `meta.job_observer`, explicitly delegate that object to exactly one native Codex
@@ -49,11 +58,34 @@ IDs named by `follow_result_job_keys`. Keep the main session available for the
 user; do not poll the same job from both sessions. The main session may perform
 an on-demand status check only when the user asks. If native subagents are not
 available, use the contract's main-session fallback and relay only meaningful
-changes. Do not hand the user polling instructions as the final UX. If that MCP
-tool is unavailable, or any required job polling/result MCP tool is unavailable,
-stop and report that the MCP dispatch surface is incomplete instead of
-continuing as a normal Codex task. Do not emulate the workflow with ordinary
-shell or coding work.
+changes. Do not hand the user polling instructions as the final UX.
+
+Once `ouroboros_start_auto` has been invoked, CLI fallback is forbidden. A
+timeout, disconnect, or ambiguous transport outcome may hide a successful
+native dispatch, so reconcile that possible native run through durable native
+handles/status instead of starting a second Auto request.
+
+### Official foreground CLI recovery
+
+This branch is allowed only when at least one required native tool is proven
+absent before any native dispatch attempt in the current static host snapshot.
+First verify `ouroboros auto --help` exposes `--runtime`, `--timeout`,
+`--efficiency-mode`, `--frugality-assurance`, and
+`--codex-recovery`; otherwise fail closed. Launch exactly one
+retained foreground process in the resolved working directory and pass the
+goal as one argv element, never through shell-string concatenation.
+
+Fresh template: `ouroboros auto <goal> --runtime codex
+--codex-recovery`, plus the translated max-round, skip/complete,
+`--timeout`, and resolved preference arguments. The MCP
+`pipeline_timeout_seconds` value maps to CLI `--timeout`; never add `--no-wait`.
+Capture the early `auto_session_id=<id>` line and wait for verified terminal
+success or a non-zero resumable blocker.
+
+Resume template: `ouroboros auto --resume <auto_session_id>
+--codex-recovery`. Do not pass goal, runtime, preferences, timeout,
+bounds, skip/complete, or other mutable fresh-start options on resume. Detached,
+nonterminal, unowned, or unproven foreground work is not completion.
 
 For Codex delegation, call the native `spawn_agent` primitive exactly once with
 `task_name="run_observer"` and include `meta.job_observer` unchanged in the child

--- a/tests/integration/test_codex_cli_passthrough_smoke.py
+++ b/tests/integration/test_codex_cli_passthrough_smoke.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -130,10 +130,10 @@ async def test_unhandled_ooo_commands_pass_through_to_codex_unchanged(
 
 
 @pytest.mark.asyncio
-async def test_packaged_ooo_auto_missing_mcp_tool_fails_closed_without_codex_fallback(
+async def test_packaged_ooo_auto_uses_codex_decision_matrix_without_static_intercept(
     tmp_path: Path,
 ) -> None:
-    """Packaged `ooo auto` must not fall through to Codex when the MCP tool is absent."""
+    """Codex receives Auto so its skill can discover native tools before dispatch."""
     runtime = create_agent_runtime(
         backend="codex",
         cli_path="/tmp/codex",
@@ -145,30 +145,35 @@ async def test_packaged_ooo_auto_missing_mcp_tool_fails_closed_without_codex_fal
     assert runtime._skill_dispatcher is not None
     with resolve_packaged_codex_skill_path("auto", skills_dir=runtime._skills_dir) as skill_md_path:
         content = skill_md_path.read_text(encoding="utf-8")
-    assert "mcp_tool: ouroboros_start_auto" in content
+    assert "mcp_tool:" not in content
+    assert "### Required native tool set" in content
+    assert "### Official foreground CLI recovery" in content
 
-    fake_server = AsyncMock()
-    fake_server.call_tool = AsyncMock(
-        side_effect=LookupError("No local handler registered for tool: ouroboros_start_auto")
-    )
+    prompt = "ooo auto Build a CLI"
+
+    async def fake_create_subprocess_exec(*command: str, **kwargs: object) -> _FakeProcess:
+        assert kwargs["cwd"] == str(tmp_path)
+        output_index = command.index("--output-last-message") + 1
+        Path(command[output_index]).write_text(
+            "Codex Auto decision matrix received",
+            encoding="utf-8",
+        )
+        return _FakeProcess(returncode=0)
 
     with (
-        patch("ouroboros.mcp.server.adapter.create_ouroboros_server", return_value=fake_server),
+        patch("ouroboros.mcp.server.adapter.create_ouroboros_server") as mock_create_server,
         patch("ouroboros.orchestrator.codex_cli_runtime.log.warning") as mock_warning,
         patch(
-            "ouroboros.orchestrator.codex_cli_runtime.asyncio.create_subprocess_exec"
+            "ouroboros.orchestrator.codex_cli_runtime.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
         ) as mock_exec,
     ):
-        messages = [message async for message in runtime.execute_task("ooo auto Build a CLI")]
+        messages = [message async for message in runtime.execute_task(prompt)]
 
-    fake_server.call_tool.assert_awaited_once()
-    assert fake_server.call_tool.await_args.args[0] == "ouroboros_start_auto"
-    mock_exec.assert_not_called()
+    mock_create_server.assert_not_called()
+    mock_exec.assert_called_once()
     mock_warning.assert_called_once()
-    assert mock_warning.call_args.kwargs["fallback"] == "terminal_error"
-    assert len(messages) == 1
-    assert messages[0].is_error is True
-    assert messages[0].content.startswith("Cannot run ooo auto")
-    assert "`ouroboros_start_auto` is unavailable" in messages[0].content
-    assert messages[0].data["error_type"] == "SkillDispatchUnavailable"
-    assert messages[0].data["tool_name"] == "ouroboros_start_auto"
+    assert mock_warning.call_args[0][0] == "codex_cli_runtime.skill_intercept_frontmatter_missing"
+    assert mock_warning.call_args.kwargs["error"] == "missing required frontmatter key: mcp_tool"
+    assert messages[-1].is_error is False
+    assert messages[-1].content == "Codex Auto decision matrix received"

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import subprocess
+import sys
+import time
 
 import pytest
 
 from ouroboros.auto.adapters import EvaluateResult, LateralResult, PartialInterviewStartError
 from ouroboros.auto.grading import GradeFinding, GradeGate, GradeResult, SeedGrade
+from ouroboros.auto.handoff_contract import RUN_HANDOFF_STARTED_STATUS
 from ouroboros.auto.interview_driver import (
     AutoInterviewDriver,
     FunctionInterviewBackend,
@@ -2411,6 +2416,125 @@ async def test_pipeline_resumes_completed_interview_without_reanswering(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_foreground_run_handoff_stays_durable_run_until_waiter_verifies(tmp_path) -> None:
+    """Direct foreground CLI must not persist handoff-only work as COMPLETE."""
+
+    async def _unused(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202
+        raise AssertionError("prepared RUN state must not restart authoring")
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+        return {
+            "job_id": "job_foreground",
+            "execution_id": "exec_foreground",
+            "session_id": "orch_foreground",
+        }
+
+    state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(state.goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    state.seed_artifact = _seed().to_dict()
+    state.last_grade = "A"
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    store = AutoStore(tmp_path)
+    driver = AutoInterviewDriver(FunctionInterviewBackend(_unused, _unused), store=store)
+    pipeline = AutoPipeline(
+        driver,
+        _unused,
+        run_starter=run_seed,
+        store=store,
+        foreground_run_wait=True,
+    )
+
+    result = await pipeline.run(state)
+    reloaded = AutoStore(tmp_path).load(state.auto_session_id)
+
+    assert result.status == AutoPhase.RUN.value
+    assert result.run_handoff_status == RUN_HANDOFF_STARTED_STATUS
+    assert result.job_id == "job_foreground"
+    assert state.phase is AutoPhase.RUN
+    assert reloaded.phase is AutoPhase.RUN
+
+
+@pytest.mark.asyncio
+async def test_foreground_handoff_reload_reconciles_same_job_without_duplicate(tmp_path) -> None:
+    """A process-boundary reload must reuse the persisted job, never redispatch."""
+    from types import SimpleNamespace
+
+    from ouroboros.mcp.job_manager import JobManager
+    from ouroboros.mcp.types import ContentType, MCPContentItem, MCPToolResult
+    from ouroboros.persistence.event_store import EventStore
+
+    jobs = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(jobs)
+    store = AutoStore(tmp_path / "auto")
+    try:
+
+        async def _ok_runner() -> MCPToolResult:
+            return MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="done"),),
+                is_error=False,
+                meta={"status": "completed", "success": True},
+            )
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_ok_runner()
+        )
+
+        async def _unused(*_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202
+            raise AssertionError("restart must not rerun authoring")
+
+        dispatches: list[str] = []
+
+        async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str]:  # noqa: ARG001
+            dispatches.append(idempotency_key)
+            return {
+                "job_id": started.job_id,
+                "execution_id": "exec_restart",
+                "session_id": "orch_restart",
+            }
+
+        state = AutoPipelineState(goal="Build a CLI", cwd=str(tmp_path))
+        ledger = SeedDraftLedger.from_goal(state.goal)
+        _fill_ready(ledger)
+        state.ledger = ledger.to_dict()
+        state.seed_artifact = _seed().to_dict()
+        state.last_grade = "A"
+        state.transition(AutoPhase.INTERVIEW, "interview")
+        state.transition(AutoPhase.SEED_GENERATION, "seed")
+        state.transition(AutoPhase.REVIEW, "review")
+        state.transition(AutoPhase.RUN, "run")
+        driver = AutoInterviewDriver(FunctionInterviewBackend(_unused, _unused), store=store)
+        first = await AutoPipeline(
+            driver,
+            _unused,
+            run_starter=run_seed,
+            store=store,
+            foreground_run_wait=True,
+        ).run(state)
+        assert first.status == AutoPhase.RUN.value
+
+        reloaded = store.load(state.auto_session_id)
+        owned_noncallable_starter = SimpleNamespace(handler=SimpleNamespace(_job_manager=manager))
+        resumed = await AutoPipeline(
+            driver,
+            _unused,
+            run_starter=owned_noncallable_starter,
+            store=store,
+        ).run(reloaded)
+
+        assert resumed.status == "complete"
+        assert reloaded.phase is AutoPhase.COMPLETE
+        assert dispatches == [state.auto_session_id]
+    finally:
+        await manager.drain(grace_seconds=1.0)
+        await jobs.close()
+
+
+@pytest.mark.asyncio
 async def test_pipeline_resume_retries_unknown_run_handoff_once(tmp_path) -> None:
     """Resuming a session with an unknown handoff retries the run starter exactly once."""
 
@@ -2484,7 +2608,7 @@ async def test_pipeline_blocks_run_start_without_tracking_handle(tmp_path) -> No
 
 
 @pytest.mark.asyncio
-async def test_pipeline_resumes_run_with_persisted_handle_without_restarting(tmp_path) -> None:
+async def test_pipeline_blocks_unowned_persisted_handle_without_restarting(tmp_path) -> None:
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         raise AssertionError("run resume should not restart interview")
 
@@ -2512,8 +2636,9 @@ async def test_pipeline_resumes_run_with_persisted_handle_without_restarting(tmp
 
     result = await pipeline.run(state)
 
-    assert result.status == "complete"
+    assert result.status == "blocked"
     assert result.job_id == "job_existing"
+    assert state.phase is AutoPhase.BLOCKED
 
 
 def _run_state_with_handle(tmp_path, job_id: str) -> AutoPipelineState:
@@ -2660,6 +2785,249 @@ async def test_run_resume_completes_when_owned_job_succeeded(tmp_path) -> None:
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
         await jobs.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("result_meta", "lifecycle_status", "terminal", "should_complete"),
+    [
+        ({}, "completed", True, False),
+        ({"status": "completed"}, "completed", True, False),
+        ({"success": True}, "completed", True, False),
+        ({"status": "completed", "success": False}, "completed", True, False),
+        ({"status": "mystery", "success": True}, "completed", True, False),
+        ({"status": "running", "success": None}, "running", False, False),
+        ({"status": "completed", "success": True}, "completed", True, True),
+        ({"status": "completed", "success": True}, "failed", True, False),
+        ({"status": "completed", "success": True}, "cancelled", True, False),
+        ({"status": "completed", "success": True}, None, True, False),
+    ],
+)
+async def test_run_resume_requires_explicit_terminal_success_conjunction(
+    tmp_path,
+    result_meta,
+    lifecycle_status,
+    terminal,
+    should_complete,
+) -> None:
+    """A persisted handle is dispatch evidence, never completion evidence."""
+    from types import SimpleNamespace
+
+    class Manager:
+        async def get_snapshot(self, _job_id: str):  # noqa: ANN202
+            return SimpleNamespace(
+                is_terminal=terminal,
+                status=SimpleNamespace(value=lifecycle_status),
+                result_meta=result_meta,
+            )
+
+    async def _unused(*_a, **_k):  # noqa: ANN002, ANN003, ANN202
+        raise AssertionError("resume must not redispatch")
+
+    state = _run_state_with_handle(tmp_path, "job_matrix")
+    if not terminal:
+        state.timeout_seconds_by_phase = {
+            **state.timeout_seconds_by_phase,
+            AutoPhase.RUN.value: 1,
+        }
+    store = AutoStore(tmp_path)
+    pipeline = AutoPipeline(
+        AutoInterviewDriver(FunctionInterviewBackend(_unused, _unused), store=store),
+        _unused,
+        run_starter=_run_starter_over_manager(Manager()),
+        store=store,
+    )
+
+    result = await pipeline.run(state)
+
+    assert (result.status == "complete") is should_complete
+    assert state.phase is (AutoPhase.COMPLETE if should_complete else AutoPhase.BLOCKED)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("handle_field", ["job_id", "execution_id", "run_session_id"])
+async def test_run_resume_blocks_when_terminal_proof_channel_is_missing(
+    tmp_path, handle_field
+) -> None:
+    """Missing manager and jobless handles must fail closed without redispatch."""
+    from types import SimpleNamespace
+
+    async def _unused(*_a, **_k):  # noqa: ANN002, ANN003, ANN202
+        raise AssertionError("resume must not redispatch")
+
+    state = _run_state_with_handle(tmp_path, "job_unowned")
+    state.job_id = None
+    setattr(state, handle_field, "job_unowned" if handle_field == "job_id" else "handle_only")
+    store = AutoStore(tmp_path)
+    pipeline = AutoPipeline(
+        AutoInterviewDriver(FunctionInterviewBackend(_unused, _unused), store=store),
+        _unused,
+        run_starter=SimpleNamespace(),
+        store=store,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert "terminal success" in (result.blocker or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_run_resume_snapshot_transport_error_blocks(tmp_path) -> None:
+    """Raised snapshot transport errors become durable resumable blockers."""
+
+    class Manager:
+        async def get_snapshot(self, _job_id: str):  # noqa: ANN202
+            raise ConnectionError("snapshot transport unavailable")
+
+    async def _unused(*_a, **_k):  # noqa: ANN002, ANN003, ANN202
+        raise AssertionError("resume must not redispatch")
+
+    state = _run_state_with_handle(tmp_path, "job_transport")
+    store = AutoStore(tmp_path)
+    pipeline = AutoPipeline(
+        AutoInterviewDriver(FunctionInterviewBackend(_unused, _unused), store=store),
+        _unused,
+        run_starter=_run_starter_over_manager(Manager()),
+        store=store,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert "snapshot" in (result.blocker or "").lower()
+
+
+def test_auto_store_session_lock_serializes_resume_processes(tmp_path) -> None:
+    """Two OS processes cannot enter one Auto session mutation concurrently."""
+    root = tmp_path / "auto"
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+    script = (
+        "import json,sys,time\n"
+        "from pathlib import Path\n"
+        "from ouroboros.auto.state import AutoStore\n"
+        "root,session,out,hold=sys.argv[1:]\n"
+        "with AutoStore(Path(root)).session_lock(session):\n"
+        " p=Path(out); p.write_text(json.dumps({'entered':time.time()}),encoding='utf-8')\n"
+        " time.sleep(float(hold))\n"
+        " p.write_text(json.dumps({'entered':json.loads(p.read_text(encoding='utf-8'))['entered'],'exited':time.time()}),encoding='utf-8')\n"
+    )
+    p1 = subprocess.Popen(  # noqa: S603
+        [sys.executable, "-c", script, str(root), "auto_lock_test", str(first), "0.5"],
+        cwd=str(tmp_path),
+    )
+    deadline = time.monotonic() + 10
+    while not first.exists() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert first.exists(), "first process never entered the session lock"
+
+    p2 = subprocess.Popen(  # noqa: S603
+        [sys.executable, "-c", script, str(root), "auto_lock_test", str(second), "0"],
+        cwd=str(tmp_path),
+    )
+    assert p1.wait(timeout=15) == 0
+    assert p2.wait(timeout=15) == 0
+
+    first_times = json.loads(first.read_text(encoding="utf-8"))
+    second_times = json.loads(second.read_text(encoding="utf-8"))
+    assert second_times["entered"] >= first_times["exited"]
+
+
+def test_auto_store_session_lock_recovers_after_process_kill(tmp_path) -> None:
+    """An OS-killed resume owner cannot orphan the per-session lease or state."""
+    root = tmp_path / "auto"
+    store = AutoStore(root)
+    state = AutoPipelineState(goal="kill recovery", cwd=str(tmp_path))
+    path = store.save(state)
+    before = path.read_bytes()
+    entered = tmp_path / "entered"
+    script = (
+        "import sys,time\n"
+        "from pathlib import Path\n"
+        "from ouroboros.auto.state import AutoStore\n"
+        "with AutoStore(Path(sys.argv[1])).session_lock(sys.argv[2]):\n"
+        " Path(sys.argv[3]).write_text('entered',encoding='utf-8')\n"
+        " time.sleep(60)\n"
+    )
+    process = subprocess.Popen(  # noqa: S603
+        [sys.executable, "-c", script, str(root), state.auto_session_id, str(entered)],
+        cwd=str(tmp_path),
+    )
+    deadline = time.monotonic() + 10
+    while not entered.exists() and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert entered.exists(), "child never acquired the session lease"
+
+    process.kill()
+    assert process.wait(timeout=10) != 0
+
+    acquired_at = time.monotonic()
+    with store.session_lock(state.auto_session_id):
+        assert store.load(state.auto_session_id).goal == "kill recovery"
+    assert time.monotonic() - acquired_at < 2
+    assert path.read_bytes() == before
+
+
+def test_concurrent_resume_check_and_dispatch_runs_once(tmp_path) -> None:
+    """The locked read/mark/dispatch boundary admits one idempotency key once."""
+    root = tmp_path / "auto"
+    store = AutoStore(root)
+    state = AutoPipelineState(goal="single dispatch", cwd=str(tmp_path))
+    store.save(state)
+    dispatch_log = tmp_path / "dispatch.log"
+    script = (
+        "import sys,time\n"
+        "from pathlib import Path\n"
+        "from ouroboros.auto.state import AutoStore\n"
+        "root,session,log=sys.argv[1:]\n"
+        "store=AutoStore(Path(root))\n"
+        "with store.session_lock(session):\n"
+        " state=store.load(session)\n"
+        " if not state.run_start_attempted:\n"
+        "  state.run_start_attempted=True; store.save(state)\n"
+        "  with Path(log).open('a',encoding='utf-8') as fh: fh.write(session+'\\n')\n"
+        "  time.sleep(0.2)\n"
+    )
+    processes = [
+        subprocess.Popen(  # noqa: S603
+            [
+                sys.executable,
+                "-c",
+                script,
+                str(root),
+                state.auto_session_id,
+                str(dispatch_log),
+            ],
+            cwd=str(tmp_path),
+        )
+        for _ in range(2)
+    ]
+    assert [process.wait(timeout=15) for process in processes] == [0, 0]
+    assert dispatch_log.read_text(encoding="utf-8").splitlines() == [state.auto_session_id]
+
+
+def test_auto_store_fsyncs_file_and_parent_directory(tmp_path, monkeypatch) -> None:
+    """The dispatch marker survives power loss, not only process death."""
+    from ouroboros.auto import state as state_module
+
+    file_fsyncs: list[int] = []
+    directory_fsyncs: list[object] = []
+    monkeypatch.setattr(state_module.os, "fsync", file_fsyncs.append)
+    monkeypatch.setattr(
+        state_module,
+        "_fsync_directory",
+        directory_fsyncs.append,
+        raising=False,
+    )
+
+    store = AutoStore(tmp_path)
+    store.save(AutoPipelineState(goal="durable", cwd=str(tmp_path)))
+
+    assert file_fsyncs
+    assert directory_fsyncs == [tmp_path]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/auto/test_pipeline_ralph_handoff.py
+++ b/tests/unit/auto/test_pipeline_ralph_handoff.py
@@ -565,6 +565,53 @@ async def test_synchronous_complete_product_success_emits_auto_product_emitted_e
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("status", "success"),
+    [
+        ("paused", True),
+        ("completed", None),
+        ("completed", False),
+        ("failed", True),
+        (None, True),
+    ],
+)
+async def test_synchronous_complete_product_fails_closed_without_success_conjunction(
+    tmp_path, status, success
+) -> None:
+    """Synchronous complete-product may complete only on completed AND true."""
+    state = _state_at_run_phase(tmp_path)
+
+    class SynchronousRunStarter:
+        synchronous_execution = True
+
+        async def __call__(self, _seed: Seed, **_kwargs: Any) -> dict[str, Any]:
+            return {
+                "job_id": None,
+                "session_id": "sync_session_bad",
+                "execution_id": "sync_exec_bad",
+                "status": status,
+                "success": success,
+            }
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("unverified synchronous execution must not dispatch Ralph")
+
+    result = await AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=SynchronousRunStarter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    ).run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.ralph_job_id is None
+    assert result.blocker
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("remaining_budget", "expected_per_iteration"),
     [
         # Budget far above the standalone 1800s default must NOT be capped at
@@ -1898,6 +1945,107 @@ async def test_run_resume_with_persisted_handle_and_complete_product_dispatches_
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "success"),
+    [("completed", None), ("completed", False), ("mystery", True), (None, True)],
+)
+async def test_complete_product_resume_requires_status_and_success_conjunction(
+    tmp_path, status, success
+) -> None:
+    """Neither half of the terminal-success proof is sufficient alone."""
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_run_unverified"
+    state.execution_id = "execution_unverified"
+    state.complete_product = True
+
+    class Manager:
+        async def get_snapshot(self, _job_id: str):  # noqa: ANN202
+            from types import SimpleNamespace
+
+            return SimpleNamespace(
+                is_terminal=True,
+                result_meta={"status": status, "success": success},
+                status=JobStatus.COMPLETED,
+            )
+
+    class Handler:
+        _job_manager = Manager()
+
+    class Starter:
+        handler = Handler()
+
+        async def __call__(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not redispatch")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("unverified resumed execution must not dispatch Ralph")
+
+    result = await AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=Starter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    ).run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.ralph_job_id is None
+    assert result.blocker
+
+
+@pytest.mark.asyncio
+async def test_complete_product_resume_rejects_failed_job_lifecycle_with_success_meta(
+    tmp_path,
+) -> None:
+    """Failed job lifecycle dominates contradictory completed/true metadata."""
+    from types import SimpleNamespace
+
+    state = _state_at_run_phase(tmp_path)
+    state.run_start_attempted = True
+    state.run_handoff_status = "started"
+    state.job_id = "job_lifecycle_failed"
+    state.execution_id = "execution_lifecycle_failed"
+    state.complete_product = True
+
+    class Manager:
+        async def get_snapshot(self, _job_id: str):  # noqa: ANN202
+            return SimpleNamespace(
+                is_terminal=True,
+                result_meta={"status": "completed", "success": True},
+                status=JobStatus.FAILED,
+            )
+
+    class Handler:
+        _job_manager = Manager()
+
+    class Starter:
+        handler = Handler()
+
+        async def __call__(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:
+            raise AssertionError("resume must not redispatch")
+
+    async def ralph_starter(*_args: Any, **_kwargs: Any) -> dict[str, Any]:
+        raise AssertionError("failed job lifecycle must not dispatch Ralph")
+
+    result = await AutoPipeline(
+        _StubInterviewDriver(),
+        _seed_generator_unused,
+        run_starter=Starter(),
+        reviewer=_PassReviewer(),
+        ralph_starter=ralph_starter,
+        complete_product=True,
+    ).run(state)
+
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
+    assert state.ralph_job_id is None
+
+
+@pytest.mark.asyncio
 async def test_run_resume_with_persisted_handle_blocks_when_owned_job_paused(
     tmp_path,
 ) -> None:
@@ -2053,7 +2201,8 @@ async def test_run_resume_with_stale_persisted_job_id_blocks_instead_of_crashing
     assert result.status == "blocked"
     assert state.phase is AutoPhase.BLOCKED
     assert state.last_tool_name == "run_starter"
-    assert "snapshot is unavailable" in (state.last_error or "")
+    assert "snapshot" in (state.last_error or "")
+    assert "terminal success" in (state.last_error or "")
     assert state.ralph_job_id is None
 
 
@@ -2106,7 +2255,8 @@ async def test_run_resume_with_persisted_job_id_blocks_when_starter_has_no_snaps
     assert result.status == "blocked"
     assert state.phase is AutoPhase.BLOCKED
     assert state.last_tool_name == "run_starter"
-    assert "snapshot is unavailable" in (state.last_error or "")
+    assert "snapshot" in (state.last_error or "")
+    assert "terminal success" in (state.last_error or "")
     assert state.ralph_job_id is None
 
 
@@ -2289,11 +2439,10 @@ async def test_run_resume_with_persisted_handle_blocks_when_owned_job_failed(
 
 
 @pytest.mark.asyncio
-async def test_run_resume_with_persisted_handle_complete_product_off_completes(
+async def test_run_resume_with_unowned_handle_complete_product_off_blocks(
     tmp_path,
 ) -> None:
-    """``complete_product=False`` resume keeps the legacy short-circuit to
-    COMPLETE byte-identical so default-off callers see no behavior change."""
+    """Default mode also requires owned terminal proof before COMPLETE."""
     state = _state_at_run_phase(tmp_path)
     state.run_start_attempted = True
     state.run_handoff_status = "started"
@@ -2314,8 +2463,8 @@ async def test_run_resume_with_persisted_handle_complete_product_off_completes(
 
     result = await pipeline.run(state)
 
-    assert result.status == "complete"
-    assert state.phase is AutoPhase.COMPLETE
+    assert result.status == "blocked"
+    assert state.phase is AutoPhase.BLOCKED
     assert state.ralph_job_id is None
 
 

--- a/tests/unit/auto/test_surface.py
+++ b/tests/unit/auto/test_surface.py
@@ -154,18 +154,26 @@ def test_cli_auto_status_requires_resume() -> None:
     assert "--status requires --resume auto_<id>" in result.output
 
 
-def test_auto_skill_frontmatter_dispatches_to_mcp_tool() -> None:
+def test_auto_skill_uses_ordered_dispatch_matrix_instead_of_direct_binding() -> None:
     skill = Path(__file__).parents[3] / "skills" / "auto" / "SKILL.md"
     content = skill.read_text(encoding="utf-8")
 
     assert "name: auto" in content
-    assert "mcp_tool: ouroboros_start_auto" in content
-    assert 'goal: "$goal"' in content
-    assert 'resume: "$resume"' in content
-    assert 'skip_run: "$skip_run"' in content
-    assert 'max_interview_rounds: "$max_interview_rounds"' in content
+    assert "mcp_tool: ouroboros_start_auto" not in content
+    assert "### Required native tool set" in content
+    assert "### Official foreground CLI recovery" in content
     assert "ooo auto --resume" in content
     assert "--show-ledger" in content
+    compact = " ".join(content.split())
+    assert compact.index("Required native tool set") < compact.index("Native MCP branch")
+    assert compact.index("Native MCP branch") < compact.index(
+        "Once `ouroboros_start_auto` has been invoked"
+    )
+    assert compact.index("Once `ouroboros_start_auto` has been invoked") < compact.index(
+        "Official foreground CLI recovery"
+    )
+    assert "absent before any native dispatch attempt" in compact
+    assert "ouroboros auto --resume <auto_session_id> --codex-recovery" in compact
 
 
 def test_auto_handler_schema_contains_hang_safe_options() -> None:
@@ -1115,7 +1123,7 @@ async def test_cli_fresh_auto_uses_safe_default_cwd(monkeypatch, tmp_path) -> No
     )
 
     assert result.status == "complete"
-    assert captured["cwd"] == str(tmp_path)
+    assert captured["cwd"] == str(Path("/"))
     assert captured["runtime"] == "codex"
 
 
@@ -2657,6 +2665,27 @@ def test_auto_artifact_state_preserves_verified_ralph_completion_with_stale_hand
             product_verified=True,
         )
         == "complete_verified"
+    )
+
+
+@pytest.mark.parametrize("handoff_status", [None, "attached", "mystery"])
+def test_auto_artifact_state_defaults_unknown_complete_markers_to_unverified(
+    handoff_status,
+) -> None:
+    from ouroboros.auto.pipeline import _artifact_state_for_result
+
+    assert (
+        _artifact_state_for_result(
+            status="complete",
+            phase=AutoPhase.COMPLETE,
+            seed_path="/tmp/seed.yaml",
+            execution_id="exec_123",
+            job_id="job_123",
+            run_session_id=None,
+            run_handoff_status=handoff_status,
+            partial_product=False,
+        )
+        == "complete_unverified"
     )
 
 

--- a/tests/unit/auto/test_trace_export.py
+++ b/tests/unit/auto/test_trace_export.py
@@ -242,7 +242,7 @@ async def test_outcome_surfaces_histogram_and_gate_findings(tmp_path: Path) -> N
         (out_dir / "decisions.jsonl").read_text().splitlines()
     )
     # summary.md mentions the histogram + gate finding.
-    summary = (out_dir / "summary.md").read_text()
+    summary = (out_dir / "summary.md").read_text(encoding="utf-8")
     assert "timeout_default" in summary
     assert "constraints.latency" in summary
 

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from unittest.mock import patch
 
+import pytest
 from typer.testing import CliRunner
 
 from ouroboros.auto.pipeline import AutoPipelineResult
@@ -28,6 +29,156 @@ def test_auto_help_uses_direct_goal_command_shape() -> None:
     assert "Usage: ouroboros auto [OPTIONS] [GOAL]" in output
     assert "COMMAND [ARGS]" not in output
     assert "Goal/task for ooo auto" in output
+    assert "--efficiency-mode" in output
+    assert "--frugality-assurance" in output
+    assert "--codex-recovery" in output
+
+
+def test_auto_cli_forwards_execution_preferences() -> None:
+    """Typer must forward both recovery preference flags unchanged."""
+    captured: dict[str, object] = {}
+
+    async def fake_run_auto(**kwargs: object) -> AutoPipelineResult:
+        captured.update(kwargs)
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_preferences",
+            phase="complete",
+            grade="A",
+        )
+
+    with patch("ouroboros.cli.commands.auto._run_auto", new=fake_run_auto):
+        result = runner.invoke(
+            app,
+            [
+                "auto",
+                "safe preference goal",
+                "--skip-run",
+                "--efficiency-mode",
+                "quality_first",
+                "--frugality-assurance",
+                "strict",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert captured["efficiency_mode"] == "quality_first"
+    assert captured["frugality_assurance"] == "strict"
+
+
+@pytest.mark.parametrize(
+    ("efficiency", "assurance", "expected_efficiency", "expected_assurance", "explicit"),
+    [
+        (None, None, "adaptive", "observe", False),
+        ("adaptive", None, "adaptive", "observe", False),
+        ("quality_first", None, "quality_first", "off", False),
+        ("quality_first", "observe", "quality_first", "observe", True),
+        ("adaptive", "strict", "adaptive", "strict", True),
+    ],
+)
+def test_run_auto_persists_execution_preferences(
+    tmp_path,
+    monkeypatch,
+    efficiency,
+    assurance,
+    expected_efficiency,
+    expected_assurance,
+    explicit,
+) -> None:
+    """Every supported preference combination round-trips through AutoStore."""
+    import asyncio
+
+    from ouroboros.auto.state import AutoStore
+    from ouroboros.cli.commands.auto import _run_auto
+
+    monkeypatch.chdir(tmp_path)
+    store = AutoStore(tmp_path / "auto")
+    captured: dict[str, str] = {}
+
+    async def fake_pipeline_run(self, state):  # noqa: ARG001
+        captured["id"] = state.auto_session_id
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id=state.auto_session_id,
+            phase="complete",
+            grade="A",
+            efficiency_mode=state.efficiency_mode,
+            frugality_assurance=state.frugality_assurance,
+        )
+
+    with (
+        patch("ouroboros.cli.commands.auto.AutoStore") as store_cls,
+        patch("ouroboros.cli.commands.auto.AutoPipeline.run", new=fake_pipeline_run),
+    ):
+        store_cls.return_value = store
+        asyncio.run(
+            _run_auto(
+                goal="safe preference goal",
+                resume=None,
+                runtime="codex",
+                max_interview_rounds=2,
+                max_repair_rounds=1,
+                skip_run=True,
+                efficiency_mode=efficiency,
+                frugality_assurance=assurance,
+            )
+        )
+
+    reloaded = store.load(captured["id"])
+    assert reloaded.efficiency_mode == expected_efficiency
+    assert reloaded.frugality_assurance == expected_assurance
+    assert reloaded.frugality_assurance_explicit is explicit
+
+
+def test_resume_preference_override_rejected_without_state_mutation(tmp_path) -> None:
+    """Rejected mutable resume flags must not rewrite the durable session."""
+    import asyncio
+
+    from ouroboros.cli.commands.auto import _run_auto
+
+    state, store, session_id = _persisted_state_with_bounds(
+        tmp_path, max_interview_rounds=2, max_repair_rounds=1
+    )
+    path = store.path_for(session_id)
+    before = path.read_bytes()
+
+    with patch("ouroboros.cli.commands.auto.AutoStore") as store_cls:
+        store_cls.return_value = store
+        with pytest.raises(ValueError, match="cannot be changed on resume"):
+            asyncio.run(
+                _run_auto(
+                    goal=None,
+                    resume=session_id,
+                    runtime=None,
+                    max_interview_rounds=None,
+                    max_repair_rounds=None,
+                    skip_run=False,
+                    efficiency_mode="quality_first",
+                )
+            )
+
+    assert path.read_bytes() == before
+    assert store.load(session_id).efficiency_mode == state.efficiency_mode
+
+
+def test_auto_status_prints_execution_preferences(tmp_path) -> None:
+    from ouroboros.auto.state import AutoStore
+
+    state = AutoPipelineState(goal="status", cwd=str(tmp_path))
+    state.efficiency_mode = "quality_first"
+    state.frugality_assurance = "strict"
+    state.frugality_assurance_explicit = True
+    store = AutoStore(tmp_path)
+    store.save(state)
+
+    with patch("ouroboros.cli.commands.auto.AutoStore") as store_cls:
+        store_cls.return_value = store
+        result = runner.invoke(app, ["auto", "--status", "--resume", state.auto_session_id])
+
+    output = _plain(result.output)
+    assert result.exit_code == 0
+    assert "Efficiency mode: quality_first" in output
+    assert "Frugality assurance: strict (explicit)" in output
 
 
 def test_auto_help_documents_detached_wait_and_retrieve_commands() -> None:
@@ -98,14 +249,16 @@ def test_auto_detached_start_output_includes_handles_and_wait_retrieve_guidance(
     assert "Attached at:" not in output
     assert "Run reconciled at:" not in output
     assert output == (
-        "╭───────── Info ─────────╮\n"
+        "┌───────── Info ─────────┐\n"
         "│ Auto pipeline detached │\n"
-        "╰────────────────────────╯\n"
+        "└────────────────────────┘\n"
         "Auto session: auto_detached_123\n"
         "Status: detached\n"
         "Product status: not verified complete; background work is still running\n"
         "Authoring backend: in-process (unspecified)\n"
         "Run backend: unspecified\n"
+        "Efficiency mode: adaptive\n"
+        "Frugality assurance: observe\n"
         "Seed grade: A\n"
         "Seed: /tmp/seed.yaml\n"
         "Seed origin: none\n"
@@ -1055,3 +1208,510 @@ def test_print_result_attached_completion_remains_product_complete() -> None:
     assert "Status: complete" in output
     assert "Status: run_handoff_started" not in output
     assert "Product status: not verified complete" not in output
+
+
+@pytest.mark.parametrize(
+    "extra_args",
+    [
+        ["changed goal"],
+        ["--runtime", "codex"],
+        ["--max-interview-rounds", "9"],
+        ["--max-repair-rounds", "9"],
+        ["--skip-run"],
+        ["--efficiency-mode", "adaptive"],
+        ["--frugality-assurance", "observe"],
+        ["--timeout", "900"],
+        ["--complete-product"],
+        ["--domain", "coding"],
+        ["--commit-policy", "none"],
+        ["--worktree-policy", "current"],
+        ["--attach-execution", "exec_external"],
+        ["--attach-job", "job_external"],
+        ["--attach-session", "session_external"],
+        ["--attach-source", "operator"],
+        ["--reconcile-run"],
+        ["--reconcile-source", "operator"],
+    ],
+)
+def test_codex_recovery_resume_rejects_mutating_arguments_before_state_change(
+    tmp_path, extra_args
+) -> None:
+    """Recovery resume is an immutable replay command, not a retarget surface."""
+    state, store, session_id = _persisted_state_with_bounds(
+        tmp_path, max_interview_rounds=2, max_repair_rounds=1
+    )
+    path = store.path_for(session_id)
+    before = path.read_bytes()
+
+    async def must_not_run(**_kwargs):  # noqa: ANN202
+        raise AssertionError("invalid recovery resume reached execution")
+
+    with (
+        patch("ouroboros.cli.commands.auto.AutoStore") as store_cls,
+        patch("ouroboros.cli.commands.auto._run_auto", new=must_not_run),
+    ):
+        store_cls.return_value = store
+        result = runner.invoke(
+            app,
+            ["auto", *extra_args, "--resume", session_id, "--codex-recovery"],
+        )
+
+    assert result.exit_code == 1
+    assert "immutable" in _plain(result.output).lower()
+    assert path.read_bytes() == before
+    assert store.load(session_id).goal == state.goal
+
+
+def test_codex_recovery_flag_is_forwarded_to_run_auto() -> None:
+    captured: dict[str, object] = {}
+
+    async def fake_run_auto(**kwargs):  # noqa: ANN202
+        captured.update(kwargs)
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_recovery",
+            phase="complete",
+            grade="A",
+            seed_path="seed.yaml",
+            recovery_terminal_proof=True,
+        )
+
+    with patch("ouroboros.cli.commands.auto._run_auto", new=fake_run_auto):
+        result = runner.invoke(
+            app,
+            [
+                "auto",
+                "safe recovery",
+                "--runtime",
+                "codex",
+                "--codex-recovery",
+                "--skip-run",
+            ],
+        )
+
+    assert result.exit_code == 0
+    assert captured["codex_recovery"] is True
+
+
+@pytest.mark.parametrize("handoff_status", ["attached", "started"])
+def test_codex_recovery_rejects_unverified_complete_handoff(tmp_path, handoff_status) -> None:
+    """A COMPLETE phase cannot launder attached/pending work into recovery success."""
+
+    async def fake_run_auto(**_kwargs):  # noqa: ANN202
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_unverified",
+            phase="complete",
+            job_id="job_unverified",
+            execution_id="exec_unverified",
+            run_handoff_status=handoff_status,
+        )
+
+    from ouroboros.auto.state import AutoStore
+
+    store = AutoStore(tmp_path)
+    with (
+        patch("ouroboros.cli.commands.auto._run_auto", new=fake_run_auto),
+        patch("ouroboros.cli.commands.auto.AutoStore", return_value=store),
+    ):
+        result = runner.invoke(
+            app,
+            ["auto", "--resume", "auto_unverified", "--codex-recovery"],
+        )
+
+    assert result.exit_code == 1
+    assert "Auto pipeline completed" not in _plain(result.output)
+
+
+def test_codex_recovery_rejects_stale_complete_with_handles_and_blocker(tmp_path) -> None:
+    """Missing handoff proof plus a durable error can never exit recovery zero."""
+
+    async def fake_run_auto(**_kwargs):  # noqa: ANN202
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_stale_complete",
+            phase="complete",
+            job_id="job_unknown",
+            run_handoff_status=None,
+            blocker="snapshot transport failed",
+        )
+
+    from ouroboros.auto.state import AutoStore
+
+    with (
+        patch("ouroboros.cli.commands.auto._run_auto", new=fake_run_auto),
+        patch("ouroboros.cli.commands.auto.AutoStore", return_value=AutoStore(tmp_path)),
+    ):
+        result = runner.invoke(
+            app,
+            ["auto", "--resume", "auto_stale_complete", "--codex-recovery"],
+        )
+
+    assert result.exit_code == 1
+    assert "Auto pipeline completed" not in _plain(result.output)
+
+
+@pytest.mark.parametrize("extra_args", [["--attach-job", "job_external"], ["--no-wait"]])
+def test_codex_recovery_status_rejects_mutating_options_before_load(tmp_path, extra_args) -> None:
+    """The read-only status early return cannot bypass immutable recovery parsing."""
+    from ouroboros.auto.state import AutoStore
+
+    state = AutoPipelineState(goal="status guard", cwd=str(tmp_path))
+    store = AutoStore(tmp_path)
+    path = store.save(state)
+    before = path.read_bytes()
+
+    with patch("ouroboros.cli.commands.auto.AutoStore", return_value=store):
+        result = runner.invoke(
+            app,
+            [
+                "auto",
+                "--status",
+                "--resume",
+                state.auto_session_id,
+                "--codex-recovery",
+                *extra_args,
+            ],
+        )
+
+    assert result.exit_code == 1
+    assert path.read_bytes() == before
+    assert (
+        "immutable" in _plain(result.output).lower() or "no-wait" in _plain(result.output).lower()
+    )
+
+
+def test_safe_default_cwd_preserves_root(monkeypatch) -> None:
+    """The resolved host cwd is never silently retargeted to HOME."""
+    from pathlib import Path
+
+    from ouroboros.cli.commands.auto import _safe_default_cwd
+
+    monkeypatch.setattr("ouroboros.cli.commands.auto.Path.cwd", lambda: Path("/"))
+    monkeypatch.setattr("ouroboros.cli.commands.auto.os.access", lambda *_args: True)
+
+    assert _safe_default_cwd() == Path("/")
+
+
+def test_run_auto_rejects_stale_complete_before_checkpoint_or_handler_build(
+    tmp_path,
+) -> None:
+    """Loaded COMPLETE is proof-checked before terminal side effects."""
+    import asyncio
+
+    from ouroboros.auto.state import AutoCommitPolicy, AutoStore
+    from ouroboros.cli.commands.auto import _run_auto
+
+    state = AutoPipelineState(goal="stale complete", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.transition(AutoPhase.COMPLETE, "legacy handoff")
+    state.job_id = "job_unknown"
+    state.run_handoff_status = None
+    state.last_error = "snapshot transport failed"
+    state.commit_policy = AutoCommitPolicy.FINAL_ONLY
+    store = AutoStore(tmp_path)
+    path = store.save(state)
+    before = path.read_bytes()
+
+    with (
+        patch("ouroboros.cli.commands.auto.AutoStore", return_value=store),
+        patch("ouroboros.auto.pipeline.checkpoint_final_auto") as checkpoint,
+    ):
+        with pytest.raises(ValueError, match="unverified persisted COMPLETE"):
+            asyncio.run(
+                _run_auto(
+                    goal=None,
+                    resume=state.auto_session_id,
+                    runtime=None,
+                    max_interview_rounds=None,
+                    max_repair_rounds=None,
+                    skip_run=False,
+                    codex_recovery=True,
+                )
+            )
+
+    checkpoint.assert_not_called()
+    assert path.read_bytes() == before
+
+
+def test_codex_recovery_rejects_legacy_completed_marker_without_terminal_proof() -> None:
+    """A legacy success label cannot stand in for durable lifecycle evidence."""
+    from ouroboros.cli.commands.auto import _codex_recovery_state_has_terminal_proof
+
+    state = AutoPipelineState(goal="legacy completed marker", cwd=".")
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.transition(AutoPhase.COMPLETE, "legacy success")
+    state.job_id = "job_legacy"
+    state.execution_id = "exec_legacy"
+    state.run_handoff_status = "completed"
+
+    assert state.run_terminal_job_status is None
+    assert state.run_terminal_status is None
+    assert state.run_terminal_success is None
+    assert _codex_recovery_state_has_terminal_proof(state) is False
+
+
+def test_codex_recovery_rejects_handleless_partial_product_even_with_seed_shape(
+    monkeypatch,
+) -> None:
+    """A degraded Seed is not an explicit verified skip-run terminal."""
+    from ouroboros.cli.commands.auto import _codex_recovery_state_result_has_terminal_proof
+
+    state = AutoPipelineState(goal="partial recovery", cwd=".")
+    state.skip_run = True
+    state.last_grade = "A"
+    state.seed_path = "seed.yaml"
+    state.seed_artifact = {"validated": "by patched receipt boundary"}
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.COMPLETE, "partial")
+    monkeypatch.setattr(
+        "ouroboros.cli.commands.auto._codex_recovery_seed_receipt_is_valid",
+        lambda _state: True,
+    )
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id=state.auto_session_id,
+        phase="complete",
+        grade="A",
+        required_grade="A",
+        skip_run=True,
+        seed_path=state.seed_path,
+        partial_product=True,
+        artifact_state="complete_unverified",
+    )
+
+    assert _codex_recovery_state_result_has_terminal_proof(state, result) is False
+
+
+def test_codex_recovery_accepts_only_explicit_verified_skip_run(
+    monkeypatch,
+) -> None:
+    """Handleless success is bound to durable state intent and Seed receipt."""
+    from ouroboros.cli.commands.auto import _codex_recovery_state_result_has_terminal_proof
+
+    state = AutoPipelineState(goal="verified seed only", cwd=".")
+    state.skip_run = True
+    state.last_grade = "A"
+    state.seed_path = "seed.yaml"
+    state.seed_artifact = {"validated": "by patched receipt boundary"}
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.COMPLETE, "skip run")
+    monkeypatch.setattr(
+        "ouroboros.cli.commands.auto._codex_recovery_seed_receipt_is_valid",
+        lambda _state: True,
+    )
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id=state.auto_session_id,
+        phase="complete",
+        grade="A",
+        required_grade="A",
+        skip_run=True,
+        seed_path=state.seed_path,
+        artifact_state="complete_verified",
+    )
+
+    assert _codex_recovery_state_result_has_terminal_proof(state, result) is True
+
+
+def test_codex_recovery_rejects_skip_run_below_required_grade(monkeypatch) -> None:
+    """A nonempty grade is not enough when it misses the persisted floor."""
+    from ouroboros.cli.commands.auto import _codex_recovery_state_result_has_terminal_proof
+
+    state = AutoPipelineState(goal="low grade seed", cwd=".")
+    state.skip_run = True
+    state.required_grade = "A"
+    state.last_grade = "C"
+    state.seed_path = "seed.yaml"
+    state.seed_artifact = {"validated": "by patched receipt boundary"}
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.COMPLETE, "skip run")
+    monkeypatch.setattr(
+        "ouroboros.cli.commands.auto._codex_recovery_seed_receipt_is_valid",
+        lambda _state: True,
+    )
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id=state.auto_session_id,
+        phase="complete",
+        grade="C",
+        required_grade="A",
+        skip_run=True,
+        seed_path=state.seed_path,
+        artifact_state="complete_verified",
+    )
+
+    assert _codex_recovery_state_result_has_terminal_proof(state, result) is False
+
+
+def test_codex_recovery_validates_seed_file_against_state_receipt(tmp_path) -> None:
+    """The durable Seed file must parse and exactly match the state artifact."""
+    from pathlib import Path
+
+    from ouroboros.auto.adapters import save_seed
+    from ouroboros.cli.commands.auto import _codex_recovery_seed_receipt_is_valid
+    from ouroboros.core.seed import (
+        EvaluationPrinciple,
+        ExitCondition,
+        OntologyField,
+        OntologySchema,
+        Seed,
+        SeedMetadata,
+    )
+
+    seed = Seed(
+        goal="Build a local CLI",
+        constraints=("Use existing patterns",),
+        acceptance_criteria=("Command prints stable output",),
+        ontology_schema=OntologySchema(
+            name="CliTask",
+            description="CLI task ontology",
+            fields=(
+                OntologyField(name="command", field_type="string", description="Command"),
+            ),
+        ),
+        evaluation_principles=(
+            EvaluationPrinciple(name="testability", description="Observable behavior"),
+        ),
+        exit_conditions=(
+            ExitCondition(
+                name="verified",
+                description="Checks pass",
+                evaluation_criteria="All acceptance criteria pass",
+            ),
+        ),
+        metadata=SeedMetadata(ambiguity_score=0.1),
+    )
+    state = AutoPipelineState(goal=seed.goal, cwd=str(tmp_path))
+    state.seed_artifact = seed.to_dict()
+    state.seed_path = save_seed(seed, seeds_dir=tmp_path)
+
+    assert _codex_recovery_seed_receipt_is_valid(state) is True
+
+    Path(state.seed_path).write_text("not: the same seed\n", encoding="utf-8")
+    assert _codex_recovery_seed_receipt_is_valid(state) is False
+
+
+def test_codex_recovery_partial_seed_exits_nonzero_without_completion_message(
+    tmp_path,
+) -> None:
+    """An unverified handleless Seed cannot be rendered as recovery success."""
+
+    async def fake_run_auto(**_kwargs):  # noqa: ANN202
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_partial_seed",
+            phase="complete",
+            grade="A",
+            required_grade="A",
+            skip_run=True,
+            seed_path="seed.yaml",
+            partial_product=True,
+            artifact_state="complete_unverified",
+            recovery_terminal_proof=False,
+        )
+
+    from ouroboros.auto.state import AutoStore
+
+    with (
+        patch("ouroboros.cli.commands.auto._run_auto", new=fake_run_auto),
+        patch("ouroboros.cli.commands.auto.AutoStore", return_value=AutoStore(tmp_path)),
+    ):
+        result = runner.invoke(
+            app,
+            ["auto", "--resume", "auto_partial_seed", "--codex-recovery"],
+        )
+
+    assert result.exit_code == 1
+    assert "Auto pipeline completed" not in _plain(result.output)
+
+
+@pytest.mark.parametrize(
+    ("job_status", "run_status", "run_success"),
+    [
+        ("failed", "completed", True),
+        ("completed", "failed", True),
+        ("completed", "completed", False),
+        ("completed", "completed", None),
+    ],
+)
+def test_codex_recovery_rejects_contradictory_execution_envelope(
+    job_status: str,
+    run_status: str,
+    run_success: bool | None,
+) -> None:
+    """Every terminal lifecycle signal must independently prove success."""
+    from ouroboros.cli.commands.auto import _codex_recovery_state_result_has_terminal_proof
+
+    state = AutoPipelineState(goal="contradictory execution", cwd=".")
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.transition(AutoPhase.COMPLETE, "execution complete")
+    state.job_id = "job_contradictory"
+    state.execution_id = "exec_contradictory"
+    state.run_handoff_status = "completed"
+    state.run_terminal_job_status = "completed"
+    state.run_terminal_status = "completed"
+    state.run_terminal_success = True
+
+    result = AutoPipelineResult(
+        status="complete",
+        auto_session_id="auto_contradictory",
+        phase="complete",
+        job_id="job_contradictory",
+        execution_id="exec_contradictory",
+        run_handoff_status="completed",
+        execution_job_status=job_status,
+        execution_run_status=run_status,
+        execution_run_success=run_success,
+        artifact_state="complete_verified",
+    )
+
+    assert _codex_recovery_state_result_has_terminal_proof(state, result) is False
+
+
+def test_codex_recovery_accepts_completed_execution_envelope(tmp_path) -> None:
+    """The exact completed/true snapshot projection exits recovery zero."""
+
+    async def fake_run_auto(**_kwargs):  # noqa: ANN202
+        return AutoPipelineResult(
+            status="complete",
+            auto_session_id="auto_verified",
+            phase="complete",
+            job_id="job_verified",
+            execution_id="exec_verified",
+            run_handoff_status="completed",
+            execution_job_status="completed",
+            execution_run_status="completed",
+            execution_run_success=True,
+            artifact_state="complete_verified",
+            recovery_terminal_proof=True,
+        )
+
+    from ouroboros.auto.state import AutoStore
+
+    with (
+        patch("ouroboros.cli.commands.auto._run_auto", new=fake_run_auto),
+        patch("ouroboros.cli.commands.auto.AutoStore", return_value=AutoStore(tmp_path)),
+    ):
+        result = runner.invoke(
+            app,
+            ["auto", "--resume", "auto_verified", "--codex-recovery"],
+        )
+
+    assert result.exit_code == 0
+    assert "Auto pipeline completed" in _plain(result.output)

--- a/tests/unit/cli/test_auto_command.py
+++ b/tests/unit/cli/test_auto_command.py
@@ -1578,9 +1578,7 @@ def test_codex_recovery_validates_seed_file_against_state_receipt(tmp_path) -> N
         ontology_schema=OntologySchema(
             name="CliTask",
             description="CLI task ontology",
-            fields=(
-                OntologyField(name="command", field_type="string", description="Command"),
-            ),
+            fields=(OntologyField(name="command", field_type="string", description="Command"),),
         ),
         evaluation_principles=(
             EvaluationPrinciple(name="testability", description="Observable behavior"),

--- a/tests/unit/cli/test_auto_run_handoff_wait.py
+++ b/tests/unit/cli/test_auto_run_handoff_wait.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+import time
 
 import pytest
 from typer.testing import CliRunner
@@ -40,6 +41,7 @@ def _plain(text: str) -> str:
 
 
 async def _cancel_manager_tasks(manager: JobManager) -> None:
+    await manager.drain(grace_seconds=1.0)
     tasks = [
         *manager._tasks.values(),  # noqa: SLF001
         *manager._runner_tasks.values(),  # noqa: SLF001
@@ -80,6 +82,22 @@ def _terminal_run_result() -> MCPToolResult:
         content=(MCPContentItem(type=ContentType.TEXT, text="run receipt: 2/2 ACs satisfied"),),
         is_error=False,
         meta={"status": "completed", "success": True},
+    )
+
+
+def _pending_handoff_result(job_id: str) -> AutoPipelineResult:
+    """Foreground CLI handoff that is durable RUN until execution is proven."""
+    return AutoPipelineResult(
+        status=AutoPhase.RUN.value,
+        auto_session_id="auto_wait",
+        phase=AutoPhase.RUN.value,
+        grade="A",
+        seed_path="/tmp/seed.yaml",
+        job_id=job_id,
+        execution_id="exec_wait",
+        run_session_id="orch_wait",
+        run_handoff_status=RUN_HANDOFF_STARTED_STATUS,
+        resume_capability=AutoResumeCapability.RESUME,
     )
 
 
@@ -565,6 +583,136 @@ async def test_wait_completed_job_without_success_meta_is_not_complete(tmp_path)
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "meta",
+    [
+        {},
+        {"status": "completed"},
+        {"status": "completed", "success": "true"},
+    ],
+)
+async def test_wait_requires_explicit_true_success_for_completed_job(tmp_path, meta) -> None:
+    """A completed job lifecycle is not an authoritative execution success."""
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(store)
+    try:
+
+        async def _runner() -> MCPToolResult:
+            return MCPToolResult(
+                content=(MCPContentItem(type=ContentType.TEXT, text="terminal without proof"),),
+                is_error=False,
+                meta=meta,
+            )
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_runner()
+        )
+        reconciled = await _await_run_handoff_terminal(
+            _pending_handoff_result(started.job_id),
+            job_manager=manager,
+            event_store=store,
+            quiet=True,
+        )
+
+        assert reconciled.status == "blocked"
+        assert reconciled.resume_capability is AutoResumeCapability.RESUME
+        assert "without confirming terminal run success" in (reconciled.blocker or "")
+    finally:
+        await _cancel_manager_tasks(manager)
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_waiter_error_blocks_and_preserves_resume_handle(tmp_path, monkeypatch) -> None:
+    """A job-wait transport/result error is a resumable non-zero boundary."""
+    store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(store)
+    started_running = asyncio.Event()
+    try:
+
+        async def _runner() -> MCPToolResult:
+            started_running.set()
+            await asyncio.sleep(3600)
+            raise AssertionError("unreachable")
+
+        class _ErrResult:
+            is_err = True
+
+        async def _fail_wait(_self, _arguments):
+            return _ErrResult()
+
+        monkeypatch.setattr(auto_command.JobWaitHandler, "handle", _fail_wait)
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_runner()
+        )
+        await asyncio.wait_for(started_running.wait(), timeout=5)
+
+        reconciled = await _await_run_handoff_terminal(
+            _pending_handoff_result(started.job_id),
+            job_manager=manager,
+            event_store=store,
+            quiet=True,
+        )
+
+        assert reconciled.status == "blocked"
+        assert reconciled.resume_capability is AutoResumeCapability.RESUME
+        assert "waiter failed" in (reconciled.blocker or "")
+    finally:
+        await _cancel_manager_tasks(manager)
+        await store.close()
+
+
+@pytest.mark.asyncio
+async def test_terminal_success_promotes_durable_run_to_complete(tmp_path) -> None:
+    """Foreground RUN becomes durable COMPLETE only after explicit success."""
+    jobs = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
+    manager = JobManager(jobs)
+    auto_store = AutoStore(tmp_path / "auto")
+    try:
+
+        async def _runner() -> MCPToolResult:
+            return _terminal_run_result()
+
+        started = await manager.start_job(
+            job_type="execute", initial_message="queued", runner=_runner()
+        )
+        state = AutoPipelineState(goal="wait", cwd=str(tmp_path))
+        state.transition(AutoPhase.INTERVIEW, "interview")
+        state.transition(AutoPhase.SEED_GENERATION, "seed")
+        state.transition(AutoPhase.REVIEW, "review")
+        state.transition(AutoPhase.RUN, "foreground handoff pending")
+        state.job_id = started.job_id
+        state.execution_id = "exec_wait"
+        state.run_session_id = "orch_wait"
+        state.run_handoff_status = RUN_HANDOFF_STARTED_STATUS
+        auto_store.save(state)
+
+        reconciled = await _await_run_handoff_terminal(
+            _pending_handoff_result(started.job_id),
+            job_manager=manager,
+            event_store=jobs,
+            quiet=True,
+            state=state,
+            store=auto_store,
+        )
+
+        reloaded = auto_store.load(state.auto_session_id)
+        assert reconciled.status == "complete"
+        assert reconciled.run_handoff_status == "completed"
+        assert reconciled.execution_job_status == "completed"
+        assert reconciled.execution_run_status == "completed"
+        assert reconciled.execution_run_success is True
+        assert reloaded.phase is AutoPhase.COMPLETE
+        assert reloaded.run_handoff_status == "completed"
+        assert reloaded.run_terminal_job_status == "completed"
+        assert reloaded.run_terminal_status == "completed"
+        assert reloaded.run_terminal_success is True
+    finally:
+        await _cancel_manager_tasks(manager)
+        await jobs.close()
+
+
+@pytest.mark.asyncio
 async def test_wait_prefers_linked_execution_terminal_over_live_wedged_job(
     tmp_path,
 ) -> None:
@@ -629,7 +777,7 @@ async def test_wait_prefers_linked_execution_terminal_over_live_wedged_job(
         assert reconciled.resume_capability is AutoResumeCapability.NONE
 
         snapshot = await manager.get_snapshot(started.job_id)
-        assert snapshot.status is JobStatus.RUNNING
+        assert snapshot.status in {JobStatus.QUEUED, JobStatus.RUNNING}
         events, _cursor = await store.get_events_after("job", started.job_id, 0)
         assert not any(event.type == "mcp.job.cancelled" for event in events)
     finally:
@@ -749,35 +897,38 @@ def test_paused_run_exit_code_reflects_non_complete() -> None:
 
 
 @pytest.mark.asyncio
-async def test_wait_is_noop_when_job_not_owned(tmp_path) -> None:
-    """An unknown/plugin-dispatch job handle leaves the result untouched."""
+async def test_wait_blocks_when_job_not_owned(tmp_path) -> None:
+    """Foreground recovery must fail closed when its manager does not own the job."""
     store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
     manager = JobManager(store)
     try:
-        result = _handoff_only_result("job_not_in_this_manager")
+        result = _pending_handoff_result("job_not_in_this_manager")
         reconciled = await _await_run_handoff_terminal(
             result,
             job_manager=manager,
             event_store=store,
             quiet=True,
         )
-        assert reconciled is result
+        assert reconciled.status == "blocked"
+        assert reconciled.resume_capability is AutoResumeCapability.RESUME
+        assert "not owned" in (reconciled.blocker or "")
     finally:
         await _cancel_manager_tasks(manager)
         await store.close()
 
 
 @pytest.mark.asyncio
-async def test_wait_is_noop_without_job_handle(tmp_path) -> None:
-    """No job_id (plugin dispatch) => nothing to wait on, result unchanged."""
+async def test_wait_blocks_without_job_handle(tmp_path) -> None:
+    """Foreground recovery cannot claim completion without an owned job handle."""
     store = EventStore(f"sqlite+aiosqlite:///{tmp_path / 'jobs.db'}")
     manager = JobManager(store)
     try:
         result = AutoPipelineResult(
-            status="complete",
+            status=AutoPhase.RUN.value,
             auto_session_id="auto_wait",
-            phase="complete",
+            phase=AutoPhase.RUN.value,
             run_handoff_status=RUN_HANDOFF_STARTED_STATUS,
+            resume_capability=AutoResumeCapability.RESUME,
         )
         reconciled = await _await_run_handoff_terminal(
             result,
@@ -785,7 +936,8 @@ async def test_wait_is_noop_without_job_handle(tmp_path) -> None:
             event_store=store,
             quiet=True,
         )
-        assert reconciled is result
+        assert reconciled.status == "blocked"
+        assert "no durable job handle" in (reconciled.blocker or "")
     finally:
         await _cancel_manager_tasks(manager)
         await store.close()
@@ -824,3 +976,124 @@ def test_no_wait_flag_detaches_and_prints_honest_notice() -> None:
     output = _plain(result.output)
     assert "will NOT survive process exit" in output
     assert "job_detached" in output
+
+
+def test_foreground_detached_result_exits_nonzero() -> None:
+    """A foreground recovery must never treat detached work as CLI success."""
+
+    async def fake_run_auto(**_kwargs: object) -> AutoPipelineResult:
+        return AutoPipelineResult(
+            status="detached",
+            auto_session_id="auto_detached",
+            phase=AutoPhase.RUN.value,
+            job_id="job_detached",
+            run_handoff_status=RUN_HANDOFF_STARTED_STATUS,
+            resume_capability=AutoResumeCapability.RESUME,
+        )
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(auto_command, "_run_auto", fake_run_auto)
+        result = runner.invoke(
+            app,
+            [
+                "auto",
+                "safe foreground goal",
+                "--runtime",
+                "codex",
+                "--codex-recovery",
+            ],
+        )
+
+    assert result.exit_code == 1
+
+
+def test_codex_recovery_rejects_no_wait_before_start() -> None:
+    """The static-tool recovery mode cannot be made fire-and-forget."""
+    result = runner.invoke(
+        app,
+        [
+            "auto",
+            "safe recovery goal",
+            "--runtime",
+            "codex",
+            "--codex-recovery",
+            "--no-wait",
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert "cannot be combined with --no-wait" in _plain(result.output)
+
+
+def test_run_meta_verdict_rejects_non_mapping_metadata() -> None:
+    """Malformed result_meta must stay unknown instead of crashing or passing."""
+    from types import SimpleNamespace
+
+    assert auto_command._run_meta_verdict(SimpleNamespace(result_meta=["completed", True])) == (
+        "",
+        None,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_point", ["initial_snapshot", "waiter", "event_query"])
+async def test_raised_foreground_transport_errors_are_resumable_and_durable(
+    tmp_path, monkeypatch, failure_point
+) -> None:
+    """Raised transport failures are structured blockers, never top-level crashes."""
+
+    class Snapshot:
+        is_terminal = False
+        status = JobStatus.RUNNING
+        job_id = "job_transport"
+        result_meta = {}
+        error = None
+        result_text = None
+        message = "running"
+
+    class Manager:
+        async def get_snapshot(self, _job_id: str) -> Snapshot:
+            if failure_point == "initial_snapshot":
+                raise ConnectionError("snapshot transport failed")
+            return Snapshot()
+
+    class Events:
+        async def query_events(self, *_args, **_kwargs):  # noqa: ANN002, ANN003, ANN202
+            if failure_point == "event_query":
+                raise ConnectionError("event query transport failed")
+            return []
+
+    if failure_point == "waiter":
+
+        async def raise_waiter(_self, _arguments):  # noqa: ANN202
+            raise ConnectionError("wait transport failed")
+
+        monkeypatch.setattr(auto_command.JobWaitHandler, "handle", raise_waiter)
+
+    state = AutoPipelineState(goal="transport", cwd=str(tmp_path))
+    state.transition(AutoPhase.INTERVIEW, "interview")
+    state.transition(AutoPhase.SEED_GENERATION, "seed")
+    state.transition(AutoPhase.REVIEW, "review")
+    state.transition(AutoPhase.RUN, "run")
+    state.job_id = "job_transport"
+    state.execution_id = "exec_wait"
+    state.run_session_id = "orch_wait"
+    state.run_handoff_status = RUN_HANDOFF_STARTED_STATUS
+    auto_store = AutoStore(tmp_path / "auto")
+    auto_store.save(state)
+
+    reconciled = await _await_run_handoff_terminal(
+        _pending_handoff_result("job_transport"),
+        job_manager=Manager(),
+        event_store=Events(),
+        quiet=True,
+        state=state,
+        store=auto_store,
+        deadline_at=time.monotonic() + 1,
+    )
+
+    assert reconciled.status == "blocked"
+    assert reconciled.resume_capability is AutoResumeCapability.RESUME
+    assert "transport" in (reconciled.blocker or "").lower()
+    reloaded = auto_store.load(state.auto_session_id)
+    assert reloaded.phase is AutoPhase.RUN

--- a/tests/unit/cli/test_codex_command.py
+++ b/tests/unit/cli/test_codex_command.py
@@ -78,9 +78,17 @@ class TestCodexDoctor:
         skill_path.write_text(
             "---\n"
             "name: auto\n"
-            "mcp_tool: ouroboros_start_auto\n"
             "---\n"
-            "Manual fallback is not allowed when the tool is unavailable.\n",
+            "### Required native tool set\n"
+            "Inspect `ouroboros_start_auto`, `ouroboros_job_wait`, and "
+            "`ouroboros_job_result` before dispatch.\n"
+            "### Native MCP branch\n"
+            "When all required tools exist, invoke `ouroboros_start_auto`.\n"
+            "Once `ouroboros_start_auto` has been invoked, CLI fallback is forbidden.\n"
+            "### Official foreground CLI recovery\n"
+            "When a required native tool is unavailable, verify "
+            "`ouroboros auto --help` then use `--codex-recovery`.\n"
+            "Manual repository fallback is unavailable and forbidden.\n",
             encoding="utf-8",
         )
 
@@ -661,8 +669,27 @@ class TestCodexDoctor:
         failures = _check_auto_dispatch_surface(codex_dir)
 
         assert "Codex rules do not map `ooo auto` to `ouroboros_start_auto`" in failures
-        assert "auto skill does not declare `mcp_tool: ouroboros_start_auto`" in failures
+        assert "auto skill is missing the ordered native/CLI recovery contract" in failures
         assert "Codex config does not contain [mcp_servers.ouroboros]" in failures
+
+    def test_check_auto_dispatch_surface_rejects_static_auto_tool_binding(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A static frontmatter binding bypasses required capability discovery."""
+        codex_dir = tmp_path / ".codex"
+        self._write_healthy_codex_surface(codex_dir)
+        skill_path = codex_dir / "skills" / "ouroboros-auto" / "SKILL.md"
+        skill_path.write_text(
+            skill_path.read_text(encoding="utf-8").replace(
+                "name: auto\n", "name: auto\nmcp_tool: ouroboros_start_auto\n"
+            ),
+            encoding="utf-8",
+        )
+
+        failures = _check_auto_dispatch_surface(codex_dir)
+
+        assert "auto skill must not declare a static `mcp_tool` binding" in failures
 
     def test_doctor_command_exits_nonzero_when_dispatch_surface_is_broken(
         self,

--- a/tests/unit/test_codex_artifacts.py
+++ b/tests/unit/test_codex_artifacts.py
@@ -196,13 +196,33 @@ class TestInstallCodexRules:
         assert not real_workspace.joinpath(".codex", "rules", CODEX_RULE_FILENAME).exists()
 
     def test_packaged_rules_fail_closed_for_ooo_auto(self) -> None:
-        """Codex rules must route ``ooo auto`` to the real MCP tool, not manual work."""
+        """Codex rules expose the ordered native-first recovery state machine."""
         rules = load_packaged_codex_rules()
         compact = " ".join(rules.split())
 
-        assert "| `ooo auto ...` | `ouroboros_start_auto`" in rules
+        assert "| `ooo auto ...` | Use the ordered Auto dispatch decision matrix" in rules
+        assert "When the user types `ooo <command>`, you MUST" not in rules
+        assert "ALWAYS route to the MCP tool" not in rules
+        assert "If a user input starts with `ooo auto`, call `ouroboros_start_auto`" not in rules
+        assert "When the full required native tool set is present" in rules
         assert "Do not emulate it with manual" in rules
-        assert "If that MCP tool is unavailable" in compact
+        discovery = compact.index("Required native tool set")
+        native = compact.index("Native MCP branch")
+        attempted = compact.index("Once `ouroboros_start_auto` has been invoked")
+        recovery = compact.index("Official foreground CLI recovery")
+        assert discovery < native < attempted < recovery
+        assert "`ouroboros_start_auto`, `ouroboros_job_wait`, and `ouroboros_job_result`" in compact
+        assert "absent before any native dispatch attempt" in compact
+        assert "ambiguous transport outcome" in compact
+        assert "CLI fallback is forbidden" in compact
+        assert "--codex-recovery" in compact
+        assert "--runtime codex" in compact
+        assert "--timeout" in compact
+        assert "goal as one argv element" in compact
+        assert "resolved working directory" in compact
+        assert "ouroboros auto --resume <auto_session_id> --codex-recovery" in compact
+        assert "Do not pass goal, runtime, preferences, timeout, bounds" in compact
+        assert "never add `--no-wait`" in compact
         assert "Do not call a `blocked` or `failed` auto-session result a dispatch" in compact
 
     def test_packaged_rules_include_rendered_skill_capability_guide(self) -> None:
@@ -267,15 +287,26 @@ class TestLoadPackagedCodexSkills:
             assert skill_md_path.read_text(encoding="utf-8").startswith("---\nname: run\n")
 
     def test_packaged_auto_skill_forbids_manual_fallback(self) -> None:
-        """The auto skill body must not allow silent manual emulation."""
+        """The auto skill uses the same ordered native-first recovery contract."""
         skill = load_packaged_codex_skill("auto")
 
         compact = " ".join(skill.split())
-        assert "must be executed by invoking MCP tool `ouroboros_start_auto`" in compact
-        assert "manual fallback is not an `ooo auto` run" in compact
+        discovery = compact.index("Required native tool set")
+        native = compact.index("Native MCP branch")
+        attempted = compact.index("Once `ouroboros_start_auto` has been invoked")
+        recovery = compact.index("Official foreground CLI recovery")
+        assert discovery < native < attempted < recovery
+        assert "absent before any native dispatch attempt" in compact
+        assert "CLI fallback is forbidden" in compact
+        assert "manual repository work is not an `ooo auto` run" in compact
+        assert "--codex-recovery" in compact
+        assert "ouroboros auto --resume <auto_session_id> --codex-recovery" in compact
+        assert "never add `--no-wait`" in compact
         assert "Do not label a `blocked` or `failed` outcome as MCP dispatch failure" in compact
         assert "The user should not have to poll the job manually" in compact
         assert "ouroboros_job_result" in compact
+        assert "mcp_tool: ouroboros_start_auto" not in skill
+        assert "before invoking `ouroboros_start_auto`" not in skill
 
     def test_packaged_interview_skill_uses_runtime_capability_terms(self) -> None:
         """Runtime skill instructions should not hardcode Claude-only tool surfaces."""


### PR DESCRIPTION
## What changed

- make `ooo auto` choose native MCP only after discovering the complete required tool set, with an official foreground CLI recovery path otherwise
- harden persisted Auto recovery with durable terminal proof, restart-safe state writes, truthful completion rendering, and deferred final checkpoints
- align Codex doctor and packaged artifacts with the ordered dispatch contract
- add recovery, lifecycle, process-lock, artifact, and passthrough regression coverage

## Why

Static tool binding and shape-based completion inference could produce duplicate dispatches, false success, or false failure after stale state, contradictory snapshots, or process restarts. Recovery now fails closed and uses one persisted state-plus-result proof boundary.

## Test plan

- [x] 1,486 scoped Auto/CLI/Codex tests passed
- [x] 567 related recovery tests passed
- [x] 11 final terminal-proof regressions passed
- [x] `ruff check` and `ruff format --check src tests` passed
- [x] `ouroboros codex doctor --live-mcp` passed
- [x] GPT-5.6 Pro completion review returned APPROVED

## R-run comparison (required for `src/ouroboros/auto/` changes)

This is a recovery/dispatch substrate change. It does not change the interview or repair round algorithm, provider-call count, or canonical per-round workload, so a per-round R-run comparison is not applicable.

| Metric                         | Baseline (sha) | This PR (sha) | Ratio |
|--------------------------------|----------------|---------------|-------|
| Rounds completed in 600 s      | N/A            | N/A           | n/a   |
| Per-round wall-clock (s/round) | N/A            | N/A           | n/a   |
| Terminal reason                | N/A            | N/A           | n/a   |
| EventStore event count         | N/A            | N/A           | n/a   |

Budget compliance: N/A — recovery/dispatch substrate only; no per-round loop change.
