### PR TITLE
feat: add minimum-privilege InfraNodus advisory gateway example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.gateway-state/
+.DS_Store
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# Ouroboros × InfraNodus Gateway
+
+A standalone, minimum-privilege MCP adapter that gives an Ouroboros operator three bounded InfraNodus graph-analysis gates without registering the upstream InfraNodus tool catalog or modifying either project.
+
+## v1 contract
+
+The server exposes exactly:
+
+- `graph_review_seed`: compare requirements with a proposed seed before `ooo run`.
+- `graph_diagnose_stagnation`: request a lateral graph perspective when a run is repeating one assumption.
+- `graph_compare_delivery`: compare acceptance criteria with delivery evidence before accepting `ooo qa` results.
+
+Every operation is read-only, non-destructive, idempotent, and closed-world. The adapter calls only `/graphsAndStatements` or `/graphAndStatements`, always with `doNotSave=true`. It has no InfraNodus write operation, GraphRAG path, URL ingestion, saved-graph lookup, HTTP/SSE listener, Ouroboros database access, or dynamic tool discovery.
+
+## Architecture
+
+```text
+Ouroboros operator / MCP host
+             |
+             | stdio; exactly 3 private tools
+             v
+ input policy -> Gateway -> allowlisted Infra client -> InfraNodus hosted API
+      |            |
+      | reject     +-> memory-only idempotency cache
+      |                metadata-only 0600 ledger
+      v
+ fail closed     bounded GraphAdvice / DEGRADED_NO_GRAPH
+```
+
+Raw inputs are normalized in memory and rejected if they contain secret-like values, email addresses, URLs, raw-code indicators, more than 20,000 characters, or more than 64 KiB. Neither raw input nor graph advice is persisted. The optional ledger stores only a timestamp, operation name, SHA-256 request key, status, and cache disposition.
+
+## Install and run
+
+Requirements: Node.js 22 and an `INFRANODUS_API_KEY` supplied through the parent process environment.
+
+```bash
+npm install
+npm run build
+INFRANODUS_API_KEY="..." GATEWAY_STATE_DIR="$PWD/.gateway-state" node dist/stdio.js
+```
+
+Do not put the API key in repository files or command arguments. Configure the MCP host to inherit `INFRANODUS_API_KEY`, run `node`, and pass the absolute `dist/stdio.js` path as its sole argument. Stdout is reserved for MCP protocol traffic; operational failures are returned as bounded tool results or written to stderr.
+
+## Verification
+
+```bash
+npm run typecheck
+npm test
+npm run test:stdio
+npm audit --omit=dev
+INFRANODUS_API_KEY="..." npm run verify:live
+```
+
+`verify:live` snapshots the private graph inventory before and after three sanitized real API calls. It prints only inventory counts/digests and bounded result metadata. It fails if any operation degrades, a response violates `GraphAdvice`, or the inventory changes.
+
+Start with the [Korean integration manual](docs/INTEGRATION_MANUAL_KO.md) for installation, Codex MCP registration, operations, troubleshooting, updates, and rollback. See [docs/OUROBOROS_RUNBOOK.md](docs/OUROBOROS_RUNBOOK.md) for the concise phase gates and [SECURITY.md](SECURITY.md) for the trust boundary.
+
+## Explicit non-goals
+
+- Automatic interception of Ouroboros lifecycle events.
+- Registration inside the Ouroboros agent tool catalog.
+- InfraNodus graph creation, updates, deletion, retrieval, GraphRAG, or full MCP proxying.
+- Numeric confidence claims or autonomous go/no-go decisions.
+
+Ouroboros 0.50.5 does not expose top-level `evaluate` or `unstuck` CLI commands. Its lateral/evaluation handlers are MCP-internal, so v1 intentionally uses operator-invoked advisory gates rather than claiming lifecycle hooks that do not exist.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security policy and trust boundary
+
+## Protected assets
+
+- `INFRANODUS_API_KEY` and its bearer header.
+- Ouroboros requirements, seeds, traces, delivery evidence, and local state.
+- InfraNodus saved graph inventory and account metadata.
+- MCP protocol integrity on stdout.
+
+## Enforced controls
+
+- The API key is accepted only from the environment and is never logged, persisted, or returned.
+- Input is normalized and screened before the upstream client is invoked.
+- The upstream endpoint and query set are constructed internally; callers cannot provide an endpoint or persistence flag.
+- `doNotSave=true` is present on every graph-analysis request.
+- Response projection reads only selected extended-summary fields, returns at most eight observations/five actions, and excludes raw graph, statements, request content, and numeric confidence.
+- Upstream error bodies are discarded. Failures become `DEGRADED_NO_GRAPH` at the gateway boundary.
+- The cache is process memory only. The optional state directory is 0700 and `ledger.jsonl` is 0600 with hashed metadata only.
+- The server is stdio-only and registers exactly three closed-world tools.
+
+## Reporting
+
+Do not paste credentials, raw sensitive inputs, saved graph names, or upstream error bodies into an issue. Report the operation name, gateway version, bounded status, and a redacted reproduction.

