### PR TITLE
feat(interview): complete terminal latency evidence

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -111,6 +111,47 @@ Emitted periodically during execution with runtime progress.
 | `progress` | `object` | Nested progress state (structure varies by runtime) |
 | `progress.runtime_status` | `string?` | Runtime-reported status when available |
 
+### Interview latency events
+
+The following interview events carry the same privacy-safe `timings_ms`
+object for newly measured handler turns:
+
+- `interview.response.emitted`: a question-bearing start, answer, or resume response.
+- `interview.completed`: a turn that completes without returning another question.
+- `interview.failed`: a terminal failure, including completion and question generation.
+- `interview.question_generation.parent_handoff`: question generation delegated to the
+  parent session after a provider envelope violation.
+
+Historical rows written before phase timing was introduced may not contain
+`timings_ms`. A `null` phase in a new timing object means that phase did not
+execute during the measured turn; it does not mean zero milliseconds.
+
+| `timings_ms` field | Type | Description |
+|--------------------|------|-------------|
+| `total` | `number?` | Monotonic server-side handler time through terminal event creation |
+| `ambiguity_scoring` | `number?` | Time spent in live ambiguity scoring |
+| `question_generation` | `number?` | Time spent awaiting `ask_next_question` |
+| `advisory_build` | `number?` | Time spent preparing server-side advisory request metadata |
+
+`total` is not user-observed wall time. It excludes work performed by the host
+after the MCP response returns. In particular, `advisory_build` does not
+measure execution of host-side advisory fan-out. `question_generation` may
+include adapter/client startup and provider latency because those operations
+remain inside the question-generation boundary.
+
+Event-specific fields remain additive. The benchmark exporter allowlists only
+the non-content metadata needed for phase analysis:
+
+| Event | Additional fields |
+|-------|-------------------|
+| `interview.response.emitted` | `response_kind`, `round_number`, `payload_chars`, `transcript_chars`, `ambiguity_prefix_present`, `is_length_guard` |
+| `interview.completed` | `total_rounds` |
+| `interview.failed` | `phase`, existing bounded `error` diagnostics |
+| `interview.question_generation.parent_handoff` | `phase`, `reason_code`, optional `provider_error_type` |
+
+Use `scripts/export_interview_latency.py` when sharing benchmark evidence. The
+exporter excludes failure text and all non-allowlisted payload fields.
+
 ### workflow.run.created / completed / failed / cancelled
 
 Durable lifecycle events for #956 Workflow IR runs. All events share the

--- a/docs/guides/interview-latency-benchmark.md
+++ b/docs/guides/interview-latency-benchmark.md
@@ -1,0 +1,156 @@
+# Interview Latency Benchmark
+
+This guide produces comparable, privacy-safe evidence for interactive
+interview latency. It is an observability procedure, not a CI performance gate
+and not evidence that every user sees the same wall clock.
+
+## Safety boundary
+
+- Run manually on a maintainer-controlled machine with Codex OAuth auth only.
+- Never run this benchmark in CI or with a committed API key.
+- Do not attach raw EventStore databases, prompts, answers, errors, logs,
+  usernames, hostnames, IP addresses, paths, credentials, or environment values.
+- Use the redacted exporter in this repository. Review its JSONL output before
+  attaching it to an issue.
+- Live runs may contact the configured model provider and consume quota.
+
+## What is measured
+
+The timing-bearing events are documented in `docs/events.md`.
+
+| Phase | Boundary |
+|-------|----------|
+| `total` | Server handler entry through terminal event creation |
+| `ambiguity_scoring` | Awaiting live ambiguity scoring |
+| `question_generation` | Awaiting `ask_next_question` |
+| `advisory_build` | Preparing advisory request metadata in the server |
+
+The measurements do not separately identify subprocess startup, MCP startup,
+network latency, or model execution inside `question_generation`. They also do
+not include host-side advisory execution after the MCP response returns.
+Measure client-observed wall time separately if that distinction is needed,
+and label it as client wall time rather than an EventStore phase.
+
+## Fixed fixture
+
+Use the same synthetic initial context for every run:
+
+```text
+Build a local CLI that reads a directory of Markdown files and writes a
+deterministic JSON summary. The primary user is a solo maintainer. It must run
+on macOS and Linux, perform no network access, preserve source files, process
+1,000 small files in under two seconds on the benchmark machine, and include
+unit tests. Success means stable key ordering, a non-zero exit on invalid input,
+and identical output for identical inputs.
+```
+
+Use these answers in order, regardless of wording differences in generated
+questions:
+
+1. `The primary user is a solo maintainer running the CLI locally.`
+2. `Inputs are UTF-8 Markdown files; output is one deterministic JSON document.`
+3. `No network calls or source-file mutation are allowed; macOS and Linux are required.`
+4. `Success is identical output for identical inputs, tested error exits, and under two seconds for 1,000 small files on this machine.`
+
+The third and later recorded answers exercise the live ambiguity-scoring path.
+If the interview completes before all four answers, record the completion event
+and do not invent an additional turn.
+
+## Environment manifest
+
+Record only the following non-secret fields beside each result set:
+
+- UTC benchmark timestamp.
+- Ouroboros git commit and package version.
+- Python version.
+- OS family, OS version, and CPU architecture, without hostname.
+- Codex CLI version.
+- Configured interview backend, model identifier, and reasoning effort.
+- Auth mode as the literal value `oauth`; never record account identity.
+- Condition: `cold` or `warm`.
+- Measured sample count and fixture revision/hash.
+- Coarse concurrent-load note such as `idle` or `normal development load`.
+
+Do not dump process environments. Record individual approved fields manually.
+
+## Cold and warm protocol
+
+Collect at least 20 complete interview samples per condition. Each sample uses
+a new interview id and the fixed fixture above.
+
+### Cold
+
+1. Start a new Ouroboros server process for each sample.
+2. Do not run an unmeasured interview request in that process.
+3. Run the fixed start plus answer sequence until completion or all four answers.
+4. Stop the server process after exporting the sample.
+
+Cold does not mean deleting OAuth credentials, keychain entries, package
+caches, or operating-system caches. Do not mutate those to manufacture a
+stronger cold-start claim.
+
+### Warm
+
+1. Start one Ouroboros server process.
+2. Run one unmeasured priming interview with the same fixture.
+3. Keep the process alive and collect at least 20 new-interview samples.
+4. Do not mix samples collected after configuration, model, or network changes.
+
+## Export
+
+For each measured interview, export only allowlisted timing evidence:
+
+```bash
+python scripts/export_interview_latency.py \
+  --interview-id interview_0123456789abcdef \
+  > interview-latency.jsonl
+```
+
+The database defaults to `~/.ouroboros/ouroboros.db`; use `--db` only when the
+EventStore lives elsewhere. The exporter opens SQLite in read-only mode and
+emits only:
+
+- SHA-256-hashed interview id.
+- Event timestamp and event type.
+- Allowlisted phase metadata.
+- `timings_ms`.
+
+It never emits stored failure text, prompt/answer previews, paths,
+credentials, or environment values.
+
+## Summary statistics
+
+Compute statistics independently for each condition, event type, and phase.
+Do not combine cold and warm samples or compare results produced by different
+commits/configurations as if they were one population.
+
+For each cell report `n`, p50, and p95. With sorted values and sample count
+`n`, use nearest-rank percentiles: rank `ceil(0.50 * n)` for p50 and
+`ceil(0.95 * n)` for p95. With 20 samples, p95 is the 19th sorted value.
+Exclude `null` phases from that phase's sample count and report the reduced `n`.
+
+Recommended report table:
+
+| Condition | Event | Phase | n | p50 ms | p95 ms |
+|-----------|-------|-------|---|--------|--------|
+| cold | `interview.response.emitted` | `question_generation` | 20+ | | |
+| cold | `interview.response.emitted` | `ambiguity_scoring` | 20+ | | |
+| warm | `interview.response.emitted` | `question_generation` | 20+ | | |
+| warm | `interview.response.emitted` | `ambiguity_scoring` | 20+ | | |
+
+An optional server remainder can be calculated as `total` minus the sum of
+non-null measured phases. Label it `unattributed_server_time`; it includes
+persistence, metadata preparation outside `advisory_build`, event creation,
+and other handler work. It is not host-side time.
+
+## Issue attachment checklist
+
+Before attaching evidence to an issue:
+
+1. Confirm every interview id is hashed.
+2. Search the artifact for prompt/answer text, `HOME`, common key prefixes,
+   usernames, and absolute path separators.
+3. Include the safe environment manifest and exact git commit.
+4. State whether the result is cold or warm and give `n`, p50, and p95.
+5. State the interpretation boundary: server phase timings do not prove total
+   user-visible latency or isolate every operation inside question generation.

