### PR TITLE
Keep aborted follow-up interviews terminal

### DIFF
--- a/src/ouroboros/cli/commands/init.py
+++ b/src/ouroboros/cli/commands/init.py
@@ -305,9 +305,10 @@ async def _run_interview_loop(
                 save_result = await engine.save_state(state)
                 if save_result.is_err:
                     print_error(
-                        "Warning: Failed to save aborted interview state: "
+                        "Failed to persist aborted interview state; do not resume this session: "
                         f"{save_result.error.message}"
                     )
+                    raise typer.Exit(code=1)
                 break
             continue
 
@@ -380,7 +381,7 @@ def _raise_for_aborted_interview(state: InterviewState) -> None:
         return
     print_error(
         "Interview stopped before completion after question generation failed. "
-        f"Session {state.interview_id} is saved with status 'aborted'; start a new "
+        f"Session {state.interview_id} is terminal with status 'aborted'; start a new "
         "interview instead of resuming this session."
     )
     raise typer.Exit(code=1)
@@ -454,12 +455,12 @@ async def _run_interview(
             disabled_event_stores=disabled_event_stores,
         )
 
-        if state.status == InterviewStatus.ABORTED:
-            console.print()
-            _raise_for_aborted_interview(state)
-
         # Outer loop for retry on high ambiguity
         while True:
+            if state.status == InterviewStatus.ABORTED:
+                console.print()
+                _raise_for_aborted_interview(state)
+
             # Interview complete
             console.print()
             print_success("Interview completed!")

--- a/tests/unit/cli/test_init_hitl.py
+++ b/tests/unit/cli/test_init_hitl.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+import typer
 
 from ouroboros.bigbang.interview import InterviewRound, InterviewState, InterviewStatus
 from ouroboros.cli.commands.init import (
@@ -14,7 +15,7 @@ from ouroboros.cli.commands.init import (
     _interview_hitl_response,
     _run_interview_loop,
 )
-from ouroboros.core.errors import ProviderError
+from ouroboros.core.errors import ProviderError, ValidationError
 from ouroboros.core.types import Result
 from ouroboros.events.hitl import create_hitl_answered_event, create_hitl_requested_event
 
@@ -151,6 +152,37 @@ async def test_question_generation_failure_declined_retry_persists_aborted_state
     assert final_state.status == InterviewStatus.ABORTED
     assert final_state.rounds == []
     assert engine.saved[-1].status == InterviewStatus.ABORTED
+
+
+@pytest.mark.asyncio
+async def test_question_generation_abort_save_failure_exits_without_claiming_persistence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed terminal write must not advertise the session as durably aborted."""
+
+    class FakeEngine:
+        async def ask_next_question(self, state: InterviewState):
+            return Result.err(ProviderError("question generation failed"))
+
+        async def save_state(self, state: InterviewState):
+            return Result.err(ValidationError("disk is read-only"))
+
+    monkeypatch.setattr(
+        "ouroboros.cli.commands.init.Confirm.ask",
+        lambda *_args, **_kwargs: False,
+    )
+    errors: list[str] = []
+    monkeypatch.setattr("ouroboros.cli.commands.init.print_error", errors.append)
+
+    state = InterviewState(interview_id="interview_question_failure")
+
+    with pytest.raises(typer.Exit) as exc_info:
+        await _run_interview_loop(FakeEngine(), state)
+
+    assert exc_info.value.exit_code == 1
+    assert state.status == InterviewStatus.ABORTED
+    assert any("Failed to persist aborted interview state" in error for error in errors)
+    assert all("is saved with status" not in error for error in errors)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_init_runtime.py
+++ b/tests/unit/cli/test_init_runtime.py
@@ -94,6 +94,58 @@ class TestInitWorkflowRuntimeHandoff:
         mock_generate_seed.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_aborted_continuation_does_not_reenter_completion_or_seed(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """An aborted follow-up loop is terminal after Seed requests more detail."""
+        initial_state = InterviewState(
+            interview_id="interview_question_failure",
+            initial_context="Build a CLI",
+        )
+        completed_state = initial_state.model_copy(deep=True)
+        completed_state.status = InterviewStatus.COMPLETED
+        aborted_state = initial_state.model_copy(deep=True)
+        aborted_state.status = InterviewStatus.ABORTED
+
+        engine = MagicMock()
+        engine.start_interview = AsyncMock(return_value=Result.ok(initial_state))
+        engine.save_state = AsyncMock(return_value=Result.ok(tmp_path / "state.json"))
+        run_loop = AsyncMock(side_effect=[completed_state, aborted_state])
+        generate_seed = AsyncMock(
+            side_effect=[
+                (None, SeedGenerationResult.CONTINUE_INTERVIEW),
+                AssertionError("aborted continuation re-entered Seed generation"),
+            ]
+        )
+
+        with (
+            patch("ouroboros.cli.commands.init._get_adapter", return_value=MagicMock()),
+            patch("ouroboros.cli.commands.init.InterviewEngine", return_value=engine),
+            patch("ouroboros.cli.commands.init._run_interview_loop", new=run_loop),
+            patch(
+                "ouroboros.cli.commands.init._get_init_event_store",
+                new=AsyncMock(return_value=None),
+            ),
+            patch("ouroboros.cli.commands.init.Confirm.ask", return_value=True),
+            patch(
+                "ouroboros.cli.commands.init._generate_seed_from_interview",
+                new=generate_seed,
+            ),
+        ):
+            with pytest.raises(typer.Exit) as exc_info:
+                await _run_interview(
+                    "Build a CLI",
+                    state_dir=tmp_path,
+                    use_orchestrator=True,
+                    workflow_runtime_backend="codex",
+                )
+
+        assert exc_info.value.exit_code == 1
+        assert run_loop.await_count == 2
+        assert generate_seed.await_count == 1
+
+    @pytest.mark.asyncio
     async def test_aborted_interview_cannot_be_resumed(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary

Follow-up to #1632. The merged fix correctly marks a declined question-generation retry as `ABORTED`, but it only guarded the initial interview loop. A later interview reopened by `SeedGenerationResult.CONTINUE_INTERVIEW` could return `ABORTED`, re-enter the outer loop, print `Interview completed!`, and invoke Seed generation again.

## Changes

- Gate every outer-loop entry on `InterviewStatus.ABORTED`, covering initial and follow-up interview loops.
- Exit before completion, Seed generation, or workflow handoff when a follow-up loop aborts.
- Fail closed when persisting the terminal state fails, and avoid claiming the session was durably saved.
- Add regressions for the follow-up-loop bypass and aborted-state persistence failure.

## Validation

- Focused CLI/provider/MCP tests: `122 passed`.
- Full CLI unit suite: `1,182 passed, 1 skipped, 2 failed`; both failures are pre-existing local setup-install-method assumptions and reproduce outside this delta.
- `ruff check src/ tests/` and `ruff format --check src/ tests/`.
- `mypy src/ouroboros`.
- `git diff --check`.

## Risk

Narrow CLI lifecycle change. Retry behavior remains unchanged while the user chooses to retry; only terminal `ABORTED` paths are blocked from completion and Seed work.