### PR TITLE
refactor(orchestrator): centralize execution authority identity

### DIFF
--- a/src/ouroboros/orchestrator/claude_worker_runtime.py
+++ b/src/ouroboros/orchestrator/claude_worker_runtime.py
@@ -133,6 +133,20 @@ class ClaudeWorkerTransport:
         # command builder just appends the flags. Empty ⇒ no ``--add-dir`` at all.
         self._add_dirs = _resolve_add_dirs(context_reference_dirs, cwd=cwd)
 
+    def execution_identity_contract(self) -> dict[str, object]:
+        """Declare static command policy; authority binds executable bytes separately."""
+        return {
+            "version": 1,
+            "configuration": {
+                "cwd": self._cwd,
+                "timeout": self._timeout,
+                "disallowed_tools": list(self._disallowed_tools),
+                "persist_sessions": self._persist_sessions,
+                "add_dirs": list(self._add_dirs),
+                "child_environment_policy_version": 1,
+            },
+        }
+
     @staticmethod
     def _permission_args(permission_mode: str | None) -> list[str]:
         normalized = (permission_mode or "").strip().lower()

--- a/src/ouroboros/orchestrator/codex_mcp_runtime.py
+++ b/src/ouroboros/orchestrator/codex_mcp_runtime.py
@@ -126,6 +126,21 @@ class CodexMcpWorkerTransport:
         # across turns so codex-reply reaches the SAME (process-bound) server.
         self._pool: dict[str, MCPSessionActor] = {}
 
+    def execution_identity_contract(self) -> dict[str, object]:
+        """Declare static server policy while excluding the live session pool."""
+        return {
+            "version": 1,
+            "configuration": {
+                "connect_timeout": self._connect_timeout,
+                "idle_timeout": self._idle_timeout,
+                "disabled_mcp_servers": list(self._disabled_mcp_servers),
+                "index_sessions": self._index_sessions,
+                "codex_home": self._codex_home,
+                "resume_scope": "process_bound_pool_v1",
+                "child_environment_policy_version": 1,
+            },
+        }
+
     def _server_config(self) -> MCPServerConfig:
         # Strip ouroboros MCP env vars so the spawned codex server cannot recurse
         # back into the ouroboros MCP server (#185 child-env discipline).

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -20,6 +20,7 @@ import os
 from pathlib import Path
 import re
 import shutil
+import stat
 from typing import Any
 import uuid
 
@@ -37,7 +38,7 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile
 from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
 from ouroboros.orchestrator.verifier import Verifier
 
-EXECUTION_AUTHORITY_VERSION = 2
+EXECUTION_AUTHORITY_VERSION = 3
 _MAX_IDENTITY_DEPTH = 8
 _MAX_IDENTITY_ITEMS = 256
 _MAX_IDENTITY_SCALAR_CHARS = 8_192
@@ -202,10 +203,23 @@ def runtime_execution_identity_contract(adapter: object) -> dict[str, object]:
     identity = provider()
     if not isinstance(identity, Mapping):
         raise ValueError("runtime execution identity contract is not a mapping")
-    normalized = _canonical_object(
+    projected = _project_explicit_identity(
         dict(identity),
         field="runtime execution identity contract",
     )
+    try:
+        _reject_sensitive_identity_fields(projected)
+    except ValueError:
+        # Provider-owned credential-bearing identity must never reach the public
+        # authority payload. Mark it unobserved so portability fails closed.
+        return {"version": 1, "observed": False}
+    normalized = _canonical_object(
+        projected,
+        field="runtime execution identity contract",
+    )
+    encoded = _canonical_json(normalized, field="runtime execution identity contract")
+    if len(encoded) > _MAX_IDENTITY_JSON_CHARS:
+        raise ValueError("runtime execution identity contract exceeds its budget")
     return {"version": 1, "observed": True, "identity": normalized}
 
 
@@ -450,28 +464,32 @@ def _resolved_executable(value: object, *, cwd: str | None) -> dict[str, object]
         realpath = os.path.realpath(expanded)
     generation: dict[str, int] | None = None
     content_digest: str | None = None
+    executable: bool | None = None
     if realpath is not None:
         try:
             digest = hashlib.sha256()
             with Path(realpath).open("rb") as executable_file:
-                stat = os.fstat(executable_file.fileno())
+                file_stat = os.fstat(executable_file.fileno())
                 while chunk := executable_file.read(1024 * 1024):
                     digest.update(chunk)
         except OSError:
             pass
         else:
             generation = {
-                "device": stat.st_dev,
-                "inode": stat.st_ino,
-                "size": stat.st_size,
-                "mtime_ns": stat.st_mtime_ns,
+                "device": file_stat.st_dev,
+                "inode": file_stat.st_ino,
+                "size": file_stat.st_size,
+                "mtime_ns": file_stat.st_mtime_ns,
+                "mode": stat.S_IMODE(file_stat.st_mode),
             }
             content_digest = "sha256:" + digest.hexdigest()
+            executable = bool(generation["mode"] & 0o111) and os.access(realpath, os.X_OK)
     return {
         "path": value,
         "realpath": realpath,
         "generation": generation,
         "content_digest": content_digest,
+        "executable": executable,
     }
 
 
@@ -509,6 +527,7 @@ def _runtime_executable_contract(adapter: object) -> dict[str, object]:
         or item.get("realpath") is not None
         and item.get("generation") is not None
         and item.get("content_digest") is not None
+        and item.get("executable") is True
         for item in (executable, launcher)
     )
     return {
@@ -649,13 +668,13 @@ def _runtime_skill_dispatcher_contract(adapter: object) -> dict[str, object]:
     }
 
 
-def _class_implementation_contract(adapter: object) -> dict[str, object]:
-    """Bind one object's class hierarchy without inspecting its instance state."""
+def _class_implementation_contract_for_type(runtime_type: type[object]) -> dict[str, object]:
+    """Bind one class hierarchy without inspecting mutable instance state."""
     classes: list[str] = []
     members: dict[str, object] = {}
     modules: dict[str, object] = {}
     durable = True
-    for runtime_class in type(adapter).__mro__:
+    for runtime_class in runtime_type.__mro__:
         if runtime_class is object:
             continue
         qualified_name = f"{runtime_class.__module__}.{runtime_class.__qualname__}"
@@ -722,6 +741,11 @@ def _class_implementation_contract(adapter: object) -> dict[str, object]:
     }
 
 
+def _class_implementation_contract(adapter: object) -> dict[str, object]:
+    """Bind one object's class hierarchy without inspecting its instance state."""
+    return _class_implementation_contract_for_type(type(adapter))
+
+
 def _safe_class_implementation_contract(value: object) -> dict[str, object]:
     try:
         return _class_implementation_contract(value)
@@ -759,25 +783,108 @@ def _instance_declared_method_overrides(value: object) -> dict[str, object]:
     return overrides
 
 