--- a/docs/INTEGRATION_MANUAL_KO.md
+++ b/docs/INTEGRATION_MANUAL_KO.md
@@ -1,0 +1,423 @@
+# Ouroboros × InfraNodus Gateway 통합 매뉴얼
+
+이 문서는 `ouroboros-infranodus-gateway`를 설치하고 MCP 호스트에 연결한 뒤, Ouroboros의 seed·정체·delivery 단계에서 안전하게 사용하는 전체 운영 절차입니다.
+
+## 1. 통합 원칙
+
+이 Gateway는 Ouroboros를 대체하거나 자동 제어하지 않습니다. InfraNodus가 제공하는 그래프 분석은 사람에게 참고 신호를 주는 advisory 계층이며, 실행·승인·QA의 최종 권한은 계속 Ouroboros와 운영자에게 있습니다.
+
+```text
+Ouroboros 작업 흐름
+       |
+       | 운영자가 안전한 요약문만 전달
+       v
+Codex 또는 MCP 호스트
+       |
+       | stdio / 정확히 3개 도구
+       v
+Ouroboros × InfraNodus Gateway
+       |
+       | 고정 API 주소 + doNotSave=true
+       v
+InfraNodus 분석 API
+```
+
+v1에서 제공하는 도구는 다음 세 개뿐입니다.
+
+| 도구 | 호출 시점 | 역할 | 최종 결정권 |
+|---|---|---|---|
+| `graph_review_seed` | seed 생성 후, `ooo run` 전 | 요구사항과 seed의 개념적 누락 비교 | 운영자 |
+| `graph_diagnose_stagnation` | 동일 가정이 반복될 때 | 새로운 관점 후보 탐색 | Ouroboros 실행 흐름과 운영자 |
+| `graph_compare_delivery` | 산출물 완성 후, 최종 수락 전 | 수락 기준과 검증 증거의 누락 비교 | `ooo qa`와 운영자 |
+
+## 2. 사전 조건
+
+- macOS 또는 Node.js를 실행할 수 있는 POSIX 환경
+- Node.js 22.x
+- npm
+- Ouroboros CLI 0.50.5 이상
+- 유효한 `INFRANODUS_API_KEY`
+- stdio MCP를 지원하는 호스트. 이 매뉴얼에서는 Codex CLI/App을 기준으로 설명합니다.
+
+현재 환경을 확인합니다.
+
+```bash
+node --version
+npm --version
+ooo --version
+codex --version
+```
+
+Node.js는 `v22.x`여야 합니다. 이 저장소의 `package.json`은 Node 22만 허용합니다.
+
+## 3. 설치와 빌드
+
+```bash
+cd /Users/heomin/Projects/ouroboros-infranodus-gateway
+npm install
+npm run typecheck
+npm test
+npm run build
+```
+
+정상 기준:
+
+- `typecheck` 종료 코드 0
+- 전체 테스트 PASS
+- `dist/stdio.js` 생성
+- API 키가 저장소 파일이나 로그에 출력되지 않음
+
+프로덕션 의존성도 확인합니다.
+
+```bash
+npm audit --omit=dev
+```
+
+High 또는 Critical 취약점이 있으면 MCP 등록 전에 중단합니다.
+
+## 4. API 키 준비
+
+API 키는 저장소, `config.toml`, 명령 인자, 문서에 직접 기록하지 않습니다. MCP 호스트를 실행한 부모 환경에만 제공합니다.
+
+현재 셸에서 키의 존재 여부만 확인합니다. 값은 출력하지 않습니다.
+
+```bash
+test -n "$INFRANODUS_API_KEY" && echo "INFRANODUS_API_KEY is set" || echo "INFRANODUS_API_KEY is missing"
+```
+
+키를 새로 설정해야 한다면 사용하는 비밀관리 도구나 셸의 비공개 세션에서 `INFRANODUS_API_KEY` 환경변수로 주입합니다. 셸 히스토리에 실제 값을 남기지 마십시오.
+
+## 5. Codex MCP 등록
+
+먼저 API 키를 macOS Keychain의 `ouroboros-infranodus-gateway` 서비스 항목에 저장합니다. Gateway의 [Keychain launcher](../scripts/start-codex-mcp.zsh)가 키를 읽어 자식 MCP 프로세스에만 주입합니다. 키 값은 TOML·저장소·셸 히스토리에 기록하지 않습니다.
+
+Codex 설정 파일 `~/.codex/config.toml`에는 다음 항목을 추가합니다.
+
+```toml
+[mcp_servers.ouroboros_infranodus]
+command = "/Users/heomin/Projects/ouroboros-infranodus-gateway/scripts/start-codex-mcp.zsh"
+args = []
+cwd = "/Users/heomin/Projects/ouroboros-infranodus-gateway"
+startup_timeout_sec = 10
+tool_timeout_sec = 35
+```
+
+이 설정은 현재 Codex의 실제 stdio MCP 형식인 `command`, `args`, `cwd`를 사용합니다. `env_vars`는 이 환경의 `mcp_servers` 설정 필드가 아니므로 사용하지 않습니다.
+
+Keychain launcher가 올바른 Node 22 runtime을 사용하도록 다음을 확인합니다.
+
+```bash
+/Users/heomin/.hermes/node/bin/node --version
+```
+
+`codex mcp add --env INFRANODUS_API_KEY=...`, `[mcp_servers.ouroboros_infranodus.env]`, `.zshrc`에 실제 키를 쓰는 방식은 설정 파일·셸 히스토리에 값이 남을 수 있으므로 사용하지 않습니다.
+
+설정 후 Codex를 다시 시작하거나 새 세션을 열고 등록 상태를 확인합니다.
+
+```bash
+codex mcp get ouroboros_infranodus
+```
+
+정상 상태:
+
+- `enabled: true`
+- `transport: stdio`
+- command가 Node 실행 파일
+- args가 이 저장소의 `dist/stdio.js`
+- API 키 값 자체는 출력되지 않음
+
+## 6. MCP 프로토콜 사전 검증
+
+실제 InfraNodus를 호출하기 전에 로컬 가짜 upstream을 사용하는 stdio 종단간 검증을 실행합니다.
+
+```bash
+cd /Users/heomin/Projects/ouroboros-infranodus-gateway
+npm run test:stdio
+```
+
+이 검증은 실제 자식 stdio MCP 프로세스를 시작하고 다음을 확인합니다.
+
+- 도구가 정확히 세 개만 노출됨
+- 모든 도구가 `readOnlyHint=true`, `destructiveHint=false`, `idempotentHint=true`, `openWorldHint=false`
+- 세 도구 모두 MCP 호출에 응답함
+- 테스트용 URL 재작성은 `tests/rewrite-fetch.mjs` preload 내부에만 존재함
+- 프로덕션 진입점은 InfraNodus의 고정 HTTPS API 주소만 사용함
+
+## 7. 안전한 입력 작성법
+
+모든 도구는 동일한 입력 필드를 받습니다.
+
+```json
+{
+  "objective": "달성해야 할 목표나 수락 기준을 안전한 산문으로 요약",
+  "candidate": "검토할 seed, 현재 접근법 또는 delivery 증거를 안전한 산문으로 요약"
+}
+```
+
+좋은 입력 예시:
+
+```json
+{
+  "objective": "로그인 실패 시 사용자가 복구 경로를 확인할 수 있어야 한다.",
+  "candidate": "현재 산출물은 로그인 성공 흐름과 오류 메시지를 검증했지만 복구 흐름 증거는 포함하지 않는다."
+}
+```
+
+보내면 안 되는 내용:
+
+- API 키, Bearer/JWT, GitHub·OpenAI·AWS 형태 토큰
+- PEM private key
+- 이메일, 전화번호, 주민번호형 식별자, 카드번호
+- `https://...` 또는 `www...` URL
+- 소스코드, 코드 블록, raw stack trace
+- 원본 인터뷰 전문, 사용자 개인정보, 저장된 그래프 이름
+- 20,000자를 넘는 분석문 또는 64 KiB를 넘는 요청
+
+정책에 거부되면 원문을 억지로 분할하거나 필터를 우회하지 말고, 민감정보를 제거한 짧은 산문 요약으로 다시 작성합니다.
+
+## 8. Gate 1: seed 검토
+
+### 8.1 Ouroboros seed 생성
+
+```bash
+ooo interview start
+ooo interview list
+ooo seed SESSION_ID
+```
+
+인터뷰가 완료된 후 생성된 seed를 그대로 보내지 말고 목표·범위·검증 기준만 요약합니다.
+
+### 8.2 `graph_review_seed` 호출
+
+- `objective`: 인터뷰에서 확정한 요구사항과 성공 조건 요약
+- `candidate`: 생성된 seed의 목표·범위·검증 절차 요약
+
+판단 규칙:
+
+1. `status=OK`이면 `observations`를 검토합니다.
+2. 실제 누락으로 판단되는 항목만 seed에 반영합니다.
+3. 관련 없거나 중복인 신호는 이유를 남기고 기각합니다.
+4. 사람이 seed를 승인한 후에만 `ooo run`을 시작합니다.
+
+InfraNodus 응답은 seed를 자동 수정하거나 실행을 시작하지 않습니다.
+
+## 9. Gate 2: 정체 진단
+
+먼저 Ouroboros의 읽기 전용 trace surface로 정체가 실제인지 확인합니다.
+
+```bash
+ooo harness list
+ooo harness show RUN_ID
+ooo harness frontier --metric METRIC
+```
+
+`frontier`는 특정 run ID를 받지 않고, 이미 export된 run들을 `outcome.json`의 지정 metric으로 순위화합니다. 단일 run을 확인할 때는 `show RUN_ID`를 사용합니다.
+
+그다음 `graph_diagnose_stagnation`에 전달합니다.
+
+- `objective`: 원래 달성하려던 결과
+- `candidate`: 반복 중인 가정, 시도한 접근, 관찰된 실패를 코드 없이 요약
+
+`observations` 중 한 항목을 새로운 가설로 선택해 Ouroboros 흐름에서 검증합니다. 응답을 자동 명령, 자동 lateral event 또는 성공 판정으로 취급하지 않습니다.
+
+Ouroboros 0.50.5에는 top-level `unstuck` 명령이 없습니다. 따라서 이 단계는 운영자가 명시적으로 호출해야 합니다.
+
+## 10. Gate 3: delivery 비교
+
+산출물 검증 후 `graph_compare_delivery`를 호출합니다.
+
+- `objective`: 수락 기준과 보안·동작·관찰 가능성 요구사항
+- `candidate`: 실제 실행한 테스트, runtime 관찰, 증거 파일을 산문으로 요약
+
+그래프 신호를 검토한 다음 Ouroboros의 권위 있는 QA를 실행합니다.
+
+```bash
+ooo qa ARTIFACT
+```
+
+`graph_compare_delivery`가 `OK`여도 `ooo qa`를 생략할 수 없습니다. InfraNodus는 보조 검토자이며 최종 품질 게이트가 아닙니다.
+
+## 11. 응답 해석
+
+정상 응답은 다음 경계를 가집니다.
+
+```json
+{
+  "status": "OK",
+  "operation": "graph_review_seed",
+  "summary": "...",
+  "observations": ["..."],
+  "nextActions": ["..."],
+  "provenance": {
+    "provider": "infranodus",
+    "mode": "no-save",
+    "endpoint": "/graphsAndStatements",
+    "cache": "miss"
+  }
+}
+```
+
+출력 제한:
+
+- observation 최대 8개
+- next action 최대 5개
+- 각 항목 최대 280자
+- raw graph, statement, 요청 원문, upstream 오류 본문, 숫자형 confidence 없음
+
+`status=DEGRADED_NO_GRAPH`이면 InfraNodus 장애나 timeout입니다. 실패를 승인으로 해석하지 말고, 로컬 Ouroboros gate를 계속 진행하면서 그래프 조언을 사용할 수 없었다고 기록합니다.
+
+## 12. 실 API 무저장 검증
+
+배포 전이나 Gateway 업데이트 후 다음 검증을 실행합니다.
+
+```bash
+cd /Users/heomin/Projects/ouroboros-infranodus-gateway
+GATEWAY_STATE_DIR="$PWD/.gateway-state" \
+LIVE_EVIDENCE_PATH="$PWD/evidence/live-verification.json" \
+npm run verify:live
+```
+
+검증기는 다음 순서로 동작합니다.
+
+1. `/listGraphs`로 호출 전 inventory count와 semantic digest를 계산합니다.
+2. 개인정보가 없는 고정 fixture로 세 작업을 각각 한 번 호출합니다.
+3. 모든 응답을 `GraphAdvice` schema로 검증합니다.
+4. 호출 후 inventory를 다시 계산합니다.
+5. count 또는 digest가 달라지면 실패합니다.
+
+성공 증거에는 그래프 이름, API 키, 입력 원문, observation 내용이 포함되지 않습니다.
+
+## 13. 로컬 상태와 권한
+
+`GATEWAY_STATE_DIR`을 설정하면 Gateway가 metadata ledger를 생성합니다.
+
+```text
+.gateway-state/             mode 0700
+└── ledger.jsonl            mode 0600
+```
+
+ledger에 저장되는 값:
+
+- timestamp
+- operation
+- 정규화된 요청의 SHA-256 hash
+- `OK` 또는 `DEGRADED_NO_GRAPH`
+- `hit`, `miss`, `bypass`
+
+요청 원문, API 키, observation, 그래프 이름은 저장하지 않습니다. 분석 결과 cache는 프로세스 메모리에만 존재하며 재시작하면 사라집니다.
+
+권한을 확인합니다.
+
+```bash
+stat -f '%N mode=%Lp' .gateway-state .gateway-state/ledger.jsonl
+```
+
+## 14. 장애 대응
+
+### MCP 서버가 시작되지 않음
+
+```bash
+codex mcp get ouroboros_infranodus
+command -v node
+test -f /Users/heomin/Projects/ouroboros-infranodus-gateway/dist/stdio.js
+test -n "$INFRANODUS_API_KEY"
+```
+
+빌드 파일이 없으면 `npm run build`를 실행합니다. API 키 값은 진단 출력에 넣지 않습니다.
+
+### `INPUT_REJECTED`
+
+민감정보, URL, 코드, 크기 제한을 확인하고 안전한 산문 요약으로 다시 작성합니다. 정책 정규식을 임시로 약화하지 않습니다.
+
+### `DEGRADED_NO_GRAPH`
+
+- Ouroboros 로컬 작업은 계속할 수 있습니다.
+- 그래프 분석을 성공으로 간주하지 않습니다.
+- 키 존재 여부와 InfraNodus 가용성을 확인합니다.
+- 같은 요청을 무한 재시도하지 않습니다.
+
+### inventory가 변경됨
+
+1. Gateway 사용을 즉시 중단합니다.
+2. MCP 등록을 비활성화합니다.
+3. `evidence/live-verification.json`을 보존합니다.
+4. InfraNodus 계정의 실제 graph inventory를 사람이 검토합니다.
+5. 원인이 규명되기 전에는 재활성화하지 않습니다.
+
+### stdout 프로토콜 오류
+
+stdio 서버 stdout은 JSON-RPC 전용입니다. `console.log`나 일반 로그를 추가하지 마십시오. 운영 메시지는 stderr 또는 bounded MCP result로만 처리합니다.
+
+## 15. 업데이트 절차
+
+Gateway, Node, MCP SDK 또는 InfraNodus 계약을 업데이트할 때:
+
+```bash
+git status --short
+npm install
+npm run typecheck
+npm test
+npm run test:stdio
+npm run build
+npm audit
+```
+
+그다음 실 API 무저장 검증을 다시 실행합니다. 다음 변경은 단순 업데이트가 아니라 별도 보안 단계로 취급합니다.
+
+- 저장된 graph 읽기
+- GraphRAG
+- URL ingestion
+- HTTP/SSE transport
+- persistent advice cache
+- Ouroboros 자동 lifecycle hook
+- InfraNodus write operation
+- 프로덕션 API base override
+
+이 항목에는 새 threat model, 사용자 승인, before/after inventory 증거, 롤백 검증이 필요합니다.
+
+## 16. 롤백과 제거
+
+Codex에서 MCP 등록을 제거합니다.
+
+```bash
+codex mcp remove ouroboros_infranodus
+```
+
+실행 중인 stdio 프로세스가 있다면 종료합니다. Gateway는 Ouroboros DB나 InfraNodus graph를 migration하지 않으므로 별도 데이터 롤백은 없습니다.
+
+`.gateway-state`는 hash metadata만 포함하지만 삭제가 필요하면 먼저 증거 보존 정책을 확인하고 명시적으로 승인받습니다. 자동 삭제하지 않습니다.
+
+## 17. 운영 체크리스트
+
+### 최초 설치
+
+- [ ] Node.js 22 확인
+- [ ] `npm install`, typecheck, test, build PASS
+- [ ] `npm audit --omit=dev`에서 High/Critical 없음
+- [ ] API 키가 환경변수로만 전달됨
+- [ ] Codex MCP 등록에서 정확한 Node·dist 경로 확인
+- [ ] `npm run test:stdio` PASS
+- [ ] `npm run verify:live`에서 inventory 불변 확인
+
+### 매 호출
+
+- [ ] 원문이 아니라 안전한 산문 요약만 사용
+- [ ] 비밀정보·PII·URL·코드 제거
+- [ ] GraphAdvice를 advisory로만 사용
+- [ ] `DEGRADED_NO_GRAPH`를 성공으로 해석하지 않음
+- [ ] 최종 결정은 Ouroboros gate와 사람이 수행
+
+### 업데이트 후
+
+- [ ] 전체 테스트와 stdio E2E 재실행
+- [ ] dependency audit 재실행
+- [ ] 실 API inventory 전후 digest 확인
+- [ ] 도구 목록이 정확히 세 개인지 확인
+- [ ] 새로운 write·GraphRAG·자동 hook이 추가되지 않았는지 확인
+
+## 관련 문서
+
+- [프로젝트 개요](../README.md)
+- [Ouroboros 단계별 런북](OUROBOROS_RUNBOOK.md)
+- [보안 경계](../SECURITY.md)
+- [최근 실 API 검증 증거](../evidence/live-verification.json)