--- a/scripts/export_interview_latency.py
+++ b/scripts/export_interview_latency.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+"""Export privacy-safe interview phase timings from the local EventStore.
+
+The command writes JSON Lines to stdout. It intentionally uses a strict
+allowlist so benchmark artifacts cannot include prompt/answer text, errors,
+paths, credentials, or environment values from persisted event payloads.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime
+import hashlib
+import json
+import math
+from pathlib import Path
+import sqlite3
+import sys
+from typing import Any
+from urllib.parse import quote
+
+_DEFAULT_DB = Path.home() / ".ouroboros" / "ouroboros.db"
+_TIMING_FIELDS = (
+    "total",
+    "ambiguity_scoring",
+    "question_generation",
+    "advisory_build",
+)
+_METADATA_FIELDS: dict[str, dict[str, type]] = {
+    "interview.response.emitted": {
+        "response_kind": str,
+        "round_number": int,
+        "payload_chars": int,
+        "transcript_chars": int,
+        "ambiguity_prefix_present": bool,
+        "is_length_guard": bool,
+    },
+    "interview.completed": {"total_rounds": int},
+    "interview.failed": {"phase": str},
+    "interview.question_generation.parent_handoff": {
+        "phase": str,
+        "reason_code": str,
+        "provider_error_type": str,
+    },
+}
+_STRING_METADATA_VALUES: dict[tuple[str, str], frozenset[str]] = {
+    ("interview.response.emitted", "response_kind"): frozenset(
+        {"start", "answer", "resume_pending"}
+    ),
+    ("interview.failed", "phase"): frozenset(
+        {"question_generation", "unexpected_error", "completion"}
+    ),
+    ("interview.question_generation.parent_handoff", "phase"): frozenset(
+        {"start_question_generation", "next_question_generation"}
+    ),
+    ("interview.question_generation.parent_handoff", "reason_code"): frozenset(
+        {"question_generation_envelope_violation"}
+    ),
+    ("interview.question_generation.parent_handoff", "provider_error_type"): frozenset(
+        {"ToolUseBlockViolation"}
+    ),
+}
+
+
+def _hash_interview_id(interview_id: str) -> str:
+    value = f"ouroboros-interview:{interview_id}".encode()
+    return hashlib.sha256(value).hexdigest()
+
+
+def _read_payload(raw_payload: object) -> dict[str, Any] | None:
+    if isinstance(raw_payload, bytes):
+        raw_payload = raw_payload.decode("utf-8", errors="strict")
+    if not isinstance(raw_payload, str):
+        return None
+    try:
+        payload = json.loads(raw_payload)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _read_timings(payload: dict[str, Any]) -> dict[str, float | int | None] | None:
+    raw_timings = payload.get("timings_ms")
+    if not isinstance(raw_timings, dict):
+        return None
+
+    timings: dict[str, float | int | None] = {}
+    for field in _TIMING_FIELDS:
+        value = raw_timings.get(field)
+        if value is None:
+            timings[field] = None
+            continue
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            return None
+        if not math.isfinite(value) or value < 0:
+            return None
+        timings[field] = value
+    if timings["total"] is None:
+        return None
+    return timings
+
+
+def _read_metadata(event_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    for field, expected_type in _METADATA_FIELDS[event_type].items():
+        value = payload.get(field)
+        if expected_type is int and isinstance(value, bool):
+            continue
+        allowed_values = _STRING_METADATA_VALUES.get((event_type, field))
+        if allowed_values is not None and value not in allowed_values:
+            continue
+        if isinstance(value, expected_type):
+            metadata[field] = value
+    return metadata
+
+
+def _read_timestamp(raw_timestamp: object) -> str | None:
+    if isinstance(raw_timestamp, datetime):
+        return raw_timestamp.isoformat()
+    if not isinstance(raw_timestamp, str) or len(raw_timestamp) > 64:
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw_timestamp.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed.isoformat()
+
+
+def _record_from_row(row: sqlite3.Row) -> dict[str, Any] | None:
+    event_type = row["event_type"]
+    if event_type not in _METADATA_FIELDS:
+        return None
+
+    payload = _read_payload(row["payload"])
+    if payload is None:
+        return None
+    timings = _read_timings(payload)
+    if timings is None:
+        return None
+    timestamp = _read_timestamp(row["timestamp"])
+    if timestamp is None:
+        return None
+
+    return {
+        "interview_id_sha256": _hash_interview_id(row["aggregate_id"]),
+        "timestamp": timestamp,
+        "event_type": event_type,
+        "metadata": _read_metadata(event_type, payload),
+        "timings_ms": timings,
+    }
+
+
+def _open_read_only(db_path: Path) -> sqlite3.Connection:
+    encoded_path = quote(db_path.resolve().as_posix(), safe="/:")
+    connection = sqlite3.connect(f"file:{encoded_path}?mode=ro", uri=True)
+    connection.row_factory = sqlite3.Row
+    return connection
+
+
+def _query_rows(
+    connection: sqlite3.Connection,
+    *,
+    interview_id: str | None,
+) -> sqlite3.Cursor:
+    placeholders = ", ".join("?" for _ in _METADATA_FIELDS)
+    query = (
+        "SELECT aggregate_id, event_type, payload, timestamp "
+        "FROM events WHERE aggregate_type = ? "
+        f"AND event_type IN ({placeholders})"
+    )
+    parameters: list[str] = ["interview", *_METADATA_FIELDS]
+    if interview_id is not None:
+        query += " AND aggregate_id = ?"
+        parameters.append(interview_id)
+    query += " ORDER BY timestamp ASC, id ASC"
+    return connection.execute(query, parameters)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--db",
+        type=Path,
+        default=_DEFAULT_DB,
+        help="EventStore SQLite database (default: ~/.ouroboros/ouroboros.db).",
+    )
+    parser.add_argument(
+        "--interview-id",
+        help="Limit export to one raw interview id; output still contains only its SHA-256 hash.",
+    )
+    args = parser.parse_args()
+
+    db_path = args.db.expanduser()
+    if not db_path.is_file():
+        print("export_interview_latency: EventStore database not found", file=sys.stderr)
+        return 2
+
+    emitted = 0
+    try:
+        with _open_read_only(db_path) as connection:
+            for row in _query_rows(connection, interview_id=args.interview_id):
+                record = _record_from_row(row)
+                if record is None:
+                    continue
+                print(json.dumps(record, sort_keys=True, separators=(",", ":")))
+                emitted += 1
+    except (OSError, sqlite3.Error, UnicodeError) as exc:
+        print(
+            f"export_interview_latency: unable to read timing events ({type(exc).__name__})",
+            file=sys.stderr,
+        )
+        return 2
+
+    if emitted == 0:
+        print("export_interview_latency: no timed interview events found", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/ouroboros/events/interview.py
+++ b/src/ouroboros/events/interview.py
@@ -60,6 +60,11 @@ def interview_response_recorded(
 def interview_completed(
     interview_id: str,
     total_rounds: int,
+    *,
+    total_duration_ms: float | None = None,
+    ambiguity_scoring_duration_ms: float | None = None,
+    question_generation_duration_ms: float | None = None,
+    advisory_build_duration_ms: float | None = None,
 ) -> BaseEvent:
     """Create event when an interview session completes."""
     return BaseEvent(
@@ -68,6 +73,12 @@ def interview_completed(
         aggregate_id=interview_id,
         data={
             "total_rounds": total_rounds,
+            "timings_ms": _interview_timings(
+                total_duration_ms=total_duration_ms,
+                ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
+                question_generation_duration_ms=question_generation_duration_ms,
+                advisory_build_duration_ms=advisory_build_duration_ms,
+            ),
         },
     )
 

--- a/src/ouroboros/events/interview.py
+++ b/src/ouroboros/events/interview.py
@@ -7,6 +7,22 @@ the dot.notation.past_tense naming convention.
 from ouroboros.events.base import BaseEvent
 
 
+def _interview_timings(
+    *,
+    total_duration_ms: float | None,
+    ambiguity_scoring_duration_ms: float | None,
+    question_generation_duration_ms: float | None,
+    advisory_build_duration_ms: float | None,
+) -> dict[str, float | None]:
+    """Return the shared privacy-safe timing payload for interview turns."""
+    return {
+        "total": total_duration_ms,
+        "ambiguity_scoring": ambiguity_scoring_duration_ms,
+        "question_generation": question_generation_duration_ms,
+        "advisory_build": advisory_build_duration_ms,
+    }
+
+
 def interview_started(
     interview_id: str,
     initial_context: str,
@@ -60,6 +76,11 @@ def interview_failed(
     interview_id: str,
     error_message: str,
     phase: str,
+    *,
+    total_duration_ms: float | None = None,
+    ambiguity_scoring_duration_ms: float | None = None,
+    question_generation_duration_ms: float | None = None,
+    advisory_build_duration_ms: float | None = None,
 ) -> BaseEvent:
     """Create event when an interview encounters a fatal error."""
     return BaseEvent(
@@ -69,6 +90,12 @@ def interview_failed(
         data={
             "error": error_message[:500],
             "phase": phase,
+            "timings_ms": _interview_timings(
+                total_duration_ms=total_duration_ms,
+                ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
+                question_generation_duration_ms=question_generation_duration_ms,
+                advisory_build_duration_ms=advisory_build_duration_ms,
+            ),
         },
     )
 
@@ -79,11 +106,21 @@ def interview_question_parent_handoff(
     phase: str,
     reason_code: str,
     provider_error_type: str | None = None,
+    total_duration_ms: float | None = None,
+    ambiguity_scoring_duration_ms: float | None = None,
+    question_generation_duration_ms: float | None = None,
+    advisory_build_duration_ms: float | None = None,
 ) -> BaseEvent:
     """Create event when question generation is handed to the parent session."""
     data = {
         "phase": phase,
         "reason_code": reason_code,
+        "timings_ms": _interview_timings(
+            total_duration_ms=total_duration_ms,
+            ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
+            question_generation_duration_ms=question_generation_duration_ms,
+            advisory_build_duration_ms=advisory_build_duration_ms,
+        ),
     }
     if provider_error_type:
         data["provider_error_type"] = provider_error_type
@@ -128,12 +165,12 @@ def interview_response_emitted(
             "transcript_chars": transcript_chars,
             "ambiguity_prefix_present": ambiguity_prefix_present,
             "is_length_guard": is_length_guard,
-            "timings_ms": {
-                "total": total_duration_ms,
-                "ambiguity_scoring": ambiguity_scoring_duration_ms,
-                "question_generation": question_generation_duration_ms,
-                "advisory_build": advisory_build_duration_ms,
-            },
+            "timings_ms": _interview_timings(
+                total_duration_ms=total_duration_ms,
+                ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
+                question_generation_duration_ms=question_generation_duration_ms,
+                advisory_build_duration_ms=advisory_build_duration_ms,
+            ),
         },
     )
 

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -2557,6 +2557,7 @@ class InterviewHandler:
         turn_started_at = time.perf_counter()
         engine, _ = self._create_interview_engine()
         _interview_id: str | None = None  # Track for error event emission
+        question_generation_duration_ms: float | None = None
 
         try:
             # Start new interview
@@ -2613,6 +2614,8 @@ class InterviewHandler:
                                 phase="start_question_generation",
                                 reason_code=_QUESTION_GENERATION_ENVELOPE_REASON_CODE,
                                 provider_error_type=_provider_error_type(question_result.error),
+                                total_duration_ms=_elapsed_ms(turn_started_at),
+                                question_generation_duration_ms=question_generation_duration_ms,
                             )
                         )
                         log.warning(
@@ -2638,6 +2641,8 @@ class InterviewHandler:
                             state.interview_id,
                             event_error_msg,
                             phase="question_generation",
+                            total_duration_ms=_elapsed_ms(turn_started_at),
+                            question_generation_duration_ms=question_generation_duration_ms,
                         )
                     )
                     # ``InterviewEngine.start_interview`` already persisted
@@ -2857,6 +2862,8 @@ class InterviewHandler:
                         _interview_id,
                         _format_interview_failure_event_error(e),
                         phase="unexpected_error",
+                        total_duration_ms=_elapsed_ms(turn_started_at),
+                        question_generation_duration_ms=question_generation_duration_ms,
                     )
                 )
             return Result.err(
@@ -2880,6 +2887,8 @@ class InterviewHandler:
         turn_started_at = time.perf_counter()
         engine, llm_adapter = self._create_interview_engine()
         _interview_id: str | None = None
+        ambiguity_scoring_duration_ms: float | None = None
+        question_generation_duration_ms: float | None = None
 
         try:
             load_result = await engine.load_state(session_id)
@@ -3216,7 +3225,6 @@ class InterviewHandler:
             # the latest ambiguity snapshot, closure threshold,
             # and completion-candidate streak.
             answered = _count_answered_rounds(state)
-            ambiguity_scoring_duration_ms: float | None = None
             if answered >= MIN_ROUNDS_BEFORE_EARLY_EXIT:
                 # Scoring must complete before question generation:
                 # _score_interview_state mutates state.ambiguity_score,
@@ -3277,6 +3285,9 @@ class InterviewHandler:
                         _interview_id,
                         _format_interview_failure_event_error(e),
                         phase="unexpected_error",
+                        total_duration_ms=_elapsed_ms(turn_started_at),
+                        ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
+                        question_generation_duration_ms=question_generation_duration_ms,
                     )
                 )
             return Result.err(
@@ -3300,6 +3311,7 @@ class InterviewHandler:
         turn_started_at = time.perf_counter()
         engine, _ = self._create_interview_engine()
         _interview_id: str | None = None
+        question_generation_duration_ms: float | None = None
 
         try:
             load_result = await engine.load_state(session_id)
@@ -3439,6 +3451,8 @@ class InterviewHandler:
                         _interview_id,
                         _format_interview_failure_event_error(e),
                         phase="unexpected_error",
+                        total_duration_ms=_elapsed_ms(turn_started_at),
+                        question_generation_duration_ms=question_generation_duration_ms,
                     )
                 )
             return Result.err(
@@ -3476,6 +3490,9 @@ class InterviewHandler:
                         phase="next_question_generation",
                         reason_code=_QUESTION_GENERATION_ENVELOPE_REASON_CODE,
                         provider_error_type=_provider_error_type(question_result.error),
+                        total_duration_ms=_elapsed_ms(turn_started_at),
+                        ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
+                        question_generation_duration_ms=question_generation_duration_ms,
                     )
                 )
                 log.warning(
@@ -3501,6 +3518,9 @@ class InterviewHandler:
                     session_id,
                     event_error_msg,
                     phase="question_generation",
+                    total_duration_ms=_elapsed_ms(turn_started_at),
+                    ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
+                    question_generation_duration_ms=question_generation_duration_ms,
                 )
             )
             if "empty response" in error_msg.lower():

--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -1961,10 +1961,28 @@ class InterviewHandler:
         score: AmbiguityScore | None = None,
         *,
         seed_ready_override: bool | None = None,
+        turn_started_at: float | None = None,
+        ambiguity_scoring_duration_ms: float | None = None,
+        question_generation_duration_ms: float | None = None,
+        advisory_build_duration_ms: float | None = None,
     ) -> Result[MCPToolResult, MCPServerError]:
         """Complete the interview and return a Seed-ready MCP response."""
         complete_result = await engine.complete_interview(state)
         if complete_result.is_err:
+            if turn_started_at is not None:
+                from ouroboros.events.interview import interview_failed
+
+                self._emit_event_bg(
+                    interview_failed(
+                        session_id,
+                        _format_interview_failure_event_error(complete_result.error),
+                        phase="completion",
+                        total_duration_ms=_elapsed_ms(turn_started_at),
+                        ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
+                        question_generation_duration_ms=question_generation_duration_ms,
+                        advisory_build_duration_ms=advisory_build_duration_ms,
+                    )
+                )
             return Result.err(
                 MCPToolError(
                     str(complete_result.error),
@@ -1986,6 +2004,12 @@ class InterviewHandler:
             interview_completed(
                 interview_id=session_id,
                 total_rounds=len(state.rounds),
+                total_duration_ms=(
+                    _elapsed_ms(turn_started_at) if turn_started_at is not None else None
+                ),
+                ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
+                question_generation_duration_ms=question_generation_duration_ms,
+                advisory_build_duration_ms=advisory_build_duration_ms,
             )
         )
 
@@ -2558,6 +2582,7 @@ class InterviewHandler:
         engine, _ = self._create_interview_engine()
         _interview_id: str | None = None  # Track for error event emission
         question_generation_duration_ms: float | None = None
+        advisory_build_duration_ms: float | None = None
 
         try:
             # Start new interview
@@ -2602,8 +2627,10 @@ class InterviewHandler:
                 # (pm_interview.py:889); apply the same optimisation here.
                 live_score = None
                 question_generation_started_at = time.perf_counter()
-                question_result = await engine.ask_next_question(state)
-                question_generation_duration_ms = _elapsed_ms(question_generation_started_at)
+                try:
+                    question_result = await engine.ask_next_question(state)
+                finally:
+                    question_generation_duration_ms = _elapsed_ms(question_generation_started_at)
                 if question_result.is_err:
                     if _is_question_generation_envelope_violation(question_result.error):
                         from ouroboros.events.interview import interview_question_parent_handoff
@@ -2615,7 +2642,9 @@ class InterviewHandler:
                                 reason_code=_QUESTION_GENERATION_ENVELOPE_REASON_CODE,
                                 provider_error_type=_provider_error_type(question_result.error),
                                 total_duration_ms=_elapsed_ms(turn_started_at),
+                                ambiguity_scoring_duration_ms=None,
                                 question_generation_duration_ms=question_generation_duration_ms,
+                                advisory_build_duration_ms=None,
                             )
                         )
                         log.warning(
@@ -2642,7 +2671,9 @@ class InterviewHandler:
                             event_error_msg,
                             phase="question_generation",
                             total_duration_ms=_elapsed_ms(turn_started_at),
+                            ambiguity_scoring_duration_ms=None,
                             question_generation_duration_ms=question_generation_duration_ms,
+                            advisory_build_duration_ms=None,
                         )
                     )
                     # ``InterviewEngine.start_interview`` already persisted
@@ -2793,20 +2824,22 @@ class InterviewHandler:
                     start_meta.update(_length_guard_meta_fields())
                 else:
                     advisory_build_started_at = time.perf_counter()
-                    _attach_question_assist_requests(
-                        start_meta,
-                        session_id=state.interview_id,
-                        question=question,
-                        phase="start",
-                        score=live_score,
-                        dispatch_mode=resolve_subagent_dispatch(
-                            self.agent_runtime_backend, self.opencode_mode
-                        ),
-                        runtime_backend=self.agent_runtime_backend,
-                        opencode_mode=self.opencode_mode,
-                        fanout_registry=self._resolved_fanout_registry(),
-                    )
-                    advisory_build_duration_ms = _elapsed_ms(advisory_build_started_at)
+                    try:
+                        _attach_question_assist_requests(
+                            start_meta,
+                            session_id=state.interview_id,
+                            question=question,
+                            phase="start",
+                            score=live_score,
+                            dispatch_mode=resolve_subagent_dispatch(
+                                self.agent_runtime_backend, self.opencode_mode
+                            ),
+                            runtime_backend=self.agent_runtime_backend,
+                            opencode_mode=self.opencode_mode,
+                            fanout_registry=self._resolved_fanout_registry(),
+                        )
+                    finally:
+                        advisory_build_duration_ms = _elapsed_ms(advisory_build_started_at)
                 if is_length_guard:
                     advisory_build_duration_ms = None
 
@@ -2863,7 +2896,9 @@ class InterviewHandler:
                         _format_interview_failure_event_error(e),
                         phase="unexpected_error",
                         total_duration_ms=_elapsed_ms(turn_started_at),
+                        ambiguity_scoring_duration_ms=None,
                         question_generation_duration_ms=question_generation_duration_ms,
+                        advisory_build_duration_ms=advisory_build_duration_ms,
                     )
                 )
             return Result.err(
@@ -2943,12 +2978,16 @@ class InterviewHandler:
                     # stale-streak invalidation contract even
                     # though this branch disables the qualifying-
                     # score increment.
-                    exit_score = await self._score_interview_state(
-                        llm_adapter,
-                        state,
-                        advance_streak=False,
-                        reset_on_failure=True,
-                    )
+                    ambiguity_scoring_started_at = time.perf_counter()
+                    try:
+                        exit_score = await self._score_interview_state(
+                            llm_adapter,
+                            state,
+                            advance_streak=False,
+                            reset_on_failure=True,
+                        )
+                    finally:
+                        ambiguity_scoring_duration_ms = _elapsed_ms(ambiguity_scoring_started_at)
                 # Safe-default synthesis is emitted only after the
                 # auto driver has filled every remaining required
                 # ledger gap with audited conservative defaults. Do
@@ -2976,6 +3015,8 @@ class InterviewHandler:
                         session_id,
                         None,
                         seed_ready_override=True,
+                        turn_started_at=turn_started_at,
+                        ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
                     )
                 if exit_score is not None and qualifies_for_seed_completion(
                     exit_score,
@@ -2989,6 +3030,8 @@ class InterviewHandler:
                             state,
                             session_id,
                             exit_score,
+                            turn_started_at=turn_started_at,
+                            ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
                         )
 
                     # Explicit 'done' with a qualifying score counts
@@ -3010,6 +3053,8 @@ class InterviewHandler:
                             state,
                             session_id,
                             exit_score,
+                            turn_started_at=turn_started_at,
+                            ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
                         )
                     # Streak advanced but still short of the
                     # threshold — persist the advance and invite the
@@ -3234,8 +3279,10 @@ class InterviewHandler:
                 # Running them in parallel would give the question
                 # generator stale routing context.
                 ambiguity_scoring_started_at = time.perf_counter()
-                live_score = await self._score_interview_state(llm_adapter, state)
-                ambiguity_scoring_duration_ms = _elapsed_ms(ambiguity_scoring_started_at)
+                try:
+                    live_score = await self._score_interview_state(llm_adapter, state)
+                finally:
+                    ambiguity_scoring_duration_ms = _elapsed_ms(ambiguity_scoring_started_at)
                 lateral_review_meta = _maybe_record_lateral_review_advisory(
                     state,
                     previous_milestone=previous_milestone,
@@ -3254,15 +3301,21 @@ class InterviewHandler:
                         state,
                         session_id,
                         live_score,
+                        turn_started_at=turn_started_at,
+                        ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
                     )
                 question_generation_started_at = time.perf_counter()
-                question_result = await engine.ask_next_question(state)
-                question_generation_duration_ms = _elapsed_ms(question_generation_started_at)
+                try:
+                    question_result = await engine.ask_next_question(state)
+                finally:
+                    question_generation_duration_ms = _elapsed_ms(question_generation_started_at)
             else:
                 live_score = None
                 question_generation_started_at = time.perf_counter()
-                question_result = await engine.ask_next_question(state)
-                question_generation_duration_ms = _elapsed_ms(question_generation_started_at)
+                try:
+                    question_result = await engine.ask_next_question(state)
+                finally:
+                    question_generation_duration_ms = _elapsed_ms(question_generation_started_at)
             return await self._respond_with_next_question(
                 engine,
                 state,
@@ -3288,6 +3341,7 @@ class InterviewHandler:
                         total_duration_ms=_elapsed_ms(turn_started_at),
                         ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
                         question_generation_duration_ms=question_generation_duration_ms,
+                        advisory_build_duration_ms=None,
                     )
                 )
             return Result.err(
@@ -3312,6 +3366,7 @@ class InterviewHandler:
         engine, _ = self._create_interview_engine()
         _interview_id: str | None = None
         question_generation_duration_ms: float | None = None
+        advisory_build_duration_ms: float | None = None
 
         try:
             load_result = await engine.load_state(session_id)
@@ -3372,20 +3427,22 @@ class InterviewHandler:
                     resume_meta.update(_length_guard_meta_fields())
                 else:
                     advisory_build_started_at = time.perf_counter()
-                    _attach_question_assist_requests(
-                        resume_meta,
-                        session_id=session_id,
-                        question=pending_question,
-                        phase="resume_pending",
-                        score=_load_state_ambiguity_score(state),
-                        dispatch_mode=resolve_subagent_dispatch(
-                            self.agent_runtime_backend, self.opencode_mode
-                        ),
-                        runtime_backend=self.agent_runtime_backend,
-                        opencode_mode=self.opencode_mode,
-                        fanout_registry=self._resolved_fanout_registry(),
-                    )
-                    advisory_build_duration_ms = _elapsed_ms(advisory_build_started_at)
+                    try:
+                        _attach_question_assist_requests(
+                            resume_meta,
+                            session_id=session_id,
+                            question=pending_question,
+                            phase="resume_pending",
+                            score=_load_state_ambiguity_score(state),
+                            dispatch_mode=resolve_subagent_dispatch(
+                                self.agent_runtime_backend, self.opencode_mode
+                            ),
+                            runtime_backend=self.agent_runtime_backend,
+                            opencode_mode=self.opencode_mode,
+                            fanout_registry=self._resolved_fanout_registry(),
+                        )
+                    finally:
+                        advisory_build_duration_ms = _elapsed_ms(advisory_build_started_at)
                 if resume_is_length_guard:
                     advisory_build_duration_ms = None
 
@@ -3427,8 +3484,10 @@ class InterviewHandler:
 
             live_score = _load_state_ambiguity_score(state)
             question_generation_started_at = time.perf_counter()
-            question_result = await engine.ask_next_question(state)
-            question_generation_duration_ms = _elapsed_ms(question_generation_started_at)
+            try:
+                question_result = await engine.ask_next_question(state)
+            finally:
+                question_generation_duration_ms = _elapsed_ms(question_generation_started_at)
             return await self._respond_with_next_question(
                 engine,
                 state,
@@ -3452,7 +3511,9 @@ class InterviewHandler:
                         _format_interview_failure_event_error(e),
                         phase="unexpected_error",
                         total_duration_ms=_elapsed_ms(turn_started_at),
+                        ambiguity_scoring_duration_ms=None,
                         question_generation_duration_ms=question_generation_duration_ms,
+                        advisory_build_duration_ms=advisory_build_duration_ms,
                     )
                 )
             return Result.err(
@@ -3521,6 +3582,7 @@ class InterviewHandler:
                     total_duration_ms=_elapsed_ms(turn_started_at),
                     ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
                     question_generation_duration_ms=question_generation_duration_ms,
+                    advisory_build_duration_ms=None,
                 )
             )
             if "empty response" in error_msg.lower():
@@ -3639,20 +3701,46 @@ class InterviewHandler:
             answer_meta.update(_length_guard_meta_fields())
         else:
             advisory_build_started_at = time.perf_counter()
-            _attach_question_assist_requests(
-                answer_meta,
-                session_id=session_id,
-                question=question,
-                phase="answer",
-                score=live_score,
-                dispatch_mode=resolve_subagent_dispatch(
-                    self.agent_runtime_backend, self.opencode_mode
-                ),
-                runtime_backend=self.agent_runtime_backend,
-                opencode_mode=self.opencode_mode,
-                fanout_registry=self._resolved_fanout_registry(),
-            )
-            advisory_build_duration_ms = _elapsed_ms(advisory_build_started_at)
+            advisory_build_error: Exception | None = None
+            try:
+                _attach_question_assist_requests(
+                    answer_meta,
+                    session_id=session_id,
+                    question=question,
+                    phase="answer",
+                    score=live_score,
+                    dispatch_mode=resolve_subagent_dispatch(
+                        self.agent_runtime_backend, self.opencode_mode
+                    ),
+                    runtime_backend=self.agent_runtime_backend,
+                    opencode_mode=self.opencode_mode,
+                    fanout_registry=self._resolved_fanout_registry(),
+                )
+            except Exception as error:
+                advisory_build_error = error
+            finally:
+                advisory_build_duration_ms = _elapsed_ms(advisory_build_started_at)
+            if advisory_build_error is not None:
+                log.error("mcp.tool.interview.error", error=str(advisory_build_error))
+                from ouroboros.events.interview import interview_failed
+
+                self._emit_event_bg(
+                    interview_failed(
+                        session_id,
+                        _format_interview_failure_event_error(advisory_build_error),
+                        phase="unexpected_error",
+                        total_duration_ms=_elapsed_ms(turn_started_at),
+                        ambiguity_scoring_duration_ms=ambiguity_scoring_duration_ms,
+                        question_generation_duration_ms=question_generation_duration_ms,
+                        advisory_build_duration_ms=advisory_build_duration_ms,
+                    )
+                )
+                return Result.err(
+                    MCPToolError(
+                        f"Interview failed: {advisory_build_error}",
+                        tool_name="ouroboros_interview",
+                    )
+                )
         if answer_is_length_guard:
             advisory_build_duration_ms = None
 

--- a/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
+++ b/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass, field
 import json
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -144,7 +144,11 @@ async def test_tool_envelope_question_failure_hands_off_to_parent_session(
         data_dir=tmp_path,
     )
 
-    outcome = await handler.handle({"initial_context": "Build a CLI", "cwd": str(tmp_path)})
+    with patch(
+        "ouroboros.mcp.tools.authoring_handlers.time.perf_counter",
+        side_effect=(100.0, 101.0, 101.5, 102.0),
+    ):
+        outcome = await handler.handle({"initial_context": "Build a CLI", "cwd": str(tmp_path)})
     await handler.close()
 
     assert outcome.is_ok
@@ -171,6 +175,17 @@ async def test_tool_envelope_question_failure_hands_off_to_parent_session(
     event_types = [call.args[0].type for call in mock_store.append.await_args_list]
     assert "interview.question_generation.parent_handoff" in event_types
     assert "interview.failed" not in event_types
+    handoff_event = next(
+        call.args[0]
+        for call in mock_store.append.await_args_list
+        if call.args[0].type == "interview.question_generation.parent_handoff"
+    )
+    assert handoff_event.data["timings_ms"] == {
+        "total": 2000.0,
+        "ambiguity_scoring": None,
+        "question_generation": 500.0,
+        "advisory_build": None,
+    }
 
 
 @pytest.mark.asyncio
@@ -245,13 +260,17 @@ async def test_tool_envelope_failure_after_answer_hands_off_without_mcp_error(
         data_dir=tmp_path,
     )
 
-    outcome = await handler.handle(
-        {
-            "session_id": session_id,
-            "answer": "Use the existing plugin manifest format.",
-            "last_question": "Which manifest format should the CLI use?",
-        }
-    )
+    with patch(
+        "ouroboros.mcp.tools.authoring_handlers.time.perf_counter",
+        side_effect=(100.0, 101.0, 101.5, 102.0),
+    ):
+        outcome = await handler.handle(
+            {
+                "session_id": session_id,
+                "answer": "Use the existing plugin manifest format.",
+                "last_question": "Which manifest format should the CLI use?",
+            }
+        )
     await handler.close()
 
     assert outcome.is_ok
@@ -272,6 +291,17 @@ async def test_tool_envelope_failure_after_answer_hands_off_without_mcp_error(
     event_types = [call.args[0].type for call in mock_store.append.await_args_list]
     assert "interview.question_generation.parent_handoff" in event_types
     assert "interview.failed" not in event_types
+    handoff_event = next(
+        call.args[0]
+        for call in mock_store.append.await_args_list
+        if call.args[0].type == "interview.question_generation.parent_handoff"
+    )
+    assert handoff_event.data["timings_ms"] == {
+        "total": 2000.0,
+        "ambiguity_scoring": None,
+        "question_generation": 500.0,
+        "advisory_build": None,
+    }
 
 
 @pytest.mark.asyncio
@@ -309,7 +339,11 @@ async def test_question_failure_event_uses_compact_provider_error(
         data_dir=tmp_path,
     )
 
-    outcome = await handler.handle({"initial_context": "Build a CLI", "cwd": str(tmp_path)})
+    with patch(
+        "ouroboros.mcp.tools.authoring_handlers.time.perf_counter",
+        side_effect=(100.0, 101.0, 101.5, 102.0),
+    ):
+        outcome = await handler.handle({"initial_context": "Build a CLI", "cwd": str(tmp_path)})
     await handler.close()
 
     assert outcome.is_ok
@@ -324,6 +358,73 @@ async def test_question_failure_event_uses_compact_provider_error(
     assert str(codex_home) not in event_error
     assert str(home) not in event_error
     assert "codex_auth_context" not in event_error
+    assert failed_events[-1].data["timings_ms"] == {
+        "total": 2000.0,
+        "ambiguity_scoring": None,
+        "question_generation": 500.0,
+        "advisory_build": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_question_failure_after_answer_closes_phase_timings(tmp_path: Path) -> None:
+    provider_error = ProviderError(
+        "Question generation timed out",
+        provider="codex_cli",
+        details={"error_type": "TimeoutError"},
+    )
+    session_id = "interview_failuretiming0001"
+    state = InterviewState(
+        interview_id=session_id,
+        initial_context="Build a CLI",
+        status=InterviewStatus.IN_PROGRESS,
+    )
+    state.rounds.append(
+        InterviewRound(
+            round_number=1,
+            question="What should the CLI do first?",
+            user_response=None,
+        )
+    )
+    engine = _FakeInterviewEngine(
+        state_dir=tmp_path,
+        question_error=provider_error,
+        states={session_id: state},
+    )
+    await engine.save_state(state)
+    mock_store = AsyncMock()
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=mock_store,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    with patch(
+        "ouroboros.mcp.tools.authoring_handlers.time.perf_counter",
+        side_effect=(100.0, 101.0, 101.5, 102.0),
+    ):
+        outcome = await handler.handle(
+            {
+                "session_id": session_id,
+                "answer": "It should scaffold plugin manifests.",
+            }
+        )
+    await handler.close()
+
+    assert outcome.is_err
+    failed_event = next(
+        call.args[0]
+        for call in mock_store.append.await_args_list
+        if call.args[0].type == "interview.failed"
+    )
+    assert failed_event.data["timings_ms"] == {
+        "total": 2000.0,
+        "ambiguity_scoring": None,
+        "question_generation": 500.0,
+        "advisory_build": None,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
+++ b/tests/unit/mcp/tools/test_interview_persists_session_on_failure.py
@@ -48,6 +48,7 @@ class _FakeInterviewEngine:
     saved_states: list[InterviewState] = field(default_factory=list)
     states: dict[str, InterviewState] = field(default_factory=dict)
     question_error: Any | None = None
+    question_exception: Exception | None = None
 
     async def start_interview(
         self, initial_context: str, cwd: str | None = None, interview_id: str | None = None
@@ -62,6 +63,8 @@ class _FakeInterviewEngine:
         return Result.ok(state)
 
     async def ask_next_question(self, state: InterviewState) -> Result[str, MCPServerError]:
+        if self.question_exception is not None:
+            raise self.question_exception
         if self.question_error is not None:
             return Result.err(self.question_error)
         return Result.err(_RecoverableProviderError("Question generation timed out"))
@@ -419,6 +422,68 @@ async def test_question_failure_after_answer_closes_phase_timings(tmp_path: Path
         for call in mock_store.append.await_args_list
         if call.args[0].type == "interview.failed"
     )
+    assert failed_event.data["timings_ms"] == {
+        "total": 2000.0,
+        "ambiguity_scoring": None,
+        "question_generation": 500.0,
+        "advisory_build": None,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["start", "answer", "resume"])
+async def test_raised_question_generation_closes_active_span(
+    tmp_path: Path,
+    action: str,
+) -> None:
+    session_id = f"interview_raised_{action}"
+    engine = _FakeInterviewEngine(
+        state_dir=tmp_path,
+        question_exception=RuntimeError("question generation raised"),
+    )
+    if action == "start":
+        arguments = {"initial_context": "Build a CLI", "cwd": str(tmp_path)}
+    else:
+        state = InterviewState(
+            interview_id=session_id,
+            initial_context="Build a CLI",
+            status=InterviewStatus.IN_PROGRESS,
+        )
+        state.rounds.append(
+            InterviewRound(
+                round_number=1,
+                question="What should the CLI do first?",
+                user_response=None if action == "answer" else "It scaffolds plugins.",
+            )
+        )
+        await engine.save_state(state)
+        arguments = {"session_id": session_id}
+        if action == "answer":
+            arguments["answer"] = "It scaffolds plugin manifests."
+
+    mock_store = AsyncMock()
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=mock_store,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    with patch(
+        "ouroboros.mcp.tools.authoring_handlers.time.perf_counter",
+        side_effect=(100.0, 101.0, 101.5, 102.0),
+    ):
+        outcome = await handler.handle(arguments)
+    await handler.close()
+
+    assert outcome.is_err
+    failed_event = next(
+        call.args[0]
+        for call in mock_store.append.await_args_list
+        if call.args[0].type == "interview.failed"
+    )
+    assert failed_event.data["phase"] == "unexpected_error"
     assert failed_event.data["timings_ms"] == {
         "total": 2000.0,
         "ambiguity_scoring": None,

--- a/tests/unit/mcp/tools/test_interview_response_diagnostics.py
+++ b/tests/unit/mcp/tools/test_interview_response_diagnostics.py
@@ -20,6 +20,7 @@ from unittest.mock import AsyncMock, patch
 from jsonschema import Draft202012Validator
 import pytest
 
+from ouroboros.bigbang.ambiguity import AmbiguityScore, ComponentScore, ScoreBreakdown
 from ouroboros.bigbang.interview import (
     INITIAL_CONTEXT_SUMMARY_QUESTION,
     InterviewRound,
@@ -118,6 +119,14 @@ class _StubInterviewEngine:
         # Always return the same canonical state object.
         return Result.ok(self.initial_state)
 
+    async def complete_interview(
+        self,
+        state: InterviewState,
+    ) -> Result[InterviewState, MCPServerError]:
+        state.status = InterviewStatus.COMPLETED
+        state.mark_updated()
+        return Result.ok(state)
+
 
 async def _drain_bg_tasks(handler: InterviewHandler) -> None:
     """Flush the handler's fire-and-forget event tasks deterministically."""
