### PR TITLE
fix(auto): preserve explicit Seed acceptance contracts

### DIFF
--- a/skills/auto/SKILL.md
+++ b/skills/auto/SKILL.md
@@ -58,6 +58,12 @@ ooo auto "Build a local-first habit tracker CLI" --complete-product
 /ouroboros:auto "Build a local-first habit tracker CLI"
 ```
 
+`ooo auto` does not accept a parent Seed ID/path or infer lineage from goal
+prose. Mentioning an existing Seed in the goal is ordinary context, not an
+authorized derivative operation. Use `ooo evolve` for typed parent evolution,
+or `ooo run` to execute an existing immutable Seed. Do not claim preserved
+lineage or AC edit scope from an `ooo auto` goal alone.
+
 ## CLI flag → MCP arg translation
 
 When the user types `ooo auto` with CLI-style flags inside chat, translate to MCP arguments before invoking `ouroboros_start_auto`:

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 import re
 
-from ouroboros.core.seed import AcceptanceCriterionInput, Seed, ac_text
+from ouroboros.core.seed import (
+    AcceptanceCriterionInput,
+    AcceptanceCriterionSpec,
+    Seed,
+    ac_text,
+)
 
 _AUTO_WRAPPER_CRITERIA = frozenset(
     {
@@ -213,19 +218,52 @@ def _restore_surviving_acceptance_specs(
     filtered: tuple[str, ...],
     original: tuple[tuple[AcceptanceCriterionInput, str], ...],
 ) -> tuple[AcceptanceCriterionInput, ...]:
-    """Keep structured contracts for criteria that survive normalization unchanged."""
-    original_by_text: dict[str, list[AcceptanceCriterionInput]] = {}
-    for criterion, text in original:
-        original_by_text.setdefault(text, []).append(criterion)
+    """Keep structured contracts when surviving criteria are canonicalized.
 
+    Normalization may rewrite a known-equivalent hello_auto criterion rather
+    than preserving its text verbatim.  That description-only rewrite must not
+    discard the criterion's semantic identity or verification evidence.
+    """
+    remaining = list(original)
     restored: list[AcceptanceCriterionInput] = []
     for text in filtered:
-        matches = original_by_text.get(text)
-        if matches:
-            restored.append(matches.pop(0))
-        else:
-            restored.append(text)
+        exact_index = next(
+            (
+                index
+                for index, (_criterion, original_text) in enumerate(remaining)
+                if original_text == text
+            ),
+            None,
+        )
+        if exact_index is not None:
+            criterion, _original_text = remaining.pop(exact_index)
+            restored.append(criterion)
+            continue
+
+        canonical_sources = [
+            (index, criterion)
+            for index, (criterion, original_text) in enumerate(remaining)
+            if isinstance(criterion, AcceptanceCriterionSpec)
+            and _structured_criterion_normalizes_to(original_text, text)
+        ]
+        if len(canonical_sources) == 1:
+            index, criterion = canonical_sources[0]
+            remaining.pop(index)
+            restored.append(criterion.model_copy(update={"description": text}))
+            continue
+
+        restored.append(text)
     return tuple(restored)
+
+
+def _structured_criterion_normalizes_to(original_text: str, normalized_text: str) -> bool:
+    """Return whether one structured hello_auto AC became ``normalized_text``."""
+    subject = _unwrap_seed_repairer_original_requirement(original_text).strip()
+    if _normalize_known_observation_execution_line(subject) == normalized_text:
+        return True
+    return normalized_text.startswith(
+        "Create `hello_auto.py` and `tests/test_hello_auto.py` so "
+    ) and _is_hello_auto_observation_unit_line(original_text)
 
 
 def normalize_observation_execution_criteria(

--- a/src/ouroboros/auto/execution_acceptance.py
+++ b/src/ouroboros/auto/execution_acceptance.py
@@ -227,6 +227,25 @@ def _restore_surviving_acceptance_specs(
     remaining = list(original)
     restored: list[AcceptanceCriterionInput] = []
     for text in filtered:
+        canonical_sources = [
+            (index, criterion)
+            for index, (criterion, original_text) in enumerate(remaining)
+            if isinstance(criterion, AcceptanceCriterionSpec)
+            and _structured_criterion_normalizes_to(original_text, text)
+        ]
+        if canonical_sources:
+            # A canonical hello_auto AC can represent several source criteria.
+            # Keep one structured entry per source, in source order: the model
+            # has scalar evidence fields, so collapsing them would necessarily
+            # discard contracts or invent an unsafe merge policy.
+            for index, _criterion in reversed(canonical_sources):
+                remaining.pop(index)
+            restored.extend(
+                criterion.model_copy(update={"description": text})
+                for _index, criterion in canonical_sources
+            )
+            continue
+
         exact_index = next(
             (
                 index
@@ -238,18 +257,6 @@ def _restore_surviving_acceptance_specs(
         if exact_index is not None:
             criterion, _original_text = remaining.pop(exact_index)
             restored.append(criterion)
-            continue
-
-        canonical_sources = [
-            (index, criterion)
-            for index, (criterion, original_text) in enumerate(remaining)
-            if isinstance(criterion, AcceptanceCriterionSpec)
-            and _structured_criterion_normalizes_to(original_text, text)
-        ]
-        if len(canonical_sources) == 1:
-            index, criterion = canonical_sources[0]
-            remaining.pop(index)
-            restored.append(criterion.model_copy(update={"description": text}))
             continue
 
         restored.append(text)

--- a/src/ouroboros/auto/pipeline.py
+++ b/src/ouroboros/auto/pipeline.py
@@ -4259,16 +4259,18 @@ class AutoPipeline:
         state.seed_artifact = seed.to_dict()
         state.seed_origin = SeedOrigin.AUTO_PIPELINE
 
-        # L1-d / #1171: derive the task class from the standardized ledger
-        # and prepend the catalog's default AC template to the Seed.
+        # L1-d / #1171: derive the task class from the standardized ledger.
+        # Catalog ACs are a fallback for a genuinely empty contract; silently
+        # prepending them to an existing Seed broadens user-authorized scope.
         inference = derive_domain_from_ledger(ledger)
         task_class = next(iter(inference.classes)) if inference.is_single else None
         if task_class is not None:
-            applied = apply_default_ac_template(seed, task_class)
-            if applied.injected_ac:
-                seed = normalize_execution_acceptance(applied.seed)
-                state.seed_id = seed.metadata.seed_id
-                state.seed_artifact = seed.to_dict()
+            if not seed.acceptance_criteria:
+                applied = apply_default_ac_template(seed, task_class)
+                if applied.injected_ac:
+                    seed = normalize_execution_acceptance(applied.seed)
+                    state.seed_id = seed.metadata.seed_id
+                    state.seed_artifact = seed.to_dict()
             state.active_task_class = task_class.value
         return seed
 

--- a/src/ouroboros/auto/seed_repairer.py
+++ b/src/ouroboros/auto/seed_repairer.py
@@ -14,7 +14,12 @@ from uuid import uuid4
 from ouroboros.auto.grading import VAGUE_TERMS, SeedGrade
 from ouroboros.auto.ledger import LedgerEntry, LedgerSource, LedgerStatus, SeedDraftLedger
 from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
-from ouroboros.core.seed import AcceptanceCriterionInput, Seed, ac_text
+from ouroboros.core.seed import (
+    AcceptanceCriterionInput,
+    AcceptanceCriterionSpec,
+    Seed,
+    ac_text,
+)
 
 
 def _review_accepts_closure_mode(review_callable: Callable[..., Any]) -> bool:
@@ -151,8 +156,14 @@ class SeedRepairer:
                 index = _target_index(finding.target)
                 if index is not None and index < len(acceptance):
                     if index not in repaired_acceptance_indices:
-                        acceptance[index] = _observable_preserving_replacement(
-                            ac_text(acceptance[index]), index=index
+                        criterion = acceptance[index]
+                        replacement = _observable_preserving_replacement(
+                            ac_text(criterion), index=index
+                        )
+                        acceptance[index] = (
+                            criterion.model_copy(update={"description": replacement})
+                            if isinstance(criterion, AcceptanceCriterionSpec)
+                            else replacement
                         )
                         repaired_acceptance_indices.add(index)
                 else:
@@ -194,7 +205,9 @@ class SeedRepairer:
                 {
                     "goal": goal,
                     "constraints": tuple(dict.fromkeys(constraints)),
-                    "acceptance_criteria": tuple(dict.fromkeys(acceptance)),
+                    # Preserve AC order, multiplicity, semantic identity, and
+                    # structured verification evidence exactly as repaired.
+                    "acceptance_criteria": tuple(acceptance),
                     "metadata": seed.metadata.model_copy(
                         update={
                             "seed_id": f"seed_{uuid4().hex[:12]}",

--- a/src/ouroboros/auto/task_class_application.py
+++ b/src/ouroboros/auto/task_class_application.py
@@ -2,9 +2,9 @@
 
 The Socratic interview standardizes the ledger; :mod:`domain_inference`
 (L1-b) classifies the ledger into a single :class:`TaskClass`; this
-module wires that class's default acceptance-criteria template into the
-:class:`ouroboros.core.seed.Seed` so the auto pipeline never ships a
-Seed that lacks the class-appropriate runtime AC.
+module wires that class's default acceptance-criteria template into an
+otherwise empty :class:`ouroboros.core.seed.Seed` contract. Existing Seed
+criteria remain authoritative and are never broadened with class defaults.
 
 The helper is intentionally split out from the inference module so:
 
@@ -41,8 +41,8 @@ class AppliedTaskClassDefaults:
         ``model_copy`` is performed) so callers can detect a no-op
         without an equality dance.
     injected_ac:
-        The acceptance-criteria entries prepended in this call —
-        possibly a subset of the catalog template if some entries were
+        The acceptance-criteria entries added in this call — possibly a
+        subset of the catalog template if some entries were
         already present verbatim in the original seed.
     task_class:
         The class whose defaults were applied (mirrors the caller's

--- a/src/ouroboros/auto/task_class_application.py
+++ b/src/ouroboros/auto/task_class_application.py
@@ -2,9 +2,10 @@
 
 The Socratic interview standardizes the ledger; :mod:`domain_inference`
 (L1-b) classifies the ledger into a single :class:`TaskClass`; this
-module wires that class's default acceptance-criteria template into an
-otherwise empty :class:`ouroboros.core.seed.Seed` contract. Existing Seed
-criteria remain authoritative and are never broadened with class defaults.
+module wires that class's default acceptance-criteria template into a
+:class:`ouroboros.core.seed.Seed`. The guarded Auto pipeline caller invokes it
+only for an empty contract, so existing pipeline Seed criteria remain
+unmodified.
 
 The helper is intentionally split out from the inference module so:
 

--- a/tests/unit/auto/test_execution_acceptance.py
+++ b/tests/unit/auto/test_execution_acceptance.py
@@ -16,6 +16,7 @@ from ouroboros.core.seed import (
     AcceptanceCriterionSpec,
     EvaluationPrinciple,
     ExitCondition,
+    InvestmentSpec,
     OntologyField,
     OntologySchema,
     Seed,
@@ -207,6 +208,47 @@ def test_normalize_execution_acceptance_preserves_surviving_success_contracts() 
     assert normalized_spec.description == spec.description
     assert normalized_spec.verify_command == "uv run pytest tests/test_hello_auto.py"
     assert normalized_spec.expected_artifacts == ("hello_auto.py",)
+
+
+def test_normalize_execution_acceptance_preserves_canonicalized_success_contract() -> None:
+    spec = AcceptanceCriterionSpec(
+        description=(
+            "A command/API check returns stable observable output or artifacts proving "
+            "the original requirement for `hello_auto.py` defines `hello_auto() -> str` "
+            "returning exactly `hello from ooo auto`."
+        ),
+        semantic_ac_key="ac_0123456789abcdef",
+        verify_command="uv run pytest tests/test_hello_auto.py",
+        expected_artifacts=("hello_auto.py", "tests/test_hello_auto.py"),
+        output_assertion="1 passed",
+        investment=InvestmentSpec(
+            difficulty="low",
+            stakes="medium",
+            provenance="declared",
+            confidence="high",
+        ),
+    )
+    seed = _seed(spec).model_copy(
+        update={
+            "goal": (
+                "Verify current ooo auto with hello_auto.py and tests/test_hello_auto.py; "
+                "hello_auto returns exactly hello from ooo auto and "
+                "uv run pytest tests/test_hello_auto.py passes."
+            )
+        }
+    )
+
+    normalized = normalize_execution_acceptance(seed)
+
+    assert len(normalized.acceptance_criteria) == 1
+    normalized_spec = normalized.acceptance_criteria[0]
+    assert isinstance(normalized_spec, AcceptanceCriterionSpec)
+    assert normalized_spec.description == _SINGLE_HELLO_AUTO_OBSERVATION_AC
+    assert normalized_spec.semantic_ac_key == spec.semantic_ac_key
+    assert normalized_spec.verify_command == spec.verify_command
+    assert normalized_spec.expected_artifacts == spec.expected_artifacts
+    assert normalized_spec.output_assertion == spec.output_assertion
+    assert normalized_spec.investment == spec.investment
 
 
 def test_normalize_execution_acceptance_preserves_extra_hello_auto_requirements() -> None:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1270,24 +1270,45 @@ async def test_pipeline_preserves_structured_contract_through_normalization(tmp_
         "hello_auto returns exactly hello from ooo auto and "
         "uv run pytest tests/test_hello_auto.py passes."
     )
-    criterion = AcceptanceCriterionSpec(
-        description=(
-            "A command/API check returns stable observable output or artifacts proving "
-            "the original requirement for `hello_auto.py` defines `hello_auto() -> str` "
-            "returning exactly `hello from ooo auto`."
-        ),
-        semantic_ac_key="ac_0123456789abcdef",
-        verify_command="uv run pytest tests/test_hello_auto.py",
-        expected_artifacts=("hello_auto.py", "tests/test_hello_auto.py"),
-        output_assertion="1 passed",
-        investment=InvestmentSpec(
-            difficulty="low",
-            stakes="medium",
-            provenance="declared",
-            confidence="high",
-        ),
+    criteria = tuple(
+        AcceptanceCriterionSpec(
+            description=description,
+            semantic_ac_key=semantic_ac_key,
+            verify_command=verify_command,
+            expected_artifacts=expected_artifacts,
+            output_assertion=output_assertion,
+            investment=InvestmentSpec(
+                difficulty="low",
+                stakes="medium",
+                provenance="declared",
+                confidence="high",
+            ),
+        )
+        for description, semantic_ac_key, verify_command, expected_artifacts, output_assertion in (
+            (
+                "`hello_auto.py` defines `hello_auto() -> str` returning exactly `hello from ooo auto`.",
+                "ac_0123456789abcdef",
+                "python -m pytest tests/test_return.py",
+                ("hello_auto.py",),
+                "return value matches",
+            ),
+            (
+                "`tests/test_hello_auto.py` imports `hello_auto` and asserts the exact return value.",
+                "ac_1123456789abcdef",
+                "python -m pytest tests/test_import.py",
+                ("tests/test_hello_auto.py",),
+                "import assertion passes",
+            ),
+            (
+                "The exact command `uv run pytest tests/test_hello_auto.py` passes.",
+                "ac_2123456789abcdef",
+                "uv run pytest tests/test_hello_auto.py",
+                (".pytest_cache",),
+                "1 passed",
+            ),
+        )
     )
-    generated_seed = _seed(ac=(criterion,)).model_copy(
+    generated_seed = _seed(ac=criteria).model_copy(
         update={"goal": goal, "constraints": ("Only edit the two hello_auto files",)}
     )
     executed: list[Seed] = []
@@ -1352,13 +1373,15 @@ async def test_pipeline_preserves_structured_contract_through_normalization(tmp_
 
     assert result.status == "complete", result.blocker
     assert len(executed) == 1
-    normalized = executed[0].acceptance_criteria[0]
-    assert isinstance(normalized, AcceptanceCriterionSpec)
-    assert normalized.semantic_ac_key == criterion.semantic_ac_key
-    assert normalized.verify_command == criterion.verify_command
-    assert normalized.expected_artifacts == criterion.expected_artifacts
-    assert normalized.output_assertion == criterion.output_assertion
-    assert normalized.investment == criterion.investment
+    normalized_criteria = executed[0].acceptance_criteria
+    assert len(normalized_criteria) == len(criteria)
+    for normalized, original in zip(normalized_criteria, criteria, strict=True):
+        assert isinstance(normalized, AcceptanceCriterionSpec)
+        assert normalized.semantic_ac_key == original.semantic_ac_key
+        assert normalized.verify_command == original.verify_command
+        assert normalized.expected_artifacts == original.expected_artifacts
+        assert normalized.output_assertion == original.output_assertion
+        assert normalized.investment == original.investment
 
 
 def test_seed_repairer_rewrites_each_acceptance_criterion_once() -> None:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -19,8 +19,11 @@ from ouroboros.auto.seed_repairer import SeedRepairer
 from ouroboros.auto.seed_reviewer import ReviewFinding, SeedReview, SeedReviewer
 from ouroboros.auto.state import AutoPhase, AutoPipelineState, AutoStore
 from ouroboros.core.seed import (
+    AcceptanceCriterionInput,
+    AcceptanceCriterionSpec,
     EvaluationPrinciple,
     ExitCondition,
+    InvestmentSpec,
     OntologyField,
     OntologySchema,
     Seed,
@@ -63,7 +66,9 @@ def _fill_ready(ledger: SeedDraftLedger) -> None:
 
 
 def _seed(
-    ac: tuple[str, ...] = ("`habit list` prints stable stdout containing created habits",),
+    ac: tuple[AcceptanceCriterionInput, ...] = (
+        "`habit list` prints stable stdout containing created habits",
+    ),
 ) -> Seed:
     return Seed(
         goal="Build a local CLI",
@@ -1273,6 +1278,44 @@ def test_seed_repairer_rewrites_each_acceptance_criterion_once() -> None:
     assert repaired_acceptance.count("original requirement for") == 1
     assert "The CLI" in repaired_acceptance
     assert "original requirement for A command/API check" not in repaired_acceptance
+
+
+def test_seed_repairer_preserves_structured_ac_identity_and_evidence() -> None:
+    criterion = AcceptanceCriterionSpec(
+        description="The CLI should be easy and user-friendly",
+        semantic_ac_key="ac_0123456789abcdef",
+        verify_command="python -m pytest -q tests/test_cli.py",
+        expected_artifacts=("artifacts/cli.txt",),
+        output_assertion="1 passed",
+        investment=InvestmentSpec(
+            difficulty="medium",
+            stakes="high",
+            provenance="declared",
+            confidence="high",
+        ),
+    )
+    untouched = AcceptanceCriterionSpec(
+        description="`habit list` prints stable stdout containing created habits",
+        semantic_ac_key="ac_fedcba9876543210",
+        verify_command="python -m pytest -q tests/test_list.py",
+    )
+    seed = _seed(ac=(criterion, untouched))
+    ledger = SeedDraftLedger.from_goal(seed.goal)
+    _fill_ready(ledger)
+    review = SeedReviewer().review(seed, ledger=ledger)
+
+    result = SeedRepairer().repair_once(seed, review, ledger=ledger)
+
+    assert result.changed
+    repaired, preserved = result.seed.acceptance_criteria
+    assert isinstance(repaired, AcceptanceCriterionSpec)
+    assert repaired.description != criterion.description
+    assert repaired.semantic_ac_key == criterion.semantic_ac_key
+    assert repaired.verify_command == criterion.verify_command
+    assert repaired.expected_artifacts == criterion.expected_artifacts
+    assert repaired.output_assertion == criterion.output_assertion
+    assert repaired.investment == criterion.investment
+    assert preserved == untouched
 
 
 def test_seed_repairer_assigns_new_seed_identity_after_mutation() -> None:

--- a/tests/unit/auto/test_interview_pipeline.py
+++ b/tests/unit/auto/test_interview_pipeline.py
@@ -1244,9 +1244,7 @@ async def test_pipeline_repairs_b_seed_to_a_and_starts_run(tmp_path) -> None:
     assert result.status == "complete"
     assert result.grade == "A"
     # The user's vague "The CLI should be easy..." AC is repaired in
-    # place. After L1-d (#1171) the catalog's default_ac_template is
-    # prepended to the Seed before the repairer runs, so the *user*
-    # entry is no longer at index [0]; locate it by content instead.
+    # place without task-class defaults broadening the non-empty contract.
     repaired_entries = [
         item.get("description", "") if isinstance(item, dict) else item
         for item in state.seed_artifact["acceptance_criteria"]
@@ -1263,6 +1261,104 @@ async def test_pipeline_repairs_b_seed_to_a_and_starts_run(tmp_path) -> None:
     assert result.run_session_id == "session_1"
     assert state.execution_id == "exec_1"
     assert state.run_session_id == "session_1"
+
+
+@pytest.mark.asyncio
+async def test_pipeline_preserves_structured_contract_through_normalization(tmp_path) -> None:
+    goal = (
+        "Verify current ooo auto with hello_auto.py and tests/test_hello_auto.py; "
+        "hello_auto returns exactly hello from ooo auto and "
+        "uv run pytest tests/test_hello_auto.py passes."
+    )
+    criterion = AcceptanceCriterionSpec(
+        description=(
+            "A command/API check returns stable observable output or artifacts proving "
+            "the original requirement for `hello_auto.py` defines `hello_auto() -> str` "
+            "returning exactly `hello from ooo auto`."
+        ),
+        semantic_ac_key="ac_0123456789abcdef",
+        verify_command="uv run pytest tests/test_hello_auto.py",
+        expected_artifacts=("hello_auto.py", "tests/test_hello_auto.py"),
+        output_assertion="1 passed",
+        investment=InvestmentSpec(
+            difficulty="low",
+            stakes="medium",
+            provenance="declared",
+            confidence="high",
+        ),
+    )
+    generated_seed = _seed(ac=(criterion,)).model_copy(
+        update={"goal": goal, "constraints": ("Only edit the two hello_auto files",)}
+    )
+    executed: list[Seed] = []
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_contract")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(_session_id: str) -> Seed:
+        return generated_seed
+
+    async def run_seed(seed: Seed, *, idempotency_key: str = "") -> dict[str, str | None]:  # noqa: ARG001
+        executed.append(seed)
+        return {
+            "job_id": "job_contract",
+            "execution_id": "exec_contract",
+            "session_id": "run_contract",
+        }
+
+    class PassingRepairer:
+        def converge(
+            self, seed: Seed, *, ledger: SeedDraftLedger
+        ) -> tuple[Seed, SeedReview, list[object]]:  # noqa: ARG002
+            review = SeedReview(
+                grade_result=GradeResult(
+                    grade=SeedGrade.A,
+                    scores={
+                        "coverage": 1.0,
+                        "ambiguity": 0.0,
+                        "testability": 1.0,
+                        "execution_feasibility": 1.0,
+                        "risk": 0.0,
+                    },
+                    findings=[],
+                    blockers=[],
+                    may_run=True,
+                ),
+                findings=(),
+            )
+            return seed, review, []
+
+    state = AutoPipelineState(goal=goal, cwd=str(tmp_path))
+    ledger = SeedDraftLedger.from_goal(goal)
+    _fill_ready(ledger)
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        run_starter=run_seed,
+        store=AutoStore(tmp_path),
+        repairer=PassingRepairer(),
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.status == "complete", result.blocker
+    assert len(executed) == 1
+    normalized = executed[0].acceptance_criteria[0]
+    assert isinstance(normalized, AcceptanceCriterionSpec)
+    assert normalized.semantic_ac_key == criterion.semantic_ac_key
+    assert normalized.verify_command == criterion.verify_command
+    assert normalized.expected_artifacts == criterion.expected_artifacts
+    assert normalized.output_assertion == criterion.output_assertion
+    assert normalized.investment == criterion.investment
 
 
 def test_seed_repairer_rewrites_each_acceptance_criterion_once() -> None:

--- a/tests/unit/auto/test_pipeline_task_class_envelope.py
+++ b/tests/unit/auto/test_pipeline_task_class_envelope.py
@@ -3,8 +3,8 @@
 Asserts:
 - After ``ouroboros_auto`` runs, ``AutoPipelineResult.active_task_class``
   is populated when the ledger unambiguously matches a single class.
-- The Seed passed downstream has the catalog's ``default_ac_template``
-  prepended to ``acceptance_criteria``.
+- Task-class defaults fill a genuinely empty acceptance contract but never
+  broaden an existing user/generated contract.
 - Unmatched and ambiguous ledgers leave ``active_task_class`` as None and AC
   untouched.
 """
@@ -170,10 +170,8 @@ def _ambiguous_ledger() -> SeedDraftLedger:
 
 
 @pytest.mark.asyncio
-async def test_envelope_carries_active_task_class_on_single_match(tmp_path) -> None:
-    """Single-match inference → ``active_task_class`` populated and the
-    catalog template AC entries are prepended to the Seed."""
-    profile = TASK_CLASS_CATALOG[TaskClass.CLI]
+async def test_envelope_preserves_existing_contract_on_single_match(tmp_path) -> None:
+    """Single-match inference records the class without broadening Seed ACs."""
 
     async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
         return InterviewTurn("What should we verify?", "interview_envelope")
@@ -207,13 +205,46 @@ async def test_envelope_carries_active_task_class_on_single_match(tmp_path) -> N
     ac_descriptions = [
         item.get("description", "") if isinstance(item, dict) else item for item in ac
     ]
-    # Template entries are prepended in order.
-    for index, expected in enumerate(profile.default_ac_template):
-        assert ac_descriptions[index] == expected, (
-            f"AC[{index}] should be the L1-d-prepended template entry; got {ac[index]!r}"
-        )
-    # The user's original AC remains present after the template.
-    assert "`habit list` prints stable stdout containing created habits" in ac_descriptions
+    assert ac_descriptions == ["`habit list` prints stable stdout containing created habits"]
+    assert not set(TASK_CLASS_CATALOG[TaskClass.CLI].default_ac_template) & set(ac_descriptions)
+
+
+@pytest.mark.asyncio
+async def test_envelope_fills_genuinely_empty_contract_on_single_match(tmp_path) -> None:
+    """Task-class defaults remain available when generation produced no ACs."""
+
+    async def start(goal: str, cwd: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("What should we verify?", "interview_envelope_empty")
+
+    async def answer(session_id: str, text: str) -> InterviewTurn:  # noqa: ARG001
+        return InterviewTurn("done", session_id, seed_ready=True, completed=True)
+
+    async def generate_seed(_session_id: str) -> Seed:
+        return _build_seed(ac=())
+
+    state = AutoPipelineState(goal="Build a habit-tracker CLI tool", cwd=str(tmp_path))
+    ledger = _cli_ledger()
+    state.ledger = ledger.to_dict()
+    driver = AutoInterviewDriver(
+        FunctionInterviewBackend(start, answer),
+        store=AutoStore(tmp_path),
+        max_rounds=1,
+    )
+    pipeline = AutoPipeline(
+        driver,
+        generate_seed,
+        store=AutoStore(tmp_path),
+        skip_run=True,
+    )
+
+    result = await pipeline.run(state)
+
+    assert result.active_task_class == TaskClass.CLI.value
+    ac_descriptions = [
+        item.get("description", "") if isinstance(item, dict) else item
+        for item in state.seed_artifact["acceptance_criteria"]
+    ]
+    assert ac_descriptions == list(TASK_CLASS_CATALOG[TaskClass.CLI].default_ac_template)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Prevents `ooo auto` from silently broadening a non-empty Seed acceptance contract with task-class defaults. Task-class inference still records the active class and still fills a genuinely empty contract, while deterministic Seed repair now preserves structured AC identity and verification evidence.

This also documents that mentioning a Seed ID/path in auto goal prose does not establish typed derivative lineage; callers must use evolution or execute the immutable Seed directly.

## Test plan

- [x] `uv run pytest -q tests/unit/auto/test_pipeline_task_class_envelope.py` — 4 passed
- [x] `uv run pytest -q tests/unit/auto/test_interview_pipeline.py -k seed_repairer` — 7 passed
- [x] Broader `tests/unit/auto tests/unit/bigbang` — 1,919 passed; 6 runtime-routing tests failed identically on clean `v0.50.5` because the user-level stage profile routes authoring/execution to different runtimes than their legacy expectations
- [x] `ruff check src tests` and `ruff format --check src tests` clean
- [x] `mypy src/ouroboros` clean
- [x] GitNexus impact: LOW for both changed methods; change detection MEDIUM, limited to expected auto/repair flows
- [x] Independent read-only review: PASS

## R-run comparison (required for `src/ouroboros/auto/` changes)

This is a deterministic contract-preservation guard and structure-preserving model copy; it does not alter per-round model calls, orchestration count, or execution scheduling.

| Metric                         | Baseline (sha) | This PR (sha) | Ratio |
|--------------------------------|----------------|---------------|-------|
| Rounds completed in 600 s      | N/A            | N/A           | n/a   |
| Per-round wall-clock (s/round) | N/A            | N/A           | n/a   |
| Terminal reason                | N/A            | N/A           | n/a   |
| EventStore event count         | N/A            | N/A           | n/a   |

Budget compliance: [ ] within 1.5× / [ ] regression flagged with mitigation / [x] N/A (substrate-only contract guard; no per-round execution change)

## Related issues

Fixes #1678