--- a/docs/OUROBOROS_RUNBOOK.md
+++ b/docs/OUROBOROS_RUNBOOK.md
@@ -1,0 +1,39 @@
+# Ouroboros manual graph gates
+
+This runbook keeps Ouroboros authoritative. InfraNodus advice is advisory and never advances, rewrites, or terminates a run.
+
+## Gate 1: seed review
+
+1. Run the normal interview and seed flow: `ooo interview start`, complete the session, then `ooo seed SESSION_ID`.
+2. Pass sanitized requirements prose as `objective` and a sanitized seed summary as `candidate` to `graph_review_seed`.
+3. Review the bounded observations. Update the seed through the normal Ouroboros workflow if a material gap is real.
+4. Start `ooo run` only after the human accepts or explicitly dismisses the advisory result.
+
+Do not send source code, URLs, credentials, personal data, or raw interview transcripts.
+
+## Gate 2: stagnation diagnosis
+
+1. Use the normal Ouroboros trace/harness surfaces to determine that the run is repeating an assumption: `ooo harness list`, `ooo harness show RUN_ID`, or `ooo harness frontier --metric METRIC`.
+2. Summarize the intended outcome as `objective` and the current failed approach as `candidate`.
+3. Call `graph_diagnose_stagnation` manually.
+4. Treat one observation as a hypothesis to test through Ouroboros. Do not treat it as an automatic lateral event.
+
+If the result is `DEGRADED_NO_GRAPH`, continue locally and record that graph advice was unavailable.
+
+## Gate 3: delivery comparison
+
+1. Summarize acceptance criteria as `objective` and verified delivery evidence as `candidate`.
+2. Call `graph_compare_delivery`.
+3. Resolve or explicitly dismiss material observations.
+4. Run the authoritative local check, `ooo qa ARTIFACT`. Its exit code remains the delivery decision.
+
+## Failure and rollback
+
+- InfraNodus timeout or error: the adapter returns `DEGRADED_NO_GRAPH`; Ouroboros continues without graph advice.
+- Policy rejection: remove sensitive/raw content and replace it with safe prose. Never weaken the policy for one call.
+- Suspected persistence: stop using the adapter, run the live inventory verifier, and compare its count and digest evidence.
+- Rollback: remove the MCP host entry and stop the stdio process. No Ouroboros or InfraNodus repository/database migration is required.
+
+## Promotion gates beyond v1
+
+Saved-graph reads, GraphRAG, automatic lifecycle hooks, and any write capability are separate security phases. Each requires a new threat model, explicit user approval, a narrower tool contract, immutable before/after inventory evidence, and its own rollback proof.