@@ -130,6 +139,32 @@ def _find_event(events: list[BaseEvent], *, event_type: str) -> BaseEvent | None
         if event.type == event_type:
             return event
     return None
+
+
+def _ready_score() -> AmbiguityScore:
+    return AmbiguityScore(
+        overall_score=0.1,
+        breakdown=ScoreBreakdown(
+            goal_clarity=ComponentScore(
+                name="Goal Clarity",
+                clarity_score=0.9,
+                weight=0.4,
+                justification="clear",
+            ),
+            constraint_clarity=ComponentScore(
+                name="Constraint Clarity",
+                clarity_score=0.9,
+                weight=0.3,
+                justification="clear",
+            ),
+            success_criteria_clarity=ComponentScore(
+                name="Success Criteria Clarity",
+                clarity_score=0.9,
+                weight=0.3,
+                justification="clear",
+            ),
+        ),
+    )
 
 
 def _assert_reasoning_meta(meta: dict[str, Any], *, phase: str, session_id: str) -> None:
@@ -934,3 +969,225 @@ async def test_later_answer_reports_distinct_phase_timings(tmp_path: Path) -> No
         "advisory_build": 500.0,
     }
     handler._score_interview_state.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_completion_event_reports_terminal_turn_timing(tmp_path: Path) -> None:
+    ready_score = _ready_score()
+    state = InterviewState(
+        interview_id="interview_complete0000001",
+        initial_context="ctx",
+        status=InterviewStatus.IN_PROGRESS,
+        ambiguity_score=ready_score.overall_score,
+        ambiguity_breakdown=ready_score.breakdown.model_dump(mode="json"),
+        completion_candidate_streak=2,
+    )
+    event_store = _CapturingEventStore()
+    engine = _StubInterviewEngine(state_dir=tmp_path, initial_state=state)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=event_store,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    with patch(
+        "ouroboros.mcp.tools.authoring_handlers.time.perf_counter",
+        side_effect=(100.0, 102.5),
+    ):
+        outcome = await handler.handle({"session_id": state.interview_id, "answer": "done"})
+    assert outcome.is_ok
+    await _drain_bg_tasks(handler)
+
+    completed = _find_event(event_store.events, event_type="interview.completed")
+    assert completed is not None
+    assert completed.data["timings_ms"] == {
+        "total": 2500.0,
+        "ambiguity_scoring": None,
+        "question_generation": None,
+        "advisory_build": None,
+    }
+    assert _find_event(event_store.events, event_type="interview.response.emitted") is None
+
+
+@pytest.mark.asyncio
+async def test_completion_after_scoring_preserves_scoring_timing(tmp_path: Path) -> None:
+    state = InterviewState(
+        interview_id="interview_complete0000002",
+        initial_context="ctx",
+        status=InterviewStatus.IN_PROGRESS,
+        completion_candidate_streak=1,
+    )
+    event_store = _CapturingEventStore()
+    engine = _StubInterviewEngine(state_dir=tmp_path, initial_state=state)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=event_store,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+    handler._score_interview_state = AsyncMock(  # type: ignore[method-assign]
+        return_value=_ready_score()
+    )
+
+    with patch(
+        "ouroboros.mcp.tools.authoring_handlers.time.perf_counter",
+        side_effect=(100.0, 101.0, 101.75, 103.0),
+    ):
+        outcome = await handler.handle({"session_id": state.interview_id, "answer": "done"})
+    assert outcome.is_ok
+    await _drain_bg_tasks(handler)
+
+    completed = _find_event(event_store.events, event_type="interview.completed")
+    assert completed is not None
+    assert completed.data["timings_ms"] == {
+        "total": 3000.0,
+        "ambiguity_scoring": 750.0,
+        "question_generation": None,
+        "advisory_build": None,
+    }
+    handler._score_interview_state.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_completion_failure_closes_terminal_turn_timing(tmp_path: Path) -> None:
+    class _FailingCompletionEngine(_StubInterviewEngine):
+        async def complete_interview(
+            self,
+            state: InterviewState,
+        ) -> Result[InterviewState, MCPServerError]:
+            return Result.err(MCPServerError("completion failed"))
+
+    ready_score = _ready_score()
+    state = InterviewState(
+        interview_id="interview_complete0000003",
+        initial_context="ctx",
+        status=InterviewStatus.IN_PROGRESS,
+        ambiguity_score=ready_score.overall_score,
+        ambiguity_breakdown=ready_score.breakdown.model_dump(mode="json"),
+        completion_candidate_streak=2,
+    )
+    event_store = _CapturingEventStore()
+    engine = _FailingCompletionEngine(state_dir=tmp_path, initial_state=state)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=event_store,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    with patch(
+        "ouroboros.mcp.tools.authoring_handlers.time.perf_counter",
+        side_effect=(100.0, 101.5),
+    ):
+        outcome = await handler.handle({"session_id": state.interview_id, "answer": "done"})
+    assert outcome.is_err
+    await _drain_bg_tasks(handler)
+
+    failed = _find_event(event_store.events, event_type="interview.failed")
+    assert failed is not None
+    assert failed.data["phase"] == "completion"
+    assert failed.data["timings_ms"] == {
+        "total": 1500.0,
+        "ambiguity_scoring": None,
+        "question_generation": None,
+        "advisory_build": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_advisory_failure_closes_all_started_phase_timings(tmp_path: Path) -> None:
+    state = InterviewState(
+        interview_id="interview_advisory0000001",
+        initial_context="ctx",
+        status=InterviewStatus.IN_PROGRESS,
+    )
+    state.rounds.append(
+        InterviewRound(
+            round_number=1,
+            question="What should this tool do?",
+            user_response=None,
+        )
+    )
+    event_store = _CapturingEventStore()
+    engine = _StubInterviewEngine(
+        state_dir=tmp_path,
+        initial_state=state,
+        next_question="Who uses it first?",
+    )
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=event_store,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+
+    with (
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers._attach_question_assist_requests",
+            side_effect=RuntimeError("advisory build failed"),
+        ),
+        patch(
+            "ouroboros.mcp.tools.authoring_handlers.time.perf_counter",
+            side_effect=(100.0, 101.0, 101.5, 102.0, 102.25, 103.0),
+        ),
+    ):
+        outcome = await handler.handle(
+            {"session_id": state.interview_id, "answer": "It creates reports."}
+        )
+    assert outcome.is_err
+    await _drain_bg_tasks(handler)
+
+    failed = _find_event(event_store.events, event_type="interview.failed")
+    assert failed is not None
+    assert failed.data["phase"] == "unexpected_error"
+    assert failed.data["timings_ms"] == {
+        "total": 3000.0,
+        "ambiguity_scoring": None,
+        "question_generation": 500.0,
+        "advisory_build": 250.0,
+    }
+    assert _find_event(event_store.events, event_type="interview.response.emitted") is None
+
+
+@pytest.mark.asyncio
+async def test_scoring_failure_closes_active_phase_timing(tmp_path: Path) -> None:
+    state = InterviewState(
+        interview_id="interview_scoring0000001",
+        initial_context="ctx",
+        status=InterviewStatus.IN_PROGRESS,
+    )
+    event_store = _CapturingEventStore()
+    engine = _StubInterviewEngine(state_dir=tmp_path, initial_state=state)
+    handler = InterviewHandler(
+        interview_engine=engine,
+        event_store=event_store,
+        agent_runtime_backend=None,
+        opencode_mode=None,
+        data_dir=tmp_path,
+    )
+    handler._score_interview_state = AsyncMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("ambiguity scoring raised")
+    )
+
+    with patch(
+        "ouroboros.mcp.tools.authoring_handlers.time.perf_counter",
+        side_effect=(100.0, 101.0, 101.5, 102.0),
+    ):
+        outcome = await handler.handle({"session_id": state.interview_id, "answer": "done"})
+    assert outcome.is_err
+    await _drain_bg_tasks(handler)
+
+    failed = _find_event(event_store.events, event_type="interview.failed")
+    assert failed is not None
+    assert failed.data["phase"] == "unexpected_error"
+    assert failed.data["timings_ms"] == {
+        "total": 2000.0,
+        "ambiguity_scoring": 500.0,
+        "question_generation": None,
+        "advisory_build": None,
+    }