-def _executor_implementation_contract(executor: object | None) -> dict[str, object]:
+def _static_executor_component_contract(component: type[object]) -> dict[str, object]:
+    """Bind a class-selected execution component without constructing it."""
+    try:
+        implementation = _class_implementation_contract_for_type(component)
+    except Exception as exc:
+        return {
+            "mode": "static_type",
+            "stability": "process_local",
+            "type": f"{component.__module__}.{component.__qualname__}",
+            "instance_nonce": uuid.uuid4().hex,
+            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+        }
+    durable = implementation.get("stability") == "durable"
+    contract: dict[str, object] = {
+        "mode": "static_type",
+        "stability": "durable" if durable else "process_local",
+        "type": f"{component.__module__}.{component.__qualname__}",
+        "implementation": implementation,
+    }
+    if not durable:
+        contract["instance_nonce"] = uuid.uuid4().hex
+    return contract
+
+
+def _executor_component_contract(component: object) -> dict[str, object]:
+    """Describe one explicit executor-owned effect component.
+
+    A class-selected dispatcher is static executor behavior and can be durable.
+    A live helper instance, such as a session-signal hub, owns mutable
+    attempt-time state. Record its presence and implementation but never
+    serialize its queue, event store, or active targets into the baseline.
+    """
+    if component is None:
+        return {"mode": "none", "stability": "durable"}
+    if isinstance(component, type):
+        return _static_executor_component_contract(component)
+    return {
+        "mode": "live_instance",
+        "stability": "process_local",
+        "type": _qualified_type(component),
+        "implementation": _safe_class_implementation_contract(component),
+        "instance_nonce": uuid.uuid4().hex,
+    }
+
+
+def _executor_component_contracts(
+    components: Mapping[str, object] | None,
+) -> dict[str, object]:
+    if components is None:
+        return {}
+    try:
+        if len(components) > _MAX_IDENTITY_ITEMS or not all(
+            isinstance(name, str) and name for name in components
+        ):
+            raise ValueError("executor components are invalid")
+        return {
+            name: _executor_component_contract(component) for name, component in components.items()
+        }
+    except Exception as exc:
+        return {
+            "unobserved": {
+                "mode": "process_local",
+                "stability": "process_local",
+                "instance_nonce": uuid.uuid4().hex,
+                "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+            }
+        }
+
+
+def _executor_implementation_contract(
+    executor: object | None,
+    *,
+    components: Mapping[str, object] | None = None,
+) -> dict[str, object]:
     """Bind the concrete effect-owning executor or fail closed when absent."""
+    component_contracts = _executor_component_contracts(components)
     if executor is None:
         return {
-            "version": 1,
+            "version": 2,
             "mode": "unbound",
             "stability": "process_local",
             "instance_nonce": uuid.uuid4().hex,
+            "components": component_contracts,
         }
     implementation = _safe_class_implementation_contract(executor)
     instance_overrides = _instance_declared_method_overrides(executor)
-    durable = implementation.get("stability") == "durable" and not instance_overrides
+    durable = (
+        implementation.get("stability") == "durable"
+        and not instance_overrides
+        and all(
+            isinstance(component, Mapping) and component.get("stability") == "durable"
+            for component in component_contracts.values()
+        )
+    )
     contract: dict[str, object] = {
-        "version": 1,
+        "version": 2,
         "mode": "bound",
         "type": _qualified_type(executor),
         "stability": "durable" if durable else "process_local",
         "implementation": implementation,
         "instance_overrides": instance_overrides,
+        "components": component_contracts,
     }
     if not durable:
         contract["instance_nonce"] = uuid.uuid4().hex
@@ -1408,6 +1515,7 @@ class ExecutionAuthorityContract:
         workspace: str | None,
         execution_policy: Mapping[str, object],
         executor: object | None = None,
+        executor_components: Mapping[str, object] | None = None,
         workspace_identity: Mapping[str, object] | None = None,
         workspace_generation: Mapping[str, object] | None = None,
         resolved_routing: ResolvedRuntimeAuthority | None = None,
@@ -1416,7 +1524,10 @@ class ExecutionAuthorityContract:
     ) -> ExecutionAuthorityContract:
         data = {
             "version": EXECUTION_AUTHORITY_VERSION,
-            "executor": _executor_implementation_contract(executor),
+            "executor": _executor_implementation_contract(
+                executor,
+                components=executor_components,
+            ),
             "workspace": canonical_workspace_authority(
                 workspace,
                 identity=workspace_identity,

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -37,7 +37,7 @@ from ouroboros.orchestrator.profile_loader import ExecutionProfile
 from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
 from ouroboros.orchestrator.verifier import Verifier
 
-EXECUTION_AUTHORITY_VERSION = 1
+EXECUTION_AUTHORITY_VERSION = 2
 _MAX_IDENTITY_DEPTH = 8
 _MAX_IDENTITY_ITEMS = 256
 _MAX_IDENTITY_SCALAR_CHARS = 8_192
@@ -391,7 +391,18 @@ def _callable_entrypoint_contract(target: object) -> dict[str, object]:
     elif inspect.isfunction(target) or inspect.isbuiltin(target):
         implementation = target
     else:
-        implementation = type(target).__call__
+        class_contract = _safe_class_implementation_contract(target)
+        instance_overrides = _instance_executable_overrides(target)
+        durable = class_contract.get("stability") == "durable" and not instance_overrides
+        contract: dict[str, object] = {
+            **class_contract,
+            "stability": "durable" if durable else "process_local",
+            "entrypoint": _callable_implementation_contract(type(target).__call__),
+            "instance_overrides": instance_overrides,
+        }
+        if not durable:
+            contract["instance_nonce"] = uuid.uuid4().hex
+        return contract
     return _callable_implementation_contract(implementation)
 
 
@@ -540,6 +551,24 @@ def _runtime_watchdog_contract(adapter: object) -> dict[str, object]:
 
 
 def _runtime_skill_dispatcher_contract(adapter: object) -> dict[str, object]:
+    interceptor_descriptor = inspect.getattr_static(adapter, "_interceptor", None)
+    if interceptor_descriptor is not None:
+        try:
+            interceptor = object.__getattribute__(adapter, "_interceptor")
+            component = _declared_component_contract(interceptor)
+        except Exception as exc:
+            return {
+                "mode": "delegated",
+                "stability": "process_local",
+                "instance_nonce": uuid.uuid4().hex,
+                "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+            }
+        return {
+            "mode": "delegated",
+            "stability": component.get("stability", "process_local"),
+            "component": component,
+        }
+
     dispatcher_descriptor = inspect.getattr_static(adapter, "_skill_dispatcher", None)
     dispatcher = (
         object.__getattribute__(adapter, "_skill_dispatcher")
@@ -695,6 +724,57 @@ def _safe_class_implementation_contract(value: object) -> dict[str, object]:
             "observed": False,
             "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
         }
+
+
+def _instance_declared_method_overrides(value: object) -> dict[str, object]:
+    """Bind only instance state that shadows executable class members."""
+    try:
+        instance_state = vars(value)
+    except TypeError:
+        return {}
+    missing = object()
+    overrides: dict[str, object] = {}
+    for name, item in instance_state.items():
+        if not isinstance(name, str) or not name:
+            continue
+        class_member = inspect.getattr_static(type(value), name, missing)
+        if class_member is missing or not (
+            callable(class_member) or isinstance(class_member, (classmethod, staticmethod))
+        ):
+            continue
+        if callable(item):
+            overrides[name] = {
+                "mode": "callable",
+                "implementation": _callable_entrypoint_contract(item),
+            }
+        else:
+            overrides[name] = {"mode": "non_callable", "type": _qualified_type(item)}
+    return overrides
+
+
+def _executor_implementation_contract(executor: object | None) -> dict[str, object]:
+    """Bind the concrete effect-owning executor or fail closed when absent."""
+    if executor is None:
+        return {
+            "version": 1,
+            "mode": "unbound",
+            "stability": "process_local",
+            "instance_nonce": uuid.uuid4().hex,
+        }
+    implementation = _safe_class_implementation_contract(executor)
+    instance_overrides = _instance_declared_method_overrides(executor)
+    durable = implementation.get("stability") == "durable" and not instance_overrides
+    contract: dict[str, object] = {
+        "version": 1,
+        "mode": "bound",
+        "type": _qualified_type(executor),
+        "stability": "durable" if durable else "process_local",
+        "implementation": implementation,
+        "instance_overrides": instance_overrides,
+    }
+    if not durable:
+        contract["instance_nonce"] = uuid.uuid4().hex
+    return contract
 
 
 def _reject_sensitive_identity_fields(value: object) -> None:
@@ -1276,6 +1356,7 @@ class ExecutionAuthorityContract:
         )
         if data.get("version") != EXECUTION_AUTHORITY_VERSION or set(data) != {
             "version",
+            "executor",
             "workspace",
             "runtime",
             "verifier",
@@ -1319,6 +1400,7 @@ class ExecutionAuthorityContract:
         verifier: Verifier | None,
         workspace: str | None,
         execution_policy: Mapping[str, object],
+        executor: object | None = None,
         workspace_identity: Mapping[str, object] | None = None,
         workspace_generation: Mapping[str, object] | None = None,
         resolved_routing: ResolvedRuntimeAuthority | None = None,
@@ -1327,6 +1409,7 @@ class ExecutionAuthorityContract:
     ) -> ExecutionAuthorityContract:
         data = {
             "version": EXECUTION_AUTHORITY_VERSION,
+            "executor": _executor_implementation_contract(executor),
             "workspace": canonical_workspace_authority(
                 workspace,
                 identity=workspace_identity,
@@ -1368,6 +1451,9 @@ class ExecutionAuthorityContract:
         those require a complete per-attempt capsule with the omitted inputs.
         """
         data = self.data
+        executor = data.get("executor")
+        if not isinstance(executor, Mapping) or executor.get("stability") != "durable":
+            return False
         workspace = data.get("workspace")
         if not isinstance(workspace, Mapping) or workspace.get("observed") is not True:
             return False

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -23,6 +23,7 @@ import shutil
 from typing import Any
 import uuid
 
+from ouroboros.core.security import is_sensitive_field
 from ouroboros.orchestrator.adapter import RuntimeHandle
 from ouroboros.orchestrator.evidence.verification import (
     _verify_atomic_evidence_against_runtime_messages,
@@ -394,6 +395,10 @@ def _callable_entrypoint_contract(target: object) -> dict[str, object]:
     return _callable_implementation_contract(implementation)
 
 
+def _qualified_type(value: object) -> str:
+    return f"{type(value).__module__}.{type(value).__qualname__}"
+
+
 def _file_content_digest(path: str | os.PathLike[str]) -> str | None:
     try:
         digest = hashlib.sha256()
@@ -608,29 +613,12 @@ def _runtime_skill_dispatcher_contract(adapter: object) -> dict[str, object]:
     }
 
 
-def _runtime_implementation_contract(adapter: object) -> dict[str, object]:
-    """Bind the runtime class hierarchy without guessing execution-critical hooks."""
+def _class_implementation_contract(adapter: object) -> dict[str, object]:
+    """Bind one object's class hierarchy without inspecting its instance state."""
     classes: list[str] = []
-    instance_callables: dict[str, object] = {}
     members: dict[str, object] = {}
     modules: dict[str, object] = {}
     durable = True
-    try:
-        instance_state = vars(adapter)
-    except TypeError:
-        instance_state = {}
-        durable = False
-        instance_state_observed = False
-    else:
-        instance_state_observed = True
-    for attribute_name, value in instance_state.items():
-        if not callable(value):
-            continue
-        instance_callables[attribute_name] = _callable_entrypoint_contract(value)
-        # Instance-level executable behavior may carry closure or mutable state
-        # that a class/module digest cannot prove portable. Bind it for audit,
-        # but fail closed for cross-process composition.
-        durable = False
     for runtime_class in type(adapter).__mro__:
         if runtime_class is object:
             continue
@@ -669,13 +657,18 @@ def _runtime_implementation_contract(adapter: object) -> dict[str, object]:
         }
         try:
             source_path = inspect.getsourcefile(runtime_class)
-        except TypeError:
+        except (OSError, TypeError):
             source_path = None
         if source_path is None:
             durable = False
             modules[qualified_name] = {"observed": False}
             continue
-        realpath = str(Path(source_path).resolve(strict=False))
+        try:
+            realpath = str(Path(source_path).resolve(strict=False))
+        except (OSError, RuntimeError):
+            durable = False
+            modules[qualified_name] = {"observed": False}
+            continue
         digest = _file_content_digest(realpath)
         if digest is None:
             durable = False
@@ -685,13 +678,201 @@ def _runtime_implementation_contract(adapter: object) -> dict[str, object]:
             "observed": True,
             "content_digest": digest,
         }
-    contract: dict[str, object] = {
+    return {
         "stability": "durable" if durable and classes else "process_local",
         "classes": classes,
-        "instance_callables": instance_callables,
-        "instance_state_observed": instance_state_observed,
         "members": members,
         "modules": modules,
+    }
+
+
+def _safe_class_implementation_contract(value: object) -> dict[str, object]:
+    try:
+        return _class_implementation_contract(value)
+    except Exception as exc:
+        return {
+            "stability": "process_local",
+            "observed": False,
+            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+        }
+
+
+def _reject_sensitive_identity_fields(value: object) -> None:
+    if isinstance(value, Mapping):
+        for key, item in value.items():
+            if is_sensitive_field(key):
+                raise ValueError("component identity contains a sensitive field")
+            _reject_sensitive_identity_fields(item)
+    elif isinstance(value, list):
+        for item in value:
+            _reject_sensitive_identity_fields(item)
+
+
+def _instance_executable_overrides(value: object) -> dict[str, object]:
+    try:
+        instance_state = vars(value)
+    except TypeError:
+        return {}
+    missing = object()
+    overrides: dict[str, object] = {}
+    for name, item in instance_state.items():
+        if not isinstance(name, str) or not name:
+            continue
+        if callable(item):
+            overrides[name] = {
+                "mode": "callable",
+                "implementation": _callable_entrypoint_contract(item),
+            }
+            continue
+        class_member = inspect.getattr_static(type(value), name, missing)
+        if class_member is missing or not (
+            callable(class_member) or isinstance(class_member, (classmethod, staticmethod))
+        ):
+            continue
+        overrides[name] = {"mode": "non_callable", "type": _qualified_type(item)}
+    return overrides
+
+
+def _declared_component_contract(value: object) -> dict[str, object]:
+    implementation = _safe_class_implementation_contract(value)
+    try:
+        executable = _runtime_executable_contract(value)
+    except Exception as exc:
+        executable = {
+            "required": True,
+            "observed": False,
+            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+        }
+    provider_descriptor = inspect.getattr_static(
+        type(value),
+        "execution_identity_contract",
+        None,
+    )
+    instance_overrides = _instance_executable_overrides(value)
+    if provider_descriptor is None:
+        return {
+            "mode": "process_local",
+            "stability": "process_local",
+            "type": _qualified_type(value),
+            "instance_nonce": uuid.uuid4().hex,
+            "reason": "identity_not_declared",
+            "implementation": implementation,
+            "executable": executable,
+        }
+    try:
+        provider = object.__getattribute__(value, "execution_identity_contract")
+        identity = provider()
+        if not isinstance(identity, Mapping):
+            raise ValueError("component identity is not a mapping")
+        projected = _project_explicit_identity(
+            dict(identity),
+            field="component execution identity",
+        )
+        _reject_sensitive_identity_fields(projected)
+        if not isinstance(projected, dict) or set(projected) != {"version", "configuration"}:
+            raise ValueError("component identity has an invalid envelope")
+        version = projected.get("version")
+        configuration = projected.get("configuration")
+        if (
+            isinstance(version, bool)
+            or version != 1
+            or not isinstance(configuration, dict)
+            or not configuration
+        ):
+            raise ValueError("component identity has an invalid version or configuration")
+        encoded = _canonical_json(projected, field="component execution identity")
+        if len(encoded) > _MAX_IDENTITY_JSON_CHARS:
+            raise ValueError("component identity exceeds its budget")
+    except Exception as exc:
+        return {
+            "mode": "process_local",
+            "stability": "process_local",
+            "type": _qualified_type(value),
+            "instance_nonce": uuid.uuid4().hex,
+            "reason": f"identity_error:{type(exc).__module__}.{type(exc).__qualname__}",
+            "implementation": implementation,
+            "executable": executable,
+        }
+    durable = (
+        not instance_overrides
+        and implementation.get("stability") == "durable"
+        and (executable.get("required") is not True or executable.get("observed") is True)
+    )
+    contract: dict[str, object] = {
+        "mode": "declared",
+        "stability": "durable" if durable else "process_local",
+        "type": _qualified_type(value),
+        "identity_digest": _sha256(encoded),
+        "instance_overrides": instance_overrides,
+        "implementation": implementation,
+        "executable": executable,
+    }
+    if not durable:
+        contract["instance_nonce"] = uuid.uuid4().hex
+    return contract
+
+
+def _runtime_composition_contract(adapter: object) -> dict[str, object]:
+    provider_descriptor = inspect.getattr_static(
+        type(adapter),
+        "execution_components",
+        None,
+    )
+    if provider_descriptor is None:
+        return {"version": 1, "mode": "none", "stability": "durable", "components": {}}
+    try:
+        provider = object.__getattribute__(adapter, "execution_components")
+        components = provider()
+        if not isinstance(components, Mapping) or len(components) > _MAX_IDENTITY_ITEMS:
+            raise ValueError("runtime execution components are invalid")
+        if not all(isinstance(name, str) and name for name in components):
+            raise ValueError("runtime execution component names are invalid")
+        contracts = {
+            name: _declared_component_contract(component) for name, component in components.items()
+        }
+    except Exception as exc:
+        return {
+            "version": 1,
+            "mode": "declared",
+            "stability": "process_local",
+            "instance_nonce": uuid.uuid4().hex,
+            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+            "components": {},
+        }
+    durable = all(contract.get("stability") == "durable" for contract in contracts.values())
+    result: dict[str, object] = {
+        "version": 1,
+        "mode": "declared",
+        "stability": "durable" if durable else "process_local",
+        "components": contracts,
+    }
+    if not durable:
+        result["instance_nonce"] = uuid.uuid4().hex
+    return result
+
+
+def _runtime_implementation_contract(adapter: object) -> dict[str, object]:
+    """Bind runtime code plus explicitly owned execution components."""
+    class_contract = _class_implementation_contract(adapter)
+    instance_overrides = _instance_executable_overrides(adapter)
+    durable = class_contract.get("stability") == "durable"
+    try:
+        vars(adapter)
+    except TypeError:
+        durable = False
+        instance_state_observed = False
+    else:
+        instance_state_observed = True
+    if instance_overrides:
+        durable = False
+    composition = _runtime_composition_contract(adapter)
+    durable = durable and composition.get("stability") == "durable"
+    contract: dict[str, object] = {
+        **class_contract,
+        "stability": "durable" if durable else "process_local",
+        "instance_overrides": instance_overrides,
+        "instance_state_observed": instance_state_observed,
+        "composition": composition,
     }
     if contract["stability"] == "process_local":
         contract["instance_nonce"] = uuid.uuid4().hex

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -384,26 +384,33 @@ def _callable_implementation_contract(target: object) -> dict[str, object]:
     }
 
 
-def _callable_entrypoint_contract(target: object) -> dict[str, object]:
-    """Fingerprint the code actually invoked for functions, methods, and callables."""
+def _callable_leaf_implementation_contract(target: object) -> dict[str, object]:
+    """Fingerprint one callable entrypoint without following nested callable state."""
     if inspect.ismethod(target):
         implementation = target.__func__
     elif inspect.isfunction(target) or inspect.isbuiltin(target):
         implementation = target
     else:
+        implementation = type(target).__call__
+    return _callable_implementation_contract(implementation)
+
+
+def _callable_entrypoint_contract(target: object) -> dict[str, object]:
+    """Fingerprint the code actually invoked for functions, methods, and callables."""
+    if not (inspect.ismethod(target) or inspect.isfunction(target) or inspect.isbuiltin(target)):
         class_contract = _safe_class_implementation_contract(target)
         instance_overrides = _instance_executable_overrides(target)
         durable = class_contract.get("stability") == "durable" and not instance_overrides
         contract: dict[str, object] = {
             **class_contract,
             "stability": "durable" if durable else "process_local",
-            "entrypoint": _callable_implementation_contract(type(target).__call__),
+            "entrypoint": _callable_leaf_implementation_contract(target),
             "instance_overrides": instance_overrides,
         }
         if not durable:
             contract["instance_nonce"] = uuid.uuid4().hex
         return contract
-    return _callable_implementation_contract(implementation)
+    return _callable_leaf_implementation_contract(target)
 
 
 def _qualified_type(value: object) -> str:
@@ -745,7 +752,7 @@ def _instance_declared_method_overrides(value: object) -> dict[str, object]:
         if callable(item):
             overrides[name] = {
                 "mode": "callable",
-                "implementation": _callable_entrypoint_contract(item),
+                "implementation": _callable_leaf_implementation_contract(item),
             }
         else:
             overrides[name] = {"mode": "non_callable", "type": _qualified_type(item)}
@@ -801,7 +808,7 @@ def _instance_executable_overrides(value: object) -> dict[str, object]:
         if callable(item):
             overrides[name] = {
                 "mode": "callable",
-                "implementation": _callable_entrypoint_contract(item),
+                "implementation": _callable_leaf_implementation_contract(item),
             }
             continue
         class_member = inspect.getattr_static(type(value), name, missing)

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -1,23 +1,33 @@
-"""Canonical execution authority shared by routing, recovery, and verification.
+"""Canonical executor-baseline authority shared by later runtime layers.
 
 This module owns identity only. It does not authorize a dispatch, persist a
-checkpoint, or declare acceptance. Later runtime layers can depend on one stable
-contract instead of deriving narrower fingerprints independently.
+checkpoint, or declare acceptance. Per-attempt inputs such as the AC, prompt,
+tool envelope, and a checkpoint-selected resume handle belong to the later
+attempt capsule. That capsule can compose this stable baseline instead of
+deriving narrower runtime, verifier, workspace, and policy fingerprints again.
 """
 
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import hashlib
 import inspect
 import json
 import marshal
 import math
+import os
 from pathlib import Path
+import shutil
 from typing import Any
 import uuid
 
+from ouroboros.orchestrator.adapter import RuntimeHandle
+from ouroboros.orchestrator.evidence.verification import (
+    _verify_atomic_evidence_against_runtime_messages,
+)
+from ouroboros.orchestrator.model_routing import ModelRouter, serialize_model_router
+from ouroboros.orchestrator.profile_loader import ExecutionProfile
 from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
 from ouroboros.orchestrator.verifier import Verifier
 
@@ -26,6 +36,7 @@ _MAX_IDENTITY_DEPTH = 8
 _MAX_IDENTITY_ITEMS = 256
 _MAX_IDENTITY_SCALAR_CHARS = 8_192
 _MAX_IDENTITY_JSON_CHARS = 64_000
+_RESOLVED_RUNTIME_AUTHORITY_TOKEN = object()
 
 
 def _canonical_json(value: object, *, field: str) -> str:
@@ -52,16 +63,48 @@ def _sha256(value: str) -> str:
     return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
 
 
-def canonical_workspace_authority(workspace: str | None) -> dict[str, object]:
-    """Return the exact checkout path that owns effects for this executor."""
-    if not isinstance(workspace, str) or not workspace.strip():
-        return {"version": 1, "observed": False}
-    canonical = str(Path(workspace).expanduser().resolve(strict=False))
+def canonical_workspace_authority(
+    workspace: str | None,
+    *,
+    identity: Mapping[str, object] | None = None,
+    generation: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """Return the checkout owner plus an optional immutable generation identity."""
+    if identity is not None:
+        owner = _canonical_object(dict(identity), field="workspace identity")
+        resolved_cwd = owner.get("effective_cwd")
+        if (
+            not isinstance(workspace, str)
+            or not workspace.strip()
+            or not isinstance(resolved_cwd, str)
+            or str(Path(workspace).expanduser().resolve(strict=False))
+            != str(Path(resolved_cwd).expanduser().resolve(strict=False))
+        ):
+            raise ValueError("workspace identity disagrees with the effective workspace")
+    elif isinstance(workspace, str) and workspace.strip():
+        owner = {
+            "mode": "direct",
+            "effective_cwd": str(Path(workspace).expanduser().resolve(strict=False)),
+        }
+    else:
+        return {
+            "version": 1,
+            "observed": False,
+            "generation": {"observed": False},
+        }
+    generation_contract: dict[str, object] = (
+        {
+            "observed": True,
+            "identity": _canonical_object(dict(generation), field="workspace generation"),
+        }
+        if generation is not None
+        else {"observed": False}
+    )
     return {
         "version": 1,
         "observed": True,
-        "mode": "direct",
-        "effective_cwd": canonical,
+        "identity": owner,
+        "generation": generation_contract,
     }
 
 
@@ -158,6 +201,93 @@ def runtime_execution_proves_effective_model(value: object) -> bool:
     return isinstance(identity, Mapping) and identity.get("effective_model_observed") is True
 
 
+def runtime_permission_mode_contract(adapter: object) -> dict[str, object]:
+    """Return the normalized permission mode that the runtime actually executes."""
+    permission_mode: object = None
+    private_descriptor = inspect.getattr_static(adapter, "_permission_mode", None)
+    if private_descriptor is not None:
+        permission_mode = object.__getattribute__(adapter, "_permission_mode")
+    if not isinstance(permission_mode, str) or not permission_mode.strip():
+        permission_mode = getattr(adapter, "permission_mode", None)
+    return (
+        {"observed": True, "mode": permission_mode.strip()}
+        if isinstance(permission_mode, str) and permission_mode.strip()
+        else {"observed": False}
+    )
+
+
+def _active_resolved_runtime_fields(adapter: object) -> dict[str, object]:
+    runtime_backend = getattr(adapter, "runtime_backend", None)
+    llm_backend = getattr(adapter, "llm_backend", None)
+    return {
+        "runtime_backend": (
+            runtime_backend.strip()
+            if isinstance(runtime_backend, str) and runtime_backend.strip()
+            else None
+        ),
+        "llm_backend": (
+            llm_backend.strip() if isinstance(llm_backend, str) and llm_backend.strip() else None
+        ),
+        "permission_mode": runtime_permission_mode_contract(adapter),
+        "constructor_model": constructor_model_contract(adapter),
+        "runtime_execution": runtime_execution_identity_contract(adapter),
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class ResolvedRuntimeAuthority:
+    """Runner-resolved runtime identity validated against the active adapter."""
+
+    canonical_json: str
+    _binding_token: object = field(repr=False, compare=False)
+    _adapter: object = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if self._binding_token is not _RESOLVED_RUNTIME_AUTHORITY_TOKEN:
+            raise ValueError("resolved runtime authority was not bound to an adapter")
+        canonical = _canonical_json(
+            json.loads(self.canonical_json),
+            field="resolved runtime authority",
+        )
+        if canonical != self.canonical_json:
+            raise ValueError("resolved runtime authority is not canonical")
+
+    @classmethod
+    def bind(
+        cls,
+        adapter: object,
+        resolved_routing: Mapping[str, object],
+    ) -> ResolvedRuntimeAuthority:
+        active = _active_resolved_runtime_fields(adapter)
+        for field_name, active_value in active.items():
+            if resolved_routing.get(field_name) != active_value:
+                raise ValueError(f"resolved runtime authority disagrees with active {field_name}")
+        return cls(
+            canonical_json=_canonical_json(
+                dict(resolved_routing),
+                field="resolved runtime authority",
+            ),
+            _binding_token=_RESOLVED_RUNTIME_AUTHORITY_TOKEN,
+            _adapter=adapter,
+        )
+
+    def require_adapter(self, adapter: object) -> None:
+        """Reject reuse of a routing identity bound against another runtime instance."""
+        if self._adapter is not adapter:
+            raise ValueError("resolved runtime authority is bound to a different adapter")
+        active = _active_resolved_runtime_fields(adapter)
+        resolved = self.data
+        for field_name, active_value in active.items():
+            if resolved.get(field_name) != active_value:
+                raise ValueError(f"resolved runtime authority drifted from active {field_name}")
+
+    @property
+    def data(self) -> dict[str, Any]:
+        return _canonical_object(
+            json.loads(self.canonical_json), field="resolved runtime authority"
+        )
+
+
 def _runtime_capabilities_contract(adapter: object) -> dict[str, object]:
     capabilities = runtime_capabilities_for(adapter)
     return {
@@ -179,11 +309,409 @@ def _runtime_capabilities_contract(adapter: object) -> dict[str, object]:
     }
 
 
-def runtime_authority_contract(adapter: object) -> dict[str, object]:
-    """Combine generic capabilities with backend-owned resolved identity."""
-    runtime_backend = getattr(adapter, "runtime_backend", None)
-    llm_backend = getattr(adapter, "llm_backend", None)
-    permission_mode = getattr(adapter, "permission_mode", None)
+def _callable_implementation_contract(target: object) -> dict[str, object]:
+    """Identify executable behavior without persisting source or code objects."""
+    module = getattr(target, "__module__", type(target).__module__)
+    qualname = getattr(target, "__qualname__", type(target).__qualname__)
+    try:
+        source_digest = _sha256(inspect.getsource(target))
+    except (OSError, TypeError):
+        source_digest = None
+    code = getattr(target, "__code__", None)
+    code_digest = (
+        "sha256:" + hashlib.sha256(marshal.dumps(code)).hexdigest()
+        if source_digest is None and code is not None
+        else None
+    )
+    if source_digest is None and code_digest is None:
+        return {
+            "stability": "process_local",
+            "instance_nonce": uuid.uuid4().hex,
+            "module": str(module),
+            "qualname": str(qualname),
+        }
+    return {
+        "stability": "durable",
+        "module": str(module),
+        "qualname": str(qualname),
+        "source_digest": source_digest,
+        "code_digest": code_digest,
+    }
+
+
+def _callable_entrypoint_contract(target: object) -> dict[str, object]:
+    """Fingerprint the code actually invoked for functions, methods, and callables."""
+    if inspect.ismethod(target):
+        implementation = target.__func__
+    elif inspect.isfunction(target) or inspect.isbuiltin(target):
+        implementation = target
+    else:
+        implementation = type(target).__call__
+    return _callable_implementation_contract(implementation)
+
+
+def _file_content_digest(path: str | os.PathLike[str]) -> str | None:
+    try:
+        digest = hashlib.sha256()
+        with Path(path).open("rb") as source_file:
+            while chunk := source_file.read(1024 * 1024):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return "sha256:" + digest.hexdigest()
+
+
+def _resolved_executable(value: object, *, cwd: str | None) -> dict[str, object] | None:
+    if isinstance(value, os.PathLike):
+        value = os.fspath(value)
+    if not isinstance(value, str) or not value:
+        return None
+    expanded = os.path.expanduser(value)
+    has_separator = os.sep in expanded or os.altsep is not None and os.altsep in expanded
+    if not has_separator:
+        search_path = os.environ.get("PATH", os.defpath)
+        if cwd is not None:
+            search_path = os.pathsep.join(
+                entry if os.path.isabs(entry) else os.path.join(cwd, entry)
+                for entry in search_path.split(os.pathsep)
+            )
+        resolved = shutil.which(expanded, path=search_path)
+        realpath = os.path.realpath(resolved) if resolved is not None else None
+    else:
+        if not os.path.isabs(expanded) and cwd is not None:
+            expanded = os.path.join(cwd, expanded)
+        realpath = os.path.realpath(expanded)
+    generation: dict[str, int] | None = None
+    content_digest: str | None = None
+    if realpath is not None:
+        try:
+            digest = hashlib.sha256()
+            with Path(realpath).open("rb") as executable_file:
+                stat = os.fstat(executable_file.fileno())
+                while chunk := executable_file.read(1024 * 1024):
+                    digest.update(chunk)
+        except OSError:
+            pass
+        else:
+            generation = {
+                "device": stat.st_dev,
+                "inode": stat.st_ino,
+                "size": stat.st_size,
+                "mtime_ns": stat.st_mtime_ns,
+            }
+            content_digest = "sha256:" + digest.hexdigest()
+    return {
+        "path": value,
+        "realpath": realpath,
+        "generation": generation,
+        "content_digest": content_digest,
+    }
+
+
+def _runtime_executable_contract(adapter: object) -> dict[str, object]:
+    """Bind subprocess executables, launchers, and delegated command policy."""
+    cwd_value = getattr(adapter, "working_directory", None) or getattr(adapter, "_cwd", None)
+    cwd = cwd_value if isinstance(cwd_value, str) and cwd_value else None
+    declared_descriptor = inspect.getattr_static(
+        type(adapter),
+        "executable_identity_contract",
+        None,
+    )
+    command_policy: dict[str, Any] | None = None
+    executable: dict[str, object] | None = None
+    launcher: dict[str, object] | None = None
+    if declared_descriptor is not None:
+        declared_provider = object.__getattribute__(adapter, "executable_identity_contract")
+        declared = declared_provider()
+        if not isinstance(declared, Mapping):
+            raise ValueError("runtime executable identity is not a mapping")
+        executable = _resolved_executable(declared.get("executable"), cwd=cwd)
+        launcher = _resolved_executable(declared.get("launcher"), cwd=cwd)
+        raw_policy = declared.get("command_policy")
+        if raw_policy is not None:
+            command_policy = _canonical_object(raw_policy, field="runtime command policy")
+    else:
+        executable = _resolved_executable(
+            getattr(adapter, "cli_path", None) or getattr(adapter, "_cli_path", None),
+            cwd=cwd,
+        )
+        launcher = _resolved_executable(getattr(adapter, "_electron_node_path", None), cwd=cwd)
+    required = executable is not None or launcher is not None or command_policy is not None
+    observed = not required or all(
+        item is None
+        or item.get("realpath") is not None
+        and item.get("generation") is not None
+        and item.get("content_digest") is not None
+        for item in (executable, launcher)
+    )
+    return {
+        "required": required,
+        "observed": observed,
+        "executable": executable,
+        "launcher": launcher,
+        "command_policy": command_policy,
+    }
+
+
+def _runtime_watchdog_contract(adapter: object) -> dict[str, object]:
+    provider_descriptor = inspect.getattr_static(
+        type(adapter),
+        "watchdog_identity_contract",
+        None,
+    )
+    if provider_descriptor is not None:
+        provider = object.__getattribute__(adapter, "watchdog_identity_contract")
+        value = provider()
+        if not isinstance(value, Mapping):
+            raise ValueError("runtime watchdog identity is not a mapping")
+        return {"observed": True, "identity": _canonical_object(value, field="watchdog identity")}
+    fields = (
+        "_startup_output_timeout_seconds",
+        "_stdout_idle_timeout_seconds",
+        "_process_shutdown_timeout_seconds",
+        "_completed_process_group_shutdown_timeout_seconds",
+        "_max_resume_retries",
+        "_max_stderr_lines",
+        "_use_process_group",
+        "_child_session_env_keys",
+    )
+    missing = object()
+    values: dict[str, object] = {}
+    for field_name in fields:
+        value = inspect.getattr_static(adapter, field_name, missing)
+        if value is not missing:
+            values[field_name.removeprefix("_")] = object.__getattribute__(
+                adapter,
+                field_name,
+            )
+    return {
+        "observed": bool(values),
+        "identity": _canonical_object(values, field="watchdog identity") if values else None,
+    }
+
+
+def _runtime_skill_dispatcher_contract(adapter: object) -> dict[str, object]:
+    dispatcher_descriptor = inspect.getattr_static(adapter, "_skill_dispatcher", None)
+    dispatcher = (
+        object.__getattribute__(adapter, "_skill_dispatcher")
+        if dispatcher_descriptor is not None
+        else None
+    )
+    local_dispatch_descriptor = inspect.getattr_static(
+        type(adapter),
+        "_maybe_dispatch_skill_intercept",
+        None,
+    )
+    if dispatcher is None and local_dispatch_descriptor is None:
+        return {"mode": "none", "stability": "durable"}
+
+    if dispatcher is None:
+        local_entrypoint = inspect.getattr_static(
+            type(adapter),
+            "_dispatch_skill_intercept_locally",
+            None,
+        )
+        return {
+            "mode": "local_fallback",
+            "stability": "process_local",
+            "instance_nonce": uuid.uuid4().hex,
+            "skills_dir": str(getattr(adapter, "_skills_dir", None)),
+            "resolver_implementation": _callable_implementation_contract(local_dispatch_descriptor),
+            "dispatcher_implementation": (
+                _callable_implementation_contract(local_entrypoint)
+                if local_entrypoint is not None
+                else None
+            ),
+        }
+
+    implementation = _callable_entrypoint_contract(dispatcher)
+    try:
+        identity_provider = getattr(dispatcher, "execution_identity_contract", None)
+    except Exception as exc:
+        return {
+            "mode": "custom",
+            "stability": "process_local",
+            "instance_nonce": uuid.uuid4().hex,
+            "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+            "implementation": implementation,
+        }
+    if callable(identity_provider):
+        try:
+            identity = identity_provider()
+            if not isinstance(identity, Mapping):
+                raise ValueError("skill dispatcher identity is not a mapping")
+            encoded = _canonical_json(dict(identity), field="skill dispatcher identity")
+        except Exception as exc:
+            return {
+                "mode": "custom",
+                "stability": "process_local",
+                "instance_nonce": uuid.uuid4().hex,
+                "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
+                "implementation": implementation,
+            }
+        if implementation.get("stability") == "durable" and local_dispatch_descriptor is None:
+            return {
+                "mode": "custom",
+                "stability": "durable",
+                "identity_digest": _sha256(encoded),
+                "implementation": implementation,
+            }
+    return {
+        "mode": "custom",
+        "stability": "process_local",
+        "instance_nonce": uuid.uuid4().hex,
+        "implementation": implementation,
+    }
+
+
+def _runtime_implementation_contract(adapter: object) -> dict[str, object]:
+    """Bind the runtime class hierarchy without guessing execution-critical hooks."""
+    classes: list[str] = []
+    instance_callables: dict[str, object] = {}
+    members: dict[str, object] = {}
+    modules: dict[str, object] = {}
+    durable = True
+    try:
+        instance_state = vars(adapter)
+    except TypeError:
+        instance_state = {}
+        durable = False
+        instance_state_observed = False
+    else:
+        instance_state_observed = True
+    for attribute_name, value in instance_state.items():
+        if not callable(value):
+            continue
+        instance_callables[attribute_name] = _callable_entrypoint_contract(value)
+        # Instance-level executable behavior may carry closure or mutable state
+        # that a class/module digest cannot prove portable. Bind it for audit,
+        # but fail closed for cross-process composition.
+        durable = False
+    for runtime_class in type(adapter).__mro__:
+        if runtime_class is object:
+            continue
+        qualified_name = f"{runtime_class.__module__}.{runtime_class.__qualname__}"
+        classes.append(qualified_name)
+        if "<locals>" in runtime_class.__qualname__:
+            durable = False
+        class_members: dict[str, object] = {}
+        for member_name, raw_member in vars(runtime_class).items():
+            targets: tuple[object, ...]
+            if isinstance(raw_member, (classmethod, staticmethod)):
+                targets = (raw_member.__func__,)
+            elif isinstance(raw_member, property):
+                targets = tuple(
+                    target
+                    for target in (raw_member.fget, raw_member.fset, raw_member.fdel)
+                    if target is not None
+                )
+            elif inspect.isfunction(raw_member):
+                targets = (raw_member,)
+            else:
+                continue
+            for index, target in enumerate(targets):
+                member_key = f"{member_name}:{index}"
+                member_contract = _callable_implementation_contract(target)
+                class_members[member_key] = member_contract
+                durable = durable and member_contract.get("stability") == "durable"
+        members[qualified_name] = {
+            "observed": bool(class_members),
+            "content_digest": _sha256(
+                _canonical_json(
+                    class_members,
+                    field=f"runtime class members {qualified_name}",
+                )
+            ),
+        }
+        try:
+            source_path = inspect.getsourcefile(runtime_class)
+        except TypeError:
+            source_path = None
+        if source_path is None:
+            durable = False
+            modules[qualified_name] = {"observed": False}
+            continue
+        realpath = str(Path(source_path).resolve(strict=False))
+        digest = _file_content_digest(realpath)
+        if digest is None:
+            durable = False
+            modules[realpath] = {"observed": False}
+            continue
+        modules[realpath] = {
+            "observed": True,
+            "content_digest": digest,
+        }
+    contract: dict[str, object] = {
+        "stability": "durable" if durable and classes else "process_local",
+        "classes": classes,
+        "instance_callables": instance_callables,
+        "instance_state_observed": instance_state_observed,
+        "members": members,
+        "modules": modules,
+    }
+    if contract["stability"] == "process_local":
+        contract["instance_nonce"] = uuid.uuid4().hex
+    return contract
+
+
+def _runtime_handle_selector_contract(
+    adapter: object,
+    runtime_handle: RuntimeHandle | None,
+) -> dict[str, object]:
+    if runtime_handle is None:
+        return {"version": 1, "mode": "none"}
+    provider_descriptor = inspect.getattr_static(
+        type(adapter),
+        "resume_handle_execution_identity_contract",
+        None,
+    )
+    if provider_descriptor is None:
+        return {"version": 1, "mode": "present", "observed": False}
+    provider = object.__getattribute__(
+        adapter,
+        "resume_handle_execution_identity_contract",
+    )
+    identity = provider(runtime_handle)
+    if not isinstance(identity, Mapping):
+        raise ValueError("runtime handle selector identity is not a mapping")
+    return {
+        "version": 1,
+        "mode": "present",
+        "observed": True,
+        "identity": _canonical_object(dict(identity), field="runtime handle selector identity"),
+    }
+
+
+def runtime_authority_contract(
+    adapter: object,
+    *,
+    resolved_routing: ResolvedRuntimeAuthority | None = None,
+    runtime_handle: RuntimeHandle | None = None,
+) -> dict[str, object]:
+    """Combine generic capabilities with one already-resolved runtime identity."""
+    if resolved_routing is None:
+        runtime_backend = getattr(adapter, "runtime_backend", None)
+        llm_backend = getattr(adapter, "llm_backend", None)
+        constructor_model = constructor_model_contract(adapter)
+        execution_identity = runtime_execution_identity_contract(adapter)
+        permission_contract = runtime_permission_mode_contract(adapter)
+    else:
+        resolved_routing.require_adapter(adapter)
+        resolved_data = resolved_routing.data
+        runtime_backend = resolved_data.get("runtime_backend")
+        llm_backend = resolved_data.get("llm_backend")
+        constructor_model = _canonical_object(
+            resolved_data.get("constructor_model"),
+            field="resolved constructor model",
+        )
+        execution_identity = _canonical_object(
+            resolved_data.get("runtime_execution"),
+            field="resolved runtime execution identity",
+        )
+        permission_contract = _canonical_object(
+            resolved_data.get("permission_mode"),
+            field="resolved permission mode",
+        )
     return {
         "version": 1,
         "runtime_backend": (
@@ -194,14 +722,15 @@ def runtime_authority_contract(adapter: object) -> dict[str, object]:
         "llm_backend": (
             llm_backend.strip() if isinstance(llm_backend, str) and llm_backend.strip() else None
         ),
-        "permission_mode": (
-            {"observed": True, "mode": permission_mode.strip()}
-            if isinstance(permission_mode, str) and permission_mode.strip()
-            else {"observed": False}
-        ),
-        "constructor_model": constructor_model_contract(adapter),
-        "execution_identity": runtime_execution_identity_contract(adapter),
+        "permission_mode": permission_contract,
+        "constructor_model": constructor_model,
+        "execution_identity": execution_identity,
         "capabilities": _runtime_capabilities_contract(adapter),
+        "implementation": _runtime_implementation_contract(adapter),
+        "executable": _runtime_executable_contract(adapter),
+        "watchdog": _runtime_watchdog_contract(adapter),
+        "skill_dispatcher": _runtime_skill_dispatcher_contract(adapter),
+        "handle_selector": _runtime_handle_selector_contract(adapter, runtime_handle),
     }
 
 
@@ -265,35 +794,25 @@ def _project_explicit_identity(
 
 
 def _verifier_implementation_contract(verifier: Verifier) -> dict[str, object]:
-    if inspect.ismethod(verifier):
-        target = verifier.__func__
-    elif inspect.isfunction(verifier) or inspect.isbuiltin(verifier):
-        target = verifier
-    else:
-        target = type(verifier).__call__
-
-    module = getattr(target, "__module__", type(verifier).__module__)
-    qualname = getattr(target, "__qualname__", type(verifier).__qualname__)
-    try:
-        source_digest = _sha256(inspect.getsource(target))
-    except (OSError, TypeError):
-        source_digest = None
-    code = getattr(target, "__code__", None)
-    code_digest = (
-        "sha256:" + hashlib.sha256(marshal.dumps(code)).hexdigest() if code is not None else None
-    )
-    return {
-        "module": str(module),
-        "qualname": str(qualname),
-        "source_digest": source_digest,
-        "code_digest": code_digest,
-    }
+    return _callable_entrypoint_contract(verifier)
 
 
-def verifier_authority_contract(verifier: Verifier | None) -> dict[str, object]:
+def verifier_authority_contract(
+    verifier: Verifier | None,
+    *,
+    runtime_transcript_verifier: object | None = None,
+) -> dict[str, object]:
     """Return durable verifier identity only when it is explicitly declared."""
+    transcript_implementation = _callable_implementation_contract(
+        runtime_transcript_verifier or _verify_atomic_evidence_against_runtime_messages
+    )
     if verifier is None:
-        return {"version": 1, "mode": "runtime_transcript"}
+        return {
+            "version": 1,
+            "mode": "runtime_transcript",
+            "implementation": transcript_implementation,
+            "behavioral_state": {"stability": "durable", "protocol_version": 1},
+        }
 
     implementation = _verifier_implementation_contract(verifier)
     identity_descriptor = inspect.getattr_static(
@@ -329,25 +848,81 @@ def verifier_authority_contract(verifier: Verifier | None) -> dict[str, object]:
                 "stability": "durable",
                 "identity_digest": _sha256(encoded),
             }
-        except (AttributeError, TypeError, ValueError) as exc:
+        except Exception as exc:
             behavioral_state = {
                 "stability": "process_local",
                 "instance_nonce": uuid.uuid4().hex,
-                "reason": str(exc),
+                "reason": f"{type(exc).__module__}.{type(exc).__qualname__}",
             }
     return {
         "version": 1,
         "mode": "custom",
         "implementation": implementation,
+        "runtime_transcript_implementation": transcript_implementation,
         "behavioral_state": behavioral_state,
+    }
+
+
+def build_execution_policy_contract(
+    *,
+    decomposition_mode: str,
+    max_decomposition_depth: int,
+    max_concurrent: int,
+    execution_profile: ExecutionProfile | None,
+    fat_harness_mode: bool,
+    run_verify_commands: bool,
+    verify_command_timeout_seconds: int,
+    ac_retry_attempts: int,
+    reasoning_effort: str | None,
+    model_router: ModelRouter | None,
+    cross_harness_redispatch: bool,
+    shadow_replay_enabled: bool,
+) -> dict[str, object]:
+    """Return the one canonical parallel-execution policy payload."""
+    return {
+        "decomposition_mode": decomposition_mode,
+        "max_decomposition_depth": max_decomposition_depth,
+        "max_concurrent": max_concurrent,
+        "execution_profile": (
+            execution_profile.model_dump(mode="json") if execution_profile is not None else None
+        ),
+        "fat_harness_mode": fat_harness_mode,
+        "run_verify_commands": run_verify_commands,
+        "verify_command_timeout_seconds": verify_command_timeout_seconds,
+        "ac_retry_attempts": ac_retry_attempts,
+        "reasoning_effort": reasoning_effort,
+        "model_routing": serialize_model_router(model_router),
+        "cross_harness_redispatch": cross_harness_redispatch,
+        "shadow_replay_enabled": shadow_replay_enabled,
     }
 
 
 @dataclass(frozen=True, slots=True)
 class ExecutionAuthorityContract:
-    """Immutable canonical JSON contract and its stable fingerprint."""
+    """Immutable executor-baseline contract and its stable fingerprint.
+
+    This excludes per-attempt AC/prompt/tool inputs and a runtime handle selected
+    later by checkpoint recovery. A later attempt capsule must compose those
+    values with this baseline before granting reusable trust or acceptance.
+    """
 
     canonical_json: str
+
+    def __post_init__(self) -> None:
+        data = _canonical_object(
+            self.canonical_json and json.loads(self.canonical_json),
+            field="execution authority contract",
+        )
+        if data.get("version") != EXECUTION_AUTHORITY_VERSION or set(data) != {
+            "version",
+            "workspace",
+            "runtime",
+            "verifier",
+            "execution_policy",
+        }:
+            raise ValueError("execution authority contract has an invalid shape")
+        if _canonical_json(data, field="execution authority contract") != self.canonical_json:
+            raise ValueError("execution authority contract is not canonical")
 
     @classmethod
     def build(
@@ -357,12 +932,28 @@ class ExecutionAuthorityContract:
         verifier: Verifier | None,
         workspace: str | None,
         execution_policy: Mapping[str, object],
+        workspace_identity: Mapping[str, object] | None = None,
+        workspace_generation: Mapping[str, object] | None = None,
+        resolved_routing: ResolvedRuntimeAuthority | None = None,
+        runtime_handle: RuntimeHandle | None = None,
+        runtime_transcript_verifier: object | None = None,
     ) -> ExecutionAuthorityContract:
         data = {
             "version": EXECUTION_AUTHORITY_VERSION,
-            "workspace": canonical_workspace_authority(workspace),
-            "runtime": runtime_authority_contract(adapter),
-            "verifier": verifier_authority_contract(verifier),
+            "workspace": canonical_workspace_authority(
+                workspace,
+                identity=workspace_identity,
+                generation=workspace_generation,
+            ),
+            "runtime": runtime_authority_contract(
+                adapter,
+                resolved_routing=resolved_routing,
+                runtime_handle=runtime_handle,
+            ),
+            "verifier": verifier_authority_contract(
+                verifier,
+                runtime_transcript_verifier=runtime_transcript_verifier,
+            ),
             "execution_policy": _canonical_object(
                 dict(execution_policy),
                 field="execution policy",
@@ -382,19 +973,90 @@ class ExecutionAuthorityContract:
         return value
 
     @property
-    def reusable_across_processes(self) -> bool:
-        verifier = self.data.get("verifier")
-        if not isinstance(verifier, Mapping) or verifier.get("mode") != "custom":
-            return True
+    def portable_across_processes(self) -> bool:
+        """Return whether this baseline can be composed into a capsule elsewhere.
+
+        Portability is an identity-stability property only. It never authorizes
+        reuse of an attempt, result, checkpoint, trust verdict, or acceptance;
+        those require a complete per-attempt capsule with the omitted inputs.
+        """
+        data = self.data
+        workspace = data.get("workspace")
+        if not isinstance(workspace, Mapping) or workspace.get("observed") is not True:
+            return False
+        generation = workspace.get("generation")
+        if not isinstance(generation, Mapping) or generation.get("observed") is not True:
+            return False
+
+        runtime = data.get("runtime")
+        if not isinstance(runtime, Mapping):
+            return False
+        runtime_backend = runtime.get("runtime_backend")
+        if not isinstance(runtime_backend, str) or not runtime_backend:
+            return False
+        for field_name in ("permission_mode", "constructor_model", "execution_identity"):
+            value = runtime.get(field_name)
+            if not isinstance(value, Mapping) or value.get("observed") is not True:
+                return False
+        execution_identity = runtime.get("execution_identity")
+        resolved_identity = (
+            execution_identity.get("identity") if isinstance(execution_identity, Mapping) else None
+        )
+        if (
+            not isinstance(resolved_identity, Mapping)
+            or resolved_identity.get("effective_model_observed") is not True
+        ):
+            return False
+        implementation = runtime.get("implementation")
+        if not isinstance(implementation, Mapping) or implementation.get("stability") != "durable":
+            return False
+        executable = runtime.get("executable")
+        if not isinstance(executable, Mapping):
+            return False
+        if executable.get("required") is True and executable.get("observed") is not True:
+            return False
+        watchdog = runtime.get("watchdog")
+        if executable.get("required") is True and (
+            not isinstance(watchdog, Mapping) or watchdog.get("observed") is not True
+        ):
+            return False
+        skill_dispatcher = runtime.get("skill_dispatcher")
+        if (
+            not isinstance(skill_dispatcher, Mapping)
+            or skill_dispatcher.get("stability") != "durable"
+        ):
+            return False
+        handle_selector = runtime.get("handle_selector")
+        if not isinstance(handle_selector, Mapping):
+            return False
+        if handle_selector.get("mode") != "none" and handle_selector.get("observed") is not True:
+            return False
+
+        verifier = data.get("verifier")
+        if not isinstance(verifier, Mapping):
+            return False
+        verifier_implementation = verifier.get("implementation")
+        transcript_implementation = (
+            verifier_implementation
+            if verifier.get("mode") == "runtime_transcript"
+            else verifier.get("runtime_transcript_implementation")
+        )
         behavioral_state = verifier.get("behavioral_state")
         return (
-            isinstance(behavioral_state, Mapping) and behavioral_state.get("stability") == "durable"
+            isinstance(verifier_implementation, Mapping)
+            and verifier_implementation.get("stability") == "durable"
+            and isinstance(transcript_implementation, Mapping)
+            and transcript_implementation.get("stability") == "durable"
+            and isinstance(behavioral_state, Mapping)
+            and behavioral_state.get("stability") == "durable"
         )
 
 
 __all__ = [
     "EXECUTION_AUTHORITY_VERSION",
     "ExecutionAuthorityContract",
+    "ResolvedRuntimeAuthority",
+    "build_execution_policy_contract",
     "canonical_workspace_authority",
     "constructor_model_contract",
     "runtime_authority_contract",

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -1,0 +1,406 @@
+"""Canonical execution authority shared by routing, recovery, and verification.
+
+This module owns identity only. It does not authorize a dispatch, persist a
+checkpoint, or declare acceptance. Later runtime layers can depend on one stable
+contract instead of deriving narrower fingerprints independently.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+import hashlib
+import inspect
+import json
+import marshal
+import math
+from pathlib import Path
+from typing import Any
+import uuid
+
+from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
+from ouroboros.orchestrator.verifier import Verifier
+
+EXECUTION_AUTHORITY_VERSION = 1
+_MAX_IDENTITY_DEPTH = 8
+_MAX_IDENTITY_ITEMS = 256
+_MAX_IDENTITY_SCALAR_CHARS = 8_192
+_MAX_IDENTITY_JSON_CHARS = 64_000
+
+
+def _canonical_json(value: object, *, field: str) -> str:
+    try:
+        return json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+            allow_nan=False,
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field} is not canonical JSON") from exc
+
+
+def _canonical_object(value: object, *, field: str) -> dict[str, Any]:
+    normalized = json.loads(_canonical_json(value, field=field))
+    if not isinstance(normalized, dict):
+        raise ValueError(f"{field} is not an object")
+    return normalized
+
+
+def _sha256(value: str) -> str:
+    return "sha256:" + hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def canonical_workspace_authority(workspace: str | None) -> dict[str, object]:
+    """Return the exact checkout path that owns effects for this executor."""
+    if not isinstance(workspace, str) or not workspace.strip():
+        return {"version": 1, "observed": False}
+    canonical = str(Path(workspace).expanduser().resolve(strict=False))
+    return {
+        "version": 1,
+        "observed": True,
+        "mode": "direct",
+        "effective_cwd": canonical,
+    }
+
+
+def constructor_model_contract(adapter: object) -> dict[str, object]:
+    """Return the normalized constructor-level model pin, when observable."""
+    try:
+        raw_model = inspect.getattr_static(adapter, "_model")
+    except AttributeError:
+        return {"observed": False}
+    if raw_model is None:
+        return {"observed": True, "model": None}
+    if not isinstance(raw_model, str):
+        return {"observed": False}
+
+    normalized_model: object = raw_model.strip() or None
+    normalizer_descriptor = inspect.getattr_static(type(adapter), "_normalize_model", None)
+    if normalizer_descriptor is not None:
+        try:
+            normalizer = object.__getattribute__(adapter, "_normalize_model")
+            normalized_model = normalizer(raw_model)
+        except Exception:
+            return {"observed": False}
+    if normalized_model is None:
+        return {"observed": True, "model": None}
+    if not isinstance(normalized_model, str) or not normalized_model.strip():
+        return {"observed": False}
+    return {"observed": True, "model": normalized_model.strip()}
+
+
+def valid_constructor_model_contract(value: object) -> bool:
+    if not isinstance(value, Mapping) or value.get("observed") is not True:
+        return False
+    model = value.get("model")
+    return set(value) == {"observed", "model"} and (
+        model is None or isinstance(model, str) and bool(model.strip())
+    )
+
+
+def runtime_execution_identity_contract(adapter: object) -> dict[str, object]:
+    """Return backend-specific resolved identity without backend logic here."""
+    provider_descriptor = inspect.getattr_static(
+        type(adapter),
+        "execution_identity_contract",
+        None,
+    )
+    if provider_descriptor is None:
+        return {"version": 1, "observed": False}
+
+    provider = object.__getattribute__(adapter, "execution_identity_contract")
+    identity = provider()
+    if not isinstance(identity, Mapping):
+        raise ValueError("runtime execution identity contract is not a mapping")
+    normalized = _canonical_object(
+        dict(identity),
+        field="runtime execution identity contract",
+    )
+    return {"version": 1, "observed": True, "identity": normalized}
+
+
+def valid_runtime_execution_identity_contract(value: object) -> bool:
+    if not isinstance(value, Mapping):
+        return False
+    version = value.get("version")
+    observed = value.get("observed")
+    if (
+        isinstance(version, bool)
+        or not isinstance(version, int)
+        or version != 1
+        or not isinstance(observed, bool)
+    ):
+        return False
+    if not observed:
+        return set(value) == {"version", "observed"}
+    identity = value.get("identity")
+    if (
+        set(value) != {"version", "observed", "identity"}
+        or not isinstance(identity, Mapping)
+        or not identity
+    ):
+        return False
+    try:
+        _canonical_json(dict(identity), field="runtime execution identity contract")
+    except ValueError:
+        return False
+    return True
+
+
+def runtime_execution_proves_effective_model(value: object) -> bool:
+    if not valid_runtime_execution_identity_contract(value):
+        return False
+    if not isinstance(value, Mapping) or value.get("observed") is not True:
+        return False
+    identity = value.get("identity")
+    return isinstance(identity, Mapping) and identity.get("effective_model_observed") is True
+
+
+def _runtime_capabilities_contract(adapter: object) -> dict[str, object]:
+    capabilities = runtime_capabilities_for(adapter)
+    return {
+        "skill_dispatch": capabilities.skill_dispatch,
+        "targeted_resume": capabilities.targeted_resume,
+        "structured_output": capabilities.structured_output,
+        "system_prompt_support": capabilities.system_prompt_support.value,
+        "tool_restriction_support": capabilities.tool_restriction_support.value,
+        "permission_mode_support": capabilities.permission_mode_support.value,
+        "reasoning_effort_support": capabilities.reasoning_effort_support.value,
+        "enforceable_reasoning_efforts": (
+            sorted(capabilities.enforceable_reasoning_efforts)
+            if capabilities.enforceable_reasoning_efforts is not None
+            else None
+        ),
+        "model_override_support": capabilities.model_override_support.value,
+        "subagent_orchestration": capabilities.subagent_orchestration.value,
+        "session_signals": capabilities.session_signals.to_event_data(),
+    }
+
+
+def runtime_authority_contract(adapter: object) -> dict[str, object]:
+    """Combine generic capabilities with backend-owned resolved identity."""
+    runtime_backend = getattr(adapter, "runtime_backend", None)
+    llm_backend = getattr(adapter, "llm_backend", None)
+    permission_mode = getattr(adapter, "permission_mode", None)
+    return {
+        "version": 1,
+        "runtime_backend": (
+            runtime_backend.strip()
+            if isinstance(runtime_backend, str) and runtime_backend.strip()
+            else None
+        ),
+        "llm_backend": (
+            llm_backend.strip() if isinstance(llm_backend, str) and llm_backend.strip() else None
+        ),
+        "permission_mode": (
+            {"observed": True, "mode": permission_mode.strip()}
+            if isinstance(permission_mode, str) and permission_mode.strip()
+            else {"observed": False}
+        ),
+        "constructor_model": constructor_model_contract(adapter),
+        "execution_identity": runtime_execution_identity_contract(adapter),
+        "capabilities": _runtime_capabilities_contract(adapter),
+    }
+
+
+def _project_explicit_identity(
+    value: object,
+    *,
+    field: str,
+    depth: int = 0,
+    seen: set[int] | None = None,
+) -> object:
+    if depth > _MAX_IDENTITY_DEPTH:
+        raise ValueError(f"{field} exceeds identity depth")
+    if value is None or isinstance(value, (bool, int)):
+        return value
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise ValueError(f"{field} contains a non-finite float")
+        return value
+    if isinstance(value, str):
+        if len(value) > _MAX_IDENTITY_SCALAR_CHARS:
+            raise ValueError(f"{field} contains oversized text")
+        return value
+
+    seen = set() if seen is None else seen
+    value_id = id(value)
+    if value_id in seen:
+        raise ValueError(f"{field} contains cyclic state")
+    seen.add(value_id)
+    try:
+        if isinstance(value, Mapping):
+            if len(value) > _MAX_IDENTITY_ITEMS:
+                raise ValueError(f"{field} contains too many mapping items")
+            projected: dict[str, object] = {}
+            for key, item in value.items():
+                if not isinstance(key, str) or not key:
+                    raise ValueError(f"{field} contains a non-string or empty key")
+                if len(key) > _MAX_IDENTITY_SCALAR_CHARS:
+                    raise ValueError(f"{field} contains an oversized key")
+                projected[key] = _project_explicit_identity(
+                    item,
+                    field=f"{field}.{key}",
+                    depth=depth + 1,
+                    seen=seen,
+                )
+            return projected
+        if isinstance(value, (list, tuple)):
+            if len(value) > _MAX_IDENTITY_ITEMS:
+                raise ValueError(f"{field} contains too many sequence items")
+            return [
+                _project_explicit_identity(
+                    item,
+                    field=f"{field}[{index}]",
+                    depth=depth + 1,
+                    seen=seen,
+                )
+                for index, item in enumerate(value)
+            ]
+        raise ValueError(f"{field} is not canonical JSON data")
+    finally:
+        seen.remove(value_id)
+
+
+def _verifier_implementation_contract(verifier: Verifier) -> dict[str, object]:
+    if inspect.ismethod(verifier):
+        target = verifier.__func__
+    elif inspect.isfunction(verifier) or inspect.isbuiltin(verifier):
+        target = verifier
+    else:
+        target = type(verifier).__call__
+
+    module = getattr(target, "__module__", type(verifier).__module__)
+    qualname = getattr(target, "__qualname__", type(verifier).__qualname__)
+    try:
+        source_digest = _sha256(inspect.getsource(target))
+    except (OSError, TypeError):
+        source_digest = None
+    code = getattr(target, "__code__", None)
+    code_digest = (
+        "sha256:" + hashlib.sha256(marshal.dumps(code)).hexdigest() if code is not None else None
+    )
+    return {
+        "module": str(module),
+        "qualname": str(qualname),
+        "source_digest": source_digest,
+        "code_digest": code_digest,
+    }
+
+
+def verifier_authority_contract(verifier: Verifier | None) -> dict[str, object]:
+    """Return durable verifier identity only when it is explicitly declared."""
+    if verifier is None:
+        return {"version": 1, "mode": "runtime_transcript"}
+
+    implementation = _verifier_implementation_contract(verifier)
+    identity_descriptor = inspect.getattr_static(
+        verifier,
+        "verification_identity_contract",
+        None,
+    )
+    if identity_descriptor is None:
+        behavioral_state: dict[str, object] = {
+            "stability": "process_local",
+            "instance_nonce": uuid.uuid4().hex,
+            "reason": "verification_identity_contract is not declared",
+        }
+    else:
+        try:
+            identity_provider = object.__getattribute__(
+                verifier,
+                "verification_identity_contract",
+            )
+            if not callable(identity_provider):
+                raise ValueError("verification_identity_contract is not callable")
+            identity = identity_provider()
+            if not isinstance(identity, Mapping):
+                raise ValueError("verification_identity_contract is not a mapping")
+            projected = _project_explicit_identity(
+                dict(identity),
+                field="verification identity contract",
+            )
+            encoded = _canonical_json(projected, field="verification identity contract")
+            if len(encoded) > _MAX_IDENTITY_JSON_CHARS:
+                raise ValueError("verification identity contract exceeds its budget")
+            behavioral_state = {
+                "stability": "durable",
+                "identity_digest": _sha256(encoded),
+            }
+        except (AttributeError, TypeError, ValueError) as exc:
+            behavioral_state = {
+                "stability": "process_local",
+                "instance_nonce": uuid.uuid4().hex,
+                "reason": str(exc),
+            }
+    return {
+        "version": 1,
+        "mode": "custom",
+        "implementation": implementation,
+        "behavioral_state": behavioral_state,
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class ExecutionAuthorityContract:
+    """Immutable canonical JSON contract and its stable fingerprint."""
+
+    canonical_json: str
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        adapter: object,
+        verifier: Verifier | None,
+        workspace: str | None,
+        execution_policy: Mapping[str, object],
+    ) -> ExecutionAuthorityContract:
+        data = {
+            "version": EXECUTION_AUTHORITY_VERSION,
+            "workspace": canonical_workspace_authority(workspace),
+            "runtime": runtime_authority_contract(adapter),
+            "verifier": verifier_authority_contract(verifier),
+            "execution_policy": _canonical_object(
+                dict(execution_policy),
+                field="execution policy",
+            ),
+        }
+        return cls(_canonical_json(data, field="execution authority contract"))
+
+    @property
+    def fingerprint(self) -> str:
+        return _sha256(self.canonical_json)
+
+    @property
+    def data(self) -> dict[str, Any]:
+        value = json.loads(self.canonical_json)
+        if not isinstance(value, dict):  # pragma: no cover - constructor invariant
+            raise ValueError("execution authority contract is not an object")
+        return value
+
+    @property
+    def reusable_across_processes(self) -> bool:
+        verifier = self.data.get("verifier")
+        if not isinstance(verifier, Mapping) or verifier.get("mode") != "custom":
+            return True
+        behavioral_state = verifier.get("behavioral_state")
+        return (
+            isinstance(behavioral_state, Mapping) and behavioral_state.get("stability") == "durable"
+        )
+
+
+__all__ = [
+    "EXECUTION_AUTHORITY_VERSION",
+    "ExecutionAuthorityContract",
+    "canonical_workspace_authority",
+    "constructor_model_contract",
+    "runtime_authority_contract",
+    "runtime_execution_identity_contract",
+    "runtime_execution_proves_effective_model",
+    "valid_constructor_model_contract",
+    "valid_runtime_execution_identity_contract",
+    "verifier_authority_contract",
+]

--- a/src/ouroboros/orchestrator/execution_authority.py
+++ b/src/ouroboros/orchestrator/execution_authority.py
@@ -18,6 +18,7 @@ import marshal
 import math
 import os
 from pathlib import Path
+import re
 import shutil
 from typing import Any
 import uuid
@@ -26,7 +27,11 @@ from ouroboros.orchestrator.adapter import RuntimeHandle
 from ouroboros.orchestrator.evidence.verification import (
     _verify_atomic_evidence_against_runtime_messages,
 )
-from ouroboros.orchestrator.model_routing import ModelRouter, serialize_model_router
+from ouroboros.orchestrator.model_routing import (
+    ModelRouter,
+    deserialize_model_router,
+    serialize_model_router,
+)
 from ouroboros.orchestrator.profile_loader import ExecutionProfile
 from ouroboros.orchestrator.runtime_param_negotiation import runtime_capabilities_for
 from ouroboros.orchestrator.verifier import Verifier
@@ -37,6 +42,24 @@ _MAX_IDENTITY_ITEMS = 256
 _MAX_IDENTITY_SCALAR_CHARS = 8_192
 _MAX_IDENTITY_JSON_CHARS = 64_000
 _RESOLVED_RUNTIME_AUTHORITY_TOKEN = object()
+_SHA256_DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
+_EXECUTION_POLICY_VERSION = 1
+_EXECUTION_POLICY_KEYS = {
+    "version",
+    "decomposition_mode",
+    "max_decomposition_depth",
+    "max_concurrent",
+    "execution_profile",
+    "fat_harness_mode",
+    "run_verify_commands",
+    "verify_command_timeout_seconds",
+    "ac_retry_attempts",
+    "reasoning_effort",
+    "model_routing",
+    "cross_harness_redispatch",
+    "shadow_replay_enabled",
+    "dispatch_rate",
+}
 
 
 def _canonical_json(value: object, *, field: str) -> str:
@@ -92,20 +115,41 @@ def canonical_workspace_authority(
             "observed": False,
             "generation": {"observed": False},
         }
-    generation_contract: dict[str, object] = (
-        {
-            "observed": True,
-            "identity": _canonical_object(dict(generation), field="workspace generation"),
-        }
-        if generation is not None
-        else {"observed": False}
-    )
+    generation_contract: dict[str, object] = {"observed": False}
+    if generation is not None:
+        generation_identity = _canonical_object(
+            dict(generation),
+            field="workspace generation",
+        )
+        if generation_identity:
+            if not _valid_workspace_generation_identity(generation_identity):
+                raise ValueError("workspace generation identity is invalid")
+            generation_contract = {
+                "observed": True,
+                "identity": generation_identity,
+            }
     return {
         "version": 1,
         "observed": True,
         "identity": owner,
         "generation": generation_contract,
     }
+
+
+def _valid_workspace_generation_identity(value: object) -> bool:
+    if not isinstance(value, Mapping) or set(value) != {"version", "kind", "digest"}:
+        return False
+    version = value.get("version")
+    kind = value.get("kind")
+    digest = value.get("digest")
+    return (
+        not isinstance(version, bool)
+        and version == 1
+        and isinstance(kind, str)
+        and bool(kind.strip())
+        and isinstance(digest, str)
+        and _SHA256_DIGEST_PATTERN.fullmatch(digest) is not None
+    )
 
 
 def constructor_model_contract(adapter: object) -> dict[str, object]:
@@ -719,6 +763,7 @@ def runtime_authority_contract(
             if isinstance(runtime_backend, str) and runtime_backend.strip()
             else None
         ),
+        "self_governs_rate_limit": bool(getattr(adapter, "self_governs_rate_limit", False)),
         "llm_backend": (
             llm_backend.strip() if isinstance(llm_backend, str) and llm_backend.strip() else None
         ),
@@ -863,6 +908,135 @@ def verifier_authority_contract(
     }
 
 
+def _positive_int_or_none(value: object) -> bool:
+    return value is None or (not isinstance(value, bool) and isinstance(value, int) and value > 0)
+
+
+def _positive_number(value: object) -> bool:
+    return (
+        not isinstance(value, bool)
+        and isinstance(value, (int, float))
+        and math.isfinite(value)
+        and value > 0
+    )
+
+
+def _valid_dispatch_rate_contract(value: object) -> bool:
+    if not isinstance(value, Mapping) or set(value) != {
+        "version",
+        "backend",
+        "owner",
+        "observed",
+        "self_governs_rate_limit",
+        "requests_per_minute",
+        "tokens_per_minute",
+        "gate_enabled",
+        "window_seconds",
+        "heartbeat_seconds",
+        "max_wait_seconds",
+        "token_estimation_version",
+    }:
+        return False
+    version = value.get("version")
+    token_version = value.get("token_estimation_version")
+    backend = value.get("backend")
+    owner = value.get("owner")
+    observed = value.get("observed")
+    self_governs = value.get("self_governs_rate_limit")
+    request_limit = value.get("requests_per_minute")
+    token_limit = value.get("tokens_per_minute")
+    gate_enabled = value.get("gate_enabled")
+    if (
+        isinstance(version, bool)
+        or version != 1
+        or isinstance(token_version, bool)
+        or token_version != 1
+        or not isinstance(backend, str)
+        or not backend.strip()
+        or owner not in {"ouroboros", "runtime"}
+        or not isinstance(observed, bool)
+        or not isinstance(self_governs, bool)
+        or not isinstance(gate_enabled, bool)
+        or not _positive_int_or_none(request_limit)
+        or not _positive_int_or_none(token_limit)
+        or not _positive_number(value.get("window_seconds"))
+        or not _positive_number(value.get("heartbeat_seconds"))
+        or not _positive_number(value.get("max_wait_seconds"))
+    ):
+        return False
+    if owner == "runtime":
+        return (
+            self_governs
+            and not observed
+            and request_limit is None
+            and token_limit is None
+            and not gate_enabled
+        )
+    return (
+        not self_governs
+        and observed
+        and gate_enabled == (request_limit is not None or token_limit is not None)
+    )
+
+
+def valid_execution_policy_contract(value: object) -> bool:
+    if not isinstance(value, Mapping) or set(value) != _EXECUTION_POLICY_KEYS:
+        return False
+    version = value.get("version")
+    depth = value.get("max_decomposition_depth")
+    concurrency = value.get("max_concurrent")
+    timeout = value.get("verify_command_timeout_seconds")
+    retries = value.get("ac_retry_attempts")
+    if (
+        isinstance(version, bool)
+        or version != _EXECUTION_POLICY_VERSION
+        or value.get("decomposition_mode") not in {"preflight", "bounce_only", "off"}
+        or isinstance(depth, bool)
+        or not isinstance(depth, int)
+        or depth < 0
+        or isinstance(concurrency, bool)
+        or not isinstance(concurrency, int)
+        or concurrency < 1
+        or isinstance(timeout, bool)
+        or not isinstance(timeout, int)
+        or timeout < 1
+        or isinstance(retries, bool)
+        or not isinstance(retries, int)
+        or retries < 0
+    ):
+        return False
+    for flag_name in (
+        "fat_harness_mode",
+        "run_verify_commands",
+        "cross_harness_redispatch",
+        "shadow_replay_enabled",
+    ):
+        if not isinstance(value.get(flag_name), bool):
+            return False
+    reasoning_effort = value.get("reasoning_effort")
+    if reasoning_effort is not None and (
+        not isinstance(reasoning_effort, str) or not reasoning_effort.strip()
+    ):
+        return False
+
+    raw_profile = value.get("execution_profile")
+    if raw_profile is not None:
+        if not isinstance(raw_profile, Mapping):
+            return False
+        try:
+            profile = ExecutionProfile.model_validate(dict(raw_profile))
+        except ValueError:
+            return False
+        if profile.model_dump(mode="json") != dict(raw_profile):
+            return False
+
+    raw_routing = value.get("model_routing")
+    recognized, router = deserialize_model_router(raw_routing)
+    if not recognized or serialize_model_router(router) != raw_routing:
+        return False
+    return _valid_dispatch_rate_contract(value.get("dispatch_rate"))
+
+
 def build_execution_policy_contract(
     *,
     decomposition_mode: str,
@@ -877,9 +1051,11 @@ def build_execution_policy_contract(
     model_router: ModelRouter | None,
     cross_harness_redispatch: bool,
     shadow_replay_enabled: bool,
+    dispatch_rate_policy: Mapping[str, object],
 ) -> dict[str, object]:
     """Return the one canonical parallel-execution policy payload."""
     return {
+        "version": _EXECUTION_POLICY_VERSION,
         "decomposition_mode": decomposition_mode,
         "max_decomposition_depth": max_decomposition_depth,
         "max_concurrent": max_concurrent,
@@ -894,6 +1070,10 @@ def build_execution_policy_contract(
         "model_routing": serialize_model_router(model_router),
         "cross_harness_redispatch": cross_harness_redispatch,
         "shadow_replay_enabled": shadow_replay_enabled,
+        "dispatch_rate": _canonical_object(
+            dict(dispatch_rate_policy),
+            field="dispatch rate policy",
+        ),
     }
 
 
@@ -921,6 +1101,32 @@ class ExecutionAuthorityContract:
             "execution_policy",
         }:
             raise ValueError("execution authority contract has an invalid shape")
+        if not valid_execution_policy_contract(data.get("execution_policy")):
+            raise ValueError("execution authority contract has an invalid execution policy")
+        runtime = data.get("runtime")
+        execution_policy = data.get("execution_policy")
+        runtime_backend = runtime.get("runtime_backend") if isinstance(runtime, Mapping) else None
+        dispatch_rate = (
+            execution_policy.get("dispatch_rate") if isinstance(execution_policy, Mapping) else None
+        )
+        dispatch_backend = (
+            dispatch_rate.get("backend") if isinstance(dispatch_rate, Mapping) else None
+        )
+        dispatch_self_governs = (
+            dispatch_rate.get("self_governs_rate_limit")
+            if isinstance(dispatch_rate, Mapping)
+            else None
+        )
+        runtime_self_governs = (
+            runtime.get("self_governs_rate_limit") if isinstance(runtime, Mapping) else None
+        )
+        expected_backend = (
+            runtime_backend if isinstance(runtime_backend, str) and runtime_backend else "unknown"
+        )
+        if dispatch_backend != expected_backend:
+            raise ValueError("dispatch rate policy disagrees with the runtime backend")
+        if dispatch_self_governs is not runtime_self_governs:
+            raise ValueError("dispatch rate policy disagrees with runtime self-governance")
         if _canonical_json(data, field="execution authority contract") != self.canonical_json:
             raise ValueError("execution authority contract is not canonical")
 
@@ -986,6 +1192,17 @@ class ExecutionAuthorityContract:
             return False
         generation = workspace.get("generation")
         if not isinstance(generation, Mapping) or generation.get("observed") is not True:
+            return False
+        if not _valid_workspace_generation_identity(generation.get("identity")):
+            return False
+
+        execution_policy = data.get("execution_policy")
+        if not valid_execution_policy_contract(execution_policy):
+            return False
+        dispatch_rate = (
+            execution_policy.get("dispatch_rate") if isinstance(execution_policy, Mapping) else None
+        )
+        if not isinstance(dispatch_rate, Mapping) or dispatch_rate.get("observed") is not True:
             return False
 
         runtime = data.get("runtime")
@@ -1063,6 +1280,7 @@ __all__ = [
     "runtime_execution_identity_contract",
     "runtime_execution_proves_effective_model",
     "valid_constructor_model_contract",
+    "valid_execution_policy_contract",
     "valid_runtime_execution_identity_contract",
     "verifier_authority_contract",
 ]

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -85,7 +85,10 @@ from ouroboros.orchestrator.atomic_prompt_builder import (
     AtomicPromptBuilder,
     _build_success_contract_block,  # noqa: F401  (re-exported for tests/back-compat)
 )
-from ouroboros.orchestrator.backend_limits import resolve_backend_limits
+from ouroboros.orchestrator.backend_limits import (
+    BackendConcurrencyLimits,
+    resolve_backend_limits,
+)
 from ouroboros.orchestrator.context_governor import SiblingStatus, compose_context
 from ouroboros.orchestrator.coordinator import CoordinatorReview, LevelCoordinator
 from ouroboros.orchestrator.decomposition_params import (
@@ -290,8 +293,7 @@ from ouroboros.orchestrator.parallel_executor_models import (
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, SuggestedModelTier
 from ouroboros.orchestrator.rate_limit import (
     RateLimitBackoff,
-    RateLimitGate,
-    build_rate_limit_gate,
+    ResolvedDispatchRatePolicy,
     estimate_runtime_request_tokens,
 )
 from ouroboros.orchestrator.runtime_param_negotiation import (
@@ -907,6 +909,7 @@ class ParallelACExecutor:
         session_signal_hub: SessionSignalHub | None = None,
         resolved_routing_authority: ResolvedRuntimeAuthority | None = None,
         workspace_authority_identity: Mapping[str, object] | None = None,
+        dispatch_rate_policy: ResolvedDispatchRatePolicy | None = None,
     ):
         """Initialize executor.
 
@@ -1004,7 +1007,11 @@ class ParallelACExecutor:
         self._checkpoint_store = checkpoint_store
         self._decomposition_decisions: dict[str, DecompositionDecisionRecord] = {}
         self._execution_counters_lock = asyncio.Lock()
-        self._dispatch_rate_gate = self._build_dispatch_rate_gate(adapter)
+        self._dispatch_rate_policy = dispatch_rate_policy or self._resolve_dispatch_rate_policy(
+            adapter
+        )
+        self._validate_dispatch_rate_policy(adapter, self._dispatch_rate_policy)
+        self._dispatch_rate_gate = self._dispatch_rate_policy.build_gate()
         # Param degradations already surfaced this run, keyed by (param, support),
         # so the operator is told once rather than on every dispatch.
         self._announced_param_degradations: set[tuple[str, str]] = set()
@@ -1035,6 +1042,7 @@ class ParallelACExecutor:
             model_router=self._model_router,
             cross_harness_redispatch=self._cross_harness_redispatch_enabled,
             shadow_replay_enabled=self._shadow_replay_enabled,
+            dispatch_rate_policy=self._dispatch_rate_policy.to_contract_data(),
         )
         workspace = task_cwd or getattr(adapter, "working_directory", None) or os.getcwd()
         self._execution_authority = ExecutionAuthorityContract.build(
@@ -1054,8 +1062,11 @@ class ParallelACExecutor:
         return self._execution_authority
 
     @staticmethod
-    def _build_dispatch_rate_gate(adapter: AgentRuntime) -> RateLimitGate:
-        """Build the shared dispatch rate gate for non-self-governing backends.
+    def _resolve_dispatch_rate_policy(
+        adapter: AgentRuntime,
+        limits: BackendConcurrencyLimits | None = None,
+    ) -> ResolvedDispatchRatePolicy:
+        """Resolve one immutable policy for behavior and authority identity.
 
         Ouroboros — not the runtime — paces delivery within the backend's
         declared RPM/TPM budget. Native adapters that already run their own
@@ -1067,16 +1078,25 @@ class ParallelACExecutor:
         """
         backend_attr = getattr(adapter, "runtime_backend", "")
         backend = backend_attr if isinstance(backend_attr, str) and backend_attr else "unknown"
-
-        if getattr(adapter, "self_governs_rate_limit", False):
-            return build_rate_limit_gate(backend, request_limit=None, token_limit=None)
-
-        limits = resolve_backend_limits(backend)
-        return build_rate_limit_gate(
-            backend,
-            request_limit=limits.requests_per_minute,
-            token_limit=limits.tokens_per_minute,
+        self_governs = bool(getattr(adapter, "self_governs_rate_limit", False))
+        resolved_limits = limits or resolve_backend_limits(backend)
+        return ResolvedDispatchRatePolicy.resolve(
+            backend=backend,
+            self_governs_rate_limit=self_governs,
+            requests_per_minute=resolved_limits.requests_per_minute,
+            tokens_per_minute=resolved_limits.tokens_per_minute,
         )
+
+    @staticmethod
+    def _validate_dispatch_rate_policy(
+        adapter: AgentRuntime,
+        policy: ResolvedDispatchRatePolicy,
+    ) -> None:
+        backend_attr = getattr(adapter, "runtime_backend", "")
+        backend = backend_attr if isinstance(backend_attr, str) and backend_attr else "unknown"
+        self_governs = bool(getattr(adapter, "self_governs_rate_limit", False))
+        if policy.backend != backend or policy.self_governs_rate_limit is not self_governs:
+            raise ValueError("dispatch rate policy disagrees with the active runtime")
 
     async def _await_dispatch_rate_budget(
         self,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -254,6 +254,7 @@ from ouroboros.orchestrator.evidence_schema import (
     extract_evidence,
     validate_evidence,
 )
+from ouroboros.orchestrator.execution_authority import ExecutionAuthorityContract
 from ouroboros.orchestrator.execution_event_emitter import ExecutionEventEmitter
 from ouroboros.orchestrator.execution_runtime_scope import (
     ACRuntimeIdentity,
@@ -273,6 +274,7 @@ from ouroboros.orchestrator.level_context import (
 from ouroboros.orchestrator.model_routing import (
     decide_model,
     resolve_execute_model,
+    serialize_model_router,
     tier_from_profile_hint,
 )
 from ouroboros.orchestrator.parallel_executor_models import (
@@ -1015,6 +1017,35 @@ class ParallelACExecutor:
         self._alt_harness_redispatched_acs: set[str] = set()
         self._alt_harness_status_by_root: dict[int, str] = {}
         self._recovery_exhausted_emitted: set[tuple[str, int]] = set()
+        workspace = task_cwd or getattr(adapter, "working_directory", None)
+        self._execution_authority = ExecutionAuthorityContract.build(
+            adapter=adapter,
+            verifier=atomic_verifier,
+            workspace=workspace if isinstance(workspace, str) else None,
+            execution_policy={
+                "decomposition_mode": self._decomposition_mode,
+                "max_decomposition_depth": self._max_decomposition_depth,
+                "max_concurrent": max_concurrent,
+                "execution_profile": (
+                    self._execution_profile.model_dump(mode="json")
+                    if self._execution_profile is not None
+                    else None
+                ),
+                "fat_harness_mode": self._fat_harness_mode,
+                "run_verify_commands": self._run_verify_commands,
+                "verify_command_timeout_seconds": self._verify_command_timeout_seconds,
+                "ac_retry_attempts": self._ac_retry_attempts,
+                "reasoning_effort": self._reasoning_effort,
+                "model_routing": serialize_model_router(self._model_router),
+                "cross_harness_redispatch": self._cross_harness_redispatch_enabled,
+                "shadow_replay_enabled": self._shadow_replay_enabled,
+            },
+        )
+
+    @property
+    def execution_authority(self) -> ExecutionAuthorityContract:
+        """Return the immutable authority snapshot used by this executor."""
+        return self._execution_authority
 
     @staticmethod
     def _build_dispatch_rate_gate(adapter: AgentRuntime) -> RateLimitGate:

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -254,7 +254,11 @@ from ouroboros.orchestrator.evidence_schema import (
     extract_evidence,
     validate_evidence,
 )
-from ouroboros.orchestrator.execution_authority import ExecutionAuthorityContract
+from ouroboros.orchestrator.execution_authority import (
+    ExecutionAuthorityContract,
+    ResolvedRuntimeAuthority,
+    build_execution_policy_contract,
+)
 from ouroboros.orchestrator.execution_event_emitter import ExecutionEventEmitter
 from ouroboros.orchestrator.execution_runtime_scope import (
     ACRuntimeIdentity,
@@ -274,7 +278,6 @@ from ouroboros.orchestrator.level_context import (
 from ouroboros.orchestrator.model_routing import (
     decide_model,
     resolve_execute_model,
-    serialize_model_router,
     tier_from_profile_hint,
 )
 from ouroboros.orchestrator.parallel_executor_models import (
@@ -902,6 +905,8 @@ class ParallelACExecutor:
         cross_harness_redispatch: bool | None = None,
         shadow_replay_enabled: bool = False,
         session_signal_hub: SessionSignalHub | None = None,
+        resolved_routing_authority: ResolvedRuntimeAuthority | None = None,
+        workspace_authority_identity: Mapping[str, object] | None = None,
     ):
         """Initialize executor.
 
@@ -1017,29 +1022,30 @@ class ParallelACExecutor:
         self._alt_harness_redispatched_acs: set[str] = set()
         self._alt_harness_status_by_root: dict[int, str] = {}
         self._recovery_exhausted_emitted: set[tuple[str, int]] = set()
-        workspace = task_cwd or getattr(adapter, "working_directory", None)
+        execution_policy = build_execution_policy_contract(
+            decomposition_mode=self._decomposition_mode,
+            max_decomposition_depth=self._max_decomposition_depth,
+            max_concurrent=max_concurrent,
+            execution_profile=self._execution_profile,
+            fat_harness_mode=self._fat_harness_mode,
+            run_verify_commands=self._run_verify_commands,
+            verify_command_timeout_seconds=self._verify_command_timeout_seconds,
+            ac_retry_attempts=self._ac_retry_attempts,
+            reasoning_effort=self._reasoning_effort,
+            model_router=self._model_router,
+            cross_harness_redispatch=self._cross_harness_redispatch_enabled,
+            shadow_replay_enabled=self._shadow_replay_enabled,
+        )
+        workspace = task_cwd or getattr(adapter, "working_directory", None) or os.getcwd()
         self._execution_authority = ExecutionAuthorityContract.build(
             adapter=adapter,
             verifier=atomic_verifier,
-            workspace=workspace if isinstance(workspace, str) else None,
-            execution_policy={
-                "decomposition_mode": self._decomposition_mode,
-                "max_decomposition_depth": self._max_decomposition_depth,
-                "max_concurrent": max_concurrent,
-                "execution_profile": (
-                    self._execution_profile.model_dump(mode="json")
-                    if self._execution_profile is not None
-                    else None
-                ),
-                "fat_harness_mode": self._fat_harness_mode,
-                "run_verify_commands": self._run_verify_commands,
-                "verify_command_timeout_seconds": self._verify_command_timeout_seconds,
-                "ac_retry_attempts": self._ac_retry_attempts,
-                "reasoning_effort": self._reasoning_effort,
-                "model_routing": serialize_model_router(self._model_router),
-                "cross_harness_redispatch": self._cross_harness_redispatch_enabled,
-                "shadow_replay_enabled": self._shadow_replay_enabled,
-            },
+            workspace=workspace if isinstance(workspace, str) else os.getcwd(),
+            workspace_identity=workspace_authority_identity,
+            execution_policy=execution_policy,
+            resolved_routing=resolved_routing_authority,
+            runtime_handle=self._inherited_runtime_handle,
+            runtime_transcript_verifier=self._verify_atomic_evidence_against_runtime_messages,
         )
 
     @property
@@ -3473,23 +3479,6 @@ class ParallelACExecutor:
             permission_mode="bypassPermissions",
         )
 
-        event = create_alt_harness_redispatch_event(
-            session_id=rerun_kwargs["session_id"],
-            ac_index=rerun_kwargs["ac_index"],
-            ac_id=runtime_identity.ac_id,
-            execution_id=rerun_kwargs["execution_id"] or None,
-            decision=decision,
-            redispatch_index=1,
-            failure_class=failure_class,
-        )
-        await self._safe_emit_event(event)
-        log.info(
-            "parallel_executor.alt_harness_redispatch",
-            from_backend=decision.from_backend,
-            to_backend=backend,
-            ac_index=rerun_kwargs["ac_index"],
-        )
-
         alt_executor = ParallelACExecutor(
             alt_adapter,
             self._event_store,
@@ -3505,12 +3494,37 @@ class ParallelACExecutor:
             # The router's backend-mismatch guard makes it inert on a different
             # backend, so passing it to the alt-harness executor is safe.
             model_router=self._model_router,
+            run_verify_commands=self._run_verify_commands,
+            verify_command_timeout_seconds=self._verify_command_timeout_seconds,
+            # This path intentionally performs one alternate-route attempt;
+            # ordinary same-runtime retries were already exhausted by the parent.
+            ac_retry_attempts=0,
             cross_harness_redispatch=False,
             # The router is inert on a different backend, so the baseline resolves
             # no parent-tier model and the replay self-skips — threading the flag
             # just keeps the throwaway executor's behavior consistent.
             shadow_replay_enabled=self._shadow_replay_enabled,
             session_signal_hub=self._session_signal_hub,
+        )
+
+        # Emit "redispatched" only after the alternate runtime and its authority
+        # snapshot are ready. Construction failures are preparation failures, not
+        # evidence that another harness actually received the AC.
+        event = create_alt_harness_redispatch_event(
+            session_id=rerun_kwargs["session_id"],
+            ac_index=rerun_kwargs["ac_index"],
+            ac_id=runtime_identity.ac_id,
+            execution_id=rerun_kwargs["execution_id"] or None,
+            decision=decision,
+            redispatch_index=1,
+            failure_class=failure_class,
+        )
+        await self._safe_emit_event(event)
+        log.info(
+            "parallel_executor.alt_harness_redispatch",
+            from_backend=decision.from_backend,
+            to_backend=backend,
+            ac_index=rerun_kwargs["ac_index"],
         )
         return await alt_executor._execute_single_ac(**rerun_kwargs, retry_attempt=retry_attempt)
 

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -1048,6 +1048,7 @@ class ParallelACExecutor:
         self._execution_authority = ExecutionAuthorityContract.build(
             adapter=adapter,
             verifier=atomic_verifier,
+            executor=self,
             workspace=workspace if isinstance(workspace, str) else os.getcwd(),
             workspace_identity=workspace_authority_identity,
             execution_policy=execution_policy,

--- a/src/ouroboros/orchestrator/parallel_executor.py
+++ b/src/ouroboros/orchestrator/parallel_executor.py
@@ -986,6 +986,9 @@ class ParallelACExecutor:
         # successful decomposed child is re-executed in an isolated workspace to
         # measure its parent-tier baseline spend. See ``shadow_replay`` module.
         self._shadow_replay_enabled = shadow_replay_enabled
+        # Capture the selected dispatch implementation once. The authority
+        # baseline binds this factory, and execution uses the same factory.
+        self._leaf_dispatcher_factory = LeafDispatcher
         self._session_signal_hub = session_signal_hub
         self._atomic_verifier = atomic_verifier
         self._coordinator = LevelCoordinator(
@@ -1011,7 +1014,10 @@ class ParallelACExecutor:
             adapter
         )
         self._validate_dispatch_rate_policy(adapter, self._dispatch_rate_policy)
-        self._dispatch_rate_gate = self._dispatch_rate_policy.build_gate()
+        dispatch_rate_gate = self._dispatch_rate_policy.build_gate()
+        if dispatch_rate_gate.enabled is not self._dispatch_rate_policy.gate_enabled:
+            raise ValueError("dispatch rate gate disagrees with the resolved policy")
+        self._dispatch_rate_gate = dispatch_rate_gate
         # Param degradations already surfaced this run, keyed by (param, support),
         # so the operator is told once rather than on every dispatch.
         self._announced_param_degradations: set[tuple[str, str]] = set()
@@ -1049,6 +1055,10 @@ class ParallelACExecutor:
             adapter=adapter,
             verifier=atomic_verifier,
             executor=self,
+            executor_components={
+                "leaf_dispatcher": self._leaf_dispatcher_factory,
+                "session_signal_hub": self._session_signal_hub,
+            },
             workspace=workspace if isinstance(workspace, str) else os.getcwd(),
             workspace_identity=workspace_authority_identity,
             execution_policy=execution_policy,
@@ -1093,6 +1103,8 @@ class ParallelACExecutor:
         adapter: AgentRuntime,
         policy: ResolvedDispatchRatePolicy,
     ) -> None:
+        if type(policy) is not ResolvedDispatchRatePolicy:
+            raise ValueError("dispatch rate policy must use the canonical policy type")
         backend_attr = getattr(adapter, "runtime_backend", "")
         backend = backend_attr if isinstance(backend_attr, str) and backend_attr else "unknown"
         self_governs = bool(getattr(adapter, "self_governs_rate_limit", False))
@@ -4550,7 +4562,7 @@ Respond with either ATOMIC or the structured JSON object only.
                 await self._session_signal_hub.register_replaying(signal_target)
                 signal_target_registered = True
 
-            await LeafDispatcher(self).stream(
+            await self._leaf_dispatcher_factory(self).stream(
                 state=dispatch_state,
                 prompt=prompt,
                 tools=tools,
@@ -4652,7 +4664,7 @@ Respond with either ATOMIC or the structured JSON object only.
                     )
                     inform_mode = queued_signal.effective_mode is SessionSignalMode.INFORM
                     try:
-                        await LeafDispatcher(self).stream(
+                        await self._leaf_dispatcher_factory(self).stream(
                             state=dispatch_state,
                             prompt=(
                                 render_inform_signal_prompt(queued_signal.signal)

--- a/src/ouroboros/orchestrator/rate_limit.py
+++ b/src/ouroboros/orchestrator/rate_limit.py
@@ -7,11 +7,12 @@ from collections import deque
 from collections.abc import Callable
 from dataclasses import dataclass
 import time
-from typing import Any
+from typing import Any, Literal
 
 RATE_LIMIT_WINDOW_SECONDS = 60.0
 RATE_LIMIT_HEARTBEAT_SECONDS = 30.0
 RATE_LIMIT_MAX_WAIT_SECONDS = 120.0
+RATE_LIMIT_TOKEN_ESTIMATION_VERSION = 1
 DEFAULT_ANTHROPIC_RPM_CEILING = 40
 DEFAULT_ANTHROPIC_TPM_CEILING = 32_000
 _TOKEN_ESTIMATE_DIVISOR = 4
@@ -223,11 +224,98 @@ class RateLimitGate:
             total_waited += sleep_seconds
 
 
+@dataclass(frozen=True, slots=True)
+class ResolvedDispatchRatePolicy:
+    """Immutable settings used by both dispatch behavior and authority identity."""
+
+    backend: str
+    owner: Literal["ouroboros", "runtime"]
+    observed: bool
+    self_governs_rate_limit: bool
+    requests_per_minute: int | None
+    tokens_per_minute: int | None
+    window_seconds: float = RATE_LIMIT_WINDOW_SECONDS
+    heartbeat_seconds: float = RATE_LIMIT_HEARTBEAT_SECONDS
+    max_wait_seconds: float = RATE_LIMIT_MAX_WAIT_SECONDS
+    token_estimation_version: int = RATE_LIMIT_TOKEN_ESTIMATION_VERSION
+
+    @classmethod
+    def resolve(
+        cls,
+        *,
+        backend: str,
+        self_governs_rate_limit: bool,
+        requests_per_minute: int | None,
+        tokens_per_minute: int | None,
+    ) -> ResolvedDispatchRatePolicy:
+        normalized_backend = backend.strip() or "unknown"
+        if self_governs_rate_limit:
+            # Ouroboros deliberately installs a dormant gate, but the runtime's
+            # internal limiter is not yet exposed as a durable identity contract.
+            return cls(
+                backend=normalized_backend,
+                owner="runtime",
+                observed=False,
+                self_governs_rate_limit=True,
+                requests_per_minute=None,
+                tokens_per_minute=None,
+            )
+        return cls(
+            backend=normalized_backend,
+            owner="ouroboros",
+            observed=True,
+            self_governs_rate_limit=False,
+            requests_per_minute=(
+                requests_per_minute
+                if requests_per_minute is not None and requests_per_minute > 0
+                else None
+            ),
+            tokens_per_minute=(
+                tokens_per_minute
+                if tokens_per_minute is not None and tokens_per_minute > 0
+                else None
+            ),
+        )
+
+    @property
+    def gate_enabled(self) -> bool:
+        return self.owner == "ouroboros" and (
+            self.requests_per_minute is not None or self.tokens_per_minute is not None
+        )
+
+    def build_gate(self) -> RateLimitGate:
+        return build_rate_limit_gate(
+            self.backend,
+            request_limit=self.requests_per_minute if self.owner == "ouroboros" else None,
+            token_limit=self.tokens_per_minute if self.owner == "ouroboros" else None,
+            window_seconds=self.window_seconds,
+            max_wait_seconds=self.max_wait_seconds,
+            heartbeat_seconds=self.heartbeat_seconds,
+        )
+
+    def to_contract_data(self) -> dict[str, object]:
+        return {
+            "version": 1,
+            "backend": self.backend,
+            "owner": self.owner,
+            "observed": self.observed,
+            "self_governs_rate_limit": self.self_governs_rate_limit,
+            "requests_per_minute": self.requests_per_minute,
+            "tokens_per_minute": self.tokens_per_minute,
+            "gate_enabled": self.gate_enabled,
+            "window_seconds": self.window_seconds,
+            "heartbeat_seconds": self.heartbeat_seconds,
+            "max_wait_seconds": self.max_wait_seconds,
+            "token_estimation_version": self.token_estimation_version,
+        }
+
+
 def build_rate_limit_gate(
     runtime_backend: str,
     *,
     request_limit: int | None,
     token_limit: int | None,
+    window_seconds: float = RATE_LIMIT_WINDOW_SECONDS,
     max_wait_seconds: float = RATE_LIMIT_MAX_WAIT_SECONDS,
     heartbeat_seconds: float = RATE_LIMIT_HEARTBEAT_SECONDS,
     sleep: Callable[[float], Any] | None = None,
@@ -241,6 +329,7 @@ def build_rate_limit_gate(
         runtime_backend=runtime_backend,
         request_limit=request_limit,
         token_limit=token_limit,
+        window_seconds=window_seconds,
     )
     return RateLimitGate(
         bucket,
@@ -267,10 +356,12 @@ __all__ = [
     "DEFAULT_ANTHROPIC_TPM_CEILING",
     "RATE_LIMIT_HEARTBEAT_SECONDS",
     "RATE_LIMIT_MAX_WAIT_SECONDS",
+    "RATE_LIMIT_TOKEN_ESTIMATION_VERSION",
     "RATE_LIMIT_WINDOW_SECONDS",
     "RateLimitBackoff",
     "RateLimitGate",
     "RateLimitSnapshot",
+    "ResolvedDispatchRatePolicy",
     "SharedRateLimitBucket",
     "build_rate_limit_gate",
     "estimate_runtime_request_tokens",

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -64,6 +64,7 @@ from ouroboros.orchestrator.adapter import (
     RuntimeHandle,
 )
 from ouroboros.orchestrator.backend_limits import (
+    BackendConcurrencyLimits,
     plan_fan_out_concurrency,
     resolve_backend_limits,
 )
@@ -122,6 +123,7 @@ from ouroboros.orchestrator.policy import (
 )
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, ProfileError, load_profile
 from ouroboros.orchestrator.profile_strategy import ProfileBackedStrategy
+from ouroboros.orchestrator.rate_limit import ResolvedDispatchRatePolicy
 from ouroboros.orchestrator.runtime_message_projection import (
     message_tool_input,
     message_tool_name,
@@ -1223,7 +1225,10 @@ class OrchestratorRunner:
                 break
         return current_seed_id, tuple(cohort)
 
-    def _plan_parallel_workers(self) -> int:
+    def _plan_parallel_workers(
+        self,
+        limits: BackendConcurrencyLimits | None = None,
+    ) -> int:
         """Return the effective fan-out worker count for the connected backend.
 
         Ouroboros caps delivery fan-out to the connected backend's known
@@ -1232,8 +1237,8 @@ class OrchestratorRunner:
         runtimes — serialize by default and are raised only via
         ``OUROBOROS_MAX_CONCURRENCY``.
         """
-        limits = resolve_backend_limits(self._adapter.runtime_backend)
-        return plan_fan_out_concurrency(self._max_parallel_workers, limits)
+        resolved_limits = limits or resolve_backend_limits(self._adapter.runtime_backend)
+        return plan_fan_out_concurrency(self._max_parallel_workers, resolved_limits)
 
     @property
     def mcp_manager(self) -> MCPClientManager | None:
@@ -4706,7 +4711,14 @@ class OrchestratorRunner:
 
         # Cap fan-out to the connected backend's concurrency constraints so a
         # parallel dispatch never stampedes the LLM's rate/quota window (R3).
-        effective_workers = self._plan_parallel_workers()
+        delivery_limits = resolve_backend_limits(self._adapter.runtime_backend)
+        effective_workers = self._plan_parallel_workers(delivery_limits)
+        dispatch_rate_policy = ResolvedDispatchRatePolicy.resolve(
+            backend=self._adapter.runtime_backend,
+            self_governs_rate_limit=bool(getattr(self._adapter, "self_governs_rate_limit", False)),
+            requests_per_minute=delivery_limits.requests_per_minute,
+            tokens_per_minute=delivery_limits.tokens_per_minute,
+        )
         if effective_workers < self._max_parallel_workers:
             self._console.print(
                 f"[yellow]Fan-out capped to {effective_workers} worker(s) for backend "
@@ -4766,6 +4778,7 @@ class OrchestratorRunner:
             workspace_authority_identity=(
                 workspace_identity if isinstance(workspace_identity, Mapping) else None
             ),
+            dispatch_rate_policy=dispatch_rate_policy,
         )
 
         # Check for cancellation before starting parallel execution

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -88,6 +88,13 @@ from ouroboros.orchestrator.events import (
     create_tool_called_event,
     create_workflow_progress_event,
 )
+from ouroboros.orchestrator.execution_authority import (
+    constructor_model_contract,
+    runtime_execution_identity_contract,
+    runtime_execution_proves_effective_model,
+    valid_constructor_model_contract,
+    valid_runtime_execution_identity_contract,
+)
 from ouroboros.orchestrator.execution_guidance import (
     ExecutionGuidanceBundle,
     resolve_execution_guidance,
@@ -1584,45 +1591,12 @@ class OrchestratorRunner:
         runtimes that expose no constructor model at all; current-format resume
         then fails closed because the effective pin cannot be verified.
         """
-        try:
-            raw_model = inspect.getattr_static(self._adapter, "_model")
-        except AttributeError:
-            return {"observed": False}
-        if raw_model is None:
-            return {"observed": True, "model": None}
-        if not isinstance(raw_model, str):
-            return {"observed": False}
-
-        normalized_model: object = raw_model.strip() or None
-        normalizer_descriptor = inspect.getattr_static(
-            type(self._adapter),
-            "_normalize_model",
-            None,
-        )
-        if normalizer_descriptor is not None:
-            try:
-                normalizer = object.__getattribute__(self._adapter, "_normalize_model")
-                normalized_model = normalizer(raw_model)
-            except Exception:
-                return {"observed": False}
-        if normalized_model is None:
-            return {"observed": True, "model": None}
-        if not isinstance(normalized_model, str) or not normalized_model.strip():
-            return {"observed": False}
-        return {"observed": True, "model": normalized_model.strip()}
+        return constructor_model_contract(self._adapter)
 
     @staticmethod
     def _valid_constructor_model_contract(value: object) -> bool:
         """Return whether a persisted constructor-model contract is canonical."""
-        if not isinstance(value, Mapping):
-            return False
-        observed = value.get("observed")
-        if observed is not True:
-            return False
-        model = value.get("model")
-        return set(value) == {"observed", "model"} and (
-            model is None or isinstance(model, str) and bool(model.strip())
-        )
+        return valid_constructor_model_contract(value)
 
     def _runtime_execution_identity_contract(self) -> dict[str, Any]:
         """Return backend-specific resolved execution inputs, when observable.
@@ -1636,31 +1610,9 @@ class OrchestratorRunner:
         backend's private configuration model.
         """
 
-        provider_descriptor = inspect.getattr_static(
-            type(self._adapter),
-            "execution_identity_contract",
-            None,
-        )
-        if provider_descriptor is None:
-            return {"version": 1, "observed": False}
-
-        provider = object.__getattribute__(self._adapter, "execution_identity_contract")
-        identity = provider()
-        if not isinstance(identity, Mapping):
-            raise OrchestratorError(
-                message="Runtime returned an invalid execution identity contract",
-                details={"adapter_type": type(self._adapter).__name__},
-            )
         try:
-            encoded = json.dumps(
-                dict(identity),
-                sort_keys=True,
-                separators=(",", ":"),
-                ensure_ascii=True,
-                allow_nan=False,
-            )
-            normalized_identity = json.loads(encoded)
-        except (TypeError, ValueError) as exc:
+            return runtime_execution_identity_contract(self._adapter)
+        except ValueError as exc:
             raise OrchestratorError(
                 message="Runtime returned an invalid execution identity contract",
                 details={
@@ -1668,61 +1620,16 @@ class OrchestratorRunner:
                     "cause": str(exc),
                 },
             ) from exc
-        if not isinstance(normalized_identity, dict):
-            raise OrchestratorError(
-                message="Runtime returned an invalid execution identity contract",
-                details={"adapter_type": type(self._adapter).__name__},
-            )
-        return {
-            "version": 1,
-            "observed": True,
-            "identity": normalized_identity,
-        }
 
     @staticmethod
     def _valid_runtime_execution_identity_contract(value: object) -> bool:
         """Return whether a persisted backend execution identity is canonical."""
-        if not isinstance(value, Mapping):
-            return False
-        version = value.get("version")
-        observed = value.get("observed")
-        if (
-            isinstance(version, bool)
-            or not isinstance(version, int)
-            or version != 1
-            or not isinstance(observed, bool)
-        ):
-            return False
-        if not observed:
-            return set(value) == {"version", "observed"}
-        identity = value.get("identity")
-        if (
-            set(value) != {"version", "observed", "identity"}
-            or not isinstance(identity, Mapping)
-            or not identity
-        ):
-            return False
-        try:
-            json.dumps(
-                dict(identity),
-                sort_keys=True,
-                separators=(",", ":"),
-                ensure_ascii=True,
-                allow_nan=False,
-            )
-        except (TypeError, ValueError):
-            return False
-        return True
+        return valid_runtime_execution_identity_contract(value)
 
     @staticmethod
     def _runtime_execution_proves_effective_model(value: object) -> bool:
         """Return whether a backend identity observed a concrete model/profile."""
-        if not OrchestratorRunner._valid_runtime_execution_identity_contract(value):
-            return False
-        if not isinstance(value, Mapping) or value.get("observed") is not True:
-            return False
-        identity = value.get("identity")
-        return isinstance(identity, Mapping) and identity.get("effective_model_observed") is True
+        return runtime_execution_proves_effective_model(value)
 
     def _validate_resume_handle_execution_identity(
         self,

--- a/src/ouroboros/orchestrator/runner.py
+++ b/src/ouroboros/orchestrator/runner.py
@@ -89,6 +89,7 @@ from ouroboros.orchestrator.events import (
     create_workflow_progress_event,
 )
 from ouroboros.orchestrator.execution_authority import (
+    ResolvedRuntimeAuthority,
     constructor_model_contract,
     runtime_execution_identity_contract,
     runtime_execution_proves_effective_model,
@@ -4722,6 +4723,24 @@ class OrchestratorRunner:
         # Execute in parallel. Reuse the base effort resolved once in __init__
         # (self._reasoning_effort) so a single runner instance has one consistent
         # effort source across its direct paths and the parallel executor.
+        from ouroboros.config import get_cross_harness_redispatch_enabled
+
+        cross_harness_redispatch = get_cross_harness_redispatch_enabled()
+        raw_execution_contract = self._execution_contract
+        if not isinstance(raw_execution_contract, Mapping):
+            raw_execution_contract = self._build_execution_contract(seed=seed)
+            self._execution_contract = raw_execution_contract
+        resolved_routing = raw_execution_contract.get("model_routing")
+        raw_resume = raw_execution_contract.get("resume")
+        workspace_identity = (
+            raw_resume.get("workspace") if isinstance(raw_resume, Mapping) else None
+        )
+        if not isinstance(resolved_routing, Mapping):
+            raise OrchestratorError(message="Parallel runtime authority is missing")
+        bound_runtime_authority = ResolvedRuntimeAuthority.bind(
+            self._adapter,
+            resolved_routing,
+        )
         parallel_executor = ParallelACExecutor(
             adapter=self._adapter,
             event_store=self._event_store,
@@ -4740,8 +4759,13 @@ class OrchestratorRunner:
             run_verify_commands=self._run_verify_commands,
             verify_command_timeout_seconds=self._verify_command_timeout_seconds,
             ac_retry_attempts=self._ac_retry_attempts,
+            cross_harness_redispatch=cross_harness_redispatch,
             shadow_replay_enabled=self._shadow_replay_enabled,
             session_signal_hub=self._session_signal_hub,
+            resolved_routing_authority=bound_runtime_authority,
+            workspace_authority_identity=(
+                workspace_identity if isinstance(workspace_identity, Mapping) else None
+            ),
         )
 
         # Check for cancellation before starting parallel execution

--- a/src/ouroboros/orchestrator/skill_intercept.py
+++ b/src/ouroboros/orchestrator/skill_intercept.py
@@ -95,6 +95,22 @@ class SkillInterceptor:
 
     # -- public entry point -------------------------------------------------
 
+    def execution_identity_contract(self) -> dict[str, object]:
+        """Declare the static policy that determines delegated skill dispatch."""
+        return {
+            "version": 1,
+            "configuration": {
+                "cwd": self._cwd,
+                "runtime_backend": self._runtime_backend,
+                "runtime_handle_backend": self._runtime_handle_backend,
+                "permission_mode": self._permission_mode,
+                "llm_backend": self._llm_backend,
+                "log_namespace": self._log_namespace,
+                "skills_dir": str(self._skills_dir) if self._skills_dir is not None else None,
+                "dispatch_protocol_version": 1,
+            },
+        }
+
     async def maybe_dispatch(
         self,
         prompt: str,

--- a/src/ouroboros/orchestrator/worker_runtime.py
+++ b/src/ouroboros/orchestrator/worker_runtime.py
@@ -16,7 +16,7 @@ the SAME pool code — only the transport differs.
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Mapping
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 import os
@@ -73,6 +73,16 @@ class LeaderDrivenWorkerTransport(Protocol):
     @property
     def backend_name(self) -> str:
         """Canonical backend id stamped into the emitted ``RuntimeHandle``."""
+        ...
+
+    def execution_identity_contract(self) -> Mapping[str, object]:
+        """Return the versioned static execution policy.
+
+        Shape: ``{"version": 1, "configuration": {...}}``. The configuration
+        owns all execution-relevant static state, including delegated-client
+        identity, but excludes credentials and live session state. Legacy
+        transports remain usable but receive process-local authority.
+        """
         ...
 
     async def spawn(
@@ -147,6 +157,10 @@ class LeaderDrivenWorkerRuntime:
         self._model_override_support = model_override_support
         self._targeted_resume = targeted_resume
         self._provider_name = runtime_backend
+
+    def execution_components(self) -> Mapping[str, object]:
+        """Declare the transport as this runtime's execution composition boundary."""
+        return {"transport": self._transport}
 
     # -- AgentRuntime Protocol properties ---------------------------------
 

--- a/tests/unit/orchestrator/test_alt_harness_hook.py
+++ b/tests/unit/orchestrator/test_alt_harness_hook.py
@@ -153,6 +153,8 @@ async def test_alternate_runtime_preserves_verification_policy(
         assert alt_executor._run_verify_commands is False
         assert alt_executor._verify_command_timeout_seconds == 7
         assert alt_executor._ac_retry_attempts == 0
+        assert alt_executor._dispatch_rate_policy.backend == "codex_cli"
+        assert alt_executor._dispatch_rate_policy.self_governs_rate_limit is True
         return _succeeded()
 
     monkeypatch.setattr(

--- a/tests/unit/orchestrator/test_alt_harness_hook.py
+++ b/tests/unit/orchestrator/test_alt_harness_hook.py
@@ -17,11 +17,17 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ouroboros.orchestrator import cross_harness_redispatch as chr
+from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 from ouroboros.orchestrator.parallel_executor_models import ACExecutionResult
 
 
-def _make_executor(*, enabled: bool) -> ParallelACExecutor:
+def _make_executor(
+    *,
+    enabled: bool,
+    run_verify_commands: bool = True,
+    verify_command_timeout_seconds: int = 600,
+) -> ParallelACExecutor:
     adapter = MagicMock()
     adapter.runtime_backend = "claude"
     adapter.working_directory = "/tmp/work"
@@ -31,6 +37,8 @@ def _make_executor(*, enabled: bool) -> ParallelACExecutor:
         event_store=AsyncMock(),
         console=MagicMock(),
         enable_decomposition=False,
+        run_verify_commands=run_verify_commands,
+        verify_command_timeout_seconds=verify_command_timeout_seconds,
         cross_harness_redispatch=enabled,
     )
     return executor
@@ -118,6 +126,105 @@ async def test_alternate_runtime_is_created_with_forced_bypass(
 
     assert result is not None and result.success is True
     assert created_kwargs["permission_mode"] == "bypassPermissions"
+
+
+@pytest.mark.asyncio
+async def test_alternate_runtime_preserves_verification_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = _make_executor(
+        enabled=True,
+        run_verify_commands=False,
+        verify_command_timeout_seconds=7,
+    )
+
+    def _fake_create_agent_runtime(**_kwargs: object) -> MagicMock:
+        runtime = MagicMock()
+        runtime.runtime_backend = "codex_cli"
+        runtime.working_directory = "/tmp/work"
+        runtime.permission_mode = "bypassPermissions"
+        runtime.self_governs_rate_limit = True
+        return runtime
+
+    async def _fake_execute_single_ac(
+        alt_executor: ParallelACExecutor,
+        **_kwargs: Any,
+    ) -> ACExecutionResult:
+        assert alt_executor._run_verify_commands is False
+        assert alt_executor._verify_command_timeout_seconds == 7
+        assert alt_executor._ac_retry_attempts == 0
+        return _succeeded()
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.runtime_factory.create_agent_runtime",
+        _fake_create_agent_runtime,
+    )
+    monkeypatch.setattr(ParallelACExecutor, "_execute_single_ac", _fake_execute_single_ac)
+
+    result = await executor._run_single_ac_on_backend(
+        "codex",
+        rerun_kwargs=_rerun_kwargs(),
+        retry_attempt=1,
+        decision=chr.AltHarnessDecision(
+            should_redispatch=True,
+            from_backend="claude",
+            to_backend="codex",
+            policy=None,
+            reason="test",
+        ),
+        runtime_identity=executor._resolve_ac_runtime_identity(
+            0,
+            execution_context_id="exec-1",
+        ),
+        failure_class="fabrication_suspected",
+    )
+    assert result is not None and result.success is True
+
+
+@pytest.mark.asyncio
+async def test_alternate_redispatch_event_waits_for_authority_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executor = _make_executor(enabled=True)
+    emit_event = AsyncMock()
+    monkeypatch.setattr(executor, "_safe_emit_event", emit_event)
+
+    class InvalidAuthorityRuntime:
+        capabilities = FULL_CAPABILITIES
+        runtime_backend = "codex_cli"
+        llm_backend = "codex"
+        permission_mode = "bypassPermissions"
+        working_directory = "/tmp/work"
+        self_governs_rate_limit = True
+        _model = None
+
+        def execution_identity_contract(self) -> dict[str, object]:
+            raise ValueError("invalid runtime authority")
+
+    monkeypatch.setattr(
+        "ouroboros.orchestrator.runtime_factory.create_agent_runtime",
+        lambda **_kwargs: InvalidAuthorityRuntime(),
+    )
+
+    with pytest.raises(ValueError, match="invalid runtime authority"):
+        await executor._run_single_ac_on_backend(
+            "codex",
+            rerun_kwargs=_rerun_kwargs(),
+            retry_attempt=1,
+            decision=chr.AltHarnessDecision(
+                should_redispatch=True,
+                from_backend="claude",
+                to_backend="codex",
+                policy=None,
+                reason="test",
+            ),
+            runtime_identity=executor._resolve_ac_runtime_identity(
+                0,
+                execution_context_id="exec-1",
+            ),
+            failure_class="fabrication_suspected",
+        )
+    emit_event.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import os
 from types import MethodType
 from unittest.mock import AsyncMock, MagicMock
@@ -10,9 +11,11 @@ from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, RuntimeHandle
 from ouroboros.orchestrator.execution_authority import (
     ExecutionAuthorityContract,
     ResolvedRuntimeAuthority,
+    build_execution_policy_contract,
 )
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
+from ouroboros.orchestrator.rate_limit import ResolvedDispatchRatePolicy
 from ouroboros.orchestrator.verifier import VerifierVerdict
 
 
@@ -92,6 +95,39 @@ class _SlottedRuntime:
             yield self.handler
 
 
+def _generation(label: str = "generation-a") -> dict[str, object]:
+    return {
+        "version": 1,
+        "kind": "test-snapshot-v1",
+        "digest": "sha256:" + hashlib.sha256(label.encode()).hexdigest(),
+    }
+
+
+def _policy(*, backend: str = "test-runtime", **overrides: object) -> dict[str, object]:
+    policy = build_execution_policy_contract(
+        decomposition_mode="preflight",
+        max_decomposition_depth=3,
+        max_concurrent=2,
+        execution_profile=None,
+        fat_harness_mode=False,
+        run_verify_commands=True,
+        verify_command_timeout_seconds=600,
+        ac_retry_attempts=2,
+        reasoning_effort=None,
+        model_router=None,
+        cross_harness_redispatch=False,
+        shadow_replay_enabled=False,
+        dispatch_rate_policy=ResolvedDispatchRatePolicy.resolve(
+            backend=backend,
+            self_governs_rate_limit=False,
+            requests_per_minute=None,
+            tokens_per_minute=None,
+        ).to_contract_data(),
+    )
+    policy.update(overrides)
+    return policy
+
+
 def _contract(
     *,
     runtime: _Runtime | None = None,
@@ -105,8 +141,8 @@ def _contract(
         adapter=runtime or _Runtime(),
         verifier=verifier,  # type: ignore[arg-type]
         workspace=workspace,
-        execution_policy=policy or {"retry_attempts": 2},
-        workspace_generation=generation or {"tree": "generation-a"},
+        execution_policy=policy if policy is not None else _policy(),
+        workspace_generation=generation if generation is not None else _generation(),
         runtime_handle=runtime_handle,
     )
 
@@ -244,14 +280,93 @@ def test_undeclared_custom_verifier_is_process_local() -> None:
 def test_workspace_and_policy_drift_change_authority() -> None:
     baseline = _contract()
     assert baseline.fingerprint != _contract(workspace="/tmp/workspace-b").fingerprint
-    assert baseline.fingerprint != _contract(policy={"retry_attempts": 3}).fingerprint
+    assert baseline.fingerprint != _contract(policy=_policy(ac_retry_attempts=3)).fingerprint
 
 
 def test_workspace_generation_drift_changes_authority() -> None:
     assert (
-        _contract(generation={"tree": "a"}).fingerprint
-        != _contract(generation={"tree": "b"}).fingerprint
+        _contract(generation=_generation("a")).fingerprint
+        != _contract(generation=_generation("b")).fingerprint
     )
+
+
+def test_empty_workspace_generation_is_unobserved_and_not_portable() -> None:
+    contract = _contract(generation={})
+    assert contract.data["workspace"]["generation"] == {"observed": False}
+    assert contract.portable_across_processes is False
+
+
+def test_malformed_workspace_generation_is_rejected() -> None:
+    with pytest.raises(ValueError, match="workspace generation identity is invalid"):
+        _contract(generation={"version": 1, "kind": "test", "digest": "not-a-digest"})
+
+
+@pytest.mark.parametrize("missing_key", sorted(_policy()))
+def test_incomplete_execution_policy_is_rejected(missing_key: str) -> None:
+    policy = _policy()
+    del policy[missing_key]
+    with pytest.raises(ValueError, match="invalid execution policy"):
+        _contract(policy=policy)
+
+
+def test_dispatch_rate_policy_drift_changes_executor_authority(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    runtime.self_governs_rate_limit = False  # type: ignore[attr-defined]
+
+    monkeypatch.setenv("OUROBOROS_TEST_RUNTIME_RPM", "1")
+    first = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+    )
+    monkeypatch.setenv("OUROBOROS_TEST_RUNTIME_RPM", "9")
+    second = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+    )
+
+    first_policy = first.execution_authority.data["execution_policy"]["dispatch_rate"]
+    second_policy = second.execution_authority.data["execution_policy"]["dispatch_rate"]
+    assert first_policy["requests_per_minute"] == 1
+    assert second_policy["requests_per_minute"] == 9
+    assert first.execution_authority.fingerprint != second.execution_authority.fingerprint
+
+
+def test_self_governing_rate_policy_is_explicit_and_not_portable(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    runtime.self_governs_rate_limit = True  # type: ignore[attr-defined]
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        task_cwd=str(tmp_path),
+    )
+    rate_policy = executor.execution_authority.data["execution_policy"]["dispatch_rate"]
+    assert rate_policy["owner"] == "runtime"
+    assert rate_policy["observed"] is False
+    assert executor._dispatch_rate_gate.enabled is False
+    assert executor.execution_authority.portable_across_processes is False
+
+
+def test_dispatch_rate_backend_must_match_runtime_backend() -> None:
+    policy = _policy()
+    rate_policy = dict(policy["dispatch_rate"])  # type: ignore[arg-type]
+    rate_policy["backend"] = "foreign-runtime"
+    policy["dispatch_rate"] = rate_policy
+    with pytest.raises(ValueError, match="disagrees with the runtime backend"):
+        _contract(policy=policy)
+
+
+def test_dispatch_rate_self_governance_must_match_runtime() -> None:
+    runtime = _Runtime()
+    runtime.self_governs_rate_limit = True  # type: ignore[attr-defined]
+    with pytest.raises(ValueError, match="disagrees with runtime self-governance"):
+        _contract(runtime=runtime, policy=_policy())
 
 
 def test_unobserved_workspace_or_runtime_is_not_reusable() -> None:
@@ -266,7 +381,7 @@ def test_unobserved_workspace_or_runtime_is_not_reusable() -> None:
         adapter=UnobservedRuntime(),
         verifier=None,
         workspace=None,
-        execution_policy={},
+        execution_policy=_policy(backend="legacy"),
     )
     assert contract.portable_across_processes is False
 
@@ -413,8 +528,8 @@ def test_bound_runtime_authority_is_used_without_raw_mapping_injection() -> None
         adapter=runtime,
         verifier=None,
         workspace="/tmp/workspace-a",
-        workspace_generation={"tree": "a"},
-        execution_policy={},
+        workspace_generation=_generation("a"),
+        execution_policy=_policy(),
         resolved_routing=bound,
     )
     assert contract.data["runtime"]["execution_identity"]["identity"]["profile"] == "persisted"
@@ -440,8 +555,8 @@ def test_bound_runtime_authority_rejects_a_different_adapter_instance() -> None:
             adapter=replacement,
             verifier=None,
             workspace="/tmp/workspace-a",
-            workspace_generation={"tree": "a"},
-            execution_policy={},
+            workspace_generation=_generation("a"),
+            execution_policy=_policy(),
             resolved_routing=bound,
         )
 
@@ -466,8 +581,8 @@ def test_bound_runtime_authority_rejects_same_adapter_identity_drift() -> None:
             adapter=runtime,
             verifier=None,
             workspace="/tmp/workspace-a",
-            workspace_generation={"tree": "a"},
-            execution_policy={},
+            workspace_generation=_generation("a"),
+            execution_policy=_policy(),
             resolved_routing=bound,
         )
 

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1,9 +1,16 @@
 from __future__ import annotations
 
+import os
+from types import MethodType
 from unittest.mock import AsyncMock, MagicMock
 
-from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
-from ouroboros.orchestrator.execution_authority import ExecutionAuthorityContract
+import pytest
+
+from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, RuntimeHandle
+from ouroboros.orchestrator.execution_authority import (
+    ExecutionAuthorityContract,
+    ResolvedRuntimeAuthority,
+)
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
 from ouroboros.orchestrator.verifier import VerifierVerdict
@@ -17,13 +24,39 @@ class _Runtime:
     working_directory: str | None = None
     _model = None
 
-    def __init__(self, *, profile: str = "profile-a") -> None:
+    def __init__(
+        self,
+        *,
+        profile: str = "profile-a",
+        cli_path: str | None = None,
+        startup_timeout: float = 1.0,
+        idle_timeout: float = 2.0,
+    ) -> None:
         self.profile = profile
+        self._cli_path = cli_path
+        self._startup_output_timeout_seconds = startup_timeout
+        self._stdout_idle_timeout_seconds = idle_timeout
+        self._process_shutdown_timeout_seconds = 3.0
+        self._completed_process_group_shutdown_timeout_seconds = 0.2
 
     def execution_identity_contract(self) -> dict[str, object]:
         return {
             "profile": self.profile,
             "effective_model_observed": True,
+        }
+
+    async def execute_task(self, **_: object):
+        if False:  # pragma: no cover - implementation identity only
+            yield None
+
+    def resume_handle_execution_identity_contract(
+        self,
+        runtime_handle: RuntimeHandle | None,
+    ) -> dict[str, object]:
+        return {
+            "profile": (
+                runtime_handle.metadata.get("profile") if runtime_handle is not None else None
+            )
         }
 
 
@@ -38,18 +71,43 @@ class _Verifier:
         return VerifierVerdict(passed=True)
 
 
+class _SlottedRuntime:
+    __slots__ = ("handler",)
+
+    capabilities = FULL_CAPABILITIES
+    runtime_backend = "test-runtime"
+    llm_backend = "test-llm"
+    permission_mode = "bypassPermissions"
+    working_directory = None
+    _model = None
+
+    def __init__(self, handler: object) -> None:
+        self.handler = handler
+
+    def execution_identity_contract(self) -> dict[str, object]:
+        return {"effective_model_observed": True, "profile": "slotted"}
+
+    async def execute_task(self, **_: object):
+        if False:  # pragma: no cover - implementation identity only
+            yield self.handler
+
+
 def _contract(
     *,
     runtime: _Runtime | None = None,
     verifier: object | None = None,
     workspace: str = "/tmp/workspace-a",
     policy: dict[str, object] | None = None,
+    generation: dict[str, object] | None = None,
+    runtime_handle: RuntimeHandle | None = None,
 ) -> ExecutionAuthorityContract:
     return ExecutionAuthorityContract.build(
         adapter=runtime or _Runtime(),
         verifier=verifier,  # type: ignore[arg-type]
         workspace=workspace,
         execution_policy=policy or {"retry_attempts": 2},
+        workspace_generation=generation or {"tree": "generation-a"},
+        runtime_handle=runtime_handle,
     )
 
 
@@ -60,6 +118,108 @@ def test_runtime_profile_drift_changes_authority() -> None:
     )
 
 
+def test_runtime_executable_and_watchdog_drift_change_authority() -> None:
+    baseline = _contract(runtime=_Runtime(cli_path="/bin/true"))
+    changed_executable = _contract(runtime=_Runtime(cli_path="/bin/false"))
+    changed_watchdog = _contract(
+        runtime=_Runtime(cli_path="/bin/true", startup_timeout=9.0, idle_timeout=99.0)
+    )
+    assert baseline.fingerprint != changed_executable.fingerprint
+    assert baseline.fingerprint != changed_watchdog.fingerprint
+
+
+def test_runtime_command_builder_override_changes_authority() -> None:
+    class CommandOne(_Runtime):
+        def _build_command(self) -> list[str]:
+            return ["cli", "one"]
+
+    class CommandTwo(_Runtime):
+        def _build_command(self) -> list[str]:
+            return ["cli", "two"]
+
+    assert (
+        _contract(runtime=CommandOne()).fingerprint != _contract(runtime=CommandTwo()).fingerprint
+    )
+
+
+def test_in_place_executable_generation_change_changes_authority(tmp_path) -> None:
+    executable = tmp_path / "runtime-cli"
+    executable.write_text("one", encoding="utf-8")
+    baseline = _contract(runtime=_Runtime(cli_path=str(executable)))
+    previous = executable.stat()
+    executable.write_text("two", encoding="utf-8")
+    os.utime(
+        executable,
+        ns=(previous.st_atime_ns, max(executable.stat().st_mtime_ns, previous.st_mtime_ns + 1)),
+    )
+    changed = _contract(runtime=_Runtime(cli_path=str(executable)))
+    assert baseline.fingerprint != changed.fingerprint
+
+
+def test_executable_content_drift_changes_authority_with_restored_stat(tmp_path) -> None:
+    executable = tmp_path / "runtime-cli"
+    executable.write_text("one", encoding="utf-8")
+    previous = executable.stat()
+    baseline = _contract(runtime=_Runtime(cli_path=str(executable)))
+    executable.write_text("two", encoding="utf-8")
+    os.utime(executable, ns=(previous.st_atime_ns, previous.st_mtime_ns))
+    changed = _contract(runtime=_Runtime(cli_path=str(executable)))
+    assert baseline.fingerprint != changed.fingerprint
+
+
+def test_runtime_execution_body_and_parser_drift_change_authority() -> None:
+    class ImplementationOne(_Runtime):
+        async def _execute_task_impl(self, **_: object):
+            if False:  # pragma: no cover - implementation identity only
+                yield "one"
+
+        def _parse_json_event(self, _line: str) -> str:
+            return "one"
+
+        def _convert_event(self, _event: object) -> str:
+            return "one"
+
+    class ImplementationTwo(_Runtime):
+        async def _execute_task_impl(self, **_: object):
+            if False:  # pragma: no cover - implementation identity only
+                yield "two"
+
+        def _parse_json_event(self, _line: str) -> str:
+            return "two"
+
+        def _convert_event(self, _event: object) -> str:
+            return "two"
+
+    assert (
+        _contract(runtime=ImplementationOne()).fingerprint
+        != _contract(runtime=ImplementationTwo()).fingerprint
+    )
+
+
+def test_instance_level_execution_override_is_process_local() -> None:
+    runtime = _Runtime()
+    baseline = _contract(runtime=runtime)
+
+    async def replacement(self: _Runtime, **_: object):
+        if False:  # pragma: no cover - implementation identity only
+            yield self.profile
+
+    runtime.execute_task = MethodType(replacement, runtime)  # type: ignore[method-assign]
+    overridden = _contract(runtime=runtime)
+    assert baseline.fingerprint != overridden.fingerprint
+    assert overridden.portable_across_processes is False
+
+
+def test_unobservable_slotted_instance_state_is_process_local() -> None:
+    runtime = _SlottedRuntime(lambda: "one")
+    baseline = _contract(runtime=runtime)  # type: ignore[arg-type]
+    runtime.handler = lambda: "two"
+    changed = _contract(runtime=runtime)  # type: ignore[arg-type]
+    assert baseline.fingerprint != changed.fingerprint
+    assert baseline.portable_across_processes is False
+    assert changed.portable_across_processes is False
+
+
 def test_verifier_identity_drift_changes_authority() -> None:
     first = _contract(verifier=_Verifier("judge-a"))
     same = _contract(verifier=_Verifier("judge-a"))
@@ -67,7 +227,7 @@ def test_verifier_identity_drift_changes_authority() -> None:
 
     assert first.fingerprint == same.fingerprint
     assert first.fingerprint != changed.fingerprint
-    assert first.reusable_across_processes is True
+    assert first.portable_across_processes is True
 
 
 def test_undeclared_custom_verifier_is_process_local() -> None:
@@ -77,7 +237,7 @@ def test_undeclared_custom_verifier_is_process_local() -> None:
     first = _contract(verifier=verifier)
     second = _contract(verifier=verifier)
 
-    assert first.reusable_across_processes is False
+    assert first.portable_across_processes is False
     assert first.fingerprint != second.fingerprint
 
 
@@ -85,6 +245,58 @@ def test_workspace_and_policy_drift_change_authority() -> None:
     baseline = _contract()
     assert baseline.fingerprint != _contract(workspace="/tmp/workspace-b").fingerprint
     assert baseline.fingerprint != _contract(policy={"retry_attempts": 3}).fingerprint
+
+
+def test_workspace_generation_drift_changes_authority() -> None:
+    assert (
+        _contract(generation={"tree": "a"}).fingerprint
+        != _contract(generation={"tree": "b"}).fingerprint
+    )
+
+
+def test_unobserved_workspace_or_runtime_is_not_reusable() -> None:
+    class UnobservedRuntime:
+        capabilities = FULL_CAPABILITIES
+        runtime_backend = "legacy"
+        llm_backend = None
+        permission_mode = None
+        working_directory = None
+
+    contract = ExecutionAuthorityContract.build(
+        adapter=UnobservedRuntime(),
+        verifier=None,
+        workspace=None,
+        execution_policy={},
+    )
+    assert contract.portable_across_processes is False
+
+
+def test_runtime_handle_selector_changes_authority() -> None:
+    cheap = RuntimeHandle(backend="codex_cli", metadata={"profile": "cheap"})
+    expensive = RuntimeHandle(backend="codex_cli", metadata={"profile": "expensive"})
+    assert (
+        _contract(runtime_handle=cheap).fingerprint
+        != _contract(runtime_handle=expensive).fingerprint
+    )
+
+
+def test_verifier_identity_provider_failure_degrades_to_process_local() -> None:
+    class RaisingVerifier:
+        def verification_identity_contract(self) -> dict[str, object]:
+            raise OSError("offline")
+
+        def __call__(self, **_: object) -> VerifierVerdict:
+            return VerifierVerdict(passed=True)
+
+    contract = _contract(verifier=RaisingVerifier())
+    assert contract.portable_across_processes is False
+    assert contract.data["verifier"]["behavioral_state"]["stability"] == "process_local"
+
+
+def test_runtime_transcript_verifier_has_implementation_identity() -> None:
+    verifier = _contract().data["verifier"]
+    assert verifier["mode"] == "runtime_transcript"
+    assert verifier["implementation"]["stability"] == "durable"
 
 
 def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
@@ -102,7 +314,7 @@ def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
 
     authority = executor.execution_authority
     assert authority.fingerprint.startswith("sha256:")
-    assert authority.data["workspace"]["effective_cwd"] == str(tmp_path.resolve())
+    assert authority.data["workspace"]["identity"]["effective_cwd"] == str(tmp_path.resolve())
     assert authority.data["runtime"]["execution_identity"]["identity"]["profile"] == "profile-a"
     assert authority.data["execution_policy"]["ac_retry_attempts"] == 2
 
@@ -123,3 +335,204 @@ def test_profile_policy_drift_changes_executor_authority(tmp_path) -> None:
         ).execution_authority.fingerprint
 
     assert build(base_profile) != build(changed_profile)
+
+
+def test_transcript_verifier_wrapper_override_changes_executor_authority(tmp_path) -> None:
+    class OverriddenExecutor(ParallelACExecutor):
+        def _verify_atomic_evidence_against_runtime_messages(self, **kwargs: object):  # type: ignore[no-untyped-def]
+            return super()._verify_atomic_evidence_against_runtime_messages(**kwargs)  # type: ignore[arg-type]
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "console": MagicMock(),
+        "task_cwd": str(tmp_path),
+        "execution_profile": load_profile("code"),
+    }
+    baseline = ParallelACExecutor(**kwargs).execution_authority.fingerprint  # type: ignore[arg-type]
+    overridden = OverriddenExecutor(**kwargs).execution_authority.fingerprint  # type: ignore[arg-type]
+    assert baseline != overridden
+
+
+def test_shadow_replay_binds_transcript_wrapper_with_custom_verifier(tmp_path) -> None:
+    class OverriddenExecutor(ParallelACExecutor):
+        def _verify_atomic_evidence_against_runtime_messages(self, **kwargs: object):  # type: ignore[no-untyped-def]
+            return super()._verify_atomic_evidence_against_runtime_messages(**kwargs)  # type: ignore[arg-type]
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "console": MagicMock(),
+        "task_cwd": str(tmp_path),
+        "execution_profile": load_profile("code"),
+        "atomic_verifier": _Verifier("judge-a"),
+        "shadow_replay_enabled": True,
+    }
+    baseline = ParallelACExecutor(**kwargs).execution_authority.fingerprint  # type: ignore[arg-type]
+    overridden = OverriddenExecutor(**kwargs).execution_authority.fingerprint  # type: ignore[arg-type]
+    assert baseline != overridden
+
+
+def test_resolved_runtime_authority_rejects_adapter_mismatch() -> None:
+    runtime = _Runtime(profile="actual")
+    resolved_routing = {
+        "runtime_backend": "test-runtime",
+        "llm_backend": "test-llm",
+        "permission_mode": {"observed": True, "mode": "bypassPermissions"},
+        "constructor_model": {"observed": True, "model": None},
+        "runtime_execution": {
+            "version": 1,
+            "observed": True,
+            "identity": {"profile": "fake", "effective_model_observed": True},
+        },
+    }
+    with pytest.raises(ValueError, match="runtime_execution"):
+        ResolvedRuntimeAuthority.bind(runtime, resolved_routing)
+
+
+def test_bound_runtime_authority_is_used_without_raw_mapping_injection() -> None:
+    runtime = _Runtime(profile="persisted")
+    resolved_routing = {
+        "runtime_backend": "test-runtime",
+        "llm_backend": "test-llm",
+        "permission_mode": {"observed": True, "mode": "bypassPermissions"},
+        "constructor_model": {"observed": True, "model": None},
+        "runtime_execution": runtime.execution_identity_contract(),
+    }
+    resolved_routing["runtime_execution"] = {
+        "version": 1,
+        "observed": True,
+        "identity": resolved_routing["runtime_execution"],
+    }
+    bound = ResolvedRuntimeAuthority.bind(runtime, resolved_routing)
+    contract = ExecutionAuthorityContract.build(
+        adapter=runtime,
+        verifier=None,
+        workspace="/tmp/workspace-a",
+        workspace_generation={"tree": "a"},
+        execution_policy={},
+        resolved_routing=bound,
+    )
+    assert contract.data["runtime"]["execution_identity"]["identity"]["profile"] == "persisted"
+
+
+def test_bound_runtime_authority_rejects_a_different_adapter_instance() -> None:
+    original = _Runtime(profile="same")
+    replacement = _Runtime(profile="same")
+    resolved_routing = {
+        "runtime_backend": "test-runtime",
+        "llm_backend": "test-llm",
+        "permission_mode": {"observed": True, "mode": "bypassPermissions"},
+        "constructor_model": {"observed": True, "model": None},
+        "runtime_execution": {
+            "version": 1,
+            "observed": True,
+            "identity": original.execution_identity_contract(),
+        },
+    }
+    bound = ResolvedRuntimeAuthority.bind(original, resolved_routing)
+    with pytest.raises(ValueError, match="different adapter"):
+        ExecutionAuthorityContract.build(
+            adapter=replacement,
+            verifier=None,
+            workspace="/tmp/workspace-a",
+            workspace_generation={"tree": "a"},
+            execution_policy={},
+            resolved_routing=bound,
+        )
+
+
+def test_bound_runtime_authority_rejects_same_adapter_identity_drift() -> None:
+    runtime = _Runtime(profile="before")
+    resolved_routing = {
+        "runtime_backend": "test-runtime",
+        "llm_backend": "test-llm",
+        "permission_mode": {"observed": True, "mode": "bypassPermissions"},
+        "constructor_model": {"observed": True, "model": None},
+        "runtime_execution": {
+            "version": 1,
+            "observed": True,
+            "identity": runtime.execution_identity_contract(),
+        },
+    }
+    bound = ResolvedRuntimeAuthority.bind(runtime, resolved_routing)
+    runtime.profile = "after"
+    with pytest.raises(ValueError, match="drifted from active runtime_execution"):
+        ExecutionAuthorityContract.build(
+            adapter=runtime,
+            verifier=None,
+            workspace="/tmp/workspace-a",
+            workspace_generation={"tree": "a"},
+            execution_policy={},
+            resolved_routing=bound,
+        )
+
+
+def test_resolved_runtime_authority_reads_effective_private_permission_mode() -> None:
+    runtime = _Runtime()
+    runtime._permission_mode = "acceptEdits"  # type: ignore[attr-defined]
+    resolved_routing = {
+        "runtime_backend": "test-runtime",
+        "llm_backend": "test-llm",
+        "permission_mode": {"observed": True, "mode": "bypassPermissions"},
+        "constructor_model": {"observed": True, "model": None},
+        "runtime_execution": {
+            "version": 1,
+            "observed": True,
+            "identity": runtime.execution_identity_contract(),
+        },
+    }
+    with pytest.raises(ValueError, match="permission_mode"):
+        ResolvedRuntimeAuthority.bind(runtime, resolved_routing)
+
+
+def test_local_skill_fallback_is_process_local() -> None:
+    class LocalSkillRuntime(_Runtime):
+        _skill_dispatcher = None
+        _skills_dir = "/tmp/skills"
+
+        async def _maybe_dispatch_skill_intercept(self, **_: object) -> None:
+            return None
+
+        async def _dispatch_skill_intercept_locally(self, **_: object) -> None:
+            return None
+
+    contract = _contract(runtime=LocalSkillRuntime())
+    assert contract.portable_across_processes is False
+    assert contract.data["runtime"]["skill_dispatcher"]["mode"] == "local_fallback"
+
+
+def test_declared_callable_dispatcher_has_durable_implementation_identity() -> None:
+    class StableDispatcher:
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {"dispatcher": "stable"}
+
+        async def __call__(self, **_: object) -> None:
+            return None
+
+    runtime = _Runtime()
+    runtime._skill_dispatcher = StableDispatcher()  # type: ignore[attr-defined]
+    contract = _contract(runtime=runtime)
+    dispatcher = contract.data["runtime"]["skill_dispatcher"]
+    assert dispatcher["stability"] == "durable"
+    assert dispatcher["implementation"]["stability"] == "durable"
+
+
+def test_dispatcher_identity_provider_failure_degrades_to_process_local() -> None:
+    class RaisingDispatcher:
+        @property
+        def execution_identity_contract(self) -> object:
+            raise OSError("offline")
+
+        async def __call__(self, **_: object) -> None:
+            return None
+
+    runtime = _Runtime()
+    runtime._skill_dispatcher = RaisingDispatcher()  # type: ignore[attr-defined]
+    contract = _contract(runtime=runtime)
+    assert contract.portable_across_processes is False
+    assert contract.data["runtime"]["skill_dispatcher"]["stability"] == "process_local"

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -104,6 +104,17 @@ class _FailingHelperVerifier(_HelperVerifierBase):
         return False
 
 
+class _SelfReferentialVerifier:
+    def __init__(self) -> None:
+        self.helper = self
+
+    def verification_identity_contract(self) -> dict[str, object]:
+        return {"judge": "self-referential"}
+
+    def __call__(self, **_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+
 class _BypassDispatchRateExecutor(ParallelACExecutor):
     async def _await_dispatch_rate_budget(
         self,
@@ -531,6 +542,17 @@ def test_callable_verifier_helper_override_changes_authority() -> None:
     assert passing.fingerprint != failing.fingerprint
     assert passing.data["verifier"]["implementation"]["stability"] == "durable"
     assert failing.data["verifier"]["implementation"]["stability"] == "durable"
+
+
+def test_self_referential_callable_verifier_fails_closed_without_recursing() -> None:
+    first = _contract(verifier=_SelfReferentialVerifier())
+    second = _contract(verifier=_SelfReferentialVerifier())
+
+    assert first.fingerprint != second.fingerprint
+    assert first.portable_across_processes is False
+    implementation = first.data["verifier"]["implementation"]
+    assert implementation["stability"] == "process_local"
+    assert implementation["instance_overrides"]["helper"]["mode"] == "callable"
 
 
 def test_undeclared_custom_verifier_is_process_local() -> None:

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -16,6 +16,7 @@ from ouroboros.orchestrator.execution_authority import (
     build_execution_policy_contract,
 )
 from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
+from ouroboros.orchestrator.pi_runtime import PiRuntime
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
 from ouroboros.orchestrator.rate_limit import ResolvedDispatchRatePolicy
 from ouroboros.orchestrator.verifier import VerifierVerdict
@@ -75,6 +76,50 @@ class _Verifier:
 
     def __call__(self, **_: object) -> VerifierVerdict:
         return VerifierVerdict(passed=True)
+
+
+class _ExecutionOwner:
+    def execute(self) -> None:
+        """Stable test-only effect-owner implementation."""
+
+
+class _HelperVerifierBase:
+    def verification_identity_contract(self) -> dict[str, object]:
+        return {"judge": "shared"}
+
+    def __call__(self, **_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=self._passed())
+
+    def _passed(self) -> bool:
+        raise NotImplementedError
+
+
+class _PassingHelperVerifier(_HelperVerifierBase):
+    def _passed(self) -> bool:
+        return True
+
+
+class _FailingHelperVerifier(_HelperVerifierBase):
+    def _passed(self) -> bool:
+        return False
+
+
+class _BypassDispatchRateExecutor(ParallelACExecutor):
+    async def _await_dispatch_rate_budget(
+        self,
+        *,
+        prompt: str,
+        system_prompt: str | None,
+    ) -> None:
+        del prompt, system_prompt
+
+
+class _StableDispatcher:
+    def execution_identity_contract(self) -> dict[str, object]:
+        return {"dispatcher": "stable"}
+
+    async def __call__(self, **_: object) -> None:
+        return None
 
 
 class _SlottedRuntime:
@@ -143,6 +188,7 @@ def _contract(
     return ExecutionAuthorityContract.build(
         adapter=runtime or _Runtime(),
         verifier=verifier,  # type: ignore[arg-type]
+        executor=_ExecutionOwner(),
         workspace=workspace,
         execution_policy=policy if policy is not None else _policy(),
         workspace_generation=generation if generation is not None else _generation(),
@@ -164,6 +210,7 @@ def _worker_contract(
     return ExecutionAuthorityContract.build(
         adapter=runtime,
         verifier=None,
+        executor=_ExecutionOwner(),
         workspace="/tmp/workspace-a",
         workspace_generation=_generation(),
         execution_policy=_policy(backend=backend),
@@ -336,6 +383,7 @@ def test_bundled_transport_identity_is_stable_and_binds_instance_override() -> N
         return ExecutionAuthorityContract.build(
             adapter=runtime,
             verifier=None,
+            executor=_ExecutionOwner(),
             workspace="/tmp/workspace-a",
             workspace_generation=_generation(),
             execution_policy=_policy(backend="claude_mcp"),
@@ -476,6 +524,15 @@ def test_verifier_identity_drift_changes_authority() -> None:
     assert first.portable_across_processes is True
 
 
+def test_callable_verifier_helper_override_changes_authority() -> None:
+    passing = _contract(verifier=_PassingHelperVerifier())
+    failing = _contract(verifier=_FailingHelperVerifier())
+
+    assert passing.fingerprint != failing.fingerprint
+    assert passing.data["verifier"]["implementation"]["stability"] == "durable"
+    assert failing.data["verifier"]["implementation"]["stability"] == "durable"
+
+
 def test_undeclared_custom_verifier_is_process_local() -> None:
     def verifier(**_: object) -> VerifierVerdict:
         return VerifierVerdict(passed=True)
@@ -545,6 +602,67 @@ def test_dispatch_rate_policy_drift_changes_executor_authority(
     assert first_policy["requests_per_minute"] == 1
     assert second_policy["requests_per_minute"] == 9
     assert first.execution_authority.fingerprint != second.execution_authority.fingerprint
+
+
+def test_executor_implementation_override_changes_authority(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    rate_policy = ResolvedDispatchRatePolicy.resolve(
+        backend="test-runtime",
+        self_governs_rate_limit=False,
+        requests_per_minute=1,
+        tokens_per_minute=None,
+    )
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "task_cwd": str(tmp_path),
+        "dispatch_rate_policy": rate_policy,
+    }
+
+    baseline = ParallelACExecutor(**kwargs).execution_authority  # type: ignore[arg-type]
+    bypassed = _BypassDispatchRateExecutor(**kwargs).execution_authority  # type: ignore[arg-type]
+
+    assert baseline.data["execution_policy"]["dispatch_rate"]["gate_enabled"] is True
+    assert baseline.fingerprint != bypassed.fingerprint
+    assert baseline.data["executor"]["stability"] == "durable"
+    assert bypassed.data["executor"]["stability"] == "durable"
+
+
+def test_delegated_skill_interceptor_configuration_changes_authority(tmp_path) -> None:
+    first_runtime = PiRuntime(
+        cli_path="/usr/bin/true",
+        cwd=tmp_path,
+        skills_dir=tmp_path / "skills-a",
+    )
+    second_runtime = PiRuntime(
+        cli_path="/usr/bin/true",
+        cwd=tmp_path,
+        skills_dir=tmp_path / "skills-b",
+    )
+
+    first = ExecutionAuthorityContract.build(
+        adapter=first_runtime,
+        verifier=None,
+        executor=_ExecutionOwner(),
+        workspace=str(tmp_path),
+        workspace_generation=_generation(),
+        execution_policy=_policy(backend="pi"),
+    )
+    second = ExecutionAuthorityContract.build(
+        adapter=second_runtime,
+        verifier=None,
+        executor=_ExecutionOwner(),
+        workspace=str(tmp_path),
+        workspace_generation=_generation(),
+        execution_policy=_policy(backend="pi"),
+    )
+
+    skill_dispatcher = first.data["runtime"]["skill_dispatcher"]
+    assert skill_dispatcher["mode"] == "delegated"
+    assert skill_dispatcher["component"]["mode"] == "declared"
+    assert skill_dispatcher["stability"] == "durable"
+    assert first.fingerprint != second.fingerprint
 
 
 def test_self_governing_rate_policy_is_explicit_and_not_portable(tmp_path) -> None:
@@ -737,6 +855,7 @@ def test_bound_runtime_authority_is_used_without_raw_mapping_injection() -> None
     contract = ExecutionAuthorityContract.build(
         adapter=runtime,
         verifier=None,
+        executor=_ExecutionOwner(),
         workspace="/tmp/workspace-a",
         workspace_generation=_generation("a"),
         execution_policy=_policy(),
@@ -832,15 +951,8 @@ def test_local_skill_fallback_is_process_local() -> None:
 
 
 def test_declared_callable_dispatcher_has_durable_implementation_identity() -> None:
-    class StableDispatcher:
-        def execution_identity_contract(self) -> dict[str, object]:
-            return {"dispatcher": "stable"}
-
-        async def __call__(self, **_: object) -> None:
-            return None
-
     runtime = _Runtime()
-    runtime._skill_dispatcher = StableDispatcher()  # type: ignore[attr-defined]
+    runtime._skill_dispatcher = _StableDispatcher()  # type: ignore[attr-defined]
     contract = _contract(runtime=runtime)
     dispatcher = contract.data["runtime"]["skill_dispatcher"]
     assert dispatcher["stability"] == "durable"

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -8,6 +8,8 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, RuntimeHandle
+from ouroboros.orchestrator.claude_worker_runtime import ClaudeWorkerTransport
+from ouroboros.orchestrator.codex_mcp_runtime import CodexMcpWorkerTransport
 from ouroboros.orchestrator.execution_authority import (
     ExecutionAuthorityContract,
     ResolvedRuntimeAuthority,
@@ -17,6 +19,7 @@ from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
 from ouroboros.orchestrator.rate_limit import ResolvedDispatchRatePolicy
 from ouroboros.orchestrator.verifier import VerifierVerdict
+from ouroboros.orchestrator.worker_runtime import LeaderDrivenWorkerRuntime
 
 
 class _Runtime:
@@ -147,6 +150,26 @@ def _contract(
     )
 
 
+def _worker_contract(
+    transport: object,
+    *,
+    backend: str,
+    llm_backend: str,
+) -> ExecutionAuthorityContract:
+    runtime = LeaderDrivenWorkerRuntime(
+        transport=transport,  # type: ignore[arg-type]
+        runtime_backend=backend,
+        llm_backend=llm_backend,
+    )
+    return ExecutionAuthorityContract.build(
+        adapter=runtime,
+        verifier=None,
+        workspace="/tmp/workspace-a",
+        workspace_generation=_generation(),
+        execution_policy=_policy(backend=backend),
+    )
+
+
 def test_runtime_profile_drift_changes_authority() -> None:
     assert (
         _contract(runtime=_Runtime(profile="a")).fingerprint
@@ -244,6 +267,193 @@ def test_instance_level_execution_override_is_process_local() -> None:
     overridden = _contract(runtime=runtime)
     assert baseline.fingerprint != overridden.fingerprint
     assert overridden.portable_across_processes is False
+
+    runtime.execute_task = None  # type: ignore[method-assign]
+    non_callable = _contract(runtime=runtime)
+    assert baseline.fingerprint != non_callable.fingerprint
+    assert non_callable.portable_across_processes is False
+
+    runtime_with_handler = _Runtime()
+    runtime_with_handler._handler = lambda: "one"  # type: ignore[attr-defined]
+    handler_contract = _contract(runtime=runtime_with_handler)
+    assert (
+        handler_contract.data["runtime"]["implementation"]["instance_overrides"]["_handler"]["mode"]
+        == "callable"
+    )
+    assert handler_contract.portable_across_processes is False
+
+
+def test_bundled_worker_transport_policy_changes_authority() -> None:
+    claude_first = _worker_contract(
+        ClaudeWorkerTransport(
+            cli_path="/usr/bin/true",
+            timeout=1,
+            disallowed_tools=("tool-a",),
+            persist_sessions=False,
+        ),
+        backend="claude_mcp",
+        llm_backend="claude",
+    )
+    claude_second = _worker_contract(
+        ClaudeWorkerTransport(
+            cli_path="/usr/bin/false",
+            timeout=9,
+            disallowed_tools=("tool-b",),
+            persist_sessions=True,
+        ),
+        backend="claude_mcp",
+        llm_backend="claude",
+    )
+    codex_first = _worker_contract(
+        CodexMcpWorkerTransport(cli_path="/usr/bin/true", idle_timeout=1),
+        backend="codex_mcp",
+        llm_backend="codex",
+    )
+    codex_second = _worker_contract(
+        CodexMcpWorkerTransport(cli_path="/usr/bin/false", idle_timeout=9),
+        backend="codex_mcp",
+        llm_backend="codex",
+    )
+
+    assert claude_first.fingerprint != claude_second.fingerprint
+    assert codex_first.fingerprint != codex_second.fingerprint
+    transport = claude_first.data["runtime"]["implementation"]["composition"]["components"][
+        "transport"
+    ]
+    assert transport["mode"] == "declared"
+    assert transport["executable"]["observed"] is True
+
+
+def test_bundled_transport_identity_is_stable_and_binds_instance_override() -> None:
+    transport = ClaudeWorkerTransport(cli_path="/usr/bin/true")
+    runtime = LeaderDrivenWorkerRuntime(
+        transport=transport,
+        runtime_backend="claude_mcp",
+        llm_backend="claude",
+    )
+
+    def build() -> ExecutionAuthorityContract:
+        return ExecutionAuthorityContract.build(
+            adapter=runtime,
+            verifier=None,
+            workspace="/tmp/workspace-a",
+            workspace_generation=_generation(),
+            execution_policy=_policy(backend="claude_mcp"),
+        )
+
+    first = build()
+    assert first.fingerprint == build().fingerprint
+
+    transport.spawn = lambda **_: None  # type: ignore[method-assign]
+    overridden = build()
+    assert first.fingerprint != overridden.fingerprint
+    component = overridden.data["runtime"]["implementation"]["composition"]["components"][
+        "transport"
+    ]
+    assert component["stability"] == "process_local"
+
+    transport.spawn = None  # type: ignore[method-assign]
+    non_callable = build()
+    assert first.fingerprint != non_callable.fingerprint
+    component = non_callable.data["runtime"]["implementation"]["composition"]["components"][
+        "transport"
+    ]
+    assert component["instance_overrides"]["spawn"]["mode"] == "non_callable"
+
+
+def test_undeclared_transport_fails_closed_without_colliding() -> None:
+    class OpaqueTransport:
+        backend_name = "opaque"
+
+        async def spawn(self, **_: object) -> object:
+            raise NotImplementedError
+
+        async def resume(self, **_: object) -> object:
+            raise NotImplementedError
+
+    first = _worker_contract(
+        OpaqueTransport(),
+        backend="opaque",
+        llm_backend="opaque",
+    )
+    second = _worker_contract(
+        OpaqueTransport(),
+        backend="opaque",
+        llm_backend="opaque",
+    )
+
+    assert first.fingerprint != second.fingerprint
+    component = first.data["runtime"]["implementation"]["composition"]["components"]["transport"]
+    assert component["mode"] == "process_local"
+    assert first.portable_across_processes is False
+
+
+def test_malformed_transport_identity_fails_closed_without_leaking() -> None:
+    class MalformedTransport:
+        backend_name = "malformed"
+
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {"version": True, "configuration": {"api_token": "sentinel-secret"}}
+
+        async def spawn(self, **_: object) -> object:
+            raise NotImplementedError
+
+        async def resume(self, **_: object) -> object:
+            raise NotImplementedError
+
+    contract = _worker_contract(
+        MalformedTransport(),
+        backend="malformed",
+        llm_backend="malformed",
+    )
+    component = contract.data["runtime"]["implementation"]["composition"]["components"]["transport"]
+    assert component["mode"] == "process_local"
+    assert "sentinel-secret" not in contract.canonical_json
+
+
+def test_sensitive_transport_identity_fails_closed_without_leaking() -> None:
+    class SensitiveTransport:
+        backend_name = "sensitive"
+
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                "version": 1,
+                "configuration": {"api_token": "sentinel-secret"},
+            }
+
+        async def spawn(self, **_: object) -> object:
+            raise NotImplementedError
+
+        async def resume(self, **_: object) -> object:
+            raise NotImplementedError
+
+    contract = _worker_contract(
+        SensitiveTransport(),
+        backend="sensitive",
+        llm_backend="sensitive",
+    )
+
+    component = contract.data["runtime"]["implementation"]["composition"]["components"]["transport"]
+    assert component["mode"] == "process_local"
+    assert "identity_digest" not in component
+    assert "sentinel-secret" not in contract.canonical_json
+
+
+def test_codex_transport_live_pool_is_excluded_from_static_identity() -> None:
+    transport = CodexMcpWorkerTransport(cli_path="/usr/bin/true")
+    baseline = _worker_contract(
+        transport,
+        backend="codex_mcp",
+        llm_backend="codex",
+    )
+    transport._pool["session"] = object()  # type: ignore[assignment]
+    changed_live_state = _worker_contract(
+        transport,
+        backend="codex_mcp",
+        llm_backend="codex",
+    )
+
+    assert baseline.fingerprint == changed_live_state.fingerprint
 
 
 def test_unobservable_slotted_instance_state_is_process_local() -> None:

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from ouroboros.orchestrator import parallel_executor as parallel_executor_module
 from ouroboros.orchestrator.adapter import FULL_CAPABILITIES, RuntimeHandle
 from ouroboros.orchestrator.claude_worker_runtime import ClaudeWorkerTransport
 from ouroboros.orchestrator.codex_mcp_runtime import CodexMcpWorkerTransport
@@ -19,6 +20,7 @@ from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
 from ouroboros.orchestrator.pi_runtime import PiRuntime
 from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
 from ouroboros.orchestrator.rate_limit import ResolvedDispatchRatePolicy
+from ouroboros.orchestrator.synapse import SessionSignalHub
 from ouroboros.orchestrator.verifier import VerifierVerdict
 from ouroboros.orchestrator.worker_runtime import LeaderDrivenWorkerRuntime
 
@@ -123,6 +125,16 @@ class _BypassDispatchRateExecutor(ParallelACExecutor):
         system_prompt: str | None,
     ) -> None:
         del prompt, system_prompt
+
+
+class _ReplacementLeafDispatcher:
+    """Distinct dispatch implementation for authority collision coverage."""
+
+    def __init__(self, executor: ParallelACExecutor) -> None:
+        self.executor = executor
+
+    async def stream(self, **_: object) -> None:
+        return None
 
 
 class _StableDispatcher:
@@ -282,6 +294,21 @@ def test_executable_content_drift_changes_authority_with_restored_stat(tmp_path)
     os.utime(executable, ns=(previous.st_atime_ns, previous.st_mtime_ns))
     changed = _contract(runtime=_Runtime(cli_path=str(executable)))
     assert baseline.fingerprint != changed.fingerprint
+
+
+def test_non_executable_runtime_target_fails_closed_and_changes_authority(tmp_path) -> None:
+    executable = tmp_path / "runtime-cli"
+    executable.write_text("one", encoding="utf-8")
+    os.chmod(executable, 0o755)
+    baseline = _contract(runtime=_Runtime(cli_path=str(executable)))
+
+    os.chmod(executable, 0o644)
+    changed = _contract(runtime=_Runtime(cli_path=str(executable)))
+
+    assert baseline.fingerprint != changed.fingerprint
+    assert baseline.portable_across_processes is True
+    assert changed.data["runtime"]["executable"]["observed"] is False
+    assert changed.portable_across_processes is False
 
 
 def test_runtime_execution_body_and_parser_drift_change_authority() -> None:
@@ -498,6 +525,21 @@ def test_sensitive_transport_identity_fails_closed_without_leaking() -> None:
     assert "sentinel-secret" not in contract.canonical_json
 
 
+def test_sensitive_runtime_identity_fails_closed_without_leaking() -> None:
+    class SensitiveRuntime(_Runtime):
+        def execution_identity_contract(self) -> dict[str, object]:
+            return {
+                "effective_model_observed": True,
+                "api_token": "sentinel-secret",
+            }
+
+    contract = _contract(runtime=SensitiveRuntime())
+
+    assert contract.data["runtime"]["execution_identity"] == {"version": 1, "observed": False}
+    assert contract.portable_across_processes is False
+    assert "sentinel-secret" not in contract.canonical_json
+
+
 def test_codex_transport_live_pool_is_excluded_from_static_identity() -> None:
     transport = CodexMcpWorkerTransport(cli_path="/usr/bin/true")
     baseline = _worker_contract(
@@ -649,6 +691,92 @@ def test_executor_implementation_override_changes_authority(tmp_path) -> None:
     assert baseline.fingerprint != bypassed.fingerprint
     assert baseline.data["executor"]["stability"] == "durable"
     assert bypassed.data["executor"]["stability"] == "durable"
+
+
+def test_leaf_dispatcher_replacement_changes_executor_authority(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "task_cwd": str(tmp_path),
+        "dispatch_rate_policy": ResolvedDispatchRatePolicy.resolve(
+            backend="test-runtime",
+            self_governs_rate_limit=False,
+            requests_per_minute=1,
+            tokens_per_minute=None,
+        ),
+    }
+
+    baseline = ParallelACExecutor(**kwargs).execution_authority  # type: ignore[arg-type]
+    monkeypatch.setattr(parallel_executor_module, "LeafDispatcher", _ReplacementLeafDispatcher)
+    replaced = ParallelACExecutor(**kwargs).execution_authority  # type: ignore[arg-type]
+
+    assert baseline.fingerprint != replaced.fingerprint
+    component = replaced.data["executor"]["components"]["leaf_dispatcher"]
+    assert component["mode"] == "static_type"
+    assert component["type"].endswith("._ReplacementLeafDispatcher")
+
+
+def test_live_session_signal_hub_makes_executor_authority_process_local(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    kwargs = {
+        "adapter": runtime,
+        "event_store": AsyncMock(),
+        "task_cwd": str(tmp_path),
+        "dispatch_rate_policy": ResolvedDispatchRatePolicy.resolve(
+            backend="test-runtime",
+            self_governs_rate_limit=False,
+            requests_per_minute=1,
+            tokens_per_minute=None,
+        ),
+    }
+
+    baseline = ParallelACExecutor(**kwargs).execution_authority  # type: ignore[arg-type]
+    with_hub = ParallelACExecutor(
+        **kwargs,
+        session_signal_hub=SessionSignalHub(),
+    ).execution_authority  # type: ignore[arg-type]
+
+    assert baseline.fingerprint != with_hub.fingerprint
+    assert with_hub.portable_across_processes is False
+    component = with_hub.data["executor"]["components"]["session_signal_hub"]
+    assert component["mode"] == "live_instance"
+    assert component["stability"] == "process_local"
+
+
+def test_noncanonical_dispatch_rate_policy_is_rejected(tmp_path) -> None:
+    class DormantRatePolicy(ResolvedDispatchRatePolicy):
+        def build_gate(self):  # type: ignore[no-untyped-def]
+            return ResolvedDispatchRatePolicy.resolve(
+                backend=self.backend,
+                self_governs_rate_limit=False,
+                requests_per_minute=None,
+                tokens_per_minute=None,
+            ).build_gate()
+
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    policy = DormantRatePolicy(
+        backend="test-runtime",
+        owner="ouroboros",
+        observed=True,
+        self_governs_rate_limit=False,
+        requests_per_minute=1,
+        tokens_per_minute=None,
+    )
+
+    with pytest.raises(ValueError, match="canonical policy type"):
+        ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type]
+            event_store=AsyncMock(),
+            task_cwd=str(tmp_path),
+            dispatch_rate_policy=policy,
+        )
 
 
 def test_delegated_skill_interceptor_configuration_changes_authority(tmp_path) -> None:

--- a/tests/unit/orchestrator/test_execution_authority.py
+++ b/tests/unit/orchestrator/test_execution_authority.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+from ouroboros.orchestrator.adapter import FULL_CAPABILITIES
+from ouroboros.orchestrator.execution_authority import ExecutionAuthorityContract
+from ouroboros.orchestrator.parallel_executor import ParallelACExecutor
+from ouroboros.orchestrator.profile_loader import ExecutionProfile, load_profile
+from ouroboros.orchestrator.verifier import VerifierVerdict
+
+
+class _Runtime:
+    capabilities = FULL_CAPABILITIES
+    runtime_backend = "test-runtime"
+    llm_backend = "test-llm"
+    permission_mode = "bypassPermissions"
+    working_directory: str | None = None
+    _model = None
+
+    def __init__(self, *, profile: str = "profile-a") -> None:
+        self.profile = profile
+
+    def execution_identity_contract(self) -> dict[str, object]:
+        return {
+            "profile": self.profile,
+            "effective_model_observed": True,
+        }
+
+
+class _Verifier:
+    def __init__(self, identity: str) -> None:
+        self.identity = identity
+
+    def verification_identity_contract(self) -> dict[str, object]:
+        return {"judge": self.identity}
+
+    def __call__(self, **_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+
+def _contract(
+    *,
+    runtime: _Runtime | None = None,
+    verifier: object | None = None,
+    workspace: str = "/tmp/workspace-a",
+    policy: dict[str, object] | None = None,
+) -> ExecutionAuthorityContract:
+    return ExecutionAuthorityContract.build(
+        adapter=runtime or _Runtime(),
+        verifier=verifier,  # type: ignore[arg-type]
+        workspace=workspace,
+        execution_policy=policy or {"retry_attempts": 2},
+    )
+
+
+def test_runtime_profile_drift_changes_authority() -> None:
+    assert (
+        _contract(runtime=_Runtime(profile="a")).fingerprint
+        != _contract(runtime=_Runtime(profile="b")).fingerprint
+    )
+
+
+def test_verifier_identity_drift_changes_authority() -> None:
+    first = _contract(verifier=_Verifier("judge-a"))
+    same = _contract(verifier=_Verifier("judge-a"))
+    changed = _contract(verifier=_Verifier("judge-b"))
+
+    assert first.fingerprint == same.fingerprint
+    assert first.fingerprint != changed.fingerprint
+    assert first.reusable_across_processes is True
+
+
+def test_undeclared_custom_verifier_is_process_local() -> None:
+    def verifier(**_: object) -> VerifierVerdict:
+        return VerifierVerdict(passed=True)
+
+    first = _contract(verifier=verifier)
+    second = _contract(verifier=verifier)
+
+    assert first.reusable_across_processes is False
+    assert first.fingerprint != second.fingerprint
+
+
+def test_workspace_and_policy_drift_change_authority() -> None:
+    baseline = _contract()
+    assert baseline.fingerprint != _contract(workspace="/tmp/workspace-b").fingerprint
+    assert baseline.fingerprint != _contract(policy={"retry_attempts": 3}).fingerprint
+
+
+def test_parallel_executor_exposes_one_authority_snapshot(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    executor = ParallelACExecutor(
+        adapter=runtime,  # type: ignore[arg-type]
+        event_store=AsyncMock(),
+        console=MagicMock(),
+        task_cwd=str(tmp_path),
+        execution_profile=load_profile("code"),
+        atomic_verifier=_Verifier("judge-a"),
+        ac_retry_attempts=2,
+    )
+
+    authority = executor.execution_authority
+    assert authority.fingerprint.startswith("sha256:")
+    assert authority.data["workspace"]["effective_cwd"] == str(tmp_path.resolve())
+    assert authority.data["runtime"]["execution_identity"]["identity"]["profile"] == "profile-a"
+    assert authority.data["execution_policy"]["ac_retry_attempts"] == 2
+
+
+def test_profile_policy_drift_changes_executor_authority(tmp_path) -> None:
+    runtime = _Runtime()
+    runtime.working_directory = str(tmp_path)
+    base_profile = load_profile("code")
+    changed_profile = base_profile.model_copy(update={"profile": "code-v2"})
+
+    def build(profile: ExecutionProfile) -> str:
+        return ParallelACExecutor(
+            adapter=runtime,  # type: ignore[arg-type]
+            event_store=AsyncMock(),
+            console=MagicMock(),
+            task_cwd=str(tmp_path),
+            execution_profile=profile,
+        ).execution_authority.fingerprint
+
+    assert build(base_profile) != build(changed_profile)

--- a/tests/unit/orchestrator/test_parallel_executor.py
+++ b/tests/unit/orchestrator/test_parallel_executor.py
@@ -1419,7 +1419,10 @@ def test_unprotected_tail_pipe_is_form_mismatch_not_command_proof() -> None:
 def test_atomic_verifier_classifies_masked_test_command_as_form_mismatch() -> None:
     """Masked test commands are contract mismatches, not fabricated work."""
     profile = load_profile("code").model_copy(
-        update={"evidence_schema": EvidenceSchema(required=("commands_run",))}
+        update={
+            "evidence_schema": EvidenceSchema(required=("commands_run",)),
+            "must_produce": ("commands_run",),
+        }
     )
     executor = ParallelACExecutor(
         adapter=MagicMock(working_directory="/workspace"),

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -2622,8 +2622,10 @@ class TestOrchestratorRunner:
         sample_seed: Seed,
     ) -> None:
         """Runner wiring should make profile-aware decomposition live in production."""
+        from ouroboros.orchestrator.backend_limits import resolve_backend_limits
         from ouroboros.orchestrator.mcp_tools import assemble_session_tool_catalog
 
+        mock_adapter.self_governs_rate_limit = False
         runner = OrchestratorRunner(
             mock_adapter,
             mock_event_store,
@@ -2672,6 +2674,10 @@ class TestOrchestratorRunner:
                 "ouroboros.orchestrator.parallel_executor.ParallelACExecutor",
                 _FakeParallelExecutor,
             ),
+            patch(
+                "ouroboros.orchestrator.runner.resolve_backend_limits",
+                wraps=resolve_backend_limits,
+            ) as resolve_limits,
         ):
             result = await runner._execute_parallel(
                 seed=sample_seed,
@@ -2693,6 +2699,10 @@ class TestOrchestratorRunner:
         resolved_routing = captured_init["resolved_routing_authority"]
         assert resolved_routing.data == runner._execution_contract["model_routing"]
         assert "workspace_authority_identity" in captured_init
+        dispatch_rate_policy = captured_init["dispatch_rate_policy"]
+        assert dispatch_rate_policy.backend == mock_adapter.runtime_backend
+        assert dispatch_rate_policy.self_governs_rate_limit is False
+        resolve_limits.assert_called_once_with(mock_adapter.runtime_backend)
 
     @pytest.mark.asyncio
     async def test_execute_parallel_passes_fat_harness_mode_to_executor(

--- a/tests/unit/orchestrator/test_runner.py
+++ b/tests/unit/orchestrator/test_runner.py
@@ -2690,6 +2690,9 @@ class TestOrchestratorRunner:
         assert profile.axis == "testable_unit"
         assert captured_init["fat_harness_mode"] is True
         assert captured_init["decomposition_mode"] == "preflight"
+        resolved_routing = captured_init["resolved_routing_authority"]
+        assert resolved_routing.data == runner._execution_contract["model_routing"]
+        assert "workspace_authority_identity" in captured_init
 
     @pytest.mark.asyncio
     async def test_execute_parallel_passes_fat_harness_mode_to_executor(


### PR DESCRIPTION
## Stack: AC Runtime Foundation (1/3)

> This is the only open implementation layer in the approval-gated stack.
>
> | Layer | Status | Scope |
> |---|---|---|
> | **1. Execution Authority SSOT** | **current — re-review requested at `67f4aef3`** | executor baseline: effect owner + runtime + verifier + workspace + execution policy |
> | 2. Attempt vs acceptance events | locked | opened only after this PR is approved |
> | 3. Capsule + fresh-session dispatch | locked | opened only after layer 2 is approved |

Refs #1681

## Summary

Introduce one provider-neutral executor-baseline authority contract for later routing, capsule, recovery, and verification layers.

This baseline does **not** authorize dispatch, checkpoint reuse, trust, or acceptance. Per-attempt inputs—AC semantics, prompt, tool envelope/catalog, checkpoint-selected runtime handle, and settled workspace generation—belong to the later attempt capsule.

## What the baseline binds

- the effect-owning workspace and optional immutable workspace generation;
- the concrete `ParallelACExecutor` class hierarchy and instance-level method overrides;
- runtime backend, LLM backend, normalized permission mode, constructor model, and backend-owned `execution_identity_contract()`;
- the concrete adapter instance, with runtime identity revalidated when the executor consumes the bound routing contract;
- runtime capabilities, executable/launcher realpath, stat generation, and content digest;
- the full runtime class hierarchy, executable class members, and source-module digests without a backend-specific hook allow-list;
- explicitly owned runtime composition, including versioned leader-driven transport policy, transport implementation, and transport executable bytes;
- watchdog/retry/process settings, inherited runtime-handle selectors, and skill-dispatch behavior;
- delegated `SkillInterceptor` implementation and configuration, including the effective skills directory;
- the exact custom verifier implementation, declared behavioral identity, and runtime-transcript verifier wrapper;
- an exact versioned execution-policy schema covering decomposition, concurrency, verification, retry, reasoning effort, model routing, alternate-harness, shadow replay, and dispatch-rate policy;
- the resolved delivery-rate owner, backend, RPM/TPM, gate state, timing constants, and token-estimator version used by the actual dispatch gate.

## Fail-closed behavior

- A runner-resolved routing identity cannot be injected as a raw mapping or reused with another adapter instance.
- Same-adapter model/profile/permission drift is rejected before baseline construction.
- Empty workspace generation is unobserved; malformed generation and incomplete/unknown execution-policy schemas are rejected.
- Unobserved workspace generation, runtime-owned rate policy, or required runtime/verifier/dispatcher identity prevents cross-process baseline portability.
- Instance-level executable overrides, including non-callable method shadows, are process-local.
- Missing, malformed, incomplete, or credential-bearing component identities are process-local and receive collision-resistant nonces.
- An unbound or unstable executor implementation is process-local and cannot claim baseline portability.
- Nested or cyclic callable override state is recorded through non-recursive leaf identity and remains process-local.
- Dispatch-rate backend and self-governance must agree with the active runtime.
- `portable_across_processes` means only that the baseline may be composed into a later capsule; it never means an attempt, result, checkpoint, trust verdict, or acceptance is reusable.

## Review-request fixes

- Resolve the workspace through the same effective-CWD fallback used by execution.
- Bind executable and launcher bytes, command/protocol implementation, watchdog, dispatcher, and runtime-handle selector identity.
- Preserve verification enablement and timeout on alternate-harness execution; keep its ordinary retry count explicitly at zero.
- Emit `execution.ac.alt_harness_redispatched` only after the alternate runtime and its authority baseline are ready.
- Bind the runner's persisted routing identity to the actual executor adapter instead of rebuilding an unrelated snapshot.
- Resolve backend delivery limits once in the runner, then use one immutable rate policy for worker planning, the executor gate, and authority identity.
- Bind delegated worker transports through an explicit provider-owned component boundary instead of inferring arbitrary object graphs.
- Bind bundled Claude/Codex transport configuration, implementation, executable generation, and child-environment policy while excluding Codex live pool state.
- Bind the concrete executor implementation, delegated skill-interceptor configuration, and the complete callable verifier hierarchy instead of hashing only `__call__`.

## Non-goals

- No checkpoint schema changes.
- No per-attempt capsule or fresh-session dispatch.
- No new automatic route-selection decision.
- No reusable decomposition trust.
- No terminal-event or final-acceptance changes.

Those changes remain approval-gated in #1681.

## Review guide

1. Review `execution_authority.py` as an identity-only executor baseline, not a complete attempt authority.
2. Confirm `ResolvedRuntimeAuthority` is adapter-bound and revalidated at consumption.
3. Confirm runtime implementation and explicit component identity remain provider-neutral and fail closed rather than becoming a backend-name allow-list.
4. Confirm alternate-harness policy and event ordering preserve the parent contract.
5. Review the drift/collision tests as the acceptance contract for this layer.

## Validation

- `uv run ruff check` on all changed files
- `uv run mypy` on all source files
- `58 passed` in the focused execution-authority suite
- `3073 passed, 2 skipped` across `tests/unit/orchestrator` with an isolated writable test home
- `git diff --check`
- R3 five-lens cross-engine review: clean, with no reproducible finding