--- a/docs/README.md
+++ b/docs/README.md
@@ -47,6 +47,7 @@ replayable execution contract on your choice of runtime backend.
 - [Execution vs. Evaluation Contract](./guides/execution-vs-evaluation.md) - Task completion, AC verdict, and drift terminology boundaries
 - [Shared `ooo` Skill Dispatch Router](./guides/ooo-skill-dispatch-router.md) - Runtime setup boundary for Codex CLI, Hermes, and OpenCode skill dispatch
 - [MCP Best Practices](./guides/mcp-best-practices.md) - Upstream MCP server configuration, security, and workflow mapping
+- [InfraNodus Advisory Gateway Example](../examples/infranodus-gateway/README.md) - A minimum-privilege MCP adapter that keeps graph analysis advisory and Ouroboros authoritative
 - [QA Backends](./guides/qa-backends.md) - External QA backend patterns, including OpenCron-style synthetic checks
 - [TUI Usage Guide](./guides/tui-usage.md) - Dashboard, screens, keyboard shortcuts
 

--- a/evidence/live-verification.json
+++ b/evidence/live-verification.json
@@ -1,0 +1,33 @@
+{
+  "status": "PASS",
+  "inventory": {
+    "beforeCount": 112,
+    "afterCount": 112,
+    "beforeDigest": "1c088d6cd097dec9f36159367b28f105ea88c35a27254de9093454b22379deb0",
+    "afterDigest": "1c088d6cd097dec9f36159367b28f105ea88c35a27254de9093454b22379deb0",
+    "unchanged": true
+  },
+  "operations": [
+    {
+      "operation": "graph_review_seed",
+      "status": "OK",
+      "observationCount": 8,
+      "endpoint": "/graphsAndStatements",
+      "mode": "no-save"
+    },
+    {
+      "operation": "graph_diagnose_stagnation",
+      "status": "OK",
+      "observationCount": 8,
+      "endpoint": "/graphAndStatements",
+      "mode": "no-save"
+    },
+    {
+      "operation": "graph_compare_delivery",
+      "status": "OK",
+      "observationCount": 8,
+      "endpoint": "/graphsAndStatements",
+      "mode": "no-save"
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2463 @@
+{
+  "name": "ouroboros-infranodus-gateway",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ouroboros-infranodus-gateway",
+      "version": "0.1.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "1.29.0",
+        "zod": "4.4.3"
+      },
+      "devDependencies": {
+        "@types/node": "22.20.1",
+        "typescript": "5.9.3",
+        "vitest": "4.1.10"
+      },
+      "engines": {
+        "node": ">=22 <23"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.139.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.139.0.tgz",
+      "integrity": "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
+      "integrity": "sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.1.5.tgz",
+      "integrity": "sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.1.5.tgz",
+      "integrity": "sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.1.5.tgz",
+      "integrity": "sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.1.5.tgz",
+      "integrity": "sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.1.5.tgz",
+      "integrity": "sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.1.5.tgz",
+      "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.1.5.tgz",
+      "integrity": "sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.1.5.tgz",
+      "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.1.5.tgz",
+      "integrity": "sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.1.5.tgz",
+      "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.1.5.tgz",
+      "integrity": "sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.1.5.tgz",
+      "integrity": "sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.11.1",
+        "@emnapi/runtime": "1.11.1",
+        "@napi-rs/wasm-runtime": "^1.1.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.1.5.tgz",
+      "integrity": "sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.1.5.tgz",
+      "integrity": "sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
+      "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.139.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.1.5",
+        "@rolldown/binding-darwin-arm64": "1.1.5",
+        "@rolldown/binding-darwin-x64": "1.1.5",
+        "@rolldown/binding-freebsd-x64": "1.1.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.1.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.1.5",
+        "@rolldown/binding-linux-arm64-musl": "1.1.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.1.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-gnu": "1.1.5",
+        "@rolldown/binding-linux-x64-musl": "1.1.5",
+        "@rolldown/binding-openharmony-arm64": "1.1.5",
+        "@rolldown/binding-wasm32-wasi": "1.1.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.1.5",
+        "@rolldown/binding-win32-x64-msvc": "1.1.5"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.3.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ouroboros-infranodus-gateway",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "engines": {
+    "node": ">=22 <23"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:stdio": "npm run build && vitest run tests/stdio.test.ts",
+    "verify:live": "npm run build && node dist/live-verify.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "1.29.0",
+    "zod": "4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "22.20.1",
+    "typescript": "5.9.3",
+    "vitest": "4.1.10"
+  }
+}

--- a/scripts/start-codex-mcp.zsh
+++ b/scripts/start-codex-mcp.zsh
@@ -1,0 +1,15 @@
+#!/bin/zsh
+set -euo pipefail
+
+readonly SERVICE_NAME="ouroboros-infranodus-gateway"
+readonly NODE_BIN="/Users/heomin/.hermes/node/bin/node"
+readonly SERVER_BIN="/Users/heomin/Projects/ouroboros-infranodus-gateway/dist/stdio.js"
+
+api_key="$(/usr/bin/security find-generic-password -a "$USER" -s "$SERVICE_NAME" -w)"
+if [[ -z "$api_key" ]]; then
+  print -u2 "Missing Keychain item: $SERVICE_NAME"
+  exit 78
+fi
+
+export INFRANODUS_API_KEY="$api_key"
+exec "$NODE_BIN" "$SERVER_BIN"

--- a/src/contracts.ts
+++ b/src/contracts.ts
@@ -1,0 +1,25 @@
+import { z } from "zod";
+
+export const OperationSchema = z.enum([
+  "graph_review_seed",
+  "graph_diagnose_stagnation",
+  "graph_compare_delivery",
+]);
+
+export type Operation = z.infer<typeof OperationSchema>;
+
+export const GraphAdviceSchema = z.object({
+  status: z.enum(["OK", "DEGRADED_NO_GRAPH"]),
+  operation: OperationSchema,
+  summary: z.string().max(280),
+  observations: z.array(z.string().max(280)).max(8),
+  nextActions: z.array(z.string().max(280)).max(5),
+  provenance: z.object({
+    provider: z.literal("infranodus"),
+    mode: z.literal("no-save"),
+    endpoint: z.enum(["/graphsAndStatements", "/graphAndStatements"]),
+    cache: z.enum(["hit", "miss", "bypass"]),
+  }),
+});
+
+export type GraphAdvice = z.infer<typeof GraphAdviceSchema>;

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1,0 +1,122 @@
+import { createHash } from "node:crypto";
+import { appendFile, chmod, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import type { GraphAdvice, Operation } from "./contracts.js";
+import type { InfraAnalysis } from "./infra-client.js";
+import { normalizeInput, type GatewayInput } from "./policy.js";
+
+export interface AnalysisClient {
+  analyze(operation: Operation, input: GatewayInput): Promise<InfraAnalysis>;
+}
+
+export interface GatewayOptions {
+  client: AnalysisClient;
+  stateDir?: string;
+}
+
+export class Gateway {
+  readonly #client: AnalysisClient;
+  readonly #stateDir: string | undefined;
+  readonly #cache = new Map<string, GraphAdvice>();
+
+  constructor(options: GatewayOptions) {
+    this.#client = options.client;
+    this.#stateDir = options.stateDir;
+  }
+
+  async execute(
+    operation: Operation,
+    input: GatewayInput,
+  ): Promise<GraphAdvice> {
+    const normalized = normalizeInput(input);
+    const keyHash = createHash("sha256")
+      .update(JSON.stringify({ operation, ...normalized }))
+      .digest("hex");
+    const cached = this.#cache.get(keyHash);
+    if (cached) {
+      const result: GraphAdvice = {
+        ...cached,
+        provenance: { ...cached.provenance, cache: "hit" },
+      };
+      await this.#record(operation, keyHash, result.status, "hit");
+      return result;
+    }
+
+    try {
+      const analysis = await this.#client.analyze(operation, normalized);
+      const advice: GraphAdvice = {
+        status: "OK",
+        operation,
+        summary: analysis.signals.length > 0
+          ? `InfraNodus returned ${analysis.signals.length} bounded graph signal${analysis.signals.length === 1 ? "" : "s"}.`
+          : "InfraNodus returned no bounded graph signals for this input.",
+        observations: analysis.signals.slice(0, 8).map((signal) => signal.slice(0, 280)),
+        nextActions: actionsFor(operation),
+        provenance: {
+          provider: "infranodus",
+          mode: "no-save",
+          endpoint: analysis.endpoint,
+          cache: "miss",
+        },
+      };
+      this.#cache.set(keyHash, advice);
+      await this.#record(operation, keyHash, "OK", "miss");
+      return advice;
+    } catch {
+      const endpoint = operation === "graph_diagnose_stagnation"
+        ? "/graphAndStatements"
+        : "/graphsAndStatements";
+      const advice: GraphAdvice = {
+        status: "DEGRADED_NO_GRAPH",
+        operation,
+        summary: "Graph analysis is unavailable; continue with the local Ouroboros gate.",
+        observations: [],
+        nextActions: ["Continue the local gate and record that graph advice was unavailable."],
+        provenance: {
+          provider: "infranodus",
+          mode: "no-save",
+          endpoint,
+          cache: "bypass",
+        },
+      };
+      await this.#record(operation, keyHash, "DEGRADED_NO_GRAPH", "bypass");
+      return advice;
+    }
+  }
+
+  async #record(
+    operation: Operation,
+    keyHash: string,
+    status: GraphAdvice["status"],
+    cache: GraphAdvice["provenance"]["cache"],
+  ): Promise<void> {
+    if (!this.#stateDir) return;
+    await mkdir(this.#stateDir, { recursive: true, mode: 0o700 });
+    await chmod(this.#stateDir, 0o700);
+    const ledgerPath = join(this.#stateDir, "ledger.jsonl");
+    await appendFile(
+      ledgerPath,
+      `${JSON.stringify({
+        timestamp: new Date().toISOString(),
+        operation,
+        keyHash,
+        status,
+        cache,
+      })}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    );
+    await chmod(ledgerPath, 0o600);
+  }
+}
+
+function actionsFor(operation: Operation): string[] {
+  switch (operation) {
+    case "graph_review_seed":
+      return ["Review the graph signals before accepting the seed."];
+    case "graph_diagnose_stagnation":
+      return ["Test one graph signal as a new lateral hypothesis."];
+    case "graph_compare_delivery":
+      return ["Resolve material graph gaps before completing the delivery gate."];
+  }
+}

--- a/src/infra-client.ts
+++ b/src/infra-client.ts
@@ -1,0 +1,155 @@
+import type { Operation } from "./contracts.js";
+import type { GatewayInput } from "./policy.js";
+
+export interface InfraClientOptions {
+  apiKey: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export interface InfraAnalysis {
+  endpoint: "/graphsAndStatements" | "/graphAndStatements";
+  signals: string[];
+}
+
+export class InfraUnavailableError extends Error {
+  readonly code = "INFRANODUS_UNAVAILABLE";
+
+  constructor() {
+    super("InfraNodus analysis is temporarily unavailable");
+    this.name = "InfraUnavailableError";
+  }
+}
+
+export class InfraClient {
+  readonly #apiKey: string;
+  readonly #baseUrl: string;
+  readonly #fetch: typeof fetch;
+  readonly #timeoutMs: number;
+
+  constructor(options: InfraClientOptions) {
+    if (!options.apiKey.trim()) {
+      throw new Error("INFRANODUS_API_KEY is required");
+    }
+    this.#apiKey = options.apiKey;
+    this.#baseUrl = (options.baseUrl ?? "https://infranodus.com/api/v1").replace(
+      /\/$/u,
+      "",
+    );
+    this.#fetch = options.fetchImpl ?? fetch;
+    this.#timeoutMs = options.timeoutMs ?? 20_000;
+  }
+
+  async analyze(
+    operation: Operation,
+    input: GatewayInput,
+  ): Promise<InfraAnalysis> {
+    const isStagnation = operation === "graph_diagnose_stagnation";
+    const endpoint = isStagnation
+      ? "/graphAndStatements"
+      : "/graphsAndStatements";
+    const query = new URLSearchParams(
+      isStagnation
+        ? {
+            doNotSave: "true",
+            addStats: "true",
+            includeGraphSummary: "false",
+            extendedGraphSummary: "true",
+            includeGraph: "false",
+            includeStatements: "false",
+            aiTopics: "true",
+          }
+        : {
+            doNotSave: "true",
+            addStats: "true",
+            includeStatements: "false",
+            includeGraphSummary: "false",
+            extendedGraphSummary: "true",
+            includeGraph: "false",
+            compactGraph: "true",
+            compactStatements: "true",
+            aiTopics: "true",
+            optimize: "develop",
+            compareMode: "difference",
+          },
+    );
+    const analysisBody = isStagnation
+      ? { text: `${input.objective}\n\nCurrent approach:\n${input.candidate}` }
+      : {
+          contexts: [
+            { text: input.objective, modifyAnalyzedText: "none" },
+            { text: input.candidate, modifyAnalyzedText: "none" },
+          ],
+          aiTopics: "true",
+        };
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.#timeoutMs);
+
+    try {
+      const response = await this.#fetch(`${this.#baseUrl}${endpoint}?${query}`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          authorization: `Bearer ${this.#apiKey}`,
+        },
+        body: JSON.stringify({
+          ...analysisBody,
+          modal: "mcp_server",
+          source: "ouroboros-infranodus-gateway",
+          tool: operation,
+        }),
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new InfraUnavailableError();
+      }
+      const data: unknown = await response.json();
+      return { endpoint, signals: extractSignals(data) };
+    } catch {
+      throw new InfraUnavailableError();
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function extractSignals(payload: unknown): string[] {
+  const root = isRecord(payload) && isRecord(payload.entriesAndGraphOfContext)
+    ? payload.entriesAndGraphOfContext
+    : payload;
+  if (!isRecord(root) || !isRecord(root.extendedGraphSummary)) {
+    return [];
+  }
+
+  const summary = root.extendedGraphSummary;
+  const candidates = [
+    summary.contentGaps,
+    summary.mainTopics,
+    summary.mainConcepts,
+    summary.conceptualGateways,
+    summary.topRelations,
+  ];
+  const signals: string[] = [];
+  const collect = (value: unknown): void => {
+    if (signals.length >= 8) return;
+    if (typeof value === "string") {
+      const normalized = value.replace(/\s+/gu, " ").trim().slice(0, 280);
+      if (normalized && !signals.includes(normalized)) signals.push(normalized);
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) collect(item);
+      return;
+    }
+    if (isRecord(value)) {
+      for (const item of Object.values(value)) collect(item);
+    }
+  };
+  for (const candidate of candidates) collect(candidate);
+  return signals;
+}

--- a/src/live-verification.ts
+++ b/src/live-verification.ts
@@ -1,0 +1,141 @@
+export interface LiveVerificationOptions {
+  apiKey: string;
+  baseUrl?: string;
+  fetchImpl?: typeof fetch;
+  stateDir?: string;
+}
+
+export interface LiveVerificationResult {
+  status: "PASS";
+  inventory: {
+    beforeCount: number;
+    afterCount: number;
+    beforeDigest: string;
+    afterDigest: string;
+    unchanged: true;
+  };
+  operations: Array<{
+    operation: string;
+    status: string;
+    observationCount: number;
+    endpoint: string;
+    mode: "no-save";
+  }>;
+}
+
+export async function runLiveVerification(
+  options: LiveVerificationOptions,
+): Promise<LiveVerificationResult> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const baseUrl = (options.baseUrl ?? "https://infranodus.com/api/v1").replace(/\/$/u, "");
+  const before = await inventorySnapshot(baseUrl, options.apiKey, fetchImpl);
+  const gateway = new Gateway({
+    client: new InfraClient({
+      apiKey: options.apiKey,
+      baseUrl,
+      fetchImpl,
+      timeoutMs: 30_000,
+    }),
+    ...(options.stateDir ? { stateDir: options.stateDir } : {}),
+  });
+  const fixtures: ReadonlyArray<readonly [Operation, { objective: string; candidate: string }]> = [
+    [
+      "graph_review_seed",
+      {
+        objective: "A seed should state a measurable outcome, bounded scope, and verification gate.",
+        candidate: "The proposed seed defines the outcome and scope, then requires a reproducible check.",
+      },
+    ],
+    [
+      "graph_diagnose_stagnation",
+      {
+        objective: "Identify a materially different hypothesis when progress repeats one assumption.",
+        candidate: "The current approach keeps adjusting implementation details without testing a new model.",
+      },
+    ],
+    [
+      "graph_compare_delivery",
+      {
+        objective: "Delivery evidence should cover behavior, security boundaries, and an observable runtime check.",
+        candidate: "The evidence includes passing tests, bounded permissions, and a live protocol invocation.",
+      },
+    ],
+  ];
+  const operations: LiveVerificationResult["operations"] = [];
+
+  for (const [operation, input] of fixtures) {
+    const advice = GraphAdviceSchema.parse(await gateway.execute(operation, input));
+    if (advice.status !== "OK") {
+      throw new Error(`Live verification failed safely for ${operation}`);
+    }
+    operations.push({
+      operation,
+      status: advice.status,
+      observationCount: advice.observations.length,
+      endpoint: advice.provenance.endpoint,
+      mode: advice.provenance.mode,
+    });
+  }
+
+  const after = await inventorySnapshot(baseUrl, options.apiKey, fetchImpl);
+  if (before.count !== after.count || before.digest !== after.digest) {
+    throw new Error("Live verification detected a graph inventory change");
+  }
+
+  return {
+    status: "PASS",
+    inventory: {
+      beforeCount: before.count,
+      afterCount: after.count,
+      beforeDigest: before.digest,
+      afterDigest: after.digest,
+      unchanged: true,
+    },
+    operations,
+  };
+}
+
+async function inventorySnapshot(
+  baseUrl: string,
+  apiKey: string,
+  fetchImpl: typeof fetch,
+): Promise<{ count: number; digest: string }> {
+  const response = await fetchImpl(`${baseUrl}/listGraphs`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      modal: "mcp_server",
+      source: "ouroboros-infranodus-gateway",
+      tool: "live_inventory_guard",
+    }),
+  });
+  if (!response.ok) throw new Error("Graph inventory check is unavailable");
+  const payload: unknown = await response.json();
+  if (!Array.isArray(payload)) throw new Error("Graph inventory response was invalid");
+  const canonical = canonicalize(payload);
+  return {
+    count: payload.length,
+    digest: createHash("sha256").update(canonical).digest("hex"),
+  };
+}
+
+function canonicalize(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalize).sort().join(",")}]`;
+  }
+  if (typeof value === "object" && value !== null) {
+    const entries = Object.entries(value)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([key, item]) => `${JSON.stringify(key)}:${canonicalize(item)}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+import { createHash } from "node:crypto";
+
+import { GraphAdviceSchema, type Operation } from "./contracts.js";
+import { Gateway } from "./gateway.js";
+import { InfraClient } from "./infra-client.js";

--- a/src/live-verify.ts
+++ b/src/live-verify.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
+
+import { runLiveVerification } from "./live-verification.js";
+
+const apiKey = process.env.INFRANODUS_API_KEY ?? "";
+if (!apiKey) {
+  process.stderr.write("INFRANODUS_API_KEY is required for live verification\n");
+  process.exitCode = 2;
+} else {
+  const result = await runLiveVerification({
+    apiKey,
+    ...(process.env.GATEWAY_STATE_DIR
+      ? { stateDir: process.env.GATEWAY_STATE_DIR }
+      : {}),
+  });
+  const serialized = `${JSON.stringify(result, null, 2)}\n`;
+  if (process.env.LIVE_EVIDENCE_PATH) {
+    await mkdir(dirname(process.env.LIVE_EVIDENCE_PATH), { recursive: true });
+    await writeFile(process.env.LIVE_EVIDENCE_PATH, serialized, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+  }
+  process.stdout.write(serialized);
+}

--- a/src/policy.ts
+++ b/src/policy.ts
@@ -1,0 +1,74 @@
+export interface GatewayInput {
+  objective: string;
+  candidate: string;
+}
+
+const ABSOLUTE_BYTES = 64 * 1024;
+const DEFAULT_CHARACTERS = 20_000;
+
+const BLOCKED_PATTERNS: ReadonlyArray<readonly [string, RegExp]> = [
+  ["secret", /\b(?:api[_-]?key|access[_-]?token|client[_-]?secret|password)\s*[:=]\s*\S+/iu],
+  ["bearer token", /\bbearer\s+[a-z0-9._~+/-]{20,}/iu],
+  ["provider credential", /\b(?:sk-(?:proj-)?[a-z0-9_-]{20,}|gh[pousr]_[a-z0-9]{20,}|AKIA[0-9A-Z]{16})\b/iu],
+  ["JWT", /\beyJ[a-z0-9_-]{5,}\.[a-z0-9_-]{5,}\.[a-z0-9_-]{5,}\b/iu],
+  ["private key", /-----BEGIN (?:(?:RSA|EC|OPENSSH|ENCRYPTED) )?PRIVATE KEY-----/iu],
+  ["email address", /\b[a-z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-z0-9-]+(?:\.[a-z0-9-]+)+\b/iu],
+  ["international phone number", /\+\d{1,3}[ .-]?(?:\d[ .-]?){8,12}\d/u],
+  ["Korean phone number", /\b01[016789][ .-]?\d{3,4}[ .-]?\d{4}\b/u],
+  ["Korean resident identifier", /\b\d{6}[ -]?[1-4]\d{6}\b/u],
+  ["payment card number", /\b(?:\d[ -]?){12,18}\d\b/u],
+  ["URL", /(?:\b(?:https?|ftp):\/\/\S+|\bwww\.[a-z0-9-]+(?:\.[a-z0-9-]+)+(?:\/\S*)?)/iu],
+  ["fenced code", /```/u],
+  ["raw code", /(?:\bfunction\s+[a-z_$][\w$]*\s*\(|\b(?:const|let|var)\s+[a-z_$][\w$]*\s*=|\bimport\s+.+\s+from\s+|\bprocess\.env\b|\bdef\s+[a-z_]\w*\s*\([^)]*\)\s*:|\bpackage\s+main\b|\bfunc\s+[a-z_]\w*\s*\(|\bfn\s+[a-z_]\w*\s*\(|\bpublic\s+(?:final\s+)?class\s+[a-z_]\w*)/iu],
+];
+
+export class PolicyError extends Error {
+  readonly code = "INPUT_REJECTED";
+
+  constructor(reason: string) {
+    super(`Input rejected: ${reason}`);
+    this.name = "PolicyError";
+  }
+}
+
+function normalizeText(value: string, field: string): string {
+  if (typeof value !== "string") {
+    throw new PolicyError(`${field} must be text`);
+  }
+
+  const normalized = value
+    .normalize("NFKC")
+    .replace(/\r\n?/gu, "\n")
+    .replace(/[\t ]+/gu, " ")
+    .replace(/ *\n */gu, "\n")
+    .trim();
+
+  if (!normalized) {
+    throw new PolicyError(`${field} is empty`);
+  }
+
+  for (const [label, pattern] of BLOCKED_PATTERNS) {
+    if (pattern.test(normalized)) {
+      throw new PolicyError(`${label} content is not allowed`);
+    }
+  }
+
+  return normalized;
+}
+
+export function normalizeInput(input: GatewayInput): GatewayInput {
+  const rawBytes = new TextEncoder().encode(
+    `${input.objective}\u0000${input.candidate}`,
+  ).byteLength;
+  if (rawBytes > ABSOLUTE_BYTES) {
+    throw new PolicyError("payload exceeds the 64 KiB absolute ceiling");
+  }
+
+  const objective = normalizeText(input.objective, "objective");
+  const candidate = normalizeText(input.candidate, "candidate");
+  if (objective.length + candidate.length > DEFAULT_CHARACTERS) {
+    throw new PolicyError("payload exceeds the 20,000-character analysis bound");
+  }
+
+  return Object.freeze({ objective, candidate });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,0 +1,61 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+
+import { GraphAdviceSchema, type Operation } from "./contracts.js";
+import type { Gateway } from "./gateway.js";
+import { PolicyError } from "./policy.js";
+
+const InputSchema = z.object({
+  objective: z.string().describe("Goal, requirement, or acceptance criteria in safe prose"),
+  candidate: z.string().describe("Seed, current approach, or delivery evidence in safe prose"),
+});
+
+const TOOL_DESCRIPTIONS: Record<Operation, string> = {
+  graph_review_seed: "Compare safe requirements prose with a proposed Ouroboros seed before approval.",
+  graph_diagnose_stagnation: "Find graph-based gaps in a stalled approach without reading or writing a saved graph.",
+  graph_compare_delivery: "Compare safe acceptance prose with delivery evidence before the QA completion gate.",
+};
+
+export function createServer(gateway: Gateway): McpServer {
+  const server = new McpServer({
+    name: "ouroboros-infranodus-gateway",
+    version: "0.1.0",
+  });
+
+  for (const operation of Object.keys(TOOL_DESCRIPTIONS) as Operation[]) {
+    server.registerTool(
+      operation,
+      {
+        title: operation,
+        description: TOOL_DESCRIPTIONS[operation],
+        inputSchema: InputSchema,
+        outputSchema: GraphAdviceSchema,
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+      },
+      async ({ objective, candidate }) => {
+        try {
+          const advice = await gateway.execute(operation, { objective, candidate });
+          return {
+            content: [{ type: "text", text: JSON.stringify(advice) }],
+            structuredContent: advice,
+          };
+        } catch (error) {
+          const message = error instanceof PolicyError
+            ? error.message
+            : "Gateway request failed safely";
+          return {
+            content: [{ type: "text", text: message }],
+            isError: true,
+          };
+        }
+      },
+    );
+  }
+
+  return server;
+}

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+import { Gateway } from "./gateway.js";
+import { InfraClient } from "./infra-client.js";
+import { createServer } from "./server.js";
+
+const apiKey = process.env.INFRANODUS_API_KEY ?? "";
+const client = new InfraClient({ apiKey });
+const gateway = new Gateway({
+  client,
+  ...(process.env.GATEWAY_STATE_DIR
+    ? { stateDir: process.env.GATEWAY_STATE_DIR }
+    : {}),
+});
+const server = createServer(gateway);
+await server.connect(new StdioServerTransport());

--- a/tests/gateway.test.ts
+++ b/tests/gateway.test.ts
@@ -1,0 +1,113 @@
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { GraphAdviceSchema } from "../src/contracts.js";
+import { Gateway } from "../src/gateway.js";
+
+const cleanup: string[] = [];
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true })));
+});
+
+describe("Gateway resilience and metadata-only state", () => {
+  it("rejects sensitive input before invoking the analysis client", async () => {
+    const analyze = vi.fn();
+    const gateway = new Gateway({ client: { analyze } });
+
+    await expect(
+      gateway.execute("graph_review_seed", {
+        objective: "Review the seed.",
+        candidate: "API_KEY=super-secret-value-123456",
+      }),
+    ).rejects.toThrow(/rejected/i);
+    expect(analyze).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates identical analysis in memory and marks the cache hit", async () => {
+    const analyze = vi.fn().mockResolvedValue({
+      endpoint: "/graphsAndStatements",
+      signals: ["Recovery evidence is absent", "resilience"],
+    });
+    const gateway = new Gateway({ client: { analyze } });
+    const input = {
+      objective: "Validate the recovery requirement.",
+      candidate: "The delivery includes login only.",
+    };
+
+    const first = await gateway.execute("graph_review_seed", input);
+    const second = await gateway.execute("graph_review_seed", input);
+
+    expect(analyze).toHaveBeenCalledOnce();
+    expect(first.provenance.cache).toBe("miss");
+    expect(second.provenance.cache).toBe("hit");
+    expect(GraphAdviceSchema.parse(first)).toEqual(first);
+    expect(first.observations).toEqual([
+      "Recovery evidence is absent",
+      "resilience",
+    ]);
+  });
+
+  it("returns bounded degraded advice when InfraNodus is unavailable", async () => {
+    const gateway = new Gateway({
+      client: { analyze: vi.fn().mockRejectedValue(new Error("private failure")) },
+    });
+
+    const advice = await gateway.execute("graph_diagnose_stagnation", {
+      objective: "Find a new perspective.",
+      candidate: "The current attempt repeats one assumption.",
+    });
+
+    expect(advice).toMatchObject({
+      status: "DEGRADED_NO_GRAPH",
+      observations: [],
+      provenance: {
+        provider: "infranodus",
+        mode: "no-save",
+        endpoint: "/graphAndStatements",
+        cache: "bypass",
+      },
+    });
+    expect(JSON.stringify(advice)).not.toContain("private failure");
+    expect(GraphAdviceSchema.parse(advice)).toEqual(advice);
+  });
+
+  it("writes only hashed metadata with private filesystem modes", async () => {
+    const parent = await mkdtemp(join(tmpdir(), "oig-state-test-"));
+    cleanup.push(parent);
+    const stateDir = join(parent, "state");
+    const objective = "Validate a private acceptance criterion.";
+    const candidate = "Safe delivery summary without identifiers.";
+    const gateway = new Gateway({
+      client: {
+        analyze: vi.fn().mockResolvedValue({
+          endpoint: "/graphsAndStatements",
+          signals: ["One bounded observation"],
+        }),
+      },
+      stateDir,
+    });
+
+    await gateway.execute("graph_compare_delivery", { objective, candidate });
+
+    const ledgerPath = join(stateDir, "ledger.jsonl");
+    const [dirStats, fileStats, ledger] = await Promise.all([
+      stat(stateDir),
+      stat(ledgerPath),
+      readFile(ledgerPath, "utf8"),
+    ]);
+    expect(dirStats.mode & 0o777).toBe(0o700);
+    expect(fileStats.mode & 0o777).toBe(0o600);
+    expect(ledger).not.toContain(objective);
+    expect(ledger).not.toContain(candidate);
+    expect(ledger).not.toContain("One bounded observation");
+    expect(JSON.parse(ledger.trim())).toMatchObject({
+      operation: "graph_compare_delivery",
+      status: "OK",
+      cache: "miss",
+    });
+    expect(JSON.parse(ledger.trim()).keyHash).toMatch(/^[a-f0-9]{64}$/u);
+  });
+});

--- a/tests/infra-client.test.ts
+++ b/tests/infra-client.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { InfraClient } from "../src/infra-client.js";
+
+describe("InfraClient allowlisted no-save contract", () => {
+  it.each([
+    ["graph_review_seed", "/graphsAndStatements", "contexts"],
+    ["graph_compare_delivery", "/graphsAndStatements", "contexts"],
+    ["graph_diagnose_stagnation", "/graphAndStatements", "text"],
+  ] as const)("maps %s to its only allowed endpoint", async (operation, endpoint, bodyField) => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          extendedGraphSummary: {
+            contentGaps: ["Missing recovery evidence"],
+            mainTopics: ["onboarding", "resilience"],
+          },
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const client = new InfraClient({
+      apiKey: "test-key-never-logged",
+      baseUrl: "https://infranodus.test/api/v1",
+      fetchImpl,
+    });
+
+    const result = await client.analyze(operation, {
+      objective: "Validate onboarding requirements.",
+      candidate: "The delivery has login but lacks recovery evidence.",
+    });
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, init] = fetchImpl.mock.calls[0] ?? [];
+    const requestUrl = new URL(String(url));
+    expect(requestUrl.pathname).toContain(endpoint);
+    expect(requestUrl.searchParams.get("doNotSave")).toBe("true");
+    expect(requestUrl.searchParams.has("save")).toBe(false);
+    expect(init?.method).toBe("POST");
+    expect(new Headers(init?.headers).get("authorization")).toBe(
+      "Bearer test-key-never-logged",
+    );
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    expect(body).toHaveProperty(bodyField);
+    expect(body).toMatchObject({
+      modal: "mcp_server",
+      source: "ouroboros-infranodus-gateway",
+      tool: operation,
+    });
+    expect(result.endpoint).toBe(endpoint);
+    expect(result.signals).toEqual([
+      "Missing recovery evidence",
+      "onboarding",
+      "resilience",
+    ]);
+  });
+
+  it("does not leak an upstream error body", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("private upstream diagnostic", { status: 500 }),
+    );
+    const client = new InfraClient({ apiKey: "test-key", fetchImpl });
+
+    await expect(
+      client.analyze("graph_review_seed", {
+        objective: "Review",
+        candidate: "Safe prose.",
+      }),
+    ).rejects.not.toThrow(/private upstream diagnostic/);
+  });
+
+  it("aborts a request at the configured deadline", async () => {
+    const fetchImpl = vi.fn<typeof fetch>().mockImplementation(
+      (_url, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("aborted", "AbortError")),
+          );
+        }),
+    );
+    const client = new InfraClient({ apiKey: "test-key", fetchImpl, timeoutMs: 5 });
+
+    await expect(
+      client.analyze("graph_diagnose_stagnation", {
+        objective: "Find a missing perspective.",
+        candidate: "The current attempt repeats the same assumption.",
+      }),
+    ).rejects.toThrow(/unavailable/i);
+  });
+});

--- a/tests/live-verification.test.ts
+++ b/tests/live-verification.test.ts
@@ -1,0 +1,53 @@
+import { createServer, type Server } from "node:http";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runLiveVerification } from "../src/live-verification.js";
+
+const servers: Server[] = [];
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map(
+    (server) => new Promise<void>((resolve, reject) =>
+      server.close((error) => error ? reject(error) : resolve()),
+    ),
+  ));
+});
+
+describe("live no-save verifier", () => {
+  it("proves three calls leave graph inventory unchanged", async () => {
+    const paths: string[] = [];
+    const server = createServer((request, response) => {
+      paths.push(request.url ?? "");
+      response.writeHead(200, { "content-type": "application/json" });
+      if (request.url === "/api/v1/listGraphs") {
+        response.end(JSON.stringify([
+          { id: 7, contextName: "private-name-never-reported", createdAt: "2026-01-01" },
+        ]));
+      } else {
+        response.end(JSON.stringify({
+          extendedGraphSummary: { contentGaps: ["A bounded verification signal"] },
+        }));
+      }
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const address = server.address();
+    if (!address || typeof address === "string") throw new Error("missing port");
+
+    const result = await runLiveVerification({
+      apiKey: "fake-live-key",
+      baseUrl: `http://127.0.0.1:${address.port}/api/v1`,
+    });
+
+    expect(result).toMatchObject({
+      status: "PASS",
+      inventory: { beforeCount: 1, afterCount: 1, unchanged: true },
+    });
+    expect(result.inventory.beforeDigest).toBe(result.inventory.afterDigest);
+    expect(result.operations).toHaveLength(3);
+    expect(paths.filter((path) => path === "/api/v1/listGraphs")).toHaveLength(2);
+    expect(paths.filter((path) => path.includes("doNotSave=true"))).toHaveLength(3);
+    expect(JSON.stringify(result)).not.toContain("private-name-never-reported");
+    expect(JSON.stringify(result)).not.toContain("A bounded verification signal");
+  });
+});