--- a/tests/unit/scripts/test_export_interview_latency.py
+++ b/tests/unit/scripts/test_export_interview_latency.py
@@ -1,0 +1,223 @@
+"""Tests for the privacy-safe interview latency exporter."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+import sqlite3
+import subprocess
+import sys
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPT = REPO_ROOT / "scripts" / "export_interview_latency.py"
+
+
+def _create_event_store(path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(path)
+    connection.execute(
+        """
+        CREATE TABLE events (
+            id TEXT PRIMARY KEY,
+            aggregate_type TEXT NOT NULL,
+            aggregate_id TEXT NOT NULL,
+            event_type TEXT NOT NULL,
+            payload TEXT NOT NULL,
+            timestamp TEXT NOT NULL
+        )
+        """
+    )
+    return connection
+
+
+def _insert_event(
+    connection: sqlite3.Connection,
+    *,
+    event_id: str,
+    interview_id: str,
+    event_type: str,
+    payload: dict[str, object],
+    timestamp: str,
+) -> None:
+    connection.execute(
+        """
+        INSERT INTO events (
+            id, aggregate_type, aggregate_id, event_type, payload, timestamp
+        ) VALUES (?, 'interview', ?, ?, ?, ?)
+        """,
+        (event_id, interview_id, event_type, json.dumps(payload), timestamp),
+    )
+
+
+def _run_exporter(db_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), "--db", str(db_path), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_exporter_allowlists_fields_and_hashes_interview_id(tmp_path: Path) -> None:
+    db_path = tmp_path / "events.db"
+    raw_interview_id = "interview_0123456789abcdef"
+    secret_prompt = "Build the private acquisition workflow"
+    secret_answer = "Use /Users/alice/secret-plan.md and token sk-secret"
+    with _create_event_store(db_path) as connection:
+        _insert_event(
+            connection,
+            event_id="event-1",
+            interview_id=raw_interview_id,
+            event_type="interview.response.emitted",
+            timestamp="2026-07-17T18:00:00+00:00",
+            payload={
+                "response_kind": "answer",
+                "round_number": 4,
+                "payload_chars": 120,
+                "transcript_chars": 900,
+                "ambiguity_prefix_present": False,
+                "is_length_guard": False,
+                "timings_ms": {
+                    "total": 3000.0,
+                    "ambiguity_scoring": 750.0,
+                    "question_generation": 1500.0,
+                    "advisory_build": 250.0,
+                },
+                "prompt": secret_prompt,
+                "response_preview": secret_answer,
+                "error": secret_answer,
+                "environment": {"HOME": "/Users/alice"},
+            },
+        )
+
+    before = db_path.read_bytes()
+    result = _run_exporter(db_path, "--interview-id", raw_interview_id)
+    after = db_path.read_bytes()
+
+    assert result.returncode == 0, result.stderr
+    assert before == after, "export must leave the EventStore unchanged"
+    record = json.loads(result.stdout)
+    expected_hash = hashlib.sha256(f"ouroboros-interview:{raw_interview_id}".encode()).hexdigest()
+    assert record == {
+        "interview_id_sha256": expected_hash,
+        "timestamp": "2026-07-17T18:00:00+00:00",
+        "event_type": "interview.response.emitted",
+        "metadata": {
+            "response_kind": "answer",
+            "round_number": 4,
+            "payload_chars": 120,
+            "transcript_chars": 900,
+            "ambiguity_prefix_present": False,
+            "is_length_guard": False,
+        },
+        "timings_ms": {
+            "total": 3000.0,
+            "ambiguity_scoring": 750.0,
+            "question_generation": 1500.0,
+            "advisory_build": 250.0,
+        },
+    }
+    assert raw_interview_id not in result.stdout
+    assert secret_prompt not in result.stdout
+    assert secret_answer not in result.stdout
+    assert "/Users/alice" not in result.stdout
+
+
+def test_exporter_includes_terminal_events_but_excludes_failure_text(tmp_path: Path) -> None:
+    db_path = tmp_path / "events.db"
+    raw_error = "provider failed with token sk-secret at /Users/alice/project"
+    unsafe_error_type = "RuntimeError at /Users/alice/private-config.json"
+    timing_payload = {
+        "total": 2000.0,
+        "ambiguity_scoring": None,
+        "question_generation": 500.0,
+        "advisory_build": None,
+    }
+    with _create_event_store(db_path) as connection:
+        _insert_event(
+            connection,
+            event_id="event-1",
+            interview_id="interview_failure",
+            event_type="interview.failed",
+            timestamp="2026-07-17T18:01:00+00:00",
+            payload={
+                "phase": "question_generation",
+                "error": raw_error,
+                "timings_ms": timing_payload,
+            },
+        )
+        _insert_event(
+            connection,
+            event_id="event-2",
+            interview_id="interview_handoff",
+            event_type="interview.question_generation.parent_handoff",
+            timestamp="2026-07-17T18:02:00+00:00",
+            payload={
+                "phase": "next_question_generation",
+                "reason_code": "question_generation_envelope_violation",
+                "provider_error_type": "ToolUseBlockViolation",
+                "timings_ms": timing_payload,
+            },
+        )
+        _insert_event(
+            connection,
+            event_id="event-3",
+            interview_id="interview_handoff_unsafe",
+            event_type="interview.question_generation.parent_handoff",
+            timestamp="2026-07-17T18:02:30+00:00",
+            payload={
+                "phase": "next_question_generation",
+                "reason_code": "question_generation_envelope_violation",
+                "provider_error_type": unsafe_error_type,
+                "timings_ms": timing_payload,
+            },
+        )
+        _insert_event(
+            connection,
+            event_id="event-4",
+            interview_id="interview_legacy",
+            event_type="interview.completed",
+            timestamp="2026-07-17T18:03:00+00:00",
+            payload={
+                "total_rounds": 3,
+                "timings_ms": {
+                    "total": None,
+                    "ambiguity_scoring": None,
+                    "question_generation": None,
+                    "advisory_build": None,
+                },
+            },
+        )
+
+    result = _run_exporter(db_path)
+
+    assert result.returncode == 0, result.stderr
+    records = [json.loads(line) for line in result.stdout.splitlines()]
+    assert [record["event_type"] for record in records] == [
+        "interview.failed",
+        "interview.question_generation.parent_handoff",
+        "interview.question_generation.parent_handoff",
+    ]
+    assert records[0]["metadata"] == {"phase": "question_generation"}
+    assert records[1]["metadata"] == {
+        "phase": "next_question_generation",
+        "reason_code": "question_generation_envelope_violation",
+        "provider_error_type": "ToolUseBlockViolation",
+    }
+    assert records[2]["metadata"] == {
+        "phase": "next_question_generation",
+        "reason_code": "question_generation_envelope_violation",
+    }
+    assert raw_error not in result.stdout
+    assert unsafe_error_type not in result.stdout
+    assert "sk-secret" not in result.stdout
+    assert "/Users/alice" not in result.stdout
+
+
+def test_exporter_fails_cleanly_when_database_is_missing(tmp_path: Path) -> None:
+    result = _run_exporter(tmp_path / "missing.db")
+
+    assert result.returncode == 2
+    assert result.stdout == ""
+    assert "database not found" in result.stderr
+    assert str(tmp_path) not in result.stderr


### PR DESCRIPTION
## Summary

Completes the server-side evidence path started in #1640 for #1636:

- `interview.failed`, `interview.question_generation.parent_handoff`, and `interview.completed` now carry the shared privacy-safe `timings_ms` shape.
- Active ambiguity-scoring, question-generation, and advisory-build spans close even when the timed collaborator raises.
- `scripts/export_interview_latency.py` reads EventStore SQLite in read-only mode and emits only hashed interview ids, validated timestamps, allowlisted metadata, and finite non-negative phase timings.
- `docs/events.md` and `docs/guides/interview-latency-benchmark.md` define null semantics, cold/warm sampling, OAuth-only manual execution, p50/p95 reporting, and privacy exclusions.

This remains observability-only. It does not optimize interview behavior or claim that server handler time equals user-visible wall time.

## Review follow-up

The prior bot review warned that raised provider/scorer exceptions could leave an active phase as `null`. Commit `4f78f817a` closes those spans with exception-safe timing and adds deterministic coverage for:

- raised question generation on start, answer, and resume;
- raised ambiguity scoring;
- raised advisory preparation;
- completion success, completion after scoring, and completion failure.

## Local verification

- `pytest tests/unit/mcp/tools/test_interview_*.py tests/unit/scripts/test_export_interview_latency.py -q` - 104 passed
- Ruff check and format check - passed
- MyPy on changed source/exporter - passed
- `py_compile` and `git diff --check` - passed
- Independent code-review agent - no blocker findings

## Remaining evidence boundary

- The live OAuth cold/warm benchmark was not run automatically; the new guide makes it an explicit maintainer opt-in because it contacts the provider and consumes quota.
- Child-process/MCP startup and provider latency remain aggregated inside `question_generation`.
- Host-side advisory execution after the MCP response remains outside `advisory_build` and `total`.

Refs #1636
Refs #1635