### PR TITLE
feat(interview): expose advisory wire contract version

### DIFF
--- a/src/ouroboros/mcp/tools/authoring_handlers.py
+++ b/src/ouroboros/mcp/tools/authoring_handlers.py
@@ -698,6 +698,7 @@ def _build_question_advisory_request(
     mcp_tool_capability = ouroboros_tool_capability_metadata("ouroboros_interview")
     advisory = mcp_tool_capability["orchestration"]["question_advisory_fanout"]
     request: dict[str, Any] = {
+        "contract_id": advisory["contract_id"],
         "session_id": session_id,
         "question_identity": stable_code_investigation_question_identity(question),
         "question": question,
@@ -765,6 +766,7 @@ def _attach_question_assist_requests(
         last_question=last_question,
     )
     meta["question_advisory_request"] = advisory_request
+    meta["question_advisory_contract_id"] = advisory_request["contract_id"]
     try:
         advisory_payloads = build_interview_question_advisory_subagents(advisory_request)
     except ValueError as exc:

--- a/src/ouroboros/orchestrator/capabilities/interview_schemas.py
+++ b/src/ouroboros/orchestrator/capabilities/interview_schemas.py
@@ -481,6 +481,7 @@ def _interview_question_advisory_request_schema() -> dict[str, Any]:
         "type": "object",
         "additionalProperties": False,
         "required": [
+            "contract_id",
             "session_id",
             "question_identity",
             "question",
@@ -495,6 +496,10 @@ def _interview_question_advisory_request_schema() -> dict[str, Any]:
             "mcp_tool_capability",
         ],
         "properties": {
+            "contract_id": {
+                "const": "interview_question_advisory_fanout.v1",
+                "description": "Versioned wire contract for this advisory request.",
+            },
             "session_id": {
                 "type": "string",
                 "description": "Current Ouroboros interview session ID.",

--- a/tests/unit/mcp/tools/test_fanout_core.py
+++ b/tests/unit/mcp/tools/test_fanout_core.py
@@ -154,12 +154,14 @@ def _advisory_meta(dispatch_mode: SubagentDispatchMode, **kwargs: Any) -> dict[s
 def test_advisory_producer_byte_identical_without_registry() -> None:
     """No registry -> emitted fan-out meta is the exact pre-registry contract."""
     host = _advisory_meta(SubagentDispatchMode.HOST_DRIVEN)
+    assert host["question_advisory_contract_id"] == "interview_question_advisory_fanout.v1"
     assert host["question_advisory_dispatch_mode"] == "host_driven"
     assert host["question_advisory_host_action"] == "spawn_subagents"
     assert host["question_advisory_result_correlation_key"] == "context.lane_id"
     assert "question_advisory_fanout_id" not in host
 
     seq = _advisory_meta(SubagentDispatchMode.SEQUENTIAL)
+    assert seq["question_advisory_contract_id"] == "interview_question_advisory_fanout.v1"
     assert seq["question_advisory_dispatch_mode"] == "sequential"
     assert seq["question_advisory_host_action"] == "process_payloads_sequentially"
     assert seq["question_advisory_result_correlation_key"] == "context.lane_id"

--- a/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
+++ b/tests/unit/mcp/tools/test_interview_lateral_review_advisory.py
@@ -239,6 +239,11 @@ async def test_handler_surfaces_runnable_lateral_review_dispatch() -> None:
     }
     assert result.value.meta["question_advisory_recommended"] is True
     advisory = result.value.meta["question_advisory_request"]
+    assert advisory["contract_id"] == "interview_question_advisory_fanout.v1"
+    assert (
+        result.value.meta["question_advisory_contract_id"]
+        == "interview_question_advisory_fanout.v1"
+    )
     assert advisory["session_id"] == "sess-817"
     assert advisory["question"] == "What edge case remains?"
     assert advisory["phase"] == "answer"
@@ -324,6 +329,7 @@ async def test_advisory_fanout_is_host_driven_stamped_on_codex_runtime() -> None
     assert len(meta["question_advisory_subagents"]) == 5
     # ...but now stamped so the Codex host fans them out itself.
     assert meta["question_advisory_dispatch_mode"] == "host_driven"
+    assert meta["question_advisory_contract_id"] == "interview_question_advisory_fanout.v1"
     assert meta["question_advisory_host_action"] == "spawn_subagents"
     # Advisory lanes correlate by lane_id (persona is None on some lanes).
     assert meta["question_advisory_result_correlation_key"] == "context.lane_id"
@@ -345,6 +351,7 @@ def test_question_advisory_sequential_runtime_emits_processing_contract() -> Non
 
     assert len(meta["question_advisory_subagents"]) == 5
     assert meta["question_advisory_dispatch_mode"] == "sequential"
+    assert meta["question_advisory_contract_id"] == "interview_question_advisory_fanout.v1"
     assert meta["question_advisory_host_action"] == "process_payloads_sequentially"
     assert meta["question_advisory_result_correlation_key"] == "context.lane_id"
     assert (

--- a/tests/unit/orchestrator/test_capabilities.py
+++ b/tests/unit/orchestrator/test_capabilities.py
@@ -4966,6 +4966,7 @@ def test_question_advisory_request_model_validates_parent_runtime_payload() -> N
 
     question = "Which users need this first?"
     request = {
+        "contract_id": fanout["contract_id"],
         "session_id": "sess-123",
         "question_identity": stable_code_investigation_question_identity(question),
         "question": question,


### PR DESCRIPTION
## Summary
- stamp the existing `interview_question_advisory_fanout.v1` contract ID on advisory requests
- expose the same ID at top-level response metadata for host capability negotiation
- validate the versioned request shape across host-driven and sequential dispatch paths

## Scope boundary
This does not implement background delivery, result persistence, TTL, consume, or cancellation semantics. Those remain design-gated in #1639.

## Verification
- 36 focused fanout/advisory tests passed
- Ruff passed
- MyPy passed
- `git diff --check` passed

Refs #1639