--- a/tests/policy.test.ts
+++ b/tests/policy.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+describe("input policy", () => {
+  it("normalizes a safe review request into a bounded immutable payload", async () => {
+    const policy = await import("../src/policy.js").catch(() => ({}));
+
+    expect(policy).toHaveProperty("normalizeInput");
+    if (!("normalizeInput" in policy) || typeof policy.normalizeInput !== "function") {
+      return;
+    }
+
+    expect(
+      policy.normalizeInput({
+        objective: "  Validate the onboarding acceptance criteria.  ",
+        candidate: "The delivered flow includes login and a recovery path.",
+      }),
+    ).toEqual({
+      objective: "Validate the onboarding acceptance criteria.",
+      candidate: "The delivered flow includes login and a recovery path.",
+    });
+  });
+
+  it.each([
+    ["secret label", "API_KEY=super-secret-value-123456"],
+    ["bearer token", "Bearer abcdefghijklmnopqrstuvwxyz123456"],
+    ["OpenAI-style token", "sk-proj-AbCdEfGhIjKlMnOpQrStUvWxYz1234567890"],
+    ["GitHub-style token", "ghp_AbCdEfGhIjKlMnOpQrStUvWxYz1234567890"],
+    ["AWS access key", "AKIAIOSFODNN7EXAMPLE"],
+    ["JWT", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signaturevalue"],
+    ["PEM private key", "-----BEGIN PRIVATE KEY-----"],
+    ["encrypted PEM private key", "-----BEGIN ENCRYPTED PRIVATE KEY-----"],
+    ["email address", "Contact jane@example.com for details"],
+    ["international phone", "Call +61 412 345 678 for access"],
+    ["Korean phone", "담당자 010-1234-5678"],
+    ["Korean resident identifier", "식별번호 900101-1234567"],
+    ["payment card number", "Use card 4111 1111 1111 1111"],
+    ["URL", "See https://example.com/private/spec"],
+    ["host-form URL", "See www.example.com/private/spec"],
+    ["fenced code", "```ts\nconst secret = process.env.KEY\n```"],
+    ["raw code", "function deploy() { return process.env.TOKEN; }"],
+    ["Python code", "def deploy():\n return True"],
+    ["Go code", "package main\nfunc main() {}"],
+    ["Rust code", "fn main() { println!(\"hello\"); }"],
+    ["Java code", "public class Main { static void run() {} }"],
+  ])("rejects %s before any upstream call", async (_label, candidate) => {
+    const { normalizeInput } = await import("../src/policy.js");
+
+    expect(() =>
+      normalizeInput({ objective: "Review delivery", candidate }),
+    ).toThrowError(/rejected/i);
+  });
+
+  it("rejects content beyond the 64 KiB absolute ceiling", async () => {
+    const { normalizeInput } = await import("../src/policy.js");
+
+    expect(() =>
+      normalizeInput({ objective: "Review", candidate: "x".repeat(65_537) }),
+    ).toThrowError(/64 KiB/i);
+  });
+
+  it("rejects content beyond the default 20,000-character analysis bound", async () => {
+    const { normalizeInput } = await import("../src/policy.js");
+
+    expect(() =>
+      normalizeInput({ objective: "Review", candidate: "x".repeat(20_001) }),
+    ).toThrowError(/20,000/i);
+  });
+
+  it("returns a new frozen value instead of retaining the caller object", async () => {
+    const { normalizeInput } = await import("../src/policy.js");
+    const input = { objective: "Review", candidate: "Safe prose." };
+    const normalized = normalizeInput(input);
+
+    expect(normalized).not.toBe(input);
+    expect(Object.isFrozen(normalized)).toBe(true);
+  });
+});

--- a/tests/rewrite-fetch.mjs
+++ b/tests/rewrite-fetch.mjs
@@ -1,0 +1,14 @@
+const nativeFetch = globalThis.fetch;
+const testBase = process.env.OIG_TEST_BASE;
+
+if (!testBase) {
+  throw new Error("OIG_TEST_BASE is required by the test-only fetch preload");
+}
+
+globalThis.fetch = (input, init) => {
+  const original = new URL(
+    typeof input === "string" || input instanceof URL ? input : input.url,
+  );
+  const rewritten = new URL(`${original.pathname}${original.search}`, testBase);
+  return nativeFetch(rewritten, init);
+};

--- a/tests/stdio.test.ts
+++ b/tests/stdio.test.ts
@@ -1,0 +1,91 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { GraphAdviceSchema } from "../src/contracts.js";
+
+const cleanupDirectories: string[] = [];
+const cleanupServers: Server[] = [];
+
+afterEach(async () => {
+  await Promise.all(cleanupServers.splice(0).map(
+    (server) => new Promise<void>((resolve, reject) =>
+      server.close((error) => error ? reject(error) : resolve()),
+    ),
+  ));
+  await Promise.all(
+    cleanupDirectories.splice(0).map((path) => rm(path, { recursive: true })),
+  );
+});
+
+describe("real stdio MCP surface", () => {
+  it("exposes and executes exactly three read-only tools", async () => {
+    const upstream = createServer((_request, response) => {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({
+        extendedGraphSummary: { contentGaps: ["Bounded fake signal"] },
+      }));
+    });
+    cleanupServers.push(upstream);
+    await new Promise<void>((resolve) => upstream.listen(0, "127.0.0.1", resolve));
+    const address = upstream.address();
+    if (!address || typeof address === "string") throw new Error("missing test port");
+    const stateParent = await mkdtemp(join(tmpdir(), "oig-stdio-test-"));
+    cleanupDirectories.push(stateParent);
+
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [join(process.cwd(), "dist/stdio.js")],
+      env: {
+        INFRANODUS_API_KEY: "stdio-test-key",
+        NODE_OPTIONS: `--import=${join(process.cwd(), "tests/rewrite-fetch.mjs")}`,
+        OIG_TEST_BASE: `http://127.0.0.1:${address.port}`,
+        GATEWAY_STATE_DIR: join(stateParent, "state"),
+      },
+      stderr: "pipe",
+    });
+    const client = new Client({ name: "stdio-contract-test", version: "1.0.0" });
+    await client.connect(transport);
+
+    try {
+      const listed = await client.listTools();
+      const names = listed.tools.map((tool) => tool.name).sort();
+      expect(names).toEqual([
+        "graph_compare_delivery",
+        "graph_diagnose_stagnation",
+        "graph_review_seed",
+      ]);
+      for (const tool of listed.tools) {
+        expect(tool.annotations).toMatchObject({
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        });
+      }
+
+      for (const name of names) {
+        const result = await client.callTool({
+          name,
+          arguments: {
+            objective: "Validate the bounded acceptance criteria.",
+            candidate: "The safe delivery summary covers the main flow.",
+          },
+        });
+        expect(result.isError).not.toBe(true);
+        expect(GraphAdviceSchema.parse(result.structuredContent)).toMatchObject({
+          status: "OK",
+          operation: name,
+          provenance: { mode: "no-save" },
+        });
+      }
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "declaration": true,
+    "sourceMap": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["tests"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "exactOptionalPropertyTypes": true,
+    "verbatimModuleSyntax": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add a standalone InfraNodus MCP gateway under `examples/infranodus-gateway`
- expose only bounded advisory operations: seed review, stagnation diagnosis, and delivery comparison
- retain Ouroboros as the sole execution and delivery authority; the gateway never mutates Ouroboros state
- add Korean integration/runbook documentation and a Keychain-friendly Codex MCP launcher
- link the example from the documentation index

## Safety properties
- requests use `doNotSave=true` and redact credentials, tokens, PII, and private keys before egress
- remote failures return bounded `DEGRADED_NO_GRAPH` results instead of blocking the workflow
- no InfraNodus write or raw-tool surface is exposed

## Verification
- `npm run build`
- `npm test` (36 passed)
- `npm run test:stdio` (1 passed)
- `npm audit --omit=dev` (0 vulnerabilities)

The live verification evidence contains no credentials or raw request bodies.