### PR TITLE
feat(orchestrator): add the Ouroboros AC runtime

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ replayable execution contract on your choice of runtime backend.
 ### Architecture
 
 - [System Architecture](./architecture.md) - Six-phase architecture, runtime abstraction layer, and core concepts
+- [Ouroboros AC Runtime RFC](./rfc/ouroboros-ac-runtime.md) - Acceptance-criterion VM: Grill, context paging, fresh AC capsules, gate-anchored trust, and RLM-inspired frugality
 - [Interview Milestone Lateral Contract](./rfc/interview-milestone-lateral-contract.md) - Proposed contract for bounded lateral review at ambiguity milestone transitions
 - [CLI Reference](./cli-reference.md) - Command-line interface flags and options
 - [Configuration Reference](./config-reference.md) - All `config.yaml` options and environment variables

--- a/docs/events.md
+++ b/docs/events.md
@@ -154,8 +154,12 @@ Lifecycle events carry the same `ac_dispatch_id`. Dispatch events form one
 validated predecessor chain, and recovery considers only its unique head; it
 never infers a successor from timestamps, replay-list position, or lifecycle
 event type priority across boundaries. Only a correlated reusable same-attempt
-handle at that head can resume. A failed head without such a handle remains
-ambiguous, because provider effects may precede the reported adapter failure. A
+handle at that head can resume. Terminal failure takes precedence over a
+resumable handle: a head with a durable `execution.session.failed` is NOT
+resumed even when it carries a reusable handle, because provider effects may
+precede the reported failure and resuming would send another provider turn. The
+only safe resume of a failed head is an explicit `execution.session.recovered`
+linkage to a live replacement session; without it, recovery fails closed. A
 completed head blocks same-attempt redispatch as already terminal and
 reconstructs its durable successful result for the caller. When the AC ran a
 verify gate, the completed lifecycle also carries a bounded exact-shape

--- a/docs/events.md
+++ b/docs/events.md
@@ -107,12 +107,13 @@ session freshness.
 | `session_id` | `string` | Orchestrator session id |
 | `semantic_ac_key` | `string` | Stable semantic AC identity |
 | `capsule_fingerprint` | `string` | SHA-256 identity of the complete capsule contract |
-| `capsule` | `object` | Strict versioned `ACExecutionCapsule` contract |
+| `capsule_manifest` | `object` | Strict versioned manifest whose free-form values and paths are represented only by SHA-256 digests |
 | `session_origin` | `string` | `"fresh"` or `"restored_same_attempt"` |
 
-The nested capsule contains compact facts and typed context references, not a
-provider transcript. A native runtime handle is bound to the capsule fingerprint
-and may resume only the same AC attempt.
+The nested manifest contains compact identities and typed context-reference
+digests, not a provider transcript or copies of free-form Seed/prompt/workspace
+text. Recovery strictly parses and re-fingerprints the manifest before a native
+runtime handle may resume the same AC attempt.
 
 ### mcp.job.cancelled
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -93,6 +93,27 @@ name further.
 | `ac_id` | `string` | Legacy source acceptance-criterion identifier for the execution unit |
 | `status` | `string` | Legacy worker completion status: `"passed"` means completed, `"failed"` means failed |
 
+### execution.ac.capsule.compiled
+
+Authority-bearing event emitted before a provider driver may start an AC
+attempt. Unlike observe-only telemetry, persistence failure blocks dispatch.
+The capsule makes Ouroboros — rather than Claude, Codex, or another provider —
+the owner of AC identity, context references, workspace authority, and native
+session freshness.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `execution_id` | `string` | Durable execution/run anchor |
+| `session_id` | `string` | Orchestrator session id |
+| `semantic_ac_key` | `string` | Stable semantic AC identity |
+| `capsule_fingerprint` | `string` | SHA-256 identity of the complete capsule contract |
+| `capsule` | `object` | Strict versioned `ACExecutionCapsule` contract |
+| `session_origin` | `string` | `"fresh"` or `"restored_same_attempt"` |
+
+The nested capsule contains compact facts and typed context references, not a
+provider transcript. A native runtime handle is bound to the capsule fingerprint
+and may resume only the same AC attempt.
+
 ### mcp.job.cancelled
 
 Emitted when a background MCP job is cancelled.

--- a/docs/events.md
+++ b/docs/events.md
@@ -221,7 +221,7 @@ and decomposed-parent verify gates.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `verify_key` | `string` | Stable per-attempt gate identity. Namespaces: `atomic:…` (atomic gate), `decomposed_parent:…` (decomposed-parent gate), `apply_gate:…` (failed-runtime recovery gate), `flip_gate:…` (sibling-evidence flip gate), `skip_completed:…` (`--skip-completed` proof gate) |
+| `verify_key` | `string` | Stable per-attempt gate identity. `acgate:<execution>:<ac_index>:<retry>` is the single authoritative per-attempt key shared by the atomic gate, the failed-runtime recovery gate, and the sibling-flip gate, so a post-verify failure never reruns the command under a different key; `decomposed_parent:…` keys the decomposed-parent gate and `skip_completed:…` the pre-execution `--skip-completed` proof gate. A command-bearing completed-attempt recovery requires exactly one matching intent+outcome under this key before its cached PASS is trusted. |
 | `verify_command_digest` | `string` | Digest of the exact command, expected artifacts, and output assertion |
 | `execution_id` | `string` | Durable execution/run anchor |
 | `session_id` | `string` | Orchestrator session id |

--- a/docs/events.md
+++ b/docs/events.md
@@ -148,7 +148,11 @@ exact follow-up phase is not reconstructed from persisted metadata, so replaying
 the original AC prompt is refused rather than risking repeated acceptance work.
 Capsule authority also binds the actual subprocess `executable` (canonical path
 and realpath) and any launcher (e.g. a Zcode Electron/Node host), so a restart
-cannot resume the same capsule under a different binary.
+cannot resume the same capsule under a different binary. For a runtime that wraps
+a transport (e.g. `LeaderDrivenWorkerRuntime`), the transport's delegated
+`executable_identity_contract()` also contributes its command-affecting policy
+(e.g. Claude's `--add-dir` / `--disallowedTools`), so a change in launched-binary
+access changes authority too.
 
 Lifecycle events carry the same `ac_dispatch_id`. Dispatch events form one
 validated predecessor chain, and recovery considers only its unique head; it
@@ -205,7 +209,7 @@ and decomposed-parent verify gates.
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `verify_key` | `string` | Stable per-attempt gate identity (`atomic:…` or `decomposed_parent:…`) |
+| `verify_key` | `string` | Stable per-attempt gate identity. Namespaces: `atomic:…` (atomic gate), `decomposed_parent:…` (decomposed-parent gate), `apply_gate:…` (failed-runtime recovery gate), `flip_gate:…` (sibling-evidence flip gate), `skip_completed:…` (`--skip-completed` proof gate) |
 | `verify_command_digest` | `string` | Digest of the exact command, expected artifacts, and output assertion |
 | `execution_id` | `string` | Durable execution/run anchor |
 | `session_id` | `string` | Orchestrator session id |

--- a/docs/events.md
+++ b/docs/events.md
@@ -132,12 +132,23 @@ that provider invocation.
 |-------|------|-------------|
 | `ac_dispatch_id` | `string` | Unique correlation id for this exact provider entry |
 | `previous_ac_dispatch_id` | `string \| null` | Exact predecessor boundary in the same attempt; `null` only for the chain root |
+| `dispatch_kind` | `string` | Provider-entry phase: `"primary"` replays the AC prompt, `"session_signal_followup"` replays a Synapse signal turn. Absent on legacy records is treated as `"primary"`. |
+| `signal_id` | `string \| null` | SessionSignal id (follow-up dispatches only) |
+| `signal_mode` | `string \| null` | Effective signal mode, e.g. `"inform"`/`"after_turn"` (follow-up dispatches only) |
+| `follow_up_input_digest` | `string \| null` | `sha256:` digest of the exact rendered follow-up prompt (follow-up dispatches only) |
 | `execution_id` | `string` | Durable execution/run anchor |
 | `session_id` | `string` | Orchestrator session id |
 | `capsule_fingerprint` | `string` | Capsule authority used for this dispatch |
 | `session_origin` | `string` | `"fresh"` or `"restored_same_attempt"` |
 | `runtime_backend` | `string \| null` | Provider-neutral runtime selector |
 | `runtime` | `object \| null` | Minimal reconnect/authority handle; excludes cwd, transcript, tool catalog, capability graph, control plane, and arbitrary metadata |
+
+A non-primary (`session_signal_followup`) head fails closed on recovery: the
+exact follow-up phase is not reconstructed from persisted metadata, so replaying
+the original AC prompt is refused rather than risking repeated acceptance work.
+Capsule authority also binds the actual subprocess `executable` (canonical path
+and realpath) and any launcher (e.g. a Zcode Electron/Node host), so a restart
+cannot resume the same capsule under a different binary.
 
 Lifecycle events carry the same `ac_dispatch_id`. Dispatch events form one
 validated predecessor chain, and recovery considers only its unique head; it
@@ -158,8 +169,43 @@ such a linkage, conflicting session ids or equally authoritative response-chain
 cursors remain ambiguous and fail closed.
 
 The recovery handle contract is exact-shape, metadata-allowlisted, and bounded
-to 64 KiB before deserialization. Persisted payloads cannot smuggle excluded
-runtime context back into replay through unknown fields.
+to 64 KiB (measured in UTF-8 bytes) before deserialization. Persisted payloads
+cannot smuggle excluded runtime context back into replay through unknown fields.
+
+### execution.ac.dispatch.sealed
+
+Seals an already-completed provider turn immediately before a SessionSignal
+follow-up dispatch supersedes it. If the follow-up's own dispatch record fails
+to persist — or a crash lands before the follow-up reaches a terminal outcome —
+the predecessor becomes the chain head again. A sealed head with no durable
+terminal completion fails closed on recovery instead of resuming and replaying
+the original AC prompt over already-completed work.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ac_dispatch_id` | `string` | The predecessor dispatch being sealed |
+| `execution_id` | `string` | Durable execution/run anchor |
+| `session_id` | `string` | Orchestrator session id |
+| `capsule_fingerprint` | `string` | Capsule authority of the sealed dispatch |
+
+### execution.ac.verify.intent / execution.ac.verify.outcome
+
+Make a non-idempotent `verify_command` single-shot across crash recovery. The
+intent is persisted immediately before the command runs and the outcome
+immediately after; both are keyed to a stable `verify_key` (the AC/node identity
+plus retry attempt) and a `verify_command_digest` binding the exact command and
+contract. On recovery the orchestrator consumes a recorded outcome instead of
+re-running the command; an intent with no matching outcome — the command may
+already have run — fails closed rather than replaying it. Applies to both atomic
+and decomposed-parent verify gates.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `verify_key` | `string` | Stable per-attempt gate identity (`atomic:…` or `decomposed_parent:…`) |
+| `verify_command_digest` | `string` | Digest of the exact command, expected artifacts, and output assertion |
+| `execution_id` | `string` | Durable execution/run anchor |
+| `session_id` | `string` | Orchestrator session id |
+| `verify_gate_outcome` | `object` | (outcome only) Bounded exact-shape gate result: `passed`, `reason`, `output_tail`, `missing_artifacts` |
 
 ### mcp.job.cancelled
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -182,12 +182,21 @@ cannot smuggle excluded runtime context back into replay through unknown fields.
 
 ### execution.ac.dispatch.sealed
 
-Seals an already-completed provider turn immediately before a SessionSignal
-follow-up dispatch supersedes it. If the follow-up's own dispatch record fails
-to persist — or a crash lands before the follow-up reaches a terminal outcome —
-the predecessor becomes the chain head again. A sealed head with no durable
-terminal completion fails closed on recovery instead of resuming and replaying
-the original AC prompt over already-completed work.
+General fail-closed marker: a sealed dispatch that ends up the active recovery
+head (with no durable terminal completion) is refused rather than resumed, so
+consumers must NOT read a seal as completion. It is written for every phase where
+a provider turn ran but its authoritative terminal is not yet durable, so a crash
+in that window cannot replay the AC prompt over already-done or ambiguous work:
+
+- a completed provider turn, immediately after its stream and BEFORE signal
+  handling, verification, evidence, and shadow replay (the later
+  `execution.session.completed` supersedes the seal on the normal path);
+- an effectful or opaque-driver stall (a stall after an observed tool effect, or
+  any stall on a driver that does not attest real-time tool-effect visibility);
+- a SessionSignal follow-up before it supersedes its (already-completed)
+  predecessor, and a stalled effectful follow-up.
+
+A sealed head fails closed on recovery instead of resuming and replaying the AC.
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -213,7 +222,11 @@ and decomposed-parent verify gates.
 | `verify_command_digest` | `string` | Digest of the exact command, expected artifacts, and output assertion |
 | `execution_id` | `string` | Durable execution/run anchor |
 | `session_id` | `string` | Orchestrator session id |
-| `verify_gate_outcome` | `object` | (outcome only) Bounded exact-shape gate result: `passed`, `reason`, `output_tail`, `missing_artifacts` |
+| `verify_gate_outcome` | `object` | (outcome only) Bounded exact-shape gate result: `passed`, `reason`, `output_tail`, `missing_artifacts` (count- and length-capped, with `missing_artifacts_omitted` when truncated). Enforced ≤ 64 KiB UTF-8 both at persistence and on replay. |
+
+An outcome is trusted only when preceded by exactly one matching intent for the
+same `verify_key` and `verify_command_digest`; orphan, duplicate, or out-of-order
+records fail closed rather than manufacture acceptance evidence.
 
 ### mcp.job.cancelled
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -120,6 +120,47 @@ also records `omitted_context_count` and a rolling `omitted_context_digest`.
 This is an auditable bounded-retrieval fact, not a claim that a page resolver
 already exists.
 
+### execution.ac.attempt.dispatched
+
+Authority-bearing transition persisted immediately before Ouroboros invokes a
+provider for an AC attempt, including resumed SessionSignal turns. A compiled
+capsule alone does not prove whether a particular provider boundary was crossed;
+this event makes every entry distinct and durable. Persistence failure blocks
+that provider invocation.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ac_dispatch_id` | `string` | Unique correlation id for this exact provider entry |
+| `previous_ac_dispatch_id` | `string \| null` | Exact predecessor boundary in the same attempt; `null` only for the chain root |
+| `execution_id` | `string` | Durable execution/run anchor |
+| `session_id` | `string` | Orchestrator session id |
+| `capsule_fingerprint` | `string` | Capsule authority used for this dispatch |
+| `session_origin` | `string` | `"fresh"` or `"restored_same_attempt"` |
+| `runtime_backend` | `string \| null` | Provider-neutral runtime selector |
+| `runtime` | `object \| null` | Minimal reconnect/authority handle; excludes cwd, transcript, tool catalog, capability graph, control plane, and arbitrary metadata |
+
+Lifecycle events carry the same `ac_dispatch_id`. Dispatch events form one
+validated predecessor chain, and recovery considers only its unique head; it
+never infers a successor from timestamps, replay-list position, or lifecycle
+event type priority across boundaries. Only a correlated reusable same-attempt
+handle at that head can resume. A failed head without such a handle remains
+ambiguous, because provider effects may precede the reported adapter failure. A
+completed head blocks same-attempt redispatch as already terminal and
+reconstructs its durable successful result for the caller. When the AC ran a
+verify gate, the completed lifecycle also carries a bounded exact-shape
+`verify_gate_outcome`, so crash recovery does not replay a potentially
+non-idempotent `verify_command`. Recovery must not manufacture a fresh provider
+session merely because no first streamed message became durable.
+
+If `execution.session.recovered` explicitly links a failed resume id to a
+replacement resume id, that durable edge supersedes the failed handle. Absent
+such a linkage, conflicting session ids or equally authoritative response-chain
+cursors remain ambiguous and fail closed.
+
+The recovery handle contract is exact-shape, metadata-allowlisted, and bounded
+to 64 KiB before deserialization. Persisted payloads cannot smuggle excluded
+runtime context back into replay through unknown fields.
+
 ### mcp.job.cancelled
 
 Emitted when a background MCP job is cancelled.

--- a/docs/events.md
+++ b/docs/events.md
@@ -115,6 +115,11 @@ digests, not a provider transcript or copies of free-form Seed/prompt/workspace
 text. Recovery strictly parses and re-fingerprints the manifest before a native
 runtime handle may resume the same AC attempt.
 
+When the prompt budget cannot include every optional reference, the manifest
+also records `omitted_context_count` and a rolling `omitted_context_digest`.
+This is an auditable bounded-retrieval fact, not a claim that a page resolver
+already exists.
+
 ### mcp.job.cancelled
 
 Emitted when a background MCP job is cancelled.

--- a/docs/events.md
+++ b/docs/events.md
@@ -152,7 +152,10 @@ cannot resume the same capsule under a different binary. For a runtime that wrap
 a transport (e.g. `LeaderDrivenWorkerRuntime`), the transport's delegated
 `executable_identity_contract()` also contributes its command-affecting policy
 (e.g. Claude's `--add-dir` / `--disallowedTools`), so a change in launched-binary
-access changes authority too.
+access changes authority too. A runtime's effective watchdog/termination policy
+(startup-output and stdout-idle timeouts, process-shutdown grace), surfaced via
+`watchdog_identity_contract()`, is likewise bound, so a restart cannot resume the
+same capsule under changed interruption semantics.
 
 Lifecycle events carry the same `ac_dispatch_id`. Dispatch events form one
 validated predecessor chain, and recovery considers only its unique head; it

--- a/docs/rfc/ouroboros-ac-runtime.md
+++ b/docs/rfc/ouroboros-ac-runtime.md
@@ -1,0 +1,309 @@
+# RFC — Ouroboros Runtime: an Acceptance-Criterion VM for AI Engineering
+
+> Status: proposed architecture
+> Tagline: **Compile intent. Page context. Prove work. Reuse trust.**
+
+## Thesis
+
+AI coding harnesses should be provider drivers, not the owners of a software
+workflow. Claude, Codex, Gemini, OpenCode, and future models may execute work,
+but Ouroboros owns the durable semantics:
+
+- what the user meant;
+- which independently verifiable outcome is being attempted;
+- what context that attempt may see;
+- which workspace and authority it may mutate;
+- what evidence counts as success;
+- when a cheaper model is safe;
+- how a crash resumes without inventing state.
+
+Ouroboros Runtime is therefore an acceptance-criterion virtual machine. It
+compiles a clarified intent into an AC graph, executes every AC in a disposable
+provider context, pages external context on demand, and accepts work only through
+the existing deterministic gate/evidence system.
+
+## The Product Loop
+
+```text
+GRILL -> COMPILE -> PAGE -> RUN -> PROVE -> LEARN
+  ^                                         |
+  +-----------------------------------------+
+```
+
+### 1. Grill — preserve reasoning coherence
+
+The discovery phase follows the strongest lesson from `grill-me`: do not split
+or compact a line of reasoning while the problem is still ambiguous. The model
+and user stay in one coherent decision thread until the important branches,
+terms, constraints, and fears are explicit.
+
+The output is not a transcript summary. It is a durable **Intent Ledger**:
+
+- domain vocabulary and resolved ambiguities;
+- accepted constraints and rejected alternatives;
+- open questions and their owners;
+- success gates and evidence requirements;
+- ADR/spec/issue references for settled detail.
+
+If the discovery thread approaches its healthy reasoning window, Ouroboros
+freezes the ledger and opens a fresh discovery session from references. It never
+drags the full conversation forward merely because it exists.
+
+### 2. Compile — turn intent into executable AC IR
+
+The AC compiler transforms the Intent Ledger into a dependency graph of
+tracer-bullet vertical slices. An AC is atomic because it has one independently
+verifiable outcome and bounded blast radius, not because it has an arbitrary
+token count.
+
+Operationally, each leaf should be expected to fit one fresh model context. A
+rough 100k-token smart-zone target is a planning heuristic. If a unit cannot fit
+but still has only one acceptance gate, it remains one AC and may use a physical
+continuation segment; if it contains multiple independently verifiable outcomes,
+the compiler splits it before dispatch.
+
+The compiled graph is the runtime's IR. Recovery restores this exact graph; it
+does not ask another model to derive a potentially different plan and then apply
+old outcomes to it.
+
+### 3. Page — use context like virtual memory
+
+RLM's most valuable idea is not “use more tokens” or “always call a small model.”
+It is to keep the large environment outside the main prompt and let the runtime
+retrieve or recursively process only the pieces needed for the current step.
+
+Every AC receives a compact **AC Capsule**:
+
+- semantic AC identity and acceptance contract;
+- canonical workspace and dispatch authority;
+- dependency/gate/artifact references;
+- a small deterministic project map and verify commands;
+- model, effort, retry, and isolation policy;
+- a context-page budget.
+
+The capsule contains references, not copies. Large sources remain in the
+workspace, event ledger, specs, diffs, docs, and test output. The model can ask
+for bounded **Context Pages** such as:
+
+- `symbol:PaymentService.create`;
+- `diff:dependency-AC-2`;
+- `gate:AC-3/latest-failure`;
+- `decision:auth-session-model`;
+- `tests:affected-by/src/payment.py`.
+
+Each page is bounded, provenance-carrying, content-hashed, and disposable. A
+page may be produced deterministically or by a read-only **Probe**. Probe output
+is advisory context, never acceptance evidence by itself.
+
+### 4. Run — shed context at AC boundaries
+
+Every AC attempt starts in a fresh provider session. This is the universal
+cross-harness guarantee: it does not depend on Claude, Codex, or another driver
+reporting token usage correctly.
+
+The model shares no prior chat by default. It receives the capsule, works against
+the authoritative workspace, pages additional context as needed, and emits
+normalized tool/output events. Native provider resume is allowed only within the
+same AC attempt after a crash; a handle can never cross an AC, retry, workspace,
+or authority boundary.
+
+When one genuinely atomic AC outgrows a physical session, Ouroboros **sheds** the
+provider context:
+
+1. persist a reference-first continuation capsule;
+2. close and invalidate the native session;
+3. start a fresh segment for the same AC and retry attempt;
+4. preserve model/effort/persona/gate semantics;
+5. continue from workspace and ledger state, not transcript replay.
+
+Token telemetry may trigger shedding where available, but it is a fallback
+signal. Billed work tokens are not claimed to equal resident context occupancy.
+
+### 5. Prove — gates, not prose, create trust
+
+Provider self-report is not acceptance. The runtime normalizes tool facts,
+artifacts, command results, and typed evidence, then applies the existing AC gate.
+
+Decomposition trust is gate-anchored:
+
+- every child passes its child-local gate;
+- the parent gate is re-run over the union of promoted child effects;
+- missing evidence is indeterminate, never trustworthy;
+- real negative evidence wins over missing evidence;
+- the verdict is durable and authority-bound.
+
+This is the central lesson from the #1648 experiment: proposal shape, model prose,
+and apparent MECE structure cannot authorize a cheaper route. Only executed and
+verified outcomes can.
+
+### 6. Learn — make frugality an evidence feedback loop
+
+Frugality is split into four independent levers:
+
+1. **Attention frugality** — fresh contexts and bounded pages remove irrelevant
+   history from the model's active reasoning surface.
+2. **Retrieval frugality** — cheap read-only Probes summarize or index large
+   material with citations; their output cannot mutate state or satisfy a gate.
+3. **Model frugality** — trusted decomposed ACs may run one model tier cheaper
+   while retaining reasoning depth; failures progressively regain stronger
+   models and eventually lateral personas.
+4. **Execution frugality** — durable workspace/gate/event state prevents repeated
+   discovery and lets sessions be disposable.
+
+The runtime can also support **speculative frugal execution** for workspace-pure
+ACs:
+
+1. run a cheaper model in an isolated overlay/worktree;
+2. execute the child gate inside that isolation boundary;
+3. promote the patch only when the gate passes and side-effect policy permits;
+4. otherwise discard the overlay and rerun at the base tier;
+5. after all promotions, re-run the parent gate before registering trust.
+
+This creates first-run savings without letting an untrusted cheap model corrupt
+the live workspace. It is disabled unless filesystem, verification, network, and
+external side effects are all isolation-attested.
+
+## Execution Units
+
+| Unit | Purpose | Mutation | Trust semantics | Typical model |
+|---|---|---:|---|---|
+| Decision Thread | Grill ambiguity into an Intent Ledger | Docs/ledger only | User-confirmed decisions | strong conversational model |
+| Context Page | Bounded deterministic retrieval | No | content hash + provenance | none |
+| Probe | Recursive RLM-style inspection/summarization | No | advisory, cited, never gate evidence alone | frugal model |
+| AC Capsule | Independently verifiable implementation slice | Yes | AC gate | base or trusted-frugal model |
+| Continuation Capsule | Fresh physical session for the same AC | Yes | same gate/retry identity | unchanged |
+| Verifier | Deterministic or isolated semantic judgment | No live mutation | authoritative gate outcome | code/process, optional strong model |
+
+The Probe/AC distinction prevents a common decomposition failure: not every
+question deserves a durable child AC. A Probe retrieves knowledge. An AC changes
+the product and must own a gate.
+
+## Runtime Planes
+
+### Control plane
+
+- Grill state machine and Intent Ledger
+- AC compiler and dependency graph
+- scheduler, retries, lateral escalation, parking
+- trust registry and economics policy
+- checkpoint/recovery reducer
+
+### Memory plane
+
+- shared or isolated workspace
+- Seed/spec/ADR/issue references
+- event and evidence ledger
+- context-page cache keyed by source digest
+- patch/overlay artifacts
+
+### Execution plane
+
+- AC Capsule materializer
+- Context Page resolver and Probe runner
+- provider drivers (`AgentRuntime`)
+- native session lifecycle and capability negotiation
+
+### Verification plane
+
+- child-local success gates
+- parent-gate revalidation
+- typed evidence and TraceGuard
+- decomposition attestation
+- frugality proof and outcome finalization
+
+## State Machine
+
+```text
+PLANNED
+  -> CAPSULED
+  -> DISPATCHED
+  -> OBSERVED
+  -> GATED
+      -> ACCEPTED
+      -> RETRY_SCHEDULED
+      -> DECOMPOSED
+      -> SHED_AND_CONTINUE
+      -> ALT_DRIVER
+      -> LATERAL_ESCALATION
+      -> PARKED
+      -> INFRA_FATAL
+```
+
+Every transition emits an event before the next authority-bearing effect. Crash
+recovery folds events into state and resumes from the last complete transition.
+It never infers progress from a provider transcript or re-derives an execution
+plan against old outcomes.
+
+## Provider Contract
+
+All providers implement the same driver boundary. Capabilities affect
+optimizations, not AC semantics:
+
+| Capability | Effect |
+|---|---|
+| native model override | Can enforce trusted-frugal and escalation routing |
+| live token usage | Can request an in-session shed at a safe boundary |
+| terminal token usage | Can audit cost and shed incomplete work after a turn |
+| targeted resume | May restore the same AC attempt after a crash |
+| structured output | Improves evidence normalization |
+| isolation attestation | May participate in speculative frugal execution |
+
+A telemetry-free driver still receives a fresh session per AC and bounded
+Ouroboros-injected context. It is merely unmeasured for token-triggered shedding.
+
+## Lessons Incorporated
+
+### From the Grill workflow
+
+- Keep discovery coherent until questions are resolved.
+- Convert conversation into durable decisions before splitting execution.
+- Make implementation slices vertical, independently verifiable, and fresh.
+- Handoffs reference settled artifacts instead of duplicating them.
+
+### From #1648 and the review loop
+
+- Trust false positives are unacceptable; ambiguity fails closed.
+- First-round decomposition prose cannot authorize a discount.
+- Reusable trust must bind workspace, Seed, tools, prompt, permissions, runtime,
+  model routing, and execution profile.
+- Retry, continuation, and decomposition are different state axes.
+- Recovery contracts must be exact and durable; plan drift is a correctness bug.
+- Provider capabilities must be truthful rather than assumed from a backend name.
+
+### From the token-envelope experiment
+
+- Token count is not semantic atomicity.
+- Provider usage is a work/cost signal, not exact context occupancy.
+- Universal behavior must come from Ouroboros-owned session boundaries.
+- Live/terminal token rollover remains useful as an exceptional safety net.
+
+### From RLM
+
+- Treat large context as an external environment.
+- Retrieve/process recursively instead of eagerly stuffing the main prompt.
+- Keep sub-results bounded and provenance-carrying.
+- Spend strong-model attention on planning, synthesis, and hard exceptions;
+  delegate safe read-only work and proven slices economically.
+
+## Implementation Strategy
+
+1. **AC Capsule contract** — versioned capsule, typed references, fingerprint,
+   prompt materialization, and durable compiled event.
+2. **Session ownership** — assert fresh provider session per AC attempt and bind
+   any same-attempt resume handle to the capsule fingerprint.
+3. **Context paging** — promote `context_governor`, `context_pack`, and
+   `LevelContext` into typed resolvers; stop eager prose injection.
+4. **Probe runtime** — read-only recursive queries with citations and no
+   acceptance authority.
+5. **Speculative frugal lane** — isolated cheap execution, gate, patch promotion,
+   and parent revalidation for side-effect-safe ACs.
+6. **Shed fallback** — capability-driven live/terminal measurement and durable
+   same-AC continuation.
+7. **Kernel extraction** — move transition/recovery logic out of the monolithic
+   executor into a pure event-folded state machine with effect handlers at the
+   edges.
+
+The first PR should land only steps 1 and 2 as a complete vertical slice. The
+remaining steps form a stack; none should be hidden inside a single giant runtime
+rewrite.
+

--- a/docs/rfc/ouroboros-ac-runtime.md
+++ b/docs/rfc/ouroboros-ac-runtime.md
@@ -138,6 +138,12 @@ Decomposition trust is gate-anchored:
 - real negative evidence wins over missing evidence;
 - the verdict is durable and authority-bound.
 
+Custom semantic verifiers follow the same rule. Ouroboros does not guess a
+durable identity from Python source, closures, globals, or callable state. A
+verifier may opt into recovery and reusable trust only with a bounded canonical
+`verification_identity_contract()`; otherwise its authority is process-local and
+any crash restart fails closed into a fresh, non-reusable identity.
+
 This is the central lesson from the #1648 experiment: proposal shape, model prose,
 and apparent MECE structure cannot authorize a cheaper route. Only executed and
 verified outcomes can.

--- a/docs/rfc/ouroboros-ac-runtime.md
+++ b/docs/rfc/ouroboros-ac-runtime.md
@@ -79,7 +79,7 @@ Every AC receives a compact **AC Capsule**:
 - dependency/gate/artifact references;
 - a small deterministic project map and verify commands;
 - model, effort, retry, and isolation policy;
-- a context-page budget.
+- a bounded context-reference budget.
 
 The capsule contains references, not copies. Large sources remain in the
 workspace, event ledger, specs, diffs, docs, and test output. The model can ask
@@ -94,6 +94,12 @@ for bounded **Context Pages** such as:
 Each page is bounded, provenance-carrying, content-hashed, and disposable. A
 page may be produced deterministically or by a read-only **Probe**. Probe output
 is advisory context, never acceptance evidence by itself.
+
+The initial Capsule vertical slice does not pretend that a page exists before a
+resolver exists. It selects a newest-first bounded reference frontier and records
+the count plus rolling digest of any omitted optional references. The provider is
+told that retrieval was bounded; no synthetic `context-index` locator is emitted.
+Actual page locators become legal only with step 3's durable resolver.
 
 ### 4. Run — shed context at AC boundaries
 
@@ -306,4 +312,3 @@ Ouroboros-injected context. It is merely unmeasured for token-triggered shedding
 The first PR should land only steps 1 and 2 as a complete vertical slice. The
 remaining steps form a stack; none should be hidden inside a single giant runtime
 rewrite.
-

--- a/docs/rfc/ouroboros-ac-runtime.md
+++ b/docs/rfc/ouroboros-ac-runtime.md
@@ -25,9 +25,9 @@ the existing deterministic gate/evidence system.
 ## The Product Loop
 
 ```text
-GRILL -> COMPILE -> PAGE -> RUN -> PROVE -> LEARN
-  ^                                         |
-  +-----------------------------------------+
+GRILL -> COMPILE -> CAPSULE -> PAGE -> RUN -> PROVE -> LEARN
+  ^                                                    |
+  +----------------------------------------------------+
 ```
 
 ### 1. Grill — preserve reasoning coherence
@@ -57,7 +57,8 @@ verifiable outcome and bounded blast radius, not because it has an arbitrary
 token count.
 
 Operationally, each leaf should be expected to fit one fresh model context. A
-rough 100k-token smart-zone target is a planning heuristic. If a unit cannot fit
+configurable 140k-token continuation ceiling is an advisory attention policy,
+not an atomicity definition or a universal provider limit. If a unit cannot fit
 but still has only one acceptance gate, it remains one AC and may use a physical
 continuation segment; if it contains multiple independently verifiable outcomes,
 the compiler splits it before dispatch.
@@ -112,6 +113,24 @@ the authoritative workspace, pages additional context as needed, and emits
 normalized tool/output events. Native provider resume is allowed only within the
 same AC attempt after a crash; a handle can never cross an AC, retry, workspace,
 or authority boundary.
+
+Ouroboros persists two distinct pre-effect transitions: the authority-bearing
+`execution.ac.capsule.compiled` event, then
+`execution.ac.attempt.dispatched` immediately before entering the provider.
+Every provider entry gets a unique `ac_dispatch_id`, which is propagated into
+its lifecycle events. Each dispatch also names its exact predecessor, forming a
+single validated chain whose unique head is the only recoverable boundary.
+Recovery therefore correlates by durable identity rather than timestamp,
+replay position, or lifecycle-event priority. Only a correlated reusable
+same-attempt handle at the head may resume; a failed head without one remains
+ambiguous, while a completed head blocks same-attempt redispatch as already
+terminal. Completed lifecycle records include the bounded verify-gate result,
+preventing a crash from replaying a potentially non-idempotent verify command.
+The dispatch event stores only minimal reconnect and authority fields: workspace
+is rebound from the current capsule before validation, and transcript paths,
+tool catalogs, capability graphs, control-plane projections, and arbitrary
+metadata are excluded. This closes the pre-first-message crash gap without
+turning the durable event stream into a copy of provider context.
 
 When one genuinely atomic AC outgrows a physical session, Ouroboros **sheds** the
 provider context:

--- a/src/ouroboros/core/seed.py
+++ b/src/ouroboros/core/seed.py
@@ -290,6 +290,21 @@ class AcceptanceCriterionSpec(BaseModel, frozen=True):
             return tuple(str(item).strip() for item in value if str(item).strip())
         return value
 
+    @model_validator(mode="after")
+    def _require_command_for_output_assertion(self) -> AcceptanceCriterionSpec:
+        """Reject an ``output_assertion`` with no ``verify_command`` to assert on.
+
+        ``output_assertion`` is only meaningful against the output of a
+        ``verify_command``. Allowing it standalone let an output-only contract
+        report a success contract while the verify gate returned PASS without ever
+        evaluating the assertion — an unenforced acceptance field. Requiring the
+        command closes that gap at the schema, so no downstream path can accept an
+        unevaluated assertion.
+        """
+        if self.output_assertion and not self.verify_command:
+            raise ValueError("output_assertion requires a verify_command to assert against")
+        return self
+
     @property
     def has_success_contract(self) -> bool:
         """Return True when explicit evidence fields are populated."""

--- a/src/ouroboros/orchestrator/ac_execution_capsule.py
+++ b/src/ouroboros/orchestrator/ac_execution_capsule.py
@@ -8,7 +8,7 @@ event ledger, and verify-gate records.
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Iterator, Mapping, Sequence
 from dataclasses import dataclass, replace
 from enum import StrEnum
 import hashlib
@@ -20,8 +20,9 @@ from ouroboros.orchestrator.adapter import RuntimeHandle
 from ouroboros.orchestrator.execution_runtime_scope import ACRuntimeIdentity
 from ouroboros.orchestrator.level_context import LevelContext
 
-AC_EXECUTION_CAPSULE_VERSION = 1
+AC_EXECUTION_CAPSULE_VERSION = 2
 DEFAULT_AC_CONTEXT_BUDGET_CHARS = 12_000
+MAX_AC_CONTEXT_REFERENCES = 256
 _MAX_REFERENCE_LOCATOR_CHARS = 2_048
 _MAX_REFERENCE_HINT_CHARS = 240
 
@@ -77,7 +78,6 @@ class ACContextReferenceKind(StrEnum):
     DEPENDENCY = "dependency"
     ARTIFACT = "artifact"
     GATE = "gate"
-    INDEX = "index"
 
 
 @dataclass(frozen=True, slots=True)
@@ -280,6 +280,8 @@ class ACExecutionCapsuleManifest:
     ac_content_digest: str
     success_contract_digest: str
     context_references: tuple[ACContextReferenceManifest, ...]
+    omitted_context_count: int
+    omitted_context_digest: str | None
     context_budget_chars: int
     fresh_session_required: bool = True
     version: int = AC_EXECUTION_CAPSULE_VERSION
@@ -314,6 +316,19 @@ class ACExecutionCapsuleManifest:
             or self.context_budget_chars <= 0
         ):
             raise ValueError("capsule manifest context budget is invalid")
+        if (
+            not isinstance(self.omitted_context_count, int)
+            or isinstance(self.omitted_context_count, bool)
+            or self.omitted_context_count < 0
+        ):
+            raise ValueError("capsule manifest omitted context count is invalid")
+        if self.omitted_context_count:
+            _validate_sha256_digest(
+                self.omitted_context_digest,
+                field="capsule manifest omitted context digest",
+            )
+        elif self.omitted_context_digest is not None:
+            raise ValueError("capsule manifest omitted context digest is unexpected")
         if self.fresh_session_required is not True:
             raise ValueError("capsule manifest must require a fresh session")
         if not self.context_references:
@@ -350,6 +365,8 @@ class ACExecutionCapsuleManifest:
             "context_references": [
                 reference.to_contract_data() for reference in self.context_references
             ],
+            "omitted_context_count": self.omitted_context_count,
+            "omitted_context_digest": self.omitted_context_digest,
             "context_budget_chars": self.context_budget_chars,
             "fresh_session_required": self.fresh_session_required,
         }
@@ -372,6 +389,8 @@ class ACExecutionCapsuleManifest:
             "ac_content_digest",
             "success_contract_digest",
             "context_references",
+            "omitted_context_count",
+            "omitted_context_digest",
             "context_budget_chars",
             "fresh_session_required",
         }
@@ -416,6 +435,8 @@ class ACExecutionCapsuleManifest:
             context_references=tuple(
                 ACContextReferenceManifest.from_contract_data(reference) for reference in references
             ),
+            omitted_context_count=raw.get("omitted_context_count"),  # type: ignore[arg-type]
+            omitted_context_digest=raw.get("omitted_context_digest"),  # type: ignore[arg-type]
             context_budget_chars=raw.get("context_budget_chars"),  # type: ignore[arg-type]
             fresh_session_required=raw.get("fresh_session_required"),  # type: ignore[arg-type]
         )
@@ -439,6 +460,8 @@ class ACExecutionCapsule:
     ac_content: str
     success_contract: ACSuccessContract
     context_references: tuple[ACContextReference, ...]
+    omitted_context_count: int
+    omitted_context_digest: str | None
     context_budget_chars: int
     fresh_session_required: bool = True
     version: int = AC_EXECUTION_CAPSULE_VERSION
@@ -480,6 +503,19 @@ class ACExecutionCapsule:
             or self.context_budget_chars <= 0
         ):
             raise ValueError("capsule context budget is invalid")
+        if (
+            not isinstance(self.omitted_context_count, int)
+            or isinstance(self.omitted_context_count, bool)
+            or self.omitted_context_count < 0
+        ):
+            raise ValueError("capsule omitted context count is invalid")
+        if self.omitted_context_count:
+            _validate_sha256_digest(
+                self.omitted_context_digest,
+                field="capsule omitted context digest",
+            )
+        elif self.omitted_context_digest is not None:
+            raise ValueError("capsule omitted context digest is unexpected")
         if self.fresh_session_required is not True:
             raise ValueError("an AC execution capsule must require a fresh session")
         if not os.path.isabs(self.workspace) or os.path.realpath(self.workspace) != self.workspace:
@@ -514,6 +550,8 @@ class ACExecutionCapsule:
                 ACContextReferenceManifest.from_reference(reference)
                 for reference in self.context_references
             ),
+            omitted_context_count=self.omitted_context_count,
+            omitted_context_digest=self.omitted_context_digest,
             context_budget_chars=self.context_budget_chars,
             fresh_session_required=self.fresh_session_required,
         )
@@ -523,10 +561,11 @@ class ACExecutionCapsule:
         return self.manifest.fingerprint
 
     def to_prompt_reference_block(self) -> str:
-        """Render the small external-memory index given to the provider driver."""
+        """Render the bounded external-memory frontier given to the provider driver."""
         return _render_prompt_reference_block(
             self.context_references,
             fingerprint=self.fingerprint,
+            omitted_context_count=self.omitted_context_count,
         )
 
 
@@ -534,6 +573,7 @@ def _render_prompt_reference_block(
     references: Sequence[ACContextReference],
     *,
     fingerprint: str,
+    omitted_context_count: int = 0,
 ) -> str:
     """Render a reference-only provider block with a fixed-size fingerprint."""
     lines = [
@@ -547,46 +587,33 @@ def _render_prompt_reference_block(
     for reference in references:
         hint = f" — {reference.hint}" if reference.hint else ""
         lines.append(f"- {reference.kind.value}: {reference.locator}{hint}")
+    if omitted_context_count:
+        lines.append(
+            f"- bounded-retrieval: {omitted_context_count} optional references omitted; "
+            "the workspace and Seed remain authoritative"
+        )
     return "\n".join(lines)
 
 
 def _bounded_context_references(
     *,
     required: Sequence[ACContextReference],
-    optional: Sequence[ACContextReference],
-    execution_id: str,
+    optional: Iterable[ACContextReference],
     context_budget_chars: int,
-) -> tuple[ACContextReference, ...]:
-    """Fit deterministic references and summarize overflow as one index page."""
+) -> tuple[tuple[ACContextReference, ...], int, str | None]:
+    """Select a bounded reference frontier and attest what was omitted.
+
+    Omitted references are never represented as a page unless a real resolver
+    exists. The capsule instead records a rolling digest and count, while the
+    provider sees an explicit bounded-retrieval notice. A hard reference cap
+    bounds compiler work independently of adversarial Seed/dependency size.
+    """
     placeholder_fingerprint = "sha256:" + "0" * 64
-    all_references = tuple(required) + tuple(optional)
-    if (
-        len(
-            _render_prompt_reference_block(
-                all_references,
-                fingerprint=placeholder_fingerprint,
-            )
-        )
-        <= context_budget_chars
-    ):
-        return all_references
-
-    def _index_reference(omitted: Sequence[ACContextReference]) -> ACContextReference:
-        return ACContextReference(
-            kind=ACContextReferenceKind.INDEX,
-            locator=f"execution:{execution_id}:context-index",
-            digest=_sha256_text(
-                _canonical_json([reference.to_contract_data() for reference in omitted])
-            ),
-            hint=f"{len(omitted)} additional references; page from the event ledger",
-        )
-
     selected = list(required)
-    placeholder_index = _index_reference(optional)
     if (
         len(
             _render_prompt_reference_block(
-                (*selected, placeholder_index),
+                selected,
                 fingerprint=placeholder_fingerprint,
             )
         )
@@ -594,35 +621,44 @@ def _bounded_context_references(
     ):
         raise ValueError("capsule context budget cannot fit required references")
 
-    selected_optional_count = 0
+    omitted_count = 0
+    omitted_hasher = hashlib.sha256()
+    reference_count = len(selected)
     for reference in optional:
-        candidate = (*selected, reference, placeholder_index)
-        if (
+        reference_count += 1
+        if reference_count > MAX_AC_CONTEXT_REFERENCES:
+            raise ValueError(
+                f"capsule context reference limit exceeded ({MAX_AC_CONTEXT_REFERENCES})"
+            )
+        candidate = (*selected, reference)
+        fits_with_omission_notice = (
             len(
                 _render_prompt_reference_block(
                     candidate,
                     fingerprint=placeholder_fingerprint,
+                    omitted_context_count=MAX_AC_CONTEXT_REFERENCES,
                 )
             )
-            > context_budget_chars
-        ):
-            break
-        selected.append(reference)
-        selected_optional_count += 1
+            <= context_budget_chars
+        )
+        if omitted_count == 0 and fits_with_omission_notice:
+            selected.append(reference)
+            continue
+        omitted_count += 1
+        omitted_hasher.update(_canonical_json(reference.to_contract_data()).encode("utf-8"))
+        omitted_hasher.update(b"\n")
 
-    omitted = tuple(optional[selected_optional_count:])
-    if omitted:
-        selected.append(_index_reference(omitted))
-    return tuple(selected)
+    omitted_digest = "sha256:" + omitted_hasher.hexdigest() if omitted_count else None
+    return tuple(selected), omitted_count, omitted_digest
 
 
 def _dependency_references(
     execution_id: str,
     level_contexts: Sequence[LevelContext],
-) -> list[ACContextReference]:
-    references: list[ACContextReference] = []
-    for context in level_contexts:
-        for summary in context.completed_acs:
+) -> Iterator[ACContextReference]:
+    """Yield the newest accepted dependencies first for bounded retrieval."""
+    for context in reversed(level_contexts):
+        for summary in reversed(context.completed_acs):
             if not summary.success:
                 continue
             payload = {
@@ -634,15 +670,12 @@ def _dependency_references(
                 "key_output": summary.key_output,
                 "public_api": summary.public_api,
             }
-            references.append(
-                ACContextReference(
-                    kind=ACContextReferenceKind.DEPENDENCY,
-                    locator=f"execution:{execution_id}:ac:{summary.ac_index + 1}",
-                    digest=_sha256_text(_canonical_json(payload)),
-                    hint=f"accepted dependency from level {context.level_number + 1}",
-                )
+            yield ACContextReference(
+                kind=ACContextReferenceKind.DEPENDENCY,
+                locator=f"execution:{execution_id}:ac:{summary.ac_index + 1}",
+                digest=_sha256_text(_canonical_json(payload)),
+                hint=f"accepted dependency from level {context.level_number + 1}",
             )
-    return references
 
 
 def compile_ac_execution_capsule(
@@ -676,15 +709,16 @@ def compile_ac_execution_capsule(
             hint="goal and semantic AC authority",
         ),
     ]
-    optional_references = _dependency_references(execution_id, level_contexts)
-    optional_references.extend(
-        ACContextReference(
-            kind=ACContextReferenceKind.ARTIFACT,
-            locator=f"workspace:{path}",
-            hint="seed-authored expected artifact",
-        )
-        for path in success_contract.expected_artifacts
-    )
+
+    def _optional_references() -> Iterator[ACContextReference]:
+        for path in success_contract.expected_artifacts:
+            yield ACContextReference(
+                kind=ACContextReferenceKind.ARTIFACT,
+                locator=f"workspace:{path}",
+                hint="seed-authored expected artifact",
+            )
+        yield from _dependency_references(execution_id, level_contexts)
+
     if success_contract.has_success_contract:
         required_references.append(
             ACContextReference(
@@ -694,10 +728,9 @@ def compile_ac_execution_capsule(
                 hint="authoritative acceptance contract",
             )
         )
-    references = _bounded_context_references(
+    references, omitted_context_count, omitted_context_digest = _bounded_context_references(
         required=required_references,
-        optional=optional_references,
-        execution_id=execution_id,
+        optional=_optional_references(),
         context_budget_chars=context_budget_chars,
     )
     return ACExecutionCapsule(
@@ -715,6 +748,8 @@ def compile_ac_execution_capsule(
         ac_content=ac_content,
         success_contract=success_contract,
         context_references=references,
+        omitted_context_count=omitted_context_count,
+        omitted_context_digest=omitted_context_digest,
         context_budget_chars=context_budget_chars,
     )
 

--- a/src/ouroboros/orchestrator/ac_execution_capsule.py
+++ b/src/ouroboros/orchestrator/ac_execution_capsule.py
@@ -51,6 +51,24 @@ def _validate_sha256_digest(value: object, *, field: str) -> str:
     return value
 
 
+def build_ac_dispatch_authority_scope(
+    *,
+    base_scope: str,
+    dispatch_contract: Mapping[str, object],
+    execution_policy: Mapping[str, object],
+) -> str:
+    """Fingerprint every authority-bearing input that can change AC dispatch."""
+    if not isinstance(base_scope, str) or not base_scope:
+        raise ValueError("AC dispatch authority base scope is missing")
+    payload = {
+        "version": 1,
+        "base_scope": base_scope,
+        "dispatch_contract": dict(dispatch_contract),
+        "execution_policy": dict(execution_policy),
+    }
+    return _sha256_text(_canonical_json(payload))
+
+
 class ACContextReferenceKind(StrEnum):
     """External context source named by an execution capsule."""
 
@@ -672,5 +690,6 @@ __all__ = [
     "ACExecutionCapsuleManifest",
     "ACSuccessContract",
     "bind_capsule_to_runtime_handle",
+    "build_ac_dispatch_authority_scope",
     "compile_ac_execution_capsule",
 ]

--- a/src/ouroboros/orchestrator/ac_execution_capsule.py
+++ b/src/ouroboros/orchestrator/ac_execution_capsule.py
@@ -652,7 +652,7 @@ def _bounded_context_references(
     return tuple(selected), omitted_count, omitted_digest
 
 
-def _dependency_references(
+def build_ac_dependency_references(
     execution_id: str,
     level_contexts: Sequence[LevelContext],
 ) -> Iterator[ACContextReference]:
@@ -690,6 +690,7 @@ def compile_ac_execution_capsule(
     ac_spec: AcceptanceCriterionSpec | None,
     success_contract_override: ACSuccessContract | None = None,
     level_contexts: Sequence[LevelContext] = (),
+    dependency_references: Iterable[ACContextReference] | None = None,
     segment_index: int = 0,
     context_budget_chars: int = DEFAULT_AC_CONTEXT_BUDGET_CHARS,
 ) -> ACExecutionCapsule:
@@ -717,7 +718,11 @@ def compile_ac_execution_capsule(
                 locator=f"workspace:{path}",
                 hint="seed-authored expected artifact",
             )
-        yield from _dependency_references(execution_id, level_contexts)
+        yield from (
+            dependency_references
+            if dependency_references is not None
+            else build_ac_dependency_references(execution_id, level_contexts)
+        )
 
     if success_contract.has_success_contract:
         required_references.append(
@@ -817,6 +822,7 @@ __all__ = [
     "ACExecutionCapsuleManifest",
     "ACSuccessContract",
     "bind_capsule_to_runtime_handle",
+    "build_ac_dependency_references",
     "build_ac_dispatch_authority_scope",
     "compile_ac_execution_capsule",
 ]

--- a/src/ouroboros/orchestrator/ac_execution_capsule.py
+++ b/src/ouroboros/orchestrator/ac_execution_capsule.py
@@ -25,6 +25,9 @@ DEFAULT_AC_CONTEXT_BUDGET_CHARS = 12_000
 MAX_AC_CONTEXT_REFERENCES = 256
 _MAX_REFERENCE_LOCATOR_CHARS = 2_048
 _MAX_REFERENCE_HINT_CHARS = 240
+MAX_AC_SUCCESS_CONTRACT_ARTIFACTS = MAX_AC_CONTEXT_REFERENCES - 3
+MAX_AC_SUCCESS_CONTRACT_CHARS = 64_000
+_MAX_SUCCESS_CONTRACT_ARTIFACT_CHARS = _MAX_REFERENCE_LOCATOR_CHARS - len("workspace:")
 
 
 def _sha256_text(value: str) -> str:
@@ -207,10 +210,30 @@ class ACSuccessContract:
     def __post_init__(self) -> None:
         if self.verify_command is not None and not isinstance(self.verify_command, str):
             raise ValueError("success contract verify command is invalid")
-        if any(not isinstance(path, str) or not path for path in self.expected_artifacts):
-            raise ValueError("success contract artifacts are invalid")
         if self.output_assertion is not None and not isinstance(self.output_assertion, str):
             raise ValueError("success contract output assertion is invalid")
+        try:
+            artifact_count = len(self.expected_artifacts)
+        except TypeError as exc:
+            raise ValueError("success contract artifacts are invalid") from exc
+        if artifact_count > MAX_AC_SUCCESS_CONTRACT_ARTIFACTS:
+            raise ValueError(
+                f"success contract artifact limit exceeded ({MAX_AC_SUCCESS_CONTRACT_ARTIFACTS})"
+            )
+
+        contract_chars = len(self.verify_command or "") + len(self.output_assertion or "")
+        for path in self.expected_artifacts:
+            if (
+                not isinstance(path, str)
+                or not path
+                or len(path) > _MAX_SUCCESS_CONTRACT_ARTIFACT_CHARS
+            ):
+                raise ValueError("success contract artifacts are invalid")
+            contract_chars += len(path)
+        if contract_chars > MAX_AC_SUCCESS_CONTRACT_CHARS:
+            raise ValueError(
+                f"success contract character budget exceeded ({MAX_AC_SUCCESS_CONTRACT_CHARS})"
+            )
 
     def to_contract_data(self) -> dict[str, object]:
         return {
@@ -815,6 +838,9 @@ def bind_capsule_to_runtime_handle(
 __all__ = [
     "AC_EXECUTION_CAPSULE_VERSION",
     "DEFAULT_AC_CONTEXT_BUDGET_CHARS",
+    "MAX_AC_CONTEXT_REFERENCES",
+    "MAX_AC_SUCCESS_CONTRACT_ARTIFACTS",
+    "MAX_AC_SUCCESS_CONTRACT_CHARS",
     "ACContextReference",
     "ACContextReferenceManifest",
     "ACContextReferenceKind",

--- a/src/ouroboros/orchestrator/ac_execution_capsule.py
+++ b/src/ouroboros/orchestrator/ac_execution_capsule.py
@@ -212,6 +212,11 @@ class ACSuccessContract:
             raise ValueError("success contract verify command is invalid")
         if self.output_assertion is not None and not isinstance(self.output_assertion, str):
             raise ValueError("success contract output assertion is invalid")
+        # Mirror AcceptanceCriterionSpec: an output_assertion has no authoritative
+        # output to assert against without a verify_command, so the projected
+        # capsule contract must not carry that otherwise-unevaluable shape.
+        if self.output_assertion and not self.verify_command:
+            raise ValueError("success contract output_assertion requires a verify_command")
         try:
             artifact_count = len(self.expected_artifacts)
         except TypeError as exc:

--- a/src/ouroboros/orchestrator/ac_execution_capsule.py
+++ b/src/ouroboros/orchestrator/ac_execution_capsule.py
@@ -219,6 +219,10 @@ class ACSuccessContract:
             "output_assertion": self.output_assertion,
         }
 
+    @property
+    def has_success_contract(self) -> bool:
+        return bool(self.verify_command or self.expected_artifacts or self.output_assertion)
+
     @classmethod
     def from_ac_spec(cls, spec: AcceptanceCriterionSpec | None) -> ACSuccessContract:
         if spec is None:
@@ -651,13 +655,14 @@ def compile_ac_execution_capsule(
     seed_goal: str,
     ac_content: str,
     ac_spec: AcceptanceCriterionSpec | None,
+    success_contract_override: ACSuccessContract | None = None,
     level_contexts: Sequence[LevelContext] = (),
     segment_index: int = 0,
     context_budget_chars: int = DEFAULT_AC_CONTEXT_BUDGET_CHARS,
 ) -> ACExecutionCapsule:
     """Compile one deterministic capsule from existing orchestrator authority."""
     canonical_workspace = os.path.realpath(workspace)
-    success_contract = ACSuccessContract.from_ac_spec(ac_spec)
+    success_contract = success_contract_override or ACSuccessContract.from_ac_spec(ac_spec)
     required_references: list[ACContextReference] = [
         ACContextReference(
             kind=ACContextReferenceKind.WORKSPACE,
@@ -680,7 +685,7 @@ def compile_ac_execution_capsule(
         )
         for path in success_contract.expected_artifacts
     )
-    if ac_spec is not None and ac_spec.has_success_contract:
+    if success_contract.has_success_contract:
         required_references.append(
             ACContextReference(
                 kind=ACContextReferenceKind.GATE,

--- a/src/ouroboros/orchestrator/ac_execution_capsule.py
+++ b/src/ouroboros/orchestrator/ac_execution_capsule.py
@@ -39,6 +39,18 @@ def _canonical_json(value: object) -> str:
     )
 
 
+def _validate_sha256_digest(value: object, *, field: str) -> str:
+    if not isinstance(value, str) or len(value) != len("sha256:") + 64:
+        raise ValueError(f"{field} is malformed")
+    if not value.startswith("sha256:"):
+        raise ValueError(f"{field} is malformed")
+    try:
+        int(value.removeprefix("sha256:"), 16)
+    except ValueError as exc:
+        raise ValueError(f"{field} is malformed") from exc
+    return value
+
+
 class ACContextReferenceKind(StrEnum):
     """External context source named by an execution capsule."""
 
@@ -69,15 +81,8 @@ class ACContextReference:
             raise ValueError("context reference hint is oversized")
         if any(character in self.hint for character in ("\x00", "\r", "\n")):
             raise ValueError("context reference hint contains control characters")
-        if self.digest is not None and (
-            len(self.digest) != len("sha256:") + 64 or not self.digest.startswith("sha256:")
-        ):
-            raise ValueError("context reference digest is malformed")
         if self.digest is not None:
-            try:
-                int(self.digest.removeprefix("sha256:"), 16)
-            except ValueError as exc:
-                raise ValueError("context reference digest is malformed") from exc
+            _validate_sha256_digest(self.digest, field="context reference digest")
 
     def to_contract_data(self) -> dict[str, object]:
         return {
@@ -105,6 +110,71 @@ class ACContextReference:
         if not isinstance(hint, str):
             raise ValueError("context reference hint is invalid")
         return cls(kind=kind, locator=locator, digest=digest, hint=hint)
+
+
+@dataclass(frozen=True, slots=True)
+class ACContextReferenceManifest:
+    """Non-sensitive durable identity for one external context reference."""
+
+    kind: ACContextReferenceKind
+    locator_digest: str
+    content_digest: str | None
+    hint_digest: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, ACContextReferenceKind):
+            raise ValueError("context reference manifest kind is invalid")
+        _validate_sha256_digest(
+            self.locator_digest,
+            field="context reference manifest locator digest",
+        )
+        if self.content_digest is not None:
+            _validate_sha256_digest(
+                self.content_digest,
+                field="context reference manifest content digest",
+            )
+        _validate_sha256_digest(
+            self.hint_digest,
+            field="context reference manifest hint digest",
+        )
+
+    def to_contract_data(self) -> dict[str, object]:
+        return {
+            "kind": self.kind.value,
+            "locator_digest": self.locator_digest,
+            "content_digest": self.content_digest,
+            "hint_digest": self.hint_digest,
+        }
+
+    @classmethod
+    def from_reference(cls, reference: ACContextReference) -> ACContextReferenceManifest:
+        return cls(
+            kind=reference.kind,
+            locator_digest=_sha256_text(reference.locator),
+            content_digest=reference.digest,
+            hint_digest=_sha256_text(reference.hint),
+        )
+
+    @classmethod
+    def from_contract_data(cls, raw: object) -> ACContextReferenceManifest:
+        expected = {"kind", "locator_digest", "content_digest", "hint_digest"}
+        if not isinstance(raw, Mapping) or set(raw) != expected:
+            raise ValueError("context reference manifest has an invalid shape")
+        try:
+            kind = ACContextReferenceKind(raw.get("kind"))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("context reference manifest kind is invalid") from exc
+        locator_digest = raw.get("locator_digest")
+        content_digest = raw.get("content_digest")
+        hint_digest = raw.get("hint_digest")
+        if content_digest is not None and not isinstance(content_digest, str):
+            raise ValueError("context reference manifest content digest is invalid")
+        return cls(
+            kind=kind,
+            locator_digest=locator_digest,  # type: ignore[arg-type]
+            content_digest=content_digest,
+            hint_digest=hint_digest,  # type: ignore[arg-type]
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -160,6 +230,171 @@ class ACSuccessContract:
             verify_command=verify_command,
             expected_artifacts=tuple(expected_artifacts),
             output_assertion=output_assertion,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ACExecutionCapsuleManifest:
+    """Strict durable capsule identity with all free-form values hashed.
+
+    Provider prompts still receive the in-memory :class:`ACExecutionCapsule`,
+    but the event ledger stores only this manifest. Recovery can therefore
+    validate exact authority without copying credentials, PII, prompts, or
+    absolute workspace paths into another durable payload.
+    """
+
+    execution_id: str
+    semantic_ac_key: str
+    ac_id: str
+    session_scope_id: str
+    session_attempt_id: str
+    node_id: str | None
+    retry_attempt: int
+    segment_index: int
+    workspace_digest: str
+    authority_scope_digest: str
+    seed_goal_digest: str
+    ac_content_digest: str
+    success_contract_digest: str
+    context_references: tuple[ACContextReferenceManifest, ...]
+    context_budget_chars: int
+    fresh_session_required: bool = True
+    version: int = AC_EXECUTION_CAPSULE_VERSION
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("execution_id", self.execution_id),
+            ("semantic_ac_key", self.semantic_ac_key),
+            ("ac_id", self.ac_id),
+            ("session_scope_id", self.session_scope_id),
+            ("session_attempt_id", self.session_attempt_id),
+        ):
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"capsule manifest {name} is missing")
+        if self.node_id is not None and (not isinstance(self.node_id, str) or not self.node_id):
+            raise ValueError("capsule manifest node id is invalid")
+        if (
+            not isinstance(self.version, int)
+            or isinstance(self.version, bool)
+            or self.version != AC_EXECUTION_CAPSULE_VERSION
+        ):
+            raise ValueError("capsule manifest version is unsupported")
+        for name, value in (
+            ("retry attempt", self.retry_attempt),
+            ("segment index", self.segment_index),
+        ):
+            if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+                raise ValueError(f"capsule manifest {name} is invalid")
+        if (
+            not isinstance(self.context_budget_chars, int)
+            or isinstance(self.context_budget_chars, bool)
+            or self.context_budget_chars <= 0
+        ):
+            raise ValueError("capsule manifest context budget is invalid")
+        if self.fresh_session_required is not True:
+            raise ValueError("capsule manifest must require a fresh session")
+        if not self.context_references:
+            raise ValueError("capsule manifest must contain context references")
+        for name, value in (
+            ("workspace digest", self.workspace_digest),
+            ("authority scope digest", self.authority_scope_digest),
+            ("seed goal digest", self.seed_goal_digest),
+            ("AC content digest", self.ac_content_digest),
+            ("success contract digest", self.success_contract_digest),
+        ):
+            _validate_sha256_digest(value, field=f"capsule manifest {name}")
+
+    @property
+    def fingerprint(self) -> str:
+        return _sha256_text(_canonical_json(self.to_contract_data()))
+
+    def to_contract_data(self) -> dict[str, object]:
+        return {
+            "version": self.version,
+            "execution_id": self.execution_id,
+            "semantic_ac_key": self.semantic_ac_key,
+            "ac_id": self.ac_id,
+            "session_scope_id": self.session_scope_id,
+            "session_attempt_id": self.session_attempt_id,
+            "node_id": self.node_id,
+            "retry_attempt": self.retry_attempt,
+            "segment_index": self.segment_index,
+            "workspace_digest": self.workspace_digest,
+            "authority_scope_digest": self.authority_scope_digest,
+            "seed_goal_digest": self.seed_goal_digest,
+            "ac_content_digest": self.ac_content_digest,
+            "success_contract_digest": self.success_contract_digest,
+            "context_references": [
+                reference.to_contract_data() for reference in self.context_references
+            ],
+            "context_budget_chars": self.context_budget_chars,
+            "fresh_session_required": self.fresh_session_required,
+        }
+
+    @classmethod
+    def from_contract_data(cls, raw: object) -> ACExecutionCapsuleManifest:
+        expected = {
+            "version",
+            "execution_id",
+            "semantic_ac_key",
+            "ac_id",
+            "session_scope_id",
+            "session_attempt_id",
+            "node_id",
+            "retry_attempt",
+            "segment_index",
+            "workspace_digest",
+            "authority_scope_digest",
+            "seed_goal_digest",
+            "ac_content_digest",
+            "success_contract_digest",
+            "context_references",
+            "context_budget_chars",
+            "fresh_session_required",
+        }
+        if not isinstance(raw, Mapping) or set(raw) != expected:
+            raise ValueError("AC execution capsule manifest has an invalid shape")
+        references = raw.get("context_references")
+        if not isinstance(references, list):
+            raise ValueError("capsule manifest context references are invalid")
+        node_id = raw.get("node_id")
+        if node_id is not None and not isinstance(node_id, str):
+            raise ValueError("capsule manifest node id is invalid")
+        scalar_names = (
+            "execution_id",
+            "semantic_ac_key",
+            "ac_id",
+            "session_scope_id",
+            "session_attempt_id",
+            "workspace_digest",
+            "authority_scope_digest",
+            "seed_goal_digest",
+            "ac_content_digest",
+            "success_contract_digest",
+        )
+        scalars = {name: raw.get(name) for name in scalar_names}
+        if any(not isinstance(value, str) for value in scalars.values()):
+            raise ValueError("capsule manifest string field is invalid")
+        return cls(
+            version=raw.get("version"),  # type: ignore[arg-type]
+            execution_id=scalars["execution_id"],  # type: ignore[arg-type]
+            semantic_ac_key=scalars["semantic_ac_key"],  # type: ignore[arg-type]
+            ac_id=scalars["ac_id"],  # type: ignore[arg-type]
+            session_scope_id=scalars["session_scope_id"],  # type: ignore[arg-type]
+            session_attempt_id=scalars["session_attempt_id"],  # type: ignore[arg-type]
+            node_id=node_id,
+            retry_attempt=raw.get("retry_attempt"),  # type: ignore[arg-type]
+            segment_index=raw.get("segment_index"),  # type: ignore[arg-type]
+            workspace_digest=scalars["workspace_digest"],  # type: ignore[arg-type]
+            authority_scope_digest=scalars["authority_scope_digest"],  # type: ignore[arg-type]
+            seed_goal_digest=scalars["seed_goal_digest"],  # type: ignore[arg-type]
+            ac_content_digest=scalars["ac_content_digest"],  # type: ignore[arg-type]
+            success_contract_digest=scalars["success_contract_digest"],  # type: ignore[arg-type]
+            context_references=tuple(
+                ACContextReferenceManifest.from_contract_data(reference) for reference in references
+            ),
+            context_budget_chars=raw.get("context_budget_chars"),  # type: ignore[arg-type]
+            fresh_session_required=raw.get("fresh_session_required"),  # type: ignore[arg-type]
         )
 
 
@@ -232,98 +467,35 @@ class ACExecutionCapsule:
             raise ValueError("capsule must contain at least one context reference")
 
     @property
-    def fingerprint(self) -> str:
-        return _sha256_text(_canonical_json(self.to_contract_data()))
-
-    def to_contract_data(self) -> dict[str, object]:
-        return {
-            "version": self.version,
-            "execution_id": self.execution_id,
-            "semantic_ac_key": self.semantic_ac_key,
-            "ac_id": self.ac_id,
-            "session_scope_id": self.session_scope_id,
-            "session_attempt_id": self.session_attempt_id,
-            "node_id": self.node_id,
-            "retry_attempt": self.retry_attempt,
-            "segment_index": self.segment_index,
-            "workspace": self.workspace,
-            "authority_scope": self.authority_scope,
-            "seed_goal": self.seed_goal,
-            "ac_content": self.ac_content,
-            "success_contract": self.success_contract.to_contract_data(),
-            "context_references": [
-                reference.to_contract_data() for reference in self.context_references
-            ],
-            "context_budget_chars": self.context_budget_chars,
-            "fresh_session_required": self.fresh_session_required,
-        }
-
-    @classmethod
-    def from_contract_data(cls, raw: object) -> ACExecutionCapsule:
-        expected = {
-            "version",
-            "execution_id",
-            "semantic_ac_key",
-            "ac_id",
-            "session_scope_id",
-            "session_attempt_id",
-            "node_id",
-            "retry_attempt",
-            "segment_index",
-            "workspace",
-            "authority_scope",
-            "seed_goal",
-            "ac_content",
-            "success_contract",
-            "context_references",
-            "context_budget_chars",
-            "fresh_session_required",
-        }
-        if not isinstance(raw, Mapping) or set(raw) != expected:
-            raise ValueError("AC execution capsule has an invalid shape")
-        references = raw.get("context_references")
-        if not isinstance(references, list):
-            raise ValueError("capsule context references are invalid")
-        scalar_fields = {
-            name: raw.get(name)
-            for name in (
-                "execution_id",
-                "semantic_ac_key",
-                "ac_id",
-                "session_scope_id",
-                "session_attempt_id",
-                "workspace",
-                "authority_scope",
-                "seed_goal",
-                "ac_content",
-            )
-        }
-        if any(not isinstance(value, str) for value in scalar_fields.values()):
-            raise ValueError("capsule string field is invalid")
-        node_id = raw.get("node_id")
-        if node_id is not None and not isinstance(node_id, str):
-            raise ValueError("capsule node id is invalid")
-        return cls(
-            version=raw.get("version"),  # type: ignore[arg-type]
-            execution_id=scalar_fields["execution_id"],  # type: ignore[arg-type]
-            semantic_ac_key=scalar_fields["semantic_ac_key"],  # type: ignore[arg-type]
-            ac_id=scalar_fields["ac_id"],  # type: ignore[arg-type]
-            session_scope_id=scalar_fields["session_scope_id"],  # type: ignore[arg-type]
-            session_attempt_id=scalar_fields["session_attempt_id"],  # type: ignore[arg-type]
-            node_id=node_id,
-            retry_attempt=raw.get("retry_attempt"),  # type: ignore[arg-type]
-            segment_index=raw.get("segment_index"),  # type: ignore[arg-type]
-            workspace=scalar_fields["workspace"],  # type: ignore[arg-type]
-            authority_scope=scalar_fields["authority_scope"],  # type: ignore[arg-type]
-            seed_goal=scalar_fields["seed_goal"],  # type: ignore[arg-type]
-            ac_content=scalar_fields["ac_content"],  # type: ignore[arg-type]
-            success_contract=ACSuccessContract.from_contract_data(raw.get("success_contract")),
-            context_references=tuple(
-                ACContextReference.from_contract_data(reference) for reference in references
+    def manifest(self) -> ACExecutionCapsuleManifest:
+        return ACExecutionCapsuleManifest(
+            version=self.version,
+            execution_id=self.execution_id,
+            semantic_ac_key=self.semantic_ac_key,
+            ac_id=self.ac_id,
+            session_scope_id=self.session_scope_id,
+            session_attempt_id=self.session_attempt_id,
+            node_id=self.node_id,
+            retry_attempt=self.retry_attempt,
+            segment_index=self.segment_index,
+            workspace_digest=_sha256_text(self.workspace),
+            authority_scope_digest=_sha256_text(self.authority_scope),
+            seed_goal_digest=_sha256_text(self.seed_goal),
+            ac_content_digest=_sha256_text(self.ac_content),
+            success_contract_digest=_sha256_text(
+                _canonical_json(self.success_contract.to_contract_data())
             ),
-            context_budget_chars=raw.get("context_budget_chars"),  # type: ignore[arg-type]
-            fresh_session_required=raw.get("fresh_session_required"),  # type: ignore[arg-type]
+            context_references=tuple(
+                ACContextReferenceManifest.from_reference(reference)
+                for reference in self.context_references
+            ),
+            context_budget_chars=self.context_budget_chars,
+            fresh_session_required=self.fresh_session_required,
         )
+
+    @property
+    def fingerprint(self) -> str:
+        return self.manifest.fingerprint
 
     def to_prompt_reference_block(self) -> str:
         """Render the small external-memory index given to the provider driver."""
@@ -479,8 +651,10 @@ __all__ = [
     "AC_EXECUTION_CAPSULE_VERSION",
     "DEFAULT_AC_CONTEXT_BUDGET_CHARS",
     "ACContextReference",
+    "ACContextReferenceManifest",
     "ACContextReferenceKind",
     "ACExecutionCapsule",
+    "ACExecutionCapsuleManifest",
     "ACSuccessContract",
     "bind_capsule_to_runtime_handle",
     "compile_ac_execution_capsule",

--- a/src/ouroboros/orchestrator/ac_execution_capsule.py
+++ b/src/ouroboros/orchestrator/ac_execution_capsule.py
@@ -77,6 +77,7 @@ class ACContextReferenceKind(StrEnum):
     DEPENDENCY = "dependency"
     ARTIFACT = "artifact"
     GATE = "gate"
+    INDEX = "index"
 
 
 @dataclass(frozen=True, slots=True)
@@ -483,6 +484,8 @@ class ACExecutionCapsule:
             raise ValueError("capsule node id is invalid")
         if not self.context_references:
             raise ValueError("capsule must contain at least one context reference")
+        if len(self.to_prompt_reference_block()) > self.context_budget_chars:
+            raise ValueError("capsule context references exceed the declared budget")
 
     @property
     def manifest(self) -> ACExecutionCapsuleManifest:
@@ -517,18 +520,96 @@ class ACExecutionCapsule:
 
     def to_prompt_reference_block(self) -> str:
         """Render the small external-memory index given to the provider driver."""
-        lines = [
-            "## Ouroboros AC Runtime",
-            "This AC runs in a fresh provider context. The shared workspace and "
-            "Ouroboros event/gate records are authoritative; inspect referenced "
-            "sources as needed instead of assuming prior chat history.",
-            f"Capsule: {self.fingerprint}",
-            "Context references:",
-        ]
-        for reference in self.context_references:
-            hint = f" — {reference.hint}" if reference.hint else ""
-            lines.append(f"- {reference.kind.value}: {reference.locator}{hint}")
-        return "\n".join(lines)
+        return _render_prompt_reference_block(
+            self.context_references,
+            fingerprint=self.fingerprint,
+        )
+
+
+def _render_prompt_reference_block(
+    references: Sequence[ACContextReference],
+    *,
+    fingerprint: str,
+) -> str:
+    """Render a reference-only provider block with a fixed-size fingerprint."""
+    lines = [
+        "## Ouroboros AC Runtime",
+        "This AC runs in a fresh provider context. The shared workspace and "
+        "Ouroboros event/gate records are authoritative; inspect referenced "
+        "sources as needed instead of assuming prior chat history.",
+        f"Capsule: {fingerprint}",
+        "Context references:",
+    ]
+    for reference in references:
+        hint = f" — {reference.hint}" if reference.hint else ""
+        lines.append(f"- {reference.kind.value}: {reference.locator}{hint}")
+    return "\n".join(lines)
+
+
+def _bounded_context_references(
+    *,
+    required: Sequence[ACContextReference],
+    optional: Sequence[ACContextReference],
+    execution_id: str,
+    context_budget_chars: int,
+) -> tuple[ACContextReference, ...]:
+    """Fit deterministic references and summarize overflow as one index page."""
+    placeholder_fingerprint = "sha256:" + "0" * 64
+    all_references = tuple(required) + tuple(optional)
+    if (
+        len(
+            _render_prompt_reference_block(
+                all_references,
+                fingerprint=placeholder_fingerprint,
+            )
+        )
+        <= context_budget_chars
+    ):
+        return all_references
+
+    def _index_reference(omitted: Sequence[ACContextReference]) -> ACContextReference:
+        return ACContextReference(
+            kind=ACContextReferenceKind.INDEX,
+            locator=f"execution:{execution_id}:context-index",
+            digest=_sha256_text(
+                _canonical_json([reference.to_contract_data() for reference in omitted])
+            ),
+            hint=f"{len(omitted)} additional references; page from the event ledger",
+        )
+
+    selected = list(required)
+    placeholder_index = _index_reference(optional)
+    if (
+        len(
+            _render_prompt_reference_block(
+                (*selected, placeholder_index),
+                fingerprint=placeholder_fingerprint,
+            )
+        )
+        > context_budget_chars
+    ):
+        raise ValueError("capsule context budget cannot fit required references")
+
+    selected_optional_count = 0
+    for reference in optional:
+        candidate = (*selected, reference, placeholder_index)
+        if (
+            len(
+                _render_prompt_reference_block(
+                    candidate,
+                    fingerprint=placeholder_fingerprint,
+                )
+            )
+            > context_budget_chars
+        ):
+            break
+        selected.append(reference)
+        selected_optional_count += 1
+
+    omitted = tuple(optional[selected_optional_count:])
+    if omitted:
+        selected.append(_index_reference(omitted))
+    return tuple(selected)
 
 
 def _dependency_references(
@@ -577,7 +658,7 @@ def compile_ac_execution_capsule(
     """Compile one deterministic capsule from existing orchestrator authority."""
     canonical_workspace = os.path.realpath(workspace)
     success_contract = ACSuccessContract.from_ac_spec(ac_spec)
-    references: list[ACContextReference] = [
+    required_references: list[ACContextReference] = [
         ACContextReference(
             kind=ACContextReferenceKind.WORKSPACE,
             locator=canonical_workspace,
@@ -590,8 +671,8 @@ def compile_ac_execution_capsule(
             hint="goal and semantic AC authority",
         ),
     ]
-    references.extend(_dependency_references(execution_id, level_contexts))
-    references.extend(
+    optional_references = _dependency_references(execution_id, level_contexts)
+    optional_references.extend(
         ACContextReference(
             kind=ACContextReferenceKind.ARTIFACT,
             locator=f"workspace:{path}",
@@ -600,7 +681,7 @@ def compile_ac_execution_capsule(
         for path in success_contract.expected_artifacts
     )
     if ac_spec is not None and ac_spec.has_success_contract:
-        references.append(
+        required_references.append(
             ACContextReference(
                 kind=ACContextReferenceKind.GATE,
                 locator=f"gate:{runtime_identity.ac_id}",
@@ -608,6 +689,12 @@ def compile_ac_execution_capsule(
                 hint="authoritative acceptance contract",
             )
         )
+    references = _bounded_context_references(
+        required=required_references,
+        optional=optional_references,
+        execution_id=execution_id,
+        context_budget_chars=context_budget_chars,
+    )
     return ACExecutionCapsule(
         execution_id=execution_id,
         semantic_ac_key=semantic_ac_key,
@@ -622,7 +709,7 @@ def compile_ac_execution_capsule(
         seed_goal=seed_goal,
         ac_content=ac_content,
         success_contract=success_contract,
-        context_references=tuple(references),
+        context_references=references,
         context_budget_chars=context_budget_chars,
     )
 

--- a/src/ouroboros/orchestrator/ac_execution_capsule.py
+++ b/src/ouroboros/orchestrator/ac_execution_capsule.py
@@ -422,6 +422,8 @@ class ACExecutionCapsuleManifest:
         references = raw.get("context_references")
         if not isinstance(references, list):
             raise ValueError("capsule manifest context references are invalid")
+        if len(references) > MAX_AC_CONTEXT_REFERENCES:
+            raise ValueError("capsule manifest context reference limit exceeded")
         node_id = raw.get("node_id")
         if node_id is not None and not isinstance(node_id, str):
             raise ValueError("capsule manifest node id is invalid")

--- a/src/ouroboros/orchestrator/ac_execution_capsule.py
+++ b/src/ouroboros/orchestrator/ac_execution_capsule.py
@@ -1,0 +1,487 @@
+"""Provider-neutral execution capsule for one Ouroboros acceptance criterion.
+
+The capsule is the runtime-owned boundary above Claude, Codex, and every other
+``AgentRuntime`` driver.  It deliberately carries compact facts and references,
+not a provider transcript: durable workflow state lives in the workspace, Seed,
+event ledger, and verify-gate records.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from enum import StrEnum
+import hashlib
+import json
+import os
+
+from ouroboros.core.seed import AcceptanceCriterionSpec
+from ouroboros.orchestrator.adapter import RuntimeHandle
+from ouroboros.orchestrator.execution_runtime_scope import ACRuntimeIdentity
+from ouroboros.orchestrator.level_context import LevelContext
+
+AC_EXECUTION_CAPSULE_VERSION = 1
+DEFAULT_AC_CONTEXT_BUDGET_CHARS = 12_000
+_MAX_REFERENCE_LOCATOR_CHARS = 2_048
+_MAX_REFERENCE_HINT_CHARS = 240
+
+
+def _sha256_text(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _canonical_json(value: object) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+
+
+class ACContextReferenceKind(StrEnum):
+    """External context source named by an execution capsule."""
+
+    WORKSPACE = "workspace"
+    SEED = "seed"
+    DEPENDENCY = "dependency"
+    ARTIFACT = "artifact"
+    GATE = "gate"
+
+
+@dataclass(frozen=True, slots=True)
+class ACContextReference:
+    """A compact pointer to context that remains outside the model prompt."""
+
+    kind: ACContextReferenceKind
+    locator: str
+    digest: str | None = None
+    hint: str = ""
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.kind, ACContextReferenceKind):
+            raise ValueError("context reference kind is invalid")
+        if not self.locator or len(self.locator) > _MAX_REFERENCE_LOCATOR_CHARS:
+            raise ValueError("context reference locator is missing or oversized")
+        if any(character in self.locator for character in ("\x00", "\r", "\n")):
+            raise ValueError("context reference locator contains control characters")
+        if len(self.hint) > _MAX_REFERENCE_HINT_CHARS:
+            raise ValueError("context reference hint is oversized")
+        if any(character in self.hint for character in ("\x00", "\r", "\n")):
+            raise ValueError("context reference hint contains control characters")
+        if self.digest is not None and (
+            len(self.digest) != len("sha256:") + 64 or not self.digest.startswith("sha256:")
+        ):
+            raise ValueError("context reference digest is malformed")
+        if self.digest is not None:
+            try:
+                int(self.digest.removeprefix("sha256:"), 16)
+            except ValueError as exc:
+                raise ValueError("context reference digest is malformed") from exc
+
+    def to_contract_data(self) -> dict[str, object]:
+        return {
+            "kind": self.kind.value,
+            "locator": self.locator,
+            "digest": self.digest,
+            "hint": self.hint,
+        }
+
+    @classmethod
+    def from_contract_data(cls, raw: object) -> ACContextReference:
+        if not isinstance(raw, Mapping) or set(raw) != {"kind", "locator", "digest", "hint"}:
+            raise ValueError("context reference contract has an invalid shape")
+        try:
+            kind = ACContextReferenceKind(raw.get("kind"))
+        except (TypeError, ValueError) as exc:
+            raise ValueError("context reference kind is invalid") from exc
+        locator = raw.get("locator")
+        digest = raw.get("digest")
+        hint = raw.get("hint")
+        if not isinstance(locator, str):
+            raise ValueError("context reference locator is invalid")
+        if digest is not None and not isinstance(digest, str):
+            raise ValueError("context reference digest is invalid")
+        if not isinstance(hint, str):
+            raise ValueError("context reference hint is invalid")
+        return cls(kind=kind, locator=locator, digest=digest, hint=hint)
+
+
+@dataclass(frozen=True, slots=True)
+class ACSuccessContract:
+    """Seed-authored acceptance gate projected into a capsule."""
+
+    verify_command: str | None = None
+    expected_artifacts: tuple[str, ...] = ()
+    output_assertion: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.verify_command is not None and not isinstance(self.verify_command, str):
+            raise ValueError("success contract verify command is invalid")
+        if any(not isinstance(path, str) or not path for path in self.expected_artifacts):
+            raise ValueError("success contract artifacts are invalid")
+        if self.output_assertion is not None and not isinstance(self.output_assertion, str):
+            raise ValueError("success contract output assertion is invalid")
+
+    def to_contract_data(self) -> dict[str, object]:
+        return {
+            "verify_command": self.verify_command,
+            "expected_artifacts": list(self.expected_artifacts),
+            "output_assertion": self.output_assertion,
+        }
+
+    @classmethod
+    def from_ac_spec(cls, spec: AcceptanceCriterionSpec | None) -> ACSuccessContract:
+        if spec is None:
+            return cls()
+        return cls(
+            verify_command=spec.verify_command,
+            expected_artifacts=tuple(spec.expected_artifacts),
+            output_assertion=spec.output_assertion,
+        )
+
+    @classmethod
+    def from_contract_data(cls, raw: object) -> ACSuccessContract:
+        expected = {"verify_command", "expected_artifacts", "output_assertion"}
+        if not isinstance(raw, Mapping) or set(raw) != expected:
+            raise ValueError("success contract has an invalid shape")
+        verify_command = raw.get("verify_command")
+        expected_artifacts = raw.get("expected_artifacts")
+        output_assertion = raw.get("output_assertion")
+        if verify_command is not None and not isinstance(verify_command, str):
+            raise ValueError("success contract verify command is invalid")
+        if not isinstance(expected_artifacts, list) or any(
+            not isinstance(path, str) or not path for path in expected_artifacts
+        ):
+            raise ValueError("success contract artifacts are invalid")
+        if output_assertion is not None and not isinstance(output_assertion, str):
+            raise ValueError("success contract output assertion is invalid")
+        return cls(
+            verify_command=verify_command,
+            expected_artifacts=tuple(expected_artifacts),
+            output_assertion=output_assertion,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ACExecutionCapsule:
+    """Versioned Ouroboros-owned contract for one physical AC session."""
+
+    execution_id: str
+    semantic_ac_key: str
+    ac_id: str
+    session_scope_id: str
+    session_attempt_id: str
+    node_id: str | None
+    retry_attempt: int
+    segment_index: int
+    workspace: str
+    authority_scope: str
+    seed_goal: str
+    ac_content: str
+    success_contract: ACSuccessContract
+    context_references: tuple[ACContextReference, ...]
+    context_budget_chars: int
+    fresh_session_required: bool = True
+    version: int = AC_EXECUTION_CAPSULE_VERSION
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("execution_id", self.execution_id),
+            ("semantic_ac_key", self.semantic_ac_key),
+            ("ac_id", self.ac_id),
+            ("session_scope_id", self.session_scope_id),
+            ("session_attempt_id", self.session_attempt_id),
+            ("authority_scope", self.authority_scope),
+            ("seed_goal", self.seed_goal),
+            ("ac_content", self.ac_content),
+        ):
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"capsule {name} is missing")
+        if (
+            not isinstance(self.version, int)
+            or isinstance(self.version, bool)
+            or self.version != AC_EXECUTION_CAPSULE_VERSION
+        ):
+            raise ValueError("capsule version is unsupported")
+        if (
+            not isinstance(self.retry_attempt, int)
+            or isinstance(self.retry_attempt, bool)
+            or self.retry_attempt < 0
+        ):
+            raise ValueError("capsule retry attempt is invalid")
+        if (
+            not isinstance(self.segment_index, int)
+            or isinstance(self.segment_index, bool)
+            or self.segment_index < 0
+        ):
+            raise ValueError("capsule segment index is invalid")
+        if (
+            not isinstance(self.context_budget_chars, int)
+            or isinstance(self.context_budget_chars, bool)
+            or self.context_budget_chars <= 0
+        ):
+            raise ValueError("capsule context budget is invalid")
+        if self.fresh_session_required is not True:
+            raise ValueError("an AC execution capsule must require a fresh session")
+        if not os.path.isabs(self.workspace) or os.path.realpath(self.workspace) != self.workspace:
+            raise ValueError("capsule workspace must be a canonical absolute path")
+        if self.node_id is not None and (not isinstance(self.node_id, str) or not self.node_id):
+            raise ValueError("capsule node id is invalid")
+        if not self.context_references:
+            raise ValueError("capsule must contain at least one context reference")
+
+    @property
+    def fingerprint(self) -> str:
+        return _sha256_text(_canonical_json(self.to_contract_data()))
+
+    def to_contract_data(self) -> dict[str, object]:
+        return {
+            "version": self.version,
+            "execution_id": self.execution_id,
+            "semantic_ac_key": self.semantic_ac_key,
+            "ac_id": self.ac_id,
+            "session_scope_id": self.session_scope_id,
+            "session_attempt_id": self.session_attempt_id,
+            "node_id": self.node_id,
+            "retry_attempt": self.retry_attempt,
+            "segment_index": self.segment_index,
+            "workspace": self.workspace,
+            "authority_scope": self.authority_scope,
+            "seed_goal": self.seed_goal,
+            "ac_content": self.ac_content,
+            "success_contract": self.success_contract.to_contract_data(),
+            "context_references": [
+                reference.to_contract_data() for reference in self.context_references
+            ],
+            "context_budget_chars": self.context_budget_chars,
+            "fresh_session_required": self.fresh_session_required,
+        }
+
+    @classmethod
+    def from_contract_data(cls, raw: object) -> ACExecutionCapsule:
+        expected = {
+            "version",
+            "execution_id",
+            "semantic_ac_key",
+            "ac_id",
+            "session_scope_id",
+            "session_attempt_id",
+            "node_id",
+            "retry_attempt",
+            "segment_index",
+            "workspace",
+            "authority_scope",
+            "seed_goal",
+            "ac_content",
+            "success_contract",
+            "context_references",
+            "context_budget_chars",
+            "fresh_session_required",
+        }
+        if not isinstance(raw, Mapping) or set(raw) != expected:
+            raise ValueError("AC execution capsule has an invalid shape")
+        references = raw.get("context_references")
+        if not isinstance(references, list):
+            raise ValueError("capsule context references are invalid")
+        scalar_fields = {
+            name: raw.get(name)
+            for name in (
+                "execution_id",
+                "semantic_ac_key",
+                "ac_id",
+                "session_scope_id",
+                "session_attempt_id",
+                "workspace",
+                "authority_scope",
+                "seed_goal",
+                "ac_content",
+            )
+        }
+        if any(not isinstance(value, str) for value in scalar_fields.values()):
+            raise ValueError("capsule string field is invalid")
+        node_id = raw.get("node_id")
+        if node_id is not None and not isinstance(node_id, str):
+            raise ValueError("capsule node id is invalid")
+        return cls(
+            version=raw.get("version"),  # type: ignore[arg-type]
+            execution_id=scalar_fields["execution_id"],  # type: ignore[arg-type]
+            semantic_ac_key=scalar_fields["semantic_ac_key"],  # type: ignore[arg-type]
+            ac_id=scalar_fields["ac_id"],  # type: ignore[arg-type]
+            session_scope_id=scalar_fields["session_scope_id"],  # type: ignore[arg-type]
+            session_attempt_id=scalar_fields["session_attempt_id"],  # type: ignore[arg-type]
+            node_id=node_id,
+            retry_attempt=raw.get("retry_attempt"),  # type: ignore[arg-type]
+            segment_index=raw.get("segment_index"),  # type: ignore[arg-type]
+            workspace=scalar_fields["workspace"],  # type: ignore[arg-type]
+            authority_scope=scalar_fields["authority_scope"],  # type: ignore[arg-type]
+            seed_goal=scalar_fields["seed_goal"],  # type: ignore[arg-type]
+            ac_content=scalar_fields["ac_content"],  # type: ignore[arg-type]
+            success_contract=ACSuccessContract.from_contract_data(raw.get("success_contract")),
+            context_references=tuple(
+                ACContextReference.from_contract_data(reference) for reference in references
+            ),
+            context_budget_chars=raw.get("context_budget_chars"),  # type: ignore[arg-type]
+            fresh_session_required=raw.get("fresh_session_required"),  # type: ignore[arg-type]
+        )
+
+    def to_prompt_reference_block(self) -> str:
+        """Render the small external-memory index given to the provider driver."""
+        lines = [
+            "## Ouroboros AC Runtime",
+            "This AC runs in a fresh provider context. The shared workspace and "
+            "Ouroboros event/gate records are authoritative; inspect referenced "
+            "sources as needed instead of assuming prior chat history.",
+            f"Capsule: {self.fingerprint}",
+            "Context references:",
+        ]
+        for reference in self.context_references:
+            hint = f" — {reference.hint}" if reference.hint else ""
+            lines.append(f"- {reference.kind.value}: {reference.locator}{hint}")
+        return "\n".join(lines)
+
+
+def _dependency_references(
+    execution_id: str,
+    level_contexts: Sequence[LevelContext],
+) -> list[ACContextReference]:
+    references: list[ACContextReference] = []
+    for context in level_contexts:
+        for summary in context.completed_acs:
+            if not summary.success:
+                continue
+            payload = {
+                "level_number": context.level_number,
+                "ac_index": summary.ac_index,
+                "ac_content": summary.ac_content,
+                "tools_used": list(summary.tools_used),
+                "files_modified": list(summary.files_modified),
+                "key_output": summary.key_output,
+                "public_api": summary.public_api,
+            }
+            references.append(
+                ACContextReference(
+                    kind=ACContextReferenceKind.DEPENDENCY,
+                    locator=f"execution:{execution_id}:ac:{summary.ac_index + 1}",
+                    digest=_sha256_text(_canonical_json(payload)),
+                    hint=f"accepted dependency from level {context.level_number + 1}",
+                )
+            )
+    return references
+
+
+def compile_ac_execution_capsule(
+    *,
+    runtime_identity: ACRuntimeIdentity,
+    execution_id: str,
+    semantic_ac_key: str,
+    workspace: str,
+    authority_scope: str,
+    seed_goal: str,
+    ac_content: str,
+    ac_spec: AcceptanceCriterionSpec | None,
+    level_contexts: Sequence[LevelContext] = (),
+    segment_index: int = 0,
+    context_budget_chars: int = DEFAULT_AC_CONTEXT_BUDGET_CHARS,
+) -> ACExecutionCapsule:
+    """Compile one deterministic capsule from existing orchestrator authority."""
+    canonical_workspace = os.path.realpath(workspace)
+    success_contract = ACSuccessContract.from_ac_spec(ac_spec)
+    references: list[ACContextReference] = [
+        ACContextReference(
+            kind=ACContextReferenceKind.WORKSPACE,
+            locator=canonical_workspace,
+            hint="authoritative mutable implementation state",
+        ),
+        ACContextReference(
+            kind=ACContextReferenceKind.SEED,
+            locator=f"seed-goal:{semantic_ac_key}",
+            digest=_sha256_text(seed_goal),
+            hint="goal and semantic AC authority",
+        ),
+    ]
+    references.extend(_dependency_references(execution_id, level_contexts))
+    references.extend(
+        ACContextReference(
+            kind=ACContextReferenceKind.ARTIFACT,
+            locator=f"workspace:{path}",
+            hint="seed-authored expected artifact",
+        )
+        for path in success_contract.expected_artifacts
+    )
+    if ac_spec is not None and ac_spec.has_success_contract:
+        references.append(
+            ACContextReference(
+                kind=ACContextReferenceKind.GATE,
+                locator=f"gate:{runtime_identity.ac_id}",
+                digest=_sha256_text(_canonical_json(success_contract.to_contract_data())),
+                hint="authoritative acceptance contract",
+            )
+        )
+    return ACExecutionCapsule(
+        execution_id=execution_id,
+        semantic_ac_key=semantic_ac_key,
+        ac_id=runtime_identity.ac_id,
+        session_scope_id=runtime_identity.session_scope_id,
+        session_attempt_id=runtime_identity.session_attempt_id,
+        node_id=runtime_identity.node_id,
+        retry_attempt=runtime_identity.retry_attempt,
+        segment_index=segment_index,
+        workspace=canonical_workspace,
+        authority_scope=authority_scope,
+        seed_goal=seed_goal,
+        ac_content=ac_content,
+        success_contract=success_contract,
+        context_references=tuple(references),
+        context_budget_chars=context_budget_chars,
+    )
+
+
+def bind_capsule_to_runtime_handle(
+    capsule: ACExecutionCapsule,
+    runtime_handle: RuntimeHandle | None,
+    *,
+    restored_same_attempt: bool,
+) -> RuntimeHandle | None:
+    """Bind a provider handle to exactly one AC capsule.
+
+    A newly compiled AC may receive a handle-shaped configuration object (cwd,
+    permissions, capability metadata), but it must not inherit any provider
+    continuity identifier.  Crash recovery may reconnect only to the same AC
+    attempt, and any already-bound handle must agree with the capsule fingerprint.
+    """
+    if runtime_handle is None:
+        return None
+    continuity_values = (
+        runtime_handle.native_session_id,
+        runtime_handle.conversation_id,
+        runtime_handle.previous_response_id,
+        runtime_handle.transcript_path,
+        runtime_handle.server_session_id,
+    )
+    if not restored_same_attempt and any(continuity_values):
+        raise ValueError("a fresh AC capsule cannot inherit provider session continuity")
+    existing_fingerprint = runtime_handle.metadata.get("ac_capsule_fingerprint")
+    if existing_fingerprint is not None and existing_fingerprint != capsule.fingerprint:
+        raise ValueError("runtime handle is bound to a different AC capsule")
+    metadata = dict(runtime_handle.metadata)
+    metadata.update(
+        {
+            "ac_capsule_version": capsule.version,
+            "ac_capsule_fingerprint": capsule.fingerprint,
+            "ac_session_origin": ("restored_same_attempt" if restored_same_attempt else "fresh"),
+        }
+    )
+    return replace(runtime_handle, metadata=metadata)
+
+
+__all__ = [
+    "AC_EXECUTION_CAPSULE_VERSION",
+    "DEFAULT_AC_CONTEXT_BUDGET_CHARS",
+    "ACContextReference",
+    "ACContextReferenceKind",
+    "ACExecutionCapsule",
+    "ACSuccessContract",
+    "bind_capsule_to_runtime_handle",
+    "compile_ac_execution_capsule",
+]

--- a/src/ouroboros/orchestrator/ac_execution_capsule.py
+++ b/src/ouroboros/orchestrator/ac_execution_capsule.py
@@ -614,6 +614,8 @@ def bind_capsule_to_runtime_handle(
     runtime_handle: RuntimeHandle | None,
     *,
     restored_same_attempt: bool,
+    expected_backend: str | None = None,
+    expected_approval_mode: str | None = None,
 ) -> RuntimeHandle | None:
     """Bind a provider handle to exactly one AC capsule.
 
@@ -633,6 +635,19 @@ def bind_capsule_to_runtime_handle(
     )
     if not restored_same_attempt and any(continuity_values):
         raise ValueError("a fresh AC capsule cannot inherit provider session continuity")
+    if restored_same_attempt:
+        if not runtime_handle.cwd:
+            raise ValueError("a resumed runtime handle must declare its workspace")
+        restored_workspace = os.path.realpath(os.path.expanduser(runtime_handle.cwd))
+        if restored_workspace != capsule.workspace:
+            raise ValueError("runtime handle workspace disagrees with the AC capsule")
+        if expected_backend is not None and runtime_handle.backend != expected_backend:
+            raise ValueError("runtime handle backend disagrees with the AC capsule authority")
+        if (
+            expected_approval_mode is not None
+            and runtime_handle.approval_mode != expected_approval_mode
+        ):
+            raise ValueError("runtime handle approval mode disagrees with the AC capsule authority")
     existing_fingerprint = runtime_handle.metadata.get("ac_capsule_fingerprint")
     if existing_fingerprint is not None and existing_fingerprint != capsule.fingerprint:
         raise ValueError("runtime handle is bound to a different AC capsule")

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -49,6 +49,16 @@ if TYPE_CHECKING:
 log = get_logger(__name__)
 
 _IMPLEMENTATION_SESSION_KIND = "implementation_session"
+_AC_EFFECT_EVENT_TYPES = frozenset(
+    {
+        "execution.tool.started",
+        "execution.tool.completed",
+    }
+)
+
+
+class AmbiguousACExecutionError(RuntimeError):
+    """A prior AC attempt may have external effects but cannot be resumed safely."""
 
 
 class ACRuntimeHandleManager:
@@ -564,6 +574,15 @@ class ACRuntimeHandleManager:
                 self.runtime_handles.pop(runtime_identity.cache_key, None)
                 cached_handle = None
 
+            unresolved_effect_event = any(
+                event.type in _AC_EFFECT_EVENT_TYPES
+                and self._event_matches_ac_runtime_identity(
+                    event.data if isinstance(event.data, dict) else {},
+                    runtime_identity,
+                )
+                for event in events
+            )
+
             for event in reversed(events):
                 event_data = event.data if isinstance(event.data, dict) else {}
                 if not self._event_matches_ac_runtime_identity(event_data, runtime_identity):
@@ -632,6 +651,12 @@ class ACRuntimeHandleManager:
 
                 self.runtime_handles[runtime_identity.cache_key] = runtime_handle
                 return runtime_handle
+
+            if unresolved_effect_event:
+                raise AmbiguousACExecutionError(
+                    "AC attempt recorded tool effects without a reusable runtime handle; "
+                    "refusing fresh redispatch because non-idempotent effects may duplicate"
+                )
 
         return None
 

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -70,6 +70,11 @@ _AC_EFFECT_EVENT_TYPES = frozenset(
 #: without it), so recovery never infers a new phase for legacy records.
 _AC_DISPATCH_KINDS = frozenset({"primary", "session_signal_followup"})
 
+#: Seal marker for a completed provider turn a follow-up dispatch is about to
+#: supersede. A sealed dispatch that ends up the active recovery head (i.e. its
+#: follow-up never durably completed) fails closed instead of replaying the AC.
+_AC_DISPATCH_SEALED_EVENT = "execution.ac.dispatch.sealed"
+
 
 class AmbiguousACExecutionError(RuntimeError):
     """A prior AC attempt may have external effects but cannot be resumed safely."""
@@ -816,11 +821,17 @@ class ACRuntimeHandleManager:
             dispatch_events: dict[str, Any] = {}
             dispatch_predecessors: dict[str, str | None] = {}
             dispatch_kinds: dict[str, str] = {}
+            sealed_dispatch_ids: set[str] = set()
             for event in attempt_events:
                 event_data = event.data if isinstance(event.data, dict) else {}
                 if not self._event_matches_ac_runtime_identity(event_data, runtime_identity):
                     continue
                 matching_events.append(event)
+                if event.type == _AC_DISPATCH_SEALED_EVENT:
+                    sealed_id = self._event_ac_dispatch_id(event_data)
+                    if sealed_id is not None:
+                        sealed_dispatch_ids.add(sealed_id)
+                    continue
                 if event.type != _AC_ATTEMPT_DISPATCHED_EVENT:
                     continue
                 dispatch_id = self._event_ac_dispatch_id(event_data)
@@ -1182,6 +1193,18 @@ class ACRuntimeHandleManager:
                         f"({active_dispatch_kind}) as the active dispatch head; refusing to "
                         "resume because replaying the original AC prompt would repeat "
                         "acceptance work in the wrong phase"
+                    )
+                # A sealed head is a completed provider turn that a follow-up
+                # dispatch tried to supersede without durably completing (the
+                # completed/failed terminal check above already returned for a
+                # cleanly finalized attempt). Resuming it would replay the
+                # original AC prompt over already-done work, so fail closed.
+                if active_dispatch_id in sealed_dispatch_ids:
+                    raise AmbiguousACExecutionError(
+                        "AC recovery resolved a sealed provider-entry phase as the active "
+                        "dispatch head; refusing to resume because a follow-up superseded it "
+                        "without a durable terminal outcome and replaying the AC prompt would "
+                        "repeat completed work"
                     )
                 active_dispatch_candidates = candidate_handles[active_dispatch_id]
                 if not active_dispatch_candidates:

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -660,6 +660,7 @@ class ACRuntimeHandleManager:
         retry_attempt: int = 0,
         expected_capsule_fingerprint: str | None = None,
         expected_capsule_workspace: str | None = None,
+        runtime_attests_realtime_effects: bool = False,
     ) -> RuntimeHandle | None:
         """Load the latest reusable AC-scoped runtime handle from execution events."""
         runtime_identity = self._resolve_ac_runtime_identity(
@@ -1277,6 +1278,21 @@ class ACRuntimeHandleManager:
                         "non-idempotent effects"
                     )
                 active_dispatch_candidates = candidate_handles[active_dispatch_id]
+                # Opaque runtimes (no real-time tool-effect visibility) may have
+                # applied a non-idempotent effect BEFORE any event was emitted, so
+                # the absence of a recorded effect above does not prove none
+                # occurred. Resuming an active head resends the original AC prompt
+                # as a new turn, so unless the runtime attests it streams effects in
+                # real time (letting the effect-check above be authoritative), an
+                # active, resumable head must fail closed rather than risk a
+                # duplicate turn.
+                if active_dispatch_candidates and not runtime_attests_realtime_effects:
+                    raise AmbiguousACExecutionError(
+                        "AC active dispatch head is resumable on a runtime that does not attest "
+                        "real-time tool-effect visibility; refusing to resume because an opaque "
+                        "effect may already have occurred and replaying the AC prompt would "
+                        "start another provider turn"
+                    )
                 if not active_dispatch_candidates:
                     if active_dispatch_id in failed_dispatches:
                         raise AmbiguousACExecutionError(

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -691,6 +691,11 @@ class ACRuntimeHandleManager:
                         node_identity=node_identity,
                         retry_attempt=retry_attempt,
                     )
+                    if unresolved_effect_event:
+                        raise AmbiguousACExecutionError(
+                            "AC attempt recorded tool effects without a reusable runtime handle; "
+                            "refusing fresh redispatch because non-idempotent effects may duplicate"
+                        )
                     return None
                 if event.type not in _REUSABLE_RUNTIME_EVENT_TYPES:
                     continue

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -456,7 +456,7 @@ class ACRuntimeHandleManager:
         )
         if cached_runtime_handle is not None and cached_handle is None:
             self.runtime_handles.pop(runtime_identity.cache_key, None)
-        if cached_handle is not None:
+        if cached_handle is not None and expected_capsule_fingerprint is None:
             return cached_handle
 
         candidate_scope_ids = (
@@ -483,6 +483,7 @@ class ACRuntimeHandleManager:
                     raise
                 continue
 
+            capsule_authorized = expected_capsule_fingerprint is None
             if expected_capsule_fingerprint is not None:
                 for event in events:
                     if event.type != "execution.ac.capsule.compiled":
@@ -516,6 +517,21 @@ class ACRuntimeHandleManager:
                         raise ValueError(
                             "durable AC capsule fingerprint disagrees with the current dispatch"
                         )
+                    capsule_authorized = True
+
+            if not capsule_authorized:
+                continue
+
+            if cached_handle is not None:
+                cached_fingerprint = cached_handle.metadata.get("ac_capsule_fingerprint")
+                cached_attempt_id = cached_handle.metadata.get("session_attempt_id")
+                if (
+                    cached_fingerprint == expected_capsule_fingerprint
+                    and cached_attempt_id == runtime_identity.session_attempt_id
+                ):
+                    return cached_handle
+                self.runtime_handles.pop(runtime_identity.cache_key, None)
+                cached_handle = None
 
             for event in reversed(events):
                 event_data = event.data if isinstance(event.data, dict) else {}
@@ -552,6 +568,18 @@ class ACRuntimeHandleManager:
                     continue
                 if runtime_handle is None:
                     continue
+                if expected_capsule_fingerprint is not None:
+                    runtime_fingerprint = runtime_handle.metadata.get("ac_capsule_fingerprint")
+                    runtime_attempt_id = runtime_handle.metadata.get("session_attempt_id")
+                    if runtime_fingerprint not in {None, expected_capsule_fingerprint}:
+                        raise ValueError(
+                            "persisted runtime handle disagrees with the durable AC capsule"
+                        )
+                    if (
+                        runtime_fingerprint is None
+                        or runtime_attempt_id != runtime_identity.session_attempt_id
+                    ):
+                        continue
                 runtime_handle = self._normalize_ac_runtime_handle(
                     runtime_handle,
                     runtime_scope=runtime_identity.runtime_scope,

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import replace
 from datetime import UTC, datetime
+import inspect
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -75,6 +77,85 @@ class ACRuntimeHandleManager:
         self._event_store = event_store
         self._task_cwd = task_cwd
         self.runtime_handles: dict[str, RuntimeHandle] = {}
+        self._event_replay_cache: dict[tuple[str, str], list[Any]] = {}
+        self._event_replay_cursors: dict[tuple[str, str], int] = {}
+
+    async def _replay_runtime_scope_events(
+        self,
+        aggregate_type: str,
+        aggregate_id: str,
+    ) -> list[Any]:
+        """Incrementally replay one runtime scope when the store supports cursors."""
+        cache_key = (aggregate_type, aggregate_id)
+        incremental_descriptor = inspect.getattr_static(
+            type(self._event_store),
+            "get_events_after",
+            None,
+        )
+        if incremental_descriptor is None:
+            return await self._event_store.replay(aggregate_type, aggregate_id)
+
+        getter = object.__getattribute__(self._event_store, "get_events_after")
+        cursor = self._event_replay_cursors.get(cache_key, 0)
+        result = await getter(aggregate_type, aggregate_id, cursor)
+        if (
+            not isinstance(result, tuple)
+            or len(result) != 2
+            or not isinstance(result[0], list)
+            or not isinstance(result[1], int)
+        ):
+            return await self._event_store.replay(aggregate_type, aggregate_id)
+        new_events, next_cursor = result
+        cached_events = self._event_replay_cache.setdefault(cache_key, [])
+        cached_events.extend(new_events)
+        self._event_replay_cursors[cache_key] = next_cursor
+        return list(cached_events)
+
+    @staticmethod
+    def _event_retry_attempt(event_data: Mapping[str, Any]) -> int | None:
+        value = event_data.get("retry_attempt")
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+            return value
+        attempt_number = event_data.get("attempt_number")
+        if (
+            isinstance(attempt_number, int)
+            and not isinstance(attempt_number, bool)
+            and attempt_number >= 1
+        ):
+            return attempt_number - 1
+        session_attempt_id = event_data.get("session_attempt_id")
+        if isinstance(session_attempt_id, str):
+            marker, separator, suffix = session_attempt_id.rpartition("_attempt_")
+            if marker and separator and suffix.isdigit() and int(suffix) >= 1:
+                return int(suffix) - 1
+        runtime_payload = event_data.get("runtime")
+        if isinstance(runtime_payload, Mapping):
+            metadata = runtime_payload.get("metadata")
+            if isinstance(metadata, Mapping):
+                value = metadata.get("retry_attempt")
+                if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                    return value
+        return None
+
+    @classmethod
+    def _events_for_runtime_attempt(
+        cls,
+        events: list[Any],
+        *,
+        retry_attempt: int,
+    ) -> list[Any]:
+        """Slice the append-only AC stream down to the current attempt tail."""
+        attempt_events: list[Any] = []
+        for event in reversed(events):
+            event_data = event.data if isinstance(getattr(event, "data", None), dict) else {}
+            observed_attempt = cls._event_retry_attempt(event_data)
+            if observed_attempt == retry_attempt:
+                attempt_events.append(event)
+                continue
+            if observed_attempt is not None and observed_attempt < retry_attempt:
+                break
+        attempt_events.reverse()
+        return attempt_events
 
     @staticmethod
     def _build_expected_ac_runtime_metadata(
@@ -501,12 +582,16 @@ class ACRuntimeHandleManager:
             return cached_handle
 
         candidate_scope_ids = (
-            runtime_identity.session_scope_id,
-            *runtime_identity.legacy_session_scope_ids,
+            (runtime_identity.session_scope_id,)
+            if expected_capsule_fingerprint is not None
+            else (
+                runtime_identity.session_scope_id,
+                *runtime_identity.legacy_session_scope_ids,
+            )
         )
         for candidate_scope_id in dict.fromkeys(candidate_scope_ids):
             try:
-                events = await self._event_store.replay(
+                events = await self._replay_runtime_scope_events(
                     runtime_identity.runtime_scope.aggregate_type,
                     candidate_scope_id,
                 )
@@ -523,10 +608,18 @@ class ACRuntimeHandleManager:
                 if expected_capsule_fingerprint is not None:
                     raise
                 continue
+            attempt_events = (
+                self._events_for_runtime_attempt(
+                    events,
+                    retry_attempt=runtime_identity.retry_attempt,
+                )
+                if expected_capsule_fingerprint is not None
+                else events
+            )
 
             capsule_authorized = expected_capsule_fingerprint is None
             if expected_capsule_fingerprint is not None:
-                for event in events:
+                for event in attempt_events:
                     if event.type != "execution.ac.capsule.compiled":
                         continue
                     event_data = event.data if isinstance(event.data, dict) else {}
@@ -580,10 +673,10 @@ class ACRuntimeHandleManager:
                     event.data if isinstance(event.data, dict) else {},
                     runtime_identity,
                 )
-                for event in events
+                for event in attempt_events
             )
 
-            for event in reversed(events):
+            for event in reversed(attempt_events):
                 event_data = event.data if isinstance(event.data, dict) else {}
                 if not self._event_matches_ac_runtime_identity(event_data, runtime_identity):
                     continue

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -943,7 +943,14 @@ class ACRuntimeHandleManager:
         previous_handle: RuntimeHandle | None,
     ) -> RuntimeHandle:
         """Carry forward logical turn state and record same-attempt recovery linkage."""
-        metadata = dict(runtime_handle.metadata)
+        metadata = (
+            {
+                **dict(previous_handle.metadata),
+                **dict(runtime_handle.metadata),
+            }
+            if previous_handle is not None
+            else dict(runtime_handle.metadata)
+        )
         metadata.setdefault("turn_number", cls._runtime_turn_number(runtime_handle))
         metadata.setdefault(
             "turn_id",

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -55,7 +55,9 @@ _IMPLEMENTATION_SESSION_KIND = "implementation_session"
 _AC_ATTEMPT_DISPATCHED_EVENT = "execution.ac.attempt.dispatched"
 _AC_REUSABLE_RUNTIME_EVENT_TYPES = _REUSABLE_RUNTIME_EVENT_TYPES | {_AC_ATTEMPT_DISPATCHED_EVENT}
 _VERIFY_GATE_OUTCOME_KEYS = frozenset({"passed", "reason", "output_tail", "missing_artifacts"})
-_MAX_VERIFY_GATE_OUTCOME_CHARS = 65_536
+# 64 KiB measured in UTF-8 bytes (the persisted/replayed size), not Unicode code
+# points — a multi-byte outcome must be bounded by its actual encoded size.
+_MAX_VERIFY_GATE_OUTCOME_BYTES = 65_536
 _AC_EFFECT_EVENT_TYPES = frozenset(
     {
         "execution.tool.started",
@@ -256,7 +258,7 @@ class ACRuntimeHandleManager:
             separators=(",", ":"),
             ensure_ascii=False,
         )
-        if len(encoded) > _MAX_VERIFY_GATE_OUTCOME_CHARS:
+        if len(encoded.encode("utf-8")) > _MAX_VERIFY_GATE_OUTCOME_BYTES:
             raise ValueError("durable completed AC verify outcome exceeds the size limit")
         return normalized
 

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -428,6 +428,7 @@ class ACRuntimeHandleManager:
         sub_ac_index: int | None = None,
         node_identity: ExecutionNodeIdentity | None = None,
         retry_attempt: int = 0,
+        expected_capsule_fingerprint: str | None = None,
     ) -> RuntimeHandle | None:
         """Load the latest reusable AC-scoped runtime handle from execution events."""
         runtime_identity = self._resolve_ac_runtime_identity(
@@ -477,7 +478,25 @@ class ACRuntimeHandleManager:
                     retry_attempt=retry_attempt,
                     session_scope_id=candidate_scope_id,
                 )
+                if expected_capsule_fingerprint is not None:
+                    raise
                 continue
+
+            if expected_capsule_fingerprint is not None:
+                for event in events:
+                    if event.type != "execution.ac.capsule.compiled":
+                        continue
+                    event_data = event.data if isinstance(event.data, dict) else {}
+                    if (
+                        event_data.get("ac_id") != runtime_identity.ac_id
+                        or event_data.get("session_attempt_id")
+                        != runtime_identity.session_attempt_id
+                    ):
+                        continue
+                    if event_data.get("capsule_fingerprint") != expected_capsule_fingerprint:
+                        raise ValueError(
+                            "durable AC capsule fingerprint disagrees with the current dispatch"
+                        )
 
             for event in reversed(events):
                 event_data = event.data if isinstance(event.data, dict) else {}

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from ouroboros.observability.logging import get_logger
+from ouroboros.orchestrator.ac_execution_capsule import ACExecutionCapsuleManifest
 from ouroboros.orchestrator.adapter import (
     RuntimeHandle,
     runtime_handle_tool_catalog,
@@ -493,7 +494,25 @@ class ACRuntimeHandleManager:
                         != runtime_identity.session_attempt_id
                     ):
                         continue
-                    if event_data.get("capsule_fingerprint") != expected_capsule_fingerprint:
+                    try:
+                        manifest = ACExecutionCapsuleManifest.from_contract_data(
+                            event_data.get("capsule_manifest")
+                        )
+                    except ValueError as exc:
+                        raise ValueError("durable AC capsule manifest is malformed") from exc
+                    persisted_fingerprint = event_data.get("capsule_fingerprint")
+                    if persisted_fingerprint != manifest.fingerprint:
+                        raise ValueError(
+                            "durable AC capsule fingerprint disagrees with its manifest"
+                        )
+                    if (
+                        manifest.ac_id != runtime_identity.ac_id
+                        or manifest.session_attempt_id != runtime_identity.session_attempt_id
+                    ):
+                        raise ValueError(
+                            "durable AC capsule manifest disagrees with its event identity"
+                        )
+                    if manifest.fingerprint != expected_capsule_fingerprint:
                         raise ValueError(
                             "durable AC capsule fingerprint disagrees with the current dispatch"
                         )

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -63,6 +63,13 @@ _AC_EFFECT_EVENT_TYPES = frozenset(
     }
 )
 
+#: Provider-entry phases a durable dispatch boundary may open. ``primary``
+#: replays the original AC prompt on resume; ``session_signal_followup`` replays
+#: a Synapse signal turn. An absent value on a persisted dispatch predates the
+#: field and is treated as ``primary`` (follow-up dispatches never existed
+#: without it), so recovery never infers a new phase for legacy records.
+_AC_DISPATCH_KINDS = frozenset({"primary", "session_signal_followup"})
+
 
 class AmbiguousACExecutionError(RuntimeError):
     """A prior AC attempt may have external effects but cannot be resumed safely."""
@@ -808,6 +815,7 @@ class ACRuntimeHandleManager:
             matching_events: list[Any] = []
             dispatch_events: dict[str, Any] = {}
             dispatch_predecessors: dict[str, str | None] = {}
+            dispatch_kinds: dict[str, str] = {}
             for event in attempt_events:
                 event_data = event.data if isinstance(event.data, dict) else {}
                 if not self._event_matches_ac_runtime_identity(event_data, runtime_identity):
@@ -839,8 +847,37 @@ class ACRuntimeHandleManager:
                     "restored_same_attempt",
                 }:
                     raise ValueError("durable AC dispatch session origin is invalid")
+                # Resolve the provider-entry PHASE this dispatch opened. A dispatch
+                # persisted before this field existed is, by construction, a
+                # ``primary`` AC dispatch (SessionSignal follow-up dispatches never
+                # existed without it), so an absent value keeps that historical
+                # meaning without inferring anything new. An explicitly persisted
+                # follow-up must carry its signal identity/mode and exact input
+                # digest, or the record is corrupt and rejected — recovery must not
+                # resume a follow-up phase whose exact input it cannot prove.
+                dispatch_kind = event_data.get("dispatch_kind")
+                if dispatch_kind is None:
+                    dispatch_kind = "primary"
+                elif dispatch_kind not in _AC_DISPATCH_KINDS:
+                    raise ValueError("durable AC dispatch kind is invalid")
+                if dispatch_kind == "session_signal_followup":
+                    signal_id = event_data.get("signal_id")
+                    signal_mode = event_data.get("signal_mode")
+                    input_digest = event_data.get("follow_up_input_digest")
+                    if (
+                        not isinstance(signal_id, str)
+                        or not signal_id
+                        or not isinstance(signal_mode, str)
+                        or not signal_mode
+                        or not isinstance(input_digest, str)
+                        or not input_digest.startswith("sha256:")
+                    ):
+                        raise ValueError(
+                            "durable SessionSignal follow-up dispatch is missing phase identity"
+                        )
                 dispatch_events[dispatch_id] = event
                 dispatch_predecessors[dispatch_id] = predecessor_id
+                dispatch_kinds[dispatch_id] = dispatch_kind
 
             active_dispatch_id: str | None = None
             if dispatch_events:
@@ -1131,6 +1168,21 @@ class ACRuntimeHandleManager:
             if dispatch_events:
                 if active_dispatch_id is None:  # pragma: no cover - guarded by chain validation
                     raise ValueError("durable AC dispatch history has no active boundary")
+                # Fail closed on a non-primary chain head. The caller
+                # (``_execute_atomic_ac``) always replays the ORIGINAL AC prompt
+                # after this handle is returned, so resuming a SessionSignal
+                # follow-up head would re-run the AC's acceptance work. We do not
+                # reconstruct the exact follow-up phase from persisted metadata
+                # here, so the only safe outcome is to refuse resumption rather
+                # than repeat a possibly non-idempotent AC prompt.
+                active_dispatch_kind = dispatch_kinds[active_dispatch_id]
+                if active_dispatch_kind != "primary":
+                    raise AmbiguousACExecutionError(
+                        "AC recovery resolved a non-primary provider-entry phase "
+                        f"({active_dispatch_kind}) as the active dispatch head; refusing to "
+                        "resume because replaying the original AC prompt would repeat "
+                        "acceptance work in the wrong phase"
+                    )
                 active_dispatch_candidates = candidate_handles[active_dispatch_id]
                 if not active_dispatch_candidates:
                     if active_dispatch_id in failed_dispatches:

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -757,6 +757,25 @@ class ACRuntimeHandleManager:
                     capsule_authorized = True
 
             if not capsule_authorized:
+                # A dispatch boundary without its prerequisite capsule is corrupt
+                # or partially-written history — the provider may already have been
+                # entered under authority we cannot verify. Treating it as fresh
+                # (skipping to None) would let the caller re-enter the provider, so
+                # fail closed instead. Absent any matching dispatch, this scope is
+                # legitimately empty for this attempt and is skipped.
+                if any(
+                    event.type == _AC_ATTEMPT_DISPATCHED_EVENT
+                    and self._event_matches_ac_runtime_identity(
+                        event.data if isinstance(event.data, dict) else {},
+                        runtime_identity,
+                    )
+                    for event in attempt_events
+                ):
+                    raise AmbiguousACExecutionError(
+                        "durable AC dispatch boundary exists without its prerequisite capsule "
+                        "authority; refusing to treat the attempt as fresh because the provider "
+                        "may already have been entered"
+                    )
                 continue
 
             unresolved_effect_event = any(

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -254,12 +254,21 @@ class ACRuntimeHandleManager:
             not isinstance(item, str) for item in missing_artifacts
         ):
             raise ValueError("durable completed AC verify outcome has invalid artifacts")
-        normalized = {
+        # Validate and preserve the optional byte-fitting omission counter rather
+        # than silently accepting a malformed value and dropping it.
+        omitted = value.get("missing_artifacts_omitted")
+        if omitted is not None and (
+            not isinstance(omitted, int) or isinstance(omitted, bool) or omitted < 0
+        ):
+            raise ValueError("durable completed AC verify outcome has an invalid omission count")
+        normalized: dict[str, Any] = {
             "passed": passed,
             "reason": reason,
             "output_tail": output_tail,
             "missing_artifacts": list(missing_artifacts),
         }
+        if omitted:
+            normalized["missing_artifacts_omitted"] = omitted
         encoded = json.dumps(
             normalized,
             sort_keys=True,

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -1255,6 +1255,27 @@ class ACRuntimeHandleManager:
                         "durable recovery linkage; refusing to resume its provider session "
                         "because external effects may precede the reported failure"
                     )
+                # Durable effect evidence outranks a resumable handle. An active
+                # dispatch that recorded a tool effect but did not terminate cannot
+                # be safely resumed: the caller (``_execute_atomic_ac``) resends the
+                # ORIGINAL AC prompt on resume, which starts ANOTHER provider turn
+                # and can duplicate the non-idempotent effect. We have no mechanism
+                # to continue the exact in-flight turn without resending the prompt,
+                # so fail closed regardless of handle availability.
+                if any(
+                    event.type in _AC_EFFECT_EVENT_TYPES
+                    and self._event_ac_dispatch_id(
+                        event.data if isinstance(event.data, dict) else {}
+                    )
+                    == active_dispatch_id
+                    for event in matching_events
+                ):
+                    raise AmbiguousACExecutionError(
+                        "AC active dispatch head recorded durable tool effects without "
+                        "terminating; refusing to resume because replaying the original AC "
+                        "prompt would start another provider turn and may duplicate "
+                        "non-idempotent effects"
+                    )
                 active_dispatch_candidates = candidate_handles[active_dispatch_id]
                 if not active_dispatch_candidates:
                     if active_dispatch_id in failed_dispatches:

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from dataclasses import replace
 from datetime import UTC, datetime
 import inspect
+import json
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -51,6 +52,10 @@ if TYPE_CHECKING:
 log = get_logger(__name__)
 
 _IMPLEMENTATION_SESSION_KIND = "implementation_session"
+_AC_ATTEMPT_DISPATCHED_EVENT = "execution.ac.attempt.dispatched"
+_AC_REUSABLE_RUNTIME_EVENT_TYPES = _REUSABLE_RUNTIME_EVENT_TYPES | {_AC_ATTEMPT_DISPATCHED_EVENT}
+_VERIFY_GATE_OUTCOME_KEYS = frozenset({"passed", "reason", "output_tail", "missing_artifacts"})
+_MAX_VERIFY_GATE_OUTCOME_CHARS = 65_536
 _AC_EFFECT_EVENT_TYPES = frozenset(
     {
         "execution.tool.started",
@@ -61,6 +66,23 @@ _AC_EFFECT_EVENT_TYPES = frozenset(
 
 class AmbiguousACExecutionError(RuntimeError):
     """A prior AC attempt may have external effects but cannot be resumed safely."""
+
+
+class CompletedACExecutionError(RuntimeError):
+    """The exact AC attempt already recorded a completed provider dispatch."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        result_summary: str | None = None,
+        session_id: str | None = None,
+        verify_gate_outcome: Mapping[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.result_summary = result_summary
+        self.session_id = session_id
+        self.verify_gate_outcome = verify_gate_outcome
 
 
 class ACRuntimeHandleManager:
@@ -144,18 +166,87 @@ class ACRuntimeHandleManager:
         *,
         retry_attempt: int,
     ) -> list[Any]:
-        """Slice the append-only AC stream down to the current attempt tail."""
+        """Select one attempt without depending on replay timestamp ordering."""
         attempt_events: list[Any] = []
-        for event in reversed(events):
+        for event in events:
             event_data = event.data if isinstance(getattr(event, "data", None), dict) else {}
             observed_attempt = cls._event_retry_attempt(event_data)
             if observed_attempt == retry_attempt:
                 attempt_events.append(event)
-                continue
-            if observed_attempt is not None and observed_attempt < retry_attempt:
-                break
-        attempt_events.reverse()
         return attempt_events
+
+    @staticmethod
+    def _validate_ac_dispatch_id(value: object) -> str:
+        """Return a canonical dispatch correlation id or reject persisted drift."""
+        if (
+            not isinstance(value, str)
+            or len(value) != 32
+            or any(character not in "0123456789abcdef" for character in value)
+        ):
+            raise ValueError("durable AC dispatch id is malformed")
+        return value
+
+    @classmethod
+    def _event_ac_dispatch_id(cls, event_data: Mapping[str, Any]) -> str | None:
+        """Read dispatch correlation from the event and its runtime payload."""
+        event_value = event_data.get("ac_dispatch_id")
+        runtime_value: object = None
+        runtime_payload = event_data.get("runtime")
+        if isinstance(runtime_payload, Mapping):
+            metadata = runtime_payload.get("metadata")
+            if isinstance(metadata, Mapping):
+                runtime_value = metadata.get("ac_dispatch_id")
+
+        event_dispatch_id = (
+            cls._validate_ac_dispatch_id(event_value) if event_value is not None else None
+        )
+        runtime_dispatch_id = (
+            cls._validate_ac_dispatch_id(runtime_value) if runtime_value is not None else None
+        )
+        if (
+            event_dispatch_id is not None
+            and runtime_dispatch_id is not None
+            and event_dispatch_id != runtime_dispatch_id
+        ):
+            raise ValueError("durable runtime handle dispatch id disagrees with its event")
+        return event_dispatch_id or runtime_dispatch_id
+
+    @staticmethod
+    def _parse_verify_gate_outcome(value: object) -> dict[str, Any] | None:
+        """Parse the bounded exact-shape verify result used for crash recovery."""
+        if value is None:
+            return None
+        if not isinstance(value, Mapping) or set(value) != _VERIFY_GATE_OUTCOME_KEYS:
+            raise ValueError("durable completed AC verify outcome has an invalid shape")
+        passed = value.get("passed")
+        reason = value.get("reason")
+        output_tail = value.get("output_tail")
+        missing_artifacts = value.get("missing_artifacts")
+        if not isinstance(passed, bool):
+            raise ValueError("durable completed AC verify outcome has an invalid verdict")
+        if reason is not None and not isinstance(reason, str):
+            raise ValueError("durable completed AC verify outcome has an invalid reason")
+        if not isinstance(output_tail, str):
+            raise ValueError("durable completed AC verify outcome has invalid output")
+        if not isinstance(missing_artifacts, list) or any(
+            not isinstance(item, str) for item in missing_artifacts
+        ):
+            raise ValueError("durable completed AC verify outcome has invalid artifacts")
+        normalized = {
+            "passed": passed,
+            "reason": reason,
+            "output_tail": output_tail,
+            "missing_artifacts": list(missing_artifacts),
+        }
+        encoded = json.dumps(
+            normalized,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        if len(encoded) > _MAX_VERIFY_GATE_OUTCOME_CHARS:
+            raise ValueError("durable completed AC verify outcome exceeds the size limit")
+        return normalized
 
     @staticmethod
     def _build_expected_ac_runtime_metadata(
@@ -656,17 +747,6 @@ class ACRuntimeHandleManager:
             if not capsule_authorized:
                 continue
 
-            if cached_handle is not None:
-                cached_fingerprint = cached_handle.metadata.get("ac_capsule_fingerprint")
-                cached_attempt_id = cached_handle.metadata.get("session_attempt_id")
-                if (
-                    cached_fingerprint == expected_capsule_fingerprint
-                    and cached_attempt_id == runtime_identity.session_attempt_id
-                ):
-                    return cached_handle
-                self.runtime_handles.pop(runtime_identity.cache_key, None)
-                cached_handle = None
-
             unresolved_effect_event = any(
                 event.type in _AC_EFFECT_EVENT_TYPES
                 and self._event_matches_ac_runtime_identity(
@@ -676,34 +756,172 @@ class ACRuntimeHandleManager:
                 for event in attempt_events
             )
 
-            for event in reversed(attempt_events):
-                event_data = event.data if isinstance(event.data, dict) else {}
-                if not self._event_matches_ac_runtime_identity(event_data, runtime_identity):
-                    continue
-
-                if event.type in _NON_REUSABLE_RUNTIME_EVENT_TYPES:
-                    self._forget_ac_runtime_handle(
-                        ac_index,
-                        execution_context_id=execution_context_id,
+            if expected_capsule_fingerprint is None:
+                if cached_handle is not None:
+                    return cached_handle
+                for event in reversed(attempt_events):
+                    event_data = event.data if isinstance(event.data, dict) else {}
+                    if not self._event_matches_ac_runtime_identity(event_data, runtime_identity):
+                        continue
+                    if event.type in _NON_REUSABLE_RUNTIME_EVENT_TYPES:
+                        self._forget_ac_runtime_handle(
+                            ac_index,
+                            execution_context_id=execution_context_id,
+                            is_sub_ac=is_sub_ac,
+                            parent_ac_index=parent_ac_index,
+                            sub_ac_index=sub_ac_index,
+                            node_identity=node_identity,
+                            retry_attempt=retry_attempt,
+                        )
+                        if unresolved_effect_event:
+                            raise AmbiguousACExecutionError(
+                                "AC attempt recorded tool effects without a reusable runtime "
+                                "handle; refusing fresh redispatch because non-idempotent "
+                                "effects may duplicate"
+                            )
+                        return None
+                    if event.type not in _REUSABLE_RUNTIME_EVENT_TYPES:
+                        continue
+                    runtime_handle = RuntimeHandle.from_dict(event_data.get("runtime"))
+                    runtime_handle = self._normalize_ac_runtime_handle(
+                        runtime_handle,
+                        runtime_scope=runtime_identity.runtime_scope,
+                        ac_index=ac_index,
                         is_sub_ac=is_sub_ac,
                         parent_ac_index=parent_ac_index,
                         sub_ac_index=sub_ac_index,
                         node_identity=node_identity,
                         retry_attempt=retry_attempt,
+                        source="persisted_event",
+                        require_resume_scope_match=True,
                     )
-                    if unresolved_effect_event:
-                        raise AmbiguousACExecutionError(
-                            "AC attempt recorded tool effects without a reusable runtime handle; "
-                            "refusing fresh redispatch because non-idempotent effects may duplicate"
-                        )
-                    return None
-                if event.type not in _REUSABLE_RUNTIME_EVENT_TYPES:
-                    continue
+                    if runtime_handle is not None:
+                        self.runtime_handles[runtime_identity.cache_key] = runtime_handle
+                        return runtime_handle
+                if unresolved_effect_event:
+                    raise AmbiguousACExecutionError(
+                        "AC attempt recorded tool effects without a reusable runtime handle; "
+                        "refusing fresh redispatch because non-idempotent effects may duplicate"
+                    )
+                continue
 
+            matching_events: list[Any] = []
+            dispatch_events: dict[str, Any] = {}
+            dispatch_predecessors: dict[str, str | None] = {}
+            for event in attempt_events:
+                event_data = event.data if isinstance(event.data, dict) else {}
+                if not self._event_matches_ac_runtime_identity(event_data, runtime_identity):
+                    continue
+                matching_events.append(event)
+                if event.type != _AC_ATTEMPT_DISPATCHED_EVENT:
+                    continue
+                dispatch_id = self._event_ac_dispatch_id(event_data)
+                if dispatch_id is None:
+                    raise ValueError("durable AC dispatch id is missing")
+                if dispatch_id in dispatch_events:
+                    raise ValueError("durable AC dispatch id is duplicated")
+                if "previous_ac_dispatch_id" not in event_data:
+                    raise ValueError("durable AC dispatch predecessor is missing")
+                predecessor_value = event_data.get("previous_ac_dispatch_id")
+                predecessor_id = (
+                    self._validate_ac_dispatch_id(predecessor_value)
+                    if predecessor_value is not None
+                    else None
+                )
+                if predecessor_id == dispatch_id:
+                    raise ValueError("durable AC dispatch predecessor references itself")
+                if event_data.get("capsule_fingerprint") != expected_capsule_fingerprint:
+                    raise ValueError(
+                        "durable AC dispatch fingerprint disagrees with the current capsule"
+                    )
+                if event_data.get("session_origin") not in {
+                    "fresh",
+                    "restored_same_attempt",
+                }:
+                    raise ValueError("durable AC dispatch session origin is invalid")
+                dispatch_events[dispatch_id] = event
+                dispatch_predecessors[dispatch_id] = predecessor_id
+
+            active_dispatch_id: str | None = None
+            if dispatch_events:
+                successor_by_dispatch: dict[str, str] = {}
+                for dispatch_id, predecessor_id in dispatch_predecessors.items():
+                    if predecessor_id is None:
+                        continue
+                    if predecessor_id not in dispatch_events:
+                        raise ValueError(
+                            "durable AC dispatch predecessor references an unknown dispatch id"
+                        )
+                    known_successor = successor_by_dispatch.get(predecessor_id)
+                    if known_successor not in {None, dispatch_id}:
+                        raise ValueError(
+                            "durable AC dispatch history branches from one predecessor"
+                        )
+                    successor_by_dispatch[predecessor_id] = dispatch_id
+
+                roots = [
+                    dispatch_id
+                    for dispatch_id, predecessor_id in dispatch_predecessors.items()
+                    if predecessor_id is None
+                ]
+                heads = [
+                    dispatch_id
+                    for dispatch_id in dispatch_events
+                    if dispatch_id not in successor_by_dispatch
+                ]
+                if len(roots) != 1 or len(heads) != 1:
+                    raise ValueError("durable AC dispatch history is not one linear chain")
+
+                active_dispatch_id = heads[0]
+                visited_dispatches: set[str] = set()
+                cursor: str | None = active_dispatch_id
+                while cursor is not None:
+                    if cursor in visited_dispatches:
+                        raise ValueError("durable AC dispatch history contains a cycle")
+                    visited_dispatches.add(cursor)
+                    cursor = dispatch_predecessors[cursor]
+                if len(visited_dispatches) != len(dispatch_events):
+                    raise ValueError("durable AC dispatch history is disconnected")
+
+            candidate_handles: dict[str, list[tuple[int, RuntimeHandle]]] = {
+                dispatch_id: [] for dispatch_id in dispatch_events
+            }
+            legacy_candidates: list[tuple[int, RuntimeHandle]] = []
+            completed_dispatches: dict[str, list[Mapping[str, Any]]] = {
+                dispatch_id: [] for dispatch_id in dispatch_events
+            }
+            failed_dispatches: set[str] = set()
+            recovery_successors: dict[str, str] = {}
+
+            def _load_candidate(
+                event: Any,
+                event_data: Mapping[str, Any],
+                *,
+                dispatch_id: str | None,
+            ) -> RuntimeHandle | None:
                 runtime_payload = event_data.get("runtime")
+                if (
+                    event.type != _AC_ATTEMPT_DISPATCHED_EVENT
+                    and isinstance(runtime_payload, Mapping)
+                    and isinstance(runtime_payload.get("cwd"), str)
+                    and expected_capsule_workspace is not None
+                ):
+                    persisted_workspace = os.path.realpath(
+                        os.path.expanduser(runtime_payload["cwd"])
+                    )
+                    if persisted_workspace != expected_capsule_workspace:
+                        raise ValueError("persisted runtime handle workspace authority changed")
                 try:
-                    runtime_handle = RuntimeHandle.from_dict(runtime_payload)
+                    runtime_handle = (
+                        RuntimeHandle.from_dispatch_recovery_dict(runtime_payload)
+                        if event.type == _AC_ATTEMPT_DISPATCHED_EVENT
+                        else RuntimeHandle.from_persisted_recovery_projection(runtime_payload)
+                    )
                 except ValueError as exc:
+                    if event.type == _AC_ATTEMPT_DISPATCHED_EVENT:
+                        raise ValueError(
+                            "durable AC dispatch recovery handle is malformed"
+                        ) from exc
                     log.warning(
                         "parallel_executor.persisted_runtime_handle_invalid",
                         aggregate_id=event.aggregate_id,
@@ -713,25 +931,29 @@ class ACRuntimeHandleManager:
                         if isinstance(runtime_payload, dict)
                         else None,
                     )
-                    continue
+                    return None
                 if runtime_handle is None:
-                    continue
-                if expected_capsule_fingerprint is not None:
-                    self._validate_resumable_handle_authority(
-                        runtime_handle,
-                        expected_workspace=expected_capsule_workspace,
+                    return None
+                runtime_handle = replace(runtime_handle, cwd=expected_capsule_workspace)
+                self._validate_resumable_handle_authority(
+                    runtime_handle,
+                    expected_workspace=expected_capsule_workspace,
+                )
+                runtime_fingerprint = runtime_handle.metadata.get("ac_capsule_fingerprint")
+                runtime_attempt_id = runtime_handle.metadata.get("session_attempt_id")
+                if runtime_fingerprint != expected_capsule_fingerprint:
+                    raise ValueError(
+                        "persisted runtime handle disagrees with the durable AC capsule"
                     )
-                    runtime_fingerprint = runtime_handle.metadata.get("ac_capsule_fingerprint")
-                    runtime_attempt_id = runtime_handle.metadata.get("session_attempt_id")
-                    if runtime_fingerprint not in {None, expected_capsule_fingerprint}:
-                        raise ValueError(
-                            "persisted runtime handle disagrees with the durable AC capsule"
-                        )
-                    if (
-                        runtime_fingerprint is None
-                        or runtime_attempt_id != runtime_identity.session_attempt_id
-                    ):
-                        continue
+                if runtime_attempt_id != runtime_identity.session_attempt_id:
+                    raise ValueError(
+                        "persisted runtime handle disagrees with the durable AC attempt"
+                    )
+                runtime_dispatch_id = runtime_handle.metadata.get("ac_dispatch_id")
+                if dispatch_id is not None and runtime_dispatch_id != dispatch_id:
+                    raise ValueError(
+                        "persisted runtime handle disagrees with the durable AC dispatch"
+                    )
                 runtime_handle = self._normalize_ac_runtime_handle(
                     runtime_handle,
                     runtime_scope=runtime_identity.runtime_scope,
@@ -744,9 +966,244 @@ class ACRuntimeHandleManager:
                     source="persisted_event",
                     require_resume_scope_match=True,
                 )
+                if not self._is_resumable_runtime_handle(runtime_handle):
+                    return None
+                return runtime_handle
+
+            recovery_priority = {
+                _AC_ATTEMPT_DISPATCHED_EVENT: 0,
+                "execution.session.failed": 1,
+                "execution.session.started": 2,
+                "execution.session.resumed": 3,
+                "execution.session.recovered": 4,
+            }
+            recovery_event_types = _AC_REUSABLE_RUNTIME_EVENT_TYPES | {"execution.session.failed"}
+            for event in matching_events:
+                if event.type not in recovery_event_types | {"execution.session.completed"}:
+                    continue
+                event_data = event.data if isinstance(event.data, dict) else {}
+                event_dispatch_id = self._event_ac_dispatch_id(event_data)
+                if dispatch_events:
+                    if event_dispatch_id is None:
+                        continue
+                    if event_dispatch_id not in dispatch_events:
+                        raise ValueError(
+                            "durable AC lifecycle event references an unknown dispatch id"
+                        )
+                if event.type == "execution.session.completed":
+                    if event_data.get("success") is not True:
+                        raise ValueError("durable completed AC lifecycle is not successful")
+                    if event_dispatch_id is not None:
+                        completed_dispatches[event_dispatch_id].append(event_data)
+                    elif not dispatch_events:
+                        verify_gate_outcome = self._parse_verify_gate_outcome(
+                            event_data.get("verify_gate_outcome")
+                        )
+                        raise CompletedACExecutionError(
+                            "AC attempt already completed; refusing same-attempt redispatch",
+                            result_summary=event_data.get("result_summary")
+                            if isinstance(event_data.get("result_summary"), str)
+                            else None,
+                            session_id=event_data.get("session_id")
+                            if isinstance(event_data.get("session_id"), str)
+                            else None,
+                            verify_gate_outcome=verify_gate_outcome,
+                        )
+                    continue
+                if event.type == "execution.session.failed" and event_dispatch_id is not None:
+                    failed_dispatches.add(event_dispatch_id)
+                runtime_handle = _load_candidate(
+                    event,
+                    event_data,
+                    dispatch_id=event_dispatch_id if dispatch_events else None,
+                )
                 if runtime_handle is None:
                     continue
+                if event.type == "execution.session.recovered":
+                    discontinuity = event_data.get("recovery_discontinuity")
+                    if not isinstance(discontinuity, Mapping):
+                        raise ValueError("durable recovered lifecycle is missing linkage")
+                    failed = discontinuity.get("failed")
+                    replacement = discontinuity.get("replacement")
+                    if not isinstance(failed, Mapping) or not isinstance(replacement, Mapping):
+                        raise ValueError("durable recovered lifecycle linkage is malformed")
+                    failed_resume_id = failed.get("resume_session_id")
+                    replacement_resume_id = replacement.get("resume_session_id")
+                    if (
+                        not isinstance(failed_resume_id, str)
+                        or not failed_resume_id
+                        or not isinstance(replacement_resume_id, str)
+                        or not replacement_resume_id
+                    ):
+                        raise ValueError("durable recovered lifecycle linkage is incomplete")
+                    if self._runtime_resume_session_id(runtime_handle) != replacement_resume_id:
+                        raise ValueError(
+                            "durable recovered lifecycle replacement disagrees with its handle"
+                        )
+                    known_successor = recovery_successors.get(failed_resume_id)
+                    if known_successor not in {None, replacement_resume_id}:
+                        raise AmbiguousACExecutionError(
+                            "AC recovery history maps one failed runtime session to conflicting "
+                            "replacement sessions"
+                        )
+                    recovery_successors[failed_resume_id] = replacement_resume_id
+                priority = recovery_priority[event.type]
+                if event_dispatch_id is None:
+                    legacy_candidates.append((priority, runtime_handle))
+                else:
+                    candidate_handles[event_dispatch_id].append((priority, runtime_handle))
 
+            if cached_handle is not None and self._is_resumable_runtime_handle(cached_handle):
+                cached_fingerprint = cached_handle.metadata.get("ac_capsule_fingerprint")
+                cached_attempt_id = cached_handle.metadata.get("session_attempt_id")
+                if (
+                    cached_fingerprint != expected_capsule_fingerprint
+                    or cached_attempt_id != runtime_identity.session_attempt_id
+                ):
+                    self.runtime_handles.pop(runtime_identity.cache_key, None)
+                    cached_handle = None
+                else:
+                    cached_dispatch_value = cached_handle.metadata.get("ac_dispatch_id")
+                    cached_dispatch_id = (
+                        self._validate_ac_dispatch_id(cached_dispatch_value)
+                        if cached_dispatch_value is not None
+                        else None
+                    )
+                    if dispatch_events:
+                        if cached_dispatch_id not in dispatch_events:
+                            raise ValueError(
+                                "cached runtime handle references an unknown AC dispatch"
+                            )
+                        candidate_handles[cached_dispatch_id].append((5, cached_handle))
+                    else:
+                        legacy_candidates.append((5, cached_handle))
+
+            active_completed_events = (
+                completed_dispatches[active_dispatch_id] if active_dispatch_id is not None else []
+            )
+            if active_completed_events:
+                self._forget_ac_runtime_handle(
+                    ac_index,
+                    execution_context_id=execution_context_id,
+                    is_sub_ac=is_sub_ac,
+                    parent_ac_index=parent_ac_index,
+                    sub_ac_index=sub_ac_index,
+                    node_identity=node_identity,
+                    retry_attempt=retry_attempt,
+                )
+                completed_facts = {
+                    (
+                        event_data.get("result_summary")
+                        if isinstance(event_data.get("result_summary"), str)
+                        else None,
+                        event_data.get("session_id")
+                        if isinstance(event_data.get("session_id"), str)
+                        else None,
+                    )
+                    for event_data in active_completed_events
+                }
+                if len(completed_facts) != 1:
+                    raise ValueError("durable completed AC lifecycle events disagree")
+                result_summary, completed_session_id = next(iter(completed_facts))
+                parsed_verify_outcomes = [
+                    self._parse_verify_gate_outcome(event_data.get("verify_gate_outcome"))
+                    for event_data in active_completed_events
+                ]
+                completed_verify_outcomes = {
+                    json.dumps(
+                        outcome,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                        ensure_ascii=False,
+                    )
+                    for outcome in parsed_verify_outcomes
+                }
+                if len(completed_verify_outcomes) != 1:
+                    raise ValueError("durable completed AC verify outcomes disagree")
+                completed_verify_outcome = parsed_verify_outcomes[0]
+                raise CompletedACExecutionError(
+                    "AC attempt already completed; refusing same-attempt redispatch",
+                    result_summary=result_summary,
+                    session_id=completed_session_id,
+                    verify_gate_outcome=completed_verify_outcome,
+                )
+
+            if dispatch_events:
+                if active_dispatch_id is None:  # pragma: no cover - guarded by chain validation
+                    raise ValueError("durable AC dispatch history has no active boundary")
+                active_dispatch_candidates = candidate_handles[active_dispatch_id]
+                if not active_dispatch_candidates:
+                    if active_dispatch_id in failed_dispatches:
+                        raise AmbiguousACExecutionError(
+                            "AC provider dispatch failed without a reusable runtime handle; "
+                            "refusing fresh redispatch because external effects may have occurred"
+                        )
+                    raise AmbiguousACExecutionError(
+                        "AC attempt crossed the provider dispatch boundary without a reusable "
+                        "runtime handle; refusing fresh redispatch because external effects may "
+                        "have occurred"
+                    )
+                all_candidates = active_dispatch_candidates
+            else:
+                all_candidates = legacy_candidates
+
+            resume_ids = {
+                self._runtime_resume_session_id(runtime_handle)
+                for _, runtime_handle in all_candidates
+            }
+            resume_ids.discard(None)
+            resolved_resume_ids: set[str] = set()
+            for resume_id in resume_ids:
+                current_id = resume_id
+                visited: set[str] = set()
+                while current_id in recovery_successors:
+                    if current_id in visited:
+                        raise AmbiguousACExecutionError(
+                            "AC recovery history contains a runtime-session replacement cycle"
+                        )
+                    visited.add(current_id)
+                    current_id = recovery_successors[current_id]
+                resolved_resume_ids.add(current_id)
+            if len(resolved_resume_ids) > 1:
+                raise AmbiguousACExecutionError(
+                    "AC attempt has conflicting reusable runtime sessions; refusing to guess "
+                    "which provider session owns the external effects"
+                )
+            if all_candidates:
+                active_resume_id = next(iter(resolved_resume_ids))
+                active_candidates = [
+                    candidate
+                    for candidate in all_candidates
+                    if self._runtime_resume_session_id(candidate[1]) == active_resume_id
+                ]
+                if not active_candidates:
+                    raise AmbiguousACExecutionError(
+                        "AC recovery history names a replacement runtime session without a "
+                        "reusable handle"
+                    )
+                highest_priority = max(priority for priority, _ in active_candidates)
+                highest_candidates = [
+                    runtime_handle
+                    for priority, runtime_handle in active_candidates
+                    if priority == highest_priority
+                ]
+                continuity_facts = {
+                    (
+                        runtime_handle.backend,
+                        runtime_handle.native_session_id,
+                        runtime_handle.server_session_id,
+                        runtime_handle.conversation_id,
+                        runtime_handle.previous_response_id,
+                        runtime_handle.approval_mode,
+                    )
+                    for runtime_handle in highest_candidates
+                }
+                if len(continuity_facts) != 1:
+                    raise AmbiguousACExecutionError(
+                        "AC recovery history has equally authoritative but conflicting runtime "
+                        "continuation handles"
+                    )
+                runtime_handle = highest_candidates[0]
                 self.runtime_handles[runtime_identity.cache_key] = runtime_handle
                 return runtime_handle
 
@@ -754,6 +1211,11 @@ class ACRuntimeHandleManager:
                 raise AmbiguousACExecutionError(
                     "AC attempt recorded tool effects without a reusable runtime handle; "
                     "refusing fresh redispatch because non-idempotent effects may duplicate"
+                )
+            if any(event.type == "execution.session.failed" for event in matching_events):
+                raise AmbiguousACExecutionError(
+                    "AC provider dispatch failed without a reusable runtime handle; refusing "
+                    "fresh redispatch because external effects may have occurred"
                 )
 
         return None
@@ -1154,6 +1616,7 @@ class ACRuntimeHandleManager:
         *,
         event_type: str,
         runtime_identity: ACRuntimeIdentity,
+        dispatch_id: str | None = None,
         ac_content: str,
         runtime_handle: RuntimeHandle | None,
         execution_id: str | None = None,
@@ -1161,6 +1624,7 @@ class ACRuntimeHandleManager:
         result_summary: str | None = None,
         success: bool | None = None,
         error: str | None = None,
+        verify_gate_outcome: Mapping[str, Any] | None = None,
     ) -> None:
         """Persist AC-scoped runtime lifecycle events using normalized metadata."""
         from ouroboros.events.base import BaseEvent
@@ -1168,13 +1632,36 @@ class ACRuntimeHandleManager:
         effective_session_id = session_id or self._runtime_resume_session_id(runtime_handle)
         server_session_id = runtime_handle.server_session_id if runtime_handle is not None else None
         identity_metadata = runtime_identity.to_metadata()
+        runtime_dispatch_value = (
+            runtime_handle.metadata.get("ac_dispatch_id") if runtime_handle is not None else None
+        )
+        runtime_dispatch_id = (
+            self._validate_ac_dispatch_id(runtime_dispatch_value)
+            if runtime_dispatch_value is not None
+            else None
+        )
+        if dispatch_id is not None:
+            dispatch_id = self._validate_ac_dispatch_id(dispatch_id)
+        if (
+            dispatch_id is not None
+            and runtime_dispatch_id is not None
+            and dispatch_id != runtime_dispatch_id
+        ):
+            raise ValueError("runtime lifecycle dispatch id disagrees with its handle")
+        effective_dispatch_id = dispatch_id or runtime_dispatch_id
 
+        persisted_verify_gate_outcome = self._parse_verify_gate_outcome(verify_gate_outcome)
         event = BaseEvent(
             type=event_type,
             aggregate_type=runtime_identity.runtime_scope.aggregate_type,
             aggregate_id=runtime_identity.session_scope_id,
             data={
                 **identity_metadata,
+                **(
+                    {"ac_dispatch_id": effective_dispatch_id}
+                    if effective_dispatch_id is not None
+                    else {}
+                ),
                 "ac_id": runtime_identity.ac_id,
                 "acceptance_criterion": ac_content,
                 "scope": runtime_identity.scope,
@@ -1194,6 +1681,7 @@ class ACRuntimeHandleManager:
                 "success": success,
                 "result_summary": result_summary,
                 "error": error,
+                "verify_gate_outcome": (persisted_verify_gate_outcome),
             },
         )
         if runtime_handle is not None:

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -55,6 +55,9 @@ _IMPLEMENTATION_SESSION_KIND = "implementation_session"
 _AC_ATTEMPT_DISPATCHED_EVENT = "execution.ac.attempt.dispatched"
 _AC_REUSABLE_RUNTIME_EVENT_TYPES = _REUSABLE_RUNTIME_EVENT_TYPES | {_AC_ATTEMPT_DISPATCHED_EVENT}
 _VERIFY_GATE_OUTCOME_KEYS = frozenset({"passed", "reason", "output_tail", "missing_artifacts"})
+# The byte-bounding writer records this counter when it drops trailing artifacts
+# to fit the size cap; accept it on replay without treating it as a shape error.
+_VERIFY_GATE_OUTCOME_OPTIONAL_KEYS = frozenset({"missing_artifacts_omitted"})
 # 64 KiB measured in UTF-8 bytes (the persisted/replayed size), not Unicode code
 # points — a multi-byte outcome must be bounded by its actual encoded size.
 _MAX_VERIFY_GATE_OUTCOME_BYTES = 65_536
@@ -230,7 +233,12 @@ class ACRuntimeHandleManager:
         """Parse the bounded exact-shape verify result used for crash recovery."""
         if value is None:
             return None
-        if not isinstance(value, Mapping) or set(value) != _VERIFY_GATE_OUTCOME_KEYS:
+        if not isinstance(value, Mapping):
+            raise ValueError("durable completed AC verify outcome has an invalid shape")
+        keys = set(value)
+        if not keys >= _VERIFY_GATE_OUTCOME_KEYS or (
+            keys - _VERIFY_GATE_OUTCOME_KEYS - _VERIFY_GATE_OUTCOME_OPTIONAL_KEYS
+        ):
             raise ValueError("durable completed AC verify outcome has an invalid shape")
         passed = value.get("passed")
         reason = value.get("reason")

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import replace
 from datetime import UTC, datetime
+import os
 from typing import TYPE_CHECKING, Any
 
 from ouroboros.observability.logging import get_logger
@@ -325,6 +326,30 @@ class ACRuntimeHandleManager:
                 )
         return normalized_handle
 
+    def _validate_resumable_handle_authority(
+        self,
+        runtime_handle: RuntimeHandle,
+        *,
+        expected_workspace: str | None,
+    ) -> None:
+        """Reject provider continuity from a different runtime authority."""
+        if not self._is_resumable_runtime_handle(runtime_handle):
+            return
+        runtime_backend = getattr(self._adapter, "runtime_backend", None)
+        if isinstance(runtime_backend, str) and runtime_backend:
+            if runtime_handle.backend != runtime_backend:
+                raise ValueError("persisted runtime handle backend authority changed")
+        permission_mode = getattr(self._adapter, "permission_mode", None)
+        if isinstance(permission_mode, str) and permission_mode:
+            if runtime_handle.approval_mode != permission_mode:
+                raise ValueError("persisted runtime handle permission authority changed")
+        if expected_workspace is not None:
+            if not runtime_handle.cwd:
+                raise ValueError("persisted runtime handle workspace authority is missing")
+            observed_workspace = os.path.realpath(os.path.expanduser(runtime_handle.cwd))
+            if observed_workspace != expected_workspace:
+                raise ValueError("persisted runtime handle workspace authority changed")
+
     def _build_ac_runtime_handle(
         self,
         ac_index: int,
@@ -430,6 +455,7 @@ class ACRuntimeHandleManager:
         node_identity: ExecutionNodeIdentity | None = None,
         retry_attempt: int = 0,
         expected_capsule_fingerprint: str | None = None,
+        expected_capsule_workspace: str | None = None,
     ) -> RuntimeHandle | None:
         """Load the latest reusable AC-scoped runtime handle from execution events."""
         runtime_identity = self._resolve_ac_runtime_identity(
@@ -442,6 +468,11 @@ class ACRuntimeHandleManager:
             retry_attempt=retry_attempt,
         )
         cached_runtime_handle = self.runtime_handles.get(runtime_identity.cache_key)
+        if cached_runtime_handle is not None and expected_capsule_fingerprint is not None:
+            self._validate_resumable_handle_authority(
+                cached_runtime_handle,
+                expected_workspace=expected_capsule_workspace,
+            )
         cached_handle = self._normalize_ac_runtime_handle(
             cached_runtime_handle,
             runtime_scope=runtime_identity.runtime_scope,
@@ -569,6 +600,10 @@ class ACRuntimeHandleManager:
                 if runtime_handle is None:
                     continue
                 if expected_capsule_fingerprint is not None:
+                    self._validate_resumable_handle_authority(
+                        runtime_handle,
+                        expected_workspace=expected_capsule_workspace,
+                    )
                     runtime_fingerprint = runtime_handle.metadata.get("ac_capsule_fingerprint")
                     runtime_attempt_id = runtime_handle.metadata.get("session_attempt_id")
                     if runtime_fingerprint not in {None, expected_capsule_fingerprint}:

--- a/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
+++ b/src/ouroboros/orchestrator/ac_runtime_handle_manager.py
@@ -939,6 +939,7 @@ class ACRuntimeHandleManager:
                 dispatch_id: [] for dispatch_id in dispatch_events
             }
             failed_dispatches: set[str] = set()
+            recovered_dispatch_ids: set[str] = set()
             recovery_successors: dict[str, str] = {}
 
             def _load_candidate(
@@ -1060,6 +1061,8 @@ class ACRuntimeHandleManager:
                     continue
                 if event.type == "execution.session.failed" and event_dispatch_id is not None:
                     failed_dispatches.add(event_dispatch_id)
+                if event.type == "execution.session.recovered" and event_dispatch_id is not None:
+                    recovered_dispatch_ids.add(event_dispatch_id)
                 runtime_handle = _load_candidate(
                     event,
                     event_data,
@@ -1205,6 +1208,23 @@ class ACRuntimeHandleManager:
                         "dispatch head; refusing to resume because a follow-up superseded it "
                         "without a durable terminal outcome and replaying the AC prompt would "
                         "repeat completed work"
+                    )
+                # Terminal failure evidence takes precedence over a resumable
+                # handle. A dispatch with a durable ``execution.session.failed``
+                # ran a provider turn whose effects may precede the reported
+                # failure; resuming it would send another provider turn and could
+                # repeat non-idempotent effects. The ONLY safe resume is an
+                # explicit ``execution.session.recovered`` linkage to a live
+                # replacement session; without it, fail closed before selecting a
+                # handle instead of reconnecting to the failed session.
+                if (
+                    active_dispatch_id in failed_dispatches
+                    and active_dispatch_id not in recovered_dispatch_ids
+                ):
+                    raise AmbiguousACExecutionError(
+                        "AC recovery resolved a terminally failed dispatch head without a "
+                        "durable recovery linkage; refusing to resume its provider session "
+                        "because external effects may precede the reported failure"
                     )
                 active_dispatch_candidates = candidate_handles[active_dispatch_id]
                 if not active_dispatch_candidates:

--- a/src/ouroboros/orchestrator/adapter.py
+++ b/src/ouroboros/orchestrator/adapter.py
@@ -138,7 +138,10 @@ _DISPATCH_RECOVERY_PAYLOAD_KEYS = frozenset(
         "previous_response_id",
     }
 )
-_MAX_DISPATCH_RECOVERY_PAYLOAD_CHARS = 65_536
+# 64 KiB measured in UTF-8 bytes (the on-the-wire/persisted size), not Unicode
+# code points — a payload of multi-byte characters must be bounded by its actual
+# encoded size.
+_MAX_DISPATCH_RECOVERY_PAYLOAD_BYTES = 65_536
 
 _RUNTIME_TERMINAL_STATES = frozenset({"cancelled", "completed", "failed", "terminated"})
 _RUNTIME_LIFECYCLE_STATE_BY_EVENT_TYPE = {
@@ -735,7 +738,7 @@ class RuntimeHandle:
             separators=(",", ":"),
             ensure_ascii=False,
         )
-        if len(encoded) > _MAX_DISPATCH_RECOVERY_PAYLOAD_CHARS:
+        if len(encoded.encode("utf-8")) > _MAX_DISPATCH_RECOVERY_PAYLOAD_BYTES:
             raise ValueError("dispatch recovery handle exceeds the size limit")
         return payload
 
@@ -761,7 +764,7 @@ class RuntimeHandle:
             )
         except (TypeError, ValueError) as exc:
             raise ValueError("dispatch recovery handle is not serializable") from exc
-        if len(encoded) > _MAX_DISPATCH_RECOVERY_PAYLOAD_CHARS:
+        if len(encoded.encode("utf-8")) > _MAX_DISPATCH_RECOVERY_PAYLOAD_BYTES:
             raise ValueError("dispatch recovery handle exceeds the size limit")
         return cls.from_dict(value)
 

--- a/src/ouroboros/orchestrator/adapter.py
+++ b/src/ouroboros/orchestrator/adapter.py
@@ -22,6 +22,7 @@ from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from enum import StrEnum
+import json
 import math
 import os
 from pathlib import Path
@@ -33,6 +34,9 @@ from ouroboros.core.session_signal import SessionSignalCapabilities
 from ouroboros.core.types import Result
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.backend_limits import resolve_backend_limits
+from ouroboros.orchestrator.evidence.runtime_metadata import (
+    _AC_RUNTIME_OWNERSHIP_METADATA_KEYS,
+)
 from ouroboros.orchestrator.rate_limit import (
     DEFAULT_ANTHROPIC_RPM_CEILING,
     DEFAULT_ANTHROPIC_TPM_CEILING,
@@ -70,6 +74,10 @@ _OPENCODE_PERSISTED_METADATA_KEYS = frozenset(
     {
         "ac_id",
         "ac_index",
+        "ac_capsule_fingerprint",
+        "ac_capsule_version",
+        "ac_dispatch_id",
+        "ac_session_origin",
         "attempt_number",
         "depth",
         "display_path",
@@ -109,6 +117,28 @@ _OPENCODE_PERSISTED_METADATA_KEYS = frozenset(
         "turn_number",
     }
 )
+
+_DISPATCH_RECOVERY_METADATA_KEYS = _AC_RUNTIME_OWNERSHIP_METADATA_KEYS | frozenset(
+    {
+        "ac_capsule_fingerprint",
+        "ac_capsule_version",
+        "ac_dispatch_id",
+        "ac_session_origin",
+        "server_session_id",
+    }
+)
+_DISPATCH_RECOVERY_PAYLOAD_KEYS = frozenset(
+    {
+        "approval_mode",
+        "backend",
+        "conversation_id",
+        "kind",
+        "metadata",
+        "native_session_id",
+        "previous_response_id",
+    }
+)
+_MAX_DISPATCH_RECOVERY_PAYLOAD_CHARS = 65_536
 
 _RUNTIME_TERMINAL_STATES = frozenset({"cancelled", "completed", "failed", "terminated"})
 _RUNTIME_LIFECYCLE_STATE_BY_EVENT_TYPE = {
@@ -607,7 +637,7 @@ class RuntimeHandle:
 
     def snapshot(self) -> dict[str, Any]:
         """Return a serializable snapshot of lifecycle and control state."""
-        return {
+        payload = {
             "backend": self.backend,
             "kind": self.kind,
             "native_session_id": self.native_session_id,
@@ -624,6 +654,7 @@ class RuntimeHandle:
             "can_terminate": self.can_terminate,
             "metadata": dict(self.metadata),
         }
+        return payload
 
     async def observe(self) -> dict[str, Any]:
         """Return the latest observable runtime state for this handle."""
@@ -674,6 +705,91 @@ class RuntimeHandle:
             "approval_mode": self.approval_mode,
             "metadata": metadata,
         }
+
+    def to_dispatch_recovery_dict(self) -> dict[str, Any]:
+        """Serialize only authority and reconnect state for a dispatch boundary.
+
+        The pre-provider dispatch event is correctness-bearing and replayed on
+        every crash recovery.  It must not duplicate workspace paths, transcript
+        locations, tool schemas, capability graphs, control-plane projections,
+        or arbitrary provider metadata.  The current capsule rebinds workspace
+        authority before a recovered handle is validated.
+        """
+        metadata = {
+            key: value
+            for key, value in self.metadata.items()
+            if key in _DISPATCH_RECOVERY_METADATA_KEYS
+        }
+        payload = {
+            "backend": self.backend,
+            "kind": self.kind,
+            "native_session_id": self.native_session_id,
+            "conversation_id": self.conversation_id,
+            "previous_response_id": self.previous_response_id,
+            "approval_mode": self.approval_mode,
+            "metadata": metadata,
+        }
+        encoded = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        if len(encoded) > _MAX_DISPATCH_RECOVERY_PAYLOAD_CHARS:
+            raise ValueError("dispatch recovery handle exceeds the size limit")
+        return payload
+
+    @classmethod
+    def from_dispatch_recovery_dict(cls, value: object) -> RuntimeHandle | None:
+        """Parse the bounded, allowlisted provider-boundary recovery contract."""
+        if value is None:
+            return None
+        if not isinstance(value, dict) or set(value) != _DISPATCH_RECOVERY_PAYLOAD_KEYS:
+            raise ValueError("dispatch recovery handle has an invalid shape")
+        metadata = value.get("metadata")
+        if not isinstance(metadata, dict):
+            raise ValueError("dispatch recovery handle metadata is invalid")
+        unknown_metadata = set(metadata) - _DISPATCH_RECOVERY_METADATA_KEYS
+        if unknown_metadata:
+            raise ValueError("dispatch recovery handle metadata is not allowlisted")
+        try:
+            encoded = json.dumps(
+                value,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            )
+        except (TypeError, ValueError) as exc:
+            raise ValueError("dispatch recovery handle is not serializable") from exc
+        if len(encoded) > _MAX_DISPATCH_RECOVERY_PAYLOAD_CHARS:
+            raise ValueError("dispatch recovery handle exceeds the size limit")
+        return cls.from_dict(value)
+
+    @classmethod
+    def from_persisted_recovery_projection(cls, value: object) -> RuntimeHandle | None:
+        """Project a full lifecycle handle onto the bounded recovery contract."""
+        if value is None:
+            return None
+        if not isinstance(value, Mapping):
+            raise ValueError("persisted runtime handle is invalid")
+        raw_metadata = value.get("metadata")
+        if not isinstance(raw_metadata, Mapping):
+            raise ValueError("persisted runtime handle metadata is invalid")
+        metadata = {
+            key: raw_metadata[key]
+            for key in _DISPATCH_RECOVERY_METADATA_KEYS
+            if key in raw_metadata
+        }
+        payload = {
+            "backend": value.get("backend", value.get("provider")),
+            "kind": value.get("kind", "agent_runtime"),
+            "native_session_id": value.get("native_session_id"),
+            "conversation_id": value.get("conversation_id"),
+            "previous_response_id": value.get("previous_response_id"),
+            "approval_mode": value.get("approval_mode"),
+            "metadata": metadata,
+        }
+        return cls.from_dispatch_recovery_dict(payload)
 
     def to_session_state_dict(self) -> dict[str, Any]:
         """Serialize only the runtime state required to resume a session later.

--- a/src/ouroboros/orchestrator/adapter.py
+++ b/src/ouroboros/orchestrator/adapter.py
@@ -1078,6 +1078,15 @@ class RuntimeCapabilities:
     # Synapse is independently capability-gated.  Existing runtimes must remain
     # unchanged until a transport proves and tests each delivery boundary.
     session_signals: SessionSignalCapabilities = field(default_factory=SessionSignalCapabilities)
+    # Whether the driver yields tool-effect events in REAL TIME (before the tool
+    # runs / as it runs), so a stall with no observed tool effect proves no
+    # effect occurred. Defaults to False: a buffered driver that awaits the whole
+    # turn before yielding tool events (e.g. the Claude worker transport) can
+    # mutate the workspace and then hang WITHOUT emitting any message, so the
+    # orchestrator must fail closed on such a stall rather than fresh-redispatch.
+    # A runtime opts in to True only when it verifiably streams tool effects as
+    # they happen, which lets an effect-free stall stay retryable.
+    realtime_tool_effect_visibility: bool = False
 
 
 # Default capability profile for first-class backends (Claude, Codex).

--- a/src/ouroboros/orchestrator/atomic_prompt_builder.py
+++ b/src/ouroboros/orchestrator/atomic_prompt_builder.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 
 from ouroboros.core.seed import AcceptanceCriterionSpec
 from ouroboros.core.seed_contract_prompt import render_auto_recursion_guard
+from ouroboros.orchestrator.ac_execution_capsule import ACExecutionCapsule
 from ouroboros.orchestrator.evidence.ac_classification import (
     _effective_evidence_schema_for_ac,
     _is_documentation_only_ac,
@@ -83,21 +84,22 @@ class AtomicPromptBuilder:
     def build(
         self,
         *,
+        capsule: ACExecutionCapsule,
         ac_index: int,
-        ac_content: str,
-        seed_goal: str,
         is_sub_ac: bool,
         parent_ac_index: int | None,
         sub_ac_index: int | None,
         node_identity: ExecutionNodeIdentity | None,
         level_contexts: list[LevelContext] | None,
         sibling_acs: list[_SiblingACRef] | None,
-        retry_attempt: int,
         retry_prompt_extra: str,
         ac_spec: AcceptanceCriterionSpec | None,
     ) -> AtomicPromptBundle:
         """Build the prompt for one atomic leaf dispatch."""
         executor = self._executor
+        ac_content = capsule.ac_content
+        seed_goal = capsule.seed_goal
+        retry_attempt = capsule.retry_attempt
 
         # Build prompt
         if node_identity is not None:
@@ -291,6 +293,8 @@ Files present:
 
 ## Goal Context
 {seed_goal}
+
+{capsule.to_prompt_reference_block()}
 
 {render_auto_recursion_guard()}
 

--- a/src/ouroboros/orchestrator/atomic_prompt_builder.py
+++ b/src/ouroboros/orchestrator/atomic_prompt_builder.py
@@ -17,7 +17,10 @@ from typing import TYPE_CHECKING, Any
 
 from ouroboros.core.seed import AcceptanceCriterionSpec
 from ouroboros.core.seed_contract_prompt import render_auto_recursion_guard
-from ouroboros.orchestrator.ac_execution_capsule import ACExecutionCapsule
+from ouroboros.orchestrator.ac_execution_capsule import (
+    ACExecutionCapsule,
+    ACSuccessContract,
+)
 from ouroboros.orchestrator.evidence.ac_classification import (
     _effective_evidence_schema_for_ac,
     _is_documentation_only_ac,
@@ -31,7 +34,9 @@ if TYPE_CHECKING:
     from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 
 
-def _build_success_contract_block(spec: AcceptanceCriterionSpec | None) -> str:
+def _build_success_contract_block(
+    spec: AcceptanceCriterionSpec | ACSuccessContract | None,
+) -> str:
     """Render the worker-facing SUCCESS CONTRACT block for an AC, or ``""``.
 
     The parallel leaf dispatch builds its own prompt (it does not go through the
@@ -42,22 +47,23 @@ def _build_success_contract_block(spec: AcceptanceCriterionSpec | None) -> str:
     worker runs and reports the same evidence the verify gate checks. Contract-less
     ACs return ``""`` — the prompt stays byte-identical to before.
     """
-    if spec is None or not spec.has_success_contract:
+    contract = spec if isinstance(spec, ACSuccessContract) else ACSuccessContract.from_ac_spec(spec)
+    if not contract.has_success_contract:
         return ""
     lines = ["SUCCESS CONTRACT for this AC:"]
-    if spec.verify_command:
+    if contract.verify_command:
         lines.append(
-            f"- Run locally before completion: {spec.verify_command}. "
+            f"- Run locally before completion: {contract.verify_command}. "
             "The verify gate re-runs it and records authoritative evidence."
         )
-    if spec.expected_artifacts:
+    if contract.expected_artifacts:
         lines.append(
             "- Expected artifacts: "
-            + ", ".join(spec.expected_artifacts)
+            + ", ".join(contract.expected_artifacts)
             + " — ensure they exist in the workspace"
         )
-    if spec.output_assertion:
-        lines.append(f"- Expected output: {spec.output_assertion}")
+    if contract.output_assertion:
+        lines.append(f"- Expected output: {contract.output_assertion}")
     return "\n".join(lines)
 
 
@@ -93,7 +99,6 @@ class AtomicPromptBuilder:
         level_contexts: list[LevelContext] | None,
         sibling_acs: list[_SiblingACRef] | None,
         retry_prompt_extra: str,
-        ac_spec: AcceptanceCriterionSpec | None,
     ) -> AtomicPromptBundle:
         """Build the prompt for one atomic leaf dispatch."""
         executor = self._executor
@@ -126,7 +131,7 @@ class AtomicPromptBuilder:
         # Surface this AC's success contract to the worker so it runs and reports
         # the exact evidence the verify gate will grade. Empty for contract-less
         # ACs → the prompt stays byte-identical to before.
-        contract_block = _build_success_contract_block(ac_spec)
+        contract_block = _build_success_contract_block(capsule.success_contract)
         if contract_block:
             task_section = f"{task_section}\n\n{contract_block}"
         legacy_context_section = (
@@ -212,12 +217,8 @@ class AtomicPromptBuilder:
             file_listing = "(unable to list)"
 
         if executor._fat_harness_mode and executor._execution_profile is not None:
-            has_success_contract = isinstance(ac_spec, AcceptanceCriterionSpec) and bool(
-                ac_spec.verify_command
-            )
-            has_expected_artifacts = isinstance(ac_spec, AcceptanceCriterionSpec) and bool(
-                ac_spec.expected_artifacts
-            )
+            has_success_contract = bool(capsule.success_contract.verify_command)
+            has_expected_artifacts = bool(capsule.success_contract.expected_artifacts)
             # Only delegate tests_passed/files_touched to the verify gate when it
             # will actually run; with run_verify_commands off the worker's
             # displayed required-fields must still list them.

--- a/src/ouroboros/orchestrator/atomic_prompt_builder.py
+++ b/src/ouroboros/orchestrator/atomic_prompt_builder.py
@@ -44,8 +44,13 @@ def _build_success_contract_block(
     pack carry a *per-AC* contract), so a worker was never told the exact
     verify_command / expected_artifacts / output_assertion the harness will grade
     it against. When the AC's spec carries a contract, surface it verbatim so the
-    worker runs and reports the same evidence the verify gate checks. Contract-less
-    ACs return ``""`` — the prompt stays byte-identical to before.
+    worker knows the exact bar it will be graded against. Contract-less ACs return
+    ``""`` — the prompt stays byte-identical to before.
+
+    The worker is explicitly told NOT to run ``verify_command`` itself: the
+    orchestrator's verify gate is the single authoritative, durably-recorded
+    execution, and a compliant worker running a (possibly non-idempotent) command
+    would double-execute it — the first run outside the single-shot oracle.
     """
     contract = spec if isinstance(spec, ACSuccessContract) else ACSuccessContract.from_ac_spec(spec)
     if not contract.has_success_contract:
@@ -53,8 +58,9 @@ def _build_success_contract_block(
     lines = ["SUCCESS CONTRACT for this AC:"]
     if contract.verify_command:
         lines.append(
-            f"- Run locally before completion: {contract.verify_command}. "
-            "The verify gate re-runs it and records authoritative evidence."
+            f"- The harness verify gate will run and grade (authoritatively): "
+            f"{contract.verify_command}. Do NOT run this command yourself — make "
+            "your changes so it will pass when the gate runs it once."
         )
     if contract.expected_artifacts:
         lines.append(

--- a/src/ouroboros/orchestrator/claude_worker_runtime.py
+++ b/src/ouroboros/orchestrator/claude_worker_runtime.py
@@ -133,6 +133,25 @@ class ClaudeWorkerTransport:
         # command builder just appends the flags. Empty ⇒ no ``--add-dir`` at all.
         self._add_dirs = _resolve_add_dirs(context_reference_dirs, cwd=cwd)
 
+    def executable_identity_contract(self) -> dict[str, object]:
+        """Expose the executable AND the command-affecting policy for capsule authority.
+
+        The launched binary alone does not capture what the command is allowed to
+        do: ``--disallowedTools``, ``--add-dir`` (brownfield context reference
+        dirs), and session persistence all change the worker's actual access and
+        must participate in capsule identity, so a restart cannot resume the same
+        capsule under a different access policy.
+        """
+        return {
+            "executable": self._cli_path,
+            "launcher": None,
+            "command_policy": {
+                "disallowed_tools": sorted(self._disallowed_tools),
+                "add_dirs": list(self._add_dirs),
+                "persist_sessions": self._persist_sessions,
+            },
+        }
+
     @staticmethod
     def _permission_args(permission_mode: str | None) -> list[str]:
         normalized = (permission_mode or "").strip().lower()

--- a/src/ouroboros/orchestrator/codex_cli_runtime.py
+++ b/src/ouroboros/orchestrator/codex_cli_runtime.py
@@ -570,6 +570,25 @@ class CodexCliRuntime:
             "resume_handle_selector": self.resume_handle_execution_identity_contract(None),
         }
 
+    def watchdog_identity_contract(self) -> dict[str, float | None]:
+        """Return the effective watchdog/termination timeouts for capsule authority.
+
+        These decide WHEN a provider turn is interrupted (no startup output, then
+        stdout idle) and how long process shutdown is awaited, so two runtimes
+        with different values have different interruption semantics and must not
+        resume the same capsule. Values are the resolved effective settings (a
+        non-positive constructor input has already been normalized to ``None`` =
+        no watchdog).
+        """
+        return {
+            "startup_output_timeout_seconds": self._startup_output_timeout_seconds,
+            "stdout_idle_timeout_seconds": self._stdout_idle_timeout_seconds,
+            "process_shutdown_timeout_seconds": self._process_shutdown_timeout_seconds,
+            "completed_process_group_shutdown_timeout_seconds": (
+                self._completed_process_group_shutdown_timeout_seconds
+            ),
+        }
+
     def resume_handle_execution_identity_contract(
         self,
         runtime_handle: RuntimeHandle | None,

--- a/src/ouroboros/orchestrator/execution_event_emitter.py
+++ b/src/ouroboros/orchestrator/execution_event_emitter.py
@@ -97,18 +97,46 @@ def bound_verify_gate_outcome(outcome: Mapping[str, Any]) -> dict[str, Any]:
         item[:_MAX_VERIFY_MISSING_ARTIFACT_CHARS]
         for item in list(raw_missing)[:_MAX_VERIFY_MISSING_ARTIFACTS]
     ]
+    bounded_reason = reason[:_MAX_VERIFY_TEXT_CHARS] if reason is not None else None
+    bounded_output = output_tail[:_MAX_VERIFY_TEXT_CHARS]
+
+    def _byte_size(payload: dict[str, Any]) -> int:
+        return len(json.dumps(payload, ensure_ascii=False, sort_keys=True).encode("utf-8"))
+
+    # Bound by ENCODED SIZE, not code points: a valid contract can carry many
+    # multi-byte artifact paths, so char-only truncation could still overflow the
+    # byte cap. Fit the payload by DROPPING trailing artifacts (recording the
+    # omission) rather than raising — the intent is already durable, so a raise
+    # here would make an accepted contract permanently unrecoverable. Free-text
+    # fields are already char-capped well under the byte cap, so a base outcome
+    # with no artifacts always fits.
+    prior_and_char_dropped = (len(raw_missing) - len(bounded_missing)) + prior_omitted
+    base: dict[str, Any] = {
+        "passed": passed,
+        "reason": bounded_reason,
+        "output_tail": bounded_output,
+        "missing_artifacts": [],
+        # Reserve room for the counter so adding it later cannot overflow.
+        "missing_artifacts_omitted": prior_and_char_dropped + len(bounded_missing),
+    }
+    used = _byte_size(base)
+    included: list[str] = []
+    for entry in bounded_missing:
+        entry_bytes = len(json.dumps(entry, ensure_ascii=False).encode("utf-8")) + 1
+        if used + entry_bytes > _MAX_VERIFY_OUTCOME_BYTES:
+            break
+        included.append(entry)
+        used += entry_bytes
+
+    total_omitted = prior_and_char_dropped + (len(bounded_missing) - len(included))
     result: dict[str, Any] = {
         "passed": passed,
-        "reason": reason[:_MAX_VERIFY_TEXT_CHARS] if reason is not None else None,
-        "output_tail": output_tail[:_MAX_VERIFY_TEXT_CHARS],
-        "missing_artifacts": bounded_missing,
+        "reason": bounded_reason,
+        "output_tail": bounded_output,
+        "missing_artifacts": included,
     }
-    total_omitted = (len(raw_missing) - len(bounded_missing)) + prior_omitted
     if total_omitted > 0:
         result["missing_artifacts_omitted"] = total_omitted
-    encoded = json.dumps(result, ensure_ascii=False, sort_keys=True)
-    if len(encoded.encode("utf-8")) > _MAX_VERIFY_OUTCOME_BYTES:
-        raise ValueError("verify outcome exceeds the durable size bound")
     return result
 
 

--- a/src/ouroboros/orchestrator/execution_event_emitter.py
+++ b/src/ouroboros/orchestrator/execution_event_emitter.py
@@ -111,33 +111,28 @@ def bound_verify_gate_outcome(outcome: Mapping[str, Any]) -> dict[str, Any]:
     # fields are already char-capped well under the byte cap, so a base outcome
     # with no artifacts always fits.
     prior_and_char_dropped = (len(raw_missing) - len(bounded_missing)) + prior_omitted
-    base: dict[str, Any] = {
-        "passed": passed,
-        "reason": bounded_reason,
-        "output_tail": bounded_output,
-        "missing_artifacts": [],
-        # Reserve room for the counter so adding it later cannot overflow.
-        "missing_artifacts_omitted": prior_and_char_dropped + len(bounded_missing),
-    }
-    used = _byte_size(base)
+
+    def _build(included: list[str]) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "passed": passed,
+            "reason": bounded_reason,
+            "output_tail": bounded_output,
+            "missing_artifacts": included,
+        }
+        omitted = prior_and_char_dropped + (len(bounded_missing) - len(included))
+        if omitted > 0:
+            payload["missing_artifacts_omitted"] = omitted
+        return payload
+
+    # Add entries one at a time, measuring the ACTUAL serialized payload each time
+    # (including the omission counter) rather than a per-entry estimate — an
+    # estimate could admit one entry too many and overrun the byte cap by a byte.
     included: list[str] = []
     for entry in bounded_missing:
-        entry_bytes = len(json.dumps(entry, ensure_ascii=False).encode("utf-8")) + 1
-        if used + entry_bytes > _MAX_VERIFY_OUTCOME_BYTES:
+        if _byte_size(_build([*included, entry])) > _MAX_VERIFY_OUTCOME_BYTES:
             break
         included.append(entry)
-        used += entry_bytes
-
-    total_omitted = prior_and_char_dropped + (len(bounded_missing) - len(included))
-    result: dict[str, Any] = {
-        "passed": passed,
-        "reason": bounded_reason,
-        "output_tail": bounded_output,
-        "missing_artifacts": included,
-    }
-    if total_omitted > 0:
-        result["missing_artifacts_omitted"] = total_omitted
-    return result
+    return _build(included)
 
 
 class ExecutionEventEmitter:

--- a/src/ouroboros/orchestrator/execution_event_emitter.py
+++ b/src/ouroboros/orchestrator/execution_event_emitter.py
@@ -212,6 +212,110 @@ class ExecutionEventEmitter:
             )
         )
 
+    async def emit_ac_dispatch_sealed(
+        self,
+        *,
+        runtime_identity: ACRuntimeIdentity,
+        dispatch_id: str,
+        execution_id: str,
+        session_id: str,
+        capsule_fingerprint: str,
+    ) -> None:
+        """Durably seal a completed provider turn before a follow-up supersedes it.
+
+        A SessionSignal follow-up dispatch reuses the same provider session as its
+        (already-completed) predecessor. If the follow-up's own dispatch record
+        fails to persist, recovery would otherwise resume the predecessor as a
+        reusable, non-terminal chain head and replay the ORIGINAL AC prompt,
+        duplicating completed primary work. Sealing the predecessor first makes
+        recovery fail closed on it unless a terminal completion is also durable.
+        Persistence failure propagates and prevents the follow-up.
+        """
+        if len(dispatch_id) != 32 or any(
+            character not in "0123456789abcdef" for character in dispatch_id
+        ):
+            raise ValueError("AC dispatch id is invalid")
+        await self._event_store.append(
+            BaseEvent(
+                type="execution.ac.dispatch.sealed",
+                aggregate_type=runtime_identity.runtime_scope.aggregate_type,
+                aggregate_id=runtime_identity.session_scope_id,
+                data={
+                    **runtime_identity.to_metadata(),
+                    "ac_dispatch_id": dispatch_id,
+                    "execution_id": execution_id,
+                    "session_id": session_id,
+                    "capsule_fingerprint": capsule_fingerprint,
+                },
+            )
+        )
+
+    async def emit_ac_verify_intent(
+        self,
+        *,
+        aggregate_id: str,
+        verify_key: str,
+        command_digest: str,
+        execution_id: str,
+        session_id: str,
+        identity_metadata: dict[str, Any],
+    ) -> None:
+        """Durably record that a non-idempotent verify command is about to run.
+
+        A verify command is an acceptance effect. Persisting the INTENT before it
+        runs — and its outcome after — makes the command single-shot across crash
+        recovery: a durable intent with no matching outcome means the command may
+        already have run, so recovery must fail closed instead of running it
+        again. Persistence failure propagates and prevents the command.
+        """
+        await self._event_store.append(
+            BaseEvent(
+                type="execution.ac.verify.intent",
+                aggregate_type="execution",
+                aggregate_id=aggregate_id,
+                data={
+                    **identity_metadata,
+                    "verify_key": verify_key,
+                    "verify_command_digest": command_digest,
+                    "execution_id": execution_id,
+                    "session_id": session_id,
+                },
+            )
+        )
+
+    async def emit_ac_verify_outcome(
+        self,
+        *,
+        aggregate_id: str,
+        verify_key: str,
+        command_digest: str,
+        execution_id: str,
+        session_id: str,
+        identity_metadata: dict[str, Any],
+        verify_gate_outcome: dict[str, Any],
+    ) -> None:
+        """Durably record a verify command's outcome, keyed to its intent.
+
+        Recovery consumes this instead of re-running the command. The
+        ``verify_command_digest`` binds the outcome to the exact command/contract
+        that produced it, so a changed contract never consumes a stale outcome.
+        """
+        await self._event_store.append(
+            BaseEvent(
+                type="execution.ac.verify.outcome",
+                aggregate_type="execution",
+                aggregate_id=aggregate_id,
+                data={
+                    **identity_metadata,
+                    "verify_key": verify_key,
+                    "verify_command_digest": command_digest,
+                    "execution_id": execution_id,
+                    "session_id": session_id,
+                    "verify_gate_outcome": verify_gate_outcome,
+                },
+            )
+        )
+
     async def emit_decomposition_decision_finalized(
         self,
         *,

--- a/src/ouroboros/orchestrator/execution_event_emitter.py
+++ b/src/ouroboros/orchestrator/execution_event_emitter.py
@@ -32,6 +32,7 @@ from ouroboros.orchestrator.workflow_state import coerce_ac_marker_update
 
 if TYPE_CHECKING:
     from ouroboros.core.seed import Seed
+    from ouroboros.orchestrator.ac_execution_capsule import ACExecutionCapsule
     from ouroboros.orchestrator.adapter import AgentMessage
     from ouroboros.orchestrator.coordinator import CoordinatorReview
     from ouroboros.persistence.event_store import EventStore
@@ -74,6 +75,37 @@ class ExecutionEventEmitter:
                 parts.append(f"{key}: {rendered}")
         preview = ", ".join(parts)
         return preview[:100] if preview else None
+
+    async def emit_ac_capsule_compiled(
+        self,
+        *,
+        runtime_identity: ACRuntimeIdentity,
+        session_id: str,
+        capsule: ACExecutionCapsule,
+        session_origin: str,
+    ) -> None:
+        """Durably persist the authority contract before provider dispatch.
+
+        Unlike observe-only telemetry, this event defines which AC capsule a
+        provider session is allowed to execute. Persistence failure therefore
+        propagates and prevents the external effect from starting.
+        """
+        await self._event_store.append(
+            BaseEvent(
+                type="execution.ac.capsule.compiled",
+                aggregate_type=runtime_identity.runtime_scope.aggregate_type,
+                aggregate_id=runtime_identity.session_scope_id,
+                data={
+                    **runtime_identity.to_metadata(),
+                    "execution_id": capsule.execution_id,
+                    "session_id": session_id,
+                    "semantic_ac_key": capsule.semantic_ac_key,
+                    "capsule_fingerprint": capsule.fingerprint,
+                    "capsule": capsule.to_contract_data(),
+                    "session_origin": session_origin,
+                },
+            )
+        )
 
     async def emit_decomposition_decision_finalized(
         self,

--- a/src/ouroboros/orchestrator/execution_event_emitter.py
+++ b/src/ouroboros/orchestrator/execution_event_emitter.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
+import json
 from typing import TYPE_CHECKING, Any
 
 from ouroboros.core.seed import ac_text
@@ -40,6 +41,56 @@ if TYPE_CHECKING:
 
 SafeEmitEvent = Callable[[Any], Awaitable[bool]]
 ToolDetailFormatter = Callable[[str, dict[str, Any]], str]
+
+# Durable verify-outcome payload bounds (measured in UTF-8 bytes for the final
+# serialized value). ``expected_artifacts`` is not otherwise size-limited, so a
+# failing gate could list thousands of missing paths; bound the count, per-entry
+# length, and free-text fields, then hard-cap the serialized size.
+_MAX_VERIFY_OUTCOME_BYTES = 65_536
+_MAX_VERIFY_MISSING_ARTIFACTS = 64
+_MAX_VERIFY_MISSING_ARTIFACT_CHARS = 512
+_MAX_VERIFY_TEXT_CHARS = 4096
+
+
+def bound_verify_gate_outcome(outcome: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a bounded, shape-validated verify outcome safe to persist/replay.
+
+    Preserves the acceptance verdict (``passed``) exactly while capping the
+    unbounded ``missing_artifacts`` list and the free-text ``reason``/
+    ``output_tail`` fields, recording an omission count when the list is
+    truncated. Raises ``ValueError`` if the bounded payload still exceeds the
+    hard UTF-8 size cap, so an oversized record can never be persisted.
+    """
+    if not isinstance(outcome, Mapping):
+        raise ValueError("verify outcome payload is not a mapping")
+
+    def _bounded_text(value: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise ValueError("verify outcome text field is not a string")
+        return value[:_MAX_VERIFY_TEXT_CHARS]
+
+    raw_missing = outcome.get("missing_artifacts") or []
+    if not isinstance(raw_missing, (list, tuple)):
+        raise ValueError("verify outcome missing_artifacts is not a sequence")
+    bounded_missing = [
+        str(item)[:_MAX_VERIFY_MISSING_ARTIFACT_CHARS]
+        for item in list(raw_missing)[:_MAX_VERIFY_MISSING_ARTIFACTS]
+    ]
+    result: dict[str, Any] = {
+        "passed": bool(outcome.get("passed")),
+        "reason": _bounded_text(outcome.get("reason")),
+        "output_tail": _bounded_text(outcome.get("output_tail")) or "",
+        "missing_artifacts": bounded_missing,
+    }
+    omitted = len(raw_missing) - len(bounded_missing)
+    if omitted > 0:
+        result["missing_artifacts_omitted"] = omitted
+    encoded = json.dumps(result, ensure_ascii=False, sort_keys=True)
+    if len(encoded.encode("utf-8")) > _MAX_VERIFY_OUTCOME_BYTES:
+        raise ValueError("verify outcome exceeds the durable size bound")
+    return result
 
 
 class ExecutionEventEmitter:
@@ -299,6 +350,9 @@ class ExecutionEventEmitter:
         Recovery consumes this instead of re-running the command. The
         ``verify_command_digest`` binds the outcome to the exact command/contract
         that produced it, so a changed contract never consumes a stale outcome.
+        The outcome is bounded before persistence — a contract with a very large
+        ``expected_artifacts`` list (which is not otherwise size-limited) could
+        otherwise emit a multi-megabyte event.
         """
         await self._event_store.append(
             BaseEvent(
@@ -311,7 +365,7 @@ class ExecutionEventEmitter:
                     "verify_command_digest": command_digest,
                     "execution_id": execution_id,
                     "session_id": session_id,
-                    "verify_gate_outcome": verify_gate_outcome,
+                    "verify_gate_outcome": bound_verify_gate_outcome(verify_gate_outcome),
                 },
             )
         )

--- a/src/ouroboros/orchestrator/execution_event_emitter.py
+++ b/src/ouroboros/orchestrator/execution_event_emitter.py
@@ -33,7 +33,7 @@ from ouroboros.orchestrator.workflow_state import coerce_ac_marker_update
 if TYPE_CHECKING:
     from ouroboros.core.seed import Seed
     from ouroboros.orchestrator.ac_execution_capsule import ACExecutionCapsule
-    from ouroboros.orchestrator.adapter import AgentMessage
+    from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
     from ouroboros.orchestrator.coordinator import CoordinatorReview
     from ouroboros.persistence.event_store import EventStore
 
@@ -103,6 +103,75 @@ class ExecutionEventEmitter:
                     "capsule_fingerprint": capsule.fingerprint,
                     "capsule_manifest": capsule.manifest.to_contract_data(),
                     "session_origin": session_origin,
+                },
+            )
+        )
+
+    async def emit_ac_attempt_dispatched(
+        self,
+        *,
+        runtime_identity: ACRuntimeIdentity,
+        dispatch_id: str,
+        previous_dispatch_id: str | None,
+        execution_id: str,
+        session_id: str,
+        capsule_fingerprint: str,
+        session_origin: str,
+        runtime_handle: RuntimeHandle | None,
+    ) -> None:
+        """Persist the provider-boundary transition before invoking the runtime.
+
+        A compiled capsule proves dispatch authority, but it does not prove that
+        the provider was entered. This second durable transition closes that
+        crash gap: recovery must treat a dispatch without a resumable handle or
+        terminal successor as an uncertain external-effect boundary.
+        """
+        if not isinstance(capsule_fingerprint, str) or not capsule_fingerprint.startswith(
+            "sha256:"
+        ):
+            raise ValueError("AC dispatch capsule fingerprint is invalid")
+        if len(dispatch_id) != 32 or any(
+            character not in "0123456789abcdef" for character in dispatch_id
+        ):
+            raise ValueError("AC dispatch id is invalid")
+        if previous_dispatch_id is not None:
+            if len(previous_dispatch_id) != 32 or any(
+                character not in "0123456789abcdef" for character in previous_dispatch_id
+            ):
+                raise ValueError("previous AC dispatch id is invalid")
+            if previous_dispatch_id == dispatch_id:
+                raise ValueError("AC dispatch cannot name itself as its predecessor")
+        if session_origin not in {"fresh", "restored_same_attempt"}:
+            raise ValueError("AC dispatch session origin is invalid")
+        if runtime_handle is not None:
+            runtime_dispatch_id = runtime_handle.metadata.get("ac_dispatch_id")
+            if runtime_dispatch_id != dispatch_id:
+                raise ValueError("runtime handle dispatch id disagrees with dispatch event")
+            if runtime_handle.metadata.get("ac_capsule_fingerprint") != capsule_fingerprint:
+                raise ValueError("runtime handle capsule disagrees with dispatch event")
+            if runtime_handle.metadata.get("ac_session_origin") != session_origin:
+                raise ValueError("runtime handle session origin disagrees with dispatch event")
+        await self._event_store.append(
+            BaseEvent(
+                type="execution.ac.attempt.dispatched",
+                aggregate_type=runtime_identity.runtime_scope.aggregate_type,
+                aggregate_id=runtime_identity.session_scope_id,
+                data={
+                    **runtime_identity.to_metadata(),
+                    "ac_dispatch_id": dispatch_id,
+                    "previous_ac_dispatch_id": previous_dispatch_id,
+                    "execution_id": execution_id,
+                    "session_id": session_id,
+                    "capsule_fingerprint": capsule_fingerprint,
+                    "session_origin": session_origin,
+                    "runtime_backend": (
+                        runtime_handle.backend if runtime_handle is not None else None
+                    ),
+                    "runtime": (
+                        runtime_handle.to_dispatch_recovery_dict()
+                        if runtime_handle is not None
+                        else None
+                    ),
                 },
             )
         )
@@ -1112,6 +1181,7 @@ class ExecutionEventEmitter:
         self,
         *,
         runtime_identity: ACRuntimeIdentity,
+        dispatch_id: str,
         tool_name: str,
         tool_detail: str,
         tool_input: dict[str, Any],
@@ -1125,6 +1195,7 @@ class ExecutionEventEmitter:
                 aggregate_id=runtime_identity.session_scope_id,
                 data={
                     **runtime_identity.to_metadata(),
+                    "ac_dispatch_id": dispatch_id,
                     "tool_name": tool_name,
                     "tool_detail": tool_detail,
                     "tool_input": tool_input,
@@ -1137,6 +1208,7 @@ class ExecutionEventEmitter:
         self,
         *,
         runtime_identity: ACRuntimeIdentity,
+        dispatch_id: str,
         tool_name: str,
         tool_result_text: str,
         runtime_metadata: dict[str, Any],
@@ -1149,6 +1221,7 @@ class ExecutionEventEmitter:
                 aggregate_id=runtime_identity.session_scope_id,
                 data={
                     **runtime_identity.to_metadata(),
+                    "ac_dispatch_id": dispatch_id,
                     "tool_name": tool_name,
                     "tool_result_text": tool_result_text,
                     **runtime_metadata,

--- a/src/ouroboros/orchestrator/execution_event_emitter.py
+++ b/src/ouroboros/orchestrator/execution_event_emitter.py
@@ -52,41 +52,60 @@ _MAX_VERIFY_MISSING_ARTIFACT_CHARS = 512
 _MAX_VERIFY_TEXT_CHARS = 4096
 
 
-def bound_verify_gate_outcome(outcome: Mapping[str, Any]) -> dict[str, Any]:
-    """Return a bounded, shape-validated verify outcome safe to persist/replay.
+_VERIFY_OUTCOME_REQUIRED_KEYS = frozenset({"passed", "reason", "output_tail", "missing_artifacts"})
+_VERIFY_OUTCOME_ALLOWED_KEYS = _VERIFY_OUTCOME_REQUIRED_KEYS | {"missing_artifacts_omitted"}
 
-    Preserves the acceptance verdict (``passed``) exactly while capping the
-    unbounded ``missing_artifacts`` list and the free-text ``reason``/
-    ``output_tail`` fields, recording an omission count when the list is
-    truncated. Raises ``ValueError`` if the bounded payload still exceeds the
-    hard UTF-8 size cap, so an oversized record can never be persisted.
+
+def bound_verify_gate_outcome(outcome: Mapping[str, Any]) -> dict[str, Any]:
+    """Strictly validate, then bound, a verify outcome for persistence/replay.
+
+    Used as the exact-shape validator on BOTH the persist and replay paths, so it
+    accepts ONLY the exact keys with their NATIVE types — it never coerces. This
+    matters on replay: a corrupted record with ``"passed": "false"`` or ``1``
+    must NOT become a trusted PASS. It then caps the unbounded ``missing_artifacts``
+    list and the free-text fields (recording an omission count) and rejects any
+    payload still over the hard UTF-8 byte cap.
     """
     if not isinstance(outcome, Mapping):
         raise ValueError("verify outcome payload is not a mapping")
+    keys = set(outcome)
+    if not keys >= _VERIFY_OUTCOME_REQUIRED_KEYS:
+        raise ValueError("verify outcome payload is missing required fields")
+    if keys - _VERIFY_OUTCOME_ALLOWED_KEYS:
+        raise ValueError("verify outcome payload has unexpected fields")
 
-    def _bounded_text(value: object) -> str | None:
-        if value is None:
-            return None
-        if not isinstance(value, str):
-            raise ValueError("verify outcome text field is not a string")
-        return value[:_MAX_VERIFY_TEXT_CHARS]
+    passed = outcome["passed"]
+    if not isinstance(passed, bool):
+        # bool is an int subclass; reject ints/strings that would coerce to a verdict.
+        raise ValueError("verify outcome 'passed' is not a boolean")
+    reason = outcome["reason"]
+    if reason is not None and not isinstance(reason, str):
+        raise ValueError("verify outcome 'reason' is not a string or null")
+    output_tail = outcome["output_tail"]
+    if not isinstance(output_tail, str):
+        raise ValueError("verify outcome 'output_tail' is not a string")
+    raw_missing = outcome["missing_artifacts"]
+    if not isinstance(raw_missing, (list, tuple)) or not all(
+        isinstance(item, str) for item in raw_missing
+    ):
+        raise ValueError("verify outcome 'missing_artifacts' is not a list of strings")
+    prior_omitted = outcome.get("missing_artifacts_omitted", 0)
+    if not isinstance(prior_omitted, int) or isinstance(prior_omitted, bool) or prior_omitted < 0:
+        raise ValueError("verify outcome 'missing_artifacts_omitted' is invalid")
 
-    raw_missing = outcome.get("missing_artifacts") or []
-    if not isinstance(raw_missing, (list, tuple)):
-        raise ValueError("verify outcome missing_artifacts is not a sequence")
     bounded_missing = [
-        str(item)[:_MAX_VERIFY_MISSING_ARTIFACT_CHARS]
+        item[:_MAX_VERIFY_MISSING_ARTIFACT_CHARS]
         for item in list(raw_missing)[:_MAX_VERIFY_MISSING_ARTIFACTS]
     ]
     result: dict[str, Any] = {
-        "passed": bool(outcome.get("passed")),
-        "reason": _bounded_text(outcome.get("reason")),
-        "output_tail": _bounded_text(outcome.get("output_tail")) or "",
+        "passed": passed,
+        "reason": reason[:_MAX_VERIFY_TEXT_CHARS] if reason is not None else None,
+        "output_tail": output_tail[:_MAX_VERIFY_TEXT_CHARS],
         "missing_artifacts": bounded_missing,
     }
-    omitted = len(raw_missing) - len(bounded_missing)
-    if omitted > 0:
-        result["missing_artifacts_omitted"] = omitted
+    total_omitted = (len(raw_missing) - len(bounded_missing)) + prior_omitted
+    if total_omitted > 0:
+        result["missing_artifacts_omitted"] = total_omitted
     encoded = json.dumps(result, ensure_ascii=False, sort_keys=True)
     if len(encoded.encode("utf-8")) > _MAX_VERIFY_OUTCOME_BYTES:
         raise ValueError("verify outcome exceeds the durable size bound")

--- a/src/ouroboros/orchestrator/execution_event_emitter.py
+++ b/src/ouroboros/orchestrator/execution_event_emitter.py
@@ -118,6 +118,10 @@ class ExecutionEventEmitter:
         capsule_fingerprint: str,
         session_origin: str,
         runtime_handle: RuntimeHandle | None,
+        dispatch_kind: str = "primary",
+        signal_id: str | None = None,
+        signal_mode: str | None = None,
+        follow_up_input_digest: str | None = None,
     ) -> None:
         """Persist the provider-boundary transition before invoking the runtime.
 
@@ -125,7 +129,35 @@ class ExecutionEventEmitter:
         the provider was entered. This second durable transition closes that
         crash gap: recovery must treat a dispatch without a resumable handle or
         terminal successor as an uncertain external-effect boundary.
+
+        ``dispatch_kind`` names the provider-entry PHASE this boundary opens. A
+        ``primary`` dispatch replays the original AC prompt; a
+        ``session_signal_followup`` dispatch replays a Synapse signal turn's
+        prompt instead. Recovery MUST distinguish them: resuming a follow-up
+        chain head while replaying the original AC prompt would repeat the AC's
+        acceptance work. Follow-up dispatches therefore persist the signal
+        identity/mode and the exact rendered follow-up input digest so recovery
+        can either reconstruct the exact phase or fail closed, never silently
+        fall back to the original prompt.
         """
+        if dispatch_kind not in {"primary", "session_signal_followup"}:
+            raise ValueError("AC dispatch kind is invalid")
+        follow_up_fields = (signal_id, signal_mode, follow_up_input_digest)
+        if dispatch_kind == "session_signal_followup":
+            if any(field is None for field in follow_up_fields):
+                raise ValueError(
+                    "SessionSignal follow-up dispatch requires signal id, mode, and input digest"
+                )
+            if not isinstance(signal_id, str) or not signal_id:
+                raise ValueError("SessionSignal follow-up dispatch signal id is invalid")
+            if not isinstance(signal_mode, str) or not signal_mode:
+                raise ValueError("SessionSignal follow-up dispatch signal mode is invalid")
+            if not isinstance(follow_up_input_digest, str) or not follow_up_input_digest.startswith(
+                "sha256:"
+            ):
+                raise ValueError("SessionSignal follow-up dispatch input digest is invalid")
+        elif any(field is not None for field in follow_up_fields):
+            raise ValueError("primary AC dispatch must not carry SessionSignal follow-up identity")
         if not isinstance(capsule_fingerprint, str) or not capsule_fingerprint.startswith(
             "sha256:"
         ):
@@ -160,6 +192,10 @@ class ExecutionEventEmitter:
                     **runtime_identity.to_metadata(),
                     "ac_dispatch_id": dispatch_id,
                     "previous_ac_dispatch_id": previous_dispatch_id,
+                    "dispatch_kind": dispatch_kind,
+                    "signal_id": signal_id,
+                    "signal_mode": signal_mode,
+                    "follow_up_input_digest": follow_up_input_digest,
                     "execution_id": execution_id,
                     "session_id": session_id,
                     "capsule_fingerprint": capsule_fingerprint,

--- a/src/ouroboros/orchestrator/execution_event_emitter.py
+++ b/src/ouroboros/orchestrator/execution_event_emitter.py
@@ -101,7 +101,7 @@ class ExecutionEventEmitter:
                     "session_id": session_id,
                     "semantic_ac_key": capsule.semantic_ac_key,
                     "capsule_fingerprint": capsule.fingerprint,
-                    "capsule": capsule.to_contract_data(),
+                    "capsule_manifest": capsule.manifest.to_contract_data(),
                     "session_origin": session_origin,
                 },
             )

--- a/src/ouroboros/orchestrator/leaf_dispatcher.py
+++ b/src/ouroboros/orchestrator/leaf_dispatcher.py
@@ -61,6 +61,13 @@ class LeafDispatchState:
     success: bool = False
     stalled: bool = False
     infra_fatal: bool = False
+    # True once this dispatch has emitted a durable tool-effect event
+    # (``execution.tool.started``/``...completed``). A stall that occurs after a
+    # tool effect cannot be re-dispatched under a bumped retry attempt: recovery
+    # filters the prior attempt's effect events, so a fresh dispatch would bypass
+    # the ambiguity guard and could duplicate a non-idempotent effect. The
+    # executor reads this to fail such stalls closed instead of retrying.
+    tool_effects_observed: bool = False
 
 
 # Fix 4 (round 3, BLOCKING): some runtime adapters (e.g.
@@ -525,6 +532,10 @@ class LeafDispatcher:
                     executor._console.print(f"{indent}[yellow]{label} → {tool_detail}[/yellow]")
                     executor._flush_console()
 
+                    # A dispatched tool effect is now durable; a subsequent stall
+                    # must fail closed rather than re-dispatch (see
+                    # ``LeafDispatchState.tool_effects_observed``).
+                    state.tool_effects_observed = True
                     await executor._event_emitter.emit_atomic_tool_started(
                         runtime_identity=runtime_identity,
                         dispatch_id=dispatch_id,
@@ -542,6 +553,7 @@ class LeafDispatcher:
                 else:
                     completed_tool_name = None
                 if completed_tool_name is not None:
+                    state.tool_effects_observed = True
                     await executor._event_emitter.emit_atomic_tool_completed(
                         runtime_identity=runtime_identity,
                         dispatch_id=dispatch_id,

--- a/src/ouroboros/orchestrator/leaf_dispatcher.py
+++ b/src/ouroboros/orchestrator/leaf_dispatcher.py
@@ -349,6 +349,7 @@ class LeafDispatcher:
         system_prompt: str,
         execute_effort_kwargs: dict[str, Any],
         runtime_identity: ACRuntimeIdentity,
+        dispatch_id: str,
         execution_context_id: str,
         session_id: str,
         ac_index: int,
@@ -428,6 +429,7 @@ class LeafDispatcher:
                             await executor._emit_ac_runtime_event(
                                 event_type="execution.session.recovered",
                                 runtime_identity=runtime_identity,
+                                dispatch_id=dispatch_id,
                                 ac_content=ac_content,
                                 runtime_handle=state.runtime_handle,
                                 execution_id=execution_context_id,
@@ -471,6 +473,7 @@ class LeafDispatcher:
                     await executor._emit_ac_runtime_event(
                         event_type=lifecycle_event_type,
                         runtime_identity=runtime_identity,
+                        dispatch_id=dispatch_id,
                         ac_content=ac_content,
                         runtime_handle=state.runtime_handle,
                         execution_id=execution_context_id,
@@ -524,6 +527,7 @@ class LeafDispatcher:
 
                     await executor._event_emitter.emit_atomic_tool_started(
                         runtime_identity=runtime_identity,
+                        dispatch_id=dispatch_id,
                         tool_name=projected.tool_name,
                         tool_detail=tool_detail,
                         tool_input=tool_input,
@@ -540,6 +544,7 @@ class LeafDispatcher:
                 if completed_tool_name is not None:
                     await executor._event_emitter.emit_atomic_tool_completed(
                         runtime_identity=runtime_identity,
+                        dispatch_id=dispatch_id,
                         tool_name=completed_tool_name,
                         tool_result_text=projected.content,
                         runtime_metadata=executor._runtime_event_metadata(message),

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -285,8 +285,17 @@ class OpenCodeRuntime:
                 except Exception:
                     dispatcher_identity = None
             if dispatcher_identity is None:
+                # No durable identity contract: the class alone cannot distinguish
+                # two same-class instances with different state/behavior, and
+                # nothing durable would let a restart re-establish trust. Bind a
+                # process-local nonce (stable within THIS process, distinct per
+                # instance) so different dispatchers differ AND any restart — which
+                # cannot reproduce the nonce — fails closed rather than trusting an
+                # unidentifiable dispatcher.
                 dispatcher_identity = {
-                    "type": f"{type(dispatcher).__module__}.{type(dispatcher).__qualname__}"
+                    "type": f"{type(dispatcher).__module__}.{type(dispatcher).__qualname__}",
+                    "process_local_nonce": id(dispatcher),
+                    "durable_identity": False,
                 }
 
         return {

--- a/src/ouroboros/orchestrator/opencode_runtime.py
+++ b/src/ouroboros/orchestrator/opencode_runtime.py
@@ -260,6 +260,44 @@ class OpenCodeRuntime:
         """
         return self._runtime_handle_backend
 
+    def execution_identity_contract(self) -> dict[str, Any]:
+        """Return OpenCode dispatch identity that controls PRE-provider routing.
+
+        ``opencode_mode`` and ``llm_backend`` choose how skills resolve and whether
+        MCP/plugin dispatch is used, ``skills_dir`` selects which custom skills are
+        available, and a custom ``skill_dispatcher`` replaces the default handler —
+        all before the provider runs. These must participate in capsule authority
+        so a resume cannot execute through a different handler/provider route under
+        the same capsule. A custom dispatcher contributes a bounded, process-local
+        identity (its own ``identity()`` if provided, else its type).
+        """
+
+        def _text(value: object) -> str | None:
+            return value.strip() if isinstance(value, str) and value.strip() else None
+
+        dispatcher = self._skill_dispatcher
+        dispatcher_identity: object | None = None
+        if dispatcher is not None:
+            identity_fn = getattr(dispatcher, "identity", None)
+            if callable(identity_fn):
+                try:
+                    dispatcher_identity = identity_fn()
+                except Exception:
+                    dispatcher_identity = None
+            if dispatcher_identity is None:
+                dispatcher_identity = {
+                    "type": f"{type(dispatcher).__module__}.{type(dispatcher).__qualname__}"
+                }
+
+        return {
+            "kind": "opencode_v1",
+            "constructor_model": self._normalize_model(self._model),
+            "opencode_mode": _text(self._opencode_mode),
+            "llm_backend": _text(self._llm_backend),
+            "skills_dir": str(self._skills_dir) if self._skills_dir else None,
+            "skill_dispatcher": dispatcher_identity,
+        }
+
     @property
     def capabilities(self) -> RuntimeCapabilities:
         # OpenCode composes the system prompt and tool guidance into the user

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -34,6 +34,7 @@ from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 import hashlib
 import inspect
+from itertools import islice
 import json
 import math
 import os
@@ -89,8 +90,11 @@ from ouroboros.harness.journal import EvidenceEntry, EvidenceManifest
 from ouroboros.harness.traceguard_validator import validate_evidence_claims
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.ac_execution_capsule import (
+    MAX_AC_CONTEXT_REFERENCES,
+    ACContextReference,
     ACSuccessContract,
     bind_capsule_to_runtime_handle,
+    build_ac_dependency_references,
     build_ac_dispatch_authority_scope,
     compile_ac_execution_capsule,
 )
@@ -1419,6 +1423,19 @@ class ParallelACExecutor:
             event_store,
             safe_emit_event=self._safe_emit_event,
         )
+        self._capsule_tool_catalog_cache: dict[
+            int,
+            tuple[tuple[MCPToolDefinition, ...], dict[str, object]],
+        ] = {}
+        self._capsule_level_context_cache: dict[
+            int,
+            tuple[list[LevelContext], str],
+        ] = {}
+        self._capsule_level_item_digest_cache: dict[int, tuple[LevelContext, str]] = {}
+        self._capsule_dependency_reference_cache: dict[
+            tuple[str, int],
+            tuple[list[LevelContext], tuple[ACContextReference, ...]],
+        ] = {}
         self._checkpoint_store = checkpoint_store
         self._checkpoint_execution_lease_held = checkpoint_execution_lease_held
         self._decomposition_decisions: dict[str, DecompositionDecisionRecord] = {}
@@ -2418,6 +2435,139 @@ class ParallelACExecutor:
             "session_signals": capabilities.session_signals.to_event_data(),
         }
 
+    def _authority_digest(self, value: object, *, field: str) -> str:
+        normalized = self._canonical_authority_value(value, field=field)
+        return self._prompt_identity(
+            json.dumps(
+                normalized,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+                allow_nan=False,
+            )
+        )
+
+    def _capsule_tool_catalog_authority(
+        self,
+        tool_catalog: tuple[MCPToolDefinition, ...] | None,
+    ) -> dict[str, object]:
+        """Hash a catalog once per immutable catalog object."""
+        from ouroboros.orchestrator.mcp_tools import serialize_tool_catalog
+
+        if tool_catalog is None:
+            return {"present": False, "count": 0, "digest": None}
+        cached = self._capsule_tool_catalog_cache.get(id(tool_catalog))
+        if cached is not None and cached[0] is tool_catalog:
+            return cached[1]
+        serialized = serialize_tool_catalog(tool_catalog)
+        authority = {
+            "present": True,
+            "count": len(serialized),
+            "digest": self._authority_digest(
+                serialized,
+                field="AC capsule tool catalog",
+            ),
+        }
+        self._capsule_tool_catalog_cache[id(tool_catalog)] = (tool_catalog, authority)
+        return authority
+
+    def _level_context_item_digest(self, context: LevelContext) -> str:
+        cached = self._capsule_level_item_digest_cache.get(id(context))
+        if cached is not None and cached[0] is context:
+            return cached[1]
+        serialized = serialize_level_contexts([context])
+        digest = self._authority_digest(
+            serialized[0],
+            field="AC capsule level context",
+        )
+        self._capsule_level_item_digest_cache[id(context)] = (context, digest)
+        return digest
+
+    def _level_context_chain_digest(self, level_contexts: list[LevelContext] | None) -> str:
+        if not level_contexts:
+            return self._prompt_identity("ac-level-context-chain:v1")
+        cached = self._capsule_level_context_cache.get(id(level_contexts))
+        if cached is not None and cached[0] is level_contexts:
+            return cached[1]
+        digest = self._prompt_identity("ac-level-context-chain:v1")
+        for context in level_contexts:
+            digest = self._prompt_identity(f"{digest}\n{self._level_context_item_digest(context)}")
+        self._capsule_level_context_cache[id(level_contexts)] = (level_contexts, digest)
+        return digest
+
+    def _copy_level_context_chain_digest(
+        self,
+        *,
+        source: list[LevelContext],
+        target: list[LevelContext],
+    ) -> None:
+        digest = self._level_context_chain_digest(source)
+        self._capsule_level_context_cache[id(target)] = (target, digest)
+
+    def _capsule_dependency_references(
+        self,
+        *,
+        execution_id: str,
+        level_contexts: list[LevelContext] | None,
+    ) -> tuple[ACContextReference, ...]:
+        if not level_contexts:
+            return ()
+        cache_key = (execution_id, id(level_contexts))
+        cached = self._capsule_dependency_reference_cache.get(cache_key)
+        if cached is not None and cached[0] is level_contexts:
+            return cached[1]
+        references = tuple(
+            islice(
+                build_ac_dependency_references(execution_id, level_contexts),
+                MAX_AC_CONTEXT_REFERENCES + 1,
+            )
+        )
+        self._capsule_dependency_reference_cache[cache_key] = (
+            level_contexts,
+            references,
+        )
+        return references
+
+    def _build_capsule_dispatch_authority_contract(
+        self,
+        *,
+        tools: list[str],
+        tool_catalog: tuple[MCPToolDefinition, ...] | None,
+        system_prompt: str,
+        level_contexts: list[LevelContext] | None,
+    ) -> dict[str, object]:
+        """Build an exact digest-only authority contract without large copies."""
+        workspace = self._task_cwd or getattr(self._adapter, "working_directory", None)
+        workspace_identity = os.path.realpath(os.path.expanduser(workspace or os.getcwd()))
+        runtime_backend = getattr(self._adapter, "runtime_backend", None)
+        permission_mode = getattr(self._adapter, "permission_mode", None)
+        constructor_model = getattr(self._adapter, "_model", None)
+        return {
+            "version": 1,
+            "workspace": workspace_identity,
+            "runtime": {
+                "backend": runtime_backend if isinstance(runtime_backend, str) else None,
+                "permission_mode": (permission_mode if isinstance(permission_mode, str) else None),
+                "constructor_model": (
+                    constructor_model if isinstance(constructor_model, str) else None
+                ),
+                "capabilities": self._runtime_capabilities_contract(self._adapter),
+                "execution": self._runtime_execution_authority,
+            },
+            "model_routing": serialize_model_router(self._model_router),
+            "execution_profile": serialize_execution_profile(self._execution_profile),
+            "tools": {
+                "count": len(tools),
+                "digest": self._authority_digest(tools, field="AC capsule tools"),
+            },
+            "tool_catalog": self._capsule_tool_catalog_authority(tool_catalog),
+            "system_prompt_digest": self._prompt_identity(system_prompt),
+            "level_contexts": {
+                "count": len(level_contexts or ()),
+                "chain_digest": self._level_context_chain_digest(level_contexts),
+            },
+        }
+
     def _build_checkpoint_dispatch_contract(
         self,
         *,
@@ -2485,12 +2635,11 @@ class ParallelACExecutor:
         retry_prompt_extra: str = "",
     ) -> str:
         """Bind a capsule to the exact provider dispatch authority in force."""
-        dispatch_contract = self._build_checkpoint_dispatch_contract(
+        dispatch_contract = self._build_capsule_dispatch_authority_contract(
             tools=tools,
             tool_catalog=tool_catalog,
             system_prompt=system_prompt,
-            system_prompt_builder=None,
-            reconciled_level_contexts=level_contexts,
+            level_contexts=level_contexts,
         )
         execution_policy: dict[str, object] = {
             "reasoning_effort": self._reasoning_effort,
@@ -4276,12 +4425,13 @@ class ParallelACExecutor:
             )
         return [by_level[level_number] for level_number in sorted(by_level)]
 
-    @staticmethod
     def _merge_level_context(
+        self,
         level_contexts: list[LevelContext],
         incoming: LevelContext,
     ) -> list[LevelContext]:
         """Merge a new stage handoff with an existing reconciled stage context."""
+        previous_digest = self._level_context_chain_digest(level_contexts)
         by_level = {context.level_number: context for context in level_contexts}
         existing = by_level.get(incoming.level_number)
         if existing is None:
@@ -4294,7 +4444,17 @@ class ParallelACExecutor:
                 completed_acs=tuple(summaries[index] for index in sorted(summaries)),
                 coordinator_review=(incoming.coordinator_review or existing.coordinator_review),
             )
-        return [by_level[level_number] for level_number in sorted(by_level)]
+        merged = [by_level[level_number] for level_number in sorted(by_level)]
+        if existing is None and (
+            not level_contexts or incoming.level_number > level_contexts[-1].level_number
+        ):
+            digest = self._prompt_identity(
+                f"{previous_digest}\n{self._level_context_item_digest(incoming)}"
+            )
+            self._capsule_level_context_cache[id(merged)] = (merged, digest)
+        else:
+            self._level_context_chain_digest(merged)
+        return merged
 
     @staticmethod
     def _recovery_exhausted_payload_malformed(
@@ -6257,6 +6417,10 @@ class ParallelACExecutor:
 
                 # Capture current contexts for this level's closure
                 current_contexts = list(level_contexts)
+                self._copy_level_context_chain_digest(
+                    source=level_contexts,
+                    target=current_contexts,
+                )
 
                 for batch_index, batch in enumerate(stage_batches, start=1):
                     batch_executable = [ac_idx for ac_idx in batch if ac_idx in executable]
@@ -8543,9 +8707,7 @@ class ParallelACExecutor:
             capsule_success_contract=capsule_success_contract,
         )
         parent_expected_artifacts: tuple[str, ...] = (
-            tuple(active_success_spec.expected_artifacts)
-            if active_success_spec is not None
-            else ()
+            tuple(active_success_spec.expected_artifacts) if active_success_spec is not None else ()
         )
         ac_label = (
             f"AC #{node_identity.display_path}"
@@ -9198,6 +9360,10 @@ Respond with either ATOMIC or the structured JSON object only.
             ac_spec=ac_spec,
             success_contract_override=capsule_success_contract,
             level_contexts=tuple(level_contexts or ()),
+            dependency_references=self._capsule_dependency_references(
+                execution_id=execution_context_id,
+                level_contexts=level_contexts,
+            ),
         )
 
         # Build prompt (label/indent, governed task section, success contract,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2600,9 +2600,13 @@ class ParallelACExecutor:
             expanded = os.path.expanduser(value)
             return {"path": value, "realpath": os.path.realpath(expanded)}
 
-        def _probe(obj: object) -> tuple[dict[str, str] | None, dict[str, str] | None]:
+        def _probe(
+            obj: object,
+        ) -> tuple[dict[str, str] | None, dict[str, str] | None, object | None]:
             # An explicit contract wins — a wrapping runtime uses it to name the
-            # executable/launcher its transport really invokes.
+            # executable/launcher its transport really invokes AND any additional
+            # command-affecting policy (e.g. Claude's --add-dir / --disallowedTools)
+            # that changes what the process is allowed to do.
             contract = getattr(obj, "executable_identity_contract", None)
             if callable(contract):
                 try:
@@ -2610,7 +2614,12 @@ class ParallelACExecutor:
                 except Exception:
                     declared = None
                 if isinstance(declared, Mapping):
-                    return _resolve(declared.get("executable")), _resolve(declared.get("launcher"))
+                    command_policy = declared.get("command_policy")
+                    return (
+                        _resolve(declared.get("executable")),
+                        _resolve(declared.get("launcher")),
+                        command_policy if isinstance(command_policy, Mapping) else None,
+                    )
             # ``cli_path`` is exposed both as a property (Codex) and as a private
             # attribute (most subprocess runtimes); probe the public form first.
             executable = _resolve(getattr(obj, "cli_path", None)) or _resolve(
@@ -2619,20 +2628,23 @@ class ParallelACExecutor:
             # Zcode launches its CLI through an Electron/Node host; that launcher
             # is part of what actually executes and must be bound too.
             launcher = _resolve(getattr(obj, "_electron_node_path", None))
-            return executable, launcher
+            return executable, launcher, None
 
-        executable, launcher = _probe(adapter)
-        if executable is None and launcher is None:
+        executable, launcher, command_policy = _probe(adapter)
+        if executable is None and launcher is None and command_policy is None:
             # A wrapping runtime holds the real launcher under a transport; probe
             # one delegation level so a delegated executable still fingerprints.
             transport = getattr(adapter, "_transport", None)
             if transport is not None:
-                executable, launcher = _probe(transport)
+                executable, launcher, command_policy = _probe(transport)
         return {
             "version": 1,
-            "observed": executable is not None or launcher is not None,
+            "observed": (
+                executable is not None or launcher is not None or command_policy is not None
+            ),
             "executable": executable,
             "launcher": launcher,
+            "command_policy": dict(command_policy) if isinstance(command_policy, Mapping) else None,
         }
 
     @staticmethod
@@ -6537,7 +6549,18 @@ class ParallelACExecutor:
                         and (spec.verify_command or spec.expected_artifacts)
                     ):
                         cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
-                        gate = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+                        # Route through the single-shot oracle so a crash after the
+                        # command but before status/checkpoint persistence does not
+                        # rerun a non-idempotent verify_command on the next launch.
+                        gate = await self._run_verify_gate_single_shot(
+                            spec=spec,
+                            cwd=cwd,
+                            aggregate_id=execution_id or session_id,
+                            verify_key=f"skip_completed:{ac_idx}",
+                            execution_id=execution_id,
+                            session_id=session_id,
+                            identity_metadata={"ac_index": ac_idx},
+                        )
                         if not gate.passed:
                             executable.append(ac_idx)
                             log.info(
@@ -10059,6 +10082,22 @@ Respond with either ATOMIC or the structured JSON object only.
                     forced_frontier_routing=force_frontier_routing,
                 )
 
+            # Seal the completed provider turn BEFORE any post-processing. The
+            # authoritative terminal (session.completed/failed) is not durable
+            # until after signal handling, verification, evidence, and optional
+            # shadow replay — a crash anywhere in that window would otherwise
+            # leave only attempt.dispatched + session.started, and recovery would
+            # resume the handle and replay the original AC prompt. A sealed head
+            # without a durable terminal fails closed instead; on the normal path
+            # the later session.completed takes precedence over the seal.
+            await self._event_emitter.emit_ac_dispatch_sealed(
+                runtime_identity=runtime_identity,
+                dispatch_id=dispatch_id,
+                execution_id=execution_context_id,
+                session_id=session_id,
+                capsule_fingerprint=capsule.fingerprint,
+            )
+
             if signal_target is not None and self._session_signal_hub is not None:
                 await self._session_signal_hub.refresh_pending(signal_target)
                 while True:
@@ -10185,6 +10224,12 @@ Respond with either ATOMIC or the structured JSON object only.
                         )
                         dispatch_id = signal_dispatch_id
                         provider_boundary_persisted = True
+                        # Reset per-dispatch state so the follow-up's OWN stall and
+                        # tool-effect state is measured (the primary's was already
+                        # consumed above), and the follow-up gets the same
+                        # stall/seal handling as the primary provider entry.
+                        dispatch_state.stalled = False
+                        dispatch_state.tool_effects_observed = False
                         await LeafDispatcher(self).stream(
                             state=dispatch_state,
                             prompt=follow_up_prompt,
@@ -10240,6 +10285,47 @@ Respond with either ATOMIC or the structured JSON object only.
                             dispatch_state.infra_fatal = primary_infra_fatal
                             continue
                         raise
+
+                    # Apply the same stall/seal handling to the follow-up provider
+                    # entry as the primary. A follow-up that emitted a tool effect
+                    # and then stalled must NOT be quietly recorded as an
+                    # acknowledged, successful signal turn: seal it and fail closed
+                    # so a cold restart cannot resume it and repeat the effect. An
+                    # effect-free follow-up stall is a non-durable delivery
+                    # uncertainty, handled like a missing acknowledgement.
+                    if dispatch_state.stalled:
+                        await self._event_store.append(
+                            create_session_signal_delivery_uncertain_event(
+                                queued_signal.signal,
+                                effective_mode=queued_signal.effective_mode,
+                                detail="The runtime stalled during the follow-up turn.",
+                                runtime_backend=signal_target.runtime_backend,
+                                orchestrator_session_id=session_id,
+                            )
+                        )
+                        if dispatch_state.tool_effects_observed:
+                            await self._event_emitter.emit_ac_dispatch_sealed(
+                                runtime_identity=runtime_identity,
+                                dispatch_id=signal_dispatch_id,
+                                execution_id=execution_context_id,
+                                session_id=session_id,
+                                capsule_fingerprint=capsule.fingerprint,
+                            )
+                            raise AmbiguousACExecutionError(
+                                "SessionSignal follow-up stalled after emitting tool effects; "
+                                "refusing to record success because a cold restart could resume "
+                                "the stalled follow-up and repeat non-idempotent effects"
+                            )
+                        if inform_mode:
+                            dispatch_state.success = primary_success
+                            dispatch_state.final_message = primary_final_message
+                            dispatch_state.infra_fatal = primary_infra_fatal
+                            continue
+                        dispatch_state.success = False
+                        dispatch_state.final_message = (
+                            "Synapse after-turn follow-up stalled before completion."
+                        )
+                        break
 
                     signal_messages = messages[message_count_before_signal:]
                     acknowledgement_messages = [
@@ -11489,7 +11575,17 @@ Respond with either ATOMIC or the structured JSON object only.
                     outcome=cached_outcome,
                 )
             else:
-                outcome = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+                # Route through the single-shot oracle so replaying this flip gate
+                # never re-runs a non-idempotent verify_command.
+                outcome = await self._run_verify_gate_single_shot(
+                    spec=spec,
+                    cwd=cwd,
+                    aggregate_id=execution_id or session_id,
+                    verify_key=f"flip_gate:{ac_idx}:{result.retry_attempt}",
+                    execution_id=execution_id,
+                    session_id=session_id,
+                    identity_metadata={"ac_index": ac_idx, "retry_attempt": result.retry_attempt},
+                )
             if not outcome.passed:
                 gated_out.add(ac_idx)
         return frozenset(gated_out)

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1204,6 +1204,16 @@ _MAX_VERIFIER_AUTHORITY_SCALAR_CHARS = 8_192
 _MAX_VERIFIER_AUTHORITY_JSON_CHARS = 64_000
 
 
+class _AltHarnessPreEntryError(Exception):
+    """An alternate-harness redispatch failed BEFORE any provider entry.
+
+    Only a construction/spawn failure that provably precedes provider entry may
+    fall back to the original result; a failure after the alternate has entered
+    the provider (and possibly mutated the shared workspace) must instead fail
+    closed as ambiguity, so it is NOT wrapped in this type.
+    """
+
+
 class ParallelACExecutor:
     """Executes ACs in parallel based on dependency graph."""
 
@@ -8806,11 +8816,13 @@ class ParallelACExecutor:
             # The alternate ran in the SAME shared workspace and may already have
             # applied non-idempotent effects; swallowing this to ``None`` would let
             # the caller finalize/escalate from the stale pre-redispatch state.
-            # Propagate the ambiguity so it fails closed (the fallback below is only
-            # for failures proven to occur before any provider entry).
+            # Propagate the ambiguity so it fails closed.
             self._alt_harness_status_by_root[root_ac_index] = "failed"
             raise
-        except Exception as exc:  # never make a failure worse
+        except _AltHarnessPreEntryError as exc:
+            # Proven to fail BEFORE any provider entry (runtime construction/spawn):
+            # the shared workspace was not touched, so falling back to the original
+            # result is safe — never make a failure worse.
             self._alt_harness_status_by_root[root_ac_index] = "failed"
             log.warning(
                 "parallel_executor.alt_harness_redispatch_failed",
@@ -8819,6 +8831,17 @@ class ParallelACExecutor:
                 error=str(exc),
             )
             return None
+        except Exception as exc:
+            # A generic failure AFTER provider entry (e.g. terminal-event
+            # persistence raising once the alternate already mutated the shared
+            # workspace) must NOT restore the stale original result. Fail closed as
+            # ambiguity so recovery cannot finalize from pre-redispatch state.
+            self._alt_harness_status_by_root[root_ac_index] = "failed"
+            raise AmbiguousACExecutionError(
+                "alternate-harness redispatch failed after provider entry "
+                f"({type(exc).__name__}); the alternate may have mutated the shared "
+                "workspace, so refusing to restore the original result"
+            ) from exc
         if alt_result is None:
             self._alt_harness_status_by_root[root_ac_index] = "failed"
             return None
@@ -8886,22 +8909,30 @@ class ParallelACExecutor:
         )
         from ouroboros.orchestrator.runtime_factory import create_agent_runtime
 
-        cwd = self._task_cwd or self._adapter.working_directory
-        alt_adapter = create_agent_runtime(
-            backend=backend,
-            cwd=cwd,
-            permission_mode="bypassPermissions",
-        )
+        # Everything up to (but NOT including) ``_execute_single_ac`` runs BEFORE
+        # any provider entry, so a failure here is a safe pre-entry fallback. A
+        # failure inside ``_execute_single_ac`` may follow provider entry and a
+        # workspace mutation, so it is deliberately left OUTSIDE this guard to
+        # propagate as ambiguity.
+        try:
+            cwd = self._task_cwd or self._adapter.working_directory
+            alt_adapter = create_agent_runtime(
+                backend=backend,
+                cwd=cwd,
+                permission_mode="bypassPermissions",
+            )
 
-        event = create_alt_harness_redispatch_event(
-            session_id=rerun_kwargs["session_id"],
-            ac_index=rerun_kwargs["ac_index"],
-            ac_id=runtime_identity.ac_id,
-            execution_id=rerun_kwargs["execution_id"] or None,
-            decision=decision,
-            redispatch_index=1,
-            failure_class=failure_class,
-        )
+            event = create_alt_harness_redispatch_event(
+                session_id=rerun_kwargs["session_id"],
+                ac_index=rerun_kwargs["ac_index"],
+                ac_id=runtime_identity.ac_id,
+                execution_id=rerun_kwargs["execution_id"] or None,
+                decision=decision,
+                redispatch_index=1,
+                failure_class=failure_class,
+            )
+        except Exception as exc:
+            raise _AltHarnessPreEntryError(str(exc)) from exc
         await self._safe_emit_event(event)
         log.info(
             "parallel_executor.alt_harness_redispatch",
@@ -9853,6 +9884,14 @@ Respond with either ATOMIC or the structured JSON object only.
             ),
         )
 
+        # Snapshot the executable identity the capsule authority was built from, so
+        # we can revalidate it IMMEDIATELY before provider dispatch and refuse a
+        # symlink/PATH swap that happened in the compile→launch window (the capsule
+        # records a realpath, but the adapter launches the raw path later).
+        capsule_executable_identity = self._runtime_executable_identity(
+            self._adapter, cwd=capsule.workspace
+        )
+
         # Build prompt (label/indent, governed task section, success contract,
         # retry/parallel-awareness sections, cwd scan, completion contract).
         prompt_bundle = AtomicPromptBuilder(self).build(
@@ -10184,6 +10223,20 @@ Respond with either ATOMIC or the structured JSON object only.
                 )
                 await self._session_signal_hub.register_replaying(signal_target)
                 signal_target_registered = True
+
+            # Enforce (not just sample) the executable authority at the launch
+            # boundary: re-resolve it now and refuse if it drifted from the
+            # capsule since compile (e.g. a symlink swapped under the recorded
+            # realpath), so the launched binary always matches capsule authority.
+            if (
+                self._runtime_executable_identity(self._adapter, cwd=capsule.workspace)
+                != capsule_executable_identity
+            ):
+                raise AmbiguousACExecutionError(
+                    "runtime executable identity drifted between capsule compilation and "
+                    "dispatch; refusing to launch a binary that no longer matches capsule "
+                    "authority"
+                )
 
             await self._event_emitter.emit_ac_attempt_dispatched(
                 runtime_identity=runtime_identity,
@@ -10689,17 +10742,31 @@ Respond with either ATOMIC or the structured JSON object only.
             # once, after all children finish, by ``_attest_decomposition_round``.
             verify_gate_active = self._run_verify_commands and not is_sub_ac
             verify_gate_outcome: _VerifyGateOutcome | None = None
-            if success and verify_gate_active and has_success_contract:
+            # A verify_command's result is only authoritative for the FINAL shared
+            # workspace. This atomic leaf runs concurrently with its siblings (and
+            # precedes coordinator reconciliation), so running the command HERE
+            # would capture a mid-run snapshot that a later sibling edit could
+            # invalidate while the cached PASS survives. Defer the single
+            # authoritative command run to the batch-completion verify gate
+            # (``_apply_verify_gate``, applied to every AC after all siblings in the
+            # batch finish): leaving ``verify_gate_outcome`` unset makes that gate
+            # run the command ONCE (via the single-shot oracle) over the final
+            # workspace. A pure expected-artifacts contract is idempotent and its
+            # existence check is re-validated at finalization, so it still runs here.
+            defer_command_to_finalization = isinstance(ac_spec, AcceptanceCriterionSpec) and bool(
+                ac_spec.verify_command
+            )
+            if (
+                success
+                and verify_gate_active
+                and has_success_contract
+                and not defer_command_to_finalization
+            ):
                 cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
                 verify_gate_outcome = await self._run_verify_gate_single_shot(
                     spec=ac_spec,
                     cwd=cwd,
                     aggregate_id=execution_context_id,
-                    # One authoritative per-attempt key shared by the atomic gate,
-                    # the failed-runtime recovery gate (_apply_verify_gate), and the
-                    # sibling-flip gate, so a post-verify failure (e.g. a lost
-                    # session.completed) never reruns the command under a different
-                    # key — the later path consumes this attempt's durable outcome.
                     verify_key=self._ac_verify_gate_key(
                         execution_scope=execution_context_id,
                         ac_index=ac_index,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2354,7 +2354,20 @@ class ParallelACExecutor:
             return {"kind": "datetime", "value": value.isoformat()}
         if isinstance(value, timedelta):
             return {"kind": "timedelta", "seconds": value.total_seconds()}
-        if inspect.isroutine(value) or inspect.isclass(value):
+        if inspect.ismodule(value):
+            raise ValueError(f"{field} contains mutable module state")
+        if inspect.isclass(value):
+            try:
+                source = inspect.getsource(value)
+            except (OSError, TypeError) as exc:
+                raise ValueError(f"{field} contains an opaque class") from exc
+            return {
+                "kind": "class",
+                "module": str(getattr(value, "__module__", "")),
+                "qualname": str(getattr(value, "__qualname__", value.__name__)),
+                "source_digest": cls._prompt_identity(source),
+            }
+        if inspect.isroutine(value):
             raise ValueError(f"{field} contains nested executable state")
 
         seen = set() if seen is None else seen
@@ -2510,6 +2523,7 @@ class ParallelACExecutor:
                 raw_state: object = {"explicit_identity": dict(identity)}
             elif inspect.isfunction(verifier) or inspect.ismethod(verifier):
                 function = verifier.__func__ if inspect.ismethod(verifier) else verifier
+                closure_vars = inspect.getclosurevars(function)
                 closure_values: list[object] = []
                 for cell in getattr(function, "__closure__", None) or ():
                     try:
@@ -2522,6 +2536,9 @@ class ParallelACExecutor:
                     "closure": closure_values,
                     "function_attributes": dict(vars(function)),
                     "bound_instance": verifier.__self__ if inspect.ismethod(verifier) else None,
+                    "referenced_globals": dict(closure_vars.globals),
+                    "referenced_builtins": sorted(closure_vars.builtins),
+                    "unbound_names": sorted(closure_vars.unbound),
                 }
             else:
                 raw_state = {"callable_instance": verifier}

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2317,7 +2317,7 @@ class ParallelACExecutor:
         return {"version": 1, "observed": True, "identity": normalized}
 
     @classmethod
-    def _project_verifier_authority_value(
+    def _project_verifier_identity_value(
         cls,
         value: object,
         *,
@@ -2325,7 +2325,7 @@ class ParallelACExecutor:
         depth: int = 0,
         seen: set[int] | None = None,
     ) -> object:
-        """Project verifier state into bounded, deterministic JSON authority."""
+        """Validate one explicit verifier identity as bounded canonical JSON."""
         if depth > _MAX_VERIFIER_AUTHORITY_DEPTH:
             raise ValueError(f"{field} exceeds verifier authority depth")
         if value is None or isinstance(value, (bool, int)):
@@ -2338,37 +2338,6 @@ class ParallelACExecutor:
             if len(value) > _MAX_VERIFIER_AUTHORITY_SCALAR_CHARS:
                 raise ValueError(f"{field} contains oversized text")
             return value
-        if isinstance(value, bytes):
-            if len(value) > _MAX_VERIFIER_AUTHORITY_SCALAR_CHARS:
-                raise ValueError(f"{field} contains oversized bytes")
-            return {
-                "kind": "bytes",
-                "digest": "sha256:" + hashlib.sha256(value).hexdigest(),
-            }
-        if isinstance(value, Path):
-            path = os.fspath(value)
-            if len(path) > _MAX_VERIFIER_AUTHORITY_SCALAR_CHARS:
-                raise ValueError(f"{field} contains an oversized path")
-            return {"kind": "path", "value": path}
-        if isinstance(value, datetime):
-            return {"kind": "datetime", "value": value.isoformat()}
-        if isinstance(value, timedelta):
-            return {"kind": "timedelta", "seconds": value.total_seconds()}
-        if inspect.ismodule(value):
-            raise ValueError(f"{field} contains mutable module state")
-        if inspect.isclass(value):
-            try:
-                source = inspect.getsource(value)
-            except (OSError, TypeError) as exc:
-                raise ValueError(f"{field} contains an opaque class") from exc
-            return {
-                "kind": "class",
-                "module": str(getattr(value, "__module__", "")),
-                "qualname": str(getattr(value, "__qualname__", value.__name__)),
-                "source_digest": cls._prompt_identity(source),
-            }
-        if inspect.isroutine(value):
-            raise ValueError(f"{field} contains nested executable state")
 
         seen = set() if seen is None else seen
         value_id = id(value)
@@ -2379,97 +2348,32 @@ class ParallelACExecutor:
             if isinstance(value, Mapping):
                 if len(value) > _MAX_VERIFIER_AUTHORITY_ITEMS:
                     raise ValueError(f"{field} contains too many mapping items")
-                items: list[list[object]] = []
+                projected: dict[str, object] = {}
                 for key, item in value.items():
-                    projected_key = cls._project_verifier_authority_value(
-                        key,
-                        field=f"{field}.key",
-                        depth=depth + 1,
-                        seen=seen,
-                    )
-                    projected_value = cls._project_verifier_authority_value(
+                    if not isinstance(key, str) or not key:
+                        raise ValueError(f"{field} contains a non-string or empty key")
+                    if len(key) > _MAX_VERIFIER_AUTHORITY_SCALAR_CHARS:
+                        raise ValueError(f"{field} contains an oversized key")
+                    projected[key] = cls._project_verifier_identity_value(
                         item,
-                        field=f"{field}.value",
+                        field=f"{field}.{key}",
                         depth=depth + 1,
                         seen=seen,
                     )
-                    items.append([projected_key, projected_value])
-                items.sort(
-                    key=lambda pair: json.dumps(
-                        pair[0],
-                        sort_keys=True,
-                        separators=(",", ":"),
-                        ensure_ascii=True,
-                    )
-                )
-                return {"kind": "mapping", "items": items}
+                return projected
             if isinstance(value, (list, tuple)):
                 if len(value) > _MAX_VERIFIER_AUTHORITY_ITEMS:
                     raise ValueError(f"{field} contains too many sequence items")
-                return {
-                    "kind": "tuple" if isinstance(value, tuple) else "list",
-                    "items": [
-                        cls._project_verifier_authority_value(
-                            item,
-                            field=f"{field}[{index}]",
-                            depth=depth + 1,
-                            seen=seen,
-                        )
-                        for index, item in enumerate(value)
-                    ],
-                }
-            if isinstance(value, (set, frozenset)):
-                if len(value) > _MAX_VERIFIER_AUTHORITY_ITEMS:
-                    raise ValueError(f"{field} contains too many set items")
-                items = [
-                    cls._project_verifier_authority_value(
+                return [
+                    cls._project_verifier_identity_value(
                         item,
-                        field=f"{field}.item",
+                        field=f"{field}[{index}]",
                         depth=depth + 1,
                         seen=seen,
                     )
-                    for item in value
+                    for index, item in enumerate(value)
                 ]
-                items.sort(
-                    key=lambda item: json.dumps(
-                        item,
-                        sort_keys=True,
-                        separators=(",", ":"),
-                        ensure_ascii=True,
-                    )
-                )
-                return {
-                    "kind": "frozenset" if isinstance(value, frozenset) else "set",
-                    "items": items,
-                }
-
-            object_state: dict[str, object] = {}
-            try:
-                object_state.update(vars(value))
-            except TypeError:
-                pass
-            slots = inspect.getattr_static(type(value), "__slots__", ())
-            if isinstance(slots, str):
-                slots = (slots,)
-            for slot in slots:
-                if slot in {"__dict__", "__weakref__"} or slot in object_state:
-                    continue
-                try:
-                    object_state[slot] = object.__getattribute__(value, slot)
-                except AttributeError:
-                    continue
-            if not object_state:
-                raise ValueError(f"{field} has no inspectable stable state")
-            return {
-                "kind": "object",
-                "type": f"{type(value).__module__}.{type(value).__qualname__}",
-                "state": cls._project_verifier_authority_value(
-                    object_state,
-                    field=f"{field}.state",
-                    depth=depth + 1,
-                    seen=seen,
-                ),
-            }
+            raise ValueError(f"{field} is not canonical JSON data")
         finally:
             seen.remove(value_id)
 
@@ -2503,49 +2407,40 @@ class ParallelACExecutor:
         }
 
     def _verifier_state_authority_contract(self, verifier: Verifier) -> dict[str, object]:
-        """Bind behavioral verifier state or deliberately disable durable reuse."""
+        """Reuse verifier authority only when the verifier declares stable identity."""
+
+        def _process_local(reason: str) -> dict[str, object]:
+            nonce = uuid.uuid4().hex
+            log.warning(
+                "parallel_executor.atomic_verifier_authority_process_local",
+                verifier_type=f"{type(verifier).__module__}.{type(verifier).__qualname__}",
+                reason=reason,
+            )
+            return {
+                "stability": "process_local",
+                "instance_nonce": nonce,
+            }
+
+        identity_descriptor = inspect.getattr_static(
+            verifier,
+            "verification_identity_contract",
+            None,
+        )
+        if identity_descriptor is None:
+            return _process_local("custom verifier did not declare verification_identity_contract")
         try:
-            identity_descriptor = inspect.getattr_static(
+            identity_provider = object.__getattribute__(
                 verifier,
                 "verification_identity_contract",
-                None,
             )
-            if identity_descriptor is not None:
-                identity_provider = object.__getattribute__(
-                    verifier,
-                    "verification_identity_contract",
-                )
-                if not callable(identity_provider):
-                    raise ValueError("verification_identity_contract is not callable")
-                identity = identity_provider()
-                if not isinstance(identity, Mapping):
-                    raise ValueError("verification_identity_contract is not a mapping")
-                raw_state: object = {"explicit_identity": dict(identity)}
-            elif inspect.isfunction(verifier) or inspect.ismethod(verifier):
-                function = verifier.__func__ if inspect.ismethod(verifier) else verifier
-                closure_vars = inspect.getclosurevars(function)
-                closure_values: list[object] = []
-                for cell in getattr(function, "__closure__", None) or ():
-                    try:
-                        closure_values.append(cell.cell_contents)
-                    except ValueError:
-                        closure_values.append({"empty_cell": True})
-                raw_state = {
-                    "defaults": getattr(function, "__defaults__", None),
-                    "kwdefaults": getattr(function, "__kwdefaults__", None),
-                    "closure": closure_values,
-                    "function_attributes": dict(vars(function)),
-                    "bound_instance": verifier.__self__ if inspect.ismethod(verifier) else None,
-                    "referenced_globals": dict(closure_vars.globals),
-                    "referenced_builtins": sorted(closure_vars.builtins),
-                    "unbound_names": sorted(closure_vars.unbound),
-                }
-            else:
-                raw_state = {"callable_instance": verifier}
-
-            projected = self._project_verifier_authority_value(
-                raw_state,
-                field="atomic verifier state",
+            if not callable(identity_provider):
+                raise ValueError("verification_identity_contract is not callable")
+            identity = identity_provider()
+            if not isinstance(identity, Mapping):
+                raise ValueError("verification_identity_contract is not a mapping")
+            projected = self._project_verifier_identity_value(
+                dict(identity),
+                field="atomic verifier identity contract",
             )
             encoded = json.dumps(
                 projected,
@@ -2561,16 +2456,7 @@ class ParallelACExecutor:
                 "state_digest": self._prompt_identity(encoded),
             }
         except (AttributeError, TypeError, ValueError) as exc:
-            nonce = uuid.uuid4().hex
-            log.warning(
-                "parallel_executor.atomic_verifier_authority_process_local",
-                verifier_type=f"{type(verifier).__module__}.{type(verifier).__qualname__}",
-                reason=str(exc),
-            )
-            return {
-                "stability": "process_local",
-                "instance_nonce": nonce,
-            }
+            return _process_local(str(exc))
 
     def _atomic_verifier_authority_contract(self) -> dict[str, object]:
         """Return a durable identity for the acceptance judge in force."""

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -87,6 +87,10 @@ from ouroboros.harness.deliver_gate import (
 from ouroboros.harness.journal import EvidenceEntry, EvidenceManifest
 from ouroboros.harness.traceguard_validator import validate_evidence_claims
 from ouroboros.observability.logging import get_logger
+from ouroboros.orchestrator.ac_execution_capsule import (
+    bind_capsule_to_runtime_handle,
+    compile_ac_execution_capsule,
+)
 from ouroboros.orchestrator.ac_runtime_handle_manager import ACRuntimeHandleManager
 from ouroboros.orchestrator.adapter import (
     AgentMessage,
@@ -1851,6 +1855,7 @@ class ParallelACExecutor:
         sub_ac_index: int | None = None,
         node_identity: ExecutionNodeIdentity | None = None,
         retry_attempt: int = 0,
+        expected_capsule_fingerprint: str | None = None,
     ) -> RuntimeHandle | None:
         return await self._ac_runtime_handle_manager._load_persisted_ac_runtime_handle(
             ac_index,
@@ -1860,6 +1865,7 @@ class ParallelACExecutor:
             sub_ac_index=sub_ac_index,
             node_identity=node_identity,
             retry_attempt=retry_attempt,
+            expected_capsule_fingerprint=expected_capsule_fingerprint,
         )
 
     def _remember_ac_runtime_handle(
@@ -8963,20 +8969,43 @@ Respond with either ATOMIC or the structured JSON object only.
         """
         ac_session_id: str | None = None
         semantic_ac_key = semantic_ac_key or derive_semantic_ac_key(ac_spec or ac_content)
+        execution_context_id = execution_id or session_id
+        runtime_identity = build_ac_runtime_identity(
+            ac_index,
+            execution_context_id=execution_context_id,
+            is_sub_ac=is_sub_ac,
+            parent_ac_index=parent_ac_index,
+            sub_ac_index=sub_ac_index,
+            node_identity=node_identity,
+            retry_attempt=retry_attempt,
+        )
+        capsule = compile_ac_execution_capsule(
+            runtime_identity=runtime_identity,
+            execution_id=execution_context_id,
+            semantic_ac_key=semantic_ac_key,
+            workspace=(
+                self._task_cwd or getattr(self._adapter, "working_directory", None) or os.getcwd()
+            ),
+            authority_scope=(
+                self._decomposition_attestation_scope or f"execution:{execution_context_id}"
+            ),
+            seed_goal=seed_goal,
+            ac_content=ac_content,
+            ac_spec=ac_spec,
+            level_contexts=tuple(level_contexts or ()),
+        )
 
         # Build prompt (label/indent, governed task section, success contract,
         # retry/parallel-awareness sections, cwd scan, completion contract).
         prompt_bundle = AtomicPromptBuilder(self).build(
+            capsule=capsule,
             ac_index=ac_index,
-            ac_content=ac_content,
-            seed_goal=seed_goal,
             is_sub_ac=is_sub_ac,
             parent_ac_index=parent_ac_index,
             sub_ac_index=sub_ac_index,
             node_identity=node_identity,
             level_contexts=level_contexts,
             sibling_acs=sibling_acs,
-            retry_attempt=retry_attempt,
             retry_prompt_extra=retry_prompt_extra,
             ac_spec=ac_spec,
         )
@@ -8989,7 +9018,6 @@ Respond with either ATOMIC or the structured JSON object only.
         final_message = ""
         success = False
         clear_cached_runtime_handle = False
-        execution_context_id = execution_id or session_id
         persisted_runtime_handle = await self._load_persisted_ac_runtime_handle(
             ac_index,
             execution_context_id=execution_context_id,
@@ -8998,6 +9026,7 @@ Respond with either ATOMIC or the structured JSON object only.
             sub_ac_index=sub_ac_index,
             node_identity=node_identity,
             retry_attempt=retry_attempt,
+            expected_capsule_fingerprint=capsule.fingerprint,
         )
         if persisted_runtime_handle is not None:
             self._remember_ac_runtime_handle(
@@ -9020,14 +9049,18 @@ Respond with either ATOMIC or the structured JSON object only.
             retry_attempt=retry_attempt,
             tool_catalog=tool_catalog,
         )
-        runtime_identity = build_ac_runtime_identity(
-            ac_index,
-            execution_context_id=execution_context_id,
-            is_sub_ac=is_sub_ac,
-            parent_ac_index=parent_ac_index,
-            sub_ac_index=sub_ac_index,
-            node_identity=node_identity,
-            retry_attempt=retry_attempt,
+        runtime_handle = bind_capsule_to_runtime_handle(
+            capsule,
+            runtime_handle,
+            restored_same_attempt=persisted_runtime_handle is not None,
+        )
+        await self._event_emitter.emit_ac_capsule_compiled(
+            runtime_identity=runtime_identity,
+            session_id=session_id,
+            capsule=capsule,
+            session_origin=(
+                "restored_same_attempt" if persisted_runtime_handle is not None else "fresh"
+            ),
         )
         await self._emit_atomic_context_governed_event(
             runtime_identity=runtime_identity,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2622,7 +2622,20 @@ class ParallelACExecutor:
             # identity) rather than silently collapsing to the raw name.
             has_sep = os.sep in expanded or (os.altsep is not None and os.altsep in expanded)
             if not has_sep:
-                which = shutil.which(expanded)
+                # ``create_subprocess_exec`` resolves a bare name against the child
+                # process's PATH, and a RELATIVE PATH entry (e.g. ``PATH=bin``) is
+                # resolved from the CHILD's working directory — not the
+                # orchestrator's. Anchor relative PATH entries to the effective
+                # child cwd so ``<cwd>/bin/probe-cli`` is fingerprinted (and a
+                # swap of its target changes authority) instead of collapsing to
+                # ``unresolved`` because it does not exist under the orchestrator.
+                search_path = os.environ.get("PATH", os.defpath)
+                if cwd is not None:
+                    search_path = os.pathsep.join(
+                        entry if not entry or os.path.isabs(entry) else os.path.join(cwd, entry)
+                        for entry in search_path.split(os.pathsep)
+                    )
+                which = shutil.which(expanded, path=search_path)
                 if which is None:
                     return {"path": value, "realpath": None, "path_resolution": "unresolved"}
                 return {"path": value, "realpath": os.path.realpath(which)}
@@ -2701,6 +2714,9 @@ class ParallelACExecutor:
             "_stdout_idle_timeout_seconds",
             "_process_shutdown_timeout_seconds",
             "_completed_process_group_shutdown_timeout_seconds",
+            # Total-turn kill timeout (e.g. ClaudeWorkerTransport._timeout, applied
+            # via asyncio.wait_for) — also decides when a turn is interrupted.
+            "_timeout",
         )
 
         def _probe(obj: object) -> dict[str, object] | None:
@@ -2982,6 +2998,10 @@ class ParallelACExecutor:
             # execution semantics, so it must change authority — otherwise a
             # restart could resume the same capsule under different signal policy.
             "session_signal_hub_enabled": self._session_signal_hub is not None,
+            # Effective sibling concurrency is shared-workspace execution
+            # semantics: concurrency 1 vs 8 interleave sibling mutations
+            # differently, so a resume must not silently change it.
+            "max_concurrent": self._max_concurrent,
             "prompt_authority": {
                 "retry_prompt_digest": self._prompt_identity(retry_prompt_extra),
                 "siblings": [

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2124,12 +2124,17 @@ class ParallelACExecutor:
             success=success,
             error=error,
             verify_gate_outcome=(
-                {
-                    "passed": verify_gate_outcome.passed,
-                    "reason": verify_gate_outcome.reason,
-                    "output_tail": verify_gate_outcome.output_tail,
-                    "missing_artifacts": list(verify_gate_outcome.missing_artifacts),
-                }
+                # Byte-bounded so the completed-lifecycle outcome always fits the
+                # durable size cap (and can therefore be re-parsed on recovery),
+                # exactly like the verify.outcome event.
+                bound_verify_gate_outcome(
+                    {
+                        "passed": verify_gate_outcome.passed,
+                        "reason": verify_gate_outcome.reason,
+                        "output_tail": verify_gate_outcome.output_tail,
+                        "missing_artifacts": list(verify_gate_outcome.missing_artifacts),
+                    }
+                )
                 if verify_gate_outcome is not None
                 else None
             ),
@@ -2631,8 +2636,14 @@ class ParallelACExecutor:
                 # ``unresolved`` because it does not exist under the orchestrator.
                 search_path = os.environ.get("PATH", os.defpath)
                 if cwd is not None:
+                    # A relative OR EMPTY PATH component is resolved by the child
+                    # against its cwd (POSIX: an empty component means the current
+                    # directory), so anchor both to the child cwd — only an
+                    # absolute component is left as-is. Leaving empty components
+                    # unanchored let ``PATH=""`` collapse distinct workspace-local
+                    # binaries to the same ``unresolved`` identity.
                     search_path = os.pathsep.join(
-                        entry if not entry or os.path.isabs(entry) else os.path.join(cwd, entry)
+                        entry if os.path.isabs(entry) else os.path.join(cwd, entry)
                         for entry in search_path.split(os.pathsep)
                     )
                 which = shutil.which(expanded, path=search_path)

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -36,6 +36,7 @@ import hashlib
 import inspect
 from itertools import islice
 import json
+import marshal
 import math
 import os
 from pathlib import Path
@@ -1166,6 +1167,10 @@ def _pid_alive(pid: int) -> bool:
 _CHECKPOINT_OWNER_FRESHNESS = timedelta(minutes=15)
 _EXECUTION_CHECKPOINT_CONTRACT_VERSION = 2
 _CHECKPOINT_DISPATCH_CONTRACT_VERSION = 2
+_MAX_VERIFIER_AUTHORITY_DEPTH = 8
+_MAX_VERIFIER_AUTHORITY_ITEMS = 256
+_MAX_VERIFIER_AUTHORITY_SCALAR_CHARS = 8_192
+_MAX_VERIFIER_AUTHORITY_JSON_CHARS = 64_000
 
 
 class ParallelACExecutor:
@@ -2311,36 +2316,255 @@ class ParallelACExecutor:
             raise ValueError("runtime execution identity contract is not an object")
         return {"version": 1, "observed": True, "identity": normalized}
 
+    @classmethod
+    def _project_verifier_authority_value(
+        cls,
+        value: object,
+        *,
+        field: str,
+        depth: int = 0,
+        seen: set[int] | None = None,
+    ) -> object:
+        """Project verifier state into bounded, deterministic JSON authority."""
+        if depth > _MAX_VERIFIER_AUTHORITY_DEPTH:
+            raise ValueError(f"{field} exceeds verifier authority depth")
+        if value is None or isinstance(value, (bool, int)):
+            return value
+        if isinstance(value, float):
+            if not math.isfinite(value):
+                raise ValueError(f"{field} contains a non-finite float")
+            return value
+        if isinstance(value, str):
+            if len(value) > _MAX_VERIFIER_AUTHORITY_SCALAR_CHARS:
+                raise ValueError(f"{field} contains oversized text")
+            return value
+        if isinstance(value, bytes):
+            if len(value) > _MAX_VERIFIER_AUTHORITY_SCALAR_CHARS:
+                raise ValueError(f"{field} contains oversized bytes")
+            return {
+                "kind": "bytes",
+                "digest": "sha256:" + hashlib.sha256(value).hexdigest(),
+            }
+        if isinstance(value, Path):
+            path = os.fspath(value)
+            if len(path) > _MAX_VERIFIER_AUTHORITY_SCALAR_CHARS:
+                raise ValueError(f"{field} contains an oversized path")
+            return {"kind": "path", "value": path}
+        if isinstance(value, datetime):
+            return {"kind": "datetime", "value": value.isoformat()}
+        if isinstance(value, timedelta):
+            return {"kind": "timedelta", "seconds": value.total_seconds()}
+        if inspect.isroutine(value) or inspect.isclass(value):
+            raise ValueError(f"{field} contains nested executable state")
+
+        seen = set() if seen is None else seen
+        value_id = id(value)
+        if value_id in seen:
+            raise ValueError(f"{field} contains cyclic state")
+        seen.add(value_id)
+        try:
+            if isinstance(value, Mapping):
+                if len(value) > _MAX_VERIFIER_AUTHORITY_ITEMS:
+                    raise ValueError(f"{field} contains too many mapping items")
+                items: list[list[object]] = []
+                for key, item in value.items():
+                    projected_key = cls._project_verifier_authority_value(
+                        key,
+                        field=f"{field}.key",
+                        depth=depth + 1,
+                        seen=seen,
+                    )
+                    projected_value = cls._project_verifier_authority_value(
+                        item,
+                        field=f"{field}.value",
+                        depth=depth + 1,
+                        seen=seen,
+                    )
+                    items.append([projected_key, projected_value])
+                items.sort(
+                    key=lambda pair: json.dumps(
+                        pair[0],
+                        sort_keys=True,
+                        separators=(",", ":"),
+                        ensure_ascii=True,
+                    )
+                )
+                return {"kind": "mapping", "items": items}
+            if isinstance(value, (list, tuple)):
+                if len(value) > _MAX_VERIFIER_AUTHORITY_ITEMS:
+                    raise ValueError(f"{field} contains too many sequence items")
+                return {
+                    "kind": "tuple" if isinstance(value, tuple) else "list",
+                    "items": [
+                        cls._project_verifier_authority_value(
+                            item,
+                            field=f"{field}[{index}]",
+                            depth=depth + 1,
+                            seen=seen,
+                        )
+                        for index, item in enumerate(value)
+                    ],
+                }
+            if isinstance(value, (set, frozenset)):
+                if len(value) > _MAX_VERIFIER_AUTHORITY_ITEMS:
+                    raise ValueError(f"{field} contains too many set items")
+                items = [
+                    cls._project_verifier_authority_value(
+                        item,
+                        field=f"{field}.item",
+                        depth=depth + 1,
+                        seen=seen,
+                    )
+                    for item in value
+                ]
+                items.sort(
+                    key=lambda item: json.dumps(
+                        item,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                        ensure_ascii=True,
+                    )
+                )
+                return {
+                    "kind": "frozenset" if isinstance(value, frozenset) else "set",
+                    "items": items,
+                }
+
+            object_state: dict[str, object] = {}
+            try:
+                object_state.update(vars(value))
+            except TypeError:
+                pass
+            slots = inspect.getattr_static(type(value), "__slots__", ())
+            if isinstance(slots, str):
+                slots = (slots,)
+            for slot in slots:
+                if slot in {"__dict__", "__weakref__"} or slot in object_state:
+                    continue
+                try:
+                    object_state[slot] = object.__getattribute__(value, slot)
+                except AttributeError:
+                    continue
+            if not object_state:
+                raise ValueError(f"{field} has no inspectable stable state")
+            return {
+                "kind": "object",
+                "type": f"{type(value).__module__}.{type(value).__qualname__}",
+                "state": cls._project_verifier_authority_value(
+                    object_state,
+                    field=f"{field}.state",
+                    depth=depth + 1,
+                    seen=seen,
+                ),
+            }
+        finally:
+            seen.remove(value_id)
+
+    @classmethod
+    def _verifier_implementation_contract(cls, verifier: Verifier) -> dict[str, object]:
+        """Identify the executable code behind a function, method, or callable object."""
+        if inspect.ismethod(verifier):
+            target = verifier.__func__
+        elif inspect.isfunction(verifier) or inspect.isbuiltin(verifier):
+            target = verifier
+        else:
+            target = type(verifier).__call__
+
+        module = getattr(target, "__module__", type(verifier).__module__)
+        qualname = getattr(target, "__qualname__", type(verifier).__qualname__)
+        try:
+            source_digest = cls._prompt_identity(inspect.getsource(target))
+        except (OSError, TypeError):
+            source_digest = None
+        code = getattr(target, "__code__", None)
+        code_digest = (
+            "sha256:" + hashlib.sha256(marshal.dumps(code)).hexdigest()
+            if code is not None
+            else None
+        )
+        return {
+            "module": str(module),
+            "qualname": str(qualname),
+            "source_digest": source_digest,
+            "code_digest": code_digest,
+        }
+
+    def _verifier_state_authority_contract(self, verifier: Verifier) -> dict[str, object]:
+        """Bind behavioral verifier state or deliberately disable durable reuse."""
+        try:
+            identity_descriptor = inspect.getattr_static(
+                verifier,
+                "verification_identity_contract",
+                None,
+            )
+            if identity_descriptor is not None:
+                identity_provider = object.__getattribute__(
+                    verifier,
+                    "verification_identity_contract",
+                )
+                if not callable(identity_provider):
+                    raise ValueError("verification_identity_contract is not callable")
+                identity = identity_provider()
+                if not isinstance(identity, Mapping):
+                    raise ValueError("verification_identity_contract is not a mapping")
+                raw_state: object = {"explicit_identity": dict(identity)}
+            elif inspect.isfunction(verifier) or inspect.ismethod(verifier):
+                function = verifier.__func__ if inspect.ismethod(verifier) else verifier
+                closure_values: list[object] = []
+                for cell in getattr(function, "__closure__", None) or ():
+                    try:
+                        closure_values.append(cell.cell_contents)
+                    except ValueError:
+                        closure_values.append({"empty_cell": True})
+                raw_state = {
+                    "defaults": getattr(function, "__defaults__", None),
+                    "kwdefaults": getattr(function, "__kwdefaults__", None),
+                    "closure": closure_values,
+                    "function_attributes": dict(vars(function)),
+                    "bound_instance": verifier.__self__ if inspect.ismethod(verifier) else None,
+                }
+            else:
+                raw_state = {"callable_instance": verifier}
+
+            projected = self._project_verifier_authority_value(
+                raw_state,
+                field="atomic verifier state",
+            )
+            encoded = json.dumps(
+                projected,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+                allow_nan=False,
+            )
+            if len(encoded) > _MAX_VERIFIER_AUTHORITY_JSON_CHARS:
+                raise ValueError("atomic verifier state exceeds authority budget")
+            return {
+                "stability": "durable",
+                "state_digest": self._prompt_identity(encoded),
+            }
+        except (AttributeError, TypeError, ValueError) as exc:
+            nonce = uuid.uuid4().hex
+            log.warning(
+                "parallel_executor.atomic_verifier_authority_process_local",
+                verifier_type=f"{type(verifier).__module__}.{type(verifier).__qualname__}",
+                reason=str(exc),
+            )
+            return {
+                "stability": "process_local",
+                "instance_nonce": nonce,
+            }
+
     def _atomic_verifier_authority_contract(self) -> dict[str, object]:
         """Return a durable identity for the acceptance judge in force."""
         verifier = self._atomic_verifier
         if verifier is None:
             return {"version": 1, "mode": "runtime_transcript"}
-
-        module = getattr(verifier, "__module__", type(verifier).__module__)
-        qualname = getattr(verifier, "__qualname__", type(verifier).__qualname__)
-        try:
-            source = inspect.getsource(verifier)
-        except (OSError, TypeError):
-            code = getattr(verifier, "__code__", None)
-            source = repr(
-                (
-                    getattr(code, "co_code", None),
-                    getattr(code, "co_consts", None),
-                    getattr(verifier, "__defaults__", None),
-                    getattr(verifier, "__kwdefaults__", None),
-                    tuple(
-                        repr(cell.cell_contents)
-                        for cell in (getattr(verifier, "__closure__", None) or ())
-                    ),
-                )
-            )
         return {
             "version": 1,
             "mode": "custom",
-            "module": str(module),
-            "qualname": str(qualname),
-            "implementation_digest": self._prompt_identity(source),
+            "implementation": self._verifier_implementation_contract(verifier),
+            "behavioral_state": self._verifier_state_authority_contract(verifier),
         }
 
     @staticmethod

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -33,6 +33,7 @@ import contextlib
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime, timedelta
 import hashlib
+import inspect
 import json
 import math
 import os
@@ -1394,6 +1395,8 @@ class ParallelACExecutor:
         self._shadow_replay_enabled = shadow_replay_enabled
         self._session_signal_hub = session_signal_hub
         self._atomic_verifier = atomic_verifier
+        self._runtime_execution_authority = self._runtime_execution_authority_contract()
+        self._atomic_verifier_authority = self._atomic_verifier_authority_contract()
         self._coordinator = LevelCoordinator(
             adapter,
             inherited_runtime_handle=self._inherited_runtime_handle,
@@ -2256,6 +2259,74 @@ class ParallelACExecutor:
         return "sha256:" + hashlib.sha256(system_prompt.encode("utf-8")).hexdigest()
 
     @staticmethod
+    def _canonical_authority_value(value: object, *, field: str) -> object:
+        """Round-trip one authority payload through strict canonical JSON."""
+        try:
+            encoded = json.dumps(
+                value,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+                allow_nan=False,
+            )
+            return json.loads(encoded)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{field} is not canonical JSON") from exc
+
+    def _runtime_execution_authority_contract(self) -> dict[str, object]:
+        """Capture backend-specific provider/model identity when exposed."""
+        provider_descriptor = inspect.getattr_static(
+            type(self._adapter),
+            "execution_identity_contract",
+            None,
+        )
+        if provider_descriptor is None:
+            return {"version": 1, "observed": False}
+        provider = object.__getattribute__(self._adapter, "execution_identity_contract")
+        identity = provider()
+        if not isinstance(identity, Mapping):
+            raise ValueError("runtime execution identity contract is not a mapping")
+        normalized = self._canonical_authority_value(
+            dict(identity),
+            field="runtime execution identity contract",
+        )
+        if not isinstance(normalized, dict):
+            raise ValueError("runtime execution identity contract is not an object")
+        return {"version": 1, "observed": True, "identity": normalized}
+
+    def _atomic_verifier_authority_contract(self) -> dict[str, object]:
+        """Return a durable identity for the acceptance judge in force."""
+        verifier = self._atomic_verifier
+        if verifier is None:
+            return {"version": 1, "mode": "runtime_transcript"}
+
+        module = getattr(verifier, "__module__", type(verifier).__module__)
+        qualname = getattr(verifier, "__qualname__", type(verifier).__qualname__)
+        try:
+            source = inspect.getsource(verifier)
+        except (OSError, TypeError):
+            code = getattr(verifier, "__code__", None)
+            source = repr(
+                (
+                    getattr(code, "co_code", None),
+                    getattr(code, "co_consts", None),
+                    getattr(verifier, "__defaults__", None),
+                    getattr(verifier, "__kwdefaults__", None),
+                    tuple(
+                        repr(cell.cell_contents)
+                        for cell in (getattr(verifier, "__closure__", None) or ())
+                    ),
+                )
+            )
+        return {
+            "version": 1,
+            "mode": "custom",
+            "module": str(module),
+            "qualname": str(qualname),
+            "implementation_digest": self._prompt_identity(source),
+        }
+
+    @staticmethod
     def _normalize_externally_satisfied_acs(
         raw: Mapping[int, Mapping[str, Any]] | None,
         *,
@@ -2410,6 +2481,8 @@ class ParallelACExecutor:
         decomposition_trustworthy: bool,
         force_frontier_routing: bool,
         investment_spec: InvestmentSpec | None,
+        sibling_acs: list[_SiblingACRef] | None = None,
+        retry_prompt_extra: str = "",
     ) -> str:
         """Bind a capsule to the exact provider dispatch authority in force."""
         dispatch_contract = self._build_checkpoint_dispatch_contract(
@@ -2427,6 +2500,25 @@ class ParallelACExecutor:
             "investment_spec": (
                 investment_spec.model_dump(mode="json") if investment_spec is not None else None
             ),
+            "runtime_execution_authority": self._runtime_execution_authority,
+            "atomic_verifier_authority": self._atomic_verifier_authority,
+            "prompt_authority": {
+                "retry_prompt_digest": self._prompt_identity(retry_prompt_extra),
+                "siblings": [
+                    {
+                        "ac_index": sibling_index,
+                        "content_digest": self._prompt_identity(sibling_content),
+                    }
+                    for sibling_index, sibling_content in (sibling_acs or [])
+                ],
+                "fat_harness_mode": self._fat_harness_mode,
+                "run_verify_commands": self._run_verify_commands,
+                "verify_command_timeout_seconds": self._verify_command_timeout_seconds,
+                "context_pack_enabled": self._context_pack_enabled,
+                "prompt_guidance_contract": self._prompt_guidance_contract,
+                "decomposition_mode": self._decomposition_mode,
+                "max_decomposition_depth": self._max_decomposition_depth,
+            },
         }
         return build_ac_dispatch_authority_scope(
             base_scope=(
@@ -9098,6 +9190,8 @@ Respond with either ATOMIC or the structured JSON object only.
                 decomposition_trustworthy=decomposition_trustworthy,
                 force_frontier_routing=force_frontier_routing,
                 investment_spec=investment_spec,
+                sibling_acs=sibling_acs,
+                retry_prompt_extra=retry_prompt_extra,
             ),
             seed_goal=seed_goal,
             ac_content=ac_content,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2682,6 +2682,27 @@ class ParallelACExecutor:
         }
 
     @staticmethod
+    def _runtime_watchdog_identity(adapter: object) -> dict[str, object]:
+        """Bind the effective watchdog/termination policy into capsule authority.
+
+        Startup- and stdout-idle watchdog timeouts (and process-shutdown grace)
+        change WHEN a provider turn is interrupted, so two runtimes with different
+        timeouts have materially different termination semantics and must not
+        share a capsule fingerprint. A runtime that owns a watchdog exposes a
+        provider-neutral ``watchdog_identity_contract()``; absent it, the policy
+        is recorded as unobserved.
+        """
+        contract = getattr(adapter, "watchdog_identity_contract", None)
+        if callable(contract):
+            try:
+                declared = contract()
+            except Exception:
+                declared = None
+            if isinstance(declared, Mapping):
+                return {"version": 1, "observed": True, "policy": dict(declared)}
+        return {"version": 1, "observed": False, "policy": None}
+
+    @staticmethod
     def _runtime_capabilities_contract(adapter: object) -> dict[str, Any] | None:
         capabilities = getattr(adapter, "capabilities", None)
         if not isinstance(capabilities, RuntimeCapabilities):
@@ -2829,6 +2850,7 @@ class ParallelACExecutor:
                 "executable": self._runtime_executable_identity(
                     self._adapter, cwd=workspace_identity
                 ),
+                "watchdog": self._runtime_watchdog_identity(self._adapter),
             },
             "model_routing": serialize_model_router(self._model_router),
             "execution_profile": serialize_execution_profile(self._execution_profile),
@@ -8680,6 +8702,14 @@ class ParallelACExecutor:
                 runtime_identity=runtime_identity,
                 failure_class=failure.value if failure is not None else None,
             )
+        except AmbiguousACExecutionError:
+            # The alternate ran in the SAME shared workspace and may already have
+            # applied non-idempotent effects; swallowing this to ``None`` would let
+            # the caller finalize/escalate from the stale pre-redispatch state.
+            # Propagate the ambiguity so it fails closed (the fallback below is only
+            # for failures proven to occur before any provider entry).
+            self._alt_harness_status_by_root[root_ac_index] = "failed"
+            raise
         except Exception as exc:  # never make a failure worse
             self._alt_harness_status_by_root[root_ac_index] = "failed"
             log.warning(
@@ -11286,6 +11316,16 @@ Respond with either ATOMIC or the structured JSON object only.
 
         command = spec.verify_command
         if not command:
+            # Defense in depth (the schema already forbids this): an
+            # ``output_assertion`` with no command has no authoritative output to
+            # assert against, so it can never be satisfied — fail closed rather
+            # than silently PASS an unevaluated acceptance field.
+            if spec.output_assertion:
+                return _VerifyGateOutcome(
+                    passed=False,
+                    reason="output_assertion has no verify_command to assert against",
+                    output_tail="",
+                )
             return _VerifyGateOutcome(passed=True, reason=None, output_tail="")
         subprocess_kwargs: dict[str, Any] = {}
         if os.name != "nt":

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2571,6 +2571,43 @@ class ParallelACExecutor:
         return contexts
 
     @staticmethod
+    def _runtime_executable_identity(adapter: object) -> dict[str, object]:
+        """Bind the actual subprocess executable and launcher into capsule authority.
+
+        Backend, model, and the adapter's execution-identity contract do not
+        capture WHICH binary the runtime launches: two otherwise-identical
+        adapters pointing ``cli_path`` at different executables (or a wrapper
+        launcher such as Zcode's Electron/Node host) produce identical authority
+        otherwise, so a restart could resume the same capsule under a different
+        executable. Record the canonical executable and launcher paths (raw and
+        realpath, so both a path change and a symlink swap change authority) as a
+        provider-neutral field every subprocess runtime contributes.
+        """
+
+        def _resolve(value: object) -> dict[str, str] | None:
+            if isinstance(value, os.PathLike):
+                value = os.fspath(value)
+            if not isinstance(value, str) or not value:
+                return None
+            expanded = os.path.expanduser(value)
+            return {"path": value, "realpath": os.path.realpath(expanded)}
+
+        # ``cli_path`` is exposed both as a property (Codex) and as a private
+        # attribute (most subprocess runtimes); probe the public form first.
+        executable = _resolve(getattr(adapter, "cli_path", None)) or _resolve(
+            getattr(adapter, "_cli_path", None)
+        )
+        # Zcode launches its CLI through an Electron/Node host; that launcher is
+        # part of what actually executes and must be bound too.
+        launcher = _resolve(getattr(adapter, "_electron_node_path", None))
+        return {
+            "version": 1,
+            "observed": executable is not None or launcher is not None,
+            "executable": executable,
+            "launcher": launcher,
+        }
+
+    @staticmethod
     def _runtime_capabilities_contract(adapter: object) -> dict[str, Any] | None:
         capabilities = getattr(adapter, "capabilities", None)
         if not isinstance(capabilities, RuntimeCapabilities):
@@ -2711,6 +2748,7 @@ class ParallelACExecutor:
                 ),
                 "capabilities": self._runtime_capabilities_contract(self._adapter),
                 "execution": self._runtime_execution_authority,
+                "executable": self._runtime_executable_identity(self._adapter),
             },
             "model_routing": serialize_model_router(self._model_router),
             "execution_profile": serialize_execution_profile(self._execution_profile),
@@ -7330,6 +7368,9 @@ class ParallelACExecutor:
             node_identity=node_identity,
             final_sub_results=final_sub_results,
             ac_spec=active_success_spec,
+            execution_id=execution_id,
+            session_id=session_id,
+            retry_attempt=retry_attempt,
             child_artifact_attributions=tuple(child_artifact_attributions),
         )
         self._decomposition_attestations[node_identity.node_id] = attestation
@@ -7504,6 +7545,9 @@ class ParallelACExecutor:
         node_identity: ExecutionNodeIdentity,
         final_sub_results: list[ACExecutionResult],
         ac_spec: AcceptanceCriterionSpec | None,
+        execution_id: str,
+        session_id: str,
+        retry_attempt: int,
         child_artifact_attributions: tuple[tuple[bool, bool | None, str], ...] | None = None,
     ) -> tuple[DecompositionAttestation, _VerifyGateOutcome | None]:
         """Gate-anchor one finished decomposition round (Task 1).
@@ -7643,7 +7687,15 @@ class ParallelACExecutor:
         if parent_has_contract and self._run_verify_commands:
             assert ac_spec is not None  # narrowed by parent_has_contract
             cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
-            parent_verify_gate_outcome = await self._run_ac_verify_gate(spec=ac_spec, cwd=cwd)
+            parent_verify_gate_outcome = await self._run_verify_gate_single_shot(
+                spec=ac_spec,
+                cwd=cwd,
+                aggregate_id=execution_id or session_id,
+                verify_key=f"decomposed_parent:{node_identity.node_id}:{retry_attempt}",
+                execution_id=execution_id,
+                session_id=session_id,
+                identity_metadata=node_identity.to_event_metadata(),
+            )
             parent = ParentVerifyOutcome(
                 has_verify_command=True,
                 passed=parent_verify_gate_outcome.passed,
@@ -10064,6 +10116,19 @@ Respond with either ATOMIC or the structured JSON object only.
                             retry_attempt=retry_attempt,
                         )
                     try:
+                        # Seal the (already-completed) predecessor dispatch before
+                        # persisting the follow-up. If the follow-up dispatch write
+                        # then fails — or a crash lands between it and the
+                        # follow-up's terminal completion — recovery finds the
+                        # predecessor sealed and fails closed instead of resuming
+                        # it and replaying the original AC prompt.
+                        await self._event_emitter.emit_ac_dispatch_sealed(
+                            runtime_identity=runtime_identity,
+                            dispatch_id=dispatch_id,
+                            execution_id=execution_context_id,
+                            session_id=session_id,
+                            capsule_fingerprint=capsule.fingerprint,
+                        )
                         await self._event_emitter.emit_ac_attempt_dispatched(
                             runtime_identity=runtime_identity,
                             dispatch_id=signal_dispatch_id,
@@ -10276,7 +10341,18 @@ Respond with either ATOMIC or the structured JSON object only.
             verify_gate_outcome: _VerifyGateOutcome | None = None
             if success and verify_gate_active and has_success_contract:
                 cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
-                verify_gate_outcome = await self._run_ac_verify_gate(spec=ac_spec, cwd=cwd)
+                verify_gate_outcome = await self._run_verify_gate_single_shot(
+                    spec=ac_spec,
+                    cwd=cwd,
+                    aggregate_id=execution_context_id,
+                    verify_key=(
+                        f"atomic:{runtime_identity.ac_id}:"
+                        f"{runtime_identity.session_attempt_id}:{retry_attempt}"
+                    ),
+                    execution_id=execution_context_id,
+                    session_id=session_id,
+                    identity_metadata=runtime_identity.to_metadata(),
+                )
 
             typed_evidence, typed_validation, typed_error = self._observe_atomic_typed_evidence(
                 ac_content=ac_content,
@@ -10800,6 +10876,158 @@ Respond with either ATOMIC or the structured JSON object only.
         except EvidenceError as exc:
             return None, None, str(exc)
         return record, validation, None
+
+    def _verify_gate_command_digest(self, spec: AcceptanceCriterionSpec) -> str:
+        """Bind a durable verify outcome to the exact command/contract that ran.
+
+        A persisted outcome may only be consumed for the identical command,
+        expected artifacts, and output assertion — a changed contract must run a
+        fresh gate rather than reuse a stale, unrelated result.
+        """
+        return self._authority_digest(
+            {
+                "verify_command": spec.verify_command,
+                "expected_artifacts": list(spec.expected_artifacts or ()),
+                "output_assertion": spec.output_assertion,
+            },
+            field="AC verify command identity",
+        )
+
+    async def _load_persisted_verify_decision(
+        self,
+        *,
+        aggregate_id: str,
+        verify_key: str,
+        command_digest: str,
+    ) -> tuple[_VerifyGateOutcome | None, bool]:
+        """Return ``(durable_outcome, intent_without_outcome)`` for a verify gate.
+
+        Replays the execution aggregate for this exact verify key and command
+        digest. A recorded outcome is returned so recovery consumes it instead of
+        re-running the (non-idempotent) command; an intent with no matching
+        outcome reports ``intent_without_outcome=True`` so recovery fails closed
+        rather than replaying a command that may already have run.
+
+        If history cannot be read at all, single-shot execution cannot be
+        guaranteed, so this fails closed (consistent with the runtime-handle
+        recovery loader, which also raises on replay failure) rather than
+        risking a duplicate non-idempotent command.
+        """
+        try:
+            events = await self._event_store.replay("execution", aggregate_id)
+        except Exception as exc:
+            raise AmbiguousACExecutionError(
+                "could not read durable verify history; refusing to run a non-idempotent "
+                "verify command without a single-shot guarantee"
+            ) from exc
+        intent_seen = False
+        durable_outcome: _VerifyGateOutcome | None = None
+        conflicting = False
+        for event in events:
+            data = event.data if isinstance(event.data, dict) else {}
+            if data.get("verify_key") != verify_key:
+                continue
+            if data.get("verify_command_digest") != command_digest:
+                # A different command under the same key means the contract
+                # changed; that stale record cannot authorize skipping THIS
+                # command, and its presence makes the gate ambiguous.
+                if event.type in {
+                    "execution.ac.verify.intent",
+                    "execution.ac.verify.outcome",
+                }:
+                    conflicting = True
+                continue
+            if event.type == "execution.ac.verify.intent":
+                intent_seen = True
+            elif event.type == "execution.ac.verify.outcome":
+                projected = _recovered_verify_gate_outcome(data.get("verify_gate_outcome"))
+                if projected is None:
+                    raise AmbiguousACExecutionError(
+                        "durable verify outcome record is malformed; refusing to replay "
+                        "a non-idempotent verify command"
+                    )
+                if durable_outcome is not None and (
+                    durable_outcome.passed != projected.passed
+                    or durable_outcome.reason != projected.reason
+                ):
+                    conflicting = True
+                durable_outcome = projected
+        if conflicting:
+            raise AmbiguousACExecutionError(
+                "durable verify records for this attempt disagree; refusing to replay or "
+                "trust an ambiguous non-idempotent verify command"
+            )
+        if durable_outcome is not None:
+            return durable_outcome, False
+        return None, intent_seen
+
+    async def _run_verify_gate_single_shot(
+        self,
+        *,
+        spec: AcceptanceCriterionSpec,
+        cwd: str,
+        aggregate_id: str,
+        verify_key: str,
+        execution_id: str,
+        session_id: str,
+        identity_metadata: dict[str, Any],
+    ) -> _VerifyGateOutcome:
+        """Run the verify gate exactly once across crash recovery.
+
+        For a pure expected-artifacts contract (no ``verify_command``) the gate is
+        idempotent, so it runs directly. When a ``verify_command`` is present it
+        is an acceptance effect that must never replay: a durable intent is
+        persisted before it runs and its outcome after, and recovery consumes the
+        outcome (or fails closed on an intent without an outcome) instead of
+        running the command again. Applies to both atomic and decomposed-parent
+        gates.
+        """
+        if not spec.verify_command:
+            return await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+
+        command_digest = self._verify_gate_command_digest(spec)
+        durable_outcome, intent_without_outcome = await self._load_persisted_verify_decision(
+            aggregate_id=aggregate_id,
+            verify_key=verify_key,
+            command_digest=command_digest,
+        )
+        if durable_outcome is not None:
+            # Consume the recorded outcome without rerunning the command, but
+            # revalidate the artifact leg — sibling ACs may have removed a file
+            # after the command passed.
+            return _revalidate_cached_verify_gate_outcome(
+                spec=spec, cwd=cwd, outcome=durable_outcome
+            )
+        if intent_without_outcome:
+            raise AmbiguousACExecutionError(
+                "a verify command was durably attempted but its outcome was never recorded; "
+                "refusing to replay a possibly-executed non-idempotent verify command"
+            )
+
+        await self._event_emitter.emit_ac_verify_intent(
+            aggregate_id=aggregate_id,
+            verify_key=verify_key,
+            command_digest=command_digest,
+            execution_id=execution_id,
+            session_id=session_id,
+            identity_metadata=identity_metadata,
+        )
+        outcome = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+        await self._event_emitter.emit_ac_verify_outcome(
+            aggregate_id=aggregate_id,
+            verify_key=verify_key,
+            command_digest=command_digest,
+            execution_id=execution_id,
+            session_id=session_id,
+            identity_metadata=identity_metadata,
+            verify_gate_outcome={
+                "passed": outcome.passed,
+                "reason": outcome.reason,
+                "output_tail": outcome.output_tail,
+                "missing_artifacts": list(outcome.missing_artifacts),
+            },
+        )
+        return outcome
 
     async def _run_ac_verify_gate(
         self, *, spec: AcceptanceCriterionSpec, cwd: str

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -99,7 +99,11 @@ from ouroboros.orchestrator.ac_execution_capsule import (
     build_ac_dispatch_authority_scope,
     compile_ac_execution_capsule,
 )
-from ouroboros.orchestrator.ac_runtime_handle_manager import ACRuntimeHandleManager
+from ouroboros.orchestrator.ac_runtime_handle_manager import (
+    ACRuntimeHandleManager,
+    AmbiguousACExecutionError,
+    CompletedACExecutionError,
+)
 from ouroboros.orchestrator.adapter import (
     AgentMessage,
     ParamSupport,
@@ -757,6 +761,20 @@ class _VerifyGateOutcome:
     reason: str | None
     output_tail: str
     missing_artifacts: tuple[str, ...] = ()
+
+
+def _recovered_verify_gate_outcome(
+    value: Mapping[str, Any] | None,
+) -> _VerifyGateOutcome | None:
+    """Rehydrate the strict durable verify projection without running its command."""
+    if value is None:
+        return None
+    return _VerifyGateOutcome(
+        passed=value["passed"],
+        reason=value["reason"],
+        output_tail=value["output_tail"],
+        missing_artifacts=tuple(value["missing_artifacts"]),
+    )
 
 
 @dataclass(frozen=True)
@@ -2071,6 +2089,7 @@ class ParallelACExecutor:
         *,
         event_type: str,
         runtime_identity: ACRuntimeIdentity,
+        dispatch_id: str | None = None,
         ac_content: str,
         runtime_handle: RuntimeHandle | None,
         execution_id: str | None = None,
@@ -2078,10 +2097,12 @@ class ParallelACExecutor:
         result_summary: str | None = None,
         success: bool | None = None,
         error: str | None = None,
+        verify_gate_outcome: _VerifyGateOutcome | None = None,
     ) -> None:
         await self._ac_runtime_handle_manager._emit_ac_runtime_event(
             event_type=event_type,
             runtime_identity=runtime_identity,
+            dispatch_id=dispatch_id,
             ac_content=ac_content,
             runtime_handle=runtime_handle,
             execution_id=execution_id,
@@ -2089,6 +2110,16 @@ class ParallelACExecutor:
             result_summary=result_summary,
             success=success,
             error=error,
+            verify_gate_outcome=(
+                {
+                    "passed": verify_gate_outcome.passed,
+                    "reason": verify_gate_outcome.reason,
+                    "output_tail": verify_gate_outcome.output_tail,
+                    "missing_artifacts": list(verify_gate_outcome.missing_artifacts),
+                }
+                if verify_gate_outcome is not None
+                else None
+            ),
         )
 
     @staticmethod
@@ -8210,33 +8241,69 @@ class ParallelACExecutor:
             "capsule_success_contract": capsule_success_contract,
         }
         while True:
-            atomic_result = await self._execute_atomic_ac(
-                ac_index=ac_index,
-                ac_content=ac_content,
-                session_id=session_id,
-                tools=tools,
-                tool_catalog=tool_catalog,
-                system_prompt=system_prompt,
-                seed_goal=seed_goal,
-                depth=depth,
-                start_time=start_time,
-                execution_id=execution_id,
-                level_contexts=level_contexts,
-                sibling_acs=sibling_acs,
-                retry_attempt=atomic_retry_attempt,
-                execution_counters=execution_counters,
-                retry_prompt_extra=retry_prompt_extra,
-                is_sub_ac=is_sub_ac,
-                parent_ac_index=parent_ac_index,
-                sub_ac_index=sub_ac_index,
-                node_identity=node_identity,
-                ac_spec=ac_spec,
-                investment_spec=investment_spec,
-                decomposition_trustworthy=decomposition_trustworthy,
-                semantic_ac_key=semantic_ac_key,
-                force_frontier_routing=force_frontier_routing,
-                capsule_success_contract=capsule_success_contract,
-            )
+            try:
+                atomic_result = await self._execute_atomic_ac(
+                    ac_index=ac_index,
+                    ac_content=ac_content,
+                    session_id=session_id,
+                    tools=tools,
+                    tool_catalog=tool_catalog,
+                    system_prompt=system_prompt,
+                    seed_goal=seed_goal,
+                    depth=depth,
+                    start_time=start_time,
+                    execution_id=execution_id,
+                    level_contexts=level_contexts,
+                    sibling_acs=sibling_acs,
+                    retry_attempt=atomic_retry_attempt,
+                    execution_counters=execution_counters,
+                    retry_prompt_extra=retry_prompt_extra,
+                    is_sub_ac=is_sub_ac,
+                    parent_ac_index=parent_ac_index,
+                    sub_ac_index=sub_ac_index,
+                    node_identity=node_identity,
+                    ac_spec=ac_spec,
+                    investment_spec=investment_spec,
+                    decomposition_trustworthy=decomposition_trustworthy,
+                    semantic_ac_key=semantic_ac_key,
+                    force_frontier_routing=force_frontier_routing,
+                    capsule_success_contract=capsule_success_contract,
+                )
+            except CompletedACExecutionError as completed:
+                recovered_verify_outcome = _recovered_verify_gate_outcome(
+                    completed.verify_gate_outcome
+                )
+                if (
+                    self._run_verify_commands
+                    and isinstance(ac_spec, AcceptanceCriterionSpec)
+                    and ac_spec.verify_command
+                    and recovered_verify_outcome is None
+                ):
+                    raise AmbiguousACExecutionError(
+                        "Completed AC recovery is missing its non-idempotent verify-command "
+                        "outcome; refusing to replay the command"
+                    ) from completed
+                log.info(
+                    "parallel_executor.ac.completed_recovered",
+                    ac_index=ac_index,
+                    depth=depth,
+                    retry_attempt=atomic_retry_attempt,
+                )
+                return _finalize_node_result(
+                    ACExecutionResult(
+                        ac_index=ac_index,
+                        ac_content=ac_content,
+                        success=True,
+                        messages=(),
+                        final_message=completed.result_summary or "",
+                        duration_seconds=(datetime.now(UTC) - start_time).total_seconds(),
+                        session_id=completed.session_id,
+                        retry_attempt=atomic_retry_attempt,
+                        depth=depth,
+                        verify_gate_outcome=recovered_verify_outcome,
+                        forced_frontier_routing=force_frontier_routing,
+                    )
+                )
             if atomic_result.error != _STALL_SENTINEL:
                 if not atomic_result.success and not force_atomic_execution:
                     (
@@ -9571,13 +9638,14 @@ Respond with either ATOMIC or the structured JSON object only.
             node_identity=node_identity,
             retry_attempt=retry_attempt,
         )
+        session_origin = (
+            "restored_same_attempt" if persisted_runtime_handle is not None else "fresh"
+        )
         await self._event_emitter.emit_ac_capsule_compiled(
             runtime_identity=runtime_identity,
             session_id=session_id,
             capsule=capsule,
-            session_origin=(
-                "restored_same_attempt" if persisted_runtime_handle is not None else "fresh"
-            ),
+            session_origin=session_origin,
         )
         await self._emit_atomic_context_governed_event(
             runtime_identity=runtime_identity,
@@ -9766,9 +9834,32 @@ Respond with either ATOMIC or the structured JSON object only.
                 with contextlib.suppress(Exception):
                     shadow_snapshot_stack.close()
                 shadow_snapshot_stack = contextlib.ExitStack()
+        dispatch_id = uuid.uuid4().hex
+        previous_dispatch_id: str | None = None
+        if runtime_handle is not None:
+            previous_dispatch_value = runtime_handle.metadata.get("ac_dispatch_id")
+            if previous_dispatch_value is not None:
+                previous_dispatch_id = ACRuntimeHandleManager._validate_ac_dispatch_id(
+                    previous_dispatch_value
+                )
+            runtime_handle = replace(
+                runtime_handle,
+                metadata={**runtime_handle.metadata, "ac_dispatch_id": dispatch_id},
+            )
+            runtime_handle = self._remember_ac_runtime_handle(
+                ac_index,
+                runtime_handle,
+                execution_context_id=execution_context_id,
+                is_sub_ac=is_sub_ac,
+                parent_ac_index=parent_ac_index,
+                sub_ac_index=sub_ac_index,
+                node_identity=node_identity,
+                retry_attempt=retry_attempt,
+            )
         dispatch_state = LeafDispatchState(messages=messages, runtime_handle=runtime_handle)
         signal_target: SessionSignalTarget | None = None
         signal_target_registered = False
+        provider_boundary_persisted = False
         try:
             if self._session_signal_hub is not None:
                 signal_target = SessionSignalTarget(
@@ -9791,6 +9882,17 @@ Respond with either ATOMIC or the structured JSON object only.
                 await self._session_signal_hub.register_replaying(signal_target)
                 signal_target_registered = True
 
+            await self._event_emitter.emit_ac_attempt_dispatched(
+                runtime_identity=runtime_identity,
+                dispatch_id=dispatch_id,
+                previous_dispatch_id=previous_dispatch_id,
+                execution_id=execution_context_id,
+                session_id=session_id,
+                capsule_fingerprint=capsule.fingerprint,
+                session_origin=session_origin,
+                runtime_handle=dispatch_state.runtime_handle,
+            )
+            provider_boundary_persisted = True
             await LeafDispatcher(self).stream(
                 state=dispatch_state,
                 prompt=prompt,
@@ -9798,6 +9900,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 system_prompt=system_prompt,
                 execute_effort_kwargs=execute_effort_kwargs,
                 runtime_identity=runtime_identity,
+                dispatch_id=dispatch_id,
                 execution_context_id=execution_context_id,
                 session_id=session_id,
                 ac_index=ac_index,
@@ -9901,7 +10004,42 @@ Respond with either ATOMIC or the structured JSON object only.
                         )
                     )
                     inform_mode = queued_signal.effective_mode is SessionSignalMode.INFORM
+                    previous_provider_boundary_persisted = provider_boundary_persisted
+                    provider_boundary_persisted = False
+                    signal_dispatch_id = uuid.uuid4().hex
+                    previous_runtime_handle = dispatch_state.runtime_handle
+                    if previous_runtime_handle is not None:
+                        dispatch_state.runtime_handle = replace(
+                            previous_runtime_handle,
+                            metadata={
+                                **previous_runtime_handle.metadata,
+                                "ac_dispatch_id": signal_dispatch_id,
+                                "ac_session_origin": "restored_same_attempt",
+                            },
+                        )
+                        dispatch_state.runtime_handle = self._remember_ac_runtime_handle(
+                            ac_index,
+                            dispatch_state.runtime_handle,
+                            execution_context_id=execution_context_id,
+                            is_sub_ac=is_sub_ac,
+                            parent_ac_index=parent_ac_index,
+                            sub_ac_index=sub_ac_index,
+                            node_identity=node_identity,
+                            retry_attempt=retry_attempt,
+                        )
                     try:
+                        await self._event_emitter.emit_ac_attempt_dispatched(
+                            runtime_identity=runtime_identity,
+                            dispatch_id=signal_dispatch_id,
+                            previous_dispatch_id=dispatch_id,
+                            execution_id=execution_context_id,
+                            session_id=session_id,
+                            capsule_fingerprint=capsule.fingerprint,
+                            session_origin="restored_same_attempt",
+                            runtime_handle=dispatch_state.runtime_handle,
+                        )
+                        dispatch_id = signal_dispatch_id
+                        provider_boundary_persisted = True
                         await LeafDispatcher(self).stream(
                             state=dispatch_state,
                             prompt=(
@@ -9913,6 +10051,7 @@ Respond with either ATOMIC or the structured JSON object only.
                             system_prompt=system_prompt,
                             execute_effort_kwargs=execute_effort_kwargs,
                             runtime_identity=runtime_identity,
+                            dispatch_id=signal_dispatch_id,
                             execution_context_id=execution_context_id,
                             session_id=session_id,
                             ac_index=ac_index,
@@ -9928,6 +10067,18 @@ Respond with either ATOMIC or the structured JSON object only.
                             execution_counters=execution_counters,
                         )
                     except Exception as exc:
+                        if dispatch_id != signal_dispatch_id:
+                            dispatch_state.runtime_handle = previous_runtime_handle
+                            self._remember_ac_runtime_handle(
+                                ac_index,
+                                previous_runtime_handle,
+                                execution_context_id=execution_context_id,
+                                is_sub_ac=is_sub_ac,
+                                parent_ac_index=parent_ac_index,
+                                sub_ac_index=sub_ac_index,
+                                node_identity=node_identity,
+                                retry_attempt=retry_attempt,
+                            )
                         await self._event_store.append(
                             create_session_signal_delivery_uncertain_event(
                                 queued_signal.signal,
@@ -9941,6 +10092,8 @@ Respond with either ATOMIC or the structured JSON object only.
                             )
                         )
                         if inform_mode:
+                            if dispatch_id != signal_dispatch_id:
+                                provider_boundary_persisted = previous_provider_boundary_persisted
                             dispatch_state.success = primary_success
                             dispatch_state.final_message = primary_final_message
                             dispatch_state.infra_fatal = primary_infra_fatal
@@ -10226,12 +10379,14 @@ Respond with either ATOMIC or the structured JSON object only.
                     "execution.session.completed" if success else "execution.session.failed"
                 ),
                 runtime_identity=runtime_identity,
+                dispatch_id=dispatch_id,
                 ac_content=ac_content,
                 runtime_handle=runtime_handle,
                 execution_id=execution_context_id,
                 session_id=ac_session_id,
                 result_summary=result_final_message or None,
                 success=success,
+                verify_gate_outcome=verify_gate_outcome,
                 error=(
                     None
                     if success
@@ -10316,16 +10471,18 @@ Respond with either ATOMIC or the structured JSON object only.
                 node_identity=node_identity,
                 retry_attempt=retry_attempt,
             )
-            await self._emit_ac_runtime_event(
-                event_type="execution.session.failed",
-                runtime_identity=runtime_identity,
-                ac_content=ac_content,
-                runtime_handle=dispatch_state.runtime_handle,
-                execution_id=execution_context_id,
-                session_id=dispatch_state.ac_session_id,
-                success=False,
-                error=str(e),
-            )
+            if provider_boundary_persisted:
+                await self._emit_ac_runtime_event(
+                    event_type="execution.session.failed",
+                    runtime_identity=runtime_identity,
+                    dispatch_id=dispatch_id,
+                    ac_content=ac_content,
+                    runtime_handle=dispatch_state.runtime_handle,
+                    execution_id=execution_context_id,
+                    session_id=dispatch_state.ac_session_id,
+                    success=False,
+                    error=str(e),
+                )
             clear_cached_runtime_handle = True
 
             log.exception(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -6633,9 +6633,15 @@ class ParallelACExecutor:
         semantic_ac_key: str,
         investment_spec: InvestmentSpec | None = None,
         ac_spec: AcceptanceCriterionSpec | None = None,
+        capsule_success_contract: ACSuccessContract | None = None,
     ) -> ACExecutionResult:
         """Dispatch one finalized split through the shared recursive child path."""
         sub_acs = [child.description for child in decision.children]
+        active_success_spec = self._active_success_contract_spec(
+            ac_content=ac_content,
+            ac_spec=ac_spec,
+            capsule_success_contract=capsule_success_contract,
+        )
         # A prior round's gate-anchored attestation (Task 1) poisons THIS root
         # AC's future retries: once a decomposition round is proven untrustworthy
         # by re-running the parent's own verify gate, a fresh (unverified) SPLIT
@@ -6648,7 +6654,7 @@ class ParallelACExecutor:
             decision=decision,
             semantic_ac_key=semantic_ac_key,
             seed_goal=seed_goal,
-            ac_spec=ac_spec,
+            ac_spec=active_success_spec,
             execution_id=execution_id,
         )
         prior_attestation = await self._load_decomposition_attestation(
@@ -6707,15 +6713,15 @@ class ParallelACExecutor:
         # un-creditable, never evidence.
         artifact_oracle_active = (
             self._run_verify_commands
-            and isinstance(ac_spec, AcceptanceCriterionSpec)
-            and bool(ac_spec.expected_artifacts)
+            and isinstance(active_success_spec, AcceptanceCriterionSpec)
+            and bool(active_success_spec.expected_artifacts)
             and len(decision.children) == len(sub_acs)
         )
         artifact_cwd = ""
         child_artifact_slices: tuple[tuple[str, ...], ...] = tuple(() for _ in sub_acs)
         if artifact_oracle_active:
-            assert ac_spec is not None  # narrowed by artifact_oracle_active
-            parent_artifact_set = frozenset(ac_spec.expected_artifacts)
+            assert active_success_spec is not None  # narrowed by artifact_oracle_active
+            parent_artifact_set = frozenset(active_success_spec.expected_artifacts)
             child_artifact_slices = tuple(
                 tuple(path for path in child.expected_artifacts if path in parent_artifact_set)
                 for child in decision.children
@@ -6909,7 +6915,7 @@ class ParallelACExecutor:
         attestation, parent_verify_gate_outcome = await self._attest_decomposition_round(
             node_identity=node_identity,
             final_sub_results=final_sub_results,
-            ac_spec=ac_spec,
+            ac_spec=active_success_spec,
             child_artifact_attributions=tuple(child_artifact_attributions),
         )
         self._decomposition_attestations[node_identity.node_id] = attestation
@@ -7456,6 +7462,7 @@ class ParallelACExecutor:
         start_time: datetime,
         semantic_ac_key: str,
         investment_spec: InvestmentSpec | None = None,
+        capsule_success_contract: ACSuccessContract | None = None,
     ) -> tuple[ACExecutionResult | None, DecompositionDecisionRecord | None]:
         """Run cause-matched bounce recovery before alternate-harness fallback."""
         # Infra-fatal means the runtime itself failed.  It is neither evidence
@@ -7467,7 +7474,15 @@ class ParallelACExecutor:
         if previous is not None and previous.source is DecompositionSource.BOUNCE:
             return None, previous
 
-        trace = self._build_decomposition_trace_summary(result=result, ac_spec=ac_spec)
+        active_success_spec = self._active_success_contract_spec(
+            ac_content=ac_content,
+            ac_spec=ac_spec,
+            capsule_success_contract=capsule_success_contract,
+        )
+        trace = self._build_decomposition_trace_summary(
+            result=result,
+            ac_spec=active_success_spec,
+        )
         classification = await self._classify_bounce_result(result=result, trace=trace)
         verdict = result.atomic_verifier_verdict
         retry_admission = (
@@ -7517,7 +7532,8 @@ class ParallelACExecutor:
             execution_id=execution_id,
             retry_attempt=retry_attempt,
             depth=depth,
-            ac_spec=ac_spec,
+            ac_spec=active_success_spec,
+            capsule_success_contract=capsule_success_contract,
             source=DecompositionSource.BOUNCE,
             cause=BounceCause.TOO_BIG,
             trace_summary=trace.summary,
@@ -7559,6 +7575,7 @@ class ParallelACExecutor:
                 semantic_ac_key=semantic_ac_key,
                 investment_spec=investment_spec,
                 ac_spec=ac_spec,
+                capsule_success_contract=capsule_success_contract,
             )
             return recovered, decision
         return None, decision
@@ -7699,6 +7716,7 @@ class ParallelACExecutor:
                     retry_attempt=retry_attempt,
                     depth=depth,
                     ac_spec=ac_spec,
+                    capsule_success_contract=capsule_success_contract,
                     source=DecompositionSource.PREFLIGHT,
                 )
                 node_decision = self._coerce_decomposition_decision(
@@ -7739,6 +7757,7 @@ class ParallelACExecutor:
                 semantic_ac_key=semantic_ac_key,
                 investment_spec=investment_spec,
                 ac_spec=ac_spec,
+                capsule_success_contract=capsule_success_contract,
             )
 
         if (
@@ -7859,6 +7878,7 @@ class ParallelACExecutor:
                         start_time=start_time,
                         semantic_ac_key=semantic_ac_key,
                         investment_spec=investment_spec,
+                        capsule_success_contract=capsule_success_contract,
                     )
                     if bounce_decision is not None:
                         node_decision = bounce_decision
@@ -8376,6 +8396,31 @@ class ParallelACExecutor:
             return None, attestation_reasons
         return proposal, attestation_reasons
 
+    @staticmethod
+    def _active_success_contract_spec(
+        *,
+        ac_content: str,
+        ac_spec: AcceptanceCriterionSpec | None,
+        capsule_success_contract: ACSuccessContract | None,
+    ) -> AcceptanceCriterionSpec | None:
+        """Project the contract owned by the current recursive AC node.
+
+        ``ac_spec`` remains the root Seed record used for semantic identity and
+        prompt context. Once a decomposition child receives an explicit capsule
+        contract, however, that child-local contract is the only acceptance
+        authority its descendants may partition or attest. An explicitly empty
+        child contract must therefore stay empty instead of falling back to the
+        root AC's broader gate.
+        """
+        if capsule_success_contract is None:
+            return ac_spec
+        return AcceptanceCriterionSpec(
+            description=ac_content,
+            verify_command=capsule_success_contract.verify_command,
+            expected_artifacts=capsule_success_contract.expected_artifacts,
+            output_assertion=capsule_success_contract.output_assertion,
+        )
+
     async def _try_decompose_ac(
         self,
         ac_content: str,
@@ -8389,6 +8434,7 @@ class ParallelACExecutor:
         retry_attempt: int = 0,
         depth: int = 0,
         ac_spec: AcceptanceCriterionSpec | None = None,
+        capsule_success_contract: ACSuccessContract | None = None,
         source: DecompositionSource = DecompositionSource.PREFLIGHT,
         cause: BounceCause | None = None,
         trace_summary: str = "",
@@ -8399,8 +8445,15 @@ class ParallelACExecutor:
         # The PARENT's own seed-authored expected_artifacts (fixed before the
         # decomposer ever runs) is the only material a proposal may partition
         # into per-child artifact slices -- see validate_decomposition_proposal.
+        active_success_spec = self._active_success_contract_spec(
+            ac_content=ac_content,
+            ac_spec=ac_spec,
+            capsule_success_contract=capsule_success_contract,
+        )
         parent_expected_artifacts: tuple[str, ...] = (
-            tuple(ac_spec.expected_artifacts) if ac_spec is not None else ()
+            tuple(active_success_spec.expected_artifacts)
+            if active_success_spec is not None
+            else ()
         )
         ac_label = (
             f"AC #{node_identity.display_path}"

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1856,6 +1856,7 @@ class ParallelACExecutor:
         node_identity: ExecutionNodeIdentity | None = None,
         retry_attempt: int = 0,
         expected_capsule_fingerprint: str | None = None,
+        expected_capsule_workspace: str | None = None,
     ) -> RuntimeHandle | None:
         return await self._ac_runtime_handle_manager._load_persisted_ac_runtime_handle(
             ac_index,
@@ -1866,6 +1867,7 @@ class ParallelACExecutor:
             node_identity=node_identity,
             retry_attempt=retry_attempt,
             expected_capsule_fingerprint=expected_capsule_fingerprint,
+            expected_capsule_workspace=expected_capsule_workspace,
         )
 
     def _remember_ac_runtime_handle(
@@ -9027,8 +9029,16 @@ Respond with either ATOMIC or the structured JSON object only.
             node_identity=node_identity,
             retry_attempt=retry_attempt,
             expected_capsule_fingerprint=capsule.fingerprint,
+            expected_capsule_workspace=capsule.workspace,
         )
         if persisted_runtime_handle is not None:
+            persisted_runtime_handle = bind_capsule_to_runtime_handle(
+                capsule,
+                persisted_runtime_handle,
+                restored_same_attempt=True,
+                expected_backend=getattr(self._adapter, "runtime_backend", None),
+                expected_approval_mode=getattr(self._adapter, "permission_mode", None),
+            )
             self._remember_ac_runtime_handle(
                 ac_index,
                 persisted_runtime_handle,
@@ -9053,6 +9063,8 @@ Respond with either ATOMIC or the structured JSON object only.
             capsule,
             runtime_handle,
             restored_same_attempt=persisted_runtime_handle is not None,
+            expected_backend=getattr(self._adapter, "runtime_backend", None),
+            expected_approval_mode=getattr(self._adapter, "permission_mode", None),
         )
         await self._event_emitter.emit_ac_capsule_compiled(
             runtime_identity=runtime_identity,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -9268,6 +9268,16 @@ Respond with either ATOMIC or the structured JSON object only.
             expected_backend=getattr(self._adapter, "runtime_backend", None),
             expected_approval_mode=getattr(self._adapter, "permission_mode", None),
         )
+        runtime_handle = self._remember_ac_runtime_handle(
+            ac_index,
+            runtime_handle,
+            execution_context_id=execution_context_id,
+            is_sub_ac=is_sub_ac,
+            parent_ac_index=parent_ac_index,
+            sub_ac_index=sub_ac_index,
+            node_identity=node_identity,
+            retry_attempt=retry_attempt,
+        )
         await self._event_emitter.emit_ac_capsule_compiled(
             runtime_identity=runtime_identity,
             session_id=session_id,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -7896,16 +7896,41 @@ class ParallelACExecutor:
         parent_verify_gate_outcome: _VerifyGateOutcome | None = None
         if parent_has_contract and self._run_verify_commands:
             assert ac_spec is not None  # narrowed by parent_has_contract
-            cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
-            parent_verify_gate_outcome = await self._run_verify_gate_single_shot(
-                spec=ac_spec,
-                cwd=cwd,
-                aggregate_id=execution_id or session_id,
-                verify_key=f"decomposed_parent:{node_identity.node_id}:{retry_attempt}",
-                execution_id=execution_id,
-                session_id=session_id,
-                identity_metadata=node_identity.to_event_metadata(),
-            )
+            live_cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
+            gate_kwargs: dict[str, Any] = {
+                "spec": ac_spec,
+                "aggregate_id": execution_id or session_id,
+                "verify_key": f"decomposed_parent:{node_identity.node_id}:{retry_attempt}",
+                "execution_id": execution_id,
+                "session_id": session_id,
+                "identity_metadata": node_identity.to_event_metadata(),
+            }
+            if ac_spec.verify_command:
+                # R14-2: a command-bearing parent gate runs the same class of
+                # arbitrary, possibly-mutating shell as the leaf/batch gates and
+                # over the same shared workspace. Grade it against a frozen
+                # snapshot so it can neither observe nor cause a cross-gate
+                # mutation. ``isolated_workspace`` is a best-effort snapshot (as in
+                # shadow-replay): on the rare environmental failure to freeze a
+                # tree that in production always exists, degrade to the prior
+                # in-place grading rather than fabricate an attestation failure.
+                with isolated_workspace(live_cwd) as snapshot_cwd:
+                    if snapshot_cwd is None:
+                        log.warning(
+                            "parallel_executor.ac.verify_gate.isolation_unavailable",
+                            session_id=session_id,
+                            execution_id=execution_id,
+                            node_id=node_identity.node_id,
+                            cwd=live_cwd,
+                        )
+                    parent_verify_gate_outcome = await self._run_verify_gate_single_shot(
+                        cwd=snapshot_cwd if snapshot_cwd is not None else live_cwd,
+                        **gate_kwargs,
+                    )
+            else:
+                parent_verify_gate_outcome = await self._run_verify_gate_single_shot(
+                    cwd=live_cwd, **gate_kwargs
+                )
             parent = ParentVerifyOutcome(
                 has_verify_command=True,
                 passed=parent_verify_gate_outcome.passed,
@@ -8540,20 +8565,27 @@ class ParallelACExecutor:
                     and isinstance(ac_spec, AcceptanceCriterionSpec)
                     and ac_spec.verify_command
                 ):
-                    if recovered_verify_outcome is None:
-                        raise AmbiguousACExecutionError(
-                            "Completed AC recovery is missing its non-idempotent verify-command "
-                            "outcome; refusing to replay the command"
-                        ) from completed
-                    # The completed lifecycle's cached PASS is not self-authorizing:
-                    # require the durable single-shot verify chain (exactly one
-                    # intent + matching outcome) to back it, so an orphan or
-                    # corrupted completion cannot manufacture command-backed
-                    # acceptance. The durable oracle outcome is authoritative.
+                    # R14-1: a command-bearing AC DEFERS its (non-idempotent)
+                    # verify_command out of the atomic leaf to the batch-completion
+                    # gate (R13-1), so a completed leaf lifecycle never carries a
+                    # cached command outcome -- ``completed.verify_gate_outcome`` is
+                    # structurally absent here, and even a stale/fabricated one is
+                    # not self-authorizing. The single authority is the durable
+                    # finalization oracle, consulted under the shared per-attempt
+                    # key:
+                    #   * a recorded outcome -> consume it (this attempt was already
+                    #     graded durably), never replaying the command;
+                    #   * an intent with no outcome -> the command may have run with
+                    #     side effects before the crash; ambiguous, fail closed;
+                    #   * no durable record at all -> the deferred finalization gate
+                    #     never started for this attempt, so the command has provably
+                    #     NOT run. This is NOT ambiguous: leave the outcome
+                    #     unresolved and let the batch-completion gate run the
+                    #     single-shot oracle ONCE over the settled workspace.
                     execution_scope = execution_id or session_id
                     (
                         durable_verify_outcome,
-                        _intent_only,
+                        intent_without_outcome,
                     ) = await self._load_persisted_verify_decision(
                         aggregate_id=execution_scope,
                         verify_key=self._ac_verify_gate_key(
@@ -8563,13 +8595,20 @@ class ParallelACExecutor:
                         ),
                         command_digest=self._verify_gate_command_digest(ac_spec),
                     )
-                    if durable_verify_outcome is None:
+                    if durable_verify_outcome is not None:
+                        recovered_verify_outcome = durable_verify_outcome
+                    elif intent_without_outcome:
                         raise AmbiguousACExecutionError(
-                            "Completed AC recovery lacks the durable verify intent/outcome chain "
-                            "backing its verify-command result; refusing to trust a completion "
-                            "that cannot prove its acceptance evidence"
+                            "Completed AC recovery found a durable verify intent with no "
+                            "matching outcome; the non-idempotent verify-command may have "
+                            "partially run -- refusing to trust or replay it"
                         ) from completed
-                    recovered_verify_outcome = durable_verify_outcome
+                    else:
+                        # Finalization has not started for this attempt; defer the
+                        # single authoritative run to the batch-completion gate
+                        # instead of failing closed on a legitimately-unverified
+                        # deferred completion.
+                        recovered_verify_outcome = None
                 log.info(
                     "parallel_executor.ac.completed_recovered",
                     ac_index=ac_index,
@@ -11584,6 +11623,102 @@ Respond with either ATOMIC or the structured JSON object only.
             )
         return _VerifyGateOutcome(passed=True, reason=None, output_tail=tail)
 
+    async def _apply_verify_gate_isolated(
+        self,
+        *,
+        seed: Seed,
+        ac_index: int,
+        result: ACExecutionResult,
+        session_id: str,
+        execution_id: str,
+    ) -> ACExecutionResult:
+        """Apply the batch verify gate over a private, frozen workspace snapshot.
+
+        R14-2: a ``verify_command`` is arbitrary shell that may MUTATE the shared
+        workspace. Every batch / escalation / alt-harness gate finalizes
+        sequentially over the one settled tree, so a later command's side effects
+        could invalidate acceptance an earlier gate already granted
+        (order-dependent, non-reproducible) and could corrupt the delivered
+        artifact. Grade every command-bearing gate against an isolated copy of the
+        settled workspace so no verifier can observe or cause a cross-gate
+        mutation: each gate sees the identical settled state and the delivered
+        tree is never touched by a verifier.
+
+        A gate that only re-checks an already-recorded command outcome, or whose
+        contract is purely ``expected_artifacts`` (idempotent, read-only), needs
+        no sandbox and grades the live delivered tree directly -- the artifact leg
+        must reflect what will actually be shipped. Only a fresh command RUN is
+        sandboxed.
+        """
+        if not self._run_verify_commands:
+            return result
+        spec = (
+            seed.acceptance_criteria[ac_index]
+            if 0 <= ac_index < len(seed.acceptance_criteria)
+            else None
+        )
+        needs_command_run = (
+            isinstance(spec, AcceptanceCriterionSpec)
+            and bool(spec.verify_command)
+            and not isinstance(result.verify_gate_outcome, _VerifyGateOutcome)
+        )
+        if not needs_command_run:
+            return await self._apply_verify_gate(
+                seed=seed,
+                ac_index=ac_index,
+                result=result,
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+        live_cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
+        with isolated_workspace(live_cwd) as snapshot_cwd:
+            if snapshot_cwd is None:
+                # The settled tree could not be frozen (copy failure or a symlink
+                # escaping the snapshot). Running the possibly-mutating command in
+                # the shared live workspace could silently invalidate a sibling
+                # gate, so fail a would-be-accepted result closed rather than grade
+                # against an unsafe tree. An already-failing result keeps its
+                # failure -- its recovery command cannot be run safely either.
+                log.warning(
+                    "parallel_executor.ac.verify_gate.isolation_unavailable",
+                    session_id=session_id,
+                    execution_id=execution_id,
+                    ac_index=ac_index,
+                    cwd=live_cwd,
+                )
+                if not result.success:
+                    return result
+                from ouroboros.orchestrator.failure_taxonomy import FailureClass
+
+                reason = (
+                    "verify gate could not isolate an immutable snapshot of the "
+                    "settled workspace; refusing to run verify_command in the shared "
+                    "live workspace where it could invalidate a sibling gate"
+                )
+                return replace(
+                    result,
+                    success=False,
+                    error=reason,
+                    final_message=reason,
+                    outcome=ACExecutionOutcome.FAILED,
+                    atomic_verifier_verdict=VerifierVerdict(
+                        passed=False,
+                        reasons=(reason,),
+                        failure_class=FailureClass.EVIDENCE_MISSING.value,
+                    ),
+                    verify_gate_outcome=_VerifyGateOutcome(
+                        passed=False, reason=reason, output_tail=""
+                    ),
+                )
+            return await self._apply_verify_gate(
+                seed=seed,
+                ac_index=ac_index,
+                result=result,
+                session_id=session_id,
+                execution_id=execution_id,
+                verify_workspace=snapshot_cwd,
+            )
+
     async def _apply_verify_gate(
         self,
         *,
@@ -11592,6 +11727,7 @@ Respond with either ATOMIC or the structured JSON object only.
         result: ACExecutionResult,
         session_id: str,
         execution_id: str,
+        verify_workspace: str | None = None,
     ) -> ACExecutionResult:
         """Gate a successful AC on its success contract (PR-V V1).
 
@@ -11612,7 +11748,11 @@ Respond with either ATOMIC or the structured JSON object only.
         ):
             return result
 
-        cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
+        # ``verify_workspace``, when provided by ``_apply_verify_gate_isolated``,
+        # is a private frozen snapshot of the settled tree (R14-2); the command
+        # and every artifact check run there so a verifier can neither observe
+        # nor cause a cross-gate mutation. When absent, grade the live tree.
+        cwd = verify_workspace or self._task_cwd or self._adapter.working_directory or os.getcwd()
         cached_outcome = result.verify_gate_outcome
         if isinstance(cached_outcome, _VerifyGateOutcome):
             outcome = _revalidate_cached_verify_gate_outcome(
@@ -13331,7 +13471,7 @@ Respond with either ATOMIC or the structured JSON object only.
             )
         elif not candidate.forced_frontier_routing:
             candidate = replace(candidate, forced_frontier_routing=True)
-        candidate = await self._apply_verify_gate(
+        candidate = await self._apply_verify_gate_isolated(
             seed=seed,
             ac_index=ac_idx,
             result=candidate,
@@ -13549,7 +13689,7 @@ Respond with either ATOMIC or the structured JSON object only.
                         # normalize mocked/custom runtimes at the orchestration
                         # boundary so durable replay still records the truth.
                         candidate = replace(candidate, forced_frontier_routing=True)
-                    candidate = await self._apply_verify_gate(
+                    candidate = await self._apply_verify_gate_isolated(
                         seed=seed,
                         ac_index=ac_idx,
                         result=candidate,
@@ -13794,7 +13934,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 )
             elif not candidate.forced_frontier_routing:
                 candidate = replace(candidate, forced_frontier_routing=True)
-            candidate = await self._apply_verify_gate(
+            candidate = await self._apply_verify_gate_isolated(
                 seed=seed,
                 ac_index=ac_idx,
                 result=candidate,
@@ -13995,7 +14135,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 continue
             result = results[position]
             if isinstance(result, ACExecutionResult):
-                gated = await self._apply_verify_gate(
+                gated = await self._apply_verify_gate_isolated(
                     seed=seed,
                     ac_index=ac_idx,
                     result=result,
@@ -14105,7 +14245,7 @@ Respond with either ATOMIC or the structured JSON object only.
             for retry_position, ac_idx in enumerate(retry_idxs):
                 gated = retry_results[retry_position]
                 if isinstance(gated, ACExecutionResult):
-                    gated = await self._apply_verify_gate(
+                    gated = await self._apply_verify_gate_isolated(
                         seed=seed,
                         ac_index=ac_idx,
                         result=gated,
@@ -14253,7 +14393,7 @@ Respond with either ATOMIC or the structured JSON object only.
                             # get, so an
                             # alternate 'success' with a failing verify_command or
                             # missing expected artifact is not accepted as success.
-                            finalized_alt = await self._apply_verify_gate(
+                            finalized_alt = await self._apply_verify_gate_isolated(
                                 seed=seed,
                                 ac_index=ac_idx,
                                 result=alt,
@@ -14387,7 +14527,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 )
             elif not atomic_candidate.forced_frontier_routing:
                 atomic_candidate = replace(atomic_candidate, forced_frontier_routing=True)
-            atomic_candidate = await self._apply_verify_gate(
+            atomic_candidate = await self._apply_verify_gate_isolated(
                 seed=seed,
                 ac_index=ac_idx,
                 result=atomic_candidate,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -7140,6 +7140,20 @@ class ParallelACExecutor:
             # All levels done — cancel the background progress emitter
             outer_tg.cancel_scope.cancel()
 
+        # Every stage and coordinator reconciliation has now settled, so the
+        # shared workspace is FINAL. Re-verify each accepted command-bearing AC's
+        # ``verify_command`` over this final tree as the authoritative acceptance
+        # (a per-attempt gate that a later stage or reconciliation invalidated is
+        # corrected here) and (re)emit the terminal outcome only now, so no
+        # accepted verdict predates the final workspace. Runs BEFORE the drain so
+        # its correctness-bearing markers are flushed on the same exit path.
+        all_results = await self._apply_final_workspace_acceptance(
+            seed=seed,
+            results=all_results,
+            session_id=session_id,
+            execution_id=execution_id,
+        )
+
         # Give any deferred correctness-bearing writes (ladder resolution,
         # decomposition attestation — scheduled disproportionately near the
         # END of a run) a bounded final shot BEFORE returning control toward
@@ -11361,6 +11375,19 @@ Respond with either ATOMIC or the structured JSON object only.
         """
         return f"acgate:{execution_scope}:{ac_index}:{retry_attempt}"
 
+    @staticmethod
+    def _ac_final_verify_gate_key(*, execution_scope: str, ac_index: int) -> str:
+        """Single-shot key for the global FINAL-workspace acceptance gate.
+
+        Distinct from the per-attempt :meth:`_ac_verify_gate_key` so the final
+        gate runs the ``verify_command`` once more over the settled final tree
+        (after every stage and coordinator reconciliation) instead of consuming a
+        provisional per-attempt outcome. Attempt-independent: the final workspace
+        is a property of the whole run, not of any one attempt, and this single
+        run is what crash recovery consumes on a cold restart.
+        """
+        return f"acgate_final:{execution_scope}:{ac_index}"
+
     def _verify_gate_command_digest(self, spec: AcceptanceCriterionSpec) -> str:
         """Bind a durable verify outcome to the exact command/contract that ran.
 
@@ -11733,6 +11760,146 @@ Respond with either ATOMIC or the structured JSON object only.
                 output_tail=tail,
             )
         return _VerifyGateOutcome(passed=True, reason=None, output_tail=tail)
+
+    async def _apply_final_workspace_acceptance(
+        self,
+        *,
+        seed: Seed,
+        results: list[ACExecutionResult],
+        session_id: str,
+        execution_id: str,
+    ) -> list[ACExecutionResult]:
+        """Re-verify every accepted command-bearing AC over the TRUE final workspace.
+
+        Per-batch, decomposition-parent, and sibling-flip gates all run before
+        later stages and coordinator reconciliation, so a ``verify_command`` that
+        passed earlier can be silently invalidated by a later workspace mutation.
+        This global pass runs ONCE, after every stage and reconciliation has
+        settled (the shared tree is now final), and re-runs each currently-accepted
+        AC's ``verify_command`` over that final tree as the AUTHORITATIVE
+        acceptance -- (re)emitting the terminal ``outcome_finalized`` marker only
+        now, so no accepted verdict predates the final workspace. Because it also
+        re-checks results restored by crash recovery, a stale per-attempt success
+        cannot survive a restart: the final gate always has the last word.
+
+        The command is a pure observer of the settled tree (enforced by the
+        no-mutation contract in :meth:`_run_verify_gate_single_shot`), so
+        re-evaluating it here does not perturb the delivered workspace. The final
+        gate keys the single-shot oracle on :meth:`_ac_final_verify_gate_key`, so
+        a cold restart consumes this one final outcome rather than re-running the
+        command.
+        """
+        if not self._run_verify_commands:
+            return results
+        execution_scope = execution_id or session_id
+        cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
+        updated = list(results)
+        for position, result in enumerate(updated):
+            ac_index = result.ac_index
+            if ac_index < 0 or ac_index >= len(seed.acceptance_criteria):
+                continue
+            spec = seed.acceptance_criteria[ac_index]
+            if not isinstance(spec, AcceptanceCriterionSpec) or not spec.verify_command:
+                continue
+            # Only an AC that is currently ACCEPTED needs a final-workspace
+            # re-check; a failed/blocked/invalid/externally-satisfied AC is already
+            # terminal and is never resurrected here.
+            if result.outcome != ACExecutionOutcome.SUCCEEDED:
+                continue
+            try:
+                final_outcome = await self._run_verify_gate_single_shot(
+                    spec=spec,
+                    cwd=cwd,
+                    aggregate_id=execution_scope,
+                    verify_key=self._ac_final_verify_gate_key(
+                        execution_scope=execution_scope, ac_index=ac_index
+                    ),
+                    execution_id=execution_id,
+                    session_id=session_id,
+                    identity_metadata={"ac_index": ac_index, "gate": "final_workspace_acceptance"},
+                )
+            except AmbiguousACExecutionError as exc:
+                # The final gate's durable single-shot chain is ambiguous (an
+                # intent with no recorded outcome, or unreadable history): the
+                # non-idempotent command may have partially run. Fail THIS AC
+                # closed rather than trusting an unverifiable final acceptance;
+                # the rest of the run still finalizes.
+                final_outcome = _VerifyGateOutcome(
+                    passed=False,
+                    reason=f"final-workspace verify gate is ambiguous: {exc}",
+                    output_tail="",
+                )
+            if final_outcome.passed:
+                accepted = replace(result, verify_gate_outcome=final_outcome)
+                updated[position] = accepted
+                await self._emit_ac_outcome_finalized(
+                    result=accepted,
+                    root_ac_index=ac_index,
+                    session_id=session_id,
+                    execution_id=execution_id,
+                )
+                continue
+
+            # The FINAL workspace fails the contract -> flip to FAILED. This is the
+            # authoritative verdict; a passing per-attempt gate that a later stage
+            # invalidated is now corrected.
+            from ouroboros.events.base import BaseEvent
+            from ouroboros.orchestrator.failure_taxonomy import FailureClass
+
+            reason = f"Final-workspace verify gate failed: {final_outcome.reason}"
+            detail = reason
+            if final_outcome.output_tail:
+                detail = (
+                    f"{reason}\n--- verify_command output (tail) ---\n{final_outcome.output_tail}"
+                )
+            failed = replace(
+                result,
+                success=False,
+                error=detail,
+                final_message=detail,
+                outcome=ACExecutionOutcome.FAILED,
+                atomic_verifier_verdict=VerifierVerdict(
+                    passed=False,
+                    reasons=(reason,),
+                    failure_class=FailureClass.EVIDENCE_MISSING.value,
+                ),
+                verify_gate_outcome=final_outcome,
+            )
+            updated[position] = failed
+            await self._safe_emit_event(
+                BaseEvent(
+                    type="execution.verify.failed",
+                    aggregate_type="execution",
+                    aggregate_id=execution_scope,
+                    data={
+                        "session_id": session_id,
+                        "execution_id": execution_id,
+                        "ac_index": ac_index,
+                        "ac_content": ac_text(spec),
+                        "verify_command": spec.verify_command,
+                        "expected_artifacts": list(spec.expected_artifacts),
+                        "missing_artifacts": list(final_outcome.missing_artifacts),
+                        "reason": final_outcome.reason,
+                        "failure_class": FailureClass.EVIDENCE_MISSING.value,
+                        "output_tail": final_outcome.output_tail,
+                        "gate": "final_workspace_acceptance",
+                    },
+                )
+            )
+            await self._emit_ac_outcome_finalized(
+                result=failed,
+                root_ac_index=ac_index,
+                session_id=session_id,
+                execution_id=execution_id,
+            )
+            log.warning(
+                "parallel_executor.ac.final_workspace_verify_failed",
+                session_id=session_id,
+                execution_id=execution_id,
+                ac_index=ac_index,
+                reason=final_outcome.reason,
+            )
+        return updated
 
     async def _apply_verify_gate(
         self,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -89,6 +89,7 @@ from ouroboros.harness.traceguard_validator import validate_evidence_claims
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.ac_execution_capsule import (
     bind_capsule_to_runtime_handle,
+    build_ac_dispatch_authority_scope,
     compile_ac_execution_capsule,
 )
 from ouroboros.orchestrator.ac_runtime_handle_manager import ACRuntimeHandleManager
@@ -2395,6 +2396,44 @@ class ParallelACExecutor:
                 else {"mode": "direct", "identity": self._prompt_identity(system_prompt)}
             ),
         }
+
+    def _build_ac_capsule_authority_scope(
+        self,
+        *,
+        execution_context_id: str,
+        tools: list[str],
+        tool_catalog: tuple[MCPToolDefinition, ...] | None,
+        system_prompt: str,
+        level_contexts: list[LevelContext] | None,
+        is_sub_ac: bool,
+        decomposition_trustworthy: bool,
+        force_frontier_routing: bool,
+        investment_spec: InvestmentSpec | None,
+    ) -> str:
+        """Bind a capsule to the exact provider dispatch authority in force."""
+        dispatch_contract = self._build_checkpoint_dispatch_contract(
+            tools=tools,
+            tool_catalog=tool_catalog,
+            system_prompt=system_prompt,
+            system_prompt_builder=None,
+            reconciled_level_contexts=level_contexts,
+        )
+        execution_policy: dict[str, object] = {
+            "reasoning_effort": self._reasoning_effort,
+            "is_sub_ac": is_sub_ac,
+            "decomposition_trustworthy": decomposition_trustworthy,
+            "force_frontier_routing": force_frontier_routing,
+            "investment_spec": (
+                investment_spec.model_dump(mode="json") if investment_spec is not None else None
+            ),
+        }
+        return build_ac_dispatch_authority_scope(
+            base_scope=(
+                self._decomposition_attestation_scope or f"execution:{execution_context_id}"
+            ),
+            dispatch_contract=dispatch_contract,
+            execution_policy=execution_policy,
+        )
 
     @staticmethod
     def _checkpoint_dispatch_contract_malformed(
@@ -8988,8 +9027,16 @@ Respond with either ATOMIC or the structured JSON object only.
             workspace=(
                 self._task_cwd or getattr(self._adapter, "working_directory", None) or os.getcwd()
             ),
-            authority_scope=(
-                self._decomposition_attestation_scope or f"execution:{execution_context_id}"
+            authority_scope=self._build_ac_capsule_authority_scope(
+                execution_context_id=execution_context_id,
+                tools=tools,
+                tool_catalog=tool_catalog,
+                system_prompt=system_prompt,
+                level_contexts=level_contexts,
+                is_sub_ac=is_sub_ac,
+                decomposition_trustworthy=decomposition_trustworthy,
+                force_frontier_routing=force_frontier_routing,
+                investment_spec=investment_spec,
             ),
             seed_goal=seed_goal,
             ac_content=ac_content,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -290,6 +290,7 @@ from ouroboros.orchestrator.evidence_schema import (
     validate_evidence,
 )
 from ouroboros.orchestrator.execution_event_emitter import (
+    _MAX_VERIFY_MISSING_ARTIFACT_CHARS,
     _MAX_VERIFY_MISSING_ARTIFACTS,
     _MAX_VERIFY_TEXT_CHARS,
     ExecutionEventEmitter,
@@ -2688,19 +2689,45 @@ class ParallelACExecutor:
         Startup- and stdout-idle watchdog timeouts (and process-shutdown grace)
         change WHEN a provider turn is interrupted, so two runtimes with different
         timeouts have materially different termination semantics and must not
-        share a capsule fingerprint. A runtime that owns a watchdog exposes a
-        provider-neutral ``watchdog_identity_contract()``; absent it, the policy
-        is recorded as unobserved.
+        share a capsule fingerprint. Resolution is provider-neutral: a runtime may
+        expose an explicit ``watchdog_identity_contract()``, but otherwise the
+        well-known watchdog timeout attributes every subprocess runtime carries
+        (Codex, OpenCode, Hermes, Pi, GJC, ...) are probed directly, and a wrapped
+        ``_transport`` is probed one level, so a configurable interruption policy
+        is never left unobserved.
         """
-        contract = getattr(adapter, "watchdog_identity_contract", None)
-        if callable(contract):
-            try:
-                declared = contract()
-            except Exception:
-                declared = None
-            if isinstance(declared, Mapping):
-                return {"version": 1, "observed": True, "policy": dict(declared)}
-        return {"version": 1, "observed": False, "policy": None}
+        _watchdog_attrs = (
+            "_startup_output_timeout_seconds",
+            "_stdout_idle_timeout_seconds",
+            "_process_shutdown_timeout_seconds",
+            "_completed_process_group_shutdown_timeout_seconds",
+        )
+
+        def _probe(obj: object) -> dict[str, object] | None:
+            contract = getattr(obj, "watchdog_identity_contract", None)
+            if callable(contract):
+                try:
+                    declared = contract()
+                except Exception:
+                    declared = None
+                if isinstance(declared, Mapping):
+                    return dict(declared)
+            policy: dict[str, object] = {}
+            for attr in _watchdog_attrs:
+                value = getattr(obj, attr, None)
+                # Only bind genuine numeric/None timeout settings — never a
+                # MagicMock or other incidental attribute.
+                if value is None or isinstance(value, (int, float)):
+                    if hasattr(obj, attr):
+                        policy[attr.lstrip("_")] = value
+            return policy or None
+
+        policy = _probe(adapter)
+        if policy is None:
+            transport = getattr(adapter, "_transport", None)
+            if transport is not None:
+                policy = _probe(transport)
+        return {"version": 1, "observed": policy is not None, "policy": policy}
 
     @staticmethod
     def _runtime_capabilities_contract(adapter: object) -> dict[str, Any] | None:
@@ -8454,12 +8481,37 @@ class ParallelACExecutor:
                     self._run_verify_commands
                     and isinstance(ac_spec, AcceptanceCriterionSpec)
                     and ac_spec.verify_command
-                    and recovered_verify_outcome is None
                 ):
-                    raise AmbiguousACExecutionError(
-                        "Completed AC recovery is missing its non-idempotent verify-command "
-                        "outcome; refusing to replay the command"
-                    ) from completed
+                    if recovered_verify_outcome is None:
+                        raise AmbiguousACExecutionError(
+                            "Completed AC recovery is missing its non-idempotent verify-command "
+                            "outcome; refusing to replay the command"
+                        ) from completed
+                    # The completed lifecycle's cached PASS is not self-authorizing:
+                    # require the durable single-shot verify chain (exactly one
+                    # intent + matching outcome) to back it, so an orphan or
+                    # corrupted completion cannot manufacture command-backed
+                    # acceptance. The durable oracle outcome is authoritative.
+                    execution_scope = execution_id or session_id
+                    (
+                        durable_verify_outcome,
+                        _intent_only,
+                    ) = await self._load_persisted_verify_decision(
+                        aggregate_id=execution_scope,
+                        verify_key=self._ac_verify_gate_key(
+                            execution_scope=execution_scope,
+                            ac_index=ac_index,
+                            retry_attempt=atomic_retry_attempt,
+                        ),
+                        command_digest=self._verify_gate_command_digest(ac_spec),
+                    )
+                    if durable_verify_outcome is None:
+                        raise AmbiguousACExecutionError(
+                            "Completed AC recovery lacks the durable verify intent/outcome chain "
+                            "backing its verify-command result; refusing to trust a completion "
+                            "that cannot prove its acceptance evidence"
+                        ) from completed
+                    recovered_verify_outcome = durable_verify_outcome
                 log.info(
                     "parallel_executor.ac.completed_recovered",
                     ac_index=ac_index,
@@ -10585,9 +10637,15 @@ Respond with either ATOMIC or the structured JSON object only.
                     spec=ac_spec,
                     cwd=cwd,
                     aggregate_id=execution_context_id,
-                    verify_key=(
-                        f"atomic:{runtime_identity.ac_id}:"
-                        f"{runtime_identity.session_attempt_id}:{retry_attempt}"
+                    # One authoritative per-attempt key shared by the atomic gate,
+                    # the failed-runtime recovery gate (_apply_verify_gate), and the
+                    # sibling-flip gate, so a post-verify failure (e.g. a lost
+                    # session.completed) never reruns the command under a different
+                    # key — the later path consumes this attempt's durable outcome.
+                    verify_key=self._ac_verify_gate_key(
+                        execution_scope=execution_context_id,
+                        ac_index=ac_index,
+                        retry_attempt=retry_attempt,
                     ),
                     execution_id=execution_context_id,
                     session_id=session_id,
@@ -11117,6 +11175,17 @@ Respond with either ATOMIC or the structured JSON object only.
             return None, None, str(exc)
         return record, validation, None
 
+    @staticmethod
+    def _ac_verify_gate_key(*, execution_scope: str, ac_index: int, retry_attempt: int) -> str:
+        """One stable per-attempt verify-oracle key shared across every gate path.
+
+        The atomic gate, the failed-runtime recovery gate, and the sibling-flip
+        gate all reference the SAME (execution, AC, attempt) verify command, so
+        they key the single-shot oracle identically and a later path consumes the
+        durable outcome instead of re-running the command.
+        """
+        return f"acgate:{execution_scope}:{ac_index}:{retry_attempt}"
+
     def _verify_gate_command_digest(self, spec: AcceptanceCriterionSpec) -> str:
         """Bind a durable verify outcome to the exact command/contract that ran.
 
@@ -11300,10 +11369,15 @@ Respond with either ATOMIC or the structured JSON object only.
 
         missing_artifacts = _missing_expected_artifacts(spec.expected_artifacts, cwd)
         if missing_artifacts:
-            # ``expected_artifacts`` is not size-limited, so bound the reported
-            # miss list (verdict is preserved) before it flows into any durable
-            # outcome; the emitter/replay enforce a hard byte cap on top of this.
-            capped_missing = missing_artifacts[:_MAX_VERIFY_MISSING_ARTIFACTS]
+            # ``expected_artifacts`` is not size-limited, so bound BOTH the count
+            # and each entry's length (verdict is preserved) before it flows into
+            # any durable outcome — the completed-lifecycle path persists this
+            # outcome directly, so an unbounded per-entry length would blow the
+            # byte cap. The emitter/replay enforce a hard byte cap on top of this.
+            capped_missing = tuple(
+                entry[:_MAX_VERIFY_MISSING_ARTIFACT_CHARS]
+                for entry in missing_artifacts[:_MAX_VERIFY_MISSING_ARTIFACTS]
+            )
             reason = "expected_artifacts missing: " + ", ".join(capped_missing)
             if len(missing_artifacts) > len(capped_missing):
                 reason += f" (+{len(missing_artifacts) - len(capped_missing)} more)"
@@ -11431,7 +11505,14 @@ Respond with either ATOMIC or the structured JSON object only.
                 spec=spec,
                 cwd=cwd,
                 aggregate_id=execution_id or session_id,
-                verify_key=f"apply_gate:{ac_index}:{result.retry_attempt}",
+                # Same per-attempt key as the atomic gate: if the atomic outcome
+                # was persisted but its result-carried copy was lost (e.g. a failed
+                # session.completed), this consumes it instead of re-running.
+                verify_key=self._ac_verify_gate_key(
+                    execution_scope=execution_id or session_id,
+                    ac_index=ac_index,
+                    retry_attempt=result.retry_attempt,
+                ),
                 execution_id=execution_id,
                 session_id=session_id,
                 identity_metadata={"ac_index": ac_index, "retry_attempt": result.retry_attempt},
@@ -11727,7 +11808,12 @@ Respond with either ATOMIC or the structured JSON object only.
                     spec=spec,
                     cwd=cwd,
                     aggregate_id=execution_id or session_id,
-                    verify_key=f"flip_gate:{ac_idx}:{result.retry_attempt}",
+                    # Same per-attempt key as the atomic/apply gates — one oracle.
+                    verify_key=self._ac_verify_gate_key(
+                        execution_scope=execution_id or session_id,
+                        ac_index=ac_idx,
+                        retry_attempt=result.retry_attempt,
+                    ),
                     execution_id=execution_id,
                     session_id=session_id,
                     identity_metadata={"ac_index": ac_idx, "retry_attempt": result.retry_attempt},

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1915,6 +1915,7 @@ class ParallelACExecutor:
         retry_attempt: int = 0,
         expected_capsule_fingerprint: str | None = None,
         expected_capsule_workspace: str | None = None,
+        runtime_attests_realtime_effects: bool = False,
     ) -> RuntimeHandle | None:
         return await self._ac_runtime_handle_manager._load_persisted_ac_runtime_handle(
             ac_index,
@@ -1926,6 +1927,7 @@ class ParallelACExecutor:
             retry_attempt=retry_attempt,
             expected_capsule_fingerprint=expected_capsule_fingerprint,
             expected_capsule_workspace=expected_capsule_workspace,
+            runtime_attests_realtime_effects=runtime_attests_realtime_effects,
         )
 
     def _remember_ac_runtime_handle(
@@ -3003,12 +3005,18 @@ class ParallelACExecutor:
             ),
             "runtime_execution_authority": self._runtime_execution_authority,
             "atomic_verifier_authority": self._atomic_verifier_authority,
-            # Whether Synapse signal delivery is wired in. An executor WITH a hub
-            # registers/replays durable signals and may run provider follow-up
-            # turns; one WITHOUT it never does. That changes acceptance-affecting
-            # execution semantics, so it must change authority — otherwise a
-            # restart could resume the same capsule under different signal policy.
-            "session_signal_hub_enabled": self._session_signal_hub is not None,
+            # Synapse signal delivery policy. A hub changes acceptance-affecting
+            # semantics (it may run provider follow-up turns), and — critically —
+            # only a hub with a DURABLE event store replays cross-process queued
+            # signals on restart, so the durable-relay mode must participate in
+            # authority, not merely whether a hub is present.
+            "session_signal_hub": {
+                "enabled": self._session_signal_hub is not None,
+                "durable_relay": (
+                    self._session_signal_hub is not None
+                    and getattr(self._session_signal_hub, "event_store", None) is not None
+                ),
+            },
             # Effective sibling concurrency is shared-workspace execution
             # semantics: concurrency 1 vs 8 interleave sibling mutations
             # differently, so a resume must not silently change it.
@@ -9877,6 +9885,16 @@ Respond with either ATOMIC or the structured JSON object only.
             retry_attempt=retry_attempt,
             expected_capsule_fingerprint=capsule.fingerprint,
             expected_capsule_workspace=capsule.workspace,
+            # Only a runtime that streams tool effects in real time makes the
+            # loader's recorded-effect check authoritative; an opaque runtime's
+            # active head must fail closed rather than resume-and-resend.
+            runtime_attests_realtime_effects=bool(
+                getattr(
+                    getattr(self._adapter, "capabilities", None),
+                    "realtime_tool_effect_visibility",
+                    False,
+                )
+            ),
         )
         if persisted_runtime_handle is not None:
             persisted_runtime_handle = bind_capsule_to_runtime_handle(

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -41,6 +41,7 @@ import math
 import os
 from pathlib import Path
 import re
+import shutil
 import socket
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 import uuid
@@ -288,7 +289,12 @@ from ouroboros.orchestrator.evidence_schema import (
     extract_evidence,
     validate_evidence,
 )
-from ouroboros.orchestrator.execution_event_emitter import ExecutionEventEmitter
+from ouroboros.orchestrator.execution_event_emitter import (
+    _MAX_VERIFY_MISSING_ARTIFACTS,
+    _MAX_VERIFY_TEXT_CHARS,
+    ExecutionEventEmitter,
+    bound_verify_gate_outcome,
+)
 from ouroboros.orchestrator.execution_runtime_scope import (
     ACRuntimeIdentity,
     ExecutionNodeIdentity,
@@ -766,14 +772,20 @@ class _VerifyGateOutcome:
 def _recovered_verify_gate_outcome(
     value: Mapping[str, Any] | None,
 ) -> _VerifyGateOutcome | None:
-    """Rehydrate the strict durable verify projection without running its command."""
+    """Rehydrate the strict durable verify projection without running its command.
+
+    Enforces the same bound during replay as at persistence: a corrupted or
+    oversized persisted outcome (e.g. an unbounded ``missing_artifacts`` list)
+    raises rather than being trusted as acceptance evidence.
+    """
     if value is None:
         return None
+    bounded = bound_verify_gate_outcome(value)
     return _VerifyGateOutcome(
-        passed=value["passed"],
-        reason=value["reason"],
-        output_tail=value["output_tail"],
-        missing_artifacts=tuple(value["missing_artifacts"]),
+        passed=bounded["passed"],
+        reason=bounded["reason"],
+        output_tail=bounded["output_tail"],
+        missing_artifacts=tuple(bounded["missing_artifacts"]),
     )
 
 
@@ -2592,17 +2604,30 @@ class ParallelACExecutor:
         is probed so a delegated launcher still participates in identity.
         """
 
-        def _resolve(value: object) -> dict[str, str] | None:
+        def _resolve(value: object) -> dict[str, object] | None:
             if isinstance(value, os.PathLike):
                 value = os.fspath(value)
             if not isinstance(value, str) or not value:
                 return None
             expanded = os.path.expanduser(value)
+            # A bare command name (no path separator) is resolved by
+            # ``create_subprocess_exec`` through the effective child PATH, NOT
+            # relative to the workspace. Fingerprinting a cwd-relative realpath
+            # would make ``claude`` look identical even when PATH points it at two
+            # different binaries, so resolve it through PATH here; a name that PATH
+            # cannot resolve is recorded as ``unresolved`` (a distinct, fail-visible
+            # identity) rather than silently collapsing to the raw name.
+            has_sep = os.sep in expanded or (os.altsep is not None and os.altsep in expanded)
+            if not has_sep:
+                which = shutil.which(expanded)
+                if which is None:
+                    return {"path": value, "realpath": None, "path_resolution": "unresolved"}
+                return {"path": value, "realpath": os.path.realpath(which)}
             return {"path": value, "realpath": os.path.realpath(expanded)}
 
         def _probe(
             obj: object,
-        ) -> tuple[dict[str, str] | None, dict[str, str] | None, object | None]:
+        ) -> tuple[dict[str, object] | None, dict[str, object] | None, object | None]:
             # An explicit contract wins — a wrapping runtime uses it to name the
             # executable/launcher its transport really invokes AND any additional
             # command-affecting policy (e.g. Claude's --add-dir / --disallowedTools)
@@ -2887,6 +2912,12 @@ class ParallelACExecutor:
             ),
             "runtime_execution_authority": self._runtime_execution_authority,
             "atomic_verifier_authority": self._atomic_verifier_authority,
+            # Whether Synapse signal delivery is wired in. An executor WITH a hub
+            # registers/replays durable signals and may run provider follow-up
+            # turns; one WITHOUT it never does. That changes acceptance-affecting
+            # execution semantics, so it must change authority — otherwise a
+            # restart could resume the same capsule under different signal policy.
+            "session_signal_hub_enabled": self._session_signal_hub is not None,
             "prompt_authority": {
                 "retry_prompt_digest": self._prompt_identity(retry_prompt_extra),
                 "siblings": [
@@ -10051,12 +10082,23 @@ Respond with either ATOMIC or the structured JSON object only.
                 # potentially repeating a non-idempotent effect. Reconcile it as an
                 # explicit ambiguous/fail-closed terminal outcome instead; only a
                 # stall with no observed effect keeps the retryable stall sentinel.
-                if dispatch_state.tool_effects_observed:
-                    # Persist the ambiguity durably BEFORE raising. The raise only
-                    # clears the in-memory handle; a cold restart would otherwise
-                    # find this dispatch's session.started handle, treat it as a
-                    # resumable active head, and re-enter the provider. Sealing the
-                    # dispatch makes recovery fail closed on it instead.
+                # A stall is only safely retryable when we can PROVE no effect
+                # occurred: either a tool effect WAS observed (effectful stall), or
+                # the driver does not stream tool effects in real time (an opaque
+                # driver may have mutated the workspace/external systems and then
+                # hung before yielding any message). Both cases seal the dispatch
+                # durably BEFORE raising — the raise only clears the in-memory
+                # handle, so a cold restart would otherwise find this dispatch's
+                # session.started handle, treat it as a resumable active head, and
+                # re-enter the provider. Sealing makes recovery fail closed instead.
+                realtime_effect_visibility = bool(
+                    getattr(
+                        getattr(self._adapter, "capabilities", None),
+                        "realtime_tool_effect_visibility",
+                        False,
+                    )
+                )
+                if dispatch_state.tool_effects_observed or not realtime_effect_visibility:
                     await self._event_emitter.emit_ac_dispatch_sealed(
                         runtime_identity=runtime_identity,
                         dispatch_id=dispatch_id,
@@ -10064,10 +10106,15 @@ Respond with either ATOMIC or the structured JSON object only.
                         session_id=session_id,
                         capsule_fingerprint=capsule.fingerprint,
                     )
+                    reason = (
+                        "after emitting tool effects"
+                        if dispatch_state.tool_effects_observed
+                        else "and its driver does not attest real-time tool-effect visibility"
+                    )
                     raise AmbiguousACExecutionError(
-                        "AC provider stalled after emitting tool effects; refusing stall retry "
-                        "because a fresh redispatch would bypass the recovery ambiguity guard and "
-                        "may duplicate non-idempotent effects"
+                        f"AC provider stalled {reason}; refusing stall retry because a fresh "
+                        "redispatch would bypass the recovery ambiguity guard and may duplicate "
+                        "non-idempotent effects"
                     )
                 return ACExecutionResult(
                     ac_index=ac_index,
@@ -11046,7 +11093,8 @@ Respond with either ATOMIC or the structured JSON object only.
                 "could not read durable verify history; refusing to run a non-idempotent "
                 "verify command without a single-shot guarantee"
             ) from exc
-        intent_seen = False
+        intent_count = 0
+        outcome_count = 0
         durable_outcome: _VerifyGateOutcome | None = None
         conflicting = False
         for event in events:
@@ -11064,8 +11112,17 @@ Respond with either ATOMIC or the structured JSON object only.
                     conflicting = True
                 continue
             if event.type == "execution.ac.verify.intent":
-                intent_seen = True
+                intent_count += 1
             elif event.type == "execution.ac.verify.outcome":
+                # An outcome is only trustworthy as the durable result of a real
+                # command run, which is always preceded by its intent. An outcome
+                # with no preceding intent is an orphan (corrupted or injected)
+                # record that could manufacture acceptance evidence — reject it.
+                if intent_count == 0:
+                    raise AmbiguousACExecutionError(
+                        "durable verify outcome has no preceding intent; refusing to trust an "
+                        "orphan verify record that could manufacture acceptance evidence"
+                    )
                 projected = _recovered_verify_gate_outcome(data.get("verify_gate_outcome"))
                 if projected is None:
                     raise AmbiguousACExecutionError(
@@ -11077,7 +11134,12 @@ Respond with either ATOMIC or the structured JSON object only.
                     or durable_outcome.reason != projected.reason
                 ):
                     conflicting = True
+                outcome_count += 1
                 durable_outcome = projected
+        # Exactly-one intent / at-most-one outcome: duplicates are out-of-order or
+        # replayed records and make the single-shot guarantee ambiguous.
+        if intent_count > 1 or outcome_count > 1:
+            conflicting = True
         if conflicting:
             raise AmbiguousACExecutionError(
                 "durable verify records for this attempt disagree; refusing to replay or "
@@ -11085,7 +11147,7 @@ Respond with either ATOMIC or the structured JSON object only.
             )
         if durable_outcome is not None:
             return durable_outcome, False
-        return None, intent_seen
+        return None, intent_count > 0
 
     async def _run_verify_gate_single_shot(
         self,
@@ -11171,11 +11233,18 @@ Respond with either ATOMIC or the structured JSON object only.
 
         missing_artifacts = _missing_expected_artifacts(spec.expected_artifacts, cwd)
         if missing_artifacts:
+            # ``expected_artifacts`` is not size-limited, so bound the reported
+            # miss list (verdict is preserved) before it flows into any durable
+            # outcome; the emitter/replay enforce a hard byte cap on top of this.
+            capped_missing = missing_artifacts[:_MAX_VERIFY_MISSING_ARTIFACTS]
+            reason = "expected_artifacts missing: " + ", ".join(capped_missing)
+            if len(missing_artifacts) > len(capped_missing):
+                reason += f" (+{len(missing_artifacts) - len(capped_missing)} more)"
             return _VerifyGateOutcome(
                 passed=False,
-                reason="expected_artifacts missing: " + ", ".join(missing_artifacts),
+                reason=reason[:_MAX_VERIFY_TEXT_CHARS],
                 output_tail="",
-                missing_artifacts=missing_artifacts,
+                missing_artifacts=capped_missing,
             )
 
         command = spec.verify_command

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -754,6 +754,27 @@ _DEFERRED_DURABLE_WRITE_MAX_ATTEMPTS = 48
 # the full multi-hour parked-cadence budget.
 _DEFERRED_DURABLE_WRITE_DRAIN_TIMEOUT_SECONDS = 10.0
 _VERIFY_OUTPUT_TAIL_CHARS = 2000  # How much verify-command output to attach
+# Directories excluded from the verify_command no-mutation fingerprint: VCS
+# metadata, installed dependencies, and tool caches legitimately churn while a
+# verify_command runs (a test run writes ``__pycache__``/``.pytest_cache``; git
+# read commands touch ``.git/index``) and are not acceptance-relevant source of
+# truth. Every other path -- source AND build outputs a contract may assert on
+# -- participates, so a verifier that mutates the delivered tree is caught. The
+# command itself still runs over the COMPLETE live tree, so these directories
+# remain fully visible to it (unlike a shadow-replay snapshot).
+_VERIFY_MUTATION_IGNORE_DIRS = frozenset(
+    {
+        ".git",
+        "node_modules",
+        ".venv",
+        "venv",
+        "__pycache__",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".tox",
+    }
+)
 _DURABLE_CONTEXT_MAX_AC_CONTENT_CHARS = 2000
 _DURABLE_CONTEXT_MAX_TOOL_NAMES = 64
 _DURABLE_CONTEXT_MAX_FILE_PATHS = 128
@@ -7896,41 +7917,16 @@ class ParallelACExecutor:
         parent_verify_gate_outcome: _VerifyGateOutcome | None = None
         if parent_has_contract and self._run_verify_commands:
             assert ac_spec is not None  # narrowed by parent_has_contract
-            live_cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
-            gate_kwargs: dict[str, Any] = {
-                "spec": ac_spec,
-                "aggregate_id": execution_id or session_id,
-                "verify_key": f"decomposed_parent:{node_identity.node_id}:{retry_attempt}",
-                "execution_id": execution_id,
-                "session_id": session_id,
-                "identity_metadata": node_identity.to_event_metadata(),
-            }
-            if ac_spec.verify_command:
-                # R14-2: a command-bearing parent gate runs the same class of
-                # arbitrary, possibly-mutating shell as the leaf/batch gates and
-                # over the same shared workspace. Grade it against a frozen
-                # snapshot so it can neither observe nor cause a cross-gate
-                # mutation. ``isolated_workspace`` is a best-effort snapshot (as in
-                # shadow-replay): on the rare environmental failure to freeze a
-                # tree that in production always exists, degrade to the prior
-                # in-place grading rather than fabricate an attestation failure.
-                with isolated_workspace(live_cwd) as snapshot_cwd:
-                    if snapshot_cwd is None:
-                        log.warning(
-                            "parallel_executor.ac.verify_gate.isolation_unavailable",
-                            session_id=session_id,
-                            execution_id=execution_id,
-                            node_id=node_identity.node_id,
-                            cwd=live_cwd,
-                        )
-                    parent_verify_gate_outcome = await self._run_verify_gate_single_shot(
-                        cwd=snapshot_cwd if snapshot_cwd is not None else live_cwd,
-                        **gate_kwargs,
-                    )
-            else:
-                parent_verify_gate_outcome = await self._run_verify_gate_single_shot(
-                    cwd=live_cwd, **gate_kwargs
-                )
+            cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
+            parent_verify_gate_outcome = await self._run_verify_gate_single_shot(
+                spec=ac_spec,
+                cwd=cwd,
+                aggregate_id=execution_id or session_id,
+                verify_key=f"decomposed_parent:{node_identity.node_id}:{retry_attempt}",
+                execution_id=execution_id,
+                session_id=session_id,
+                identity_metadata=node_identity.to_event_metadata(),
+            )
             parent = ParentVerifyOutcome(
                 has_verify_command=True,
                 passed=parent_verify_gate_outcome.passed,
@@ -11449,6 +11445,38 @@ Respond with either ATOMIC or the structured JSON object only.
             return durable_outcome, False
         return None, intent_count > 0
 
+    @staticmethod
+    def _verify_workspace_mutation_fingerprint(cwd: str) -> str:
+        """Fingerprint the acceptance-relevant workspace tree under ``cwd``.
+
+        Used by the no-mutation contract to detect whether a ``verify_command``
+        mutated the shared workspace. Records ``(relpath, mode, size, mtime_ns)``
+        for every file outside :data:`_VERIFY_MUTATION_IGNORE_DIRS` (VCS metadata,
+        installed dependencies, and tool caches that legitimately churn), so any
+        create/delete/modify/chmod of an acceptance-relevant file changes the
+        fingerprint. Deterministic (records are sorted) and independent of walk
+        order. Returns ``""`` when ``cwd`` is not a directory (e.g. a stub
+        adapter), which the caller treats as "no observable mutation".
+        """
+        if not os.path.isdir(cwd):
+            return ""
+        records: list[str] = []
+        for current, dirnames, filenames in os.walk(cwd, followlinks=False):
+            dirnames[:] = [d for d in dirnames if d not in _VERIFY_MUTATION_IGNORE_DIRS]
+            for name in filenames:
+                path = os.path.join(current, name)
+                rel = os.path.relpath(path, cwd)
+                try:
+                    st = os.lstat(path)
+                    records.append(f"{rel}\x00{st.st_mode}\x00{st.st_size}\x00{st.st_mtime_ns}")
+                except OSError:
+                    records.append(f"{rel}\x00<unreadable>")
+        digest = hashlib.sha256()
+        for record in sorted(records):
+            digest.update(record.encode("utf-8", "surrogatepass"))
+            digest.update(b"\n")
+        return digest.hexdigest()
+
     async def _run_verify_gate_single_shot(
         self,
         *,
@@ -11500,7 +11528,36 @@ Respond with either ATOMIC or the structured JSON object only.
             session_id=session_id,
             identity_metadata=identity_metadata,
         )
+        # No-mutation contract (blockers R15-2/R15-3): the command runs over the
+        # COMPLETE live tree so every dependency/build/VCS input a contract may
+        # reference is present (a shadow-replay snapshot strips those and would
+        # mis-grade). To keep every accepted verifier a pure observer of the
+        # settled state -- unable to corrupt the delivered artifact or invalidate
+        # a sibling gate -- fingerprint the acceptance-relevant tree around the run
+        # and fail closed if the command mutated it. Folding the verdict in BEFORE
+        # the outcome is persisted keeps crash recovery consistent: recovery
+        # consumes this same failed outcome, never a stale PASS the command later
+        # invalidated by its own side effect.
+        fingerprint_before = self._verify_workspace_mutation_fingerprint(cwd)
         outcome = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+        fingerprint_after = self._verify_workspace_mutation_fingerprint(cwd)
+        if outcome.passed and fingerprint_after != fingerprint_before:
+            log.warning(
+                "parallel_executor.ac.verify_gate.workspace_mutated",
+                session_id=session_id,
+                execution_id=execution_id,
+                verify_key=verify_key,
+            )
+            outcome = _VerifyGateOutcome(
+                passed=False,
+                reason=(
+                    "verify_command mutated the shared workspace; a verify command "
+                    "must be a pure observer of the settled state (a mutation can "
+                    "invalidate a sibling gate or corrupt the delivered artifact)"
+                ),
+                output_tail=outcome.output_tail,
+                missing_artifacts=outcome.missing_artifacts,
+            )
         await self._event_emitter.emit_ac_verify_outcome(
             aggregate_id=aggregate_id,
             verify_key=verify_key,
@@ -11623,102 +11680,6 @@ Respond with either ATOMIC or the structured JSON object only.
             )
         return _VerifyGateOutcome(passed=True, reason=None, output_tail=tail)
 
-    async def _apply_verify_gate_isolated(
-        self,
-        *,
-        seed: Seed,
-        ac_index: int,
-        result: ACExecutionResult,
-        session_id: str,
-        execution_id: str,
-    ) -> ACExecutionResult:
-        """Apply the batch verify gate over a private, frozen workspace snapshot.
-
-        R14-2: a ``verify_command`` is arbitrary shell that may MUTATE the shared
-        workspace. Every batch / escalation / alt-harness gate finalizes
-        sequentially over the one settled tree, so a later command's side effects
-        could invalidate acceptance an earlier gate already granted
-        (order-dependent, non-reproducible) and could corrupt the delivered
-        artifact. Grade every command-bearing gate against an isolated copy of the
-        settled workspace so no verifier can observe or cause a cross-gate
-        mutation: each gate sees the identical settled state and the delivered
-        tree is never touched by a verifier.
-
-        A gate that only re-checks an already-recorded command outcome, or whose
-        contract is purely ``expected_artifacts`` (idempotent, read-only), needs
-        no sandbox and grades the live delivered tree directly -- the artifact leg
-        must reflect what will actually be shipped. Only a fresh command RUN is
-        sandboxed.
-        """
-        if not self._run_verify_commands:
-            return result
-        spec = (
-            seed.acceptance_criteria[ac_index]
-            if 0 <= ac_index < len(seed.acceptance_criteria)
-            else None
-        )
-        needs_command_run = (
-            isinstance(spec, AcceptanceCriterionSpec)
-            and bool(spec.verify_command)
-            and not isinstance(result.verify_gate_outcome, _VerifyGateOutcome)
-        )
-        if not needs_command_run:
-            return await self._apply_verify_gate(
-                seed=seed,
-                ac_index=ac_index,
-                result=result,
-                session_id=session_id,
-                execution_id=execution_id,
-            )
-        live_cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
-        with isolated_workspace(live_cwd) as snapshot_cwd:
-            if snapshot_cwd is None:
-                # The settled tree could not be frozen (copy failure or a symlink
-                # escaping the snapshot). Running the possibly-mutating command in
-                # the shared live workspace could silently invalidate a sibling
-                # gate, so fail a would-be-accepted result closed rather than grade
-                # against an unsafe tree. An already-failing result keeps its
-                # failure -- its recovery command cannot be run safely either.
-                log.warning(
-                    "parallel_executor.ac.verify_gate.isolation_unavailable",
-                    session_id=session_id,
-                    execution_id=execution_id,
-                    ac_index=ac_index,
-                    cwd=live_cwd,
-                )
-                if not result.success:
-                    return result
-                from ouroboros.orchestrator.failure_taxonomy import FailureClass
-
-                reason = (
-                    "verify gate could not isolate an immutable snapshot of the "
-                    "settled workspace; refusing to run verify_command in the shared "
-                    "live workspace where it could invalidate a sibling gate"
-                )
-                return replace(
-                    result,
-                    success=False,
-                    error=reason,
-                    final_message=reason,
-                    outcome=ACExecutionOutcome.FAILED,
-                    atomic_verifier_verdict=VerifierVerdict(
-                        passed=False,
-                        reasons=(reason,),
-                        failure_class=FailureClass.EVIDENCE_MISSING.value,
-                    ),
-                    verify_gate_outcome=_VerifyGateOutcome(
-                        passed=False, reason=reason, output_tail=""
-                    ),
-                )
-            return await self._apply_verify_gate(
-                seed=seed,
-                ac_index=ac_index,
-                result=result,
-                session_id=session_id,
-                execution_id=execution_id,
-                verify_workspace=snapshot_cwd,
-            )
-
     async def _apply_verify_gate(
         self,
         *,
@@ -11727,7 +11688,6 @@ Respond with either ATOMIC or the structured JSON object only.
         result: ACExecutionResult,
         session_id: str,
         execution_id: str,
-        verify_workspace: str | None = None,
     ) -> ACExecutionResult:
         """Gate a successful AC on its success contract (PR-V V1).
 
@@ -11748,11 +11708,7 @@ Respond with either ATOMIC or the structured JSON object only.
         ):
             return result
 
-        # ``verify_workspace``, when provided by ``_apply_verify_gate_isolated``,
-        # is a private frozen snapshot of the settled tree (R14-2); the command
-        # and every artifact check run there so a verifier can neither observe
-        # nor cause a cross-gate mutation. When absent, grade the live tree.
-        cwd = verify_workspace or self._task_cwd or self._adapter.working_directory or os.getcwd()
+        cwd = self._task_cwd or self._adapter.working_directory or os.getcwd()
         cached_outcome = result.verify_gate_outcome
         if isinstance(cached_outcome, _VerifyGateOutcome):
             outcome = _revalidate_cached_verify_gate_outcome(
@@ -13471,7 +13427,7 @@ Respond with either ATOMIC or the structured JSON object only.
             )
         elif not candidate.forced_frontier_routing:
             candidate = replace(candidate, forced_frontier_routing=True)
-        candidate = await self._apply_verify_gate_isolated(
+        candidate = await self._apply_verify_gate(
             seed=seed,
             ac_index=ac_idx,
             result=candidate,
@@ -13689,7 +13645,7 @@ Respond with either ATOMIC or the structured JSON object only.
                         # normalize mocked/custom runtimes at the orchestration
                         # boundary so durable replay still records the truth.
                         candidate = replace(candidate, forced_frontier_routing=True)
-                    candidate = await self._apply_verify_gate_isolated(
+                    candidate = await self._apply_verify_gate(
                         seed=seed,
                         ac_index=ac_idx,
                         result=candidate,
@@ -13934,7 +13890,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 )
             elif not candidate.forced_frontier_routing:
                 candidate = replace(candidate, forced_frontier_routing=True)
-            candidate = await self._apply_verify_gate_isolated(
+            candidate = await self._apply_verify_gate(
                 seed=seed,
                 ac_index=ac_idx,
                 result=candidate,
@@ -14135,7 +14091,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 continue
             result = results[position]
             if isinstance(result, ACExecutionResult):
-                gated = await self._apply_verify_gate_isolated(
+                gated = await self._apply_verify_gate(
                     seed=seed,
                     ac_index=ac_idx,
                     result=result,
@@ -14245,7 +14201,7 @@ Respond with either ATOMIC or the structured JSON object only.
             for retry_position, ac_idx in enumerate(retry_idxs):
                 gated = retry_results[retry_position]
                 if isinstance(gated, ACExecutionResult):
-                    gated = await self._apply_verify_gate_isolated(
+                    gated = await self._apply_verify_gate(
                         seed=seed,
                         ac_index=ac_idx,
                         result=gated,
@@ -14393,7 +14349,7 @@ Respond with either ATOMIC or the structured JSON object only.
                             # get, so an
                             # alternate 'success' with a failing verify_command or
                             # missing expected artifact is not accepted as success.
-                            finalized_alt = await self._apply_verify_gate_isolated(
+                            finalized_alt = await self._apply_verify_gate(
                                 seed=seed,
                                 ac_index=ac_idx,
                                 result=alt,
@@ -14527,7 +14483,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 )
             elif not atomic_candidate.forced_frontier_routing:
                 atomic_candidate = replace(atomic_candidate, forced_frontier_routing=True)
-            atomic_candidate = await self._apply_verify_gate_isolated(
+            atomic_candidate = await self._apply_verify_gate(
                 seed=seed,
                 ac_index=ac_idx,
                 result=atomic_candidate,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -43,6 +43,7 @@ from pathlib import Path
 import re
 import shutil
 import socket
+import stat
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 import uuid
 
@@ -754,25 +755,39 @@ _DEFERRED_DURABLE_WRITE_MAX_ATTEMPTS = 48
 # the full multi-hour parked-cadence budget.
 _DEFERRED_DURABLE_WRITE_DRAIN_TIMEOUT_SECONDS = 10.0
 _VERIFY_OUTPUT_TAIL_CHARS = 2000  # How much verify-command output to attach
-# Directories excluded from the verify_command no-mutation fingerprint: VCS
-# metadata, installed dependencies, and tool caches legitimately churn while a
-# verify_command runs (a test run writes ``__pycache__``/``.pytest_cache``; git
-# read commands touch ``.git/index``) and are not acceptance-relevant source of
-# truth. Every other path -- source AND build outputs a contract may assert on
-# -- participates, so a verifier that mutates the delivered tree is caught. The
-# command itself still runs over the COMPLETE live tree, so these directories
-# remain fully visible to it (unlike a shadow-replay snapshot).
-_VERIFY_MUTATION_IGNORE_DIRS = frozenset(
+# The verify_command no-mutation fingerprint is COMPREHENSIVE: it content-hashes
+# every acceptance-relevant file -- including dependency, build, and VCS
+# directories (``node_modules``, ``.venv``, ``dist``, ``build``, ``.git`` refs/
+# objects) a contract may read as an input -- so any create/delete/modify a
+# verifier performs is detected, and a content change that preserves size/mtime
+# cannot slip through. Only directories the verify TOOLING itself regenerates as
+# it runs are excluded (a ``pytest`` verify writes ``__pycache__``/
+# ``.pytest_cache``; those are the tool's own cache, never acceptance source of
+# truth) -- excluding them prevents false-positive mutation flags on a
+# legitimate verify command. The command still runs over the COMPLETE live tree,
+# so every excluded directory remains fully visible to it.
+_VERIFY_FINGERPRINT_IGNORE_DIRS = frozenset(
     {
-        ".git",
-        "node_modules",
-        ".venv",
-        "venv",
         "__pycache__",
         ".mypy_cache",
         ".pytest_cache",
         ".ruff_cache",
         ".tox",
+    }
+)
+# Transient git bookkeeping that even read-only git commands (``git status``/
+# ``git diff``) legitimately rewrite -- excluded so a pure git-reading verifier
+# is not falsely flagged, while every meaningful ``.git`` object/ref (which a
+# real git mutation like ``git commit`` changes) still participates.
+_VERIFY_FINGERPRINT_TRANSIENT_GIT_BASENAMES = frozenset(
+    {
+        "index",
+        "ORIG_HEAD",
+        "FETCH_HEAD",
+        "COMMIT_EDITMSG",
+        "MERGE_HEAD",
+        "MERGE_MSG",
+        "packed-refs.lock",
     }
 )
 _DURABLE_CONTEXT_MAX_AC_CONTENT_CHARS = 2000
@@ -11447,35 +11462,74 @@ Respond with either ATOMIC or the structured JSON object only.
 
     @staticmethod
     def _verify_workspace_mutation_fingerprint(cwd: str) -> str:
-        """Fingerprint the acceptance-relevant workspace tree under ``cwd``.
+        """Comprehensive content fingerprint of the workspace tree under ``cwd``.
 
         Used by the no-mutation contract to detect whether a ``verify_command``
-        mutated the shared workspace. Records ``(relpath, mode, size, mtime_ns)``
-        for every file outside :data:`_VERIFY_MUTATION_IGNORE_DIRS` (VCS metadata,
-        installed dependencies, and tool caches that legitimately churn), so any
-        create/delete/modify/chmod of an acceptance-relevant file changes the
-        fingerprint. Deterministic (records are sorted) and independent of walk
-        order. Returns ``""`` when ``cwd`` is not a directory (e.g. a stub
-        adapter), which the caller treats as "no observable mutation".
+        mutated any acceptance-relevant input. CONTENT-hashes every file (regular
+        files by their bytes, symlinks by their target) together with its mode,
+        so a create/delete/modify/chmod -- even one that preserves size and
+        mtime -- changes the fingerprint. Dependency, build, and VCS directories
+        (``node_modules``/``.venv``/``dist``/``build``/``.git``) participate, so a
+        verifier that removes or rewrites a dependency or committed input is
+        caught. Only the verify tooling's own regenerable caches
+        (:data:`_VERIFY_FINGERPRINT_IGNORE_DIRS`) and transient git bookkeeping
+        (:data:`_VERIFY_FINGERPRINT_TRANSIENT_GIT_BASENAMES`, plus ``.git/logs``
+        and ``*.lock``) are skipped, since a legitimate verify command churns
+        those. Deterministic (records sorted); returns ``""`` when ``cwd`` is not
+        a directory (e.g. a stub adapter), which the caller treats as "no
+        observable mutation".
         """
         if not os.path.isdir(cwd):
             return ""
-        records: list[str] = []
+        records: list[bytes] = []
         for current, dirnames, filenames in os.walk(cwd, followlinks=False):
-            dirnames[:] = [d for d in dirnames if d not in _VERIFY_MUTATION_IGNORE_DIRS]
+            dirnames[:] = [d for d in dirnames if d not in _VERIFY_FINGERPRINT_IGNORE_DIRS]
             for name in filenames:
                 path = os.path.join(current, name)
                 rel = os.path.relpath(path, cwd)
+                if ParallelACExecutor._is_transient_git_fingerprint_path(rel):
+                    continue
+                rel_bytes = rel.encode("utf-8", "surrogatepass")
                 try:
                     st = os.lstat(path)
-                    records.append(f"{rel}\x00{st.st_mode}\x00{st.st_size}\x00{st.st_mtime_ns}")
+                    if stat.S_ISLNK(st.st_mode):
+                        payload = b"L" + os.readlink(path).encode("utf-8", "surrogatepass")
+                    elif stat.S_ISREG(st.st_mode):
+                        file_hash = hashlib.sha256()
+                        with open(path, "rb") as handle:
+                            for chunk in iter(lambda: handle.read(1 << 20), b""):
+                                file_hash.update(chunk)
+                        payload = b"F" + file_hash.digest()
+                    else:
+                        payload = b"O"  # fifo/socket/device: identity by path+mode
+                    records.append(
+                        rel_bytes + b"\x00" + str(st.st_mode).encode("ascii") + b"\x00" + payload
+                    )
                 except OSError:
-                    records.append(f"{rel}\x00<unreadable>")
+                    records.append(rel_bytes + b"\x00<unreadable>")
         digest = hashlib.sha256()
         for record in sorted(records):
-            digest.update(record.encode("utf-8", "surrogatepass"))
+            digest.update(record)
             digest.update(b"\n")
         return digest.hexdigest()
+
+    @staticmethod
+    def _is_transient_git_fingerprint_path(rel: str) -> bool:
+        """Whether ``rel`` is transient git bookkeeping excluded from the fingerprint.
+
+        Matches ``.git`` churn that even read-only git commands rewrite (the index,
+        reflogs, and lock files), so a verify command that merely inspects git
+        state is not falsely flagged as mutating the workspace. Meaningful git
+        state (refs, objects, ``HEAD``) is NOT matched and still participates.
+        """
+        parts = rel.split(os.sep)
+        if not parts or parts[0] != ".git":
+            return False
+        if rel.endswith(".lock"):
+            return True
+        if len(parts) >= 2 and parts[1] == "logs":
+            return True
+        return len(parts) == 2 and parts[1] in _VERIFY_FINGERPRINT_TRANSIENT_GIT_BASENAMES
 
     async def _run_verify_gate_single_shot(
         self,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2582,6 +2582,14 @@ class ParallelACExecutor:
         executable. Record the canonical executable and launcher paths (raw and
         realpath, so both a path change and a symlink swap change authority) as a
         provider-neutral field every subprocess runtime contributes.
+
+        Resolution is provider-neutral and delegation-aware. An adapter may
+        expose an explicit ``executable_identity_contract()`` (the preferred
+        contract for runtimes that wrap a transport, e.g.
+        ``LeaderDrivenWorkerRuntime`` whose real CLI lives under
+        ``_transport._cli_path``); otherwise its own ``cli_path``/``_cli_path``
+        and launcher attributes are probed, and finally a wrapped ``_transport``
+        is probed so a delegated launcher still participates in identity.
         """
 
         def _resolve(value: object) -> dict[str, str] | None:
@@ -2592,14 +2600,34 @@ class ParallelACExecutor:
             expanded = os.path.expanduser(value)
             return {"path": value, "realpath": os.path.realpath(expanded)}
 
-        # ``cli_path`` is exposed both as a property (Codex) and as a private
-        # attribute (most subprocess runtimes); probe the public form first.
-        executable = _resolve(getattr(adapter, "cli_path", None)) or _resolve(
-            getattr(adapter, "_cli_path", None)
-        )
-        # Zcode launches its CLI through an Electron/Node host; that launcher is
-        # part of what actually executes and must be bound too.
-        launcher = _resolve(getattr(adapter, "_electron_node_path", None))
+        def _probe(obj: object) -> tuple[dict[str, str] | None, dict[str, str] | None]:
+            # An explicit contract wins — a wrapping runtime uses it to name the
+            # executable/launcher its transport really invokes.
+            contract = getattr(obj, "executable_identity_contract", None)
+            if callable(contract):
+                try:
+                    declared = contract()
+                except Exception:
+                    declared = None
+                if isinstance(declared, Mapping):
+                    return _resolve(declared.get("executable")), _resolve(declared.get("launcher"))
+            # ``cli_path`` is exposed both as a property (Codex) and as a private
+            # attribute (most subprocess runtimes); probe the public form first.
+            executable = _resolve(getattr(obj, "cli_path", None)) or _resolve(
+                getattr(obj, "_cli_path", None)
+            )
+            # Zcode launches its CLI through an Electron/Node host; that launcher
+            # is part of what actually executes and must be bound too.
+            launcher = _resolve(getattr(obj, "_electron_node_path", None))
+            return executable, launcher
+
+        executable, launcher = _probe(adapter)
+        if executable is None and launcher is None:
+            # A wrapping runtime holds the real launcher under a transport; probe
+            # one delegation level so a delegated executable still fingerprints.
+            transport = getattr(adapter, "_transport", None)
+            if transport is not None:
+                executable, launcher = _probe(transport)
         return {
             "version": 1,
             "observed": executable is not None or launcher is not None,
@@ -10001,6 +10029,18 @@ Respond with either ATOMIC or the structured JSON object only.
                 # explicit ambiguous/fail-closed terminal outcome instead; only a
                 # stall with no observed effect keeps the retryable stall sentinel.
                 if dispatch_state.tool_effects_observed:
+                    # Persist the ambiguity durably BEFORE raising. The raise only
+                    # clears the in-memory handle; a cold restart would otherwise
+                    # find this dispatch's session.started handle, treat it as a
+                    # resumable active head, and re-enter the provider. Sealing the
+                    # dispatch makes recovery fail closed on it instead.
+                    await self._event_emitter.emit_ac_dispatch_sealed(
+                        runtime_identity=runtime_identity,
+                        dispatch_id=dispatch_id,
+                        execution_id=execution_context_id,
+                        session_id=session_id,
+                        capsule_fingerprint=capsule.fingerprint,
+                    )
                     raise AmbiguousACExecutionError(
                         "AC provider stalled after emitting tool effects; refusing stall retry "
                         "because a fresh redispatch would bypass the recovery ambiguity guard and "
@@ -11150,7 +11190,20 @@ Respond with either ATOMIC or the structured JSON object only.
                 outcome=cached_outcome,
             )
         else:
-            outcome = await self._run_ac_verify_gate(spec=spec, cwd=cwd)
+            # A failed atomic result carries no cached outcome, so this recovery
+            # gate would otherwise run the (non-idempotent) verify_command with no
+            # durable intent/outcome — replaying the same failed result would run
+            # it twice. Route it through the single-shot oracle keyed to the
+            # AC/attempt so recovery consumes the outcome instead of re-running.
+            outcome = await self._run_verify_gate_single_shot(
+                spec=spec,
+                cwd=cwd,
+                aggregate_id=execution_id or session_id,
+                verify_key=f"apply_gate:{ac_index}:{result.retry_attempt}",
+                execution_id=execution_id,
+                session_id=session_id,
+                identity_metadata={"ac_index": ac_index, "retry_attempt": result.retry_attempt},
+            )
         if outcome.passed:
             if not result.success and not result.is_blocked and not result.is_invalid:
                 from ouroboros.events.base import BaseEvent

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -11511,6 +11511,16 @@ Respond with either ATOMIC or the structured JSON object only.
         records: list[bytes] = []
         for current, dirnames, filenames in os.walk(cwd, followlinks=False):
             dirnames[:] = [d for d in dirnames if d not in _VERIFY_FINGERPRINT_IGNORE_DIRS]
+            # Record DIRECTORIES too, so creating/removing an (even empty)
+            # directory a contract asserts on -- e.g. ``verify_command="rmdir
+            # artifact_dir"`` deleting a required empty dir -- changes the
+            # fingerprint. A file-only manifest would miss an empty-dir mutation.
+            for dirname in dirnames:
+                dpath = os.path.join(current, dirname)
+                drel = os.path.relpath(dpath, cwd)
+                if ParallelACExecutor._is_transient_git_fingerprint_path(drel):
+                    continue
+                records.append(drel.encode("utf-8", "surrogatepass") + b"\x00D")
             for name in filenames:
                 path = os.path.join(current, name)
                 rel = os.path.relpath(path, cwd)
@@ -11799,7 +11809,13 @@ Respond with either ATOMIC or the structured JSON object only.
             if ac_index < 0 or ac_index >= len(seed.acceptance_criteria):
                 continue
             spec = seed.acceptance_criteria[ac_index]
-            if not isinstance(spec, AcceptanceCriterionSpec) or not spec.verify_command:
+            # Every success-contract form is re-checked over the final tree: a
+            # command AND/OR expected_artifacts. An artifact-only contract must be
+            # re-verified too -- a later stage can delete a required artifact after
+            # its provisional gate passed.
+            if not isinstance(spec, AcceptanceCriterionSpec) or not (
+                spec.verify_command or spec.expected_artifacts
+            ):
                 continue
             # Only an AC that is currently ACCEPTED needs a final-workspace
             # re-check; a failed/blocked/invalid/externally-satisfied AC is already

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -8648,6 +8648,14 @@ class ParallelACExecutor:
             session_signal_hub=self._session_signal_hub,
             context_pack_enabled=self._context_pack_enabled,
             prompt_guidance_contract=self._prompt_guidance_contract,
+            # A verify command is an acceptance effect, so the operator's policy
+            # and timeout are a capsule-boundary invariant that every runtime
+            # path must preserve. Without threading these, the throwaway alt
+            # executor silently reverts to the ``True``/600 defaults and could
+            # run an operator-disabled, potentially non-idempotent verify command
+            # during cross-harness redispatch.
+            run_verify_commands=self._run_verify_commands,
+            verify_command_timeout_seconds=self._verify_command_timeout_seconds,
         )
         return await alt_executor._execute_single_ac(**rerun_kwargs, retry_attempt=retry_attempt)
 
@@ -9891,6 +9899,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 capsule_fingerprint=capsule.fingerprint,
                 session_origin=session_origin,
                 runtime_handle=dispatch_state.runtime_handle,
+                dispatch_kind="primary",
             )
             provider_boundary_persisted = True
             await LeafDispatcher(self).stream(
@@ -9929,8 +9938,22 @@ Respond with either ATOMIC or the structured JSON object only.
                     depth=depth,
                     silent_seconds=STALL_TIMEOUT_SECONDS,
                     message_count=dispatch_state.message_count,
+                    tool_effects_observed=dispatch_state.tool_effects_observed,
                 )
                 clear_cached_runtime_handle = True
+                # An effectful stall must not take the ordinary stall-retry path.
+                # That path (caller bumps ``retry_attempt`` and re-dispatches)
+                # starts a fresh attempt whose recovery filters out this attempt's
+                # durable tool-effect events, bypassing the ambiguity guard and
+                # potentially repeating a non-idempotent effect. Reconcile it as an
+                # explicit ambiguous/fail-closed terminal outcome instead; only a
+                # stall with no observed effect keeps the retryable stall sentinel.
+                if dispatch_state.tool_effects_observed:
+                    raise AmbiguousACExecutionError(
+                        "AC provider stalled after emitting tool effects; refusing stall retry "
+                        "because a fresh redispatch would bypass the recovery ambiguity guard and "
+                        "may duplicate non-idempotent effects"
+                    )
                 return ACExecutionResult(
                     ac_index=ac_index,
                     ac_content=ac_content,
@@ -10004,6 +10027,19 @@ Respond with either ATOMIC or the structured JSON object only.
                         )
                     )
                     inform_mode = queued_signal.effective_mode is SessionSignalMode.INFORM
+                    # Render the exact follow-up input ONCE and persist its
+                    # digest with the dispatch boundary below, so recovery can
+                    # tell a follow-up chain head apart from the original AC
+                    # phase (and refuse to replay the AC prompt) instead of
+                    # inferring phase identity from event order.
+                    follow_up_prompt = (
+                        render_inform_signal_prompt(queued_signal.signal)
+                        if inform_mode
+                        else render_after_turn_signal_prompt(queued_signal.signal)
+                    )
+                    follow_up_input_digest = (
+                        "sha256:" + hashlib.sha256(follow_up_prompt.encode("utf-8")).hexdigest()
+                    )
                     previous_provider_boundary_persisted = provider_boundary_persisted
                     provider_boundary_persisted = False
                     signal_dispatch_id = uuid.uuid4().hex
@@ -10037,16 +10073,16 @@ Respond with either ATOMIC or the structured JSON object only.
                             capsule_fingerprint=capsule.fingerprint,
                             session_origin="restored_same_attempt",
                             runtime_handle=dispatch_state.runtime_handle,
+                            dispatch_kind="session_signal_followup",
+                            signal_id=queued_signal.signal.signal_id,
+                            signal_mode=str(queued_signal.effective_mode),
+                            follow_up_input_digest=follow_up_input_digest,
                         )
                         dispatch_id = signal_dispatch_id
                         provider_boundary_persisted = True
                         await LeafDispatcher(self).stream(
                             state=dispatch_state,
-                            prompt=(
-                                render_inform_signal_prompt(queued_signal.signal)
-                                if inform_mode
-                                else render_after_turn_signal_prompt(queued_signal.signal)
-                            ),
+                            prompt=follow_up_prompt,
                             tools=[] if inform_mode else tools,
                             system_prompt=system_prompt,
                             execute_effort_kwargs=execute_effort_kwargs,
@@ -10444,6 +10480,16 @@ Respond with either ATOMIC or the structured JSON object only.
                 forced_frontier_routing=force_frontier_routing,
             )
 
+        except AmbiguousACExecutionError:
+            # A fail-closed ambiguity raised inside the dispatch body (e.g. an
+            # effectful stall — a stall observed AFTER this dispatch emitted a
+            # durable tool effect) must NOT be reclassified as infra-fatal below,
+            # and must NOT return a plain failed result (which the caller would
+            # feed to bounce decomposition / cross-harness redispatch, re-running
+            # the same effect in the shared workspace). Re-raise it to the batch
+            # boundary, which records a terminal FAILED result with no redispatch
+            # — the same fail-closed contract the recovery loader already uses.
+            raise
         except Exception as e:
             # Anything reaching this handler escaped the runtime dispatch
             # (``LeafDispatcher.stream`` / ``self._adapter.execute_task``) or

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -88,6 +88,7 @@ from ouroboros.harness.journal import EvidenceEntry, EvidenceManifest
 from ouroboros.harness.traceguard_validator import validate_evidence_claims
 from ouroboros.observability.logging import get_logger
 from ouroboros.orchestrator.ac_execution_capsule import (
+    ACSuccessContract,
     bind_capsule_to_runtime_handle,
     build_ac_dispatch_authority_scope,
     compile_ac_execution_capsule,
@@ -6776,6 +6777,9 @@ class ParallelACExecutor:
                     investment_spec=investment_spec,
                     decomposition_trustworthy=child_decomposition_trustworthy,
                     semantic_ac_key=semantic_ac_key,
+                    capsule_success_contract=ACSuccessContract(
+                        expected_artifacts=assigned_artifacts
+                    ),
                     # Forward the PARENT's spec for prompt context and
                     # semantic-key derivation. Children NEVER execute this
                     # borrowed contract as their own verify gate (Fix 1,
@@ -7586,6 +7590,7 @@ class ParallelACExecutor:
         semantic_ac_key: str | None = None,
         force_frontier_routing: bool = False,
         force_atomic_execution: bool = False,
+        capsule_success_contract: ACSuccessContract | None = None,
     ) -> ACExecutionResult:
         """Execute a single AC via the sole recursive AC execution entry point.
 
@@ -7800,6 +7805,7 @@ class ParallelACExecutor:
             "semantic_ac_key": semantic_ac_key,
             "force_frontier_routing": force_frontier_routing,
             "force_atomic_execution": force_atomic_execution,
+            "capsule_success_contract": capsule_success_contract,
         }
         while True:
             atomic_result = await self._execute_atomic_ac(
@@ -7827,6 +7833,7 @@ class ParallelACExecutor:
                 decomposition_trustworthy=decomposition_trustworthy,
                 semantic_ac_key=semantic_ac_key,
                 force_frontier_routing=force_frontier_routing,
+                capsule_success_contract=capsule_success_contract,
             )
             if atomic_result.error != _STALL_SENTINEL:
                 if not atomic_result.success and not force_atomic_execution:
@@ -8986,6 +8993,7 @@ Respond with either ATOMIC or the structured JSON object only.
         decomposition_trustworthy: bool = False,
         semantic_ac_key: str | None = None,
         force_frontier_routing: bool = False,
+        capsule_success_contract: ACSuccessContract | None = None,
     ) -> ACExecutionResult:
         """Execute an atomic AC directly via Claude Agent.
 
@@ -9041,6 +9049,7 @@ Respond with either ATOMIC or the structured JSON object only.
             seed_goal=seed_goal,
             ac_content=ac_content,
             ac_spec=ac_spec,
+            success_contract_override=capsule_success_contract,
             level_contexts=tuple(level_contexts or ()),
         )
 
@@ -9056,7 +9065,6 @@ Respond with either ATOMIC or the structured JSON object only.
             level_contexts=level_contexts,
             sibling_acs=sibling_acs,
             retry_prompt_extra=retry_prompt_extra,
-            ac_spec=ac_spec,
         )
         prompt = prompt_bundle.prompt
         label = prompt_bundle.label

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -3013,6 +3013,15 @@ class ParallelACExecutor:
             # semantics: concurrency 1 vs 8 interleave sibling mutations
             # differently, so a resume must not silently change it.
             "max_concurrent": self._max_concurrent,
+            # Every declared execution-semantic knob that changes what work runs
+            # (or how many provider turns execute) must participate in authority,
+            # so a restart cannot resume the same capsule under a different policy
+            # (e.g. shadow replay performs an extra provider execution).
+            "shadow_replay_enabled": self._shadow_replay_enabled,
+            "cross_harness_redispatch_enabled": self._cross_harness_redispatch_enabled,
+            "ac_retry_attempts": self._ac_retry_attempts,
+            "lateral_escalation_enabled": self._lateral_escalation_enabled,
+            "parked_retry_backoff_seconds": self._parked_retry_backoff_seconds,
             "prompt_authority": {
                 "retry_prompt_digest": self._prompt_identity(retry_prompt_extra),
                 "siblings": [

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -2583,7 +2583,9 @@ class ParallelACExecutor:
         return contexts
 
     @staticmethod
-    def _runtime_executable_identity(adapter: object) -> dict[str, object]:
+    def _runtime_executable_identity(
+        adapter: object, *, cwd: str | None = None
+    ) -> dict[str, object]:
         """Bind the actual subprocess executable and launcher into capsule authority.
 
         Backend, model, and the adapter's execution-identity contract do not
@@ -2623,6 +2625,13 @@ class ParallelACExecutor:
                 if which is None:
                     return {"path": value, "realpath": None, "path_resolution": "unresolved"}
                 return {"path": value, "realpath": os.path.realpath(which)}
+            # A RELATIVE path with a separator (e.g. ``./tool``) is resolved by the
+            # child against ITS working directory, not the orchestrator process
+            # directory. Anchor it to the effective child cwd before realpath so
+            # capsule identity binds the binary actually launched (and follows a
+            # symlink-target swap under that cwd).
+            if not os.path.isabs(expanded) and cwd is not None:
+                expanded = os.path.join(cwd, expanded)
             return {"path": value, "realpath": os.path.realpath(expanded)}
 
         def _probe(
@@ -2693,6 +2702,10 @@ class ParallelACExecutor:
             "model_override_support": capabilities.model_override_support.value,
             "subagent_orchestration": capabilities.subagent_orchestration.value,
             "session_signals": capabilities.session_signals.to_event_data(),
+            # Execution-semantic: this flag chooses retryable vs sealed/fail-closed
+            # stall handling, so it must participate in capsule/checkpoint authority
+            # — two runtimes differing only in it are NOT interchangeable on resume.
+            "realtime_tool_effect_visibility": capabilities.realtime_tool_effect_visibility,
         }
 
     def _authority_digest(self, value: object, *, field: str) -> str:
@@ -2813,7 +2826,9 @@ class ParallelACExecutor:
                 ),
                 "capabilities": self._runtime_capabilities_contract(self._adapter),
                 "execution": self._runtime_execution_authority,
-                "executable": self._runtime_executable_identity(self._adapter),
+                "executable": self._runtime_executable_identity(
+                    self._adapter, cwd=workspace_identity
+                ),
             },
             "model_routing": serialize_model_router(self._model_router),
             "execution_profile": serialize_execution_profile(self._execution_profile),
@@ -3015,11 +3030,17 @@ class ParallelACExecutor:
                 "model_override_support",
                 "subagent_orchestration",
                 "session_signals",
+                "realtime_tool_effect_visibility",
             }:
                 return "dispatch_contract.runtime capabilities have an invalid shape"
             if any(
                 not isinstance(raw_capabilities.get(key), bool)
-                for key in ("skill_dispatch", "targeted_resume", "structured_output")
+                for key in (
+                    "skill_dispatch",
+                    "targeted_resume",
+                    "structured_output",
+                    "realtime_tool_effect_visibility",
+                )
             ):
                 return "dispatch_contract.runtime capabilities contain invalid booleans"
             support_values = {support.value for support in ParamSupport}
@@ -10350,7 +10371,21 @@ Respond with either ATOMIC or the structured JSON object only.
                                 orchestrator_session_id=session_id,
                             )
                         )
-                        if dispatch_state.tool_effects_observed:
+                        # Same rule as the primary provider entry: a follow-up
+                        # stall is only safely non-fatal when we can PROVE no
+                        # effect occurred — a tool effect WAS observed, or the
+                        # driver does not stream effects in real time (an opaque
+                        # driver may have applied an effect and then yielded
+                        # nothing). Both seal and fail closed so the stalled
+                        # follow-up is never redispatched by bounce/retry.
+                        followup_realtime_visibility = bool(
+                            getattr(
+                                getattr(self._adapter, "capabilities", None),
+                                "realtime_tool_effect_visibility",
+                                False,
+                            )
+                        )
+                        if dispatch_state.tool_effects_observed or not followup_realtime_visibility:
                             await self._event_emitter.emit_ac_dispatch_sealed(
                                 runtime_identity=runtime_identity,
                                 dispatch_id=signal_dispatch_id,
@@ -10359,9 +10394,11 @@ Respond with either ATOMIC or the structured JSON object only.
                                 capsule_fingerprint=capsule.fingerprint,
                             )
                             raise AmbiguousACExecutionError(
-                                "SessionSignal follow-up stalled after emitting tool effects; "
-                                "refusing to record success because a cold restart could resume "
-                                "the stalled follow-up and repeat non-idempotent effects"
+                                "SessionSignal follow-up stalled and its effects cannot be "
+                                "proven absent (a tool effect was observed, or the driver does "
+                                "not attest real-time tool-effect visibility); refusing to record "
+                                "success because a cold restart could resume the stalled follow-up "
+                                "and repeat non-idempotent effects"
                             )
                         if inform_mode:
                             dispatch_state.success = primary_success

--- a/src/ouroboros/orchestrator/worker_runtime.py
+++ b/src/ouroboros/orchestrator/worker_runtime.py
@@ -16,7 +16,7 @@ the SAME pool code — only the transport differs.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 import os
@@ -150,15 +150,23 @@ class LeaderDrivenWorkerRuntime:
 
     # -- AgentRuntime Protocol properties ---------------------------------
 
-    def executable_identity_contract(self) -> dict[str, str | None]:
-        """Expose the real executable/launcher this runtime drives via its transport.
+    def executable_identity_contract(self) -> dict[str, object]:
+        """Expose the real executable and command policy this runtime drives.
 
-        The launched binary lives on the wrapped transport (e.g. its
-        ``cli_path``/``_cli_path``), not on this runtime. Surface it so capsule
-        authority fingerprints the actual executable and a restart cannot resume
-        the same capsule under a different transport binary.
+        The launched binary and its command-affecting policy (e.g. Claude's
+        ``--add-dir``/``--disallowedTools``) live on the wrapped transport, not on
+        this runtime. A transport that publishes its own
+        ``executable_identity_contract()`` is delegated to verbatim so its full
+        command authority participates in capsule identity; otherwise its
+        executable path is probed. Either way a restart cannot resume the same
+        capsule under a different transport binary or access policy.
         """
         transport = self._transport
+        delegated = getattr(transport, "executable_identity_contract", None)
+        if callable(delegated):
+            contract = delegated()
+            if isinstance(contract, Mapping):
+                return dict(contract)
         executable = getattr(transport, "cli_path", None)
         if not isinstance(executable, str) or not executable:
             candidate = getattr(transport, "_cli_path", None)

--- a/src/ouroboros/orchestrator/worker_runtime.py
+++ b/src/ouroboros/orchestrator/worker_runtime.py
@@ -150,6 +150,25 @@ class LeaderDrivenWorkerRuntime:
 
     # -- AgentRuntime Protocol properties ---------------------------------
 
+    def executable_identity_contract(self) -> dict[str, str | None]:
+        """Expose the real executable/launcher this runtime drives via its transport.
+
+        The launched binary lives on the wrapped transport (e.g. its
+        ``cli_path``/``_cli_path``), not on this runtime. Surface it so capsule
+        authority fingerprints the actual executable and a restart cannot resume
+        the same capsule under a different transport binary.
+        """
+        transport = self._transport
+        executable = getattr(transport, "cli_path", None)
+        if not isinstance(executable, str) or not executable:
+            candidate = getattr(transport, "_cli_path", None)
+            executable = candidate if isinstance(candidate, str) and candidate else None
+        launcher = getattr(transport, "_electron_node_path", None)
+        return {
+            "executable": executable,
+            "launcher": launcher if isinstance(launcher, str) and launcher else None,
+        }
+
     @property
     def runtime_backend(self) -> str:
         return self._runtime_backend

--- a/tests/unit/core/test_seed.py
+++ b/tests/unit/core/test_seed.py
@@ -451,6 +451,20 @@ class TestSeed:
         assert ok.output_assertion == "OK"
         assert pytest_literal.output_assertion == "5 passed"
 
+    def test_output_assertion_requires_verify_command(self) -> None:
+        """R7 blocker #2: an output_assertion with no verify_command is rejected.
+
+        A standalone output_assertion has no authoritative output to assert
+        against; allowing it let an output-only contract pass without evaluation.
+        """
+        import pytest as _pytest
+
+        with _pytest.raises(ValueError, match="output_assertion requires a verify_command"):
+            AcceptanceCriterionSpec(
+                description="Asserts on output that no command produces",
+                output_assertion="OK",
+            )
+
     def test_seed_acceptance_criteria_materialize_semantic_keys(self) -> None:
         """Legacy description-only ACs gain deterministic persisted identities."""
         seed = Seed(

--- a/tests/unit/orchestrator/test_ac_execution_capsule.py
+++ b/tests/unit/orchestrator/test_ac_execution_capsule.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+import json
 
 import pytest
 
@@ -10,7 +11,7 @@ from ouroboros.core.seed import AcceptanceCriterionSpec
 from ouroboros.orchestrator.ac_execution_capsule import (
     ACContextReference,
     ACContextReferenceKind,
-    ACExecutionCapsule,
+    ACExecutionCapsuleManifest,
     bind_capsule_to_runtime_handle,
     compile_ac_execution_capsule,
 )
@@ -58,9 +59,9 @@ def _capsule(tmp_path):
 def test_capsule_round_trips_and_fingerprint_is_stable(tmp_path) -> None:
     capsule = _capsule(tmp_path)
 
-    restored = ACExecutionCapsule.from_contract_data(capsule.to_contract_data())
+    restored = ACExecutionCapsuleManifest.from_contract_data(capsule.manifest.to_contract_data())
 
-    assert restored == capsule
+    assert restored == capsule.manifest
     assert restored.fingerprint == capsule.fingerprint
     assert restored.fresh_session_required is True
     assert [reference.kind for reference in restored.context_references] == [
@@ -70,6 +71,40 @@ def test_capsule_round_trips_and_fingerprint_is_stable(tmp_path) -> None:
         ACContextReferenceKind.ARTIFACT,
         ACContextReferenceKind.GATE,
     ]
+
+
+def test_capsule_manifest_hashes_free_form_authority(tmp_path) -> None:
+    capsule = replace(
+        _capsule(tmp_path),
+        seed_goal="Contact owner@example.com with api_key=sk-live-secret",
+        ac_content="Use Authorization: Bearer private-token",
+        success_contract=replace(
+            _capsule(tmp_path).success_contract,
+            verify_command="curl -H 'Authorization: Bearer private-token'",
+        ),
+    )
+
+    persisted = json.dumps(capsule.manifest.to_contract_data(), sort_keys=True)
+
+    assert "owner@example.com" not in persisted
+    assert "sk-live-secret" not in persisted
+    assert "private-token" not in persisted
+    assert str(tmp_path.resolve()) not in persisted
+    assert capsule.manifest.fingerprint == capsule.fingerprint
+
+
+def test_capsule_manifest_rejects_corrupt_version_and_digests(tmp_path) -> None:
+    manifest = _capsule(tmp_path).manifest.to_contract_data()
+
+    unsupported = dict(manifest)
+    unsupported["version"] = 999
+    with pytest.raises(ValueError, match="version is unsupported"):
+        ACExecutionCapsuleManifest.from_contract_data(unsupported)
+
+    corrupt = dict(manifest)
+    corrupt["seed_goal_digest"] = "sha256:not-a-digest"
+    with pytest.raises(ValueError, match="seed goal digest is malformed"):
+        ACExecutionCapsuleManifest.from_contract_data(corrupt)
 
 
 def test_capsule_references_dependency_without_copying_its_output(tmp_path) -> None:

--- a/tests/unit/orchestrator/test_ac_execution_capsule.py
+++ b/tests/unit/orchestrator/test_ac_execution_capsule.py
@@ -113,6 +113,15 @@ def test_capsule_manifest_rejects_corrupt_version_and_digests(tmp_path) -> None:
         ACExecutionCapsuleManifest.from_contract_data(corrupt)
 
 
+def test_capsule_manifest_rejects_unbounded_persisted_references(tmp_path) -> None:
+    manifest = _capsule(tmp_path).manifest.to_contract_data()
+    reference = manifest["context_references"][0]
+    manifest["context_references"] = [reference] * (MAX_AC_CONTEXT_REFERENCES + 1)
+
+    with pytest.raises(ValueError, match="context reference limit exceeded"):
+        ACExecutionCapsuleManifest.from_contract_data(manifest)
+
+
 def test_capsule_references_dependency_without_copying_its_output(tmp_path) -> None:
     capsule = _capsule(tmp_path)
     rendered = capsule.to_prompt_reference_block()

--- a/tests/unit/orchestrator/test_ac_execution_capsule.py
+++ b/tests/unit/orchestrator/test_ac_execution_capsule.py
@@ -233,6 +233,12 @@ def test_success_contract_rejects_unbounded_text_before_serialization() -> None:
         ACSuccessContract(verify_command="x" * (MAX_AC_SUCCESS_CONTRACT_CHARS + 1))
 
 
+def test_success_contract_rejects_output_assertion_without_command() -> None:
+    """R9 (non-blocking): mirror the spec rule — output_assertion needs a command."""
+    with pytest.raises(ValueError, match="output_assertion requires a verify_command"):
+        ACSuccessContract(output_assertion="OK")
+
+
 def test_capsule_fingerprint_changes_with_acceptance_authority(tmp_path) -> None:
     capsule = _capsule(tmp_path)
     changed = replace(

--- a/tests/unit/orchestrator/test_ac_execution_capsule.py
+++ b/tests/unit/orchestrator/test_ac_execution_capsule.py
@@ -169,6 +169,7 @@ def test_restored_handle_must_match_capsule_fingerprint(tmp_path) -> None:
     handle = RuntimeHandle(
         backend="claude",
         native_session_id="same-attempt-session",
+        cwd=str(tmp_path.resolve()),
         metadata={"ac_capsule_fingerprint": "sha256:" + "0" * 64},
     )
 
@@ -177,6 +178,46 @@ def test_restored_handle_must_match_capsule_fingerprint(tmp_path) -> None:
             capsule,
             handle,
             restored_same_attempt=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("handle_changes", "expected_backend", "expected_approval_mode", "message"),
+    [
+        ({"cwd": "/tmp/other-workspace"}, "codex_cli", "acceptEdits", "workspace"),
+        ({"backend": "claude"}, "codex_cli", "acceptEdits", "backend"),
+        (
+            {"approval_mode": "bypassPermissions"},
+            "codex_cli",
+            "acceptEdits",
+            "approval mode",
+        ),
+    ],
+)
+def test_restored_handle_must_match_runtime_authority(
+    tmp_path,
+    handle_changes: dict[str, object],
+    expected_backend: str,
+    expected_approval_mode: str,
+    message: str,
+) -> None:
+    capsule = _capsule(tmp_path)
+    handle = RuntimeHandle(
+        backend="codex_cli",
+        native_session_id="same-attempt-session",
+        cwd=str(tmp_path.resolve()),
+        approval_mode="acceptEdits",
+        metadata={"ac_capsule_fingerprint": capsule.fingerprint},
+    )
+    handle = replace(handle, **handle_changes)
+
+    with pytest.raises(ValueError, match=message):
+        bind_capsule_to_runtime_handle(
+            capsule,
+            handle,
+            restored_same_attempt=True,
+            expected_backend=expected_backend,
+            expected_approval_mode=expected_approval_mode,
         )
 
 

--- a/tests/unit/orchestrator/test_ac_execution_capsule.py
+++ b/tests/unit/orchestrator/test_ac_execution_capsule.py
@@ -13,6 +13,7 @@ from ouroboros.orchestrator.ac_execution_capsule import (
     ACContextReferenceKind,
     ACExecutionCapsuleManifest,
     bind_capsule_to_runtime_handle,
+    build_ac_dispatch_authority_scope,
     compile_ac_execution_capsule,
 )
 from ouroboros.orchestrator.adapter import RuntimeHandle
@@ -124,6 +125,47 @@ def test_capsule_fingerprint_changes_with_acceptance_authority(tmp_path) -> None
     )
 
     assert changed.fingerprint != capsule.fingerprint
+
+
+@pytest.mark.parametrize(
+    ("section", "replacement"),
+    [
+        ("dispatch", {"tools": ["Read"]}),
+        ("dispatch", {"system_prompt": {"identity": "sha256:changed"}}),
+        ("dispatch", {"runtime": {"backend": "codex", "permission_mode": "bypass"}}),
+        ("policy", {"reasoning_effort": "xhigh"}),
+        ("policy", {"force_frontier_routing": True}),
+    ],
+)
+def test_dispatch_authority_scope_changes_with_execution_inputs(
+    section: str,
+    replacement: dict[str, object],
+) -> None:
+    dispatch = {
+        "tools": ["Read", "Edit"],
+        "system_prompt": {"identity": "sha256:original"},
+        "runtime": {"backend": "claude", "permission_mode": "acceptEdits"},
+    }
+    policy = {"reasoning_effort": "high", "force_frontier_routing": False}
+    original = build_ac_dispatch_authority_scope(
+        base_scope="execution:1",
+        dispatch_contract=dispatch,
+        execution_policy=policy,
+    )
+
+    changed_dispatch = dict(dispatch)
+    changed_policy = dict(policy)
+    if section == "dispatch":
+        changed_dispatch.update(replacement)
+    else:
+        changed_policy.update(replacement)
+    changed = build_ac_dispatch_authority_scope(
+        base_scope="execution:1",
+        dispatch_contract=changed_dispatch,
+        execution_policy=changed_policy,
+    )
+
+    assert changed != original
 
 
 def test_context_reference_rejects_prompt_control_characters() -> None:

--- a/tests/unit/orchestrator/test_ac_execution_capsule.py
+++ b/tests/unit/orchestrator/test_ac_execution_capsule.py
@@ -11,6 +11,8 @@ from ouroboros.core.seed import AcceptanceCriterionSpec
 from ouroboros.orchestrator.ac_execution_capsule import (
     AC_EXECUTION_CAPSULE_VERSION,
     MAX_AC_CONTEXT_REFERENCES,
+    MAX_AC_SUCCESS_CONTRACT_ARTIFACTS,
+    MAX_AC_SUCCESS_CONTRACT_CHARS,
     ACContextReference,
     ACContextReferenceKind,
     ACExecutionCapsuleManifest,
@@ -189,6 +191,37 @@ def test_capsule_rejects_unbounded_reference_work(tmp_path) -> None:
             level_contexts=(LevelContext(level_number=0, completed_acs=summaries),),
             context_budget_chars=1_000,
         )
+
+
+def test_capsule_rejects_unbounded_success_contract_before_hashing(tmp_path) -> None:
+    identity = build_ac_runtime_identity(
+        0,
+        execution_context_id="execution-contract-limit",
+        retry_attempt=0,
+    )
+    spec = AcceptanceCriterionSpec(
+        description="Implement the bounded AC",
+        expected_artifacts=tuple(
+            f"out/artifact-{index}.txt" for index in range(MAX_AC_SUCCESS_CONTRACT_ARTIFACTS + 1)
+        ),
+    )
+
+    with pytest.raises(ValueError, match="success contract artifact limit exceeded"):
+        compile_ac_execution_capsule(
+            runtime_identity=identity,
+            execution_id="execution-contract-limit",
+            semantic_ac_key="semantic-key",
+            workspace=str(tmp_path.resolve()),
+            authority_scope="authority:v1",
+            seed_goal="Ship the feature",
+            ac_content="Implement the bounded AC",
+            ac_spec=spec,
+        )
+
+
+def test_success_contract_rejects_unbounded_text_before_serialization() -> None:
+    with pytest.raises(ValueError, match="success contract character budget exceeded"):
+        ACSuccessContract(verify_command="x" * (MAX_AC_SUCCESS_CONTRACT_CHARS + 1))
 
 
 def test_capsule_fingerprint_changes_with_acceptance_authority(tmp_path) -> None:

--- a/tests/unit/orchestrator/test_ac_execution_capsule.py
+++ b/tests/unit/orchestrator/test_ac_execution_capsule.py
@@ -9,6 +9,8 @@ import pytest
 
 from ouroboros.core.seed import AcceptanceCriterionSpec
 from ouroboros.orchestrator.ac_execution_capsule import (
+    AC_EXECUTION_CAPSULE_VERSION,
+    MAX_AC_CONTEXT_REFERENCES,
     ACContextReference,
     ACContextReferenceKind,
     ACExecutionCapsuleManifest,
@@ -70,8 +72,8 @@ def test_capsule_round_trips_and_fingerprint_is_stable(tmp_path) -> None:
         ACContextReferenceKind.WORKSPACE,
         ACContextReferenceKind.SEED,
         ACContextReferenceKind.GATE,
-        ACContextReferenceKind.DEPENDENCY,
         ACContextReferenceKind.ARTIFACT,
+        ACContextReferenceKind.DEPENDENCY,
     ]
 
 
@@ -118,7 +120,7 @@ def test_capsule_references_dependency_without_copying_its_output(tmp_path) -> N
     assert "fresh provider context" in rendered
 
 
-def test_capsule_pages_reference_overflow_within_context_budget(tmp_path) -> None:
+def test_capsule_attests_reference_omission_within_context_budget(tmp_path) -> None:
     identity = build_ac_runtime_identity(
         0,
         execution_context_id="execution-budget",
@@ -131,7 +133,7 @@ def test_capsule_pages_reference_overflow_within_context_budget(tmp_path) -> Non
             success=True,
             files_modified=(f"src/dependency_{index}.py",),
         )
-        for index in range(500)
+        for index in range(100)
     )
     capsule = compile_ac_execution_capsule(
         runtime_identity=identity,
@@ -150,11 +152,43 @@ def test_capsule_pages_reference_overflow_within_context_budget(tmp_path) -> Non
     )
 
     assert len(capsule.to_prompt_reference_block()) <= 1_000
-    assert ACContextReferenceKind.INDEX in {
-        reference.kind for reference in capsule.context_references
-    }
+    assert capsule.omitted_context_count > 0
+    assert capsule.omitted_context_digest is not None
+    assert "bounded-retrieval" in capsule.to_prompt_reference_block()
+    assert "page from the event ledger" not in capsule.to_prompt_reference_block()
     assert len(capsule.context_references) < 20
     assert len(json.dumps(capsule.manifest.to_contract_data())) < 10_000
+    assert capsule.version == AC_EXECUTION_CAPSULE_VERSION
+
+
+def test_capsule_rejects_unbounded_reference_work(tmp_path) -> None:
+    identity = build_ac_runtime_identity(
+        0,
+        execution_context_id="execution-reference-limit",
+        retry_attempt=0,
+    )
+    summaries = tuple(
+        ACContextSummary(
+            ac_index=index,
+            ac_content=f"Dependency {index}",
+            success=True,
+        )
+        for index in range(MAX_AC_CONTEXT_REFERENCES + 1)
+    )
+
+    with pytest.raises(ValueError, match="context reference limit exceeded"):
+        compile_ac_execution_capsule(
+            runtime_identity=identity,
+            execution_id="execution-reference-limit",
+            semantic_ac_key="semantic-key",
+            workspace=str(tmp_path.resolve()),
+            authority_scope="authority:v1",
+            seed_goal="Ship the feature",
+            ac_content="Implement the bounded AC",
+            ac_spec=None,
+            level_contexts=(LevelContext(level_number=0, completed_acs=summaries),),
+            context_budget_chars=1_000,
+        )
 
 
 def test_capsule_fingerprint_changes_with_acceptance_authority(tmp_path) -> None:

--- a/tests/unit/orchestrator/test_ac_execution_capsule.py
+++ b/tests/unit/orchestrator/test_ac_execution_capsule.py
@@ -68,9 +68,9 @@ def test_capsule_round_trips_and_fingerprint_is_stable(tmp_path) -> None:
     assert [reference.kind for reference in restored.context_references] == [
         ACContextReferenceKind.WORKSPACE,
         ACContextReferenceKind.SEED,
+        ACContextReferenceKind.GATE,
         ACContextReferenceKind.DEPENDENCY,
         ACContextReferenceKind.ARTIFACT,
-        ACContextReferenceKind.GATE,
     ]
 
 
@@ -115,6 +115,45 @@ def test_capsule_references_dependency_without_copying_its_output(tmp_path) -> N
     assert "execution:execution-1:ac:2" in rendered
     assert "src/dependency.py" not in rendered
     assert "fresh provider context" in rendered
+
+
+def test_capsule_pages_reference_overflow_within_context_budget(tmp_path) -> None:
+    identity = build_ac_runtime_identity(
+        0,
+        execution_context_id="execution-budget",
+        retry_attempt=0,
+    )
+    summaries = tuple(
+        ACContextSummary(
+            ac_index=index,
+            ac_content=f"Dependency {index}",
+            success=True,
+            files_modified=(f"src/dependency_{index}.py",),
+        )
+        for index in range(500)
+    )
+    capsule = compile_ac_execution_capsule(
+        runtime_identity=identity,
+        execution_id="execution-budget",
+        semantic_ac_key="semantic-key",
+        workspace=str(tmp_path.resolve()),
+        authority_scope="authority:v1",
+        seed_goal="Ship the feature",
+        ac_content="Implement the bounded AC",
+        ac_spec=AcceptanceCriterionSpec(
+            description="Implement the bounded AC",
+            verify_command="pytest -q",
+        ),
+        level_contexts=(LevelContext(level_number=0, completed_acs=summaries),),
+        context_budget_chars=1_000,
+    )
+
+    assert len(capsule.to_prompt_reference_block()) <= 1_000
+    assert ACContextReferenceKind.INDEX in {
+        reference.kind for reference in capsule.context_references
+    }
+    assert len(capsule.context_references) < 20
+    assert len(json.dumps(capsule.manifest.to_contract_data())) < 10_000
 
 
 def test_capsule_fingerprint_changes_with_acceptance_authority(tmp_path) -> None:
@@ -269,6 +308,7 @@ def test_restored_handle_must_match_runtime_authority(
         ("workspace", "relative/path"),
         ("fresh_session_required", False),
         ("context_budget_chars", 0),
+        ("context_budget_chars", 1),
         ("context_budget_chars", True),
         ("segment_index", -1),
         ("version", True),

--- a/tests/unit/orchestrator/test_ac_execution_capsule.py
+++ b/tests/unit/orchestrator/test_ac_execution_capsule.py
@@ -1,0 +1,163 @@
+"""Provider-neutral AC execution capsule contract."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+from ouroboros.core.seed import AcceptanceCriterionSpec
+from ouroboros.orchestrator.ac_execution_capsule import (
+    ACContextReference,
+    ACContextReferenceKind,
+    ACExecutionCapsule,
+    bind_capsule_to_runtime_handle,
+    compile_ac_execution_capsule,
+)
+from ouroboros.orchestrator.adapter import RuntimeHandle
+from ouroboros.orchestrator.execution_runtime_scope import build_ac_runtime_identity
+from ouroboros.orchestrator.level_context import ACContextSummary, LevelContext
+
+
+def _capsule(tmp_path):
+    identity = build_ac_runtime_identity(
+        0,
+        execution_context_id="execution-1",
+        retry_attempt=0,
+    )
+    return compile_ac_execution_capsule(
+        runtime_identity=identity,
+        execution_id="execution-1",
+        semantic_ac_key="semantic-key",
+        workspace=str(tmp_path.resolve()),
+        authority_scope="authority:v1",
+        seed_goal="Ship the feature",
+        ac_content="Implement one independently verifiable behavior",
+        ac_spec=AcceptanceCriterionSpec(
+            description="Implement one independently verifiable behavior",
+            verify_command="pytest -q",
+            expected_artifacts=("src/feature.py",),
+            output_assertion="tests pass",
+        ),
+        level_contexts=(
+            LevelContext(
+                level_number=0,
+                completed_acs=(
+                    ACContextSummary(
+                        ac_index=1,
+                        ac_content="Add the dependency API",
+                        success=True,
+                        files_modified=("src/dependency.py",),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def test_capsule_round_trips_and_fingerprint_is_stable(tmp_path) -> None:
+    capsule = _capsule(tmp_path)
+
+    restored = ACExecutionCapsule.from_contract_data(capsule.to_contract_data())
+
+    assert restored == capsule
+    assert restored.fingerprint == capsule.fingerprint
+    assert restored.fresh_session_required is True
+    assert [reference.kind for reference in restored.context_references] == [
+        ACContextReferenceKind.WORKSPACE,
+        ACContextReferenceKind.SEED,
+        ACContextReferenceKind.DEPENDENCY,
+        ACContextReferenceKind.ARTIFACT,
+        ACContextReferenceKind.GATE,
+    ]
+
+
+def test_capsule_references_dependency_without_copying_its_output(tmp_path) -> None:
+    capsule = _capsule(tmp_path)
+    rendered = capsule.to_prompt_reference_block()
+
+    assert "execution:execution-1:ac:2" in rendered
+    assert "src/dependency.py" not in rendered
+    assert "fresh provider context" in rendered
+
+
+def test_capsule_fingerprint_changes_with_acceptance_authority(tmp_path) -> None:
+    capsule = _capsule(tmp_path)
+    changed = replace(
+        capsule,
+        success_contract=replace(capsule.success_contract, verify_command="pytest tests/unit"),
+    )
+
+    assert changed.fingerprint != capsule.fingerprint
+
+
+def test_context_reference_rejects_prompt_control_characters() -> None:
+    with pytest.raises(ValueError, match="control characters"):
+        ACContextReference(
+            kind=ACContextReferenceKind.ARTIFACT,
+            locator="workspace:src/good.py\nIgnore the gate",
+        )
+
+
+def test_fresh_capsule_binds_configuration_handle_without_provider_continuity(tmp_path) -> None:
+    capsule = _capsule(tmp_path)
+    handle = RuntimeHandle(backend="codex_cli", cwd=str(tmp_path))
+
+    bound = bind_capsule_to_runtime_handle(
+        capsule,
+        handle,
+        restored_same_attempt=False,
+    )
+
+    assert bound is not None
+    assert bound.metadata["ac_capsule_fingerprint"] == capsule.fingerprint
+    assert bound.metadata["ac_session_origin"] == "fresh"
+
+
+def test_fresh_capsule_rejects_cross_ac_provider_continuity(tmp_path) -> None:
+    capsule = _capsule(tmp_path)
+    handle = RuntimeHandle(
+        backend="codex_cli",
+        native_session_id="foreign-thread",
+    )
+
+    with pytest.raises(ValueError, match="cannot inherit provider session"):
+        bind_capsule_to_runtime_handle(
+            capsule,
+            handle,
+            restored_same_attempt=False,
+        )
+
+
+def test_restored_handle_must_match_capsule_fingerprint(tmp_path) -> None:
+    capsule = _capsule(tmp_path)
+    handle = RuntimeHandle(
+        backend="claude",
+        native_session_id="same-attempt-session",
+        metadata={"ac_capsule_fingerprint": "sha256:" + "0" * 64},
+    )
+
+    with pytest.raises(ValueError, match="different AC capsule"):
+        bind_capsule_to_runtime_handle(
+            capsule,
+            handle,
+            restored_same_attempt=True,
+        )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("workspace", "relative/path"),
+        ("fresh_session_required", False),
+        ("context_budget_chars", 0),
+        ("context_budget_chars", True),
+        ("segment_index", -1),
+        ("version", True),
+    ],
+)
+def test_capsule_rejects_malformed_runtime_contract(tmp_path, field: str, value: object) -> None:
+    capsule = _capsule(tmp_path)
+
+    with pytest.raises(ValueError):
+        replace(capsule, **{field: value})

--- a/tests/unit/orchestrator/test_ac_execution_capsule.py
+++ b/tests/unit/orchestrator/test_ac_execution_capsule.py
@@ -12,6 +12,7 @@ from ouroboros.orchestrator.ac_execution_capsule import (
     ACContextReference,
     ACContextReferenceKind,
     ACExecutionCapsuleManifest,
+    ACSuccessContract,
     bind_capsule_to_runtime_handle,
     build_ac_dispatch_authority_scope,
     compile_ac_execution_capsule,
@@ -164,6 +165,46 @@ def test_capsule_fingerprint_changes_with_acceptance_authority(tmp_path) -> None
     )
 
     assert changed.fingerprint != capsule.fingerprint
+
+
+def test_capsule_success_contract_override_is_child_local(tmp_path) -> None:
+    identity = build_ac_runtime_identity(
+        0,
+        execution_context_id="execution-child-contract",
+        retry_attempt=0,
+    )
+    parent_spec = AcceptanceCriterionSpec(
+        description="Parent",
+        verify_command="pytest -q",
+        expected_artifacts=("out_a.txt", "out_b.txt"),
+    )
+
+    child_a = compile_ac_execution_capsule(
+        runtime_identity=identity,
+        execution_id="execution-child-contract",
+        semantic_ac_key="semantic-key",
+        workspace=str(tmp_path.resolve()),
+        authority_scope="authority:v1",
+        seed_goal="Ship",
+        ac_content="Child",
+        ac_spec=parent_spec,
+        success_contract_override=ACSuccessContract(expected_artifacts=("out_a.txt",)),
+    )
+    child_b = compile_ac_execution_capsule(
+        runtime_identity=identity,
+        execution_id="execution-child-contract",
+        semantic_ac_key="semantic-key",
+        workspace=str(tmp_path.resolve()),
+        authority_scope="authority:v1",
+        seed_goal="Ship",
+        ac_content="Child",
+        ac_spec=parent_spec,
+        success_contract_override=ACSuccessContract(expected_artifacts=("out_b.txt",)),
+    )
+
+    assert child_a.success_contract.expected_artifacts == ("out_a.txt",)
+    assert child_b.success_contract.expected_artifacts == ("out_b.txt",)
+    assert child_a.fingerprint != child_b.fingerprint
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/orchestrator/test_adapter.py
+++ b/tests/unit/orchestrator/test_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
+from dataclasses import replace
 from types import ModuleType
 from typing import Any, get_args, get_origin, get_type_hints
 from unittest.mock import AsyncMock, patch
@@ -601,6 +602,10 @@ class TestRuntimeHandle:
             updated_at="2026-03-13T09:00:00+00:00",
             metadata={
                 "ac_id": "ac_2",
+                "ac_capsule_fingerprint": "sha256:" + "a" * 64,
+                "ac_capsule_version": 2,
+                "ac_dispatch_id": "d" * 32,
+                "ac_session_origin": "fresh",
                 "server_session_id": "server-42",
                 "session_attempt_id": "ac_2_attempt_2",
                 "session_scope_id": "ac_2",
@@ -626,6 +631,10 @@ class TestRuntimeHandle:
             "approval_mode": "acceptEdits",
             "metadata": {
                 "ac_id": "ac_2",
+                "ac_capsule_fingerprint": "sha256:" + "a" * 64,
+                "ac_capsule_version": 2,
+                "ac_dispatch_id": "d" * 32,
+                "ac_session_origin": "fresh",
                 "server_session_id": "server-42",
                 "session_attempt_id": "ac_2_attempt_2",
                 "session_scope_id": "ac_2",
@@ -647,6 +656,122 @@ class TestRuntimeHandle:
         assert restored.session_scope_id == "ac_2"
         assert restored.session_attempt_id == "ac_2_attempt_2"
         assert "runtime_event_type" not in restored.metadata
+
+    def test_dispatch_recovery_dict_excludes_workspace_and_unbounded_metadata(self) -> None:
+        """The provider-boundary event stores only reconnect and AC authority state."""
+        handle = RuntimeHandle(
+            backend="codex_cli",
+            kind="implementation_session",
+            native_session_id="codex-session-1",
+            conversation_id="conversation-1",
+            previous_response_id="response-1",
+            transcript_path="/secret/transcript.jsonl",
+            cwd="/private/worktree",
+            approval_mode="acceptEdits",
+            metadata={
+                "ac_id": "ac_1",
+                "ac_capsule_fingerprint": "sha256:" + "a" * 64,
+                "ac_capsule_version": 2,
+                "ac_dispatch_id": "d" * 32,
+                "ac_session_origin": "fresh",
+                "session_attempt_id": "ac_1_attempt_1",
+                "session_scope_id": "ac_1",
+                "server_session_id": "server-1",
+                "tool_catalog": [{"name": "ExternalTool", "description": "x" * 10_000}],
+                "capability_graph": {"nodes": ["x"] * 1_000},
+                "control_plane": {"rules": ["x"] * 1_000},
+                "provider_secret": "drop-me",
+            },
+        )
+
+        persisted = handle.to_dispatch_recovery_dict()
+
+        assert persisted == {
+            "backend": "codex_cli",
+            "kind": "implementation_session",
+            "native_session_id": "codex-session-1",
+            "conversation_id": "conversation-1",
+            "previous_response_id": "response-1",
+            "approval_mode": "acceptEdits",
+            "metadata": {
+                "ac_id": "ac_1",
+                "ac_capsule_fingerprint": "sha256:" + "a" * 64,
+                "ac_capsule_version": 2,
+                "ac_dispatch_id": "d" * 32,
+                "ac_session_origin": "fresh",
+                "session_attempt_id": "ac_1_attempt_1",
+                "session_scope_id": "ac_1",
+                "server_session_id": "server-1",
+            },
+        }
+        restored = RuntimeHandle.from_dispatch_recovery_dict(persisted)
+        assert restored is not None
+        assert restored.native_session_id == "codex-session-1"
+        projected = RuntimeHandle.from_persisted_recovery_projection(handle.to_dict())
+        assert projected is not None
+        assert projected.native_session_id == "codex-session-1"
+        assert "tool_catalog" not in projected.metadata
+        assert "capability_graph" not in projected.metadata
+        assert "control_plane" not in projected.metadata
+
+        with_workspace = {**persisted, "cwd": "/untrusted/worktree"}
+        with pytest.raises(ValueError, match="invalid shape"):
+            RuntimeHandle.from_dispatch_recovery_dict(with_workspace)
+
+        with_unbounded_metadata = {
+            **persisted,
+            "metadata": {**persisted["metadata"], "tool_catalog": [{"name": "leak"}]},
+        }
+        with pytest.raises(ValueError, match="not allowlisted"):
+            RuntimeHandle.from_dispatch_recovery_dict(with_unbounded_metadata)
+
+        oversized = {**persisted, "native_session_id": "x" * 70_000}
+        with pytest.raises(ValueError, match="size limit"):
+            RuntimeHandle.from_dispatch_recovery_dict(oversized)
+        with pytest.raises(ValueError, match="size limit"):
+            replace(handle, native_session_id="x" * 70_000).to_dispatch_recovery_dict()
+
+    def test_persisted_recovery_projection_accepts_opencode_and_legacy_provider_shape(
+        self,
+    ) -> None:
+        """OpenCode's compact lifecycle payload and provider alias both remain resumable."""
+        handle = RuntimeHandle(
+            backend="opencode",
+            kind="implementation_session",
+            native_session_id="opencode-session-compact",
+            conversation_id="not-persisted-by-opencode",
+            previous_response_id="not-persisted-by-opencode",
+            cwd="/private/worktree",
+            approval_mode="acceptEdits",
+            metadata={
+                "ac_id": "ac_1",
+                "ac_capsule_fingerprint": "sha256:" + "a" * 64,
+                "ac_capsule_version": 2,
+                "ac_dispatch_id": "d" * 32,
+                "ac_session_origin": "fresh",
+                "session_attempt_id": "ac_1_attempt_1",
+                "session_scope_id": "ac_1",
+                "server_session_id": "server-compact",
+                "provider_secret": "drop-me",
+            },
+        )
+        compact = handle.to_persisted_dict()
+        assert "conversation_id" not in compact
+        assert "previous_response_id" not in compact
+
+        restored = RuntimeHandle.from_persisted_recovery_projection(compact)
+        assert restored is not None
+        assert restored.backend == "opencode"
+        assert restored.native_session_id == "opencode-session-compact"
+        assert restored.metadata["server_session_id"] == "server-compact"
+        assert "provider_secret" not in restored.metadata
+
+        legacy_provider = {**compact, "provider": compact["backend"]}
+        legacy_provider.pop("backend")
+        restored_legacy = RuntimeHandle.from_persisted_recovery_projection(legacy_provider)
+        assert restored_legacy is not None
+        assert restored_legacy.backend == "opencode"
+        assert restored_legacy.native_session_id == "opencode-session-compact"
 
     def test_opencode_handle_exposes_reconnect_identifiers(self) -> None:
         """OpenCode handles should expose the reconnect ids carried in metadata."""

--- a/tests/unit/orchestrator/test_alt_harness_hook.py
+++ b/tests/unit/orchestrator/test_alt_harness_hook.py
@@ -350,12 +350,15 @@ async def test_no_alternative_falls_back(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.mark.asyncio
-async def test_rerun_error_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_rerun_pre_entry_error_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A PRE-provider-entry construction/spawn failure safely falls back to None."""
+    from ouroboros.orchestrator.parallel_executor import _AltHarnessPreEntryError
+
     executor = _make_executor(enabled=True)
     monkeypatch.setattr(chr, "pick_alternative_runtime", lambda *_a, **_k: "codex")
 
     async def _boom(backend: str, **kwargs: Any) -> ACExecutionResult:
-        raise RuntimeError("fresh runtime failed to spawn")
+        raise _AltHarnessPreEntryError("fresh runtime failed to spawn")
 
     executor._run_single_ac_on_backend = _boom  # type: ignore[method-assign]
     result = await executor._maybe_redispatch_alt_harness(
@@ -366,6 +369,33 @@ async def test_rerun_error_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
         stall_retries_exhausted=True,
     )
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_rerun_post_entry_error_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """R13 blocker #2: a generic failure AFTER provider entry must NOT fall back.
+
+    Terminal-event persistence (etc.) raising once the alternate already mutated
+    the shared workspace must propagate as ambiguity, not restore the stale
+    original result.
+    """
+    from ouroboros.orchestrator.ac_runtime_handle_manager import AmbiguousACExecutionError
+
+    executor = _make_executor(enabled=True)
+    monkeypatch.setattr(chr, "pick_alternative_runtime", lambda *_a, **_k: "codex")
+
+    async def _boom(backend: str, **kwargs: Any) -> ACExecutionResult:
+        raise RuntimeError("terminal persistence failed after the alternate ran")
+
+    executor._run_single_ac_on_backend = _boom  # type: ignore[method-assign]
+    with pytest.raises(AmbiguousACExecutionError, match="after provider entry"):
+        await executor._maybe_redispatch_alt_harness(
+            result=_failed(),
+            execution_context_id="exec-1",
+            rerun_kwargs=_rerun_kwargs(),
+            atomic_retry_attempt=0,
+            stall_retries_exhausted=True,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_alt_harness_hook.py
+++ b/tests/unit/orchestrator/test_alt_harness_hook.py
@@ -16,7 +16,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ouroboros.events.base import BaseEvent
 from ouroboros.orchestrator import cross_harness_redispatch as chr
+from ouroboros.orchestrator.adapter import AgentMessage, RuntimeHandle
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 from ouroboros.orchestrator.parallel_executor_models import ACExecutionResult
 
@@ -118,6 +120,98 @@ async def test_alternate_runtime_is_created_with_forced_bypass(
 
     assert result is not None and result.success is True
     assert created_kwargs["permission_mode"] == "bypassPermissions"
+
+
+@pytest.mark.asyncio
+async def test_alternate_runtime_executes_through_fresh_capsule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real throwaway executor must compile, persist, and dispatch a fresh capsule."""
+    events: list[BaseEvent] = []
+    event_store = AsyncMock()
+
+    async def _append(event: BaseEvent) -> None:
+        events.append(event)
+
+    async def _replay(aggregate_type: str, aggregate_id: str) -> list[BaseEvent]:
+        return [
+            event
+            for event in events
+            if event.aggregate_type == aggregate_type and event.aggregate_id == aggregate_id
+        ]
+
+    event_store.append.side_effect = _append
+    event_store.replay.side_effect = _replay
+    parent_adapter = MagicMock()
+    parent_adapter.runtime_backend = "claude"
+    parent_adapter.working_directory = "/tmp/work"
+    parent_adapter.permission_mode = "acceptEdits"
+    parent_adapter.self_governs_rate_limit = True
+    executor = ParallelACExecutor(
+        adapter=parent_adapter,
+        event_store=event_store,
+        console=MagicMock(),
+        enable_decomposition=False,
+        cross_harness_redispatch=True,
+    )
+
+    class _AltRuntime:
+        runtime_backend = "codex_cli"
+        working_directory = "/tmp/work"
+        permission_mode = "bypassPermissions"
+        self_governs_rate_limit = True
+
+        def __init__(self) -> None:
+            self.resume_handles: list[RuntimeHandle | None] = []
+
+        async def execute_task(
+            self,
+            prompt: str,
+            tools: list[str] | None = None,
+            system_prompt: str | None = None,
+            resume_handle: RuntimeHandle | None = None,
+            resume_session_id: str | None = None,
+        ):
+            del prompt, tools, system_prompt, resume_session_id
+            self.resume_handles.append(resume_handle)
+            yield AgentMessage(
+                type="result",
+                content="[TASK_COMPLETE]",
+                data={"subtype": "success"},
+                resume_handle=resume_handle,
+            )
+
+    alt_runtime = _AltRuntime()
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.runtime_factory.create_agent_runtime",
+        lambda **_kwargs: alt_runtime,
+    )
+
+    result = await executor._run_single_ac_on_backend(
+        "codex_cli",
+        rerun_kwargs=_rerun_kwargs(),
+        retry_attempt=1,
+        decision=chr.AltHarnessDecision(
+            should_redispatch=True,
+            from_backend="claude",
+            to_backend="codex_cli",
+            policy=None,
+            reason="test",
+        ),
+        runtime_identity=executor._resolve_ac_runtime_identity(
+            0,
+            execution_context_id="exec-1",
+        ),
+        failure_class="fabrication_suspected",
+    )
+
+    assert result is not None and result.success is True
+    assert alt_runtime.resume_handles[0] is not None
+    assert alt_runtime.resume_handles[0].native_session_id is None
+    assert alt_runtime.resume_handles[0].metadata["ac_session_origin"] == "fresh"
+    capsule_event = next(event for event in events if event.type == "execution.ac.capsule.compiled")
+    assert capsule_event.data["session_origin"] == "fresh"
+    assert capsule_event.data["capsule_fingerprint"].startswith("sha256:")
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_alt_harness_hook.py
+++ b/tests/unit/orchestrator/test_alt_harness_hook.py
@@ -369,6 +369,33 @@ async def test_rerun_error_falls_back(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_alt_ambiguity_propagates_not_swallowed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """R7 blocker #1: an alternate that raises ambiguity must not fall back to None.
+
+    The alternate ran in the shared workspace and may have applied non-idempotent
+    effects; swallowing the ambiguity would let the caller finalize/escalate from
+    stale pre-redispatch state. The ambiguity must propagate (fail closed).
+    """
+    from ouroboros.orchestrator.ac_runtime_handle_manager import AmbiguousACExecutionError
+
+    executor = _make_executor(enabled=True)
+    monkeypatch.setattr(chr, "pick_alternative_runtime", lambda *_a, **_k: "codex")
+
+    async def _ambiguous(backend: str, **kwargs: Any) -> ACExecutionResult:
+        raise AmbiguousACExecutionError("alternate may have mutated the shared workspace")
+
+    executor._run_single_ac_on_backend = _ambiguous  # type: ignore[method-assign]
+    with pytest.raises(AmbiguousACExecutionError, match="shared workspace"):
+        await executor._maybe_redispatch_alt_harness(
+            result=_failed(),
+            execution_context_id="exec-1",
+            rerun_kwargs=_rerun_kwargs(),
+            atomic_retry_attempt=0,
+            stall_retries_exhausted=True,
+        )
+
+
+@pytest.mark.asyncio
 async def test_alt_failure_is_surfaced_as_authoritative(monkeypatch: pytest.MonkeyPatch) -> None:
     """A FAILED alternate that ran in the workspace is surfaced, not discarded.
 

--- a/tests/unit/orchestrator/test_alt_harness_hook.py
+++ b/tests/unit/orchestrator/test_alt_harness_hook.py
@@ -123,6 +123,80 @@ async def test_alternate_runtime_is_created_with_forced_bypass(
 
 
 @pytest.mark.asyncio
+async def test_alternate_runtime_inherits_verify_policy_and_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Blocker #2: the alternate executor must inherit the operator's verify policy.
+
+    A verify command is an acceptance effect, so an operator who disabled verify
+    commands (or set a custom timeout) must have that policy honored on the
+    cross-harness redispatch path too. Without threading these, the throwaway alt
+    executor silently reverts to ``True``/600 and could run a disabled,
+    potentially non-idempotent verify command in the shared workspace.
+    """
+    adapter = MagicMock()
+    adapter.runtime_backend = "claude"
+    adapter.working_directory = "/tmp/work"
+    adapter.self_governs_rate_limit = True
+    executor = ParallelACExecutor(
+        adapter=adapter,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        cross_harness_redispatch=True,
+        run_verify_commands=False,
+        verify_command_timeout_seconds=123,
+    )
+
+    def _fake_create_agent_runtime(**_kwargs: object) -> MagicMock:
+        runtime = MagicMock()
+        runtime.runtime_backend = "codex_cli"
+        runtime.working_directory = "/tmp/work"
+        runtime.permission_mode = "bypassPermissions"
+        runtime.self_governs_rate_limit = True
+        return runtime
+
+    captured: dict[str, ParallelACExecutor] = {}
+
+    async def _fake_execute_single_ac(
+        _self: ParallelACExecutor,
+        **_kwargs: Any,
+    ) -> ACExecutionResult:
+        captured["alt"] = _self
+        return _succeeded()
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.runtime_factory.create_agent_runtime",
+        _fake_create_agent_runtime,
+    )
+    monkeypatch.setattr(ParallelACExecutor, "_execute_single_ac", _fake_execute_single_ac)
+
+    result = await executor._run_single_ac_on_backend(
+        "codex",
+        rerun_kwargs=_rerun_kwargs(),
+        retry_attempt=1,
+        decision=chr.AltHarnessDecision(
+            should_redispatch=True,
+            from_backend="claude",
+            to_backend="codex",
+            policy=None,
+            reason="test",
+        ),
+        runtime_identity=executor._resolve_ac_runtime_identity(
+            0,
+            execution_context_id="exec-1",
+        ),
+        failure_class="fabrication_suspected",
+    )
+
+    assert result is not None and result.success is True
+    alt_executor = captured["alt"]
+    assert alt_executor is not executor
+    assert alt_executor._run_verify_commands is False
+    assert alt_executor._verify_command_timeout_seconds == 123
+
+
+@pytest.mark.asyncio
 async def test_alternate_runtime_executes_through_fresh_capsule(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/orchestrator/test_decomposition_attestation_wiring.py
+++ b/tests/unit/orchestrator/test_decomposition_attestation_wiring.py
@@ -1016,6 +1016,65 @@ class TestPerChildArtifactSliceOracle:
         )
 
     @pytest.mark.asyncio
+    async def test_nested_split_keeps_the_current_child_contract(self, tmp_path) -> None:
+        """A child that decomposes again must never regain its root sibling's gate."""
+        executor = _make_live_artifact_executor(
+            tmp_path,
+            writes_per_dispatch=[("out_a.txt",), ()],
+        )
+        node_identity = ExecutionNodeIdentity.root(
+            execution_context_id="exec-art-nested",
+            ac_index=0,
+        ).child(0)
+        decision = _artifact_split_decision(
+            node_identity.node_id,
+            slices=(("out_a.txt",), ()),
+        )
+        root_spec = AcceptanceCriterionSpec(
+            description="root AC",
+            expected_artifacts=("out_a.txt", "out_b.txt"),
+        )
+
+        result = await executor._execute_decomposition_children(
+            **_decomposition_children_kwargs(
+                node_identity,
+                decision,
+                root_spec,
+                "exec-art-nested",
+            ),
+            capsule_success_contract=ACSuccessContract(
+                expected_artifacts=("out_a.txt",),
+            ),
+        )
+
+        assert result.verify_gate_outcome is not None
+        assert result.verify_gate_outcome.passed is True
+        assert "out_b.txt" not in (result.verify_gate_outcome.reason or "")
+
+        capsule_events = [
+            event
+            for event in executor._test_appended_events  # type: ignore[attr-defined]
+            if event.type == "execution.ac.capsule.compiled"
+        ]
+        assert len(capsule_events) == 2
+        root_contract = ACSuccessContract(
+            expected_artifacts=("out_a.txt", "out_b.txt"),
+        )
+        root_contract_digest = "sha256:" + hashlib.sha256(
+            json.dumps(
+                root_contract.to_contract_data(),
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ).encode("utf-8")
+        ).hexdigest()
+        assert all(
+            event.data["capsule_manifest"]["success_contract_digest"]
+            != root_contract_digest
+            for event in capsule_events
+        )
+
+    @pytest.mark.asyncio
     async def test_children_creating_their_slices_earn_trustworthy(self, tmp_path) -> None:
         """The whole point of the feature: a real decomposition round where
         every child genuinely creates its assigned artifacts (and the parent's

--- a/tests/unit/orchestrator/test_decomposition_attestation_wiring.py
+++ b/tests/unit/orchestrator/test_decomposition_attestation_wiring.py
@@ -1060,17 +1060,19 @@ class TestPerChildArtifactSliceOracle:
         root_contract = ACSuccessContract(
             expected_artifacts=("out_a.txt", "out_b.txt"),
         )
-        root_contract_digest = "sha256:" + hashlib.sha256(
-            json.dumps(
-                root_contract.to_contract_data(),
-                sort_keys=True,
-                separators=(",", ":"),
-                ensure_ascii=False,
-            ).encode("utf-8")
-        ).hexdigest()
+        root_contract_digest = (
+            "sha256:"
+            + hashlib.sha256(
+                json.dumps(
+                    root_contract.to_contract_data(),
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                ).encode("utf-8")
+            ).hexdigest()
+        )
         assert all(
-            event.data["capsule_manifest"]["success_contract_digest"]
-            != root_contract_digest
+            event.data["capsule_manifest"]["success_contract_digest"] != root_contract_digest
             for event in capsule_events
         )
 

--- a/tests/unit/orchestrator/test_decomposition_attestation_wiring.py
+++ b/tests/unit/orchestrator/test_decomposition_attestation_wiring.py
@@ -6,6 +6,8 @@ consulted to poison a root AC's NEXT retry's child-tier discount.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -16,6 +18,7 @@ from ouroboros.harness.decomposition_attestation import (
     DecompositionTrustVerdict,
     SiblingVerifyOutcome,
 )
+from ouroboros.orchestrator.ac_execution_capsule import ACSuccessContract
 from ouroboros.orchestrator.decomposition_policy import (
     DecompositionChild,
     DecompositionDecisionRecord,
@@ -970,6 +973,7 @@ def _make_live_artifact_executor(
     executor._emit_level_completed = AsyncMock()
     executor._emit_subtask_event = AsyncMock()
     executor._event_emitter.emit_decomposition_attested = AsyncMock()
+    executor._test_appended_events = _appended  # type: ignore[attr-defined]
     return executor
 
 
@@ -1039,6 +1043,29 @@ class TestPerChildArtifactSliceOracle:
         # The parent's own artifact gate also genuinely re-ran and passed.
         assert result.verify_gate_outcome is not None
         assert result.verify_gate_outcome.passed is True
+
+        capsule_events = [
+            event
+            for event in executor._test_appended_events  # type: ignore[attr-defined]
+            if event.type == "execution.ac.capsule.compiled"
+        ]
+
+        def _contract_digest(artifacts: tuple[str, ...]) -> str:
+            payload = ACSuccessContract(expected_artifacts=artifacts).to_contract_data()
+            canonical = json.dumps(
+                payload,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=False,
+            ).encode("utf-8")
+            return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+        assert [
+            event.data["capsule_manifest"]["success_contract_digest"] for event in capsule_events
+        ] == [
+            _contract_digest(("out_a.txt",)),
+            _contract_digest(("out_b.txt",)),
+        ]
 
     @pytest.mark.asyncio
     async def test_preexisting_slice_denies_credit_fail_closed(self, tmp_path) -> None:

--- a/tests/unit/orchestrator/test_decomposition_attestation_wiring.py
+++ b/tests/unit/orchestrator/test_decomposition_attestation_wiring.py
@@ -35,10 +35,36 @@ from ouroboros.orchestrator.parallel_executor import (
 )
 
 
+def _make_replaying_event_store() -> AsyncMock:
+    """Event-store mock whose ``replay`` returns previously appended events.
+
+    The single-shot verify oracle replays the execution aggregate to decide
+    whether a verify command already ran, so a bare ``AsyncMock`` (whose
+    ``replay`` returns a non-iterable mock) is insufficient.
+    """
+    store = AsyncMock()
+    appended: list[object] = []
+
+    async def _append(event: object) -> None:
+        appended.append(event)
+
+    async def _replay(aggregate_type: str, aggregate_id: str) -> list[object]:
+        return [
+            event
+            for event in appended
+            if getattr(event, "aggregate_type", None) == aggregate_type
+            and getattr(event, "aggregate_id", None) == aggregate_id
+        ]
+
+    store.append.side_effect = _append
+    store.replay.side_effect = _replay
+    return store
+
+
 def _make_executor(event_store: object | None = None) -> ParallelACExecutor:
     executor = ParallelACExecutor(
         adapter=MagicMock(),
-        event_store=event_store if event_store is not None else AsyncMock(),
+        event_store=event_store if event_store is not None else _make_replaying_event_store(),
         console=MagicMock(),
         enable_decomposition=False,
     )
@@ -105,6 +131,9 @@ class TestAttestDecompositionRound:
         attestation, parent_outcome = await executor._attest_decomposition_round(
             node_identity=node_identity,
             final_sub_results=final_sub_results,
+            execution_id="exec-1",
+            session_id="sess-1",
+            retry_attempt=0,
             ac_spec=None,
         )
 
@@ -132,6 +161,9 @@ class TestAttestDecompositionRound:
         attestation, parent_outcome = await executor._attest_decomposition_round(
             node_identity=node_identity,
             final_sub_results=final_sub_results,
+            execution_id="exec-1",
+            session_id="sess-1",
+            retry_attempt=0,
             ac_spec=ac_spec,
         )
 
@@ -161,6 +193,9 @@ class TestAttestDecompositionRound:
         attestation, parent_outcome = await executor._attest_decomposition_round(
             node_identity=node_identity,
             final_sub_results=final_sub_results,
+            execution_id="exec-1",
+            session_id="sess-1",
+            retry_attempt=0,
             ac_spec=ac_spec,
         )
 
@@ -193,6 +228,9 @@ class TestAttestDecompositionRound:
         attestation, parent_outcome = await executor._attest_decomposition_round(
             node_identity=node_identity,
             final_sub_results=final_sub_results,
+            execution_id="exec-1",
+            session_id="sess-1",
+            retry_attempt=0,
             ac_spec=ac_spec,
         )
 
@@ -223,6 +261,9 @@ class TestAttestDecompositionRound:
         attestation, _parent_outcome = await executor._attest_decomposition_round(
             node_identity=node_identity,
             final_sub_results=final_sub_results,
+            execution_id="exec-1",
+            session_id="sess-1",
+            retry_attempt=0,
             ac_spec=ac_spec,
         )
 
@@ -1424,6 +1465,9 @@ class TestPerChildArtifactSliceOracle:
         attestation, _parent = await executor._attest_decomposition_round(
             node_identity=node_identity,
             final_sub_results=final_sub_results,
+            execution_id="exec-1",
+            session_id="sess-1",
+            retry_attempt=0,
             ac_spec=ac_spec,
             child_artifact_attributions=(
                 (True, True, "artifact leg passed"),  # conflicts with failing gate leg
@@ -1850,8 +1894,12 @@ class TestDecompositionAttestationFailsClosedOnReplayFailure:
                 node_identity=node_identity,
                 start_time=datetime.now(UTC),
                 semantic_ac_key="key",
+                # This test isolates attestation-trust fail-closed behavior under a
+                # broken event store; use a pure artifact contract so the parent
+                # gate does not additionally engage the single-shot verify oracle
+                # (which legitimately requires a readable event store).
                 ac_spec=AcceptanceCriterionSpec(
-                    description="parent AC", verify_command="pytest -q"
+                    description="parent AC", expected_artifacts=("out.txt",)
                 ),
             )
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1410,6 +1410,59 @@ def test_bound_verify_gate_outcome_rejects_type_coercion() -> None:
     assert bound_verify_gate_outcome(base) == base
 
 
+def test_capsule_authority_binds_watchdog_timeout_policy() -> None:
+    """R7 blocker #3: watchdog timeouts change termination semantics → authority.
+
+    Two runtimes differing only in their stdout-idle watchdog timeout must not
+    share a capsule fingerprint.
+    """
+
+    class _Runtime:
+        runtime_backend = "codex_cli"
+        working_directory = "/tmp/project"
+        permission_mode = "acceptEdits"
+
+        def __init__(self, idle_timeout: float) -> None:
+            self._idle_timeout = idle_timeout
+
+        def watchdog_identity_contract(self) -> dict[str, float | None]:
+            return {
+                "startup_output_timeout_seconds": 60.0,
+                "stdout_idle_timeout_seconds": self._idle_timeout,
+                "process_shutdown_timeout_seconds": 5.0,
+                "completed_process_group_shutdown_timeout_seconds": 0.2,
+            }
+
+    def _authority(idle_timeout: float) -> dict[str, object]:
+        executor = ParallelACExecutor(
+            adapter=_Runtime(idle_timeout),
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        return executor._build_capsule_dispatch_authority_contract(
+            tools=["Read"],
+            tool_catalog=None,
+            system_prompt="system",
+            level_contexts=None,
+        )
+
+    fast = _authority(1.0)
+    slow = _authority(999.0)
+    assert fast["runtime"]["watchdog"]["observed"] is True  # type: ignore[index]
+    assert fast != slow
+
+
+def test_codex_runtime_watchdog_identity_reflects_timeouts() -> None:
+    """R7 blocker #3: the real Codex runtime surfaces its effective watchdog policy."""
+    from ouroboros.orchestrator.codex_cli_runtime import CodexCliRuntime
+
+    runtime = CodexCliRuntime(stdout_idle_timeout_seconds=1.0)
+    contract = runtime.watchdog_identity_contract()
+    assert contract["stdout_idle_timeout_seconds"] == 1.0
+    assert "startup_output_timeout_seconds" in contract
+
+
 def test_runtime_capabilities_contract_includes_realtime_effect_visibility() -> None:
     """R6 blocker #1: the stall-affecting capability participates in authority."""
     from ouroboros.orchestrator.adapter import FULL_CAPABILITIES

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -5178,8 +5178,7 @@ class TestParallelACExecutor:
                 matching = [
                     event
                     for event in self.events
-                    if event.aggregate_type == aggregate_type
-                    and event.aggregate_id == aggregate_id
+                    if event.aggregate_type == aggregate_type and event.aggregate_id == aggregate_id
                 ]
                 new_events = matching[last_row_id:]
                 self.returned_events += len(new_events)

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -12477,6 +12477,107 @@ class TestParallelACExecutor:
         assert finalized.success is False
 
     @pytest.mark.asyncio
+    async def test_isolated_verify_gate_grades_immutable_snapshot_not_shared_mutation(
+        self, tmp_path: Any
+    ) -> None:
+        """R14-2: batch verify gates grade a frozen snapshot, not the shared live tree.
+
+        A verify_command is arbitrary shell that may mutate the workspace. Batch
+        gates finalize sequentially over one settled tree, so a later command's
+        side effects must not invalidate acceptance an earlier gate already
+        granted, nor corrupt the delivered artifact. Each command-bearing gate
+        runs against a private frozen snapshot: mutations are discarded and every
+        gate observes the identical settled state regardless of order.
+        """
+        marker = tmp_path / "marker.txt"
+        marker.write_text("good\n", encoding="utf-8")
+
+        assert_good = AcceptanceCriterionSpec(
+            description="marker stays good", verify_command="grep -q good marker.txt"
+        )
+        mutating = AcceptanceCriterionSpec(
+            description="verifier mutates the shared tree",
+            verify_command="printf 'bad\\n' > marker.txt",
+        )
+        seed = _make_seed(assert_good, mutating)
+
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory=str(tmp_path),
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            task_cwd=str(tmp_path),
+        )
+
+        async def _gate(idx: int) -> ACExecutionResult:
+            return await executor._apply_verify_gate_isolated(
+                seed=seed,
+                ac_index=idx,
+                result=ACExecutionResult(ac_index=idx, ac_content="ac", success=True),
+                session_id="s",
+                execution_id="e",
+            )
+
+        # Run the MUTATING gate FIRST, then the assertion gate: order must not
+        # matter because neither touches the shared live tree.
+        mutated_first = await _gate(1)
+        good_after = await _gate(0)
+
+        assert mutated_first.success is True  # the mutating command exits 0
+        assert good_after.success is True  # still sees good in its own snapshot
+        # The delivered workspace is untouched by either verifier.
+        assert marker.read_text(encoding="utf-8") == "good\n"
+
+    @pytest.mark.asyncio
+    async def test_isolated_verify_gate_fails_closed_when_snapshot_unavailable(
+        self, tmp_path: Any, monkeypatch: Any
+    ) -> None:
+        """R14-2: an un-snapshottable settled tree fails a would-be PASS closed.
+
+        Rather than run a possibly-mutating verify_command against the shared live
+        workspace (where it could invalidate a sibling gate), a workspace that
+        cannot be frozen fails a successful result closed.
+        """
+        import contextlib as _contextlib
+
+        @_contextlib.contextmanager
+        def _no_snapshot(_cwd: str) -> Any:
+            yield None
+
+        monkeypatch.setattr(
+            "ouroboros.orchestrator.parallel_executor.isolated_workspace", _no_snapshot
+        )
+        seed = _make_seed(AcceptanceCriterionSpec(description="ac", verify_command="exit 0"))
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory=str(tmp_path),
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            task_cwd=str(tmp_path),
+        )
+
+        gated = await executor._apply_verify_gate_isolated(
+            seed=seed,
+            ac_index=0,
+            result=ACExecutionResult(ac_index=0, ac_content="ac", success=True),
+            session_id="s",
+            execution_id="e",
+        )
+
+        assert gated.success is False
+        assert "could not isolate" in (gated.error or "")
+
+    @pytest.mark.asyncio
     async def test_completed_recovery_reuses_durable_verify_outcome_without_command_replay(
         self, tmp_path: Any
     ) -> None:
@@ -12634,56 +12735,74 @@ class TestParallelACExecutor:
         assert counter.read_text(encoding="utf-8") == "1"
 
     @pytest.mark.asyncio
-    async def test_completed_recovery_without_verify_outcome_refuses_command_replay(
-        self,
+    async def test_completed_recovery_without_verify_record_defers_to_finalization(
+        self, tmp_path: Any
     ) -> None:
-        """Legacy completion without a cached command verdict fails closed."""
+        """R14-1: a deferred completion with no durable verify record is NOT ambiguous.
+
+        The command-bearing verify_command is deferred out of the atomic leaf
+        (R13-1), so a completed leaf lifecycle legitimately carries no verify
+        outcome and no intent. Recovery must not fail closed on that normal state:
+        the command has provably NOT run, so it leaves the outcome unresolved and
+        lets the batch-completion gate run the single-shot oracle ONCE over the
+        settled workspace. Verification is neither skipped nor duplicated.
+        """
+        event_store, _ = _make_replaying_event_store()
         executor = ParallelACExecutor(
             adapter=SimpleNamespace(
                 runtime_backend="codex_cli",
-                working_directory="/tmp/project",
+                working_directory=str(tmp_path),
                 permission_mode="acceptEdits",
             ),
-            event_store=AsyncMock(),
+            event_store=event_store,
             console=MagicMock(),
             enable_decomposition=False,
         )
         executor._execute_atomic_ac = AsyncMock(
             side_effect=CompletedACExecutionError(
                 "already completed",
-                result_summary="legacy completion",
-                session_id="legacy-provider-session",
+                result_summary="deferred completion",
+                session_id="deferred-provider-session",
             )
         )
 
-        with pytest.raises(
-            AmbiguousACExecutionError,
-            match="missing its non-idempotent verify-command outcome",
-        ):
-            await executor._execute_single_ac(
-                ac_index=0,
-                ac_content="Run the command once",
-                session_id="session-missing-verify-outcome",
-                tools=[],
-                tool_catalog=None,
-                system_prompt="system",
-                seed_goal="Ship",
-                ac_spec=AcceptanceCriterionSpec(
-                    description="Run the command once",
-                    verify_command="apply-once",
-                ),
-            )
+        recovered = await executor._execute_single_ac(
+            ac_index=0,
+            ac_content="Run the command once",
+            session_id="session-deferred-verify",
+            execution_id="session-deferred-verify",
+            tools=[],
+            tool_catalog=None,
+            system_prompt="system",
+            seed_goal="Ship",
+            ac_spec=AcceptanceCriterionSpec(
+                description="Run the command once",
+                verify_command="apply-once",
+            ),
+        )
+
+        # No durable verify record -> the command has provably not run; recovery
+        # defers grading to the batch-completion gate rather than failing closed.
+        assert recovered.success is True
+        assert recovered.verify_gate_outcome is None
 
     @pytest.mark.asyncio
-    async def test_completed_recovery_requires_durable_verify_chain(self) -> None:
-        """R8 blocker #2: a completion with a cached PASS but NO durable verify
-        intent/outcome chain fails closed — an orphan completion cannot
-        manufacture command-backed acceptance."""
+    async def test_completed_recovery_ignores_uncorroborated_cached_pass(
+        self, tmp_path: Any
+    ) -> None:
+        """R14-1/R8 blocker #2: a completion's cached PASS is not self-authorizing.
+
+        A completion may carry a cached PASS verdict with NO durable verify
+        intent/outcome chain backing it (orphan/fabricated). Recovery discards
+        that uncorroborated verdict and defers to the batch-completion gate, so a
+        forged completion cannot manufacture command-backed acceptance: the real
+        verify_command must still pass at finalization over the settled workspace.
+        """
         event_store, _ = _make_replaying_event_store()
         executor = ParallelACExecutor(
             adapter=SimpleNamespace(
                 runtime_backend="codex_cli",
-                working_directory="/tmp/project",
+                working_directory=str(tmp_path),
                 permission_mode="acceptEdits",
             ),
             event_store=event_store,
@@ -12706,23 +12825,168 @@ class TestParallelACExecutor:
             )
         )
 
-        with pytest.raises(
-            AmbiguousACExecutionError, match="lacks the durable verify intent/outcome chain"
-        ):
+        recovered = await executor._execute_single_ac(
+            ac_index=0,
+            ac_content="Run the command once",
+            session_id="session-orphan-completion",
+            execution_id="session-orphan-completion",
+            tools=[],
+            tool_catalog=None,
+            system_prompt="system",
+            seed_goal="Ship",
+            ac_spec=AcceptanceCriterionSpec(
+                description="Run the command once",
+                verify_command="apply-once",
+            ),
+        )
+
+        # The uncorroborated cached PASS is discarded, not trusted: the outcome is
+        # unresolved, forcing the finalization gate to grade the real command.
+        assert recovered.verify_gate_outcome is None
+
+    @pytest.mark.asyncio
+    async def test_completed_recovery_intent_without_outcome_fails_closed(
+        self, tmp_path: Any
+    ) -> None:
+        """R14-1: an intent with no matching outcome is ambiguous and fails closed.
+
+        If a durable verify intent was persisted but its outcome was never
+        recorded, the non-idempotent verify_command may have run with side effects
+        before the crash. Recovery must refuse to trust or replay it.
+        """
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory=str(tmp_path),
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        ac_spec = AcceptanceCriterionSpec(
+            description="Run the command once",
+            verify_command="apply-once",
+        )
+        execution_scope = "session-intent-only"
+        appended_events.append(
+            BaseEvent(
+                type="execution.ac.verify.intent",
+                aggregate_type="execution",
+                aggregate_id=execution_scope,
+                data={
+                    "verify_key": executor._ac_verify_gate_key(
+                        execution_scope=execution_scope, ac_index=0, retry_attempt=0
+                    ),
+                    "verify_command_digest": executor._verify_gate_command_digest(ac_spec),
+                },
+            )
+        )
+        executor._execute_atomic_ac = AsyncMock(
+            side_effect=CompletedACExecutionError(
+                "already completed",
+                result_summary="partial completion",
+                session_id="intent-only-provider-session",
+            )
+        )
+
+        with pytest.raises(AmbiguousACExecutionError, match="intent with no matching outcome"):
             await executor._execute_single_ac(
                 ac_index=0,
                 ac_content="Run the command once",
-                session_id="session-orphan-completion",
-                execution_id="session-orphan-completion",
+                session_id=execution_scope,
+                execution_id=execution_scope,
                 tools=[],
                 tool_catalog=None,
                 system_prompt="system",
                 seed_goal="Ship",
-                ac_spec=AcceptanceCriterionSpec(
-                    description="Run the command once",
-                    verify_command="apply-once",
-                ),
+                ac_spec=ac_spec,
             )
+
+    @pytest.mark.asyncio
+    async def test_completed_recovery_consumes_deferred_finalization_outcome(
+        self, tmp_path: Any
+    ) -> None:
+        """R14-1 blocker: a deferred completion IS recoverable once finalization ran.
+
+        The reviewer's probe: a leaf completed and persisted ``session.completed``
+        with ``verify_gate_outcome=None`` (deferred), then the batch-completion gate
+        durably wrote both verify intent AND outcome, then the process restarted.
+        Recovery must consume the finalization oracle's outcome -- not reproduce
+        ``AmbiguousACExecutionError`` -- because the completion legitimately carries
+        no leaf-cached verdict under the deferral design.
+        """
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory=str(tmp_path),
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        ac_spec = AcceptanceCriterionSpec(
+            description="Run the command once",
+            verify_command="apply-once",
+        )
+        execution_scope = "session-deferred-finalized"
+        verify_key = executor._ac_verify_gate_key(
+            execution_scope=execution_scope, ac_index=0, retry_attempt=0
+        )
+        command_digest = executor._verify_gate_command_digest(ac_spec)
+        appended_events.extend(
+            [
+                BaseEvent(
+                    type="execution.ac.verify.intent",
+                    aggregate_type="execution",
+                    aggregate_id=execution_scope,
+                    data={"verify_key": verify_key, "verify_command_digest": command_digest},
+                ),
+                BaseEvent(
+                    type="execution.ac.verify.outcome",
+                    aggregate_type="execution",
+                    aggregate_id=execution_scope,
+                    data={
+                        "verify_key": verify_key,
+                        "verify_command_digest": command_digest,
+                        "verify_gate_outcome": {
+                            "passed": True,
+                            "reason": None,
+                            "output_tail": "",
+                            "missing_artifacts": [],
+                        },
+                    },
+                ),
+            ]
+        )
+        # A DEFERRED completion: session.completed carried no leaf verdict.
+        executor._execute_atomic_ac = AsyncMock(
+            side_effect=CompletedACExecutionError(
+                "already completed",
+                result_summary="deferred completion",
+                session_id="deferred-finalized-provider-session",
+            )
+        )
+
+        recovered = await executor._execute_single_ac(
+            ac_index=0,
+            ac_content="Run the command once",
+            session_id=execution_scope,
+            execution_id=execution_scope,
+            tools=[],
+            tool_catalog=None,
+            system_prompt="system",
+            seed_goal="Ship",
+            ac_spec=ac_spec,
+        )
+
+        # The durable finalization outcome is consumed -- recovery succeeds.
+        assert recovered.success is True
+        assert recovered.verify_gate_outcome is not None
+        assert recovered.verify_gate_outcome.passed is True
 
     @pytest.mark.asyncio
     async def test_verify_gate_recovers_failed_artifact_result_when_contract_passes(

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -12573,6 +12573,46 @@ class TestParallelACExecutor:
         assert (tmp_path / "node_modules" / "probe").exists()
 
     @pytest.mark.asyncio
+    async def test_verify_command_deleting_dependency_is_failed_closed(self, tmp_path: Any) -> None:
+        """R16/B2: the mutation fingerprint is comprehensive, covering dependency
+        directories. A verifier that deletes an acceptance input under
+        ``node_modules`` (or ``.git``/``.venv``) is detected and failed closed,
+        not accepted as PASS.
+        """
+        (tmp_path / "node_modules").mkdir()
+        (tmp_path / "node_modules" / "probe").write_text("dep\n", encoding="utf-8")
+        spec = AcceptanceCriterionSpec(
+            description="verifier deletes a dependency input",
+            verify_command="rm node_modules/probe",  # exits 0 but MUTATES a dep
+        )
+        seed = _make_seed(spec)
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory=str(tmp_path),
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            task_cwd=str(tmp_path),
+        )
+
+        gated = await executor._apply_verify_gate(
+            seed=seed,
+            ac_index=0,
+            result=ACExecutionResult(ac_index=0, ac_content="ac", success=True),
+            session_id="s",
+            execution_id="e",
+        )
+
+        assert gated.success is False
+        assert gated.verify_gate_outcome is not None
+        assert gated.verify_gate_outcome.passed is False
+        assert "mutat" in (gated.verify_gate_outcome.reason or "").lower()
+
+    @pytest.mark.asyncio
     async def test_completed_recovery_reuses_durable_verify_outcome_without_command_replay(
         self, tmp_path: Any
     ) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1102,6 +1102,73 @@ def test_capsule_authority_covers_prompt_gate_runtime_and_verifier_inputs() -> N
     assert scope(verifier_drift) != baseline
 
 
+def test_capsule_authority_distinguishes_verifier_closure_state() -> None:
+    """Factory-created judges with the same source must not share authority."""
+
+    def configured_verifier(passed: bool):
+        def verifier(**_kwargs: Any) -> VerifierVerdict:
+            return VerifierVerdict(passed=passed)
+
+        return verifier
+
+    runtime = SimpleNamespace(
+        runtime_backend="codex_cli",
+        working_directory="/tmp/project",
+        permission_mode="acceptEdits",
+    )
+    passing = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        atomic_verifier=configured_verifier(True),
+    )
+    rejecting = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        atomic_verifier=configured_verifier(False),
+    )
+
+    assert passing._atomic_verifier_authority != rejecting._atomic_verifier_authority
+    assert passing._atomic_verifier_authority["behavioral_state"]["stability"] == "durable"
+
+
+def test_capsule_authority_distinguishes_callable_verifier_state() -> None:
+    """Callable instances bind their configured acceptance behavior."""
+
+    class ConfiguredVerifier:
+        def __init__(self, passed: bool) -> None:
+            self.passed = passed
+
+        def __call__(self, **_kwargs: Any) -> VerifierVerdict:
+            return VerifierVerdict(passed=self.passed)
+
+    runtime = SimpleNamespace(
+        runtime_backend="codex_cli",
+        working_directory="/tmp/project",
+        permission_mode="acceptEdits",
+    )
+    passing = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        atomic_verifier=ConfiguredVerifier(True),
+    )
+    rejecting = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        atomic_verifier=ConfiguredVerifier(False),
+    )
+
+    assert passing._atomic_verifier_authority != rejecting._atomic_verifier_authority
+    assert passing._atomic_verifier_authority["behavioral_state"]["stability"] == "durable"
+
+
 def test_capsule_authority_reuses_large_context_and_catalog_digests(monkeypatch) -> None:
     """Sibling ACs and retries must not reserialize the same authority inputs."""
     import ouroboros.orchestrator.mcp_tools as mcp_tools

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1576,6 +1576,84 @@ def test_opencode_execution_identity_contract_binds_dispatch_policy() -> None:
     assert "_Dispatcher" in contract["skill_dispatcher"]["type"]
 
 
+def test_opencode_unidentifiable_dispatcher_gets_process_local_nonce() -> None:
+    """R13 warning: two same-class stateful dispatchers are NOT identity-equal.
+
+    Without a durable identity contract, the class alone cannot tell two distinct
+    dispatcher instances apart; a process-local nonce distinguishes them and makes
+    any restart (which cannot reproduce the nonce) fail closed.
+    """
+    from ouroboros.orchestrator.opencode_runtime import OpenCodeRuntime
+
+    class _StatefulDispatcher:
+        def __init__(self, state: str) -> None:
+            self.state = state
+
+    a = OpenCodeRuntime(skill_dispatcher=_StatefulDispatcher("a"))
+    b = OpenCodeRuntime(skill_dispatcher=_StatefulDispatcher("b"))
+    ca = a.execution_identity_contract()["skill_dispatcher"]
+    cb = b.execution_identity_contract()["skill_dispatcher"]
+    assert ca["durable_identity"] is False
+    assert "process_local_nonce" in ca
+    assert ca != cb  # distinct instances → distinct identity
+
+
+@pytest.mark.asyncio
+async def test_executable_drift_before_dispatch_fails_closed(tmp_path: Any) -> None:
+    """R13 blocker #3: a symlink swap in the compile→launch window is refused."""
+    link = tmp_path / "tool"
+    link.symlink_to("/bin/true")
+
+    class _Runtime:
+        runtime_backend = "codex_cli"
+        working_directory = str(tmp_path)
+        permission_mode = "acceptEdits"
+        _cli_path = str(tmp_path / "tool")
+
+        def __init__(self, swap: Any) -> None:
+            self._swap = swap
+
+        async def execute_task(self, **_kwargs: object):
+            # This would be the provider entry — it must never be reached because
+            # the pre-dispatch executable revalidation fails closed first.
+            yield AgentMessage(type="result", content="[TASK_COMPLETE]")  # pragma: no cover
+
+    # Swap the symlink target between capsule compile and dispatch by monkeypatching
+    # _runtime_executable_identity to return a drifted value on the SECOND call.
+    executor = ParallelACExecutor(
+        adapter=_Runtime(None),
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        task_cwd=str(tmp_path),
+    )
+    calls = {"n": 0}
+    real = ParallelACExecutor._runtime_executable_identity
+
+    def _drifting(adapter: Any, *, cwd: str | None = None) -> dict[str, object]:
+        calls["n"] += 1
+        base = real(adapter, cwd=cwd)
+        # Calls 1 (authority build) and 2 (compile-time snapshot) return the true
+        # value; the pre-dispatch revalidation (call 3+) sees a drifted target.
+        if calls["n"] >= 3:
+            return {**base, "executable": {"path": "tool", "realpath": "/bin/false"}}
+        return base
+
+    executor._runtime_executable_identity = _drifting  # type: ignore[method-assign, assignment]
+
+    with pytest.raises(AmbiguousACExecutionError, match="executable identity drifted"):
+        await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Refuse a drifted executable",
+            session_id="orch_drift",
+            tools=["Read"],
+            system_prompt="system",
+            seed_goal="Ship",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+
 def test_capsule_authority_binds_signal_hub_durable_relay_mode() -> None:
     """R12 blocker #3: a durable-relay hub differs in authority from a non-durable one.
 
@@ -12151,6 +12229,12 @@ class TestParallelACExecutor:
             task_cwd=str(tmp_path),
         )
 
+        ac_spec = AcceptanceCriterionSpec(
+            description="Create output.txt with the smoke marker.",
+            expected_artifacts=("output.txt",),
+            verify_command="test -f output.txt",
+        )
+        seed = _make_seed(ac_spec)
         result = await executor._execute_atomic_ac(
             ac_index=0,
             ac_content="Create output.txt with the smoke marker.",
@@ -12161,17 +12245,21 @@ class TestParallelACExecutor:
             seed_goal="Ship the artifact",
             depth=0,
             start_time=datetime.now(UTC),
-            ac_spec=AcceptanceCriterionSpec(
-                description="Create output.txt with the smoke marker.",
-                expected_artifacts=("output.txt",),
-                verify_command="test -f output.txt",
-            ),
+            ac_spec=ac_spec,
         )
-
-        assert result.success is True
-        assert result.error is None
-        assert result.typed_evidence is None
-        assert result.atomic_verifier_verdict is None
+        # R13: the verify_command is deferred to the batch-completion gate, so the
+        # passing artifact/command gate now replaces evidence at THAT authoritative
+        # gate (over the final workspace), which recovers the AC to success.
+        finalized = await executor._apply_verify_gate(
+            seed=seed,
+            ac_index=0,
+            result=result,
+            session_id="orch_123",
+            execution_id="exec_123",
+        )
+        assert finalized.success is True
+        assert finalized.typed_evidence is None
+        assert finalized.atomic_verifier_verdict is None
         evidence_event = next(
             event
             for event in appended_events
@@ -12179,7 +12267,14 @@ class TestParallelACExecutor:
         )
         assert evidence_event.data["required_fields"] == []
         assert evidence_event.data["typed_evidence_present"] is False
-        assert evidence_event.data["enforcement_error"] is None
+        # R13: the verify_command is deferred, so the leaf can no longer replace
+        # evidence in-place; it records the evidence gap and the batch-completion
+        # gate then recovers the AC via the passing command over the final
+        # workspace (asserted by finalized.success above).
+        verify_recovered = [
+            event for event in appended_events if event.type == "execution.verify.recovered"
+        ]
+        assert verify_recovered
 
     @pytest.mark.asyncio
     async def test_verify_only_code_contract_still_requires_files_touched_evidence(
@@ -12291,19 +12386,14 @@ class TestParallelACExecutor:
             start_time=datetime.now(UTC),
             ac_spec=seed.acceptance_criteria[0],
         )
+        # R13: the verify_command is DEFERRED out of the concurrent atomic leaf,
+        # so the leaf neither runs it (counter untouched) nor caches an outcome.
         assert result.success is True
-        assert result.verify_gate_outcome is not None
-        assert counter.read_text(encoding="utf-8") == "1"
-        completed_event = next(
-            event for event in appended_events if event.type == "execution.session.completed"
-        )
-        assert completed_event.data["verify_gate_outcome"] == {
-            "passed": True,
-            "reason": None,
-            "output_tail": "",
-            "missing_artifacts": [],
-        }
+        assert result.verify_gate_outcome is None
+        assert not counter.exists()
 
+        # The single authoritative run happens at the batch-completion gate, over
+        # the FINAL workspace — the command runs exactly once here.
         finalized = await executor._apply_verify_gate(
             seed=seed,
             ac_index=0,
@@ -12311,9 +12401,80 @@ class TestParallelACExecutor:
             session_id="orch_123",
             execution_id="exec_123",
         )
-
         assert finalized.success is True
         assert counter.read_text(encoding="utf-8") == "1"
+
+        # A second finalization consumes the durable outcome — still single-shot.
+        again = await executor._apply_verify_gate(
+            seed=seed,
+            ac_index=0,
+            result=finalized,
+            session_id="orch_123",
+            execution_id="exec_123",
+        )
+        assert again.success is True
+        assert counter.read_text(encoding="utf-8") == "1"
+
+    @pytest.mark.asyncio
+    async def test_verify_command_reflects_final_workspace_not_leaf_snapshot(
+        self, tmp_path: Any
+    ) -> None:
+        """R13 blocker #1: the verify_command is authoritative for the FINAL workspace.
+
+        The command is deferred out of the concurrent atomic leaf, so a workspace
+        mutation after the leaf (a sibling-style edit) is reflected: the deferred
+        gate re-evaluates the predicate over the final state and fails the AC.
+        """
+        target = tmp_path / "marker.txt"
+        target.write_text("PASS_CONTENT\n", encoding="utf-8")
+        spec = AcceptanceCriterionSpec(
+            description="marker.txt contains PASS_CONTENT",
+            verify_command="grep -q PASS_CONTENT marker.txt",
+        )
+        seed = _make_seed(spec)
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = str(tmp_path)
+            permission_mode = "acceptEdits"
+
+            async def execute_task(self, **_kwargs: object):
+                yield AgentMessage(type="result", content="[TASK_COMPLETE]")
+
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_Runtime(),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            task_cwd=str(tmp_path),
+        )
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="marker.txt contains PASS_CONTENT",
+            session_id="orch_final_ws",
+            tools=["Read"],
+            system_prompt="system",
+            seed_goal="Ship",
+            depth=0,
+            start_time=datetime.now(UTC),
+            ac_spec=spec,
+        )
+        # Leaf deferred the command (did not evaluate the predicate).
+        assert result.verify_gate_outcome is None
+
+        # A sibling-style mutation lands AFTER the leaf but before the authoritative gate.
+        target.write_text("FAIL_CONTENT\n", encoding="utf-8")
+
+        finalized = await executor._apply_verify_gate(
+            seed=seed,
+            ac_index=0,
+            result=result,
+            session_id="orch_final_ws",
+            execution_id="orch_final_ws",
+        )
+        # The gate observed the FINAL (mutated) workspace and failed the AC.
+        assert finalized.success is False
 
     @pytest.mark.asyncio
     async def test_completed_recovery_reuses_durable_verify_outcome_without_command_replay(

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -12613,6 +12613,89 @@ class TestParallelACExecutor:
         assert "mutat" in (gated.verify_gate_outcome.reason or "").lower()
 
     @pytest.mark.asyncio
+    async def test_final_workspace_acceptance_flips_stale_pass_to_failed(
+        self, tmp_path: Any
+    ) -> None:
+        """R16/B1: acceptance is re-verified over the TRUE final workspace.
+
+        An AC accepted by an earlier per-attempt gate is re-run over the final
+        tree; if a later stage or coordinator reconciliation invalidated its
+        verified file, the final-workspace gate flips it to FAILED so no accepted
+        verdict predates the final workspace.
+        """
+        marker = tmp_path / "marker.txt"
+        marker.write_text("good\n", encoding="utf-8")
+        spec = AcceptanceCriterionSpec(
+            description="marker stays good", verify_command="grep -q good marker.txt"
+        )
+        seed = _make_seed(spec)
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory=str(tmp_path),
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            task_cwd=str(tmp_path),
+        )
+        accepted = ACExecutionResult(
+            ac_index=0,
+            ac_content="ac",
+            success=True,
+            outcome=ACExecutionOutcome.SUCCEEDED,
+        )
+        # A later stage invalidates the file the earlier gate verified.
+        marker.write_text("bad\n", encoding="utf-8")
+
+        results = await executor._apply_final_workspace_acceptance(
+            seed=seed, results=[accepted], session_id="s", execution_id="e"
+        )
+
+        assert results[0].success is False
+        assert results[0].outcome == ACExecutionOutcome.FAILED
+        assert "final-workspace" in (results[0].error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_final_workspace_acceptance_confirms_valid_pass(self, tmp_path: Any) -> None:
+        """R16/B1: an AC still satisfied at the final workspace stays accepted."""
+        (tmp_path / "marker.txt").write_text("good\n", encoding="utf-8")
+        spec = AcceptanceCriterionSpec(
+            description="marker stays good", verify_command="grep -q good marker.txt"
+        )
+        seed = _make_seed(spec)
+        event_store, appended = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory=str(tmp_path),
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            task_cwd=str(tmp_path),
+        )
+        accepted = ACExecutionResult(
+            ac_index=0,
+            ac_content="ac",
+            success=True,
+            outcome=ACExecutionOutcome.SUCCEEDED,
+        )
+
+        results = await executor._apply_final_workspace_acceptance(
+            seed=seed, results=[accepted], session_id="s", execution_id="e"
+        )
+
+        assert results[0].success is True
+        assert results[0].outcome == ACExecutionOutcome.SUCCEEDED
+        # The authoritative terminal marker is (re)published only after this gate.
+        finalized = [e for e in appended if e.type == "execution.ac.outcome_finalized"]
+        assert finalized and finalized[-1].data["success"] is True
+
+    @pytest.mark.asyncio
     async def test_completed_recovery_reuses_durable_verify_outcome_without_command_replay(
         self, tmp_path: Any
     ) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -18,10 +18,12 @@ from ouroboros.core.seed import (
     OntologySchema,
     Seed,
     SeedMetadata,
+    derive_semantic_ac_key,
 )
 from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.types import MCPToolDefinition
 from ouroboros.orchestrator.ac_execution_capsule import (
+    ACExecutionCapsule,
     ACExecutionCapsuleManifest,
     compile_ac_execution_capsule,
 )
@@ -38,6 +40,7 @@ from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
 from ouroboros.orchestrator.evidence.claims import _runtime_messages_support_file_claim
 from ouroboros.orchestrator.evidence_schema import EvidenceRecord, ValidationResult
 from ouroboros.orchestrator.execution_runtime_scope import (
+    ACRuntimeIdentity,
     ExecutionNodeIdentity,
     build_ac_runtime_identity,
 )
@@ -953,6 +956,49 @@ def _make_replaying_event_store() -> tuple[AsyncMock, list[BaseEvent]]:
     event_store.append.side_effect = _append
     event_store.replay.side_effect = _replay
     return event_store, appended_events
+
+
+def _compile_test_capsule(
+    *,
+    ac_index: int,
+    ac_content: str,
+    session_id: str,
+    seed_goal: str,
+    retry_attempt: int = 0,
+    workspace: str = "/tmp/project",
+) -> tuple[ACRuntimeIdentity, ACExecutionCapsule]:
+    identity = build_ac_runtime_identity(
+        ac_index,
+        execution_context_id=session_id,
+        retry_attempt=retry_attempt,
+    )
+    capsule = compile_ac_execution_capsule(
+        runtime_identity=identity,
+        execution_id=session_id,
+        semantic_ac_key=derive_semantic_ac_key(ac_content),
+        workspace=os.path.realpath(workspace),
+        authority_scope=f"execution:{session_id}",
+        seed_goal=seed_goal,
+        ac_content=ac_content,
+        ac_spec=None,
+    )
+    return identity, capsule
+
+
+def _compiled_capsule_event(
+    identity: ACRuntimeIdentity,
+    capsule: ACExecutionCapsule,
+) -> BaseEvent:
+    return BaseEvent(
+        type="execution.ac.capsule.compiled",
+        aggregate_type="execution",
+        aggregate_id=identity.session_scope_id,
+        data={
+            **identity.to_metadata(),
+            "capsule_fingerprint": capsule.fingerprint,
+            "capsule_manifest": capsule.manifest.to_contract_data(),
+        },
+    )
 
 
 @pytest.mark.parametrize(
@@ -4516,6 +4562,177 @@ class TestParallelACExecutor:
             )
 
         assert runtime.calls == 0
+
+    @pytest.mark.asyncio
+    async def test_atomic_ac_resumes_only_with_matching_durable_capsule(self) -> None:
+        """A native handle may resume only after the exact capsule is durable."""
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            def __init__(self) -> None:
+                self.resume_handles: list[RuntimeHandle | None] = []
+
+            async def execute_task(self, **kwargs: object):
+                self.resume_handles.append(kwargs.get("resume_handle"))
+                yield AgentMessage(type="result", content="[TASK_COMPLETE]")
+
+        runtime = _Runtime()
+        event_store, appended_events = _make_replaying_event_store()
+        runtime_identity = build_ac_runtime_identity(
+            0,
+            execution_context_id="session-capsule-resume",
+            retry_attempt=0,
+        )
+        persisted_capsule = compile_ac_execution_capsule(
+            runtime_identity=runtime_identity,
+            execution_id="session-capsule-resume",
+            semantic_ac_key="semantic-key",
+            workspace=os.path.realpath("/tmp/project"),
+            authority_scope="execution:session-capsule-resume",
+            seed_goal="Ship",
+            ac_content="Implement the AC",
+            ac_spec=None,
+        )
+        persisted_handle = RuntimeHandle(
+            backend="codex_cli",
+            kind="implementation_session",
+            native_session_id="codex-same-attempt",
+            cwd="/tmp/project",
+            approval_mode="acceptEdits",
+            metadata={
+                **runtime_identity.to_metadata(),
+                "ac_capsule_version": persisted_capsule.version,
+                "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_session_origin": "fresh",
+            },
+        )
+        appended_events.extend(
+            [
+                BaseEvent(
+                    type="execution.ac.capsule.compiled",
+                    aggregate_type="execution",
+                    aggregate_id=runtime_identity.session_scope_id,
+                    data={
+                        **runtime_identity.to_metadata(),
+                        "capsule_fingerprint": persisted_capsule.fingerprint,
+                        "capsule_manifest": persisted_capsule.manifest.to_contract_data(),
+                    },
+                ),
+                BaseEvent(
+                    type="execution.session.started",
+                    aggregate_type="execution",
+                    aggregate_id=runtime_identity.session_scope_id,
+                    data={
+                        **runtime_identity.to_metadata(),
+                        "runtime": persisted_handle.to_dict(),
+                    },
+                ),
+            ]
+        )
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+
+        await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement the AC",
+            session_id="session-capsule-resume",
+            tools=["Read", "Edit"],
+            system_prompt="system",
+            seed_goal="Ship",
+            depth=0,
+            start_time=datetime.now(UTC),
+            semantic_ac_key="semantic-key",
+        )
+
+        assert runtime.resume_handles[0] is not None
+        assert runtime.resume_handles[0].native_session_id == "codex-same-attempt"
+        compiled_events = [
+            event for event in appended_events if event.type == "execution.ac.capsule.compiled"
+        ]
+        assert compiled_events[-1].data["session_origin"] == "restored_same_attempt"
+
+    @pytest.mark.asyncio
+    async def test_atomic_ac_does_not_resume_legacy_handle_without_capsule(self) -> None:
+        """Pre-capsule runtime history can seed no provider continuity."""
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            def __init__(self) -> None:
+                self.resume_handles: list[RuntimeHandle | None] = []
+
+            async def execute_task(self, **kwargs: object):
+                self.resume_handles.append(kwargs.get("resume_handle"))
+                yield AgentMessage(type="result", content="[TASK_COMPLETE]")
+
+        runtime = _Runtime()
+        event_store, appended_events = _make_replaying_event_store()
+        current_identity = build_ac_runtime_identity(
+            0,
+            execution_context_id="session-capsule-legacy",
+            retry_attempt=1,
+        )
+        legacy_handle = RuntimeHandle(
+            backend="codex_cli",
+            kind="implementation_session",
+            native_session_id="legacy-retry-session",
+            cwd="/tmp/project",
+            approval_mode="acceptEdits",
+            metadata={
+                "ac_id": current_identity.ac_id,
+                "scope": "ac",
+                "session_role": "implementation",
+                "ac_index": 0,
+                "session_scope_id": current_identity.session_scope_id,
+            },
+        )
+        appended_events.append(
+            BaseEvent(
+                type="execution.session.started",
+                aggregate_type="execution",
+                aggregate_id=current_identity.session_scope_id,
+                data={
+                    "ac_id": current_identity.ac_id,
+                    "session_scope_id": current_identity.session_scope_id,
+                    "runtime": legacy_handle.to_dict(),
+                },
+            )
+        )
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+
+        await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement the AC",
+            session_id="session-capsule-legacy",
+            tools=["Read", "Edit"],
+            system_prompt="system",
+            seed_goal="Ship",
+            depth=0,
+            start_time=datetime.now(UTC),
+            retry_attempt=1,
+            semantic_ac_key="semantic-key",
+        )
+
+        assert runtime.resume_handles[0] is not None
+        assert runtime.resume_handles[0].native_session_id is None
+        compiled_event = next(
+            event for event in appended_events if event.type == "execution.ac.capsule.compiled"
+        )
+        assert compiled_event.data["session_origin"] == "fresh"
 
     @pytest.mark.asyncio
     async def test_atomic_ac_refuses_dispatch_when_capsule_replay_is_unreadable(self) -> None:
@@ -10768,27 +10985,31 @@ class TestParallelACExecutor:
                     resume_handle=resume_handle,
                 )
 
+        ac_content = "Resume the interrupted AC implementation session"
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            ac_index=1,
+            ac_content=ac_content,
+            session_id="orch_123",
+            seed_goal="Ship the feature",
+        )
         persisted_handle = RuntimeHandle(
             backend="opencode",
             kind="implementation_session",
             native_session_id="opencode-session-9",
             cwd="/tmp/project",
-            approval_mode="acceptEdits",
+            approval_mode="bypassPermissions",
             metadata={
-                "scope": "ac",
-                "session_role": "implementation",
-                "retry_attempt": 0,
-                "ac_index": 1,
-                "session_scope_id": "orch_123_ac_2",
-                "session_state_path": (
-                    "execution.workflows.orch_123.acceptance_criteria.ac_2.implementation_session"
-                ),
+                **runtime_identity.to_metadata(),
                 "server_session_id": "server-99",
+                "ac_capsule_version": persisted_capsule.version,
+                "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_session_origin": "fresh",
             },
         )
         event_store = AsyncMock()
         event_store.replay = AsyncMock(
             return_value=[
+                _compiled_capsule_event(runtime_identity, persisted_capsule),
                 BaseEvent(
                     type="execution.session.started",
                     aggregate_type="execution",
@@ -10801,7 +11022,7 @@ class TestParallelACExecutor:
                         ),
                         "runtime": persisted_handle.to_dict(),
                     },
-                )
+                ),
             ]
         )
         event_store.append = AsyncMock()
@@ -10815,7 +11036,7 @@ class TestParallelACExecutor:
 
         result = await executor._execute_atomic_ac(
             ac_index=1,
-            ac_content="Resume the interrupted AC implementation session",
+            ac_content=ac_content,
             session_id="orch_123",
             tools=["Read", "Edit"],
             system_prompt="system",
@@ -11002,6 +11223,13 @@ class TestParallelACExecutor:
                     resume_handle=resume_handle,
                 )
 
+        ac_content = "Resume the latest persisted implementation session"
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            ac_index=1,
+            ac_content=ac_content,
+            session_id="orch_123",
+            seed_goal="Ship the feature",
+        )
         started_handle = RuntimeHandle(
             backend="opencode",
             kind="implementation_session",
@@ -11009,15 +11237,11 @@ class TestParallelACExecutor:
             cwd="/tmp/project",
             approval_mode="acceptEdits",
             metadata={
-                "scope": "ac",
-                "session_role": "implementation",
-                "retry_attempt": 0,
-                "ac_index": 1,
-                "session_scope_id": "orch_123_ac_2",
-                "session_state_path": (
-                    "execution.workflows.orch_123.acceptance_criteria.ac_2.implementation_session"
-                ),
+                **runtime_identity.to_metadata(),
                 "server_session_id": "server-started",
+                "ac_capsule_version": persisted_capsule.version,
+                "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_session_origin": "fresh",
             },
         )
         resumed_handle = RuntimeHandle(
@@ -11027,20 +11251,17 @@ class TestParallelACExecutor:
             cwd="/tmp/project",
             approval_mode="acceptEdits",
             metadata={
-                "scope": "ac",
-                "session_role": "implementation",
-                "retry_attempt": 0,
-                "ac_index": 1,
-                "session_scope_id": "orch_123_ac_2",
-                "session_state_path": (
-                    "execution.workflows.orch_123.acceptance_criteria.ac_2.implementation_session"
-                ),
+                **runtime_identity.to_metadata(),
                 "server_session_id": "server-resumed",
+                "ac_capsule_version": persisted_capsule.version,
+                "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_session_origin": "restored_same_attempt",
             },
         )
         event_store = AsyncMock()
         event_store.replay = AsyncMock(
             return_value=[
+                _compiled_capsule_event(runtime_identity, persisted_capsule),
                 BaseEvent(
                     type="execution.session.started",
                     aggregate_type="execution",
@@ -11080,7 +11301,7 @@ class TestParallelACExecutor:
 
         result = await executor._execute_atomic_ac(
             ac_index=1,
-            ac_content="Resume the latest persisted implementation session",
+            ac_content=ac_content,
             session_id="orch_123",
             tools=["Read", "Edit"],
             system_prompt="system",
@@ -12609,6 +12830,13 @@ class TestParallelACExecutor:
                     resume_handle=resume_handle,
                 )
 
+        ac_content = "Resume after skipping invalid persisted event"
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            ac_index=1,
+            ac_content=ac_content,
+            session_id="orch_123",
+            seed_goal="Ship the feature",
+        )
         valid_handle = RuntimeHandle(
             backend="opencode",
             kind="implementation_session",
@@ -12616,20 +12844,17 @@ class TestParallelACExecutor:
             cwd="/tmp/project",
             approval_mode="acceptEdits",
             metadata={
-                "scope": "ac",
-                "session_role": "implementation",
-                "retry_attempt": 0,
-                "ac_index": 1,
-                "session_scope_id": "orch_123_ac_2",
-                "session_state_path": (
-                    "execution.workflows.orch_123.acceptance_criteria.ac_2.implementation_session"
-                ),
+                **runtime_identity.to_metadata(),
                 "server_session_id": "server-valid",
+                "ac_capsule_version": persisted_capsule.version,
+                "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_session_origin": "fresh",
             },
         )
         event_store = AsyncMock()
         event_store.replay = AsyncMock(
             return_value=[
+                _compiled_capsule_event(runtime_identity, persisted_capsule),
                 # First event: valid handle
                 BaseEvent(
                     type="execution.session.started",
@@ -12675,7 +12900,7 @@ class TestParallelACExecutor:
 
         result = await executor._execute_atomic_ac(
             ac_index=1,
-            ac_content="Resume after skipping invalid persisted event",
+            ac_content=ac_content,
             session_id="orch_123",
             tools=["Read", "Edit"],
             system_prompt="system",

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -3152,7 +3152,6 @@ class TestInfraFatalExemption:
             console=MagicMock(),
             enable_decomposition=False,
         )
-
         result = await executor._execute_atomic_ac(
             ac_index=0,
             ac_content="Implement AC 1",
@@ -4553,6 +4552,100 @@ class TestParallelACExecutor:
         assert result.session_id == "opencode-session-1"
         assert result.runtime_handle is not None
         assert result.runtime_handle.native_session_id == "opencode-session-1"
+
+    @pytest.mark.asyncio
+    async def test_provider_handle_keeps_capsule_metadata_when_runtime_returns_none(self) -> None:
+        """Bare provider handles inherit the bound same-attempt authority metadata."""
+
+        class _BareHandleRuntime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            async def execute_task(self, **_kwargs: object):
+                yield AgentMessage(
+                    type="system",
+                    content="session ready",
+                    data={"session_id": "bare-provider-session"},
+                    resume_handle=RuntimeHandle(
+                        backend="codex_cli",
+                        kind="agent_runtime",
+                        native_session_id="bare-provider-session",
+                        cwd="/tmp/project",
+                        approval_mode="acceptEdits",
+                        metadata={},
+                    ),
+                )
+                yield AgentMessage(
+                    type="result",
+                    content="[TASK_COMPLETE]",
+                    data={"subtype": "success"},
+                )
+
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=_BareHandleRuntime(),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        node_identity = ExecutionNodeIdentity.root(
+            execution_context_id="session-bare-provider",
+            ac_index=0,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Preserve capsule authority on provider handles",
+            session_id="session-bare-provider",
+            tools=["Read"],
+            system_prompt="system",
+            seed_goal="Ship",
+            depth=0,
+            start_time=datetime.now(UTC),
+            node_identity=node_identity,
+        )
+
+        assert result.runtime_handle is not None
+        fingerprint = result.runtime_handle.metadata["ac_capsule_fingerprint"]
+        expected_identity = build_ac_runtime_identity(
+            0,
+            execution_context_id="session-bare-provider",
+            node_identity=node_identity,
+            retry_attempt=0,
+        )
+        assert (
+            result.runtime_handle.metadata["session_attempt_id"]
+            == expected_identity.session_attempt_id
+        )
+        started = next(
+            event for event in appended_events if event.type == "execution.session.started"
+        )
+        assert started.data["runtime"]["metadata"]["ac_capsule_fingerprint"] == fingerprint
+
+        replay_store, replay_events = _make_replaying_event_store()
+        replay_events.extend(
+            event
+            for event in appended_events
+            if event.type in {"execution.ac.capsule.compiled", "execution.session.started"}
+        )
+        restarted = ParallelACExecutor(
+            adapter=_BareHandleRuntime(),
+            event_store=replay_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        restored = await restarted._load_persisted_ac_runtime_handle(
+            0,
+            execution_context_id="session-bare-provider",
+            retry_attempt=0,
+            node_identity=node_identity,
+            expected_capsule_fingerprint=fingerprint,
+            expected_capsule_workspace=os.path.realpath("/tmp/project"),
+        )
+        assert restored is not None
+        assert restored.native_session_id == "bare-provider-session"
+        assert restored.metadata["ac_capsule_fingerprint"] == fingerprint
 
     @pytest.mark.asyncio
     async def test_atomic_ac_does_not_dispatch_when_capsule_persistence_fails(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1139,7 +1139,7 @@ def test_capsule_authority_distinguishes_verifier_closure_state() -> None:
     )
 
     assert passing._atomic_verifier_authority != rejecting._atomic_verifier_authority
-    assert passing._atomic_verifier_authority["behavioral_state"]["stability"] == "durable"
+    assert passing._atomic_verifier_authority["behavioral_state"]["stability"] == "process_local"
 
 
 def test_capsule_authority_distinguishes_callable_verifier_state() -> None:
@@ -1151,6 +1151,9 @@ def test_capsule_authority_distinguishes_callable_verifier_state() -> None:
 
         def __call__(self, **_kwargs: Any) -> VerifierVerdict:
             return VerifierVerdict(passed=self.passed)
+
+        def verification_identity_contract(self) -> dict[str, object]:
+            return {"version": 1, "passed": self.passed}
 
     runtime = SimpleNamespace(
         runtime_backend="codex_cli",
@@ -1171,8 +1174,16 @@ def test_capsule_authority_distinguishes_callable_verifier_state() -> None:
         enable_decomposition=False,
         atomic_verifier=ConfiguredVerifier(False),
     )
+    matching = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        atomic_verifier=ConfiguredVerifier(True),
+    )
 
     assert passing._atomic_verifier_authority != rejecting._atomic_verifier_authority
+    assert passing._atomic_verifier_authority == matching._atomic_verifier_authority
     assert passing._atomic_verifier_authority["behavioral_state"]["stability"] == "durable"
 
 
@@ -1201,7 +1212,7 @@ def test_capsule_authority_distinguishes_referenced_verifier_globals(monkeypatch
     )
 
     assert passing._atomic_verifier_authority != rejecting._atomic_verifier_authority
-    assert passing._atomic_verifier_authority["behavioral_state"]["stability"] == "durable"
+    assert passing._atomic_verifier_authority["behavioral_state"]["stability"] == "process_local"
 
 
 def test_capsule_authority_reuses_large_context_and_catalog_digests(monkeypatch) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -27,6 +27,7 @@ from ouroboros.orchestrator.ac_execution_capsule import (
     ACExecutionCapsuleManifest,
     compile_ac_execution_capsule,
 )
+from ouroboros.orchestrator.ac_runtime_handle_manager import AmbiguousACExecutionError
 from ouroboros.orchestrator.adapter import (
     FULL_CAPABILITIES,
     AgentMessage,
@@ -4679,6 +4680,70 @@ class TestParallelACExecutor:
                 ac_index=0,
                 ac_content="Implement the AC",
                 session_id="session-capsule-failure",
+                tools=["Read", "Edit"],
+                system_prompt="system",
+                seed_goal="Ship",
+                depth=0,
+                start_time=datetime.now(UTC),
+            )
+
+        assert runtime.calls == 0
+
+    @pytest.mark.asyncio
+    async def test_atomic_ac_refuses_fresh_dispatch_after_unresumable_tool_effect(self) -> None:
+        """A crash after a tool effect cannot be recovered by duplicating the attempt."""
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def execute_task(self, **_kwargs: object):
+                self.calls += 1
+                yield AgentMessage(type="result", content="[TASK_COMPLETE]")
+
+        runtime = _Runtime()
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Apply one non-idempotent migration",
+            session_id="session-capsule-effect",
+            seed_goal="Ship",
+        )
+        appended_events.extend(
+            [
+                _compiled_capsule_event(runtime_identity, persisted_capsule),
+                BaseEvent(
+                    type="execution.tool.completed",
+                    aggregate_type="execution",
+                    aggregate_id=runtime_identity.session_scope_id,
+                    data={
+                        **runtime_identity.to_metadata(),
+                        "tool_name": "Bash",
+                        "tool_result_text": "migration applied",
+                    },
+                ),
+            ]
+        )
+
+        with pytest.raises(
+            AmbiguousACExecutionError,
+            match="recorded tool effects without a reusable runtime handle",
+        ):
+            await executor._execute_atomic_ac(
+                ac_index=0,
+                ac_content="Apply one non-idempotent migration",
+                session_id="session-capsule-effect",
                 tools=["Read", "Edit"],
                 system_prompt="system",
                 seed_goal="Ship",

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1382,6 +1382,92 @@ def test_bound_verify_gate_outcome_caps_and_rejects_oversized() -> None:
         )
 
 
+def test_bound_verify_gate_outcome_rejects_type_coercion() -> None:
+    """R6 blocker #3: replay validation must not coerce a verdict.
+
+    A persisted outcome with a non-boolean ``passed`` (e.g. ``"false"`` or ``1``)
+    must be rejected, never coerced into a trusted PASS; unknown fields and
+    non-string artifacts are rejected too.
+    """
+    from ouroboros.orchestrator.execution_event_emitter import bound_verify_gate_outcome
+
+    base = {"passed": True, "reason": None, "output_tail": "", "missing_artifacts": []}
+
+    for bad_passed in ("false", "true", 1, 0, None):
+        with pytest.raises(ValueError, match="'passed' is not a boolean"):
+            bound_verify_gate_outcome({**base, "passed": bad_passed})
+
+    with pytest.raises(ValueError, match="unexpected fields"):
+        bound_verify_gate_outcome({**base, "injected": "x"})
+
+    with pytest.raises(ValueError, match="missing required fields"):
+        bound_verify_gate_outcome({"passed": True})
+
+    with pytest.raises(ValueError, match="'missing_artifacts' is not a list of strings"):
+        bound_verify_gate_outcome({**base, "missing_artifacts": [123]})
+
+    # A correctly-typed payload round-trips unchanged.
+    assert bound_verify_gate_outcome(base) == base
+
+
+def test_runtime_capabilities_contract_includes_realtime_effect_visibility() -> None:
+    """R6 blocker #1: the stall-affecting capability participates in authority."""
+    from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
+
+    class _Runtime:
+        runtime_backend = "codex_cli"
+        working_directory = "/tmp/project"
+        permission_mode = "acceptEdits"
+
+        def __init__(self, *, realtime: bool) -> None:
+            self.capabilities = replace(FULL_CAPABILITIES, realtime_tool_effect_visibility=realtime)
+
+    def _authority(realtime: bool) -> dict[str, object]:
+        executor = ParallelACExecutor(
+            adapter=_Runtime(realtime=realtime),
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        return executor._build_capsule_dispatch_authority_contract(
+            tools=["Read"],
+            tool_catalog=None,
+            system_prompt="system",
+            level_contexts=None,
+        )
+
+    with_rt = _authority(True)
+    without_rt = _authority(False)
+    assert (
+        with_rt["runtime"]["capabilities"]["realtime_tool_effect_visibility"] is True  # type: ignore[index]
+    )
+    assert with_rt != without_rt
+
+
+def test_runtime_executable_identity_resolves_relative_path_against_child_cwd(
+    tmp_path: Any,
+) -> None:
+    """R6 blocker #4: a relative ``./tool`` binds to the child cwd's target."""
+    import os as _os
+
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    link = workspace / "tool"
+    link.symlink_to("/bin/true")
+
+    class _Runtime:
+        _cli_path = "./tool"
+
+    identity = ParallelACExecutor._runtime_executable_identity(_Runtime(), cwd=str(workspace))
+    assert identity["executable"]["realpath"] == _os.path.realpath(str(workspace / "tool"))
+
+    # Swapping the symlink target under the SAME cwd changes authority.
+    link.unlink()
+    link.symlink_to("/bin/false")
+    swapped = ParallelACExecutor._runtime_executable_identity(_Runtime(), cwd=str(workspace))
+    assert swapped["executable"]["realpath"] != identity["executable"]["realpath"]
+
+
 def test_capsule_authority_covers_prompt_gate_runtime_and_verifier_inputs() -> None:
     """Every input that can alter provider work or acceptance must change authority."""
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -4735,6 +4735,60 @@ class TestParallelACExecutor:
         assert compiled_event.data["session_origin"] == "fresh"
 
     @pytest.mark.asyncio
+    async def test_capsule_resume_rejects_foreign_workspace_handle(self) -> None:
+        """A matching fingerprint cannot authorize continuity from another checkout."""
+        runtime_identity, capsule = _compile_test_capsule(
+            ac_index=0,
+            ac_content="Implement the AC",
+            session_id="session-capsule-foreign-workspace",
+            seed_goal="Ship",
+        )
+        foreign_handle = RuntimeHandle(
+            backend="codex_cli",
+            kind="implementation_session",
+            native_session_id="foreign-workspace-session",
+            cwd="/tmp/foreign-project",
+            approval_mode="acceptEdits",
+            metadata={
+                **runtime_identity.to_metadata(),
+                "ac_capsule_fingerprint": capsule.fingerprint,
+            },
+        )
+        event_store = AsyncMock()
+        event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, capsule),
+            BaseEvent(
+                type="execution.session.started",
+                aggregate_type="execution",
+                aggregate_id=runtime_identity.session_scope_id,
+                data={
+                    **runtime_identity.to_metadata(),
+                    "runtime": foreign_handle.to_dict(),
+                },
+            ),
+        ]
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+
+        with pytest.raises(ValueError, match="workspace authority changed"):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="session-capsule-foreign-workspace",
+                retry_attempt=0,
+                expected_capsule_fingerprint=capsule.fingerprint,
+                expected_capsule_workspace=capsule.workspace,
+            )
+
+    @pytest.mark.asyncio
     async def test_atomic_ac_refuses_dispatch_when_capsule_replay_is_unreadable(self) -> None:
         """A fresh dispatch cannot guess that no authority-bearing capsule exists."""
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1183,6 +1183,51 @@ def test_runtime_executable_identity_binds_zcode_launcher() -> None:
     assert identity["launcher"]["path"] == "/opt/zcode/node"
 
 
+def test_runtime_executable_identity_follows_delegated_transport() -> None:
+    """R3 blocker #4: a runtime whose real CLI lives on a wrapped transport.
+
+    ``LeaderDrivenWorkerRuntime`` keeps the launched binary under
+    ``_transport._cli_path``. Two such runtimes at different transport binaries
+    must not both fingerprint as ``observed=False`` / identical authority.
+    """
+
+    class _Transport:
+        def __init__(self, cli_path: str) -> None:
+            self._cli_path = cli_path
+
+    class _WrappingRuntime:
+        # Mirrors LeaderDrivenWorkerRuntime.executable_identity_contract delegating
+        # to its transport's executable.
+        def __init__(self, cli_path: str) -> None:
+            self._transport = _Transport(cli_path)
+
+        def executable_identity_contract(self) -> dict[str, str | None]:
+            return {"executable": self._transport._cli_path, "launcher": None}
+
+    true_identity = ParallelACExecutor._runtime_executable_identity(_WrappingRuntime("/bin/true"))
+    false_identity = ParallelACExecutor._runtime_executable_identity(_WrappingRuntime("/bin/false"))
+    assert true_identity["observed"] is True
+    assert false_identity["observed"] is True
+    assert true_identity["executable"]["path"] == "/bin/true"
+    assert false_identity["executable"]["path"] == "/bin/false"
+    assert true_identity != false_identity
+
+
+def test_runtime_executable_identity_probes_transport_without_contract() -> None:
+    """R3 blocker #4: even without an explicit contract, a wrapped transport's
+    ``_cli_path`` is probed one delegation level so the launcher still binds."""
+
+    class _Transport:
+        _cli_path = "/usr/local/bin/worker-cli"
+
+    class _WrappingRuntime:
+        _transport = _Transport()
+
+    identity = ParallelACExecutor._runtime_executable_identity(_WrappingRuntime())
+    assert identity["observed"] is True
+    assert identity["executable"]["path"] == "/usr/local/bin/worker-cli"
+
+
 def test_capsule_authority_covers_prompt_gate_runtime_and_verifier_inputs() -> None:
     """Every input that can alter provider work or acceptance must change authority."""
 
@@ -5482,7 +5527,7 @@ class TestParallelACExecutor:
             ]
         )
 
-        with pytest.raises(AmbiguousACExecutionError, match="failed without a reusable"):
+        with pytest.raises(AmbiguousACExecutionError, match="terminally failed dispatch head"):
             await executor._load_persisted_ac_runtime_handle(
                 0,
                 execution_context_id="session-dispatch-terminal-successor",
@@ -5492,9 +5537,15 @@ class TestParallelACExecutor:
             )
 
     @pytest.mark.asyncio
-    async def test_capsule_loader_resumes_failed_dispatch_with_correlated_handle(self) -> None:
-        """A failure is recoverable only when its exact provider session is reconnectable."""
+    async def test_capsule_loader_fails_closed_on_failed_head_even_with_handle(self) -> None:
+        """R3 blocker #1: a terminally failed head is not resumed even with a handle.
 
+        A durable ``execution.session.failed`` head ran a provider turn whose
+        effects may precede the reported failure; resuming its session would send
+        another provider turn and could repeat non-idempotent effects. Without an
+        explicit ``execution.session.recovered`` linkage, recovery must fail closed
+        rather than reconnect to the failed session.
+        """
         runtime = SimpleNamespace(
             runtime_backend="codex_cli",
             working_directory="/tmp/project",
@@ -5510,7 +5561,7 @@ class TestParallelACExecutor:
         runtime_identity, persisted_capsule = _compile_test_capsule(
             executor=executor,
             ac_index=0,
-            ac_content="Resume the exact provider session after adapter failure",
+            ac_content="Do not resume a terminally failed provider session",
             session_id="session-dispatch-failed-resume",
             seed_goal="Ship",
         )
@@ -5543,16 +5594,14 @@ class TestParallelACExecutor:
             ),
         ]
 
-        restored = await executor._load_persisted_ac_runtime_handle(
-            0,
-            execution_context_id="session-dispatch-failed-resume",
-            retry_attempt=0,
-            expected_capsule_fingerprint=persisted_capsule.fingerprint,
-            expected_capsule_workspace=persisted_capsule.workspace,
-        )
-
-        assert restored is not None
-        assert restored.native_session_id == "codex-failed-resume"
+        with pytest.raises(AmbiguousACExecutionError, match="terminally failed dispatch head"):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="session-dispatch-failed-resume",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
 
     @pytest.mark.asyncio
     async def test_capsule_loader_resumes_only_latest_boundary_in_multi_dispatch_attempt(
@@ -5598,9 +5647,12 @@ class TestParallelACExecutor:
             )
 
         event_store.replay.return_value = [
+            # Both boundaries are resumable (started) — this test isolates
+            # latest-boundary head selection, not failed-head recovery, which is
+            # covered by test_capsule_loader_fails_closed_on_failed_head_even_with_handle.
             _dispatch_lifecycle_event(
                 runtime_identity,
-                "execution.session.failed",
+                "execution.session.started",
                 dispatch_id=second_dispatch_id,
                 runtime_handle=_handle("response-after-signal"),
             ),
@@ -12888,7 +12940,7 @@ class TestParallelACExecutor:
                 )
                 await anyio.sleep_forever()
 
-        event_store, _ = _make_replaying_event_store()
+        event_store, appended = _make_replaying_event_store()
         runtime = _EffectfulThenStallRuntime()
         executor = ParallelACExecutor(
             adapter=runtime,
@@ -12911,6 +12963,10 @@ class TestParallelACExecutor:
             )
 
         assert runtime.calls == 1
+        # R3 blocker #2: the ambiguity is persisted (sealed) BEFORE the raise, so a
+        # cold restart fails closed on the sealed head instead of re-entering the
+        # provider using the dispatch's still-resumable session handle.
+        assert any(e.type == "execution.ac.dispatch.sealed" for e in appended)
 
     @pytest.mark.asyncio
     async def test_effect_free_stall_stays_retryable(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -13066,6 +13122,64 @@ class TestParallelACExecutor:
                 identity_metadata={"ac_id": "ac-0"},
             )
         assert run_count == 0  # the possibly-executed command was NOT run again
+
+    @pytest.mark.asyncio
+    async def test_apply_verify_gate_recovery_is_single_shot(self) -> None:
+        """R3 blocker #3: the failed-runtime recovery gate uses the single-shot oracle.
+
+        A failed atomic result carries no cached outcome, so `_apply_verify_gate`
+        runs the verify command. Replaying the SAME failed result must consume the
+        durable outcome instead of running the (side-effecting) command twice.
+        """
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        run_count = 0
+
+        async def _counting_gate(*, spec: Any, cwd: str) -> _VerifyGateOutcome:
+            nonlocal run_count
+            run_count += 1
+            return _VerifyGateOutcome(passed=True, reason=None, output_tail="ok")
+
+        executor._run_ac_verify_gate = _counting_gate  # type: ignore[method-assign]
+        seed = _make_seed(
+            AcceptanceCriterionSpec(description="AC", verify_command="./deploy.sh"),
+        )
+        failed_result = ACExecutionResult(
+            ac_index=0,
+            ac_content="AC",
+            success=False,
+            error="runtime failed",
+            retry_attempt=0,
+        )
+
+        first = await executor._apply_verify_gate(
+            seed=seed,
+            ac_index=0,
+            result=failed_result,
+            session_id="sess",
+            execution_id="exec-apply-gate",
+        )
+        assert run_count == 1
+        assert first.success is True  # contract passed → recovered
+
+        # Replaying the same failed result must not run the command again.
+        await executor._apply_verify_gate(
+            seed=seed,
+            ac_index=0,
+            result=failed_result,
+            session_id="sess",
+            execution_id="exec-apply-gate",
+        )
+        assert run_count == 1
 
     @pytest.mark.asyncio
     async def test_alt_harness_defers_until_same_runtime_retry_budget_spent(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1066,6 +1066,24 @@ def _dispatched_capsule_event(
     )
 
 
+def _sealed_dispatch_event(
+    identity: ACRuntimeIdentity,
+    capsule: ACExecutionCapsule,
+    *,
+    dispatch_id: str,
+) -> BaseEvent:
+    return BaseEvent(
+        type="execution.ac.dispatch.sealed",
+        aggregate_type="execution",
+        aggregate_id=identity.session_scope_id,
+        data={
+            **identity.to_metadata(),
+            "ac_dispatch_id": dispatch_id,
+            "capsule_fingerprint": capsule.fingerprint,
+        },
+    )
+
+
 def _dispatch_lifecycle_event(
     identity: ACRuntimeIdentity,
     event_type: str,
@@ -1108,6 +1126,61 @@ _GLOBAL_VERIFIER_PASS = True
 
 def _global_state_verifier(**_kwargs: Any) -> VerifierVerdict:
     return VerifierVerdict(passed=_GLOBAL_VERIFIER_PASS)
+
+
+def test_capsule_authority_binds_subprocess_executable_path() -> None:
+    """R2 blocker #3: which binary the runtime launches is part of authority.
+
+    Two otherwise-identical adapters whose ``cli_path`` points at different
+    executables must produce different capsule dispatch authority, so a restart
+    cannot resume the same capsule under a different executable.
+    """
+
+    class _Runtime:
+        runtime_backend = "codex_cli"
+        working_directory = "/tmp/project"
+        permission_mode = "acceptEdits"
+
+        def __init__(self, cli_path: str) -> None:
+            self._cli_path = cli_path
+
+    def _authority(cli_path: str) -> dict[str, object]:
+        executor = ParallelACExecutor(
+            adapter=_Runtime(cli_path),
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        return executor._build_capsule_dispatch_authority_contract(
+            tools=["Read"],
+            tool_catalog=None,
+            system_prompt="system",
+            level_contexts=None,
+        )
+
+    true_authority = _authority("/bin/true")
+    false_authority = _authority("/bin/false")
+
+    true_executable = true_authority["runtime"]["executable"]  # type: ignore[index]
+    false_executable = false_authority["runtime"]["executable"]  # type: ignore[index]
+    assert true_executable["observed"] is True
+    assert true_executable["executable"]["path"] == "/bin/true"
+    assert false_executable["executable"]["path"] == "/bin/false"
+    # The whole dispatch authority contract — the fingerprint input — must differ.
+    assert true_authority != false_authority
+
+
+def test_runtime_executable_identity_binds_zcode_launcher() -> None:
+    """R2 blocker #3: the Electron/Node launcher is part of what executes."""
+
+    class _ZcodeLike:
+        _cli_path = "/opt/zcode/cli.js"
+        _electron_node_path = "/opt/zcode/node"
+
+    identity = ParallelACExecutor._runtime_executable_identity(_ZcodeLike())
+    assert identity["observed"] is True
+    assert identity["executable"]["path"] == "/opt/zcode/cli.js"
+    assert identity["launcher"]["path"] == "/opt/zcode/node"
 
 
 def test_capsule_authority_covers_prompt_gate_runtime_and_verifier_inputs() -> None:
@@ -5709,6 +5782,80 @@ class TestParallelACExecutor:
             await executor._load_persisted_ac_runtime_handle(
                 0,
                 execution_context_id="session-signal-followup-corrupt",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_fails_closed_on_sealed_primary_head(self) -> None:
+        """A sealed primary whose follow-up write never landed must not replay.
+
+        R2 blocker #1: after the primary provider turn completes, a SessionSignal
+        follow-up seals the primary and then persists its own dispatch. If that
+        follow-up write fails (or a crash lands before the follow-up terminal),
+        the primary is the chain head again — but it is sealed, so recovery must
+        fail closed instead of resuming it and replaying the original AC prompt.
+        """
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Do not replay a sealed primary after a lost follow-up write",
+            session_id="session-sealed-primary-head",
+            seed_goal="Ship",
+        )
+        primary_dispatch_id = "1" * 32
+        handle = RuntimeHandle(
+            backend="codex_cli",
+            kind="implementation_session",
+            native_session_id="codex-sealed-primary",
+            cwd="/tmp/project",
+            approval_mode="acceptEdits",
+            metadata={
+                **runtime_identity.to_metadata(),
+                "ac_capsule_version": persisted_capsule.version,
+                "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_session_origin": "fresh",
+            },
+        )
+        event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=primary_dispatch_id,
+                dispatch_kind="primary",
+            ),
+            _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.started",
+                dispatch_id=primary_dispatch_id,
+                runtime_handle=handle,
+            ),
+            # The follow-up sealed the primary but its own dispatch write was lost.
+            _sealed_dispatch_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=primary_dispatch_id,
+            ),
+        ]
+
+        with pytest.raises(AmbiguousACExecutionError, match="sealed provider-entry phase"):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="session-sealed-primary-head",
                 retry_attempt=0,
                 expected_capsule_fingerprint=persisted_capsule.fingerprint,
                 expected_capsule_workspace=persisted_capsule.workspace,
@@ -12817,6 +12964,108 @@ class TestParallelACExecutor:
         assert result.success is False
         assert result.error == _STALL_SENTINEL
         assert runtime.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_verify_gate_single_shot_consumes_durable_outcome_on_recovery(self) -> None:
+        """R2 blocker #2: a recovered verify gate consumes its outcome, never reruns.
+
+        The first gate persists an intent and outcome and runs the (non-idempotent)
+        command once. A second run for the SAME attempt/key — the crash-recovery
+        case — consumes the durable outcome and must not run the command again.
+        """
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        run_count = 0
+
+        async def _counting_gate(*, spec: Any, cwd: str) -> _VerifyGateOutcome:
+            nonlocal run_count
+            run_count += 1
+            return _VerifyGateOutcome(passed=True, reason=None, output_tail="ok")
+
+        executor._run_ac_verify_gate = _counting_gate  # type: ignore[method-assign]
+        spec = AcceptanceCriterionSpec(description="AC", verify_command="./deploy.sh")
+
+        kwargs: dict[str, Any] = {
+            "spec": spec,
+            "cwd": "/tmp/project",
+            "aggregate_id": "exec-verify-oracle",
+            "verify_key": "atomic:ac-0:attempt-0:0",
+            "execution_id": "exec-verify-oracle",
+            "session_id": "sess",
+            "identity_metadata": {"ac_id": "ac-0"},
+        }
+
+        first = await executor._run_verify_gate_single_shot(**kwargs)
+        assert first.passed is True
+        assert run_count == 1
+
+        # Crash-recovery re-entry: same key + store → consume the durable outcome.
+        second = await executor._run_verify_gate_single_shot(**kwargs)
+        assert second.passed is True
+        assert run_count == 1  # command did NOT run again
+
+    @pytest.mark.asyncio
+    async def test_verify_gate_single_shot_fails_closed_on_intent_without_outcome(self) -> None:
+        """R2 blocker #2: a crash after the command ran but before the outcome
+        persisted leaves an intent with no outcome; recovery must fail closed
+        rather than replay a possibly-executed non-idempotent command."""
+        from ouroboros.events.base import BaseEvent
+
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        spec = AcceptanceCriterionSpec(description="AC", verify_command="./deploy.sh")
+        command_digest = executor._verify_gate_command_digest(spec)
+        # Simulate a durable intent whose outcome write never landed.
+        await event_store.append(
+            BaseEvent(
+                type="execution.ac.verify.intent",
+                aggregate_type="execution",
+                aggregate_id="exec-verify-orphan",
+                data={
+                    "verify_key": "atomic:ac-0:attempt-0:0",
+                    "verify_command_digest": command_digest,
+                },
+            )
+        )
+
+        run_count = 0
+
+        async def _counting_gate(*, spec: Any, cwd: str) -> _VerifyGateOutcome:
+            nonlocal run_count
+            run_count += 1
+            return _VerifyGateOutcome(passed=True, reason=None, output_tail="ok")
+
+        executor._run_ac_verify_gate = _counting_gate  # type: ignore[method-assign]
+
+        with pytest.raises(AmbiguousACExecutionError, match="never recorded"):
+            await executor._run_verify_gate_single_shot(
+                spec=spec,
+                cwd="/tmp/project",
+                aggregate_id="exec-verify-orphan",
+                verify_key="atomic:ac-0:attempt-0:0",
+                execution_id="exec-verify-orphan",
+                session_id="sess",
+                identity_metadata={"ac_id": "ac-0"},
+            )
+        assert run_count == 0  # the possibly-executed command was NOT run again
 
     @pytest.mark.asyncio
     async def test_alt_harness_defers_until_same_runtime_retry_budget_spent(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1271,6 +1271,117 @@ def test_claude_worker_transport_executable_contract_includes_command_policy() -
     assert "add_dirs" in contract["command_policy"]
 
 
+def test_runtime_executable_identity_resolves_bare_name_via_path(
+    tmp_path: Any, monkeypatch: Any
+) -> None:
+    """R5 blocker #4: a bare command name is fingerprinted via the effective PATH.
+
+    ``create_subprocess_exec`` resolves a bare name through PATH, not the
+    workspace, so ``claude`` pointing at two different binaries under two PATHs
+    must produce different executable identity.
+    """
+    import os as _os
+    import stat
+
+    def _make_bin(directory: Any, target: str) -> None:
+        directory.mkdir(parents=True, exist_ok=True)
+        script = directory / "toolx"
+        script.write_text(f"#!/bin/sh\nexec {target}\n")
+        script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+    dir_a = tmp_path / "a"
+    dir_b = tmp_path / "b"
+    _make_bin(dir_a, "/bin/true")
+    _make_bin(dir_b, "/bin/false")
+
+    class _Runtime:
+        _cli_path = "toolx"
+
+    monkeypatch.setenv("PATH", str(dir_a))
+    identity_a = ParallelACExecutor._runtime_executable_identity(_Runtime())
+    monkeypatch.setenv("PATH", str(dir_b))
+    identity_b = ParallelACExecutor._runtime_executable_identity(_Runtime())
+
+    assert identity_a["executable"]["realpath"] == _os.path.realpath(str(dir_a / "toolx"))
+    assert identity_b["executable"]["realpath"] == _os.path.realpath(str(dir_b / "toolx"))
+    assert identity_a != identity_b
+
+
+def test_runtime_executable_identity_marks_unresolved_bare_name(monkeypatch: Any) -> None:
+    """R5 blocker #4: a bare name PATH cannot resolve is a distinct fail-visible id."""
+
+    class _Runtime:
+        _cli_path = "definitely-not-a-real-binary-xyz"
+
+    monkeypatch.setenv("PATH", "/nonexistent-dir")
+    identity = ParallelACExecutor._runtime_executable_identity(_Runtime())
+    assert identity["executable"]["realpath"] is None
+    assert identity["executable"]["path_resolution"] == "unresolved"
+
+
+def test_capsule_authority_binds_session_signal_hub_presence() -> None:
+    """R5 blocker #5: enabling the signal hub changes acceptance-affecting semantics."""
+
+    class _Runtime:
+        runtime_backend = "codex_cli"
+        working_directory = "/tmp/project"
+        permission_mode = "acceptEdits"
+
+    def _scope(with_hub: bool) -> str:
+        executor = ParallelACExecutor(
+            adapter=_Runtime(),
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            enable_decomposition=False,
+            session_signal_hub=MagicMock() if with_hub else None,
+        )
+        return executor._build_ac_capsule_authority_scope(
+            execution_context_id="exec-1",
+            tools=["Read"],
+            tool_catalog=None,
+            system_prompt="system",
+            level_contexts=None,
+            is_sub_ac=False,
+            decomposition_trustworthy=False,
+            force_frontier_routing=False,
+            investment_spec=None,
+        )
+
+    assert _scope(with_hub=True) != _scope(with_hub=False)
+
+
+def test_bound_verify_gate_outcome_caps_and_rejects_oversized() -> None:
+    """R5 blocker #6: verify outcomes are bounded before persistence."""
+    from ouroboros.orchestrator.execution_event_emitter import (
+        _MAX_VERIFY_MISSING_ARTIFACTS,
+        bound_verify_gate_outcome,
+    )
+
+    outcome = {
+        "passed": False,
+        "reason": "expected_artifacts missing",
+        "output_tail": "",
+        "missing_artifacts": [f"path/{i}" for i in range(1000)],
+    }
+    bounded = bound_verify_gate_outcome(outcome)
+    assert bounded["passed"] is False
+    assert len(bounded["missing_artifacts"]) == _MAX_VERIFY_MISSING_ARTIFACTS
+    assert bounded["missing_artifacts_omitted"] == 1000 - _MAX_VERIFY_MISSING_ARTIFACTS
+
+    # Even after count/length caps, pathological 4-byte-per-char content can blow
+    # the hard UTF-8 byte cap; such a payload is rejected outright.
+    with pytest.raises(ValueError, match="size bound"):
+        bound_verify_gate_outcome(
+            {
+                "passed": True,
+                "reason": None,
+                "output_tail": "",
+                # "𐍈" is 4 UTF-8 bytes: 64 entries × 512 chars × 4 bytes ≈ 128 KiB.
+                "missing_artifacts": ["𐍈" * 512 for _ in range(_MAX_VERIFY_MISSING_ARTIFACTS)],
+            }
+        )
+
+
 def test_capsule_authority_covers_prompt_gate_runtime_and_verifier_inputs() -> None:
     """Every input that can alter provider work or acceptance must change authority."""
 
@@ -5951,6 +6062,53 @@ class TestParallelACExecutor:
             await executor._load_persisted_ac_runtime_handle(
                 0,
                 execution_context_id="session-sealed-primary-head",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_fails_closed_on_dispatch_without_capsule(self) -> None:
+        """R5 blocker #2: a dispatch boundary with no prerequisite capsule is corrupt.
+
+        A matching attempt.dispatched with a missing capsule.compiled event is
+        partial/corrupt history — the provider may already have been entered under
+        authority we cannot verify. Recovery must fail closed rather than silently
+        return None and let the caller re-enter as fresh.
+        """
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Dispatch without its capsule must fail closed",
+            session_id="session-dispatch-no-capsule",
+            seed_goal="Ship",
+        )
+        # A dispatch event WITHOUT the prerequisite capsule.compiled event.
+        event_store.replay.return_value = [
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id="1" * 32,
+                dispatch_kind="primary",
+            ),
+        ]
+
+        with pytest.raises(AmbiguousACExecutionError, match="without its prerequisite capsule"):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="session-dispatch-no-capsule",
                 retry_attempt=0,
                 expected_capsule_fingerprint=persisted_capsule.fingerprint,
                 expected_capsule_workspace=persisted_capsule.workspace,
@@ -13013,16 +13171,16 @@ class TestParallelACExecutor:
 
     @pytest.mark.asyncio
     async def test_effect_free_stall_stays_retryable(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Blocker #3: a stall with NO observed tool effect keeps the retry sentinel.
+        """Blocker #3: an effect-free stall on a REAL-TIME driver keeps the sentinel.
 
-        The complement of the effectful-stall guard: when no effect was
-        dispatched, a fresh redispatch cannot duplicate anything, so the existing
-        retryable stall behavior is preserved (the sentinel error the batch/leaf
-        retry loop keys on).
+        When the driver attests real-time tool-effect visibility, no observed
+        effect proves no effect occurred, so a fresh redispatch cannot duplicate
+        anything and the existing retryable stall behavior is preserved.
         """
         import anyio
 
         from ouroboros.orchestrator import leaf_dispatcher
+        from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
 
         monkeypatch.setattr(leaf_dispatcher, "STALL_TIMEOUT_SECONDS", 0.15)
 
@@ -13030,6 +13188,9 @@ class TestParallelACExecutor:
             runtime_backend = "codex_cli"
             working_directory = "/tmp/project"
             permission_mode = "acceptEdits"
+            # Attests it streams tool effects in real time, so a stall with no
+            # observed effect is genuinely effect-free and stays retryable.
+            capabilities = replace(FULL_CAPABILITIES, realtime_tool_effect_visibility=True)
 
             def __init__(self) -> None:
                 self.calls = 0
@@ -13062,6 +13223,61 @@ class TestParallelACExecutor:
 
         assert result.success is False
         assert result.error == _STALL_SENTINEL
+
+    @pytest.mark.asyncio
+    async def test_opaque_driver_stall_fails_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """R5 blocker #1: a stall on a driver WITHOUT real-time effect visibility.
+
+        A buffered driver (default ``realtime_tool_effect_visibility=False``) may
+        have mutated the workspace and then hung before yielding any message, so
+        even an effect-free-looking stall must seal and fail closed rather than
+        fresh-redispatch.
+        """
+        import anyio
+
+        from ouroboros.orchestrator import leaf_dispatcher
+
+        monkeypatch.setattr(leaf_dispatcher, "STALL_TIMEOUT_SECONDS", 0.15)
+
+        class _OpaqueStallRuntime:
+            runtime_backend = "claude_mcp"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+            # No capabilities attribute → defaults to no real-time visibility.
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def execute_task(self, **_kwargs: object):
+                self.calls += 1
+                await anyio.sleep_forever()
+                yield  # pragma: no cover - never reached; keeps this an async generator
+
+        event_store, appended = _make_replaying_event_store()
+        runtime = _OpaqueStallRuntime()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            cross_harness_redispatch=False,
+        )
+
+        with pytest.raises(
+            AmbiguousACExecutionError, match="does not attest real-time tool-effect visibility"
+        ):
+            await executor._execute_atomic_ac(
+                ac_index=0,
+                ac_content="An opaque-driver stall fails closed",
+                session_id="session-opaque-stall",
+                tools=["Edit"],
+                system_prompt="system",
+                seed_goal="Ship",
+                depth=0,
+                start_time=datetime.now(UTC),
+            )
+        assert runtime.calls == 1
+        assert any(e.type == "execution.ac.dispatch.sealed" for e in appended)
         assert runtime.calls == 1
 
     @pytest.mark.asyncio
@@ -13165,6 +13381,68 @@ class TestParallelACExecutor:
                 identity_metadata={"ac_id": "ac-0"},
             )
         assert run_count == 0  # the possibly-executed command was NOT run again
+
+    @pytest.mark.asyncio
+    async def test_verify_gate_rejects_orphan_outcome_without_intent(self) -> None:
+        """R5 blocker #3: a verify outcome with no preceding intent is not trusted.
+
+        An outcome-only record (corrupted or injected) could otherwise manufacture
+        a passing acceptance verdict without the verifier ever running.
+        """
+        from ouroboros.events.base import BaseEvent
+
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        spec = AcceptanceCriterionSpec(description="AC", verify_command="./deploy.sh")
+        command_digest = executor._verify_gate_command_digest(spec)
+        # A durable outcome with NO preceding intent (the orphan the probe injects).
+        await event_store.append(
+            BaseEvent(
+                type="execution.ac.verify.outcome",
+                aggregate_type="execution",
+                aggregate_id="exec-orphan-outcome",
+                data={
+                    "verify_key": "atomic:ac-0:attempt-0:0",
+                    "verify_command_digest": command_digest,
+                    "verify_gate_outcome": {
+                        "passed": True,
+                        "reason": None,
+                        "output_tail": "",
+                        "missing_artifacts": [],
+                    },
+                },
+            )
+        )
+
+        run_count = 0
+
+        async def _counting_gate(*, spec: Any, cwd: str) -> _VerifyGateOutcome:
+            nonlocal run_count
+            run_count += 1
+            return _VerifyGateOutcome(passed=True, reason=None, output_tail="")
+
+        executor._run_ac_verify_gate = _counting_gate  # type: ignore[method-assign]
+
+        with pytest.raises(AmbiguousACExecutionError, match="orphan verify record"):
+            await executor._run_verify_gate_single_shot(
+                spec=spec,
+                cwd="/tmp/project",
+                aggregate_id="exec-orphan-outcome",
+                verify_key="atomic:ac-0:attempt-0:0",
+                execution_id="exec-orphan-outcome",
+                session_id="sess",
+                identity_metadata={"ac_id": "ac-0"},
+            )
+        assert run_count == 0
 
     @pytest.mark.asyncio
     async def test_successful_turn_seals_before_terminal_completion(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1555,6 +1555,66 @@ def test_watchdog_identity_binds_total_turn_timeout() -> None:
     assert fast != slow
 
 
+def test_opencode_execution_identity_contract_binds_dispatch_policy() -> None:
+    """R12 blocker #2: OpenCode pre-provider dispatch policy participates in identity."""
+    from ouroboros.orchestrator.opencode_runtime import OpenCodeRuntime
+
+    plugin = OpenCodeRuntime(opencode_mode="plugin", llm_backend="x")
+    default = OpenCodeRuntime(opencode_mode="default", llm_backend="x")
+    assert plugin.execution_identity_contract()["opencode_mode"] == "plugin"
+    assert plugin.execution_identity_contract() != default.execution_identity_contract()
+
+    # A custom skill dispatcher contributes a bounded, process-local identity.
+    class _Dispatcher:
+        pass
+
+    with_dispatcher = OpenCodeRuntime(
+        opencode_mode="plugin", llm_backend="x", skill_dispatcher=_Dispatcher()
+    )
+    contract = with_dispatcher.execution_identity_contract()
+    assert contract["skill_dispatcher"] is not None
+    assert "_Dispatcher" in contract["skill_dispatcher"]["type"]
+
+
+def test_capsule_authority_binds_signal_hub_durable_relay_mode() -> None:
+    """R12 blocker #3: a durable-relay hub differs in authority from a non-durable one.
+
+    Only a hub with a durable event store replays cross-process queued signals, so
+    it must not share a capsule fingerprint with a hub that cannot.
+    """
+    from ouroboros.orchestrator.synapse import SessionSignalHub
+
+    class _Runtime:
+        runtime_backend = "codex_cli"
+        working_directory = "/tmp/project"
+        permission_mode = "acceptEdits"
+
+    def _scope(hub: object | None) -> str:
+        executor = ParallelACExecutor(
+            adapter=_Runtime(),
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            enable_decomposition=False,
+            session_signal_hub=hub,
+        )
+        return executor._build_ac_capsule_authority_scope(
+            execution_context_id="exec-1",
+            tools=["Read"],
+            tool_catalog=None,
+            system_prompt="system",
+            level_contexts=None,
+            is_sub_ac=False,
+            decomposition_trustworthy=False,
+            force_frontier_routing=False,
+            investment_spec=None,
+        )
+
+    non_durable = _scope(SessionSignalHub(event_store=None))
+    durable = _scope(SessionSignalHub(event_store=MagicMock()))
+    assert non_durable != durable
+    assert non_durable != _scope(None)
+
+
 def test_capsule_authority_binds_execution_semantic_policy() -> None:
     """R11: every declared execution-semantic knob participates in capsule authority."""
 
@@ -5567,6 +5627,7 @@ class TestParallelACExecutor:
             node_identity=node_identity,
             expected_capsule_fingerprint=fingerprint,
             expected_capsule_workspace=os.path.realpath("/tmp/project"),
+            runtime_attests_realtime_effects=True,
         )
         assert restored is not None
         assert restored.native_session_id == "bare-provider-session"
@@ -5856,6 +5917,7 @@ class TestParallelACExecutor:
             retry_attempt=0,
             expected_capsule_fingerprint=persisted_capsule.fingerprint,
             expected_capsule_workspace=persisted_capsule.workspace,
+            runtime_attests_realtime_effects=True,
         )
 
         assert restored is not None
@@ -5916,6 +5978,7 @@ class TestParallelACExecutor:
             retry_attempt=0,
             expected_capsule_fingerprint=persisted_capsule.fingerprint,
             expected_capsule_workspace=persisted_capsule.workspace,
+            runtime_attests_realtime_effects=True,
         )
 
         assert restored is not None
@@ -6177,6 +6240,7 @@ class TestParallelACExecutor:
             retry_attempt=0,
             expected_capsule_fingerprint=persisted_capsule.fingerprint,
             expected_capsule_workspace=persisted_capsule.workspace,
+            runtime_attests_realtime_effects=True,
         )
 
         assert restored is not None
@@ -6528,6 +6592,87 @@ class TestParallelACExecutor:
             )
 
     @pytest.mark.asyncio
+    async def test_capsule_loader_fails_closed_on_opaque_active_resume(self) -> None:
+        """R12 blocker #1: an opaque runtime cannot resume an active head.
+
+        With NO recorded effect but a resumable handle, an opaque runtime
+        (default ``realtime_tool_effect_visibility=False``) may still have applied
+        an effect before any event was emitted, so resuming (which resends the AC
+        prompt) fails closed; an attesting runtime resumes.
+        """
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Opaque active head must not resume",
+            session_id="session-opaque-active",
+            seed_goal="Ship",
+        )
+        dispatch_id = "4" * 32
+        handle = RuntimeHandle(
+            backend="codex_cli",
+            kind="implementation_session",
+            native_session_id="codex-opaque",
+            cwd="/tmp/project",
+            approval_mode="acceptEdits",
+            metadata={
+                **runtime_identity.to_metadata(),
+                "ac_capsule_version": persisted_capsule.version,
+                "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_session_origin": "fresh",
+            },
+        )
+        # Resumable active head, NO recorded tool effect.
+        event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=dispatch_id,
+                dispatch_kind="primary",
+            ),
+            _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.started",
+                dispatch_id=dispatch_id,
+                runtime_handle=handle,
+            ),
+        ]
+
+        # Opaque runtime (no attestation) → fail closed.
+        with pytest.raises(AmbiguousACExecutionError, match="does not attest real-time"):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="session-opaque-active",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+        # A runtime that attests real-time effect visibility resumes.
+        restored = await executor._load_persisted_ac_runtime_handle(
+            0,
+            execution_context_id="session-opaque-active",
+            retry_attempt=0,
+            expected_capsule_fingerprint=persisted_capsule.fingerprint,
+            expected_capsule_workspace=persisted_capsule.workspace,
+            runtime_attests_realtime_effects=True,
+        )
+        assert restored is not None
+        assert restored.native_session_id == "codex-opaque"
+
+    @pytest.mark.asyncio
     async def test_capsule_loader_follows_explicit_recovery_session_successor(self) -> None:
         """A durable recovered linkage supersedes its failed provider session."""
 
@@ -6601,6 +6746,7 @@ class TestParallelACExecutor:
             retry_attempt=0,
             expected_capsule_fingerprint=persisted_capsule.fingerprint,
             expected_capsule_workspace=persisted_capsule.workspace,
+            runtime_attests_realtime_effects=True,
         )
 
         assert restored is not None
@@ -6675,6 +6821,7 @@ class TestParallelACExecutor:
                 retry_attempt=0,
                 expected_capsule_fingerprint=persisted_capsule.fingerprint,
                 expected_capsule_workspace=persisted_capsule.workspace,
+                runtime_attests_realtime_effects=True,
             )
 
     @pytest.mark.asyncio
@@ -6972,6 +7119,7 @@ class TestParallelACExecutor:
                 retry_attempt=0,
                 expected_capsule_fingerprint=persisted_capsule.fingerprint,
                 expected_capsule_workspace=persisted_capsule.workspace,
+                runtime_attests_realtime_effects=True,
             )
 
     @pytest.mark.asyncio
@@ -14890,6 +15038,10 @@ class TestParallelACExecutor:
         """A fresh executor should rehydrate the same-attempt runtime handle from events."""
 
         class _StubPersistedResumeRuntime:
+            # Attests real-time tool-effect visibility so an active head may resume
+            # (the opaque-runtime guard fails such resumes closed otherwise).
+            capabilities = replace(FULL_CAPABILITIES, realtime_tool_effect_visibility=True)
+
             def __init__(self) -> None:
                 self.calls: list[dict[str, object]] = []
                 self._runtime_handle_backend = "opencode"
@@ -15246,6 +15398,7 @@ class TestParallelACExecutor:
                 retry_attempt=0,
                 expected_capsule_fingerprint=persisted_capsule.fingerprint,
                 expected_capsule_workspace=persisted_capsule.workspace,
+                runtime_attests_realtime_effects=True,
             )
 
     @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1228,6 +1228,49 @@ def test_runtime_executable_identity_probes_transport_without_contract() -> None
     assert identity["executable"]["path"] == "/usr/local/bin/worker-cli"
 
 
+def test_runtime_executable_identity_binds_command_policy() -> None:
+    """R4 blocker #3: command-affecting transport policy participates in authority.
+
+    Two runtimes with the same executable but different ``add_dirs`` (Claude's
+    ``--add-dir`` access) must produce different executable identity, so a restart
+    cannot resume the same capsule under a different access policy.
+    """
+
+    class _Runtime:
+        def __init__(self, add_dirs: list[str]) -> None:
+            self._add_dirs = add_dirs
+
+        def executable_identity_contract(self) -> dict[str, object]:
+            return {
+                "executable": "/bin/claude",
+                "launcher": None,
+                "command_policy": {
+                    "disallowed_tools": ["mcp__ouroboros"],
+                    "add_dirs": self._add_dirs,
+                    "persist_sessions": False,
+                },
+            }
+
+    narrow = ParallelACExecutor._runtime_executable_identity(_Runtime(["/repo/a"]))
+    wide = ParallelACExecutor._runtime_executable_identity(_Runtime(["/repo/a", "/repo/b"]))
+    assert narrow["executable"]["path"] == wide["executable"]["path"] == "/bin/claude"
+    assert narrow["command_policy"]["add_dirs"] == ["/repo/a"]
+    assert wide["command_policy"]["add_dirs"] == ["/repo/a", "/repo/b"]
+    # Same binary, different access policy → different authority.
+    assert narrow != wide
+
+
+def test_claude_worker_transport_executable_contract_includes_command_policy() -> None:
+    """R4 blocker #3: the real Claude transport surfaces its command policy."""
+    from ouroboros.orchestrator.claude_worker_runtime import ClaudeWorkerTransport
+
+    transport = ClaudeWorkerTransport(cli_path="/bin/claude", disallowed_tools=("mcp__x",))
+    contract = transport.executable_identity_contract()
+    assert contract["executable"] == "/bin/claude"
+    assert contract["command_policy"]["disallowed_tools"] == ["mcp__x"]
+    assert "add_dirs" in contract["command_policy"]
+
+
 def test_capsule_authority_covers_prompt_gate_runtime_and_verifier_inputs() -> None:
     """Every input that can alter provider work or acceptance must change authority."""
 
@@ -13122,6 +13165,104 @@ class TestParallelACExecutor:
                 identity_metadata={"ac_id": "ac-0"},
             )
         assert run_count == 0  # the possibly-executed command was NOT run again
+
+    @pytest.mark.asyncio
+    async def test_successful_turn_seals_before_terminal_completion(self) -> None:
+        """R4 blocker #1: a completed provider turn is sealed before post-processing.
+
+        The authoritative terminal is not durable until after signal/verify/
+        evidence/shadow. A seal is persisted right after the provider stream so a
+        crash in that window fails closed on recovery instead of replaying the AC
+        prompt; on the normal path the later completion supersedes the seal.
+        """
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def execute_task(self, **_kwargs: object):
+                self.calls += 1
+                yield AgentMessage(type="result", content="[TASK_COMPLETE]")
+
+        event_store, appended = _make_replaying_event_store()
+        runtime = _Runtime()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Seal the provider turn before finalization",
+            session_id="session-seal-before-terminal",
+            tools=["Read"],
+            system_prompt="system",
+            seed_goal="Ship",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+        assert result.success is True
+        types = [e.type for e in appended]
+        assert "execution.ac.dispatch.sealed" in types
+        # The seal precedes the authoritative terminal completion.
+        assert types.index("execution.ac.dispatch.sealed") < types.index(
+            "execution.session.completed"
+        )
+
+    @pytest.mark.asyncio
+    async def test_flip_gate_recovery_is_single_shot(self) -> None:
+        """R4 blocker #2: the sibling-flip gate uses the single-shot verify oracle."""
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        run_count = 0
+
+        async def _counting_gate(*, spec: Any, cwd: str) -> _VerifyGateOutcome:
+            nonlocal run_count
+            run_count += 1
+            return _VerifyGateOutcome(passed=False, reason="nope", output_tail="")
+
+        executor._run_ac_verify_gate = _counting_gate  # type: ignore[method-assign]
+        seed = _make_seed(
+            AcceptanceCriterionSpec(description="AC", verify_command="./deploy.sh"),
+        )
+        failed = ACExecutionResult(
+            ac_index=0,
+            ac_content="AC",
+            success=False,
+            outcome=ACExecutionOutcome.FAILED,
+            retry_attempt=0,
+        )
+
+        first = await executor._compute_sibling_flip_gated_out(
+            seed=seed,
+            level_results=[failed],
+            session_id="sess",
+            execution_id="exec-flip",
+        )
+        assert 0 in first  # gated out (contract failed)
+        assert run_count == 1
+        # Replaying must consume the durable outcome, not re-run the command.
+        await executor._compute_sibling_flip_gated_out(
+            seed=seed,
+            level_results=[failed],
+            session_id="sess",
+            execution_id="exec-flip",
+        )
+        assert run_count == 1
 
     @pytest.mark.asyncio
     async def test_apply_verify_gate_recovery_is_single_shot(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -28,7 +28,10 @@ from ouroboros.orchestrator.ac_execution_capsule import (
     ACExecutionCapsuleManifest,
     compile_ac_execution_capsule,
 )
-from ouroboros.orchestrator.ac_runtime_handle_manager import AmbiguousACExecutionError
+from ouroboros.orchestrator.ac_runtime_handle_manager import (
+    AmbiguousACExecutionError,
+    CompletedACExecutionError,
+)
 from ouroboros.orchestrator.adapter import (
     FULL_CAPABILITIES,
     AgentMessage,
@@ -64,6 +67,7 @@ from ouroboros.orchestrator.parallel_executor import (
     _runtime_messages_have_masked_test_command_form,
     _runtime_messages_support_command_claim,
     _runtime_messages_support_test_claim,
+    _VerifyGateOutcome,
     render_parallel_completion_message,
     render_parallel_verification_report,
 )
@@ -969,16 +973,19 @@ def _compile_test_capsule(
     seed_goal: str,
     retry_attempt: int = 0,
     workspace: str = "/tmp/project",
+    node_identity: ExecutionNodeIdentity | None = None,
+    ac_spec: AcceptanceCriterionSpec | None = None,
 ) -> tuple[ACRuntimeIdentity, ACExecutionCapsule]:
     identity = build_ac_runtime_identity(
         ac_index,
         execution_context_id=session_id,
+        node_identity=node_identity,
         retry_attempt=retry_attempt,
     )
     capsule = compile_ac_execution_capsule(
         runtime_identity=identity,
         execution_id=session_id,
-        semantic_ac_key=derive_semantic_ac_key(ac_content),
+        semantic_ac_key=derive_semantic_ac_key(ac_spec or ac_content),
         workspace=os.path.realpath(workspace),
         authority_scope=executor._build_ac_capsule_authority_scope(
             execution_context_id=session_id,
@@ -993,7 +1000,7 @@ def _compile_test_capsule(
         ),
         seed_goal=seed_goal,
         ac_content=ac_content,
-        ac_spec=None,
+        ac_spec=ac_spec,
     )
     return identity, capsule
 
@@ -1010,6 +1017,74 @@ def _compiled_capsule_event(
             **identity.to_metadata(),
             "capsule_fingerprint": capsule.fingerprint,
             "capsule_manifest": capsule.manifest.to_contract_data(),
+        },
+    )
+
+
+def _dispatched_capsule_event(
+    identity: ACRuntimeIdentity,
+    capsule: ACExecutionCapsule,
+    *,
+    dispatch_id: str = "d" * 32,
+    previous_dispatch_id: str | None = None,
+    session_origin: str = "fresh",
+    runtime_handle: RuntimeHandle | None = None,
+) -> BaseEvent:
+    if runtime_handle is not None:
+        runtime_handle = replace(
+            runtime_handle,
+            metadata={**runtime_handle.metadata, "ac_dispatch_id": dispatch_id},
+        )
+    return BaseEvent(
+        type="execution.ac.attempt.dispatched",
+        aggregate_type="execution",
+        aggregate_id=identity.session_scope_id,
+        data={
+            **identity.to_metadata(),
+            "ac_dispatch_id": dispatch_id,
+            "previous_ac_dispatch_id": previous_dispatch_id,
+            "capsule_fingerprint": capsule.fingerprint,
+            "session_origin": session_origin,
+            "runtime": (
+                runtime_handle.to_dispatch_recovery_dict() if runtime_handle is not None else None
+            ),
+        },
+    )
+
+
+def _dispatch_lifecycle_event(
+    identity: ACRuntimeIdentity,
+    event_type: str,
+    *,
+    dispatch_id: str,
+    runtime_handle: RuntimeHandle | None,
+    timestamp: datetime | None = None,
+    result_summary: str | None = None,
+    session_id: str | None = None,
+    extra_data: dict[str, Any] | None = None,
+) -> BaseEvent:
+    if runtime_handle is not None:
+        runtime_handle = replace(
+            runtime_handle,
+            metadata={**runtime_handle.metadata, "ac_dispatch_id": dispatch_id},
+        )
+    return BaseEvent(
+        type=event_type,
+        timestamp=timestamp or datetime.now(UTC),
+        aggregate_type="execution",
+        aggregate_id=identity.session_scope_id,
+        data={
+            **identity.to_metadata(),
+            "ac_dispatch_id": dispatch_id,
+            "success": True
+            if event_type == "execution.session.completed"
+            else False
+            if event_type == "execution.session.failed"
+            else None,
+            "result_summary": result_summary,
+            "session_id": session_id,
+            "runtime": runtime_handle.to_persisted_dict() if runtime_handle is not None else None,
+            **(extra_data or {}),
         },
     )
 
@@ -4846,7 +4921,12 @@ class TestParallelACExecutor:
         replay_events.extend(
             event
             for event in appended_events
-            if event.type in {"execution.ac.capsule.compiled", "execution.session.started"}
+            if event.type
+            in {
+                "execution.ac.capsule.compiled",
+                "execution.ac.attempt.dispatched",
+                "execution.session.started",
+            }
         )
         restarted = ParallelACExecutor(
             adapter=_BareHandleRuntime(),
@@ -4907,9 +4987,1342 @@ class TestParallelACExecutor:
 
         assert runtime.calls == 0
 
+    @pytest.mark.asyncio
+    async def test_atomic_ac_persists_dispatch_transition_before_provider_call(self) -> None:
+        """The uncertain provider boundary must be durable before execute_task starts."""
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            def __init__(self, appended_events: list[BaseEvent]) -> None:
+                self.appended_events = appended_events
+                self.calls = 0
+
+            async def execute_task(self, **_kwargs: object):
+                self.calls += 1
+                assert self.appended_events[-1].type == "execution.ac.attempt.dispatched"
+                yield AgentMessage(type="result", content="[TASK_COMPLETE]")
+
+        event_store, appended_events = _make_replaying_event_store()
+        runtime = _Runtime(appended_events)
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Persist provider dispatch uncertainty",
+            session_id="session-dispatch-transition",
+            tools=["Read", "Edit"],
+            system_prompt="system",
+            seed_goal="Ship",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert runtime.calls == 1
+        assert result.success is True
+        dispatch_event = next(
+            event for event in appended_events if event.type == "execution.ac.attempt.dispatched"
+        )
+        capsule_event = next(
+            event for event in appended_events if event.type == "execution.ac.capsule.compiled"
+        )
+        assert (
+            dispatch_event.data["capsule_fingerprint"] == capsule_event.data["capsule_fingerprint"]
+        )
+        dispatch_id = dispatch_event.data["ac_dispatch_id"]
+        assert isinstance(dispatch_id, str) and len(dispatch_id) == 32
+        dispatch_runtime = dispatch_event.data["runtime"]
+        assert "cwd" not in dispatch_runtime
+        assert "transcript_path" not in dispatch_runtime
+        assert "tool_catalog" not in dispatch_runtime["metadata"]
+        assert "capability_graph" not in dispatch_runtime["metadata"]
+        assert "control_plane" not in dispatch_runtime["metadata"]
+        completed_event = next(
+            event for event in appended_events if event.type == "execution.session.completed"
+        )
+        assert completed_event.data["ac_dispatch_id"] == dispatch_id
+
+    @pytest.mark.asyncio
+    async def test_atomic_ac_does_not_call_provider_when_dispatch_transition_fails(self) -> None:
+        """Failure to persist DISPATCHED must leave the provider untouched."""
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def execute_task(self, **_kwargs: object):
+                self.calls += 1
+                yield AgentMessage(type="result", content="[TASK_COMPLETE]")
+
+        runtime = _Runtime()
+        event_store, appended_events = _make_replaying_event_store()
+
+        async def _append(event: BaseEvent) -> None:
+            if event.type == "execution.ac.attempt.dispatched":
+                raise OSError("dispatch transition unavailable")
+            appended_events.append(event)
+
+        event_store.append.side_effect = _append
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Block unsafe provider dispatch",
+            session_id="session-dispatch-persist-failure",
+            tools=["Read", "Edit"],
+            system_prompt="system",
+            seed_goal="Ship",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert runtime.calls == 0
+        assert result.success is False
+        assert result.infra_fatal is True
+        assert result.error == "dispatch transition unavailable"
+        assert any(event.type == "execution.ac.capsule.compiled" for event in appended_events)
+        assert not any(event.type == "execution.session.failed" for event in appended_events)
+
+        event_store.append.side_effect = appended_events.append
+        retried = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Block unsafe provider dispatch",
+            session_id="session-dispatch-persist-failure",
+            tools=["Read", "Edit"],
+            system_prompt="system",
+            seed_goal="Ship",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert retried.success is True
+        assert runtime.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_atomic_ac_refuses_fresh_dispatch_after_pre_message_crash(self) -> None:
+        """A durable dispatch with no handle/terminal successor is effect-ambiguous."""
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def execute_task(self, **_kwargs: object):
+                self.calls += 1
+                yield AgentMessage(type="result", content="[TASK_COMPLETE]")
+
+        runtime = _Runtime()
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Apply one external effect before the first message",
+            session_id="session-pre-message-crash",
+            seed_goal="Ship",
+        )
+        appended_events.extend(
+            [
+                _compiled_capsule_event(runtime_identity, persisted_capsule),
+                _dispatched_capsule_event(runtime_identity, persisted_capsule),
+            ]
+        )
+
+        with pytest.raises(
+            AmbiguousACExecutionError,
+            match="crossed the provider dispatch boundary",
+        ):
+            await executor._execute_atomic_ac(
+                ac_index=0,
+                ac_content="Apply one external effect before the first message",
+                session_id="session-pre-message-crash",
+                tools=["Read", "Edit"],
+                system_prompt="system",
+                seed_goal="Ship",
+                depth=0,
+                start_time=datetime.now(UTC),
+            )
+
+        assert runtime.calls == 0
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_correlates_dispatch_across_timestamp_rollback(self) -> None:
+        """Recovery uses dispatch identity, never timestamp/list successor order."""
+
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Recover by dispatch identity despite clock rollback",
+            session_id="session-dispatch-order",
+            seed_goal="Ship",
+        )
+        dispatch_id = "a" * 32
+        persisted_handle = RuntimeHandle(
+            backend="codex_cli",
+            kind="implementation_session",
+            native_session_id="codex-clock-rollback",
+            cwd="/tmp/project",
+            approval_mode="acceptEdits",
+            metadata={
+                **runtime_identity.to_metadata(),
+                "ac_capsule_version": persisted_capsule.version,
+                "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_dispatch_id": "e" * 32,
+                "ac_session_origin": "fresh",
+            },
+        )
+        lifecycle = _dispatch_lifecycle_event(
+            runtime_identity,
+            "execution.session.started",
+            dispatch_id=dispatch_id,
+            runtime_handle=persisted_handle,
+            timestamp=datetime(2020, 1, 1, tzinfo=UTC),
+        )
+        event_store.replay.return_value = [
+            lifecycle,
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=dispatch_id,
+            ),
+        ]
+
+        restored = await executor._load_persisted_ac_runtime_handle(
+            0,
+            execution_context_id="session-dispatch-order",
+            retry_attempt=0,
+            expected_capsule_fingerprint=persisted_capsule.fingerprint,
+            expected_capsule_workspace=persisted_capsule.workspace,
+        )
+
+        assert restored is not None
+        assert restored.native_session_id == "codex-clock-rollback"
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_rebinds_dispatch_workspace_before_resume(self) -> None:
+        """Minimal dispatch payloads regain cwd only from current capsule authority."""
+
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Resume from a minimal provider-boundary record",
+            session_id="session-dispatch-minimal-resume",
+            seed_goal="Ship",
+        )
+        persisted_handle = RuntimeHandle(
+            backend="codex_cli",
+            kind="implementation_session",
+            native_session_id="codex-minimal-resume",
+            cwd="/must-not-be-persisted",
+            approval_mode="acceptEdits",
+            metadata={
+                **runtime_identity.to_metadata(),
+                "ac_capsule_version": persisted_capsule.version,
+                "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_session_origin": "restored_same_attempt",
+            },
+        )
+        dispatch_event = _dispatched_capsule_event(
+            runtime_identity,
+            persisted_capsule,
+            dispatch_id="9" * 32,
+            session_origin="restored_same_attempt",
+            runtime_handle=persisted_handle,
+        )
+        assert "cwd" not in dispatch_event.data["runtime"]
+        event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            dispatch_event,
+        ]
+
+        restored = await executor._load_persisted_ac_runtime_handle(
+            0,
+            execution_context_id="session-dispatch-minimal-resume",
+            retry_attempt=0,
+            expected_capsule_fingerprint=persisted_capsule.fingerprint,
+            expected_capsule_workspace=persisted_capsule.workspace,
+        )
+
+        assert restored is not None
+        assert restored.native_session_id == "codex-minimal-resume"
+        assert restored.cwd == persisted_capsule.workspace
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_rejects_nonminimal_dispatch_runtime_payload(self) -> None:
+        """Unknown dispatch fields cannot re-enter recovery through persisted corruption."""
+
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Reject a nonminimal dispatch recovery payload",
+            session_id="session-dispatch-nonminimal",
+            seed_goal="Ship",
+        )
+        handle = RuntimeHandle(
+            backend="codex_cli",
+            kind="implementation_session",
+            native_session_id="codex-nonminimal",
+            cwd="/tmp/project",
+            approval_mode="acceptEdits",
+            metadata={
+                **runtime_identity.to_metadata(),
+                "ac_capsule_version": persisted_capsule.version,
+                "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_session_origin": "restored_same_attempt",
+            },
+        )
+        dispatch_event = _dispatched_capsule_event(
+            runtime_identity,
+            persisted_capsule,
+            dispatch_id="4" * 32,
+            session_origin="restored_same_attempt",
+            runtime_handle=handle,
+        )
+        dispatch_event.data["runtime"]["cwd"] = "/smuggled/worktree"
+        event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            dispatch_event,
+        ]
+
+        with pytest.raises(ValueError, match="dispatch recovery handle is malformed"):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="session-dispatch-nonminimal",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_keeps_failed_dispatch_ambiguous_without_handle(self) -> None:
+        """Adapter failure does not prove the provider performed no external effect."""
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=_Runtime(),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Close dispatch uncertainty with a terminal successor",
+            session_id="session-dispatch-terminal-successor",
+            seed_goal="Ship",
+        )
+        dispatch_id = "b" * 32
+        event_store.replay = AsyncMock(
+            return_value=[
+                _compiled_capsule_event(runtime_identity, persisted_capsule),
+                _dispatched_capsule_event(
+                    runtime_identity,
+                    persisted_capsule,
+                    dispatch_id=dispatch_id,
+                ),
+                _dispatch_lifecycle_event(
+                    runtime_identity,
+                    "execution.session.failed",
+                    dispatch_id=dispatch_id,
+                    runtime_handle=None,
+                ),
+            ]
+        )
+
+        with pytest.raises(AmbiguousACExecutionError, match="failed without a reusable"):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="session-dispatch-terminal-successor",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_resumes_failed_dispatch_with_correlated_handle(self) -> None:
+        """A failure is recoverable only when its exact provider session is reconnectable."""
+
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Resume the exact provider session after adapter failure",
+            session_id="session-dispatch-failed-resume",
+            seed_goal="Ship",
+        )
+        dispatch_id = "8" * 32
+        handle = RuntimeHandle(
+            backend="codex_cli",
+            kind="implementation_session",
+            native_session_id="codex-failed-resume",
+            cwd="/tmp/project",
+            approval_mode="acceptEdits",
+            metadata={
+                **runtime_identity.to_metadata(),
+                "ac_capsule_version": persisted_capsule.version,
+                "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_session_origin": "fresh",
+            },
+        )
+        event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=dispatch_id,
+            ),
+            _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.failed",
+                dispatch_id=dispatch_id,
+                runtime_handle=handle,
+            ),
+        ]
+
+        restored = await executor._load_persisted_ac_runtime_handle(
+            0,
+            execution_context_id="session-dispatch-failed-resume",
+            retry_attempt=0,
+            expected_capsule_fingerprint=persisted_capsule.fingerprint,
+            expected_capsule_workspace=persisted_capsule.workspace,
+        )
+
+        assert restored is not None
+        assert restored.native_session_id == "codex-failed-resume"
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_resumes_only_latest_boundary_in_multi_dispatch_attempt(
+        self,
+    ) -> None:
+        """A later signal dispatch owns recovery even when an older event ranks higher."""
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Resume the exact latest provider boundary",
+            session_id="session-multi-dispatch-latest",
+            seed_goal="Ship",
+        )
+        first_dispatch_id = "1" * 32
+        second_dispatch_id = "2" * 32
+
+        def _handle(previous_response_id: str) -> RuntimeHandle:
+            return RuntimeHandle(
+                backend="codex_cli",
+                kind="implementation_session",
+                native_session_id="codex-shared-session",
+                previous_response_id=previous_response_id,
+                cwd="/tmp/project",
+                approval_mode="acceptEdits",
+                metadata={
+                    **runtime_identity.to_metadata(),
+                    "ac_capsule_version": persisted_capsule.version,
+                    "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                    "ac_session_origin": "restored_same_attempt",
+                },
+            )
+
+        event_store.replay.return_value = [
+            _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.failed",
+                dispatch_id=second_dispatch_id,
+                runtime_handle=_handle("response-after-signal"),
+            ),
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.started",
+                dispatch_id=first_dispatch_id,
+                runtime_handle=_handle("response-before-signal"),
+            ),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=second_dispatch_id,
+                previous_dispatch_id=first_dispatch_id,
+                session_origin="restored_same_attempt",
+            ),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=first_dispatch_id,
+            ),
+        ]
+
+        restored = await executor._load_persisted_ac_runtime_handle(
+            0,
+            execution_context_id="session-multi-dispatch-latest",
+            retry_attempt=0,
+            expected_capsule_fingerprint=persisted_capsule.fingerprint,
+            expected_capsule_workspace=persisted_capsule.workspace,
+        )
+
+        assert restored is not None
+        assert restored.previous_response_id == "response-after-signal"
+        assert restored.metadata["ac_dispatch_id"] == second_dispatch_id
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_follows_explicit_recovery_session_successor(self) -> None:
+        """A durable recovered linkage supersedes its failed provider session."""
+
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Follow the explicit replacement provider session",
+            session_id="session-dispatch-recovered-successor",
+            seed_goal="Ship",
+        )
+        dispatch_id = "6" * 32
+
+        def _handle(session: str) -> RuntimeHandle:
+            return RuntimeHandle(
+                backend="codex_cli",
+                kind="implementation_session",
+                native_session_id=session,
+                cwd="/tmp/project",
+                approval_mode="acceptEdits",
+                metadata={
+                    **runtime_identity.to_metadata(),
+                    "ac_capsule_version": persisted_capsule.version,
+                    "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                    "ac_session_origin": "fresh",
+                },
+            )
+
+        event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=dispatch_id,
+            ),
+            _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.started",
+                dispatch_id=dispatch_id,
+                runtime_handle=_handle("codex-failed-session"),
+            ),
+            _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.recovered",
+                dispatch_id=dispatch_id,
+                runtime_handle=_handle("codex-replacement-session"),
+                extra_data={
+                    "recovery_discontinuity": {
+                        "reason": "replacement_session",
+                        "failed": {"resume_session_id": "codex-failed-session"},
+                        "replacement": {"resume_session_id": "codex-replacement-session"},
+                    }
+                },
+            ),
+        ]
+
+        restored = await executor._load_persisted_ac_runtime_handle(
+            0,
+            execution_context_id="session-dispatch-recovered-successor",
+            retry_attempt=0,
+            expected_capsule_fingerprint=persisted_capsule.fingerprint,
+            expected_capsule_workspace=persisted_capsule.workspace,
+        )
+
+        assert restored is not None
+        assert restored.native_session_id == "codex-replacement-session"
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_rejects_tied_conflicting_continuation_handles(self) -> None:
+        """Timestamp order cannot choose between divergent response-chain cursors."""
+
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Reject divergent continuation cursors",
+            session_id="session-dispatch-cursor-conflict",
+            seed_goal="Ship",
+        )
+        dispatch_id = "5" * 32
+
+        def _handle(previous_response_id: str) -> RuntimeHandle:
+            return RuntimeHandle(
+                backend="codex_cli",
+                kind="implementation_session",
+                native_session_id="codex-same-session",
+                previous_response_id=previous_response_id,
+                cwd="/tmp/project",
+                approval_mode="acceptEdits",
+                metadata={
+                    **runtime_identity.to_metadata(),
+                    "ac_capsule_version": persisted_capsule.version,
+                    "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                    "ac_session_origin": "fresh",
+                },
+            )
+
+        event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=dispatch_id,
+            ),
+            _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.resumed",
+                dispatch_id=dispatch_id,
+                runtime_handle=_handle("response-a"),
+            ),
+            _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.resumed",
+                dispatch_id=dispatch_id,
+                runtime_handle=_handle("response-b"),
+            ),
+        ]
+
+        with pytest.raises(AmbiguousACExecutionError, match="equally authoritative"):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="session-dispatch-cursor-conflict",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_rejects_lifecycle_for_unknown_dispatch(self) -> None:
+        """A resumable handle cannot be borrowed from another provider entry."""
+
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Reject a mismatched lifecycle dispatch",
+            session_id="session-dispatch-mismatch",
+            seed_goal="Ship",
+        )
+        handle = RuntimeHandle(
+            backend="codex_cli",
+            kind="implementation_session",
+            native_session_id="codex-foreign-dispatch",
+            cwd="/tmp/project",
+            approval_mode="acceptEdits",
+            metadata={
+                **runtime_identity.to_metadata(),
+                "ac_capsule_version": persisted_capsule.version,
+                "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_session_origin": "fresh",
+            },
+        )
+        event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id="1" * 32,
+            ),
+            _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.started",
+                dispatch_id="2" * 32,
+                runtime_handle=handle,
+            ),
+        ]
+
+        with pytest.raises(ValueError, match="unknown dispatch id"):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="session-dispatch-mismatch",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+    @pytest.mark.parametrize(
+        ("corruption", "error_match"),
+        [
+            ("missing_id", "dispatch id is missing"),
+            ("duplicate_id", "dispatch id is duplicated"),
+            ("fingerprint", "dispatch fingerprint disagrees"),
+            ("origin", "dispatch session origin is invalid"),
+            ("missing_predecessor", "dispatch predecessor is missing"),
+            ("unknown_predecessor", "predecessor references an unknown"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_capsule_loader_rejects_corrupt_dispatch_contract(
+        self,
+        corruption: str,
+        error_match: str,
+    ) -> None:
+        """Every authority-bearing dispatch field is validated fail-closed."""
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Reject corrupted durable dispatch authority",
+            session_id=f"session-corrupt-dispatch-{corruption}",
+            seed_goal="Ship",
+        )
+        dispatch_event = _dispatched_capsule_event(
+            runtime_identity,
+            persisted_capsule,
+            dispatch_id="3" * 32,
+        )
+        dispatch_events = [dispatch_event]
+        if corruption == "missing_id":
+            dispatch_event.data.pop("ac_dispatch_id")
+        elif corruption == "duplicate_id":
+            dispatch_events.append(dispatch_event)
+        elif corruption == "fingerprint":
+            dispatch_event.data["capsule_fingerprint"] = "sha256:" + "0" * 64
+        elif corruption == "origin":
+            dispatch_event.data["session_origin"] = "foreign_attempt"
+        elif corruption == "missing_predecessor":
+            dispatch_event.data.pop("previous_ac_dispatch_id")
+        elif corruption == "unknown_predecessor":
+            dispatch_event.data["previous_ac_dispatch_id"] = "4" * 32
+        executor._event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            *dispatch_events,
+        ]
+
+        with pytest.raises(ValueError, match=error_match):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id=f"session-corrupt-dispatch-{corruption}",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+    @pytest.mark.parametrize(
+        ("topology", "links", "error_match"),
+        [
+            (
+                "branch",
+                (("1", None), ("2", "1"), ("3", "1")),
+                "branches from one predecessor",
+            ),
+            (
+                "multiple_roots",
+                (("1", None), ("2", None)),
+                "not one linear chain",
+            ),
+            (
+                "cycle",
+                (("1", "2"), ("2", "1")),
+                "not one linear chain",
+            ),
+            (
+                "disconnected",
+                (("1", None), ("2", "1"), ("3", "4"), ("4", "3")),
+                "is disconnected",
+            ),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_capsule_loader_rejects_non_linear_dispatch_topology(
+        self,
+        topology: str,
+        links: tuple[tuple[str, str | None], ...],
+        error_match: str,
+    ) -> None:
+        """Branching, root ambiguity, cycles, and disconnected chains fail closed."""
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        execution_id = f"session-corrupt-dispatch-topology-{topology}"
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Reject non-linear durable dispatch history",
+            session_id=execution_id,
+            seed_goal="Ship",
+        )
+        executor._event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            *[
+                _dispatched_capsule_event(
+                    runtime_identity,
+                    persisted_capsule,
+                    dispatch_id=dispatch_digit * 32,
+                    previous_dispatch_id=(
+                        predecessor_digit * 32 if predecessor_digit is not None else None
+                    ),
+                )
+                for dispatch_digit, predecessor_digit in links
+            ],
+        ]
+
+        with pytest.raises(ValueError, match=error_match):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id=execution_id,
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+    @pytest.mark.parametrize(
+        ("corruption", "error_type", "error_match"),
+        [
+            ("malformed", ValueError, "linkage is malformed"),
+            ("cycle", AmbiguousACExecutionError, "replacement cycle"),
+            ("conflict", AmbiguousACExecutionError, "conflicting replacement"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_capsule_loader_rejects_corrupt_recovery_links(
+        self,
+        corruption: str,
+        error_type: type[Exception],
+        error_match: str,
+    ) -> None:
+        """Malformed, cyclic, and branching replacement histories never pick a session."""
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Reject corrupt provider-session replacement history",
+            session_id=f"session-corrupt-recovery-{corruption}",
+            seed_goal="Ship",
+        )
+        dispatch_id = "5" * 32
+
+        def _recovered_event(failed: str, replacement: str) -> BaseEvent:
+            handle = RuntimeHandle(
+                backend="codex_cli",
+                kind="implementation_session",
+                native_session_id=replacement,
+                cwd="/tmp/project",
+                approval_mode="acceptEdits",
+                metadata={
+                    **runtime_identity.to_metadata(),
+                    "ac_capsule_version": persisted_capsule.version,
+                    "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                    "ac_session_origin": "restored_same_attempt",
+                },
+            )
+            return _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.recovered",
+                dispatch_id=dispatch_id,
+                runtime_handle=handle,
+                extra_data={
+                    "recovery_discontinuity": {
+                        "failed": {"resume_session_id": failed},
+                        "replacement": {"resume_session_id": replacement},
+                    }
+                },
+            )
+
+        if corruption == "malformed":
+            malformed = _recovered_event("session-a", "session-b")
+            malformed.data["recovery_discontinuity"] = {"failed": {}}
+            recovery_events = [malformed]
+        elif corruption == "cycle":
+            recovery_events = [
+                _recovered_event("session-a", "session-b"),
+                _recovered_event("session-b", "session-a"),
+            ]
+        else:
+            recovery_events = [
+                _recovered_event("session-a", "session-b"),
+                _recovered_event("session-a", "session-c"),
+            ]
+        executor._event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=dispatch_id,
+            ),
+            *recovery_events,
+        ]
+
+        with pytest.raises(error_type, match=error_match):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id=f"session-corrupt-recovery-{corruption}",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_blocks_same_attempt_after_completed_dispatch(self) -> None:
+        """A completed dispatch is terminal, not permission for fresh redispatch."""
+
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Do not repeat an already completed provider dispatch",
+            session_id="session-dispatch-completed",
+            seed_goal="Ship",
+        )
+        dispatch_id = "c" * 32
+        event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=dispatch_id,
+            ),
+            _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.completed",
+                dispatch_id=dispatch_id,
+                runtime_handle=None,
+            ),
+        ]
+
+        with pytest.raises(CompletedACExecutionError, match="already completed"):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="session-dispatch-completed",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+    @pytest.mark.parametrize(
+        ("corruption", "error_match"),
+        [
+            ("facts", "lifecycle events disagree"),
+            ("verify_shape", "verify outcome has an invalid shape"),
+            ("verify_facts", "verify outcomes disagree"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_capsule_loader_rejects_corrupt_completed_contract(
+        self,
+        corruption: str,
+        error_match: str,
+    ) -> None:
+        """Duplicate terminal facts must agree exactly before success is reconstructed."""
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Reject conflicting durable completion facts",
+            session_id=f"session-corrupt-completed-{corruption}",
+            seed_goal="Ship",
+        )
+        dispatch_id = "6" * 32
+        passed_outcome = {
+            "passed": True,
+            "reason": None,
+            "output_tail": "",
+            "missing_artifacts": [],
+        }
+        first = _dispatch_lifecycle_event(
+            runtime_identity,
+            "execution.session.completed",
+            dispatch_id=dispatch_id,
+            runtime_handle=None,
+            result_summary="done",
+            session_id="completed-session",
+            extra_data={"verify_gate_outcome": passed_outcome},
+        )
+        second = _dispatch_lifecycle_event(
+            runtime_identity,
+            "execution.session.completed",
+            dispatch_id=dispatch_id,
+            runtime_handle=None,
+            result_summary="done",
+            session_id="completed-session",
+            extra_data={"verify_gate_outcome": passed_outcome},
+        )
+        if corruption == "facts":
+            second.data["result_summary"] = "different"
+        elif corruption == "verify_shape":
+            first.data["verify_gate_outcome"] = {"passed": True}
+        else:
+            second.data["verify_gate_outcome"] = {
+                **passed_outcome,
+                "output_tail": "different",
+            }
+        executor._event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=dispatch_id,
+            ),
+            first,
+            second,
+        ]
+
+        with pytest.raises(ValueError, match=error_match):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id=f"session-corrupt-completed-{corruption}",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_preserves_legacy_no_dispatch_completion(self) -> None:
+        """Pre-dispatch-id completed streams remain terminal and retain their result."""
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Recover a legacy completed attempt",
+            session_id="session-legacy-completed",
+            seed_goal="Ship",
+        )
+        executor._event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            BaseEvent(
+                type="execution.session.completed",
+                aggregate_type="execution",
+                aggregate_id=runtime_identity.session_scope_id,
+                data={
+                    **runtime_identity.to_metadata(),
+                    "success": True,
+                    "result_summary": "legacy done",
+                    "session_id": "legacy-session",
+                    "runtime": None,
+                },
+            ),
+        ]
+
+        with pytest.raises(CompletedACExecutionError) as completed:
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="session-legacy-completed",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+        assert completed.value.result_summary == "legacy done"
+        assert completed.value.session_id == "legacy-session"
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_preserves_legacy_no_dispatch_failed_resume(self) -> None:
+        """A legacy failed stream may resume only its exact capsule-bound handle."""
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Resume a legacy failed attempt",
+            session_id="session-legacy-failed-resume",
+            seed_goal="Ship",
+        )
+        handle = RuntimeHandle(
+            backend="codex_cli",
+            kind="implementation_session",
+            native_session_id="legacy-failed-session",
+            cwd="/tmp/project",
+            approval_mode="acceptEdits",
+            metadata={
+                **runtime_identity.to_metadata(),
+                "ac_capsule_version": persisted_capsule.version,
+                "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_session_origin": "restored_same_attempt",
+            },
+        )
+        executor._event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            BaseEvent(
+                type="execution.session.failed",
+                aggregate_type="execution",
+                aggregate_id=runtime_identity.session_scope_id,
+                data={
+                    **runtime_identity.to_metadata(),
+                    "success": False,
+                    "runtime": handle.to_persisted_dict(),
+                },
+            ),
+        ]
+
+        restored = await executor._load_persisted_ac_runtime_handle(
+            0,
+            execution_context_id="session-legacy-failed-resume",
+            retry_attempt=0,
+            expected_capsule_fingerprint=persisted_capsule.fingerprint,
+            expected_capsule_workspace=persisted_capsule.workspace,
+        )
+
+        assert restored is not None
+        assert restored.native_session_id == "legacy-failed-session"
+
+    @pytest.mark.asyncio
+    async def test_single_ac_recovers_completed_dispatch_as_success(self) -> None:
+        """Crash recovery returns the already-gated result instead of failing the workflow."""
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def execute_task(self, **_kwargs: object):
+                self.calls += 1
+                yield AgentMessage(type="result", content="[TASK_COMPLETE]")
+
+        runtime = _Runtime()
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        ac_content = "Recover one already completed AC"
+        node_identity = ExecutionNodeIdentity.root(
+            execution_context_id="session-dispatch-completed-recovery",
+            ac_index=0,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content=ac_content,
+            session_id="session-dispatch-completed-recovery",
+            seed_goal="Ship",
+            node_identity=node_identity,
+        )
+        dispatch_id = "7" * 32
+        appended_events.extend(
+            [
+                _compiled_capsule_event(runtime_identity, persisted_capsule),
+                _dispatched_capsule_event(
+                    runtime_identity,
+                    persisted_capsule,
+                    dispatch_id=dispatch_id,
+                ),
+                _dispatch_lifecycle_event(
+                    runtime_identity,
+                    "execution.session.completed",
+                    dispatch_id=dispatch_id,
+                    runtime_handle=None,
+                    result_summary="[TASK_COMPLETE] recovered",
+                    session_id="codex-completed-session",
+                ),
+            ]
+        )
+
+        result = await executor._execute_single_ac(
+            ac_index=0,
+            ac_content=ac_content,
+            session_id="session-dispatch-completed-recovery",
+            tools=["Read", "Edit"],
+            tool_catalog=None,
+            system_prompt="system",
+            seed_goal="Ship",
+            node_identity=node_identity,
+        )
+
+        assert result.success is True
+        assert result.final_message == "[TASK_COMPLETE] recovered"
+        assert result.session_id == "codex-completed-session"
+        assert runtime.calls == 0
+        assert (
+            len(
+                [
+                    event
+                    for event in appended_events
+                    if event.type == "execution.ac.attempt.dispatched"
+                ]
+            )
+            == 1
+        )
+
     @pytest.mark.parametrize(
         "terminal_event_type",
-        [None, "execution.session.completed", "execution.session.failed"],
+        [None, "execution.session.failed"],
     )
     @pytest.mark.asyncio
     async def test_atomic_ac_refuses_fresh_dispatch_after_unresumable_tool_effect(
@@ -9726,13 +11139,14 @@ class TestParallelACExecutor:
                 },
             }
         )
+        event_store, appended_events = _make_replaying_event_store()
         executor = ParallelACExecutor(
             adapter=_FinalMessageRuntime(
                 'Done.\n```json\n{"files_touched":["output.txt"]}\n```',
                 native_session_id="opencode-session-single-shot-contract",
                 cwd=str(tmp_path),
             ),
-            event_store=AsyncMock(),
+            event_store=event_store,
             console=MagicMock(),
             enable_decomposition=False,
             execution_profile=load_profile("artifact"),
@@ -9755,6 +11169,15 @@ class TestParallelACExecutor:
         assert result.success is True
         assert result.verify_gate_outcome is not None
         assert counter.read_text(encoding="utf-8") == "1"
+        completed_event = next(
+            event for event in appended_events if event.type == "execution.session.completed"
+        )
+        assert completed_event.data["verify_gate_outcome"] == {
+            "passed": True,
+            "reason": None,
+            "output_tail": "",
+            "missing_artifacts": [],
+        }
 
         finalized = await executor._apply_verify_gate(
             seed=seed,
@@ -9766,6 +11189,170 @@ class TestParallelACExecutor:
 
         assert finalized.success is True
         assert counter.read_text(encoding="utf-8") == "1"
+
+    @pytest.mark.asyncio
+    async def test_completed_recovery_reuses_durable_verify_outcome_without_command_replay(
+        self, tmp_path: Any
+    ) -> None:
+        """Crash recovery never repeats a verify command that already ran once."""
+        (tmp_path / "output.txt").write_text("done\n", encoding="utf-8")
+        counter = tmp_path / "verify-count.txt"
+        counter.write_text("1", encoding="utf-8")
+        command = (
+            "python3 -c \"from pathlib import Path; p=Path('verify-count.txt'); "
+            "n=int(p.read_text()) if p.exists() else 0; p.write_text(str(n+1)); "
+            'raise SystemExit(0 if n == 0 else 7)"'
+        )
+        seed = Seed.from_dict(
+            {
+                "goal": "Create output.txt",
+                "task_type": "artifact",
+                "acceptance_criteria": [
+                    {
+                        "description": "Create output.txt once.",
+                        "expected_artifacts": ["output.txt"],
+                        "verify_command": command,
+                    }
+                ],
+                "ontology_schema": {
+                    "name": "RecoveredArtifact",
+                    "description": "Recovered artifact contract.",
+                    "fields": [],
+                },
+                "metadata": {"ambiguity_score": 0.0, "generation_mode": "test"},
+            }
+        )
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = str(tmp_path)
+            permission_mode = "acceptEdits"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def execute_task(self, **_kwargs: object):
+                self.calls += 1
+                yield AgentMessage(type="result", content="must not run")
+
+        runtime = _Runtime()
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            task_cwd=str(tmp_path),
+        )
+        ac_spec = seed.acceptance_criteria[0]
+        assert isinstance(ac_spec, AcceptanceCriterionSpec)
+        node_identity = ExecutionNodeIdentity.root(
+            execution_context_id="session-completed-verify-recovery",
+            ac_index=0,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content=ac_spec.description,
+            session_id="session-completed-verify-recovery",
+            seed_goal=seed.goal,
+            workspace=str(tmp_path),
+            node_identity=node_identity,
+            ac_spec=ac_spec,
+        )
+        dispatch_id = "7" * 32
+        appended_events.extend(
+            [
+                _compiled_capsule_event(runtime_identity, persisted_capsule),
+                _dispatched_capsule_event(
+                    runtime_identity,
+                    persisted_capsule,
+                    dispatch_id=dispatch_id,
+                ),
+                _dispatch_lifecycle_event(
+                    runtime_identity,
+                    "execution.session.completed",
+                    dispatch_id=dispatch_id,
+                    runtime_handle=None,
+                    result_summary="already verified",
+                    session_id="completed-provider-session",
+                    extra_data={
+                        "verify_gate_outcome": {
+                            "passed": True,
+                            "reason": None,
+                            "output_tail": "",
+                            "missing_artifacts": [],
+                        }
+                    },
+                ),
+            ]
+        )
+
+        recovered = await executor._execute_single_ac(
+            ac_index=0,
+            ac_content=ac_spec.description,
+            session_id="session-completed-verify-recovery",
+            tools=["Read", "Edit"],
+            tool_catalog=None,
+            system_prompt="system",
+            seed_goal=seed.goal,
+            node_identity=node_identity,
+            ac_spec=ac_spec,
+        )
+        finalized = await executor._apply_verify_gate(
+            seed=seed,
+            ac_index=0,
+            result=recovered,
+            session_id="session-completed-verify-recovery",
+            execution_id="session-completed-verify-recovery",
+        )
+
+        assert finalized.success is True
+        assert finalized.verify_gate_outcome is not None
+        assert finalized.verify_gate_outcome.passed is True
+        assert runtime.calls == 0
+        assert counter.read_text(encoding="utf-8") == "1"
+
+    @pytest.mark.asyncio
+    async def test_completed_recovery_without_verify_outcome_refuses_command_replay(
+        self,
+    ) -> None:
+        """Legacy completion without a cached command verdict fails closed."""
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        executor._execute_atomic_ac = AsyncMock(
+            side_effect=CompletedACExecutionError(
+                "already completed",
+                result_summary="legacy completion",
+                session_id="legacy-provider-session",
+            )
+        )
+
+        with pytest.raises(
+            AmbiguousACExecutionError,
+            match="missing its non-idempotent verify-command outcome",
+        ):
+            await executor._execute_single_ac(
+                ac_index=0,
+                ac_content="Run the command once",
+                session_id="session-missing-verify-outcome",
+                tools=[],
+                tool_catalog=None,
+                system_prompt="system",
+                seed_goal="Ship",
+                ac_spec=AcceptanceCriterionSpec(
+                    description="Run the command once",
+                    verify_command="apply-once",
+                ),
+            )
 
     @pytest.mark.asyncio
     async def test_verify_gate_recovers_failed_artifact_result_when_contract_passes(
@@ -11617,6 +13204,41 @@ class TestParallelACExecutor:
         assert event_store.append.await_count == 2
 
     @pytest.mark.asyncio
+    async def test_completed_verify_outcome_rejects_oversized_durable_projection(self) -> None:
+        """Verify command output cannot amplify the durable completion stream."""
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=MagicMock(),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity = executor._resolve_ac_runtime_identity(
+            0,
+            execution_context_id="exec_oversized_verify_outcome",
+            retry_attempt=0,
+        )
+
+        with pytest.raises(ValueError, match="verify outcome exceeds the size limit"):
+            await executor._emit_ac_runtime_event(
+                event_type="execution.session.completed",
+                runtime_identity=runtime_identity,
+                ac_content="Bound the durable verify outcome",
+                runtime_handle=None,
+                execution_id="exec_oversized_verify_outcome",
+                session_id="server-oversized",
+                result_summary="[TASK_COMPLETE]",
+                success=True,
+                verify_gate_outcome=_VerifyGateOutcome(
+                    passed=True,
+                    reason=None,
+                    output_tail="x" * 65_536,
+                ),
+            )
+
+        event_store.append.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_restarted_executor_loads_persisted_runtime_handle_for_same_attempt(self) -> None:
         """A fresh executor should rehydrate the same-attempt runtime handle from events."""
 
@@ -11696,18 +13318,16 @@ class TestParallelACExecutor:
         event_store.replay = AsyncMock(
             return_value=[
                 _compiled_capsule_event(runtime_identity, persisted_capsule),
-                BaseEvent(
-                    type="execution.session.started",
-                    aggregate_type="execution",
-                    aggregate_id="orch_123_ac_2",
-                    data={
-                        "retry_attempt": 0,
-                        "session_state_path": (
-                            "execution.workflows.orch_123.acceptance_criteria."
-                            "ac_2.implementation_session"
-                        ),
-                        "runtime": persisted_handle.to_dict(),
-                    },
+                _dispatched_capsule_event(
+                    runtime_identity,
+                    persisted_capsule,
+                    dispatch_id="e" * 32,
+                ),
+                _dispatch_lifecycle_event(
+                    runtime_identity,
+                    "execution.session.started",
+                    dispatch_id="e" * 32,
+                    runtime_handle=persisted_handle,
                 ),
             ]
         )
@@ -11854,10 +13474,10 @@ class TestParallelACExecutor:
         assert result_handle == expected_handle
 
     @pytest.mark.asyncio
-    async def test_restarted_executor_prefers_latest_resumed_runtime_handle_for_same_attempt(
+    async def test_restarted_executor_rejects_conflicting_runtime_sessions_for_same_dispatch(
         self,
     ) -> None:
-        """Resume should hydrate from the newest active lifecycle event for the same attempt."""
+        """Replay order cannot choose between conflicting active provider sessions."""
 
         class _StubResumedHandleRuntime:
             def __init__(self) -> None:
@@ -11929,6 +13549,7 @@ class TestParallelACExecutor:
                 "server_session_id": "server-started",
                 "ac_capsule_version": persisted_capsule.version,
                 "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_dispatch_id": "f" * 32,
                 "ac_session_origin": "fresh",
             },
         )
@@ -11943,62 +13564,42 @@ class TestParallelACExecutor:
                 "server_session_id": "server-resumed",
                 "ac_capsule_version": persisted_capsule.version,
                 "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_dispatch_id": "f" * 32,
                 "ac_session_origin": "restored_same_attempt",
             },
         )
         event_store.replay = AsyncMock(
             return_value=[
                 _compiled_capsule_event(runtime_identity, persisted_capsule),
-                BaseEvent(
-                    type="execution.session.started",
-                    aggregate_type="execution",
-                    aggregate_id="orch_123_ac_2",
-                    data={
-                        "retry_attempt": 0,
-                        "session_state_path": (
-                            "execution.workflows.orch_123.acceptance_criteria."
-                            "ac_2.implementation_session"
-                        ),
-                        "runtime": started_handle.to_dict(),
-                    },
+                _dispatched_capsule_event(
+                    runtime_identity,
+                    persisted_capsule,
+                    dispatch_id="f" * 32,
                 ),
-                BaseEvent(
-                    type="execution.session.resumed",
-                    aggregate_type="execution",
-                    aggregate_id="orch_123_ac_2",
-                    data={
-                        "retry_attempt": 0,
-                        "session_state_path": (
-                            "execution.workflows.orch_123.acceptance_criteria."
-                            "ac_2.implementation_session"
-                        ),
-                        "runtime": resumed_handle.to_dict(),
-                    },
+                _dispatch_lifecycle_event(
+                    runtime_identity,
+                    "execution.session.started",
+                    dispatch_id="f" * 32,
+                    runtime_handle=started_handle,
+                ),
+                _dispatch_lifecycle_event(
+                    runtime_identity,
+                    "execution.session.resumed",
+                    dispatch_id="f" * 32,
+                    runtime_handle=resumed_handle,
                 ),
             ]
         )
         event_store.append = AsyncMock()
 
-        result = await executor._execute_atomic_ac(
-            ac_index=1,
-            ac_content=ac_content,
-            session_id="orch_123",
-            tools=["Read", "Edit"],
-            system_prompt="system",
-            seed_goal="Ship the feature",
-            depth=0,
-            start_time=datetime.now(UTC),
-            retry_attempt=0,
-        )
-
-        resume_handle = runtime.calls[0]["resume_handle"]
-        assert isinstance(resume_handle, RuntimeHandle)
-        assert resume_handle.native_session_id == "opencode-session-resumed"
-        assert resume_handle.metadata["server_session_id"] == "server-resumed"
-        event_store.replay.assert_awaited_once_with("execution", "orch_123_ac_2")
-        assert result.runtime_handle is not None
-        assert result.runtime_handle.native_session_id == resume_handle.native_session_id
-        assert result.runtime_handle.metadata == resume_handle.metadata
+        with pytest.raises(AmbiguousACExecutionError, match="conflicting reusable"):
+            await executor._load_persisted_ac_runtime_handle(
+                1,
+                execution_context_id="orch_123",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
 
     @pytest.mark.asyncio
     async def test_restarted_executor_does_not_cross_resume_into_another_execution_context(

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -21,6 +21,7 @@ from ouroboros.core.seed import (
 )
 from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.types import MCPToolDefinition
+from ouroboros.orchestrator.ac_execution_capsule import ACExecutionCapsule
 from ouroboros.orchestrator.adapter import (
     FULL_CAPABILITIES,
     AgentMessage,
@@ -4363,6 +4364,9 @@ class TestParallelACExecutor:
         ]
         assert resume_handle.metadata["session_scope_id"] == "orch_123_ac_3"
         assert resume_handle.metadata["session_attempt_id"] == "orch_123_ac_3_attempt_1"
+        assert resume_handle.metadata["ac_capsule_version"] == 1
+        assert resume_handle.metadata["ac_capsule_fingerprint"].startswith("sha256:")
+        assert resume_handle.metadata["ac_session_origin"] == "fresh"
         assert (
             resume_handle.metadata["session_state_path"]
             == "execution.workflows.orch_123.acceptance_criteria.ac_3.implementation_session"
@@ -4370,6 +4374,16 @@ class TestParallelACExecutor:
         started_event = next(
             event for event in appended_events if event.type == "execution.session.started"
         )
+        capsule_event = next(
+            event for event in appended_events if event.type == "execution.ac.capsule.compiled"
+        )
+        restored_capsule = ACExecutionCapsule.from_contract_data(capsule_event.data["capsule"])
+        assert capsule_event.data["capsule_fingerprint"] == restored_capsule.fingerprint
+        assert capsule_event.data["session_origin"] == "fresh"
+        assert isinstance(runtime_call["prompt"], str)
+        assert "Ouroboros AC Runtime" in runtime_call["prompt"]
+        assert restored_capsule.ac_content == "Implement AC 3"
+        assert restored_capsule.workspace == os.path.realpath("/tmp/project")
         assert [tool["name"] for tool in started_event.data["tool_catalog"]] == ["Read", "Edit"]
         assert [
             tool["name"] for tool in started_event.data["runtime"]["metadata"]["tool_catalog"]
@@ -4385,6 +4399,139 @@ class TestParallelACExecutor:
         assert result.session_id == "opencode-session-1"
         assert result.runtime_handle is not None
         assert result.runtime_handle.native_session_id == "opencode-session-1"
+
+    @pytest.mark.asyncio
+    async def test_atomic_ac_does_not_dispatch_when_capsule_persistence_fails(self) -> None:
+        """An authority-bearing capsule must be durable before provider effects."""
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def execute_task(self, **_kwargs: object):
+                self.calls += 1
+                yield AgentMessage(type="result", content="[TASK_COMPLETE]")
+
+        runtime = _Runtime()
+        event_store = AsyncMock()
+        event_store.replay.return_value = []
+        event_store.append.side_effect = OSError("event store unavailable")
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+
+        with pytest.raises(OSError, match="event store unavailable"):
+            await executor._execute_atomic_ac(
+                ac_index=0,
+                ac_content="Implement the AC",
+                session_id="session-capsule-failure",
+                tools=["Read", "Edit"],
+                system_prompt="system",
+                seed_goal="Ship",
+                depth=0,
+                start_time=datetime.now(UTC),
+            )
+
+        assert runtime.calls == 0
+
+    @pytest.mark.asyncio
+    async def test_atomic_ac_refuses_durable_capsule_drift_before_resume(self) -> None:
+        """Recovery cannot apply an old provider session to a new capsule."""
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def execute_task(self, **_kwargs: object):
+                self.calls += 1
+                yield AgentMessage(type="result", content="[TASK_COMPLETE]")
+
+        runtime = _Runtime()
+        event_store, appended_events = _make_replaying_event_store()
+        appended_events.append(
+            BaseEvent(
+                type="execution.ac.capsule.compiled",
+                aggregate_type="execution",
+                aggregate_id="session-capsule-mismatch_ac_1",
+                data={
+                    "ac_id": "session-capsule-mismatch_ac_1",
+                    "session_attempt_id": "session-capsule-mismatch_ac_1_attempt_1",
+                    "capsule_fingerprint": "sha256:" + "0" * 64,
+                },
+            )
+        )
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+
+        with pytest.raises(ValueError, match="capsule fingerprint disagrees"):
+            await executor._execute_atomic_ac(
+                ac_index=0,
+                ac_content="Changed AC authority",
+                session_id="session-capsule-mismatch",
+                tools=["Read", "Edit"],
+                system_prompt="system",
+                seed_goal="Ship",
+                depth=0,
+                start_time=datetime.now(UTC),
+            )
+
+        assert runtime.calls == 0
+
+    @pytest.mark.asyncio
+    async def test_atomic_ac_refuses_dispatch_when_capsule_replay_is_unreadable(self) -> None:
+        """A fresh dispatch cannot guess that no authority-bearing capsule exists."""
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def execute_task(self, **_kwargs: object):
+                self.calls += 1
+                yield AgentMessage(type="result", content="[TASK_COMPLETE]")
+
+        runtime = _Runtime()
+        event_store = AsyncMock()
+        event_store.replay.side_effect = OSError("replay unavailable")
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+
+        with pytest.raises(OSError, match="replay unavailable"):
+            await executor._execute_atomic_ac(
+                ac_index=0,
+                ac_content="Implement the AC",
+                session_id="session-capsule-replay",
+                tools=["Read", "Edit"],
+                system_prompt="system",
+                seed_goal="Ship",
+                depth=0,
+                start_time=datetime.now(UTC),
+            )
+
+        assert runtime.calls == 0
+        event_store.append.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_atomic_ac_terminates_live_runtime_handle_after_completion(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1014,6 +1014,13 @@ def _compiled_capsule_event(
     )
 
 
+_GLOBAL_VERIFIER_PASS = True
+
+
+def _global_state_verifier(**_kwargs: Any) -> VerifierVerdict:
+    return VerifierVerdict(passed=_GLOBAL_VERIFIER_PASS)
+
+
 def test_capsule_authority_covers_prompt_gate_runtime_and_verifier_inputs() -> None:
     """Every input that can alter provider work or acceptance must change authority."""
 
@@ -1163,6 +1170,34 @@ def test_capsule_authority_distinguishes_callable_verifier_state() -> None:
         console=MagicMock(),
         enable_decomposition=False,
         atomic_verifier=ConfiguredVerifier(False),
+    )
+
+    assert passing._atomic_verifier_authority != rejecting._atomic_verifier_authority
+    assert passing._atomic_verifier_authority["behavioral_state"]["stability"] == "durable"
+
+
+def test_capsule_authority_distinguishes_referenced_verifier_globals(monkeypatch) -> None:
+    """Changing a module-global policy cannot preserve acceptance authority."""
+    runtime = SimpleNamespace(
+        runtime_backend="codex_cli",
+        working_directory="/tmp/project",
+        permission_mode="acceptEdits",
+    )
+    monkeypatch.setitem(_global_state_verifier.__globals__, "_GLOBAL_VERIFIER_PASS", True)
+    passing = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        atomic_verifier=_global_state_verifier,
+    )
+    monkeypatch.setitem(_global_state_verifier.__globals__, "_GLOBAL_VERIFIER_PASS", False)
+    rejecting = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        atomic_verifier=_global_state_verifier,
     )
 
     assert passing._atomic_verifier_authority != rejecting._atomic_verifier_authority

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -960,6 +960,7 @@ def _make_replaying_event_store() -> tuple[AsyncMock, list[BaseEvent]]:
 
 def _compile_test_capsule(
     *,
+    executor: ParallelACExecutor,
     ac_index: int,
     ac_content: str,
     session_id: str,
@@ -977,7 +978,17 @@ def _compile_test_capsule(
         execution_id=session_id,
         semantic_ac_key=derive_semantic_ac_key(ac_content),
         workspace=os.path.realpath(workspace),
-        authority_scope=f"execution:{session_id}",
+        authority_scope=executor._build_ac_capsule_authority_scope(
+            execution_context_id=session_id,
+            tools=["Read", "Edit"],
+            tool_catalog=None,
+            system_prompt="system",
+            level_contexts=None,
+            is_sub_ac=False,
+            decomposition_trustworthy=False,
+            force_frontier_routing=False,
+            investment_spec=None,
+        ),
         seed_goal=seed_goal,
         ac_content=ac_content,
         ac_spec=None,
@@ -4514,19 +4525,18 @@ class TestParallelACExecutor:
 
         runtime = _Runtime()
         event_store, appended_events = _make_replaying_event_store()
-        persisted_capsule = compile_ac_execution_capsule(
-            runtime_identity=build_ac_runtime_identity(
-                0,
-                execution_context_id="session-capsule-mismatch",
-                retry_attempt=0,
-            ),
-            execution_id="session-capsule-mismatch",
-            semantic_ac_key="semantic-key",
-            workspace=os.path.realpath("/tmp/project"),
-            authority_scope="execution:session-capsule-mismatch",
-            seed_goal="Ship",
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
             ac_content="Original AC authority",
-            ac_spec=None,
+            session_id="session-capsule-mismatch",
+            seed_goal="Ship",
         )
         appended_events.append(
             BaseEvent(
@@ -4541,13 +4551,6 @@ class TestParallelACExecutor:
                 },
             )
         )
-        executor = ParallelACExecutor(
-            adapter=runtime,
-            event_store=event_store,
-            console=MagicMock(),
-            enable_decomposition=False,
-        )
-
         with pytest.raises(ValueError, match="capsule fingerprint disagrees"):
             await executor._execute_atomic_ac(
                 ac_index=0,
@@ -4558,7 +4561,53 @@ class TestParallelACExecutor:
                 seed_goal="Ship",
                 depth=0,
                 start_time=datetime.now(UTC),
-                semantic_ac_key="semantic-key",
+            )
+
+        assert runtime.calls == 0
+
+    @pytest.mark.asyncio
+    async def test_atomic_ac_refuses_dispatch_authority_drift_before_resume(self) -> None:
+        """Tools, prompt, runtime, and routing authority are capsule identity."""
+
+        class _Runtime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def execute_task(self, **_kwargs: object):
+                self.calls += 1
+                yield AgentMessage(type="result", content="[TASK_COMPLETE]")
+
+        runtime = _Runtime()
+        event_store, appended_events = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Implement the AC",
+            session_id="session-capsule-dispatch-drift",
+            seed_goal="Ship",
+        )
+        appended_events.append(_compiled_capsule_event(runtime_identity, persisted_capsule))
+
+        with pytest.raises(ValueError, match="capsule fingerprint disagrees"):
+            await executor._execute_atomic_ac(
+                ac_index=0,
+                ac_content="Implement the AC",
+                session_id="session-capsule-dispatch-drift",
+                tools=["Read", "Edit"],
+                system_prompt="changed-system-prompt",
+                seed_goal="Ship",
+                depth=0,
+                start_time=datetime.now(UTC),
             )
 
         assert runtime.calls == 0
@@ -4581,20 +4630,18 @@ class TestParallelACExecutor:
 
         runtime = _Runtime()
         event_store, appended_events = _make_replaying_event_store()
-        runtime_identity = build_ac_runtime_identity(
-            0,
-            execution_context_id="session-capsule-resume",
-            retry_attempt=0,
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
         )
-        persisted_capsule = compile_ac_execution_capsule(
-            runtime_identity=runtime_identity,
-            execution_id="session-capsule-resume",
-            semantic_ac_key="semantic-key",
-            workspace=os.path.realpath("/tmp/project"),
-            authority_scope="execution:session-capsule-resume",
-            seed_goal="Ship",
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
             ac_content="Implement the AC",
-            ac_spec=None,
+            session_id="session-capsule-resume",
+            seed_goal="Ship",
         )
         persisted_handle = RuntimeHandle(
             backend="codex_cli",
@@ -4632,13 +4679,6 @@ class TestParallelACExecutor:
                 ),
             ]
         )
-        executor = ParallelACExecutor(
-            adapter=runtime,
-            event_store=event_store,
-            console=MagicMock(),
-            enable_decomposition=False,
-        )
-
         await executor._execute_atomic_ac(
             ac_index=0,
             ac_content="Implement the AC",
@@ -4648,7 +4688,6 @@ class TestParallelACExecutor:
             seed_goal="Ship",
             depth=0,
             start_time=datetime.now(UTC),
-            semantic_ac_key="semantic-key",
         )
 
         assert runtime.resume_handles[0] is not None
@@ -4737,7 +4776,20 @@ class TestParallelACExecutor:
     @pytest.mark.asyncio
     async def test_capsule_resume_rejects_foreign_workspace_handle(self) -> None:
         """A matching fingerprint cannot authorize continuity from another checkout."""
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
         runtime_identity, capsule = _compile_test_capsule(
+            executor=executor,
             ac_index=0,
             ac_content="Implement the AC",
             session_id="session-capsule-foreign-workspace",
@@ -4754,7 +4806,6 @@ class TestParallelACExecutor:
                 "ac_capsule_fingerprint": capsule.fingerprint,
             },
         )
-        event_store = AsyncMock()
         event_store.replay.return_value = [
             _compiled_capsule_event(runtime_identity, capsule),
             BaseEvent(
@@ -4767,18 +4818,6 @@ class TestParallelACExecutor:
                 },
             ),
         ]
-        runtime = SimpleNamespace(
-            runtime_backend="codex_cli",
-            working_directory="/tmp/project",
-            permission_mode="acceptEdits",
-        )
-        executor = ParallelACExecutor(
-            adapter=runtime,
-            event_store=event_store,
-            console=MagicMock(),
-            enable_decomposition=False,
-        )
-
         with pytest.raises(ValueError, match="workspace authority changed"):
             await executor._load_persisted_ac_runtime_handle(
                 0,
@@ -11039,8 +11078,17 @@ class TestParallelACExecutor:
                     resume_handle=resume_handle,
                 )
 
+        runtime = _StubPersistedResumeRuntime()
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
         ac_content = "Resume the interrupted AC implementation session"
         runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
             ac_index=1,
             ac_content=ac_content,
             session_id="orch_123",
@@ -11060,7 +11108,6 @@ class TestParallelACExecutor:
                 "ac_session_origin": "fresh",
             },
         )
-        event_store = AsyncMock()
         event_store.replay = AsyncMock(
             return_value=[
                 _compiled_capsule_event(runtime_identity, persisted_capsule),
@@ -11080,13 +11127,6 @@ class TestParallelACExecutor:
             ]
         )
         event_store.append = AsyncMock()
-        runtime = _StubPersistedResumeRuntime()
-        executor = ParallelACExecutor(
-            adapter=runtime,
-            event_store=event_store,
-            console=MagicMock(),
-            enable_decomposition=False,
-        )
 
         result = await executor._execute_atomic_ac(
             ac_index=1,
@@ -11277,8 +11317,17 @@ class TestParallelACExecutor:
                     resume_handle=resume_handle,
                 )
 
+        runtime = _StubResumedHandleRuntime()
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
         ac_content = "Resume the latest persisted implementation session"
         runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
             ac_index=1,
             ac_content=ac_content,
             session_id="orch_123",
@@ -11312,7 +11361,6 @@ class TestParallelACExecutor:
                 "ac_session_origin": "restored_same_attempt",
             },
         )
-        event_store = AsyncMock()
         event_store.replay = AsyncMock(
             return_value=[
                 _compiled_capsule_event(runtime_identity, persisted_capsule),
@@ -11345,13 +11393,6 @@ class TestParallelACExecutor:
             ]
         )
         event_store.append = AsyncMock()
-        runtime = _StubResumedHandleRuntime()
-        executor = ParallelACExecutor(
-            adapter=runtime,
-            event_store=event_store,
-            console=MagicMock(),
-            enable_decomposition=False,
-        )
 
         result = await executor._execute_atomic_ac(
             ac_index=1,
@@ -12884,8 +12925,17 @@ class TestParallelACExecutor:
                     resume_handle=resume_handle,
                 )
 
+        runtime = _StubResumeAfterInvalidRuntime()
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
         ac_content = "Resume after skipping invalid persisted event"
         runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
             ac_index=1,
             ac_content=ac_content,
             session_id="orch_123",
@@ -12905,7 +12955,6 @@ class TestParallelACExecutor:
                 "ac_session_origin": "fresh",
             },
         )
-        event_store = AsyncMock()
         event_store.replay = AsyncMock(
             return_value=[
                 _compiled_capsule_event(runtime_identity, persisted_capsule),
@@ -12944,13 +12993,6 @@ class TestParallelACExecutor:
             ]
         )
         event_store.append = AsyncMock()
-        runtime = _StubResumeAfterInvalidRuntime()
-        executor = ParallelACExecutor(
-            adapter=runtime,
-            event_store=event_store,
-            console=MagicMock(),
-            enable_decomposition=False,
-        )
 
         result = await executor._execute_atomic_ac(
             ac_index=1,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1463,6 +1463,89 @@ def test_codex_runtime_watchdog_identity_reflects_timeouts() -> None:
     assert "startup_output_timeout_seconds" in contract
 
 
+def test_runtime_executable_identity_resolves_bare_name_relative_path_against_child_cwd(
+    tmp_path: Any, monkeypatch: Any
+) -> None:
+    """R9 blocker #1: a bare name under a RELATIVE PATH entry binds the child cwd.
+
+    ``PATH=bin`` resolves ``bin/<name>`` from the CHILD's workspace, not the
+    orchestrator. Two workspaces with different ``bin/probe`` targets must
+    produce different executable identity, not both collapse to ``unresolved``.
+    """
+    import os as _os
+    import stat
+
+    def _make_ws(name: str, target: str) -> Any:
+        ws = tmp_path / name
+        (ws / "bin").mkdir(parents=True)
+        script = ws / "bin" / "probe"
+        script.write_text(f"#!/bin/sh\nexec {target}\n")
+        script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        return ws
+
+    ws_true = _make_ws("wtrue", "/bin/true")
+    ws_false = _make_ws("wfalse", "/bin/false")
+
+    class _Runtime:
+        _cli_path = "probe"
+
+    monkeypatch.setenv("PATH", "bin")  # relative PATH entry
+    id_true = ParallelACExecutor._runtime_executable_identity(_Runtime(), cwd=str(ws_true))
+    id_false = ParallelACExecutor._runtime_executable_identity(_Runtime(), cwd=str(ws_false))
+    assert id_true["executable"]["realpath"] == _os.path.realpath(str(ws_true / "bin" / "probe"))
+    assert id_false["executable"]["realpath"] == _os.path.realpath(str(ws_false / "bin" / "probe"))
+    assert id_true != id_false
+
+
+def test_watchdog_identity_binds_total_turn_timeout() -> None:
+    """R9 blocker #2: a wrapped transport's total-turn ``_timeout`` participates."""
+
+    class _Transport:
+        def __init__(self, timeout: float) -> None:
+            self._timeout = timeout
+
+    class _WrappingRuntime:
+        def __init__(self, timeout: float) -> None:
+            self._transport = _Transport(timeout)
+
+    fast = ParallelACExecutor._runtime_watchdog_identity(_WrappingRuntime(1.0))
+    slow = ParallelACExecutor._runtime_watchdog_identity(_WrappingRuntime(999.0))
+    assert fast["observed"] is True
+    assert fast["policy"]["timeout"] == 1.0
+    assert fast != slow
+
+
+def test_capsule_authority_binds_max_concurrent() -> None:
+    """R9 blocker #3: shared-workspace concurrency participates in capsule identity."""
+
+    class _Runtime:
+        runtime_backend = "codex_cli"
+        working_directory = "/tmp/project"
+        permission_mode = "acceptEdits"
+
+    def _scope(max_concurrent: int) -> str:
+        executor = ParallelACExecutor(
+            adapter=_Runtime(),
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            enable_decomposition=False,
+            max_concurrent=max_concurrent,
+        )
+        return executor._build_ac_capsule_authority_scope(
+            execution_context_id="exec-1",
+            tools=["Read"],
+            tool_catalog=None,
+            system_prompt="system",
+            level_contexts=None,
+            is_sub_ac=False,
+            decomposition_trustworthy=False,
+            force_frontier_routing=False,
+            investment_spec=None,
+        )
+
+    assert _scope(1) != _scope(8)
+
+
 def test_watchdog_identity_is_provider_neutral_via_attributes() -> None:
     """R8 blocker #3: runtimes without a watchdog contract still fingerprint policy.
 

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1012,6 +1012,94 @@ def _compiled_capsule_event(
     )
 
 
+def test_capsule_authority_covers_prompt_gate_runtime_and_verifier_inputs() -> None:
+    """Every input that can alter provider work or acceptance must change authority."""
+
+    class _Runtime:
+        runtime_backend = "codex_cli"
+        working_directory = "/tmp/project"
+        permission_mode = "acceptEdits"
+
+        def __init__(self, profile: str) -> None:
+            self.profile = profile
+
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {"profile": self.profile, "effective_model_observed": True}
+
+    def verifier_a(**_kwargs: Any) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+    def verifier_b(**_kwargs: Any) -> VerifierVerdict:
+        return VerifierVerdict(passed=False)
+
+    base = ParallelACExecutor(
+        adapter=_Runtime("profile-a"),
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        atomic_verifier=verifier_a,
+    )
+
+    def scope(executor: ParallelACExecutor, **overrides: Any) -> str:
+        kwargs: dict[str, Any] = {
+            "execution_context_id": "exec-authority",
+            "tools": ["Read"],
+            "tool_catalog": None,
+            "system_prompt": "system",
+            "level_contexts": None,
+            "is_sub_ac": False,
+            "decomposition_trustworthy": False,
+            "force_frontier_routing": False,
+            "investment_spec": None,
+            "sibling_acs": [(0, "current"), (1, "sibling A")],
+            "retry_prompt_extra": "retry A",
+        }
+        kwargs.update(overrides)
+        return executor._build_ac_capsule_authority_scope(**kwargs)
+
+    baseline = scope(base)
+    assert scope(base, retry_prompt_extra="retry B") != baseline
+    assert scope(base, sibling_acs=[(0, "current"), (1, "sibling B")]) != baseline
+
+    fat = ParallelACExecutor(
+        adapter=_Runtime("profile-a"),
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        fat_harness_mode=True,
+        atomic_verifier=verifier_a,
+    )
+    assert scope(fat) != baseline
+
+    verify_off = ParallelACExecutor(
+        adapter=_Runtime("profile-a"),
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        run_verify_commands=False,
+        atomic_verifier=verifier_a,
+    )
+    assert scope(verify_off) != baseline
+
+    runtime_drift = ParallelACExecutor(
+        adapter=_Runtime("profile-b"),
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        atomic_verifier=verifier_a,
+    )
+    assert scope(runtime_drift) != baseline
+
+    verifier_drift = ParallelACExecutor(
+        adapter=_Runtime("profile-a"),
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+        atomic_verifier=verifier_b,
+    )
+    assert scope(verifier_drift) != baseline
+
+
 @pytest.mark.parametrize(
     ("content", "expected"),
     (

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1555,6 +1555,43 @@ def test_watchdog_identity_binds_total_turn_timeout() -> None:
     assert fast != slow
 
 
+def test_capsule_authority_binds_execution_semantic_policy() -> None:
+    """R11: every declared execution-semantic knob participates in capsule authority."""
+
+    class _Runtime:
+        runtime_backend = "codex_cli"
+        working_directory = "/tmp/project"
+        permission_mode = "acceptEdits"
+
+    def _scope(**overrides: Any) -> str:
+        executor = ParallelACExecutor(
+            adapter=_Runtime(),
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            enable_decomposition=False,
+            **overrides,
+        )
+        return executor._build_ac_capsule_authority_scope(
+            execution_context_id="exec-1",
+            tools=["Read"],
+            tool_catalog=None,
+            system_prompt="system",
+            level_contexts=None,
+            is_sub_ac=False,
+            decomposition_trustworthy=False,
+            force_frontier_routing=False,
+            investment_spec=None,
+        )
+
+    baseline = _scope()
+    # Each execution-semantic field must independently change authority.
+    assert _scope(shadow_replay_enabled=True) != baseline
+    assert _scope(cross_harness_redispatch=True) != _scope(cross_harness_redispatch=False)
+    assert _scope(ac_retry_attempts=3) != baseline
+    assert _scope(lateral_escalation_enabled=True) != baseline
+    assert _scope(parked_retry_backoff_seconds=42.0) != baseline
+
+
 def test_capsule_authority_binds_max_concurrent() -> None:
     """R9 blocker #3: shared-workspace concurrency participates in capsule identity."""
 
@@ -6412,6 +6449,79 @@ class TestParallelACExecutor:
             await executor._load_persisted_ac_runtime_handle(
                 0,
                 execution_context_id="session-dispatch-no-capsule",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_fails_closed_on_effectful_active_dispatch(self) -> None:
+        """R11 blocker #1: durable effect evidence outranks a resumable handle.
+
+        An active dispatch that recorded a tool effect but did not terminate must
+        NOT resume: the caller resends the original AC prompt on resume, starting
+        another provider turn that can duplicate a non-idempotent effect.
+        """
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Do not resume an effectful in-flight turn",
+            session_id="session-effectful-active",
+            seed_goal="Ship",
+        )
+        dispatch_id = "3" * 32
+        handle = RuntimeHandle(
+            backend="codex_cli",
+            kind="implementation_session",
+            native_session_id="codex-inflight",
+            cwd="/tmp/project",
+            approval_mode="acceptEdits",
+            metadata={
+                **runtime_identity.to_metadata(),
+                "ac_capsule_version": persisted_capsule.version,
+                "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                "ac_session_origin": "fresh",
+            },
+        )
+        event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=dispatch_id,
+                dispatch_kind="primary",
+            ),
+            _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.started",
+                dispatch_id=dispatch_id,
+                runtime_handle=handle,
+            ),
+            # A durable tool effect on the active dispatch, with no terminal event.
+            BaseEvent(
+                type="execution.tool.started",
+                aggregate_type="execution",
+                aggregate_id=runtime_identity.session_scope_id,
+                data={**runtime_identity.to_metadata(), "ac_dispatch_id": dispatch_id},
+            ),
+        ]
+
+        with pytest.raises(AmbiguousACExecutionError, match="recorded durable tool effects"):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="session-effectful-active",
                 retry_attempt=0,
                 expected_capsule_fingerprint=persisted_capsule.fingerprint,
                 expected_capsule_workspace=persisted_capsule.workspace,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -4794,8 +4794,15 @@ class TestParallelACExecutor:
 
         assert runtime.calls == 0
 
+    @pytest.mark.parametrize(
+        "terminal_event_type",
+        [None, "execution.session.completed", "execution.session.failed"],
+    )
     @pytest.mark.asyncio
-    async def test_atomic_ac_refuses_fresh_dispatch_after_unresumable_tool_effect(self) -> None:
+    async def test_atomic_ac_refuses_fresh_dispatch_after_unresumable_tool_effect(
+        self,
+        terminal_event_type: str | None,
+    ) -> None:
         """A crash after a tool effect cannot be recovered by duplicating the attempt."""
 
         class _Runtime:
@@ -4840,6 +4847,18 @@ class TestParallelACExecutor:
                 ),
             ]
         )
+        if terminal_event_type is not None:
+            appended_events.append(
+                BaseEvent(
+                    type=terminal_event_type,
+                    aggregate_type="execution",
+                    aggregate_id=runtime_identity.session_scope_id,
+                    data={
+                        **runtime_identity.to_metadata(),
+                        "runtime": None,
+                    },
+                )
+            )
 
         with pytest.raises(
             AmbiguousACExecutionError,

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -12659,6 +12659,86 @@ class TestParallelACExecutor:
         assert "final-workspace" in (results[0].error or "").lower()
 
     @pytest.mark.asyncio
+    async def test_final_workspace_acceptance_rechecks_artifact_only_contract(
+        self, tmp_path: Any
+    ) -> None:
+        """R17/B1: the final pass re-checks ARTIFACT-ONLY contracts too.
+
+        An AC whose success contract is only ``expected_artifacts`` (no command)
+        is still re-verified over the final workspace, so a later stage that
+        deletes a required artifact after its provisional gate invalidates
+        acceptance.
+        """
+        artifact = tmp_path / "artifact.txt"
+        artifact.write_text("ready\n", encoding="utf-8")
+        spec = AcceptanceCriterionSpec(
+            description="artifact must exist", expected_artifacts=("artifact.txt",)
+        )
+        seed = _make_seed(spec)
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory=str(tmp_path),
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            task_cwd=str(tmp_path),
+        )
+        accepted = ACExecutionResult(
+            ac_index=0, ac_content="ac", success=True, outcome=ACExecutionOutcome.SUCCEEDED
+        )
+        # A later stage deletes the required artifact after its provisional gate.
+        artifact.unlink()
+
+        results = await executor._apply_final_workspace_acceptance(
+            seed=seed, results=[accepted], session_id="s", execution_id="e"
+        )
+
+        assert results[0].success is False
+        assert results[0].outcome == ACExecutionOutcome.FAILED
+
+    @pytest.mark.asyncio
+    async def test_verify_command_removing_required_directory_fails_closed(
+        self, tmp_path: Any
+    ) -> None:
+        """R17/B5: the fingerprint covers directories, so a verifier that removes a
+        required (even empty) directory is detected and failed closed."""
+        (tmp_path / "artifact_dir").mkdir()
+        spec = AcceptanceCriterionSpec(
+            description="empty dir must survive",
+            verify_command="rmdir artifact_dir",  # exits 0 but removes a dir
+            expected_artifacts=("artifact_dir",),
+        )
+        seed = _make_seed(spec)
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory=str(tmp_path),
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            task_cwd=str(tmp_path),
+        )
+
+        gated = await executor._apply_verify_gate(
+            seed=seed,
+            ac_index=0,
+            result=ACExecutionResult(ac_index=0, ac_content="ac", success=True),
+            session_id="s",
+            execution_id="e",
+        )
+
+        assert gated.success is False
+        assert gated.verify_gate_outcome is not None
+        assert gated.verify_gate_outcome.passed is False
+
+    @pytest.mark.asyncio
     async def test_final_workspace_acceptance_confirms_valid_pass(self, tmp_path: Any) -> None:
         """R16/B1: an AC still satisfied at the final workspace stays accepted."""
         (tmp_path / "marker.txt").write_text("good\n", encoding="utf-8")

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1463,6 +1463,47 @@ def test_codex_runtime_watchdog_identity_reflects_timeouts() -> None:
     assert "startup_output_timeout_seconds" in contract
 
 
+def test_watchdog_identity_is_provider_neutral_via_attributes() -> None:
+    """R8 blocker #3: runtimes without a watchdog contract still fingerprint policy.
+
+    OpenCode/Hermes/Pi/GJC expose ``_startup_output_timeout_seconds`` /
+    ``_stdout_idle_timeout_seconds`` attributes but no ``watchdog_identity_contract()``;
+    the executor must still bind those, so idle timeouts 1 vs 999 differ.
+    """
+
+    class _AttrOnlyRuntime:
+        # No watchdog_identity_contract() method — attribute-only, like OpenCode.
+        _startup_output_timeout_seconds = 120.0
+
+        def __init__(self, idle: float) -> None:
+            self._stdout_idle_timeout_seconds = idle
+
+    fast = ParallelACExecutor._runtime_watchdog_identity(_AttrOnlyRuntime(1.0))
+    slow = ParallelACExecutor._runtime_watchdog_identity(_AttrOnlyRuntime(999.0))
+    assert fast["observed"] is True
+    assert fast["policy"]["stdout_idle_timeout_seconds"] == 1.0
+    assert fast != slow
+
+
+def test_completed_verify_outcome_bounded_by_utf8_bytes() -> None:
+    """R8 blocker #4: the completed-lifecycle outcome validator bounds UTF-8 bytes.
+
+    A payload under the char limit but over 64 KiB of UTF-8 bytes (multi-byte
+    artifact paths) must be rejected, not accepted.
+    """
+    from ouroboros.orchestrator.ac_runtime_handle_manager import ACRuntimeHandleManager
+
+    # 40 entries × ~700 4-byte chars ≈ 112 KiB bytes but only ~28k chars.
+    outcome = {
+        "passed": True,
+        "reason": None,
+        "output_tail": "",
+        "missing_artifacts": ["𐍈" * 700 for _ in range(40)],
+    }
+    with pytest.raises(ValueError, match="exceeds the size limit"):
+        ACRuntimeHandleManager._parse_verify_gate_outcome(outcome)
+
+
 def test_runtime_capabilities_contract_includes_realtime_effect_visibility() -> None:
     """R6 blocker #1: the stall-affecting capability participates in authority."""
     from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
@@ -11990,6 +12031,40 @@ class TestParallelACExecutor:
                 ),
             ]
         )
+        # The completion must be backed by the durable single-shot verify chain
+        # (exactly one intent + matching outcome) under the shared per-attempt key.
+        _verify_command_digest = executor._verify_gate_command_digest(ac_spec)
+        _verify_key = executor._ac_verify_gate_key(
+            execution_scope="session-completed-verify-recovery", ac_index=0, retry_attempt=0
+        )
+        appended_events.extend(
+            [
+                BaseEvent(
+                    type="execution.ac.verify.intent",
+                    aggregate_type="execution",
+                    aggregate_id="session-completed-verify-recovery",
+                    data={
+                        "verify_key": _verify_key,
+                        "verify_command_digest": _verify_command_digest,
+                    },
+                ),
+                BaseEvent(
+                    type="execution.ac.verify.outcome",
+                    aggregate_type="execution",
+                    aggregate_id="session-completed-verify-recovery",
+                    data={
+                        "verify_key": _verify_key,
+                        "verify_command_digest": _verify_command_digest,
+                        "verify_gate_outcome": {
+                            "passed": True,
+                            "reason": None,
+                            "output_tail": "",
+                            "missing_artifacts": [],
+                        },
+                    },
+                ),
+            ]
+        )
 
         recovered = await executor._execute_single_ac(
             ac_index=0,
@@ -12047,6 +12122,56 @@ class TestParallelACExecutor:
                 ac_index=0,
                 ac_content="Run the command once",
                 session_id="session-missing-verify-outcome",
+                tools=[],
+                tool_catalog=None,
+                system_prompt="system",
+                seed_goal="Ship",
+                ac_spec=AcceptanceCriterionSpec(
+                    description="Run the command once",
+                    verify_command="apply-once",
+                ),
+            )
+
+    @pytest.mark.asyncio
+    async def test_completed_recovery_requires_durable_verify_chain(self) -> None:
+        """R8 blocker #2: a completion with a cached PASS but NO durable verify
+        intent/outcome chain fails closed — an orphan completion cannot
+        manufacture command-backed acceptance."""
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        # A completion carrying a cached PASS verdict, but no verify.intent/outcome
+        # events were ever persisted for this attempt.
+        executor._execute_atomic_ac = AsyncMock(
+            side_effect=CompletedACExecutionError(
+                "already completed",
+                result_summary="fabricated completion",
+                session_id="orphan-provider-session",
+                verify_gate_outcome={
+                    "passed": True,
+                    "reason": None,
+                    "output_tail": "",
+                    "missing_artifacts": [],
+                },
+            )
+        )
+
+        with pytest.raises(
+            AmbiguousACExecutionError, match="lacks the durable verify intent/outcome chain"
+        ):
+            await executor._execute_single_ac(
+                ac_index=0,
+                ac_content="Run the command once",
+                session_id="session-orphan-completion",
+                execution_id="session-orphan-completion",
                 tools=[],
                 tool_catalog=None,
                 system_prompt="system",
@@ -13738,6 +13863,83 @@ class TestParallelACExecutor:
             execution_id="exec-apply-gate",
         )
         assert run_count == 1
+
+    @pytest.mark.asyncio
+    async def test_apply_gate_consumes_atomic_outcome_under_shared_key(self) -> None:
+        """R8 blocker #1: one per-attempt oracle key spans the atomic and apply gates.
+
+        If the atomic outcome was persisted but its result-carried copy was lost
+        (e.g. a failed session.completed), the recovery gate consumes the durable
+        atomic outcome instead of re-running the command under a separate key.
+        """
+        from ouroboros.events.base import BaseEvent
+
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        seed = _make_seed(
+            AcceptanceCriterionSpec(description="AC", verify_command="./deploy.sh"),
+        )
+        spec = seed.acceptance_criteria[0]
+        assert isinstance(spec, AcceptanceCriterionSpec)
+        digest = executor._verify_gate_command_digest(spec)
+        # Simulate the atomic gate having already persisted its intent+outcome
+        # under the SHARED per-attempt key (execution scope, ac_index, retry 0).
+        key = executor._ac_verify_gate_key(
+            execution_scope="exec-shared", ac_index=0, retry_attempt=0
+        )
+        for event_type, extra in (
+            ("execution.ac.verify.intent", {}),
+            (
+                "execution.ac.verify.outcome",
+                {
+                    "verify_gate_outcome": {
+                        "passed": True,
+                        "reason": None,
+                        "output_tail": "ok",
+                        "missing_artifacts": [],
+                    }
+                },
+            ),
+        ):
+            await event_store.append(
+                BaseEvent(
+                    type=event_type,
+                    aggregate_type="execution",
+                    aggregate_id="exec-shared",
+                    data={"verify_key": key, "verify_command_digest": digest, **extra},
+                )
+            )
+
+        run_count = 0
+
+        async def _counting_gate(*, spec: Any, cwd: str) -> _VerifyGateOutcome:
+            nonlocal run_count
+            run_count += 1
+            return _VerifyGateOutcome(passed=False, reason="ran again", output_tail="")
+
+        executor._run_ac_verify_gate = _counting_gate  # type: ignore[method-assign]
+        failed_result = ACExecutionResult(
+            ac_index=0, ac_content="AC", success=False, error="lost completion", retry_attempt=0
+        )
+        finalized = await executor._apply_verify_gate(
+            seed=seed,
+            ac_index=0,
+            result=failed_result,
+            session_id="sess",
+            execution_id="exec-shared",
+        )
+        # Consumed the durable atomic outcome (PASS) — the command did NOT re-run.
+        assert run_count == 0
+        assert finalized.success is True
 
     @pytest.mark.asyncio
     async def test_alt_harness_defers_until_same_runtime_retry_budget_spent(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -12331,9 +12331,13 @@ class TestParallelACExecutor:
     ) -> None:
         """A cached atomic verify outcome prevents duplicate shell side effects."""
         (tmp_path / "output.txt").write_text("OZO_RUN_SMOKE_OK\n", encoding="utf-8")
-        counter = tmp_path / "verify-count.txt"
+        # The run counter lives OUTSIDE the workspace: a verify_command must be a
+        # pure observer of the settled tree (no-mutation contract), so writing the
+        # counter into ``cwd`` would itself trip the mutation guard. An absolute
+        # sibling path measures single-shot without mutating the graded tree.
+        counter = tmp_path.parent / (tmp_path.name + "-verify-count.txt")
         command = (
-            "python3 -c \"from pathlib import Path; p=Path('verify-count.txt'); "
+            f'python3 -c "from pathlib import Path; p=Path({str(counter)!r}); '
             "n=int(p.read_text()) if p.exists() else 0; p.write_text(str(n+1)); "
             'raise SystemExit(0 if n == 0 else 7)"'
         )
@@ -12477,31 +12481,23 @@ class TestParallelACExecutor:
         assert finalized.success is False
 
     @pytest.mark.asyncio
-    async def test_isolated_verify_gate_grades_immutable_snapshot_not_shared_mutation(
-        self, tmp_path: Any
-    ) -> None:
-        """R14-2: batch verify gates grade a frozen snapshot, not the shared live tree.
+    async def test_verify_command_that_mutates_workspace_fails_closed(self, tmp_path: Any) -> None:
+        """No-mutation contract (R15 B2/B3): a verify_command that mutates the
+        settled workspace is failed closed even when it exits 0.
 
-        A verify_command is arbitrary shell that may mutate the workspace. Batch
-        gates finalize sequentially over one settled tree, so a later command's
-        side effects must not invalidate acceptance an earlier gate already
-        granted, nor corrupt the delivered artifact. Each command-bearing gate
-        runs against a private frozen snapshot: mutations are discarded and every
-        gate observes the identical settled state regardless of order.
+        A verifier must be a pure observer of the settled state so it can neither
+        corrupt the delivered artifact nor silently invalidate a sibling gate. The
+        command grades the COMPLETE live tree (no snapshot), and the failure is
+        folded into the DURABLE outcome so crash recovery consumes the FAIL rather
+        than a stale PASS the command itself invalidated by its side effect.
         """
-        marker = tmp_path / "marker.txt"
-        marker.write_text("good\n", encoding="utf-8")
-
-        assert_good = AcceptanceCriterionSpec(
-            description="marker stays good", verify_command="grep -q good marker.txt"
+        (tmp_path / "marker.txt").write_text("good\n", encoding="utf-8")
+        spec = AcceptanceCriterionSpec(
+            description="mutating verifier",
+            verify_command="printf 'bad\\n' > marker.txt",  # exits 0 but MUTATES
         )
-        mutating = AcceptanceCriterionSpec(
-            description="verifier mutates the shared tree",
-            verify_command="printf 'bad\\n' > marker.txt",
-        )
-        seed = _make_seed(assert_good, mutating)
-
-        event_store, _ = _make_replaying_event_store()
+        seed = _make_seed(spec)
+        event_store, appended = _make_replaying_event_store()
         executor = ParallelACExecutor(
             adapter=SimpleNamespace(
                 runtime_backend="codex_cli",
@@ -12514,59 +12510,7 @@ class TestParallelACExecutor:
             task_cwd=str(tmp_path),
         )
 
-        async def _gate(idx: int) -> ACExecutionResult:
-            return await executor._apply_verify_gate_isolated(
-                seed=seed,
-                ac_index=idx,
-                result=ACExecutionResult(ac_index=idx, ac_content="ac", success=True),
-                session_id="s",
-                execution_id="e",
-            )
-
-        # Run the MUTATING gate FIRST, then the assertion gate: order must not
-        # matter because neither touches the shared live tree.
-        mutated_first = await _gate(1)
-        good_after = await _gate(0)
-
-        assert mutated_first.success is True  # the mutating command exits 0
-        assert good_after.success is True  # still sees good in its own snapshot
-        # The delivered workspace is untouched by either verifier.
-        assert marker.read_text(encoding="utf-8") == "good\n"
-
-    @pytest.mark.asyncio
-    async def test_isolated_verify_gate_fails_closed_when_snapshot_unavailable(
-        self, tmp_path: Any, monkeypatch: Any
-    ) -> None:
-        """R14-2: an un-snapshottable settled tree fails a would-be PASS closed.
-
-        Rather than run a possibly-mutating verify_command against the shared live
-        workspace (where it could invalidate a sibling gate), a workspace that
-        cannot be frozen fails a successful result closed.
-        """
-        import contextlib as _contextlib
-
-        @_contextlib.contextmanager
-        def _no_snapshot(_cwd: str) -> Any:
-            yield None
-
-        monkeypatch.setattr(
-            "ouroboros.orchestrator.parallel_executor.isolated_workspace", _no_snapshot
-        )
-        seed = _make_seed(AcceptanceCriterionSpec(description="ac", verify_command="exit 0"))
-        event_store, _ = _make_replaying_event_store()
-        executor = ParallelACExecutor(
-            adapter=SimpleNamespace(
-                runtime_backend="codex_cli",
-                working_directory=str(tmp_path),
-                permission_mode="acceptEdits",
-            ),
-            event_store=event_store,
-            console=MagicMock(),
-            enable_decomposition=False,
-            task_cwd=str(tmp_path),
-        )
-
-        gated = await executor._apply_verify_gate_isolated(
+        gated = await executor._apply_verify_gate(
             seed=seed,
             ac_index=0,
             result=ACExecutionResult(ac_index=0, ac_content="ac", success=True),
@@ -12575,7 +12519,58 @@ class TestParallelACExecutor:
         )
 
         assert gated.success is False
-        assert "could not isolate" in (gated.error or "")
+        assert gated.verify_gate_outcome is not None
+        assert gated.verify_gate_outcome.passed is False
+        assert "mutat" in (gated.verify_gate_outcome.reason or "").lower()
+        # The durable outcome records the FAIL, so a recovery consumption cannot
+        # resurrect the command's exit-0 PASS.
+        outcomes = [e for e in appended if e.type == "execution.ac.verify.outcome"]
+        assert outcomes
+        assert outcomes[-1].data["verify_gate_outcome"]["passed"] is False
+
+    @pytest.mark.asyncio
+    async def test_verify_command_grades_complete_live_tree_not_stripped_snapshot(
+        self, tmp_path: Any
+    ) -> None:
+        """R15/B2: verify_command grades the COMPLETE live tree.
+
+        Contracts that depend on dependency/build/VCS directories a shadow-replay
+        snapshot would strip (``.git``, ``node_modules``, ``dist``, ...) still see
+        them, because the command runs over the live workspace, not a filtered
+        copy.
+        """
+        (tmp_path / "node_modules").mkdir()
+        (tmp_path / "node_modules" / "probe").write_text("dep\n", encoding="utf-8")
+        spec = AcceptanceCriterionSpec(
+            description="depends on node_modules",
+            verify_command="test -f node_modules/probe",
+        )
+        seed = _make_seed(spec)
+        event_store, _ = _make_replaying_event_store()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory=str(tmp_path),
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            task_cwd=str(tmp_path),
+        )
+
+        gated = await executor._apply_verify_gate(
+            seed=seed,
+            ac_index=0,
+            result=ACExecutionResult(ac_index=0, ac_content="ac", success=True),
+            session_id="s",
+            execution_id="e",
+        )
+
+        # The command sees node_modules/probe in the live tree -> passes. A
+        # snapshot excluding node_modules would have failed this valid contract.
+        assert gated.success is True
+        assert (tmp_path / "node_modules" / "probe").exists()
 
     @pytest.mark.asyncio
     async def test_completed_recovery_reuses_durable_verify_outcome_without_command_replay(

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -21,7 +21,10 @@ from ouroboros.core.seed import (
 )
 from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.types import MCPToolDefinition
-from ouroboros.orchestrator.ac_execution_capsule import ACExecutionCapsule
+from ouroboros.orchestrator.ac_execution_capsule import (
+    ACExecutionCapsuleManifest,
+    compile_ac_execution_capsule,
+)
 from ouroboros.orchestrator.adapter import (
     FULL_CAPABILITIES,
     AgentMessage,
@@ -34,7 +37,10 @@ from ouroboros.orchestrator.decomposition_policy import DecompositionDisposition
 from ouroboros.orchestrator.dependency_analyzer import ACNode, DependencyGraph
 from ouroboros.orchestrator.evidence.claims import _runtime_messages_support_file_claim
 from ouroboros.orchestrator.evidence_schema import EvidenceRecord, ValidationResult
-from ouroboros.orchestrator.execution_runtime_scope import ExecutionNodeIdentity
+from ouroboros.orchestrator.execution_runtime_scope import (
+    ExecutionNodeIdentity,
+    build_ac_runtime_identity,
+)
 from ouroboros.orchestrator.leaf_dispatcher import _correlated_tool_result_name
 from ouroboros.orchestrator.level_context import ACContextSummary, LevelContext
 from ouroboros.orchestrator.parallel_executor import (
@@ -4377,13 +4383,16 @@ class TestParallelACExecutor:
         capsule_event = next(
             event for event in appended_events if event.type == "execution.ac.capsule.compiled"
         )
-        restored_capsule = ACExecutionCapsule.from_contract_data(capsule_event.data["capsule"])
-        assert capsule_event.data["capsule_fingerprint"] == restored_capsule.fingerprint
+        restored_manifest = ACExecutionCapsuleManifest.from_contract_data(
+            capsule_event.data["capsule_manifest"]
+        )
+        assert capsule_event.data["capsule_fingerprint"] == restored_manifest.fingerprint
         assert capsule_event.data["session_origin"] == "fresh"
         assert isinstance(runtime_call["prompt"], str)
         assert "Ouroboros AC Runtime" in runtime_call["prompt"]
-        assert restored_capsule.ac_content == "Implement AC 3"
-        assert restored_capsule.workspace == os.path.realpath("/tmp/project")
+        assert "Implement AC 3" in runtime_call["prompt"]
+        assert restored_manifest.ac_content_digest.startswith("sha256:")
+        assert restored_manifest.workspace_digest.startswith("sha256:")
         assert [tool["name"] for tool in started_event.data["tool_catalog"]] == ["Read", "Edit"]
         assert [
             tool["name"] for tool in started_event.data["runtime"]["metadata"]["tool_catalog"]
@@ -4459,6 +4468,20 @@ class TestParallelACExecutor:
 
         runtime = _Runtime()
         event_store, appended_events = _make_replaying_event_store()
+        persisted_capsule = compile_ac_execution_capsule(
+            runtime_identity=build_ac_runtime_identity(
+                0,
+                execution_context_id="session-capsule-mismatch",
+                retry_attempt=0,
+            ),
+            execution_id="session-capsule-mismatch",
+            semantic_ac_key="semantic-key",
+            workspace=os.path.realpath("/tmp/project"),
+            authority_scope="execution:session-capsule-mismatch",
+            seed_goal="Ship",
+            ac_content="Original AC authority",
+            ac_spec=None,
+        )
         appended_events.append(
             BaseEvent(
                 type="execution.ac.capsule.compiled",
@@ -4467,7 +4490,8 @@ class TestParallelACExecutor:
                 data={
                     "ac_id": "session-capsule-mismatch_ac_1",
                     "session_attempt_id": "session-capsule-mismatch_ac_1_attempt_1",
-                    "capsule_fingerprint": "sha256:" + "0" * 64,
+                    "capsule_fingerprint": persisted_capsule.fingerprint,
+                    "capsule_manifest": persisted_capsule.manifest.to_contract_data(),
                 },
             )
         )
@@ -4488,6 +4512,7 @@ class TestParallelACExecutor:
                 seed_goal="Ship",
                 depth=0,
                 start_time=datetime.now(UTC),
+                semantic_ac_key="semantic-key",
             )
 
         assert runtime.calls == 0

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1102,6 +1102,110 @@ def test_capsule_authority_covers_prompt_gate_runtime_and_verifier_inputs() -> N
     assert scope(verifier_drift) != baseline
 
 
+def test_capsule_authority_reuses_large_context_and_catalog_digests(monkeypatch) -> None:
+    """Sibling ACs and retries must not reserialize the same authority inputs."""
+    import ouroboros.orchestrator.mcp_tools as mcp_tools
+    import ouroboros.orchestrator.parallel_executor as pe
+
+    runtime = SimpleNamespace(
+        runtime_backend="codex_cli",
+        working_directory="/tmp/project",
+        permission_mode="acceptEdits",
+    )
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+    )
+    level_contexts = [
+        LevelContext(
+            level_number=index,
+            completed_acs=(
+                ACContextSummary(
+                    ac_index=index,
+                    ac_content=f"Dependency {index}",
+                    success=True,
+                ),
+            ),
+        )
+        for index in range(8)
+    ]
+    tool_catalog = (
+        MCPToolDefinition(name="Read", description="Read files"),
+        MCPToolDefinition(name="Edit", description="Edit files"),
+    )
+    real_serialize_levels = pe.serialize_level_contexts
+    real_serialize_tools = mcp_tools.serialize_tool_catalog
+    level_batch_sizes: list[int] = []
+    tool_calls = 0
+
+    def count_levels(contexts):
+        level_batch_sizes.append(len(contexts))
+        return real_serialize_levels(contexts)
+
+    def count_tools(catalog):
+        nonlocal tool_calls
+        tool_calls += 1
+        return real_serialize_tools(catalog)
+
+    monkeypatch.setattr(pe, "serialize_level_contexts", count_levels)
+    monkeypatch.setattr(mcp_tools, "serialize_tool_catalog", count_tools)
+
+    for _ in range(3):
+        executor._build_ac_capsule_authority_scope(
+            execution_context_id="exec-cache",
+            tools=["Read", "Edit"],
+            tool_catalog=tool_catalog,
+            system_prompt="system",
+            level_contexts=level_contexts,
+            is_sub_ac=False,
+            decomposition_trustworthy=False,
+            force_frontier_routing=False,
+            investment_spec=None,
+        )
+        executor._capsule_dependency_references(
+            execution_id="exec-cache",
+            level_contexts=level_contexts,
+        )
+
+    assert tool_calls == 1
+    assert level_batch_sizes == [1] * len(level_contexts)
+
+
+def test_level_context_authority_digest_extends_incrementally(monkeypatch) -> None:
+    """Sequential stage growth serializes each accepted handoff exactly once."""
+    import ouroboros.orchestrator.parallel_executor as pe
+
+    executor = ParallelACExecutor(
+        adapter=SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        ),
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        enable_decomposition=False,
+    )
+    real_serialize = pe.serialize_level_contexts
+    serialized_level_numbers: list[int] = []
+
+    def count_levels(contexts):
+        serialized_level_numbers.extend(context.level_number for context in contexts)
+        return real_serialize(contexts)
+
+    monkeypatch.setattr(pe, "serialize_level_contexts", count_levels)
+    contexts: list[LevelContext] = []
+    for level_number in range(20):
+        contexts = executor._merge_level_context(
+            contexts,
+            LevelContext(level_number=level_number, completed_acs=()),
+        )
+        executor._level_context_chain_digest(contexts)
+
+    assert serialized_level_numbers == list(range(20))
+
+
 @pytest.mark.parametrize(
     ("content", "expected"),
     (

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -52,6 +52,7 @@ from ouroboros.orchestrator.execution_runtime_scope import (
 from ouroboros.orchestrator.leaf_dispatcher import _correlated_tool_result_name
 from ouroboros.orchestrator.level_context import ACContextSummary, LevelContext
 from ouroboros.orchestrator.parallel_executor import (
+    _STALL_SENTINEL,
     MAX_STALL_RETRIES,
     STALL_TIMEOUT_SECONDS,
     ACExecutionOutcome,
@@ -1029,26 +1030,39 @@ def _dispatched_capsule_event(
     previous_dispatch_id: str | None = None,
     session_origin: str = "fresh",
     runtime_handle: RuntimeHandle | None = None,
+    dispatch_kind: str | None = None,
+    signal_id: str | None = None,
+    signal_mode: str | None = None,
+    follow_up_input_digest: str | None = None,
 ) -> BaseEvent:
     if runtime_handle is not None:
         runtime_handle = replace(
             runtime_handle,
             metadata={**runtime_handle.metadata, "ac_dispatch_id": dispatch_id},
         )
+    data: dict[str, Any] = {
+        **identity.to_metadata(),
+        "ac_dispatch_id": dispatch_id,
+        "previous_ac_dispatch_id": previous_dispatch_id,
+        "capsule_fingerprint": capsule.fingerprint,
+        "session_origin": session_origin,
+        "runtime": (
+            runtime_handle.to_dispatch_recovery_dict() if runtime_handle is not None else None
+        ),
+    }
+    # Only stamp the phase-identity fields when a caller opts in, so the default
+    # event shape reproduces a legacy dispatch (no ``dispatch_kind``) — the
+    # backward-compatible "treat absent as primary" recovery path.
+    if dispatch_kind is not None:
+        data["dispatch_kind"] = dispatch_kind
+        data["signal_id"] = signal_id
+        data["signal_mode"] = signal_mode
+        data["follow_up_input_digest"] = follow_up_input_digest
     return BaseEvent(
         type="execution.ac.attempt.dispatched",
         aggregate_type="execution",
         aggregate_id=identity.session_scope_id,
-        data={
-            **identity.to_metadata(),
-            "ac_dispatch_id": dispatch_id,
-            "previous_ac_dispatch_id": previous_dispatch_id,
-            "capsule_fingerprint": capsule.fingerprint,
-            "session_origin": session_origin,
-            "runtime": (
-                runtime_handle.to_dispatch_recovery_dict() if runtime_handle is not None else None
-            ),
-        },
+        data=data,
     )
 
 
@@ -5549,6 +5563,156 @@ class TestParallelACExecutor:
         assert restored is not None
         assert restored.previous_response_id == "response-after-signal"
         assert restored.metadata["ac_dispatch_id"] == second_dispatch_id
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_fails_closed_on_signal_followup_dispatch_head(self) -> None:
+        """A crashed SessionSignal follow-up head must not resume the AC prompt.
+
+        Blocker #1: the follow-up dispatch persists an explicit
+        ``session_signal_followup`` phase. Resuming it would let the caller
+        replay the ORIGINAL AC prompt in a session that is mid-signal-turn,
+        repeating the AC's (possibly non-idempotent) acceptance work. With no
+        safe exact reconstruction the loader must fail closed instead.
+        """
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Do not repeat the AC after a signal-turn crash",
+            session_id="session-signal-followup-head",
+            seed_goal="Ship",
+        )
+        primary_dispatch_id = "1" * 32
+        followup_dispatch_id = "2" * 32
+
+        def _handle(previous_response_id: str, origin: str) -> RuntimeHandle:
+            return RuntimeHandle(
+                backend="codex_cli",
+                kind="implementation_session",
+                native_session_id="codex-shared-session",
+                previous_response_id=previous_response_id,
+                cwd="/tmp/project",
+                approval_mode="acceptEdits",
+                metadata={
+                    **runtime_identity.to_metadata(),
+                    "ac_capsule_version": persisted_capsule.version,
+                    "ac_capsule_fingerprint": persisted_capsule.fingerprint,
+                    "ac_session_origin": origin,
+                },
+            )
+
+        event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=primary_dispatch_id,
+                dispatch_kind="primary",
+            ),
+            _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.started",
+                dispatch_id=primary_dispatch_id,
+                runtime_handle=_handle("response-before-signal", "fresh"),
+            ),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=followup_dispatch_id,
+                previous_dispatch_id=primary_dispatch_id,
+                session_origin="restored_same_attempt",
+                dispatch_kind="session_signal_followup",
+                signal_id="sig-123",
+                signal_mode="inform",
+                follow_up_input_digest="sha256:" + "a" * 64,
+            ),
+            _dispatch_lifecycle_event(
+                runtime_identity,
+                "execution.session.started",
+                dispatch_id=followup_dispatch_id,
+                runtime_handle=_handle("response-after-signal", "restored_same_attempt"),
+            ),
+        ]
+
+        with pytest.raises(AmbiguousACExecutionError, match="non-primary provider-entry phase"):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="session-signal-followup-head",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_rejects_signal_followup_missing_phase_identity(self) -> None:
+        """A follow-up dispatch without its signal identity is corrupt, not resumable.
+
+        Blocker #1: a ``session_signal_followup`` phase that lost its signal
+        id/mode/input digest cannot prove which phase it opened, so the loader
+        rejects the record rather than guessing.
+        """
+        runtime = SimpleNamespace(
+            runtime_backend="codex_cli",
+            working_directory="/tmp/project",
+            permission_mode="acceptEdits",
+        )
+        event_store = AsyncMock()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        runtime_identity, persisted_capsule = _compile_test_capsule(
+            executor=executor,
+            ac_index=0,
+            ac_content="Reject a follow-up missing its phase identity",
+            session_id="session-signal-followup-corrupt",
+            seed_goal="Ship",
+        )
+        primary_dispatch_id = "1" * 32
+        followup_dispatch_id = "2" * 32
+
+        event_store.replay.return_value = [
+            _compiled_capsule_event(runtime_identity, persisted_capsule),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=primary_dispatch_id,
+                dispatch_kind="primary",
+            ),
+            _dispatched_capsule_event(
+                runtime_identity,
+                persisted_capsule,
+                dispatch_id=followup_dispatch_id,
+                previous_dispatch_id=primary_dispatch_id,
+                session_origin="restored_same_attempt",
+                dispatch_kind="session_signal_followup",
+                signal_id=None,
+                signal_mode=None,
+                follow_up_input_digest=None,
+            ),
+        ]
+
+        with pytest.raises(ValueError, match="missing phase identity"):
+            await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="session-signal-followup-corrupt",
+                retry_attempt=0,
+                expected_capsule_fingerprint=persisted_capsule.fingerprint,
+                expected_capsule_workspace=persisted_capsule.workspace,
+            )
 
     @pytest.mark.asyncio
     async def test_capsule_loader_follows_explicit_recovery_session_successor(self) -> None:
@@ -12539,6 +12703,120 @@ class TestParallelACExecutor:
             "abandon",
         ]
         assert all(event.data["max_attempts"] == MAX_STALL_RETRIES + 1 for event in stall_events)
+
+    @pytest.mark.asyncio
+    async def test_effectful_stall_fails_closed_without_redispatch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Blocker #3: a stall AFTER a tool effect must not take the retry path.
+
+        The provider emits a durable tool effect, then goes silent. The ordinary
+        stall retry would bump ``retry_attempt`` and re-dispatch, whose recovery
+        filters this attempt's effect events and bypasses the ambiguity guard —
+        potentially duplicating a non-idempotent effect. The effectful stall must
+        instead fail closed as an ``AmbiguousACExecutionError`` with the provider
+        entered exactly once.
+        """
+        import anyio
+
+        from ouroboros.orchestrator import leaf_dispatcher
+
+        monkeypatch.setattr(leaf_dispatcher, "STALL_TIMEOUT_SECONDS", 0.15)
+
+        class _EffectfulThenStallRuntime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def execute_task(self, **_kwargs: object):
+                self.calls += 1
+                yield AgentMessage(
+                    type="tool_use",
+                    content="edit a file",
+                    tool_name="Edit",
+                    data={"tool_input": {"file_path": "app.py"}},
+                )
+                await anyio.sleep_forever()
+
+        event_store, _ = _make_replaying_event_store()
+        runtime = _EffectfulThenStallRuntime()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            cross_harness_redispatch=False,
+        )
+
+        with pytest.raises(AmbiguousACExecutionError, match="stalled after emitting tool effects"):
+            await executor._execute_atomic_ac(
+                ac_index=0,
+                ac_content="Do not duplicate the effect after an effectful stall",
+                session_id="session-effectful-stall",
+                tools=["Edit"],
+                system_prompt="system",
+                seed_goal="Ship",
+                depth=0,
+                start_time=datetime.now(UTC),
+            )
+
+        assert runtime.calls == 1
+
+    @pytest.mark.asyncio
+    async def test_effect_free_stall_stays_retryable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Blocker #3: a stall with NO observed tool effect keeps the retry sentinel.
+
+        The complement of the effectful-stall guard: when no effect was
+        dispatched, a fresh redispatch cannot duplicate anything, so the existing
+        retryable stall behavior is preserved (the sentinel error the batch/leaf
+        retry loop keys on).
+        """
+        import anyio
+
+        from ouroboros.orchestrator import leaf_dispatcher
+
+        monkeypatch.setattr(leaf_dispatcher, "STALL_TIMEOUT_SECONDS", 0.15)
+
+        class _SilentStallRuntime:
+            runtime_backend = "codex_cli"
+            working_directory = "/tmp/project"
+            permission_mode = "acceptEdits"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            async def execute_task(self, **_kwargs: object):
+                self.calls += 1
+                await anyio.sleep_forever()
+                yield  # pragma: no cover - never reached; keeps this an async generator
+
+        event_store, _ = _make_replaying_event_store()
+        runtime = _SilentStallRuntime()
+        executor = ParallelACExecutor(
+            adapter=runtime,
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+            cross_harness_redispatch=False,
+        )
+
+        result = await executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="A silent stall stays retryable",
+            session_id="session-silent-stall",
+            tools=["Edit"],
+            system_prompt="system",
+            seed_goal="Ship",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+
+        assert result.success is False
+        assert result.error == _STALL_SENTINEL
+        assert runtime.calls == 1
 
     @pytest.mark.asyncio
     async def test_alt_harness_defers_until_same_runtime_retry_budget_spent(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1350,10 +1350,13 @@ def test_capsule_authority_binds_session_signal_hub_presence() -> None:
     assert _scope(with_hub=True) != _scope(with_hub=False)
 
 
-def test_bound_verify_gate_outcome_caps_and_rejects_oversized() -> None:
-    """R5 blocker #6: verify outcomes are bounded before persistence."""
+def test_bound_verify_gate_outcome_caps_and_fits_within_byte_budget() -> None:
+    """R5/R10: verify outcomes are count-, length-, and BYTE-bounded before persist."""
+    import json as _json
+
     from ouroboros.orchestrator.execution_event_emitter import (
         _MAX_VERIFY_MISSING_ARTIFACTS,
+        _MAX_VERIFY_OUTCOME_BYTES,
         bound_verify_gate_outcome,
     )
 
@@ -1368,18 +1371,22 @@ def test_bound_verify_gate_outcome_caps_and_rejects_oversized() -> None:
     assert len(bounded["missing_artifacts"]) == _MAX_VERIFY_MISSING_ARTIFACTS
     assert bounded["missing_artifacts_omitted"] == 1000 - _MAX_VERIFY_MISSING_ARTIFACTS
 
-    # Even after count/length caps, pathological 4-byte-per-char content can blow
-    # the hard UTF-8 byte cap; such a payload is rejected outright.
-    with pytest.raises(ValueError, match="size bound"):
-        bound_verify_gate_outcome(
-            {
-                "passed": True,
-                "reason": None,
-                "output_tail": "",
-                # "𐍈" is 4 UTF-8 bytes: 64 entries × 512 chars × 4 bytes ≈ 128 KiB.
-                "missing_artifacts": ["𐍈" * 512 for _ in range(_MAX_VERIFY_MISSING_ARTIFACTS)],
-            }
-        )
+    # R10 blocker #3: pathological 4-byte-per-char content is FITTED (trailing
+    # entries dropped, omission recorded), never raised — a valid contract must
+    # always be able to persist an outcome (the intent is already durable).
+    fitted = bound_verify_gate_outcome(
+        {
+            "passed": True,
+            "reason": None,
+            "output_tail": "",
+            # "𐍈" is 4 UTF-8 bytes: 64 entries × 512 chars × 4 bytes ≈ 128 KiB.
+            "missing_artifacts": ["𐍈" * 512 for _ in range(_MAX_VERIFY_MISSING_ARTIFACTS)],
+        }
+    )
+    assert fitted["passed"] is True
+    assert fitted["missing_artifacts_omitted"] > 0
+    encoded_bytes = len(_json.dumps(fitted, ensure_ascii=False).encode("utf-8"))
+    assert encoded_bytes <= _MAX_VERIFY_OUTCOME_BYTES
 
 
 def test_bound_verify_gate_outcome_rejects_type_coercion() -> None:
@@ -1494,6 +1501,39 @@ def test_runtime_executable_identity_resolves_bare_name_relative_path_against_ch
     id_false = ParallelACExecutor._runtime_executable_identity(_Runtime(), cwd=str(ws_false))
     assert id_true["executable"]["realpath"] == _os.path.realpath(str(ws_true / "bin" / "probe"))
     assert id_false["executable"]["realpath"] == _os.path.realpath(str(ws_false / "bin" / "probe"))
+    assert id_true != id_false
+
+
+def test_runtime_executable_identity_anchors_empty_path_component_to_child_cwd(
+    tmp_path: Any, monkeypatch: Any
+) -> None:
+    """R10 blocker #2: an EMPTY PATH component is child-cwd-relative, not orchestrator.
+
+    ``PATH=""`` means the child's current directory; two workspaces each with a
+    local ``probe`` binary must produce different identity, not both ``unresolved``.
+    """
+    import os as _os
+    import stat
+
+    def _make_ws(name: str, target: str) -> Any:
+        ws = tmp_path / name
+        ws.mkdir()
+        script = ws / "probe"
+        script.write_text(f"#!/bin/sh\nexec {target}\n")
+        script.chmod(script.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+        return ws
+
+    ws_true = _make_ws("etrue", "/bin/true")
+    ws_false = _make_ws("efalse", "/bin/false")
+
+    class _Runtime:
+        _cli_path = "probe"
+
+    monkeypatch.setenv("PATH", "")  # empty → child current directory
+    id_true = ParallelACExecutor._runtime_executable_identity(_Runtime(), cwd=str(ws_true))
+    id_false = ParallelACExecutor._runtime_executable_identity(_Runtime(), cwd=str(ws_false))
+    assert id_true["executable"]["realpath"] == _os.path.realpath(str(ws_true / "probe"))
+    assert id_false["executable"]["realpath"] == _os.path.realpath(str(ws_false / "probe"))
     assert id_true != id_false
 
 
@@ -14688,9 +14728,13 @@ class TestParallelACExecutor:
         assert event_store.append.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_completed_verify_outcome_rejects_oversized_durable_projection(self) -> None:
-        """Verify command output cannot amplify the durable completion stream."""
-        event_store = AsyncMock()
+    async def test_completed_verify_outcome_is_byte_bounded_before_persist(self) -> None:
+        """R10: an oversized verify output is BOUNDED (not rejected) so the
+        completion always persists and stays re-parseable on recovery."""
+        from ouroboros.orchestrator.ac_runtime_handle_manager import ACRuntimeHandleManager
+        from ouroboros.orchestrator.execution_event_emitter import _MAX_VERIFY_OUTCOME_BYTES
+
+        event_store, appended = _make_replaying_event_store()
         executor = ParallelACExecutor(
             adapter=MagicMock(),
             event_store=event_store,
@@ -14703,24 +14747,33 @@ class TestParallelACExecutor:
             retry_attempt=0,
         )
 
-        with pytest.raises(ValueError, match="verify outcome exceeds the size limit"):
-            await executor._emit_ac_runtime_event(
-                event_type="execution.session.completed",
-                runtime_identity=runtime_identity,
-                ac_content="Bound the durable verify outcome",
-                runtime_handle=None,
-                execution_id="exec_oversized_verify_outcome",
-                session_id="server-oversized",
-                result_summary="[TASK_COMPLETE]",
-                success=True,
-                verify_gate_outcome=_VerifyGateOutcome(
-                    passed=True,
-                    reason=None,
-                    output_tail="x" * 65_536,
-                ),
-            )
+        await executor._emit_ac_runtime_event(
+            event_type="execution.session.completed",
+            runtime_identity=runtime_identity,
+            ac_content="Bound the durable verify outcome",
+            runtime_handle=None,
+            execution_id="exec_oversized_verify_outcome",
+            session_id="server-oversized",
+            result_summary="[TASK_COMPLETE]",
+            success=True,
+            verify_gate_outcome=_VerifyGateOutcome(
+                passed=True,
+                reason=None,
+                output_tail="x" * 65_536,
+            ),
+        )
 
-        event_store.append.assert_not_awaited()
+        completed = next(e for e in appended if e.type == "execution.session.completed")
+        outcome = completed.data["verify_gate_outcome"]
+        # Output was truncated to fit; the event re-parses within the byte cap.
+        assert len(outcome["output_tail"]) < 65_536
+        assert ACRuntimeHandleManager._parse_verify_gate_outcome(outcome) is not None
+        import json as _json
+
+        assert (
+            len(_json.dumps(outcome, ensure_ascii=False).encode("utf-8"))
+            <= _MAX_VERIFY_OUTCOME_BYTES
+        )
 
     @pytest.mark.asyncio
     async def test_restarted_executor_loads_persisted_runtime_handle_for_same_attempt(self) -> None:

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -23,6 +23,7 @@ from ouroboros.core.seed import (
 from ouroboros.events.base import BaseEvent
 from ouroboros.mcp.types import MCPToolDefinition
 from ouroboros.orchestrator.ac_execution_capsule import (
+    AC_EXECUTION_CAPSULE_VERSION,
     ACExecutionCapsule,
     ACExecutionCapsuleManifest,
     compile_ac_execution_capsule,
@@ -4515,7 +4516,7 @@ class TestParallelACExecutor:
         ]
         assert resume_handle.metadata["session_scope_id"] == "orch_123_ac_3"
         assert resume_handle.metadata["session_attempt_id"] == "orch_123_ac_3_attempt_1"
-        assert resume_handle.metadata["ac_capsule_version"] == 1
+        assert resume_handle.metadata["ac_capsule_version"] == AC_EXECUTION_CAPSULE_VERSION
         assert resume_handle.metadata["ac_capsule_fingerprint"].startswith("sha256:")
         assert resume_handle.metadata["ac_session_origin"] == "fresh"
         assert (

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -5125,6 +5125,109 @@ class TestParallelACExecutor:
         assert compiled_event.data["session_origin"] == "fresh"
 
     @pytest.mark.asyncio
+    async def test_capsule_loader_skips_legacy_scope_replay(self) -> None:
+        """Capsule-era attempts are authored only in the canonical AC aggregate."""
+        event_store = AsyncMock()
+        event_store.replay.return_value = []
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=event_store,
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+        identity = build_ac_runtime_identity(
+            3,
+            execution_context_id="exec-canonical-replay",
+            retry_attempt=2,
+        )
+
+        restored = await executor._load_persisted_ac_runtime_handle(
+            3,
+            execution_context_id="exec-canonical-replay",
+            retry_attempt=2,
+            expected_capsule_fingerprint="sha256:" + "0" * 64,
+            expected_capsule_workspace=os.path.realpath("/tmp/project"),
+        )
+
+        assert restored is None
+        event_store.replay.assert_awaited_once_with(
+            "execution",
+            identity.session_scope_id,
+        )
+
+    @pytest.mark.asyncio
+    async def test_capsule_loader_incrementally_fetches_retry_history(self) -> None:
+        """Growing retry history is fetched once, not replayed from row zero per attempt."""
+
+        class _IncrementalStore:
+            def __init__(self) -> None:
+                self.events: list[BaseEvent] = []
+                self.returned_events = 0
+                self.replay_calls = 0
+
+            async def get_events_after(
+                self,
+                aggregate_type: str,
+                aggregate_id: str,
+                last_row_id: int,
+            ) -> tuple[list[BaseEvent], int]:
+                matching = [
+                    event
+                    for event in self.events
+                    if event.aggregate_type == aggregate_type
+                    and event.aggregate_id == aggregate_id
+                ]
+                new_events = matching[last_row_id:]
+                self.returned_events += len(new_events)
+                return new_events, len(matching)
+
+            async def replay(self, _aggregate_type: str, _aggregate_id: str):
+                self.replay_calls += 1
+                raise AssertionError("full replay should not be used")
+
+        store = _IncrementalStore()
+        executor = ParallelACExecutor(
+            adapter=SimpleNamespace(
+                runtime_backend="codex_cli",
+                working_directory="/tmp/project",
+                permission_mode="acceptEdits",
+            ),
+            event_store=store,  # type: ignore[arg-type]
+            console=MagicMock(),
+            enable_decomposition=False,
+        )
+
+        for retry_attempt in range(5):
+            restored = await executor._load_persisted_ac_runtime_handle(
+                0,
+                execution_context_id="exec-incremental-replay",
+                retry_attempt=retry_attempt,
+                expected_capsule_fingerprint="sha256:" + "0" * 64,
+                expected_capsule_workspace=os.path.realpath("/tmp/project"),
+            )
+            assert restored is None
+            identity = build_ac_runtime_identity(
+                0,
+                execution_context_id="exec-incremental-replay",
+                retry_attempt=retry_attempt,
+            )
+            store.events.append(
+                BaseEvent(
+                    type="execution.session.failed",
+                    aggregate_type="execution",
+                    aggregate_id=identity.session_scope_id,
+                    data=identity.to_metadata(),
+                )
+            )
+
+        assert store.replay_calls == 0
+        assert store.returned_events == 4
+
+    @pytest.mark.asyncio
     async def test_capsule_resume_rejects_foreign_workspace_handle(self) -> None:
         """A matching fingerprint cannot authorize continuity from another checkout."""
         runtime = SimpleNamespace(

--- a/tests/unit/orchestrator/test_parallel_executor_checkpoint_recovery.py
+++ b/tests/unit/orchestrator/test_parallel_executor_checkpoint_recovery.py
@@ -3897,7 +3897,14 @@ class TestCheckpointDispatchContract:
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "drift",
-        ["workspace", "runtime_backend", "permission_mode", "constructor_model", "capabilities"],
+        [
+            "workspace",
+            "runtime_backend",
+            "permission_mode",
+            "constructor_model",
+            "capabilities",
+            "realtime_effect_visibility",
+        ],
     )
     async def test_runtime_authority_drift_is_rejected_before_dispatch(
         self, tmp_path: Path, drift: str
@@ -3923,6 +3930,16 @@ class TestCheckpointDispatchContract:
             resumed_permission = "bypassPermissions"
         elif drift == "constructor_model":
             resumed_model = "model-b"
+        elif drift == "realtime_effect_visibility":
+            # Same shape, only the stall-affecting flag flips — it must still
+            # count as authority drift (original defaults to False).
+            resumed_capabilities = RuntimeCapabilities(
+                skill_dispatch=True,
+                targeted_resume=True,
+                structured_output=True,
+                model_override_support=ParamSupport.NATIVE,
+                realtime_tool_effect_visibility=True,
+            )
         else:
             resumed_capabilities = RuntimeCapabilities(
                 skill_dispatch=True,

--- a/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
+++ b/tests/unit/orchestrator/test_parallel_executor_verify_by_default.py
@@ -1389,10 +1389,15 @@ class TestSuccessContractBlock:
         )
         block = _build_success_contract_block(spec)
         assert block.startswith("SUCCESS CONTRACT for this AC:")
+        # R10 blocker #1: the worker is told the gate runs it, and NOT to run it
+        # itself — otherwise a compliant worker would double-execute a possibly
+        # non-idempotent command (the first run outside the single-shot oracle).
         assert (
-            "- Run locally before completion: make build. "
-            "The verify gate re-runs it and records authoritative evidence." in block
+            "- The harness verify gate will run and grade (authoritatively): make build. "
+            "Do NOT run this command yourself — make your changes so it will pass "
+            "when the gate runs it once." in block
         )
+        assert "Run locally before completion" not in block
         assert (
             "- Expected artifacts: dist/app, dist/app.map — ensure they exist in the workspace"
             in block
@@ -1402,9 +1407,7 @@ class TestSuccessContractBlock:
     def test_partial_contract_only_renders_present_fields(self) -> None:
         spec = AcceptanceCriterionSpec(description="verify only", verify_command="pytest -q")
         block = _build_success_contract_block(spec)
-        assert (
-            "- Run locally before completion: pytest -q. "
-            "The verify gate re-runs it and records authoritative evidence." in block
-        )
+        assert "Do NOT run this command yourself" in block
+        assert "Run locally before completion" not in block
         assert "Expected artifacts" not in block
         assert "Expected output" not in block

--- a/tests/unit/orchestrator/test_synapse_after_turn_integration.py
+++ b/tests/unit/orchestrator/test_synapse_after_turn_integration.py
@@ -144,6 +144,133 @@ class _InformRuntime(_TwoTurnRuntime):
         )
 
 
+class _EffectfulStallFollowupRuntime(_TwoTurnRuntime):
+    """Follow-up turn acknowledges, emits a tool effect, then stalls silently."""
+
+    async def execute_task(self, **kwargs: Any):
+        if not self.prompts:
+            async for message in super().execute_task(**kwargs):
+                yield message
+            return
+
+        prompt = str(kwargs["prompt"])
+        resume_handle = kwargs.get("resume_handle")
+        self.prompts.append(prompt)
+        assert resume_handle is not None
+        # Acknowledge the after-turn signal, then emit a real tool effect, then
+        # go silent (stall) without ever completing the turn.
+        yield AgentMessage(
+            type="assistant",
+            content="Applying the clarification now.",
+            resume_handle=resume_handle,
+        )
+        yield AgentMessage(
+            type="tool_use",
+            content="edit confirmation copy",
+            tool_name="Edit",
+            data={"tool_input": {"file_path": "confirm.py"}},
+            resume_handle=resume_handle,
+        )
+        await asyncio.Event().wait()  # stall forever
+
+
+@pytest.mark.asyncio
+async def test_after_turn_followup_effectful_stall_seals_and_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """R4 blocker #4: a follow-up that emits an effect then stalls is not recorded
+    as an acknowledged success — it is sealed and fails closed so a cold restart
+    cannot resume the stalled follow-up and repeat the effect."""
+    from ouroboros.orchestrator import leaf_dispatcher
+    from ouroboros.orchestrator.ac_runtime_handle_manager import AmbiguousACExecutionError
+
+    monkeypatch.setattr(leaf_dispatcher, "STALL_TIMEOUT_SECONDS", 0.2)
+
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    hub = SessionSignalHub(event_store=store)
+    runtime = _EffectfulStallFollowupRuntime(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=store,
+        console=MagicMock(),
+        enable_decomposition=False,
+        session_signal_hub=hub,
+    )
+    target_resolver = EventStoreSessionSignalTargetResolver(
+        event_store=store,
+        capabilities_by_backend={
+            runtime.runtime_backend: runtime.capabilities.session_signals,
+        },
+    )
+    mailbox = SessionSignalMailbox(event_store=store, target_resolver=target_resolver)
+    execution_id = "exec_stall_followup"
+    scope_id = "exec_stall_followup_ac_1"
+    attempt_id = "exec_stall_followup_ac_1_attempt_1"
+    idempotency_key = "user_turn_1_ac_1"
+    signal = SessionSignal(
+        signal_id=derive_session_signal_id(
+            expected_execution_id=execution_id,
+            target_session_scope_id=scope_id,
+            target_session_attempt_id=attempt_id,
+            idempotency_key=idempotency_key,
+        ),
+        target_session_scope_id=scope_id,
+        target_session_attempt_id=attempt_id,
+        expected_execution_id=execution_id,
+        mode=SessionSignalMode.AFTER_TURN,
+        message="Make the confirmation copy explicit.",
+        source=SessionSignalSource.USER,
+        reason="The user clarified the desired UX.",
+        idempotency_key=idempotency_key,
+    )
+
+    execution_task = asyncio.create_task(
+        executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement the confirmation interaction",
+            session_id="orch_stall_followup",
+            execution_id=execution_id,
+            tools=[],
+            system_prompt="test",
+            seed_goal="Deliver a friendly confirmation UX",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+    )
+    try:
+        await asyncio.wait_for(runtime.first_turn_started.wait(), timeout=2)
+        for _attempt in range(20):
+            if await target_resolver.list_targets(execution_id=execution_id):
+                break
+            await asyncio.sleep(0.01)
+        queued = await mailbox.request(signal)
+        assert queued.state is SessionSignalState.QUEUED
+        runtime.release_first_turn.set()
+
+        with pytest.raises(AmbiguousACExecutionError, match="follow-up stalled after emitting"):
+            await asyncio.wait_for(execution_task, timeout=5)
+
+        runtime_events = await store.replay("execution", scope_id)
+        sealed = [e for e in runtime_events if e.type == "execution.ac.dispatch.sealed"]
+        dispatched = [e for e in runtime_events if e.type == "execution.ac.attempt.dispatched"]
+        followup = next(
+            e for e in dispatched if e.data.get("dispatch_kind") == "session_signal_followup"
+        )
+        # The follow-up dispatch itself is sealed (not just the primary).
+        assert any(e.data.get("ac_dispatch_id") == followup.data["ac_dispatch_id"] for e in sealed)
+        # No successful completion was recorded for this attempt.
+        assert not [
+            e
+            for e in runtime_events
+            if e.type == "execution.session.completed" and e.data.get("success") is True
+        ]
+    finally:
+        if not execution_task.done():
+            execution_task.cancel()
+        await store.close()
+
+
 def test_bounded_reply_reassembles_streamed_assistant_chunks() -> None:
     messages = [
         AgentMessage(type="assistant", content="SYNAPSE_"),

--- a/tests/unit/orchestrator/test_synapse_after_turn_integration.py
+++ b/tests/unit/orchestrator/test_synapse_after_turn_integration.py
@@ -245,9 +245,25 @@ async def test_cross_process_after_turn_signal_is_applied_and_completed(tmp_path
         result = await asyncio.wait_for(execution_task, timeout=5)
         signal_events = await store.replay("session_signal", signal.signal_id)
         projection = project_session_signal(signal_events)
+        runtime_events = await store.replay("execution", scope_id)
+        dispatch_events = [
+            event for event in runtime_events if event.type == "execution.ac.attempt.dispatched"
+        ]
 
         assert result.success is True
         assert len(runtime.prompts) == 2
+        assert len(dispatch_events) == 2
+        assert len({event.data["ac_dispatch_id"] for event in dispatch_events}) == 2
+        assert dispatch_events[0].data["previous_ac_dispatch_id"] is None
+        assert (
+            dispatch_events[1].data["previous_ac_dispatch_id"]
+            == dispatch_events[0].data["ac_dispatch_id"]
+        )
+        assert dispatch_events[1].data["session_origin"] == "restored_same_attempt"
+        assert (
+            dispatch_events[1].data["runtime"]["metadata"]["ac_session_origin"]
+            == "restored_same_attempt"
+        )
         assert projection.state is SessionSignalState.COMPLETED
         assert projection.effective_mode is SessionSignalMode.AFTER_TURN
         assert [event.type for event in signal_events] == [
@@ -321,6 +337,104 @@ async def test_error_only_resume_is_delivery_uncertain_not_applied(tmp_path: Pat
             "control.session.signal.delivering",
             "control.session.signal.delivery_uncertain",
         ]
+    finally:
+        if not execution_task.done():
+            execution_task.cancel()
+        await store.close()
+
+
+@pytest.mark.parametrize(
+    ("mode", "runtime_type", "expected_success"),
+    [
+        (SessionSignalMode.AFTER_TURN, _TwoTurnRuntime, False),
+        (SessionSignalMode.INFORM, _InformRuntime, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_signal_dispatch_persistence_failure_never_marks_provider_failed(
+    tmp_path: Path,
+    mode: SessionSignalMode,
+    runtime_type: type[_TwoTurnRuntime],
+    expected_success: bool,
+) -> None:
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    hub = SessionSignalHub()
+    runtime = runtime_type(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=store,
+        console=MagicMock(),
+        enable_decomposition=False,
+        session_signal_hub=hub,
+    )
+    mailbox = SessionSignalMailbox(store, hub, delivery_queue=hub)
+    execution_id = f"exec_signal_dispatch_failure_{mode.value}"
+    scope_id = f"{execution_id}_ac_1"
+    signal = SessionSignal(
+        signal_id=f"sig_dispatch_persistence_failure_{mode.value}",
+        target_session_scope_id=scope_id,
+        target_session_attempt_id=f"{scope_id}_attempt_1",
+        expected_execution_id=execution_id,
+        mode=mode,
+        message="Apply this only after the dispatch boundary is durable.",
+        source=SessionSignalSource.USER,
+        reason="Exercise the resumed provider boundary.",
+        idempotency_key="dispatch_persistence_failure_1",
+    )
+    execution_task = asyncio.create_task(
+        executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Keep the signal dispatch fail-closed",
+            session_id="orch_signal_dispatch_failure",
+            execution_id=execution_id,
+            tools=[],
+            system_prompt="test",
+            seed_goal="Never claim an unpersisted provider entry",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+    )
+    try:
+        await asyncio.wait_for(runtime.first_turn_started.wait(), timeout=2)
+        assert (await mailbox.request(signal)).state is SessionSignalState.QUEUED
+
+        original_append = store.append
+        failed_followup_dispatch = False
+
+        async def _append_with_failed_followup(event):  # noqa: ANN001
+            nonlocal failed_followup_dispatch
+            if event.type == "execution.ac.attempt.dispatched" and not failed_followup_dispatch:
+                failed_followup_dispatch = True
+                raise OSError("follow-up dispatch persistence unavailable")
+            await original_append(event)
+
+        store.append = _append_with_failed_followup  # type: ignore[method-assign]
+        runtime.release_first_turn.set()
+
+        result = await asyncio.wait_for(execution_task, timeout=5)
+        signal_events = await store.replay("session_signal", signal.signal_id)
+        runtime_events = await store.replay("execution", scope_id)
+
+        assert result.success is expected_success
+        assert result.infra_fatal is (not expected_success)
+        assert len(runtime.prompts) == 1
+        assert failed_followup_dispatch is True
+        assert project_session_signal(signal_events).state is SessionSignalState.DELIVERY_UNCERTAIN
+        assert (
+            len(
+                [
+                    event
+                    for event in runtime_events
+                    if event.type == "execution.ac.attempt.dispatched"
+                ]
+            )
+            == 1
+        )
+        assert not any(event.type == "execution.session.failed" for event in runtime_events)
+        assert any(event.type == "execution.session.completed" for event in runtime_events) is (
+            expected_success
+        )
     finally:
         if not execution_task.done():
             execution_task.cancel()

--- a/tests/unit/orchestrator/test_synapse_after_turn_integration.py
+++ b/tests/unit/orchestrator/test_synapse_after_turn_integration.py
@@ -248,7 +248,7 @@ async def test_after_turn_followup_effectful_stall_seals_and_fails_closed(
         assert queued.state is SessionSignalState.QUEUED
         runtime.release_first_turn.set()
 
-        with pytest.raises(AmbiguousACExecutionError, match="follow-up stalled after emitting"):
+        with pytest.raises(AmbiguousACExecutionError, match="follow-up stalled and its effects"):
             await asyncio.wait_for(execution_task, timeout=5)
 
         runtime_events = await store.replay("execution", scope_id)
@@ -265,6 +265,129 @@ async def test_after_turn_followup_effectful_stall_seals_and_fails_closed(
             for e in runtime_events
             if e.type == "execution.session.completed" and e.data.get("success") is True
         ]
+    finally:
+        if not execution_task.done():
+            execution_task.cancel()
+        await store.close()
+
+
+class _SilentStallFollowupRuntime(_TwoTurnRuntime):
+    """Follow-up turn acknowledges, emits NO tool event, then stalls silently.
+
+    The default (opaque) driver has no real-time effect visibility, so even
+    without an observed tool effect the follow-up may have applied an effect
+    before hanging — it must still seal and fail closed.
+    """
+
+    async def execute_task(self, **kwargs: Any):
+        if not self.prompts:
+            async for message in super().execute_task(**kwargs):
+                yield message
+            return
+
+        prompt = str(kwargs["prompt"])
+        resume_handle = kwargs.get("resume_handle")
+        self.prompts.append(prompt)
+        assert resume_handle is not None
+        yield AgentMessage(
+            type="assistant",
+            content="Working on it.",
+            resume_handle=resume_handle,
+        )
+        await asyncio.Event().wait()  # stall forever, no tool event emitted
+
+
+@pytest.mark.asyncio
+async def test_after_turn_opaque_followup_stall_fails_closed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """R6 blocker #2: an opaque-driver follow-up stall with NO observed effect
+    still seals and fails closed (not an ordinary redispatch-eligible failure)."""
+    from ouroboros.orchestrator import leaf_dispatcher
+    from ouroboros.orchestrator.ac_runtime_handle_manager import AmbiguousACExecutionError
+
+    monkeypatch.setattr(leaf_dispatcher, "STALL_TIMEOUT_SECONDS", 0.2)
+
+    store = EventStore("sqlite+aiosqlite:///:memory:")
+    await store.initialize()
+    hub = SessionSignalHub(event_store=store)
+    runtime = _SilentStallFollowupRuntime(tmp_path)
+    # Default capabilities → realtime_tool_effect_visibility is False (opaque).
+    assert runtime.capabilities.realtime_tool_effect_visibility is False
+    executor = ParallelACExecutor(
+        adapter=runtime,
+        event_store=store,
+        console=MagicMock(),
+        enable_decomposition=False,
+        session_signal_hub=hub,
+    )
+    target_resolver = EventStoreSessionSignalTargetResolver(
+        event_store=store,
+        capabilities_by_backend={
+            runtime.runtime_backend: runtime.capabilities.session_signals,
+        },
+    )
+    mailbox = SessionSignalMailbox(event_store=store, target_resolver=target_resolver)
+    execution_id = "exec_opaque_followup"
+    scope_id = "exec_opaque_followup_ac_1"
+    attempt_id = "exec_opaque_followup_ac_1_attempt_1"
+    idempotency_key = "user_turn_1_ac_1"
+    signal = SessionSignal(
+        signal_id=derive_session_signal_id(
+            expected_execution_id=execution_id,
+            target_session_scope_id=scope_id,
+            target_session_attempt_id=attempt_id,
+            idempotency_key=idempotency_key,
+        ),
+        target_session_scope_id=scope_id,
+        target_session_attempt_id=attempt_id,
+        expected_execution_id=execution_id,
+        mode=SessionSignalMode.AFTER_TURN,
+        message="Make the confirmation copy explicit.",
+        source=SessionSignalSource.USER,
+        reason="The user clarified the desired UX.",
+        idempotency_key=idempotency_key,
+    )
+
+    execution_task = asyncio.create_task(
+        executor._execute_atomic_ac(
+            ac_index=0,
+            ac_content="Implement the confirmation interaction",
+            session_id="orch_opaque_followup",
+            execution_id=execution_id,
+            tools=[],
+            system_prompt="test",
+            seed_goal="Deliver a friendly confirmation UX",
+            depth=0,
+            start_time=datetime.now(UTC),
+        )
+    )
+    try:
+        await asyncio.wait_for(runtime.first_turn_started.wait(), timeout=2)
+        for _attempt in range(20):
+            if await target_resolver.list_targets(execution_id=execution_id):
+                break
+            await asyncio.sleep(0.01)
+        queued = await mailbox.request(signal)
+        assert queued.state is SessionSignalState.QUEUED
+        runtime.release_first_turn.set()
+
+        with pytest.raises(AmbiguousACExecutionError, match="does not attest real-time"):
+            await asyncio.wait_for(execution_task, timeout=5)
+
+        runtime_events = await store.replay("execution", scope_id)
+        followup = next(
+            e
+            for e in runtime_events
+            if e.type == "execution.ac.attempt.dispatched"
+            and e.data.get("dispatch_kind") == "session_signal_followup"
+        )
+        sealed_ids = {
+            e.data.get("ac_dispatch_id")
+            for e in runtime_events
+            if e.type == "execution.ac.dispatch.sealed"
+        }
+        assert followup.data["ac_dispatch_id"] in sealed_ids
     finally:
         if not execution_task.done():
             execution_task.cancel()


### PR DESCRIPTION
Depends on #1648

## Summary

- Introduces an Ouroboros-owned acceptance-criterion runtime above Claude, Codex, OpenCode, and other `AgentRuntime` drivers.
- Defines atomic work by one independently verifiable outcome plus bounded blast radius; token thresholds remain planning/continuation safeguards, not semantic boundaries.
- Combines grill-style decision closure with RLM-inspired external memory, bounded retrieval, fresh provider sessions, and gate-proven trust.

## Changes

### AC capsule vertical slice

- Compiles every AC attempt into a versioned, provider-neutral capsule with semantic identity, workspace, dispatch authority, success contract, and bounded context references.
- Persists only redacted/hash-based manifests and authorizes provider effects only after the capsule is durable.
- Starts a fresh provider session per AC attempt and allows resume only for the exact same capsule, workspace, runtime authority, retry, and node identity.

### Trust and recovery boundaries

- Binds tools, prompt modes, retry/sibling context, runtime execution identity, routing policy, verification modes, and custom verifier authority into capsule identity.
- Requires custom verifiers to expose a bounded canonical `verification_identity_contract()` before their trust can survive a process restart; otherwise their identity is process-local and fails closed.
- Refuses fresh redispatch when an interrupted attempt may already have emitted non-idempotent tool effects, including terminal-session crash gaps.

### RLM-inspired frugality

- Keeps large context outside the provider prompt and selects a newest-first bounded reference frontier with omission count and rolling digest.
- Removes synthetic paging claims until a real resolver exists, and bounds references and success-contract materialization before hashing or prompt construction.
- Caches repeated authority projections and incrementally replays attempt history to keep the runtime economical without weakening trust.

### Architecture

- Adds the RFC: **Ouroboros Runtime — an Acceptance-Criterion VM for AI Engineering**.
- Establishes the loop `GRILL -> COMPILE -> PAGE -> RUN -> PROVE -> LEARN` and separates Decision Threads, Context Pages/Probes, AC Capsules, continuation segments, and verifiers.

## Validation

- Pre-PR gear: `R3` (`12 files`, `3,873 additions`, authority/session-sensitive boundary).
- Independent adversarial review: final 2-vote verdict `CLEAN`.
- `tests/unit/orchestrator`: `3,587 passed, 1 skipped`.
- Full suite: `13,479 passed, 12 skipped`; the same 17 existing Auto/OpenCode environment failures reproduce on the #1648 base and are unrelated to this diff.
- Ruff check/format, targeted MyPy, and mechanical pre-PR checks pass.

## Notes

- This is intentionally stacked on #1648 and implements the first complete vertical slice: capsule compilation plus session ownership.
- Durable context-page resolution, read-only Probe execution, speculative frugal promotion, and token-triggered continuation remain follow-up stack layers.
